### PR TITLE
CPU->CPU copy removed during load weights for DGPU

### DIFF
--- a/src/core/dev_api/openvino/runtime/shared_buffer.hpp
+++ b/src/core/dev_api/openvino/runtime/shared_buffer.hpp
@@ -36,11 +36,23 @@ public:
     explicit SharedStreamBuffer(const void* data, size_t size)
         : SharedStreamBuffer(reinterpret_cast<const char*>(data), size) {}
 
+    std::streamsize sget_data_ptr(const void** ppData, std::streamsize count) {
+        return xsget_data_ptr(ppData, count);
+    }
+
 protected:
     // override std::streambuf methods
     std::streamsize xsgetn(char* s, std::streamsize count) override {
         auto real_count = std::min<std::streamsize>(m_size - m_offset, count);
         std::memcpy(s, m_data + m_offset, real_count);
+        m_offset += real_count;
+        return real_count;
+    }
+
+    // gets a ptr to the weights in mem (shared buffer) and forwards the buffer offset by count
+    virtual std::streamsize xsget_data_ptr(const void** ppData, std::streamsize count) {
+        auto real_count = std::min<std::streamsize>(m_size - m_offset, count);
+        *ppData = m_data + m_offset;
         m_offset += real_count;
         return real_count;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
@@ -11,6 +11,7 @@
 #include "buffer.hpp"
 #include "helpers.hpp"
 #include "bind.hpp"
+#include "openvino/runtime/shared_buffer.hpp"
 
 namespace cldnn {
 struct memory;
@@ -53,6 +54,15 @@ public:
         auto const read_size = _stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
         OPENVINO_ASSERT(read_size == size,
             "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
+    }
+
+    /*@brief Gets a ptr to the primitive weights in mem
+    * @param ppData Ptr containing a ptr to weights in mem
+    * @param size Primitive size
+    */
+    virtual void get_data_ptr(const void** ppData, std::streamsize size) {
+        const auto read_size = (dynamic_cast<ov::SharedStreamBuffer*>(_stream.rdbuf()))->sget_data_ptr(ppData, size);
+        OPENVINO_ASSERT(read_size == size, "[GPU] Failed to get " + std::to_string(size) + " bytes from stream! Got " + std::to_string(read_size));
     }
 
     void setKernelImplParams(void* impl_params) { _impl_params = impl_params; }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -422,49 +422,12 @@ struct data : public primitive_base<data> {
             if (is_alloc_host_accessible(_allocation_type)) {
                 ib >> make_data(mem->buffer_ptr(), data_size);
             } else {
-                const size_t DATA_BLOCK_SIZE = 2 * 1024 * 1024;
                 auto& strm = ib.get_engine().get_service_stream();
-                if (data_size < DATA_BLOCK_SIZE || output_layout.format.is_image_2d()) {
-                    std::vector<uint8_t> _buf(data_size);
-                    ib >> make_data(_buf.data(), data_size);
-                    mem->copy_from(strm, _buf.data());
-                } else {
-                    std::vector<uint8_t> _buf1(DATA_BLOCK_SIZE);
-                    std::vector<uint8_t> _buf2(DATA_BLOCK_SIZE);
-                    bool buf_flag = true;
-                    event::ptr ev1, ev2;
-                    ev1 = ev2 = nullptr;
-                    size_t dst_offset = 0;
-                    while (dst_offset < data_size) {
-                        const bool is_blocking = false;
-                        const size_t src_offset = 0;
-                        size_t copy_size =
-                            (data_size > (dst_offset + DATA_BLOCK_SIZE)) ? DATA_BLOCK_SIZE : (data_size - dst_offset);
-                        if (buf_flag) {
-                            ib >> make_data(_buf1.data(), copy_size);
-                            if (ev2 != nullptr) {
-                                ev2->wait();
-                                ev2 = nullptr;
-                            }
-                            ev1 = mem->copy_from(strm, _buf1.data(), src_offset, dst_offset, copy_size, is_blocking);
-                        } else {
-                            ib >> make_data(_buf2.data(), copy_size);
-                            if (ev1 != nullptr) {
-                                ev1->wait();
-                                ev1 = nullptr;
-                            }
-                            ev2 = mem->copy_from(strm, _buf2.data(), src_offset, dst_offset, copy_size, is_blocking);
-                        }
-                        dst_offset += DATA_BLOCK_SIZE;
-                        buf_flag = !buf_flag;
-                    }
-                    if (ev2 != nullptr) {
-                        ev2->wait();
-                    }
-                    if (ev1 != nullptr) {
-                        ev1->wait();
-                    }
-                }
+                const void* pWeight;
+
+                // Returns a ptr to the prim weights in mem
+                ib.get_data_ptr(&pWeight, data_size);
+                mem->copy_from(strm, pWeight);
             }
         }
     }


### PR DESCRIPTION
This optimization is targeted for DGPU only. Removing the CPU->CPU copy prior to CPU->GPU copy improves load_weights() time by ~30% across various models. That improves onnxruntime session creation time by 3-5%.
Details can be found here: https://jira.devtools.intel.com/projects/AGIJ/issues/AGIJ-27
