### PR TITLE
Limit Good First Issues to a single assignee

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -96,7 +96,7 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
-                    body: `@${user} this issue is already assigned to @${currentAssignee}.`
+                    body: `@${user} this issue is already assigned to a contributor.`
                   });
                   console.log(`Issue #${issue.number} already assigned to ${currentAssignee}, ignoring .take from ${user}`);
                   return;


### PR DESCRIPTION
### Details:
 - GFI assignment should limit the amount of assignees to 1
 - Current behavior causes confusion where multiple people are working on a single issue in parallel, ex. https://github.com/openvinotoolkit/openvino/issues/32725
 - Tested in https://github.com/p-wysocki/openvino/issues/155

### Tickets:
 - N/A
