### PR TITLE
[gpu] fix windows SEH exception issue

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -124,6 +124,23 @@ static void create_data(ProgramBuilder& p, const ov::Shape& const_shape, const s
             const auto* f64data = op->get_data_ptr<double>();
             auto f32buf = reinterpret_cast<float*>(buf);
             f32buf[0] = static_cast<float>(f64data[0]);
+        } else if (out_dtype == cldnn::data_types::f32 &&
+                   (op->get_output_element_type(0) == ov::element::u16 ||
+                    op->get_output_element_type(0) == ov::element::i16)) {
+            size_t count = ov::shape_size(const_shape);
+            auto f32buf = reinterpret_cast<float*>(buf);
+
+            if (op->get_output_element_type(0) == ov::element::u16) {
+                const auto* u16data = op->get_data_ptr<uint16_t>();
+                for (size_t i = 0; i < count; i++) {
+                    f32buf[i] = static_cast<float>(u16data[i]);
+                }
+            } else {
+                const auto* i16data = op->get_data_ptr<int16_t>();
+                for (size_t i = 0; i < count; i++) {
+                    f32buf[i] = static_cast<float>(i16data[i]);
+                }
+            }
         } else {
             std::memcpy(&buf[0], &data[0], bufSize);
         }

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/constant_result.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/constant_result.hpp
@@ -34,6 +34,7 @@ public:
 
 protected:
     void SetUp() override;
+    void run() override;
 };
 
 }  // namespace test

--- a/src/tests/functional/plugin/shared/src/subgraph/constant_result.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/constant_result.cpp
@@ -66,5 +66,49 @@ void ConstantResultSubgraphTest::SetUp() {
 
     createGraph(type, input_shape, input_type);
 }
+
+void ConstantResultSubgraphTest::run() {
+    compile_model();
+    inferRequest = compiledModel.create_infer_request();
+    ASSERT_TRUE(inferRequest);
+    inferRequest.infer();
+
+    const auto& [type, input_shape, input_type, _] = this->GetParam();
+    if (input_type == ov::element::i16 || input_type == ov::element::u16) {
+        auto outputs = function->get_results();
+        for (size_t i = 0; i < outputs.size(); ++i) {
+            auto result_tensor = inferRequest.get_tensor(outputs[i]);
+            ASSERT_TRUE(result_tensor);
+
+            auto constant_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(
+                outputs[i]->get_input_node_shared_ptr(0));
+            ASSERT_TRUE(constant_node) << "Failed to get constant node for output " << i;
+
+            size_t num_elements = result_tensor.get_size();
+            ASSERT_EQ(result_tensor.get_element_type(), input_type)
+                << "Output type mismatch for " << input_type;
+
+            if (input_type == ov::element::i16) {
+                auto expected_data = constant_node->get_data_ptr<int16_t>();
+                auto actual_data = result_tensor.data<int16_t>();
+                for (size_t j = 0; j < num_elements; ++j) {
+                    EXPECT_EQ(actual_data[j], expected_data[j])
+                        << "Mismatch at element " << j << "/" << num_elements
+                        << ": expected " << expected_data[j]
+                        << ", got " << actual_data[j];
+                }
+            } else {
+                auto expected_data = constant_node->get_data_ptr<uint16_t>();
+                auto actual_data = result_tensor.data<uint16_t>();
+                for (size_t j = 0; j < num_elements; ++j) {
+                    EXPECT_EQ(actual_data[j], expected_data[j])
+                        << "Mismatch at element " << j << "/" << num_elements
+                        << ": expected " << expected_data[j]
+                        << ", got " << actual_data[j];
+                }
+            }
+        }
+    }
+}
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
 ### Details:
  - Updated `create_data` to use the actual data size calculated from the original element type and shape for `u16`/`i16` types, ensuring `memcpy` only reads the valid memory region.

### Description of the issue
  - The `create_data` function used the layout's buffer size for `memcpy`, which is incorrect for `u16`/`i16` types as they are converted to `f32` in the layout. This caused `bufSize` (4 bytes/elem) to be larger than the actual source data (2 bytes/elem), leading to a buffer overread and SEH exception 0xc0000005.

#### The code and line that caused this issue (if it is not changed directly)
https://github.com/openvinotoolkit/openvino/blob/0eb9180da04433d75acd6a010a151fc859187800/src/plugins/intel_gpu/src/plugin/ops/constant.cpp#L129

#### Reproduction step and snapshot
 - Test command
```
timeout 600 valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --error-exitcode=1 --log-file=valgrind_i16_test.log ./bin/intel64/Debug/ov_gpu_func_tests '--gtest_filter=*ConstantResultSubgraphTest.Inference/SubgraphType=SEVERAL_COMPONENT_IS=[1,3,10,10]_IT=i16_Device=GPU' > valgrind_console.txt
```
 - Output
```
==630497== Invalid read of size 8
==630497==    by 0x485293F: memmove (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==630497==    by 0x190A8A20: ov::intel_gpu::create_data(...) (constant.cpp:128)
...
==630497==  Address 0xed432e8 is 16 bytes after a block of size 600 alloc'd
```

#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [v] Did you include test case for this fix, if necessary?
 - [v] Did you review existing test that can be extended to cover this scenario? Which test did you review?

 ### Tickets:
  - *CVS-172561*
