### PR TITLE
[GHA] covarage - make counter updates thread-safe and align lcov params

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 name: Code coverage
-on: [pull_request, workflow_dispatch]
+on: workflow_dispatch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Changes:
- Build OpenVINO with `-fprofile-update=atomic` and `--coverage` to avoid negative counters.
- Remove `ov_coverage` CMake target from the workflow (coverage is generated directly via `lcov`).
- Capture coverage only from `build/` with `lcov --base-directory` set to repo root.
- Exclude generated protobuf files, all `*/tests/*`, and `thirdparty/*` from the report (as in coverage.cmake)
- Add `--ignore-errors mismatch,unused` to make lcov/genhtml robust.
- Generate short coverage summary in GHA.
- Generate artifact with full archived lcov/genhtml report.