### PR TITLE
Fix issue 32684

### DIFF
--- a/src/inference/src/dev/threading/cpu_streams_executor.cpp
+++ b/src/inference/src/dev/threading/cpu_streams_executor.cpp
@@ -142,6 +142,9 @@ struct CPUStreamsExecutor::Impl {
                 auto real_numa_node_id = _numaNodeId;
 #    else
                 auto real_numa_node_id = get_org_numa_id(_numaNodeId);
+                if (tbb_version >= 12040 && real_numa_node_id != -1) {
+                    real_numa_node_id = _numaNodeId;
+                }
 #    endif
                 _taskArena.reset(new custom::task_arena{custom::task_arena::constraints{}
                                                             .set_numa_id(real_numa_node_id)

--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -609,7 +609,8 @@ void parse_cache_info_linux(const std::vector<std::vector<std::string>> system_i
 
     for (size_t n = 0; n < offline_list.size(); n++) {
         _proc_type_table[0][ALL_PROC]--;
-        _proc_type_table[_cpu_mapping_table[offline_list[n] - n][CPU_MAP_NUMA_NODE_ID] + 1][ALL_PROC]--;
+        if (_proc_type_table.size() > 1)
+            _proc_type_table[_cpu_mapping_table[offline_list[n] - n][CPU_MAP_NUMA_NODE_ID] + 1][ALL_PROC]--;
         _cpu_mapping_table.erase(_cpu_mapping_table.begin() + offline_list[n] - n);
         _processors--;
     }


### PR DESCRIPTION
1. Decrement _proc_type_table[0][ALL_PROC] when the core is offline.
2. Verify _cpu_mapping_table[i][CPU_MAP_CORE_TYPE] is properly initialized before usage.
3. Use NUMA ID provided by TBB for accurate mapping.