### PR TITLE
[NPU][CMAKE]: Enable Android build

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -43,7 +43,7 @@ endif()
 
 ov_dependent_option (ENABLE_ONEDNN_FOR_GPU "Enable oneDNN with GPU support" ${ENABLE_ONEDNN_FOR_GPU_DEFAULT} "ENABLE_INTEL_GPU" OFF)
 
-ov_dependent_option (ENABLE_INTEL_NPU "NPU plugin for OpenVINO runtime" ON "X86_64;WIN32 OR LINUX" OFF)
+ov_dependent_option (ENABLE_INTEL_NPU "NPU plugin for OpenVINO runtime" ON "X86_64;WIN32 OR LINUX OR ANDROID" OFF)
 ov_dependent_option (ENABLE_INTEL_NPU_INTERNAL "NPU plugin internal components for OpenVINO runtime" ON "ENABLE_INTEL_NPU" OFF)
 
 ov_option (ENABLE_DEBUG_CAPS "enable OpenVINO debug capabilities at runtime" OFF)


### PR DESCRIPTION
### Details:
 
In theory, it is possible to build NPU plugin with the Android toolchain. Although I don't think Intel has any official product/support for NPU on Android, I think it is not bad to allow users to build the plugin. Users can figure out how to enable NPU on Android themselves if they decided to include the NPU plugin on Android. This should not be a blocker for allowing users to build NPU plugin on Android.



Maybe I need to set this default to OFF on Android though?