### PR TITLE
[CI] Disable `canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor` test as sporadically failing

### DIFF
--- a/src/tests/functional/base_func_tests/include/behavior/ov_infer_request/callback.hpp
+++ b/src/tests/functional/base_func_tests/include/behavior/ov_infer_request/callback.hpp
@@ -40,7 +40,8 @@ TEST_P(OVInferRequestCallbackTests, syncInferDoesNotCallCompletionCallback) {
 }
 
 // test that can wait all callbacks on dtor
-TEST_P(OVInferRequestCallbackTests, canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor) {
+// Ticket: 151980
+TEST_P(OVInferRequestCallbackTests, DISABLED_canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor) {
     const int NUM_ITER = 10;
     struct TestUserData {
         std::atomic<int> numIter = {0};


### PR DESCRIPTION
### Tickets:
 - *151980*
