### PR TITLE
[ONNX FE] Onnx Cast op, when float to int4/uint, need to round-to-nearest

### DIFF
--- a/src/frontends/onnx/frontend/src/op/cast.cpp
+++ b/src/frontends/onnx/frontend/src/op/cast.cpp
@@ -4,6 +4,7 @@
 
 #include "core/operator_set.hpp"
 #include "openvino/op/convert.hpp"
+#include "openvino/op/round.hpp"
 #include "utils/common.hpp"
 using namespace ov::op;
 
@@ -17,6 +18,15 @@ ov::OutputVector cast(const ov::frontend::onnx::Node& node) {
     auto data = node.get_ov_inputs().at(0);
     int64_t target_type = node.get_attribute_value<int64_t>("to");
     ov::element::Type elem_type = common::get_ov_element_type(target_type);
+
+    // according to https://github.com/onnx/onnx/blob/main/docs/docsgen/source/technical/int4.md#cast
+    // Cast to a 4 bit type is done by rounding to the nearest-integer (with ties to even) nearest-even integer and
+    // truncating.
+    const ov::element::Type data_type = data.get_element_type();
+    if (data_type.is_real() && (elem_type == ov::element::i4 || elem_type == ov::element::u4)) {
+        auto data_rounded = std::make_shared<v5::Round>(data, v5::Round::RoundMode::HALF_AWAY_FROM_ZERO);
+        return {std::make_shared<v0::Convert>(data_rounded, elem_type)};
+    }
 
     return {std::make_shared<v0::Convert>(data, elem_type)};
 }

--- a/src/frontends/onnx/tests/models/cast_float32_to_int4.prototxt
+++ b/src/frontends/onnx/tests/models/cast_float32_to_int4.prototxt
@@ -1,0 +1,45 @@
+ir_version: 10
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "input"
+    output: "output"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 22
+      type: INT
+    }
+  }
+  name: "test-model-cast"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 22
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 21
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -6238,6 +6238,17 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_constant_of_shape_null_node) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, cast_float32_to_int4) {
+    auto model = convert_model("cast_float32_to_int4.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_input<float>(Shape{4}, std::vector<float>{1.6f, 2.4f, -1.6f, -2.4f});
+    test_case.add_expected_output<uint8_t>({0x22, 0xEE});
+
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, castlike_float16_to_uint32) {
     auto model = convert_model("castlike_float16_to_uint32.onnx");
 


### PR DESCRIPTION
### Details:
 - According to https://github.com/microsoft/onnxruntime/issues/26451, need to add a round op when transforming onnx cast op, convert from floating to int4/uint.
 - [ONNX INT4 Cast Ref](https://github.com/onnx/onnx/blob/main/docs/docsgen/source/technical/int4.md#cast)

### Tickets:
 - *CVS-172796*
