### PR TITLE
[PyOV] Force higher lower bound for `scipy-image` for Python 3.13

### DIFF
--- a/tests/e2e_tests/requirements.txt
+++ b/tests/e2e_tests/requirements.txt
@@ -10,11 +10,8 @@ opencv-python>=4.5; sys_platform != "darwin"
 opencv-python==4.12.0.88; sys_platform == "darwin"
 unittest-xml-reporting==3.2.0
 lpips==0.1.4
-
-# for utils/e2e/comparator note: python 3.6 wheels is not available since 0.18
-# Add upper-bound due CVS-105039, CVS-105040
-scikit-image>=0.17.2
-
+scikit-image>=0.17.2; python_version < '3.13'
+scikit-image>=0.25.0; python_version >= '3.13'
 
 # for utils legacy
 tabulate==0.9.0


### PR DESCRIPTION
### Details:
 - Python 3.13 pipelines choose to build `scipy-image==0.24.0` or `0.19.3` from sources, which fails
 - starting from `0.25.0` prebuild Python 3.13 wheels are available

### Tickets:
 - 168868
