### PR TITLE
[core] Remove deprecate code for string <-> wstring conversion

### DIFF
--- a/src/common/util/src/wstring_convert_util.cpp
+++ b/src/common/util/src/wstring_convert_util.cpp
@@ -4,6 +4,7 @@
 
 #include "openvino/util/wstring_convert_util.hpp"
 
+#include <cstdint>
 #include <stdexcept>
 #ifdef _WIN32
 #    include <windows.h>


### PR DESCRIPTION
### Details:
 - Remove using deprecated standard lib functions for string conversion, e.g. `codecvt_utf8`

### Tickets:
 - CVS-120545
