### PR TITLE
[NPU] Fuse getQueryResultFromSupportedLayers into queryGraph

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/include/ze_graph_ext_wrappers.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/ze_graph_ext_wrappers.hpp
@@ -64,10 +64,6 @@ public:
     void initializeGraph(const GraphDescriptor& graphDescriptor, uint32_t commandQueueGroupOrdinal) const;
 
 private:
-    std::unordered_set<std::string> getQueryResultFromSupportedLayers(
-        ze_result_t result,
-        ze_graph_query_network_handle_t& hGraphQueryNetwork) const;
-
     void getMetadata(ze_graph_handle_t graphHandle,
                      uint32_t index,
                      std::vector<IODescriptor>& inputs,

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -182,34 +182,6 @@ static std::unordered_set<std::string> parseQueryResult(std::vector<char>& data)
     return result;
 }
 
-std::unordered_set<std::string> ZeGraphExtWrappers::getQueryResultFromSupportedLayers(
-    ze_result_t result,
-    ze_graph_query_network_handle_t& hGraphQueryNetwork) const {
-    // Get the size of query result
-    _logger.debug("getQueryResultFromSupportLayers - perform pfnQueryNetworkGetSupportedLayers to get size");
-    size_t size = 0;
-    result = _zeroInitStruct->getGraphDdiTable().pfnQueryNetworkGetSupportedLayers(hGraphQueryNetwork, &size, nullptr);
-    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnQueryNetworkGetSupportedLayers get size of query result",
-                                    result,
-                                    _zeroInitStruct->getGraphDdiTable());
-
-    // Get the result data of query
-    _logger.debug("getQueryResultFromSupportLayers - perform pfnQueryNetworkGetSupportedLayers to get data");
-    std::vector<char> supportedLayers(size);
-    result = _zeroInitStruct->getGraphDdiTable().pfnQueryNetworkGetSupportedLayers(hGraphQueryNetwork,
-                                                                                   &size,
-                                                                                   supportedLayers.data());
-    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnQueryNetworkGetSupportedLayers get result data of query",
-                                    result,
-                                    _zeroInitStruct->getGraphDdiTable());
-
-    _logger.debug("getQueryResultFromSupportLayers - perform pfnQueryNetworkDestroy");
-    result = _zeroInitStruct->getGraphDdiTable().pfnQueryNetworkDestroy(hGraphQueryNetwork);
-    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnQueryNetworkDestroy", result, _zeroInitStruct->getGraphDdiTable());
-
-    return parseQueryResult(supportedLayers);
-}
-
 std::unordered_set<std::string> ZeGraphExtWrappers::queryGraph(std::pair<size_t, std::shared_ptr<uint8_t>> serializedIR,
                                                                const std::string& buildFlags) const {
     // For ext version >= 1.5
@@ -232,12 +204,32 @@ std::unordered_set<std::string> ZeGraphExtWrappers::queryGraph(std::pair<size_t,
                                                                                     &hGraphQueryNetwork);
     THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnQueryNetworkCreate2", result, _zeroInitStruct->getGraphDdiTable());
 
-    return getQueryResultFromSupportedLayers(result, hGraphQueryNetwork);
-
     _logger.warning("queryGraph - Driver version is %d.%d, queryNetwork is unsupported.",
                     ZE_MAJOR_VERSION(_graphExtVersion),
                     ZE_MINOR_VERSION(_graphExtVersion));
-    return std::unordered_set<std::string>();
+
+    _logger.debug("queryGraph - perform pfnQueryNetworkGetSupportedLayers to get size");
+    size_t size = 0;
+    result = _zeroInitStruct->getGraphDdiTable().pfnQueryNetworkGetSupportedLayers(hGraphQueryNetwork, &size, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnQueryNetworkGetSupportedLayers get size of query result",
+                                    result,
+                                    _zeroInitStruct->getGraphDdiTable());
+
+    // Get the result data of query
+    _logger.debug("queryGraph - perform pfnQueryNetworkGetSupportedLayers to get data");
+    std::vector<char> supportedLayers(size);
+    result = _zeroInitStruct->getGraphDdiTable().pfnQueryNetworkGetSupportedLayers(hGraphQueryNetwork,
+                                                                                   &size,
+                                                                                   supportedLayers.data());
+    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnQueryNetworkGetSupportedLayers get result data of query",
+                                    result,
+                                    _zeroInitStruct->getGraphDdiTable());
+
+    _logger.debug("queryGraph - perform pfnQueryNetworkDestroy");
+    result = _zeroInitStruct->getGraphDdiTable().pfnQueryNetworkDestroy(hGraphQueryNetwork);
+    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnQueryNetworkDestroy", result, _zeroInitStruct->getGraphDdiTable());
+
+    return parseQueryResult(supportedLayers);
 }
 
 bool ZeGraphExtWrappers::canCpuVaBeImported(void* data, size_t size, const uint32_t flags) const {


### PR DESCRIPTION
### Details:
`getQueryResultFromSupportedLayers` is always called inside `queryGraph`. Therefore, I am moving its logic into `queryGraph`.

### Tickets:
 - *none*
