### PR TITLE
Disable CPU func tests execution cache to debug test failure

### DIFF
--- a/.github/workflows/job_cpu_functional_tests.yml
+++ b/.github/workflows/job_cpu_functional_tests.yml
@@ -52,13 +52,13 @@ jobs:
             .github/actions
           sparse-checkout-cone-mode: false
           submodules: 'false'
-          
+
       - name: Download OpenVINO artifacts (package)
         uses: akashchi/download-artifact@d59a9c15fec3fdb7c9adf09464124d00f9c11415
         with:
           name: openvino_package
           path: ${{ env.INSTALL_DIR }}
-      
+
       - name: Download OpenVINO artifacts (tests)
         uses: akashchi/download-artifact@d59a9c15fec3fdb7c9adf09464124d00f9c11415
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: Install OpenVINO dependencies (mac)
         if: runner.os == 'macOS'
         run: brew install pigz
-      
+
       - name: Extract OpenVINO packages
         run: |
             pigz -dc openvino_package.tar.gz | tar -xf - -v
@@ -85,13 +85,13 @@ jobs:
       - name: Install python dependencies for run_parallel.py
         run: python3 -m pip install -r ${INSTALL_TEST_DIR}/functional_test_utils/layer_tests_summary/requirements.txt
 
-      - name: Restore tests execution time
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ${{ env.PARALLEL_TEST_CACHE }}
-          key: ${{ runner.os }}-${{ runner.arch }}-tests-functional-cpu-stamp-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-tests-functional-cpu-stamp
+      # - name: Restore tests execution time
+      #   uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      #   with:
+      #     path: ${{ env.PARALLEL_TEST_CACHE }}
+      #     key: ${{ runner.os }}-${{ runner.arch }}-tests-functional-cpu-stamp-${{ github.sha }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ runner.arch }}-tests-functional-cpu-stamp
 
       - name: Intel CPU plugin func tests (parallel)
         run: |


### PR DESCRIPTION
### Details:
Fixes failures in CPU functional tests on Linux ARM64 workflows

```
[ RUN      ] smoke_ScaledAttn_CPU/ScaledAttnLayerCPUTest.CompareWithRefs/netPRC=f32_IS=[?.8.?.64]_[?.8.?.64]_[?.1.?.?]_TS=(1.8.100.64)_(1.8.1.64)_(2.8.10.64)_(2.8.10.64)_(1.8.100.64)_(1.8.1.64)_(2.8.10.64)_(2.8.10.64)_(1.1.1.100)_(1.1.1.1)_(2.1.1.10)_(2.1.10.10)_is_causal=0_has_attn=0_has_scale=0_trgDev=CPU_primitive=ref_any

MEM_USAGE=3343528KB
Coordinate:  0 Expected: 7.21875 Actual: 2365.05 Diff: 2357.83 abs_threshold: 0.000721994
src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp:97: Failure
[ COMPARATION ] COMPARATION FAILED! abs_threshold: 0.000000 rel_threshold: 0.000100
[  FAILED  ] smoke_ScaledAttn_CPU/ScaledAttnLayerCPUTest.CompareWithRefs/netPRC=f32_IS=[?.8.?.64]_[?.8.?.64]_[?.1.?.?]_TS=(1.8.100.64)_(1.8.1.64)_(2.8.10.64)_(2.8.10.64)_(1.8.100.64)_(1.8.1.64)_(2.8.10.64)_(2.8.10.64)_(1.1.1.100)_(1.1.1.1)_(2.1.1.10)_(2.1.10.10)_is_causal=0_has_attn=0_has_scale=0_trgDev=CPU_primitive=ref_any, where GetParam() = (4-byte object <04-00 00-00>, { ({ ?, 8, ?, 64 }, { { 1, 8, 100, 64 }, { 1, 8, 1, 64 }, { 2, 8, 10, 64 }, { 2, 8, 10, 64 } }), ({ ?, 8, ?, 64 }, { { 1, 8, 100, 64 }, { 1, 8, 1, 64 }, { 2, 8, 10, 64 }, { 2, 8, 10, 64 } }), ({ ?, 1, ?, ? }, { { 1, 1, 1, 100 }, { 1, 1, 1, 1 }, { 2, 1, 1, 10 }, { 2, 1, 10, 10 } }) }, false, false, false, "CPU", ({}, {}, { "ref_any" }, "ref_any")) (122 ms)
```
### Tickets:
CVS-177577
