### PR TITLE
[NPU][WS] Run the init pipeline on a single thread by default

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -17,7 +17,7 @@
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/runtime/make_tensor.hpp"
 
-#define USE_SINGLE_THREADED_RUN_INIT 0
+#define USE_SINGLE_THREADED_RUN_INIT 1
 
 namespace intel_npu {
 


### PR DESCRIPTION
### Details:
 - There's a subset of drivers that do not support the multi-threaded pipeline cause of some bug. Until we gather some more info & come up with a better solution, we've decided to leave the single-threaded implementation as the default one.

### Tickets:
 - *EISW-191773*
