### PR TITLE
Naz/src dst layout mismatch reduce op

### DIFF
--- a/src/common/low_precision_transformations/src/reduce_sum.cpp
+++ b/src/common/low_precision_transformations/src/reduce_sum.cpp
@@ -70,7 +70,6 @@ void ReduceSumTransformation::changeDequantizationValues(
         }
 
         // (a1 - s) + (a2 - s) + ... + (an - s) = (a1 + a2 + ... + an) - n * s
-        ov::element::Type deqPrecision = dequantization.subtractConstant->get_element_type();
         const auto reductionSizeConstant = ov::opset1::Constant::create(deqPrecision, Shape{}, { static_cast<float>(reductionSize) });
         OPENVINO_ASSERT(deqPrecision == dequantization.subtract->get_input_element_type(0),
                         "dequantization precision ", deqPrecision,


### PR DESCRIPTION
We are enabling CoPilot models on GPU.
The below issue happens because of layout mismatch between input and output.
https://github.com/openvinotoolkit/openvino/blob/71d7d40b18f31beb2cf1db0f26cd212f9bacd45e/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.cpp#L23
When input and output layout does not match the in_dims and the output tensor are set incorrectly.

<img width="1818" height="1001" alt="graph 3" src="https://github.com/user-attachments/assets/fd9f3070-585c-4773-ae6c-a80302f793f2" />
<img width="1861" height="1008" alt="reduction_sum2 (1)" src="https://github.com/user-attachments/assets/7b4c0121-eb30-4f6a-aba7-a5562a88abe5" />

For the above graph, input tensor size is [1,12,77,2,4] and output tensor size is [1,12,77,2]
When debugging the code, the output tensor is set incorrectly --> [1,12,2,1]

### Tickets:
 - *CVS-177906*
