### PR TITLE
[CI] [GHA] Add `RUBY_TCP_NO_FAST_FALLBACK` to the `Smart_CI` job

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,6 +23,8 @@ permissions: read-all
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -12,6 +12,8 @@ permissions: read-all
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -21,6 +21,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -32,6 +32,8 @@ jobs:
   
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/debian_10_arm.yml
+++ b/.github/workflows/debian_10_arm.yml
@@ -23,6 +23,8 @@ permissions: read-all
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/dev_cpu_linux_snippets_libxsmm.yml
+++ b/.github/workflows/dev_cpu_linux_snippets_libxsmm.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -23,6 +23,8 @@ permissions: read-all
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -27,6 +27,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/linux_conditional_compilation.yml
+++ b/.github/workflows/linux_conditional_compilation.yml
@@ -28,6 +28,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/linux_riscv.yml
+++ b/.github/workflows/linux_riscv.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/linux_riscv_xuantie_dev_cpu.yml
+++ b/.github/workflows/linux_riscv_xuantie_dev_cpu.yml
@@ -44,6 +44,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -43,6 +43,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -46,6 +46,8 @@ jobs:
 
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/mac_arm64.yml
+++ b/.github/workflows/mac_arm64.yml
@@ -46,6 +46,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       skip_workflow: "${{ steps.smart_ci.outputs.skip_workflow }}"

--- a/.github/workflows/manylinux_2014.yml
+++ b/.github/workflows/manylinux_2014.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/ubuntu_22.yml
+++ b/.github/workflows/ubuntu_22.yml
@@ -31,6 +31,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/ubuntu_22_arm64_cross_compilation.yml
+++ b/.github/workflows/ubuntu_22_arm64_cross_compilation.yml
@@ -28,6 +28,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/ubuntu_22_dpcpp.yml
+++ b/.github/workflows/ubuntu_22_dpcpp.yml
@@ -19,6 +19,8 @@ permissions: read-all
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/ubuntu_24.yml
+++ b/.github/workflows/ubuntu_24.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -23,6 +23,8 @@ permissions: read-all
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       changed_components: "${{ steps.smart_ci.outputs.changed_components }}"

--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -30,6 +30,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       skip_workflow: "${{ steps.smart_ci.outputs.skip_workflow }}"

--- a/.github/workflows/windows_vs2022_debug.yml
+++ b/.github/workflows/windows_vs2022_debug.yml
@@ -25,6 +25,8 @@ env:
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       skip_workflow: "${{ steps.smart_ci.outputs.skip_workflow }}"

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -27,6 +27,8 @@ permissions: read-all
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
+    env:
+      RUBY_TCP_NO_FAST_FALLBACK: 1
     outputs:
       affected_components: "${{ steps.smart_ci.outputs.affected_components }}"
       skip_workflow: "${{ steps.smart_ci.outputs.skip_workflow }}"


### PR DESCRIPTION
### Details:
 - Should mitigate things like https://github.com/openvinotoolkit/openvino/actions/runs/17907844869/job/50912427588?pr=32172, as described in https://github.com/rubygems/rubygems/issues/8390
