### PR TITLE
[GPU] fix for out-of-resource error from sdpa_micro_pa for mixed stage

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -290,7 +290,7 @@ sdpa_config_t xehpg_q_h64_s128_2nd = {16, 8, 8, 8, 8, 4, 8, 4};
 sdpa_config_t xehpg_q_h64_2nd = {16, 16, 8, 8, 16, 2, 8, 4};
 
 sdpa_config_t xehpg_h128_pa = {16, 16, 16, 16, 8, 1, 8, 1};
-sdpa_config_t xehpg_h128 = {16, 16, 32, 8, 8, 4, 4, 8};
+sdpa_config_t xehpg_h128 = {16, 16, 32, 8, 8, 2, 4, 4};
 sdpa_config_t xehpg_h128_s32 = {16, 16, 16, 8, 16, 2, 8, 4};
 sdpa_config_t xehpg_h128_2nd = {8, 16, 16, 8, 16, 1, 8, 2};
 


### PR DESCRIPTION
### Details:
 - changed a sdpa_micro config `xehpg_h128_pa` to resolve out-of-resource error on ARL-H

### Tickets:
 - 175441, 175742, 175938
