### PR TITLE
[CPU] Disable deconvolution Prelu post-ops fusion

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -416,6 +416,12 @@ bool Deconvolution::canFuse(const NodePtr& node) const {
     if (canBeExecutedInInt8()) {
         return canFuseSimpleOperation(node);
     }
+
+    // WA for CVS-176001: disable Prelu post-ops fusion to avoid falling back to reference implementation.
+    if (node->getAlgorithm() == Algorithm::EltwisePrelu) {
+        return false;
+    }
+
     // Upstream ONEDNN conv_backward_data primitive can't support any post-ops, fork onednn added depthwise support in
     // conv_backward_data JIT implementation. ONEDNN deconv primitive can support most of post-ops, but the post-ops
     // implementation details are different. So current deconv implementation list in onednn has 2 kinds of implements:


### PR DESCRIPTION
### Details:
 - *Disable deconvolution Prelu post-ops fusion to avoid falling back to reference implementation*
 - *...*

### Tickets:
 - *https://jira.devtools.intel.com/browse/CVS-176001*
 - *https://jira.devtools.intel.com/browse/MFDNN-14380*
