### PR TITLE
[GPU] Relax absolute threshold for ROIAlign

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
@@ -4,9 +4,43 @@
 #include "single_op_tests/roi_align.hpp"
 #include "common_test_utils/test_constants.hpp"
 
+#include <random>
+
 namespace {
 using ov::test::ROIAlignLayerTest;
 using ov::test::ROIAlignV9LayerTest;
+
+class ROIAlignLayerTestGPU : public ROIAlignLayerTest {
+protected:
+    void SetUp() override {
+        ROIAlignLayerTest::SetUp();
+        auto param = this->GetParam();
+        ov::element::Type model_type = std::get<7>(param);
+        if (model_type == ov::element::f32) {
+            // ROIAlign involves calculations such as interpolation, pooling, and clamping,
+            // so for small number, it can introduce more error than other ops.
+            // Therefore, it needs to relax threshold for GPU device to avoid false-positive results.
+            // Please see how to set abs_threshold in other frameworks , e.g, TensorFlow (1e-5), PyTorch (1e-5).
+            abs_threshold = 1e-5;
+        }
+    }
+};
+
+class ROIAlignV9LayerTestGPU : public ROIAlignV9LayerTest {
+protected:
+    void SetUp() override {
+        ROIAlignV9LayerTest::SetUp();
+        auto param = this->GetParam();
+        ov::element::Type model_type = std::get<8>(param);
+        if (model_type == ov::element::f32) {
+            // ROIAlign involves calculations such as interpolation, pooling, and clamping,
+            // so for small number, it can introduce more error than other ops.
+            // Therefore, it needs to relax threshold for GPU device to avoid false-positive results.
+            // Please see how to set abs_threshold in other frameworks , e.g, TensorFlow (1e-5), PyTorch (1e-5).
+            abs_threshold = 1e-5;
+        }
+    }
+};
 
 const std::vector<ov::element::Type> netPRCs = {
     ov::element::f32
@@ -21,8 +55,16 @@ const std::vector<ov::element::Type> netPRCs = {
     // ov::element::f16
 };
 
+TEST_P(ROIAlignLayerTestGPU, Inference) {
+    run();
+}
+
+TEST_P(ROIAlignV9LayerTestGPU, Inference) {
+    run();
+}
+
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_average,
-                         ROIAlignLayerTest,
+                         ROIAlignLayerTestGPU,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{3, 8, 16, 16}},
                                                                                                 {{2, 1, 16, 16}},
@@ -35,10 +77,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_average,
                                             ::testing::Values("avg"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignLayerTest::getTestCaseName);
+                         ROIAlignLayerTestGPU::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_max,
-                         ROIAlignLayerTest,
+                         ROIAlignLayerTestGPU,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{2, 8, 20, 20}},
                                                                                                 {{2, 1, 20, 20}},
@@ -51,10 +93,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_max,
                                             ::testing::Values("max"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignLayerTest::getTestCaseName);
+                         ROIAlignLayerTestGPU::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_avg_asym,
-                         ROIAlignV9LayerTest,
+                         ROIAlignV9LayerTestGPU,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{2, 1, 8, 8}},
                                                                                                 {{2, 8, 20, 20}},
@@ -69,10 +111,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_avg_asym,
                                             ::testing::Values("asymmetric"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignV9LayerTest::getTestCaseName);
+                         ROIAlignV9LayerTestGPU::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_avg_hpfn,
-                         ROIAlignV9LayerTest,
+                         ROIAlignV9LayerTestGPU,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{2, 1, 8, 8}},
                                                                                                 {{2, 8, 20, 20}},
@@ -87,10 +129,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_avg_hpfn,
                                             ::testing::Values("half_pixel_for_nn"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignV9LayerTest::getTestCaseName);
+                         ROIAlignV9LayerTestGPU::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_max_hp,
-                         ROIAlignV9LayerTest,
+                         ROIAlignV9LayerTestGPU,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{2, 1, 8, 8}},
                                                                                                 {{2, 8, 20, 20}},
@@ -105,5 +147,5 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_max_hp,
                                             ::testing::Values("half_pixel"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignV9LayerTest::getTestCaseName);
+                         ROIAlignV9LayerTestGPU::getTestCaseName);
 }  // namespace

--- a/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
@@ -48,8 +48,8 @@ std::string ROIAlignLayerTest::getTestCaseName(const testing::TestParamInfo<roia
 }
 
 static int randInt(int low, int high) {
-    std::random_device rd;
-    std::mt19937 gen(rd());
+    const int seed = 42;
+    std::mt19937 gen(seed);
     std::uniform_int_distribution<int> dis(low, high);
     return dis(gen);
 }
@@ -171,6 +171,14 @@ void ROIAlignV9LayerTest::SetUp() {
     targetDevice = _targetDevice;
 
     init_input_shapes(input_shapes);
+
+    if (targetDevice == ov::test::utils::DEVICE_GPU) {
+        // ROIAlign involves calculations such as interpolation, pooling, and clamping,
+        // so for small number, it can introduce more error than other ops.
+        // Therefore, it needs to relax threshold for GPU device to avoid false-positive results.
+        // Please see how to set abs_threshold in other frameworks , e.g, TensorFlow (1e-5), PyTorch (1e-5).
+        abs_threshold = 1e-5;
+    }
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0]);
     std::vector<float> proposal_vector;

--- a/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
@@ -172,14 +172,6 @@ void ROIAlignV9LayerTest::SetUp() {
 
     init_input_shapes(input_shapes);
 
-    if (targetDevice == ov::test::utils::DEVICE_GPU) {
-        // ROIAlign involves calculations such as interpolation, pooling, and clamping,
-        // so for small number, it can introduce more error than other ops.
-        // Therefore, it needs to relax threshold for GPU device to avoid false-positive results.
-        // Please see how to set abs_threshold in other frameworks , e.g, TensorFlow (1e-5), PyTorch (1e-5).
-        abs_threshold = 1e-5;
-    }
-
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0]);
     std::vector<float> proposal_vector;
     std::vector<int> roi_idx_vector;


### PR DESCRIPTION
### Details:
 - ROIAlign involves calculations such as interpolation, pooling, and clamping, so for small number, it can introduce more error than other ops.
 - Therefore, it needs to relax threshold for GPU device to avoid false-positive results.
 - For reference, `TensorFlow` sets for `atol` to `1e-5` for bilinear resizing test.

### Tickets:
 - 142900
