### PR TITLE
[GPU] fix position_ids precision issue for long input token

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
@@ -17,6 +17,12 @@ protected:
     void insert_converts_after_if_needed(const std::shared_ptr<ov::Node>& node, const ov::element::Type original_et, size_t& output_idx);
 };
 
+class IncreasePositionIdsPrecisionForQwen25VL : public IncreasePositionIdsPrecisionForRoPE {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("IncreasePositionIdsPrecisionForQwen25VL");
+    IncreasePositionIdsPrecisionForQwen25VL();
+};
+
 class IncreasePositionIdsPrecisionForLtxVideo : public IncreasePositionIdsPrecisionForRoPE {
 public:
     OPENVINO_MATCHER_PASS_RTTI("IncreasePositionIdsPrecisionForLtxVideo");

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_position_ids_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_position_ids_precision_test.cpp
@@ -29,6 +29,7 @@
 #include "openvino/op/strided_slice.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/broadcast.hpp"
+#include "openvino/op/variadic_split.hpp"
 #include "ov_ops/rms.hpp"
 #include "openvino/op/split.hpp"
 #include "openvino/op/scaled_dot_product_attention.hpp"
@@ -547,6 +548,179 @@ TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideo) {
         auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(transpose_2, transpose_3, transpose_4, true);
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_1, input_2, input_3, input_4});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForQwen25VL) {
+    {
+        auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ 3, -1, -1 });
+        auto input_convert = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
+        auto input_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(input_convert,
+                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto convert_2 = std::make_shared<ov::op::v0::Convert>(input_unsqueeze, ov::element::f16);
+
+        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(input_convert, ov::element::i32);
+        auto gather_0 = std::make_shared<ov::op::v8::Gather>(shape_of,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{
+                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
+                gather_0,
+                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{64}),
+                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1})}, 0);
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
+            std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 1, 64, 1}), concat);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(broadcast, convert_2);
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(matmul,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int64_t>{0, 1, 3, 2}));
+        auto concat_2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{transpose, transpose}, 3);
+
+        auto cos = std::make_shared<ov::op::v0::Cos>(concat_2);
+        auto variadic_split_cos = std::make_shared<ov::op::v1::VariadicSplit>(cos,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{3}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{6}, std::vector<int64_t>{16,24,24,16,24,24}));
+        auto gather_cos_0 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(0),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_1 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(1),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_2 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(2),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_3 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(3),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_4 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(4),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_5 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(5),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto concat_cos = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{
+            gather_cos_0, gather_cos_1, gather_cos_2, gather_cos_3, gather_cos_4, gather_cos_5}, 2);
+        auto unsqueeze_cos = std::make_shared<ov::op::v0::Unsqueeze>(concat_cos,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+
+        auto sin = std::make_shared<ov::op::v0::Sin>(concat_2);
+        auto variadic_split_sin = std::make_shared<ov::op::v1::VariadicSplit>(sin,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{3}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{6}, std::vector<int64_t>{16,24,24,16,24,24}));
+        auto gather_sin_0 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(0),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_1 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(1),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_2 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(2),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_3 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(3),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_4 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(4),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_5 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(5),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto concat_sin = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{
+            gather_sin_0, gather_sin_1, gather_sin_2, gather_sin_3, gather_sin_4, gather_sin_5}, 2);
+        auto unsqueeze_sin = std::make_shared<ov::op::v0::Unsqueeze>(concat_sin,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+
+        auto input_2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ -1, -1, 28, 128});
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{input_2, unsqueeze_cos, unsqueeze_sin},
+                ov::op::internal::RoPE::Config());
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{position_ids, input_2});
+        manager.register_pass<IncreasePositionIdsPrecision>();
+    }
+    {
+        auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ 3, -1, -1 });
+        auto input_convert = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
+        auto input_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(input_convert,
+                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto convert_2 = std::make_shared<ov::op::v0::Convert>(input_unsqueeze, ov::element::f32);
+
+        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(input_convert, ov::element::i32);
+        auto gather_0 = std::make_shared<ov::op::v8::Gather>(shape_of,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{
+                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
+                gather_0,
+                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{64}),
+                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1})}, 0);
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
+            std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 1, 64, 1}), concat);
+        auto broadcast_to_f32 = std::make_shared<ov::op::v0::Convert>(broadcast, ov::element::f32);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(broadcast_to_f32, convert_2);
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(matmul,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int64_t>{0, 1, 3, 2}));
+        auto concat_2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{transpose, transpose}, 3);
+
+        auto cos = std::make_shared<ov::op::v0::Cos>(concat_2);
+        auto cos_to_f16 = std::make_shared<ov::op::v0::Convert>(cos, ov::element::f16);
+        auto variadic_split_cos = std::make_shared<ov::op::v1::VariadicSplit>(cos_to_f16,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{3}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{6}, std::vector<int64_t>{16,24,24,16,24,24}));
+        auto gather_cos_0 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(0),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_1 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(1),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_2 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(2),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_3 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(3),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_4 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(4),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_cos_5 = std::make_shared<ov::op::v8::Gather>(variadic_split_cos->output(5),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto concat_cos = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{
+            gather_cos_0, gather_cos_1, gather_cos_2, gather_cos_3, gather_cos_4, gather_cos_5}, 2);
+        auto unsqueeze_cos = std::make_shared<ov::op::v0::Unsqueeze>(concat_cos,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+
+        auto sin = std::make_shared<ov::op::v0::Sin>(concat_2);
+        auto sin_to_f16 = std::make_shared<ov::op::v0::Convert>(sin, ov::element::f16);
+        auto variadic_split_sin = std::make_shared<ov::op::v1::VariadicSplit>(sin_to_f16,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{3}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{6}, std::vector<int64_t>{16,24,24,16,24,24}));
+        auto gather_sin_0 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(0),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_1 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(1),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_2 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(2),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_3 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(3),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_4 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(4),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto gather_sin_5 = std::make_shared<ov::op::v8::Gather>(variadic_split_sin->output(5),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+        auto concat_sin = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{
+            gather_sin_0, gather_sin_1, gather_sin_2, gather_sin_3, gather_sin_4, gather_sin_5}, 2);
+        auto unsqueeze_sin = std::make_shared<ov::op::v0::Unsqueeze>(concat_sin,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+
+        auto input_2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ -1, -1, 28, 128});
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{input_2, unsqueeze_cos, unsqueeze_sin},
+                    ov::op::internal::RoPE::Config());
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{position_ids, input_2});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }


