### PR TITLE
[Snippets] LoopManager: error-prone code is removed

### DIFF
--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -46,10 +46,6 @@ public:
              size_t increment,
              const std::vector<LoopPort>& entries,
              const std::vector<LoopPort>& exits);
-    LoopInfo(size_t work_amount,
-             size_t increment,
-             const std::vector<ExpressionPort>& entries,
-             const std::vector<ExpressionPort>& exits);
     virtual ~LoopInfo() = default;
 
     /**
@@ -127,11 +123,6 @@ public:
      * @param increment - step of loop counter increment
      */
     void set_increment(size_t increment);
-    /**
-     * @brief Sets `dim_idx` to all input and output ports
-     * @param dim_idx - index
-     */
-    void set_dim_idx(size_t dim_idx);
 
     /**
      * @brief Replace the current LoopPort `actual_port` with new `target_ports`
@@ -253,12 +244,6 @@ public:
                     size_t increment,
                     const std::vector<LoopPort>& entries,
                     const std::vector<LoopPort>& exits,
-                    SpecificIterationHandlers handlers = SpecificIterationHandlers());
-    UnifiedLoopInfo(size_t work_amount,
-                    size_t increment,
-                    const std::vector<ExpressionPort>& entries,
-                    const std::vector<ExpressionPort>& exits,
-
                     SpecificIterationHandlers handlers = SpecificIterationHandlers());
 
     /**

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -80,80 +80,59 @@ public:
     static std::vector<size_t> get_common_outer_loops(const std::vector<ExpressionPtr>& exprs);
 
     /**
-     * @brief Create new LoopInfo and mark all expressions in loop bounds by new loop ID
+     * @brief Automatically marks new loops, number of which is defined by `loop_depth` parameter.
+     * Loop increments for the most inner loop is defined by `vector_size` parameter.
+     * The increment for the rest loops is equal to 1.
      * @param loop_begin_pos the first expression iterator
      * @param loop_end_pos the next iterator after last expression
      * @param loop_depth count of loops for marking
-     * @param vector_size increment of loop
+     * @param vector_size increment of most-inner loop
      */
     void mark_loop(LinearIR::constExprIt loop_begin_pos,
                    LinearIR::constExprIt loop_end_pos,
                    size_t loop_depth,
                    size_t vector_size);
     /**
-     * @brief Create new UnifiedLoopInfo and mark all expressions in loop bounds by new loop ID with more manual
-     * parameters
+     * @brief Creates new UnifiedLoopInfo and marks all expressions in loop bounds by new loop ID.
      * @param loop_begin_pos the first expression iterator
      * @param loop_end_pos the next iterator after last expression
      * @param work_amount work amount of the loop
      * @param increment the step of loop counter increment
      * @param entries input loop ports
      * @param exits output loop ports
-     * @param set_default_handlers flag defines whether it is needed to set default set of SpecificIterationHandlers or
-     * not
+     * @param set_default_handlers defines whether default set of SpecificIterationHandlers should be set
      * @return new loop ID
      */
-    template <typename T>
     size_t mark_loop(LinearIR::constExprIt loop_begin_pos,
                      LinearIR::constExprIt loop_end_pos,
                      size_t work_amount,
                      size_t increment,
-                     const std::vector<T>& entries,
-                     const std::vector<T>& exits,
-                     bool set_default_handlers = true) {
-        const auto normalized_increment =
-            utils::is_dynamic_value(work_amount) || work_amount == 0 ? increment : std::min(increment, work_amount);
-        const auto loop_info = std::make_shared<UnifiedLoopInfo>(work_amount, normalized_increment, entries, exits);
-        if (set_default_handlers) {
-            loop_info->set_handlers(
-                SpecificIterationHandlers(work_amount, normalized_increment, loop_info->get_dim_idx()));
-        }
-
-        const auto loop_id = this->add_loop_info(loop_info);
-        for (auto expr_it = loop_begin_pos; expr_it != loop_end_pos; ++expr_it) {
-            insert_loop_id(*expr_it, loop_id);
-        }
-        return loop_id;
-    }
+                     const std::vector<LoopPort>& entries,
+                     const std::vector<LoopPort>& exits,
+                     bool set_default_handlers = true);
     /**
-     * @brief Create new UnifiedLoopInfo and mark all expressions in loop bounds by new loop ID with more manual
-     * parameters
+     * @brief Creates new UnifiedLoopInfo and marks all expressions in loop bounds by new loop ID.
+     * @note: This helper takes entry/exit ports with ExpressionPort type.
+     * In this case, an additional `dim_idx` parameter must be set: it will be set to each LoopPort of the new loop.
      * @param loop_begin_pos the first expression iterator
      * @param loop_end_pos the next iterator after last expression
      * @param work_amount work amount of the loop
      * @param increment the step of loop counter increment
      * @param dim_idx loop iterates by this index of dimension
-     * @param entries input loop ports
-     * @param exits output loop ports
+     * @param entries_expr_ports input loop ports
+     * @param exits_expr_ports output loop ports
      * @param set_default_handlers flag defines whether it is needed to set default set of SpecificIterationHandlers or
      *                             not
      * @return new loop ID
      */
