### PR TITLE
[GPU] Fix dyn-quan with weight gs16

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -84,9 +84,9 @@ DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size
             return false;
         }
 
-        if (adj_group_size == 16) {
+        if (adj_group_size < 32) {
             GPU_DEBUG_LOG << "Dynamic quantization: quantized activation by group size " << adj_group_size
-                            << " is not supported by onednn matmul" << std::endl;
+                            << " is not supported by onednn matmul if it is less than 32" << std::endl;
             return false;
         }
 

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -514,8 +514,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_dyn_quan_scalar_wzp,
 
 INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_dyn_quan_precomputed_reduction_with_gs16,
                          MatmulWeightsDecompression,
-                         ::testing::Combine(::testing::Values(ShapeParams{{{-1, -1, 1024}, {{1024, 1, 1024}}},
-                                                                            {1024, 1024}, 16}),  // shape
+                         ::testing::Combine(::testing::Values(ShapeParams{{{-1, -1, 128}, {{128, 1, 128}}},
+                                                                            {128, 128}, 16}),  // shape
                                             ::testing::Values(ov::element::u8),
                                             ::testing::Values(ov::element::f16),
                                             ::testing::Values(false),


### PR DESCRIPTION
### Description of the issue
 - Execution failed without error message 
 - It executed onednn matmul which has weight group size 16.
 - dynamic quantized source with group size 16 scaling is not supported by onednn matmul.
  `0:UNIMPLEMENTED (0 ms) __REPRO: --max-ms-per-prb=2000 --matmul --engine=gpu --allow-enum-tags-only=false --dt=s8:u8:f16 --stag=abc --wtag=cab --dtag=abc --bia-dt=f16 --bia_mask=4 --attr-scales=src:per_tensor:f16:1x16+wei:per_tensor:f16:16x1 --attr-zero-points=wei:per_tensor:u8:16x1 --attr-scratchpad=user 208x1x2048:1x2048x2560`
- target layer : <img width="1246" height="236" alt="image" src="https://github.com/user-attachments/assets/861259b4-dab8-47e9-9029-ddb71ec275cf" />


#### The code and line that caused this issue
 - When Resample primitive is created, input1 and 2 may be converted to attribute from this code
   src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
 
#### Reproduction step and snapshot
 - Reproduced by benchmark
 `.\benchmark_app.exe -d GPU -nireq 1 -niter 1 -m Qwen2.5-3B-Instruct-gs16\openvino_model.xml -data_shape "input_ids[1,200],attention_mask[1,200],position_ids[1,200],beam_idx[1]" -layout "input_ids[NC],attention_mask[NC],position_ids[NC],beam_idx[N]"`

#### Checklist
 - [x] Is it a proper fix?
 - [X] Did you include test case for this fix, if necessary? 
 - [x] Did you review existing test that can be extended to cover this scenario? Passed llm_bench 

### Tickets:
 - CVS-175900, CVS-175902
