### PR TITLE
[NPU] Model marshalling: fallback to copying weights for all unhandled Constant nodes

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/xml_serializer.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/xml_serializer.cpp
@@ -10,7 +10,20 @@
 namespace intel_npu {
 
 ov::util::ConstantWriter& XmlSerializer::get_constant_write_handler() {
-    return *m_weightless_constant_writer;
+    if (m_use_weightless_writer) {
+        return *m_weightless_constant_writer;
+    } else {
+        return m_base_constant_writer;
+    }
+}
+
+bool XmlSerializer::append_node_attributes(ov::Node& node) {
+    // If the "WeightsPointerAttribute" is found, then we have the metadata required to avoid copying the weights
+    // corresponding to this node.
+    m_use_weightless_writer = node.get_rt_info().count(WeightsPointerAttribute::get_type_info_static()) != 0;
+    auto result = ov::util::XmlSerializer::append_node_attributes(node);
+    m_use_weightless_writer = false;
+    return result;
 }
 
 std::unique_ptr<ov::util::XmlSerializer> XmlSerializer::make_visitor(pugi::xml_node& data,


### PR DESCRIPTION
### Details:
 - The [new model marshalling algorithm](https://github.com/openvinotoolkit/openvino/pull/31939) is not handling subgraphs properly. See [this code passage](https://github.com/openvinotoolkit/openvino/blob/0f37471fb697a07c46f03c01dedb624c85628b34/src/plugins/intel_npu/src/compiler_adapter/src/vcl_serializer.cpp#L152-L163): the attribute is added only on `ov::Constant` nodes found at depth level one. Models within models, which may be registered as "subgraph operators" (e.g. `TensorIterator`) are omitted. In this current state, the attribute is required on all constant nodes, otherwise the run will fail at the deserialization stage.
 - As a temporary fix to unblock [this PR](https://github.com/openvinotoolkit/openvino/pull/30732), all constant nodes that have been omitted will have their weights copied in a separate buffer. We may consider this a safety measure for now, with no real impact on performance. The impact can be great if, say, a model has a huge submodel within it, but the data we've gathered so far suggests these cases are not frequent (none of our models from the CI validation jobs use this feature).

### Tickets:
 - *CVS-177414*
