### PR TITLE
[GPU] Fix lack of clEnqueueAcquire(Release)VA_APIMediaSurface for ULLS

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -225,7 +225,7 @@ struct surfaces_lock {
     surfaces_lock& operator=(const surfaces_lock& other) = delete;
 
     static std::unique_ptr<surfaces_lock> create(engine_types engine_type, std::vector<memory::ptr> mem, const stream& stream);
-    static bool is_surface_lock_check_needed(const shared_mem_type& mem_type);
+    static bool is_lock_needed(const shared_mem_type& mem_type);
 };
 
 template<typename T>

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -686,18 +686,18 @@ std::map<primitive_id, network_output> network::execute(const std::vector<event:
     std::vector<memory::ptr> in_out_mem;
     bool shared_mem_found = std::any_of(_in_out_shared_mem_types.begin(),
                                         _in_out_shared_mem_types.end(),
-                                        surfaces_lock::is_surface_lock_check_needed);
+                                        surfaces_lock::is_lock_needed);
 
     if (shared_mem_found) {
         for (auto& inst : _inputs) {
             if (inst->output_memory_ptr() &&
-                surfaces_lock::is_surface_lock_check_needed(inst->output_memory_ptr()->get_internal_params().mem_type))
+                surfaces_lock::is_lock_needed(inst->output_memory_ptr()->get_internal_params().mem_type))
                 in_out_mem.push_back(inst->output_memory_ptr());
         }
 
         for (auto& inst : _outputs) {
             if (inst->output_memory_ptr() &&
-                surfaces_lock::is_surface_lock_check_needed(inst->output_memory_ptr()->get_internal_params().mem_type))
+                surfaces_lock::is_lock_needed(inst->output_memory_ptr()->get_internal_params().mem_type))
                 in_out_mem.push_back(inst->output_memory_ptr());
         }
     }

--- a/src/plugins/intel_gpu/src/runtime/memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<surfaces_lock> surfaces_lock::create(engine_types engine_type, s
     }
 }
 
-bool surfaces_lock::is_surface_lock_check_needed(const shared_mem_type& mem_type) {
+bool surfaces_lock::is_lock_needed(const shared_mem_type& mem_type) {
     return mem_type == shared_mem_type::shared_mem_vasurface ||
            mem_type == shared_mem_type::shared_mem_dxbuffer ||
            mem_type == shared_mem_type::shared_mem_image;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -709,7 +709,7 @@ std::vector<cl_mem> ocl_surfaces_lock::get_handles(std::vector<memory::ptr> mem)
     std::vector<cl_mem> res;
     for (auto& m : mem) {
         auto mem_type = m->get_internal_params().mem_type;
-        if (is_surface_lock_check_needed(mem_type)) {
+        if (is_lock_needed(mem_type)) {
             res.push_back(static_cast<cl_mem>(m->get_internal_params().mem));
         }
     }


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - Currently OpenVINO does not call clEnqueueAcquireVA_APIMediaSurfacesINTEL
and clEnqueueReleaseVA_APIMediaSurfacesINTEL when calling clCreateFromVA_APIMediaSurfaceINTEL
,which prevents proper support of ULLS (Ultra Low Latency Submission - an Intel OpenCL  extension feature)
 - Solution: Fixed missing the surface_lock condition. Acquire and Release are called by surface_lock but mem_type for shared_mem_image is missed and actually was not called. Added shared_mem_image mem_type. Consolidate the check logic in surface_lock.
- Removed dummy internal buffers in non reduce mode.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model) 
Need to prepare set up dlstreamer: https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dl-streamer/get_started/install/install_guide_ubuntu.html 
(python3venv) gta@DUT4396ARLH:~ $ for i in {1..20}; do echo ${i}; (~/edge-ai-libraries/libraries/dl-streamer/scripts/hello_dlstreamer.sh --output=json) &> stdout.txt && cat output.json | awk 'NR==10 || NR==11 || NR==12' | awk 'match($0, /"x_max":[ ]*([0-9]+\.[0-9]+)/, arr) { print arr[1] }' && rm output.json && rm stdout.txt; done;
1
0.7732421990222065
0.7482421986496774
0.7242187607917003
2
0.7732421990222065
0.7482421986496774
0.7242187607917003
3
0.7732421990222065
0.7482421986496774
0.7242187607917003
...

Expected is consistent but actual inconsistent result (0.8xxx)

#### Checklist 
 - [x] Is it a proper fix?
 - [ ] Did you include test case for this fix, if necessary? 
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *CVS-176068*
