### PR TITLE
[CORE] Remove deprecated methods from bfloat16 and float16 classes

### DIFF
--- a/src/core/include/openvino/core/type/bfloat16.hpp
+++ b/src/core/include/openvino/core/type/bfloat16.hpp
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include "openvino/core/core_visibility.hpp"
-#include "openvino/core/deprecated.hpp"
 
 #define ROUND_MODE_TO_NEAREST_EVEN
 
@@ -37,12 +36,6 @@ public:
 
     template <typename I>
     explicit bfloat16(I value) : m_value{bfloat16{static_cast<float>(value)}.m_value} {}
-
-    OPENVINO_DEPRECATED("This type is deprecated and will be removed in 2026.0. Use `std::to_string` instead.")
-    std::string to_string() const;
-
-    OPENVINO_DEPRECATED("This type is deprecated and will be removed in 2026.0. Use `sizeof` instead.")
-    size_t size() const;
 
     template <typename T>
     bool operator==(const T& other) const;

--- a/src/core/include/openvino/core/type/float16.hpp
+++ b/src/core/include/openvino/core/type/float16.hpp
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include "openvino/core/core_visibility.hpp"
-#include "openvino/core/deprecated.hpp"
 
 #define ROUND_MODE_TO_NEAREST_EVEN
 
@@ -33,12 +32,6 @@ public:
 
     template <typename I>
     explicit float16(I value) : m_value{float16{static_cast<float>(value)}.m_value} {}
-
-    OPENVINO_DEPRECATED("This type is deprecated and will be removed in 2026.0. Use `std::to_string` instead.")
-    std::string to_string() const;
-
-    OPENVINO_DEPRECATED("This type is deprecated and will be removed in 2026.0. Use `sizeof` instead.")
-    size_t size() const;
 
     template <typename T>
     bool operator==(const T& other) const;

--- a/src/core/src/type/bfloat16.cpp
+++ b/src/core/src/type/bfloat16.cpp
@@ -47,14 +47,6 @@ std::vector<bfloat16> bfloat16::from_float_vector(const std::vector<float>& v_f3
     return v_bf16;
 }
 
-std::string bfloat16::to_string() const {
-    return std::to_string(static_cast<float>(*this));
-}
-
-size_t bfloat16::size() const {
-    return sizeof(m_value);
-}
-
 #if defined __GNUC__ && __GNUC__ == 11
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wuninitialized"

--- a/src/core/src/type/float16.cpp
+++ b/src/core/src/type/float16.cpp
@@ -109,14 +109,6 @@ float16::float16(float value) {
     m_value = ((iv & smask) | frac) >> 16;
 }
 
-std::string float16::to_string() const {
-    return std::to_string(static_cast<float>(*this));
-}
-
-size_t float16::size() const {
-    return sizeof(m_value);
-}
-
 float16::operator float() const {
     union {
         uint32_t i_val;


### PR DESCRIPTION
### Details:
 - remove deprecated methods: `to_string`, `size`

### Tickets:
 - [*174871*](https://jira.devtools.intel.com/browse/CVS-174871)
