### PR TITLE
[core] SharedStreambuffer accepts const pointer

### DIFF
--- a/src/core/dev_api/openvino/runtime/shared_buffer.hpp
+++ b/src/core/dev_api/openvino/runtime/shared_buffer.hpp
@@ -28,11 +28,13 @@ private:
     T _shared_object;
 };
 
-/// \brief SharedStreamBuffer class to store pointer to pre-acclocated buffer and provide streambuf interface.
+/// \brief SharedStreamBuffer class to store pointer to pre-allocated buffer and provide streambuf interface.
 ///  Can return ptr to shared memory and its size
 class SharedStreamBuffer : public std::streambuf {
 public:
-    SharedStreamBuffer(char* data, size_t size) : m_data(data), m_size(size), m_offset(0) {}
+    SharedStreamBuffer(const char* data, size_t size) : m_data(data), m_size(size), m_offset(0) {}
+    explicit SharedStreamBuffer(const void* data, size_t size)
+        : SharedStreamBuffer(reinterpret_cast<const char*>(data), size) {}
 
 protected:
     // override std::streambuf methods
@@ -65,7 +67,7 @@ protected:
         return pos_type(m_offset);
     }
 
-    char* m_data;
+    const char* m_data;
     size_t m_size;
     size_t m_offset;
 };

--- a/src/plugins/hetero/src/plugin.cpp
+++ b/src/plugins/hetero/src/plugin.cpp
@@ -156,7 +156,7 @@ std::shared_ptr<ov::ICompiledModel> ov::hetero::Plugin::import_model(std::istrea
 
 std::shared_ptr<ov::ICompiledModel> ov::hetero::Plugin::import_model(const ov::Tensor& model,
                                                                      const ov::AnyMap& properties) const {
-    ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
+    ov::SharedStreamBuffer buffer{model.data(), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, properties);
 }

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -446,7 +446,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model
 std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model,
                                                          const ov::SoPtr<ov::IRemoteContext>& context,
                                                          const ov::AnyMap& config) const{
-    SharedStreamBuffer buf{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
+    SharedStreamBuffer buf{model.data(), model.get_byte_size()};
     std::istream stream(&buf);
     return import_model(stream, context, config);
 }

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -824,7 +824,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& compi
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "Plugin::import_model");
 
     // Need to create intermediate istream for NPUW
-    ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(compiled_blob.data()), compiled_blob.get_byte_size()};
+    ov::SharedStreamBuffer buffer{compiled_blob.data(), compiled_blob.get_byte_size()};
     std::istream stream{&buffer};
 
     auto npu_plugin_properties = properties;

--- a/src/plugins/proxy/src/plugin.cpp
+++ b/src/plugins/proxy/src/plugin.cpp
@@ -496,7 +496,7 @@ std::shared_ptr<ov::ICompiledModel> ov::proxy::Plugin::import_model(std::istream
 
 std::shared_ptr<ov::ICompiledModel> ov::proxy::Plugin::import_model(const ov::Tensor& model,
                                                                     const ov::AnyMap& properties) const {
-    ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
+    ov::SharedStreamBuffer buffer{model.data(), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, properties);
 }
@@ -504,7 +504,7 @@ std::shared_ptr<ov::ICompiledModel> ov::proxy::Plugin::import_model(const ov::Te
 std::shared_ptr<ov::ICompiledModel> ov::proxy::Plugin::import_model(const ov::Tensor& model,
                                                                     const ov::SoPtr<ov::IRemoteContext>& context,
                                                                     const ov::AnyMap& properties) const {
-    ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
+    ov::SharedStreamBuffer buffer{model.data(), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, context, properties);
 }

--- a/src/plugins/template/src/plugin.cpp
+++ b/src/plugins/template/src/plugin.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<ov::Model> get_ov_model_from_blob(const ov::template_plugin::Plu
                                                   const ov::AnyMap& properties) {
     if (auto blob_it = properties.find(ov::hint::compiled_blob.name()); blob_it != properties.end()) {
         if (auto blob = blob_it->second.as<ov::Tensor>(); blob) {
-            ov::SharedStreamBuffer shared_buffer(reinterpret_cast<char*>(blob.data()), blob.get_byte_size());
+            ov::SharedStreamBuffer shared_buffer(blob.data(), blob.get_byte_size());
             std::istream blob_stream(&shared_buffer);
             blob_stream.seekg(offset, std::ios::beg);
             const auto model = get_model_str(blob_stream);
@@ -268,7 +268,7 @@ std::shared_ptr<ov::ICompiledModel> ov::template_plugin::Plugin::import_model(
 
 std::shared_ptr<ov::ICompiledModel> ov::template_plugin::Plugin::import_model(const ov::Tensor& model,
                                                                               const ov::AnyMap& properties) const {
-    ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
+    ov::SharedStreamBuffer buffer{model.data(), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, properties);
 }
@@ -277,7 +277,7 @@ std::shared_ptr<ov::ICompiledModel> ov::template_plugin::Plugin::import_model(
     const ov::Tensor& model,
     const ov::SoPtr<ov::IRemoteContext>& context,
     const ov::AnyMap& properties) const {
-    ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
+    ov::SharedStreamBuffer buffer{model.data(), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, properties);
 }


### PR DESCRIPTION
### Details:
 - Change SharedStreamBuffer to accept constant pointer
 - Extend ctor to use const void* pointer.
 - Changes are preparation for ov::Tensor::Data() API change, which is used for read-only purposes.
 - Requires to update e.g. openvino_contrib for new Tensor API
 - No functional change

### Tickets:
 - CVS-174872
