### PR TITLE
[PT FE]: Add support for aten::find

### DIFF
--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -637,6 +637,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::new_full", op::translate_new_full},
         {"aten::new_ones", op::translate_new_ones},
         {"aten::new_zeros", op::translate_new_zeros},
+        {"aten::find", op::translate_nonzero},
         {"aten::nonzero", op::translate_nonzero},
         // aten::nonzero_numpy - Supported in limited set of patterns
         {"aten::norm", op::translate_norm},

--- a/tests/layer_tests/pytorch_tests/test_find.py
+++ b/tests/layer_tests/pytorch_tests/test_find.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import numpy as np
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+class TestFind(PytorchLayerTest):
+    def _prepare_input(self):
+        return (np.random.randint(0, 2, self.input_shape).astype(self.input_dtype),)
+
+    def create_model(self):
+        class aten_find_model(torch.nn.Module):
+            def forward(self, x):
+                return torch.nonzero(x)
+
+        ref_net = None
+        return aten_find_model(), ref_net, "aten::nonzero"
+
+    @pytest.mark.parametrize("input_shape", [
+        [1, 10],
+        [10, 1, 2],
+        [2, 3, 4, 5]
+    ])
+    @pytest.mark.parametrize("input_dtype", [
+        np.float32,
+        np.int32,
+        np.int64
+    ])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_find(self, ie_device, precision, ir_version, input_shape, input_dtype):
+        self.input_shape = input_shape
+        self.input_dtype = input_dtype
+        self._test(*self.create_model(), ie_device, precision, ir_version)


### PR DESCRIPTION
### Details:

- The aten::find operation is an alias for the existing aten::nonzero operation.
-  Added aten::find to the PyTorch Frontend operator table to map it to the existing op::translate_nonzero translator.
- A new layer test is added to validate that models using this operation are converted and executed correctly.
 

### Tickets:
 - Closes #29694 

