### PR TITLE
[NPU] Common Options cleanup

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -419,6 +419,7 @@ struct CACHING_PROPERTIES final : OptionBase<CACHING_PROPERTIES, std::string> {
         return OptionMode::RunTime;
     }
 };
+
 struct INTERNAL_SUPPORTED_PROPERTIES final : OptionBase<INTERNAL_SUPPORTED_PROPERTIES, std::string> {
     static std::string_view key() {
         return ov::internal::supported_properties.name();


### PR DESCRIPTION
### Details:
 - Reduce options with `Both` qualifier, as most of them can be designated as Compile time or Runtime. 

### Tickets:
 - C 175471
