### PR TITLE
[GPU] fix 3D Conv with b_fs_zyx_fsv16 output

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.cpp
@@ -289,6 +289,10 @@ JitConstants ConvolutionKernel_b_fs_zyx_fsv16::GetJitConstants(const convolution
         else
             mb_block = (is_1stconv && output.Batch().v % 16 == 0) ? 16 : 1;
 
+        // If batch dim of output layout is not blocked format, mb_block should be set as 1.
+        if (mb_block == 16 && output.GetLayout() == DataLayout::b_fs_zyx_fsv16)
+            mb_block = 1;
+
         jit.AddConstant(MakeJitConstant("MB_BLOCK", mb_block));
     }
 


### PR DESCRIPTION
### Details:
 - If batch dim of output layout is not blocked format (such as b_fs_zyx_fsv16), `mb_block` should be always set as 1 for `gen9_common_conv_fwd_data`.

### Tickets:
 - 174786
