### PR TITLE
[PyOV] Cleanup fdupes cmake script for free threaded Python

### DIFF
--- a/src/bindings/python/wheel/fdupes_check.cmake
+++ b/src/bindings/python/wheel/fdupes_check.cmake
@@ -8,13 +8,6 @@ foreach(var Python3_EXECUTABLE WORKING_DIRECTORY REPORT_FILE WHEEL_VERSION PACKA
     endif()
 endforeach()
 
-get_filename_component(wheel_name "${PACKAGE_FILE}" NAME)
-if(wheel_name MATCHES ".*cp313t.*")
-    message(STATUS "Skipping duplicate file check for Python 3.13t. Ticket: 171533")
-    file(WRITE "${REPORT_FILE}" "")
-    return()
-endif()
-
 # find programs
 
 find_program(fdupes_PROGRAM NAMES fdupes DOC "Path to fdupes")


### PR DESCRIPTION
### Details:
 - Experimental Python 3.13t broke fdupes check
 - We're skipping this Python version and going straight to Python 3.14t (for which it works correctly), so there's no reason to have this skip

### Tickets:
 - CVS-171533
