### PR TITLE
Disable fuseElementWise for FQ with mult-power (div conversion to mult-power)

### DIFF
--- a/src/common/low_precision_transformations/src/fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize.cpp
@@ -138,7 +138,7 @@ bool all_precisions_equal(const std::shared_ptr<Node>& node) {
 }  // namespace fq
 
 bool FakeQuantizeTransformation::checkElementwise(const std::shared_ptr<Node>& eltwise) {
-    if (eltwise->get_input_size() > 0 && fq::getDataInput(eltwise).get_partial_shape() != eltwise->get_output_partial_shape(0)) {
+    if (eltwise->get_input_size() > 0 && fq::getDataInput(eltwise).get_node() != nullptr &&  fq::getDataInput(eltwise).get_partial_shape() != eltwise->get_output_partial_shape(0)) {
         return false;
     }
 
@@ -174,10 +174,6 @@ std::shared_ptr<opset1::FakeQuantize> FakeQuantizeTransformation::fuseElementwis
     const std::shared_ptr<opset1::FakeQuantize>& fakeQuantize,
     const bool updatePrecisions) {
     const std::shared_ptr<Node> eltwise = fakeQuantize->get_input_node_shared_ptr(0);
-
-    if (checkElementwise(eltwise) && fq::getDataInput(eltwise).get_node() != nullptr) {
-        return nullptr;
-    }
 
     if (!updatePrecisions && !fq::all_precisions_equal(eltwise)) {
         return nullptr;

--- a/src/common/low_precision_transformations/tests/fuse_dequantize_to_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_dequantize_to_fake_quantize_transformation.cpp
@@ -280,7 +280,7 @@ const std::vector<FuseDequantizeToFakeQuantizeTransformationTestValues> testValu
            element::f16,
            {},
            element::f16,
-           {{}, {}, {{0.01f, 0.1f, 1.f}},
+           {{}, {}, {{0.01f, 0.1f, 1.f}}},
            element::f16,
            {256ul, {}, {0.f}, {2.55f}, {0.f}, {2.55f}}
        },
@@ -288,7 +288,7 @@ const std::vector<FuseDequantizeToFakeQuantizeTransformationTestValues> testValu
            element::f16,
            {},
            element::f16,
-           {{}, {}, {{0.01f, 0.1f, 1.f}},
+           {{}, {}, {{0.01f, 0.1f, 1.f}}},
            element::f16,
            element::f16,
            {256ul, {}, {0.f}, {2.55f}, {0.f}, {2.55f}}


### PR DESCRIPTION
We are enabling CoPilot models on OV GPU. 
For some models, we get the attached error due to this fusion. 
https://github.com/openvinotoolkit/openvino/blob/71d7d40b18f31beb2cf1db0f26cd212f9bacd45e/src/common/low_precision_transformations/src/fake_quantize.cpp#L50

<img width="1909" height="1029" alt="fuseElementWise" src="https://github.com/user-attachments/assets/7a5a92e2-6e48-40fb-a9db-1fd172bc31fa" />
<img width="1879" height="1020" alt="div-FQ-unsqueeze" src="https://github.com/user-attachments/assets/678f6d57-b113-4693-913e-1a239511508f" />

There are patterns of Div + FQ + Reshape in the CoPilot model.  The Div operation is decomposed to mult + power in 
https://github.com/openvinotoolkit/openvino/blob/71d7d40b18f31beb2cf1db0f26cd212f9bacd45e/src/common/transformations/src/transformations/common_optimizations/common_optimizations.cpp#L175C25-L175C38

The mult which is part of above conversion is fused to FQ layer which cause incorrect shape from power op be propagated to Reshape.

### Tickets:
 - *CVS-177903*

