### PR TITLE
[GPU] update the gops calculation

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
@@ -46,6 +46,16 @@ struct gfx_version {
                < std::tie(r.major, r.minor, r.revision); // same order
     }
 
+    friend bool operator >= (const gfx_version& l, const gfx_version& r)  {
+        return std::tie(l.major, l.minor, l.revision)
+               >= std::tie(r.major, r.minor, r.revision); // same order
+    }
+
+    friend bool operator <= (const gfx_version& l, const gfx_version& r)  {
+        return std::tie(l.major, l.minor, l.revision)
+               <= std::tie(r.major, r.minor, r.revision); // same order
+    }
+
     bool operator==(const gfx_version& other) {
         return major == other.major &&
                minor == other.minor &&


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - DEVICE_GOPS is a GPU device property that for older devices shows GOPS for float16, float32 and int8. For LNL and ARC I only see float32 GOPS.
 - check platform versions and add missed specs.
 - refer links
 -- gops: https://gfxspecs.intel.com/
 -- gfx version: https://github.com/intel-innersource/drivers.gpu.specification.platforms/blob/generated_os/gen/templates/doc/listing.md

#### The code and line that caused this issue (if it is not changed directly)
 - src/plugins/intel_gpu/src/runtime/device.cpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
python sample
```
import openvino as ov

try:
    core = ov.Core()

    for dev_id in core.available_devices:
        if not 'GPU' in dev_id:
            continue

        FULL_DEVICE_NAME = core.get_property(dev_id, "FULL_DEVICE_NAME")
        DEVICE_ARCHITECTURE = core.get_property(dev_id, "DEVICE_ARCHITECTURE")
        device_gops = core.get_property(dev_id, "DEVICE_GOPS")
        print(f"FULL_DEVICE_NAME: {FULL_DEVICE_NAME}")
        print(f"- DEVICE_ARCHITECTURE: {DEVICE_ARCHITECTURE}")
        print(f"- DEVICE_GOPS: {device_gops}\n")

except Exception as e:
    print(f"An error occurred: {e}")
```

issue log
```
# 10th gen Core
FULL_DEVICE_NAME (RO): Intel(R) Core(TM) i7-1065G7 CPU @ 1.30GHz
DEVICE_ARCHITECTURE (RO): GPU: vendor=0x8086 arch=v11.0.0
DEVICE_GOPS (RO): {<Type: 'float16'>: 2252.800048828125, <Type: 'float32'>: 1126.4000244140625, <Type: 'int8_t'>: 1126.4000244140625, <Type: 'uint8_t'>: 1126.4000244140625}

# 11th gen Core
FULL_DEVICE_NAME (RO): 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
DEVICE_ARCHITECTURE (RO): GPU: vendor=0x8086 arch=v12.0.0
DEVICE_GOPS (RO): {<Type: 'float16'>: 4147.2001953125, <Type: 'float32'>: 2073.60009765625, <Type: 'int8_t'>: 8294.400390625, <Type: 'uint8_t'>: 8294.400390625}                                                                   
# LNL
FULL_DEVICE_NAME (RO): Intel(R) Core(TM) Ultra 7 258V
DEVICE_ARCHITECTURE (RO): GPU: vendor=0x8086 arch=v20.4.4
DEVICE_GOPS (RO): {<Type: 'float16'>: 0.0, <Type: 'float32'>: 1996.800048828125, <Type: 'int8_t'>: 0.0, <Type: 'uint8_t'>: 0.0}

# ARC 770
FULL_DEVICE_NAME (RO): Intel(R) Arc(TM) A770 Graphics (dGPU)
DEVICE_ARCHITECTURE (RO): GPU: vendor=0x8086 arch=v12.55.8
DEVICE_GOPS (RO): {<Type: 'float16'>: 0.0, <Type: 'float32'>: 19660.80078125, <Type: 'int8_t'>: 0.0, <Type: 'uint8_t'>: 0.0} 
```

#### Checklist
 - [ ] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 171761
