### PR TITLE
[NPUW] Phi-3 2K accuracy fix

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -476,7 +476,7 @@ public:
         // where K range and Q range are created by the same rules as before and Q_pos range is
         // a position_ids array.
         // 4. We also clean mask in places where paddings used instead of real tokens via:
-        //    Clean mask = 3 | ~(attention_mask_input[past_kv_len:]).T
+        //    Clean mask = 3 | !(attention_mask_input[past_kv_len:]).T
         auto past_kv_len = opp::wrap_type<ov::op::v8::Gather>({opp::any_input(), opp::any_input(), opp::any_input()});
         auto pos_ids_param = opp::wrap_type<ov::op::v0::Parameter>();
         auto pos_ids_shape_of = opp::wrap_type<ov::op::v3::ShapeOf>({pos_ids_param});
@@ -556,7 +556,7 @@ public:
             auto target_inputs = matched_bitwise_or->output(0).get_target_inputs();
             auto new_inv_sliding_mask = std::make_shared<ov::op::v13::BitwiseOr>(matched_bitwise_or, bitwise_and);
 
-            // 4. Removing extra padding via : 3 | ~(attention_mask_input[past_kv_len:]).T
+            // 4. Removing extra padding via : 3 | !(attention_mask_input[past_kv_len:]).T
             std::vector<int64_t> shape_rank_one{1};
             auto shape_rank_one_const =
                 std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, shape_rank_one);
@@ -572,7 +572,7 @@ public:
                                                                           const_one);
             auto present_atten_mask_bool =
                 std::make_shared<ov::op::v0::Convert>(present_atten_mask, ov::element::boolean);
-            auto inv_present_atten_mask = std::make_shared<ov::op::v13::BitwiseNot>(present_atten_mask_bool);
+            auto inv_present_atten_mask = std::make_shared<ov::op::v1::LogicalNot>(present_atten_mask_bool);
             auto inv_present_atten_mask_col =
                 std::make_shared<ov::op::v1::Reshape>(inv_present_atten_mask, vector_shape_const, false);
             auto clean_inv_sliding_mask =


### PR DESCRIPTION
### Details:
 - *Added `Phi3SlidingMask` pass that replaces formula :*
 ```
 1. Range(0, atten_mask_len) <= (Range(past_kv_len, atten_mask_len).T - sliding_window)
 2. Range(0, atten_mask_len) > (Range(past_kv_len, atten_mask_len).T - sliding_window)
 3. Result = 1 | 2
 ```

*to*

```
 1. Range(0, atten_mask_len) <= (position_ids.T - sliding_window)
 2. Range(0, atten_mask_len) > (Range(past_kv_len, atten_mask_len).T - sliding_window)
 3. Intermediate_result_1 = 1 | 2
 4. Range(0, atten_mask_len) <= (Range(past_kv_len, atten_mask_len).T - sliding_window)
 5. Range(0, atten_mask_len) >= past_kv_len
 6.  Intermediate_result_2 = 4 & 5
 7. Result = Intermediate_result_1 | Intermediate_result_2
 8. To clean from attention to padding tokens: Result |= !(attention_mask[past_kv_len, atten_mask_len]).T
```
*to create correct final sliding window mask for left-padded present tokens and right-padded past ones*


### Tickets:
 - *EISW-187252*
