### PR TITLE
core/reference: Add default case to switch statement in depth_to_space()

### DIFF
--- a/src/core/reference/src/op/depth_to_space.cpp
+++ b/src/core/reference/src/op/depth_to_space.cpp
@@ -89,6 +89,8 @@ void depth_to_space(const char* const in,
         }
         break;
     }
+    default:
+        OPENVINO_ASSERT(false, "DepthToSpace: Unknown mode value: ", static_cast<int>(mode));
     }
 
     Shape post_transpose_shape(axes_order.size());


### PR DESCRIPTION
Add a default case with OPENVINO_ASSERT to the switch statement in depth_to_space() function to handle unknown mode values. This ensures that invalid mode parameters are caught early with a clear error message rather than falling through silently.

The assertion provides meaningful diagnostic information by displaying the actual invalid mode value, which helps in debugging and prevents undefined behavior when an unsupported mode is passed to the function.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
