### PR TITLE
Avoid inserting Convert operations for irregular ov::Result case

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/compiler.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/compiler.cpp
@@ -29,6 +29,7 @@ void dump_partitioning(const ov::npuw::Ensemble& ens, const std::string& to) {
 
     pugi::xml_node node = doc.append_child("ensemble");
     node.append_attribute("gflops") = std::to_string(ens.gflops).data();
+    node.append_attribute("irregular_results") = std::to_string(ens.irregular_results).data();
 
     pugi::xml_node part = node.append_child("partitioning");
     pugi::xml_node rep;
@@ -83,6 +84,7 @@ void dump_partitioning(const ov::npuw::Ensemble& ens, const std::string& to) {
 
     doc.save_file(to.data());
 }
+
 }  // namespace detail
 
 // Interface to get online partitioning from the model
@@ -308,6 +310,7 @@ public:
 
         ov::npuw::Ensemble ens;
         ens.gflops = 1.;  // FIXME: calculate proper flops
+        ens.irregular_results = !m_snapshot->isRegularResultCase();
 
         auto graph = m_snapshot->getGraph();
         // Iterate in topological order

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
@@ -135,6 +135,10 @@ std::shared_ptr<ov::Node> Group::getInitialNode() const {
     return *(m_content.begin());
 }
 
+const std::unordered_set<std::shared_ptr<ov::Node>>& Group::getOutputs() const {
+    return m_output_layers;
+}
+
 void Group::addInput(const std::shared_ptr<ov::Node>& node) {
     m_input_layers.insert(node);
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.hpp
@@ -49,6 +49,7 @@ public:
     own::ade::NodeHandle getHandle() const;
     // Note: can only be used during initial group initialization
     std::shared_ptr<ov::Node> getInitialNode() const;
+    const std::unordered_set<std::shared_ptr<ov::Node>>& getOutputs() const;
     void addInput(const std::shared_ptr<ov::Node>& node);
     void addOutput(const std::shared_ptr<ov::Node>& node);
     void addContent(const std::shared_ptr<ov::Node>& node);

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.hpp
@@ -56,6 +56,9 @@ public:
 
     void stripTag(const std::string& tag);
 
+    // Passes to detect corner cases
+    bool isRegularResultCase() const;
+
     // Utility
     std::shared_ptr<own::ade::Graph> getGraph() const;
     const detail::OVPortsMap& getPortsMap() const;

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.cpp
@@ -182,7 +182,10 @@ ov::npuw::Ensemble load_groups(const std::shared_ptr<ov::Model>& model, const st
 
     LOG_INFO("Found " << repeated.size() << " different repeated block(s)");
 
-    return ov::npuw::Ensemble{get_float_attr(root, "gflops"), std::move(partitions), std::move(repeated)};
+    return ov::npuw::Ensemble{get_float_attr(root, "gflops"),
+                              get_bool_attr(root, "irregular_results", false),
+                              std::move(partitions),
+                              std::move(repeated)};
 }
 
 class Partitioner {
@@ -376,7 +379,7 @@ void Partitioner::identifySubgraphs() {
     LOG_INFO("Identifying subgraphs for model " << model->get_friendly_name() << "...");
     LOG_BLOCK();
 
-    const bool connect_in_f16 = cfg.get<::intel_npu::NPUW_F16IC>();
+    const bool connect_in_f16 = cfg.get<::intel_npu::NPUW_F16IC>() && !ens.irregular_results;
 
     using namespace ov::npuw;
     std::vector<ov::npuw::Group>& partitions = ens.groups;

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.hpp
@@ -158,6 +158,7 @@ struct RepeatedBlock {
 
 struct Ensemble {
     float gflops;
+    bool irregular_results;
     std::vector<Group> groups;
 
     // Just a map as I don't expect 100s of _different_

--- a/src/plugins/intel_npu/tests/unit/npuw/model_generator/model_generator.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/model_generator/model_generator.cpp
@@ -4,10 +4,9 @@
 
 #include "model_generator.hpp"
 
+#include "openvino/op/ops.hpp"
 #include "openvino/openvino.hpp"
 #include "openvino/opsets/opset11.hpp"
-#include "openvino/op/ops.hpp"
-
 
 std::shared_ptr<ov::Model> ModelGenerator::get_model_with_one_op() {
     auto param = std::make_shared<ov::opset11::Parameter>(ov::element::i64, ov::PartialShape{1, 3, 2, 2});
@@ -22,7 +21,8 @@ std::shared_ptr<ov::Model> ModelGenerator::get_model_with_one_op() {
 }
 
 std::shared_ptr<ov::Model> ModelGenerator::get_model_without_repeated_blocks() {
-    std::shared_ptr<ov::op::v0::Parameter> input = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1, 1, 40});
+    std::shared_ptr<ov::op::v0::Parameter> input =
+        std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1, 1, 40});
     m_nodes.push_back(input);
     set_name(input);
 
@@ -39,8 +39,19 @@ std::shared_ptr<ov::Model> ModelGenerator::get_model_without_repeated_blocks() {
 }
 
 std::shared_ptr<ov::Model> ModelGenerator::get_model_with_repeated_blocks(std::size_t repetitions) {
+    return get_model_with_repeated_blocks_and_results(repetitions, {});
+}
+
+std::shared_ptr<ov::Model> ModelGenerator::get_model_with_repeated_blocks() {
+    return get_model_with_repeated_blocks(10);
+}
+
+std::shared_ptr<ov::Model> ModelGenerator::get_model_with_repeated_blocks_and_results(
+    std::size_t repetitions,
+    const std::vector<std::size_t>& block_indices) {
     // Generate head
-    std::shared_ptr<ov::op::v0::Parameter> input = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1, 1, 40});
+    std::shared_ptr<ov::op::v0::Parameter> input =
+        std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1, 1, 40});
     m_nodes.push_back(input);
     set_name(input);
 
