### PR TITLE
[GPU] fix scatterelementsupdate kernel selection issue

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.cpp
@@ -101,20 +101,27 @@ CommonDispatchData ScatterElementsUpdateKernelRef::SetDefault(const scatter_elem
             switch (rank) {
                 case 4:
                     dispatchData.gws = {indices.X().v * indices.Y().v, indices.Feature().v, indices.Batch().v};
-                    dispatchData.lws = {1, 1, indices.Batch().v};
+                    dims_by_gws = {{Tensor::DataChannelName::X, Tensor::DataChannelName::Y},
+                                  {Tensor::DataChannelName::FEATURE},
+                                  {Tensor::DataChannelName::BATCH}};
                     break;
                 case 5:
                     dispatchData.gws = {indices.X().v * indices.Y().v, indices.Z().v * indices.Feature().v, indices.Batch().v};
-                    dispatchData.lws = {1, 1, indices.Batch().v};
+                    dims_by_gws = {{Tensor::DataChannelName::X, Tensor::DataChannelName::Y},
+                                  {Tensor::DataChannelName::Z, Tensor::DataChannelName::FEATURE},
+                                  {Tensor::DataChannelName::BATCH}};
                     break;
                 case 6:
                     dispatchData.gws = {indices.X().v * indices.Y().v, indices.Z().v * indices.W().v, indices.Feature().v * indices.Batch().v};
-                    dispatchData.lws = {1, 1, indices.Batch().v};
+                    dims_by_gws = {{Tensor::DataChannelName::X, Tensor::DataChannelName::Y},
+                                  {Tensor::DataChannelName::Z, Tensor::DataChannelName::W},
+                                  {Tensor::DataChannelName::FEATURE, Tensor::DataChannelName::BATCH}};
                     break;
                 default:
                     throw std::invalid_argument("Unsupported data layout for scatter elements update primitive");
                     break;
               }
+              dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo, in_layout, out_layout, dims_by_gws);
         } else {
             switch (rank) {
                 case 4:

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/scatter_elements_update.cpp
@@ -86,4 +86,25 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(idxPrecisions[0]),
                        ::testing::Values(ov::test::utils::DEVICE_GPU)),
     ScatterElementsUpdate12LayerTest::getTestCaseName);
+
+const std::map<std::vector<size_t>, std::map<std::vector<size_t>, std::vector<int>>> batch1100Shapes {
+    {{1100, 4, 1, 1}, {{{1100, 1, 1, 1}, {1}}}},
+};
+
+const std::vector<std::vector<int64_t>> batch1100Indices = {
+    std::vector<int64_t>(1100, 0),
+    std::vector<int64_t>(1100, 1),
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_lws_constraint_batch1100_ScatterEltsUpdate12,
+    ScatterElementsUpdate12LayerTest,
+    ::testing::Combine(::testing::ValuesIn(combine_shapes(batch1100Shapes)),
+                       ::testing::ValuesIn(batch1100Indices),
+                       ::testing::ValuesIn(reduceModes),
+                       ::testing::Values(true),
+                       ::testing::Values(inputPrecisions[0]),
+                       ::testing::Values(idxPrecisions[0]),
+                       ::testing::Values(ov::test::utils::DEVICE_GPU)),
+    ScatterElementsUpdate12LayerTest::getTestCaseName);
 }  // namespace

--- a/src/tests/functional/plugin/shared/src/single_op/scatter_elements_update.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/scatter_elements_update.cpp
@@ -63,7 +63,18 @@ std::string ScatterElementsUpdate12LayerTest::getTestCaseName(const testing::Tes
     result << "Axis=" << axis << "_";
     result << "ReduceMode=" << as_string(reduceMode) << "_";
     result << "UseInitVal=" << useInitVal << "_";
-    result << "Indices=" << ov::test::utils::vec2str(indices_value) << "_";
+    result << "Indices=";
+    if (indices_value.size() <= 50) {
+        result << ov::test::utils::vec2str(indices_value);
+    } else {
+        result << "(";
+        for (size_t i = 0; i < 15; ++i) {
+            if (i > 0) result << ".";
+            result << indices_value[i];
+        }
+        result << "..." << indices_value.size() << "_elements)";
+    }
+    result << "_";
     result << "modelType=" << model_type.to_string() << "_";
     result << "idxType=" << indices_type.to_string() << "_";
     result << "trgDev=" << target_device;


### PR DESCRIPTION
 ### Details:
  - Fixed LWS (Local Work Size) constraint violation in ScatterElementsUpdate kernel
  - Limited LWS to prevent kernel selection failure

### Description of the issue(symptom, root-cause, how it was resolved)
  - ScatterElementsUpdate_4 operation fails with "LWS cannot be greater than 1024" error when batch size >= 1024
  - Commit [1e9eb22b ](https://github.com/openvinotoolkit/openvino/commit/1e9eb22b9593aa51bf8240e5f16641db3cdf55a2#diff-185aeca4571e2f64c3d5c951d6aa1f49c53563d4af08fbf0d11f974967822ceb)introduced atomic operations optimization but didn't respect GPU hardware constraint that LWS product cannot exceed maxWorkGroupSize (typically 1024)
  - Limit LWS third dimension, ensuring compliance with hardware limits.

#### The code and line that caused this issue (if it is not changed directly)
https://github.com/openvinotoolkit/openvino/blob/aecaaff7e2be4c4bac0fefdbc50390bd04261f42/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.cpp#L104
https://github.com/openvinotoolkit/openvino/blob/aecaaff7e2be4c4bac0fefdbc50390bd04261f42/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.cpp#L108
https://github.com/openvinotoolkit/openvino/blob/aecaaff7e2be4c4bac0fefdbc50390bd04261f42/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.cpp#L112

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
cat >> my_test_lists.txt  << EOF
notebooks/table-question-answering/table-question-answering.ipynb
EOF
python .ci/patch_notebooks.py -td gpu notebooks/table-question-answering/
python .ci/validate_notebooks.py --device gpu --test_list my_test_lists.txt 

#### Problematic graph
  - Models containing ScatterElementsUpdate operations with reduction mode and batch dimension >= 1024
  - The issue appears during GPU kernel compilation phase when LWS validation fails
<img width="1946" height="1552" alt="image" src="https://github.com/user-attachments/assets/6ea91321-b336-46b8-b07b-a29f99d3c6cb" />

#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [v] Did you include test case for this fix, if necessary?
 - [v] Did you review existing test that can be extended to cover this scenario? Which test did you review?

 ### Tickets:
  - *CVS-171210*

