### PR TITLE
[CPU] Avoid creating itt structs when not collected

### DIFF
--- a/src/common/itt/include/openvino/itt.hpp
+++ b/src/common/itt/include/openvino/itt.hpp
@@ -41,6 +41,7 @@ typedef struct handle_ {
  * @cond
  */
 namespace internal {
+bool is_initialized();
 domain_t domain(const char* name);
 handle_t handle(const char* name);
 void taskBegin(domain_t d, handle_t t);

--- a/src/common/itt/src/itt.cpp
+++ b/src/common/itt/src/itt.cpp
@@ -21,7 +21,7 @@ namespace internal {
 
 static __itt_collection_state state = __itt_get_collection_state();
 
-static inline bool is_initialized() {
+bool is_initialized() {
     return state == __itt_collection_init_successful;
 }
 
@@ -109,6 +109,10 @@ void regionEnd(domain_t d) {
 }
 
 #else
+
+bool is_initialized() {
+    return false;
+}
 
 domain_t domain(const char*) {
     return nullptr;

--- a/src/plugins/intel_cpu/src/itt.h
+++ b/src/plugins/intel_cpu/src/itt.h
@@ -29,13 +29,17 @@ namespace ov::intel_cpu::itt {
 
 class ScopedOpExecTask {
 public:
-    explicit ScopedOpExecTask(const char* name) noexcept : ScopedOpExecTask(openvino::itt::handle(name)) {}
-    explicit ScopedOpExecTask(const std::string& name) noexcept : ScopedOpExecTask(name.c_str()) {}
-    explicit ScopedOpExecTask(openvino::itt::handle_t handle) noexcept : m_handle(handle) {
-        openvino::itt::internal::taskBegin(::ov::itt::domains::ov_op_exec(), m_handle);
+    explicit ScopedOpExecTask(const char* name) noexcept {
+        if (openvino::itt::internal::is_initialized()) {
+            m_handle = openvino::itt::handle(name);
+            openvino::itt::internal::taskBegin(::ov::itt::domains::ov_op_exec(), m_handle);
+        }
     }
+    explicit ScopedOpExecTask(const std::string& name) noexcept : ScopedOpExecTask(name.c_str()) {}
     ~ScopedOpExecTask() noexcept {
-        openvino::itt::internal::taskEnd(::ov::itt::domains::ov_op_exec());
+        if (openvino::itt::internal::is_initialized()) {
+            openvino::itt::internal::taskEnd(::ov::itt::domains::ov_op_exec());
+        }
     }
 
     ScopedOpExecTask(const ScopedOpExecTask&) = delete;


### PR DESCRIPTION
### Details:
 - ITT has mutex guards in scope of creation of handles and domains
 - Avoid not only collecting the counters but creating handles and domains as well
 - The models with a lot of simple fast nodes (i.e. Reshape) were impacted the most
 - Similar change should be applied for core ITT logic as well to avoid same issues in the future.
 - As future perf improvement, even when itt collection is enabled, it seems to be better to create all the handles beforehand to avoid contention during execution time.
 
### Tickets:
 - 176306

PR to the release branch:
- https://github.com/openvinotoolkit/openvino/pull/32778