### PR TITLE
[Snippets] Fix port descriptor index in LinearIR::replace_with_node

### DIFF
--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -438,7 +438,7 @@ LinearIR::exprIt LinearIR::replace_with_node(const std::vector<ExpressionPtr>& o
     for (size_t i = 0; i < new_node->get_output_size(); ++i) {
         snippets::lowered::PortDescriptorUtils::set_port_descriptor_ptr(
             new_node->output(i),
-            last_old_expr->get_output_port_descriptor(0)->clone());
+            last_old_expr->get_output_port_descriptor(i)->clone());
     }
 
     const auto new_expr = create_expression(new_node, new_inputs, loop_ids, false);

--- a/src/common/snippets/tests/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/tests/src/lowered/linear_ir.cpp
@@ -19,11 +19,7 @@ namespace ov {
 namespace test {
 namespace snippets {
 
-namespace {
-ov::snippets::VectorDims make_dims(std::initializer_list<size_t> values) {
-    return ov::snippets::VectorDims(values);
-}
-}  // namespace
+using namespace ov::snippets;
 
 TEST(LinearIRReplaceWithNode, PreservesPerOutputDescriptors) {
     const auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 6});
@@ -35,24 +31,21 @@ TEST(LinearIRReplaceWithNode, PreservesPerOutputDescriptors) {
     auto factory = std::make_shared<ov::snippets::IShapeInferSnippetsFactory>();
     ov::snippets::lowered::LinearIR linear_ir(model, factory);
 
-    const auto& split_expr = linear_ir.get_expr_by_node(op);
-    ASSERT_NE(nullptr, split_expr);
+    const auto& online_sm_expr = linear_ir.get_expr_by_node(op);
+    ASSERT_NE(nullptr, online_sm_expr);
 
-    init_expr_descriptors(split_expr);
+    const std::vector<VectorDims> subtensors = {get_default_subtensor(2), VectorDims{1, 3}, VectorDims{1, 6}};
+    const std::vector<VectorDims> layouts = {VectorDims{}, VectorDims{0, 1}, VectorDims{1, 0}};
+    init_expr_descriptors(online_sm_expr, subtensors, layouts);
 
-    split_expr->get_output_port_descriptor(0)->set_subtensor(make_dims({1, 3}));
-    split_expr->get_output_port_descriptor(0)->set_layout(make_dims({0, 1}));
-    split_expr->get_output_port_descriptor(1)->set_subtensor(make_dims({1, 6}));
-    split_expr->get_output_port_descriptor(1)->set_layout(make_dims({1, 0}));
-
-    const auto expected_desc_0 = split_expr->get_output_port_descriptor(0)->clone();
-    const auto expected_desc_1 = split_expr->get_output_port_descriptor(1)->clone();
+    const auto expected_desc_0 = online_sm_expr->get_output_port_descriptor(0)->clone();
+    const auto expected_desc_1 = online_sm_expr->get_output_port_descriptor(1)->clone();
 
     ASSERT_NE(expected_desc_0->get_subtensor(), expected_desc_1->get_subtensor());
     ASSERT_NE(expected_desc_0->get_layout(), expected_desc_1->get_layout());
 
     const auto new_node = std::make_shared<ov::snippets::op::OnlineSoftmax>(param);
-    linear_ir.replace_with_node({split_expr}, new_node);
+    linear_ir.replace_with_node({online_sm_expr}, new_node);
 
     const auto& new_expr = linear_ir.get_expr_by_node(new_node);
     ASSERT_NE(nullptr, new_expr);

--- a/src/common/snippets/tests/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/tests/src/lowered/linear_ir.cpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "openvino/op/result.hpp"
+#include "snippets/op/scalar.hpp"
+#include "snippets/op/reshape.hpp"
+#include "snippets/op/online_softmax.hpp"
+#include "openvino/op/parameter.hpp"
+
+#include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/port_descriptor.hpp"
+
+#include "lir_test_utils.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+namespace {
+ov::snippets::VectorDims make_dims(std::initializer_list<size_t> values) {
+    return ov::snippets::VectorDims(values);
+}
+}  // namespace
+
+TEST(LinearIRReplaceWithNode, PreservesPerOutputDescriptors) {
+    const auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 6});
+    const auto op = std::make_shared<ov::snippets::op::OnlineSoftmax>(param);
+    const auto result_0 = std::make_shared<ov::op::v0::Result>(op->output(0));
+    const auto result_1 = std::make_shared<ov::op::v0::Result>(op->output(1));
+    const auto model = std::make_shared<ov::Model>(ov::OutputVector{result_0, result_1}, ov::ParameterVector{param});
+
+    auto factory = std::make_shared<ov::snippets::IShapeInferSnippetsFactory>();
+    ov::snippets::lowered::LinearIR linear_ir(model, factory);
+
+    const auto& split_expr = linear_ir.get_expr_by_node(op);
+    ASSERT_NE(nullptr, split_expr);
+
+    init_expr_descriptors(split_expr);
+
+    split_expr->get_output_port_descriptor(0)->set_subtensor(make_dims({1, 3}));
+    split_expr->get_output_port_descriptor(0)->set_layout(make_dims({0, 1}));
+    split_expr->get_output_port_descriptor(1)->set_subtensor(make_dims({1, 6}));
+    split_expr->get_output_port_descriptor(1)->set_layout(make_dims({1, 0}));
+
+    const auto expected_desc_0 = split_expr->get_output_port_descriptor(0)->clone();
+    const auto expected_desc_1 = split_expr->get_output_port_descriptor(1)->clone();
+
+    ASSERT_NE(expected_desc_0->get_subtensor(), expected_desc_1->get_subtensor());
+    ASSERT_NE(expected_desc_0->get_layout(), expected_desc_1->get_layout());
+
+    const auto new_node = std::make_shared<ov::snippets::op::OnlineSoftmax>(param);
+    linear_ir.replace_with_node({split_expr}, new_node);
+
+    const auto& new_expr = linear_ir.get_expr_by_node(new_node);
+    ASSERT_NE(nullptr, new_expr);
+
+    const auto& new_desc_0 = new_expr->get_output_port_descriptor(0);
+    const auto& new_desc_1 = new_expr->get_output_port_descriptor(1);
+
+    EXPECT_EQ(new_desc_0->get_subtensor(), expected_desc_0->get_subtensor());
+    EXPECT_EQ(new_desc_1->get_subtensor(), expected_desc_1->get_subtensor());
+    EXPECT_EQ(new_desc_0->get_layout(), expected_desc_0->get_layout());
+    EXPECT_EQ(new_desc_1->get_layout(), expected_desc_1->get_layout());
+}
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
Ensure LinearIR::replace_with_node clones correct port descriptor instead of reusing the descriptor under the index 0 unconditionally 

### Tickets:
 - N/A
