### PR TITLE
[CPU] Add EXCLUDE_FROM_ALL for plugin 3rdparty subdirectories

### DIFF
--- a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
@@ -178,12 +178,12 @@ if (ENABLE_SNIPPETS_LIBXSMM_TPP)
     # This flag is to suppress "warning as error" in libxsmm compilation, such as
     # "generator_common_aarch64.c:60:6: error: no previous declaration for ‘libxsmm_generator_vcvt_f32i8_aarch64_sve’ [-Werror=missing-declarations]"
     ov_add_compiler_flags(-Wno-missing-declarations)
-    add_subdirectory(libxsmm)
+    add_subdirectory(libxsmm EXCLUDE_FROM_ALL)
     ov_install_static_lib(libxsmm ${OV_CPACK_COMP_CORE})
 endif()
 
 if(ENABLE_MLAS_FOR_CPU)
-    add_subdirectory(mlas)
+    add_subdirectory(mlas EXCLUDE_FROM_ALL)
     ov_install_static_lib(mlas ${OV_CPACK_COMP_CORE})
 endif()
 
@@ -199,7 +199,7 @@ if(ENABLE_SHL_FOR_CPU)
         ov_add_compiler_flags(-Wno-maybe-uninitialized)
         ov_add_compiler_flags(-Wno-unused-function)
         ov_add_compiler_flags(-Wno-suggest-parentheses)
-        add_subdirectory(shl)
+        add_subdirectory(shl EXCLUDE_FROM_ALL)
     endfunction()
 
     # Suppress warnings detected in SHL library build to clean up RISC-V build log.
@@ -214,7 +214,7 @@ endif()
 
 if(RISCV64)
     set(XBYAK_RISCV_V ON)
-    add_subdirectory(xbyak_riscv)
+    add_subdirectory(xbyak_riscv EXCLUDE_FROM_ALL)
     ov_install_static_lib(xbyak_riscv ${OV_CPACK_COMP_CORE})
 endif()
 


### PR DESCRIPTION
### Details:
 - Exclude building unnecessary 3rdparty libraries targets, such as samples (e.g. samples in xbyak_riscv) in ALL target
 - Reflect integration logic from oneDNN, KleidiAI

### Tickets:
 - N/A
