### PR TITLE
[CI] Reenable test_accuracy_conformance test

### DIFF
--- a/tests/llm/accuracy_conformance.py
+++ b/tests/llm/accuracy_conformance.py
@@ -198,7 +198,6 @@ test_scope = init_test_scope()
 )
 def test_accuracy_conformance(model_id, precision, device):
     # Get expected values from catalog (use original device for lookup)
-    pytest.skip('Skipping the test for 165769. Reenable in 176009 once 165769 is done.')
     expected_reference = get_reference(model_id, device, precision)
     if expected_reference == NOTEST:
         pytest.xfail(f'Test is skipped for {model_id}, {precision}, {device}.')


### PR DESCRIPTION
### Details:
Reenable the test_accuracy_conformance test after moving code from GenAI to the SDPAToPA transformation in d555df8

### Tickets:
 - [CVS-165769](https://jira.devtools.intel.com/browse/CVS-165769)

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
