### PR TITLE
[GPU] Prevent sharing memory for onednn concat

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/basic_memory_dependencies.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/basic_memory_dependencies.cpp
@@ -61,7 +61,7 @@ void basic_memory_dependencies::run(program& p) {
             }
 
             // onednn concatenation doesn't support non-zero padding which can occur for unaligned feature.
-            if (node->is_type<concatenation>()) {
+            if (node->is_type<concatenation>() && format::is_blocked(node->get_output_layout().format)) {
                 node->can_share_buffer(false);
                 for (auto& dep : node->get_dependencies()) {
                     dep.first->can_share_buffer(false);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/basic_memory_dependencies.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/basic_memory_dependencies.cpp
@@ -77,7 +77,7 @@ void basic_memory_dependencies::run(program& p) {
                     return l.feature() % f_bs == 0;
                 };
 
-                if (!is_feature_aligned(node->get_output_layout())) {
+                if (node->is_dynamic() || (!node->is_dynamic() && !is_feature_aligned(node->get_output_layout()))) {
                     node->can_share_buffer(false);
                     for (auto& dep : node->get_dependencies()) {
                         dep.first->can_share_buffer(false);


### PR DESCRIPTION
### Details:
 - Prevent buffer share for onednn concatenation.

### Issues:
- onednn concatenation doesn't support non-zero padding which can occur for unaligned feature.
- To support this case, onednn concatenation node shouldn't share the memory.

### Graphs:
<img width="1219" height="622" alt="image" src="https://github.com/user-attachments/assets/55b9f320-2e89-4284-8721-65892d99913b" />

### Checklist:
- [x] Is it a proper fix? (Not a workaround)
- [ ] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario? 

### Tickets:
 - 172243
