### PR TITLE
[GPU] Serialize layout optimizer

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -221,6 +221,9 @@ public:
     void set_implementation_forcing(const ov::intel_gpu::ImplForcingMap& map);
     const std::map<primitive_id, std::pair<format::type, impl_types>>& get_implementation_forcing() const;
 
+    void save(cldnn::BinaryOutputBuffer& ob) const;
+    void load(cldnn::BinaryInputBuffer& ib);
+
     void update_formats_map(const convolution_node& node);
     bool is_format_optimized(const convolution_node& node, const format& format, bool use_weak_restrictions = false);
     bool is_format_optimized(const deconvolution_node& node, const format& format);

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -108,8 +108,46 @@ public:
         int32_t bs_fs_yx_bsv16_fsv16_network = 0;
         std::map<primitive_type_id, bool> onednn_impls = {};
 
-        void save(BinaryOutputBuffer& ob) const;
-        void load(BinaryInputBuffer& ib);
+        void save(BinaryOutputBuffer& ob) const {
+            ob << group_convolution;
+            ob << byxf_onednn_convolution;
+            ob << bfyx_only_layer;
+            ob << fs_b_yx_fsv32_network;
+            ob << b_fs_zyx_fsv32_network;
+            ob << b_fs_yx_fsv16_network;
+            ob << b_fs_zyx_fsv16_network;
+            ob << bs_fs_yx_bsv16_fsv16_network;
+
+            ob << onednn_impls.size();
+            for (const auto& onednn_impl : onednn_impls) {
+                ob << prim_map_storage::instance().get_type_string(onednn_impl.first);
+                ob << onednn_impl.second;
+            }
+        }
+
+        void load(BinaryInputBuffer& ib) {
+            ib >> group_convolution;
+            ib >> byxf_onednn_convolution;
+            ib >> bfyx_only_layer;
+            ib >> fs_b_yx_fsv32_network;
+            ib >> b_fs_zyx_fsv32_network;
+            ib >> b_fs_yx_fsv16_network;
+            ib >> b_fs_zyx_fsv16_network;
+            ib >> bs_fs_yx_bsv16_fsv16_network;
+
+            size_t onednn_impls_size = 0;
+            ib >> onednn_impls_size;
+
+            onednn_impls.clear();
+            for (size_t i = 0; i < onednn_impls_size; ++i) {
+                primitive_id p_id{};
+                bool enabled = false;
+                ib >> p_id;
+                ib >> enabled;
+                auto ptype_id = prim_map_storage::instance().get_type_id(p_id);
+                onednn_impls[ptype_id] = enabled;
+            }
+        }
     };
 
 private:

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -107,6 +107,9 @@ public:
         int32_t b_fs_zyx_fsv16_network = 0;
         int32_t bs_fs_yx_bsv16_fsv16_network = 0;
         std::map<primitive_type_id, bool> onednn_impls = {};
+
+        void save(BinaryOutputBuffer& ob) const;
+        void load(BinaryInputBuffer& ib);
     };
 
 private:
@@ -220,9 +223,6 @@ public:
 
     void set_implementation_forcing(const ov::intel_gpu::ImplForcingMap& map);
     const std::map<primitive_id, std::pair<format::type, impl_types>>& get_implementation_forcing() const;
-
-    void save(cldnn::BinaryOutputBuffer& ob) const;
-    void load(cldnn::BinaryInputBuffer& ib);
 
     void update_formats_map(const convolution_node& node);
     bool is_format_optimized(const convolution_node& node, const format& format, bool use_weak_restrictions = false);

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -269,5 +269,13 @@ public:
     size_t get_total_conv_count();
 
     bool should_select_b_fs_yx_fsv16_layout(convolution_node const& node, layout const& output_or_weights_layout);
