### PR TITLE
[CPU] Fix scratchpad memory pointer tracking in GatherMatmul

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/gathermatmul.h
+++ b/src/plugins/intel_cpu/src/nodes/gathermatmul.h
@@ -66,9 +66,10 @@ private:
     MemoryPtr m_weightsMemory = nullptr;
     MemoryPtr m_scalesMemory = nullptr;
     MemoryPtr m_zpMemory = nullptr;
+
     MemoryPtr m_tmpInpBuffer = nullptr;
-    MemoryPtr m_tmpInput = nullptr;
-    MemoryPtr m_tmpOutput = nullptr;
+    MemoryDescPtr m_tmpInputDesc = nullptr;
+    MemoryDescPtr m_tmpOutputDesc = nullptr;
 
     bool bf16_amx_mode = false;
 };


### PR DESCRIPTION
### Details:
This PR changes the procedure of creating the temporal memory buffers in the GatherMatmul node implementation.
The problem was in scratchpad memory pointer tracking. Previously the temporary input and output memory objects were created during the update parameters phase and stored the scratch pad memory address directly. But the scratchpad is dynamic memory, so the stored memory pointers may expire at the time of the execute call.
This PR modifies the behavior to ensure that the pointers are always valid at the time of the exec call.

Port to Release 2025.4: https://github.com/openvinotoolkit/openvino/pull/32798

### Tickets:
 - CVS-176351
