### PR TITLE
Use const ref to vector in save_binary

### DIFF
--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -316,7 +316,7 @@ std::vector<uint8_t> load_binary(const std::string& path);
  * @brief save binary data to file
  * @param path - binary file path to store
  */
-void save_binary(const std::string& path, std::vector<uint8_t> binary);
+void save_binary(const std::string& path, const std::vector<uint8_t>& binary);
 void save_binary(const std::string& path, const char* binary, size_t bin_size);
 
 /**

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -515,7 +515,7 @@ std::vector<uint8_t> ov::util::load_binary(const std::string& path) {
     return {};
 }
 
-void ov::util::save_binary(const std::string& path, std::vector<uint8_t> binary) {
+void ov::util::save_binary(const std::string& path, const std::vector<uint8_t>& binary) {
     save_binary(path, reinterpret_cast<const char*>(&binary[0]), binary.size());
     return;
 }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/file_util.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/file_util.hpp
@@ -12,6 +12,6 @@
 namespace ov::intel_gpu {
 
 // Version of save_binary that don't trow an exception if attempt to open file fails
-void save_binary(const std::string& path, std::vector<uint8_t> binary);
+void save_binary(const std::string& path, const std::vector<uint8_t>& binary);
 
 }  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/runtime/file_util.cpp
+++ b/src/plugins/intel_gpu/src/runtime/file_util.cpp
@@ -7,7 +7,7 @@
 
 namespace ov::intel_gpu {
 
-void save_binary(const std::string &path, std::vector<uint8_t> binary) {
+void save_binary(const std::string &path, const std::vector<uint8_t>& binary) {
     try {
         ov::util::save_binary(path, binary);
     } catch (std::runtime_error&) {}


### PR DESCRIPTION
### Details:
 - save_binary function should use const reference to vector to avoid unnecessary vector copy. This change can speed up cache creation for GPU kernels.

### Tickets:
 - 
