### PR TITLE
[PT FE]: Add support for aten::smooth_l1_loss operation

### DIFF
--- a/src/frontends/pytorch/src/op/l1_loss.cpp
+++ b/src/frontends/pytorch/src/op/l1_loss.cpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/abs.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert_like.hpp"
+#include "openvino/op/reduce_mean.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/subtract.hpp"
+#include "utils.hpp"
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+// aten::l1_loss(Tensor input, Tensor target, int reduction=1) -> Tensor
+OutputVector translate_l1_loss(const NodeContext& node) {
+    auto a = node.get_input(0);
+    auto b = node.get_input(1);
+    align_eltwise_input_types(node, a, b);
+
+    // reduction parse (accept any integral constant)
+    auto reduction = std::string{"mean"};
+    if (node.get_input_size() > 2 && !node.input_is_none(2)) {
+        auto red_input = node.get_input(2);
+        if (auto red_const = std::dynamic_pointer_cast<v0::Constant>(red_input.get_node_shared_ptr())) {
+            int64_t red_val = 1;
+            if (red_const->get_element_type().is_integral_number()) {
+                red_val = red_const->cast_vector<int64_t>()[0];
+            }
+            reduction = (red_val == 0) ? "none" : (red_val == 1) ? "mean" : (red_val == 2) ? "sum" : reduction;
+        }
+    } else {
+        reduction = node.get_attribute<std::string>("reduction", "mean");
+    }
+
+    auto abs_diff = node.mark_node(std::make_shared<v0::Abs>(node.mark_node(std::make_shared<v1::Subtract>(a, b))));
+    std::shared_ptr<ov::Node> out = abs_diff;
+    if (reduction == "mean") {
+        out = node.mark_node(std::make_shared<v1::ReduceMean>(out, get_axes_range(node, 0), false));
+    } else if (reduction == "sum") {
+        out = node.mark_node(std::make_shared<v1::ReduceSum>(out, get_axes_range(node, 0), false));
+    }
+    out = node.mark_node(std::make_shared<v1::ConvertLike>(out, a));
+    return {out->output(0)};
+}
+
+OutputVector translate_l1_loss_fx(const NodeContext& node) {
+    return translate_l1_loss(node);
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op/smooth_l1_loss.cpp
+++ b/src/frontends/pytorch/src/op/smooth_l1_loss.cpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <cmath>
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/abs.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert_like.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/less.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reduce_mean.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/subtract.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+// aten::smooth_l1_loss(Tensor input, Tensor target, int reduction=1, float beta=1.0) -> Tensor
+OutputVector translate_smooth_l1_loss(const NodeContext& node) {
+    // Inputs
+    auto input = node.get_input(0);
+    auto target = node.get_input(1);
+
+    // Align dtypes
+    target = node.mark_node(std::make_shared<v1::ConvertLike>(target, input));
+    align_eltwise_input_types(node, input, target);
+    auto a = input;
+    auto b = target;
+
+    // Scalar constants (float32; aligned via ConvertLike)
+    auto c05 = v0::Constant::create(element::f32, Shape{}, {0.5f});
+    auto c05_like = node.mark_node(std::make_shared<v1::ConvertLike>(c05, a));
+    auto eps = v0::Constant::create(element::f32, Shape{}, {1e-5f});
+    auto eps_like = node.mark_node(std::make_shared<v1::ConvertLike>(eps, a));
+
+    // Beta parameter: input[3] (FX) or attribute (TS)
+    ov::Output<ov::Node> beta_like;
+    if (node.get_input_size() > 3 && !node.input_is_none(3)) {
+        beta_like = node.mark_node(std::make_shared<v1::ConvertLike>(node.get_input(3), a));
+    } else {
+        float beta_attr = node.get_attribute<float>("beta", 1.0f);
+        OPENVINO_ASSERT(beta_attr >= 0.f, "smooth_l1_loss: beta must be non-negative");
+        beta_like = node.mark_node(
+            std::make_shared<v1::ConvertLike>(v0::Constant::create(element::f32, Shape{}, {beta_attr}), a));
+    }
+
+    // Per-element loss
+    auto diff = node.mark_node(std::make_shared<v1::Subtract>(a, b));
+    auto l1 = node.mark_node(std::make_shared<v0::Abs>(diff));
+    auto is_small =
+        node.mark_node(std::make_shared<v1::Less>(node.mark_node(std::make_shared<v0::Abs>(beta_like)), eps_like));
+
+    // Quadratic region: 0.5 * diff^2 / beta
+    auto diff_sq = node.mark_node(std::make_shared<v1::Multiply>(diff, diff));
+    auto quad_num = node.mark_node(std::make_shared<v1::Multiply>(c05_like, diff_sq));
+    auto quad = node.mark_node(std::make_shared<v1::Divide>(quad_num, beta_like));
+    // Linear region: |x| - 0.5 * beta
+    auto lin = node.mark_node(
+        std::make_shared<v1::Subtract>(l1, node.mark_node(std::make_shared<v1::Multiply>(c05_like, beta_like))));
+
+    auto elem = node.mark_node(
+        std::make_shared<v1::Select>(node.mark_node(std::make_shared<v1::Less>(l1, beta_like)), quad, lin));
+    auto safe = node.mark_node(std::make_shared<v1::Select>(is_small, l1, elem));
+
+    // Reduction (0/1/2 -> none/mean/sum) or attribute
+    std::string reduction = "mean";
+    if (node.get_input_size() > 2 && !node.input_is_none(2)) {
+        auto red_input = node.get_input(2);
+        if (auto red_const = std::dynamic_pointer_cast<v0::Constant>(red_input.get_node_shared_ptr())) {
+            int64_t red_val = 1;
+            if (red_const->get_element_type().is_integral_number()) {
+                red_val = red_const->cast_vector<int64_t>()[0];
+            }
+            reduction = (red_val == 0) ? "none" : (red_val == 1) ? "mean" : (red_val == 2) ? "sum" : reduction;
+        }
+    } else {
+        reduction = node.get_attribute<std::string>("reduction", "mean");
+    }
+
+    if (reduction == "none") {
+        auto out = node.mark_node(std::make_shared<v1::ConvertLike>(safe, a));
+        return {out->output(0)};
+    }
+
+    auto axes = get_axes_range(node, 0);
+    if (reduction == "mean") {
+        auto out = node.mark_node(std::make_shared<v1::ReduceMean>(safe, axes, false));
+        out = node.mark_node(std::make_shared<v1::ConvertLike>(out, a));
+        return {out->output(0)};
+    }
+    auto out = node.mark_node(std::make_shared<v1::ReduceSum>(safe, axes, false));
+    out = node.mark_node(std::make_shared<v1::ConvertLike>(out, a));
+    return {out->output(0)};
+}
+
+OutputVector translate_smooth_l1_loss_fx(const NodeContext& node) {
+    return translate_smooth_l1_loss(node);
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -142,6 +142,7 @@ OP_CONVERTER(translate_inverse);
 OP_CONVERTER(translate_istft);
 OP_CONVERTER(translate_is_nonzero);
 OP_CONVERTER(translate_kthvalue);
+OP_CONVERTER(translate_l1_loss);
 OP_CONVERTER(translate_layer_norm);
 OP_CONVERTER(translate_len);
 OP_CONVERTER(translate_lerp);
@@ -246,6 +247,7 @@ OP_CONVERTER(translate_shape_as_tensor);
 OP_CONVERTER(translate_sign);
 OP_CONVERTER(translate_size);
 OP_CONVERTER(translate_slice);
+OP_CONVERTER(translate_smooth_l1_loss);
 OP_CONVERTER(translate_softmax);
 OP_CONVERTER(translate_sort);
 OP_CONVERTER(translate_split_with_sizes);
@@ -316,6 +318,7 @@ OP_CONVERTER(translate_full_like_fx);
 OP_CONVERTER(translate_gelu_fx);
 OP_CONVERTER(translate_group_norm_fx);
 OP_CONVERTER(translate_index_fx);
+OP_CONVERTER(translate_l1_loss_fx);
 OP_CONVERTER(translate_layer_norm_fx);
 OP_CONVERTER(translate_leaky_relu_fx);
 OP_CONVERTER(translate_log_sigmoid_fx);
@@ -339,6 +342,7 @@ OP_CONVERTER(translate_search_sorted);
 OP_CONVERTER(translate_select_scatter_fx);
 OP_CONVERTER(translate_slice_fx);
 OP_CONVERTER(translate_slice_scatter_fx);
+OP_CONVERTER(translate_smooth_l1_loss_fx);
 OP_CONVERTER(translate_softmax_fx);
 OP_CONVERTER(translate_sort_fx);
 OP_CONVERTER(translate_stack_fx);
@@ -571,6 +575,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::isinf", op::translate_1to1_match_1_inputs<opset10::IsInf>},
         {"aten::isnan", op::translate_1to1_match_1_inputs<opset10::IsNaN>},
         {"aten::item", op::translate_1to1_match_1_inputs<opset10::Squeeze>},
+        {"aten::l1_loss", op::translate_l1_loss},
         {"aten::layer_norm", op::translate_layer_norm},
         {"aten::le", op::translate_1to1_match_2_inputs_align_types<opset10::LessEqual>},
         {"aten::leaky_relu", op::translate_1to1_match_2_inputs<opset10::PRelu>},
@@ -716,6 +721,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::sinh_", op::inplace_op<op::translate_1to1_match_1_inputs<opset10::Sinh>>},
         {"aten::size", op::translate_size},
         {"aten::slice", op::quantizable_op<op::translate_slice>},
+        {"aten::smooth_l1_loss", op::translate_smooth_l1_loss},
         {"aten::softmax", op::translate_softmax},
         {"aten::softplus", op::translate_1to1_match_1_inputs<opset10::SoftPlus>},
         {"aten::sort", op::translate_sort},
@@ -966,6 +972,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.isfinite.default", op::translate_1to1_match_1_inputs<opset10::IsFinite>},
         {"aten.isinf.default", op::translate_1to1_match_1_inputs<opset10::IsInf>},
         {"aten.isnan.default", op::translate_1to1_match_1_inputs<opset10::IsNaN>},
+        {"aten.l1_loss.default", op::translate_l1_loss_fx},
         {"aten.le.Scalar", op::translate_1to1_match_2_inputs_align_types<opset10::LessEqual>},
         {"aten.le.Tensor", op::translate_1to1_match_2_inputs_align_types<opset10::LessEqual>},
         {"aten.leaky_relu.default", op::translate_leaky_relu_fx},
@@ -1056,6 +1063,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.slice.Tensor", op::translate_slice_fx},
         {"aten.slice_copy.Tensor", op::translate_slice_fx},
         {"aten.slice_scatter.default", op::translate_slice_scatter_fx},
+        {"aten.smooth_l1_loss.default", op::translate_smooth_l1_loss_fx},
         {"aten.sort.default", op::translate_sort_fx},
         {"aten.split.Tensor", op::translate_chunk_fx},
         {"aten.split_with_sizes.default", op::translate_split_with_sizes},

--- a/tests/layer_tests/pytorch_tests/test_l1_loss.py
+++ b/tests/layer_tests/pytorch_tests/test_l1_loss.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestL1Loss(PytorchLayerTest):
+    def _prepare_input(self):
+        x = np.random.uniform(-0.1, 0.1, size=(6, 7)).astype(np.float32)
+        y = np.random.uniform(-0.1, 0.1, size=(6, 7)).astype(np.float32)
+        return (x, y)
+
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
+    def test_l1_loss_basic(self, reduction, ie_device, precision, ir_version):
+        class M(torch.nn.Module):
+            def __init__(self, reduction):
+                super().__init__()
+                self.reduction = reduction
+            def forward(self, x, y):
+                return F.l1_loss(x, y, reduction=self.reduction)
+        model = M(reduction).eval()
+        x = np.random.randn(6, 7).astype(np.float32)
+        y = np.random.randn(6, 7).astype(np.float32)
+        self._test(model, None, "aten::l1_loss", ie_device, precision, ir_version, inputs=[x, y])
+
+
+class TestL1LossFromSmoothL1(PytorchLayerTest):
+    @pytest.mark.nightly
+    def test_beta_zero_from_smooth_l1_lowers_to_l1(self, ie_device, precision, ir_version):
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                # TS lowers smooth_l1(beta=0) to aten::l1_loss
+                return F.smooth_l1_loss(x, y, beta=0.0, reduction="mean")
+
+        model = M().eval()
+        x = np.random.randn(2, 3, 8, 8).astype(np.float32)
+        y = np.random.randn(2, 3, 8, 8).astype(np.float32)
+
+        kind = "aten::l1_loss"  
+        self._test(model, None, kind, ie_device, precision, ir_version, inputs=[x, y])

--- a/tests/layer_tests/pytorch_tests/test_smooth_l1_loss.py
+++ b/tests/layer_tests/pytorch_tests/test_smooth_l1_loss.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+np.random.seed(0)
+torch.manual_seed(0)
+
+
+class TestSmoothL1Loss(PytorchLayerTest):
+    def _prepare_input(self):
+        input_shape = (2, 3, 8, 8)
+        return (np.random.uniform(-0.1, 0.1, size=input_shape).astype(np.float32),
+                np.random.uniform(-0.1, 0.1, size=input_shape).astype(np.float32))
+
+    def _tolerances(self, precision):
+        return (1e-4, 1e-4) if str(precision).upper() == "FP32" else (3e-3, 3e-3)
+
+    def create_model(self, reduction="mean", beta=1.0):
+        class aten_smooth_l1_loss(torch.nn.Module):
+            def __init__(self, reduction, beta):
+                super(aten_smooth_l1_loss, self).__init__()
+                self.reduction = reduction
+                self.beta = beta
+
+            def forward(self, input, target):
+                return F.smooth_l1_loss(input, target, reduction=self.reduction, beta=self.beta)
+
+        ref_net = None
+        kind = "aten::smooth_l1_loss"  # keep smooth_l1 kind for all betas
+        return aten_smooth_l1_loss(reduction, beta).eval(), ref_net, kind
+
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
+    def test_smooth_l1_core(self, reduction, ie_device, precision, ir_version):
+        self._test(*self.create_model(reduction, 1.0), ie_device, precision, ir_version)
+
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
+    def test_smooth_l1_beta_zero_matches_l1(self, reduction, ie_device, precision, ir_version):
+        class M(torch.nn.Module):
+            def __init__(self, reduction):
+                super().__init__(); self.reduction = reduction
+            def forward(self, x, y):
+                return F.smooth_l1_loss(x, y, beta=0.0, reduction=self.reduction)
+        model = M(reduction).eval()
+        x = np.random.uniform(-0.1, 0.1, size=(4, 5)).astype(np.float32)
+        y = np.random.uniform(-0.1, 0.1, size=(4, 5)).astype(np.float32)
+        rtol, atol = self._tolerances(precision)
+        def _cmp(ov_outs, pt_outs):
+            np.testing.assert_allclose(np.asarray(ov_outs), np.asarray(pt_outs), rtol=rtol, atol=atol)
+        self._test(model, None, "aten::l1_loss", ie_device, precision, ir_version,
+                   inputs=[x, y], compare_func=_cmp)
+
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
+    def test_smooth_l1_broadcasting(self, reduction, ie_device, precision, ir_version):
+        class M(torch.nn.Module):
+            def __init__(self, reduction):
+                super().__init__(); self.reduction = reduction
+            def forward(self, x, y):
+                return F.smooth_l1_loss(x, y, reduction=self.reduction, beta=0.5)
+        model = M(reduction).eval()
+        x = np.random.uniform(-0.1, 0.1, size=(2, 3, 8, 8)).astype(np.float32)
+        y = np.random.uniform(-0.1, 0.1, size=(1, 3, 1, 1)).astype(np.float32)
+        self._test(model, None, "aten::smooth_l1_loss", ie_device, precision, ir_version, inputs=[x, y])


### PR DESCRIPTION
### Details:
Added support for `aten::smooth_l1_loss`.  
- Added support for `aten::l1_loss` translator as well, since PyTorch automatically lowers `smooth_l1_loss(beta=0)` to `l1_loss`.  
- `beta` is supported both as a static TorchScript attribute and as a dynamic FX input, with a runtime fallback to pure L1 behavior when `|beta|` is close to zero.  

### Tickets:
- *https://github.com/openvinotoolkit/openvino/issues/29715*