### PR TITLE
[GPU] Fix build_failure of cm_sdpa_common

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cm/include/cm_sdpa_common.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/include/cm_sdpa_common.hpp
@@ -681,6 +681,7 @@ void sdpa_kernel(
                 Transpose2DMatrix(QmatI32, rQ[num_full_blocks].format<uint, REG_K/2, q_step>());
                 rQ[num_full_blocks].format<half>() = cm_mul<half>(rQ[num_full_blocks].format<half>(), (half)scale_factor);
             }
+        }
     }
 
     constexpr int num_P_tiles = REG_N / REG_M;


### PR DESCRIPTION
### Details:
 - *Fix the following build failure on DG2ADL machine*
```shell
 `[ RUN      ] smoke_vlsdpa_gpu_test/vlsdpa_gpu_test.basic_caching/vlsdpa_gpu_test_72_2_(0.16.32)
unknown file: error: C++ exception with description "Program build failed(0_part_0):
C:\Users\paul\AppData\Local\Temp\tmp_cm_to_spv-db68c4\src.cm(834,2): error: function definition is not allowed here
){
 ^
C:\Users\paul\AppData\Local\Temp\tmp_cm_to_spv-db68c4\src.cm(958,1): error: expected '}'
^
C:\Users\paul\AppData\Local\Temp\tmp_cm_to_spv-db68c4\src.cm(12,22): note: to match this '{'
namespace KERNEL_NAME{
....
2 errors generated.

" thrown in the test body.
``` 


### Tickets:
 - *CVS-178472*