@@ -60,18 +71,20 @@ std::shared_ptr<ov::Model> ModelGenerator::get_model_with_repeated_blocks(std::s
 
     // Generate repeated blocks
     std::shared_ptr<ov::Node> output = get_block(head[6]);
-    std::vector<std::shared_ptr<ov::Node>> outputs;
-    outputs.push_back(output);
+    std::vector<std::shared_ptr<ov::Node>> block_outputs;
+    block_outputs.push_back(output);
 
     for (size_t i = 0; i < repetitions - 1; ++i) {
         output = get_block(output);
-        outputs.push_back(output);
+        block_outputs.push_back(output);
     }
 
     // Generate tail
     std::vector<std::shared_ptr<ov::Node>> tail(6, nullptr);
-    tail[0] = std::make_shared<ov::op::v0::Concat>(outputs, -1);
-    tail[1] = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int>{1, 40, int(repetitions)});
+    tail[0] = std::make_shared<ov::op::v0::Concat>(block_outputs, -1);
+    tail[1] = std::make_shared<ov::op::v0::Constant>(ov::element::i32,
+                                                     ov::Shape{3},
+                                                     std::vector<int>{1, 40, int(repetitions)});
     tail[2] = std::make_shared<ov::op::v1::Reshape>(tail[0], tail[1], false);
     tail[3] = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1, 1, 1});
     tail[4] = std::make_shared<ov::op::v1::Multiply>(tail[2], tail[3]);
@@ -82,19 +95,117 @@ std::shared_ptr<ov::Model> ModelGenerator::get_model_with_repeated_blocks(std::s
         set_name(t);
     }
 
+    // Create Results
+    ov::ResultVector results;
+
+    // Add Results for specified blocks
+    for (size_t idx : block_indices) {
+        if (idx < block_outputs.size()) {
+            auto result = std::make_shared<ov::op::v0::Result>(block_outputs[idx]);
+            m_nodes.push_back(result);
+            set_name(result);
+            results.push_back(result);
+        }
+    }
+
     // Create model
-    auto result = std::make_shared<ov::op::v0::Result>(tail[5]);
-    m_nodes.push_back(result);
-    set_name(result);
+    // Always add final tail Result
+    auto final_result = std::make_shared<ov::op::v0::Result>(tail[5]);
+    m_nodes.push_back(final_result);
+    set_name(final_result);
+    results.push_back(final_result);
 
     ov::ParameterVector params = {input};
-    ov::ResultVector results = {result};
 
     return std::make_shared<ov::Model>(results, params);
 }
 
