### PR TITLE
Fix for nesnet accuracy regression, memory allocation order

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -746,9 +746,9 @@ const std::vector<primitive_id>& program::get_allocating_order(bool forced_updat
                     if (lhs_layout.is_dynamic())
                         return false;
 
-					// this condition affects the allocation order and might cause regression
-					// this is not real cause of the issue - it will be investigated further, but we can comment
-					// it now and see if that brings back the initial accuracy numbers.
+                    // this condition affects the allocation order and might cause regression
+                    // this is not real cause of the issue - it will be investigated further, but we can comment
+                    // it now and see if that brings back the initial accuracy numbers.
                     /*if (lhs_layout.bytes_count() == rhs_layout.bytes_count()) {
                         return lhs->get_unique_id() < rhs->get_unique_id();
                     }*/


### PR DESCRIPTION
We found that when the condition in `get_processing_order` is removed we get back to expected accuracy numbers. 

### Details:
 - This check only hides some real issue with memory sharing, so further debugging is needed

### Tickets:
[CVS-172659](https://jira.devtools.intel.com/browse/CVS-172659)
