### PR TITLE
[NPU][IE-MDK] Exit test application when NPU Driver is missing

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_threading_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_threading_tests.cpp
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "core_threading_tests.hpp"
 #include <utility>
-
-#include "behavior/ov_plugin/core_threading.hpp"
-#include "common/utils.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 
 namespace {
@@ -24,26 +22,24 @@ const Params params_cached[] = {std::tuple<Device, Config>{ov::test::utils::DEVI
 
 }  // namespace
 
-INSTANTIATE_TEST_SUITE_P(
-    compatibility_smoke_BehaviorTests_CoreThreadingTest_NPU,
-    CoreThreadingTest,
-    testing::ValuesIn(params),
-    ov::test::utils::appendDriverVersionTestName<CoreThreadingTest>);  // need to get also driver version to skip
-                                                                       // failing tests with PV driver
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_CoreThreadingTest_NPU,
+                         CoreThreadingTestNPU,
+                         testing::ValuesIn(params),
+                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestNPU>);
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU,
-                         CoreThreadingTestsWithIter,
+                         CoreThreadingTestsWithIterNPU,
                          testing::Combine(testing::ValuesIn(params), testing::Values(15), testing::Values(50)),
-                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIter>);
+                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIterNPU>);
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU,
-                         CoreThreadingTestsWithCacheEnabled,
+                         CoreThreadingTestsWithCacheEnabledNPU,
                          testing::Combine(testing::ValuesIn(params_cached), testing::Values(10), testing::Values(30)),
-                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithCacheEnabled>);
+                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithCacheEnabledNPU>);
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_UmdCacheDisabled_NPU,
-                         CoreThreadingTestsWithIter,
+                         CoreThreadingTestsWithIterNPU,
                          testing::Combine(testing::ValuesIn(params_disable_umd_cache),
                                           testing::Values(8),
                                           testing::Values(20)),
