### PR TITLE
[GPU] Fix an issue with reorder+permute buffer fusing

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -1031,6 +1031,9 @@ void prepare_buffer_fusing::run(program& p) {
                 return;
             }
             auto &permute_node = users.front()->as<permute>();
+            if (!permute_node.get_fused_primitives().empty()) {
+                return;
+            }
 
             auto &input_layout = node.get_input_layout(0);
             auto &output_layout = node.get_output_layout(0);

--- a/src/plugins/intel_gpu/src/graph/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorder.cpp
@@ -287,6 +287,8 @@ void reorder_inst::update_output_memory() {
     if (!dependencies().front().first->outputs_allocated())
         return;
 
+    GPU_DEBUG_TRACE_DETAIL << id() << " : update_output_memory with mem of input " << get_node().get_dependency(0).id()
+                           << " : " << input_memory_ptr()->buffer_ptr() << std::endl;
     // Can_be_optimized nodes are allocating from memory_pool too. In this case,
     // we need release the legacy output memory from memory pool explicitly.
     if (static_cast<bool>(_outputs[0]) &&


### PR DESCRIPTION
### Details:
 - Currently buffer fusing of reorder+permute is allowed if the input dimension order of reorder is the same as the permute order
 - However, even if permute has a fused prim, it is optimized out, which causes accuracy issue where the actual expected result is different
 - Fix to skip buffer fusing if permute has a fused prim

#### The code and line that caused this issue (if it is not changed directly)
- https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp#L1023

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - python gaia.py -i GaiaBlur/gaia-in-1st/%06d.jpg -o GaiaBlur/gaia-out-1st/GPU-2x-%06d.png -d GPU -m ghq-v5-gaia-fp16-576x672-2x.onnx
 - ./ov_gpu_unit_tests --gtest_filter=*prepare_buffer_fusing.reorder_permute_with_fused_prim*

#### Problematic graph
<img width="787" height="418" alt="image" src="https://github.com/user-attachments/assets/daf375bd-adfe-4ca7-954e-0083f9cca2c6" />

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp#L1636

### Tickets:
 - [CVS-172025](https://jira.devtools.intel.com/browse/CVS-172025)
