### PR TITLE
[GPU] remove cache encryption restriction with CacheMode

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -184,11 +184,9 @@ void CompiledModel::export_model(std::ostream& model) const {
 
     const ov::EncryptionCallbacks encryption_callbacks = m_config.get_cache_encryption_callbacks();
 
-    // Do not allow encryption for CacheMode::OPTIMIZE_SPEED - the cache size may cause severe memory penalty.
     const ov::CacheMode cache_mode = m_config.get_cache_mode();
-    const bool encryption_enabled = encryption_callbacks.encrypt && cache_mode == ov::CacheMode::OPTIMIZE_SIZE;
     std::unique_ptr<cldnn::BinaryOutputBuffer> ob_ptr =
-        encryption_enabled
+        encryption_callbacks.encrypt
             ? std::make_unique<cldnn::EncryptedBinaryOutputBuffer>(model, encryption_callbacks.encrypt)
             : std::make_unique<cldnn::BinaryOutputBuffer>(model);
     auto& ob = *ob_ptr;

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -399,10 +399,9 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model,
 
     ov::CacheMode cache_mode = config.get_cache_mode();
     ov::EncryptionCallbacks encryption_callbacks = config.get_cache_encryption_callbacks();
-    const bool encryption_enabled = encryption_callbacks.decrypt && cache_mode == ov::CacheMode::OPTIMIZE_SIZE;
 
     std::unique_ptr<cldnn::BinaryInputBuffer> ib_ptr =
-        encryption_enabled ? std::make_unique<cldnn::EncryptedBinaryInputBuffer>(model,
+        encryption_callbacks.decrypt ? std::make_unique<cldnn::EncryptedBinaryInputBuffer>(model,
                                                                                  context_impl->get_engine(),
                                                                                  encryption_callbacks.decrypt)
                            : std::make_unique<cldnn::BinaryInputBuffer>(model, context_impl->get_engine());


### PR DESCRIPTION
### Details:
 - Allow cache encryption with any CacheMode in GPU plugin

### Tickets:
 - [CVS-174532](https://jira.devtools.intel.com/browse/CVS-174532)
