### PR TITLE
[CPU] Get rid of 'withBias' flag in FullyConnected node

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
@@ -760,12 +760,14 @@ DnnlShapeAgnosticDataPtr DnnlConvolutionPrimitive::createShapeAgnosticData(const
     OPENVINO_ASSERT(!cacheWeightsWithUndefData,
                     "dnnl convolution weights caching for dynamic shapes is not implemented");
 
+    const bool hasBias = !memory.at(ARG_BIAS)->getDesc().empty();
+
     ConvAttrs attrs{{1},
                     {0},
                     {0},
                     {0},
                     AutoPaddingType::None,
-                    fcAttrs.withBias,
+                    hasBias,
                     fcAttrs.weightsNonTransposed,
                     false,
                     false,
@@ -882,7 +884,6 @@ DnnlMemoryDescPtr DnnlConvolutionPrimitive::makeTransposedWeightDescriptor(const
                                                                            const DnnlMemoryDescPtr& dstDesc,
                                                                            const ConvAttrs& attrs) {
     FCAttrs fcAttrs{};
-    fcAttrs.withBias = attrs.withBias;
     fcAttrs.weightsNonTransposed = attrs.weightsNonTransposed;
 
     return DnnlFCPrimitive::makeTransposedWeightDescriptor(srcDesc, dstDesc, fcAttrs);

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
@@ -14,9 +14,6 @@ namespace ov::intel_cpu {
 
 // @todo require explicit initialization of all the attributes?
 struct FCAttrs {
-    // @todo probably we don't want with bias flag, since this information is already
-    // a part of src memory descs
-    bool withBias = false;
     bool weightsNonTransposed = false;
     bool sparseWeights = false;
     uint64_t dynamicQuantizationGroupSize = 0;

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -292,8 +292,9 @@ const std::vector<ExecutorImplementation<FCAttrs>>& getImplementations() {
                         const std::shared_ptr<DnnlShapeAgnosticData>& shareAgnosticData) const {
 
                         const bool fcSemantic = true;
+                        const bool hasBias = !memory.at(ARG_BIAS)->getDesc().empty();
                         ConvAttrs convAttrs{{1}, {0}, {0}, {0},
-                                            AutoPaddingType::None, attrs.withBias, attrs.weightsNonTransposed,
+                                            AutoPaddingType::None, hasBias, attrs.weightsNonTransposed,
                                             false, false, fcSemantic, false, ZeroPointsType::None, {}, attrs.postOps};
 
                         auto primitive =
@@ -380,9 +381,7 @@ const std::vector<ExecutorImplementation<FCAttrs>>& getImplementations() {
                 VERIFY(noSparseDecompression(config), UNSUPPORTED_SPARSE_WEIGHTS);
                 VERIFY(all_of(f32, srcType(config), dstType(config)), UNSUPPORTED_SRC_PRECISIONS);
                 VERIFY(any_of(weiType(config), f32, i8, i4), UNSUPPORTED_WEI_PRECISIONS);
-                if (config.attrs.withBias) {
-                    VERIFY(biaType(config) == f32, UNSUPPORTED_SRC_PRECISIONS);
-                }
+                VERIFY(implication(hasBias(config), biaType(config) == f32), UNSUPPORTED_SRC_PRECISIONS);
                 VERIFY(weiRank(config) == 2U, UNSUPPORTED_WEI_RANK);
                 VERIFY(MatMulKleidiAIExecutor::supports(config), UNSUPPORTED_BY_EXECUTOR);
 

--- a/src/plugins/intel_cpu/src/nodes/executors/implementation_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/implementation_utils.hpp
@@ -34,6 +34,11 @@ ov::element::Type memoryDescType(const Config& config) {
 }
 
 template <typename Config>
+bool hasBias(const Config& config) {
+    return !config.descs.at(ARG_BIAS)->empty();
+}
+
+template <typename Config>
 ov::element::Type srcType(const Config& config) {
     return memoryDescType<Config, ARG_SRC>(config);
 }

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.hpp
@@ -109,8 +109,6 @@ private:
         kai_get_dst_size_matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_8x8x32_neon_i8mm,
         kai_run_matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_8x8x32_neon_i8mm};
 
-    const FCAttrs& m_attrs;
-    const MemoryArgs& m_memoryArgs;
     DnnlScratchPadPtr scratchPad;
     ACLFCAttrs aclfcAttrs;
     MemoryPtr biasMem;
@@ -127,7 +125,6 @@ private:
     size_t BLOCK_SIZE_M_LOWP;
     size_t packedlhs_block_in_bytes = 0UL;
     bool INT4_IMPL;
-    int curNumaNode = -1;
     bool useDynamicQuant = false;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
@@ -103,8 +103,7 @@ bool MlasGemmExecutor::supports(const FCConfig& config) {
 }
 
 MlasGemmExecutor::MlasGemmExecutor(const FCAttrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr& context)
-    : m_attrs(attrs),
-      m_memoryArgs(memory),
+    : m_memoryArgs(memory),
       packedWeights(prepareWeightMemory(memory.at(ARG_WEI), context, !attrs.weightsNonTransposed)),
 
       N(batchDim(memory.at(ARG_WEI)->getStaticDims())),
@@ -151,7 +150,7 @@ void MlasGemmExecutor::moveMemToNumaNode(int numaNodeID) {
     }
     curNumaNode = numaNodeID;
     mbind_move(packedWeights, numaNodeID);
-    if (m_attrs.withBias) {
+    if (!m_memoryArgs.at(ARG_BIAS)->getDesc().empty()) {
         mbind_move(m_memoryArgs.at(ARG_BIAS), numaNodeID);
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
@@ -32,7 +32,6 @@ public:
     void moveMemToNumaNode(int numaNodeID) override;
 
 private:
-    const FCAttrs& m_attrs;
     const MemoryArgs& m_memoryArgs;
     const MemoryCPtr packedWeights;
     int64_t M = 0, N, K;


### PR DESCRIPTION
Not necessery anymore, since bias is always present
and it is either empty or not