### PR TITLE
[`NPU`] Move `allocate_tensor` and `create_tensor` into `ZeroInferRequest` class

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -61,9 +61,22 @@ private:
     std::shared_ptr<ov::ITensor>& get_level_zero_input(size_t index, size_t tensorNo = 0) const;
     std::vector<std::shared_ptr<ov::ITensor>>& get_level_zero_inputs(size_t index) const;
 
-    std::shared_ptr<ov::ITensor> create_tensor(ov::element::Type type,
-                                               const ov::Shape& shape,
-                                               const ov::Allocator& allocator = {}) const override;
+    /**
+     * @brief Allocates a tensor on host and stores the reference inside multiple attributes.
+     * @param descriptor Tensor's metadata
+     * @param index The index which the allocated tensor shall use.
+     * @param isInput Determines the containers in which the newly allocated tensors will be stored.
+     * @param allocator If provided, the tensor uses the custom allocator instead of using the default one.
+     * @param batchSize If provided, the value of the shape on the 0th axis is overriden with this value.
+     * @return Pointer towards the allocated tensor
+     */
+    std::shared_ptr<ov::ITensor> allocate_tensor(const size_t index,
+                                                 const bool isInput,
+                                                 const ov::Allocator& allocator,
+                                                 const std::optional<std::size_t> batchSize = std::nullopt) const;
+    std::shared_ptr<ZeroTensor> create_tensor(ov::element::Type type,
+                                              const ov::Shape& shape,
+                                              const ov::Allocator& allocator = {}) const;
 
     void add_state(const IODescriptor& descriptor, size_t tensorIndex) const override;
 

--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -73,9 +73,6 @@ private:
                                                  const bool isInput,
                                                  const ov::Allocator& allocator,
                                                  const std::optional<std::size_t> batchSize = std::nullopt) const;
-    std::shared_ptr<ZeroTensor> create_tensor(ov::element::Type type,
-                                              const ov::Shape& shape,
-                                              const ov::Allocator& allocator = {}) const;
 
     void add_state(const IODescriptor& descriptor, size_t tensorIndex) const override;
 

--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -63,7 +63,6 @@ private:
 
     /**
      * @brief Allocates a tensor on host and stores the reference inside multiple attributes.
-     * @param descriptor Tensor's metadata
      * @param index The index which the allocated tensor shall use.
      * @param isInput Determines the containers in which the newly allocated tensors will be stored.
      * @param allocator If provided, the tensor uses the custom allocator instead of using the default one.

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/sync_infer_request.hpp
@@ -148,25 +148,6 @@ protected:
      */
     virtual void check_network_precision(const ov::element::Type_t precision) const = 0;
 
-    /**
-     * @brief Allocates a tensor on host and stores the reference inside multiple attributes.
-     * @param descriptor Tensor's metadata
-     * @param index The index which the allocated tensor shall use.
-     * @param isInput Determines the containers in which the newly allocated tensors will be stored.
-     * @param allocator If provided, the tensor uses the custom allocator instead of using the default one.
-     * @param batchSize If provided, the value of the shape on the 0th axis is overriden with this value.
-     * @return Pointer towards the allocated tensor
-     */
-    std::shared_ptr<ov::ITensor> allocate_tensor(const IODescriptor& descriptor,
-                                                 const size_t index,
-                                                 const bool isInput,
-                                                 const ov::Allocator& allocator = {},
-                                                 const std::optional<std::size_t> batchSize = std::nullopt) const;
-
-    virtual std::shared_ptr<ov::ITensor> create_tensor(ov::element::Type type,
-                                                       const ov::Shape& shape,
-                                                       const ov::Allocator& allocator = {}) const;
-
     virtual void add_state(const IODescriptor& descriptor, const size_t tensorIndex) const;
 
     bool is_batched_input(size_t idx) const;

--- a/src/plugins/intel_npu/src/common/src/sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/common/src/sync_infer_request.cpp
@@ -323,53 +323,6 @@ void SyncInferRequest::check_tensors() const {
     }
 }
 
