### PR TITLE
[GHA] Fix pytest version for keras tests

### DIFF
--- a/.github/workflows/job_keras3_backend.yml
+++ b/.github/workflows/job_keras3_backend.yml
@@ -93,6 +93,7 @@ jobs:
           pip install --upgrade pip setuptools
           pip install -r requirements.txt --upgrade
           pip install --no-deps tf_keras==2.18.0
+          pip install pytest==8.4.2
           # make sure that no other keras is installed via pip
           pip uninstall -y keras keras-nightly
           # manually set keras
@@ -109,7 +110,7 @@ jobs:
         run: |
           IGNORE_FILE="keras/src/backend/openvino/excluded_tests.txt"
           IGNORE_ARGS=$(awk '{print "--ignore=" $0}' "$IGNORE_FILE")
-          pytest keras --ignore keras/src/applications --ignore keras/src/wrappers/sklearn_test.py $IGNORE_ARGS --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-keras3_pytest.xml
+          pytest keras --ignore keras/src/applications $IGNORE_ARGS --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-keras3_pytest.xml
 
       - name: Upload Test Results
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0


### PR DESCRIPTION
Main suspect for the recent [Keras tests failures](https://github.com/openvinotoolkit/openvino/actions/runs/19216349998/job/54928397864): https://pypi.org/project/pytest/9.0.0 
Unrestricted requirement comes from https://github.com/keras-team/keras/blob/19ca9c1d7e02410acb353de8748f7cb9240dad30/requirements-common.txt#L4

**Tickets**:
- CVS-176386