### PR TITLE
[PyOV] Deprecate `PostponedConstant` constructor causing Tensor copy

### DIFF
--- a/src/bindings/python/src/openvino/utils/postponed_constant.py
+++ b/src/bindings/python/src/openvino/utils/postponed_constant.py
@@ -47,6 +47,18 @@ class PostponedConstant(Op):
         self.m_maker = maker
         if name is not None:
             self.friendly_name = name
+        
+        # Check for deprecated usage and issue warning
+        if hasattr(self.m_maker, "__call__") and hasattr(self.m_maker.__call__, "__code__") and self.m_maker.__call__.__code__.co_argcount > 1:
+            # Import here to avoid circular import
+            from openvino._pyopenvino.util import deprecation_warning
+            deprecation_warning(
+                "PostponedConstant.__init__ with Callable[[Tensor], None]",
+                "2026.0",
+                "Please use PostponedConstant's 'maker' argument as Callable[[], Tensor] instead of Callable[[Tensor], None].",
+                3
+            )
+            
         self.constructor_validate_and_infer_types()
 
     def evaluate(self, outputs: TensorVector, _: list[Tensor]) -> bool:  # type: ignore

--- a/src/bindings/python/src/openvino/utils/postponed_constant.py
+++ b/src/bindings/python/src/openvino/utils/postponed_constant.py
@@ -48,9 +48,7 @@ class PostponedConstant(Op):
         if name is not None:
             self.friendly_name = name
         
-        # Check for deprecated usage and issue warning
         if hasattr(self.m_maker, "__call__") and hasattr(self.m_maker.__call__, "__code__") and self.m_maker.__call__.__code__.co_argcount > 1:
-            # Import here to avoid circular import
             from openvino._pyopenvino.util import deprecation_warning
             deprecation_warning(
                 "PostponedConstant.__init__ with Callable[[Tensor], None]",

--- a/src/bindings/python/tests/test_utils/test_utils.py
+++ b/src/bindings/python/tests/test_utils/test_utils.py
@@ -187,7 +187,16 @@ def test_serialize_postponned_constant(prepare_ir_paths):
 
 def test_serialize_postponned_constant_maker_tensor_copy(prepare_ir_paths):
     maker = MakerTensorCopy()
-    model = create_model(maker)
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            "PostponedConstant.__init__ with Callable\\[\\[Tensor\\], None\\] "
+            "is deprecated and will be removed in version 2026.0"
+        ),
+    ) as w:
+        model = create_model(maker)
+    assert issubclass(w[0].category, DeprecationWarning)
+    assert "Please use PostponedConstant's 'maker' argument as Callable[[], Tensor] instead of Callable[[Tensor], None]" in str(w[0].message)
     assert maker.called_times() == 0
 
     model_export_file_name, weights_export_file_name = prepare_ir_paths


### PR DESCRIPTION
### Details:
 - Deprecate a non-recommended way of initializing a PostponedConstant object

### Tickets:
 - CVS-173104
