### PR TITLE
[ONNX FE] Fix regression introduced for FP16 models

### DIFF
--- a/src/frontends/onnx/frontend/src/editor.cpp
+++ b/src/frontends/onnx/frontend/src/editor.cpp
@@ -237,7 +237,7 @@ void graph_topological_sort(GraphProto* graph) {
             bool can_add = true;
             for (const auto& in_name : node->input()) {
                 if (in_name.empty()) {
-                    return;
+                    continue;
                 }
                 const auto* in_node = get_node_by_out_name(in_name);
                 if (in_node == nullptr) {  // can be an initializer or an model's input


### PR DESCRIPTION
### Details:
 - *#30282 introduced regression. If node have optional inputs or any other reason when input doesn't exist, but have more inputs after this one, those inputs would be skipped, resulting in failed conversion.*

### Tickets:
 - *CVS-174291*
