### PR TITLE
[NPU][IE-MDK] Add fallbacks for platform indentification

### DIFF
--- a/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.cpp
+++ b/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.cpp
@@ -175,6 +175,10 @@ std::string getDeviceNameID(const std::string& str) {
     return parser.get_device_id();
 }
 
+std::string getTestPlatform() {
+    return ov::intel_npu::Platform::standardize(NpuTestEnvConfig::getInstance().IE_NPU_TESTS_PLATFORM);
+}
+
 }  // namespace ov::test::utils
 
 namespace InferRequestParamsAnyMapTestName {

--- a/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.hpp
@@ -54,6 +54,7 @@ std::string getTestsPlatformFromEnvironmentOr(const std::string& instead);
 std::string getDeviceNameTestCase(const std::string& str);
 std::string getDeviceName();
 std::string getDeviceNameID(const std::string& str);
+std::string getTestPlatform();
 
 }  // namespace ov::test::utils
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -45,7 +45,7 @@ public:
     AvailableDevices() {
         const auto corePtr = PluginCache::get().core();
         if (corePtr != nullptr) {
-            _availableDevices.push_back(getTestDeviceId());
+            _availableDevices.push_back(getTestPlatform());
 
             if (_availableDevices.empty()) {
                 auto deviceName = getDeviceName();


### PR DESCRIPTION
### Details:
- The skip config gets multiple fallbacks for platform identification.
- Some tests can set their own desired platform, while the skip config is populated before any test is run. This means that it needs to know what's the expected platform, in order to populate the list correctly.
- This implementation uses `IE_NPU_TESTS_PLATFORM` as the first source form platform identification, as it's a mandatory envvar to run `ov_npu_func_tests`. It then falls back to using `IE_NPU_TESTS_DEVICE_NAME`. If neither envvar provide a usable platform, the final fallback is the list returned by the NPU Plugin

### Tickets:
 - E 189860