### PR TITLE
[Py OV] Add np.number support to ops8.constant type hints

### DIFF
--- a/src/bindings/python/src/openvino/opset1/ops.py
+++ b/src/bindings/python/src/openvino/opset1/ops.py
@@ -333,7 +333,7 @@ def concat(nodes: list[NodeInput], axis: int, name: Optional[str] = None) -> Nod
 
 @nameable_op
 def constant(
-    value: NumericData,
+    value: Union[NumericData, np.number, bool, np.bool_, list],
     dtype: Union[NumericType, Type] = None,
     name: Optional[str] = None,
 ) -> Constant:

--- a/src/bindings/python/src/openvino/opset10/ops.py
+++ b/src/bindings/python/src/openvino/opset10/ops.py
@@ -13,7 +13,6 @@ from openvino.utils.types import (
     NodeInput,
     as_nodes,
     as_node,
-    make_constant_node,
 )
 
 _get_node_factory_opset4 = partial(_get_node_factory, "opset4")

--- a/src/bindings/python/src/openvino/opset2/ops.py
+++ b/src/bindings/python/src/openvino/opset2/ops.py
@@ -30,7 +30,6 @@ from openvino.utils.types import (
     get_dtype,
     get_element_type,
     get_element_type_str,
-    make_constant_node,
 )
 
 _get_node_factory_opset2 = partial(_get_node_factory, "opset2")

--- a/src/bindings/python/src/openvino/opset3/ops.py
+++ b/src/bindings/python/src/openvino/opset3/ops.py
@@ -20,7 +20,6 @@ from openvino.utils.input_validation import (
 from openvino.utils.node_factory import NodeFactory, _get_node_factory
 from openvino.utils.types import (
     NodeInput,
-    NumericData,
     NumericType,
     ScalarData,
     TensorShape,

--- a/src/bindings/python/src/openvino/opset4/ops.py
+++ b/src/bindings/python/src/openvino/opset4/ops.py
@@ -20,7 +20,6 @@ from openvino.utils.input_validation import (
 from openvino.utils.node_factory import NodeFactory, _get_node_factory
 from openvino.utils.types import (
     NodeInput,
-    NumericData,
     NumericType,
     ScalarData,
     TensorShape,

--- a/src/bindings/python/src/openvino/opset5/ops.py
+++ b/src/bindings/python/src/openvino/opset5/ops.py
@@ -20,7 +20,6 @@ from openvino.utils.input_validation import (
 from openvino.utils.node_factory import NodeFactory, _get_node_factory
 from openvino.utils.types import (
     NodeInput,
-    NumericData,
     NumericType,
     ScalarData,
     TensorShape,

--- a/src/bindings/python/src/openvino/opset7/ops.py
+++ b/src/bindings/python/src/openvino/opset7/ops.py
@@ -19,7 +19,6 @@ from openvino.utils.input_validation import (
 from openvino.utils.node_factory import NodeFactory, _get_node_factory
 from openvino.utils.types import (
     NodeInput,
-    NumericData,
     NumericType,
     ScalarData,
     TensorShape,
@@ -28,7 +27,6 @@ from openvino.utils.types import (
     get_dtype,
     get_element_type,
     get_element_type_str,
-    make_constant_node,
 )
 
 _get_node_factory_opset7 = partial(_get_node_factory, "opset7")


### PR DESCRIPTION
### Details:
 - Add np.number support to ops8.constant type hints
 - Remove unused imports