-std::shared_ptr<ov::ITensor> SyncInferRequest::allocate_tensor(const IODescriptor& descriptor,
-                                                               const size_t index,
-                                                               const bool isInput,
-                                                               const ov::Allocator& allocator,
-                                                               const std::optional<std::size_t> batchSize) const {
-    check_network_precision(descriptor.precision);
-
-    std::shared_ptr<ov::ITensor> tensor;
-    ov::Shape allocatedTensorShape = descriptor.shapeFromCompiler.get_max_shape();
-
-    if (batchSize.has_value()) {
-        allocatedTensorShape[utils::BATCH_AXIS] = *batchSize;
-    }
-
-    if (descriptor.isStateOutput) {
-        // Only one buffer is required for each (state input, state output) pair, acting as an input before running the
-        // inference and as an output after performing it. Thus both the "state input" and "state output" entries shall
-        // point to the same buffer.
-        OPENVINO_ASSERT(descriptor.relatedDescriptorIndex.has_value(),
-                        "The link between state descriptors is missing, state name: ",
-                        descriptor.nameFromCompiler);
-        tensor = get_user_input(*descriptor.relatedDescriptorIndex)._ptr;
-    } else {
-        tensor = create_tensor(descriptor.precision, allocatedTensorShape, allocator);
-    }
-
-    if (isInput) {
-        if (get_user_input(index) == nullptr) {
-            get_user_input(index) = tensor;
-        }
-
-        if (descriptor.isStateInput) {
-            add_state(descriptor, index);
-        }
-    } else if (_userOutputTensors.at(index) == nullptr) {
-        _userOutputTensors.at(index) = tensor;
-    }
-
-    return tensor;
-}
-
-std::shared_ptr<ov::ITensor> SyncInferRequest::create_tensor(ov::element::Type type,
-                                                             const ov::Shape& shape,
-                                                             const ov::Allocator& allocator) const {
-    return ov::make_tensor(type, shape, allocator);
-}
-
 void SyncInferRequest::add_state(const IODescriptor& descriptor, const size_t tensorIndex) const {
     _variableStates.push_back(
         std::make_shared<VariableState>(descriptor.nameFromCompiler, get_user_input(tensorIndex)));

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
@@ -15,13 +15,13 @@
 #include <random>
 #include <thread>
 
+#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
 #include "behavior/ov_infer_request/inference.hpp"
 #include "common/npu_test_env_cfg.hpp"
 #include "common/utils.hpp"
 #include "functional_test_utils/ov_plugin_cache.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 #include "intel_npu/utils/zero/zero_init.hpp"
-#include "intel_npu/utils/zero/zero_utils.hpp"
 #include "openvino/core/any.hpp"
 #include "openvino/core/node_vector.hpp"
 #include "openvino/op/op.hpp"
@@ -1826,118 +1826,6 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterStateTensorsUseImportCpuVa1) {
     ::operator delete(state_data[0], std::align_val_t(4096));
     ::operator delete(state_data[1], std::align_val_t(64));
     ::operator delete(state_data[2], std::align_val_t(4096));
-}
-
-/*
-    CVS-173093: Enable when user tensor data can be bound to level zero tensor allocation (no multiple L0 allocations
-   for single application malloc)
-*/
-TEST_P(CpuVaTensorsTests, DISABLED_TMP_CpuVaCorrectlyDeallocatedAfterAllInferRequests) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
-
-    const auto shape = ov::PartialShape{1, 16, 16, 16};
-    auto model = createModel(element::f32, shape, "N...");
-    auto compiledModel = core->compile_model(model, target_device, configuration);
-
-    const auto elementType = compiledModel.inputs()[0].get_element_type();
-    const size_t byteSize = ov::shape_size(shape.get_shape()) * elementType.size();
-
-    for (size_t i = 0; i < 2; ++i) {
-        auto inferRequest1 = compiledModel.create_infer_request();
-        auto inferRequest2 = compiledModel.create_infer_request();
-
-        const auto alignment = i == 0 ? std::align_val_t(4096) : std::align_val_t(2);
-        float* data = static_cast<float*>(::operator new(byteSize, alignment));
-        auto tensor = ov::Tensor{elementType, shape.get_shape(), data};
-        OV_ASSERT_NO_THROW(inferRequest1.set_tensor(compiledModel.inputs()[0], tensor))
-        OV_ASSERT_NO_THROW(inferRequest2.set_tensor(compiledModel.inputs()[0], tensor))
-
-        auto remoteContextParams =
-            core->get_default_context("NPU")
-                .get_params();  // cannot get context from ZeroInitStructsHolder instance due to static member accross
-                                // different libraries (will differ from intel_npu::Plugin)
-        auto l0Context = remoteContextParams.find(intel_npu::l0_context.name());
-        EXPECT_TRUE(l0Context != remoteContextParams.end());
-        EXPECT_TRUE(::intel_npu::zeroUtils::memory_was_allocated_in_the_same_l0_context(
-            static_cast<ze_context_handle_t>(l0Context->second.as<void*>()),
-            data));
-
-        OV_ASSERT_NO_THROW(inferRequest1.infer());
-        OV_ASSERT_NO_THROW(inferRequest2.infer());
-
-        inferRequest1 = {};
-        inferRequest2 = {};
-        tensor = {};
-
-        EXPECT_FALSE(::intel_npu::zeroUtils::memory_was_allocated_in_the_same_l0_context(
-            static_cast<ze_context_handle_t>(l0Context->second.as<void*>()),
-            data));
-
-        ::operator delete(data, alignment);
-    }
-}
-
-TEST_P(CpuVaTensorsTests, SetAlignedDifferentTensorTwiceForSameInferRequestsNoThrow) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
-
-    const auto shape = ov::PartialShape{1, 16, 16, 16};
-    auto model = createModel(element::f32, shape, "N...");
-    auto compiledModel = core->compile_model(model, target_device, configuration);
-
-    const auto elementType = compiledModel.inputs()[0].get_element_type();
-    const size_t byteSize = ov::shape_size(shape.get_shape()) * elementType.size();
-
-    auto inferRequest = compiledModel.create_infer_request();
-    float* data = static_cast<float*>(::operator new(byteSize, std::align_val_t(4096)));
-    auto tensor1 = ov::Tensor{elementType, shape.get_shape(), data};
-    auto tensor2 = ov::Tensor{elementType, shape.get_shape(), data};
-    OV_ASSERT_NO_THROW(inferRequest.set_tensor(compiledModel.inputs()[0], tensor1));
-    OV_ASSERT_NO_THROW(inferRequest.set_tensor(compiledModel.inputs()[0], tensor2));
-
-    OV_ASSERT_NO_THROW(inferRequest.infer());
-    ::operator delete(data, std::align_val_t(4096));
-}
-
-TEST_P(CpuVaTensorsTests, SetAlignedSameTensorForSameInferRequestsNoThrow) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
-
-    const auto shape = ov::PartialShape{1, 16, 16, 16};
-    auto model = createModel(element::f32, shape, "N...");
-    auto compiledModel = core->compile_model(model, target_device, configuration);
-
-    const auto elementType = compiledModel.inputs()[0].get_element_type();
-    const size_t byteSize = ov::shape_size(shape.get_shape()) * elementType.size();
-
-    auto inferRequest = compiledModel.create_infer_request();
-    float* data = static_cast<float*>(::operator new(byteSize, std::align_val_t(4096)));
-    auto tensor = ov::Tensor{elementType, shape.get_shape(), data};
-    OV_ASSERT_NO_THROW(inferRequest.set_tensor(compiledModel.inputs()[0], tensor));
-    OV_ASSERT_NO_THROW(inferRequest.set_tensor(compiledModel.inputs()[0], tensor));
-
-    OV_ASSERT_NO_THROW(inferRequest.infer());
-    ::operator delete(data, std::align_val_t(4096));
-}
-
-TEST_P(CpuVaTensorsTests, SameAlignedPtrForTwoInferRequestNoThrow) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
-
-    const auto shape = ov::PartialShape{1, 16, 16, 16};
-    auto model = createModel(element::f32, shape, "N...");
-    auto compiledModel = core->compile_model(model, target_device, configuration);
-
-    const auto elementType = compiledModel.inputs()[0].get_element_type();
-    const size_t byteSize = ov::shape_size(shape.get_shape()) * elementType.size();
-
-    auto inferRequest1 = compiledModel.create_infer_request();
-    auto inferRequest2 = compiledModel.create_infer_request();
-    float* data = static_cast<float*>(::operator new(byteSize, std::align_val_t(4096)));
-    auto tensor = ov::Tensor{elementType, shape.get_shape(), data};
-    OV_ASSERT_NO_THROW(inferRequest1.set_tensor(compiledModel.inputs()[0], tensor));
-    OV_ASSERT_NO_THROW(inferRequest2.set_tensor(compiledModel.inputs()[0], tensor));
-    inferRequest1 = {};
-
-    OV_ASSERT_NO_THROW(inferRequest2.infer());
-    ::operator delete(data, std::align_val_t(4096));
 }
 
 }  // namespace behavior

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
@@ -15,13 +15,13 @@
 #include <random>
 #include <thread>
 
