### PR TITLE
[CPU] Apply 'cppcoreguidelines-rvalue-reference-param-not-moved' clang-tidy remarks

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -20,7 +20,6 @@
 # -cppcoreguidelines-pro-type-static-cast-downcast. Performance impact
 # -cppcoreguidelines-pro-type-union-access. There are a lot of code which uses unions
 # -cppcoreguidelines-pro-type-vararg. There are a lot of code which uses vararg functions
-# -cppcoreguidelines-rvalue-reference-param-not-moved. There are a lot of code which uses rvalue references
 # -cppcoreguidelines-special-member-functions. There are a lot of code which does not define all copy/move constructors/assignment operators
 # -google-readability-todo. No big reason to enforce
 # -modernize-use-trailing-return-type. Just stylistic preference
@@ -81,7 +80,6 @@ Checks: >
   -cppcoreguidelines-pro-type-static-cast-downcast,
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-type-vararg,
-  -cppcoreguidelines-rvalue-reference-param-not-moved,
   -cppcoreguidelines-special-member-functions,
   -google-build-using-namespace,
   -google-explicit-constructor,

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/utils.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/utils.cpp
@@ -51,7 +51,7 @@ template <cpu_isa_t isa,
 struct regs_to_spill {
     static std::vector<Xbyak::Reg> get(const std::set<snippets::Reg>& live_regs) {
         std::vector<Xbyak::Reg> regs_to_spill;
-        auto push_if_live = [&live_regs, &regs_to_spill](Xbyak::Reg&& reg) {
+        auto push_if_live = [&live_regs, &regs_to_spill](Xbyak::Reg reg) {
             if (live_regs.empty() || (live_regs.count(Xbyak2SnippetsReg(reg)) != 0U)) {
                 regs_to_spill.emplace_back(reg);
             }

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -96,7 +96,7 @@ protected:
         cmp(idx, end);
         jge(exit);
 
-        fn(idx);
+        std::move(fn)(idx);
 
         add(idx, step);
         jmp(loop);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
@@ -828,7 +828,7 @@ void jit_kernel::foreach (const B& begin,
     cmp(idx, end);
     jge(exit, T_NEAR);
 
-    fn(idx);
+    std::move(fn)(idx);
 
     add(idx, step);
     jmp(loop, T_NEAR);

--- a/src/plugins/intel_cpu/src/shape_inference/static_shape.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_shape.cpp
@@ -183,11 +183,13 @@ void NodeValidationFailure::create(const char* file,
                                    const char* check_string,
                                    std::pair<const Node*, const std::vector<intel_cpu::StaticShape>*>&& ctx,
                                    const std::string& explanation) {
-    throw ov::NodeValidationFailure(make_what(file,
-                                              line,
-                                              check_string,
-                                              node_validation_failure_loc_string(ctx.first),
-                                              ov::op::validate::shape_infer_explanation_str(*ctx.second, explanation)));
+    auto context = std::move(ctx);
+    throw ov::NodeValidationFailure(
+        make_what(file,
+                  line,
+                  check_string,
+                  node_validation_failure_loc_string(context.first),
+                  ov::op::validate::shape_infer_explanation_str(*context.second, explanation)));
 }
 
 template <>
@@ -196,10 +198,12 @@ void NodeValidationFailure::create(const char* file,
                                    const char* check_string,
                                    std::pair<const Node*, const std::vector<intel_cpu::StaticShapeRef>*>&& ctx,
                                    const std::string& explanation) {
-    throw ov::NodeValidationFailure(make_what(file,
-                                              line,
-                                              check_string,
-                                              node_validation_failure_loc_string(ctx.first),
-                                              ov::op::validate::shape_infer_explanation_str(*ctx.second, explanation)));
+    auto context = std::move(ctx);
+    throw ov::NodeValidationFailure(
+        make_what(file,
+                  line,
+                  check_string,
+                  node_validation_failure_loc_string(context.first),
+                  ov::op::validate::shape_infer_explanation_str(*context.second, explanation)));
 }
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - Fix "cppcoreguidelines-rvalue-reference-param-not-moved" remarks reported by clang-tidy
 - Enable "cppcoreguidelines-rvalue-reference-param-not-moved" clang-tidy checks on CI by default

### Tickets:
 - N/A