### PR TITLE
[CPU][ARM] Define HWCAP2_I8MM constant properly

### DIFF
--- a/src/inference/src/system_conf.cpp
+++ b/src/inference/src/system_conf.cpp
@@ -22,6 +22,7 @@
 #    include <sys/auxv.h>
 #    define ARM_COMPUTE_CPU_FEATURE_HWCAP_FPHP    (1 << 9)
 #    define ARM_COMPUTE_CPU_FEATURE_HWCAP_ASIMDHP (1 << 10)
+#    define ARM_COMPUTE_CPU_FEATURE_HWCAP2_I8MM   (1 << 13)
 #    define ARM_COMPUTE_CPU_FEATURE_HWCAP_SVE     (1 << 24)
 #elif defined(__APPLE__) && defined(__aarch64__)
 #    include <sys/sysctl.h>
@@ -224,7 +225,7 @@ bool with_cpu_arm_i8mm() {
 #    if !defined(_WIN64) && !defined(BARE_METAL) && !defined(__APPLE__) && !defined(__OpenBSD__) && \
         !defined(__arm__) && defined(__aarch64__)
     const uint32_t hwcaps = getauxval(AT_HWCAP);
-    return hwcaps & HWCAP2_I8MM;
+    return hwcaps & ARM_COMPUTE_CPU_FEATURE_HWCAP2_I8MM;
 #    elif !defined(_WIN64) && !defined(BARE_METAL) && !defined(__APPLE__) && !defined(__OpenBSD__) && \
         !defined(__aarch64__) && defined(__arm__)
     return false;


### PR DESCRIPTION
### Details:
 - Conda build fails because of undefined constant
```
2025-11-27T15:37:38.4727265Z [866/2847] Building CXX object src/inference/CMakeFiles/openvino_runtime_obj.dir/src/system_conf.cpp.o
2025-11-27T15:37:38.4735202Z FAILED: [code=1] src/inference/CMakeFiles/openvino_runtime_obj.dir/src/system_conf.cpp.o 
2025-11-27T15:37:38.4766196Z $BUILD_PREFIX/bin/aarch64-conda-linux-gnu-c++ -DIMPLEMENT_OPENVINO_RUNTIME_API -DIN_OV_COMPONENT -DOV_BUILD_POSTFIX=\"\" -DOV_NATIVE_PARENT_PROJECT_ROOT_DIR=\"work\" -DOV_THREAD=OV_THREAD_TBB -DPROXY_PLUGIN_ENABLED -I$SRC_DIR/src/inference/src -I$SRC_DIR/src/inference/dev_api -I$SRC_DIR/src/core/include -I$SRC_DIR/src/inference/include -I$SRC_DIR/src/frontends/common/include -I$SRC_DIR/src/frontends/onnx/frontend/include -I$SRC_DIR/src/frontends/paddle/include -I$SRC_DIR/src/frontends/pytorch/include -I$SRC_DIR/src/frontends/tensorflow/include -I$SRC_DIR/src/frontends/tensorflow_lite/include -I$SRC_DIR/src/core/dev_api -I$SRC_DIR/src/common/transformations/include -I$SRC_DIR/src/common/low_precision_transformations/include -I$SRC_DIR/src/common/itt/include -I$SRC_DIR/src/common/util/include -I$SRC_DIR/src/plugins/proxy/dev_api -I$SRC_DIR/build/src/inference -I$SRC_DIR/src/common/conditional_compilation/include -Wsuggest-override -fvisibility-inlines-hidden -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/openvino-split-2025.4.0 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -Wno-deprecated-declarations -fsigned-char -ffunction-sections -fdata-sections -fdiagnostics-show-option -Wall -Wundef -Wmissing-declarations -O3 -DNDEBUG  -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv -fstack-protector-strong -s -ffile-prefix-map=$SRC_DIR/= -ffile-prefix-map=..//= -std=c++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -pthread -MD -MT src/inference/CMakeFiles/openvino_runtime_obj.dir/src/system_conf.cpp.o -MF src/inference/CMakeFiles/openvino_runtime_obj.dir/src/system_conf.cpp.o.d -o src/inference/CMakeFiles/openvino_runtime_obj.dir/src/system_conf.cpp.o -c $SRC_DIR/src/inference/src/system_conf.cpp
2025-11-27T15:37:38.4770723Z $SRC_DIR/src/inference/src/system_conf.cpp: In function 'bool ov::with_cpu_arm_i8mm()':
2025-11-27T15:37:38.4771992Z $SRC_DIR/src/inference/src/system_conf.cpp:227:21: error: 'HWCAP2_I8MM' was not declared in this scope
2025-11-27T15:37:38.4772565Z   227 |     return hwcaps & HWCAP2_I8MM;
2025-11-27T15:37:38.4773146Z       |                     ^~~~~~~~~~~
2025-11-27T15:40:59.1157837Z [867/2847] Performing build step for 'arm_compute_build'
2025-11-27T15:40:59.1160859Z Mkdir("build/arm64-v8a")
```
https://dev.azure.com/conda-forge/84710dde-1620-425b-80d0-4cf5baca359d/_apis/build/builds/1403136/logs/40
 - The constant was introduced in https://github.com/openvinotoolkit/openvino/pull/31801

### Tickets:
 - *ticket-id*
