### PR TITLE
Fix: Prevent dangling reference crash by correcting C++ return value policy.

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/compiled_model.cpp
+++ b/src/bindings/python/src/pyopenvino/core/compiled_model.cpp
@@ -251,6 +251,7 @@ void regclass_CompiledModel(py::module m) {
 
     cls.def("output",
             (const ov::Output<const ov::Node>& (ov::CompiledModel::*)() const) & ov::CompiledModel::output,
+            py::return_value_policy::reference_internal,
             R"(
                 Gets a single output of a compiled model.
                 If the model has more than one output, this method throws an exception.
@@ -261,6 +262,7 @@ void regclass_CompiledModel(py::module m) {
 
     cls.def("output",
             (const ov::Output<const ov::Node>& (ov::CompiledModel::*)(size_t) const) & ov::CompiledModel::output,
+            py::return_value_policy::reference_internal,
             py::arg("index"),
             R"(
                 Gets output of a compiled model identified by an index.
@@ -275,6 +277,7 @@ void regclass_CompiledModel(py::module m) {
     cls.def("output",
             (const ov::Output<const ov::Node>& (ov::CompiledModel::*)(const std::string&) const) &
                 ov::CompiledModel::output,
+            py::return_value_policy::reference_internal,
             py::arg("tensor_name"),
             R"(
                 Gets output of a compiled model identified by a tensor_name.


### PR DESCRIPTION
This PR fixes a critical memory safety issue where a C++ function was returning a const & reference to Python without proper lifetime management.

The Problem: The returned reference's lifetime was tied to a parent C++ object. When the parent object was garbage-collected in Python, the reference became a dangling pointer, leading to unpredictable segmentation faults (use-after-free).

The Solution: This has been resolved by applying the py::return_value_policy::reference_internal policy to the binding. This ensures the parent object's lifetime is extended as long as the returned reference is in use by Python, preventing any memory corruption.

### Tickets:
 - 174729
