### PR TITLE
[Spec][MOE][Internal Op] Specification of MOE internal operation

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/moe.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/moe.rst
@@ -81,7 +81,7 @@ The ``router_topk_output_indices`` are used to select the top-k experts for opti
   * **Required**: *yes*
   * **Supported values**:
    
-     * ``GEMM2_BIAS_SWIGLU_CLAMP``: Two GEMMs with bias, SwiGLU activation, and clamp.
+    * ``GEMM2_BIAS_SWIGLU_CLAMP``: Two GEMMs with bias, SwiGLU activation, and clamp.
     * ``GEMM3_SWIGLU``: Three GEMMs with SwiGLU activation.
 
 * *expert_alpha*


### PR DESCRIPTION
### Details:
 - Specification of MOE internal operation
 - Internal ops are used mainly for fusion transformations and optimizations, 
 they will not appear in the converted model public IR
 
 Describes MOE used in PR: 
 - https://github.com/openvinotoolkit/openvino/pull/32183

### Tickets:
 - 171911