### PR TITLE
[NPU][IE-MDK] Refine Batching and Random test failure logging

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
@@ -171,8 +171,9 @@ TEST_P(BatchedTensorsRunTests, SetInputRemoteTensorsMultipleInfer) {
         }
         req.infer();  // Adds '1' to each element
         for (size_t j = 0; j < one_shape_size * batch; ++j) {
-            EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
+            ASSERT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                << ", actual=" << actual[j] << " for index " << j;
+
         }
     }
 }
@@ -218,7 +219,7 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentTensorsMultipleInfer) {
         }
         req.infer();  // Adds '1' to each element
         for (size_t j = 0; j < one_shape_size * batch; ++j) {
-            EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
+            ASSERT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                << ", actual=" << actual[j] << " for index " << j;
         }
     }
@@ -269,7 +270,7 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentTensorsMultipleInferMCL) {
             }
             req.infer();  // Adds '1' to each element
             for (size_t j = 0; j < one_shape_size * batch; ++j) {
-                EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
+                ASSERT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                    << ", actual=" << actual[j] << " for index " << j;
             }
         }
@@ -301,7 +302,7 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentTensorsMultipleInferMCL) {
             }
             req.infer();  // Adds '1' to each element
             for (size_t j = 0; j < one_shape_size * batch; ++j) {
-                EXPECT_EQ(actual[j], testNum + 201) << "Infer " << testNum << ": Expected=" << testNum + 21
+                ASSERT_EQ(actual[j], testNum + 201) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                     << ", actual=" << actual[j] << " for index " << j;
             }
         }
@@ -372,7 +373,7 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentRemoteTensorsMultipleInferMCL) {
 
             req.infer();  // Adds '1' to each element
             for (size_t j = 0; j < one_shape_size * batch; ++j) {
-                EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
+                ASSERT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                    << ", actual=" << actual[j] << " for index " << j;
             }
         }
@@ -425,7 +426,7 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentRemoteTensorsMultipleInferMCL) {
 
             req.infer();  // Adds '1' to each element
             for (size_t j = 0; j < one_shape_size * batch; ++j) {
-                EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
+                ASSERT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                    << ", actual=" << actual[j] << " for index " << j;
             }
         }
@@ -477,7 +478,7 @@ TEST_P(DynamicBatchedTensorsRunTests, DynamicSetInputRemoteTensorsMultipleInfer)
         for (size_t i = 0; i < batch; i++) {
             for (size_t j = 0; j < one_shape_size; ++j) {
                 auto expected = testNum + 20 * (i + 1) + 1;
-                EXPECT_EQ(actual[i * one_shape_size + j], expected)
+                ASSERT_EQ(actual[i * one_shape_size + j], expected)
                     << "Infer " << testNum << ": Expected=" << expected << ", actual=" << actual[j] << " for index "
                     << j << ", batch: " << i;
             }
@@ -520,7 +521,7 @@ void executeMutlipleTensorsBatchInfer(ov::InferRequest req,
         for (size_t i = 0; i < batch_value; i++) {
             for (size_t j = 0; j < non_batched_shape_size; ++j) {
                 auto expected = testNum + 20 * (i + 1) + 1;
-                EXPECT_EQ(actual[i * non_batched_shape_size + j], expected)
+                ASSERT_EQ(actual[i * non_batched_shape_size + j], expected)
                     << "Infer " << testNum << ": Expected=" << expected << ", actual=" << actual[j] << " for index "
                     << j << ", batch: " << i;
             }
@@ -629,7 +630,7 @@ TEST_P(DynamicBatchedTensorsRunTests, SetInputRemoteSingleBatchedTensorSingleInf
         req.infer();  // Adds '1' to each element
         for (size_t j = 0; j < tensor_shape_size; ++j) {
             auto expected = testNum + 20 * (j / one_shape_size + 1) + 1;
-            EXPECT_EQ(actual[j], expected)
+            ASSERT_EQ(actual[j], expected)
                 << "Infer " << testNum << ": Expected=" << expected << ", actual=" << actual[j] << " for index " << j
                 << ", batch: " << j / one_shape_size;
         }
@@ -666,7 +667,7 @@ void executeContiguousTensorBatchInfer(ov::InferRequest req,
     // check that we got valid inference results on each lines of N
     for (size_t j = 0; j < tensor_shape_size; ++j) {
         auto expected = batch_value + 20 * (j / non_batched_shape_size + 1) + 1;
-        EXPECT_EQ(actual[j], expected) << "Infer " << batch_value << ": Expected=" << expected
+        ASSERT_EQ(actual[j], expected) << "Infer " << batch_value << ": Expected=" << expected
                                        << ", actual=" << actual[j] << " for index " << j
                                        << ", batch: " << j / non_batched_shape_size;
     }
@@ -782,7 +783,7 @@ TEST_P(DynamicBatchedTensorsRunTests, DynamicSetInputDifferentTensorsMultipleInf
         }
         req.infer();  // Adds '1' to each element
         for (size_t j = 0; j < one_shape_size * batch; ++j) {
-            EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
+            ASSERT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                << ", actual=" << actual[j] << " for index " << j;
         }
     }

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
@@ -527,7 +527,7 @@ TEST_P(BatchingRunTests, SetInputTensorInfer) {
 
     inference_request.infer();  // Adds '1' to each element
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
+        ASSERT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
     }
 }
 
@@ -554,7 +554,7 @@ TEST_P(BatchingRunTests, SetInputTensorAsync) {
     inference_request.start_async();  // Adds '1' to each element
     inference_request.wait_for(std::chrono::milliseconds(1000));
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
+        ASSERT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
     }
 }
 
@@ -583,7 +583,7 @@ TEST_P(BatchingRunTests, SetInputTensorInfer_Caching) {
 
     inference_request.infer();  // Adds '1' to each element
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
+        ASSERT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
     }
 
     delete[] buffer;
@@ -612,7 +612,7 @@ TEST_P(BatchingRunTests, CheckTwoRunsInfer) {
     }
     inference_request.infer();  // Adds '1' to each element
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
+        ASSERT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
     }
 
     auto l0_host_input_tensor = context.create_host_tensor(ov::element::f32, batch_shape);
@@ -630,7 +630,7 @@ TEST_P(BatchingRunTests, CheckTwoRunsInfer) {
     auto* actual_host_tensor = l0_host_output_tensor.data();
     actual = reinterpret_cast<float*>(actual_host_tensor);
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
+        ASSERT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
     }
 
     delete[] buffer;

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
@@ -372,7 +372,7 @@ TEST_P(RandomTensorOverZeroTensorRunTests, SetRandomTensorOverZeroTensor0) {
     auto output_tensor = inference_request.get_output_tensor(0);
     auto* output_data = output_tensor.data<float>();
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(output_data[i], 6.f, 1e-5) << "Expected=6, actual=" << output_data[i] << " for index " << i;
+        ASSERT_NEAR(output_data[i], 6.f, 1e-5) << "Expected=6, actual=" << output_data[i] << " for index " << i;
     }
 
     float* buffer = new float[shape_size];
@@ -385,11 +385,11 @@ TEST_P(RandomTensorOverZeroTensorRunTests, SetRandomTensorOverZeroTensor0) {
     inference_request.set_input_tensor(tensor);
     inference_request.infer();  // Adds '1' to each element
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(output_data[i], 10.f, 1e-5) << "Expected=10, actual=" << output_data[i] << " for index " << i;
+        ASSERT_NEAR(output_data[i], 10.f, 1e-5) << "Expected=10, actual=" << output_data[i] << " for index " << i;
     }
 
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(input_zero_data[i], 5.f, 1e-5) << "Expected=5, actual=" << input_zero_data[i] << " for index " << i;
+        ASSERT_NEAR(input_zero_data[i], 5.f, 1e-5) << "Expected=5, actual=" << input_zero_data[i] << " for index " << i;
     }
 
     delete[] buffer;
