### PR TITLE
[NPU] Model marshalling: remove the capability of copying some weights based on a size threshold

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -1426,18 +1426,4 @@ struct USE_BASE_MODEL_SERIALIZER final : OptionBase<USE_BASE_MODEL_SERIALIZER, b
     }
 };
 
-struct SERIALIZATION_WEIGHTS_SIZE_THRESHOLD final : OptionBase<SERIALIZATION_WEIGHTS_SIZE_THRESHOLD, size_t> {
-    static std::string_view key() {
-        return ov::intel_npu::serialization_weights_size_threshold.name();
-    }
-
-    static size_t defaultValue() {
-        return 0;
-    }
-
-    static OptionMode mode() {
-        return OptionMode::RunTime;
-    }
-};
-
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
@@ -357,20 +357,10 @@ static constexpr ov::Property<bool> weightless_blob{"NPU_WEIGHTLESS_BLOB"};
  *
  * The base serializer is the OV implementation of the "XmlSerializer" without any extensions. All weights are copied in
  * a separate buffer. By turning this off, the NPU extension of the serializer is enabled. This allows optimizing the
- * process by reducing the amount of weights that will be copied in a separate buffer. However, this solution may be
+ * process by storing metadata (memory location & bytes size) instead of weights values. However, this solution may be
  * less reliable.
  */
 static constexpr ov::Property<bool> use_base_model_serializer{"NPU_USE_BASE_MODEL_SERIALIZER"};
