### PR TITLE
[GPU] restore legacy logic to check support_formats for inputs

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_bfyx_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_bfyx_opt.hpp
@@ -40,8 +40,13 @@ struct GroupNormalizationBfyxOpt : public GroupNormalizationBase {
         };
 
         const auto& in0_layout = node.get_input_layout(0);
+        const auto& in1_layout = node.get_input_layout(1);
+        const auto& in2_layout = node.get_input_layout(2);
         const auto& out_layout = node.get_output_layout(0);
-        if (!one_of(in0_layout.format, supported_input_fmts) || !one_of(out_layout.format, supported_output_fmts)) {
+        if (!(one_of(in0_layout.format, supported_input_fmts) ||
+              one_of(in1_layout.format, supported_input_fmts) ||
+              one_of(in2_layout.format, supported_input_fmts)) ||
+            !one_of(out_layout.format, supported_output_fmts)) {
             return false;
         }
 


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - choosed the group normalization ref kernel. It has some known issues.

#### The code and line that caused this issue (if it is not changed directly)
 - src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_bfyx_opt.hpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - benchmark_app -d GPU -m restoreformerpp_fp16.xml -hint none -nstreams 2 -nireq 4 -niter 1 -data_shape input[1,3,512,512]

#### Problematic graph
<img width="1152" height="353" alt="image" src="https://github.com/user-attachments/assets/b0c31df5-fdfb-4466-bc4a-a6939cf47b86" />

#### Checklist
 - [ ] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 173364
