### PR TITLE
[doc] Remove redundant note on OpenMP default for RISC-V

### DIFF
--- a/docs/dev/build_riscv64.md
+++ b/docs/dev/build_riscv64.md
@@ -96,7 +96,6 @@ This method provides the best performance available at the moment.
      -DCMAKE_INSTALL_PREFIX=<openvino_install_path> \
      -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64.linux.toolchain.cmake
    ```
-   > **NOTE**: By default OpenVINO is built with OpenMP support on RISC-V devices.
 
    Then run `make` to build the project:
    ```sh


### PR DESCRIPTION
### Details:
TBB is used by default on RISC-V as well since https://github.com/openvinotoolkit/openvino/pull/31925

### Tickets:
 - N/A