-#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
 #include "behavior/ov_infer_request/inference.hpp"
 #include "common/npu_test_env_cfg.hpp"
 #include "common/utils.hpp"
 #include "functional_test_utils/ov_plugin_cache.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 #include "intel_npu/utils/zero/zero_init.hpp"
+#include "intel_npu/utils/zero/zero_utils.hpp"
 #include "openvino/core/any.hpp"
 #include "openvino/core/node_vector.hpp"
 #include "openvino/op/op.hpp"
@@ -30,6 +30,7 @@
 #include "openvino/runtime/core.hpp"
 #include "openvino/runtime/intel_npu/level_zero/level_zero.hpp"
 #include "overload/overload_test_utils_npu.hpp"
+#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
 
 using CompilationParams = std::tuple<std::string,  // Device name
                                      ov::AnyMap    // Config
@@ -1826,6 +1827,114 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterStateTensorsUseImportCpuVa1) {
     ::operator delete(state_data[0], std::align_val_t(4096));
     ::operator delete(state_data[1], std::align_val_t(64));
     ::operator delete(state_data[2], std::align_val_t(4096));
+}
+
+TEST_P(CpuVaTensorsTests, CpuVaCorrectlyDeallocatedAfterAllInferRequests) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+
+    const auto shape = ov::PartialShape{1, 16, 16, 16};
+    auto model = createModel(element::f32, shape, "N...");
+    auto compiledModel = core->compile_model(model, target_device, configuration);
+
+    const auto elementType = compiledModel.inputs()[0].get_element_type();
+    const size_t byteSize = ov::shape_size(shape.get_shape()) * elementType.size();
+
+    for (size_t i = 0; i < 2; ++i) {
+        auto inferRequest1 = compiledModel.create_infer_request();
+        auto inferRequest2 = compiledModel.create_infer_request();
+
+        const auto alignment = i == 0 ? std::align_val_t(4096) : std::align_val_t(2);
+        float* data = static_cast<float*>(::operator new(byteSize, alignment));
+        auto tensor = ov::Tensor{elementType, shape.get_shape(), data};
+        OV_ASSERT_NO_THROW(inferRequest1.set_tensor(compiledModel.inputs()[0], tensor))
+        OV_ASSERT_NO_THROW(inferRequest2.set_tensor(compiledModel.inputs()[0], tensor))
+
+        auto remoteContextParams =
+            core->get_default_context("NPU")
+                .get_params();  // cannot get context from ZeroInitStructsHolder instance due to static member accross
+                                // different libraries (will differ from intel_npu::Plugin)
+        auto l0Context = remoteContextParams.find(intel_npu::l0_context.name());
+        EXPECT_TRUE(l0Context != remoteContextParams.end());
+        EXPECT_TRUE(::intel_npu::zeroUtils::memory_was_allocated_in_the_same_l0_context(
+            reinterpret_cast<ze_context_handle_t>(l0Context->second.as<void*>()),
+            data));
+
+        OV_ASSERT_NO_THROW(inferRequest1.infer());
+        OV_ASSERT_NO_THROW(inferRequest2.infer());
+
+        inferRequest1 = {};
+        inferRequest2 = {};
+        tensor = {};
+
+        EXPECT_FALSE(::intel_npu::zeroUtils::memory_was_allocated_in_the_same_l0_context(
+            reinterpret_cast<ze_context_handle_t>(l0Context->second.as<void*>()),
+            data));
+
+        ::operator delete(data, alignment);
+    }
+}
+
+TEST_P(CpuVaTensorsTests, SetAlignedDifferentTensorTwiceForSameInferRequestsNoThrow) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+
+    const auto shape = ov::PartialShape{1, 16, 16, 16};
+    auto model = createModel(element::f32, shape, "N...");
+    auto compiledModel = core->compile_model(model, target_device, configuration);
+
+    const auto elementType = compiledModel.inputs()[0].get_element_type();
+    const size_t byteSize = ov::shape_size(shape.get_shape()) * elementType.size();
+
+    auto inferRequest = compiledModel.create_infer_request();
+    float* data = static_cast<float*>(::operator new(byteSize, std::align_val_t(4096)));
+    auto tensor1 = ov::Tensor{elementType, shape.get_shape(), data};
+    auto tensor2 = ov::Tensor{elementType, shape.get_shape(), data};
+    OV_ASSERT_NO_THROW(inferRequest.set_tensor(compiledModel.inputs()[0], tensor1));
+    OV_ASSERT_NO_THROW(inferRequest.set_tensor(compiledModel.inputs()[0], tensor2));
+
+    OV_ASSERT_NO_THROW(inferRequest.infer());
+    ::operator delete(data, std::align_val_t(4096));
+}
+
+TEST_P(CpuVaTensorsTests, SetAlignedSameTensorForSameInferRequestsNoThrow) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+
+    const auto shape = ov::PartialShape{1, 16, 16, 16};
+    auto model = createModel(element::f32, shape, "N...");
+    auto compiledModel = core->compile_model(model, target_device, configuration);
+
+    const auto elementType = compiledModel.inputs()[0].get_element_type();
+    const size_t byteSize = ov::shape_size(shape.get_shape()) * elementType.size();
+
+    auto inferRequest = compiledModel.create_infer_request();
+    float* data = static_cast<float*>(::operator new(byteSize, std::align_val_t(4096)));
+    auto tensor = ov::Tensor{elementType, shape.get_shape(), data};
+    OV_ASSERT_NO_THROW(inferRequest.set_tensor(compiledModel.inputs()[0], tensor));
+    OV_ASSERT_NO_THROW(inferRequest.set_tensor(compiledModel.inputs()[0], tensor));
+
+    OV_ASSERT_NO_THROW(inferRequest.infer());
+    ::operator delete(data, std::align_val_t(4096));
+}
+
+TEST_P(CpuVaTensorsTests, SameAlignedPtrForTwoInferRequestNoThrow) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+
+    const auto shape = ov::PartialShape{1, 16, 16, 16};
+    auto model = createModel(element::f32, shape, "N...");
+    auto compiledModel = core->compile_model(model, target_device, configuration);
+
+    const auto elementType = compiledModel.inputs()[0].get_element_type();
+    const size_t byteSize = ov::shape_size(shape.get_shape()) * elementType.size();
+
+    auto inferRequest1 = compiledModel.create_infer_request();
+    auto inferRequest2 = compiledModel.create_infer_request();
+    float* data = static_cast<float*>(::operator new(byteSize, std::align_val_t(4096)));
+    auto tensor = ov::Tensor{elementType, shape.get_shape(), data};
+    OV_ASSERT_NO_THROW(inferRequest1.set_tensor(compiledModel.inputs()[0], tensor));
+    OV_ASSERT_NO_THROW(inferRequest2.set_tensor(compiledModel.inputs()[0], tensor));
+    inferRequest1 = {};
+
+    OV_ASSERT_NO_THROW(inferRequest2.infer());
+    ::operator delete(data, std::align_val_t(4096));
 }
 
 }  // namespace behavior


