### PR TITLE
[PT FE]: Add support for aten::replace

### DIFF
--- a/src/frontends/pytorch/src/op/replace.cpp
+++ b/src/frontends/pytorch/src/op/replace.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/equal.hpp"
+#include "openvino/op/select.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+OutputVector translate_replace(const NodeContext& context) {
+    num_inputs_check(context, 3, 3);
+    auto input_tensor = context.get_input(0);
+    auto target_value = context.get_input(1);
+    auto replace_value = context.get_input(2);
+
+    
+    auto condition = std::make_shared<v1::Equal>(input_tensor, target_value);
+    auto select_node = std::make_shared<v1::Select>(condition, replace_value, input_tensor);
+
+    return {context.mark_node(select_node)};
+};
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -225,6 +225,7 @@ OP_CONVERTER(translate_reflection_pad_nd);
 OP_CONVERTER(translate_relu6);
 OP_CONVERTER(translate_remainder);
 OP_CONVERTER(translate_repeat_interleave);
+OP_CONVERTER(translate_replace);
 OP_CONVERTER(translate_replication_pad_nd);
 OP_CONVERTER(translate_reshape);
 OP_CONVERTER(translate_reshape_as);
@@ -679,6 +680,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::remainder", op::translate_remainder},
         {"aten::repeat", op::translate_1to1_match_2_inputs<opset10::Tile>},
         {"aten::repeat_interleave", op::translate_repeat_interleave},
+        {"aten::replace", op::translate_replace},
         {"aten::replication_pad1d", op::translate_replication_pad_nd},
         {"aten::replication_pad2d", op::translate_replication_pad_nd},
         {"aten::replication_pad3d", op::translate_replication_pad_nd},

--- a/tests/layer_tests/pytorch_tests/test_replace.py
+++ b/tests/layer_tests/pytorch_tests/test_replace.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import numpy as np
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+class TestReplace(PytorchLayerTest):
+    def _prepare_input(self, input_shape, input_dtype, target_val, replacement_val):
+        return (
+            np.random.randint(0, 10, input_shape).astype(input_dtype),
+            np.array(target_val, dtype=input_dtype),
+            np.array(replacement_val, dtype=input_dtype)
+        )
+
+    def create_model(self):
+        class aten_replace_model(torch.nn.Module):
+            def forward(self, x, target, replacement):
+                return torch.where(x == target, replacement, x)
+
+        ref_net = None
+
+        return aten_replace_model(), ref_net, "aten::where"
+
+    @pytest.mark.parametrize("input_shape", [
+        [10],
+        [5, 10],
+        [2, 3, 4, 5]
+    ])
+    @pytest.mark.parametrize("input_dtype", [
+        np.float32,
+        np.int32,
+    ])
+    @pytest.mark.parametrize("target_val, replacement_val", [
+        (5, 42),
+        (0, -1)
+    ])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_replace(self, ie_device, precision, ir_version, input_shape, input_dtype, target_val, replacement_val):
+        self._test(*self.create_model(),
+                   ie_device,
+                   precision,
+                   ir_version,
+                   kwargs_to_prepare_input={
+                       "input_shape": input_shape,
+                       "input_dtype": input_dtype,
+                       "target_val": target_val,
+                       "replacement_val": replacement_val
+                   })


### PR DESCRIPTION
### Details:
 -  Adds support for the aten::replace operation by creating a new C++ translator that maps it to the OpenVINO Select operation.
-  A new layer test is added to validate the functionality of the translator.

### Tickets:
 - Closes #29712 
