### PR TITLE
CPU: fallback to FP32 when FP16 Softmax is unsupported

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -102,7 +102,7 @@ void SoftMax::getSupportedDescriptors() {
 
     ov::element::Type precision = getOriginalInputPrecisionAtPort(0);
     bool tryFP16 = (precision == ov::element::f16);
-    
+
     if (none_of(precision, ov::element::f32, ov::element::bf16, ov::element::f16)) {
         precision = ov::element::f32;
     }
@@ -131,8 +131,7 @@ void SoftMax::getSupportedDescriptors() {
         auto fallbackType = DnnlExtensionUtils::ElementTypeToDataType(ov::element::f32);
 
         if (inShape.getRank() == 3) {
-            auto in_candidate =
-                std::make_shared<DnnlBlockedMemoryDesc>(inShape, fallbackType, memory::format_tag::abc);
+            auto in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inShape, fallbackType, memory::format_tag::abc);
             createDescriptor({in_candidate}, {});
         }
 

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -101,6 +101,8 @@ void SoftMax::getSupportedDescriptors() {
     }
 
     ov::element::Type precision = getOriginalInputPrecisionAtPort(0);
+    bool tryFP16 = (precision == ov::element::f16);
+    
     if (none_of(precision, ov::element::f32, ov::element::bf16, ov::element::f16)) {
         precision = ov::element::f32;
     }
@@ -123,6 +125,26 @@ void SoftMax::getSupportedDescriptors() {
         }
 
         createDescriptor({in_candidate}, {});
+    }
+
+    if (descs.empty() && tryFP16) {
+        auto fallbackType = DnnlExtensionUtils::ElementTypeToDataType(ov::element::f32);
+
+        if (inShape.getRank() == 3) {
+            auto in_candidate =
+                std::make_shared<DnnlBlockedMemoryDesc>(inShape, fallbackType, memory::format_tag::abc);
+            createDescriptor({in_candidate}, {});
+        }
+
+        for (auto format : getAvailableFormatsForDims(inShape)) {
+            auto in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inShape, fallbackType, format);
+
+            if (in_candidate->blocksExtended()) {
+                continue;
+            }
+
+            createDescriptor({in_candidate}, {});
+        }
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -136,13 +136,10 @@ void SoftMax::getSupportedDescriptors() {
         }
 
         for (auto format : getAvailableFormatsForDims(inShape)) {
-            auto in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inShape, fallbackType, format);
-
-            if (in_candidate->blocksExtended()) {
-                continue;
+            VecMemoryDescs inputDescs{std::make_shared<DnnlBlockedMemoryDesc>(inShape, fallbackType, format)};
+            if (!inputDescs.back()->blocksExtended()) {
+                createDescriptor(inputDescs, {});
             }
-
-            createDescriptor({in_candidate}, {});
         }
     }
 }

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/softmax.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/softmax.cpp
@@ -1,8 +1,9 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
 #include "custom/single_layer_tests/classes/softmax.hpp"
+
 #include "utils/cpu_test_utils.hpp"
 
 using namespace CPUTestUtils;
@@ -146,6 +147,23 @@ INSTANTIATE_TEST_SUITE_P(smoke_SoftMax_Unsupported_CPU,
                          SoftMaxLayerCPUTest,
                          UnsupportedParams,
                          SoftMaxLayerCPUTest::getTestCaseName);
+
+const std::vector<SoftMaxConfig> configsFP16{
+    // Static shapes — various ranks to cover FP16 fallback branches
+    {ov::test::InputShape{ov::PartialShape{10, 10}, {ov::Shape{10, 10}}}, 1},
+    {ov::test::InputShape{ov::PartialShape{5, 5, 5}, {ov::Shape{5, 5, 5}}}, 2},
+    {ov::test::InputShape{ov::PartialShape{5, 5, 5, 5}, {ov::Shape{5, 5, 5, 5}}}, 3},
+    // Shape from bug report #33381
+    {ov::test::InputShape{ov::PartialShape{7, 22, 1, 1, 63}, {ov::Shape{7, 22, 1, 1, 63}}}, 4},
+};
+
+const auto FP16Params = testing::Combine(testing::Values(ElementType::f16),
+                                         testing::ValuesIn(configsFP16),
+                                         testing::Values(ov::test::utils::DEVICE_CPU),
+                                         testing::Values(CPUSpecificParams{{}, {}, {}, CPUTestsBase::any_type}),
+                                         testing::Values(CPUTestUtils::empty_plugin_config));
+
+INSTANTIATE_TEST_SUITE_P(smoke_SoftMax_FP16_CPU, SoftMaxLayerCPUTest, FP16Params, SoftMaxLayerCPUTest::getTestCaseName);
 }  // namespace SoftMax
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
FP16 Softmax on CPU may fail with "Supported primitive descriptors list is empty" when Softmax is a model output.
This change retries descriptor creation using FP32 when FP16 is requested but unsupported by oneDNN.

Tested locally with a minimal FP16 ONNX Softmax model on CPU.

### Tickets:
 - #33381
