### PR TITLE
[GHA] Return back the normal timeout for C++ unit on Win Debug

### DIFF
--- a/.github/workflows/windows_vs2022_debug.yml
+++ b/.github/workflows/windows_vs2022_debug.yml
@@ -86,7 +86,7 @@ jobs:
       affected-components: ${{ needs.smart_ci.outputs.affected_components }}
       os: 'windows_2022'
       build-type: 'Debug'
-      timeout-minutes: 90
+      timeout-minutes: 60
 
   Overall_Status:
     name: ci/gha_overall_status_windows_debug


### PR DESCRIPTION
Execution time after https://github.com/openvinotoolkit/openvino/pull/33039 is back to normal