### PR TITLE
Only allow open source contributors to `.take` good first issues

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -86,6 +86,10 @@ jobs:
               const user = context.payload.comment.user.login;
 
               if (comment === ".take") {
+                if (!issue.labels?.some(l => l.name.toLowerCase() === LABEL)) {
+                  console.log(`Issue #${issue.number} - not a good first issue, ignoring .take command`);
+                  return;
+                }
                 await github.rest.issues.addAssignees({
                   owner: context.repo.owner,
                   repo: context.repo.repo,


### PR DESCRIPTION
### Details:
 - There have been multiple instances where open source contributors would pick up non-good-first-issues and work on them, causing confusion
 - This change limits the `.take` functionality to work only on issues with `good first issue` labels
 - Tested in https://github.com/p-wysocki/openvino/issues/90

### Tickets:
 - N/A, topic comes from an email thread
