### PR TITLE
[core] Remove `cache_model_path` from config pass to device

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -206,8 +206,10 @@ void clean_batch_properties(const std::string& device_name, ov::AnyMap& config, 
     }
 }
 
-static const auto core_properties_names =
-    ov::util::make_array(ov::cache_dir.name(), ov::enable_mmap.name(), ov::force_tbb_terminate.name());
+static const auto core_properties_names = ov::util::make_array(ov::cache_dir.name(),
+                                                               ov::enable_mmap.name(),
+                                                               ov::force_tbb_terminate.name(),
+                                                               ov::cache_model_path.name());
 
 static const auto auto_batch_properties_names =
     ov::util::make_array(ov::auto_batch_timeout.name(), ov::hint::allow_auto_batching.name());

--- a/src/inference/tests/functional/caching_test.cpp
+++ b/src/inference/tests/functional/caching_test.cpp
@@ -3043,7 +3043,10 @@ TEST_P(CachingTest, import_from_cache_model_by_custom_model_rt_info) {
     });
     MkDirGuard guard(m_cacheDir);
     EXPECT_CALL(*mockPlugin, compile_model(_, _, _)).Times(0);
-    EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
+    EXPECT_CALL(
+        *mockPlugin,
+        compile_model(A<const std::shared_ptr<const ov::Model>&>(), Not(Contains(Key(ov::cache_model_path.name())))))
+        .Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);


### PR DESCRIPTION
### Details:
 - Remove `ov::cache_model_path` from config passed to device on compile model. The property must be handled on core level only.

### Tickets:
 - CVS-177263
