### PR TITLE
[core] reduce test iteration to fix time degradation

### DIFF
--- a/src/inference/tests/functional/ov_core_threading.cpp
+++ b/src/inference/tests/functional/ov_core_threading.cpp
@@ -99,7 +99,7 @@ TEST_F(CoreThreadingTests, RegisterPlugin) {
             core.get_versions(deviceName);
             core.unload_plugin(deviceName);
         },
-        4000);
+        500);
 }
 
 // tested function: RegisterPlugins
@@ -138,7 +138,7 @@ TEST_F(CoreThreadingTests, RegisterPlugins) {
             core.unload_plugin(deviceName);
             std::filesystem::remove(fileName);
         },
-        1000);
+        500);
 }
 
 #endif  // !OPENVINO_STATIC_LIBRARY


### PR DESCRIPTION
[core] reduce test iteration to fix time degradation

This commit is to enable CI tests to run in a resonable time on Windows debug build.

There's a problem with function ov::CoreImpl::get_plugin which is spotted on high count of iteration in multithread run, the locking mechanisms used waste big time on read and write.

### Details:
 - **CoreThreadingTests.RegisterPlugin** test can spanning arbitrary number of threads, by default are 8 threads. the bottleneck seems to be the extensive use of locks in terms of construction and destruction of objects which cause the test to timeout when using high number of iteration per thread.

### Tickets:
 - CVS-176899
