### PR TITLE
u16 to fp16 overflow in dq layer

### DIFF
--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -48,14 +48,10 @@ std::shared_ptr<ov::Node> get_zero_point(const ov::OutputVector& inputs) {
             }
             if (changed) {
                 auto new_zp = ov::op::v0::Constant::create(ov::element::u16, zero_point.get_shape(), zp_values);
-                auto zp_values2 =
-                    ov::as_type_ptr<ov::op::v0::Constant>(new_zp)->cast_vector<uint16_t>();
-
                 ov::copy_runtime_info(zero_point.get_node_shared_ptr(), new_zp);
                 if (zero_point.get_element_type() != scale.get_element_type())
                     return std::make_shared<v0::Convert>(new_zp, scale.get_element_type());
             }
-
         }
 
         if (zero_point.get_element_type() != scale.get_element_type()) {


### PR DESCRIPTION
This PR addresses an overflow issue that occurs in QDQ (Quantize–Dequantize) layers when the zero point (ZP) is stored in uint16 and its value exceeds the representable range of FP16.
In particular, when ZP values fall within 65504–65535, converting these values to FP16 triggers overflow. Since the GPU executes all layers in FP16 for performance reasons, these large ZP values cause incorrect behavior and numerical instability during precision conversion.
**Fix**
To prevent overflow during GPU execution, this PR introduces a clamp in the ONNX frontend:

If a dequantization (DQ) node contains ZP values in the range 65504–65535, those values are clamped to 65504, the maximum finite FP16 value.

**Impact**
This fix prevents FP16 overflow but may introduce accuracy degradation, as clamping alters the original quantization parameters.