### PR TITLE
[TRANSFORMATIONS] SDPAToPA add the model is stateful check

### DIFF
--- a/src/core/src/pass/sdpa_to_paged_attention.cpp
+++ b/src/core/src/pass/sdpa_to_paged_attention.cpp
@@ -49,7 +49,7 @@ bool ov::pass::SDPAToPagedAttention::run_on_model(const std::shared_ptr<ov::Mode
     OPENVINO_ASSERT(!model->get_variables().empty(),
                     "Model is supposed to be stateful, cannot perform "
                     "the SDPAToPagedAttention transformation. "
-                    " For proper conversion run: optimum-cli export openvino --task text-generation-with-past instead "
+                    "For proper conversion run: optimum-cli export openvino --task text-generation-with-past instead "
                     "of --task text-generation");
 
     OPENVINO_ASSERT(ov::op::util::has_op_with_type<ov::op::v13::ScaledDotProductAttention>(model),


### PR DESCRIPTION
### Details:
The SDPAToPA transformation can be executed only on a stateful model (to turn it into the stateless one). Previously, this check existed in the GenAI code, but since we've done transfer of some functionality to OV runtime, we need to add this check here.

### Tickets:
 - [CVS-165769](https://jira.devtools.intel.com/browse/CVS-165769)

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
