### PR TITLE
[Snippets][DEBUG_CAPS] Fix PerfCountEnd op param cloning

### DIFF
--- a/src/common/snippets/include/snippets/op/perf_count.hpp
+++ b/src/common/snippets/include/snippets/op/perf_count.hpp
@@ -143,7 +143,7 @@ public:
     OPENVINO_OP("PerfCountEnd", "SnippetsOpset", PerfCountEndBase);
     explicit PerfCountEnd(const Output<Node>& pc_begin,
                           std::vector<std::shared_ptr<utils::Dumper>> dumpers = {},
-                          const std::string& params = "");
+                          std::string params = "");
     PerfCountEnd() = default;
     ~PerfCountEnd() override;
 
@@ -166,6 +166,7 @@ private:
 
     std::vector<std::shared_ptr<utils::Dumper>> dumpers;
     std::shared_ptr<PerfCountBegin> m_pc_begin = nullptr;
+    std::string m_params;
 };
 
 }  // namespace op

--- a/src/common/snippets/src/op/perf_count.cpp
+++ b/src/common/snippets/src/op/perf_count.cpp
@@ -183,15 +183,16 @@ void PerfCountBegin::set_start_time() {
 
 PerfCountEnd::PerfCountEnd(const Output<Node>& pc_begin,
                            std::vector<std::shared_ptr<utils::Dumper>> dumpers,
-                           const std::string& params)
+                           std::string params)
     : PerfCountEndBase({pc_begin}),
       accumulation(0UL),
       iteration(0U),
-      dumpers(std::move(dumpers)) {
+      dumpers(std::move(dumpers)),
+      m_params(std::move(params)) {
     constructor_validate_and_infer_types();
     init_pc_begin();
     for (const auto& dumper : this->dumpers) {
-        dumper->init(params);
+        dumper->init(m_params);
     }
 }
 
@@ -202,7 +203,7 @@ PerfCountEnd::~PerfCountEnd() {
 }
 
 std::shared_ptr<Node> PerfCountEnd::clone_with_new_inputs(const OutputVector& inputs) const {
-    return std::make_shared<PerfCountEnd>(inputs.at(0), dumpers);
+    return std::make_shared<PerfCountEnd>(inputs.at(0), dumpers, m_params);
 }
 
 void PerfCountEnd::set_accumulated_time() {


### PR DESCRIPTION
### Details:
If `PerfCountEnd` is being cloned then `clone_with_new_inputs` function loses parameters preserved for further dumping to CSV.

### Tickets:
 - N/A
