### PR TITLE
[TRANSFORMATIONS] Fix Coverity warning

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/scaled_dot_product_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/scaled_dot_product_attention_decomposition.cpp
@@ -124,7 +124,7 @@ std::shared_ptr<ov::Node> ov::pass::ScaledDotProductAttentionDecomposition::deco
         scale = register_new_node<v1::ConvertLike>(scale, query);
         auto sqrt_scale = register_new_node<v0::Sqrt>(scale);
         scale = register_new_node<v1::Divide>(one_f, sqrt_scale);
-    } else if (node->get_input_size() < 7) {
+    } else {
         scale = node->input_value(4);
         if (node->get_input_size() == 6) {
             sink = node->input_value(5);


### PR DESCRIPTION
### Details:
The Coverity system may report scale node to be uninitialized with the existing if branching. Fix it to have the scale node always initialized.

### Tickets:
 - [CVS-174706](https://jira.devtools.intel.com/browse/CVS-174706)

Signed-off-by: Andrii Staikov <andii.staikov@intel.com>
