### PR TITLE
[TensorFlow Layer Test] TimeoutError OpenVINO running timeout

### DIFF
--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
@@ -6,14 +6,13 @@ import pytest
 import tensorflow as tf
 from common.tf2_layer_test_class import CommonTF2LayerTest
 
-rng = np.random.default_rng(233534)
-
 
 class TestKerasGru(CommonTF2LayerTest):
     def _prepare_input(self, inputs_info):
         assert 'x' in inputs_info, "Test error: inputs_info must contain `x`"
         x_shape = inputs_info['x']
         inputs_data = {}
+        rng = np.random.default_rng(233534)
         inputs_data['x'] = rng.uniform(-2.0, 2.0, x_shape).astype(self.input_type)
         return inputs_data
 


### PR DESCRIPTION
The test which was timing out used a seemingly constant input data seed. It was global though, so when PyTest started running testcases concurrently, the generated data in a given testcase depended on the order in which the testcase run (and this was random).

The fix makes the stimuli generator local, so that each test case has a guaranteed initial state.

Ticket: CVS-176864
