### PR TITLE
[OV JS] Export all types

### DIFF
--- a/src/bindings/js/node/lib/addon.ts
+++ b/src/bindings/js/node/lib/addon.ts
@@ -1,4 +1,4 @@
-type SupportedTypedArray =
+export type SupportedTypedArray =
   | Int8Array
   | Uint8Array
   | Int16Array
@@ -10,7 +10,7 @@ type SupportedTypedArray =
   | BigInt64Array
   | BigUint64Array;
 
-type elementTypeString =
+export type elementTypeString =
   | "u8"
   | "u32"
   | "u16"
@@ -23,7 +23,7 @@ type elementTypeString =
   | "f32"
   | "string";
 
-type OVAny = string | number | boolean;
+export type OVAny = string | number | boolean;
 
 /**
  * Core represents an OpenVINO runtime Core entity.
@@ -33,7 +33,7 @@ type OVAny = string | number | boolean;
  * are created multiple times and not shared between several Core instances.
  * It is recommended to have a single Core instance per application.
  */
-interface Core {
+export interface Core {
   /**
    * It constructs a new Core object.
    */
@@ -217,7 +217,7 @@ interface Core {
   ): { [key: string]: string };
 }
 
-interface Model {
+export interface Model {
   /**
    * It constructs a default Model object. Use {@link Core.readModel}
    * to read Model from supported file format.
@@ -330,7 +330,7 @@ interface Model {
   outputs: Output[];
 }
 
-interface Node {
+export interface Node {
   /**
    * It constructs a default Node object.
    */
@@ -347,7 +347,7 @@ interface Node {
  * by applying multiple optimization transformations,
  * then mapping to compute kernels.
  */
-interface CompiledModel {
+export interface CompiledModel {
   /**
    * It constructs a default CompiledModel object. Use {@link Core.compileModel}
    * or {@link Core.importModel} to get model compiled for a specific device.
@@ -430,7 +430,7 @@ interface CompiledModel {
  * the user. Any action performed on the TypedArray will be reflected in this
  * tensor memory.
  */
-interface Tensor {
+export interface Tensor {
   /**
    * It constructs a tensor using the element type and shape. The new tensor
    * data will be allocated by default.
@@ -499,7 +499,7 @@ interface Tensor {
  * The {@link InferRequest} object is used to make predictions and can be run in
  * asynchronous or synchronous manners.
  */
-interface InferRequest {
+export interface InferRequest {
   /**
    * It constructs a default InferRequest object.
    * Use {@link CompiledModel.createInferRequest}
@@ -619,9 +619,9 @@ interface InferRequest {
   setTensor(name: string, tensor: Tensor): void;
 }
 
-type Dimension = number | [number, number];
+export type Dimension = number | [number, number];
 
-interface Output {
+export interface Output {
   new (): Output;
   anyName: string;
   shape: number[];
@@ -631,42 +631,42 @@ interface Output {
   getPartialShape(): PartialShape;
 }
 
-interface InputTensorInfo {
+export interface InputTensorInfo {
   setElementType(elementType: element | elementTypeString): InputTensorInfo;
   setLayout(layout: string): InputTensorInfo;
   setShape(shape: number[]): InputTensorInfo;
 }
 
-interface OutputTensorInfo {
+export interface OutputTensorInfo {
   setElementType(elementType: element | elementTypeString): InputTensorInfo;
   setLayout(layout: string): InputTensorInfo;
 }
-interface PreProcessSteps {
+export interface PreProcessSteps {
   resize(algorithm: resizeAlgorithm | string): PreProcessSteps;
 }
 
-interface InputModelInfo {
+export interface InputModelInfo {
   setLayout(layout: string): InputModelInfo;
 }
 
-interface InputInfo {
+export interface InputInfo {
   tensor(): InputTensorInfo;
   preprocess(): PreProcessSteps;
   model(): InputModelInfo;
 }
 
-interface OutputInfo {
+export interface OutputInfo {
   tensor(): OutputTensorInfo;
 }
 
-interface PrePostProcessor {
+export interface PrePostProcessor {
   new (model: Model): PrePostProcessor;
   build(): PrePostProcessor;
   input(idxOrTensorName?: number | string): InputInfo;
   output(idxOrTensorName?: number | string): OutputInfo;
 }
 
-interface PartialShape {
+export interface PartialShape {
   /**
    * It constructs a PartialShape by passed string.
    * Omit parameter to create empty shape.
@@ -687,13 +687,13 @@ interface PartialShape {
  * passed, it will be undefined.
  * @param error Optional error that occurred during inference, if any.
  */
-type AsyncInferQueueCallback = (
+export type AsyncInferQueueCallback = (
   error: null | Error,
   inferRequest: InferRequest,
   userData: object,
 ) => void;
 
-interface AsyncInferQueue {
+export interface AsyncInferQueue {
   /**
    * Creates AsyncInferQueue.
    * @param compiledModel The compiledModel that will be used
@@ -727,7 +727,7 @@ interface AsyncInferQueue {
   release(): void;
 }
 
-declare enum element {
+export declare enum element {
   u8,
   u32,
   u16,
@@ -741,7 +741,7 @@ declare enum element {
   string,
 }
 
-declare enum resizeAlgorithm {
+export declare enum resizeAlgorithm {
   RESIZE_NEAREST,
   RESIZE_CUBIC,
   RESIZE_LINEAR,

--- a/src/bindings/js/node/lib/index.ts
+++ b/src/bindings/js/node/lib/index.ts
@@ -1,3 +1,5 @@
 import addon from "./addon";
 
 export { addon };
+// Re-export all types from addon
+export * from "./addon";


### PR DESCRIPTION
Exporting types allows them to be used externally, for example, in variable definition or function arguments.

### Details:
 - Export all types from `addon.ts`

### Tickets:
 - CVS-176620
