### PR TITLE
[OV JS]: Add BigInt64/Uint64 support to Tensor and InferRequest

### DIFF
--- a/src/bindings/js/node/lib/addon.ts
+++ b/src/bindings/js/node/lib/addon.ts
@@ -6,7 +6,9 @@ type SupportedTypedArray =
   | Int32Array
   | Uint32Array
   | Float32Array
-  | Float64Array;
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array;
 
 type elementTypeString =
   | "u8"

--- a/src/bindings/js/node/tests/unit/infer_request.test.js
+++ b/src/bindings/js/node/tests/unit/infer_request.test.js
@@ -7,7 +7,6 @@ const { addon: ov } = require("../..");
 const assert = require("assert");
 const { describe, it, before, beforeEach } = require("node:test");
 const { testModels, isModelAvailable, lengthFromShape, generateImage } = require("../utils.js");
-const path = require("path");
 
 describe("ov.InferRequest tests", () => {
   const { testModelFP32 } = testModels;
@@ -173,37 +172,6 @@ describe("ov.InferRequest tests", () => {
       });
     });
 
-    it("infers with BigInt64Array input using setInputTensor", () => {
-      const shape0 = originalModel.input(0).getShape();
-      const shape1 = originalModel.input(1).getShape();
-      const size0 = shape0.reduce((a, b) => a * b, 1);
-      const size1 = shape1.reduce((a, b) => a * b, 1);
-      const inputData0 = new BigInt64Array(size0).fill(1n);
-      const inputData1 = new BigInt64Array(size1).fill(2n);
-
-      const tensor0 = new ov.Tensor(ov.element.i64, shape0, inputData0);
-      const tensor1 = new ov.Tensor(ov.element.i64, shape1, inputData1);
-
-      assert.doesNotThrow(() => {
-        inferRequest.setInputTensor(0, tensor0);
-        inferRequest.setInputTensor(1, tensor1);
-        inferRequest.infer();
-        const result = inferRequest.getOutputTensor();
-        assert.ok(result instanceof ov.Tensor);
-      });
-    });
-
-    it("errors on wrong BigInt64Array size", () => {
-      const shape0 = originalModel.input(0).getShape();
-      const size0 = shape0.reduce((a, b) => a * b, 1);
-      const wrongSizeData = new BigInt64Array(Math.max(1, size0 - 1)).fill(0n);
-
-      assert.throws(
-        () => new ov.Tensor(ov.element.i64, shape0, wrongSizeData),
-        /Memory allocated using shape and element::type mismatch/,
-      );
-    });
-
     it("infers with BigUint64Array input", () => {
       const model = originalModel.clone();
       const ppp = new ov.preprocess.PrePostProcessor(model);
@@ -229,17 +197,6 @@ describe("ov.InferRequest tests", () => {
         const outputTensor = Object.values(result)[0];
         assert.ok(outputTensor instanceof ov.Tensor);
       });
-    });
-
-    it("errors on wrong BigUint64Array size", () => {
-      const shape0 = originalModel.input(0).getShape();
-      const size0 = shape0.reduce((a, b) => a * b, 1);
-      const wrongSizeData = new BigUint64Array(size0 + 1).fill(0n);
-
-      assert.throws(
-        () => new ov.Tensor(ov.element.u64, shape0, wrongSizeData),
-        /Memory allocated using shape and element::type mismatch/,
-      );
     });
   });
   describe("setters", () => {

--- a/src/bindings/js/node/tests/unit/tensor.test.js
+++ b/src/bindings/js/node/tests/unit/tensor.test.js
@@ -252,58 +252,6 @@ describe("ov.Tensor tests", () => {
       assert.strictEqual(tensor.getSize(), expectedSize);
     });
   });
