### PR TITLE
Disable b_fs_zyx_fsv16 not to use cldnn ref kernel

### DIFF
--- a/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
@@ -22,8 +22,7 @@ static std::vector<format> supported_dyn_formats = {
     format::bfyx,
     format::bfzyx,
     format::bfwzyx,
-    format::b_fs_yx_fsv16,
-    format::b_fs_zyx_fsv16
+    format::b_fs_yx_fsv16
 };
 
 const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<reorder>::get_implementations() {


### PR DESCRIPTION
### Details:
 - b_fs_zyx_fsv16 cldnn ref-kernel is enabled for dynamic shape by PR#31221. This caused perf regression by using ref-kernel which previously had used onednn kernel.
 target model unet3d_mlperf
 - Before PR#31221 : throughput 1.8 FPS
 - Wtih PR#31221 : throughput 0.59 FPS  
 
 #### The code and line that caused this issue
 - Disabled b_fs_zyx_fsv16 in reorder impl : reorder_impls.cpp 

#### Reproduction step and snapshot
 - Can be reproduced by benchmark_app
 `benchmark_app -m unet3d_mlperf\onnx\onnx\FP16\1\ov\unet3d_mlperf.xml -d GPU -nstreams 2 -nireq 4 -t 10 -b 1 -hint none -data_shape input[1,4,224,224,160] -shape input[?,4,?,?,160]`
 
#### Checklist
 - [ ] Is it a proper fix? A new ticket is needed to enable this format with optimized kernel.
 - [ ] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? 

### Tickets:
 - CVS-173587
