### PR TITLE
[core] Deprecate redundant f16, bf16 functions

### DIFF
--- a/src/core/include/openvino/core/type/bfloat16.hpp
+++ b/src/core/include/openvino/core/type/bfloat16.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "openvino/core/core_visibility.hpp"
+#include "openvino/core/deprecated.hpp"
 
 #define ROUND_MODE_TO_NEAREST_EVEN
 
@@ -37,8 +38,12 @@ public:
     template <typename I>
     explicit bfloat16(I value) : m_value{bfloat16{static_cast<float>(value)}.m_value} {}
 
+    OPENVINO_DEPRECATED("This type is deprecated and will be removed in 2026.0. Use `std::to_string` instead.")
     std::string to_string() const;
+
+    OPENVINO_DEPRECATED("This type is deprecated and will be removed in 2026.0. Use `sizeof` instead.")
     size_t size() const;
+
     template <typename T>
     bool operator==(const T& other) const;
     template <typename T>

--- a/src/core/include/openvino/core/type/float16.hpp
+++ b/src/core/include/openvino/core/type/float16.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "openvino/core/core_visibility.hpp"
+#include "openvino/core/deprecated.hpp"
 
 #define ROUND_MODE_TO_NEAREST_EVEN
 
@@ -33,8 +34,12 @@ public:
     template <typename I>
     explicit float16(I value) : m_value{float16{static_cast<float>(value)}.m_value} {}
 
+    OPENVINO_DEPRECATED("This type is deprecated and will be removed in 2026.0. Use `std::to_string` instead.")
     std::string to_string() const;
+
+    OPENVINO_DEPRECATED("This type is deprecated and will be removed in 2026.0. Use `sizeof` instead.")
     size_t size() const;
+
     template <typename T>
     bool operator==(const T& other) const;
     template <typename T>

--- a/src/core/tests/bfloat16.cpp
+++ b/src/core/tests/bfloat16.cpp
@@ -13,8 +13,7 @@
 #include "openvino/runtime/aligned_buffer.hpp"
 #include "openvino/util/log.hpp"
 
-using namespace std;
-using namespace ov;
+namespace ov::test {
 
 template <typename T>
 std::string to_hex(T value) {
@@ -125,18 +124,18 @@ TEST(bfloat16, to_float) {
 }
 
 TEST(bfloat16, numeric_limits) {
-    bfloat16 infinity = numeric_limits<bfloat16>::infinity();
-    bfloat16 neg_infinity = -numeric_limits<bfloat16>::infinity();
-    bfloat16 quiet_nan = numeric_limits<bfloat16>::quiet_NaN();
-    bfloat16 signaling_nan = numeric_limits<bfloat16>::signaling_NaN();
+    bfloat16 infinity = std::numeric_limits<bfloat16>::infinity();
+    bfloat16 neg_infinity = -std::numeric_limits<bfloat16>::infinity();
+    bfloat16 quiet_nan = std::numeric_limits<bfloat16>::quiet_NaN();
+    bfloat16 signaling_nan = std::numeric_limits<bfloat16>::signaling_NaN();
 
     // Would be nice if we could have bfloat16 overloads for these, but it would require adding
     // overloads into ::std. So we just cast to float here. We can't rely on an implicit cast
     // because it fails with some versions of AppleClang.
-    EXPECT_TRUE(isinf(static_cast<float>(infinity)));
-    EXPECT_TRUE(isinf(static_cast<float>(neg_infinity)));
-    EXPECT_TRUE(isnan(static_cast<float>(quiet_nan)));
-    EXPECT_TRUE(isnan(static_cast<float>(signaling_nan)));
+    EXPECT_TRUE(std::isinf(static_cast<float>(infinity)));
+    EXPECT_TRUE(std::isinf(static_cast<float>(neg_infinity)));
+    EXPECT_TRUE(std::isnan(static_cast<float>(quiet_nan)));
+    EXPECT_TRUE(std::isnan(static_cast<float>(signaling_nan)));
 }
 
 TEST(benchmark, bfloat16) {
@@ -222,3 +221,14 @@ TEST(bfloat16, operators) {
     ASSERT_TRUE(a * b == d);
     ASSERT_TRUE(a == d / b);
 }
+
+TEST(bfloat16, to_string) {
+    const bfloat16 bf16{1.5f};
+    EXPECT_EQ(std::to_string(bf16), std::to_string(1.5f));
+}
+
+TEST(bfloat16, size) {
+    const bfloat16 bf16{10.12f};
+    EXPECT_EQ(sizeof(bf16), 2);
+}
+}  // namespace ov::test

--- a/src/core/tests/float16.cpp
+++ b/src/core/tests/float16.cpp
@@ -11,8 +11,7 @@
 
 #include "common_test_utils/float_util.hpp"
 
-using namespace std;
-using namespace ov;
+namespace ov::test {
 
 TEST(float16, conversions) {
     float16 f16;
@@ -85,8 +84,8 @@ TEST(float16, values) {
     EXPECT_EQ(static_cast<float16>(1.25 / (128.0 * 65536.0)).to_bits(), float16(0, 0, 2).to_bits());
     EXPECT_EQ(static_cast<float16>(std::numeric_limits<float>::infinity()).to_bits(), float16(0, 0x1F, 0).to_bits());
     EXPECT_EQ(static_cast<float16>(-std::numeric_limits<float>::infinity()).to_bits(), float16(1, 0x1F, 0).to_bits());
-    EXPECT_TRUE(isnan(static_cast<float16>(std::numeric_limits<float>::quiet_NaN())));
-    EXPECT_TRUE(isnan(static_cast<float16>(std::numeric_limits<float>::signaling_NaN())));
+    EXPECT_TRUE(std::isnan(static_cast<float16>(std::numeric_limits<float>::quiet_NaN())));
+    EXPECT_TRUE(std::isnan(static_cast<float16>(std::numeric_limits<float>::signaling_NaN())));
     EXPECT_EQ(static_cast<float16>(2.73786e-05).to_bits(), 459);
     EXPECT_EQ(static_cast<float16>(3.87722e-05).to_bits(), 650);
     EXPECT_EQ(static_cast<float16>(-0.0223043).to_bits(), 42422);
@@ -100,3 +99,14 @@ TEST(float16, values) {
     EXPECT_EQ(static_cast<float16>(65519.0).to_bits(), 0x7bff);
     EXPECT_EQ(static_cast<float16>(65520.0).to_bits(), 0x7c00);
 }
+
+TEST(float16, to_string) {
+    const float16 f16{1.5f};
+    EXPECT_EQ(std::to_string(f16), std::to_string(1.5f));
+}
+
+TEST(float16, size) {
+    const float16 f16{10.12f};
+    EXPECT_EQ(sizeof(f16), 2);
+}
+}  // namespace ov::test


### PR DESCRIPTION
### Details:
 - In classes `ov::float16`, `ov::bfloat16`, deprecate `to_string()` and `size()` member functions, which can be replace by std functions.

### Tickets:
 - CVS-128856
