### PR TITLE
[Snippets] Tokenization: generalize a check on gprs count sufficientness

### DIFF
--- a/src/common/snippets/include/snippets/utils/tokenization_utils.hpp
+++ b/src/common/snippets/include/snippets/utils/tokenization_utils.hpp
@@ -40,4 +40,15 @@ bool tokenize_node(const std::shared_ptr<ov::Node>& node,
  */
 std::shared_ptr<ov::snippets::op::Subgraph> tokenize_ordered_nodes(const ov::NodeVector& ordered_ops,
                                                                    bool are_shared_internal_params_allowed = false);
+
+/**
+ * @brief Calculates the potential number of body parameters that would be required for a given operation.
+ * Body parameters are created for Snippets node in 2 cases:
+ *   1. The input is not a Constant node
+ *   2. The input is a Constant node but it is not scalar
+ * @note This function assumes that 0'th input of the operation is already counted, so it is ignored here
+ * @param op The operation node to analyze
+ * @return The estimated number of body parameters needed for this operation
+ */
+size_t get_potential_body_params(const std::shared_ptr<ov::Node>& op);
 }  // namespace ov::snippets::utils

--- a/src/common/snippets/src/pass/gated_mlp_tokenization.cpp
+++ b/src/common/snippets/src/pass/gated_mlp_tokenization.cpp
@@ -4,6 +4,8 @@
 
 #include "snippets/pass/gated_mlp_tokenization.hpp"
 
+#include <algorithm>
+#include <cstddef>
 #include <memory>
 
 #include "openvino/core/except.hpp"
@@ -107,22 +109,27 @@ TokenizeGatedMLPSnippets::TokenizeGatedMLPSnippets(const SnippetsTokenization::C
             return false;
         }
 
-        static const auto body_params_count = 5;  // 2xinput + 3x fc
-        static const auto body_result_count = 1;  // one output
-        static const auto reg_group_count = 5;    // upper-bound of possible buffer count
-
-        // TODO [75567]: move this plugin-specific constraint to the plugin callback
-        if (body_params_count + body_result_count + reg_group_count > config.get_data_ptr_gpr_count()) {
-            return false;
-        }
-
-        const auto ordered_ops = ov::NodeVector{fc_gate, fc_up, act, mul, fc_down};
         const bool allow_shared_params = [&]() {
             const auto mm_gate = ov::as_type_ptr<ov::op::v0::MatMul>(fc_gate);
             const auto mm_up = ov::as_type_ptr<ov::op::v0::MatMul>(fc_up);
             OPENVINO_ASSERT(mm_gate && mm_up, "fc_gate and fc_up must have MatMul type");
             return mm_gate->get_transpose_a() == mm_up->get_transpose_a();
         }();
+        // data input (can be shared or not) + 3x matmul weights + result
+        const size_t io_count = (allow_shared_params ? 4 : 5) + 1;
+        static constexpr size_t n_reg_group = 3;
+        // Loop depth could reach 3 because of SplitLoops optimization
+        static constexpr size_t n_loops_depth = 3;
+        const auto ordered_ops = ov::NodeVector{fc_gate, fc_up, act, mul, fc_down};
+        const bool is_dynamic = std::any_of(ordered_ops.begin(), ordered_ops.end(), [](const std::shared_ptr<Node>& n) {
+            return n->is_dynamic();
+        });
+
+        // TODO [75567]: move this plugin-specific constraint to the plugin callback
+        if (!config.is_gprs_count_sufficient(io_count, n_reg_group, n_loops_depth, is_dynamic)) {
+            return false;
+        }
+
         const auto subgraph = ov::snippets::utils::tokenize_ordered_nodes(ordered_ops, allow_shared_params);
 
         // mark the Subgraph as Completed to not allow Snippets to include any nodes into this Subgraph in common

--- a/src/common/snippets/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/src/pass/mha_tokenization.cpp
@@ -19,7 +19,6 @@
 #include "openvino/core/dimension.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/node_vector.hpp"
