### PR TITLE
[PT FE] Fix support for aten::unique_consecutive

### DIFF
--- a/src/frontends/pytorch/src/op/unique.cpp
+++ b/src/frontends/pytorch/src/op/unique.cpp
@@ -42,7 +42,12 @@ OutputVector translate_unique2(const NodeContext& context) {
     // Since PyTorch 2.2.0 the `Unique` op always returns sorted values, regardless of the parameter `sorted`.
     // Reference: pytorch/pytorch#105742, pytorch/pytorch#113420,
     // https://pytorch.org/docs/1.13/generated/torch.unique.html#torch.unique
-    auto outputs = context.mark_node(std::make_shared<v10::Unique>(x, true));
+    bool sorted = true;
+    if (!context.input_is_none(1)){
+        sorted = context.const_input<bool>(1);
+        
+    }
+    auto outputs = context.mark_node(std::make_shared<v10::Unique>(x, sorted));
     auto unique_values = outputs->output(0);
     result.push_back(unique_values);
     if (return_inverse) {


### PR DESCRIPTION
Fixes support for aten::unique_consecutive.

translate_unique2 was hardcoding sorted=true, causing
torch.unique_consecutive to behave like torch.unique.

This change reads the sorted flag from context input(1)
and passes it to v10::Unique, correctly mapping:
- torch.unique → sorted=true
- torch.unique_consecutive → sorted=false

Closes #29717
