### PR TITLE
[GPU] Introduce a TransposeConv1x1Transpose fusion

### DIFF
--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -289,6 +289,8 @@ TRANSFORMATIONS_API bool is_constant_and_all_values_equal_int(const Output<Node>
 
 TRANSFORMATIONS_API bool is_on_constant_path(const ov::Output<ov::Node>& output);
 
+TRANSFORMATIONS_API bool is_on_constant_or_param_path(const ov::Output<ov::Node>& output);
+
 TRANSFORMATIONS_API bool process_subgraph(ov::pass::ModelPass& model_pass, const std::shared_ptr<Node>& node);
 
 TRANSFORMATIONS_API std::tuple<std::shared_ptr<ov::Node>,  // result

--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -536,6 +536,44 @@ bool is_on_constant_path(const ov::Output<ov::Node>& output) {
     return status;
 }
 
+bool is_on_constant_or_param_path(const ov::Output<ov::Node>& output) {
+    auto status = true;
+
+    auto root_node = output.get_node();
+    if (!root_node || root_node->get_output_size() == 0) {
+        return false;
+    }
+    std::deque<ov::Node*> nodes_to_calculate = {root_node};
+
+    std::unordered_set<ov::Node*> visited;
+    while (status && !nodes_to_calculate.empty()) {
+        auto current_node = nodes_to_calculate.front();
+        nodes_to_calculate.pop_front();
+        if (visited.count(current_node)) {
+            continue;
+        }
+        visited.insert(current_node);
+        // RandomUniform output changes during runtime, so we should not consider it as a constant
+        if (current_node->get_type_info() == ov::op::v8::RandomUniform::get_type_info_static()) {
+            return false;
+        }
+
+        if (current_node->get_input_size() == 0 &&
+            !(ov::is_type<ov::op::v0::Constant>(current_node) || ov::is_type<ov::op::v0::Parameter>(current_node))) {
+            status = false;
+        } else {
+            // not a leaf - continue to search
+            for (const auto& input_value : current_node->input_values()) {
+                const auto& input_node = input_value.get_node();
+                if (!visited.count(input_node)) {
+                    nodes_to_calculate.push_front(input_node);
+                }
+            }
+        }
+    }
+    return status;
+}
+
 bool process_subgraph(ov::pass::ModelPass& model_pass, const std::shared_ptr<Node>& node) {
     bool changed = false;
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
@@ -67,8 +67,9 @@ struct FullyConnectedImplementationManager : public ImplementationManager {
             if (fc_prim->decompression_zero_point.is_valid()) {
                 auto decompression_zp_idx = fc_prim->bias.is_valid() ? 4 : 3;
                 auto decompression_zp_dt = fc_node.get_input_layout(decompression_zp_idx).data_type;
-                if ((wei_dt != ov::element::Type_t::u4 && wei_dt != ov::element::Type_t::u8) ||
-                    (decompression_zp_dt != ov::element::Type_t::u8 && decompression_zp_dt != ov::element::Type_t::i8)) {
+                if ((wei_dt != ov::element::Type_t::i4 && wei_dt != ov::element::Type_t::u4 && wei_dt != ov::element::Type_t::u8) ||
+                    (decompression_zp_dt != ov::element::Type_t::i4 && decompression_zp_dt != ov::element::Type_t::u8 &&
+                     decompression_zp_dt != ov::element::Type_t::i8)) {
                     LOG_AND_RETURN_FALSE(node);
                 }
             }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -8,6 +8,7 @@
 #include "primitive_onednn_base.h"
 
 #include <oneapi/dnnl/dnnl.hpp>
+#include <oneapi/dnnl/dnnl_common.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -432,8 +433,10 @@ public:
         auto& engine = impl_params.prog->get_engine();
         auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
+        attr->set_fpmath_mode(dnnl::fpmath_mode::f16, true);
         auto prim_desc = get_gemm_primitive_descriptor(impl_params, *attr);
-
+        
+        //attr->set_accumulation_mode(dnnl::accumulation_mode::f16);
         return std::make_unique<gemm_onednn>(engine, config, attr, *prim_desc);
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
@@ -57,6 +57,7 @@ struct GemmImplementationManager : public ImplementationManager {
         if (one_of(in0_dt, {data_types::f32, data_types::i64}) || one_of(in1_dt, {data_types::f32, data_types::i64}))
             return false;
 
+      
         if (!one_of(in0_layout.format.value, supported_formats) ||
             !one_of(in1_layout.format.value, supported_formats) ||
             !one_of(out_layout.format.value, supported_formats))
@@ -70,8 +71,8 @@ struct GemmImplementationManager : public ImplementationManager {
         }
 
         bool f16f16_case = everyone_is(data_types::f16, in0_dt, in1_dt) && one_of(out_dt, {data_types::f16, data_types::f32, data_types::i8});
-        bool u8s8_case = one_of(in0_dt, {data_types::i8, data_types::u8}) &&
-                         one_of(in1_dt, {data_types::i8, data_types::u8}) &&
+        bool u8s8_case = one_of(in0_dt, {data_types::f16, data_types::i8, data_types::u8, data_types::i4, data_types::u4}) &&
+                         one_of(in1_dt, {data_types::f16, data_types::i8, data_types::u8, data_types::i4, data_types::u4}) &&
                          one_of(out_dt, {data_types::f16, data_types::f32, data_types::i32, data_types::i8, data_types::u8});
 
         if (!f16f16_case && !u8s8_case)

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
@@ -41,7 +41,10 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
         return in_ps.rank().is_static() && out_ps.rank().is_static() && in_ps.size() == 3 && out_ps.size() == 2;
     };
 
-    auto weights_m = wrap_type<ov::op::v0::Constant>(compressed_constant);
+    auto weights_const_m = wrap_type<ov::op::v0::Constant>(compressed_constant);
+    auto weights_param_m = wrap_type<ov::op::v0::Parameter>(compressed_constant);
+    auto weights_param_reshape_m = wrap_type<ov::op::v1::Reshape>({weights_param_m, any_input()});
+    auto weights_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{weights_const_m, weights_param_m, weights_param_reshape_m});
     auto convert_m = wrap_type<ov::op::v0::Convert>({weights_m});
 
     auto sub_const_m = wrap_type<ov::op::v0::Constant>();
@@ -87,10 +90,16 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
         bool grouped = std::count_if(scale_shape.begin(), scale_shape.end(), [](size_t d) { return d > 1; }) > 1;
         bool sub_with_convert = (pattern_map.count(sub_with_convert_m) > 0) ? true : false;
 
-        auto weight_ptr = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(weights_m).get_node_shared_ptr());
         bool weight_u8 = false;
-        if (weight_ptr->get_element_type() == ov::element::u8 || weight_ptr->get_element_type() == ov::element::i8)
-            weight_u8 = true;
+        if (pattern_map.count(weights_const_m)) {
+            auto weight_ptr = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(weights_const_m).get_node_shared_ptr());
+            if (weight_ptr->get_element_type() == ov::element::u8 || weight_ptr->get_element_type() == ov::element::i8)
+                weight_u8 = true;
+        } else {
+            auto weight_ptr = ov::as_type_ptr<ov::op::v0::Parameter>(pattern_map.at(weights_param_m).get_node_shared_ptr());
+            if (weight_ptr->get_element_type() == ov::element::u8 || weight_ptr->get_element_type() == ov::element::i8)
+                weight_u8 = true;
+        }
 
         auto reshape_const_to_2d = [has_transpose, grouped](std::shared_ptr<ov::Node> node) {
             auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);
@@ -137,61 +146,104 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
             optional_zero_point = convert_const_to_u8(reshape_const_to_2d(pattern_map.at(sub_const_m).get_node_shared_ptr()));
         }
 
