### PR TITLE
[MOE] MatMulConstTransposesExtraction to utilize postponed constants instead ConstantFold

### DIFF
--- a/src/common/transformations/tests/common_optimizations/matmul_const_transposes_extraction.cpp
+++ b/src/common/transformations/tests/common_optimizations/matmul_const_transposes_extraction.cpp
@@ -30,8 +30,10 @@ TEST_F(TransformationTestsF, MatMulConstTransposesExtractionConstantWeights) {
 
     {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 3, 4});
-        auto weights = opset8::Constant::create(element::f32, Shape{1, 2, 3}, {1, 3, 5, 2, 4, 6});
-        auto matmul = std::make_shared<opset8::MatMul>(data, weights, true, true);
+        auto weights = opset8::Constant::create(element::f32, Shape{1, 3, 2}, {1, 2, 3, 4, 5, 6});
+        auto transpose =
+            std::make_shared<opset8::Transpose>(weights, op::v0::Constant::create(element::i32, Shape{3}, {0, 2, 1}));
+        auto matmul = std::make_shared<opset8::MatMul>(data, transpose, true, true);
         model_ref = std::make_shared<Model>(matmul, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -97,8 +99,10 @@ TEST_F(TransformationTestsF, MatMulConstTransposesExtractionNonUnitDims_transpos
     }
     {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 3, 4});
-        auto weights = opset8::Constant::create(element::f32, Shape{2, 2, 3}, {1, 3, 5, 2, 4, 6, 1, 3, 5, 2, 4, 6});
-        auto matmul = std::make_shared<opset8::MatMul>(data, weights, true, true);
+        auto weights = opset8::Constant::create(element::f32, Shape{2, 3, 2}, {1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6});
+        auto transpose =
+            std::make_shared<opset8::Transpose>(weights, op::v0::Constant::create(element::i32, Shape{3}, {0, 2, 1}));
+        auto matmul = std::make_shared<opset8::MatMul>(data, transpose, true, true);
         model_ref = std::make_shared<Model>(matmul, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -117,8 +121,10 @@ TEST_F(TransformationTestsF, MatMulConstTransposesExtractionNonUnitDims_transpos
     }
     {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 4, 3});
-        auto weights = opset8::Constant::create(element::f32, Shape{2, 2, 3}, {1, 3, 5, 2, 4, 6, 1, 3, 5, 2, 4, 6});
-        auto matmul = std::make_shared<opset8::MatMul>(data, weights, false, true);
+        auto weights = opset8::Constant::create(element::f32, Shape{2, 3, 2}, {1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6});
+        auto transpose =
+            std::make_shared<opset8::Transpose>(weights, op::v0::Constant::create(element::i32, Shape{3}, {0, 2, 1}));
+        auto matmul = std::make_shared<opset8::MatMul>(data, transpose, false, true);
         model_ref = std::make_shared<Model>(matmul, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);

--- a/src/core/src/xml_util/xml_serialize_util.cpp
+++ b/src/core/src/xml_util/xml_serialize_util.cpp
@@ -25,6 +25,7 @@
 #include "openvino/op/util/max_pool_base.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/op/util/sub_graph_base.hpp"
+#include "openvino/pass/constant_folding.hpp"
 #include "openvino/runtime/string_aligned_buffer.hpp"
 #include "openvino/xml_util/constant_writer.hpp"
 #include "transformations/rt_info/disable_fp16_compression.hpp"
@@ -52,6 +53,9 @@ public:
         if (node->get_rt_info().count("postponed_constant")) {
             OPENVINO_ASSERT(node->get_output_size() == 1);
             ov::OutputVector outputs(1);
+            if (ov::pass::constant_folding_is_disabled(node)) {
+                node->get_rt_info().erase(ov::pass::DisableConstantFolding::get_type_info_static());
+            }
             OPENVINO_ASSERT(
                 node->constant_fold(outputs, node->input_values()),
                 "Node with set `postponed_constant` attribute cannot be fold to constant when saving model to IR file");


### PR DESCRIPTION

### Details:
 - *Utilize postponed constant to reduce memory utilization when folding large transposes found in MOE models*
 - *...*

### Tickets:
 - *CVS-175563*
