### PR TITLE
[ONNX] Clarify ReduceMax axes handling

### DIFF
--- a/src/frontends/onnx/frontend/src/op/reduce.cpp
+++ b/src/frontends/onnx/frontend/src/op/reduce.cpp
@@ -173,7 +173,7 @@ ov::OutputVector reduce_l2(const ov::frontend::onnx::Node& node) {
 }
 
 ov::OutputVector reduce_max(const ov::frontend::onnx::Node& node) {
-    return {make_ov_reduction_op<v1::ReduceMax>(node, node.get_ov_inputs().at(0), supported_types_v1)};
+    return {make_ov_reduction_op<v1::ReduceMax>(node, node.get_ov_inputs().at(0), supported_types_v1, false)};
 }
 
 ov::OutputVector reduce_mean(const ov::frontend::onnx::Node& node) {


### PR DESCRIPTION
### Description
This PR makes the handling of reduction axes for ReduceMax explicit for ONNX opset 13+ by using the axes input rather than attributes.

The change does not alter behavior in current releases but makes the translator logic clearer and aligns it more directly with the ONNX operator specification.

This was inspired by the investigation around issue #33262, but the issue itself no longer reproduces in current OpenVINO releases.

### Changes
- Explicitly use axes from input tensor for ReduceMax in opset 13+.

### Verification
- Verified no behavior change in local tests.

### Tickets:
- #33262
