### PR TITLE
[GPU] Enable FullyConnectedCompressed when there is a Transpose in the decomposed graph of MatMulNBits

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -805,7 +805,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::pass::ConvertGather0D>();
         manager.register_pass<ov::pass::ConvertPriorBox8To0, false>();
         manager.register_pass<ov::pass::ConvertMulticlassNmsToMulticlassNmsIE>();
-        manager.register_pass<ov::pass::TransposeMatMul>();
         manager.register_pass<ov::pass::ConvertPad12ToPad1, false>();
         manager.register_pass<DecomposeReduceForScalarOutput>();
 


### PR DESCRIPTION
### Details:
This issue does not exist in the CPU plugin, because there is a ov::pass::TransposeMatMul to fuse the Transpose into MatMul before ov::pass::MarkDequantization. We can fixe this issue in the GPU plugin using the same method.

### Jira Ticket:
 - https://jira.devtools.intel.com/browse/CVS-178637