-                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIter>);
+                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIterNPU>);

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_threading_tests.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_threading_tests.hpp
@@ -1,0 +1,630 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <thread>
+
+#include "common/utils.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "common_test_utils/subgraph_builders/2_input_subtract.hpp"
+#include "common_test_utils/subgraph_builders/multi_single_conv.hpp"
+#include "common_test_utils/subgraph_builders/single_conv.hpp"
+#include "common_test_utils/subgraph_builders/split_conv_concat.hpp"
+#include "common_test_utils/subgraph_builders/split_multi_conv_concat.hpp"
+#include "functional_test_utils/ov_plugin_cache.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "openvino/runtime/properties.hpp"
+#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
+
+using Device = std::string;
+using Config = ov::AnyMap;
+using Params = std::tuple<Device, Config>;
+
+class CoreThreadingTestsBaseNPU {
+public:
+    static void runParallel(std::function<void(void)> func,
+                            const unsigned int iterations = 100,
+                            const unsigned int threadsNum = 8) {
+        std::vector<std::thread> threads(threadsNum);
+        for (auto& thread : threads) {
+            thread = std::thread([&]() {
+                for (unsigned int i = 0; i < iterations; ++i) {
+                    func();
+                }
+            });
+        }
+
+        for (auto& thread : threads) {
+            if (thread.joinable())
+                thread.join();
+        }
+    }
+
+    void safePluginUnload(ov::Core& core, const std::string& deviceName) {
+        try {
+            core.unload_plugin(deviceName);
+        } catch (const ov::Exception& ex) {
+            // if several threads unload plugin at once, the first thread does this
+            // while all others will throw an exception that plugin is not registered
+            ASSERT_STR_CONTAINS(ex.what(), "name is not registered in the");
+        }
+    }
+
+    Config config;
+};
+
+//
+//  Parameterized tests with number of parallel threads, iterations
+//
+
+using Threads = unsigned int;
+using Iterations = unsigned int;
+
+using CoreThreadingParams = std::tuple<Params, Threads, Iterations>;
+
+class CoreThreadingTestsWithCacheEnabledNPU : public testing::WithParamInterface<CoreThreadingParams>,
+                                              public ov::test::behavior::OVPluginTestBase,
+                                              public CoreThreadingTestsBaseNPU {
+public:
+    void SetUp() override {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED();
+        std::tie(target_device, config) = std::get<0>(GetParam());
+        numThreads = std::get<1>(GetParam());
+        numIterations = std::get<2>(GetParam());
+        auto hash = std::hash<std::string>()(::testing::UnitTest::GetInstance()->current_test_info()->name());
+        std::stringstream ss;
+        ss << std::this_thread::get_id();
+        cache_path = "threading_test" + std::to_string(hash) + "_" + ss.str() + "_" + GetTimestamp() + "_cache";
+        APIBaseTest::SetUp();
+    }
+
+    void TearDown() override {
+        ov::test::utils::removeFilesWithExt(cache_path, "blob");
+        std::remove(cache_path.c_str());
+        APIBaseTest::TearDown();
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<CoreThreadingParams> obj) {
+        unsigned int numThreads, numIterations;
+        std::string deviceName;
+        Config config;
+        std::tie(deviceName, config) = std::get<0>(obj.param);
+        std::replace(deviceName.begin(), deviceName.end(), ':', '.');
+        numThreads = std::get<1>(obj.param);
+        numIterations = std::get<2>(obj.param);
+        char separator('_');
+        std::ostringstream result;
+        result << "targetDevice=" << deviceName << separator;
+        result << "config=";
+        for (auto& confItem : config) {
+            result << confItem.first << "=" << confItem.second.as<std::string>() << separator;
+        }
+        result << "numThreads=" << numThreads << separator;
+        result << "numIter=" << numIterations;
+        return result.str();
+    }
+
+protected:
+    unsigned int numIterations;
+    unsigned int numThreads;
+    std::string cache_path;
+    std::vector<std::shared_ptr<ov::Model>> models;
+
+    void SetupModels() {
+        ov::Core core;
+        std::string ir_with_meta = R"V0G0N(
+            <net name="Network" version="11">
+                <layers>
+                    <layer name="in1" type="Parameter" id="0" version="opset1">
+                        <data element_type="f32" shape="1,3,22,22"/>
+                        <output>
+                            <port id="0" precision="FP32">
+                                <dim>1</dim>
+                                <dim>3</dim>
+                                <dim>22</dim>
+                                <dim>22</dim>
+                            </port>
+                        </output>
+                    </layer>
+                    <layer name="activation" id="1" type="ReLU" version="opset1">
+                        <input>
+                            <port id="1" precision="FP32">
+                                <dim>1</dim>
+                                <dim>3</dim>
+                                <dim>22</dim>
+                                <dim>22</dim>
+                            </port>
+                        </input>
+                        <output>
+                            <port id="2" precision="FP32">
+                                <dim>1</dim>
+                                <dim>3</dim>
+                                <dim>22</dim>
+                                <dim>22</dim>
+                            </port>
+                        </output>
+                    </layer>
+                    <layer name="output" type="Result" id="2" version="opset1">
+                        <input>
+                            <port id="0" precision="FP32">
+                                <dim>1</dim>
+                                <dim>3</dim>
+                                <dim>22</dim>
+                                <dim>22</dim>
+                            </port>
+                        </input>
+                    </layer>
+                </layers>
+                <edges>
+                    <edge from-layer="1" from-port="2" to-layer="2" to-port="0"/>
+                    <edge from-layer="0" from-port="0" to-layer="1" to-port="1"/>
+                </edges>
+                <meta_data>
+                    <MO_version value="TestVersion"/>
+                    <Runtime_version value="TestVersion"/>
+                    <cli_parameters>
+                        <input_shape value="[1, 3, 22, 22]"/>
+                        <transform value=""/>
+                        <use_new_frontend value="False"/>
+                    </cli_parameters>
+                </meta_data>
+                <framework_meta>
+                    <batch value="1"/>
+                    <chunk_size value="16"/>
+                </framework_meta>
+                <quantization_parameters>
+                    <config>{
+                    'compression': {
+                        'algorithms': [
+                            {
+                                'name': 'DefaultQuantization',
+                                'params': {
+                                    'num_samples_for_tuning': 2000,
+                                    'preset': 'performance',
+                                    'stat_subset_size': 300,
+                                    'use_layerwise_tuning': false
+                                }
+                            }
+                        ],
+                        'dump_intermediate_model': true,
+                        'target_device': 'ANY'
+                    },
+                    'engine': {
+                        'models': [
+                            {
+                                'name': 'bert-small-uncased-whole-word-masking-squad-0001',
+                                'launchers': [
+                                    {
+                                        'framework': 'openvino',
+                                        'adapter': {
+                                            'type': 'bert_question_answering',
+                                            'start_token_logits_output': 'output_s',
+                                            'end_token_logits_output': 'output_e'
+                                        },
+                                        'inputs': [
+                                            {
+                                                'name': 'input_ids',
+                                                'type': 'INPUT',
+                                                'value': 'input_ids'
+                                            },
+                                            {
+                                                'name': 'attention_mask',
+                                                'type': 'INPUT',
+                                                'value': 'input_mask'
+                                            },
+                                            {
+                                                'name': 'token_type_ids',
+                                                'type': 'INPUT',
+                                                'value': 'segment_ids'
+                                            }
+                                        ],
+                                        'device': 'cpu'
+                                    }
+                                ],
+                                'datasets': [
+                                    {
+                                        'name': 'squad_v1_1_msl384_mql64_ds128_lowercase',
+                                        'annotation_conversion': {
+                                            'converter': 'squad',
+                                            'testing_file': 'PATH',
+                                            'max_seq_length': 384,
+                                            'max_query_length': 64,
+                                            'doc_stride': 128,
+                                            'lower_case': true,
+                                            'vocab_file': 'PATH'
+                                        },
+                                        'reader': {
+                                            'type': 'annotation_features_extractor',
+                                            'features': [
+                                                'input_ids',
+                                                'input_mask',
+                                                'segment_ids'
+                                            ]
+                                        },
+                                        'postprocessing': [
+                                            {
+                                                'type': 'extract_answers_tokens',
+                                                'max_answer': 30,
+                                                'n_best_size': 20
+                                            }
+                                        ],
+                                        'metrics': [
+                                            {
+                                                'name': 'F1',
+                                                'type': 'f1',
+                                                'reference': 0.9157
+                                            },
+                                            {
+                                                'name': 'EM',
+                                                'type': 'exact_match',
+                                                'reference': 0.8504
+                                            }
+                                        ],
+                                        '_command_line_mapping': {
+                                            'testing_file': 'PATH',
+                                            'vocab_file': [
+                                                'PATH'
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        'stat_requests_number': null,
+                        'eval_requests_number': null,
+                        'type': 'accuracy_checker'
+                    }
+                }</config>
+                    <version value="invalid version"/>
+                    <cli_params value="{'quantize': None, 'preset': None, 'model': None, 'weights': None, 'name': None, 'engine': None, 'ac_config': None, 'max_drop': None, 'evaluate': False, 'output_dir': 'PATH', 'direct_dump': True, 'log_level': 'INFO', 'pbar': False, 'stream_output': False, 'keep_uncompressed_weights': False, 'data_source': None}"/>
+                </quantization_parameters>
+            </net>
+            )V0G0N";
+        ov::Tensor weights = {};
+        auto model = core.read_model(ir_with_meta, weights);
+        OPENVINO_ASSERT(model);
+        models.emplace_back(model);  // model with cli_parameter
+        // test model with runtime attributes -- layout
+        model = ov::test::utils::make_split_multi_conv_concat();
+        for (auto& iter : model->get_parameters())
+            iter->set_layout("NCHW");
+        for (auto& iter : model->get_results())
+            iter->set_layout("NHCW");
+        models.emplace_back(model);
+    }
+};
+
+// tested function: set_property, compile_model
+TEST_P(CoreThreadingTestsWithCacheEnabledNPU, smoke_compiled_model_cache_enabled) {
+    auto core = ov::test::utils::create_core();
+    SetupModels();
+    core.set_property(target_device, config);
+    core.set_property(ov::cache_dir(cache_path));
+    for (auto& model : models) {
+        runParallel(
+            [&]() {
+                (void)core.compile_model(model, target_device);
+            },
+            numIterations,
+            numThreads);
+    }
+    core.set_property(ov::cache_dir(""));
+}
+
+class CoreThreadingTestNPU : public testing::WithParamInterface<Params>,
+                             public ov::test::behavior::OVPluginTestBase,
+                             public CoreThreadingTestsBaseNPU {
+public:
+    void SetUp() override {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED();
+
+        // Skip tests for PV Driver
+        // E#112064
+        const std::string PVdriver_version("1688");
+        const auto& pluginCacheCore = ov::test::utils::PluginCache::get().core(ov::test::utils::DEVICE_NPU);
+        auto driverVersion =
+            pluginCacheCore->get_property(ov::test::utils::DEVICE_NPU, ov::intel_npu::driver_version.name());
+        if (driverVersion.as<std::string>() == PVdriver_version)
+            GTEST_SKIP() << "Test not supported by PV driver verision: " << driverVersion.as<std::string>()
+                         << std::endl;
+
+        std::tie(target_device, config) = GetParam();
+        APIBaseTest::SetUp();
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<Params> obj) {
+        std::string deviceName;
+        Config config;
+        std::tie(deviceName, config) = obj.param;
+        std::replace(deviceName.begin(), deviceName.end(), ':', '.');
+        char separator('_');
+        std::ostringstream result;
+        result << "targetDevice=" << deviceName << separator;
+        result << "config=";
+        for (auto& confItem : config) {
+            result << confItem.first << "=" << confItem.second.as<std::string>() << separator;
+        }
+        return result.str();
+    }
+};
+
+// tested function: get_versions, unload_plugin
+TEST_P(CoreThreadingTestNPU, smoke_GetVersions) {
+    auto core = ov::test::utils::create_core();
+    runParallel([&]() {
+        auto versions = core.get_versions(target_device);
+        ASSERT_LE(1u, versions.size());
+        safePluginUnload(core, target_device);
+    });
+}
+
+// tested function: get_property, UnregisterPlugin
+TEST_P(CoreThreadingTestNPU, smoke_GetMetric) {
+    auto core = ov::test::utils::create_core();
+
+    runParallel([&]() {
+        core.get_property(target_device, ov::internal::supported_properties);
+        safePluginUnload(core, target_device);
+    });
+}
+
+// tested function: set_property for already created plugins
+TEST_P(CoreThreadingTestNPU, smoke_SetProperty_PluginExists) {
+    auto core = ov::test::utils::create_core();
+    core.set_property(target_device, config);
+    auto versions = core.get_versions(target_device);
+    runParallel(
+        [&]() {
+            core.set_property(target_device, config);
+        },
+        10000);
+}
+
+// tested function: get_property, unload_plugin
+TEST_P(CoreThreadingTestNPU, smoke_GetProperty_PluginExists) {
+    auto core = ov::test::utils::create_core();
+    std::string configKey = config.begin()->first;
+    core.set_property(target_device, config);
+    runParallel([&]() {
+        core.get_property(target_device, configKey);
+        safePluginUnload(core, target_device);
+    });
+}
+
+// tested function: query_model
+TEST_P(CoreThreadingTestNPU, smoke_QueryModel) {
+    auto core = ov::test::utils::create_core();
+    core.set_property(target_device, config);
+    auto model = ov::test::utils::make_2_input_subtract();
+    auto refResult = core.query_model(model, target_device);
+
+    runParallel(
+        [&]() {
+            const auto result = core.query_model(model, target_device);
+            safePluginUnload(core, target_device);
+
+            // compare QueryNetworkResult with reference
+            for (auto&& r : refResult) {
+                ASSERT_NE(result.end(), result.find(r.first));
+            }
+            for (auto&& r : result) {
+                ASSERT_NE(refResult.end(), refResult.find(r.first));
+            }
+        },
+        3000);
+}
+
+class CoreThreadingTestsWithIterNPU : public testing::WithParamInterface<CoreThreadingParams>,
+                                      public ov::test::behavior::OVPluginTestBase,
+                                      public CoreThreadingTestsBaseNPU {
+public:
+    void SetUp() override {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED();
+        std::tie(target_device, config) = std::get<0>(GetParam());
+        numThreads = std::get<1>(GetParam());
+        numIterations = std::get<2>(GetParam());
+        APIBaseTest::SetUp();
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<CoreThreadingParams> obj) {
+        unsigned int numThreads, numIterations;
+        std::string deviceName;
+        Config config;
+        std::tie(deviceName, config) = std::get<0>(obj.param);
+        std::replace(deviceName.begin(), deviceName.end(), ':', '.');
+        numThreads = std::get<1>(obj.param);
+        numIterations = std::get<2>(obj.param);
+        char separator('_');
+        std::ostringstream result;
+        result << "targetDevice=" << deviceName << separator;
+        result << "config=";
+        for (auto& confItem : config) {
+            result << confItem.first << "=" << confItem.second.as<std::string>() << separator;
+        }
+        result << "numThreads=" << numThreads << separator;
+        result << "numIter=" << numIterations;
+        return result.str();
+    }
+
+protected:
+    unsigned int numIterations;
+    unsigned int numThreads;
+
+    std::vector<std::shared_ptr<ov::Model>> models;
+    void SetupNetworks() {
+        models.emplace_back(ov::test::utils::make_2_input_subtract());
+        models.emplace_back(ov::test::utils::make_multi_single_conv());
+        models.emplace_back(ov::test::utils::make_single_conv());
+        models.emplace_back(ov::test::utils::make_split_conv_concat());
+        models.emplace_back(ov::test::utils::make_split_multi_conv_concat());
+    }
+};
+
+// tested function: compile_model
+TEST_P(CoreThreadingTestsWithIterNPU, smoke_CompileModel) {
+    auto core = ov::test::utils::create_core();
+    std::atomic<unsigned int> counter{0u};
+    SetupNetworks();
+    core.set_property(target_device, config);
+    runParallel(
+        [&]() {
+            auto value = counter++;
+            (void)core.compile_model(models[value % models.size()], target_device);
+        },
+        numIterations,
+        numThreads);
+}
+
+// tested function: single Core compile_model accuracy
+TEST_P(CoreThreadingTestsWithIterNPU, smoke_CompileModel_Accuracy_SingleCore) {
+    auto core = ov::test::utils::create_core();
+    std::atomic<unsigned int> counter{0u};
+    SetupNetworks();
+    core.set_property(target_device, config);
+
+    runParallel(
+        [&]() {
+            auto value = counter++;
+            auto model = models[value % models.size()];
+
+            std::map<ov::Output<ov::Node>, ov::Tensor> inputs;
+            for (const auto& input : model->inputs()) {
+                auto tensor = ov::test::utils::create_and_fill_tensor_normal_distribution(input.get_element_type(),
+                                                                                          input.get_shape(),
+                                                                                          0.0f,
+                                                                                          0.2f,
+                                                                                          7235346);
+                inputs.insert({input, tensor});
+            }
+
+            auto getOutputBlob = [&](ov::Core& core) {
+                ov::AnyMap f32_precision_property = {
+                    {ov::hint::inference_precision.name(), ov::element::f32.to_string()}};
+                auto compiled_model = core.compile_model(model, target_device, f32_precision_property);
+                auto req = compiled_model.create_infer_request();
+                for (const auto& input : inputs) {
+                    req.set_tensor(input.first, input.second);
+                }
+                auto output_tensor = ov::Tensor(model->output().get_element_type(), model->output().get_shape());
+                req.set_output_tensor(output_tensor);
+                req.infer();
+                return output_tensor;
+            };
+
+            auto outputActual = getOutputBlob(core);
+
+            // compare actual value using the same Core
+            auto outputRef = getOutputBlob(core);
+            ov::test::utils::compare(outputActual, outputRef);
+        },
+        numIterations,
+        numThreads);
+}
+
+// tested function: multi Core compile_model accuracy
+TEST_P(CoreThreadingTestsWithIterNPU, smoke_CompileModel_Accuracy_MultipleCores) {
+    auto core = ov::test::utils::create_core();
+    std::atomic<unsigned int> counter{0u};
+    SetupNetworks();
+    core.set_property(target_device, config);
+    runParallel(
+        [&]() {
+            auto value = counter++;
+            auto model = models[value % models.size()];
+
+            std::map<ov::Output<ov::Node>, ov::Tensor> inputs;
+            for (const auto& input : model->inputs()) {
+                auto tensor = ov::test::utils::create_and_fill_tensor_normal_distribution(input.get_element_type(),
+                                                                                          input.get_shape(),
+                                                                                          0.0f,
+                                                                                          0.2f,
+                                                                                          7235346);
+                inputs.insert({input, tensor});
+            }
+
+            auto getOutputBlob = [&](ov::Core& core) {
+                ov::AnyMap f32_precision_property = {
+                    {ov::hint::inference_precision.name(), ov::element::f32.to_string()}};
+                auto compiled_model = core.compile_model(model, target_device, f32_precision_property);
+                auto req = compiled_model.create_infer_request();
+                for (const auto& input : inputs) {
+                    req.set_tensor(input.first, input.second);
+                }
+                auto output_tensor = ov::Tensor(model->output().get_element_type(), model->output().get_shape());
+                req.set_output_tensor(output_tensor);
+                req.infer();
+                return output_tensor;
+            };
+
+            auto outputActual = getOutputBlob(core);
+
+            // compare actual value using the second Core
+            {
+                auto core_2 = ov::test::utils::create_core();
+                core_2.set_property(target_device, config);
+                auto outputRef = getOutputBlob(core_2);
+                ov::test::utils::compare(outputActual, outputRef);
+            }
+        },
+        numIterations,
+        numThreads);
+}
+
+// tested function: set_property, compile_model
+TEST_P(CoreThreadingTestsWithIterNPU, smoke_CompileModel_MultipleCores) {
+    std::atomic<unsigned int> counter{0u};
+
+    SetupNetworks();
+
+    runParallel(
+        [&]() {
+            auto value = counter++;
+            auto core = ov::test::utils::create_core();
+            ;
+            core.set_property(target_device, config);
+            (void)core.compile_model(models[value % models.size()], target_device);
+        },
+        numIterations,
+        numThreads);
+}
+
+TEST_P(CoreThreadingTestsWithIterNPU, nightly_AsyncInfer_ShareInput) {
+    SetupNetworks();
+    auto model = models[0];
+    ov::Tensor output_ref;
+    std::map<ov::Output<ov::Node>, ov::Tensor> inputs;
+    for (const auto& input : model->inputs()) {
+        auto tensor = ov::test::utils::create_and_fill_tensor_normal_distribution(input.get_element_type(),
+                                                                                  input.get_shape(),
+                                                                                  0.0f,
+                                                                                  0.2f,
+                                                                                  7235346);
+        inputs.insert({input, tensor});
+    }
+
+    runParallel(
+        [&]() {
+            auto core = ov::test::utils::create_core();
+            core.set_property(target_device, config);
+            auto compiled_model = core.compile_model(model, target_device);
+            auto nireq = compiled_model.get_property(ov::optimal_number_of_infer_requests);
+            std::vector<ov::InferRequest> inferReqsQueue;
+            int count = nireq;
+            while (count--) {
+                ov::InferRequest req = compiled_model.create_infer_request();
+                for (const auto& input : inputs) {
+                    req.set_tensor(input.first, input.second);
+                }
+                inferReqsQueue.push_back(req);
+            }
+            for (auto& req : inferReqsQueue) {
+                req.start_async();
+            }
+            for (auto& req : inferReqsQueue) {
+                req.wait();
+            }
+        },
+        numIterations,
+        numThreads);
+}

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/query_model.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/query_model.cpp
@@ -2,21 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "behavior/ov_plugin/query_model.hpp"
-#include "common/utils.hpp"
+#include "query_model.hpp"
 #include "common/npu_test_env_cfg.hpp"
 
 namespace ov {
 namespace test {
 namespace behavior {
 
-INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassModelTestP, OVClassModelTestP,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassModelTestP,
+                         OVClassModelTestP,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassModelTestP>));
 
-INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassQueryModelTestTests, OVClassQueryModelTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassQueryModelTestTests,
+                         OVClassQueryModelTestNPU,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
-                         (ov::test::utils::appendDriverVersionTestName<OVClassQueryModelTest>));
+                         (ov::test::utils::appendPlatformTypeTestName<OVClassQueryModelTestNPU>));
 
 }  // namespace behavior
 }  // namespace test

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/query_model.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/query_model.hpp
@@ -1,0 +1,122 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "common/utils.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/relu.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
+
+namespace ov {
+namespace test {
+namespace behavior {
+
+using QueryModelParamsNPU = std::string;
+class OVClassQueryModelTestNPU : public OVClassBaseTestP {
+public:
+    void SetUp() override {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED();
+
+        // Skip tests for PV Driver
+        // E#116761
+        const std::string PVdriver_version("1688");
+        const auto& pluginCacheCore = ov::test::utils::PluginCache::get().core(ov::test::utils::DEVICE_NPU);
+        auto driverVersion =
+            pluginCacheCore->get_property(ov::test::utils::DEVICE_NPU, ov::intel_npu::driver_version.name());
+        if (driverVersion.as<std::string>() == PVdriver_version)
+            GTEST_SKIP() << "Test not supported by PV driver verision: " << driverVersion.as<std::string>()
+                         << std::endl;
+
+        target_device = GetParam();
+        APIBaseTest::SetUp();
+        OVClassNetworkTest::SetUp();
+    }
+};
+
+TEST_P(OVClassModelTestP, QueryModelActualNoThrow) {
+    ov::Core ie = ov::test::utils::create_core();
+    ie.query_model(actualNetwork, target_device);
+}
+
+TEST_P(OVClassModelTestP, QueryModelWithKSO) {
+    ov::Core ie = ov::test::utils::create_core();
+
+    auto rl_map = ie.query_model(ksoNetwork, target_device);
+    auto func = ksoNetwork;
+    for (const auto& op : func->get_ops()) {
+        if (!rl_map.count(op->get_friendly_name())) {
+            FAIL() << "Op " << op->get_friendly_name() << " is not supported by " << target_device;
+        }
+    }
+}
+
+TEST_P(OVClassQueryModelTestNPU, QueryModelWithMatMul) {
+    ov::Core ie = ov::test::utils::create_core();
+
+    std::shared_ptr<ov::Model> func;
+    {
+        ov::PartialShape shape({1, 84});
+        ov::element::Type type(ov::element::Type_t::f32);
+        auto param = std::make_shared<ov::op::v0::Parameter>(type, shape);
+        auto matMulWeights = ov::op::v0::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
+        auto shapeOf = std::make_shared<ov::op::v3::ShapeOf>(matMulWeights);
+        auto gConst1 = ov::op::v0::Constant::create(ov::element::Type_t::i32, {1}, {1});
+        auto gConst2 = ov::op::v0::Constant::create(ov::element::Type_t::i64, {}, {0});
+        auto gather = std::make_shared<ov::op::v1::Gather>(shapeOf, gConst1, gConst2);
+        auto concatConst = ov::op::v0::Constant::create(ov::element::Type_t::i64, {1}, {1});
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::NodeVector{concatConst, gather}, 0);
+        auto relu = std::make_shared<ov::op::v0::Relu>(param);
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(relu, concat, false);
+        auto matMul = std::make_shared<ov::op::v0::MatMul>(reshape, matMulWeights, false, true);
+        auto matMulBias = ov::op::v0::Constant::create(ov::element::Type_t::f32, {1, 10}, {1});
+        auto addBias = std::make_shared<ov::op::v1::Add>(matMul, matMulBias);
+        auto result = std::make_shared<ov::op::v0::Result>(addBias);
+
+        ov::ParameterVector params = {param};
+        ov::ResultVector results = {result};
+
+        func = std::make_shared<ov::Model>(results, params);
+    }
+
+    auto rl_map = ie.query_model(func, target_device);
+    for (const auto& op : func->get_ops()) {
+        if (!rl_map.count(op->get_friendly_name())) {
+            FAIL() << "Op " << op->get_friendly_name() << " is not supported by " << target_device;
+        }
+    }
+}
+
+TEST_P(OVClassQueryModelTestNPU, QueryModelHETEROWithDeviceIDNoThrow) {
+    ov::Core ie = ov::test::utils::create_core();
+
+    auto deviceIDs = ie.get_property(target_device, ov::available_devices);
+    if (deviceIDs.empty())
+        GTEST_FAIL();
+    OV_ASSERT_NO_THROW(ie.query_model(actualNetwork,
+                                      ov::test::utils::DEVICE_HETERO,
+                                      ov::device::priorities(target_device + "." + deviceIDs[0], target_device)));
+}
+
+TEST_P(OVClassQueryModelTestNPU, QueryModelWithBigDeviceIDThrows) {
+    ov::Core ie = ov::test::utils::create_core();
+    ASSERT_THROW(ie.query_model(actualNetwork, target_device + ".110"), ov::Exception);
+}
+
+TEST_P(OVClassQueryModelTestNPU, QueryModelWithInvalidDeviceIDThrows) {
+    ov::Core ie = ov::test::utils::create_core();
+    ASSERT_THROW(ie.query_model(actualNetwork, target_device + ".l0"), ov::Exception);
+}
+
+}  // namespace behavior
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_npu/tests/functional/main.cpp
+++ b/src/plugins/intel_npu/tests/functional/main.cpp
@@ -65,6 +65,20 @@ int main(int argc, char** argv, char** envp) {
     const bool dryRun = ::testing::GTEST_FLAG(list_tests) || ::testing::internal::g_help_flag;
 
     if (!dryRun) {
+        // Check if device available, exit if not found.
+        std::vector<std::string> availableDevices;
+        const auto core = ov::test::utils::PluginCache::get().core();
+        if (core != nullptr) {
+            availableDevices = core->get_available_devices();
+            auto it = std::find(availableDevices.begin(), availableDevices.end(), "NPU");
+            if (it == availableDevices.end()) {
+                std::cerr << "Driver not found, exiting." << std::endl;
+                return 0;
+            }
+        } else {
+            std::cerr << "Failed to get OpenVINO Core from cache!" << std::endl;
+        }
+
         const std::string noFetch{"<not fetched>"};
         std::string backend{noFetch}, arch{noFetch}, full{noFetch};
         try {

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -620,7 +620,8 @@ Example:
     </skip_config>
 
     <!-- E#112064 -->
-    <skip_config>
+    <!-- Implementation moved to test Setup -->
+    <!-- <skip_config>
         <message>Failing Windows PV Driver core threading tests</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -629,7 +630,7 @@ Example:
         <filters>
             <filter>.*CoreThreadingTest.smoke_QueryModel/.*_driverVersion=1688.*</filter>
         </filters>
-    </skip_config>
+    </skip_config> -->
 
     <skip_config>
         <message>Failing properties tests</message>
@@ -698,13 +699,14 @@ Example:
     </skip_config>
 
     <!-- E#116761 -->
-    <skip_config>
+    <!-- Implementation moved to test Setup -->
+    <!-- <skip_config>
         <message>OVClassQueryModel tests do not work with COMPILER_TYPE=DRIVER and PV driver</message>
         <filters>
             <filter>.*OVClassQueryModelTest.QueryModelWithBigDeviceIDThrows.*_driverVersion=1688.*</filter>
             <filter>.*OVClassQueryModelTest.QueryModelWithInvalidDeviceIDThrows.*_driverVersion=1688.*</filter>
         </filters>
-    </skip_config>
+    </skip_config> -->
 
     <!-- E#109040 -->
     <skip_config>


### PR DESCRIPTION
### Details:
 - Check if Available Devices contain NPU, if not exit application
 - Change test instantiations for CoreThreading and QueryModel so they won't trigger a Plugin init
 - Add checks in gtest Setup() to skip CoreThreading tests and QueryModel tests if PV driver is detected

### Tickets:
 - E 102937