### PR TITLE
Add file descriptor support for weightless model loading

### DIFF
--- a/src/common/util/include/openvino/util/mmap_object.hpp
+++ b/src/common/util/include/openvino/util/mmap_object.hpp
@@ -15,6 +15,14 @@
 
 namespace ov {
 
+#ifdef _WIN32
+// Windows uses HANDLE (void*) for file handles
+using FileHandle = void*;
+#else
+// Linux/Unix uses int for file descriptors
+using FileHandle = int;
+#endif
+
 /**
  * @brief This class represents a mapped memory.
  * Instead of reading files, we can map the memory via mmap for Linux or MapViewOfFile for Windows.
@@ -36,6 +44,16 @@ public:
  * @return MappedMemory shared ptr object which keep mmaped memory and control the lifetime.
  */
 std::shared_ptr<ov::MappedMemory> load_mmap_object(const std::string& path);
+
+/**
+ * @brief Returns mapped memory for a file from provided file handle (cross-platform).
+ * Uses mmap on Linux/Unix (with file descriptor) or MapViewOfFile on Windows (with HANDLE).
+ * This allows external control of file access through a callback function.
+ *
+ * @param handle Platform-specific file handle (int fd on Linux, HANDLE on Windows).
+ * @return MappedMemory shared ptr object which keep mmaped memory and control the lifetime.
+ */
+std::shared_ptr<ov::MappedMemory> load_mmap_object(FileHandle handle);
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 

--- a/src/common/util/src/os/lin/lin_mmap_object.cpp
+++ b/src/common/util/src/os/lin/lin_mmap_object.cpp
@@ -64,22 +64,28 @@ public:
     MapHolder() = default;
 
     void set(const std::string& path) {
-        int prot = PROT_READ;
         int mode = O_RDONLY;
-        struct stat sb = {};
-        m_handle = HandleHolder(open(path.c_str(), mode));
-        if (m_handle.get() == -1) {
+        int fd = open(path.c_str(), mode);
+        if (fd == -1) {
             throw std::runtime_error("Can not open file " + path +
                                      " for mapping. Ensure that file exists and has appropriate permissions");
         }
-        if (fstat(m_handle.get(), &sb) == -1) {
-            throw std::runtime_error("Can not get file size for " + path);
+        set_from_fd(fd);
+    }
+
+    void set_from_fd(const int fd) {
+        int prot = PROT_READ;
+        struct stat sb = {};
+        m_handle = HandleHolder(fd);
+        if (fstat(fd, &sb) == -1) {
+            throw std::runtime_error("Can not get file size for fd=" + std::to_string(fd));
         }
         m_size = sb.st_size;
         if (m_size > 0) {
-            m_data = mmap(nullptr, m_size, prot, MAP_SHARED, m_handle.get(), 0);
+            m_data = mmap(nullptr, m_size, prot, MAP_SHARED, fd, 0);
             if (m_data == MAP_FAILED) {
-                throw std::runtime_error("Can not create file mapping for " + path + ", err=" + std::strerror(errno));
+                throw std::runtime_error("Can not create file mapping for fd=" + std::to_string(fd) +
+                                         ", err=" + std::strerror(errno));
             }
         } else {
             m_data = MAP_FAILED;
@@ -104,6 +110,13 @@ public:
 std::shared_ptr<ov::MappedMemory> load_mmap_object(const std::string& path) {
     auto holder = std::make_shared<MapHolder>();
     holder->set(path);
+    return holder;
+}
+
+std::shared_ptr<ov::MappedMemory> load_mmap_object(FileHandle handle) {
+    // On Linux, FileHandle is int (file descriptor)
+    auto holder = std::make_shared<MapHolder>();
+    holder->set_from_fd(static_cast<int>(handle));
     return holder;
 }
 

--- a/src/common/util/src/os/win/win_mmap_object.cpp
+++ b/src/common/util/src/os/win/win_mmap_object.cpp
@@ -77,6 +77,10 @@ public:
     }
 #endif
 
+    void set_from_handle(HANDLE h) {
+        map("<external_handle>", h);
+    }
+
     char* data() noexcept override {
         return static_cast<char*>(m_data);
     }
@@ -131,6 +135,18 @@ private:
 std::shared_ptr<ov::MappedMemory> load_mmap_object(const std::string& path) {
     auto holder = std::make_shared<MapHolder>();
     holder->set(path);
+    return holder;
+}
+
+std::shared_ptr<ov::MappedMemory> load_mmap_object(FileHandle handle) {
+    // On Windows, FileHandle is void* (HANDLE)
+    HANDLE h = static_cast<HANDLE>(handle);
+    if (h == INVALID_HANDLE_VALUE || h == nullptr) {
+        throw std::runtime_error("Invalid handle provided to load_mmap_object");
+    }
+
+    auto holder = std::make_shared<MapHolder>();
+    holder->set_from_handle(h);
     return holder;
 }
 

--- a/src/inference/include/openvino/runtime/common.hpp
+++ b/src/inference/include/openvino/runtime/common.hpp
@@ -49,6 +49,26 @@ namespace ov {
  */
 using SupportedOpsMap = std::map<std::string, std::string>;
 
+#ifdef _WIN32
+// Windows uses HANDLE (void*) for file handles
+using FileHandle = void*;
+#else
+// Linux/Unix uses int for file descriptors
+using FileHandle = int;
+#endif
+
+/**
+ * @brief Type definition for file handle provider callback (cross-platform).
+ * Function that takes no arguments and returns a platform-specific file handle.
+ * The callback implementation must release ownership, caller should close the FileHandle.
+ * On Linux/Unix: returns int (file descriptor)
+ * On Windows: returns void* (HANDLE cast to void*)
+ * This is useful for scenarios where file access needs to be controlled externally,
+ * such as Android content providers or Windows restricted file access scenarios.
+ * @ingroup ov_runtime_cpp_api
+ */
+using FileHandleProvider = std::function<FileHandle()>;
+
 }  // namespace ov
 
 #if defined(_WIN32) && !defined(__GNUC__)

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
@@ -55,6 +55,19 @@ static constexpr ov::Property<std::string> weights_bank_alloc{"NPUW_WEIGHTS_BANK
 
 /**
  * @brief
+ * Type: ov::FileHandleProvider.
+ * Callback function to get file handle for weights (cross-platform).
+ * The callback takes no arguments and returns a platform-specific file handle.
+ * On Linux/Unix: returns int (file descriptor)
+ * On Windows: returns void* (HANDLE)
+ * This is useful for scenarios where file access needs to be controlled externally,
+ * such as Android content providers or restricted file access scenarios.
+ * Default value: nullptr.
+ */
+static constexpr ov::Property<ov::FileHandleProvider> weights_handle_provider{"NPUW_WEIGHTS_HANDLE_PROVIDER"};
+
+/**
+ * @brief
  * Type: std::string.
  * Specify a directory where to store cached submodels.
  * Default value: empty.

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
@@ -61,10 +61,17 @@ ov::Tensor Const::eval() const {
     }
 
     // Weightless import case. Mmmap CPU weight on demand to avoid allocating all weights at once.
-    if (!m_weights_path.empty()) {
+    if (!m_weights_path.empty() || m_handle_provider) {
         NPUW_ASSERT(!m_read_from_bin &&
                     "Trying to read weight from weights file, but the weight has been already deserialized!");
-        auto mapped_memory = ov::load_mmap_object(m_weights_path);
+        std::shared_ptr<ov::MappedMemory> mapped_memory;
+        // Use handle_provider if available, otherwise use default mmap
+        if (m_handle_provider) {
+            ov::FileHandle handle = m_handle_provider();
+            mapped_memory = ov::load_mmap_object(handle);
+        } else {
+            mapped_memory = ov::load_mmap_object(m_weights_path);
+        }
         m_mmaped_weights =
             std::make_shared<ov::npuw::s11n::Weights>(mapped_memory->data(), mapped_memory->size(), mapped_memory);
         return ov::Tensor(m_cached_type, m_cached_shape, m_mmaped_weights->get_ptr(m_offset));
@@ -80,7 +87,7 @@ LazyTensor::Meta Const::eval_meta() const {
     }
 
     // Weightless import case
-    if (!m_weights_path.empty()) {
+    if (!m_weights_path.empty() || m_handle_provider) {
         return {m_cached_shape, m_cached_type};
     }
 
@@ -115,9 +122,11 @@ void Const::read_weight(const ov::npuw::s11n::WeightsContext& ctx) {
             // It doesn't introduce extra allocation, however it allows to gradually 1 by 1
             // read mmaped CPU weights and allocate them on device without loading all the weights first.
             // Thus the memory consumption during import is greatly reduced but at the slight cost of performance.
-            NPUW_ASSERT(!ctx.weights_path.empty());
+            NPUW_ASSERT(!ctx.weights_path.empty() || ctx.handle_provider);
             // Just save weights_path for the eval() to call the actual mmap.
             m_weights_path = ctx.weights_path;
+            // Also save handle_provider if available
+            m_handle_provider = ctx.handle_provider;
         }
     } else {
         auto it = ctx.consts_cache.find({m_offset, m_byte_size});

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.hpp
@@ -108,6 +108,7 @@ private:
     std::size_t m_byte_size = 0;
     ov::Tensor m_read_from_bin;
     std::string m_weights_path;
+    ov::FileHandleProvider m_handle_provider = nullptr;
     mutable ov::npuw::s11n::WeightsPtr m_mmaped_weights = nullptr;
     // FIXME: special case when a new Constant was added into the model,
     // then made into LazyTensor during folding. We need to keep a copy of it,

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
@@ -29,11 +29,13 @@ ov::npuw::s11n::WeightsContext::WeightsContext(bool _is_weightless,
 ov::npuw::s11n::WeightsContext::WeightsContext(const ov::npuw::s11n::WeightsPtr& _weights,
                                                const std::string& _weights_path,
                                                const s11n::WeightsContext::ConstsCache& _consts_cache,
-                                               const BF16Cache& _bf16_consts)
+                                               const BF16Cache& _bf16_consts,
+                                               const ov::FileHandleProvider& _handle_provider)
     : weights(_weights),
       weights_path(_weights_path),
       consts_cache(_consts_cache),
-      bf16_consts(_bf16_consts) {
+      bf16_consts(_bf16_consts),
+      handle_provider(_handle_provider) {
     is_weightless = _weights || !_consts_cache.empty();
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
@@ -17,6 +17,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "openvino/runtime/common.hpp"
+
 namespace ov {
 namespace npuw {
 namespace s11n {
@@ -131,7 +133,8 @@ struct WeightsContext {
     WeightsContext(const ov::npuw::s11n::WeightsPtr& _weights,
                    const std::string& _weights_path,
                    const ConstsCache& _consts_cache,
-                   const BF16Cache& _bf16_consts);
+                   const BF16Cache& _bf16_consts,
+                   const ov::FileHandleProvider& _handle_provider = nullptr);
 
     WeightsContext& operator=(const WeightsContext& other) = default;
 
@@ -146,6 +149,7 @@ struct WeightsContext {
     std::string weights_path;
     ConstsCache consts_cache;
     BF16Cache bf16_consts;
+    ov::FileHandleProvider handle_provider = nullptr;
 };
 
 struct PyramidCtx {


### PR DESCRIPTION
### Details:
- Add ov::FdGetterType and ov::hint::fd_getter property
- Extend load_mmap_object() with fd-based overload (Linux only)
- Integrate fd_getter through NPUW deserialization flow
- Windows implementation throws unsupported exception

### Tickets:
 - EISW-179643
