### PR TITLE
[GPU] add dynamic_quantize info to dump graph.

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/utils.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/utils.hpp
@@ -236,6 +236,19 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec) {
     return os;
 }
 
+// vector type static casting function
+template <typename To, typename From, typename Alloc = std::allocator<From>,
+          typename = std::enable_if_t<std::is_convertible<From, To>::value>>
+inline std::vector<To> convert_vector(const std::vector<From, Alloc>& v) {
+    std::vector<To> out;
+    out.reserve(v.size());
+    std::transform(v.begin(), v.end(), std::back_inserter(out),
+                [](From x){ return static_cast<To>(x); });
+
+    return out;
+}
+
+
 // The following code is derived from Boost C++ library
 // Copyright 2005-2014 Daniel James.
 // Distributed under the Boost Software License, Version 1.0. (See http://www.boost.org/LICENSE_1_0.txt)

--- a/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
@@ -219,12 +219,7 @@ void dump_graph_init(std::ofstream& graph,
         std::ostringstream oss;
         if (ptr->is_type<dynamic_quantize>()) {
             auto dyn_quan = ptr->as<dynamic_quantize>().get_primitive();
-            oss << "\n" << "group_sizes: ";
-            for (size_t i = 0; i < dyn_quan->attrs.group_sizes.size(); ++i) {
-                oss << dyn_quan->attrs.group_sizes[i];
-                if (i != dyn_quan->attrs.group_sizes.size() - 1)
-                    oss << ", ";
-            }
+            oss << "\n" << "group_sizes: " << ov::util::join(cldnn::convert_vector<int64_t>(dyn_quan->attrs.group_sizes));
             if (dyn_quan->attrs.precomputed_reduction) {
                 oss << "\n" << "precomputed_reduction_dt: " << dyn_quan->attrs.precomputed_reduction_dt;
             }

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -426,13 +426,7 @@ std::shared_ptr<ov::Model> Graph::get_runtime_model(std::vector<cldnn::primitive
         if (prim_info.type_id == "dynamic_quantize") {
             auto& node = get_network()->get_primitive(prim_info.original_id)->get_node();
             auto dyn_quan = node.as<cldnn::dynamic_quantize>().get_primitive();
-            std::ostringstream oss;
-            for (size_t i = 0; i < dyn_quan->attrs.group_sizes.size(); ++i) {
-                oss << dyn_quan->attrs.group_sizes[i];
-                if (i != dyn_quan->attrs.group_sizes.size() - 1)
-                    oss << ", ";
-            }
-            info["group_sizes"] = oss.str();
+            info["group_sizes"] = ov::util::join(cldnn::convert_vector<int64_t>(dyn_quan->attrs.group_sizes));
             if (dyn_quan->attrs.precomputed_reduction) {
                 info["precomputed_reduction_dt"] = dyn_quan->attrs.precomputed_reduction_dt.c_type_string();
             }


### PR DESCRIPTION
* dump graph (.xml): add info as attrs(key, value).
```
		<layer id="68" name="DynamicQuantize_79313" type="DynamicQuantize">
			<data execOrder="560" execTimeMcs="not_executed" group_sizes="1, 1, 18446744073709551615" originalLayersNames="DynamicQuantize_79313" outputLayouts="bfyx" outputPrecisions="i8" primitiveType="undef" runtimePrecision="f16" />
			<input>
				<port id="0" precision="FP16">
					<dim>-1</dim>
					<dim>1</dim>
					<dim>3584</dim>
				</port>
			</input>
```

* dump graph (.graph)
<img width="727" height="153" alt="image" src="https://github.com/user-attachments/assets/2b6b2ef7-0042-4a13-a7e1-01914ed4cff3" />


### Tickets:
 - 176342
