### PR TITLE
[GPU] Remove W.A for onednn concat validate_impl

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
@@ -84,10 +84,6 @@ struct ConcatenationImplementationManager : public ImplementationManager {
             return false;
         }
 
-        const auto& concat_node = node.as<concatenation>();
-        auto concat_axis = concat_node.get_primitive()->axis;
-
-        size_t index = 0;
         for (const auto& dep : node.get_dependencies()) {
             const auto& in_layout = dep.first->get_output_layout(false, dep.second);
 
@@ -99,14 +95,6 @@ struct ConcatenationImplementationManager : public ImplementationManager {
 
             if (!one_of(in_layout.format.value, supported_in_fmts))
                 return false;
-
-            // WA: Onednn has an issue in simple_concat blocked format Odd value, will be fixed next release.
-            if (index !=0 && concat_axis == 1 &&
-                !format::is_simple_data_format(in_layout.format) &&
-                in_layout.get_partial_shape()[1].is_static() &&
-                in_layout.get_partial_shape()[1].get_length() % 2 != 0)
-                return false;
-            index++;
         }
 
         return true;


### PR DESCRIPTION
Recently onednn concat accuracy problem has been fixed, now no need W.A code. Remove W.A onednn concat limitation for odd value in block format.

This PR should be merged after the onednn fixed PR(https://github.com/uxlfoundation/oneDNN/pull/4440) is into openvino.

Related W.A PR: https://github.com/openvinotoolkit/openvino/pull/32368

### Tickets:
 - *ticket-id*
