### PR TITLE
 [NPUW] WA for Qwen2.5-VL: Forbid SWA patch for VLM-s

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -820,7 +820,10 @@ void decompose_GQA(std::shared_ptr<ov::Model> model, bool is_prefill_model) {
 
 void patch_phi3_sliding_mask(const std::shared_ptr<ov::Model>& model) {
     // FIXME: Don't do these transformations for gemma3 which has token_type_ids input.
-    if (!ov::npuw::util::has_input(model, "token_type_ids")) {
+    // FIXME: Don't do these transformations for VLMs identified by inputs_embeds input.
+    //        Qwen2.5 VL/Omni uses 3D position_ids, which can't be directly used
+    //        in creation of sliding window mask.
+    if (!ov::npuw::util::has_input(model, "token_type_ids") && !ov::npuw::util::has_input(model, "inputs_embeds")) {
         ov::pass::GraphRewrite rewr;
         rewr.add_matcher<Phi3SlidingMask2>();
         rewr.add_matcher<Phi3SlidingMask>();


### PR DESCRIPTION
### Details:
 - *Workaround for Qwen2.5 VL/Omni exported with sliding mask: as Qwen2.5 VL/Omni uses 3D `position_ids`, current approach to extend sliding mask for static shapes and different layouts can't just reuse such `position_ids`. It might need adoption to work with image token positions. Reference on Qwen-2.5 position_ids content: https://towardsai.net/p/machine-learning/qwen2-5-vl-a-hands-on-code-walkthrough*
 - *PR in master: https://github.com/openvinotoolkit/openvino/pull/32763*

### Tickets:
 - *EISW-191997*
