### PR TITLE
[GPU] Fix eltwise Add fusing with Convolution in case of skip connection 

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -1299,9 +1299,6 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 } while (node_queue.size() > 1);
             } else {
                 merge_allowed = fused_node->get_users().size() == 1;
-                for (auto& parent : fused_node->get_dependencies())
-                    if (parent.first->id() == peer_node->id())
-                        merge_allowed = false;
             }
 
             if (!merge_allowed)


### PR DESCRIPTION
### Details:
- *This PR removes a following check for eltwise add fusion:*
```
for (auto& parent : fused_node->get_dependencies())
    if (parent.first->id() == peer_node->id())
        merge_allowed = false;
```
 - *The removed condition prevented eltwise add being fused in case of a skip connection like on the picture below*
 
<img width="190" height="313" alt="image" src="https://github.com/user-attachments/assets/345e4e2c-bb31-433d-b68f-090db47f39c8" />

- *In this case, the `fused_node` is Conv2 and the `peer_node` is Conv1. As Conv1 is the parent of Conv2, `merge_allowed` flag is set to false and the fusing is aborted.*

 - *After removing the code snippet, Add is properly fused together with Conv2, which can result in a significant performance boost for some models, without loss of conformance.*

### Tickets:
 - CVS-174720
