### PR TITLE
Skip sporadically failing patched model test on MacOS ARM

### DIFF
--- a/tests/layer_tests/py_frontend_tests/test_torch_frontend.py
+++ b/tests/layer_tests/py_frontend_tests/test_torch_frontend.py
@@ -988,6 +988,10 @@ def test_patched_8bit_model_converts_e4m3fn():
     np.testing.assert_allclose(res_f8_e4m3[1], res_ref[1].numpy(), atol=1e-2)
 
 
+@pytest.mark.skipif(
+    platform.system() == "Darwin" and platform.machine() in ['arm', 'armv7l', 'aarch64', 'arm64', 'ARM64'],
+    reason="PyTorch float8_e5m2 cleanup deadlock on macOS ARM64. Ticket: 172658"
+)
 def test_patched_8bit_model_converts_e5m2():
     from openvino.frontend.pytorch import patch_model
     from openvino import convert_model, compile_model


### PR DESCRIPTION
### Details:
 - Two PRs were merged before trying to fix the sporadic hang, one with manual garbage collection and one splitting the complex test case into two smaller tests
   - https://github.com/openvinotoolkit/openvino/pull/32655
   - https://github.com/openvinotoolkit/openvino/pull/32829
 - While the first PR did not help at all, the second proved that the issue does not exist for `e4m3fn` type, but persists for `e5m2` type.
 - For now I suggest skipping the test on MacOS ARM to avoid wasting validation time and redirecting the ticket to Torch/Core team for investigation.
 - I think the deadlock issue happens in torch cleanup, but I can't 100% prove it. It might be a solution to wait for newer torch releases and bugfixes.

### Tickets:
 - CVS-172658
