### PR TITLE
[GPU] Fix relevant to zero padding for eltwise

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2033,7 +2033,7 @@ void primitive_inst::prepare_primitive() {
         skip_reset = skip_concat;
     }
     // Need to reset crop's output to zeros, if followed by onednn concatenation that requires zero-padding for blocked format memory
-    if (get_node().is_type<crop>() && get_node().can_share_buffer() && _impl_params->get_output_layout(0).format.is_blocked() &&
+    if ((get_node().is_type<crop>() || get_node().is_type<eltwise>()) && get_node().can_share_buffer() && _impl_params->get_output_layout(0).format.is_blocked() &&
         get_node().get_users().size() == 1 && get_node().get_users().front()->is_type<concatenation>() &&
         get_node().get_users().front()->get_selected_impl()->is_onednn()) {
         skip_reset = false;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/eltwise_blocked_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/eltwise_blocked_opt.cl
@@ -61,16 +61,19 @@ KERNEL(eltwise_blocked_opt)(INPUTS_DECLS
     const uint f_block = (inner_f + outer_f * F_BLOCK_COUNT);
 
     // Feature axis of input tensor is smaller than inner block size : No need to calculate this block
-    if (b > OUTPUT_BATCH_NUM || (f_block*VEC_SIZE + VEC_SIZE) > (OUT_F_BLOCK * FEATURE_BLOCK_SIZE)) {
+    if ((f_block*VEC_SIZE) >= OUTPUT_FEATURE_NUM || b > OUTPUT_BATCH_NUM) {
         return;
     }
+    // if (b > OUTPUT_BATCH_NUM || (f_block*VEC_SIZE + VEC_SIZE) > (OUT_F_BLOCK * FEATURE_BLOCK_SIZE)) {
+    //     return;
+    // }
 
-    // zero-padding the blocked format padded memory area since it might be used as input of onednn concatenation
-    if (NEED_ZERO_PADDING && (f_block*VEC_SIZE) >= OUTPUT_FEATURE_NUM) {
-        OUTPUT_TYPE_BLOCK out = (MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE))(0);
-        VSTORE_N(out, global_id, output);
-        return;
-    }
+    // // zero-padding the blocked format padded memory area since it might be used as input of onednn concatenation
+    // if (NEED_ZERO_PADDING && (f_block*VEC_SIZE) >= OUTPUT_FEATURE_NUM) {
+    //     OUTPUT_TYPE_BLOCK out = (MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE))(0);
+    //     VSTORE_N(out, global_id, output);
+    //     return;
+    // }
 
     MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, VEC_SIZE) res;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/eltwise_blocked_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/eltwise_blocked_opt.cl
@@ -61,7 +61,14 @@ KERNEL(eltwise_blocked_opt)(INPUTS_DECLS
     const uint f_block = (inner_f + outer_f * F_BLOCK_COUNT);
 
     // Feature axis of input tensor is smaller than inner block size : No need to calculate this block
-    if ((f_block*VEC_SIZE) >= OUTPUT_FEATURE_NUM || b > OUTPUT_BATCH_NUM) {
+    if (b > OUTPUT_BATCH_NUM || (f_block*VEC_SIZE + VEC_SIZE) > (OUT_F_BLOCK * FEATURE_BLOCK_SIZE)) {
+        return;
+    }
+
+    // zero-padding the blocked format padded memory area since it might be used as input of onednn concatenation
+    if (NEED_ZERO_PADDING && (f_block*VEC_SIZE) >= OUTPUT_FEATURE_NUM) {
+        OUTPUT_TYPE_BLOCK out = (MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE))(0);
+        VSTORE_N(out, global_id, output);
         return;
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
@@ -303,6 +303,12 @@ JitConstants EltwiseKernel_blocked_opt::GetJitConstants(const eltwise_params& pa
     jit.AddConstant(MakeJitConstant("OUTPUT_SIZE_XY", params.outputs[0].X().v * params.outputs[0].Y().v));
     // To calculate batch, define outer block size of feature axis (divided by the inner feature-block size)
     jit.AddConstant(MakeJitConstant("OUT_F_BLOCK", CeilDiv(params.outputs[0].Feature().v, inner_feature_blk_size)));
+    jit.AddConstant(MakeJitConstant("FEATURE_BLOCK_SIZE", inner_feature_blk_size));
+    if (params.operations[0].mode == EltwiseMode::ASSIGN && inner_feature_blk_size > 1) {
+        jit.AddConstant(MakeJitConstant("NEED_ZERO_PADDING", true));
+    } else {
+        jit.AddConstant(MakeJitConstant("NEED_ZERO_PADDING", false));
+    }
 
     bool use_vload = false;
     jit.Merge(MakeInputDeclsJitConstants(params, use_vload));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
@@ -303,12 +303,12 @@ JitConstants EltwiseKernel_blocked_opt::GetJitConstants(const eltwise_params& pa
     jit.AddConstant(MakeJitConstant("OUTPUT_SIZE_XY", params.outputs[0].X().v * params.outputs[0].Y().v));
     // To calculate batch, define outer block size of feature axis (divided by the inner feature-block size)
     jit.AddConstant(MakeJitConstant("OUT_F_BLOCK", CeilDiv(params.outputs[0].Feature().v, inner_feature_blk_size)));
-    jit.AddConstant(MakeJitConstant("FEATURE_BLOCK_SIZE", inner_feature_blk_size));
-    if (params.operations[0].mode == EltwiseMode::ASSIGN && inner_feature_blk_size > 1) {
-        jit.AddConstant(MakeJitConstant("NEED_ZERO_PADDING", true));
-    } else {
-        jit.AddConstant(MakeJitConstant("NEED_ZERO_PADDING", false));
-    }
+    // jit.AddConstant(MakeJitConstant("FEATURE_BLOCK_SIZE", inner_feature_blk_size));
+    // if (params.operations[0].mode == EltwiseMode::ASSIGN && inner_feature_blk_size > 1) {
+    //     jit.AddConstant(MakeJitConstant("NEED_ZERO_PADDING", true));
+    // } else {
+    //     jit.AddConstant(MakeJitConstant("NEED_ZERO_PADDING", false));
+    // }
 
     bool use_vload = false;
     jit.Merge(MakeInputDeclsJitConstants(params, use_vload));


### PR DESCRIPTION
### Details:
 - zero padding in eltwise kernel is needed for oneDNN concat.

### Issues:
- oneDNN concat doesn't work correctly for eltwise contaminated with non-zero padding.
- This issue was resolved by initial version of [PR#31140](https://github.com/openvinotoolkit/openvino/pull/31140)
- But since the one of the commits in the PR, [PR#31140-b25de23f](https://github.com/openvinotoolkit/openvino/pull/31140/commits/b25de23f2d1a2603da22853a008affbb1e252de5), the issue is being reproduced.
  
### Tickets:
 - 172243
