### PR TITLE
[GPU] Fix onednn FC quantize for input range based.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1771,6 +1771,8 @@ void program_node::create_onednn_primitive_attributes(
                     if (q_param->_need_clamp) {
                         auto in_lo = get_input_layout(dep_idx++);
                         auto in_hi = get_input_layout(dep_idx++);
+                        resize_layout_for_fc(this, in_lo);
+                        resize_layout_for_fc(this, in_hi);
                         dnnl::algorithm clamp_max = dnnl::algorithm::binary_max;
                         dnnl::algorithm clamp_min = dnnl::algorithm::binary_min;
                         dnnl::memory::desc in_lo_desc = onednn::layout_to_memory_desc(in_lo, onednn::get_default_data_format(in_lo));
@@ -1796,6 +1798,7 @@ void program_node::create_onednn_primitive_attributes(
                             update_onednn_post_op_list(onednn_post_op_type::eltwise_linear, empty_mem);
                         } else {
                             auto in_scale = get_input_layout(dep_idx++);
+                            resize_layout_for_fc(this, in_scale);
                             dnnl::memory::desc in_scale_desc = onednn::layout_to_memory_desc(in_scale, onednn::get_default_data_format(in_scale));
                             post_ops.append_binary(dnnl::algorithm::binary_mul, in_scale_desc);
                             update_onednn_post_op_list(onednn_post_op_type::binary_mul, dep_idx - 1, onednn::get_default_data_format(in_scale), false,
@@ -1808,6 +1811,7 @@ void program_node::create_onednn_primitive_attributes(
                                 update_onednn_post_op_list(onednn_post_op_type::eltwise_linear, empty_mem);
                             } else {
                                 auto in_shift = get_input_layout(dep_idx++);
+                                resize_layout_for_fc(this, in_shift);
                                 dnnl::memory::desc in_shift_desc = onednn::layout_to_memory_desc(in_shift, onednn::get_default_data_format(in_shift));
                                 post_ops.append_binary(dnnl::algorithm::binary_add, in_shift_desc);
                                 update_onednn_post_op_list(onednn_post_op_type::binary_add, dep_idx - 1, onednn::get_default_data_format(in_shift), false,
@@ -1836,6 +1840,7 @@ void program_node::create_onednn_primitive_attributes(
                                 update_onednn_post_op_list(onednn_post_op_type::eltwise_linear, empty_mem);
                             } else {
                                 auto out_scale = get_input_layout(dep_idx++);
+                                resize_layout_for_fc(this, out_scale);
                                 dnnl::memory::desc out_scale_desc = onednn::layout_to_memory_desc(out_scale, onednn::get_default_data_format(out_scale));
                                 post_ops.append_binary(dnnl::algorithm::binary_mul, out_scale_desc);
                                 update_onednn_post_op_list(onednn_post_op_type::binary_mul, dep_idx - 1, onednn::get_default_data_format(out_scale), false,
@@ -1849,6 +1854,7 @@ void program_node::create_onednn_primitive_attributes(
                                 update_onednn_post_op_list(onednn_post_op_type::eltwise_linear, empty_mem);
                             } else {
                                 auto out_shift = get_input_layout(dep_idx++);
+                                resize_layout_for_fc(this, out_shift);
                                 dnnl::memory::desc out_shift_desc = onednn::layout_to_memory_desc(out_shift, onednn::get_default_data_format(out_shift));
                                 post_ops.append_binary(dnnl::algorithm::binary_add, out_shift_desc);
                                 update_onednn_post_op_list(onednn_post_op_type::binary_add, dep_idx - 1, onednn::get_default_data_format(out_shift), false,


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
Normally onednn FC(matmul) run 2 dimension and follow post-op should be the same dimension. But some missed conversion in input based quantization.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model) 
./benchmark_app -d GPU.1 -m googlenet-12-qdq.onnx -nireq 1 -nstreams 1 --hint none -niter 1
model: [googlenet-12-qdq.onnx](https://github.com/onnx/models/blob/main/validated/vision/classification/inception_and_googlenet/googlenet/model/googlenet-12-qdq.onnx)

#### Problematic graph 
No graph related. It's related conversion dimension to onednn.

#### Checklist 
 - [O] Is it a proper fix? (not a workaround)
 - [O] Did you include test case for this fix, if necessary? 
 - [O] Did you review existing test that can be extended to cover this scenario? Which test did you review? fully_connected_fusion_test.cpp

### Tickets:
 - *CVS-173501*
