### PR TITLE
[Snippets] InsertSpecificIterations lowered pass fix

### DIFF
--- a/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
@@ -93,18 +93,18 @@ private:
     /**
      * @brief Initializes decomposed loop: update ptr arithmetic, work_amout, increment, ID
      * @param linear_ir target Linear IR
-     * @param begin iterator of LoopBegin
-     * @param end iterator of LoopEnd
+     * @param decomposed_loop_bounds decomposed loop bounds
      * @param decomposed_loop_info loop info of the corresponding decomposed loop
      * @param loop_id_to_replace ID of the loop which should be replaced by the decomposed one
      * @param decomposed_loop_end LoopEnd of the decomposed loop
+     * @param run_handlers flag to run handlers for the decomposed loop
      */
     static void init_decomposed_loop(LinearIR& linear_ir,
-                                     LinearIR::constExprIt begin,
-                                     LinearIR::constExprIt end,
+                                     const LoopManager::LoopBounds& decomposed_loop_bounds,
                                      const ExpandedLoopInfoPtr& decomposed_loop_info,
                                      size_t loop_id_to_replace,
-                                     const std::shared_ptr<op::LoopEnd>& decomposed_loop_end);
+                                     const std::shared_ptr<op::LoopEnd>& decomposed_loop_end,
+                                     bool run_handlers);
 };
 
 }  // namespace ov::snippets::lowered::pass

