### PR TITLE
[GPU] no print empty strides

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -40,7 +40,7 @@ std::string memory_desc_to_string(const dnnl::memory::desc& desc) {
     if (strides.empty()) {
         ss << "empty";
     } else {
-        for (int i = 0; i < strides.size(); i++) {
+        for (size_t i = 0; i < strides.size(); i++) {
             ss << (i ? "x" : "") << strides[i];
         }
     }


### PR DESCRIPTION
### Details:
 - when creating weight memory descriptor in with dnnl::memory::format_tag::any (get_conv_memory_descs function in src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp) there are prints which query for strides - in that case strides are returned empty, but it is trying to print them.

found when debugging 172528

### Tickets:
 
