### PR TITLE
[GHA] More general restart pattern for 443 GitHub connection issues

### DIFF
--- a/.github/scripts/workflow_rerun/errors_to_look_for.json
+++ b/.github/scripts/workflow_rerun/errors_to_look_for.json
@@ -112,7 +112,7 @@
         "ticket": 159547
     },
     {
-        "error_text": "Failed to connect to github.com port 443: Connection refused",
+        "error_text": "Failed to connect to github.com port 443",
         "ticket": 156593
     },
     {


### PR DESCRIPTION
To also cover cases like "Failed to connect to github.com port 443 after 10 ms: Couldn't connect to server"