-  describe("BigInt Tensor support", () => {
-    let shape, elemNum;
-
-    before(() => {
-      shape = [1, 3, 4, 4];
-      elemNum = shape.reduce((a, b) => a * b, 1);
-    });
-
-    it("creates and reads BigInt64Array tensor", () => {
-      const data = new BigInt64Array(elemNum);
-      for (let i = 0; i < elemNum; i++) {
-        data[i] = BigInt(Math.floor(Math.random() * 10));
-      }
-
-      const tensor = new ov.Tensor(ov.element.i64, shape, data);
-      assert.ok(tensor instanceof ov.Tensor);
-      assert.strictEqual(tensor.getElementType(), ov.element.i64);
-      assert.deepStrictEqual(tensor.getShape(), shape);
-      assert.deepStrictEqual(tensor.data, data);
-      assert.deepStrictEqual(tensor.getData(), data);
-    });
-
-    it("errors on wrong BigInt64Array length", () => {
-      const badData = new BigInt64Array(elemNum - 1).fill(0n);
-      assert.throws(
-        () => new ov.Tensor(ov.element.i64, shape, badData),
-        /size mismatch|Memory allocated using shape and element::type mismatch/i,
-      );
-    });
-
-    it("creates and reads BigUint64Array tensor", () => {
-      const data = new BigUint64Array(elemNum);
-      for (let i = 0; i < elemNum; i++) {
-        data[i] = BigInt(Math.floor(Math.random() * 10));
-      }
-
-      const tensor = new ov.Tensor(ov.element.u64, shape, data);
-      assert.ok(tensor instanceof ov.Tensor);
-      assert.strictEqual(tensor.getElementType(), ov.element.u64);
-      assert.deepStrictEqual(tensor.getShape(), shape);
-      assert.deepStrictEqual(tensor.data, data);
-      assert.deepStrictEqual(tensor.getData(), data);
-    });
-
-    it("errors on wrong BigUint64Array length", () => {
-      const badData = new BigUint64Array(elemNum + 1).fill(0n);
-      assert.throws(
-        () => new ov.Tensor(ov.element.u64, shape, badData),
-        /size mismatch|Memory allocated using shape and element::type mismatch/i,
-      );
-    });
-  });
 
   describe("Tensor isContinuous", () => {
     it("isContinuous returns true if tensor is continuous", () => {

--- a/src/bindings/js/node/tests/unit/tensor.test.js
+++ b/src/bindings/js/node/tests/unit/tensor.test.js
@@ -252,6 +252,58 @@ describe("ov.Tensor tests", () => {
       assert.strictEqual(tensor.getSize(), expectedSize);
     });
   });
+  describe("BigInt Tensor support", () => {
+    let shape, elemNum;
+
+    before(() => {
+      shape = [1, 3, 4, 4];
+      elemNum = shape.reduce((a, b) => a * b, 1);
+    });
+
+    it("creates and reads BigInt64Array tensor", () => {
+      const data = new BigInt64Array(elemNum);
+      for (let i = 0; i < elemNum; i++) {
+        data[i] = BigInt(Math.floor(Math.random() * 10));
+      }
+
+      const tensor = new ov.Tensor(ov.element.i64, shape, data);
+      assert.ok(tensor instanceof ov.Tensor);
+      assert.strictEqual(tensor.getElementType(), ov.element.i64);
+      assert.deepStrictEqual(tensor.getShape(), shape);
+      assert.deepStrictEqual(tensor.data, data);
+      assert.deepStrictEqual(tensor.getData(), data);
+    });
+
+    it("errors on wrong BigInt64Array length", () => {
+      const badData = new BigInt64Array(elemNum - 1).fill(0n);
+      assert.throws(
+        () => new ov.Tensor(ov.element.i64, shape, badData),
+        /size mismatch|Memory allocated using shape and element::type mismatch/i,
+      );
+    });
+
+    it("creates and reads BigUint64Array tensor", () => {
+      const data = new BigUint64Array(elemNum);
+      for (let i = 0; i < elemNum; i++) {
+        data[i] = BigInt(Math.floor(Math.random() * 10));
+      }
+
+      const tensor = new ov.Tensor(ov.element.u64, shape, data);
+      assert.ok(tensor instanceof ov.Tensor);
+      assert.strictEqual(tensor.getElementType(), ov.element.u64);
+      assert.deepStrictEqual(tensor.getShape(), shape);
+      assert.deepStrictEqual(tensor.data, data);
+      assert.deepStrictEqual(tensor.getData(), data);
+    });
+
+    it("errors on wrong BigUint64Array length", () => {
+      const badData = new BigUint64Array(elemNum + 1).fill(0n);
+      assert.throws(
+        () => new ov.Tensor(ov.element.u64, shape, badData),
+        /size mismatch|Memory allocated using shape and element::type mismatch/i,
+      );
+    });
+  });
 
   describe("Tensor isContinuous", () => {
     it("isContinuous returns true if tensor is continuous", () => {


### PR DESCRIPTION
### Details:
 this fixes issue #32106 

 Added support BigInt64Array and BigUint64Array 
 - Add BigInt64Array and BigUint64Array to the [SupportedTypedArray](https://github.com/openvinotoolkit/openvino/blob/master/src/bindings/js/node/lib/addon.ts#L1).
 - Add tests for using the new types in Tensor and InferRequest.infer()
 
Ticket: CVS-168014
