### PR TITLE
GPU: allow VL-SDPA fallback without DPAS

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cm/cm_sdpa_vlen.cm
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/cm_sdpa_vlen.cm
@@ -15,7 +15,7 @@
  * limitations under the License.
  *******************************************************************************/
 namespace KERNEL_NAME {
-    
+
 #include "cm_sdpa_common.hpp"
 
 #ifdef CM_HAS_LSC_UNTYPED_2D
@@ -138,6 +138,7 @@ _GENX_MAIN_ void KERNEL_NAME(
                                 reinterpret_cast<svmptr_t>(output + qo_offset));
 #endif
 #else
+#if CM_HAS_DPAS
     sdpa_kernel<false, num_heads, num_kv_heads, head_size, 0>(
                                 slm_K,
                                 slm_V,
@@ -156,6 +157,29 @@ _GENX_MAIN_ void KERNEL_NAME(
                                 kv_offset * sizeof(half),
                                 qo_offset * sizeof(half)
                                 );
+#else
+    sdpa_kernel_mma<false, num_heads, num_kv_heads, head_size, 0>(
+                                slm_K,
+                                slm_V,
+                                wg_local_id,
+                                local_size,
+                                0, //q_start,
+                                kv_seq_len, //kv_stop,
+                                q_len, //q_len,
+                                kv_seq_len, //kv_len,
+                                query,
+                                key,
+                                value,
+                                output,
+                                qo_offset * sizeof(half),
+                                kv_offset * sizeof(half),
+                                kv_offset * sizeof(half),
+                                qo_offset * sizeof(half)
+                                );
+
+
+
+#endif
 #endif
 }
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/vl_sdpa_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/vl_sdpa_opt.hpp
@@ -42,10 +42,9 @@ struct VLSDPAOptImplementationManager : public ImplementationManager {
         assert(node.is_type<vl_sdpa>());
         auto& engine = node.get_program().get_engine();
         const auto& config = node.get_program().get_config();
-        const auto& info = engine.get_device_info();
 
         // CM optimized for systolic-array architectures
-        if (!check_cm_jit_support(engine, config) || !info.supports_immad || !config.get_use_cm()) {
+        if (!check_cm_jit_support(engine, config) || !config.get_use_cm()) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -87,7 +87,6 @@ bool check_cm_jit_support(cldnn::engine& e, const cldnn::ExecutionConfig& config
     // This program checks if cm sources can be jitted by current IGC version
     const char* kernel_code = R""""(
         static_assert(__cplusplus >= 201703L);
-        static_assert(CM_HAS_DPAS);
         CM_INLINE uint64_t dummy() {
             return ((uint64_t)0L);
         }

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -367,10 +367,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         pass_config->set_callback<ov::pass::SDPAToVLSDPA>(
                 [&](const_node_ptr &) -> bool {
                     auto& engine = m_context->get_engine();
-                    const auto& info = engine.get_device_info();
-                    if (!(info.supports_immad)) { // CM optimized for systolic-array architectures
-                        return true;
-                    }
 
 #ifdef GPU_DEBUG_CONFIG
                     if (!config.get_use_cm()) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/vlsdpa_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/vlsdpa_gpu_test.cpp
@@ -197,7 +197,7 @@ struct vlsdpa_gpu_test : public ::testing::TestWithParam<vlsdpa_test_params> {
     static bool check_vlsdpa_available() {
         auto& engine = get_test_engine();
         ExecutionConfig config = get_test_default_config(engine);
-        if (!cldnn::check_cm_jit_support(engine, config) || !engine.get_device_info().supports_immad) {
+        if (!cldnn::check_cm_jit_support(engine, config)) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- remove the `supports_immad` gate so SDPA→VL-SDPA runs even on non-DPAS GPUs
- Use CM_HAS_DPAS to go through the non-DPAS path
- drop DPAS-only static_asserts and update vlsdpa unit tests/docs accordingly

## Testing
- [ ] ./bin/intel64/Release/ov_gpu_unit_tests --gtest_filter="smoke_vlsdpa_gpu_test/vlsdpa_gpu_test.*"  (currently fails: CM stub still hits DPAS path;)
