### PR TITLE
[GPU] Revert arg max min axis change and fix incorrect offset calculation

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/arg_max_min_axis.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/arg_max_min_axis.cl
@@ -123,10 +123,6 @@ KERNEL(arg_max_min_modified)(
     ,__global INPUT0_TYPE* tmp_buffer0
     ,__global INPUT0_TYPE* tmp_buffer1
     ,__global INPUT0_TYPE* tmp_buffer2
-#elif USE_LOCAL_MEMORY
-    ,__local INPUT0_TYPE* tmp_buffer0
-    ,__local INPUT0_TYPE* tmp_buffer1
-    ,__local INPUT0_TYPE* tmp_buffer2
 #endif
 )
 {
@@ -138,14 +134,11 @@ KERNEL(arg_max_min_modified)(
     iav_type result[TOP_K];
 #else
 #ifdef USE_INTERNAL_BUFFERS
-    const uint iav_type_size = INPUT0_TYPE_SIZE + 4;
+    const uint iav_type_size = sizeof(iav_type);
     const uint buffer_size = iav_type_size * VALUES_NUM;
     const uint buffer_offset = buffer_size * OPERATION_NUM;
     __global iav_type *result = OFFSET_GLOBAL_PTR(iav_type, tmp_buffer0, output_idx * buffer_size);
     __global iav_type *temp_buf = OFFSET_GLOBAL_PTR(iav_type, tmp_buffer0, buffer_offset + output_idx * buffer_size);
-#elif USE_LOCAL_MEMORY
-    __local iav_type *result = tmp_buffer0;
-    __local iav_type *temp_buf = tmp_buffer1;
 #else
     iav_type result[VALUES_NUM], temp_buf[VALUES_NUM];
 #endif
@@ -391,10 +384,6 @@ KERNEL(arg_max_min_modified)(
         __global uint* merge_counter = OFFSET_GLOBAL_PTR(uint, tmp_buffer1, output_idx * counter_size);
         __global uint* max_merge_counter = OFFSET_GLOBAL_PTR(uint, tmp_buffer1, counter_offset + output_idx * counter_size);
         __global bool* subgroup_done = OFFSET_GLOBAL_PTR(bool, tmp_buffer2, output_idx);
-    #elif USE_LOCAL_MEMORY == 1
-        __local uint* merge_counter = tmp_buffer0;
-        __local uint* max_merge_counter = tmp_buffer1;
-        __local bool* subgroup_done = tmp_buffer2;
     #else
         uint merge_counter[group_num];
         uint max_merge_counter[group_num];
@@ -461,12 +450,14 @@ KERNEL(arg_max_min_modified)(
 #else // SORT_BY_VALUE
     for (uint top_k = 0; top_k < TOP_K; ++top_k) {
         uint out_position = 0;
+
         for (uint i = 0; i < TOP_K; ++i) {
             if (i == top_k)
                 continue;
             if (result[i].index < result[top_k].index)
                 out_position++;
         }
+
         indices[AXIS] = out_position;
 #ifdef TOP_K_ORDER
         output[FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR indices[0], indices[1], 0, indices[2], indices[3], indices[4])] = TO_OUTPUT_TYPE(result[top_k].value);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
@@ -108,7 +108,7 @@ ArgMaxMinKernelBase::DispatchData ArgMaxMinKernelAxis::SetDefault(const arg_max_
         size_t sort_size = params.argMaxMinSortType == ArgMaxMinSortType::VALUE ? getSortSize(params) : 1;
 
         dispatchData.gws = { ops_size, sort_size, 1 };
-        dispatchData.lws = { 1, 1, 1};
+        dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo);
     }
 
     return dispatchData;
@@ -123,49 +123,19 @@ void ArgMaxMinKernelAxis::GetUpdateDispatchDataFunc(KernelData& kd) const {
         kd.kernels[0].params.workGroups.local = dispatchData.lws;
         kd.kernels[0].skip_execution = KernelData::SkipKernelExecution(prim_params);
 
-        auto bufferSizeVec = GetTempBufferVec(prim_params, 1);
-        const size_t total_buffer_size = std::accumulate(bufferSizeVec.begin(), bufferSizeVec.end(), 0);
-        if (total_buffer_size < params.engineInfo.maxLocalMemSize) {
-            kd.kernels[0].params.local_memory_args.clear();
-            kd.kernels[0].params.local_memory_args.push_back(bufferSizeVec.at(0));
-            kd.kernels[0].params.local_memory_args.push_back(bufferSizeVec.at(1));
-            kd.kernels[0].params.local_memory_args.push_back(bufferSizeVec.at(2));
-        } else {
-            kd.internalBuffers.clear();
-            kd.internalBuffers.push_back(bufferSizeVec.at(0));
-            kd.internalBuffers.push_back(bufferSizeVec.at(1));
-            kd.internalBuffers.push_back(bufferSizeVec.at(2));
-            kd.internalBufferDataType = prim_params.inputs[0].GetDType();
-        }
+        const size_t elem_size = prim_params.inputs[0].ElementSize();
+        const size_t iav_type_size = Align(elem_size + 4, 4);
+        const size_t sort_size = getSortSize(prim_params);
+        const size_t ops_size = getOperationNumber(prim_params);
+        const size_t group_size = prim_params.topK >= 8 ? prim_params.topK : 8;
+        const size_t group_num = ((sort_size - 1) / group_size) + 1;
+
+        kd.internalBuffers.clear();
+        kd.internalBuffers.push_back(iav_type_size * sort_size * ops_size * 2);
+        kd.internalBuffers.push_back(4 * group_num * ops_size * 2);
+        kd.internalBuffers.push_back(ops_size * elem_size);
+        kd.internalBufferDataType = prim_params.inputs[0].GetDType();
     };
-}
-
-
-std::vector<size_t> ArgMaxMinKernelAxis::GetTempBufferVec(const arg_max_min_params& params, bool dynamic) const {
-    std::vector<size_t> buffer_size;
-
-    const size_t elem_size = params.inputs[0].ElementSize();
-    const size_t iav_type_size = elem_size + 4;
-    const size_t sort_size = getSortSize(params);
-    const size_t ops_size = getOperationNumber(params);
-    const size_t group_size = params.topK >= 8 ? params.topK : 8;
-    const size_t group_num = ((sort_size - 1) / group_size) + 1;
-
-    if (dynamic) {
-        const size_t buffer0_size = iav_type_size * sort_size * 2;
-        const size_t buffer1_size = iav_type_size * sort_size * 2;
-        const size_t buffer2_size = group_num;
-
-        buffer_size.assign({buffer0_size, buffer1_size, buffer2_size});
-    } else {
-        const size_t buffer0_size = iav_type_size * sort_size * ops_size * 2;
-        const size_t buffer1_size = 4 * group_num * ops_size * 2;
-        const size_t buffer2_size = ops_size * elem_size;
-
-        buffer_size.assign({buffer0_size, buffer1_size, buffer2_size});
-    }
-
-    return buffer_size;
 }
 
 KernelsData ArgMaxMinKernelAxis::GetKernelsData(const Params& params) const {
@@ -178,7 +148,6 @@ KernelsData ArgMaxMinKernelAxis::GetKernelsData(const Params& params) const {
     auto dispatchData = SetDefault(orgParams);
     KernelData kd = KernelData::Default<arg_max_min_params>(params);
     GetUpdateDispatchDataFunc(kd);
-    auto bufferSizeVec = GetTempBufferVec(orgParams, orgParams.has_dynamic_tensors());
 
     auto cldnn_jit = GetJitConstants(orgParams);
     auto entry_point = GetEntryPoint(kernelName, orgParams.layerID, params);
@@ -199,23 +168,13 @@ KernelsData ArgMaxMinKernelAxis::GetKernelsData(const Params& params) const {
                      orgParams.outputs_num,
                      orgParams.is_shape_agnostic);
 
-    const size_t total_buffer_size = std::accumulate(bufferSizeVec.begin(),
-            bufferSizeVec.end(), 0);
-
-    if (is_dynamic) {
-        kernel.params.arguments.push_back({ArgumentDescriptor::Types::LOCAL_MEMORY_SIZE, 0});
-        kernel.params.arguments.push_back({ArgumentDescriptor::Types::LOCAL_MEMORY_SIZE, 1});
-        kernel.params.arguments.push_back({ArgumentDescriptor::Types::LOCAL_MEMORY_SIZE, 2});
-        kd.kernels[0].params.local_memory_args.push_back(bufferSizeVec.at(0));
-        kd.kernels[0].params.local_memory_args.push_back(bufferSizeVec.at(1));
-        kd.kernels[0].params.local_memory_args.push_back(bufferSizeVec.at(2));
-    } else if (total_buffer_size > orgParams.engineInfo.maxLocalMemSize) {
+    if (is_dynamic || getSortSize(orgParams) * orgParams.inputs[0].ElementSize() > 4096) {
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 0});
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 1});
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 2});
-        kd.internalBuffers.push_back(bufferSizeVec.at(0));
-        kd.internalBuffers.push_back(bufferSizeVec.at(1));
-        kd.internalBuffers.push_back(bufferSizeVec.at(2));
+        kd.internalBuffers.push_back(orgParams.inputs[0].PhysicalSizeInBytes());
+        kd.internalBuffers.push_back(orgParams.inputs[0].PhysicalSizeInBytes());
+        kd.internalBuffers.push_back(orgParams.inputs[0].PhysicalSizeInBytes());
         kd.internalBufferDataType = orgParams.inputs[0].GetDType();
     }
 
