### PR TITLE
[OV DOCS] Enable member grouping in doxygen

### DIFF
--- a/docs/Doxyfile.config
+++ b/docs/Doxyfile.config
@@ -392,7 +392,7 @@ IDL_PROPERTY_SUPPORT   = YES
 # all members of a group must be documented explicitly.
 # The default value is: NO.
 
-DISTRIBUTE_GROUP_DOC   = NO
+DISTRIBUTE_GROUP_DOC   = YES
 
 # If one adds a struct or class to a group and this option is enabled, then also
 # any nested class or struct is added to the same group. By default this option


### PR DESCRIPTION
### Details:
 - Set `DISTRIBUTE_GROUP_DOC` to YES. Reuse the documentation of the first member in the group (if any) for the other members of the group
 - When  `DISTRIBUTE_GROUP_DOC` is NO only the first member of the group is added to rendered documentation. See [issue](https://github.com/openvinotoolkit/openvino/pull/33043#discussion_r2568251301)

### Tickets:
 - [CVS-178030](https://jira.devtools.intel.com/browse/CVS-178030)
