### PR TITLE
[GPU] Fix roll wrong axis, shift handling issue.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -42,17 +42,10 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
 
             // Normalize axes and sum shift
             std::vector<ov::Dimension::value_type> shift(default_rank);
-
-            // Calculate the effective rank by excluding trailing dimensions with size 1.
-            // This is necessary to correctly map negative axes when trailing dimensions cause shift 0.
-            auto first_non_one_reverse = std::find_if(input_shape.rbegin(), input_shape.rend(), [](int dim) { return dim != 1; });
-            int trailing_ones_count = first_non_one_reverse - input_shape.rbegin();
-            int effective_rank = rank - trailing_ones_count;
-
             for (size_t a = 0; a < axes_raw.size(); ++a) {
                 auto& axis = axes_raw[a];
                 if (axis < 0) {
-                    axis += effective_rank;
+                    axis += rank;
                 }
                 if (axis < 0 || axis >= rank) {
                     OPENVINO_THROW(" Incorrect axis value: ", axis);

--- a/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
@@ -28,31 +28,33 @@ void CreateRollOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v7::Roll>& op
     auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
     OPENVINO_ASSERT(axes_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op_friendly_name, " (", op->get_type_name(), ")");
     auto axes_raw = axes_constant->cast_vector<ov::Dimension::value_type>();
+    const auto rank = static_cast<ov::Dimension::value_type>(input_pshape.size());
+
+    for (auto& axis : axes_raw) {
+        if (axis < 0) {
+            axis += rank;
+        }
+        if (axis < 0 || axis >= rank) {
+            OPENVINO_THROW(op_friendly_name, " Incorrect axis value: ", axis);
+        }
+    }
 
     if (input_pshape.is_dynamic()) {
         const cldnn::roll roll_prim(layer_name, inputs.front(), shift_raw, axes_raw);
         p.add_primitive(*op, roll_prim);
     } else {
         const auto& input_shape = input_pshape.to_shape();
-        const auto rank = static_cast<ov::Dimension::value_type>(input_shape.size());
         const auto format = cldnn::format::get_default_format(rank);
         const auto default_rank = format.dimension();
 
-        // Normalize axes and sum shift
         std::vector<ov::Dimension::value_type> shift(default_rank);
+
         for (size_t a = 0; a < axes_raw.size(); ++a) {
-            auto& axis = axes_raw[a];
-            if (axis < 0) {
-                axis += rank;
-            }
-            if (axis < 0 || axis >= rank) {
-                OPENVINO_THROW(op_friendly_name, " Incorrect axis value: ", axis);
-            }
-            shift[axis] += shift_raw[a];
+            shift[axes_raw[a]] += shift_raw[a];
         }
 
         // Normalize shift
-        for (int s = 0; s < rank; ++s) {
+        for (size_t s = 0; s < static_cast<size_t>(rank); ++s) {
             auto& sh = shift[s];
             const auto dim = static_cast<ov::Dimension::value_type>(input_shape[s]);
             sh %= dim;


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 Unexpected behavior at negative axis in roll primitive with 3D shape.
From [roll-7](https://docs.openvino.ai/2024/documentation/openvino-ir-format/operation-sets/operation-specs/movement/roll-7.html), axis and shift support negative value but current roll has the problem for handling 3D shape.

 - How it was resolved
Normalized the axis during roll primitive creation.
Updating the axes in get_kernel_params() complicates the problem because canoicalize_shapes changs the shape.




#### Reproduction step and snapshot (if applicable. Do not attach for customer model) 
$ python lfm2.py   // Basic script is in the ticket.
...
<|startoftext|><|im_start|>user
What is C. elegans?<|im_end|>
<|im_start|>assistant
C. C. C. The nematode a.  the nematodes is a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a. a.

#### Problematic graph 
<img width="766" height="955" alt="image" src="https://github.com/user-attachments/assets/6b4185fb-59a3-4058-99b2-c7435f42c1c8" />


#### Checklist 
 - [x] Is it a proper fix?
 - [x] Did you include test case for this fix, if necessary? 
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *CVS-176974*
