### PR TITLE
[CPU][ARM] Do not install KleidiAI to prevent vcpkg conflict

### DIFF
--- a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
@@ -205,7 +205,6 @@ endif()
 
 if(ENABLE_KLEIDIAI_FOR_CPU)
     ov_build_kleidiai_static()
-    ov_install_static_lib(kleidiai ${OV_CPACK_COMP_CORE})
 endif()
 
 if(RISCV64)


### PR DESCRIPTION
### Details:
 - KleidiAI shouldn't be installed by OpenVINO to avoid OpenVINO and KleidiAI package conflicts raised by `vcpkg-tool`:
https://github.com/ARM-software/ComputeLibrary/issues/1178
