### PR TITLE
[GPU] Select Intel dGPU as a default device on platforms with iGPU

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -83,6 +83,14 @@ std::string Plugin::get_device_id(const ov::AnyMap& config) const {
     std::string id = m_default_device_id;
     if (config.find(ov::device::id.name()) != config.end()) {
         id = config.at(ov::device::id.name()).as<std::string>();
+    } else {
+        for (const auto& [dev_id, dev_context] : get_default_contexts()) {
+            const auto& dev_info = dev_context->get_device().get_info();
+            // prefer the first available Intel dGPU over iGPU
+            if (dev_info.dev_type == cldnn::device_type::discrete_gpu && dev_info.arch != cldnn::gpu_arch::unknown) {
+                return dev_id;
+            }
+        }
     }
     return id;
 }


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
On machines with both iGPU (i9-13900) and dGPU (B580), if the user passes "GPU" as a device name, the default device is "GPU.0", which is an iGPU. Most of the cases, this is not an intention of the user, which leads to performance and potential conformance issues. 

For example, resnet-50 performance is ~6x worse, and phi3.5 token throughput is ~10x worse. This PR resolves this by scanning the available platforms and selects the first Intel discrete GPU available. 

### Tickets:
 - [CVS-177399](https://jira.devtools.intel.com/browse/CVS-177399)
