### PR TITLE
[`NPU`] [`icompiler_adapter`] [`PART 2`] Extend icompiler_adapter interface to accept optional value

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -622,6 +622,14 @@ bool ZeGraphExtWrappers::isOptionSupported(std::string optName, std::optional<st
     }
 #endif
 
+    if (optValue.has_value() && _zeroInitStruct->getCompilerVersion() < ZE_MAKE_VERSION(7, 28)) {
+        _logger.warning("Current version of compiler is not able to check if value {} is supported for property {}, "
+                        "returning false.",
+                        optValue.value().c_str(),
+                        optName.c_str());
+        return false;
+    }
+
     const char* optname_ch = optName.c_str();
     const char* optvalue_ch = optValue.has_value() ? optValue.value().c_str() : nullptr;
     auto result = _zeroInitStruct->getGraphDdiTable().pfnCompilerIsOptionSupported(_zeroInitStruct->getDevice(),


### PR DESCRIPTION
### Details:
 - *Adds also compiler version check before calling `pfnCompilerIsOptionSupported` with `value != nullptr`*
 - *Acts as a `part 2` for PR https://github.com/openvinotoolkit/openvino/pull/32823*

### Tickets:
 - *C176496*
