### PR TITLE
[GHA] Fix misleading sanitizers workflow's name

### DIFF
--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -1,4 +1,4 @@
-name: Linux Sanitizers (Ubuntu 22.04, Python 3.9)
+name: Linux Sanitizers (Ubuntu 22.04, Python 3.11)
 on:
   schedule:
     # run daily at 00:00


### PR DESCRIPTION
It's actually Ubuntu 22 with Python 3.11, if you look at Docker environment