--- a/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
@@ -81,31 +81,29 @@ private:
     /**
      * @brief Make a copy of Loop with ID `loop_id` and insert to LinearIR before `insert_pos`
      * @param linear_ir target Linear IR
-     * @param loop_id the target loop ID
+     * @param bounds loop bounds of current loop
      * @param insert_pos insertion position iterator
-     * @param new_entry_ports reference of vector with Loop input ports that will be updated after insertion
-     * @param new_exit_ports reference of vector with Loop output ports that will be updated after insertion
+     * @param expression_map expression map to store pairs [original_expr, new_expr]
      * @return LoopBounds: iterators of new LoopBegin and LoopEnd
      */
     static LoopManager::LoopBounds insert_copy_loop(LinearIR& linear_ir,
-                                                    size_t loop_id,
+                                                    const LoopManager::LoopBounds& bounds,
                                                     const LinearIR::constExprIt& insert_pos,
-                                                    std::vector<LoopPort>& new_entry_ports,
-                                                    std::vector<LoopPort>& new_exit_ports);
+                                                    ExpressionMap& expression_map);
     /**
      * @brief Initializes decomposed loop: update ptr arithmetic, work_amout, increment, ID
      * @param linear_ir target Linear IR
      * @param begin iterator of LoopBegin
      * @param end iterator of LoopEnd
      * @param decomposed_loop_info loop info of the corresponding decomposed loop
-     * @param unified_loop_id ID of the unified loop
+     * @param loop_id_to_replace ID of the loop which should be replaced by the decomposed one
      * @param decomposed_loop_end LoopEnd of the decomposed loop
      */
     static void init_decomposed_loop(LinearIR& linear_ir,
                                      LinearIR::constExprIt begin,
                                      LinearIR::constExprIt end,
                                      const ExpandedLoopInfoPtr& decomposed_loop_info,
-                                     size_t unified_loop_id,
+                                     size_t loop_id_to_replace,
                                      const std::shared_ptr<op::LoopEnd>& decomposed_loop_end);
 };
 

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -33,11 +33,21 @@
 namespace ov::snippets::lowered::pass {
 
 namespace {
-void connect_cloned_body_with_buffers_outside(LinearIR::constExprIt cur_begin,
-                                              LinearIR::constExprIt cur_end,
-                                              LinearIR::constExprIt res_begin,
-                                              LinearIR::constExprIt res_end,
+std::vector<LoopPort> clone_ports(const ExpressionMap& expression_map, const std::vector<LoopPort>& cur_ports) {
+    std::vector<LoopPort> new_ports;
+    new_ports.resize(cur_ports.size());
+    for (size_t i = 0; i < cur_ports.size(); ++i) {
+        const auto& port = cur_ports[i];
+        new_ports[i] = *port.clone_with_new_expr(expression_map.at(port.get_expr_port()->get_expr().get()));
+    }
+    return new_ports;
+}
+
+void connect_cloned_body_with_buffers_outside(const LoopManager::LoopBounds& cur_bounds,
+                                              const LoopManager::LoopBounds& res_bounds,
                                               LinearIR& linear_ir) {
+    const auto& [cur_begin, cur_end] = cur_bounds;
+    const auto& [res_begin, res_end] = res_bounds;
     for (auto result_it = res_begin, original_it = cur_begin; result_it != res_end; ++result_it, ++original_it) {
         const auto& result_expr = *result_it;
         const auto& original_expr = *original_it;
@@ -136,39 +146,15 @@ size_t InsertSpecificIterations::get_decomposed_loop_increment(const UnifiedLoop
 }
 
 LoopManager::LoopBounds InsertSpecificIterations::insert_copy_loop(LinearIR& linear_ir,
-                                                                   const size_t loop_id,
+                                                                   const LoopManager::LoopBounds& bounds,
                                                                    const LinearIR::constExprIt& insert_pos,
-                                                                   std::vector<LoopPort>& new_entry_ports,
-                                                                   std::vector<LoopPort>& new_exit_ports) {
-    const auto& loop_manager = linear_ir.get_loop_manager();
-    const auto [loop_begin_pos, loop_end_pos] = loop_manager->get_loop_bounds(linear_ir, loop_id);
-
-    ExpressionMap expression_map;
+                                                                   ExpressionMap& expression_map) {
+    const auto& [loop_begin_pos, loop_end_pos] = bounds;
     const auto& cloning_config = LinearIRBuilder::Config(false);
     const auto& loop_copy_range =
         LinearIRBuilder(cloning_config).clone_range(loop_begin_pos, std::next(loop_end_pos), expression_map);
     const auto new_loop_begin_pos = linear_ir.insert(insert_pos, loop_copy_range.begin(), loop_copy_range.end());
     const auto new_loop_end_pos = std::prev(insert_pos);
-
-    // Add connections between output of cloned bodies and Buffers from the current LinearIR (Buffers are connections
-    // between Loops)
-    connect_cloned_body_with_buffers_outside(loop_begin_pos,
-                                             loop_end_pos,
-                                             new_loop_begin_pos,
-                                             new_loop_end_pos,
-                                             linear_ir);
-
-    auto clone_ports = [&expression_map](const std::vector<LoopPort>& ports, std::vector<LoopPort>& new_ports) {
-        new_ports.resize(ports.size());
-        for (size_t i = 0; i < ports.size(); ++i) {
-            const auto& port = ports[i];
-            new_ports[i] = *port.clone_with_new_expr(expression_map[port.get_expr_port()->get_expr().get()]);
-        }
-    };
-    const auto original_loop_info = loop_manager->get_loop_info(loop_id);
-    clone_ports(original_loop_info->get_input_ports(), new_entry_ports);
-    clone_ports(original_loop_info->get_output_ports(), new_exit_ports);
-
     return {new_loop_begin_pos, new_loop_end_pos};
 }
 
@@ -176,11 +162,11 @@ void InsertSpecificIterations::init_decomposed_loop(LinearIR& linear_ir,
                                                     LinearIR::constExprIt begin,
                                                     LinearIR::constExprIt end,
                                                     const ExpandedLoopInfoPtr& decomposed_loop_info,
-                                                    size_t unified_loop_id,
+                                                    size_t loop_id_to_replace,
                                                     const std::shared_ptr<op::LoopEnd>& decomposed_loop_end) {
     const auto& loop_manager = linear_ir.get_loop_manager();
     const auto new_id =
-        loop_manager->replace_with_new_loop(linear_ir, begin, std::next(end), decomposed_loop_info, unified_loop_id);
+        loop_manager->replace_with_new_loop(linear_ir, begin, std::next(end), decomposed_loop_info, loop_id_to_replace);
     decomposed_loop_end->set_id(new_id);
     decomposed_loop_end->set_work_amount(decomposed_loop_info->get_work_amount());
     decomposed_loop_end->set_increment(decomposed_loop_info->get_increment());
@@ -195,9 +181,9 @@ bool InsertSpecificIterations::decompose(LinearIR& linear_ir,
                                          LinearIR::constExprIt begin,
                                          LinearIR::constExprIt end,
                                          const std::shared_ptr<op::LoopEnd>& loop_end) {
-    const auto loop_id = loop_end->get_id();
+    const auto unified_loop_id = loop_end->get_id();
     const auto& loop_manager = linear_ir.get_loop_manager();
-    const auto& unified_loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
+    const auto& unified_loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(unified_loop_id);
 
     auto remaining_work_amount = unified_loop_info->get_work_amount();
     const auto is_wa_dynamic = utils::is_dynamic_value(remaining_work_amount);
@@ -219,7 +205,7 @@ bool InsertSpecificIterations::decompose(LinearIR& linear_ir,
             }
 
             auto decomposed_loop_end = loop_end;
-            auto decomposed_loop_begin_it = begin, decomposed_loop_end_it = end;
+            LoopManager::LoopBounds decomposed_loop_bounds {begin, end};
             auto decomposed_loop_entry_ports = unified_loop_info->get_input_ports();
             auto decomposed_loop_exit_ports = unified_loop_info->get_output_ports();
             auto decomposed_ptr_increments = unified_loop_info->get_ptr_increments();
@@ -228,13 +214,19 @@ bool InsertSpecificIterations::decompose(LinearIR& linear_ir,
             // Need to copy body if there are other specific sup-loops
             // Otherwise we should update the current body
             if (remaining_work_amount > 0) {
-                std::tie(decomposed_loop_begin_it, decomposed_loop_end_it) =
-                    insert_copy_loop(linear_ir,
-                                     loop_id,
-                                     begin,
-                                     decomposed_loop_entry_ports,
-                                     decomposed_loop_exit_ports);
-                decomposed_loop_end = ov::as_type_ptr<op::LoopEnd>(decomposed_loop_end_it->get()->get_node());
+                const auto cur_bounds = loop_manager->get_loop_bounds(linear_ir, unified_loop_id);
+                ExpressionMap expression_map;
+                decomposed_loop_bounds = insert_copy_loop(linear_ir, cur_bounds, begin, expression_map);
+
+                // Add connections between output of cloned bodies and Buffers from the current LinearIR
+                // (Buffers are connections between Loops)
+                connect_cloned_body_with_buffers_outside(cur_bounds, decomposed_loop_bounds, linear_ir);
+
+                const auto original_loop_info = loop_manager->get_loop_info(unified_loop_id);
+                decomposed_loop_entry_ports = clone_ports(expression_map, original_loop_info->get_input_ports());
+                decomposed_loop_exit_ports = clone_ports(expression_map, original_loop_info->get_output_ports());
+
+                decomposed_loop_end = ov::as_type_ptr<op::LoopEnd>(decomposed_loop_bounds.second->get()->get_node());
                 OPENVINO_ASSERT(decomposed_loop_end, "Cloned Loop does not contain LoopEnd op at the expected place.");
 
                 // Only latest loop iterations must have summarized finalization offsets!
@@ -258,10 +250,10 @@ bool InsertSpecificIterations::decompose(LinearIR& linear_ir,
                                                                                  iter_type,
                                                                                  unified_loop_info);
             init_decomposed_loop(linear_ir,
-                                 decomposed_loop_begin_it,
-                                 decomposed_loop_end_it,
+                                 decomposed_loop_bounds.first,
+                                 decomposed_loop_bounds.second,
                                  decomposed_loop_info,
-                                 loop_id,
+                                 unified_loop_id,
                                  decomposed_loop_end);
 
             decomposed = true;

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -268,11 +268,12 @@ bool InsertSpecificIterations::decompose(LinearIR& linear_ir,
                         continue;
                     }
                     const auto loop_begin = internal_loop_end->get_loop_begin();
-                    auto begin_it = linear_ir.find_after(std::next(decomposed_loop_bounds.first), linear_ir.get_expr_by_node(loop_begin));
+                    auto begin_it = linear_ir.find_after(std::next(decomposed_loop_bounds.first),
+                                                         linear_ir.get_expr_by_node(loop_begin));
                     OPENVINO_ASSERT(begin_it != linear_ir.cend(),
                                     "Cannot find LoopBegin for LoopEnd with id ",
                                     internal_loop_end->get_id());
-                    LoopManager::LoopBounds internal_loop_bounds {begin_it, it};
+                    LoopManager::LoopBounds internal_loop_bounds{begin_it, it};
                     const auto internal_loop_id = internal_loop_end->get_id();
                     // Note: internal loops must be already decomposed to ExpandedLoops
                     const auto internal_loop_info = loop_manager->get_loop_info<ExpandedLoopInfo>(internal_loop_id);

--- a/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
@@ -99,24 +99,31 @@ void ValidateExpandedLoops::validate_loop_information(const LinearIR& linear_ir)
     for (const auto& p : initializated_info_map) {
         const auto loop_info = p.first;
         const auto total_info = p.second;
-        INFORMATIVE_ASSERT(
-            total_info.work_amount == loop_info->get_work_amount(),
-            "total work amount of expanded loops is not equal to work amount of undefined loop with ID: " +
-                std::to_string(total_info.id));
-        INFORMATIVE_ASSERT(
-            total_info.finalization_offsets == loop_info->get_finalization_offsets(),
-            "total finalization offsets are not equal to finalization offsets of undefined loop with ID: " +
-                std::to_string(total_info.id));
+        INFORMATIVE_ASSERT(total_info.work_amount == loop_info->get_work_amount(),
+                           "total work amount of expanded loops (",
+                           total_info.work_amount,
+                           ") is not equal to work amount of unified loop (",
+                           loop_info->get_work_amount(),
+                           ") with ID: ",
+                           total_info.id);
+        INFORMATIVE_ASSERT(total_info.finalization_offsets == loop_info->get_finalization_offsets(),
+                           "total finalization offsets of expanded loops (",
+                           ::ov::util::to_string(total_info.finalization_offsets),
+                           ") are not equal to finalization offsets of unified loop (",
+                           ::ov::util::to_string(loop_info->get_finalization_offsets()),
+                           ") with ID: ",
+                           total_info.id);
     }
 }
 
 void ValidateExpandedLoops::validate_loop_expressions(const LinearIR& linear_ir) {
     const auto& loop_manager = linear_ir.get_loop_manager();
 
-    std::set<size_t> unique_loop_ids;
+    std::unordered_set<size_t> unique_loop_ids;
     for (const auto& expr : linear_ir) {
         if (const auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node())) {
             const auto loop_id = loop_end->get_id();
+            INFORMATIVE_ASSERT(unique_loop_ids.count(loop_id) == 0, "LoopEnd has duplicate loop ID: ", loop_id);
             unique_loop_ids.insert(loop_id);
 
             // At the moment, InnerSpliitedTail LoopEnd is not compatible with ExpandedLoopInfo

--- a/src/common/snippets/tests/src/lir_comparator.cpp
+++ b/src/common/snippets/tests/src/lir_comparator.cpp
@@ -92,7 +92,8 @@ LIRComparator::Result LIRComparator::compare(const LinearIRPtr& linear_ir,
         if (m_nodes_cmp_values != NodesCmpValues::NONE)
             PROPAGATE_ERROR("", Comparator(m_nodes_cmp_values).compare(node.get(), node_ref.get()));
 
-        const std::string err_prefix = "Comparison failed for nodes " + node->get_friendly_name() + ", " + node_ref->get_friendly_name() + ". ";
+        const std::string err_prefix = "Comparison failed for nodes " + node->get_friendly_name() + " (actual), " +
+                                       node_ref->get_friendly_name() + "(reference). ";
         if (should_compare(LIRCmpValues::LOOP_INDICES))
             COMPARE(err_prefix + "Loop indices", expr->get_loop_ids(), expr_ref->get_loop_ids());
 

--- a/src/common/snippets/tests/src/lir_test_utils.cpp
+++ b/src/common/snippets/tests/src/lir_test_utils.cpp
@@ -6,6 +6,7 @@
 
 #include "snippets/lowered/linear_ir_builder.hpp"
 #include "snippets/lowered/pass/split_loops.hpp"
+#include "snippets/op/loop.hpp"
 #include "snippets/utils/utils.hpp"
 
 using namespace ov::snippets::lowered::pass;
@@ -50,6 +51,13 @@ void LoweredPassTestsF::assign_loop_ids(const std::map<ExpressionPtr, std::vecto
             reordered_loop_ids.push_back(loop_ids_mapper.at(original_id));
         }
         expr->set_loop_ids(reordered_loop_ids);
+    }
+    for (const auto& expr : *linear_ir_ref) {
+        if (auto loop_end = ov::as_type_ptr<ov::snippets::op::LoopEnd>(expr->get_node())) {
+            const auto original_id = loop_end->get_id();
+            const auto reordered_id = loop_ids_mapper.at(original_id);
+            loop_end->set_id(reordered_id);
+        }
     }
 }
 

--- a/src/common/snippets/tests/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/insert_specific_iterations.cpp
@@ -1,0 +1,280 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/lowered/pass/insert_specific_iterations.hpp"
+
+#include "lir_test_utils.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "snippets/op/brgemm.hpp"
+#include "snippets/op/loop.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+using namespace ov::snippets::op;
+using namespace ov::snippets::lowered;
+using namespace ov::snippets::lowered::pass;
+
+using PortType = LoopPort::Type;
+using LoopPortDesc = UnifiedLoopInfo::LoopPortDesc;
+
+class InsertSpecificIterationsTest : public LoweredPassTestsF {
+public:
+    InsertSpecificIterationsTest() : LoweredPassTestsF() {
+        comparator.enable(LIRComparator::LIRCmpValues::LOOP_INDICES);
+        comparator.enable(LIRComparator::LIRCmpValues::PORT_DESCRIPTORS);
+        comparator.enable(LIRComparator::LIRCmpValues::PORT_CONNECTORS);
+        comparator.enable(LIRComparator::LIRCmpValues::LOOP_MANAGER);
+    }
+
+    void SetUp() override {
+        pipeline.register_pass<InsertSpecificIterations>();
+    }
+
+    size_t vector_size = 64;
+    ov::element::Type input_precision = ov::element::f32;
+    size_t m_block = 32;
+    size_t n_block = 64;
+};
+
+inline std::pair<LinearIR::constExprIt, std::shared_ptr<LoopEnd>> push_loop_end(const LinearIRPtr& linear_ir,
+                                                                                const ExpressionPtr& loop_begin_expr,
+                                                                                size_t loop_id) {
+    const auto& loop_manager = linear_ir->get_loop_manager();
+    const auto loop_info = loop_manager->get_loop_info(loop_id);
+    auto get_ptr_increments = [&]() {
+        if (auto unified_info = ov::as_type_ptr<UnifiedLoopInfo>(loop_info)) {
+            return std::make_tuple(unified_info->get_ptr_increments(),
+                                   unified_info->get_finalization_offsets(),
+                                   unified_info->get_data_sizes());
+        }
+        if (auto expanded_info = ov::as_type_ptr<ExpandedLoopInfo>(loop_info)) {
+            return std::make_tuple(expanded_info->get_ptr_increments(),
+                                   expanded_info->get_finalization_offsets(),
+                                   expanded_info->get_data_sizes());
+        }
+        OPENVINO_THROW("Unsupported LoopInfo type for getting ptr increments");
+    };
+
+    std::vector<PortConnectorPtr> loop_end_inputs;
+    loop_end_inputs.reserve(loop_info->get_input_count() + loop_info->get_output_count());
+    loop_info->iterate_through_ports([&loop_end_inputs](const LoopPort& port) {
+        loop_end_inputs.push_back(port.get_expr_port()->get_port_connector_ptr());
+    });
+    loop_end_inputs.push_back(loop_begin_expr->get_output_port_connector(0));
+
+    const auto loop_begin = ov::as_type_ptr<LoopBegin>(loop_begin_expr->get_node());
+    OPENVINO_ASSERT(loop_begin, "The expression is not LoopBegin");
+    const auto [ptr_increments, finalization_offsets, data_sizes] = get_ptr_increments();
+    const auto loop_end = std::make_shared<LoopEnd>(loop_begin,
+                                                    loop_info->get_work_amount(),
+                                                    loop_info->get_increment(),
+                                                    loop_info->get_is_incremented(),
+                                                    ptr_increments,
+                                                    finalization_offsets,
+                                                    data_sizes,
+                                                    loop_info->get_input_count(),
+                                                    loop_info->get_output_count(),
+                                                    loop_id,
+                                                    loop_info->is_parallel());
+    auto expr_it = linear_ir->insert_node(loop_end, loop_end_inputs, {}, false, linear_ir->cend());
+    return {expr_it, loop_end};
+}
+
+/*
+ * Expected Control Flow Graph:
+ * LoopBegin (outer_m_loop_main)
+ * |  LoopBegin (inner_n_loop_1_main)
+ * |  |  Brgemm1
+ * |  LoopEnd (inner_n_loop_1_main)
+ * LoopEnd (outer_m_loop_main)
+ * LoopBegin (outer_m_loop_tail)
+ * |  LoopBegin (inner_n_loop_2_main)
+ * |  |  Brgemm2
+ * |  LoopEnd (inner_n_loop_2_main)
+ * LoopEnd (outer_m_loop_tail)
+ */
+TEST_F(InsertSpecificIterationsTest, InnerExpandedLoopsCloning) {
+    const size_t m = 70;
+    const size_t n = 256;
+    const size_t k = 16;
+    const ov::Shape input_shape_0{1, 1, m, k};
+    const ov::Shape input_shape_1{1, 1, k, n};
+    const ov::snippets::VectorDims brgemm_a_subtensor{m_block, ov::snippets::utils::get_full_dim_value()};
+    const ov::snippets::VectorDims brgemm_b_subtensor{ov::snippets::utils::get_full_dim_value(), n_block};
+    const ov::snippets::VectorDims brgemm_c_subtensor{m_block, n_block};
+
+    {
+        auto param0 = linear_ir->push_node<ov::op::v0::Parameter>(input_precision, input_shape_0);
+        auto param1 = linear_ir->push_node<ov::op::v0::Parameter>(input_precision, input_shape_1);
+        auto outer_m_loop_begin = linear_ir->push_node<LoopBegin>(false);
+        auto inner_n_loop_begin = linear_ir->push_node<LoopBegin>(false);
+
+        auto brgemm = linear_ir->push_node<Brgemm>(param0.second, param1.second);
+        init_expr_descriptors(*brgemm.first, {brgemm_a_subtensor, brgemm_b_subtensor, brgemm_c_subtensor});
+
+        const auto& loop_manager = linear_ir->get_loop_manager();
+        const auto inner_n_loop = std::make_shared<UnifiedLoopInfo>(
+            n,
+            n_block,
+            std::vector<LoopPort>{LoopPort::create<PortType::NotProcessed>((*brgemm.first)->get_input_port(0)),
+                                  LoopPort::create<PortType::Incremented>((*brgemm.first)->get_input_port(1), 0)},
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm.first)->get_output_port(0), 0)},
+            std::vector<LoopPortDesc>{LoopPortDesc(0, 0, 4), LoopPortDesc(1, -256, 4)},
+            std::vector<LoopPortDesc>{LoopPortDesc(1, -256, 4)},
+            false);
+        const auto inner_n_loop_id = loop_manager->add_loop_info(inner_n_loop);
+        auto inner_n_loop_end = push_loop_end(linear_ir, *inner_n_loop_begin.first, inner_n_loop_id);
+
+        const auto outer_m_loop = std::make_shared<UnifiedLoopInfo>(
+            m,
+            m_block,
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm.first)->get_input_port(0), 1),
+                                  LoopPort::create<PortType::NotProcessed>((*brgemm.first)->get_input_port(1))},
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm.first)->get_output_port(0), 1)},
+            std::vector<LoopPortDesc>{LoopPortDesc(16, -1120, 4), LoopPortDesc(0, 0, 4)},
+            std::vector<LoopPortDesc>{LoopPortDesc(256, -17920, 4)},
+            false);
+        const auto outer_m_loop_id = loop_manager->add_loop_info(outer_m_loop);
+        auto outer_m_loop_end = push_loop_end(linear_ir, *outer_m_loop_begin.first, outer_m_loop_id);
+        auto result = linear_ir->push_node<ov::op::v0::Result>(brgemm.second);
+
+        (*inner_n_loop_begin.first)->set_loop_ids({outer_m_loop_id});
+        (*brgemm.first)->set_loop_ids({outer_m_loop_id, inner_n_loop_id});
+        (*inner_n_loop_end.first)->set_loop_ids({outer_m_loop_id});
+    }
+
+    {
+        const size_t m_tail_work_amount = m % m_block;
+        const size_t m_main_work_amount = m - m_tail_work_amount;
+        auto param0 = linear_ir_ref->push_node<ov::op::v0::Parameter>(input_precision, input_shape_0);
+        auto param1 = linear_ir_ref->push_node<ov::op::v0::Parameter>(input_precision, input_shape_1);
+        auto outer_m_loop_begin_main = linear_ir_ref->push_node<LoopBegin>(false);
+        auto inner_n_loop_1_begin = linear_ir_ref->push_node<LoopBegin>(false);
+
+        auto brgemm1 = linear_ir_ref->push_node<Brgemm>(param0.second, param1.second);
+        init_expr_descriptors(*brgemm1.first, {brgemm_a_subtensor, brgemm_b_subtensor, brgemm_c_subtensor});
+
+        const std::vector<LoopPort> inner_n_loop_1_inputs{
+            LoopPort::create<PortType::NotProcessed>((*brgemm1.first)->get_input_port(0)),
+            LoopPort::create<PortType::Incremented>((*brgemm1.first)->get_input_port(1), 0)};
+        const std::vector<LoopPort> inner_n_loop_1_outputs{
+            LoopPort::create<PortType::Incremented>((*brgemm1.first)->get_output_port(0), 0)};
+        const IOLoopPortDescs n_loop_descs{{LoopPortDesc(0, 0, 4), LoopPortDesc(1, -256, 4)},
+                                           {LoopPortDesc(1, -256, 4)}};
+
+        // To these unified loops will be connected decomposed loop iterations
+        const auto inner_n_loop_1_unified = std::make_shared<UnifiedLoopInfo>(n,
+                                                                              n_block,
+                                                                              inner_n_loop_1_inputs,
+                                                                              inner_n_loop_1_outputs,
+                                                                              n_loop_descs.first,
+                                                                              n_loop_descs.second,
+                                                                              false);
+        const auto outer_m_loop_unified = std::make_shared<UnifiedLoopInfo>(
+            m,
+            m_block,
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm1.first)->get_input_port(0), 1),
+                                  LoopPort::create<PortType::NotProcessed>((*brgemm1.first)->get_input_port(1))},
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm1.first)->get_output_port(0), 1)},
+            std::vector<LoopPortDesc>{LoopPortDesc(16, -1120, 4), LoopPortDesc(0, 0, 4)},
+            std::vector<LoopPortDesc>{LoopPortDesc(256, -17920, 4)},
+            false);
+
+        const auto& loop_manager = linear_ir_ref->get_loop_manager();
+        const auto inner_n_loop_1_main = std::make_shared<ExpandedLoopInfo>(n,
+                                                                            n_block,
+                                                                            inner_n_loop_1_inputs,
+                                                                            inner_n_loop_1_outputs,
+                                                                            std::vector<int64_t>{0, 1, 1},
+                                                                            std::vector<int64_t>{0, -256, -256},
+                                                                            std::vector<int64_t>{4, 4, 4},
+                                                                            SpecificLoopIterType::MAIN_BODY,
+                                                                            inner_n_loop_1_unified);
+
+        const auto inner_n_loop_1_id = loop_manager->add_loop_info(inner_n_loop_1_main);
+        auto inner_n_loop_1_end = push_loop_end(linear_ir_ref, *inner_n_loop_1_begin.first, inner_n_loop_1_id);
+
+        const auto outer_m_loop_main = std::make_shared<ExpandedLoopInfo>(
+            m_main_work_amount,
+            m_block,
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm1.first)->get_input_port(0), 1),
+                                  LoopPort::create<PortType::NotProcessed>((*brgemm1.first)->get_input_port(1))},
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm1.first)->get_output_port(0), 1)},
+            std::vector<int64_t>{16, 0, 256},
+            std::vector<int64_t>{0, 0, 0},
+            std::vector<int64_t>{4, 4, 4},
+            SpecificLoopIterType::MAIN_BODY,
+            outer_m_loop_unified);
+        const auto outer_m_loop_id_main = loop_manager->add_loop_info(outer_m_loop_main);
+        auto outer_m_loop_end_main = push_loop_end(linear_ir_ref, *outer_m_loop_begin_main.first, outer_m_loop_id_main);
+
+        auto outer_m_loop_begin_tail = linear_ir_ref->push_node<LoopBegin>(false);
+        auto inner_n_loop_2_begin = linear_ir_ref->push_node<LoopBegin>(false);
+
+        auto brgemm2 = linear_ir_ref->push_node<Brgemm>(param0.second, param1.second);
+        init_expr_descriptors(*brgemm2.first, {brgemm_a_subtensor, brgemm_b_subtensor, brgemm_c_subtensor});
+
+        const auto inner_n_loop_2_unified = std::make_shared<UnifiedLoopInfo>(
+            n,
+            n_block,
+            std::vector<LoopPort>{LoopPort::create<PortType::NotProcessed>((*brgemm2.first)->get_input_port(0)),
+                                  LoopPort::create<PortType::Incremented>((*brgemm2.first)->get_input_port(1), 0)},
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm2.first)->get_output_port(0), 0)},
+            n_loop_descs.first,
+            n_loop_descs.second,
+            false);
+
+        const auto inner_n_loop_2_main = std::make_shared<ExpandedLoopInfo>(
+            n,
+            n_block,
+            std::vector<LoopPort>{LoopPort::create<PortType::NotProcessed>((*brgemm2.first)->get_input_port(0)),
+                                  LoopPort::create<PortType::Incremented>((*brgemm2.first)->get_input_port(1), 0)},
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm2.first)->get_output_port(0), 0)},
+            std::vector<int64_t>{0, 1, 1},
+            std::vector<int64_t>{0, -256, -256},
+            std::vector<int64_t>{4, 4, 4},
+            SpecificLoopIterType::MAIN_BODY,
+            inner_n_loop_2_unified);
+
+        const auto inner_n_loop_2_id = loop_manager->add_loop_info(inner_n_loop_2_main);
+        auto inner_n_loop_2_end = push_loop_end(linear_ir_ref, *inner_n_loop_2_begin.first, inner_n_loop_2_id);
+
+        const auto outer_m_loop_tail = std::make_shared<ExpandedLoopInfo>(
+            m_tail_work_amount,
+            m_tail_work_amount,
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm2.first)->get_input_port(0), 1),
+                                  LoopPort::create<PortType::NotProcessed>((*brgemm2.first)->get_input_port(1))},
+            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*brgemm2.first)->get_output_port(0), 1)},
+            std::vector<int64_t>{16, 0, 256},
+            std::vector<int64_t>{-1120, 0, -17920},
+            std::vector<int64_t>{4, 4, 4},
+            SpecificLoopIterType::LAST_ITER,
+            outer_m_loop_unified,
+            true);
+        const auto outer_m_loop_id_tail = loop_manager->add_loop_info(outer_m_loop_tail);
+        auto outer_m_loop_end_tail = push_loop_end(linear_ir_ref, *outer_m_loop_begin_tail.first, outer_m_loop_id_tail);
+
+        auto result = linear_ir_ref->push_node<ov::op::v0::Result>(brgemm2.second);
+
+        const std::map<ExpressionPtr, std::vector<size_t>> expr_to_loop_ids = {
+            {*inner_n_loop_1_begin.first, {outer_m_loop_id_main}},
+            {*brgemm1.first, {outer_m_loop_id_main, inner_n_loop_1_id}},
+            {*inner_n_loop_1_end.first, {outer_m_loop_id_main}},
+            {*inner_n_loop_2_begin.first, {outer_m_loop_id_tail}},
+            {*brgemm2.first, {outer_m_loop_id_tail, inner_n_loop_2_id}},
+            {*inner_n_loop_2_end.first, {outer_m_loop_id_tail}}};
+        const std::map<size_t, size_t> loop_ids_mapper = {{inner_n_loop_1_id, 3},
+                                                          {outer_m_loop_id_main, 4},
+                                                          {inner_n_loop_2_id, 2},
+                                                          {outer_m_loop_id_tail, 5}};
+        assign_loop_ids(expr_to_loop_ids, loop_ids_mapper);
+    }
+}
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/fully_connected.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/fully_connected.cpp
@@ -31,6 +31,10 @@ static inline std::vector<std::vector<element::Type>> precisions(bool only_fp32 
 
 std::vector<std::vector<ov::test::InputShape>> fc_input_shapes{
     {
+        {PartialShape{-1, -1, -1, 16}, {{1, 1, 64, 16}}},
+        {{}, {{16, 256}}}
+    },
+    {
         {PartialShape{-1, -1, -1, 2500}, {{2, 1, 32, 2500}, {1, 3, 80, 2500}}},
         {{}, {{2500, 256}}}
     },


### PR DESCRIPTION
### Details:
 - *`InsertSpecificIterations` is refactored to improve readability (some usings are used)*
 - *`InsertSpecificIterations`: fixed the issue which led to non-unique loop indices existence: previously, when outer loop was cloned, inner expanded loop infos kept same loop id even for the cloned parts. This PR addresses this problem by performing inner loops cloning on the cloned outer loop*
 - *The changes have been covered by new lowered test*

### Tickets:
 - *part of CVS-172631*
