### PR TITLE
[core] Change MapHolder mmap flag to MAP_SHARED

### DIFF
--- a/src/common/util/src/os/lin/lin_mmap_object.cpp
+++ b/src/common/util/src/os/lin/lin_mmap_object.cpp
@@ -77,7 +77,7 @@ public:
         }
         m_size = sb.st_size;
         if (m_size > 0) {
-            m_data = mmap(nullptr, m_size, prot, MAP_PRIVATE, m_handle.get(), 0);
+            m_data = mmap(nullptr, m_size, prot, MAP_SHARED, m_handle.get(), 0);
             if (m_data == MAP_FAILED) {
                 throw std::runtime_error("Can not create file mapping for " + path + ", err=" + std::strerror(errno));
             }


### PR DESCRIPTION
### Details:
 - MAP_PRIVATE to MAP_SHARED, to avoid copy-on-write scenario, file will be still read-only.
 - To be compatible what is done on Windows by `::MapViewOfFile`

### Tickets:
 - CVS-176347
