### PR TITLE
[CPU] Fix architecture macros usage

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -80,7 +80,7 @@
 #    include <tbb/task.h>
 #endif
 
-#if defined(__x86_64__) && defined(__linux__)
+#if defined(OPENVINO_ARCH_X86_64) && defined(__linux__)
 #    include "openvino/runtime/properties.hpp"
 #endif
 
@@ -1633,7 +1633,7 @@ void Graph::InferDynamic(SyncInferRequest* request, int numaId, UpdateStrategy&&
 
 static int GetNumaNodeId([[maybe_unused]] const GraphContext::CPtr& context) {
     int numaNodeId = -1;
-#if defined(__x86_64__) && defined(__linux__)
+#if defined(OPENVINO_ARCH_X86_64) && defined(__linux__)
     if ((context->getCPUStreamExecutor()) &&
         (context->getConfig().hintPerfMode == ov::hint::PerformanceMode::LATENCY)) {
         numaNodeId = context->getCPUStreamExecutor()->get_numa_node_id();

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
@@ -24,7 +24,7 @@ using Device = std::string;
 using Config = ov::AnyMap;
 using CpuReservationTest = ::testing::Test;
 
-#if !(defined(__arm__) || defined(__APPLE__) || defined(__EMSCRIPTEN__))
+#if !(defined(OPENVINO_ARCH_ARM) || defined(__APPLE__) || defined(__EMSCRIPTEN__))
 
 TEST_F(CpuReservationTest, smoke_Mutiple_CompiledModel_Reservation) {
     std::vector<std::shared_ptr<ov::Model>> models;


### PR DESCRIPTION
### Details:
Use `OPENVINO_*` macros to distinguish CPU architectures instead of built-in

### Tickets:
 - N/A
