### PR TITLE
Bump leftover numpy dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-    "numpy>=1.16.6,<2.3.0",
+    "numpy>=1.16.6,<2.4.0",
     "openvino-telemetry>=2023.2.1",
     "packaging"
 ]


### PR DESCRIPTION
### Details:
 - Dependabot updated all of the numpy versions in the repository but this one, investigation on why needs to take place
 - This MAY cause issues on Windows when the user uses MINGW to compile `numpy` in an experimental mode, leading to crashes (as reported by @kai-waang)
 - Bringing the upper bound up will allow Windows' pip to pull a prebuilt wheel

### Tickets:
 - N/A
