### PR TITLE
Correct is_bounded value in ov low fp types

### DIFF
--- a/src/core/include/openvino/core/type/bfloat16.hpp
+++ b/src/core/include/openvino/core/type/bfloat16.hpp
@@ -234,7 +234,7 @@ public:
         return ov::bfloat16::from_bits(0);
     }
     static constexpr bool is_iec559 = false;
-    static constexpr bool is_bounded = false;
+    static constexpr bool is_bounded = true;
     static constexpr bool is_modulo = false;
     static constexpr bool traps = false;
     static constexpr bool tinyness_before = false;

--- a/src/core/include/openvino/core/type/float16.hpp
+++ b/src/core/include/openvino/core/type/float16.hpp
@@ -216,7 +216,7 @@ public:
         return ov::float16::from_bits(0);
     }
     static constexpr bool is_iec559 = false;
-    static constexpr bool is_bounded = false;
+    static constexpr bool is_bounded = true;
     static constexpr bool is_modulo = false;
     static constexpr bool traps = false;
     static constexpr bool tinyness_before = false;

--- a/src/core/include/openvino/core/type/float4_e2m1.hpp
+++ b/src/core/include/openvino/core/type/float4_e2m1.hpp
@@ -206,7 +206,7 @@ public:
         return ov::float4_e2m1::from_bits(0b0001);  // minimum positive denormalized value
     }
     static constexpr bool is_iec559 = false;
-    static constexpr bool is_bounded = false;
+    static constexpr bool is_bounded = true;
     static constexpr bool is_modulo = false;
     static constexpr bool traps = false;
     static constexpr bool tinyness_before = false;

--- a/src/core/include/openvino/core/type/float8_e4m3.hpp
+++ b/src/core/include/openvino/core/type/float8_e4m3.hpp
@@ -213,7 +213,7 @@ public:
         return ov::float8_e4m3::from_bits(0b00000001);  // minimum positive denormalized value
     }
     static constexpr bool is_iec559 = false;
-    static constexpr bool is_bounded = false;
+    static constexpr bool is_bounded = true;
     static constexpr bool is_modulo = false;
     static constexpr bool traps = false;
     static constexpr bool tinyness_before = false;

--- a/src/core/include/openvino/core/type/float8_e5m2.hpp
+++ b/src/core/include/openvino/core/type/float8_e5m2.hpp
@@ -212,7 +212,7 @@ public:
         return ov::float8_e5m2::from_bits(0b00000001);  // minimum positive denormalized value
     }
     static constexpr bool is_iec559 = false;
-    static constexpr bool is_bounded = false;
+    static constexpr bool is_bounded = true;
     static constexpr bool is_modulo = false;
     static constexpr bool traps = false;
     static constexpr bool tinyness_before = false;

--- a/src/core/include/openvino/core/type/float8_e8m0.hpp
+++ b/src/core/include/openvino/core/type/float8_e8m0.hpp
@@ -210,7 +210,7 @@ public:
         return ov::float8_e8m0::from_bits(0);  // no signaling NaN
     }
     static constexpr bool is_iec559 = false;
-    static constexpr bool is_bounded = false;
+    static constexpr bool is_bounded = true;
     static constexpr bool is_modulo = false;
     static constexpr bool traps = false;
     static constexpr bool tinyness_before = false;


### PR DESCRIPTION
### Details:
Setting `is_bounded` to true in case of bfloat16, float16, float8_e5m2, float8_e4m3, float8_e8m0 and float4_e2m1 types, as they are not based on arbitrary precision.

Quoting from [cppreference](https://en.cppreference.com/w/cpp/types/numeric_limits/is_bounded.html):

> The value of std::numeric_limits<T>::is_bounded is true for all arithmetic types T that represent a finite set of values. While all fundamental types are bounded, this constant would be false in a specialization of std::numeric_limits for a library-provided arbitrary precision arithmetic type.

### Tickets:
 - N/A
