### PR TITLE
[GPU] Treat size of shape as 1 for weight_zp is Shape{}

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -59,7 +59,8 @@ DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size
         if (precomputed_reduction && adj_group_size != UINT64_MAX && adj_group_size > 0 && has_static_wzp) {
             auto weight_zp_shape = m_fc->get_input_partial_shape(4);
             auto weight_scale_shape = m_fc->get_input_partial_shape(3);
-            const size_t wei_zp_group_size = innermost_size / weight_zp_shape[weight_zp_shape.size() - 1].get_length();
+            const bool is_zp_scalar = has_static_wzp && ov::shape_size(m_fc->get_input_shape(4)) == 1;
+            const size_t wei_zp_group_size = is_zp_scalar ? innermost_size : innermost_size / weight_zp_shape[weight_zp_shape.size() - 1].get_length();
             const size_t wei_scale_group_size = innermost_size / weight_scale_shape[weight_scale_shape.size() - 1].get_length();
             const size_t required_group_size = std::min(wei_zp_group_size, wei_scale_group_size);
             if (adj_group_size > required_group_size) {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -124,6 +124,12 @@ protected:
         return std::make_shared<ov::Model>(ov::OutputVector{mat_mul}, params, "MatmulWeightsDecompression");
     }
 
+    virtual ov::Shape get_weight_zero_point_shape(const ov::Shape& scaleshift_const_shape,
+                                                  bool per_tensor_zp) const {
+        return per_tensor_zp ? ov::Shape{1} : scaleshift_const_shape;
+    }
+
+
     std::shared_ptr<ov::Node> init_compressed_weights_subgraph(const ov::Shape& weights_shape,
                                                                const int group_size,
                                                                const ov::element::Type data_precision,
@@ -185,7 +191,7 @@ protected:
         if (reshape_on_decompression_constant)
             scaleshift_const_shape.erase(std::remove(scaleshift_const_shape.begin(), scaleshift_const_shape.end(), 1), scaleshift_const_shape.end());
         if (add_subtract) {
-            auto shift_tensor_shape = per_tensor_zp ? ov::Shape{1} : scaleshift_const_shape;
+            auto shift_tensor_shape = get_weight_zero_point_shape(scaleshift_const_shape, per_tensor_zp);
             auto shift_tensor = ov::test::utils::create_and_fill_tensor(weights_precision, shift_tensor_shape);
             if (per_tensor_zp && weights_precision.bitwidth() == 4) {
                 static_cast<uint8_t*>(shift_tensor.data())[0] = 0x88;
@@ -308,6 +314,20 @@ protected:
 
 TEST_P(MatmulWeightsDecompression, Inference) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED(); // This is necessary because of check_results
+    run();
+    check_results();
+}
+
+class MatmulWeightsDecompressionScalarWeightZp : public MatmulWeightsDecompression {
+protected:
+    ov::Shape get_weight_zero_point_shape(const ov::Shape& scaleshift_const_shape,
+                                          bool per_tensor_zp) const override {
+        return per_tensor_zp ? ov::Shape{} : scaleshift_const_shape;
+    }
+};
+
+TEST_P(MatmulWeightsDecompressionScalarWeightZp, Inference) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     run();
     check_results();
 }
@@ -477,5 +497,19 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_3D_weight,
                                             ::testing::Values(2.0f)),
                          MatmulWeightsDecompression::get_test_case_name);
 
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_dyn_quan_scalar_wzp,
+                         MatmulWeightsDecompressionScalarWeightZp,
+                         ::testing::Combine(::testing::Values(ShapeParams{{{-1, -1, 1024}, {{1024, 1, 1024}}},
+                                                                          {1024, 1024}, 128}),
+                                            ::testing::Values(ov::element::u4),
+                                            ::testing::Values(ov::element::f16),
+                                            ::testing::Values(false),
+                                            ::testing::Values(true),
+                                            ::testing::Values(true),
+                                            ::testing::Values(false),
+                                            ::testing::Values(true),
+                                            ::testing::Values(128),
+                                            ::testing::Values(2.0f)),
+                         MatmulWeightsDecompression::get_test_case_name);
 
 } // namespace


### PR DESCRIPTION
### Details:
- When `weight_zp_shape.size()` is zero, it causes an invalid memory access in `DynamicQuantizeFullyConnected` since it tries to access `weight_zp_shape[-1]`. See below.

https://github.com/openvinotoolkit/openvino/blob/8a131289505079a48265ba260c673d2d4671771b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp#L65
- This PR also addresses functional issues related to dynamic quantization in the int16 model.

### Graphs:
<img width="501" height="334" alt="image"
src="https://github.com/user-attachments/assets/15828b1b-2f71-4d42-a43f-6734f0348288" />

### Checklist:
- [x] Is it a proper fix? (Not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario?

### Tickets:
 - 175525
 - 173474
