### PR TITLE
[CPU][ARM] ACL int8 convolution: add f32 output support

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/convolution_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/convolution_implementations.cpp
@@ -71,6 +71,7 @@ static const TypeMapping dnnlConvTypeMapping {
 
 static const TypeMapping aclLowpConvTypeMapping {
     // {src, wei, bia, dst}                            pt<src, wei, bias, dst>
+    {{_i8, _i8, _any, _any},                           {bypass(), bypass(), just<f32>(), just<f32>()}},
     {{_u8, _u8 | _i8, _any, _u8},                      {bypass(), bypass(), just<i32>(), bypass()}},
     {{_i8, _i8, _any, _i8},                            {bypass(), bypass(), just<i32>(), bypass()}},
 };

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/aarch64/convolution_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/aarch64/convolution_transformation.cpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "low_precision_transformations/convolution_transformation.hpp"
+#include "low_precision_transformations/convolution_with_incorrect_weights.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+const std::vector<ov::element::Type> netPrecisions = {
+        ov::element::f32
+};
+
+const std::vector<LayerTestsDefinitions::ConvolutionTransformationParam> params = {
+    {
+        { 256ul, ov::Shape { 1, 1, 1, 1 }, { -1.28f }, { 1.27f }, { -1.28f }, { 1.27f } },
+        false,
+        { 256ul, ov::Shape { 1, 1, 1, 1 }, { -1.28f }, { 1.27f }, { -1.28f }, { 1.27f } },
+        false,
+        "Convolution",
+        "i8"
+    }
+};
+
+const std::vector<ov::Shape> shapes = {
+    { 1, 3, 16, 16 },
+    { 4, 3, 16, 16 }
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::ValuesIn(shapes),
+        ::testing::Values(ov::test::utils::DEVICE_CPU),
+        ::testing::ValuesIn(params),
+        ::testing::Values(false)),
+    ConvolutionTransformation::getTestCaseName);
+
+}  // namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/x64/convolution_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/x64/convolution_transformation.cpp
@@ -153,12 +153,18 @@ const std::vector<ov::Shape> shapes = {
     { 4, 3, 16, 16 }
 };
 
+const std::vector<bool> useMaxPool = {
+    true,
+    false
+};
+
 INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::ValuesIn(shapes),
         ::testing::Values(ov::test::utils::DEVICE_CPU),
-        ::testing::ValuesIn(params)),
+        ::testing::ValuesIn(params),
+        ::testing::ValuesIn(useMaxPool)),
     ConvolutionTransformation::getTestCaseName);
 
 const std::vector<LayerTestsDefinitions::ConvolutionWIthIncorrectWeightsParam> incorrectWeightsParams = {
@@ -206,7 +212,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionTransformation,
              ::testing::ValuesIn(netPrecisions),
              ::testing::ValuesIn(shapes),
              ::testing::Values(ov::test::utils::DEVICE_CPU),
-             ::testing::ValuesIn(params)),
+             ::testing::ValuesIn(params),
+             ::testing::ValuesIn(useMaxPool)),
              ConvolutionTransformation::getTestCaseName);
 }  // namespace convolution3D
 }  // namespace

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_transformation.hpp
@@ -27,7 +27,8 @@ typedef std::tuple<
     ov::element::Type,
     ov::Shape,
     std::string,
-    ConvolutionTransformationParam
+    ConvolutionTransformationParam,
+    bool
 > ConvolutionTransformationParams;
 
 class ConvolutionTransformation :

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
@@ -16,18 +16,19 @@
 namespace LayerTestsDefinitions {
 
 std::string ConvolutionTransformation::getTestCaseName(const testing::TestParamInfo<ConvolutionTransformationParams>& obj) {
-    auto [netPrecision, inputShape, device, param] = obj.param;
+    auto [netPrecision, inputShape, device, param, useMaxPool] = obj.param;
     ov::pass::low_precision::LayerTransformation::Params params;
     std::ostringstream result;
     result << get_test_case_name_by_params(netPrecision, inputShape, device, params) <<
            "_rank=" << inputShape.size() <<
         "D_fq_on_data={" << param.fakeQuantizeOnData <<
-        "}_fq_on_weights={" << param.fakeQuantizeOnWeights << "}";
+        "}_fq_on_weights={" << param.fakeQuantizeOnWeights << "}" <<
+        "_useMaxPool=" << useMaxPool;
     return result.str();
 }
 
 void ConvolutionTransformation::SetUp() {
-    auto [netPrecision, inputShape, device, param] = this->GetParam();
+    auto [netPrecision, inputShape, device, param, useMaxPool] = this->GetParam();
     targetDevice = device;
 
     init_input_shapes(inputShape);
@@ -36,7 +37,8 @@ void ConvolutionTransformation::SetUp() {
         netPrecision,
         inputShape,
         param.fakeQuantizeOnData,
-        param.fakeQuantizeOnWeights);
+        param.fakeQuantizeOnWeights,
+        useMaxPool);
 }
 
 void ConvolutionTransformation::run() {

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_and_convolution.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_and_convolution.hpp
@@ -26,7 +26,8 @@ public:
         const ov::element::Type precision,
         const ov::PartialShape& inputShape,
         const FakeQuantizeOnData& fakeQuantizeOnData,
-        const FakeQuantizeOnWeights& fakeQuantizeOnWeights);
+        const FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+        const bool useMaxPool);
 
     static std::shared_ptr<ov::Model> get(
         const ov::element::Type precision,

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_convolution.cpp
@@ -19,7 +19,8 @@ std::shared_ptr<ov::Model> FakeQuantizeAndConvolutionFunction::get(
     const ov::element::Type precision,
     const ov::PartialShape& inputShape,
     const FakeQuantizeOnData& fqOnData,
-    const FakeQuantizeOnWeights& fqOnWeights) {
+    const FakeQuantizeOnWeights& fqOnWeights,
+    const bool useMaxPool) {
     const auto rankLength = inputShape.rank().is_dynamic() ? 4 : inputShape.rank().get_length();
     OPENVINO_ASSERT(rankLength == 3ul || rankLength == 4ul || rankLength == 5ul, "not supported input shape rank: ", rankLength);
 
@@ -51,7 +52,7 @@ std::shared_ptr<ov::Model> FakeQuantizeAndConvolutionFunction::get(
     maxPool->set_friendly_name("maxPool");
 
     const auto convolution = std::make_shared<ov::opset1::Convolution>(
-        maxPool, //fqOnData.empty() ? input : fakeQuantizeOnActivations,
+        useMaxPool ? maxPool : fqOnData.empty() ? input : fakeQuantizeOnActivations,
         fqOnWeights.empty() ?
             weights->output(0) :
             ov::test::utils::make_fake_quantize(


### PR DESCRIPTION
### Details:
 - PR needs to be rebased as soon as ACL is upgraded to `v52.6.0` where f32 support is added: https://github.com/ARM-software/ComputeLibrary/pull/1184

### Tickets:
 - *ticket-id*
