### PR TITLE
[LOG] Add verbose logging in `torch.compile`

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/backend.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/backend.py
@@ -30,7 +30,6 @@ from openvino.frontend.pytorch.torchdynamo.backend_utils import _get_cache_dir, 
 from openvino import Core, Type, PartialShape
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
 
 """
     This is a preview feature in OpenVINO. This feature
@@ -67,6 +66,7 @@ if "openvino" not in torch.compiler.list_backends():
 
 def fx_openvino(subgraph, example_inputs, options=None):
     try:
+        logger.info("OpenVINO TorchDynamo backend initialized")
         if len(openvino_options) != 0:
             options = openvino_options
         executor_parameters = None
@@ -132,7 +132,7 @@ def fx_openvino(subgraph, example_inputs, options=None):
             _call._boxed_call = True  # type: ignore[attr-defined]
         return _call
     except Exception as e:
-        logger.debug(f"Failed in OpenVINO execution: {e}")
+        logger.warning(f"Failed in OpenVINO execution: {e}. Falling back to standard generic_backend compilation.")
         return compile_fx(subgraph, example_inputs)
 
 

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/execute.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/execute.py
@@ -144,9 +144,9 @@ class OpenVINOGraphModule(torch.nn.Module):
                 partition_id=self.partition_id,
                 options=self.options,
             )
-            logger.debug("OpenVINO graph execution successful")
+            logger.debug(f"OpenVINO graph execution successful")
         except Exception as e:
-            logger.debug(
+            logger.warning(
                 f"OpenVINO execution failed with {e}. Falling back to native PyTorch execution."
             )
             self.perm_fallback = True

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
@@ -16,7 +16,6 @@ from torch.fx.passes.tools_common import CALLABLE_NODE_OPS
 from openvino.frontend.pytorch.torchdynamo.backend_utils import _get_disabled_ops
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
 
 
 class OperatorSupport(OpSupport):

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/partition.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/partition.py
@@ -143,6 +143,7 @@ class Partitioner:
         partitions = partitioner.propose_partitions()
         self.add_get_attr_inputs(partitions)
         fused_graph_module = partitioner.fuse_partitions(partitions)
+        logger.info(f"Completed partitioning. Delegated {len(partitions)} subgraphs to OpenVINO.")
         logger.debug(f"Graph module after partitioning {fused_graph_module}")
 
         return fused_graph_module


### PR DESCRIPTION
### Details:
- Implements verbose logging with does the follows:
- Users are able to understand if `torch.compile` is running on an `openvino` backend or not.
- Number of subgraphs delegated to Openvino

Here is a sample output:
<img width="1897" height="108" alt="verbose-log" src="https://github.com/user-attachments/assets/9cd7ed24-22af-43b1-9a9f-9898ac34fb00" />

### Tickets:
 Fixes #33116 
