### PR TITLE
Revert [CPU, snippets] Use ov::Shape as alias type for VectorDims (#32687)"

### DIFF
--- a/src/common/snippets/include/snippets/lowered/pass/mha_parallel_wa_optimizer.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/mha_parallel_wa_optimizer.hpp
@@ -53,7 +53,7 @@ private:
 
     std::vector<lowered::ExpandedLoopInfoPtr> m_loops_to_split;
     std::unordered_set<size_t> m_unsqueezed_params;
-    std::vector<VectorDims> m_optimized_layouts;
+    std::vector<std::vector<size_t>> m_optimized_layouts;
     std::vector<size_t> m_dim_M_idces;
     size_t m_concurrency = 0;
 

--- a/src/common/snippets/include/snippets/op/buffer.hpp
+++ b/src/common/snippets/include/snippets/op/buffer.hpp
@@ -100,7 +100,7 @@ private:
     // The buffers with this implementation mustn't have source (parents)
     class NewMemoryImpl : public BaseImpl {
     public:
-        explicit NewMemoryImpl(ov::Shape shape, ov::element::Type element_type);
+        explicit NewMemoryImpl(const ov::Shape& shape, ov::element::Type element_type);
 
         [[nodiscard]] size_t get_allocation_size() const override;
         [[nodiscard]] std::shared_ptr<BaseImpl> clone() const override;
@@ -115,7 +115,7 @@ private:
             ov::Shape m_shape;
 
         public:
-            explicit ShapeInfer(ov::Shape shape);
+            explicit ShapeInfer(const ov::Shape& shape);
             Result infer(const std::vector<VectorDimsRef>& input_shapes) override;
         };
 

--- a/src/common/snippets/include/snippets/runtime_configurator.hpp
+++ b/src/common/snippets/include/snippets/runtime_configurator.hpp
@@ -203,7 +203,7 @@ protected:
     /**
      * @brief Extract layouts from m_io_descs
      */
-    [[nodiscard]] std::vector<ov::snippets::VectorDims> extract_layouts() const;
+    [[nodiscard]] std::vector<std::vector<size_t>> extract_layouts() const;
 
     std::shared_ptr<RuntimeConfig> m_config = nullptr;
 

--- a/src/common/snippets/include/snippets/shape_types.hpp
+++ b/src/common/snippets/include/snippets/shape_types.hpp
@@ -9,8 +9,6 @@
 #include <memory>
 #include <vector>
 
-#include "openvino/core/shape.hpp"
-
 namespace ov::snippets {
 /*
  * This header file contain declarations of shape-relevant classes used cross several snippets subsystems.
@@ -18,7 +16,7 @@ namespace ov::snippets {
  * both PortDescriptor and IShapeInferSnippets use VectorDims, but these two classes are completely independent
  * semantically.
  */
-using VectorDims = ov::Shape;
+using VectorDims = std::vector<size_t>;
 using VectorDimsPtr = std::shared_ptr<VectorDims>;
 using VectorDimsCPtr = std::shared_ptr<const VectorDims>;
 using VectorDimsRef = std::reference_wrapper<const VectorDims>;

--- a/src/common/snippets/src/lowered/port_descriptor.cpp
+++ b/src/common/snippets/src/lowered/port_descriptor.cpp
@@ -28,7 +28,7 @@ PortDescriptor::PortDescriptor(const ov::Input<ov::Node>& in, VectorDims subtens
                      std::move(layout)) {}
 
 PortDescriptor::PortDescriptor(const ov::Input<const ov::Node>& in,
-                               VectorDims subtensor_shape,
+                               std::vector<size_t> subtensor_shape,
                                std::vector<size_t> layout)
     : PortDescriptor(utils::pshape_to_vdims(in.get_partial_shape()), std::move(subtensor_shape), std::move(layout)) {}
 
@@ -38,7 +38,7 @@ PortDescriptor::PortDescriptor(const ov::Output<ov::Node>& out, VectorDims subte
                      std::move(layout)) {}
 
 PortDescriptor::PortDescriptor(const ov::Output<const ov::Node>& out,
-                               VectorDims subtensor_shape,
+                               std::vector<size_t> subtensor_shape,
                                std::vector<size_t> layout)
     : PortDescriptor(utils::pshape_to_vdims(out.get_partial_shape()), std::move(subtensor_shape), std::move(layout)) {}
 

--- a/src/common/snippets/src/op/buffer.cpp
+++ b/src/common/snippets/src/op/buffer.cpp
@@ -88,8 +88,8 @@ Buffer::IntermediateMemoryImpl::ShapeInfer::Result Buffer::IntermediateMemoryImp
     return {{input_shapes[0].get()}, ShapeInferStatus::success};
 }
 
-Buffer::NewMemoryImpl::NewMemoryImpl(ov::Shape shape, ov::element::Type element_type)
-    : m_shape(std::move(shape)),
+Buffer::NewMemoryImpl::NewMemoryImpl(const ov::Shape& shape, ov::element::Type element_type)
+    : m_shape(shape),
       m_element_type(element_type) {}
 
 size_t Buffer::NewMemoryImpl::get_allocation_size() const {
@@ -112,7 +112,7 @@ bool Buffer::NewMemoryImpl::visit_attributes(AttributeVisitor& visitor) {
     return true;
 }
 
-Buffer::NewMemoryImpl::ShapeInfer::ShapeInfer(ov::Shape shape) : m_shape(std::move(shape)) {}
+Buffer::NewMemoryImpl::ShapeInfer::ShapeInfer(const ov::Shape& shape) : m_shape(shape) {}
 
 Buffer::NewMemoryImpl::ShapeInfer::Result Buffer::NewMemoryImpl::ShapeInfer::infer(
     const std::vector<VectorDimsRef>& input_shapes) {

--- a/src/common/snippets/src/runtime_configurator.cpp
+++ b/src/common/snippets/src/runtime_configurator.cpp
@@ -357,7 +357,7 @@ void RuntimeConfigurator::update_data_offsets() const {
         auto& offsets = m_config->io_data_offsets[i];
         const auto& layout = layouts[i];
         if (!layout.empty()) {
-            VectorDims reordered_offsets(offsets.size());
+            std::vector<size_t> reordered_offsets(offsets.size());
             const auto is_input = i < m_in_num;
             for (size_t i = 0; i < layout.size(); i++) {
                 const auto& src_idx = is_input ? layout[i] : i;
@@ -377,8 +377,8 @@ std::vector<VectorDims> RuntimeConfigurator::extract_shapes() const {
     return shapes;
 }
 
-std::vector<VectorDims> RuntimeConfigurator::extract_layouts() const {
-    std::vector<VectorDims> layouts(m_io_num);
+std::vector<std::vector<size_t>> RuntimeConfigurator::extract_layouts() const {
+    std::vector<std::vector<size_t>> layouts(m_io_num);
     for (size_t i = 0; i < m_io_num; ++i) {
         layouts[i] = m_io_descs[i]->get_layout();
     }

--- a/src/common/snippets/tests/src/runtime_configurator.cpp
+++ b/src/common/snippets/tests/src/runtime_configurator.cpp
@@ -22,7 +22,7 @@ public:
     void set_state(size_t in_num,
                    const std::vector<ov::snippets::VectorDims>& shapes,
                    const std::vector<ov::snippets::VectorDims>& latest_shapes,
-                   const std::vector<ov::snippets::VectorDims>& layouts,
+                   const std::vector<std::vector<size_t>>& layouts,
                    const std::vector<size_t>& data_sizes,
                    size_t tensor_rank,
                    const std::vector<ov::snippets::VectorDims>& offsets) {

--- a/src/core/include/openvino/core/shape.hpp
+++ b/src/core/include/openvino/core/shape.hpp
@@ -30,8 +30,6 @@ public:
 
     OPENVINO_API Shape(const Shape& axis_lengths);
 
-    OPENVINO_API Shape(Shape&& other);
-
     OPENVINO_API explicit Shape(size_t n, size_t initial_value = 0);
 
     OPENVINO_API ~Shape();

--- a/src/core/src/partial_shape.cpp
+++ b/src/core/src/partial_shape.cpp
@@ -266,7 +266,7 @@ ov::Shape ov::PartialShape::to_shape() const {
         OPENVINO_THROW("to_shape was called on a dynamic shape.");
     }
 
-    ov::Shape shape_dimensions(m_dimensions.size());
+    std::vector<size_t> shape_dimensions(m_dimensions.size());
     std::transform(m_dimensions.begin(), m_dimensions.end(), shape_dimensions.begin(), [](const Dimension& d) {
         return d.get_length();
     });

--- a/src/core/src/shape.cpp
+++ b/src/core/src/shape.cpp
@@ -34,8 +34,6 @@ ov::Shape::Shape(const std::vector<size_t>& axis_lengths) : std::vector<size_t>(
 
 ov::Shape::Shape(const Shape& axis_lengths) = default;
 
-ov::Shape::Shape(Shape&& other) = default;
-
 ov::Shape::Shape(size_t n, size_t initial_value) : std::vector<size_t>(n, initial_value) {}
 
 ov::Shape::Shape(const std::string& value) {

--- a/src/plugins/intel_cpu/src/cpu_types.h
+++ b/src/plugins/intel_cpu/src/cpu_types.h
@@ -9,13 +9,12 @@
 #include <string>
 #include <vector>
 
-#include "openvino/core/shape.hpp"
 #include "utils/caseless.hpp"
 
 namespace ov::intel_cpu {
 
-using VectorDims = ov::Shape;
-using Dim = typename VectorDims::value_type;
+using Dim = std::size_t;
+using VectorDims = std::vector<Dim>;
 
 std::string dim2str(Dim dim);
 std::string dims2str(const VectorDims& dims);

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -227,7 +227,7 @@ static inline bool isPhycicalMemCompatible(const MemoryDesc& lhsMemDesc, const M
         if (dims.size() != flag.size()) {
             return dims;
         }
-        VectorDims ret;
+        std::vector<size_t> ret;
         for (size_t i = 0; i < dims.size(); i++) {
             if (flag[i] != 1) {
                 ret.push_back(dims[i]);

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <numeric>
 #include <oneapi/dnnl/dnnl.hpp>
+#include <vector>
 
 #include "cpu_memory_desc.h"
 #include "cpu_types.h"

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.h
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.h
@@ -36,7 +36,7 @@ private:
     void exec();
 
     template <bool reverse, bool exclusive, typename dataType>
-    void cumSum(const dataType* input, dataType* output, const VectorDims& strides);
+    void cumSum(const dataType* input, dataType* output, const std::vector<size_t>& strides);
 
     static void parallelItInit(size_t start, std::vector<size_t>& counters, const std::vector<size_t>& iterationRange);
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
@@ -451,7 +451,7 @@ static std::vector<DnnlPrimitiveAttrs> createPrimitiveAttrs(const ConvAttrs& att
     const auto& dstDesc = memory.at(ARG_DST)->getDescPtr();
 
     const auto& originalOutputDims = dstDesc->getShape().getMinDims();
-    const auto& outputDims = attrs.fcSemantic ? VectorDims(normalizeDims(originalOutputDims)) : originalOutputDims;
+    const auto& outputDims = attrs.fcSemantic ? normalizeDims(originalOutputDims) : originalOutputDims;
 
     auto isINT8 =
         any_of(srcDesc->getPrecision(), ov::element::u8, ov::element::i8) && weiDesc->getPrecision() == ov::element::i8;

--- a/src/plugins/intel_cpu/src/nodes/executors/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/subgraph.hpp
@@ -240,7 +240,7 @@ protected:
     }
 
     std::vector<size_t> m_buffer_offsets;
-    std::vector<VectorDims> m_data_offsets;
+    std::vector<std::vector<size_t>> m_data_offsets;
     std::vector<jit_snippets_call_args::loop_args_t> m_loop_args;
     std::function<void()> m_reset_exec_table_state;
 };

--- a/src/plugins/intel_cpu/tests/unit/cpu_tensor_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/cpu_tensor_test.cpp
@@ -154,7 +154,7 @@ inline MemoryPtr create_memory(MemoryDescPtr memdesc) {
 TEST_F(CPUTensorTest, canCreateTensor) {
     Shape shape{4, 3, 2};
     ov::Shape ov_shape = shape.toPartialShape().to_shape();
-    auto strides = VectorDims({6, 2, 1});
+    auto strides = ov::Strides({6, 2, 1});
     const std::size_t totalSize = ov::shape_size(ov_shape);
     ov::element::Type elem_type = ov::element::f32;
 
@@ -201,7 +201,7 @@ TEST_F(CPUTensorTest, canSetShape) {
 
     const Shape newShape({4, 5, 6});
     const ov::Shape ov_newShape = newShape.toPartialShape().to_shape();
-    auto new_strides = VectorDims{30, 6, 1};
+    auto new_strides = ov::Strides{30, 6, 1};
     auto new_memdesc = create_memdesc(ov::element::f32, newShape, new_strides);
 
     // set_shape to a bigger memory
@@ -231,7 +231,7 @@ TEST_F(CPUTensorTest, canSetShape) {
 TEST_F(CPUTensorTest, canSyncMemoryAndTensor) {
     const Shape origShape = {1, 2, 3};
     const ov::Shape ov_origShape = origShape.toPartialShape().to_shape();
-    auto strides = VectorDims({6, 3, 1});
+    auto strides = ov::Strides({6, 3, 1});
     auto memdesc = create_memdesc(ov::element::f32, origShape, strides);
     auto memptr = create_memory(memdesc);
     std::shared_ptr<ov::ITensor> t = std::make_shared<ov::intel_cpu::Tensor>(memptr);
@@ -241,7 +241,7 @@ TEST_F(CPUTensorTest, canSyncMemoryAndTensor) {
 
     const Shape newShape({4, 5, 6});
     const ov::Shape ov_newShape = newShape.toPartialShape().to_shape();
-    auto new_strides = VectorDims{30, 6, 1};
+    auto new_strides = ov::Strides{30, 6, 1};
     auto new_memdesc = create_memdesc(ov::element::f32, newShape, new_strides);
 
     // reallocate memory out boundary of tensor instance


### PR DESCRIPTION
Because of performance degradation introduced by using overloaded
operator [] with non-trivial logic
Nodes which use c++ implementation (such as Concat, Transpose, etc) were affected

This reverts commit 60cdd99b56fdf6a166bb05b8106d8e678d2e9915.
- https://github.com/openvinotoolkit/openvino/pull/32687

### Tickets:
 - *ticket-id*

<!-- Message of single commit: -->