### PR TITLE
[NPU] Extend functional tests to cover sub-byte element types

### DIFF
--- a/src/plugins/intel_npu/tests/functional/internal/backend/zero_tensor_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/backend/zero_tensor_tests.cpp
@@ -12,9 +12,25 @@
 using namespace ov::test::behavior;
 
 const std::vector<ov::AnyMap> configsInferRequestRunTests = {{}};
+const std::vector<ov::element::Type> defaultTensorDataType = {ov::element::f32};
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
                          ZeroTensorTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
-                                            ::testing::ValuesIn(configsInferRequestRunTests)),
+                                            ::testing::ValuesIn(configsInferRequestRunTests),
+                                            ::testing::ValuesIn(defaultTensorDataType)),
                          ZeroTensorTests::getTestCaseName);
+
+const std::vector<ov::element::Type> supportedTensorDataTypes = {
+    ov::element::f32,    ov::element::f16, ov::element::bf16, ov::element::f8e4m3, ov::element::f8e5m2,
+    ov::element::f8e8m0, ov::element::nf4, ov::element::u2,   ov::element::u4,     ov::element::i4,
+    ov::element::u8,     ov::element::i8,  ov::element::u16,  ov::element::i16,    ov::element::u32,
+    ov::element::i32,    ov::element::u64, ov::element::i64,  ov::element::f64,    ov::element::boolean,
+};
+
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
+                         ZeroTensorTestsCheckDataType,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(configsInferRequestRunTests),
+                                            ::testing::ValuesIn(supportedTensorDataTypes)),
+                         ZeroTensorTestsCheckDataType::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/internal/overload/ov_infer_request/io_tensor.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/ov_infer_request/io_tensor.hpp
@@ -226,16 +226,17 @@ TEST_P(OVInferRequestIOTensorTestNPU, InferStaticNetworkSetChangedOutputTensorTh
 
 struct OVInferRequestIOTensorSetPrecisionTestNPU : OVInferRequestIOTensorSetPrecisionTest {
     void SetUp() override {
+        const ov::Shape shape = {1, 2, 32, 32};
         std::tie(element_type, target_device, config) = this->GetParam();
         SKIP_IF_CURRENT_TEST_IS_DISABLED()
         APIBaseTest::SetUp();
-        function = ov::test::utils::make_conv_pool_relu();
+        function = ov::test::utils::make_split_concat(shape, element_type);
         execNet = core->compile_model(function, target_device, config);
         req = execNet.create_infer_request();
     }
 };
 
-TEST_P(OVInferRequestIOTensorSetPrecisionTestNPU, CanSetInBlobWithDifferentPrecision) {
+TEST_P(OVInferRequestIOTensorSetPrecisionTestNPU, CanSetOutBlobWithDifferentPrecision) {
     for (auto&& output : execNet.outputs()) {
         auto output_tensor = utils::create_and_fill_tensor(element_type, output.get_shape());
         if (output.get_element_type() == element_type) {
@@ -246,7 +247,7 @@ TEST_P(OVInferRequestIOTensorSetPrecisionTestNPU, CanSetInBlobWithDifferentPreci
     }
 }
 
-TEST_P(OVInferRequestIOTensorSetPrecisionTestNPU, CanSetOutBlobWithDifferentPrecision) {
+TEST_P(OVInferRequestIOTensorSetPrecisionTestNPU, CanSetInBlobWithDifferentPrecision) {
     for (auto&& input : execNet.inputs()) {
         auto input_tensor = utils::create_and_fill_tensor(element_type, input.get_shape());
         if (input.get_element_type() == element_type) {

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -100,7 +100,7 @@ INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                                             ::testing::ValuesIn(configs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTestNPU>);
 
-INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Mutli_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests,
                          OVInferRequestIOTensorSetPrecisionTestNPU,
                          ::testing::Combine(::testing::ValuesIn(prcs),
                                             ::testing::Values(ov::test::utils::DEVICE_MULTI),

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -196,9 +196,29 @@ Example:
     <skip_config>
         <message>Tests with unsupported precision</message>
         <filters>
-            <filter>.*InferRequestCheckTensorPrecision.*type=boolean.*</filter>
-            <filter>.*InferRequestCheckTensorPrecision.*type=f64.*</filter>
-            <filter>.*InferRequestCheckTensorPrecision.*type=u1\D.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=boolean.*device=MULTI.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=boolean.*device=AUTO.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=boolean.*device=MULTI.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=boolean.*device=AUTO.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- E###### -->
+    <skip_config>
+        <message>Data types not supported by NPU3720 PV Driver.</message>
+        <enable_rules>
+            <device>3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=boolean.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i4.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u4.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i16.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u16.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=bf16.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i64.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u64.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=f64.*</filter>
         </filters>
     </skip_config>
 
@@ -582,9 +602,6 @@ Example:
             <device>3720</device>
         </enable_rules>
         <filters>
-            <filter>.*smoke.*_BehaviorTests/OVInferRequestCheckTensorPrecision.*type=i16.*</filter>
-            <filter>.*smoke.*_BehaviorTests/OVInferRequestCheckTensorPrecision.*type=u16.*</filter>
-            <filter>.*smoke.*_BehaviorTests/OVInferRequestCheckTensorPrecision.*type=u64.*</filter>
             <filter>.*smoke_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.*</filter>
         </filters>
     </skip_config>
@@ -782,12 +799,27 @@ Example:
 
     <!-- E#170977 -->
     <skip_config>
-        <message>Skip tests with u2 precision not supported on NPU3720.</message>
+        <message>Data type u1/u2 not supported by NPU3720.</message>
         <enable_rules>
             <device>3720</device>
         </enable_rules>
         <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u1\D.*</filter>
             <filter>.*InferRequestCheckTensorPrecision.*type=u2.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u1\D.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u2.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- E###### -->
+    <skip_config>
+        <message>Data type u1 not supported by NPU4000.</message>
+        <enable_rules>
+            <device>4000</device>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u1\D.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u1\D.*</filter>
         </filters>
     </skip_config>
 


### PR DESCRIPTION
### Details:
 - *Extend ZeroTensorTests. Add new test `CopyZeroTensorAndCheckTensorDataType` to check all supported tensor data types.*
 - *Update func tests `OVInferRequestIOTensorSetPrecisionTestNPU`. Use model with same type as precision tested, so that `set_tensor` is called for all tested precisions.*
 - *Update skip config with supported precision tests.*

### Tickets:
 - *CVS-174265*
