### PR TITLE
[NPU][Properties] Remove INTERNAL_SUPPORTED_PROPERTIES property

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -420,28 +420,6 @@ struct CACHING_PROPERTIES final : OptionBase<CACHING_PROPERTIES, std::string> {
     }
 };
 
-struct INTERNAL_SUPPORTED_PROPERTIES final : OptionBase<INTERNAL_SUPPORTED_PROPERTIES, std::string> {
-    static std::string_view key() {
-        return ov::internal::supported_properties.name();
-    }
-
-    static std::string defaultValue() {
-        return {};
-    }
-
-    static bool isPublic() {
-        return false;
-    }
-
-    static uint32_t compilerSupportVersion() {
-        return ONEAPI_MAKE_VERSION(0, 0);
-    }
-
-    static OptionMode mode() {
-        return OptionMode::Both;
-    }
-};
-
 // BATCH_MODE is required to maintain backward/forward compatibility
 struct BATCH_MODE final : OptionBase<BATCH_MODE, ov::intel_npu::BatchMode> {
     static std::string_view key() {

--- a/src/plugins/intel_npu/src/plugin/src/metrics.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/metrics.cpp
@@ -21,7 +21,6 @@ Metrics::Metrics(const ov::SoPtr<IEngineBackend>& backend) : _backend(backend) {
                          ov::device::capability::EXPORT_IMPORT,
                          ov::device::architecture.name(),
                          ov::internal::caching_properties.name(),
-                         ov::internal::supported_properties.name(),
                          ov::cache_dir.name(),
                          ov::intel_npu::device_alloc_mem_size.name(),
                          ov::intel_npu::device_total_mem_size.name(),

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -656,11 +656,6 @@ void Properties::registerCompiledModelProperties() {
     REGISTER_SIMPLE_METRIC(ov::optimal_number_of_infer_requests,
                            true,
                            static_cast<uint32_t>(getOptimalNumberOfInferRequestsInParallel(config)));
-    REGISTER_CUSTOM_METRIC(ov::internal::supported_properties, false, [&](const Config&) {
-        static const std::vector<ov::PropertyName> supportedProperty{
-            ov::PropertyName(ov::internal::caching_properties.name(), ov::PropertyMutability::RO)};
-        return supportedProperty;
-    });
     REGISTER_CUSTOM_METRIC(ov::execution_devices, true, [](const Config&) {
         // TODO: log an error here as the code shouldn't have gotten here
         // this property is implemented in compiled model directly


### PR DESCRIPTION
### Details:
 - Removes INTERNAL_SUPPORTED_PROPERTIES option
 - Internal vector remains untouched at: [_internalSupportedProperties](https://github.com/openvinotoolkit/openvino/blob/cf7699d7b3f028bc805c9b6f5d582c289055b723/src/plugins/intel_npu/src/plugin/include/properties.hpp#L142)

### Tickets:
 - C 175471