-
-/**
- * @brief [Only for NPU Plugin]
- * Type: size_t. Default is 0.
- *
- * Effective only if "use_base_model_serializer" is set to false. All "ov::Constant" buffers smaller than this value
- * (byte size) will be copied in a separate buffer. The rest of the weights will be reconstructed at deserialization
- * time using buffer pointers.
- */
-static constexpr ov::Property<size_t> serialization_weights_size_threshold{"NPU_SERIALIZATION_WEIGHTS_SIZE_THRESHOLD"};
 
 /**
  * @brief [Experimental, only for NPU Plugin]

--- a/src/plugins/intel_npu/src/al/include/intel_npu/weights_pointer_attribute.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/weights_pointer_attribute.hpp
@@ -12,8 +12,7 @@ namespace intel_npu {
 
 /**
  * @brief Attribute containing the memory address of a weights buffer and the size of the buffer in bytes.
- * @details Used as part of the serialization/deserialization algorithms in order to allow processing models without
- * copying weights.
+ * @details Used as part of the model marshalling process to avoid the need of copying weights.
  */
 class WeightsPointerAttribute : public ov::RuntimeAttribute {
 public:

--- a/src/plugins/intel_npu/src/compiler_adapter/include/vcl_serializer.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/vcl_serializer.hpp
@@ -27,17 +27,15 @@ namespace driver_compiler_utils {
 /**
  * @brief Serializes the model using a format supported by the "VCL" interface.
  *
+ * @param compilerVersion The compiler version reported by the driver.
  * @param supportedOpsetVersion The last operators set version supported by the compiler.
  * @param useBaseModelSerializer "true" means the legacy serializer will be used (weights will be copied), "false" means
- * the optimized one is used instead (weights pointers are stored).
- * @param weightsSizeThreshold Relevant only if "useBaseModelSerializer" is false. The weights smaller than this value
- * will be copied into a separate buffer. The rest will have only their memory location stored.
+ * the optimized one is used instead (weights pointers are stored instead).
  */
 SerializedIR serializeIR(const std::shared_ptr<const ov::Model>& model,
                          ze_graph_compiler_version_info_t compilerVersion,
                          const uint32_t supportedOpsetVersion,
-                         const bool useBaseModelSerializer = true,
-                         const size_t weightsSizeThreshold = 0);
+                         const bool useBaseModelSerializer = true);
 
 /**
  * @brief Serialize input / output information to string format.

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -95,8 +95,7 @@ std::shared_ptr<IGraph> DriverCompilerAdapter::compile(const std::shared_ptr<con
         compilerVersion,
         maxOpsetVersion,
         config.isAvailable(ov::intel_npu::use_base_model_serializer.name()) ? config.get<USE_BASE_MODEL_SERIALIZER>()
-                                                                            : true,
-        config.get<SERIALIZATION_WEIGHTS_SIZE_THRESHOLD>());
+                                                                            : true);
 
     std::string buildFlags;
     const bool useIndices = !((compilerVersion.major < 5) || (compilerVersion.major == 5 && compilerVersion.minor < 9));
@@ -157,8 +156,7 @@ std::shared_ptr<IGraph> DriverCompilerAdapter::compileWS(const std::shared_ptr<o
         compilerVersion,
         maxOpsetVersion,
         config.isAvailable(ov::intel_npu::use_base_model_serializer.name()) ? config.get<USE_BASE_MODEL_SERIALIZER>()
-                                                                            : true,
-        config.get<SERIALIZATION_WEIGHTS_SIZE_THRESHOLD>());
+                                                                            : true);
 
     std::string buildFlags;
     const bool useIndices = !((compilerVersion.major < 5) || (compilerVersion.major == 5 && compilerVersion.minor < 9));
@@ -306,8 +304,7 @@ ov::SupportedOpsMap DriverCompilerAdapter::query(const std::shared_ptr<const ov:
         compilerVersion,
         maxOpsetVersion,
         config.isAvailable(ov::intel_npu::use_base_model_serializer.name()) ? config.get<USE_BASE_MODEL_SERIALIZER>()
-                                                                            : true,
-        config.get<SERIALIZATION_WEIGHTS_SIZE_THRESHOLD>());
+                                                                            : true);
 
     std::string buildFlags;
     buildFlags += driver_compiler_utils::serializeConfig(config, compilerVersion);

--- a/src/plugins/intel_npu/src/compiler_adapter/src/xml_serializer.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/xml_serializer.cpp
@@ -10,20 +10,7 @@
 namespace intel_npu {
 
 ov::util::ConstantWriter& XmlSerializer::get_constant_write_handler() {
-    if (m_use_weightless_writer) {
-        return *m_weightless_constant_writer;
-    } else {
-        return m_base_constant_writer;
-    }
-}
-
-bool XmlSerializer::append_node_attributes(ov::Node& node) {
-    // If the "WeightsPointerAttribute" is found, then we have the metadata required to avoid copying the weights
-    // corresponding to this node.
-    m_use_weightless_writer = node.get_rt_info().count(WeightsPointerAttribute::get_type_info_static()) != 0;
-    auto result = ov::util::XmlSerializer::append_node_attributes(node);
-    m_use_weightless_writer = false;
-    return result;
+    return *m_weightless_constant_writer;
 }
 
 std::unique_ptr<ov::util::XmlSerializer> XmlSerializer::make_visitor(pugi::xml_node& data,

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -322,7 +322,6 @@ void Plugin::init_options() {
     REGISTER_OPTION(SEPARATE_WEIGHTS_VERSION);
     REGISTER_OPTION(WS_COMPILE_CALL_NUMBER);
     REGISTER_OPTION(USE_BASE_MODEL_SERIALIZER);
-    REGISTER_OPTION(SERIALIZATION_WEIGHTS_SIZE_THRESHOLD);
 
     if (_backend) {
         if (_backend->isCommandQueueExtSupported()) {

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -384,8 +384,6 @@ void Properties::registerPluginProperties() {
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::weightless_blob, WEIGHTLESS_BLOB);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::separate_weights_version, SEPARATE_WEIGHTS_VERSION);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::use_base_model_serializer, USE_BASE_MODEL_SERIALIZER);
-    TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::serialization_weights_size_threshold,
-                                 SERIALIZATION_WEIGHTS_SIZE_THRESHOLD);
 
     TRY_REGISTER_CUSTOMFUNC_PROPERTY(ov::intel_npu::stepping, STEPPING, [&](const Config& config) {
         if (!config.has<STEPPING>()) {

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/custom_stream.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/custom_stream.cpp
@@ -66,13 +66,7 @@ TEST_P(DriverCompilerAdapterCustomStreamTestNPU, TestLargeModelNoWeightsCopy) {
     auto model = createModelWithLargeSize();
     const ze_graph_compiler_version_info_t dummyCompilerVersion{0, 0};
 
-    EXPECT_NO_THROW(::intel_npu::driver_compiler_utils::serializeIR(model, dummyCompilerVersion, 11, false, 0));
-    EXPECT_NO_THROW(::intel_npu::driver_compiler_utils::serializeIR(model, dummyCompilerVersion, 11, false, 100));
-    EXPECT_NO_THROW(::intel_npu::driver_compiler_utils::serializeIR(model,
-                                                                    dummyCompilerVersion,
-                                                                    11,
-                                                                    false,
-                                                                    static_cast<size_t>(1e9)));
+    EXPECT_NO_THROW(::intel_npu::driver_compiler_utils::serializeIR(model, dummyCompilerVersion, 11, false));
 }
 
 const std::vector<ov::AnyMap> configs = {

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/compile_and_infer.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/compile_and_infer.cpp
@@ -30,18 +30,13 @@ INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                                                 {ov::intel_npu::defer_weights_load(false)}})),
                          ov::test::utils::appendPlatformTypeTestName<OVCompileAndInferRequestTurbo>);
 
-INSTANTIATE_TEST_SUITE_P(
-    compatibility_smoke_BehaviorTests,
-    OVCompileAndInferRequestSerializers,
-    ::testing::Combine(
-        ::testing::Values(getConstantGraph(ov::element::f32)),
-        ::testing::Values(ov::test::utils::DEVICE_NPU),
-        ::testing::ValuesIn(std::vector<ov::AnyMap>{
-            {ov::intel_npu::use_base_model_serializer(true)},
-            {ov::intel_npu::use_base_model_serializer(false), ov::intel_npu::serialization_weights_size_threshold(0)},
-            {ov::intel_npu::use_base_model_serializer(false), ov::intel_npu::serialization_weights_size_threshold(100)},
-            {ov::intel_npu::use_base_model_serializer(false),
-             ov::intel_npu::serialization_weights_size_threshold(static_cast<size_t>(1e9))}})),
-    ov::test::utils::appendPlatformTypeTestName<OVCompileAndInferRequestSerializers>);
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
+                         OVCompileAndInferRequestSerializers,
+                         ::testing::Combine(::testing::Values(getConstantGraph(ov::element::f32)),
+                                            ::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(std::vector<ov::AnyMap>{
+                                                {ov::intel_npu::use_base_model_serializer(true)},
+                                                {ov::intel_npu::use_base_model_serializer(false)}})),
+                         ov::test::utils::appendPlatformTypeTestName<OVCompileAndInferRequestSerializers>);
 
 }  // namespace


### PR DESCRIPTION
### Details:
 - The data so far suggests this feature is useless, it only adds code complexity. More details in the ticket.

### Tickets:
 - *CVS-173711*
