### PR TITLE
[NPU] Loosen metadata OV version check

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/metadata.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/metadata.cpp
@@ -27,7 +27,7 @@ uint16_t OpenvinoVersion::get_patch() const {
 }
 
 bool OpenvinoVersion::operator!=(const OpenvinoVersion& version) {
-    return this->_major != version._major || this->_minor != version._minor || this->_patch != version._patch;
+    return this->_major != version._major || this->_minor != version._minor;
 }
 
 OpenvinoVersion::OpenvinoVersion(const OpenvinoVersion& version)


### PR DESCRIPTION
### Details:
Removing the check for OV patch version regarding NPU metadata compatibility

### Tickets:
 -