@@ -419,7 +419,7 @@ TEST_P(RandomTensorOverZeroTensorRunTests, SetRandomTensorOverZeroTensor1) {
     auto output_tensor0 = inference_request0.get_output_tensor(0);
     auto* output_data0 = output_tensor0.data<float>();
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(output_data0[i], 6.f, 1e-5) << "Expected=6, actual=" << output_data0[i] << " for index " << i;
+        ASSERT_NEAR(output_data0[i], 6.f, 1e-5) << "Expected=6, actual=" << output_data0[i] << " for index " << i;
     }
 
     inference_request1.set_input_tensor(output_tensor0);
@@ -428,7 +428,7 @@ TEST_P(RandomTensorOverZeroTensorRunTests, SetRandomTensorOverZeroTensor1) {
     auto output_tensor1 = inference_request1.get_output_tensor(0);
     auto* output_data1 = output_tensor1.data<float>();
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(output_data1[i], 7.f, 1e-5) << "Expected=7, actual=" << output_data1[i] << " for index " << i;
+        ASSERT_NEAR(output_data1[i], 7.f, 1e-5) << "Expected=7, actual=" << output_data1[i] << " for index " << i;
     }
 
     float* buffer = new float[shape_size];
@@ -442,15 +442,15 @@ TEST_P(RandomTensorOverZeroTensorRunTests, SetRandomTensorOverZeroTensor1) {
     inference_request1.infer();  // Adds '1' to each element
 
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(output_data1[i], 10.f, 1e-5) << "Expected=10, actual=" << output_data1[i] << " for index " << i;
+        ASSERT_NEAR(output_data1[i], 10.f, 1e-5) << "Expected=10, actual=" << output_data1[i] << " for index " << i;
     }
 
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(output_data0[i], 6.f, 1e-5) << "Expected=6, actual=" << output_data0[i] << " for index " << i;
+        ASSERT_NEAR(output_data0[i], 6.f, 1e-5) << "Expected=6, actual=" << output_data0[i] << " for index " << i;
     }
 
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(input_zero_data[i], 5.f, 1e-5) << "Expected=5, actual=" << input_zero_data[i] << " for index " << i;
+        ASSERT_NEAR(input_zero_data[i], 5.f, 1e-5) << "Expected=5, actual=" << input_zero_data[i] << " for index " << i;
     }
 
     delete[] buffer;


### PR DESCRIPTION
### Details:
 - Batching and RandomTensor tests use EXPECT_EQ as a check for test pass/fail. This is fine, but if tensor calculations are wrong then the test will report **each element** that doesn't match expected output. Issue is that log files can become extremely large if all elements are incorrect in these output tensors.
 - Proposal is to replace EXPECT_ with ASSERT_, meaning that the test will fail when the first incorrect element is detected, it will log only that element and then proceed to the next test

### Tickets:
 - E182100
