### PR TITLE
[TF FE] TestApproximateEqual Layer Test failing due to random stimuli seed

### DIFF
--- a/tests/layer_tests/tensorflow_tests/test_tf_ApproximateEqual.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ApproximateEqual.py
@@ -7,7 +7,7 @@ from common.tf_layer_test_class import CommonTFLayerTest
 
 class TestApproximateEqual(CommonTFLayerTest):
     def _prepare_input(self, inputs_info):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(43)
         assert 'tensor1:0' in inputs_info
         assert 'tensor2:0' in inputs_info
         tensor1_shape = inputs_info['tensor1:0']


### PR DESCRIPTION
This fixes a TensorFlow layer test (TestApproximateEqual) which randomly fails due to random input.

### Details:
 - Fixes the seed of test stimuli
 - Makes test deterministic

### Tickets:
 - CVS-159201
