### PR TITLE
[NPU] Call only zeInitDrivers on Windows based on the ze_loader.dll version

### DIFF
--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -209,13 +209,13 @@ jobs:
       - name: Ctest - OpenVINO unit tests
         shell: cmd
         run: |
-          set path=%path%;${{ env.OPENVINO_REPO }}\temp\Windows_AMD64\tbb\bin;${{ env.BUILD_DIR }}\bin\${{ env.CMAKE_BUILD_TYPE }}
+          set path=%path%;${{ env.OPENVINO_REPO }}\temp\Windows_AMD64\tbb\bin
           ctest -C ${{ env.CMAKE_BUILD_TYPE }} --test-dir ${{ env.BUILD_DIR }} -V -L UNIT
 
       - name: Perform code tracing via ITT collector
         shell: cmd
         run: |
-          set path=%path%;${{ env.OPENVINO_REPO }}\temp\Windows_AMD64\tbb\bin;${{ env.BUILD_DIR }}\bin\${{ env.CMAKE_BUILD_TYPE }}
+          set path=%path%;${{ env.OPENVINO_REPO }}\temp\Windows_AMD64\tbb\bin
 
           python3 ${{ env.OPENVINO_REPO }}\thirdparty\itt_collector\runtool\sea_runtool.py ^
           --bindir ${{ env.OPENVINO_REPO }}\bin\intel64\${{ env.CMAKE_BUILD_TYPE }} ^
@@ -395,7 +395,7 @@ jobs:
       - name: Run with CC-ed runtime
         shell: cmd
         run: |
-          set path=%path%;${{ env.OPENVINO_REPO }}\temp\Windows_AMD64\tbb\bin;${{ env.BUILD_DIR }}\bin\${{ env.CMAKE_BUILD_TYPE }}
+          set path=%path%;${{ env.OPENVINO_REPO }}\temp\Windows_AMD64\tbb\bin
           ${{ env.OPENVINO_REPO }}\bin\intel64\${{ env.CMAKE_BUILD_TYPE }}\benchmark_app.exe -niter 1 -nireq 1 -m ${{ env.MODELS_PATH }}\models\test_model\test_model_fp32.xml -d CPU
 
   CPU_Functional_Tests:

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
@@ -19,6 +19,7 @@ namespace intel_npu {
 
 // clang-format off
 #define symbols_list()                                        \
+    symbol_statement(zeInit)                                  \
     symbol_statement(zeCommandListAppendBarrier)              \
     symbol_statement(zeCommandListAppendEventReset)           \
     symbol_statement(zeCommandListAppendMemoryCopy)           \
@@ -54,7 +55,6 @@ namespace intel_npu {
     symbol_statement(zeFenceDestroy)                          \
     symbol_statement(zeFenceHostSynchronize)                  \
     symbol_statement(zeFenceReset)                            \
-    symbol_statement(zeInit)                                  \
     symbol_statement(zeMemAllocDevice)                        \
     symbol_statement(zeMemAllocHost)                          \
     symbol_statement(zeMemFree)                               \
@@ -80,6 +80,8 @@ public:
 
     static const std::shared_ptr<ZeroApi>& getInstance();
 
+    const uint32_t getVersion();
+
 #define symbol_statement(symbol) decltype(&::symbol) symbol;
     symbols_list();
     weak_symbols_list();
@@ -87,6 +89,8 @@ public:
 
 private:
     std::shared_ptr<void> lib;
+
+    uint32_t version = 0;
 };
 
 #define symbol_statement(symbol)                                                                            \

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -85,7 +85,7 @@ private:
     void initNpuDriver();
 
     // keep zero_api alive until context is destroyed
-    std::shared_ptr<ZeroApi> zero_api;
+    std::shared_ptr<ZeroApi> zero_api = nullptr;
 
     static const ze_driver_uuid_t uuid;
     Logger log;

--- a/src/plugins/intel_npu/src/utils/src/zero/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/utils/src/zero/CMakeLists.txt
@@ -27,6 +27,10 @@ target_include_directories(${TARGET_NAME}
 
 target_link_libraries(${TARGET_NAME} PUBLIC openvino::runtime::dev)
 
+if(WIN32)
+target_link_libraries(${TARGET_NAME} PRIVATE Version.lib)
+endif()
+
 #
 # targets install
 #


### PR DESCRIPTION
### Details:
 - *Call only zeInitDrivers on Windows based on the ze_loader.dll version*

### Tickets:
 - *CVS-174292*
