### PR TITLE
[CPU][DEBUG_CAPS] Avoid a directory check while dumping blobs

### DIFF
--- a/src/plugins/intel_cpu/src/utils/debug_caps_config.cpp
+++ b/src/plugins/intel_cpu/src/utils/debug_caps_config.cpp
@@ -5,6 +5,7 @@
 
 #include "openvino/core/except.hpp"
 #include "openvino/util/env_util.hpp"
+#include "openvino/util/file_util.hpp"
 #ifdef CPU_DEBUG_CAPS
 
 #    include <string>
@@ -63,6 +64,10 @@ void DebugCapsConfig::readProperties() {
 
     if (const auto* envVarValue = readEnv("OV_CPU_BLOB_DUMP_NODE_NAME")) {
         blobDumpFilters[FILTER::BY_NAME] = envVarValue;
+    }
+
+    if (!blobDumpFilters.empty()) {
+        ov::util::create_directory_recursive(blobDumpDir);
     }
 
     if (const auto* envVarValue = readEnv("OV_CPU_DISABLE")) {

--- a/src/plugins/intel_cpu/src/utils/node_dumper.h
+++ b/src/plugins/intel_cpu/src/utils/node_dumper.h
@@ -6,7 +6,6 @@
 #ifdef CPU_DEBUG_CAPS
 #    include <node.h>
 
-#    include "openvino/util/file_util.hpp"
 #    include "utils/debug_caps_config.h"
 
 namespace ov::intel_cpu {
@@ -24,7 +23,6 @@ public:
         : node(_node),
           count(_count),
           config(_config) {
-        ov::util::create_directory_recursive(config.blobDumpDir);
         dumpInputBlobs(node, config, count);
     }
 


### PR DESCRIPTION
This significantly reduces debug caps overhead (introduced this year) in comparison to normal build.