### PR TITLE
[NPUW] Fix multiple MatMul matching issue in NPUW LM head cutting

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -27,7 +27,6 @@ class LLMCompiledModel : public ov::npuw::ICompiledModel {
 
 public:
     static constexpr const char* output_embeds = "npuw_output_embed";
-    static constexpr const char* hidden_output_name_key = "hidden_output_name";
 
     static constexpr uint32_t whisper_batch_dim = 0u;
     static constexpr uint32_t whisper_seq_len_dim = 2u;


### PR DESCRIPTION
### Details:
**Background:**
Eagle 3 pipeline will add new output in target model to get the intermedium feature embeddings.

The `cut_lm_head` function separates the vocabulary matrix (LM head) from LLM models for efficient inference. It needs to identify the correct `MatMul` operation among multiple candidates in the model graph.

**Problem:**
When multiple `MatMul` operations match the pattern (common in LLMs), the callback executes multiple times, with each execution overwriting the previous result. Only the last matched `MatMul` is used, often missing the actual vocabulary matrix.

**Solution:**
Replaced `MatcherPass` with direct traversal and intelligent selection:
1. Collect all candidates instead of using last match
2. Select MatMul with largest matrix size (vocabulary size heuristic)
3. Optimize traversal - iterate Result nodes directly instead of all nodes


### Tickets:
 - [*CVS-175198*](https://jira.devtools.intel.com/browse/CVS-175198)
