### PR TITLE
[NPU] Use weak pointer to safely destroy shared ptr when ref count is 0

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
@@ -15,7 +15,8 @@ namespace intel_npu {
 class ZeroEngineBackend final : public IEngineBackend {
 public:
     ZeroEngineBackend();
-    virtual ~ZeroEngineBackend();
+    ~ZeroEngineBackend() override = default;
+
     const std::shared_ptr<IDevice> getDevice() const override;
     const std::shared_ptr<IDevice> getDevice(const std::string&) const override;
     const std::string getName() const override {

--- a/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
@@ -37,8 +37,6 @@ bool ZeroEngineBackend::isLUIDExtSupported() const {
     return _initStruct->isExtensionSupported(std::string(ZE_DEVICE_LUID_EXT_NAME), ZE_MAKE_VERSION(1, 0));
 }
 
-ZeroEngineBackend::~ZeroEngineBackend() = default;
-
 const std::shared_ptr<IDevice> ZeroEngineBackend::getDevice() const {
     if (_devices.empty()) {
         _logger.debug("ZeroEngineBackend - getDevice() returning empty list");

--- a/src/plugins/intel_npu/src/plugin/include/remote_context.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/remote_context.hpp
@@ -21,6 +21,8 @@ class RemoteContextImpl : public ov::IRemoteContext {
 public:
     RemoteContextImpl(const ov::SoPtr<IEngineBackend>& engineBackend, const ov::AnyMap& remote_properties = {});
 
+    ~RemoteContextImpl() override = default;
+
     /**
      * @brief Returns name of a device on which underlying object is allocated.
      * @return A device name string in fully specified format `<device_name>[.<device_id>[.<tile_id>]]` (e.g. GPU.0.1).

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
@@ -78,7 +78,7 @@ public:
 
     ~ZeroApi() = default;
 
-    static const std::shared_ptr<ZeroApi>& getInstance();
+    static const std::shared_ptr<ZeroApi> getInstance();
 
 #define symbol_statement(symbol) decltype(&::symbol) symbol;
     symbols_list();

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -79,7 +79,7 @@ public:
         return _external_memory_fd_win32_supported;
     }
 
-    static const std::shared_ptr<ZeroInitStructsHolder>& getInstance();
+    static const std::shared_ptr<ZeroInitStructsHolder> getInstance();
 
 private:
     void initNpuDriver();

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_api.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_api.cpp
@@ -4,6 +4,8 @@
 
 #include "intel_npu/utils/zero/zero_api.hpp"
 
+#include <mutex>
+
 #include "openvino/util/file_util.hpp"
 #include "openvino/util/shared_object.hpp"
 
@@ -49,8 +51,16 @@ ZeroApi::ZeroApi() {
 #undef symbol_statement
 }
 
-const std::shared_ptr<ZeroApi>& ZeroApi::getInstance() {
-    static std::shared_ptr<ZeroApi> instance = std::make_shared<ZeroApi>();
+const std::shared_ptr<ZeroApi> ZeroApi::getInstance() {
+    static std::mutex mutex;
+    static std::weak_ptr<ZeroApi> weak_instance;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    auto instance = weak_instance.lock();
+    if (!instance) {
+        instance = std::make_shared<ZeroApi>();
+        weak_instance = instance;
+    }
     return instance;
 }
 


### PR DESCRIPTION
### Details:
 - *Use a weak pointer to safely destroy the shared ptr when the ref count from the application is 0, and not increase it in the static method*

### Tickets:
 - *CVS-176148*