-    template <typename T>
     size_t mark_loop(LinearIR::constExprIt loop_begin_pos,
                      LinearIR::constExprIt loop_end_pos,
                      size_t work_amount,
                      size_t increment,
                      size_t dim_idx,
-                     const std::vector<T>& entries,
-                     const std::vector<T>& exits,
-                     bool set_default_handlers = true) {
-        const auto loop_id =
-            mark_loop(loop_begin_pos, loop_end_pos, work_amount, increment, entries, exits, set_default_handlers);
-        const auto loop_info = get_loop_info<UnifiedLoopInfo>(loop_id);
-        loop_info->set_dim_idx(dim_idx);
-        return loop_id;
-    }
+                     const std::vector<ExpressionPort>& entries_expr_ports,
+                     const std::vector<ExpressionPort>& exits_expr_ports,
+                     bool set_default_handlers = true);
     /**
      * @brief Create new Loop and replace with it: add new LoopInfo, update loop IDs in expressions and
      *        remove the old LoopInfo from the map if no one expression isn't mark by this `old_id`

--- a/src/common/snippets/include/snippets/lowered/loop_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_port.hpp
@@ -34,7 +34,7 @@ public:
 
     template <LoopPort::Type T,
               std::enable_if_t<utils::any_of(T, Type::Incremented, Type::NotIncremented), bool> = true>
-    static LoopPort create(const ExpressionPort& port, size_t dim_idx = 0) {
+    static LoopPort create(const ExpressionPort& port, size_t dim_idx) {
         return {port, dim_idx, T};
     }
 

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -37,22 +37,6 @@ LoopInfo::LoopInfo(size_t work_amount,
       m_input_ports(entries),
       m_output_ports(exits) {}
 
-LoopInfo::LoopInfo(size_t work_amount,
-                   size_t increment,
-                   const std::vector<ExpressionPort>& entries,
-                   const std::vector<ExpressionPort>& exits)
-    : m_work_amount(work_amount),
-      m_increment(increment) {
-    m_input_ports.reserve(entries.size());
-    m_output_ports.reserve(exits.size());
-    for (const auto& port : entries) {
-        m_input_ports.push_back(LoopPort::create<LoopPort::Type::Incremented>(port, 0));
-    }
-    for (const auto& port : exits) {
-        m_output_ports.push_back(LoopPort::create<LoopPort::Type::Incremented>(port, 0));
-    }
-}
-
 bool LoopInfo::is_dynamic() const {
     return utils::is_dynamic_value(m_work_amount) || utils::is_dynamic_value(m_increment);
 }
@@ -121,16 +105,6 @@ void LoopInfo::set_work_amount(size_t work_amount) {
 
 void LoopInfo::set_increment(size_t increment) {
     m_increment = increment;
-}
-
-void LoopInfo::set_dim_idx(size_t dim_idx) {
-    auto setter = [dim_idx](LoopPort& port) {
-        if (port.is_processed()) {
-            port.set_dim_idx(dim_idx);
-        }
-    };
-    std::for_each(m_input_ports.begin(), m_input_ports.end(), setter);
-    std::for_each(m_output_ports.begin(), m_output_ports.end(), setter);
 }
 
 template <>
@@ -254,18 +228,6 @@ UnifiedLoopInfo::UnifiedLoopInfo(size_t work_amount,
                                  size_t increment,
                                  const std::vector<LoopPort>& entries,
                                  const std::vector<LoopPort>& exits,
-                                 SpecificIterationHandlers handlers)
-    : LoopInfo(work_amount, increment, entries, exits),
-      m_handlers(std::move(handlers)),
-      m_input_port_descs(std::vector<LoopPortDesc>(entries.size())),
-      m_output_port_descs(std::vector<LoopPortDesc>(exits.size())) {
-    sort_ports();
-}
-
-UnifiedLoopInfo::UnifiedLoopInfo(size_t work_amount,
-                                 size_t increment,
-                                 const std::vector<ExpressionPort>& entries,
-                                 const std::vector<ExpressionPort>& exits,
                                  SpecificIterationHandlers handlers)
     : LoopInfo(work_amount, increment, entries, exits),
       m_handlers(std::move(handlers)),

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -46,10 +46,10 @@ LoopInfo::LoopInfo(size_t work_amount,
     m_input_ports.reserve(entries.size());
     m_output_ports.reserve(exits.size());
     for (const auto& port : entries) {
-        m_input_ports.push_back(LoopPort::create<LoopPort::Type::Incremented>(port));
+        m_input_ports.push_back(LoopPort::create<LoopPort::Type::Incremented>(port, 0));
     }
     for (const auto& port : exits) {
-        m_output_ports.push_back(LoopPort::create<LoopPort::Type::Incremented>(port));
+        m_output_ports.push_back(LoopPort::create<LoopPort::Type::Incremented>(port, 0));
     }
 }
 

--- a/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
+++ b/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
@@ -150,8 +150,8 @@ bool BrgemmBlockingBase::mark_blocking_loops(LinearIR& linear_ir,
     }
     if (!is_full_dim_value(n_block)) {
         const std::vector<LoopPort> entries{LoopPort::create<PortType::NotProcessed>(brgemm_expr->get_input_port(0)),
-                                            LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(1))};
-        const std::vector<LoopPort> exits{LoopPort::create<PortType::Incremented>(brgemm_expr->get_output_port(0))};
+                                            LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(1), 0)};
+        const std::vector<LoopPort> exits{LoopPort::create<PortType::Incremented>(brgemm_expr->get_output_port(0), 0)};
         mark_n_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, n_block);
     }
     if (!is_full_dim_value(m_block)) {

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -103,7 +103,6 @@ void SplitLoops::split(LinearIR& linear_ir, size_t loop_to_split_id, size_t oute
                                                        loop_end,
                                                        inner_loop_info->get_work_amount(),
                                                        outer_increment,
-                                                       inner_loop_info->get_dim_idx(),
                                                        inner_loop_info->get_input_ports(),
                                                        inner_loop_info->get_output_ports(),
                                                        false);

--- a/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
@@ -71,10 +71,10 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithParams) {
         auto begin = multiply.first;
         auto end = result.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1)),
-                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0), 0)});
         linear_ir->set_loop_depth(1);
     }
     {
@@ -90,9 +90,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithParams) {
         auto begin = sub.first;
         auto end = result.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0)),
-                                                                           LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(1))},
-                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0), 0),
+                                                                           LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(1), 0)},
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0), 0)});
     }
 }
 
@@ -129,9 +129,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithScalar) {
         auto begin = scalar.first;
         auto end = result.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0), 0)});
         linear_ir->set_loop_depth(1);
     }
     {
@@ -147,9 +147,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithScalar) {
         auto begin = sub.first;
         auto end = result.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0)),
-                                                                           LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(1))},
-                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0), 0),
+                                                                           LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(1), 0)},
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0), 0)});
     }
 }
 
@@ -192,12 +192,12 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsOutputLoopUpdateNotNeed
         auto begin = multiply.first;
         auto end = result1.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 16, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1)),
-                                                                       LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
-                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0)),
-                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(begin, end, 3, 1,
                                                  std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0), 1),
                                                                        LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1), 1),
@@ -381,17 +381,17 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         const auto result = linear_ir->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir->get_loop_manager();
         loop_manager->mark_loop(matmul.first, broadcastmove.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0)),
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0), 0),
                                                       LoopPort::create<PortType::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0), 0)});
         loop_manager->mark_loop(broadcastmove.first, result.first, 64, vector_size, 0,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0)),
-                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0))},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0), 0),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0)},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
         loop_manager->mark_loop(broadcastmove.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0)),
-                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0))},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0), 0),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0)},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir, linear_ir->begin(), linear_ir->end());
     }
     {
@@ -406,17 +406,17 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir_ref->get_loop_manager();
         loop_manager->mark_loop(matmul.first, add.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0)),
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0), 0),
                                                       LoopPort::create<PortType::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0), 0)});
         loop_manager->mark_loop(add.first, result.first, 64, vector_size, 0,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
-                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
         loop_manager->mark_loop(add.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
-                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir_ref, linear_ir_ref->begin(), linear_ir_ref->end());
     }
 }

--- a/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
@@ -380,18 +380,18 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         init_expr_descriptors(*add.first, {subtensor, subtensor, subtensor}, {layout, layout, layout});
         const auto result = linear_ir->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir->get_loop_manager();
-        loop_manager->mark_loop(matmul.first, broadcastmove.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0), 0),
+        loop_manager->mark_loop(matmul.first, broadcastmove.first, 128, block_size,
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0), 1),
                                                       LoopPort::create<PortType::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0), 0)});
-        loop_manager->mark_loop(broadcastmove.first, result.first, 64, vector_size, 0,
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0), 1)});
+        loop_manager->mark_loop(broadcastmove.first, result.first, 64, vector_size,
                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0), 0),
                                                       LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0)},
                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
-        loop_manager->mark_loop(broadcastmove.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0), 0),
-                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0)},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
+        loop_manager->mark_loop(broadcastmove.first, result.first, 128, 1,
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0), 1),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 1)},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 1)});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir, linear_ir->begin(), linear_ir->end());
     }
     {
@@ -405,18 +405,18 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         init_expr_descriptors(*add.first, {subtensor, subtensor, subtensor}, {layout, layout, layout});
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir_ref->get_loop_manager();
-        loop_manager->mark_loop(matmul.first, add.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0), 0),
+        loop_manager->mark_loop(matmul.first, add.first, 128, block_size,
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0), 1),
                                                       LoopPort::create<PortType::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0), 0)});
-        loop_manager->mark_loop(add.first, result.first, 64, vector_size, 0,
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0), 1)});
+        loop_manager->mark_loop(add.first, result.first, 64, vector_size,
                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
                                                       LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
-        loop_manager->mark_loop(add.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
-                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
-                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
+        loop_manager->mark_loop(add.first, result.first, 128, 1,
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 1),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 1)},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 1)});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir_ref, linear_ir_ref->begin(), linear_ir_ref->end());
     }
 }

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -46,14 +46,14 @@ static void init_linear_ir(const std::vector<ov::Shape>& in_shapes, LinearIR& li
                                             std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0), 1),
                                                                   LoopPort::create<PortType::NotProcessed>((*matmul.first)->get_input_port(1))},
                                             std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0), 1)});
-    linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].back(), vector_size, 0,
+    linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].back(), vector_size,
                                             std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
                                                                   LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
                                             std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
-    linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].front(), 1, 1,
-                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
-                                                                  LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
-                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
+    linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].front(), 1,
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 1),
+                                                                  LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 1)},
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 1)});
 }
 
 static void apply_transformations(LinearIR& linear_ir, const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& config) {

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -47,13 +47,13 @@ static void init_linear_ir(const std::vector<ov::Shape>& in_shapes, LinearIR& li
                                                                   LoopPort::create<PortType::NotProcessed>((*matmul.first)->get_input_port(1))},
                                             std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0), 1)});
     linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].back(), vector_size, 0,
-                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
-                                                                  LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
+                                                                  LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
     linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].front(), 1, 1,
-                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
-                                                                  LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
+                                                                  LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
 }
 
 static void apply_transformations(LinearIR& linear_ir, const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& config) {

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
@@ -69,8 +69,8 @@ void create_brgemm_loop_infos(const LinearIRPtr& linear_ir,
         linear_ir->get_loop_manager()->add_loop_info(
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(n, n_blk,
                 std::vector<LoopPort>{LoopPort::create<PortType::NotProcessed>(brgemm_expr->get_input_port(0)),
-                                      LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(1))},
-                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>(brgemm_expr->get_output_port(0))},
+                                      LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(1), 0)},
+                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>(brgemm_expr->get_output_port(0), 0)},
                 BrgemmBlockingBase::get_default_blocking_loop_handlers(n, n_block)));
     }
     if (m_block) {


### PR DESCRIPTION
### Details:
 - *Removed `LoopInfo` constructor with vector of `ExpressionPort` as entries/exits since it is unsafe (always sets `dim_idx=0` for all ports)*
 - *Left only one way to create loop from `ExpressionPort` entries and exits: via `mark_loop` helper in which it is necessary to specify `dim_idx` which will be set for all loop ports*
 - *Removed `dim_idx` from  `mark_loop` helper with `LoopPort` entries and exits, since LoopPort already contains `dim_idx` calue*
 - *`LoopPort::create`: removed default value for `dim_idx`*

As a result of removal of error-prone code with non-obvious logic, now it's impossible to forget specifying `dim_idx` for some specific loop port (otherwise, compilation fails) during loops creation.

### Tickets:
 - *prerequisite for CVS-172631*
