### PR TITLE
[core] Remove visit_attribute from WL attribute

### DIFF
--- a/src/core/dev_api/openvino/core/rt_info/weightless_caching_attributes.hpp
+++ b/src/core/dev_api/openvino/core/rt_info/weightless_caching_attributes.hpp
@@ -35,8 +35,6 @@ public:
 
     bool is_copyable() const override;
 
-    bool visit_attributes(AttributeVisitor& visitor) override;
-
     size_t original_size;
     size_t bin_offset;
     ov::element::Type original_dtype;

--- a/src/core/src/op/util/weightless_caching_attributes.cpp
+++ b/src/core/src/op/util/weightless_caching_attributes.cpp
@@ -11,13 +11,6 @@ bool ov::WeightlessCacheAttribute::is_copyable() const {
     return false;
 }
 
-bool ov::WeightlessCacheAttribute::visit_attributes(AttributeVisitor& visitor) {
-    visitor.on_attribute("original_dtype", original_dtype);
-    visitor.on_attribute("bin_offset", bin_offset);
-    visitor.on_attribute("original_size", original_size);
-    return true;
-}
-
 OPENVINO_API void ov::copy_weightless_cache_attr(const std::shared_ptr<ov::Node>& from,
                                                  const std::shared_ptr<ov::Node>& to) {
     const auto& rt_info = from->get_rt_info();


### PR DESCRIPTION
### Details:
 - Remove `ov::WeightlessCacheAttribute::visit_attributes` as IR frontend should not serialize this attribute
 
### Related PRs:
- #32599

### Tickets:
 - CVS-161826
