### PR TITLE
[TEST] Model cache validation was added to layer tests

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -695,3 +695,34 @@ const std::vector<std::regex>& disabled_test_patterns() {
 
     return patterns;
 }
+
+bool is_model_cache_enabled() {
+    return true;
+}
+
+std::vector<std::string> model_cache_disabled_test_patterns() {
+    std::vector<std::string> res_vector{
+        R"(.*CustomOp.*)",
+        R"(.*SequenceCPUTest.*)",
+        R"(.*ConvertFqRnnToQuantizedRnn.*)",
+        R"(.*IntertactionCPUTest.*)",
+        R"(.*MoESubgraphTest.*)",
+        R"(.*MoECompressedWeightsSubgraphTest.*)",
+        R"(.*RecurrentCellTransformation.*)",
+        R"(.*MemoryLayerTest.*)",
+        R"(.*RoPETestGPTOSS.*)",
+        R"(.*SimpleIfTest.*)",
+        R"(.*SimpleIf2OutTest.*)",
+        R"(.*SimpleIfNotConstConditionTest.*)",
+        R"(.*SimpleIfNotConstConditionUnusedOutputPortsTest.*)",
+        R"(.*AdaPoolLayerCPUTest.*)",
+        R"(.*ConvertCPULayerTest.*)",
+        R"(.*ConcatLayerCPUTest.*)",
+        R"(.*GroupDeconvolutionLayerCPUTest.*)",
+        R"(.*NmsLayerCPUTest.*)",
+        R"(.*OneHotLayerCPUTest.*)",
+        R"(.*TensorIteratorTest.*)",
+    };
+
+    return res_vector;
+}

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -255,3 +255,11 @@ const std::vector<std::regex>& disabled_test_patterns() {
     const static std::vector<std::regex> patterns = get_patterns();
     return patterns;
 }
+
+bool is_model_cache_enabled() {
+    return false;
+}
+
+std::vector<std::string> model_cache_disabled_test_patterns() {
+    return std::vector<std::string>{};
+}

--- a/src/plugins/template/tests/functional/skip_tests_config.cpp
+++ b/src/plugins/template/tests/functional/skip_tests_config.cpp
@@ -125,3 +125,11 @@ const std::vector<std::regex>& disabled_test_patterns() {
 
     return patterns;
 }
+
+bool is_model_cache_enabled() {
+    return false;
+}
+
+std::vector<std::string> model_cache_disabled_test_patterns() {
+    return std::vector<std::string>{};
+}

--- a/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_subgraph.hpp
@@ -42,6 +42,7 @@ protected:
     virtual void configure_model();
     virtual void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes);
     virtual void init_thresholds();
+    virtual void models_cache();
 
     void compare_models_param_res(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::Model>& f_ref);
     void compare_nodes(const std::shared_ptr<ov::Node>& node1, const std::shared_ptr<ov::Node>& node2, std::ostream& err_log);
@@ -50,12 +51,7 @@ protected:
     void init_input_shapes(const std::vector<InputShape>& shapes);
     void set_callback_exception(std::function<void(const std::exception& exp)> callback) { callback_exception = callback; }
 
-    void TearDown() override {
-        if (this->HasFailure() && !is_reported) {
-            summary.setDeviceName(targetDevice);
-            summary.updateOPsStats(function, ov::test::utils::PassRate::Statuses::FAILED, rel_influence_coef);
-        }
-    }
+    void TearDown() override;
 
     std::shared_ptr<ov::Core> core = ov::test::utils::PluginCache::get().core();
     std::string targetDevice;
@@ -87,7 +83,9 @@ protected:
     ov::test::utils::OpSummary& summary = ov::test::utils::OpSummary::getInstance();
     bool is_report_stages = false;
     bool is_reported = false;
+    bool m_check_models_caching = true;
     double rel_influence_coef = 1.f;
+    ov::TensorVector m_expected_outputs;  // Stores reference outputs for reusing.
 
     virtual std::vector<ov::Tensor> calculate_refs();
     virtual std::vector<ov::Tensor> get_plugin_outputs();

--- a/src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp
@@ -34,8 +34,7 @@
 
 #include "shared_test_classes/base/utils/ranges.hpp"
 
