### PR TITLE
Change ov_try_use_gold_linker cmake function to use mold or lld if available

### DIFF
--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ set(TARGET_NAME ov_core_unit_tests)
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
 
-ov_try_use_gold_linker()
+ov_try_use_fast_linker()
 
 add_definitions(-DSERIALIZED_ZOO=\"${TEST_MODEL_ZOO}/core/models\")
 

--- a/src/frontends/onnx/tests/CMakeLists.txt
+++ b/src/frontends/onnx/tests/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
 
-ov_try_use_gold_linker()
+ov_try_use_fast_linker()
 
 ov_deprecated_no_errors()
 


### PR DESCRIPTION
### Details:
Some tests use the gold linker, but GNU Binutils has discontinued maintenance of gold and has not
included it by default since version 2.44. However, there are faster linker implementations such as
mold and lld, so these can be used as replacements for gold.

This patch includes the following changes:
- Added find_program for linker commands
- Modified to check usage of -fuse-ld instead of gold for CMAKE_EXE_LINKER_FLAGS, CMAKE_MODULE_LINKER_FLAGS and CMAKE_SHARED_LINKER_FLAGS
- Modified to use one of the linker commands in the following priority order: mold, lld, and gold
- Renamed the ov_try_use_gold_linker function to ov_try_use_fast_linker

### Tickets:
 - *ticket-id*
