### PR TITLE
[GPU] Fix a model cache bug of onednn FC primitive

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -356,7 +356,7 @@ public:
                 _attrs->set_zero_points(DNNL_ARG_SRC, grouped, dnnl::memory::dims{1, src_group_size}, dnnl::memory::data_type::u8);
             }
 
-            if (prim->dynamic_quantized_precomputed_reduction) {
+            if (dynamic_quantized_precomputed_reduction) {
                 auto activation_precomputed_reduction_idx = ++idx;
                 auto act_precomputed_reduction_data_type = convert_data_type(impl_params->get_input_layout(activation_precomputed_reduction_idx).data_type);
                 _attrs->set_precomputed_reductions(DNNL_ARG_SRC, grouped, dnnl::memory::dims{1, src_group_size}, act_precomputed_reduction_data_type);


### PR DESCRIPTION
### Description
 - A wrong boolean variable was selected and used to set precomputed_reduction while loading the oneDNN FC primitive from cache. Fixed it.

#### The code and line that caused this issue (if it is not changed directly)
 - https://github.com/openvinotoolkit/openvino/blob/b3a4f2274c68ceb1bfa774aeec8fc0decf6f8d57/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp#L359

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
   - Not necessary.
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?