### PR TITLE
Set CppLint disabled by default

### DIFF
--- a/cmake/developer_package/features.cmake
+++ b/cmake/developer_package/features.cmake
@@ -74,7 +74,7 @@ else()
     set(STYLE_CHECKS_DEFAULT ON)
 endif()
 
-ov_option (ENABLE_CPPLINT "Enable cpplint checks during the build" ${STYLE_CHECKS_DEFAULT})
+ov_option (ENABLE_CPPLINT "Enable cpplint checks during the build" OFF)
 
 ov_dependent_option (ENABLE_CPPLINT_REPORT "Build cpplint report instead of failing the build" OFF "ENABLE_CPPLINT" OFF)
 

--- a/docs/dev/cmake_options_for_custom_compilation.md
+++ b/docs/dev/cmake_options_for_custom_compilation.md
@@ -150,7 +150,7 @@ In this case OpenVINO CMake scripts take `TBBROOT` environment variable into acc
 ## Other options
 
 * `ENABLE_CPPLINT` enables code style check using [cpplint] static code checker:
-    * `ON` is default.
+    * `OFF` is default.
 * `ENABLE_CLANG_FORMAT` enables [Clang format] code style check:
     * `ON` is default.
 * `ENABLE_FASTER_BUILD` enables [precompiled headers] and [unity build] using CMake:


### PR DESCRIPTION
### Details:
 - Sets ENABLE_CPPLINT option default to off.
 - It's needed to remove CppLint dependency first from openvino_contrib, to fully remove it from openvino repo #32543.

### Tickets:
 - CVS-167341
