### PR TITLE
[NPUW]Fixed SDPA decomposition with sink input.

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model_utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model_utils.cpp
@@ -509,7 +509,25 @@ bool ov::npuw::util::has_input(const std::shared_ptr<ov::Model>& model, const st
 
 bool ov::npuw::util::optimize_value_tensors(std::shared_ptr<ov::Model> model, bool isPrefill) {
     ov::pass::GraphRewrite rewr;
-    rewr.add_matcher<ov::pass::ScaledDotProductAttentionDecomposition>();
+
+    // Check if any SDPA has sink input
+    bool has_sdpa_with_sink = false;
+    for (const auto& op : model->get_ops()) {
+        if (auto sdpa = ov::as_type_ptr<ov::op::v13::ScaledDotProductAttention>(op)) {
+            if (sdpa->get_input_size() == 6) {
+                has_sdpa_with_sink = true;
+                break;
+            }
+        }
+    }
+
+    if (has_sdpa_with_sink) {
+        // TODO:  evaluate performance by older npu-drivers
+        rewr.add_matcher<ov::pass::ScaledDotProductAttentionDecomposition>();
+    } else {
+        rewr.add_matcher<ScaledDotProductAttentionDecomposition>(isPrefill);
+    }
+
     TransposeValueTensors::Context ctx;
     rewr.add_matcher<TransposeValueTensors_llama2>(std::ref(ctx));
     rewr.add_matcher<TransposeValueTensors_llama3>(std::ref(ctx));


### PR DESCRIPTION
### Details:
Solved GPT-OSS-20B accuracy issue on NPU.
SDPA decomposition pass in NPUW ignored sink_input.
Decompose SDPA with OV pass when SDPA has sink_input.

### Tickets:
 - *[EISW-197693](https://jira.devtools.intel.com/browse/EISW-197693)*
