### PR TITLE
[GPU] Fix modnet_webcam_portrait_matting low similarity.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -239,12 +239,14 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
           prev_output_layout.spatial(1) == 1)) && is_input_reorder(prev, next))
         return true;
 
-    if (next.is_type<quantize>() && (fmt_prev == format::bfyx || fmt_prev == format::bfzyx)) {
-        if (prev.is_input() && (prev_dt == data_types::u8 || prev_dt == data_types::i8))
-            return true;
-        if (fmt_next == format::b_fs_yx_fsv16 || fmt_next == format::b_fs_zyx_fsv16 ||
-            fmt_next == format::bs_fs_yx_bsv16_fsv16 || fmt_next == format::b_fs_yx_fsv4)
-            return true;
+    if (next.is_type<quantize>()) {
+        if ((fmt_prev == format::bfyx || fmt_prev == format::bfzyx)) {
+            if (prev.is_input() && (prev_dt == data_types::u8 || prev_dt == data_types::i8))
+                return true;
+            if (fmt_next == format::b_fs_yx_fsv16 || fmt_next == format::b_fs_zyx_fsv16 ||
+                fmt_next == format::bs_fs_yx_bsv16_fsv16 || fmt_next == format::b_fs_yx_fsv4)
+                return true;
+        }
         if (use_onednn_impls && prev.get_users().size() == 1)
             return true;
     }


### PR DESCRIPTION
Regression from https://github.com/openvinotoolkit/openvino/pull/32236

There are some refactoring code in https://github.com/openvinotoolkit/openvino/pull/32236 
(Too many if-else branches with no rules in reorder fusion function, probably just added by many people over many times, so refactoring did clean up by primitive based)
But in refactoring, there are some mistake in quantize, it caused to change in reorder-fusion rule.
- Previous refactoring:
Do reorder fusion for quantize and reorder pattern
- Refactoring
Do reorder fusion for quantize and reorder pattern only quantize' s input format is plain.

Because this reason, the graph has been changed (Reorder is not fused now) and it causes unintentional use of onednn concat. It occurs the poor similarity issue.

This PR restores previous reorder-fusion pattern which was before refactoring so address the low similarity. And separate from the issue resolution, the onednn concat accuracy problem which was discovered accidentally due to the use of onednn concat,  was issued by  [MFDNN-14504 ](https://jira.devtools.intel.com/browse/MFDNN-14504)


### Tickets:
 - *178661*
