### PR TITLE
[GPU] disable failing test for dGPU

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/hybrid.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/hybrid.cpp
@@ -342,6 +342,7 @@ protected:
 };
 
 TEST_P(MatmulWeightsDecompressionQuantizeConvolution, Inference) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     run();
     check_results();
 }


### PR DESCRIPTION
### Details:
 - This test was supposed to be disabled already, but the code did not call the filtering function.

### Tickets:
 - 170304