-        std::shared_ptr<ov::Node> fc_input_b = reshape_const_to_2d(pattern_map.at(weights_m).get_node_shared_ptr());
-        std::shared_ptr<ov::Node> fc_input_scale = scale;
-        std::shared_ptr<ov::Node> fc_input_zp = optional_zero_point;
-        std::shared_ptr<ov::Node> fc_input_bias = pattern_map.at(bias_m).get_node_shared_ptr();
-        std::vector<std::shared_ptr<ov::Node>> result_nodes = {};
+        if (pattern_map.count(weights_const_m)) {
+            std::shared_ptr<ov::Node> fc_input_b = reshape_const_to_2d(pattern_map.at(weights_const_m).get_node_shared_ptr());
+            std::shared_ptr<ov::Node> fc_input_scale = scale;
+            std::shared_ptr<ov::Node> fc_input_zp = optional_zero_point;
+            std::shared_ptr<ov::Node> fc_input_bias = pattern_map.at(bias_m).get_node_shared_ptr();
+            std::vector<std::shared_ptr<ov::Node>> result_nodes = {};
 
-        if (has_transpose) {
-            const auto& transpose = pattern_map.at(transpose_m).get_node_shared_ptr();
-            std::shared_ptr<ov::Node> transpose_const = pattern_map.at(transpose_const_m).get_node_shared_ptr();
-            if (ov::shape_size(transpose_const->get_shape()) != fc_input_b->get_output_partial_shape(0).size()) {
-                std::vector<int32_t> new_order(fc_input_b->get_output_partial_shape(0).size());
-                std::iota(new_order.begin(), new_order.end(), 0);
-                std::swap(new_order[new_order.size() - 1], new_order[new_order.size() - 2]);
-                transpose_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{new_order.size()}, new_order);
+            if (has_transpose) {
+                const auto& transpose = pattern_map.at(transpose_m).get_node_shared_ptr();
+                std::shared_ptr<ov::Node> transpose_const = pattern_map.at(transpose_const_m).get_node_shared_ptr();
+                if (ov::shape_size(transpose_const->get_shape()) != fc_input_b->get_output_partial_shape(0).size()) {
+                    std::vector<int32_t> new_order(fc_input_b->get_output_partial_shape(0).size());
+                    std::iota(new_order.begin(), new_order.end(), 0);
+                    std::swap(new_order[new_order.size() - 1], new_order[new_order.size() - 2]);
+                    transpose_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{new_order.size()}, new_order);
+                }
+
+                fc_input_b = transpose->clone_with_new_inputs({fc_input_b->output(0), transpose_const});
+                result_nodes.push_back(fc_input_b);
+
+                if (ov::shape_size(scale->output(0).get_shape()) > 1) {
+                    fc_input_scale = transpose->clone_with_new_inputs({scale->output(0), transpose_const});
+                    result_nodes.push_back(fc_input_scale);
+                }
+
+                if (with_zero_point && ov::shape_size(optional_zero_point->output(0).get_shape()) > 1) {
+                    fc_input_zp = transpose->clone_with_new_inputs({optional_zero_point->output(0), transpose_const});
+                    result_nodes.push_back(fc_input_zp);
+                }
             }
 
-            fc_input_b = transpose->clone_with_new_inputs({ fc_input_b->output(0), transpose_const });
-            result_nodes.push_back(fc_input_b);
-
-            if (ov::shape_size(scale->output(0).get_shape()) > 1) {
-                fc_input_scale = transpose->clone_with_new_inputs({ scale->output(0), transpose_const });
-                result_nodes.push_back(fc_input_scale);
+            if (pattern_map.count(mul2_m)) {
+                auto mul2_op_const = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(mul2_const_m).get_node_shared_ptr());
+                fc_input_scale = ov::op::util::make_try_fold<ov::op::v1::Multiply>(fc_input_scale, mul2_op_const);
             }
 
-            if (with_zero_point && ov::shape_size(optional_zero_point->output(0).get_shape()) > 1) {
-                fc_input_zp = transpose->clone_with_new_inputs({ optional_zero_point->output(0), transpose_const });
-                result_nodes.push_back(fc_input_zp);
+            std::shared_ptr<ov::Node> new_fc = nullptr;
+            if (with_zero_point) {
+                new_fc =
+                    std::make_shared<op::FullyConnectedCompressed>(fc_input_a, fc_input_b, fc_input_bias, fc_input_scale, fc_input_zp, fc->get_output_type());
+            } else {
+                new_fc = std::make_shared<op::FullyConnectedCompressed>(fc_input_a, fc_input_b, fc_input_bias, fc_input_scale, fc->get_output_type());
             }
-        }
 
-        if (pattern_map.count(mul2_m)) {
-            auto mul2_op_const = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(mul2_const_m).get_node_shared_ptr());
-            fc_input_scale = ov::op::util::make_try_fold<ov::op::v1::Multiply>(fc_input_scale, mul2_op_const);
-        }
-
-        std::shared_ptr<ov::Node> new_fc = nullptr;
-        if (with_zero_point) {
-            new_fc = std::make_shared<op::FullyConnectedCompressed>(fc_input_a,
-                                                                    fc_input_b,
-                                                                    fc_input_bias,
-                                                                    fc_input_scale,
-                                                                    fc_input_zp,
-                                                                    fc->get_output_type());
+            result_nodes.push_back(new_fc);
+            new_fc->set_friendly_name(fc->get_friendly_name());
+            ov::copy_runtime_info(m.get_matched_nodes(), result_nodes);
+            ov::replace_node(fc, new_fc);
         } else {
-            new_fc = std::make_shared<op::FullyConnectedCompressed>(fc_input_a,
-                                                                    fc_input_b,
-                                                                    fc_input_bias,
-                                                                    fc_input_scale,
-                                                                    fc->get_output_type());
-        }
+            std::shared_ptr<ov::Node> fc_input_b = pattern_map.count(weights_param_reshape_m) ? pattern_map.at(weights_param_reshape_m).get_node_shared_ptr()
+                                                                                              : pattern_map.at(weights_param_m).get_node_shared_ptr();
+            std::shared_ptr<ov::Node> fc_input_scale = scale;
+            std::shared_ptr<ov::Node> fc_input_zp = optional_zero_point;
+            std::shared_ptr<ov::Node> fc_input_bias = pattern_map.at(bias_m).get_node_shared_ptr();
+            std::vector<std::shared_ptr<ov::Node>> result_nodes = {};
 
