### PR TITLE
[LPT] Fix accessing out-of-range dimension in MultiplyToGroupConvolutionTransformation

### DIFF
--- a/src/common/low_precision_transformations/src/multiply_to_group_convolution.cpp
+++ b/src/common/low_precision_transformations/src/multiply_to_group_convolution.cpp
@@ -165,7 +165,7 @@ bool MultiplyToGroupConvolutionTransformation::canBeTransformed(const std::share
     }
 
     auto inPShape = operation->get_input_partial_shape(0);
-    if (inPShape.rank().is_dynamic() || inPShape[1].is_dynamic()) {
+    if (inPShape.rank().is_dynamic() || inPShape.size() < 2 || inPShape[1].is_dynamic()) {
         return false;
     }
 


### PR DESCRIPTION
### Tickets:
 - *[174562](https://jira.devtools.intel.com/browse/CVS-174562)*
