### PR TITLE
[GPU] Adjust memory utilization ratio in memory pool

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
@@ -174,7 +174,7 @@ static constexpr Property<std::vector<std::string>, ov::PropertyMutability::RW> 
 static constexpr Property<bool, ov::PropertyMutability::RW> could_use_flashattn_v2{"GPU_COULD_USE_FLASHATTN_V2"};
 static constexpr Property<uint64_t, PropertyMutability::RW> dynamic_quantization_group_size_max{"GPU_DYNAMIC_QUANTIZATION_GROUP_SIZE_MAX"};
 static constexpr Property<bool, ov::PropertyMutability::RW> validate_output_buffer{"GPU_VALIDATE_OUTPUT_BUFFER"};
-static constexpr Property<float, ov::PropertyMutability::RW> pool_mem_utilization_threshold{"GPU_POOL_MEM_UTILIZATION_THRESHOLD"};
+static constexpr Property<float, ov::PropertyMutability::RW> mem_pool_util_threshold{"GPU_MEM_POOL_UTIL_THRESHOLD"};
 }  // namespace ov::intel_gpu
 
 namespace cldnn {

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
@@ -159,7 +159,7 @@ class memory_pool {
     std::map<layout, std::list<memory_record>, padded_pool_comparer> _padded_pool;
     engine* _engine;
     const ExecutionConfig& _config;
-    float _pool_mem_utilization_threshold = 0.5f;
+    float _mem_pool_util_threshold = 0.5f;
 
 public:
     explicit memory_pool(engine& engine, const ExecutionConfig& config);

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -38,7 +38,7 @@ OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, config_file, "", "Path to custom layers 
 OV_CONFIG_RELEASE_OPTION(ov::hint, model, nullptr, "Shared pointer to the ov::Model")
 OV_CONFIG_RELEASE_OPTION(ov::internal, key_cache_quant_mode, ov::internal::CacheQuantMode::BY_CHANNEL, "AUTO or BY_CHANNEL or BY_TOKEN")
 OV_CONFIG_RELEASE_OPTION(ov::internal, value_cache_quant_mode, ov::internal::CacheQuantMode::BY_TOKEN, "AUTO or BY_CHANNEL or BY_TOKEN")
-OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, pool_mem_utilization_threshold, 0.5, "Minimum utilization ratio (0.0~1.0) for reusable memory in the pool")
+OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, mem_pool_util_threshold, 0.5, "Minimum utilization threshold (0.0~1.0) for reusable memory in the pool")
 
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, shape_predictor_settings, {10, 16 * 1024, 2, 1.1f}, "Preallocation settings")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, queue_type, QueueTypes::out_of_order, "Type of the queue that must be used for model execution. May be in-order or out-of-order")

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -161,7 +161,7 @@ memory::ptr memory_pool::get_from_non_padded_pool(const layout& layout,
     const auto layout_bytes_count = layout.bytes_count();
     auto it = _non_padded_pool.lower_bound(layout_bytes_count);
     while (it != _non_padded_pool.end()) {
-        if ((!is_dynamic || (layout_bytes_count > it->second._memory->get_layout().bytes_count() * _pool_mem_utilization_threshold)) &&
+        if ((!is_dynamic || (layout_bytes_count > it->second._memory->get_layout().bytes_count() * _mem_pool_util_threshold)) &&
             (it->second._network_id == network_id &&
             it->second._type == type &&
             it->second._memory->get_layout().format != format::fs_b_yx_fsv32 &&
@@ -375,13 +375,13 @@ void memory_pool::clear_pool_for_network(uint32_t network_id) {
 }
 
 memory_pool::memory_pool(engine& engine, const ExecutionConfig& config) : _engine(&engine), _config(config) {
-    _pool_mem_utilization_threshold = _config.get_pool_mem_utilization_threshold();
-    if (_pool_mem_utilization_threshold < 0.f || _pool_mem_utilization_threshold > 1.f) {
-        _pool_mem_utilization_threshold = std::clamp(_pool_mem_utilization_threshold, 0.f, 1.f);
-        GPU_DEBUG_INFO << "[WARNING] pool_mem_utilization should be in range [0.f, 1.f]. Reset to "
-            << _pool_mem_utilization_threshold << std::endl;
+    _mem_pool_util_threshold = _config.get_mem_pool_util_threshold();
+    if (_mem_pool_util_threshold < 0.f || _mem_pool_util_threshold > 1.f) {
+        _mem_pool_util_threshold = std::clamp(_mem_pool_util_threshold, 0.f, 1.f);
+        GPU_DEBUG_INFO << "[WARNING] mem_pool_util_threshold should be in range [0.f, 1.f]. Reset to "
+            << _mem_pool_util_threshold << std::endl;
     }
-    GPU_DEBUG_TRACE_DETAIL << "pool_mem_utilization set to " << _pool_mem_utilization_threshold << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << "mem_pool_util_threshold set to " << _mem_pool_util_threshold << std::endl;
 }
 
 #ifdef GPU_DEBUG_CONFIG


### PR DESCRIPTION
### Details:
- In the dynamic model, reusable memory from the pool is only reused if its usage rate exceeds a fixed threshold of 50%.
- Adjusting this threshold depending on the model can help reduce overall memory usage.
- An internal option has been added to allow tuning of this utilization ratio.

### Checklist
[o] Is it a proper fix? Yes.
[x] Did you include test case for this fix, if necessary?
- There are no performance or accuracy issues.
- Memory usage cannot be measured through unit tests.
- Therefore, no additional tests were added.

[x] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *173555*