+
+    void save(BinaryOutputBuffer& ob) const {
+        _optimization_attributes.save(ob);
+    }
+
+    void load(BinaryInputBuffer& ib) {
+        _optimization_attributes.load(ib);
+    }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -59,6 +59,7 @@ using namespace cldnn;
 
 void layout_optimizer::optimization_attributes::save(BinaryOutputBuffer& ob) const {
     ob << group_convolution;
+    ob << byxf_onednn_convolution;
     ob << bfyx_only_layer;
     ob << fs_b_yx_fsv32_network;
     ob << b_fs_zyx_fsv32_network;
@@ -75,6 +76,7 @@ void layout_optimizer::optimization_attributes::save(BinaryOutputBuffer& ob) con
 
 void layout_optimizer::optimization_attributes::load(BinaryInputBuffer& ib) {
     ib >> group_convolution;
+    ib >> byxf_onednn_convolution;
     ib >> bfyx_only_layer;
     ib >> fs_b_yx_fsv32_network;
     ib >> b_fs_zyx_fsv32_network;

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -57,47 +57,6 @@
 
 using namespace cldnn;
 
-void layout_optimizer::optimization_attributes::save(BinaryOutputBuffer& ob) const {
-    ob << group_convolution;
-    ob << byxf_onednn_convolution;
-    ob << bfyx_only_layer;
-    ob << fs_b_yx_fsv32_network;
-    ob << b_fs_zyx_fsv32_network;
-    ob << b_fs_yx_fsv16_network;
-    ob << b_fs_zyx_fsv16_network;
-    ob << bs_fs_yx_bsv16_fsv16_network;
-
-    ob << onednn_impls.size();
-    for (const auto& onednn_impl : onednn_impls) {
-        ob << prim_map_storage::instance().get_type_string(onednn_impl.first);
-        ob << onednn_impl.second;
-    }
-}
-
-void layout_optimizer::optimization_attributes::load(BinaryInputBuffer& ib) {
-    ib >> group_convolution;
-    ib >> byxf_onednn_convolution;
-    ib >> bfyx_only_layer;
-    ib >> fs_b_yx_fsv32_network;
-    ib >> b_fs_zyx_fsv32_network;
-    ib >> b_fs_yx_fsv16_network;
-    ib >> b_fs_zyx_fsv16_network;
-    ib >> bs_fs_yx_bsv16_fsv16_network;
-
-    size_t onednn_impls_size = 0;
-    ib >> onednn_impls_size;
-
-    onednn_impls.clear();
-    for (size_t i = 0; i < onednn_impls_size; ++i) {
-        primitive_id p_id{};
-        bool enabled = false;
-        ib >> p_id;
-        ib >> enabled;
-        auto ptype_id = prim_map_storage::instance().get_type_id(p_id);
-        onednn_impls[ptype_id] = enabled;
-    }
-}
-
 static size_t get_post_ops_count(const program_node& node) {
     size_t onednn_post_ops_count = 0;
     for (auto& fo : node.get_fused_primitives()) {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1557,6 +1557,45 @@ std::map<primitive_type_id, bool> layout_optimizer::get_all_onednn_impls_optimiz
     return _optimization_attributes.onednn_impls;
 }
 
+void layout_optimizer::save(cldnn::BinaryOutputBuffer& ob) const {
+    ob << _optimization_attributes.group_convolution;
+    ob << _optimization_attributes.bfyx_only_layer;
+    ob << _optimization_attributes.fs_b_yx_fsv32_network;
+    ob << _optimization_attributes.b_fs_zyx_fsv32_network;
+    ob << _optimization_attributes.b_fs_yx_fsv16_network;
+    ob << _optimization_attributes.b_fs_zyx_fsv16_network;
+    ob << _optimization_attributes.bs_fs_yx_bsv16_fsv16_network;
+
+    ob << _optimization_attributes.onednn_impls.size();
+    for (const auto& onednn_impl : _optimization_attributes.onednn_impls) {
+        ob << prim_map_storage::instance().get_type_string(onednn_impl.first);
+        ob << onednn_impl.second;
+    }
+}
+
+void layout_optimizer::load(cldnn::BinaryInputBuffer& ib) {
+    ib >> _optimization_attributes.group_convolution;
+    ib >> _optimization_attributes.bfyx_only_layer;
+    ib >> _optimization_attributes.fs_b_yx_fsv32_network;
+    ib >> _optimization_attributes.b_fs_zyx_fsv32_network;
+    ib >> _optimization_attributes.b_fs_yx_fsv16_network;
+    ib >> _optimization_attributes.b_fs_zyx_fsv16_network;
+    ib >> _optimization_attributes.bs_fs_yx_bsv16_fsv16_network;
+
+    size_t onednn_impls_size = 0;
+    ib >> onednn_impls_size;
+
+    _optimization_attributes.onednn_impls.clear();
+    for (size_t i = 0; i < onednn_impls_size; ++i) {
+        primitive_id p_id{};
+        bool enabled = false;
+        ib >> p_id;
+        ib >> enabled;
+        auto ptype_id = prim_map_storage::instance().get_type_id(p_id);
+        _optimization_attributes.onednn_impls[ptype_id] = enabled;
+    }
+}
+
 bool layout_optimizer::is_format_optimized(const convolution_node& node, const format& format, bool use_weak_restrictions) {
     auto input_layout = node.get_input_layout();
     auto weights_layout = node.weights().get_output_layout();

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1859,12 +1859,8 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
 
     ob << _is_body_program;
     ob << _can_be_optimized;
-    auto onednn_impls_size = get_layout_optimizer().get_all_onednn_impls_optimization_attribute().size();
-    ob << onednn_impls_size;
-    for (const auto& onednn_impl : get_layout_optimizer().get_all_onednn_impls_optimization_attribute()) {
-        ob << prim_map_storage::instance().get_type_string(onednn_impl.first);
-        ob << onednn_impl.second;
-    }
+
+    get_layout_optimizer().save(ob);
 
     processing_order.save(ob);
 
@@ -2008,21 +2004,12 @@ void program::load(cldnn::BinaryInputBuffer& ib,
     ib >> _is_body_program;
     ib >> _can_be_optimized;
 
-    size_t num_of_onednn_impls;
-    ib >> num_of_onednn_impls;
-    for (size_t num = 0; num < num_of_onednn_impls; num++) {
-        primitive_id p_id{};
-        bool enabled;
-        ib >> p_id;
-        ib >> enabled;
-        auto ptype_id = prim_map_storage::instance().get_type_id(p_id);
-        get_layout_optimizer().set_value_onednn(ptype_id, enabled);
-    }
+    get_layout_optimizer().load(ib);
+    _layout_optimizer->set_implementation_forcing(_config.get_force_implementations());
 
     _loaded_from_cache = true;
 
     processing_order.load(ib, *this);
-    set_layout_optimizer_attributes(*_layout_optimizer);
 
     {
         auto& kernels_cache = get_kernels_cache();

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1860,7 +1860,7 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     ob << _is_body_program;
     ob << _can_be_optimized;
 
-    get_layout_optimizer().get_optimization_attributes().save(ob);
+    _layout_optimizer->save(ob);
 
     processing_order.save(ob);
 
@@ -2004,7 +2004,7 @@ void program::load(cldnn::BinaryInputBuffer& ib,
     ib >> _is_body_program;
     ib >> _can_be_optimized;
 
-    get_layout_optimizer().get_optimization_attributes().load(ib);
+    _layout_optimizer->load(ib);
     _layout_optimizer->set_implementation_forcing(_config.get_force_implementations());
 
     _loaded_from_cache = true;

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1860,7 +1860,7 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     ob << _is_body_program;
     ob << _can_be_optimized;
 
-    get_layout_optimizer().save(ob);
+    get_layout_optimizer().get_optimization_attributes().save(ob);
 
     processing_order.save(ob);
 
@@ -2004,7 +2004,7 @@ void program::load(cldnn::BinaryInputBuffer& ib,
     ib >> _is_body_program;
     ib >> _can_be_optimized;
 
-    get_layout_optimizer().load(ib);
+    get_layout_optimizer().get_optimization_attributes().load(ib);
     _layout_optimizer->set_implementation_forcing(_config.get_force_implementations());
 
     _loaded_from_cache = true;


### PR DESCRIPTION
### Details:
 - In program.cpp, removed the code that called `set_layout_optimizer_attributes()` when loading the cache. Instead, changed the method to serialize each attribute of `layout_optimizer`.
 - Calling `set_layout_optimizer_attributes()` in `load()` may cause `calc_output_layout()` to be called even though the cache is used.

### Tickets:
 - 176505
