### PR TITLE
[OV][ITT][CPU Plugin] Align ITT markers to standard convention and add async support 

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1615,7 +1615,6 @@ inline void Graph::ExecuteNode(const NodePtr& node, SyncInferRequest* request, i
 }
 
 inline void Graph::ExecuteNodeWithCatch(const NodePtr& node, SyncInferRequest* request, int numaId) const {
-    // DO NOT MODIFY OR DELETE!! - Domain name cannot change
     VERBOSE_PERF_DUMP_ITT_DEBUG_LOG(itt::domains::ov_op_cpu_exec, node, getConfig());
 
     try {

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -103,7 +103,6 @@ void SyncInferRequest::update_external_tensor_ptrs() {
 }
 
 void SyncInferRequest::infer() {
-    // [Warning] The strings in ITT_SCOPED_TASK_BASE should NOT be deleted or edited!
     OV_ITT_SCOPED_TASK_BASE(itt::domains::ov_cpu_inference, std::string("SyncInferenceCPU:") + m_compiled_model.name());
     auto graphLock = m_compiled_model.lock();
     auto&& graph = graphLock._graph;

--- a/src/plugins/intel_cpu/src/itt.h
+++ b/src/plugins/intel_cpu/src/itt.h
@@ -24,7 +24,6 @@ namespace ov::intel_cpu::itt::domains {
 OV_ITT_DOMAIN(ov_intel_cpu, "ov::intel_cpu");
 OV_ITT_DOMAIN(ov_intel_cpu_LT, "ov::intel_cpu::lt");
 // Domain namespace to define CPU Inference phase tasks
-// [Warning] The strings in these ITT_DOMAINs should NOT be deleted or edited!
 OV_ITT_DOMAIN(ov_cpu_inference, "ov::phases::cpu::inference");
 OV_ITT_DOMAIN(ov_op_cpu_exec, "ov::op::cpu::exec");
 OV_ITT_DOMAIN(ov_op_cpu_details, "ov::op::cpu::details");

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -819,9 +819,7 @@ void Node::updateDynamicParams() {
 }
 
 void Node::execute(const dnnl::stream& strm, int numaId) {
-    // [Warning] The strings in this ITT_DOMAIN or the domain name should
-    // NOT be deleted or edited!
-    OV_ITT_SCOPED_TASK(itt::domains::ov_op_cpu_details, getName());
+    OV_ITT_SCOPED_TASK_BASE(itt::domains::ov_op_cpu_details, getName());
     if (isDynamicNode()) {
         executeDynamic(strm, numaId);
     } else {


### PR DESCRIPTION
Standardizing CPU ITT marker + support for asynchronous execution - Part 2

This PR is the second of a series of PRs to standardize the ITT markers in OpenVINO that will be enabled by default through host-side instrumentation.

1. The first PR addresses the enhancements required in ITT and the framework to support the creation and propagation of IDs when asynchronous execution is in play [PR#33639](https://github.com/openvinotoolkit/openvino/pull/33639).
2. This ***second PR*** will standardize ITT markers in the CPU and enhance support to include asynchronous execution.
3. The third PR will enable default markers for GPU plugin to allow visibility into inference pass begin/end and operator preparation and submission within each inference.
4. The final PR will extend the same host side markers for NPU execution, which capturing the inference span and pipeline activity.

Summary of the current PR (PR#2)
+ Use the same convention standardized in [PR#33639](https://github.com/openvinotoolkit/openvino/pull/33639)
+ Ensures the namespace for CPU Plugin activity falls under: 
  - ov::phases::inference 
  - ov::phases::cpu::inference 
  - ov::op::cpu::exec 
  - ov::op::cpu::details

Details:
CPU support with default enabled ITT markers was limited to synchronous execution. This PR enhances the default support to include asynchronous behavior and ensures a standardized convention is followed in namespaces used.

@aobolensk Please review as this is an enhancement of your work with synchronous execution.

See [CVS-179230](https://jira.devtools.intel.com/browse/CVS-179230) benchmark data for smoke tests that include low-latency models.
