### PR TITLE
[GHA] Disable merge group artifacts storage in cloud

### DIFF
--- a/.github/workflows/job_build_linux.yml
+++ b/.github/workflows/job_build_linux.yml
@@ -402,7 +402,7 @@ jobs:
 
       - name: Store artifacts to a shared drive
         id: store_artifacts
-        if: ${{ inputs.event-name != 'schedule' }}
+        if: ${{ inputs.event-name != 'schedule' && inputs.event-name != 'merge_group' }}
         uses: ./openvino/.github/actions/store_artifacts
         with:
           artifacts: |

--- a/.github/workflows/job_build_windows.yml
+++ b/.github/workflows/job_build_windows.yml
@@ -401,7 +401,7 @@ jobs:
 
       - name: Store artifacts to a shared drive
         id: store_artifacts
-        if: ${{ inputs.event-name != 'schedule' }}
+        if: ${{ inputs.event-name != 'schedule' && inputs.event-name != 'merge_group' }}
         uses: ./openvino/.github/actions/store_artifacts
         with:
           artifacts: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -428,7 +428,7 @@ jobs:
 
       - name: Store artifacts to a shared drive
         id: store_artifacts
-        if: ${{ always() }}
+        if: ${{ github.event_name != 'merge_group' }}
         uses: ./openvino/.github/actions/store_artifacts
         with:
           artifacts: |

--- a/.github/workflows/mac_arm64.yml
+++ b/.github/workflows/mac_arm64.yml
@@ -524,7 +524,7 @@ jobs:
 
       - name: Store artifacts to a shared drive
         id: store_artifacts
-        if: ${{ always() }}
+        if: ${{ github.event_name != 'merge_group' }}
         uses: ./openvino/.github/actions/store_artifacts
         with:
           artifacts: |

--- a/.github/workflows/manylinux_2014.yml
+++ b/.github/workflows/manylinux_2014.yml
@@ -259,7 +259,7 @@ jobs:
 
       - name: Store artifacts to a shared drive
         id: store_artifacts
-        if: ${{ always() }}
+        if: ${{ github.event_name != 'merge_group' }}
         uses: ./src/.github/actions/store_artifacts
         with:
           artifacts: |

--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -248,7 +248,7 @@ jobs:
 
       - name: Store artifacts to a shared drive
         id: store_artifacts
-        if: ${{ always() }}
+        if: ${{ github.event_name != 'merge_group' }}
         uses: ./src/.github/actions/store_artifacts
         with:
           artifacts: |


### PR DESCRIPTION
We use only post-commit ones anyway