### PR TITLE
Fix postponed constant usage in MOE transformation

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/matmul_const_transposes_extraction.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/matmul_const_transposes_extraction.cpp
@@ -39,8 +39,12 @@ ov::pass::MatMulConstTransposesExtraction::MatMulConstTransposesExtraction() {
             weights,
             ov::op::v0::Constant::create(element::i32, {transpose_order.size()}, transpose_order));
         if (ov::is_type<ov::op::v0::Constant>(weights.get_node_shared_ptr())) {
+            // postponed_constant attribute is needed to perform constant folding on serialization step
             transpose->get_rt_info()["postponed_constant"] = true;
+            // disable constant folding here to postpone it to serialization step
             ov::pass::disable_constant_folding(transpose);
+            // disable fp16 compression. Otherwise an additional conversion will be added after the constant, which
+            // breaks postponed_constant serialization
             ov::disable_fp16_compression(weights.get_node_shared_ptr());
         }
         auto new_matmul = std::make_shared<ov::op::v0::MatMul>(pattern_value_map.at(data_pattern),


### PR DESCRIPTION
### Details:
 - Disable f16 compression for postponed constant input weights in MOE transformation

### Tickets:
 - CVS-175710
