### PR TITLE
[CPU] Add PagedAttention Support for Sink Input and decode phases Sliding Window

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -1279,6 +1279,7 @@ struct MHAHelper {
             for (size_t h = hq_beg; h < hq_end; h++) {
                 // apply attention mask & sofmax
                 float* score = _weight.ptr<float>(ithr, h - hq_beg, pq);
+                OPENVINO_DEBUG_ASSERT(score != nullptr, "PagedAttention: _weight buffer must be allocated");
                 float* alibi_lookup = nullptr;
                 float alibi_slope = 0.F;
                 if (alibi_slopes) {
@@ -1489,6 +1490,7 @@ struct MHAHelper {
             auto ncausal = cur_kv_len;
             // apply attention mask & sofmax
             float* score = _weight_bhl.ptr<float>(b, h, pq);
+            OPENVINO_DEBUG_ASSERT(score != nullptr, "PagedAttention: _weight_bhl buffer must be allocated");
             float* alibi_lookup = nullptr;
             float alibi_slope = 0.F;
             if (alibi_slopes) {

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
@@ -313,12 +313,13 @@ bool PagedAttention::isSupportedOperation(const std::shared_ptr<const ov::Node>&
                 errorMessage = "Only Constant operation on sink input is supported";
                 return false;
             }
-#if defined(OPENVINO_ARCH_ARM64)
-            // ARM platform doesn't support non-empty sink input yet
-            // Check if sink input is non-empty (shape size > 0)
+#ifndef OPENVINO_ARCH_X86_64
+            // Non-x86_64 platforms do not support non-empty sink tensors yet
+            // Fail fast if the sink input shape has any elements
             const auto& sink_shape = op->get_input_partial_shape(PagedAttentionExecutor::ID_SINKS);
             if (sink_shape.is_static() && ov::shape_size(sink_shape.to_shape()) > 0) {
-                errorMessage = "PagedAttentionExtension with non-empty sink input is not supported on ARM platform";
+                errorMessage =
+                    "PagedAttentionExtension with non-empty sink input is not supported on non-x86_64 platforms";
                 return false;
             }
 #endif

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/paged_attn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/paged_attn.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "common_test_utils/include/common_test_utils/ov_tensor_utils.hpp"
+#include "common_test_utils/node_builders/constant.hpp"
 #include "internal_properties.hpp"
 #include "openvino/core/type/float16.hpp"
 #include "openvino/op/add.hpp"
@@ -143,14 +144,11 @@ public:
         // Use shape [1, head_num, 1, 1] when use_sink_input=true, or empty shape [0] when false
         std::shared_ptr<ov::op::v0::Constant> sinks;
         if (use_sink_input) {
-            // Create real sink tokens for testing sink functionality
-            std::vector<float> sink_data(static_cast<size_t>(head_num), 0.1f);
-            sinks = std::make_shared<ov::op::v0::Constant>(data_type,
-                                                           Shape{1, static_cast<size_t>(head_num), 1, 1},
-                                                           sink_data);
+            sinks = std::static_pointer_cast<ov::op::v0::Constant>(
+                ov::test::utils::make_constant(data_type, Shape{1, static_cast<size_t>(head_num), 1, 1}));
         } else {
             // Create empty sink (matching SDPA->PA transformation behavior when no sink)
-            sinks = std::make_shared<ov::op::v0::Constant>(data_type, Shape{0}, std::vector<float>{});
+            sinks = std::static_pointer_cast<ov::op::v0::Constant>(ov::test::utils::make_constant(data_type, Shape{0}));
         }
 
         ParameterVector params =


### PR DESCRIPTION
### Details:
 - *adds support for sink input parameter and sliding window attention mechanism in PagedAttention implementation with related test coverage.*
Key Changes
Sink Input Support: Extended PagedAttentionExtension to accept optional sink input as the 21st parameter, updated executor to handle sink tokens in attention computation
Sliding Window Attention: Implemented sliding window mechanism for both prefill and decode phases
Test Coverage: Added comprehensive test suite comparing PA vs SDPA across multiple configurations (f32/bf16, with/without sink, normal/sliding window)

### Tickets:
 - *CVS-173535 CVS-176456*
