### PR TITLE
Separate FetchContent cache dirs for different CMake generators

### DIFF
--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -175,7 +175,7 @@ jobs:
             -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON `
             -DCMAKE_JOB_POOLS:STRING=link_jobs=20 `
             -DCMAKE_JOB_POOL_LINK:STRING=link_jobs `
-            -DFETCHCONTENT_BASE_DIR="C:\FetchContentCache" `
+            -DFETCHCONTENT_BASE_DIR="C:\fcc\ninja_multi_config" `
             -S ${{ env.OPENVINO_REPO }} `
             -B ${{ env.BUILD_DIR }}
 

--- a/.github/workflows/windows_vs2022_debug.yml
+++ b/.github/workflows/windows_vs2022_debug.yml
@@ -76,6 +76,7 @@ jobs:
         -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
         -DENABLE_STRICT_DEPENDENCIES=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON
+        -DFETCHCONTENT_BASE_DIR="C:\fcc\ninja"
 
   CXX_Unit_Tests:
     name: C++ unit tests

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -80,7 +80,7 @@ jobs:
             -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
             -DENABLE_STRICT_DEPENDENCIES=OFF
             -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON
-            -DFETCHCONTENT_BASE_DIR="C:\FetchContentCache"
+            -DFETCHCONTENT_BASE_DIR="C:\fcc\ninja_multi_config"
 
   Samples:
     needs: [ Build, Smart_CI ]


### PR DESCRIPTION
### Details:
Follow-up for https://github.com/openvinotoolkit/openvino/pull/33259 to make Windows Debug use the cache as well