-std::shared_ptr<ov::Model> ModelGenerator::get_model_with_repeated_blocks() {
-    return get_model_with_repeated_blocks(10);
+std::shared_ptr<ov::Model> ModelGenerator::get_model_with_multi_output_repeating_blocks(
+    std::size_t repetitions,
+    bool last_block_has_direct_result) {
+    if (repetitions == 0) {
+        repetitions = 1;  // keep the model non-empty
+    }
+
+    auto input = std::make_shared<ov::opset11::Parameter>(ov::element::f32, ov::Shape{1, 1, 8});
+    m_nodes.push_back(input);
+    set_name(input);
+
+    // Shared constants
+    auto add_const = ov::opset11::Constant::create(ov::element::f32, ov::Shape{1}, {1.f});
+    auto k_const = ov::opset11::Constant::create(ov::element::i64, ov::Shape{}, {8});
+    auto seed_indices = ov::opset11::Constant::create(ov::element::i32, ov::Shape{1, 1, 8}, {0, 1, 2, 3, 4, 5, 6, 7});
+    auto tail_scale = ov::opset11::Constant::create(ov::element::f32, ov::Shape{1}, {0.5f});
+    auto tail_bias = ov::opset11::Constant::create(ov::element::f32, ov::Shape{1}, {2.f});
+
+    for (const auto& c : {add_const, k_const, seed_indices, tail_scale, tail_bias}) {
+        m_nodes.push_back(c);
+        set_name(c);
+    }
+
+    ov::Output<ov::Node> current_values = input;
+    ov::Output<ov::Node> current_indices = seed_indices;
+
+    for (std::size_t i = 0; i < repetitions; ++i) {
+        // Build block body; TopK remains the final op of each block to expose multiple outputs
+        auto indices_as_float = std::make_shared<ov::opset11::Convert>(current_indices, ov::element::f32);
+        m_nodes.push_back(indices_as_float);
+        set_name(indices_as_float);
+
+        auto mixed = std::make_shared<ov::opset11::Add>(current_values, indices_as_float);
+        m_nodes.push_back(mixed);
+        set_name(mixed);
+
+        auto shifted = std::make_shared<ov::opset11::Add>(mixed, add_const);
+        m_nodes.push_back(shifted);
+        set_name(shifted);
+
+        auto topk = std::make_shared<ov::opset11::TopK>(shifted,
+                                                        k_const,
+                                                        -1,
+                                                        ov::op::TopKMode::MAX,
+                                                        ov::op::TopKSortType::SORT_VALUES,
+                                                        ov::element::i32);
+        m_nodes.push_back(topk);
+        set_name(topk);
+
+        current_values = topk->output(0);
+        current_indices = topk->output(1);
+    }
+
+    // Tail consumes the final block outputs
+    auto tail_indices_as_float = std::make_shared<ov::opset11::Convert>(current_indices, ov::element::f32);
+    m_nodes.push_back(tail_indices_as_float);
+    set_name(tail_indices_as_float);
+
+    auto tail_mixed = std::make_shared<ov::opset11::Add>(current_values, tail_indices_as_float);
+    m_nodes.push_back(tail_mixed);
+    set_name(tail_mixed);
+
+    auto tail_mul = std::make_shared<ov::opset11::Multiply>(tail_mixed, tail_scale);
+    m_nodes.push_back(tail_mul);
+    set_name(tail_mul);
+
+    auto tail_add = std::make_shared<ov::opset11::Add>(tail_mul, tail_bias);
+    m_nodes.push_back(tail_add);
+    set_name(tail_add);
+
+    ov::ResultVector results;
+    auto tail_result = std::make_shared<ov::opset11::Result>(tail_add);
+    m_nodes.push_back(tail_result);
+    set_name(tail_result);
+    results.push_back(tail_result);
+
+    if (last_block_has_direct_result) {
+        auto direct_result = std::make_shared<ov::opset11::Result>(current_values);
+        m_nodes.push_back(direct_result);
+        set_name(direct_result);
+        results.push_back(direct_result);
+    }
+
+    ov::ParameterVector params = {input};
+
+    return std::make_shared<ov::Model>(results, params);
 }
 
 std::shared_ptr<ov::Node> ModelGenerator::get_block(const std::shared_ptr<ov::Node>& input) {
@@ -149,17 +260,17 @@ std::shared_ptr<ov::Node> ModelGenerator::get_block(const std::shared_ptr<ov::No
     op[6] = std::make_shared<ov::op::v0::Floor>(op[5]);
     op[7] = std::make_shared<ov::op::v3::ScatterUpdate>(model_c[5], model_c[6], op[6], model_c[7]);
     op[8] = std::make_shared<ov::op::v1::StridedSlice>(op[2],
-                                                        model_c[8],
-                                                        op[7],
-                                                        model_c[9],
-                                                        std::vector<int64_t>{1, 1, 1, 1},
-                                                        std::vector<int64_t>{1, 1, 1, 1});
+                                                       model_c[8],
+                                                       op[7],
+                                                       model_c[9],
+                                                       std::vector<int64_t>{1, 1, 1, 1},
+                                                       std::vector<int64_t>{1, 1, 1, 1});
     op[9] = std::make_shared<ov::op::v1::StridedSlice>(op[2],
-                                                        op[7],
-                                                        model_c[10],
-                                                        model_c[11],
-                                                        std::vector<int64_t>{1, 1, 1, 1},
-                                                        std::vector<int64_t>{1, 1, 1, 1});
+                                                       op[7],
+                                                       model_c[10],
+                                                       model_c[11],
+                                                       std::vector<int64_t>{1, 1, 1, 1},
+                                                       std::vector<int64_t>{1, 1, 1, 1});
     op[10] = std::make_shared<ov::op::v1::Multiply>(op[9], convert[2]);
     op[11] = std::make_shared<ov::op::v0::Concat>(std::vector<std::shared_ptr<ov::Node>>{op[10], op[8]}, -1);
     op[12] = std::make_shared<ov::op::v1::Multiply>(model_c[13], op[11]);

--- a/src/plugins/intel_npu/tests/unit/npuw/model_generator/model_generator.hpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/model_generator/model_generator.hpp
@@ -15,6 +15,23 @@ public:
     std::shared_ptr<ov::Model> get_model_with_repeated_blocks(std::size_t repetitions);
     std::shared_ptr<ov::Model> get_model_with_repeated_blocks();
 
+    // Build model with repeating blocks and configurable ov::Result consumers:
+    //   - repetitions: number of repeating blocks
+    //   - block_indices: vector of block indices (0-based) that should have ov::Result consumers
+    //                empty vector means no additional Results, only the final tail Result
+    std::shared_ptr<ov::Model> get_model_with_repeated_blocks_and_results(
+        std::size_t repetitions,
+        const std::vector<std::size_t>& block_indices);
+
+    // Build model with repeating blocks where the final op in each block has multiple outputs (TopK values + indices).
+    //   - repetitions: number of repeating blocks
+    //   - last_block_has_direct_result:
+    //       Option1 (false): for all blocks, multi-output node feeds only the next block; last block feeds only the
+    //       tail Option2 (true): same as above, plus the last block also feeds a direct ov::Result from one of its
+    //       outputs
+    std::shared_ptr<ov::Model> get_model_with_multi_output_repeating_blocks(std::size_t repetitions,
+                                                                            bool last_block_has_direct_result);
+
 private:
     std::shared_ptr<ov::Node> get_block(const std::shared_ptr<ov::Node>& input);
     void set_name(const std::shared_ptr<ov::Node>& node);

--- a/src/plugins/intel_npu/tests/unit/npuw/online_partitioning.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/online_partitioning.cpp
@@ -8,13 +8,24 @@
 
 #include "intel_npu/config/config.hpp"
 #include "intel_npu/config/npuw.hpp"
+#include "model_generator/model_generator.hpp"
 #include "openvino/op/ops.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/openvino.hpp"
 #include "partitioning/online/compiler.hpp"
 #include "partitioning/online/group.hpp"
 #include "partitioning/online/snapshot.hpp"
-#include "model_generator/model_generator.hpp"
+
+namespace {
+
+::intel_npu::Config createConfigWithKeepBlockSize(std::size_t size) {
+    auto opt_desc = std::make_shared<::intel_npu::OptionsDesc>();
+    auto cfg = ::intel_npu::Config(opt_desc);
+    ::intel_npu::registerNPUWOptions(*opt_desc);
+    std::map<std::string, std::string> cfg_map = {{"NPUW_ONLINE_KEEP_BLOCK_SIZE", std::to_string(size)}};
+    cfg.update(cfg_map);
+    return cfg;
+}
 
 bool isEqualEns(ov::npuw::Ensemble& ens1, ov::npuw::Ensemble& ens2);
 bool isEqualEns(ov::npuw::Ensemble& ens1, ov::npuw::Ensemble& ens2) {
@@ -89,16 +100,15 @@ bool isEqualEns(ov::npuw::Ensemble& ens1, ov::npuw::Ensemble& ens2) {
     return true;
 }
 
+class IsRegularResultCaseParametrized : public ::testing::TestWithParam<std::tuple<std::vector<std::size_t>, bool>> {};
+
+};  // namespace
+
 TEST(OnlinePartitioningTest, Partitioning_IsTheSame_SmallModel) {
     ModelGenerator mg;
     auto model = mg.get_model_without_repeated_blocks();
 
-    auto opt_desc = std::make_shared<::intel_npu::OptionsDesc>();
-    auto cfg = ::intel_npu::Config(opt_desc);
-    ::intel_npu::registerNPUWOptions(*opt_desc);
-    std::map<std::string, std::string> cfg_map = {{"NPUW_ONLINE_KEEP_BLOCK_SIZE", "9"}};
-    cfg.update(cfg_map);
-
+    auto cfg = createConfigWithKeepBlockSize(9);
     auto ens = ov::npuw::online::buildPartitioning(model, cfg);
 
     for (size_t i = 0; i < 100; ++i) {
@@ -111,12 +121,7 @@ TEST(OnlinePartitioningTest, Partitioning_IsTheSame_RepeatedModel) {
     ModelGenerator mg;
     auto model = mg.get_model_with_repeated_blocks();
 
-    auto opt_desc = std::make_shared<::intel_npu::OptionsDesc>();
-    auto cfg = ::intel_npu::Config(opt_desc);
-    ::intel_npu::registerNPUWOptions(*opt_desc);
-    std::map<std::string, std::string> cfg_map = {{"NPUW_ONLINE_KEEP_BLOCK_SIZE", "9"}};
-    cfg.update(cfg_map);
-
+    auto cfg = createConfigWithKeepBlockSize(9);
     auto ens = ov::npuw::online::buildPartitioning(model, cfg);
 
     for (size_t i = 0; i < 100; ++i) {
@@ -527,7 +532,8 @@ TEST(OnlinePartitioningTest, Partitioning_Compiler_Compute_RepeatedModel) {
 }
 
 TEST(OnlinePartitioningTest, Partitioning_Avoids_Pipeline_None) {
-    std::shared_ptr<ov::op::v0::Parameter> input = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
+    std::shared_ptr<ov::op::v0::Parameter> input =
+        std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
     input->set_friendly_name("input");
 
     auto n1 = std::make_shared<ov::op::v1::Add>(input, input);
@@ -563,3 +569,58 @@ TEST(OnlinePartitioningTest, Partitioning_Avoids_Pipeline_None) {
 
     EXPECT_EQ(ens.groups.size(), 3);
 }
+
+TEST(OnlinePartitioningTest, IsRegularResultCaseMultipleOutputs) {
+    ModelGenerator mg;
+    std::vector<std::pair<std::shared_ptr<ov::Model>, bool>> model_expected = {
+        {mg.get_model_with_multi_output_repeating_blocks(10, /*irregular_results=*/true), /*irregular_results=*/true},
+        {mg.get_model_with_multi_output_repeating_blocks(10, /*irregular_results=*/false),
+         /*irregular_results=*/false}};
+
+    for (auto [model, expected_result] : model_expected) {
+        auto cfg = createConfigWithKeepBlockSize(3);
+        auto ens = ov::npuw::online::buildPartitioning(model, cfg);
+
+        EXPECT_EQ(ens.irregular_results, expected_result);
+    }
+}
+
+TEST(OnlinePartitioningTest, IsRegularResultCaseWhenNoRB) {
+    bool expected_result = false;
+
+    ModelGenerator mg;
+    std::vector<std::shared_ptr<ov::Model>> models = {mg.get_model_with_one_op(),
+                                                      mg.get_model_without_repeated_blocks()};
+
+    for (auto model : models) {
+        auto cfg = createConfigWithKeepBlockSize(9);
+        auto ens = ov::npuw::online::buildPartitioning(model, cfg);
+
+        EXPECT_EQ(ens.irregular_results, expected_result);
+    }
+}
+
+TEST_P(IsRegularResultCaseParametrized, CheckForDifferentResultConfigs) {
+    auto [block_indices, expected_result] = GetParam();
+
+    ModelGenerator mg;
+    auto model = mg.get_model_with_repeated_blocks_and_results(10, block_indices);
+
+    auto cfg = createConfigWithKeepBlockSize(9);
+    auto ens = ov::npuw::online::buildPartitioning(model, cfg);
+
+    EXPECT_EQ(ens.irregular_results, expected_result);
+}
+
+INSTANTIATE_TEST_SUITE_P(OnlinePartitioningTest,
+                         IsRegularResultCaseParametrized,
+                         ::testing::Values(
+                             // All blocks have an ov::Result consumer
+                             std::make_tuple(std::vector<std::size_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+                                             /*irregular_results=*/false),
+                             // Some blocks have an ov::Result consumer
+                             std::make_tuple(std::vector<std::size_t>{2, 5, 8}, /*irregular_results=*/true),
+                             // Only last block has an additional ov::Result consumer
+                             std::make_tuple(std::vector<std::size_t>{9}, /*irregular_results=*/true),
+                             // No blocks have additional ov::Result consumers
+                             std::make_tuple(std::vector<std::size_t>{}, /*irregular_results=*/false)));


### PR DESCRIPTION
### Details:

Essentially the partitioning ignores `::intel_npu::NPUW_F16IC` option for the irregular `ov::Result`  consumer.

### Tickets:
 - E-193955