### PR DESCRIPTION
### Details:
 - *Diagram:*
```mermaid
flowchart TD;
    subgraph SG1["intel_npu::SyncInferRequest"]
       A["intel_npu::SyncInferRequest"]~~~A1["allocate_tensor"]
       A~~~A2["create_tensor"]
       style A1 fill:#808080,stroke:#000,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
       style A2 fill:#808080,stroke:#000,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
    end
    subgraph SG2["ZeroInferRequest"]
       B["ZeroInferRequest"]-->B1["set_tensor_data"]
       B~~~B2["create_tensor"]
       B1--xA1
       A1--xB2
       B~~~B3["allocate_tensor"]
       B3-.->B2
       B1-.->B3
       style B3 fill:#f96
       style B2 fill:#808080,stroke:#000,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
    end
```
 - *Added `CpuVaTensorsTests` tests:*
      - <s>*CpuVaCorrectlyDeallocatedAfterAllInferRequests (disabled)*</s>
      - <s>*SetAlignedDifferentTensorTwiceForSameInferRequestsNoThrow* (throws when import tensor feature is enabled, 2nd `set_tensor` forces dtor of imported tensor with same cpuva => `zeMemAllocHost` is called)</s>
      - <s>*SetAlignedSameTensorForSameInferRequestsNoThrow*</s>
      - <s>*SameAlignedPtrForTwoInferRequestNoThrow* (throws when import tensor feature is enabled)</s>

### Tickets:
 - *173085*
