### PR TITLE
[GPU] Add missing address space qualifier in gemm_tiled_opt kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -738,7 +738,7 @@ KERNEL(gemm_tiled_opt)(
         #else
         const uint x_pitch = output_x_pitch;
         #endif
-        OUTPUT_TYPE* d_ptr_tmp = d_ptr + sglid * x_pitch;
+        __global OUTPUT_TYPE* d_ptr_tmp = d_ptr + sglid * x_pitch;
 
         #ifdef BIAS_TERM
         ACCUMULATOR_TYPE_VEC dequantized = (ACCUMULATOR_TYPE_VEC)(ALPHA) * c_tile[write_id] + TO_ACCUMULATOR_TYPE(BETA) * c_ptr[sglid];


### PR DESCRIPTION
### Details:
 - Missing __global can cause compile error 
 "error: initializing '__private half *__private' with an expression of type '__global half *' changes address space of pointer
 OUTPUT_TYPE* d_ptr_tmp = d_ptr + sglid * x_pitch;"
 - Added missing address space qualifier(__global) in gemm_tiled_opt kernel.

### Tickets:
 - 172865
