### PR TITLE
NPUW: Introduce attention hints, allow different kvcache layouts

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw.hpp
@@ -244,14 +244,13 @@ struct ATTN_HINT_BASE : OptionBase<ATTN_HINT_BASE, ::intel_npu::npuw::llm::Atten
     }
 };
 
-struct NPUW_LLM_GENERATE_ATTENTION_HINT final: ATTN_HINT_BASE {
+struct NPUW_LLM_GENERATE_ATTENTION_HINT final : ATTN_HINT_BASE {
     static std::string_view key() {
         return ov::intel_npu::npuw::llm::generate_attn_hint.name();
     }
 };
 
-
-struct NPUW_LLM_PREFILL_ATTENTION_HINT final: ATTN_HINT_BASE {
+struct NPUW_LLM_PREFILL_ATTENTION_HINT final : ATTN_HINT_BASE {
     static std::string_view key() {
         return ov::intel_npu::npuw::llm::prefill_attn_hint.name();
     }

--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw.hpp
@@ -156,6 +156,7 @@ namespace npuw {
 namespace llm {
 enum class PrefillHint { DYNAMIC, STATIC };
 enum class GenerateHint { FAST_COMPILE, BEST_PERF };
+enum class AttentionHint { DYNAMIC, STATIC };
 }  // namespace llm
 }  // namespace npuw
 
@@ -200,6 +201,59 @@ struct NPUW_LLM_PREFILL_HINT final : OptionBase<NPUW_LLM_PREFILL_HINT, ::intel_n
 
     static bool isPublic() {
         return false;
+    }
+};
+
+struct ATTN_HINT_BASE : OptionBase<ATTN_HINT_BASE, ::intel_npu::npuw::llm::AttentionHint> {
+    static constexpr std::string_view getTypeName() {
+        return "::intel_npu::npuw::llm::AttentionHint";
+    }
+
+    static ::intel_npu::npuw::llm::AttentionHint defaultValue() {
+        return ::intel_npu::npuw::llm::AttentionHint::STATIC;
+    }
+
+    static ::intel_npu::npuw::llm::AttentionHint parse(std::string_view val) {
+        if (val == "DYNAMIC") {
+            return ::intel_npu::npuw::llm::AttentionHint::DYNAMIC;
+        } else if (val == "STATIC") {
+            return ::intel_npu::npuw::llm::AttentionHint::STATIC;
+        }
+        OPENVINO_THROW("Unsupported attention hint provided: ", val);
+        return {};
+    }
+
+    static std::string toString(const ::intel_npu::npuw::llm::AttentionHint& val) {
+        switch (val) {
+        case ::intel_npu::npuw::llm::AttentionHint::DYNAMIC:
+            return "DYNAMIC";
+        case ::intel_npu::npuw::llm::AttentionHint::STATIC:
+            return "STATIC";
+        default:
+            OPENVINO_THROW("Can't convert provided attention hint : ", int(val), " to string.");
+        }
+        return {};
+    }
+
+    static OptionMode mode() {
+        return OptionMode::RunTime;
+    }
+
+    static bool isPublic() {
+        return false;
+    }
+};
+
+struct NPUW_LLM_GENERATE_ATTENTION_HINT final: ATTN_HINT_BASE {
+    static std::string_view key() {
+        return ov::intel_npu::npuw::llm::generate_attn_hint.name();
+    }
+};
+
+
+struct NPUW_LLM_PREFILL_ATTENTION_HINT final: ATTN_HINT_BASE {
+    static std::string_view key() {
+        return ov::intel_npu::npuw::llm::prefill_attn_hint.name();
     }
 };
 

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
@@ -508,6 +508,15 @@ static constexpr ov::Property<ov::AnyMap> additional_prefill_config{"++NPUW_LLM_
 /**
  * @brief
  * Type: std::string.
+ * Hint for the attention handling in prefill stage. NPUW will use optimal configuration based on the passed preference via hint.
+ * Possible values: "DYNAMIC", "STATIC".
+ * Default value: "STATIC".
+ */
+static constexpr ov::Property<std::string> prefill_attn_hint{"NPUW_LLM_PREFILL_ATTENTION_HINT"};
+
+/**
+ * @brief
+ * Type: std::string.
  * Hint for generation stage. NPUW will use optimal configuration based on the passed preference via hint.
  * Passing this hint with "NPUW_LLM_GENERATE_CONFIG" will generate a error.
  * Possible values: "FAST_COMPILE", "BEST_PERF".
@@ -535,6 +544,15 @@ static constexpr ov::Property<ov::AnyMap> generate_config{"NPUW_LLM_GENERATE_CON
  * NOTE: !! Write-only !!
  */
 static constexpr ov::Property<ov::AnyMap> additional_generate_config{"++NPUW_LLM_GENERATE_CONFIG"};
+
+/**
+ * @brief
+ * Type: std::string.
+ * Hint for the attention handling. NPUW will use optimal configuration based on the passed preference via hint.
+ * Possible values: "DYNAMIC", "STATIC".
+ * Default value: "STATIC".
+ */
+static constexpr ov::Property<std::string> generate_attn_hint{"NPUW_LLM_GENERATE_ATTENTION_HINT"};
 
 /**
  * @brief

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
@@ -508,9 +508,8 @@ static constexpr ov::Property<ov::AnyMap> additional_prefill_config{"++NPUW_LLM_
 /**
  * @brief
  * Type: std::string.
- * Hint for the attention handling in prefill stage. NPUW will use optimal configuration based on the passed preference via hint.
- * Possible values: "DYNAMIC", "STATIC".
- * Default value: "STATIC".
+ * Hint for the attention handling in prefill stage. NPUW will use optimal configuration based on the passed preference
+ * via hint. Possible values: "DYNAMIC", "STATIC". Default value: "STATIC".
  */
 static constexpr ov::Property<std::string> prefill_attn_hint{"NPUW_LLM_PREFILL_ATTENTION_HINT"};
 

--- a/src/plugins/intel_npu/src/al/src/config/npuw.cpp
+++ b/src/plugins/intel_npu/src/al/src/config/npuw.cpp
@@ -69,6 +69,8 @@ void intel_npu::registerNPUWLLMOptions(OptionsDesc& desc) {
     desc.add<NPUW_LLM_MAX_GENERATION_TOKEN_LEN>();
     desc.add<NPUW_LLM_PREFILL_HINT>();
     desc.add<NPUW_LLM_GENERATE_HINT>();
+    desc.add<NPUW_LLM_PREFILL_ATTENTION_HINT>();
+    desc.add<NPUW_LLM_GENERATE_ATTENTION_HINT>();
     desc.add<NPUW_LLM_SHARED_HEAD>();
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -983,10 +983,10 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     // Handle attention hints. FIXME: Maybe it makes sense to make those
     // mutually exclusive with the precise configuration sections as well
     const ov::AnyMap dyn_attn_opts = {
-        { "NPUW_ONLINE_PIPELINE", "REP" },
-        { "NPUW_ONLINE_ISOLATE", "ATTN" },
-        { "NPUW_ONLINE_KEEP_BLOCK_SIZE", "4" },
-        { "NPUW_UNFOLD_IREQS", "NO" },
+        {"NPUW_ONLINE_PIPELINE", "REP"},
+        {"NPUW_ONLINE_ISOLATE", "ATTN"},
+        {"NPUW_ONLINE_KEEP_BLOCK_SIZE", "4"},
+        {"NPUW_UNFOLD_IREQS", "NO"},
     };
     if (prefill_attn_dyn) {
         merge_config_with(prefill_config, dyn_attn_opts);
@@ -1133,7 +1133,7 @@ void ov::npuw::LLMCompiledModel::serialize(std::ostream& stream, const ov::npuw:
         write(model_stream, m_kvcache_desc.dim);
         write(model_stream, m_kvcache_desc.max_generation_token_len);
         write(model_stream, m_kvcache_desc.v_tensors_transposed_pre);
-        write(model_stream, m_kvcache_desc.v_tensors_transposed_gen); // FIXME: bump required
+        write(model_stream, m_kvcache_desc.v_tensors_transposed_gen);  // FIXME: bump required
         write(model_stream, m_prefill_chunk_size);
         write(model_stream, m_use_chunk_prefill);
         write(model_stream, m_max_lora_rank);
@@ -1343,7 +1343,7 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
         read(model_stream, compiled->m_kvcache_desc.dim);
         read(model_stream, compiled->m_kvcache_desc.max_generation_token_len);
         read(model_stream, compiled->m_kvcache_desc.v_tensors_transposed_pre);
-        read(model_stream, compiled->m_kvcache_desc.v_tensors_transposed_gen); // FIXME: bump required!
+        read(model_stream, compiled->m_kvcache_desc.v_tensors_transposed_gen);  // FIXME: bump required!
         read(model_stream, compiled->m_prefill_chunk_size);
         read(model_stream, compiled->m_use_chunk_prefill);
         read(model_stream, compiled->m_max_lora_rank);

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -25,7 +25,8 @@ public:
         uint32_t num_stored_tokens = 0u;
         uint32_t dim = 0u;
         uint32_t max_generation_token_len = 0u;
-        bool v_tensors_transposed = false;
+        bool v_tensors_transposed_pre = false; // prefill
+        bool v_tensors_transposed_gen = false; // generate
     };
 
     LLMCompiledModel(const std::shared_ptr<ov::Model>& model,

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -25,8 +25,8 @@ public:
         uint32_t num_stored_tokens = 0u;
         uint32_t dim = 0u;
         uint32_t max_generation_token_len = 0u;
-        bool v_tensors_transposed_pre = false; // prefill
-        bool v_tensors_transposed_gen = false; // generate
+        bool v_tensors_transposed_pre = false;  // prefill
+        bool v_tensors_transposed_gen = false;  // generate
     };
 
     LLMCompiledModel(const std::shared_ptr<ov::Model>& model,

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -8,8 +8,8 @@
 
 #include "llm_compiled_model.hpp"
 #include "logging.hpp"
-#include "openvino/runtime/iasync_infer_request.hpp"
 #include "openvino/core/parallel.hpp"
+#include "openvino/runtime/iasync_infer_request.hpp"
 #include "util_xarch.hpp"
 
 namespace {
@@ -108,7 +108,10 @@ void copy_columns_by_row_chunks(ov::SoPtr<ov::ITensor> src, ov::SoPtr<ov::ITenso
     }
 }
 
-void copy_tensor_by_dim(ov::SoPtr<ov::ITensor> src_tensor, ov::SoPtr<ov::ITensor> dst_tensor, uint32_t kv_dim_src, uint32_t kv_dim_dst) {
+void copy_tensor_by_dim(ov::SoPtr<ov::ITensor> src_tensor,
+                        ov::SoPtr<ov::ITensor> dst_tensor,
+                        uint32_t kv_dim_src,
+                        uint32_t kv_dim_dst) {
     if (kv_dim_src != kv_dim_dst) {
         // new case - do a generic copy for now (in fact it is a permute)
         // Example:
@@ -572,7 +575,8 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
                                                        kvcache_desc.max_prompt_size - kvcache_desc.num_stored_tokens,
                                                        kvcache_desc.max_prompt_size);
 
-            auto kvcache_in_slice = make_tensor_slice(kvcache_in_tensor, gen_kv_dim, 0u, kvcache_desc.num_stored_tokens);
+            auto kvcache_in_slice =
+                make_tensor_slice(kvcache_in_tensor, gen_kv_dim, 0u, kvcache_desc.num_stored_tokens);
 
             copy_tensor_by_dim(prefill_out_slice, kvcache_in_slice, pre_kv_dim, gen_kv_dim);
         }
@@ -601,9 +605,7 @@ void ov::npuw::LLMInferRequest::update_kvcache_for(
             continue;
         }
         auto dst_tensor = request->get_tensor(in_ports.at(input_name));
-        const auto& kv_dim = (output_name.find("value") != std::string::npos && v_transposed)
-                                 ? 3u
-                                 : kvcache_desc.dim;
+        const auto& kv_dim = (output_name.find("value") != std::string::npos && v_transposed) ? 3u : kvcache_desc.dim;
         auto dst_slice = make_tensor_slice(dst_tensor,
                                            kv_dim,
                                            kvcache_desc.num_stored_tokens - num_tokens,
@@ -877,7 +879,11 @@ void ov::npuw::LLMInferRequest::infer_generate(ov::SoPtr<ov::ITensor> input_ids,
         LOG_DEBUG("Calling inference for LM head model asynchronously");
         m_lm_head_request->start_async();
         if (kvcache_desc.num_stored_tokens < kvcache_desc.total_size) {
-            update_kvcache_for(m_kvcache_request, m_kvcache_in_ports, m_kvcache_out_ports, input_tokens_len, kvcache_desc.v_tensors_transposed_gen);
+            update_kvcache_for(m_kvcache_request,
+                               m_kvcache_in_ports,
+                               m_kvcache_out_ports,
+                               input_tokens_len,
+                               kvcache_desc.v_tensors_transposed_gen);
         }
         m_lm_head_request->wait();
         LOG_DEBUG("Calling inference for LM head model -- done.");
@@ -885,7 +891,11 @@ void ov::npuw::LLMInferRequest::infer_generate(ov::SoPtr<ov::ITensor> input_ids,
         m_logits = m_lm_head_request->get_tensor(m_lm_head_logits_port);
     } else {
         if (kvcache_desc.num_stored_tokens < kvcache_desc.total_size) {
-            update_kvcache_for(m_kvcache_request, m_kvcache_in_ports, m_kvcache_out_ports, input_tokens_len, kvcache_desc.v_tensors_transposed_gen);
+            update_kvcache_for(m_kvcache_request,
+                               m_kvcache_in_ports,
+                               m_kvcache_out_ports,
+                               input_tokens_len,
+                               kvcache_desc.v_tensors_transposed_gen);
         }
 
         m_logits = m_kvcache_request->get_tensor(m_kvcache_out_ports.at(layer_names::logits));

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.hpp
@@ -51,7 +51,8 @@ private:
     void update_kvcache_for(std::shared_ptr<ov::IAsyncInferRequest> request,
                             std::unordered_map<std::string, ov::Output<const ov::Node>> in_ports,
                             std::unordered_map<std::string, ov::Output<const ov::Node>> out_ports,
-                            uint32_t tokens);
+                            uint32_t tokens,
+                            bool v_transposed);
     void trim_kvcache_for_speculative_decoding(ov::SoPtr<ov::ITensor> position_ids);
 
     void infer_chunked_prefill(ov::SoPtr<ov::ITensor> input_ids,

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -827,7 +827,9 @@ ov::Tensor ov::npuw::util::concat(const std::vector<ov::Tensor>& tt, std::size_t
     }
 }
 
-void ov::npuw::util::permute_i4d(const ov::SoPtr<ov::ITensor>& src, ov::SoPtr<ov::ITensor>& dst, const std::array<int, 4> order) {
+void ov::npuw::util::permute_i4d(const ov::SoPtr<ov::ITensor>& src,
+                                 ov::SoPtr<ov::ITensor>& dst,
+                                 const std::array<int, 4> order) {
     const auto& src_shape = src->get_shape();
     const auto& dst_shape = dst->get_shape();
     NPUW_ASSERT(src_shape.size() == 4);
@@ -840,25 +842,28 @@ void ov::npuw::util::permute_i4d(const ov::SoPtr<ov::ITensor>& src, ov::SoPtr<ov
     const auto* src_p = static_cast<uint8_t*>(src->data());
     auto* dst_p = static_cast<uint8_t*>(dst->data());
 
-    for (int i = 0; i < src_shape[0]; i++) {
-        for (int j = 0; j < src_shape[1]; j++) {
-            for (int k = 0; k < src_shape[2]; k++) {
-                for (int l = 0; l < src_shape[3]; l++) {
-                    const int v_src[4] = {i, j, k, l}; // source vector
-                    const auto src_o = v_src[0]*src_s[0] + v_src[1]*src_s[1] + v_src[2]*src_s[2] + v_src[3]*src_s[3];
+    for (std::size_t i = 0; i < src_shape[0]; i++) {
+        for (std::size_t j = 0; j < src_shape[1]; j++) {
+            for (std::size_t k = 0; k < src_shape[2]; k++) {
+                for (std::size_t l = 0; l < src_shape[3]; l++) {
+                    const std::size_t v_src[4] = {i, j, k, l};  // source vector
+                    const auto src_o =
+                        v_src[0] * src_s[0] + v_src[1] * src_s[1] + v_src[2] * src_s[2] + v_src[3] * src_s[3];
 
-                    const int v_dst[4] = { // for order 0,1,3,2:
-                        v_src[order[0]],   // i -> i
-                        v_src[order[1]],   // j -> j
-                        v_src[order[2]],   // k -> l
-                        v_src[order[3]],   // l -> k
+                    const std::size_t v_dst[4] = {
+                        // for order 0,1,3,2:
+                        v_src[order[0]],  // i -> i
+                        v_src[order[1]],  // j -> j
+                        v_src[order[2]],  // k -> l
+                        v_src[order[3]],  // l -> k
                     };
-                    const auto dst_o = v_dst[0]*dst_s[0] + v_dst[1]*dst_s[1] + v_dst[2]*dst_s[2] + v_dst[3]*dst_s[3];
+                    const auto dst_o =
+                        v_dst[0] * dst_s[0] + v_dst[1] * dst_s[1] + v_dst[2] * dst_s[2] + v_dst[3] * dst_s[3];
                     std::copy_n(src_p + src_o, elem_size, dst_p + dst_o);
-                } // l
-            } // k
-        } // j
-    } // i
+                }  // l
+            }  // k
+        }  // j
+    }  // i
 }
 
 namespace {

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -827,6 +827,40 @@ ov::Tensor ov::npuw::util::concat(const std::vector<ov::Tensor>& tt, std::size_t
     }
 }
 
+void ov::npuw::util::permute_i4d(const ov::SoPtr<ov::ITensor>& src, ov::SoPtr<ov::ITensor>& dst, const std::array<int, 4> order) {
+    const auto& src_shape = src->get_shape();
+    const auto& dst_shape = dst->get_shape();
+    NPUW_ASSERT(src_shape.size() == 4);
+    NPUW_ASSERT(dst_shape.size() == 4);
+
+    const auto& src_s = src->get_strides();
+    const auto& dst_s = dst->get_strides();
+    const auto elem_size = src->get_byte_size() / src->get_size();
+
+    const auto* src_p = static_cast<uint8_t*>(src->data());
+    auto* dst_p = static_cast<uint8_t*>(dst->data());
+
+    for (int i = 0; i < src_shape[0]; i++) {
+        for (int j = 0; j < src_shape[1]; j++) {
+            for (int k = 0; k < src_shape[2]; k++) {
+                for (int l = 0; l < src_shape[3]; l++) {
+                    const int v_src[4] = {i, j, k, l}; // source vector
+                    const auto src_o = v_src[0]*src_s[0] + v_src[1]*src_s[1] + v_src[2]*src_s[2] + v_src[3]*src_s[3];
+
+                    const int v_dst[4] = { // for order 0,1,3,2:
+                        v_src[order[0]],   // i -> i
+                        v_src[order[1]],   // j -> j
+                        v_src[order[2]],   // k -> l
+                        v_src[order[3]],   // l -> k
+                    };
+                    const auto dst_o = v_dst[0]*dst_s[0] + v_dst[1]*dst_s[1] + v_dst[2]*dst_s[2] + v_dst[3]*dst_s[3];
+                    std::copy_n(src_p + src_o, elem_size, dst_p + dst_o);
+                } // l
+            } // k
+        } // j
+    } // i
+}
+
 namespace {
 template <typename T>
 ov::npuw::util::range_1d validMaskRange(const T* data, std::size_t len) {

--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -76,6 +76,8 @@ ov::Tensor transpose(const ov::Tensor& t);
 ov::Tensor permute(const ov::Tensor& t, const std::vector<std::size_t>& axes);
 ov::Tensor concat(const std::vector<ov::Tensor>& tt, std::size_t axis);
 
+void permute_i4d(const ov::SoPtr<ov::ITensor>& src, ov::SoPtr<ov::ITensor>& dst, const std::array<int, 4> order);
+
 // Start is inclusive, end is exclusive
 using range_1d = std::pair<std::size_t, std::size_t>;
 range_1d validMaskRange(const ov::SoPtr<ov::ITensor>& t);


### PR DESCRIPTION
### Details:
 - Yet another part of the bigger #32000 
 - Introduces individual `ATTENTION_HINT`s for prefill & generate stages
 - In this PR, all `DYNAMIC` hint does is cancel the SDPA unroll & v-tensor transpose
 - When prefill & generate hints are different, the prefill-to-generate kvcache copy is in fact a permute (a new utility added)