### PR DESCRIPTION
### Description of the issue:
#### Issues
The result of inference on GPU plugin has a failure of "repeated response" for long input token (4k >)
<img width="600" height="250" alt="image" src="https://github.com/user-attachments/assets/82536d0e-e6c8-43eb-b9d1-fdd9a0b0236e" />

#### Root causes

- When converting position_ids (i32) to fp16 in Convert_2, the values are quantized to multiples of 4 due to fp16's mantissa precision limitation (10-bit). 
- Initially, the RoPE errors were small enough for the model to operate within tolerance, but as errors accumulated, it eventually fell into a repetition loop.

#### How to fix it
To resolve the FP16 precision loss issue for position_ids, the following modifications were made:

- **Position IDs precision upgrade**: Changed the Convert node from i32→f16 to i32→f32 to preserve full integer precision for position values above 4096.
- **Broadcast path type matching**: Inserted a new Convert(f16→f32) node after the Broadcast node to ensure type compatibility with the f32 position_ids in MatMul.
- **Output precision restoration**: Added Convert(f32→f16) nodes after Sin and Cos operations to restore the original precision expected by downstream nodes.

#### problematic graphs 
<img width="1000" height="800" alt="image" src="https://github.com/user-attachments/assets/b34553dc-227b-4ed4-9fb5-40e4e99f2012" />


#### Reproduction step and snapshot
```bash
python ovgenai2-vl.py --max-new-tokens 1000 --min-new-tokens 100 --device GPU.1 --model cvs_qwen2.5_vl_7b/model/qwen2.5-vl-7b-instruct/pytorch/ov/FP16/

// ovgenai2-vl.py
llm_pipeline = ov_genai.VLMPipeline(args.model, args.device)
llm_pipeline.generate(
    test_prompt,
    do_sample=False,
    streamer=my_streamer,
    max_new_tokens=args.max_new_tokens,
    min_new_tokens=args.min_new_tokens,
)

```

#### Checklist
 - [x] Is it a proper fix?
 - [X] Did you include test case for this fix, if necessary? 
 - [x] Did you review existing test that can be extended to cover this scenario?

### Tickets:
 - *CVS-176558*
