### PR TITLE
[GPU] calc index with padded size at first kernel in GroupNormalization

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cl
@@ -17,13 +17,14 @@ KERNEL(calc_mean_sqr_mean_per_feature)(
     const uint in_data_set_idx = get_global_id(0);
     const uint workers_per_dataset = LWS0 / FSV;    // 16 datasets are handled by one local workgroup
     const uint data_set_size = INPUT0_SIZE_X * INPUT0_SIZE_Y;
-    const uint items_num = data_set_size / workers_per_dataset;
-    const uint leftovers = data_set_size - (items_num * workers_per_dataset);
+    const uint padded_data_set_size = (INPUT0_SIZE_X + INPUT0_PAD_BEFORE_SIZE_X + INPUT0_PAD_AFTER_SIZE_X) * (INPUT0_SIZE_Y + INPUT0_PAD_BEFORE_SIZE_Y + INPUT0_PAD_AFTER_SIZE_Y);
+    const uint items_num = padded_data_set_size / workers_per_dataset;
+    const uint leftovers = padded_data_set_size - (items_num * workers_per_dataset);
 
     const uint INPUT0_ALIGNED_FEATURE_NUM = ALIGN(INPUT0_FEATURE_NUM, FSV);
     const uint b = (data_set_idx * FSV) / INPUT0_ALIGNED_FEATURE_NUM;
     const uint f_base = (data_set_idx * FSV) % INPUT0_ALIGNED_FEATURE_NUM;
-    const uint data_set_offset = INPUT0_GET_INDEX(b, f_base, 0, 0);
+    const uint data_set_offset = INPUT0_GET_INDEX(b, f_base, -INPUT0_PAD_BEFORE_SIZE_Y, -INPUT0_PAD_BEFORE_SIZE_X);
     const uint my_data_offset = data_set_offset + in_data_set_idx;
 
     __local ACCUMULATOR_TYPE sum_per_feature[SLM_SIZE];

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cpp
@@ -108,11 +108,11 @@ protected:
             assert(!params.is_dynamic());
             auto& wgs = kd.params.workGroups;
 
-            const auto& ol = params.output_layouts[0];
-            auto x = extract_channel(ChannelName::X, ol);
-            auto y = extract_channel(ChannelName::Y, ol);
-            auto f = extract_channel(ChannelName::FEATURE, ol);
-            auto b = extract_channel(ChannelName::BATCH, ol);
+            auto padded_dims = params.input_layouts[0].get_padded_dims();
+            auto x = padded_dims[3];
+            auto y = padded_dims[2];
+            auto f = padded_dims[1];
+            auto b = padded_dims[0];
 
             wgs.global[0] = x * y;
             wgs.global[1] = ceil_div(f, fsv) * b;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.hpp
@@ -48,12 +48,6 @@ struct GroupNormalizationFsv16Opt : public GroupNormalizationBase {
         }
 
         if (in0_layout.is_static() && out_layout.is_static()) {
-            // no support for spatial paddings in static case
-            if (in0_layout.data_padding._lower_size[3] > 0 || in0_layout.data_padding._lower_size[2] > 0 || in0_layout.data_padding._upper_size[3] > 0 ||
-                in0_layout.data_padding._upper_size[2] > 0) {
-                return false;
-            }
-
             if (!fused_ops_are_one_of<eltwise, activation, reorder>(node.get_fused_primitives())) {
                 return false;
             }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -27,6 +27,7 @@ typedef std::tuple<
     std::size_t,                            // Number of groups
     double,                                 // Epsilon
     format,                                 // First input layout
+    padding,                                // First input padding
     format,                                 // Output layout
     padding                                 // Output padding
 >
@@ -38,10 +39,11 @@ public:
 
     void SetUp() override {
         const auto& params = GetParam();
-        const auto& [input_shape, _num_groups_, _epsilon_, _in_format_, _out_format_, _output_pad_] = params;
+        const auto& [input_shape, _num_groups_, _epsilon_, _in_format_, _in_pad_, _out_format_, _output_pad_] = params;
         num_groups_ = _num_groups_;
         epsilon_ = _epsilon_;
         in_format_ = _in_format_;
+        in_pad_ = _in_pad_;
         out_format_ = _out_format_;
         output_pad_ = _output_pad_;
         std::copy(std::begin(input_shape), std::end(input_shape), std::back_inserter(data_shape_));
@@ -71,7 +73,7 @@ public:
         }
         tp.add(input_layout{scale_primitive_, scale_bias_layout_});
         tp.add(input_layout{bias_primitive_, scale_bias_layout_});
-        tp.add(reorder{reordered_data_primitive, data_primitive_, in_format_, data_types::f32});
+        tp.add(reorder{reordered_data_primitive, data_primitive_, layout{input_shape, data_types::f32, in_format_, in_pad_}});
 
         auto g = group_normalization{
             "group_normalization_output",
@@ -131,6 +133,7 @@ private:
     std::size_t num_groups_{};
     double epsilon_{};
     format in_format_{format::any};
+    padding in_pad_{padding()};
     format out_format_{format::any};
     padding output_pad_{padding()};
     network::ptr network_{};
@@ -175,6 +178,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(std::vector<size_t>{1, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_planar_4d_formats),
+        ::testing::ValuesIn({padding()}),
         ::testing::ValuesIn(f_4d_formats),
         ::testing::ValuesIn({padding(), padding({0, 0, 1, 1})})));
 
@@ -186,6 +190,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(std::vector<size_t>{1, 2, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_blocked_4d_formats),
+        ::testing::ValuesIn({padding(), padding({0, 0, 1, 1})}),
         ::testing::ValuesIn(f_4d_formats),
         ::testing::ValuesIn({padding(), padding({0, 16, 0, 0})})));
 
@@ -197,6 +202,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(std::vector<size_t>{1, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_planar_5d_formats),
+        ::testing::ValuesIn({padding()}),
         ::testing::ValuesIn(f_planar_5d_formats),
         ::testing::ValuesIn({padding(), padding({0, 0, 1, 1})})));
 


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - choosed the group normalization ref kernel. It has some known issues.

#### The code and line that caused this issue (if it is not changed directly)
 - src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cl
 - src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cpp
 - src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.hpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - benchmark_app -d GPU -m restoreformerpp_fp16.xml -hint none -nstreams 2 -nireq 4 -niter 1 -data_shape input[1,3,512,512]

#### Problematic graph
<img width="1152" height="353" alt="image" src="https://github.com/user-attachments/assets/b0c31df5-fdfb-4466-bc4a-a6939cf47b86" />

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 173364
