### PR TITLE
[actions/system_info] Print disk information for local filesystems only

### DIFF
--- a/.github/actions/system_info/action.yml
+++ b/.github/actions/system_info/action.yml
@@ -10,12 +10,12 @@ runs:
         if [[ -e /etc/fedora-release ]]; then
           yum update -y -q && yum install -y -q procps
         fi
-        
+
         echo "System: ${{ runner.os }}"
         echo "System Architecture: ${{ runner.arch }}"
         echo "CPU Info: "; lscpu
         echo "RAM Info: "; free -h --si
-        echo "MEMORY Info: "; df -h
+        echo "DISK Info: "; df -hl
 
     - if: runner.os == 'macOS'
       shell: bash
@@ -23,7 +23,7 @@ runs:
         echo "System: ${{ runner.os }}"
         echo "System Architecture: ${{ runner.arch }}"
         echo "CPU and RAM Info: "; system_profiler SPHardwareDataType
-        echo "MEMORY Info: "; df -h
+        echo "DISK Info: "; df -h
 
     - if: runner.os == 'Windows'
       shell: pwsh


### PR DESCRIPTION
### Details:
The `-l` flag shows info for local filesystem only, which leaves just the relevant data in our case, and avoids the error:
```
 MEMORY Info: 
df: /mount/build-artifacts: Resource temporarily unavailable
Filesystem      Size  Used Avail Use% Mounted on
overlay         124G   32G   93G  26% /
tmpfs            64M     0   64M   0% /dev
shm              64M     0   64M   0% /dev/shm
/dev/root       124G   32G   93G  26% /__w
overlay         124G   32G   93G  26% /mount
blobfuse2        80G  4.0K   80G   1% /mount/testdata0
blobfuse2        80G  4.0K   80G   1% /mount/testdata1
blobfuse2        80G  1.5M   80G   1% /mount/caches/pip
blobfuse2        80G  4.0K   80G   1% /mount/caches/ccache
blobfuse2        80G  4.0K   80G   1% /mount/caches/apt
blobfuse2        80G  4.0K   80G   1% /mount/caches/huggingface
tmpfs           980K   88K  892K   9% /run/docker.sock
tmpfs            16G     0   16G   0% /proc/acpi
tmpfs            16G     0   16G   0% /proc/scsi
tmpfs            16G     0   16G   0% /sys/firmware
```

As seen in this job https://github.com/openvinotoolkit/openvino/actions/runs/19969846773/job/57271685529

Also clarifying terminology a little bit.