### PR TITLE
Rerun Windows Cmake configure network errors

### DIFF
--- a/.github/scripts/workflow_rerun/errors_to_look_for.json
+++ b/.github/scripts/workflow_rerun/errors_to_look_for.json
@@ -150,5 +150,13 @@
     {
         "error_text": "Connection reset by peer - SSL_connect",
         "ticket": 173970
+    },
+    {
+        "error_text": "Error in the HTTP2 framing layer",
+        "ticket": 177549
+    },
+    {
+        "error_text": "CERT_TRUST_REVOCATION_STATUS_UNKNOWN",
+        "ticket": 177273
     }
 ]


### PR DESCRIPTION
### Details:
This PR adds log patters of errors occurring in CMake configure steps on Windows during JS API dependencies downloading

### Tickets:
 - CVS-177273
 - CVS-177549