-#include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/validation_util.hpp"
@@ -36,17 +35,17 @@
 #include "openvino/util/pp.hpp"
 #include "snippets/itt.hpp"
 #include "snippets/op/brgemm.hpp"
-#include "snippets/op/subgraph.hpp"
 #include "snippets/pass/collapse_subgraph.hpp"
 #include "snippets/pass/explicit_transpose_matmul_inputs.hpp"
 #include "snippets/pass/tokenization.hpp"
 #include "snippets/utils/tokenization_utils.hpp"
 #include "snippets/utils/utils.hpp"
 
+using namespace ov::snippets::utils;
+
 namespace {
 bool is_supported_tensor(const ov::descriptor::Tensor& t) {
-    return t.get_partial_shape().rank().is_static() &&
-           ov::snippets::utils::any_of(t.get_partial_shape().size(), 2LU, 3LU, 4LU);
+    return t.get_partial_shape().rank().is_static() && any_of(t.get_partial_shape().size(), 2LU, 3LU, 4LU);
 }
 
 bool is_supported_intermediate_op(const std::shared_ptr<ov::Node>& node) {
@@ -157,24 +156,9 @@ bool tokenize_reshape_around_softmax(std::shared_ptr<ov::Node>& interm_op,
     return true;
 }
 
-size_t get_potential_body_params(const std::shared_ptr<ov::Node>& op) {
-    size_t count = 0;
-    for (size_t i = 1; i < op->get_input_size(); ++i) {
-        const auto input = op->input_value(i);
-        const auto parent = input.get_node_shared_ptr();
-        const auto constant = ov::as_type_ptr<ov::op::v0::Constant>(parent);
-        if (!constant || (ov::shape_size(input.get_shape()) != 1 && !ov::is_type<ov::op::v0::FakeQuantize>(op) &&
-                          !ov::snippets::op::Subgraph::constant_input_should_be_inside_body(op))) {
-            count++;
-        }
-    }
-    return count;
-}
-
 bool update_intermediate_supported_ops(std::shared_ptr<ov::Node>& interm_op,
                                        ov::NodeVector& ordered_ops,
-                                       size_t& hidden_virtual_ports_count,
-                                       size_t& potential_body_params_count) {
+                                       size_t& n_potential_body_params) {
     while (is_supported_intermediate_op(interm_op)) {
         // All supported intermediate ops have only one output port
         if (interm_op->get_output_target_inputs(0).size() != 1) {
@@ -184,14 +168,6 @@ bool update_intermediate_supported_ops(std::shared_ptr<ov::Node>& interm_op,
         // Check for supported ops on branches: Broadcast/Elementwise (for example, dequantize ops)
         if (interm_op->get_input_size() > 1) {
             tokenize_broadcast(interm_op, ordered_ops);
-
-            // To avoid unsupported number of non-scalar Constants in the future after FakeQuantize decomposition
-            // (plugin specific limitation) we should calculate potential number of non-scalar Constants for
-            // FakeQuantize that will be moved up from body.
-            if (const auto fq_node = ov::as_type_ptr<ov::op::v0::FakeQuantize>(interm_op)) {
-                hidden_virtual_ports_count += ov::snippets::utils::get_non_scalar_constant_count_for_fq(fq_node);
-            }
-
             auto is_supported_branch_op = [&ordered_ops](const std::shared_ptr<ov::Node>& op) {
                 return is_supported_intermediate_op(op) &&
                        ov::snippets::pass::GetSnippetsNodeType(op) !=
@@ -224,7 +200,7 @@ bool update_intermediate_supported_ops(std::shared_ptr<ov::Node>& interm_op,
             }
         }
 
-        potential_body_params_count += get_potential_body_params(interm_op);
+        n_potential_body_params += get_potential_body_params(interm_op);
 
         ordered_ops.push_back(interm_op);
         interm_op = interm_op->get_output_target_inputs(0).begin()->get_node()->shared_from_this();
@@ -275,12 +251,9 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
             auto& pattern_to_output = m.get_pattern_value_map();
 
             // Queries + Key + Values = 3 standard inputs of MHA
-            size_t potential_body_params_count = 3;
-            // After some transformations, a different number of Constants for some operations may be created
-            // than the actual number of Constants during tokenization.
-            // To avoid unsupported number of non-scalar Constants in the future (plugin specific limitation)
-            // we should calculate potential number of non-scalar Constants that will be moved up from body.
-            size_t hidden_virtual_ports_count = 0;
+            // Also, some Constants may be extracted outside of Subgraph body,
+            // so they should be taken into account as parameters
+            size_t n_potential_body_params = 3;
             // The count of potential unique Buffers - it's hidden virtual ports as well
             // We should go through Subgraph and calculate potential non-inplace Buffers count.
             // Example:
@@ -298,12 +271,11 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
             //        (to avoid performance regressions due to scalar calculations).
             //        But operations after Transpose1 and before MatMul0  will be fused into one loop as well (look at
             //        first point)
-            size_t uniqie_buffer_reg_group_count = 1;  // After MatMul0 there is always one Buffer
+            size_t n_buffer_reg_groups = 1;  // After MatMul0 there is always one Buffer
+            // Loop depth could reach 3 because of SplitLoops optimization
+            static constexpr size_t n_loops_depth = 3;
             ov::NodeVector ordered_ops;
 
-            /* ======== Matcher Pass ========== */
-
-            /****** Skeleton ******/
             /* Skeleton on MHA-pattern is:
              *              \     /
              *              MatMul0
@@ -328,10 +300,7 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
 
             auto interm_op = matmul0->get_output_target_inputs(0).begin()->get_node()->shared_from_this();
             // Add supported operations which are between MatMul0 and Softmax to ordered_ops
-            if (!update_intermediate_supported_ops(interm_op,
-                                                   ordered_ops,
-                                                   hidden_virtual_ports_count,
-                                                   potential_body_params_count)) {
+            if (!update_intermediate_supported_ops(interm_op, ordered_ops, n_potential_body_params)) {
                 return false;
             }
 
@@ -369,10 +338,7 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
             }
 
             // Add supported operations which are between Softmax and MatMul1 to ordered_ops
-            if (!update_intermediate_supported_ops(interm_op,
-                                                   ordered_ops,
-                                                   hidden_virtual_ports_count,
-                                                   potential_body_params_count)) {
+            if (!update_intermediate_supported_ops(interm_op, ordered_ops, n_potential_body_params)) {
                 return false;
             }
 
@@ -398,10 +364,8 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
             const auto matmul0_prc =
                 op::Brgemm::get_output_type(matmul0->get_input_element_type(0), matmul0->get_input_element_type(1));
             if (matmul1->get_input_element_type(0).size() != matmul0_prc.size()) {
-                uniqie_buffer_reg_group_count++;
+                n_buffer_reg_groups++;
             }
-
-            /***********************/
 
             /***** Transposes *****/
             /* There may be Transpose and Reshape ops on inputs and outputs of MHA-pattern skeleton
@@ -464,20 +428,12 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
                     break;
                 }
 
-                // To avoid unsupported number of non-scalar Constants in the future after FakeQuantize decomposition
-                // (plugin specific limitation) we should calculate potential number of non-scalar Constants for
-                // FakeQuantize that will be moved up from body.
-                if (const auto fq_node = ov::as_type_ptr<ov::op::v0::FakeQuantize>(child)) {
-                    hidden_virtual_ports_count += ov::snippets::utils::get_non_scalar_constant_count_for_fq(fq_node);
-                }
-                potential_body_params_count += get_potential_body_params(child);
-
+                n_potential_body_params += get_potential_body_params(child);
+                const size_t n_child_consumers = child->get_output_target_inputs(0).size();
                 // TODO [75567]: move this plugin-specific constraint to the plugin callback
-                //               We cannot collapse op to Subgraph if count of potential Parameter and Result count is
-                //               higher 12
-                if (potential_body_params_count + child->get_output_target_inputs(0).size() +
-                        hidden_virtual_ports_count + uniqie_buffer_reg_group_count >
-                    12) {
+                if (!config.is_gprs_count_sufficient(n_potential_body_params + n_child_consumers,
+                                                     n_buffer_reg_groups,
+                                                     n_loops_depth)) {
                     break;
                 }
 
@@ -486,7 +442,7 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
                 has_matmul1_has_ops_on_output = true;
             }
             if (has_matmul1_has_ops_on_output) {
-                uniqie_buffer_reg_group_count++;
+                n_buffer_reg_groups++;
             }
 
             // At the moment Snippets don't support nodes between MatMul1 and Transpose3 due to Loop and strided
@@ -507,57 +463,26 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
                 }
             }
 
-            /**********************/
-
-            /* ================================ */
-
-            /* ======= Support checks ========= */
-
-            // TODO [75567]: move this plugin-specific constraint to the plugin callback
-            const auto last_node = ordered_ops.back();
-            const auto io_count =
-                potential_body_params_count + last_node->get_output_size() + hidden_virtual_ports_count;
-            const auto data_count = io_count + uniqie_buffer_reg_group_count;
-            auto available_regs = config.get_data_ptr_gpr_count();
-            // [150148, 150149] Currently Snippets don't have mechanism of spilling registers on stack.
-            //                  Due to this limitation we have to skip tokenization of some subgraphs
-            //                  if we need more registers than we have on the target machine.
-            //                  `config.get_data_ptr_gpr_count()` provides available data registers count (including
-            //                  parameters, results and buffers) after excluding 2 registers for work amounts. However,
-            //                  MHA Subgraph has `SplitLoops` optimization which adds outermost blocked Loop by M. This
-            //                  Loop requires the separate own register for `work_amount` also. Thus, we have to
-            //                  decrement `available_regs` count in MHA case. Need to notice that in general we have
-            //                  enough count of available registers. But in rare cases (when there are a lot of
-            //                  parameters/results, the heuristic value of their number is `5`) the count of available
-            //                  registers might be not enough and we have to not tokenize these subgraphs. So only for
-            //                  these rare cases we decrement `available_regs` value.
-            if (io_count > 5) {
-                available_regs--;
-            }
-
-            if (data_count > available_regs) {
+            /* ======= Plugin related checks ========= */
+            const bool is_dynamic =
+                std::any_of(ordered_ops.cbegin(), ordered_ops.cend(), [](const std::shared_ptr<Node>& n) {
+                    return n->is_dynamic();
+                });
+            if (is_dynamic && !config.is_dynamic_mha_token_enabled()) {
                 return false;
             }
 
-            // If backend doesn't enable dynamic MHA tokenization, return false
-            if (!config.is_dynamic_mha_token_enabled()) {
-                if (std::any_of(ordered_ops.cbegin(), ordered_ops.cend(), [](const std::shared_ptr<ov::Node>& op) {
-                        return op->is_dynamic();
-                    })) {
-                    return false;
-                }
+            // TODO [75567]: move this plugin-specific constraint to the plugin callback
+            const auto io_count = n_potential_body_params + ordered_ops.back()->get_output_size();
+            if (!config.is_gprs_count_sufficient(io_count, n_buffer_reg_groups, n_loops_depth, is_dynamic)) {
+                return false;
             }
 
-            /* ================================ */
-
-            const auto subgraph = ov::snippets::utils::tokenize_ordered_nodes(ordered_ops);
-
+            const auto subgraph = tokenize_ordered_nodes(ordered_ops);
             // mark the Subgraph as Completed to not allow Snippets to include any nodes into the MHA Subgraph in common
             // Tokenization
             SetSnippetsSubgraphType(subgraph, SnippetsSubgraphType::Completed);
 
             return true;
-
-            /* ================================ */
         });
 }

--- a/src/common/snippets/src/pass/mlp_seq_tokenization.cpp
+++ b/src/common/snippets/src/pass/mlp_seq_tokenization.cpp
@@ -12,7 +12,6 @@
 #include "openvino/core/except.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/node_vector.hpp"
-#include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/validation_util.hpp"
@@ -29,7 +28,6 @@
 #include "openvino/util/pp.hpp"
 #include "snippets/itt.hpp"
 #include "snippets/op/brgemm.hpp"
-#include "snippets/op/subgraph.hpp"
 #include "snippets/pass/collapse_subgraph.hpp"
 #include "snippets/pass/tokenization.hpp"
 #include "snippets/utils/tokenization_utils.hpp"
@@ -37,31 +35,12 @@
 
 namespace ov::snippets::pass {
 
-namespace {
+using namespace ov::snippets::utils;
 
+namespace {
 inline bool has_one_consumer(const std::shared_ptr<ov::Node>& node) {
     return node->get_output_target_inputs(0).size() == 1;
 }
-
-size_t get_potential_body_params(const std::shared_ptr<ov::Node>& op) {
-    if (const auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(op)) {
-        return ov::snippets::utils::get_non_scalar_constant_count_for_fq(fq);
-    }
-    size_t count = 0;
-    for (size_t i = 1; i < op->get_input_size(); ++i) {
-        const auto input = op->input_value(i);
-        const auto parent = input.get_node_shared_ptr();
-        const auto constant = ov::as_type_ptr<ov::op::v0::Constant>(parent);
-        const auto is_scalar = constant && (ov::shape_size(input.get_shape()) == 1);
-        const auto should_be_inside_body =
-            constant && ov::snippets::op::Subgraph::constant_input_should_be_inside_body(op);
-        if (!is_scalar && !should_be_inside_body) {
-            count++;
-        }
-    }
-    return count;
-}
-
 }  // namespace
 
 const size_t TokenizeMLPSeqSnippets::m_rank = 2;
@@ -116,14 +95,8 @@ TokenizeMLPSeqSnippets::TokenizeMLPSeqSnippets(const SnippetsTokenization::Confi
             OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::TokenizeMLPSeqSnippets")
             auto& pattern_to_output = m.get_pattern_value_map();
 
-            // Two inputs of first MatMul
-            size_t potential_body_params_count = 2;
-            // After some transformations, a different number of Constants for some operations may be created
-            // than the actual number of Constants during tokenization.
-            // To avoid unsupported number of non-scalar Constants in the future (plugin specific limitation)
-            // we should calculate potential number of non-scalar Constants that will be moved up from body.
-            // Heuiristic count of possible buffers - upper-bound value
-            const size_t unique_buffer_reg_group_count = 2;
+            // Two inputs of first MatMul + Result
+            size_t io_count = 3;
             ov::NodeVector ordered_ops;
 
             /* ======== Matcher Pass ========== */
@@ -152,12 +125,17 @@ TokenizeMLPSeqSnippets::TokenizeMLPSeqSnippets(const SnippetsTokenization::Confi
             if (transformation_callback(matmul0)) {
                 return false;
             }
+            const auto& out_shape = matmul0->get_output_partial_shape(0);
+            OPENVINO_ASSERT(out_shape.rank().is_static() && out_shape.size() >= 2,
+                            "MatMul out shape must be 2D at least");
+            const auto& m_dim = *(out_shape.rbegin() + 1);
 
+            bool is_dynamic = matmul0->is_dynamic();
             // Add possible FQ before matmul0
-            if (const auto fq =
-                    ov::as_type_ptr<ov::op::v0::FakeQuantize>(matmul0->input_value(0).get_node_shared_ptr())) {
+            if (auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(matmul0->get_input_node_shared_ptr(0))) {
                 if (has_one_consumer(fq)) {
-                    potential_body_params_count += ov::snippets::utils::get_non_scalar_constant_count_for_fq(fq);
+                    is_dynamic = is_dynamic || fq->is_dynamic();
+                    io_count += get_non_scalar_constant_count_for_fq(fq);
                     ordered_ops.push_back(fq);
                 }
             }
@@ -166,16 +144,14 @@ TokenizeMLPSeqSnippets::TokenizeMLPSeqSnippets(const SnippetsTokenization::Confi
             // Tokenize Sequence while we can do it
             std::shared_ptr<ov::Node> prev_op = matmul0;
             auto interm_op = prev_op->get_output_target_inputs(0).begin()->get_node()->shared_from_this();
-            auto available_regs = config.get_data_ptr_gpr_count();
-
             bool postops_fusion_possible = true;
             std::shared_ptr<ov::op::v0::MatMul> cur_matmul = matmul0;
             while (has_one_consumer(prev_op)) {
-                auto current_potential_body_params_count = potential_body_params_count;
+                auto current_io_count = io_count;
 
                 if (is_matmul_supported(interm_op) && !transformation_callback(interm_op)) {
                     // +1 for weights
-                    current_potential_body_params_count++;
+                    current_io_count++;
                     // If MatMul is the first in the sequence, postops fusion status is reset
                     postops_fusion_possible = true;
                     cur_matmul = ov::as_type_ptr<ov::op::v0::MatMul>(interm_op);
@@ -186,7 +162,7 @@ TokenizeMLPSeqSnippets::TokenizeMLPSeqSnippets(const SnippetsTokenization::Confi
                     if (!postops_fusion_possible || config.get_can_be_fused_as_postop() == nullptr ||
                         !config.get_can_be_fused_as_postop()(cur_matmul, interm_op)) {
                         postops_fusion_possible = false;
-                        current_potential_body_params_count += get_potential_body_params(interm_op);
+                        current_io_count += get_potential_body_params(interm_op);
                     }
                 } else {
                     // Unsupported op
@@ -194,8 +170,14 @@ TokenizeMLPSeqSnippets::TokenizeMLPSeqSnippets(const SnippetsTokenization::Confi
                 }
 
                 // TODO [75567]: move this plugin-specific constraint to the plugin callback
-                // +1 - for result
-                if (current_potential_body_params_count + unique_buffer_reg_group_count + 1 > available_regs) {
+                // Heuiristic count of possible buffers - upper-bound value
+                static constexpr size_t n_buffer_reg_groups = 2;
+                const bool small_m = m_dim.is_static() && (m_dim.get_length() <= 32);
+                // Loop depth could reach 3 because of SplitLoops optimization.
+                // If M is small enough, SplitLoops is not needed
+                const size_t loops_depth = small_m ? 2 : 3;
+                is_dynamic = is_dynamic || interm_op->is_dynamic();
+                if (!config.is_gprs_count_sufficient(current_io_count, n_buffer_reg_groups, loops_depth, is_dynamic)) {
                     break;
                 }
 
@@ -204,7 +186,7 @@ TokenizeMLPSeqSnippets::TokenizeMLPSeqSnippets(const SnippetsTokenization::Confi
                 interm_op = prev_op->get_output_target_inputs(0).begin()->get_node()->shared_from_this();
 
                 // Move counts
-                potential_body_params_count = current_potential_body_params_count;
+                io_count = current_io_count;
             }
 
             // Currently, sequence of MLP should contain 2 MatMuls at least
@@ -216,10 +198,7 @@ TokenizeMLPSeqSnippets::TokenizeMLPSeqSnippets(const SnippetsTokenization::Confi
                 return false;
             }
 
-            /* ====== Subgraph creation ======= */
-
-            const auto subgraph = ov::snippets::utils::tokenize_ordered_nodes(ordered_ops);
-
+            const auto subgraph = tokenize_ordered_nodes(ordered_ops);
             // mark the Subgraph as Completed to not allow Snippets to include any nodes into this Subgraph in common
             // Tokenization
             SetSnippetsSubgraphType(subgraph, SnippetsSubgraphType::Completed);


### PR DESCRIPTION
### Details:
 - *`SnippetsTokenization::Config`: introduced a new `is_gprs_count_sufficient` method which generalizes check on gprs count sufficientness. `get_data_ptr_gpr_count()` is removed to force a user to use the new helper*
 - *Tokenization passes refactoring:*
     - the new helper reused for gprs count checks
     - some outdated checks are removed
 - *CPU transformation pipeline:*
     - `available_gprs_count` values are actualized
     - added a detailed explanatory comment for both X86 and ARM platforms on how `available_gprs_count` was calculated

### Tickets:
 - *Prerequisite for CVS-172631*
