### PR TITLE
[`NPU`] [`OV CACHE`] Support `ov::internal::cache_header_alignment` property

### DIFF
--- a/src/plugins/intel_npu/src/plugin/include/properties.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/properties.hpp
@@ -131,7 +131,8 @@ private:
         ov::intel_npu::npuw::llm::additional_shared_lm_head_config.name()};
 
     const std::vector<ov::PropertyName> _internalSupportedProperties = {ov::internal::caching_properties.name(),
-                                                                        ov::internal::caching_with_mmap.name()};
+                                                                        ov::internal::caching_with_mmap.name(),
+                                                                        ov::internal::cache_header_alignment.name()};
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -9,6 +9,7 @@
 #include "intel_npu/common/device_helpers.hpp"
 #include "intel_npu/config/npuw.hpp"
 #include "intel_npu/config/options.hpp"
+#include "intel_npu/utils/utils.hpp"
 
 namespace intel_npu {
 
@@ -498,6 +499,7 @@ void Properties::registerPluginProperties() {
         REGISTER_SIMPLE_METRIC(ov::device::gops, true, _metrics->GetGops(get_specified_device_name(config)));
         REGISTER_SIMPLE_METRIC(ov::device::type, true, _metrics->GetDeviceType(get_specified_device_name(config)));
         REGISTER_SIMPLE_METRIC(ov::internal::supported_properties, false, _internalSupportedProperties);
+        REGISTER_SIMPLE_METRIC(ov::internal::cache_header_alignment, false, utils::STANDARD_PAGE_SIZE);
         REGISTER_SIMPLE_METRIC(ov::intel_npu::device_alloc_mem_size,
                                true,
                                _metrics->GetDeviceAllocMemSize(get_specified_device_name(config)));

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.cpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "caching_tests.hpp"
+
+#include <vector>
+
+#include "common/utils.hpp"
+
+using namespace ov::test::behavior;
+
+namespace {
+
+std::vector<ov::AnyMap> config = {{}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
+                         OVCompileModelLoadFromFileTestBaseNPU,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(config)),
+                         ov::test::utils::appendPlatformTypeTestName<OVCompileModelLoadFromFileTestBaseNPU>);
+
+}  // namespace

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.hpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ze_api.h>  // not redundant, needed for `ze_structure_type_t` structure
+#include <ze_mem_import_system_memory_ext.h>
+
+#include <behavior/ov_plugin/caching_tests.hpp>
+
+#include "intel_npu/utils/zero/zero_init.hpp"
+#include "openvino/core/log_util.hpp"
+
+namespace ov {
+namespace test {
+namespace behavior {
+
+using OVCompileModelLoadFromFileTestBaseNPU = CompileModelLoadFromFileTestBase;
+
+TEST_P(OVCompileModelLoadFromFileTestBaseNPU, BlobWithOVHeaderAligmentCanBeImported) {
+    core->set_property(ov::cache_dir(m_cacheFolderName));
+
+    ze_device_external_memory_properties_t externalMemorydDesc = {};
+    externalMemorydDesc.stype = ZE_STRUCTURE_TYPE_DEVICE_EXTERNAL_MEMORY_PROPERTIES;
+
+    auto res =
+        intel_npu::zeDeviceGetExternalMemoryProperties(intel_npu::ZeroInitStructsHolder::getInstance()->getDevice(),
+                                                       &externalMemorydDesc);
+    if ((res != ZE_RESULT_SUCCESS) ||
+        ((externalMemorydDesc.memoryAllocationImportTypes & ZE_EXTERNAL_MEMORY_TYPE_FLAG_STANDARD_ALLOCATION) == 0)) {
+        GTEST_SKIP() << "Standard allocation is not supported by the current configuration.";
+    }
+
+    std::stringstream custom_logger;
+    ov::util::LogCallback custom_log_callback =
+        [&](std::string_view s) {  // switch to query allocation info for import flag when possible
+            custom_logger << s << std::endl;
+        };
+    ov::util::set_log_callback(custom_log_callback);
+
+    for (size_t i = 0; i < 2; ++i) {
+        if (i != 0) {
+            configuration.emplace(ov::log::level(ov::log::Level::DEBUG));
+        }
+        core->compile_model(m_modelName, targetDevice, configuration);
+        configuration.erase(ov::log::level.name());
+    }
+    ov::util::reset_log_callback();
+    EXPECT_THAT(custom_logger.str(),
+                ::testing::HasSubstr("getGraphDescriptor - set ZE_GRAPH_FLAG_INPUT_GRAPH_PERSISTENT"));
+}
+
+}  // namespace behavior
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - *Add `ov::internal::cache_header_alignment` to `_internalSupportedProperties` list of NPU plugin*
 - *Test to check if `getGraphDescriptor - set ZE_GRAPH_FLAG_INPUT_GRAPH_PERSISTENT` would be logged for second compilation (need to improve this with a L0 call to check for imported driver allocation of blob)*

### Tickets:
 - *174559*
