### PR TITLE
[CPU] Move OVClassCompileModelAndCheckSecondaryPropertiesTest tests to nightly scope.

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -121,11 +121,11 @@ const std::vector<ov::AnyMap> configsDevicePropertiesDouble = {
 
 
 // OV Class load and check network with ov::device::properties
-INSTANTIATE_TEST_SUITE_P(smoke_CPU_OVClassCompileModelAndCheckSecondaryPropertiesTest,
+INSTANTIATE_TEST_SUITE_P(nightly_CPU_OVClassCompileModelAndCheckSecondaryPropertiesTest,
                          OVClassCompileModelAndCheckSecondaryPropertiesTest,
                          ::testing::Combine(::testing::Values("CPU"), ::testing::ValuesIn(configsDeviceProperties)));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CPU_OVClassCompileModelAndCheckWithSecondaryPropertiesDoubleTest,
+INSTANTIATE_TEST_SUITE_P(nightly_CPU_OVClassCompileModelAndCheckWithSecondaryPropertiesDoubleTest,
                          OVClassCompileModelAndCheckSecondaryPropertiesTest,
                          ::testing::Combine(::testing::Values("CPU"),
                                             ::testing::ValuesIn(configsDevicePropertiesDouble)));


### PR DESCRIPTION
…o nightly scope.

### Details:
 - *OVClassCompileModelAndCheckSecondaryPropertiesTest has sporadic failures. That affects precommit scope. So need move it to the nightly scope and continue investigation there*

### Tickets:
 - **
