### PR TITLE
[CI] [GHA] Use another token to create PR for the auto-generated Python stubs

### DIFF
--- a/.github/workflows/update_pyapi_stubs.yml
+++ b/.github/workflows/update_pyapi_stubs.yml
@@ -10,9 +10,6 @@ on:
 jobs:
   update-stubs:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     if: github.repository == 'openvinotoolkit/openvino'
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Details:
As per https://github.com/orgs/community/discussions/57484 & https://github.com/orgs/community/discussions/65321

PRs created with the default `GITHUB_TOKEN` would not have workflows triggered. The docs read:

```
When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, 
with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. 
This prevents you from accidentally creating recursive workflow runs. 
For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, 
a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
```

in

[link](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs).

If we use a generated PAT, the workflows should be triggered.

### Tickets:
 - *173561*