-        result_nodes.push_back(new_fc);
-        new_fc->set_friendly_name(fc->get_friendly_name());
-        ov::copy_runtime_info(m.get_matched_nodes(), result_nodes);
-        ov::replace_node(fc, new_fc);
+            if (has_transpose) {
+                const auto& transpose = pattern_map.at(transpose_m).get_node_shared_ptr();
+                std::shared_ptr<ov::Node> transpose_const = pattern_map.at(transpose_const_m).get_node_shared_ptr();
+                if (ov::shape_size(transpose_const->get_shape()) != fc_input_b->get_output_partial_shape(0).size()) {
+                    std::vector<int32_t> new_order(fc_input_b->get_output_partial_shape(0).size());
+                    std::iota(new_order.begin(), new_order.end(), 0);
+                    std::swap(new_order[new_order.size() - 1], new_order[new_order.size() - 2]);
+                    transpose_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{new_order.size()}, new_order);
+                }
+
+                fc_input_b = transpose->clone_with_new_inputs({fc_input_b->output(0), transpose_const});
+                result_nodes.push_back(fc_input_b);
+
+                if (ov::shape_size(scale->output(0).get_shape()) > 1) {
+                    fc_input_scale = transpose->clone_with_new_inputs({scale->output(0), transpose_const});
+                    result_nodes.push_back(fc_input_scale);
+                }
+
+                if (with_zero_point && ov::shape_size(optional_zero_point->output(0).get_shape()) > 1) {
+                    fc_input_zp = transpose->clone_with_new_inputs({optional_zero_point->output(0), transpose_const});
+                    result_nodes.push_back(fc_input_zp);
+                }
+            }
+
+            if (pattern_map.count(mul2_m)) {
+                auto mul2_op_const = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(mul2_const_m).get_node_shared_ptr());
+                fc_input_scale = ov::op::util::make_try_fold<ov::op::v1::Multiply>(fc_input_scale, mul2_op_const);
+            }
+
+            std::shared_ptr<ov::Node> new_fc = nullptr;
+            if (with_zero_point) {
+                new_fc =
+                    std::make_shared<op::FullyConnectedCompressed>(fc_input_a, fc_input_b, fc_input_bias, fc_input_scale, fc_input_zp, fc->get_output_type());
+            } else {
+                new_fc = std::make_shared<op::FullyConnectedCompressed>(fc_input_a, fc_input_b, fc_input_bias, fc_input_scale, fc->get_output_type());
+            }
+
+            result_nodes.push_back(new_fc);
+            new_fc->set_friendly_name(fc->get_friendly_name());
+            ov::copy_runtime_info(m.get_matched_nodes(), result_nodes);
+            ov::replace_node(fc, new_fc);
+        }
 
         return true;
     };

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -23,7 +23,7 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected() {
     };
     auto weights_path = [&static_rank_gt_1](const ov::Output<ov::Node>& output) {
         const auto& pshape = output.get_partial_shape();
-        return ov::op::util::is_on_constant_path(output) &&
+        return ov::op::util::is_on_constant_or_param_path(output) &&
                static_rank_gt_1(output) &&
                pshape.is_static() &&
                std::count_if(pshape.begin(), pshape.end(), [](const ov::Dimension& x) { return x != 1; }) <= 2;

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_conv1x1_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_conv1x1_to_fc.cpp
@@ -1,0 +1,239 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transpose_conv1x1_to_fc.hpp"
+
+#include <iostream>
+#include <ostream>
+#include <vector>
+
+#include "graph/include/gemm_inst.h"
+#include "intel_gpu/runtime/utils.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/node_vector.hpp"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/Convolution.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/pass/pattern/op/any.hpp"
+#include "openvino/pass/pattern/op/label.hpp"
+#include "openvino/pass/pattern/op/or.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
+
+using namespace ov::pass::pattern;
+using ov::pass::pattern::op::Or;
+
+namespace ov::intel_gpu {
+
+namespace {
+
+bool is_valid_order(const std::vector<size_t>& target_order, bool is_output_transpose) {
+    // Check valid input/output transpose order for onednn gemm primitive
+    cldnn::format fmt_dummy = cldnn::format::bfyx;
+    if (is_output_transpose) {
+        return cldnn::typed_primitive_inst<cldnn::gemm>::is_fusable_permute_output_order_onednn(target_order, fmt_dummy);
+    } else {
+        return cldnn::typed_primitive_inst<cldnn::gemm>::is_fusable_permute_input_order_onednn(target_order, fmt_dummy);
+    }
+}
+
+bool has_optimized_version(const ov::Output<ov::Node>& output, bool supports_immad, bool is_output_transpose = false) {
+    if (!output.get_element_type().is_real())
+        return false;
+
+    if (output.get_partial_shape().is_static() && !supports_immad)
+        return false;
+
+    auto order_node = output.get_node()->get_input_node_shared_ptr(1);
+    if (!ov::is_type<ov::op::v0::Constant>(order_node))
+        return false;
+
+    auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(order_node)->cast_vector<int64_t>();
+    const auto expected_dims_num = 4;
+
+    std::vector<size_t> order(std::begin(transpose_order), std::end(transpose_order));
+    if (expected_dims_num > order.size()) {
+        size_t orders_to_add = expected_dims_num - order.size();
+        for (size_t i = 0; i < orders_to_add; ++i)
+            order.insert(order.begin(), i);
+        for (size_t i = orders_to_add; i < order.size(); ++i)
+            order[i] = order[i] + orders_to_add;
+    }
+    
+    return is_valid_order(order, is_output_transpose);
+}
+}  // namespace
+
+TransposeConv1x1TransposeFusion::TransposeConv1x1TransposeFusion(bool supports_immad) {
+    add_matcher<TransposeConv1x1TransposeMatcher>(supports_immad);
+}
+
+TransposeConv1x1TransposeMatcher::TransposeConv1x1TransposeMatcher(bool supports_immad) {
+    auto static_rank_gt_1 = [](const ov::Output<ov::Node>& output) {
+        const auto& r = output.get_partial_shape().rank();
+        return r.is_static() && r.get_length() > 1;
+    };
+    auto weights_path = [&static_rank_gt_1](const ov::Output<ov::Node>& output) {
+        const auto& pshape = output.get_partial_shape();
+        return ov::op::util::is_on_constant_or_param_path(output) && static_rank_gt_1(output) && pshape.is_static() &&
+               std::count_if(pshape.begin(), pshape.end(), [](const ov::Dimension& x) {
+                   return x == 1;
+               }) == 2;
+    };
+    auto input_transpose_predicate = [supports_immad](const ov::Output<ov::Node>& output) -> bool {
+        return has_optimized_version(output, supports_immad, false);
+    };
+    auto output_transpose_predicate = [supports_immad](const ov::Output<ov::Node>& output) -> bool {
+        return has_optimized_version(output, supports_immad, true);
+    };
+
+    
+    auto first_input_m = ov::pass::pattern::any_input();
+    auto a_order_m = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
+    auto transpose_activations_m = ov::pass::pattern::wrap_type<ov::op::v1::Transpose>({first_input_m, a_order_m});        //, input_transpose_predicate);
+    auto reshape_activations_m = ov::pass::pattern::wrap_type<ov::op::v1::Reshape>({first_input_m, a_order_m});      //, input_transpose_predicate);
+    auto a_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{transpose_activations_m, reshape_activations_m});
+
+    auto weights_const_m = wrap_type<ov::op::v0::Constant>(weights_path);
+    auto weights_param_m = wrap_type<ov::op::v0::Parameter>(weights_path);
+    auto weights_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{weights_const_m, weights_param_m});
+    auto weight_convert_m = ov::pass::pattern::wrap_type<ov::op::v0::Convert>({weights_m});
+    auto weights_scales_m = ov::pass::pattern::any_input();
+    auto weights_zp_m = ov::pass::pattern::any_input();
+    auto weights_zp_convert_m = ov::pass::pattern::wrap_type<ov::op::v0::Convert>({weights_zp_m});
+    auto weight_subtract_m = ov::pass::pattern::wrap_type<ov::op::v1::Subtract>({weight_convert_m, weights_zp_convert_m});
+    // Make zp subtraction optional to account for symmetrical quantization cases
+    auto weight_dequantized_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{weight_convert_m, weight_subtract_m});
+    auto weight_mult_m = ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({weight_dequantized_m, weights_scales_m});
+    auto conv1x1_m = ov::pass::pattern::wrap_type<ov::op::v1::Convolution>({a_m, weight_mult_m});
+
+    auto convert_m = ov::pass::pattern::wrap_type<ov::op::v0::Convert>({conv1x1_m});
+    auto conv_out_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{conv1x1_m, convert_m});
+
+    auto c_order_m = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
+    auto transpose_output_m = ov::pass::pattern::wrap_type<ov::op::v1::Transpose>({conv_out_m, c_order_m});            //, output_transpose_predicate);
+    auto reshape_output_m = ov::pass::pattern::wrap_type<ov::op::v1::Reshape>({conv_out_m, c_order_m});  //, output_transpose_predicate);
+    auto output_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{transpose_output_m, reshape_output_m});
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+
+        auto conv1x1 = ov::as_type_ptr<ov::op::v1::Convolution>(pattern_map.at(conv1x1_m).get_node_shared_ptr());
+        auto weight_convert = ov::as_type_ptr<ov::op::v0::Convert>(pattern_map.at(weight_convert_m).get_node_shared_ptr());
+        auto weight_sub = (pattern_map.count(weight_subtract_m) > 0) ? pattern_map.at(weight_subtract_m).get_node_shared_ptr() : nullptr;
+        auto weight_mult = ov::as_type_ptr<ov::op::v1::Multiply>(pattern_map.at(weight_mult_m).get_node_shared_ptr());
+        auto convert_out = (pattern_map.count(convert_m) > 0) ? pattern_map.at(convert_m).get_node_shared_ptr() : nullptr;
+        if (!conv1x1 || transformation_callback(conv1x1)) {
+            return false;
+        }
+
+        auto weight = pattern_map.at(weights_m).get_node_shared_ptr();
+        auto scale = pattern_map.at(weights_scales_m).get_node_shared_ptr();
+        auto zp = (pattern_map.count(weights_zp_m) > 0) ? pattern_map.at(weights_zp_m).get_node_shared_ptr() : nullptr;
+        auto activation = pattern_map.at(first_input_m).get_node_shared_ptr();
+
+        auto reshape_const_to_2d = [](std::shared_ptr<ov::Node> node) {
+            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);
+            OPENVINO_ASSERT(constant != nullptr);
+            ov::Shape current_shape = constant->get_shape();
+            if (current_shape.size() == 2)
+                return constant;
+
+            if (current_shape.size() <= 1) {
+
+                auto new_shape = ov::Shape{(current_shape.size() == 1) ? current_shape[0] : 1, 1};
+
+                auto new_constant = std::make_shared<ov::op::v0::Constant>(*constant, new_shape);
+
+                ov::copy_weightless_cache_attr(constant, new_constant);
+                return new_constant;
+            } else {
+                OPENVINO_ASSERT(current_shape.size() == 4);
+                OPENVINO_ASSERT(current_shape[2] == 1 && current_shape[3] == 1);
+
+                auto new_shape = ov::Shape{current_shape[0], current_shape[1]};
+
+                auto new_constant = std::make_shared<ov::op::v0::Constant>(*constant, new_shape);
+
+                ov::copy_weightless_cache_attr(constant, new_constant);
+                return new_constant;
+            }
+        };        
+
+        // add reshape after weight 9216 x 3072 x 1 x 1 --> 9216 x 3072
+        std::shared_ptr<ov::op::v0::Convert> weight_squeezed_convert;
+        if (ov::as_type_ptr<ov::op::v0::Constant>(weight)) {
+            auto Reshape_weight = reshape_const_to_2d(weight);
+            MatcherPass::register_new_node(Reshape_weight);
+            Reshape_weight->set_friendly_name(weight->get_friendly_name() + "_Reshape_weight");
+            // FixMe: this is a point of interest - it protects quantized weights from being inflated by constant-folded conversion
+            // ov::disable_constant_folding(Reshape_weight);
+            weight_squeezed_convert = ov::as_type_ptr<ov::op::v0::Convert>(weight_convert->clone_with_new_inputs({Reshape_weight}));
+        } else {
+            auto param = ov::as_type_ptr<ov::op::v0::Parameter>(weight);
+            OPENVINO_ASSERT(param != nullptr);
+            std::vector<int> values_reshape_b;
+            auto shape_b = param->get_output_partial_shape(0);
+            for (auto i = 0; i < shape_b.size(); i++)
+                if (shape_b.to_shape()[i] != 1) {
+                    values_reshape_b.push_back(shape_b.to_shape()[i]);
+                }
+
+            auto reshape_weight_const = ov::op::v0::Constant::create(element::i32, Shape{2}, values_reshape_b);  //{9216, 3072});
+            auto Reshape_weight = std::make_shared<ov::op::v1::Reshape>(param, reshape_weight_const, false);
+            MatcherPass::register_new_node(Reshape_weight);
+            Reshape_weight->set_friendly_name(param->get_friendly_name() + "_Reshape_weight");
+            weight_squeezed_convert = ov::as_type_ptr<ov::op::v0::Convert>(weight_convert->clone_with_new_inputs({Reshape_weight}));
+        }
+        ov::disable_constant_folding(weight_squeezed_convert);
+
+        // add reshape after scales
+        auto Reshape_scale = reshape_const_to_2d(scale);
+        MatcherPass::register_new_node(Reshape_scale);
+        Reshape_scale->set_friendly_name(scale->get_friendly_name() + "_Reshape_scale");
+
+        auto scaled_weight = weight_mult->clone_with_new_inputs({weight_squeezed_convert, Reshape_scale});
+        if (zp) {
+            // add reshape after zero points
+            auto Reshape_zp = reshape_const_to_2d(zp);
+            MatcherPass::register_new_node(Reshape_zp);
+            Reshape_zp->set_friendly_name(zp->get_friendly_name() + "_Reshape_zp");
+            auto weights_zp_convert = ov::as_type_ptr<ov::op::v0::Convert>(pattern_map.at(weights_zp_convert_m).get_node_shared_ptr());
+            auto zp_squeezed_convert = weights_zp_convert->clone_with_new_inputs({Reshape_zp});
+            ov::disable_constant_folding(zp_squeezed_convert);
+            auto zero_adjusted_weight = weight_sub->clone_with_new_inputs({weight_squeezed_convert, zp_squeezed_convert});
+            scaled_weight = weight_mult->clone_with_new_inputs({zero_adjusted_weight, Reshape_scale});
+        }
+        ov::disable_constant_folding(scaled_weight);
+
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(activation, scaled_weight, false, true);
+        // ToDo: handle out conversion if it exists
+        if (convert_out) {
+            auto convert_final = convert_out->clone_with_new_inputs({matmul});
+            convert_final->set_friendly_name(m.get_match_root()->get_friendly_name());
+            ov::copy_runtime_info(m.get_matched_nodes(), convert_final);
+            ov::replace_node(m.get_match_root(), convert_final);
+        } else {
+            matmul->set_friendly_name(m.get_match_root()->get_friendly_name());
+            ov::copy_runtime_info(m.get_matched_nodes(), matmul);
+            ov::replace_node(m.get_match_root(), matmul);
+        }
+
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(output_m, "TransposeConv1x1TransposeMatcher");
+    this->register_matcher(m, callback);
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_conv1x1_to_fc.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_conv1x1_to_fc.hpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov::intel_gpu {
+
+class TransposeConv1x1TransposeFusion : public ov::pass::GraphRewrite {
+public:
+    OPENVINO_GRAPH_REWRITE_RTTI("TransposeConv1x1TransposeFusion");
+    TransposeConv1x1TransposeFusion(bool supports_immad = false);
+};
+
+class TransposeConv1x1TransposeMatcher : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("TransposeConv1x1TransposeMatcher");
+    TransposeConv1x1TransposeMatcher(bool supports_immad);
+};
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -90,6 +90,7 @@
 #include "plugin/transformations/optimize_subsequent_reshapes.hpp"
 #include "plugin/transformations/print_model_statistics.hpp"
 #include "plugin/transformations/sink_reshape.hpp"
+#include "plugin/transformations/transpose_conv1x1_to_fc.hpp"
 #include "plugin/transformations/transpose_fusion.hpp"
 #include "plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.hpp"
 #include "plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.hpp"
@@ -1198,6 +1199,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         ov::pass::Manager manager("GPU:PostLPT");
         manager.set_per_pass_validation(false);
 
+        manager.register_pass<ov::intel_gpu::TransposeConv1x1TransposeFusion>();
         manager.register_pass<ov::intel_gpu::ClampFP16Output>();
         manager.register_pass<ov::intel_gpu::ConvertMatMulToFullyConnected>();
         manager.register_pass<ov::intel_gpu::MoveFCReshapeToWeights>();


### PR DESCRIPTION
### Details:
 - The new transformation addresses a representation of quantized GEMMs as 1x1 convolutions, allowing them to benefit from FCCompressed optimizations
 - Patterns for recognizing weight dequantization have been adjusted to work on cases where quantized weights are provided as parameters rather than constants

### Tickets:
 - CVS-172090
