### PR TITLE
Changes made to correctly handle non ASCII characters and avoid crashes

### DIFF
--- a/src/inference/src/cpp/core.cpp
+++ b/src/inference/src/cpp/core.cpp
@@ -28,7 +28,15 @@ std::string find_plugins_xml(const std::string& xml_file) {
             return xml_file_name;
         }
     }
-    const auto ov_library_path = ov::util::get_ov_lib_path();
+
+    // get_ov_lib_path() returns UTF-8 encoded string when UNICODE support is enabled
+    const auto ov_library_path_str = ov::util::get_ov_lib_path();
+
+#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
+    ov::util::Path ov_library_path = std::filesystem::u8path(ov_library_path_str);
+#else
+    ov::util::Path ov_library_path = ov::util::Path(ov_library_path_str);
+#endif
 
     // plugins xml can be found in either:
     // 1. openvino-X.Y.Z relative to libopenvino.so folder
@@ -79,6 +87,7 @@ Core::Core(const std::string& xml_config_file) {
 
 std::map<std::string, Version> Core::get_versions(const std::string& device_name) const {
     OV_CORE_CALL_STATEMENT({ return _impl->get_versions(device_name); })}
+
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 std::shared_ptr<ov::Model> Core::read_model(const std::wstring& model_path,
                                             const std::wstring& bin_path,


### PR DESCRIPTION
As I was studying the issue #32110 

This is my observation
- In OpenVINO, the function get_ov_lib_path() returns a std::string.
- When OPENVINO_ENABLE_UNICODE_PATH_SUPPORT is enabled on Windows, this string is encoded in UTF-8.
- Later, this string was passed into path_join, which internally uses std::filesystem::path.
- Problem: On Windows, std::filesystem::path interprets a std::string as locale encoding, not UTF-8.
This mismatch caused crashes if the path contained non-ASCII characters (e.g., Korean 새 폴더3).

And the changes I proposed

- Identified the unsafe usage
Originally, the code constructed the path like this:
``` 
const auto ov_library_path = ov::util::get_ov_lib_path();
auto xmlConfigFileDefault = ov::util::path_join({ov_library_path, sub_folder, xml_file_name}).string();
```

- Introduced explicit conversion to std::filesystem::path

```
const auto ov_library_path_str = ov::util::get_ov_lib_path();

#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
    ov::util::Path ov_library_path = std::filesystem::u8path(ov_library_path_str);
#else
    ov::util::Path ov_library_path = std::filesystem::path(ov_library_path_str);
#endif
```

With Unicode support → u8path correctly interprets the UTF-8 string.
Without Unicode support → fallback to locale-based constructor (keeps legacy behavior).


- Passed the path object instead of raw string
```
auto xmlConfigFileDefault = ov::util::path_join({ov_library_path, sub_folder, xml_file_name}).string();
```




PLEASE REVIEW THIS PR AND DO LET ME KNOW IF THERE ARE ANY CHANGES REQUIRED 

THANKS





