### PR TITLE
[GPU] disable maxpool when in byxf out bfyx

### DIFF
--- a/src/plugins/intel_gpu/src/graph/registry/pooling_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/pooling_impls.cpp
@@ -24,7 +24,7 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<pooli
             // ws_undef::undef:::,attr-scratchpad:user attr-post-ops:eltwise_linear:1.52456,alg:pooling_avg_include_padding,
             // mb1ic96_ih56oh28kh2sh2dh0ph0_iw56ow28kw2sw2dw0pw0,0.0400391
             // issue: 12579
-            if (in_layout.format == format::byxf && out_layout.format == format::bfyx && ov::element::Type(in_layout.data_type).is_integral_number())
+            if (in_layout.format == format::byxf && out_layout.format == format::bfyx)
                 return false;
             return true;
         })


### PR DESCRIPTION
### Details:
 - found 0 in output when maxpooling in byxf out bfyx and f16 datatype
- found it on second maxpool in network
### Tickets:
 - 175348
