### PR TITLE
[GPU]Eliminate_host/gpu_sync_overhead_on_moe3gemm

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/moe_3gemm_fused_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/moe_3gemm_fused_inst.h
@@ -30,6 +30,7 @@ public:
 
         return params;
     }
+    std::vector<size_t> get_shape_infer_dependencies() const override { return {}; }
 };
 
 using moe_node = typed_program_node<moe_3gemm_fused_compressed>;


### PR DESCRIPTION
### Details:
 - *Eliminate host and gpu sync overhead on moe3gemm. moe3gemm has not runtime dependency, so the kernel should be created and dispatched in time*
 - *port from https://github.com/openvinotoolkit/openvino/pull/32748*

### Tickets:
 - *[CVS-176391](https://jira.devtools.intel.com/browse/CVS-176391)*
