### PR TITLE
[CORE][CPU] Remove WeightlessCacheAttribute::visit_attributes

### DIFF
--- a/src/plugins/intel_cpu/src/utils/graph_serializer/deserializer.cpp
+++ b/src/plugins/intel_cpu/src/utils/graph_serializer/deserializer.cpp
@@ -277,9 +277,10 @@ ov::Any XmlDeserializer::parse_weightless_cache_attribute(const pugi::xml_node& 
             for (const auto& attr : child.attributes()) {
                 if (strcmp(attr.name(), "name") == 0 &&
                     strcmp(attr.value(), ov::WeightlessCacheAttribute::get_type_info_static().name) == 0) {
-                    const auto origin_size = static_cast<size_t>(ov::util::pugixml::get_uint64_attr(child, "size"));
-                    const auto offset = static_cast<size_t>(ov::util::pugixml::get_uint64_attr(child, "offset"));
-                    const ov::element::Type original_dt(child.attribute("type").value());  // "element_type"?
+                    const auto origin_size =
+                        static_cast<size_t>(ov::util::pugixml::get_uint64_attr(child, "original_size"));
+                    const auto offset = static_cast<size_t>(ov::util::pugixml::get_uint64_attr(child, "bin_offset"));
+                    const ov::element::Type original_dt(child.attribute("original_dtype").value());
                     return {ov::WeightlessCacheAttribute{origin_size, offset, original_dt}};
                 }
             }

--- a/src/plugins/intel_cpu/src/utils/graph_serializer/serializer.cpp
+++ b/src/plugins/intel_cpu/src/utils/graph_serializer/serializer.cpp
@@ -89,9 +89,10 @@ private:
             const auto& type_info = attribute.get_type_info();
             node.append_attribute("name").set_value(type_info.name);
             node.append_attribute("version").set_value(type_info.get_version().data());
-            node.append_attribute("type").set_value(util::get_ir_precision_name(wl_attr->original_dtype).data());
-            node.append_attribute("offset").set_value(wl_attr->bin_offset);
-            node.append_attribute("size").set_value(wl_attr->original_size);
+            node.append_attribute("original_dtype")
+                .set_value(util::get_ir_precision_name(wl_attr->original_dtype).data());
+            node.append_attribute("bin_offset").set_value(wl_attr->bin_offset);
+            node.append_attribute("original_size").set_value(wl_attr->original_size);
 
             result = true;
         } else {


### PR DESCRIPTION
### Details:
 - *`WeightlessCacheAttribute::visit_attributes` adds redundant attributes into the serialized IR. This information is required only for CPU cached model, so will use it only there.*

### Tickets:
 - **
