### PR TITLE
Using HF_HOME instead of HF_HUB_CACHE

### DIFF
--- a/.github/workflows/job_pytorch_models_tests.yml
+++ b/.github/workflows/job_pytorch_models_tests.yml
@@ -52,13 +52,13 @@ jobs:
             .github/actions
           sparse-checkout-cone-mode: false
           submodules: 'false'
-      
+
       - name: Download OpenVINO artifacts (wheels)
         uses: akashchi/download-artifact@d59a9c15fec3fdb7c9adf09464124d00f9c11415
         with:
           name: openvino_wheels
           path: ${{ env.INSTALL_DIR }}
-      
+
       - name: Download OpenVINO artifacts (tests)
         uses: akashchi/download-artifact@d59a9c15fec3fdb7c9adf09464124d00f9c11415
         with:
@@ -72,7 +72,7 @@ jobs:
           path: ${{ env.INSTALL_DIR }}
 
       - name: Setup Variables
-        run: echo "HF_HUB_CACHE=${{ runner.os == 'Linux' && env.HF_HUB_CACHE_LIN || env.HF_HUB_CACHE_WIN }}" >> "$GITHUB_ENV"
+        run: echo "HF_HOME=${{ runner.os == 'Linux' && env.HF_HUB_CACHE_LIN || env.HF_HUB_CACHE_WIN }}" >> "$GITHUB_ENV"
 
       - name: Extract OpenVINO artifacts
         run: pigz -dc openvino_tests.tar.gz | tar -xf - -v


### PR DESCRIPTION
### Details:
Historically we used `HF_HUB_CACHE` environment variable (as described in the [docs](https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfhubcache)), but my tests showed this variable is simply ignored during Paged Attention PyTorch models tests, it works only when the model is downloaded using `huggingface-cli`.