### PR TITLE
[NPU] Make the methods private since they must be used only by ZeroMemPool

### DIFF
--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem.hpp
@@ -9,8 +9,25 @@
 
 namespace intel_npu {
 
+class ZeroMemPool;
+
 class ZeroMem final {
 public:
+    ZeroMem() = delete;
+
+    /**
+     * @brief Return allocated memory
+     */
+    void* data();
+
+    /**
+     * @brief Return size of the allocated memory
+     */
+    size_t size();
+
+private:
+    friend class intel_npu::ZeroMemPool;
+
     /**
      * @brief Allocates a new memory region in the level zero context provided through init_structs.
      * @param init_structs Holder for the level zero structures.
@@ -41,23 +58,12 @@ public:
             const bool standard_allocation);
 
     /**
-     * @brief Return allocated memory
-     */
-    void* data();
-
-    /**
-     * @brief Return size of the allocated memory
-     */
-    size_t size();
-
-    /**
      * @brief Return memory id of the allocated memory
      */
     uint64_t id();
 
     ~ZeroMem();
 
-private:
     std::shared_ptr<ZeroInitStructsHolder> _init_structs;
     Logger _logger;
 

--- a/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.hpp
@@ -14,6 +14,7 @@
 #include "common_test_utils/test_constants.hpp"
 #include "intel_npu/utils/utils.hpp"
 #include "intel_npu/utils/zero/zero_mem.hpp"
+#include "intel_npu/utils/zero/zero_mem_pool.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
 #include "ir_serializer.hpp"
 #include "openvino/runtime/intel_npu/properties.hpp"
@@ -157,9 +158,11 @@ TEST_P(ZeroGraphCompilationTests, GetInitSetArgsDestroyGraphAlignedMemoryIR) {
     OV_ASSERT_NO_THROW(zeGraphExt->initializeGraph(graphDescriptor, initCommandQueueOrdinal));
 
     size_t totalSize = 1 * 3 * 24 * 24 * sizeof(float);
-    std::unique_ptr<ZeroMem> buffer;
-    OV_ASSERT_NO_THROW(buffer =
-                           std::make_unique<ZeroMem>(zeroInitStruct, totalSize, ::utils::STANDARD_PAGE_SIZE, false));
+    std::shared_ptr<ZeroMem> buffer;
+    OV_ASSERT_NO_THROW(buffer = ZeroMemPool::get_instance().allocate_zero_memory(zeroInitStruct,
+                                                                                 totalSize,
+                                                                                 ::utils::STANDARD_PAGE_SIZE,
+                                                                                 false));
 
     OV_ASSERT_NO_THROW(zeGraphExt->setGraphArgumentValue(graphDescriptor, 0, buffer->data()));
 }
@@ -262,9 +265,11 @@ TEST_P(ZeroGraphTest, GetInitSetArgsDestroyGraphAlignedMemoryMallocBlob) {
                                                                        ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE));
         OV_ASSERT_NO_THROW(zeGraphExt->initializeGraph(graphDescriptor, initCommandQueueOrdinal));
 
-        std::unique_ptr<ZeroMem> buffer;
-        OV_ASSERT_NO_THROW(buffer =
-                               std::make_unique<ZeroMem>(zeroInitStruct, size, ::utils::STANDARD_PAGE_SIZE, false));
+        std::shared_ptr<ZeroMem> buffer;
+        OV_ASSERT_NO_THROW(buffer = ZeroMemPool::get_instance().allocate_zero_memory(zeroInitStruct,
+                                                                                     size,
+                                                                                     ::utils::STANDARD_PAGE_SIZE,
+                                                                                     false));
 
         OV_ASSERT_NO_THROW(zeGraphExt->setGraphArgumentValue(graphDescriptor, 0, buffer->data()));
 
@@ -294,9 +299,11 @@ TEST_P(ZeroGraphTest, GetInitSetArgsDestroyGraphNotAlignedMemoryMallocBlob) {
                                                                        ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE));
         OV_ASSERT_NO_THROW(zeGraphExt->initializeGraph(graphDescriptor, initCommandQueueOrdinal));
 
-        std::unique_ptr<ZeroMem> buffer;
-        OV_ASSERT_NO_THROW(buffer =
-                               std::make_unique<ZeroMem>(zeroInitStruct, size, ::utils::STANDARD_PAGE_SIZE, false));
+        std::shared_ptr<ZeroMem> buffer;
+        OV_ASSERT_NO_THROW(buffer = ZeroMemPool::get_instance().allocate_zero_memory(zeroInitStruct,
+                                                                                     size,
+                                                                                     ::utils::STANDARD_PAGE_SIZE,
+                                                                                     false));
 
         OV_ASSERT_NO_THROW(
             zeGraphExt->setGraphArgumentValue(graphDescriptor, 0, static_cast<char*>(buffer->data()) + 1));


### PR DESCRIPTION
### Details:
 - *Make the methods private since they must be used only through the ZeroMemPool class*