### PR TITLE
Avoid repeated TBB discovery

### DIFF
--- a/src/cmake/ov_parallel.cmake
+++ b/src/cmake/ov_parallel.cmake
@@ -76,7 +76,7 @@ function(_ov_get_tbb_location tbb_target _tbb_lib_location_var)
 endfunction()
 
 macro(ov_find_package_tbb)
-    if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO" OR THREADING STREQUAL "TBB_ADAPTIVE" AND NOT TBB_FOUND)
+    if((THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO" OR THREADING STREQUAL "TBB_ADAPTIVE") AND NOT TBB_FOUND)
         # conan generates TBBConfig.cmake files, which follows cmake's
         # SameMajorVersion scheme, while TBB itself follows AnyNewerVersion one
         # see https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#generating-a-package-version-file
@@ -337,7 +337,7 @@ macro(ov_find_package_openmp)
 endmacro()
 
 function(ov_set_threading_interface_for TARGET_NAME)
-    if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO" OR THREADING STREQUAL "TBB_ADAPTIVE" AND NOT TBB_FOUND)
+    if((THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO" OR THREADING STREQUAL "TBB_ADAPTIVE") AND NOT TBB_FOUND)
         # find TBB
         ov_find_package_tbb()
 


### PR DESCRIPTION
### Details:
The problem is that TBB detection logic in `src/cmake/ov_parallel.cmake` is being invoked multiple times during configuration if  `-DTHREADING=TBB` or `-DTHREADING=TBB_AUTO` are used. It works correctly only for `TBB_ADAPTIVE` case.

This patch fixes operator precedence in the check to avoid re-discovery of TBB on each `ov_find_package_tbb()` and as a result `ov_set_threading_interface_for()` CMake functions invocations

### Tickets:
 - N/A
