### PR TITLE
[CPU] Fix u8 -> bool conversion in cpu_convert.cpp

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -552,7 +552,7 @@ struct ConvertPrecision<std::tuple<src_t, dst_t>> {
         // (nan, inf, overflow) has already been assured by the conversion process.
         if (ov::intel_cpu::any_of_v<src_t, ov::float8_e4m3, ov::float8_e5m2> ||
             ov::intel_cpu::any_of_v<dst_t, ov::float8_e4m3, ov::float8_e5m2> ||
-            (std::is_integral_v<src_t> && std::is_integral_v<dst_t>)) {
+            (std::is_integral_v<src_t> && std::is_integral_v<dst_t> && ctx.dstPrc != ov::element::boolean)) {
             parallel_for(ctx.size, [&](size_t i) {
                 dst[i] = static_cast<dst_t>(src[i]);
             });

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -433,8 +433,6 @@ std::vector<std::string> disabledTestPatterns() {
     retVector.emplace_back(R"(.*proposal_params/.*)");
     // Quantized models unsupported
     retVector.emplace_back(R"(.*Quantized.*)");
-    // 176707: Accuracy issues
-    retVector.emplace_back(R"(.*smoke_IsOp/ComparisonLayerTest.*)");
 
     if (!ov::intel_cpu::riscv64::mayiuse(ov::intel_cpu::riscv64::gv)) {
         // Integer division is supported only by JIT Executor which is available on platforms with GV instruction sets.


### PR DESCRIPTION
### Details:
u8 -> bool conversion after merging https://github.com/openvinotoolkit/openvino/pull/32389 produces 127 in case of true in some cases (instead of 1)

Enable `smoke_IsOp*` tests on RISC-V platform that are affected by this comparison issue

### Tickets:
 - 176707
