### PR TITLE
[Snippets] Extract TransformConvertToConvertTruncation pass from CommonOptimizations

### DIFF
--- a/src/common/snippets/src/pass/common_optimizations.cpp
+++ b/src/common/snippets/src/pass/common_optimizations.cpp
@@ -20,7 +20,6 @@
 #include "snippets/pass/softmax_reshape_elimination.hpp"
 #include "snippets/pass/split_dimension_m.hpp"
 #include "snippets/pass/subgraph_manager.hpp"
-#include "snippets/pass/transform_convert.hpp"
 #include "snippets/pass/validate.hpp"
 
 namespace ov::snippets::pass {
@@ -43,10 +42,8 @@ CommonOptimizations::CommonOptimizations(const CommonOptimizations::Config& conf
         const auto is_quantized = subgraph->is_quantized();
         const auto is_domain_sensitive = subgraph->has_domain_sensitive_ops();
 
-        // Firstly, we should transform all original Converts inside body to ConvertTruncation to save original
-        // behavior. Then if Subgraph contains FakeQuantize we enable specific transformation for quantized subgraphs.
+        // If Subgraph contains FakeQuantize we enable specific transformation for quantized subgraphs.
         ov::pass::Manager manager(get_pass_config(), "Snippets:CommonOptimizations");
-        REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::TransformConvertToConvertTruncation, true);
         REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::ExplicitTransposeMatMulInputs, is_domain_sensitive);
         REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::CommonFakeQuantizeDecomposition, is_quantized);
         REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::SoftmaxReshapeElimination, is_domain_sensitive);

--- a/src/common/snippets/src/pass/tokenization.cpp
+++ b/src/common/snippets/src/pass/tokenization.cpp
@@ -22,6 +22,7 @@
 #include "snippets/pass/gn_tokenization.hpp"
 #include "snippets/pass/mha_tokenization.hpp"
 #include "snippets/pass/mlp_seq_tokenization.hpp"
+#include "snippets/pass/transform_convert.hpp"
 
 namespace ov::snippets::pass {
 
@@ -104,6 +105,7 @@ bool SnippetsTokenization::run_on_model(const std::shared_ptr<ov::Model>& m) {
     tokenization_passes->add_matcher<TokenizeFCSnippets>(m_tokenization_config);
     tokenization_passes->add_matcher<TokenizeSnippets>(m_tokenization_config);
 
+    manager.register_pass<TransformConvertToConvertTruncation>();
     manager.register_pass<CommonOptimizations>(m_common_optimizations_config);
     manager.run_passes(m);
 

--- a/src/common/snippets/src/pass/transform_convert.cpp
+++ b/src/common/snippets/src/pass/transform_convert.cpp
@@ -6,42 +6,46 @@
 
 #include <memory>
 
-#include "openvino/core/except.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/opsets/opset1.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
-#include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "snippets/itt.hpp"
-#include "snippets/op/convert_saturation.hpp"
 #include "snippets/op/convert_truncation.hpp"
+#include "snippets/op/subgraph.hpp"
 
 ov::snippets::pass::TransformConvertToConvertTruncation::TransformConvertToConvertTruncation() {
     MATCHER_SCOPE(TransformConvertToConvertTruncation);
-    auto convert = std::make_shared<ov::pass::pattern::op::Label>(
-        ov::pass::pattern::any_input(),
-        [](const std::shared_ptr<const Node>& n) {
-            return ov::is_type<ov::opset1::Convert>(n) &&
-                   !ov::is_type_any_of<op::ConvertTruncation, op::ConvertSaturation>(n);
-        });
+    auto matcher =
+        std::make_shared<ov::pass::pattern::Matcher>(ov::pass::pattern::wrap_type<ov::snippets::op::Subgraph>(),
+                                                     matcher_name);
 
-    register_matcher(
-        std::make_shared<ov::pass::pattern::Matcher>(ov::pass::pattern::wrap_type<ov::opset1::Convert>(), matcher_name),
-        [](ov::pass::pattern::Matcher& m) {
-            OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform,
-                               "Snippets::op::TransformConvertToConvertTruncation")
-            const auto root = m.get_match_root();
-            const auto convert = ov::as_type_ptr<ov::opset1::Convert>(root);
-            OPENVINO_ASSERT(convert, "Convert op is invalid");
-            auto convert_truncation = std::make_shared<op::ConvertTruncation>(convert->get_input_source_output(0),
-                                                                              convert->get_destination_type());
+    register_matcher(matcher, [this](ov::pass::pattern::Matcher& m) {
+        OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform,
+                           "Snippets::op::TransformConvertToConvertTruncation")
+        const auto subgraph = ov::as_type_ptr<ov::snippets::op::Subgraph>(m.get_match_root());
+        if (!subgraph || this->transformation_callback(subgraph)) {
+            return false;
+        }
+
+        auto body = subgraph->body_ptr();
+        bool modified = false;
+        for (const auto& node : body->get_ordered_ops()) {
+            const auto convert = ov::as_type_ptr<ov::opset1::Convert>(node);
+            if (!convert) {
+                continue;
+            }
+            auto convert_truncation =
+                std::make_shared<ov::snippets::op::ConvertTruncation>(convert->get_input_source_output(0),
+                                                                      convert->get_destination_type());
             convert_truncation->set_friendly_name(convert->get_friendly_name());
             ov::copy_runtime_info(convert, convert_truncation);
             ov::replace_node(convert, convert_truncation);
-
-            return true;
-        });
+            modified = true;
+        }
+        return modified;
+    });
 }


### PR DESCRIPTION
### Details:
Remove the old TransformConvertToConvertTruncation registration from CommonOptimizations and move it to the end of the pipeline

### Tickets:
 - N/A
