### PR TITLE
[CPU][TESTS] Fix "'OV_CPU_WITH_MLAS' is not defined" warning on RISC-V

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/reshape_fc.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/reshape_fc.cpp
@@ -98,7 +98,7 @@ std::vector<fusingSpecificParams> fusingParamsSet{emptyFusingSpec, fusingBias, f
 
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 const auto gemmParam = CPUSpecificParams{{}, {}, {"acl"}, "acl"};
-#elif OV_CPU_WITH_MLAS
+#elif defined(OV_CPU_WITH_MLAS)
 const auto gemmParam = CPUSpecificParams{{}, {}, {"gemm_mlas"}, "gemm_mlas"};
 #else
 const auto gemmParam = CPUSpecificParams{{}, {}, {"jit_gemm"}, "jit_gemm"};


### PR DESCRIPTION
### Tickets:
 - N/A
