### PR TITLE
[Protopipe] Workaround for INT64 input type

### DIFF
--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -95,7 +95,7 @@ static int toDepth(const std::string& prec) {
         return CV_16F;
     if (prec == "U8")
         return CV_8U;
-    if (prec == "I32")
+    if (prec == "I32" || prec == "I64")
         return CV_32S;
     throw std::logic_error("Unsupported precision type: " + prec);
 }


### PR DESCRIPTION
### Details:
 - *Protopipe throws exception if I64 is specified as input precision type in config file*
 - *OpenCV 4.x which is used by protopipe does not support INT64. As a workaround we use INT32 instead of INT64*

### Tickets:
 - *EISW-140587*
