### PR TITLE
[Arm] Enable SDPA Fusion with Sink input on ARM CPUs

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -656,7 +656,7 @@ struct MHAKernel<ScaledDotProductAttention::KT_ACL, T> {
                     PlainTensor& output_emb,
                     bool has_out_transpose,
                     bool auto_causal,
-                    [[maybe_unused]] PlainTensor& sink_input,
+                    PlainTensor& sink_input,
                     float d_scale = 0.0F) {
         auto B = query.size(0);
         auto H = query.size(1);

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -116,12 +116,6 @@ StatefulSDPAFusion::StatefulSDPAFusion() {
         const auto& pattern_map = m.get_pattern_value_map();
         auto root = m.get_match_root();
 
-// only support sink input on x86 platform currently.
-#ifndef OPENVINO_ARCH_X86_64
-        if (pattern_map.count(atten_sink)) {
-            return false;
-        }
-#endif
         // Check concat axes equality first
         const auto concat_k_node = ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_k).get_node_shared_ptr());
         const auto concat_v_node = ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_v).get_node_shared_ptr());


### PR DESCRIPTION
This PR enables SDPA fusion on ARM, when attention contains additional input **Sink** 
Checked and validated the operation with GPT-OSS 20b Model.

On implementing this code and enhanced performance during the LLM inference has been observed, refer the below table

<img width="604" height="120" alt="image" src="https://github.com/user-attachments/assets/c77b7908-4c8a-4a94-9feb-7f887bb9697b" />

** All values are in Tokens per second - decoding throughput.
Machine : Graviton4 - single socket - 96 cores.

Kindly support to review the PR and share feedback if any.

Thanks!

This work is contributed by @ashwins990 & @abhijain1204fujitsu 