### PR TITLE
[GPU] fixed: wrong calculation for the rank of decompression_zp layout

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -397,9 +397,12 @@ public:
                 if (dzp_layout.count() == 1) {
                     attr->set_zero_points(DNNL_ARG_WEIGHTS, COMMON, dnnl::memory::dims{}, dzp_data_type);
                 } else {
-                    size_t rank = dzp_layout.get_partial_shape().size();
-                    auto ngroups = dzp_layout.get_dim(rank - 1);
-                    if (ngroups == 1 && rank <= 2) {
+                    auto dzp_shape = dzp_layout.get_partial_shape();
+                    auto dzp_rank = std::count_if(dzp_shape.begin(), dzp_shape.end(), [](ov::Dimension d) { return d.get_length() > 1; });
+                    dzp_rank = std::max(static_cast<int64_t>(2), dzp_rank);
+
+                    auto ngroups = dzp_layout.get_dim(dzp_rank - 1);
+                    if (ngroups == 1 && dzp_rank <= 2) {
                         attr->set_zero_points(DNNL_ARG_WEIGHTS, per_oc, dnnl::memory::dims{}, dzp_data_type);
                     } else {
                         // should use {K, 1} for the group size + per tensor mask for 3d


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - A
 - B

#### The code and line that caused this issue (if it is not changed directly)
 - intel_gpu/src/… (or func name)

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - $ benchmark_app …
 - ...

#### Problematic graph
 - If it is related to graph, please describe the graph
 - If you need to show captured graph, attach on the ticket or upload in onenote: "PR-12345 graph"

#### Checklist
 - [ ] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 178908
