### PR TITLE
[benchmark-app] Revert set the cache mode by benchmark app

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -605,11 +605,6 @@ int main(int argc, char* argv[]) {
             if (is_virtual_device(device)) {
                 device_nstreams.erase(device);
             }
-
-            if (!FLAGS_cache_dir.empty()) {
-                // Choose between better model compilation time and cache file size.
-                device_config[ov::cache_mode.name()] = ov::CacheMode::OPTIMIZE_SPEED;
-            }
         }
         auto result = std::find_if(config.begin(), config.end(), [&](const std::pair<std::string, ov::AnyMap>& item) {
             return device_name.find(item.first) == 0;


### PR DESCRIPTION
### Details:
 - The set `ov::cache_mode` by benchmark app may trigger exception by device is this property is not supported. Is not mandatory to suppor it.
 - The set by benchmark app can overwrite user configuration and compile model in not expected way e.g.:
    ` -cache_dir <path> config:CACHE_MODE=OPTIMIZE_SIZE`
    The cache mode is in user configuration file but as `cache_dir` command line options is set the mode will be changed to speed.

### Tickets:
 - N/A
