### PR TITLE
[PyOV] add validation for MatMul contracting dimensions

### DIFF
--- a/src/bindings/python/src/openvino/opset1/ops.py
+++ b/src/bindings/python/src/openvino/opset1/ops.py
@@ -1567,15 +1567,12 @@ def matmul(
         dim_a = ps_a[idx_a]
         dim_b = ps_b[idx_b]
 
-        if dim_a.is_static and dim_b.is_static:
-            val_a = dim_a.get_length()
-            val_b = dim_b.get_length()
-            if val_a != val_b:
-                raise ValueError(
-                    f"Incompatible MatMul static dimensions: Input A dimension {val_a} "
-                    f"at index {idx_a} does not match Input B dimension {val_b} at index {idx_b}. "
-                    f"Shapes: {ps_a} and {ps_b} (transpose_a={transpose_a}, transpose_b={transpose_b})"
-                )
+        if not dim_a.compatible(dim_b):
+            raise ValueError(
+                f"Incompatible MatMul dimensions: Input A dimension {dim_a} "
+                f"at index {idx_a} does not match Input B dimension {dim_b} at index {idx_b}. "
+                f"Shapes: {ps_a} and {ps_b} (transpose_a={transpose_a}, transpose_b={transpose_b})"
+            )
              
     return _get_node_factory_opset1().create(
         "MatMul",


### PR DESCRIPTION
### Details:

- Calls validate_and_infer_types() on inputs to ensure shape propagation (e.g., from Concat or Reduce nodes) is resolved before checking.
   - Implements the contracting dimension check based on rank and transpose flags:
   - 1D inputs: Uses index 0.
   - 2D+ inputs: Uses -1 (or -2 if transposed).
 
- Correctly handles unsqueezing logic for 1D vectors during validation.


I wanted to mention however that the specific RuntimeError in the ReduceMax reproduction script still persists because of a downstream discrepancy in the C++ backend where the Python API correctly infers a reduced 1D shape of [62] during graph building, the C++ core's shape-inference logic (specifically within matmul_shape_inference.hpp) appears to encounter a regressed shape of [14, 62] during plugin-specific graph transformations.


### Tickets:
 - #33524
