### PR TITLE
[core] Fix hash calculation when weights are skipped

### DIFF
--- a/src/common/transformations/tests/hash_tests.cpp
+++ b/src/common/transformations/tests/hash_tests.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "openvino/core/model.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "transformations/hash.hpp"
+
+namespace ov::test {
+using ov::op::v0::Parameter, ov::op::v0::Constant, ov::op::v1::Add;
+
+TEST(HashTest, same_model_hashed_without_weights) {
+    uint64_t hash1 = 0, hash2 = 0;
+    constexpr auto skip_weights = true;
+
+    // create same model twice and hash without weights
+    // detects issue when first 8-byte value used instead weights which may have some bits in uninitialized state
+    {
+        int data_value = 121;
+        const auto data = Tensor(element::i32, {1}, &data_value);
+        auto out = std::make_shared<Add>(std::make_shared<Parameter>(element::i32, Shape{1}),
+                                         std::make_shared<Constant>(data));
+        auto model = std::make_shared<Model>(OutputVector{out}, "TestModel");
+
+        ov::pass::Hash hasher(hash1, skip_weights);
+        hasher.run_on_model(model);
+    }
+    {
+        int data_value = 121;
+        const auto data = ov::Tensor(element::i32, {1}, &data_value);
+        auto out = std::make_shared<Add>(std::make_shared<Parameter>(element::i32, Shape{1}),
+                                         std::make_shared<Constant>(data));
+        auto model = std::make_shared<Model>(OutputVector{out}, "TestModel");
+
+        ov::pass::Hash hasher(hash2, skip_weights);
+        hasher.run_on_model(model);
+    }
+
+    EXPECT_EQ(hash1, hash2);
+}
+}  // namespace ov::test

--- a/src/core/src/xml_util/constant_writer.cpp
+++ b/src/core/src/xml_util/constant_writer.cpp
@@ -16,7 +16,7 @@ uint64_t OstreamHashWrapperBin::get_result() const {
 }
 
 std::streamsize OstreamHashWrapperBin::xsputn(const char* s, std::streamsize n) {
-    m_res = u64_hash_combine(m_res, *reinterpret_cast<const uint64_t*>(s));
+    m_res = u64_hash_combine(m_res, n);
     return n;
 }
 


### PR DESCRIPTION
### Details:
 - Fix create blobs in cache when using GenAI continuous batching pipeline.
 - Use inputs size for hash instead first 8 bytes which could be outside the Constant data buffer.

### Tickets:
 - CVS-175747
