### PR TITLE
[TF Lite FE] Embedding Lookup implementation

### DIFF
--- a/src/frontends/tensorflow_lite/src/op/embedding_lookup.cpp
+++ b/src/frontends/tensorflow_lite/src/op/embedding_lookup.cpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_op_table.hpp"
+#include "op_translation_utils.hpp"
+#include "utils.hpp"
+
+using namespace std;
+
+namespace ov {
+namespace frontend {
+namespace tensorflow_lite {
+namespace op {
+
+OutputVector embedding_lookup(const ov::frontend::tensorflow_lite::NodeContext& node) {
+    auto axis = opset10::Constant::create(element::i32, {}, {0});
+    auto lookup_indices = node.get_input(0);
+    auto data_values = node.get_input(1);
+    auto res = make_shared<opset10::Gather>(data_values, lookup_indices, axis);
+    res->set_friendly_name(node.get_name());
+    return res->outputs();
+}
+
+}  // namespace op
+}  // namespace tensorflow_lite
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/tensorflow_lite/src/op_table.cpp
+++ b/src/frontends/tensorflow_lite/src/op_table.cpp
@@ -71,7 +71,7 @@ std::map<std::string, CreatorFunction> get_supported_ops() {
         {"DIV", translate_binary_op_with_activation<opset10::Divide>},
         // DYNAMIC_UPDATE_SLICE
         {"ELU", DEQUANTIZE_INPUTS(translate_elu_op)},
-        // EMBEDDING_LOOKUP
+        {"EMBEDDING_LOOKUP", DEQUANTIZE_INPUTS(embedding_lookup)},
         // EMBEDDING_LOOKUP_SPARSE
         {"EQUAL", translate_binary<opset10::Equal>},
         {"EXP", translate_unary<opset10::Exp>},

--- a/src/frontends/tensorflow_lite/src/op_table.hpp
+++ b/src/frontends/tensorflow_lite/src/op_table.hpp
@@ -31,6 +31,7 @@ TFL_OP_CONVERTER(concatenation);
 TFL_OP_CONVERTER(conv2d);
 TFL_OP_CONVERTER(depthwise_conv2d);
 TFL_OP_CONVERTER(dequantize);
+TFL_OP_CONVERTER(embedding_lookup);
 TFL_OP_CONVERTER(fully_connected);
 TFL_OP_CONVERTER(gather);
 TFL_OP_CONVERTER(l2_normalization);

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_EmbeddingLookup.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_EmbeddingLookup.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from common.tflite_layer_test_class import TFLiteLayerTest
+
+np.random.seed(42)
+
+test_params = [
+    {'shape': [10, 5], 'indices_shape': [3]},
+    {'shape': [20, 8], 'indices_shape': [1, 5]},
+    {'shape': [15, 10, 7], 'indices_shape': [4]},
+    {'shape': [8, 6, 4], 'indices_shape': [2, 3]},
+]
+
+
+class TestTFLiteEmbeddingLookupLayerTest(TFLiteLayerTest):
+    inputs = ["Input_x"]
+    outputs = ["EmbeddingLookup"]
+    allowed_ops = ['GATHER']
+
+    def make_model(self, params):
+        assert len(set(params.keys()).intersection({'shape', 'indices_shape', })) == 2, \
+            'Unexpected parameters for test: ' + ','.join(params.keys())
+        tf.compat.v1.reset_default_graph()
+        with tf.compat.v1.Session() as sess:
+            placeholder = tf.compat.v1.placeholder(params.get('dtype', tf.float32),
+                                                   params['shape'], name=self.inputs[0])
+            max_index = params['shape'][0] - 1
+            constant = tf.constant(np.random.randint(0, max_index + 1, size=params['indices_shape']))
+
+            tf.nn.embedding_lookup(placeholder, constant, name=self.outputs[0])
+            net = sess.graph_def
+        return net
+
+    @pytest.mark.parametrize("params", test_params)
+    @pytest.mark.nightly
+    def test_embedding_lookup(self, params, ie_device, precision, temp_dir):
+        self._test(ie_device, precision, temp_dir, params)


### PR DESCRIPTION
Implementing embedding lookup op for tflite frontend using gather op.

The openvino Gather op expects the inputs to be:
1.data: The tensor from which slices are gathered. 2.indices: Tensor with indexes to gather.
3.axis: Dimension index to gather data from.

The tfl EmbeddingLookupOp provides:
1.lookup: Tensor with indices to look for.
2.value: Tensor holding the data values.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