-namespace ov {
-namespace test {
+namespace ov::test {
 
 std::ostream& operator <<(std::ostream& os, const InputShape& inputShape) {
     auto shape_str = ov::test::utils::vec2str(inputShape.second);
@@ -57,6 +56,8 @@ void SubgraphBaseTest::run() {
     if (isCurrentTestDisabled)
         GTEST_SKIP() << "Disabled test due to configuration" << std::endl;
 
+    m_check_models_caching = !utils::current_test_model_cache_is_disabled();
+
     // in case of crash jump will be made and work will be continued
     auto crashHandler = std::unique_ptr<ov::test::utils::CrashHandler>(new ov::test::utils::CrashHandler());
 
@@ -77,6 +78,9 @@ void SubgraphBaseTest::run() {
             for (const auto& targetStaticShapeVec : targetStaticShapes) {
                 generate_inputs(targetStaticShapeVec);
                 validate();
+                if (m_check_models_caching) {
+                    models_cache();
+                }
             }
             status = ov::test::utils::PassRate::Statuses::PASSED;
         } catch (const std::exception& ex) {
@@ -433,14 +437,14 @@ std::vector<ov::Tensor> SubgraphBaseTest::calculate_refs() {
         inputs_ref[param] = inputs.at(matched_parameters[param]);
     }
 
-    auto outputs = ov::test::utils::infer_on_template(functionRefs, inputs_ref);
+    m_expected_outputs = ov::test::utils::infer_on_template(functionRefs, inputs_ref);
 
     if (is_report_stages) {
         auto end_time = std::chrono::system_clock::now();
         std::chrono::duration<double> duration = end_time - start_time;
         std::cout << "[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is finished successfully. Duration is " << duration.count() << "s" << std::endl;
     }
-    return outputs;
+    return m_expected_outputs;
 }
 
 std::vector<ov::Tensor> SubgraphBaseTest::get_plugin_outputs() {
@@ -641,5 +645,91 @@ void SubgraphBaseTest::compare_models_param_res(const std::shared_ptr<ov::Model>
     }
 }
 
-}  // namespace test
-}  // namespace ov
+void SubgraphBaseTest::models_cache() {
+    const std::string gen_ir_name = ov::test::utils::generateTestFilePrefix();
+
+    const std::string xml_path   = gen_ir_name + ".xml";
+    const std::string bin_path   = gen_ir_name + ".bin";
+    const std::string cache_path = gen_ir_name + ".blob";
+    const std::string cache_dir  = gen_ir_name + "_cache_dir";
+    // Save IR to disk
+    ov::pass::Serialize(xml_path, bin_path).run_on_model(function);
+
+    auto config = configuration;
+    config.insert(ov::cache_dir(cache_dir));
+    // Load, compile and create cache of the model.
+    auto compiled_model = core->compile_model(xml_path, targetDevice, config);
+
+    auto get_cache_path = [](const std::string& cache_dir) {
+        auto blobs = ov::test::utils::listFilesWithExt(cache_dir, "blob");
+        EXPECT_EQ(blobs.size(), 1);
+        return blobs[0];
+    };
+    auto get_modification_time = [](const std::string& path) {
+        struct stat result;
+        if (stat(path.c_str(), &result) == 0) {
+            return result.st_mtime;
+        }
+        return static_cast<time_t>(0);
+    };
+
+    const auto first_mod_time = get_modification_time(get_cache_path(cache_dir));
+    ASSERT_NE(first_mod_time, static_cast<time_t>(0));
+
+    auto compile_and_execute = [&]() {
+        // Load compiled model from cache.
+        auto imported_model = core->compile_model(xml_path, targetDevice, config);
+
+        const auto second_mod_time = get_modification_time(get_cache_path(cache_dir));
+        // There is some issue if a new cache is created during the second run.
+        ASSERT_EQ(first_mod_time, second_mod_time);
+
+        auto cache_infer_request = imported_model.create_infer_request();
+        for (const auto& input : inputs) {
+            cache_infer_request.set_tensor(input.first, input.second);
+        }
+
+        cache_infer_request.infer();
+
+        std::vector<ov::Tensor> cache_outputs{};
+        for (const auto& output : function->outputs()) {
+            cache_outputs.push_back(cache_infer_request.get_tensor(output));
+        }
+        compare(m_expected_outputs, cache_outputs);
+    };
+
+    try {  // compile_model API
+        compile_and_execute();
+    } catch (const std::exception& ex) {
+        GTEST_FATAL_FAILURE_((std::string("[ MODEL_CACHE ] Compile model API: ") + ex.what()).data());
+    } catch (...) {
+        GTEST_FATAL_FAILURE_("[ MODEL_CACHE ] compile model API: unknown exception.");
+    }
+
+    try {  // Weightless cache
+        config.insert(ov::enable_weightless(true));
+        compile_and_execute();
+    } catch (const std::exception& ex) {
+        GTEST_FATAL_FAILURE_((std::string("[ MODEL_CACHE ] Weightless cache: ") + ex.what()).data());
+    } catch (...) {
+        GTEST_FATAL_FAILURE_("[ MODEL_CACHE ] Weightless cache: unknown exception.");
+    }
+
+    // Cleanup files
+    std::remove(xml_path.c_str());
+    std::remove(bin_path.c_str());
+    std::remove(cache_path.c_str());
+
+    ov::test::utils::removeFilesWithExt(cache_dir, "blob");
+    ov::test::utils::removeFilesWithExt(cache_dir, "cl_cache");
+    ov::test::utils::removeDir(cache_dir);
+}
+
+void SubgraphBaseTest::TearDown() {
+    if (this->HasFailure() && !is_reported) {
+        summary.setDeviceName(targetDevice);
+        summary.updateOPsStats(function, ov::test::utils::PassRate::Statuses::FAILED, rel_influence_coef);
+    }
+}
+
+}  // namespace ov::test

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/tests/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/tests/skip_tests_config.cpp
@@ -8,3 +8,11 @@ const std::vector<std::regex>& disabled_test_patterns() {
     const static std::vector<std::regex> patterns{};
     return patterns;
 }
+
+bool is_model_cache_enabled() {
+    return false;
+}
+
+std::vector<std::string> model_cache_disabled_test_patterns() {
+    return std::vector<std::string>{};
+}

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/skip_tests_config.cpp
@@ -35,3 +35,11 @@ const std::vector<std::regex>& disabled_test_patterns() {
 
     return patterns;
 }
+
+bool is_model_cache_enabled() {
+    return false;
+}
+
+std::vector<std::string> model_cache_disabled_test_patterns() {
+    return std::vector<std::string>{};
+}

--- a/src/tests/test_utils/common_test_utils/tests/skip_tests_config.cpp
+++ b/src/tests/test_utils/common_test_utils/tests/skip_tests_config.cpp
@@ -11,3 +11,11 @@ const std::vector<std::regex>& disabled_test_patterns() {
     const static std::vector<std::regex> patterns{};
     return patterns;
 }
+
+bool is_model_cache_enabled() {
+    return false;
+}
+
+std::vector<std::string> model_cache_disabled_test_patterns() {
+    return std::vector<std::string>{};
+}

--- a/src/tests/test_utils/functional_test_utils/include/functional_test_utils/skip_tests_config.hpp
+++ b/src/tests/test_utils/functional_test_utils/include/functional_test_utils/skip_tests_config.hpp
@@ -12,6 +12,10 @@
 
 const std::vector<std::regex>& disabled_test_patterns();
 
+bool is_model_cache_enabled();
+
+std::vector<std::string> model_cache_disabled_test_patterns();
+
 namespace ov {
 namespace test {
 namespace utils {
@@ -19,6 +23,8 @@ namespace utils {
 extern bool disable_tests_skipping;
 
 bool current_test_is_disabled();
+
+bool current_test_model_cache_is_disabled();
 
 }  // namespace utils
 }  // namespace test

--- a/src/tests/test_utils/functional_test_utils/src/skip_tests_config.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/skip_tests_config.cpp
@@ -29,4 +29,21 @@ bool current_test_is_disabled() {
     return false;
 }
 
+bool current_test_model_cache_is_disabled() {
+    if (!is_model_cache_enabled() || disable_tests_skipping) {
+        return false;
+    }
+
+    const auto fullName = ::testing::UnitTest::GetInstance()->current_test_info()->test_case_name() + std::string(".") +
+                          ::testing::UnitTest::GetInstance()->current_test_info()->name();
+
+    for (const auto& pattern : model_cache_disabled_test_patterns()) {
+        std::regex re(pattern);
+        if (std::regex_match(fullName, re))
+            return true;
+    }
+
+    return false;
+}
+
 }  // namespace ov::test::utils


### PR DESCRIPTION
### Details:
 - *At the moment we have limited coverage of the model compilation from cache. Actually not all operations could be serialized/deserialized from cache. So need to cover all of them first.*
 - *This PR adds the option to check model compilation from cache in the layers test. Plugins can switch it on and filter failed test cases.*

### Tickets:
 - *179076*
