### PR TITLE
Use a SliceOP to copy data from input to output node

### DIFF
--- a/src/frontends/onnx/frontend/src/op/identity.cpp
+++ b/src/frontends/onnx/frontend/src/op/identity.cpp
@@ -2,8 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/op/identity.hpp"
+
 #include "core/operator_set.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/slice.hpp"
 #include "utils/common.hpp"
+
+using namespace ov::op;
 
 namespace ov {
 namespace frontend {
@@ -11,11 +17,15 @@ namespace onnx {
 namespace ai_onnx {
 namespace opset_1 {
 ov::OutputVector identity(const ov::frontend::onnx::Node& node) {
-    ov::OutputVector outputs = node.get_ov_inputs();
-    for (auto& out : outputs) {
-        common::mark_as_optimized_out(out);
-    }
-    return outputs;
+    // This operator will be optimze out in EliminateSlice pass
+    // Need this to avoid data not be copied out when Identity connects from input to result
+    // in some cases like:
+    //   Input->Identity->Result
+    auto input = node.get_ov_inputs().at(0);
+    const auto& start = v0::Constant::create(element::i32, {1}, {0});
+    const auto& end = v0::Constant::create(element::i32, {1}, {std::numeric_limits<int32_t>::max()});
+    const auto& step = v0::Constant::create(element::i32, {1}, {1});
+    return {std::make_shared<v8::Slice>(input, start, end, step)};
 }
 ONNX_OP("Identity", OPSET_SINCE(1), ai_onnx::opset_1::identity);
 }  // namespace opset_1


### PR DESCRIPTION
### Details:
 -  Place `Slice` Operator at the graph
 - Let `EliminateSlice` pass to optimize out the `Slice` if needs.

### Tickets:
 - [CVS-173262](https://jira.devtools.intel.com/browse/CVS-173262)
