### PR TITLE
Fix issue when CPU0 is offline

### DIFF
--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -425,6 +425,9 @@ void parse_cache_info_linux(const std::vector<std::vector<std::string>> system_i
             std::string::size_type endpos = 0;
             std::string sub_str = "";
 
+            if (system_info_table[nproc][0].empty()) {
+                return;
+            }
             if (((endpos = system_info_table[nproc][0].find(',', pos)) != std::string::npos) ||
                 ((endpos = system_info_table[nproc][0].find('-', pos)) != std::string::npos)) {
                 sub_str = system_info_table[nproc][0].substr(pos, endpos - pos);


### PR DESCRIPTION
The issue is below:
[When CPU0 is offline, OpenVINO cannot run properly.](https://github.com/openvinotoolkit/openvino/issues/32249)

The issue was resolved by implementing a validation check to ensure the string is not empty prior to execution.
