### PR TITLE
[GPU] Fixed wrong idx for applying attn_sink in pa_sdpa_opt

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -399,7 +399,7 @@ KERNEL(pa_sdpa_opt)(
             GET_VECTOR_ELEMENT(exp_sum, q_idx) = sub_group_reduce_add(GET_VECTOR_ELEMENT(exp_sum, q_idx));
             #ifdef HAS_SINK_INPUT
             const uint head_idx = get_global_id(1);
-            GET_VECTOR_ELEMENT(exp_sum, head_idx) += (native_exp(TO_SOFTMAX_ACCUMULATOR_TYPE(sink_ptr[head_idx] - GET_VECTOR_ELEMENT(qk_max, q_idx))));
+            GET_VECTOR_ELEMENT(exp_sum, q_idx) += (native_exp(TO_SOFTMAX_ACCUMULATOR_TYPE(sink_ptr[head_idx] - GET_VECTOR_ELEMENT(qk_max, q_idx))));
             #endif
         }
 


### PR DESCRIPTION
### Details:
 - Sink to be appiled to each query idx instead of head_idx 
 - Currently there is no practical situation this code is activated. However potentially there will be, e.g., igpu  + sink + pa 

### Tickets:
 - *ticket-id*