@@ -228,7 +187,6 @@ KernelsPriority ArgMaxMinKernelAxis::GetKernelsPriority(const Params& /*params*/
 
 JitConstants ArgMaxMinKernelAxis::GetJitConstants(const arg_max_min_params& params) const {
     auto jit = ArgMaxMinKernelBase::GetJitConstants(params);
-    auto bufferSizeVec = GetTempBufferVec(params, params.has_dynamic_tensors());
 
     if (params.has_dynamic_tensors()) {
         const std::string operation_num = getOperationNumberString(params);
@@ -245,16 +203,7 @@ JitConstants ArgMaxMinKernelAxis::GetJitConstants(const arg_max_min_params& para
     if (params.values_first)
         jit.AddConstant(MakeJitConstant("TOP_K_ORDER", 1));
 
-    const size_t total_buffer_size = std::accumulate(bufferSizeVec.begin(),
-            bufferSizeVec.end(), 0);
-
-    // For dynamic case, total_buffer_size will be 0.  If larger buffer are
-    // requested during runtime and greater than local memory size
-    // the kernel will have incorrect data
-    // total_buffer_size only for static case
-    if (params.has_dynamic_tensors()) {
-        jit.AddConstant(MakeJitConstant("USE_LOCAL_MEMORY", 1));
-    } else if (total_buffer_size > params.engineInfo.maxLocalMemSize) {
+    if (params.has_dynamic_tensors() || getSortSize(params) * params.inputs[0].ElementSize() > 4096) {
         jit.AddConstant(MakeJitConstant("USE_INTERNAL_BUFFERS", 1));
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.h
@@ -17,7 +17,6 @@ public:
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;
     ParamsKey GetSupportedKey() const override;
-    std::vector<size_t> GetTempBufferVec(const arg_max_min_params& params, bool dynamic) const;
 private:
     bool Validate(const Params&) const override;
     void GetUpdateDispatchDataFunc(KernelData& kd) const override;

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/top_k.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/top_k.cpp
@@ -116,6 +116,18 @@ protected:
             for (size_t i = 0; i < size; ++i) {
                 rawBlobDataPtr[i] = static_cast<float>(data[i]);
             }
+        } else if (model_type == ov::element::f16) {
+            std::vector<int> data(size);
+
+            int start = - static_cast<int>(size / 2);
+            std::iota(data.begin(), data.end(), start);
+            std::mt19937 gen(0);
+            std::shuffle(data.begin(), data.end(), gen);
+
+            auto *rawBlobDataPtr = static_cast<ov::float16 *>(tensor.data());
+            for (size_t i = 0; i < size; ++i) {
+                rawBlobDataPtr[i] = static_cast<ov::float16>(data[i]);
+            }
         } else {
             FAIL() << "generate_inputs for " << model_type << " precision isn't supported";
         }
@@ -148,9 +160,10 @@ TEST_P(TopKLayerGPUTest, Inference) {
 
 const std::vector<ov::element::Type> model_types = {
     ov::element::f32,
+    ov::element::f16,
 };
 
-const std::vector<int64_t> axes = {0, 1, 3};
+const std::vector<int64_t> axes = {0, 3};
 const std::vector<int64_t> k = {3, 5, 7};
 
 const std::vector<ov::op::v1::TopK::Mode> modes = {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
@@ -13,9 +13,6 @@
 
 #include "program_wrapper.h"
 
-#include <algorithm>
-#include <numeric>
-
 using namespace cldnn;
 using namespace ::tests;
 
@@ -978,105 +975,6 @@ TEST(arg_max_min_gpu, dynamic) {
     ASSERT_EQ(output_ptr.size(), out_size);
     for (uint32_t i = 0; i < out_size; i++) {
         ASSERT_FLOAT_EQ(output_ptr[i], i < (out_size / 2) ? 0 : 1);
-    }
-}
-
-TEST(arg_max_min_gpu, dynamic_local_memory) {
-    const int32_t x_size = 1, y_size = 1, feature_num = 8, batch_num = 16;
-    auto& engine = get_test_engine();
-    const int top_k = 2;
-    auto input_layout_dynamic = layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx};
-    auto input_layout_static = layout{ov::PartialShape{batch_num, feature_num, y_size, x_size}, data_types::f32, format::bfyx};
-
-    layout mutableLayout = {data_types::i32, format::bfyx, {1, 1, 1, 1}};
-    auto input = engine.allocate_memory(input_layout_static);
-    const std::vector<float> topk_vec = {2};
-    auto top_k_input = engine.allocate_memory(mutableLayout);
-    set_values(top_k_input, topk_vec);
-
-    topology topology;
-    topology.add(input_layout("input", input_layout_dynamic));
-    topology.add(data("const", top_k_input));
-    topology.add(arg_max_min("arg_max", { input_info("input"), input_info("const") }, ov::op::TopKMode::MAX, top_k, 1,
-          ov::op::TopKSortType::SORT_INDICES, true, true, data_types::f32, 2));
-    topology.add(permute("permute_1", input_info("arg_max", 0), {0, 1, 2, 3}));
-    topology.add(permute("permute_2", input_info("arg_max", 1), {0, 1, 2, 3}));
-    topology.add(concatenation("concat", { input_info("permute_1"), input_info("permute_2") }, 0));
-
-    std::vector<float> input_vec = {/*b0f0 - b0f7*/ 0.000266, 0.000106, 0.000300, 0.000202, 0.000033, 0.000050, 0.000136, 0.000161,
-                                    /*b1f0 - b1f7*/ 0.000059, 0.000104, 0.000264, 0.000212, 0.000096, 0.000148, 0.000066, 0.000120,
-                                    /*b2f0 - b2f7*/ 0.000118, 0.000204, 0.000286, 0.000362, 0.000089, 0.000102, 0.000223, 0.000187,
-                                    /*b3f0 - b3f7*/ 0.000156, 0.000205, 0.000154, 0.000072, 0.000069, 0.000279, 0.000141, 0.000117,
-                                    /*b4f0 - b4f7*/ 0.000144, 0.000163, 0.000116, 0.000171, 0.000128, 0.000124, 0.000295, 0.000078,
-                                    /*b5f0 - b5f7*/ 0.000189, 0.000180, 0.000448, 0.000198, 0.000117, 0.000060, 0.000153, 0.000137,
-                                    /*b6f0 - b6f7*/ 0.000203, 0.000210, 0.000099, 0.000101, 0.000047, 0.000059, 0.000102, 0.000128,
-                                    /*b7f0 - b7f7*/ 0.000131, 0.000146, 0.000078, 0.000317, 0.000326, 0.000411, 0.000113, 0.000093,
-                                    /*b8f0 - b8f7*/ 0.000110, 0.000046, 0.000342, 0.000231, 0.000333, 0.000071, 0.000199, 0.000209,
-                                    /*b9f0 - b9f7*/ 0.000190, 0.000139, 0.000209, 0.000018, 0.000317, 0.000111, 0.000054, 0.000078,
-                                    /*b10f0 - b10f7*/ 0.000218, 0.000126, 0.000243, 0.000105, 0.000128, 0.000120, 0.000070, 0.000054,
-                                    /*b11f0 - b11f7*/ 0.000091, 0.000212, 0.000179, 0.000159, 0.000112, 0.000098, 0.000242, 0.000292,
-                                    /*b12f0 - b12f7*/ 0.000080, 0.000084, 0.000197, 0.000068, 0.000157, 0.000181, 0.000150, 0.000084,
-                                    /*b13f0 - b13f7*/ 0.000149, 0.000299, 0.000061, 0.000122, 0.000091, 0.000083, 0.000277, 0.000335,
-                                    /*b14f0 - b14f7*/ 0.000094, 0.000128, 0.000088, 0.000208, 0.000364, 0.000202, 0.000116, 0.000168,
-                                    /*b15f0 - b15f7*/ 0.000128, 0.000160, 0.000126, 0.000089, 0.000322, 0.000112, 0.000253, 0.000218};
-
-
-
-    set_values(input, input_vec);
-
-    ExecutionConfig config = get_test_default_config(engine);
-    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
-    network network(engine, topology, config);
-    network.set_input_data("input", input);
-
-    auto inst = network.get_primitive("arg_max");
-    auto impl = inst->get_impl();
-    ASSERT_TRUE(impl != nullptr);
-    ASSERT_TRUE(impl->is_dynamic());
-
-    auto outputs = network.execute();
-    ASSERT_EQ(outputs.size(), size_t(1));
-    ASSERT_EQ(outputs.begin()->first, "concat");
-
-    const int out_size = y_size * batch_num * x_size * top_k * 2;
-    auto output = outputs.at("concat").get_memory();
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
-
-    // Calculate ref top K with values and indices
-    std::vector<float> ref_result_values;
-    std::vector<size_t> ref_result_indices;
-
-    size_t k = std::min<size_t>(2, feature_num);
-    for (size_t i = 0; i < batch_num; i++) {
-        std::vector<std::pair<size_t, float>> indexValues;
-        indexValues.reserve(feature_num);
-
-        for (size_t j = 0; j < feature_num; j++) {
-            indexValues.emplace_back(j, input_vec.at(i * feature_num + j));
-        }
-
-        std::partial_sort(indexValues.begin(), indexValues.begin() + k, indexValues.end(),
-            [](const std::pair<size_t, float>&a, const std::pair<size_t, float>&b) {
-                return a.second > b.second;
-               }
-            );
-
-        std::sort(indexValues.begin(), indexValues.begin() + k,
-            [](const std::pair<size_t, float>&a, const std::pair<size_t, float>&b) {
-                return a.first < b.first;
-               }
-            );
-
-        for (size_t elem = 0; elem < top_k; elem++) {
-            ref_result_values.push_back(indexValues[elem].second);
-            ref_result_indices.push_back(indexValues[elem].first);
-        }
-    }
-
-    ASSERT_EQ(output_ptr.size(), out_size);
-    for (uint32_t i = 0; i < out_size/2; i++) {
-        ASSERT_FLOAT_EQ(output_ptr[i], ref_result_values[i]);
-        ASSERT_EQ(output_ptr[i + top_k * batch_num], ref_result_indices[i]);
     }
 }
 


### PR DESCRIPTION
In arg_max_min_axix, use sizeof to determine size of struct iav_type.
Current method have issue to calculate for fp16 type as OpenCL compiler tend to add padding to improve memory access efficiency.

Revert "[GPU] Use local memory for arg_max_min for dynamic shape (https://github.com/openvinotoolkit/openvino/pull/31682)"
This reverts commit https://github.com/openvinotoolkit/openvino/commit/69a112194beabc6b668098faa23e7d65a26f690f.

CVS-172937, CVS-172939
