### PR TITLE
[GPU] remove checking pad for fsv16 kernel

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.hpp
@@ -48,12 +48,6 @@ struct GroupNormalizationFsv16Opt : public GroupNormalizationBase {
         }
 
         if (in0_layout.is_static() && out_layout.is_static()) {
-            // no support for spatial paddings in static case
-            if (in0_layout.data_padding._lower_size[3] > 0 || in0_layout.data_padding._lower_size[2] > 0 || in0_layout.data_padding._upper_size[3] > 0 ||
-                in0_layout.data_padding._upper_size[2] > 0) {
-                return false;
-            }
-
             if (!fused_ops_are_one_of<eltwise, activation, reorder>(node.get_fused_primitives())) {
                 return false;
             }


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - choosed the group normalization ref kernel. It has some known issues.

#### The code and line that caused this issue (if it is not changed directly)
 - C:\dev\sungeunk\repo\openvino\src\plugins\intel_gpu\src\graph\impls\ocl_v2\group_normalization_fsv16.hpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - benchmark_app -d GPU -m restoreformerpp_fp16.xml -hint none -nstreams 2 -nireq 4 -niter 1 -data_shape input[1,3,512,512]

#### Problematic graph
<img width="1152" height="353" alt="image" src="https://github.com/user-attachments/assets/b0c31df5-fdfb-4466-bc4a-a6939cf47b86" />

#### Checklist
 - [ ] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 173364
