### PR TITLE
[Python API] Fix: Create constant for strings and fix segfault 

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -65,6 +65,9 @@ void regclass_graph_op_Constant(py::module m) {
     constant.def(py::init([](py::array& array, bool shared_memory) -> std::shared_ptr<ov::op::v0::Constant> {
                      if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
                          array.dtype().kind() == 'a') {
+                        if (shared_memory) {
+                            throw std::runtime_error("Creating a String Constant with shared memory is not supported.");
+                        }
                          ov::Shape shape(array.shape(), array.shape() + array.ndim());
                          // convert NumPy array to flattened list of strings
                          std::vector<std::string> strings;

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -10,7 +10,6 @@
 #include <pybind11/stl.h>
 
 #include <stdexcept>
-#include <iostream>
 
 #include "openvino/core/shape.hpp"
 #include "openvino/runtime/tensor.hpp"
@@ -67,8 +66,8 @@ void regclass_graph_op_Constant(py::module m) {
                      if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
                          array.dtype().kind() == 'a') {
                          if (shared_memory) {
-                            std::cerr << "Warning: Creating a String Constant with shared memory is not supported. "
-                                          "Ignoring shared_memory flag." << std::endl;
+                             throw std::runtime_error("Creating a String Constant with shared memory is not supported. "
+                                                      "Set shared_memory to False or omit the parameter.");
                          }
                          ov::Shape shape(array.shape(), array.shape() + array.ndim());
 

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -9,8 +9,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <stdexcept>
 #include <iostream>
+#include <stdexcept>
 
 #include "openvino/core/shape.hpp"
 #include "openvino/runtime/tensor.hpp"
@@ -68,7 +68,8 @@ void regclass_graph_op_Constant(py::module m) {
                          array.dtype().kind() == 'a') {
                          if (shared_memory) {
                              std::cerr << "Warning: Creating a String Constant with shared memory is not supported. "
-                                          "Data will be copied." << std::endl;
+                                          "Data will be copied."
+                                       << std::endl;
                          }
                          ov::Shape shape(array.shape(), array.shape() + array.ndim());
 
@@ -79,7 +80,7 @@ void regclass_graph_op_Constant(py::module m) {
                          }
                          // convert NumPy array to flattened list of strings
                          std::string* tensor_data = tensor.data<std::string>();
-                        //  std::vector<std::string> strings;
+                         //  std::vector<std::string> strings;
                          auto flat_array = array.reshape({-1});
 
                          // copy data

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -66,9 +66,14 @@ void regclass_graph_op_Constant(py::module m) {
                      if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
                          array.dtype().kind() == 'a') {
                         if (shared_memory) {
-                            throw std::runtime_error("Creating a String Constant with shared memory is not supported.");
+                            std::cerr << "Warning: Creating a String Constant with shared memory is not supported. Ignoring shared_memory flag." << std::endl;
                         }
                          ov::Shape shape(array.shape(), array.shape() + array.ndim());
+
+                        if (array.size() == 0) {
+                            // return empty string tensor
+                            ov::Tensor tensor(ov::element::string, shape);
+                            return std::make_shared<ov::op::v0::Constant>(tensor);
                          // convert NumPy array to flattened list of strings
                          std::vector<std::string> strings;
                          auto flat_array = array.reshape({-1});

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -10,6 +10,7 @@
 #include <pybind11/stl.h>
 
 #include <stdexcept>
+#include <iostream>
 
 #include "openvino/core/shape.hpp"
 #include "openvino/runtime/tensor.hpp"
@@ -66,9 +67,8 @@ void regclass_graph_op_Constant(py::module m) {
                      if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
                          array.dtype().kind() == 'a') {
                          if (shared_memory) {
-                             std::cerr << "Warning: Creating a String Constant with shared memory is not supported. "
-                                          "Ignoring shared_memory flag."
-                                       << std::endl;
+                            std::cerr << "Warning: Creating a String Constant with shared memory is not supported. "
+                                          "Ignoring shared_memory flag." << std::endl;
                          }
                          ov::Shape shape(array.shape(), array.shape() + array.ndim());
 
@@ -86,7 +86,7 @@ void regclass_graph_op_Constant(py::module m) {
                              py::object item = flat_array.attr("item")(i);
 
                              if (item.is_none()) {
-                                 strings.push_back("None");
+                                 strings.push_back("");
                                  continue;
                              }
                              strings.push_back(py::str(item));

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -63,194 +63,192 @@ void regclass_graph_op_Constant(py::module m) {
     constant.doc() = "openvino.op.Constant wraps ov::op::v0::Constant";
     // Numpy-based constructor
     constant.def(py::init([](py::array& array, bool shared_memory) -> std::shared_ptr<ov::op::v0::Constant> {
-        if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
-            array.dtype().kind() == 'a') {
-            if (shared_memory) {
-                std::cerr << "Warning: Creating a String Constant with shared memory is not supported. Ignoring "
-                             "shared_memory flag."
-                          << std::endl;
-            }
-            ov::Shape shape(array.shape(), array.shape() + array.ndim());
+                     if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
+                         array.dtype().kind() == 'a') {
+                        if (shared_memory) {
+                            std::cerr << "Warning: Creating a String Constant with shared memory is not supported. Ignoring shared_memory flag." << std::endl;
+                        }
+                         ov::Shape shape(array.shape(), array.shape() + array.ndim());
 
-            if (array.size() == 0) {
-                // return empty string tensor
-                ov::Tensor tensor(ov::element::string, shape);
-                return std::make_shared<ov::op::v0::Constant>(tensor);
-                // convert NumPy array to flattened list of strings
-                std::vector<std::string> strings;
-                auto flat_array = array.reshape({-1});
+                        if (array.size() == 0) {
+                            // return empty string tensor
+                            ov::Tensor tensor(ov::element::string, shape);
+                            return std::make_shared<ov::op::v0::Constant>(tensor);
+                         // convert NumPy array to flattened list of strings
+                         std::vector<std::string> strings;
+                         auto flat_array = array.reshape({-1});
 
-                // copy data
-                for (int i = 0; i < flat_array.size(); ++i) {
-                    py::object item = flat_array.attr("item")(i);
+                         // copy data
+                         for (int i = 0; i < flat_array.size(); ++i) {
+                            py::object item = flat_array.attr("item")(i);
 
-                    if (item.is_none()) {
-                        strings.push_back("None");
-                        continue;
-                    }
-                    strings.push_back(py::str(item));
-                }
+                            if(item.is_none()){
+                                strings.push_back("None");
+                                continue;
+                            }
+                             strings.push_back(py::str(item));
+                         }
 
-                // create OpenVINO String Tensor
-                ov::Tensor tensor(ov::element::string, shape, &strings[0]);
+                         // create OpenVINO String Tensor
+                         ov::Tensor tensor(ov::element::string, shape, &strings[0]);
 
-                // return the Constant Op wrapping this tensor
-                return std::make_shared<ov::op::v0::Constant>(tensor);
-            }
-            return std::make_shared<ov::op::v0::Constant>(
-                Common::object_from_data<ov::op::v0::Constant>(array, shared_memory));
-        }),
+                         // return the Constant Op wrapping this tensor
+                         return std::make_shared<ov::op::v0::Constant>(tensor);
+                     }
+                     return std::make_shared<ov::op::v0::Constant>(
+                         Common::object_from_data<ov::op::v0::Constant>(array, shared_memory));
+                 }),
                  py::arg("array"),
                  py::arg("shared_memory") = false);
-        // Tensor-based constructors
-        constant.def(py::init([](ov::Tensor& tensor, bool shared_memory) {
-                         return std::make_shared<ov::op::v0::Constant>(
-                             Common::object_from_data<ov::op::v0::Constant>(tensor, shared_memory));
-                     }),
-                     py::arg("tensor"),
-                     py::arg("shared_memory") = true);
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<char>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<ov::float16>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<float>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<double>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int8_t>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int16_t>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int32_t>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int64_t>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint8_t>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint16_t>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint32_t>&>());
-        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint64_t>&>());
+    // Tensor-based constructors
+    constant.def(py::init([](ov::Tensor& tensor, bool shared_memory) {
+                     return std::make_shared<ov::op::v0::Constant>(
+                         Common::object_from_data<ov::op::v0::Constant>(tensor, shared_memory));
+                 }),
+                 py::arg("tensor"),
+                 py::arg("shared_memory") = true);
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<char>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<ov::float16>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<float>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<double>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int8_t>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int16_t>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int32_t>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int64_t>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint8_t>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint16_t>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint32_t>&>());
+    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint64_t>&>());
 
-        constant.def("get_value_strings", &ov::op::v0::Constant::get_value_strings);
+    constant.def("get_value_strings", &ov::op::v0::Constant::get_value_strings);
 
-        constant.def("get_byte_size", &ov::op::v0::Constant::get_byte_size);
+    constant.def("get_byte_size", &ov::op::v0::Constant::get_byte_size);
 
-        constant.def("get_vector", [](const ov::op::v0::Constant& self) {
-            auto element_type = self.get_element_type();
-            if (element_type == ov::element::boolean) {
-                return _cast_vector<char>(self);
-            } else if (element_type == ov::element::f16) {
-                return _cast_vector<ov::float16>(self);
-            } else if (element_type == ov::element::f32) {
-                return _cast_vector<float>(self);
-            } else if (element_type == ov::element::f64) {
-                return _cast_vector<double>(self);
-            } else if (element_type == ov::element::i8) {
-                return _cast_vector<int8_t>(self);
-            } else if (element_type == ov::element::i16) {
-                return _cast_vector<int16_t>(self);
-            } else if (element_type == ov::element::i32) {
-                return _cast_vector<int32_t>(self);
-            } else if (element_type == ov::element::i64) {
-                return _cast_vector<int64_t>(self);
-            } else if (element_type == ov::element::u8 || element_type == ov::element::u1 ||
-                       element_type == ov::element::u2 || element_type == ov::element::u4) {
-                return _cast_vector<uint8_t>(self);
-            } else if (element_type == ov::element::u16) {
-                return _cast_vector<uint16_t>(self);
-            } else if (element_type == ov::element::u32) {
-                return _cast_vector<uint32_t>(self);
-            } else if (element_type == ov::element::u64) {
-                return _cast_vector<uint64_t>(self);
-            } else {
-                throw std::runtime_error("Unsupported data type!");
-            }
-        });
+    constant.def("get_vector", [](const ov::op::v0::Constant& self) {
+        auto element_type = self.get_element_type();
+        if (element_type == ov::element::boolean) {
+            return _cast_vector<char>(self);
+        } else if (element_type == ov::element::f16) {
+            return _cast_vector<ov::float16>(self);
+        } else if (element_type == ov::element::f32) {
+            return _cast_vector<float>(self);
+        } else if (element_type == ov::element::f64) {
+            return _cast_vector<double>(self);
+        } else if (element_type == ov::element::i8) {
+            return _cast_vector<int8_t>(self);
+        } else if (element_type == ov::element::i16) {
+            return _cast_vector<int16_t>(self);
+        } else if (element_type == ov::element::i32) {
+            return _cast_vector<int32_t>(self);
+        } else if (element_type == ov::element::i64) {
+            return _cast_vector<int64_t>(self);
+        } else if (element_type == ov::element::u8 || element_type == ov::element::u1 ||
+                   element_type == ov::element::u2 || element_type == ov::element::u4) {
+            return _cast_vector<uint8_t>(self);
+        } else if (element_type == ov::element::u16) {
+            return _cast_vector<uint16_t>(self);
+        } else if (element_type == ov::element::u32) {
+            return _cast_vector<uint32_t>(self);
+        } else if (element_type == ov::element::u64) {
+            return _cast_vector<uint64_t>(self);
+        } else {
+            throw std::runtime_error("Unsupported data type!");
+        }
+    });
 
-        constant.def("get_tensor_view",
-                     &ov::op::v0::Constant::get_tensor_view,
-                     R"(
+    constant.def("get_tensor_view",
+                 &ov::op::v0::Constant::get_tensor_view,
+                 R"(
                     Get view on constant data as tensor.
 
                     :rtype: openvino.Tensor
                 )");
 
-        constant.def("get_strides",
-                     &ov::op::v0::Constant::get_strides,
-                     R"(
+    constant.def("get_strides",
+                 &ov::op::v0::Constant::get_strides,
+                 R"(
                     Constant's strides in bytes.
 
                     :rtype: openvino.Strides
                 )");
 
-        // TODO: Remove in future and re-use `get_data`
-        // Provide buffer access
-        constant.def_buffer([](const ov::op::v0::Constant& self) -> py::buffer_info {
-            auto element_type = self.get_element_type();
-            if (element_type == ov::element::boolean) {
-                return _get_buffer_info<char>(self);
-            } else if (element_type == ov::element::f16) {
-                return _get_buffer_info<ov::float16>(self);
-            } else if (element_type == ov::element::f32) {
-                return _get_buffer_info<float>(self);
-            } else if (element_type == ov::element::f64) {
-                return _get_buffer_info<double>(self);
-            } else if (element_type == ov::element::i8) {
-                return _get_buffer_info<int8_t>(self);
-            } else if (element_type == ov::element::i16) {
-                return _get_buffer_info<int16_t>(self);
-            } else if (element_type == ov::element::i32) {
-                return _get_buffer_info<int32_t>(self);
-            } else if (element_type == ov::element::i64) {
-                return _get_buffer_info<int64_t>(self);
-            } else if (element_type == ov::element::u8 || element_type == ov::element::u1 ||
-                       element_type == ov::element::u2 || element_type == ov::element::u4) {
-                return _get_buffer_info<uint8_t>(self);
-            } else if (element_type == ov::element::u16) {
-                return _get_buffer_info<uint16_t>(self);
-            } else if (element_type == ov::element::u32) {
-                return _get_buffer_info<uint32_t>(self);
-            } else if (element_type == ov::element::u64) {
-                return _get_buffer_info<uint64_t>(self);
-            } else {
-                throw std::runtime_error("Unsupported data type!");
-            }
-        });
+    // TODO: Remove in future and re-use `get_data`
+    // Provide buffer access
+    constant.def_buffer([](const ov::op::v0::Constant& self) -> py::buffer_info {
+        auto element_type = self.get_element_type();
+        if (element_type == ov::element::boolean) {
+            return _get_buffer_info<char>(self);
+        } else if (element_type == ov::element::f16) {
+            return _get_buffer_info<ov::float16>(self);
+        } else if (element_type == ov::element::f32) {
+            return _get_buffer_info<float>(self);
+        } else if (element_type == ov::element::f64) {
+            return _get_buffer_info<double>(self);
+        } else if (element_type == ov::element::i8) {
+            return _get_buffer_info<int8_t>(self);
+        } else if (element_type == ov::element::i16) {
+            return _get_buffer_info<int16_t>(self);
+        } else if (element_type == ov::element::i32) {
+            return _get_buffer_info<int32_t>(self);
+        } else if (element_type == ov::element::i64) {
+            return _get_buffer_info<int64_t>(self);
+        } else if (element_type == ov::element::u8 || element_type == ov::element::u1 ||
+                   element_type == ov::element::u2 || element_type == ov::element::u4) {
+            return _get_buffer_info<uint8_t>(self);
+        } else if (element_type == ov::element::u16) {
+            return _get_buffer_info<uint16_t>(self);
+        } else if (element_type == ov::element::u32) {
+            return _get_buffer_info<uint32_t>(self);
+        } else if (element_type == ov::element::u64) {
+            return _get_buffer_info<uint64_t>(self);
+        } else {
+            throw std::runtime_error("Unsupported data type!");
+        }
+    });
 
-        constant.def(
-            "get_data",
-            [](ov::op::v0::Constant& self, py::object& dtype, bool copy) {
-                // Destination type was set:
-                if (!dtype.is(py::none())) {
-                    py::dtype dst_dtype;
-                    if (dtype.is(py::dtype())) {
-                        dst_dtype = dtype.cast<py::dtype>();
+    constant.def(
+        "get_data",
+        [](ov::op::v0::Constant& self, py::object& dtype, bool copy) {
+            // Destination type was set:
+            if (!dtype.is(py::none())) {
+                py::dtype dst_dtype;
+                if (dtype.is(py::dtype())) {
+                    dst_dtype = dtype.cast<py::dtype>();
+                } else {
+                    dst_dtype = py::dtype::from_args(dtype);
+                }
+                const auto& ov_type = self.get_element_type();
+                const auto dtype = Common::type_helpers::get_dtype(ov_type);
+                // If dtype is the same as Constant type
+                // casting is NOT required, only check copy flag
+                if (dst_dtype.is(dtype)) {
+                    if (copy) {
+                        return Common::array_helpers::array_from_constant_copy(
+                            std::forward<ov::op::v0::Constant>(self));
                     } else {
-                        dst_dtype = py::dtype::from_args(dtype);
-                    }
-                    const auto& ov_type = self.get_element_type();
-                    const auto dtype = Common::type_helpers::get_dtype(ov_type);
-                    // If dtype is the same as Constant type
-                    // casting is NOT required, only check copy flag
-                    if (dst_dtype.is(dtype)) {
-                        if (copy) {
-                            return Common::array_helpers::array_from_constant_copy(
-                                std::forward<ov::op::v0::Constant>(self));
-                        } else {
-                            return Common::array_helpers::array_from_constant_view(
-                                std::forward<ov::op::v0::Constant>(self));
-                        }
-                    }
-                    // Otherwise always copy:
-                    else {
-                        return Common::array_helpers::array_from_constant_copy(std::forward<ov::op::v0::Constant>(self),
-                                                                               dst_dtype);
+                        return Common::array_helpers::array_from_constant_view(
+                            std::forward<ov::op::v0::Constant>(self));
                     }
                 }
-                // Copy of data in Constant type:
-                else if (copy) {
-                    return Common::array_helpers::array_from_constant_copy(std::forward<ov::op::v0::Constant>(self));
-                }
-                // Shared view of data in Constant type:
+                // Otherwise always copy:
                 else {
-                    return Common::array_helpers::array_from_constant_view(std::forward<ov::op::v0::Constant>(self));
+                    return Common::array_helpers::array_from_constant_copy(std::forward<ov::op::v0::Constant>(self),
+                                                                           dst_dtype);
                 }
-            },
-            py::kw_only(),
-            py::arg("dtype") = py::none(),
-            py::arg("copy") = false,
-            R"(
+            }
+            // Copy of data in Constant type:
+            else if (copy) {
+                return Common::array_helpers::array_from_constant_copy(std::forward<ov::op::v0::Constant>(self));
+            }
+            // Shared view of data in Constant type:
+            else {
+                return Common::array_helpers::array_from_constant_view(std::forward<ov::op::v0::Constant>(self));
+            }
+        },
+        py::kw_only(),
+        py::arg("dtype") = py::none(),
+        py::arg("copy") = false,
+        R"(
             Access to Constant's data. Returns numpy array with corresponding shape.
 
             Function tries to return a view by default, if not possible due
@@ -273,12 +271,12 @@ void regclass_graph_op_Constant(py::module m) {
             :rtype: numpy.array
         )");
 
-        constant.def_property_readonly(
-            "data",
-            [](ov::op::v0::Constant& self) {
-                return Common::array_helpers::array_from_constant_view(std::forward<ov::op::v0::Constant>(self));
-            },
-            R"(
+    constant.def_property_readonly(
+        "data",
+        [](ov::op::v0::Constant& self) {
+            return Common::array_helpers::array_from_constant_view(std::forward<ov::op::v0::Constant>(self));
+        },
+        R"(
             Access to Constant's data - creates a view of data.
 
             Returns numpy array with corresponding shape and dtype.
@@ -290,31 +288,30 @@ void regclass_graph_op_Constant(py::module m) {
             :rtype: numpy.array
         )");
 
-        constant.def_property_readonly("tensor_view",
-                                       &ov::op::v0::Constant::get_tensor_view,
-                                       R"(
+    constant.def_property_readonly("tensor_view",
+                                   &ov::op::v0::Constant::get_tensor_view,
+                                   R"(
                                     Get view on constant data as tensor.
 
                                     :rtype: openvino.Tensor
                                 )");
 
-        constant.def_property_readonly("strides",
-                                       &ov::op::v0::Constant::get_strides,
-                                       R"(
+    constant.def_property_readonly("strides",
+                                   &ov::op::v0::Constant::get_strides,
+                                   R"(
                                     Constant's strides in bytes.
 
                                     :rtype: openvino.Strides
                                 )");
 
-        constant.def("__repr__", [](const ov::op::v0::Constant& self) {
-            std::stringstream shapes_ss;
-            for (size_t i = 0; i < self.get_output_size(); ++i) {
-                if (i > 0) {
-                    shapes_ss << ", ";
-                }
-                shapes_ss << self.get_output_partial_shape(i);
+    constant.def("__repr__", [](const ov::op::v0::Constant& self) {
+        std::stringstream shapes_ss;
+        for (size_t i = 0; i < self.get_output_size(); ++i) {
+            if (i > 0) {
+                shapes_ss << ", ";
             }
-            return "<" + Common::get_class_name(self) + ": '" + self.get_friendly_name() + "' (" + shapes_ss.str() +
-                   ")>";
-        });
+            shapes_ss << self.get_output_partial_shape(i);
+        }
+        return "<" + Common::get_class_name(self) + ": '" + self.get_friendly_name() + "' (" + shapes_ss.str() + ")>";
+    });
 }

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -83,7 +83,7 @@ void regclass_graph_op_Constant(py::module m) {
                          auto flat_array = array.reshape({-1});
 
                          // copy data
-                         for (int i = 0; i < flat_array.size(); ++i) {
+                         for (py::ssize_t i = 0; i < flat_array.size(); ++i) {
                              py::object item = flat_array.attr("item")(i);
 
                              if (item.is_none()) {

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -63,192 +63,194 @@ void regclass_graph_op_Constant(py::module m) {
     constant.doc() = "openvino.op.Constant wraps ov::op::v0::Constant";
     // Numpy-based constructor
     constant.def(py::init([](py::array& array, bool shared_memory) -> std::shared_ptr<ov::op::v0::Constant> {
-                     if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
-                         array.dtype().kind() == 'a') {
-                        if (shared_memory) {
-                            std::cerr << "Warning: Creating a String Constant with shared memory is not supported. Ignoring shared_memory flag." << std::endl;
-                        }
-                         ov::Shape shape(array.shape(), array.shape() + array.ndim());
+        if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
+            array.dtype().kind() == 'a') {
+            if (shared_memory) {
+                std::cerr << "Warning: Creating a String Constant with shared memory is not supported. Ignoring "
+                             "shared_memory flag."
+                          << std::endl;
+            }
+            ov::Shape shape(array.shape(), array.shape() + array.ndim());
 
-                        if (array.size() == 0) {
-                            // return empty string tensor
-                            ov::Tensor tensor(ov::element::string, shape);
-                            return std::make_shared<ov::op::v0::Constant>(tensor);
-                         // convert NumPy array to flattened list of strings
-                         std::vector<std::string> strings;
-                         auto flat_array = array.reshape({-1});
+            if (array.size() == 0) {
+                // return empty string tensor
+                ov::Tensor tensor(ov::element::string, shape);
+                return std::make_shared<ov::op::v0::Constant>(tensor);
+                // convert NumPy array to flattened list of strings
+                std::vector<std::string> strings;
+                auto flat_array = array.reshape({-1});
 
-                         // copy data
-                         for (int i = 0; i < flat_array.size(); ++i) {
-                            py::object item = flat_array.attr("item")(i);
+                // copy data
+                for (int i = 0; i < flat_array.size(); ++i) {
+                    py::object item = flat_array.attr("item")(i);
 
-                            if(item.is_none()){
-                                strings.push_back("None");
-                                continue;
-                            }
-                             strings.push_back(py::str(item));
-                         }
+                    if (item.is_none()) {
+                        strings.push_back("None");
+                        continue;
+                    }
+                    strings.push_back(py::str(item));
+                }
 
-                         // create OpenVINO String Tensor
-                         ov::Tensor tensor(ov::element::string, shape, &strings[0]);
+                // create OpenVINO String Tensor
+                ov::Tensor tensor(ov::element::string, shape, &strings[0]);
 
-                         // return the Constant Op wrapping this tensor
-                         return std::make_shared<ov::op::v0::Constant>(tensor);
-                     }
-                     return std::make_shared<ov::op::v0::Constant>(
-                         Common::object_from_data<ov::op::v0::Constant>(array, shared_memory));
-                 }),
+                // return the Constant Op wrapping this tensor
+                return std::make_shared<ov::op::v0::Constant>(tensor);
+            }
+            return std::make_shared<ov::op::v0::Constant>(
+                Common::object_from_data<ov::op::v0::Constant>(array, shared_memory));
+        }),
                  py::arg("array"),
                  py::arg("shared_memory") = false);
-    // Tensor-based constructors
-    constant.def(py::init([](ov::Tensor& tensor, bool shared_memory) {
-                     return std::make_shared<ov::op::v0::Constant>(
-                         Common::object_from_data<ov::op::v0::Constant>(tensor, shared_memory));
-                 }),
-                 py::arg("tensor"),
-                 py::arg("shared_memory") = true);
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<char>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<ov::float16>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<float>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<double>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int8_t>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int16_t>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int32_t>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int64_t>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint8_t>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint16_t>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint32_t>&>());
-    constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint64_t>&>());
+        // Tensor-based constructors
+        constant.def(py::init([](ov::Tensor& tensor, bool shared_memory) {
+                         return std::make_shared<ov::op::v0::Constant>(
+                             Common::object_from_data<ov::op::v0::Constant>(tensor, shared_memory));
+                     }),
+                     py::arg("tensor"),
+                     py::arg("shared_memory") = true);
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<char>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<ov::float16>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<float>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<double>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int8_t>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int16_t>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int32_t>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<int64_t>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint8_t>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint16_t>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint32_t>&>());
+        constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<uint64_t>&>());
 
-    constant.def("get_value_strings", &ov::op::v0::Constant::get_value_strings);
+        constant.def("get_value_strings", &ov::op::v0::Constant::get_value_strings);
 
-    constant.def("get_byte_size", &ov::op::v0::Constant::get_byte_size);
+        constant.def("get_byte_size", &ov::op::v0::Constant::get_byte_size);
 
-    constant.def("get_vector", [](const ov::op::v0::Constant& self) {
-        auto element_type = self.get_element_type();
-        if (element_type == ov::element::boolean) {
-            return _cast_vector<char>(self);
-        } else if (element_type == ov::element::f16) {
-            return _cast_vector<ov::float16>(self);
-        } else if (element_type == ov::element::f32) {
-            return _cast_vector<float>(self);
-        } else if (element_type == ov::element::f64) {
-            return _cast_vector<double>(self);
-        } else if (element_type == ov::element::i8) {
-            return _cast_vector<int8_t>(self);
-        } else if (element_type == ov::element::i16) {
-            return _cast_vector<int16_t>(self);
-        } else if (element_type == ov::element::i32) {
-            return _cast_vector<int32_t>(self);
-        } else if (element_type == ov::element::i64) {
-            return _cast_vector<int64_t>(self);
-        } else if (element_type == ov::element::u8 || element_type == ov::element::u1 ||
-                   element_type == ov::element::u2 || element_type == ov::element::u4) {
-            return _cast_vector<uint8_t>(self);
-        } else if (element_type == ov::element::u16) {
-            return _cast_vector<uint16_t>(self);
-        } else if (element_type == ov::element::u32) {
-            return _cast_vector<uint32_t>(self);
-        } else if (element_type == ov::element::u64) {
-            return _cast_vector<uint64_t>(self);
-        } else {
-            throw std::runtime_error("Unsupported data type!");
-        }
-    });
+        constant.def("get_vector", [](const ov::op::v0::Constant& self) {
+            auto element_type = self.get_element_type();
+            if (element_type == ov::element::boolean) {
+                return _cast_vector<char>(self);
+            } else if (element_type == ov::element::f16) {
+                return _cast_vector<ov::float16>(self);
+            } else if (element_type == ov::element::f32) {
+                return _cast_vector<float>(self);
+            } else if (element_type == ov::element::f64) {
+                return _cast_vector<double>(self);
+            } else if (element_type == ov::element::i8) {
+                return _cast_vector<int8_t>(self);
+            } else if (element_type == ov::element::i16) {
+                return _cast_vector<int16_t>(self);
+            } else if (element_type == ov::element::i32) {
+                return _cast_vector<int32_t>(self);
+            } else if (element_type == ov::element::i64) {
+                return _cast_vector<int64_t>(self);
+            } else if (element_type == ov::element::u8 || element_type == ov::element::u1 ||
+                       element_type == ov::element::u2 || element_type == ov::element::u4) {
+                return _cast_vector<uint8_t>(self);
+            } else if (element_type == ov::element::u16) {
+                return _cast_vector<uint16_t>(self);
+            } else if (element_type == ov::element::u32) {
+                return _cast_vector<uint32_t>(self);
+            } else if (element_type == ov::element::u64) {
+                return _cast_vector<uint64_t>(self);
+            } else {
+                throw std::runtime_error("Unsupported data type!");
+            }
+        });
 
-    constant.def("get_tensor_view",
-                 &ov::op::v0::Constant::get_tensor_view,
-                 R"(
+        constant.def("get_tensor_view",
+                     &ov::op::v0::Constant::get_tensor_view,
+                     R"(
                     Get view on constant data as tensor.
 
                     :rtype: openvino.Tensor
                 )");
 
-    constant.def("get_strides",
-                 &ov::op::v0::Constant::get_strides,
-                 R"(
+        constant.def("get_strides",
+                     &ov::op::v0::Constant::get_strides,
+                     R"(
                     Constant's strides in bytes.
 
                     :rtype: openvino.Strides
                 )");
 
-    // TODO: Remove in future and re-use `get_data`
-    // Provide buffer access
-    constant.def_buffer([](const ov::op::v0::Constant& self) -> py::buffer_info {
-        auto element_type = self.get_element_type();
-        if (element_type == ov::element::boolean) {
-            return _get_buffer_info<char>(self);
-        } else if (element_type == ov::element::f16) {
-            return _get_buffer_info<ov::float16>(self);
-        } else if (element_type == ov::element::f32) {
-            return _get_buffer_info<float>(self);
-        } else if (element_type == ov::element::f64) {
-            return _get_buffer_info<double>(self);
-        } else if (element_type == ov::element::i8) {
-            return _get_buffer_info<int8_t>(self);
-        } else if (element_type == ov::element::i16) {
-            return _get_buffer_info<int16_t>(self);
-        } else if (element_type == ov::element::i32) {
-            return _get_buffer_info<int32_t>(self);
-        } else if (element_type == ov::element::i64) {
-            return _get_buffer_info<int64_t>(self);
-        } else if (element_type == ov::element::u8 || element_type == ov::element::u1 ||
-                   element_type == ov::element::u2 || element_type == ov::element::u4) {
-            return _get_buffer_info<uint8_t>(self);
-        } else if (element_type == ov::element::u16) {
-            return _get_buffer_info<uint16_t>(self);
-        } else if (element_type == ov::element::u32) {
-            return _get_buffer_info<uint32_t>(self);
-        } else if (element_type == ov::element::u64) {
-            return _get_buffer_info<uint64_t>(self);
-        } else {
-            throw std::runtime_error("Unsupported data type!");
-        }
-    });
+        // TODO: Remove in future and re-use `get_data`
+        // Provide buffer access
+        constant.def_buffer([](const ov::op::v0::Constant& self) -> py::buffer_info {
+            auto element_type = self.get_element_type();
+            if (element_type == ov::element::boolean) {
+                return _get_buffer_info<char>(self);
+            } else if (element_type == ov::element::f16) {
+                return _get_buffer_info<ov::float16>(self);
+            } else if (element_type == ov::element::f32) {
+                return _get_buffer_info<float>(self);
+            } else if (element_type == ov::element::f64) {
+                return _get_buffer_info<double>(self);
+            } else if (element_type == ov::element::i8) {
+                return _get_buffer_info<int8_t>(self);
+            } else if (element_type == ov::element::i16) {
+                return _get_buffer_info<int16_t>(self);
+            } else if (element_type == ov::element::i32) {
+                return _get_buffer_info<int32_t>(self);
+            } else if (element_type == ov::element::i64) {
+                return _get_buffer_info<int64_t>(self);
+            } else if (element_type == ov::element::u8 || element_type == ov::element::u1 ||
+                       element_type == ov::element::u2 || element_type == ov::element::u4) {
+                return _get_buffer_info<uint8_t>(self);
+            } else if (element_type == ov::element::u16) {
+                return _get_buffer_info<uint16_t>(self);
+            } else if (element_type == ov::element::u32) {
+                return _get_buffer_info<uint32_t>(self);
+            } else if (element_type == ov::element::u64) {
+                return _get_buffer_info<uint64_t>(self);
+            } else {
+                throw std::runtime_error("Unsupported data type!");
+            }
+        });
 
-    constant.def(
-        "get_data",
-        [](ov::op::v0::Constant& self, py::object& dtype, bool copy) {
-            // Destination type was set:
-            if (!dtype.is(py::none())) {
-                py::dtype dst_dtype;
-                if (dtype.is(py::dtype())) {
-                    dst_dtype = dtype.cast<py::dtype>();
-                } else {
-                    dst_dtype = py::dtype::from_args(dtype);
-                }
-                const auto& ov_type = self.get_element_type();
-                const auto dtype = Common::type_helpers::get_dtype(ov_type);
-                // If dtype is the same as Constant type
-                // casting is NOT required, only check copy flag
-                if (dst_dtype.is(dtype)) {
-                    if (copy) {
-                        return Common::array_helpers::array_from_constant_copy(
-                            std::forward<ov::op::v0::Constant>(self));
+        constant.def(
+            "get_data",
+            [](ov::op::v0::Constant& self, py::object& dtype, bool copy) {
+                // Destination type was set:
+                if (!dtype.is(py::none())) {
+                    py::dtype dst_dtype;
+                    if (dtype.is(py::dtype())) {
+                        dst_dtype = dtype.cast<py::dtype>();
                     } else {
-                        return Common::array_helpers::array_from_constant_view(
-                            std::forward<ov::op::v0::Constant>(self));
+                        dst_dtype = py::dtype::from_args(dtype);
+                    }
+                    const auto& ov_type = self.get_element_type();
+                    const auto dtype = Common::type_helpers::get_dtype(ov_type);
+                    // If dtype is the same as Constant type
+                    // casting is NOT required, only check copy flag
+                    if (dst_dtype.is(dtype)) {
+                        if (copy) {
+                            return Common::array_helpers::array_from_constant_copy(
+                                std::forward<ov::op::v0::Constant>(self));
+                        } else {
+                            return Common::array_helpers::array_from_constant_view(
+                                std::forward<ov::op::v0::Constant>(self));
+                        }
+                    }
+                    // Otherwise always copy:
+                    else {
+                        return Common::array_helpers::array_from_constant_copy(std::forward<ov::op::v0::Constant>(self),
+                                                                               dst_dtype);
                     }
                 }
-                // Otherwise always copy:
-                else {
-                    return Common::array_helpers::array_from_constant_copy(std::forward<ov::op::v0::Constant>(self),
-                                                                           dst_dtype);
+                // Copy of data in Constant type:
+                else if (copy) {
+                    return Common::array_helpers::array_from_constant_copy(std::forward<ov::op::v0::Constant>(self));
                 }
-            }
-            // Copy of data in Constant type:
-            else if (copy) {
-                return Common::array_helpers::array_from_constant_copy(std::forward<ov::op::v0::Constant>(self));
-            }
-            // Shared view of data in Constant type:
-            else {
-                return Common::array_helpers::array_from_constant_view(std::forward<ov::op::v0::Constant>(self));
-            }
-        },
-        py::kw_only(),
-        py::arg("dtype") = py::none(),
-        py::arg("copy") = false,
-        R"(
+                // Shared view of data in Constant type:
+                else {
+                    return Common::array_helpers::array_from_constant_view(std::forward<ov::op::v0::Constant>(self));
+                }
+            },
+            py::kw_only(),
+            py::arg("dtype") = py::none(),
+            py::arg("copy") = false,
+            R"(
             Access to Constant's data. Returns numpy array with corresponding shape.
 
             Function tries to return a view by default, if not possible due
@@ -271,12 +273,12 @@ void regclass_graph_op_Constant(py::module m) {
             :rtype: numpy.array
         )");
 
-    constant.def_property_readonly(
-        "data",
-        [](ov::op::v0::Constant& self) {
-            return Common::array_helpers::array_from_constant_view(std::forward<ov::op::v0::Constant>(self));
-        },
-        R"(
+        constant.def_property_readonly(
+            "data",
+            [](ov::op::v0::Constant& self) {
+                return Common::array_helpers::array_from_constant_view(std::forward<ov::op::v0::Constant>(self));
+            },
+            R"(
             Access to Constant's data - creates a view of data.
 
             Returns numpy array with corresponding shape and dtype.
@@ -288,30 +290,31 @@ void regclass_graph_op_Constant(py::module m) {
             :rtype: numpy.array
         )");
 
-    constant.def_property_readonly("tensor_view",
-                                   &ov::op::v0::Constant::get_tensor_view,
-                                   R"(
+        constant.def_property_readonly("tensor_view",
+                                       &ov::op::v0::Constant::get_tensor_view,
+                                       R"(
                                     Get view on constant data as tensor.
 
                                     :rtype: openvino.Tensor
                                 )");
 
-    constant.def_property_readonly("strides",
-                                   &ov::op::v0::Constant::get_strides,
-                                   R"(
+        constant.def_property_readonly("strides",
+                                       &ov::op::v0::Constant::get_strides,
+                                       R"(
                                     Constant's strides in bytes.
 
                                     :rtype: openvino.Strides
                                 )");
 
-    constant.def("__repr__", [](const ov::op::v0::Constant& self) {
-        std::stringstream shapes_ss;
-        for (size_t i = 0; i < self.get_output_size(); ++i) {
-            if (i > 0) {
-                shapes_ss << ", ";
+        constant.def("__repr__", [](const ov::op::v0::Constant& self) {
+            std::stringstream shapes_ss;
+            for (size_t i = 0; i < self.get_output_size(); ++i) {
+                if (i > 0) {
+                    shapes_ss << ", ";
+                }
+                shapes_ss << self.get_output_partial_shape(i);
             }
-            shapes_ss << self.get_output_partial_shape(i);
-        }
-        return "<" + Common::get_class_name(self) + ": '" + self.get_friendly_name() + "' (" + shapes_ss.str() + ")>";
-    });
+            return "<" + Common::get_class_name(self) + ": '" + self.get_friendly_name() + "' (" + shapes_ss.str() +
+                   ")>";
+        });
 }

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -104,8 +104,7 @@ void regclass_graph_op_Constant(py::module m) {
                  py::arg("shared_memory") = false);
     // Tensor-based constructors
     constant.def(py::init([](ov::Tensor& tensor, bool shared_memory) {
-                     return std::make_shared<ov::op::v0::Constant>(
-                         Common::object_from_data<ov::op::v0::Constant>(tensor, shared_memory));
+                     return Common::object_from_data<ov::op::v0::Constant>(tensor, shared_memory);
                  }),
                  py::arg("tensor"),
                  py::arg("shared_memory") = true);

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -80,7 +80,13 @@ void regclass_graph_op_Constant(py::module m) {
 
                          // copy data
                          for (int i = 0; i < flat_array.size(); ++i) {
-                             strings.push_back(py::str(flat_array.attr("item")(i)));
+                            py::object item = flat_array.attr("item")(i);
+
+                            if(item.is_none()){
+                                strings.push_back("None");
+                                continue;
+                            }
+                             strings.push_back(py::str(item));
                          }
 
                          // create OpenVINO String Tensor

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -80,7 +80,6 @@ void regclass_graph_op_Constant(py::module m) {
                          }
                          // convert NumPy array to flattened list of strings
                          std::string* tensor_data = tensor.data<std::string>();
-                         //  std::vector<std::string> strings;
                          auto flat_array = array.reshape({-1});
 
                          // copy data

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -65,27 +65,30 @@ void regclass_graph_op_Constant(py::module m) {
     constant.def(py::init([](py::array& array, bool shared_memory) -> std::shared_ptr<ov::op::v0::Constant> {
                      if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
                          array.dtype().kind() == 'a') {
-                        if (shared_memory) {
-                            std::cerr << "Warning: Creating a String Constant with shared memory is not supported. Ignoring shared_memory flag." << std::endl;
-                        }
+                         if (shared_memory) {
+                             std::cerr << "Warning: Creating a String Constant with shared memory is not supported. "
+                                          "Ignoring shared_memory flag."
+                                       << std::endl;
+                         }
                          ov::Shape shape(array.shape(), array.shape() + array.ndim());
 
-                        if (array.size() == 0) {
-                            // return empty string tensor
-                            ov::Tensor tensor(ov::element::string, shape);
-                            return std::make_shared<ov::op::v0::Constant>(tensor);
+                         if (array.size() == 0) {
+                             // return empty string tensor
+                             ov::Tensor tensor(ov::element::string, shape);
+                             return std::make_shared<ov::op::v0::Constant>(tensor);
+                         }
                          // convert NumPy array to flattened list of strings
                          std::vector<std::string> strings;
                          auto flat_array = array.reshape({-1});
 
                          // copy data
                          for (int i = 0; i < flat_array.size(); ++i) {
-                            py::object item = flat_array.attr("item")(i);
+                             py::object item = flat_array.attr("item")(i);
 
-                            if(item.is_none()){
-                                strings.push_back("None");
-                                continue;
-                            }
+                             if (item.is_none()) {
+                                 strings.push_back("None");
+                                 continue;
+                             }
                              strings.push_back(py::str(item));
                          }
 

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -13,7 +13,6 @@
 
 #include "openvino/core/shape.hpp"
 #include "openvino/runtime/tensor.hpp"
-#include "openvino/util/log.hpp"
 #include "pyopenvino/core/common.hpp"
 
 namespace py = pybind11;

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -69,6 +69,7 @@ void regclass_graph_op_Constant(py::module m) {
                          array.dtype().kind() == 'a') {
                          if (shared_memory) {
                              OPENVINO_WARN("Creating a String Constant with shared memory is not supported. Data will be copied.");
+                             PyErr_WarnEx(PyExc_RuntimeWarning, "Creating a String Constant with shared memory is not supported. Data will be copied.", 1);
                          }
                          ov::Shape shape(array.shape(), array.shape() + array.ndim());
 

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -15,6 +15,7 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/runtime/tensor.hpp"
 #include "pyopenvino/core/common.hpp"
+#include "openvino/util/log.hpp"
 
 namespace py = pybind11;
 
@@ -67,9 +68,7 @@ void regclass_graph_op_Constant(py::module m) {
                      if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
                          array.dtype().kind() == 'a') {
                          if (shared_memory) {
-                             std::cerr << "Warning: Creating a String Constant with shared memory is not supported. "
-                                          "Data will be copied."
-                                       << std::endl;
+                             OPENVINO_WARN("Creating a String Constant with shared memory is not supported. Data will be copied.");
                          }
                          ov::Shape shape(array.shape(), array.shape() + array.ndim());
 

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -14,8 +14,8 @@
 
 #include "openvino/core/shape.hpp"
 #include "openvino/runtime/tensor.hpp"
-#include "pyopenvino/core/common.hpp"
 #include "openvino/util/log.hpp"
+#include "pyopenvino/core/common.hpp"
 
 namespace py = pybind11;
 
@@ -64,43 +64,47 @@ void regclass_graph_op_Constant(py::module m) {
                                                                                                py::buffer_protocol());
     constant.doc() = "openvino.op.Constant wraps ov::op::v0::Constant";
     // Numpy-based constructor
-    constant.def(py::init([](py::array& array, bool shared_memory) -> std::shared_ptr<ov::op::v0::Constant> {
-                     if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
-                         array.dtype().kind() == 'a') {
-                         if (shared_memory) {
-                             OPENVINO_WARN("Creating a String Constant with shared memory is not supported. Data will be copied.");
-                             PyErr_WarnEx(PyExc_RuntimeWarning, "Creating a String Constant with shared memory is not supported. Data will be copied.", 1);
-                         }
-                         ov::Shape shape(array.shape(), array.shape() + array.ndim());
+    constant.def(
+        py::init([](py::array& array, bool shared_memory) -> std::shared_ptr<ov::op::v0::Constant> {
+            if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
+                array.dtype().kind() == 'a') {
+                if (shared_memory) {
+                    OPENVINO_WARN(
+                        "Creating a String Constant with shared memory is not supported. Data will be copied.");
+                    PyErr_WarnEx(PyExc_RuntimeWarning,
+                                 "Creating a String Constant with shared memory is not supported. Data will be copied.",
+                                 1);
+                }
+                ov::Shape shape(array.shape(), array.shape() + array.ndim());
 
-                         ov::Tensor tensor(ov::element::string, shape);
-                         if (array.size() == 0) {
-                             // return empty string tensor
-                             return std::make_shared<ov::op::v0::Constant>(tensor);
-                         }
-                         // convert NumPy array to flattened list of strings
-                         std::string* tensor_data = tensor.data<std::string>();
-                         auto flat_array = array.reshape({-1});
+                ov::Tensor tensor(ov::element::string, shape);
+                if (array.size() == 0) {
+                    // return empty string tensor
+                    return std::make_shared<ov::op::v0::Constant>(tensor);
+                }
+                // convert NumPy array to flattened list of strings
+                std::string* tensor_data = tensor.data<std::string>();
+                auto flat_array = array.reshape({-1});
 
-                         // copy data
-                         for (py::ssize_t i = 0; i < flat_array.size(); ++i) {
-                             py::object item = flat_array.attr("item")(i);
+                // copy data
+                for (py::ssize_t i = 0; i < flat_array.size(); ++i) {
+                    py::object item = flat_array.attr("item")(i);
 
-                             if (item.is_none()) {
-                                 tensor_data[i] = "";
-                                 continue;
-                             }
-                             tensor_data[i] = py::str(item).cast<std::string>();
-                         }
+                    if (item.is_none()) {
+                        tensor_data[i] = "";
+                        continue;
+                    }
+                    tensor_data[i] = py::str(item).cast<std::string>();
+                }
 
-                         // return the Constant Op wrapping this tensor
-                         return std::make_shared<ov::op::v0::Constant>(tensor);
-                     }
-                     return std::make_shared<ov::op::v0::Constant>(
-                         Common::object_from_data<ov::op::v0::Constant>(array, shared_memory));
-                 }),
-                 py::arg("array"),
-                 py::arg("shared_memory") = false);
+                // return the Constant Op wrapping this tensor
+                return std::make_shared<ov::op::v0::Constant>(tensor);
+            }
+            return std::make_shared<ov::op::v0::Constant>(
+                Common::object_from_data<ov::op::v0::Constant>(array, shared_memory));
+        }),
+        py::arg("array"),
+        py::arg("shared_memory") = false);
     // Tensor-based constructors
     constant.def(py::init([](ov::Tensor& tensor, bool shared_memory) {
                      return Common::object_from_data<ov::op::v0::Constant>(tensor, shared_memory);

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -70,9 +70,6 @@ void regclass_graph_op_Constant(py::module m) {
                 if (shared_memory) {
                     OPENVINO_WARN(
                         "Creating a String Constant with shared memory is not supported. Data will be copied.");
-                    PyErr_WarnEx(PyExc_RuntimeWarning,
-                                 "Creating a String Constant with shared memory is not supported. Data will be copied.",
-                                 1);
                 }
                 ov::Shape shape(array.shape(), array.shape() + array.ndim());
 

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -9,7 +9,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <iostream>
 #include <stdexcept>
 
 #include "openvino/core/shape.hpp"

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -68,8 +68,10 @@ void regclass_graph_op_Constant(py::module m) {
             if (array.dtype().kind() == 'U' || array.dtype().kind() == 'S' || array.dtype().kind() == 'O' ||
                 array.dtype().kind() == 'a') {
                 if (shared_memory) {
-                    OPENVINO_WARN(
-                        "Creating a String Constant with shared memory is not supported. Data will be copied.");
+                    PyErr_WarnEx(
+                        PyExc_RuntimeWarning,
+                        "Creating a String Constant with shared memory is not supported. Data will be copied.",
+                        1);
                 }
                 ov::Shape shape(array.shape(), array.shape() + array.ndim());
 

--- a/src/bindings/python/tests/test_graph/test_constant.py
+++ b/src/bindings/python/tests/test_graph/test_constant.py
@@ -321,11 +321,41 @@ OPSETS = [ov.opset12, ov.opset13]
     ],
 )
 def test_float_to_f8e5m2_constant(ov_type, numpy_dtype, opset):
-    data = np.array([
-        4.75, 4.5, -5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5,
-        0.6, 0.7, 0.8, 0.9, 1, -0.0, -0.1, -0.2, -0.3,
-        -0.4, -0.5, -0.6, -0.7, -0.8, -0.9, -1.0, 0.0000152587890625, 448, 500, 512, 57344
-    ], dtype=numpy_dtype)
+    data = np.array(
+        [
+            4.75,
+            4.5,
+            -5.25,
+            0.0,
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1,
+            -0.0,
+            -0.1,
+            -0.2,
+            -0.3,
+            -0.4,
+            -0.5,
+            -0.6,
+            -0.7,
+            -0.8,
+            -0.9,
+            -1.0,
+            0.0000152587890625,
+            448,
+            500,
+            512,
+            57344,
+        ],
+        dtype=numpy_dtype,
+    )
 
     compressed_const = opset.constant(data, dtype=ov.Type.f8e5m2, name="f8e5m2_constant")
     convert = opset.convert(compressed_const, data.dtype)
@@ -337,10 +367,38 @@ def test_float_to_f8e5m2_constant(ov_type, numpy_dtype, opset):
     tensor = np.zeros(data.shape, dtype=numpy_dtype)
     result = compiled(tensor)[0]
 
-    target = [5.0, 4.0, -5.0, 0.0, 0.09375, 0.1875, 0.3125, 0.375, 0.5, 0.625, 0.75,
-              0.75, 0.875, 1.0, -0.0, -0.09375, -0.1875, -0.3125, -0.375,
-              -0.5, -0.625, -0.75, -0.75, -0.875, -1.0, 0.0000152587890625,
-              448, 512, 512, 57344]
+    target = [
+        5.0,
+        4.0,
+        -5.0,
+        0.0,
+        0.09375,
+        0.1875,
+        0.3125,
+        0.375,
+        0.5,
+        0.625,
+        0.75,
+        0.75,
+        0.875,
+        1.0,
+        -0.0,
+        -0.09375,
+        -0.1875,
+        -0.3125,
+        -0.375,
+        -0.5,
+        -0.625,
+        -0.75,
+        -0.75,
+        -0.875,
+        -1.0,
+        0.0000152587890625,
+        448,
+        512,
+        512,
+        57344,
+    ]
     target = np.array(target, dtype=numpy_dtype)
 
     assert np.allclose(result, target)
@@ -355,9 +413,10 @@ def test_float_to_f8e5m2_constant(ov_type, numpy_dtype, opset):
     ],
 )
 def test_float_to_f8e4m3_constant(ov_type, numpy_dtype, opset):
-    data = np.array([4.75, 4.5, -5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5,
-                     0.6, 0.7, 0.8, 0.9, 1, -0.0, -0.1, -0.2, -0.3,
-                     -0.4, -0.5, -0.6, -0.7, -0.8, -0.9, -1, 448, 512], dtype=numpy_dtype)
+    data = np.array(
+        [4.75, 4.5, -5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, -0.0, -0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8, -0.9, -1, 448, 512],
+        dtype=numpy_dtype,
+    )
 
     compressed_const = opset.constant(data, dtype=ov.Type.f8e4m3, name="f8e4m3_constant")
     convert = opset.convert(compressed_const, data.dtype)
@@ -369,10 +428,35 @@ def test_float_to_f8e4m3_constant(ov_type, numpy_dtype, opset):
     tensor = np.zeros(data.shape, dtype=numpy_dtype)
     result = compiled(tensor)[0]
 
-    target = [5.0, 4.5, -5.0, 0.0, 0.1015625, 0.203125, 0.3125,
-              0.40625, 0.5, 0.625, 0.6875, 0.8125, 0.875, 1,
-              -0, -0.1015625, -0.203125, -0.3125, -0.40625, -0.5, -0.625,
-              -0.6875, -0.8125, -0.875, -1, 448, np.nan]
+    target = [
+        5.0,
+        4.5,
+        -5.0,
+        0.0,
+        0.1015625,
+        0.203125,
+        0.3125,
+        0.40625,
+        0.5,
+        0.625,
+        0.6875,
+        0.8125,
+        0.875,
+        1,
+        -0,
+        -0.1015625,
+        -0.203125,
+        -0.3125,
+        -0.40625,
+        -0.5,
+        -0.625,
+        -0.6875,
+        -0.8125,
+        -0.875,
+        -1,
+        448,
+        np.nan,
+    ]
     target = np.array(target, dtype=numpy_dtype)
 
     assert np.allclose(result, target, equal_nan=True)
@@ -448,9 +532,10 @@ def test_float_to_f8e8m0_constant_single_nan(ov_type, numpy_dtype, opset):
 def test_float_to_f8e8m0_constant(ov_type, numpy_dtype, opset):
     pytest.skip("CVS-145281 BUG: nan to inf repro. [random - depends on the device]")
 
-    data = np.array([4.75, 4.5, 5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5,
-                     0.6, 0.7, 0.8, 0.9, 1, -0.0, 1.1, 1.2, 1.3,
-                     1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 448, 512, np.nan], dtype=numpy_dtype)
+    data = np.array(
+        [4.75, 4.5, 5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, -0.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 448, 512, np.nan],
+        dtype=numpy_dtype,
+    )
 
     compressed_const = opset.constant(data, dtype=ov.Type.f8e8m0, name="f8e8m0_constant")
     convert = opset.convert(compressed_const, data.dtype)
@@ -462,10 +547,7 @@ def test_float_to_f8e8m0_constant(ov_type, numpy_dtype, opset):
     tensor = np.zeros(data.shape, dtype=numpy_dtype)
     result = compiled(tensor)[0]
 
-    target = [4.0, 4.0, 4.0, 0.0, 0.125, 0.25, 0.25,
-              0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0,
-              0.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0,
-              2.0, 2.0, 2.0, 2.0, 512, 512, np.nan]
+    target = [4.0, 4.0, 4.0, 0.0, 0.125, 0.25, 0.25, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 512, 512, np.nan]
     target = np.array(target, dtype=numpy_dtype)
 
     assert np.allclose(result, target, equal_nan=True)
@@ -480,11 +562,41 @@ def test_float_to_f8e8m0_constant(ov_type, numpy_dtype, opset):
     ],
 )
 def test_float_to_f8e5m2_convert(ov_type, numpy_dtype, opset):
-    data = np.array([
-        4.75, 4.5, -5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5,
-        0.6, 0.7, 0.8, 0.9, 1, -0.0, -0.1, -0.2, -0.3,
-        -0.4, -0.5, -0.6, -0.7, -0.8, -0.9, -1.0, 0.0000152587890625, 448, 500, 512, 57344
-    ], dtype=numpy_dtype)
+    data = np.array(
+        [
+            4.75,
+            4.5,
+            -5.25,
+            0.0,
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1,
+            -0.0,
+            -0.1,
+            -0.2,
+            -0.3,
+            -0.4,
+            -0.5,
+            -0.6,
+            -0.7,
+            -0.8,
+            -0.9,
+            -1.0,
+            0.0000152587890625,
+            448,
+            500,
+            512,
+            57344,
+        ],
+        dtype=numpy_dtype,
+    )
 
     compressed_const = opset.constant(data, dtype=ov_type, name="fx_constant")
     convert_to_fp8 = opset.convert(compressed_const, Type.f8e5m2)
@@ -497,10 +609,38 @@ def test_float_to_f8e5m2_convert(ov_type, numpy_dtype, opset):
     tensor = np.zeros(data.shape, dtype=numpy_dtype)
     result = compiled(tensor)[0]
 
-    target = [5.0, 4.0, -5.0, 0.0, 0.09375, 0.1875, 0.3125, 0.375, 0.5, 0.625, 0.75,
-              0.75, 0.875, 1.0, -0.0, -0.09375, -0.1875, -0.3125, -0.375,
-              -0.5, -0.625, -0.75, -0.75, -0.875, -1.0, 0.0000152587890625,
-              448, 512, 512, 57344]
+    target = [
+        5.0,
+        4.0,
+        -5.0,
+        0.0,
+        0.09375,
+        0.1875,
+        0.3125,
+        0.375,
+        0.5,
+        0.625,
+        0.75,
+        0.75,
+        0.875,
+        1.0,
+        -0.0,
+        -0.09375,
+        -0.1875,
+        -0.3125,
+        -0.375,
+        -0.5,
+        -0.625,
+        -0.75,
+        -0.75,
+        -0.875,
+        -1.0,
+        0.0000152587890625,
+        448,
+        512,
+        512,
+        57344,
+    ]
     target = np.array(target, dtype=numpy_dtype)
 
     assert np.allclose(result, target)
@@ -515,9 +655,10 @@ def test_float_to_f8e5m2_convert(ov_type, numpy_dtype, opset):
     ],
 )
 def test_float_to_f8e4m3_convert(ov_type, numpy_dtype, opset):
-    data = np.array([4.75, 4.5, -5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5,
-                     0.6, 0.7, 0.8, 0.9, 1, -0.0, -0.1, -0.2, -0.3,
-                     -0.4, -0.5, -0.6, -0.7, -0.8, -0.9, -1, 448, 512], dtype=numpy_dtype)
+    data = np.array(
+        [4.75, 4.5, -5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, -0.0, -0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8, -0.9, -1, 448, 512],
+        dtype=numpy_dtype,
+    )
 
     compressed_const = opset.constant(data, dtype=ov_type, name="fx_constant")
     convert_to_fp8 = opset.convert(compressed_const, Type.f8e4m3)
@@ -530,10 +671,35 @@ def test_float_to_f8e4m3_convert(ov_type, numpy_dtype, opset):
     tensor = np.zeros(data.shape, dtype=numpy_dtype)
     result = compiled(tensor)[0]
 
-    target = [5.0, 4.5, -5.0, 0.0, 0.1015625, 0.203125, 0.3125,
-              0.40625, 0.5, 0.625, 0.6875, 0.8125, 0.875, 1,
-              -0, -0.1015625, -0.203125, -0.3125, -0.40625, -0.5, -0.625,
-              -0.6875, -0.8125, -0.875, -1, 448, np.nan]
+    target = [
+        5.0,
+        4.5,
+        -5.0,
+        0.0,
+        0.1015625,
+        0.203125,
+        0.3125,
+        0.40625,
+        0.5,
+        0.625,
+        0.6875,
+        0.8125,
+        0.875,
+        1,
+        -0,
+        -0.1015625,
+        -0.203125,
+        -0.3125,
+        -0.40625,
+        -0.5,
+        -0.625,
+        -0.6875,
+        -0.8125,
+        -0.875,
+        -1,
+        448,
+        np.nan,
+    ]
     target = np.array(target, dtype=numpy_dtype)
 
     assert np.allclose(result, target, equal_nan=True)
@@ -550,9 +716,10 @@ def test_float_to_f8e4m3_convert(ov_type, numpy_dtype, opset):
 def test_float_to_f8e8m0_convert(ov_type, numpy_dtype, opset):
     pytest.skip("CVS-145281 BUG: nan to inf repro. [random - depends on the device]")
 
-    data = np.array([4.75, 4.5, 5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5,
-                     0.6, 0.7, 0.8, 0.9, 1, -0.0, 1.1, 1.2, 1.3,
-                     1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 448, 512, np.nan], dtype=numpy_dtype)
+    data = np.array(
+        [4.75, 4.5, 5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, -0.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 448, 512, np.nan],
+        dtype=numpy_dtype,
+    )
 
     compressed_const = opset.constant(data, dtype=ov_type, name="fx_constant")
     convert_to_fp8 = opset.convert(compressed_const, Type.f8e8m0)
@@ -565,10 +732,7 @@ def test_float_to_f8e8m0_convert(ov_type, numpy_dtype, opset):
     tensor = np.zeros(data.shape, dtype=numpy_dtype)
     result = compiled(tensor)[0]
 
-    target = [4.0, 4.0, 4.0, 0.0, 0.125, 0.25, 0.25,
-              0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0,
-              0.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0,
-              2.0, 2.0, 2.0, 2.0, 512, 512, np.nan]
+    target = [4.0, 4.0, 4.0, 0.0, 0.125, 0.25, 0.25, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 512, 512, np.nan]
     target = np.array(target, dtype=numpy_dtype)
 
     assert np.allclose(result, target, equal_nan=True)
@@ -800,11 +964,11 @@ def test_string_constant_basic():
     """Test creating a string constant from numpy array."""
     strings = np.array(["hello", "world", "test"])
     ov_const = ops.constant(strings)
-    
+
     assert isinstance(ov_const, Constant)
     assert ov_const.get_element_type() == Type.string
     assert tuple(ov_const.shape) == (3,)
-    
+
     result = ov_const.get_value_strings()
     assert result == ["hello", "world", "test"]
 
@@ -813,24 +977,24 @@ def test_string_constant_2d():
     """Test creating a 2D string constant."""
     strings = np.array([["a", "b"], ["c", "d"]])
     ov_const = ops.constant(strings)
-    
+
     assert isinstance(ov_const, Constant)
     assert ov_const.get_element_type() == Type.string
     assert tuple(ov_const.shape) == (2, 2)
-    
+
     result = ov_const.get_value_strings()
     assert result == ["a", "b", "c", "d"]
 
 
 def test_string_constant_empty():
     """Test creating an empty string constant."""
-    strings = np.array([], dtype='<U1')
+    strings = np.array([], dtype="<U1")
     ov_const = ops.constant(strings)
-    
+
     assert isinstance(ov_const, Constant)
     assert ov_const.get_element_type() == Type.string
     assert tuple(ov_const.shape) == (0,)
-    
+
     result = ov_const.get_value_strings()
     assert result == []
 
@@ -839,39 +1003,31 @@ def test_string_constant_with_none():
     """Test creating a string constant with None values (should convert to empty string)."""
     strings = np.array(["hello", None, "world"], dtype=object)
     ov_const = ops.constant(strings)
-    
+
     assert isinstance(ov_const, Constant)
     assert ov_const.get_element_type() == Type.string
     assert tuple(ov_const.shape) == (3,)
-    
+
     result = ov_const.get_value_strings()
     assert result == ["hello", "", "world"]
 
 
-def test_string_constant_shared_memory_warning(capfd):
+def test_string_constant_shared_memory_warning():
     """Test that shared_memory flag generates a warning for string constants."""
-    strings = np.array(["test"])
-    ov_const = ops.constant(strings, shared_memory=True)
-    
-    # Check that constant was still created
-    assert isinstance(ov_const, Constant)
-    assert ov_const.get_element_type() == Type.string
-    
-    # Note: Warning goes to stderr, check if it appears
-    captured = capfd.readouterr()
-    # The warning should be printed to stderr
-    assert "Warning" in captured.err or len(captured.err) == 0  # May not always capture in test
+    with pytest.warns(RuntimeWarning, match="Creating a String Constant with shared memory is not supported. Data will be copied."):
+        strings = np.array(["hello", "world"])
+        ops.constant(strings, shared_memory=True)
 
 
 def test_string_constant_unicode():
     """Test creating a string constant with unicode characters."""
     strings = np.array(["hello", "世界", "🌍"])
     ov_const = ops.constant(strings)
-    
+
     assert isinstance(ov_const, Constant)
     assert ov_const.get_element_type() == Type.string
     assert tuple(ov_const.shape) == (3,)
-    
+
     result = ov_const.get_value_strings()
     assert result == ["hello", "世界", "🌍"]
 
@@ -880,10 +1036,10 @@ def test_string_constant_mixed_types():
     """Test creating a string constant from object array with mixed types."""
     strings = np.array(["text", 123, 45.6, True], dtype=object)
     ov_const = ops.constant(strings)
-    
+
     assert isinstance(ov_const, Constant)
     assert ov_const.get_element_type() == Type.string
     assert tuple(ov_const.shape) == (4,)
-    
+
     result = ov_const.get_value_strings()
     assert result == ["text", "123", "45.6", "True"]

--- a/src/bindings/python/tests/test_graph/test_constant.py
+++ b/src/bindings/python/tests/test_graph/test_constant.py
@@ -1025,7 +1025,7 @@ def test_string_constant_shared_memory_warning(capfd):
     assert result == ["hello", "world"]
 
     captured = capfd.readouterr()
-    # assert "Creating a String Constant with shared memory is not supported. Data will be copied" in captured.err
+    assert "Creating a String Constant with shared memory is not supported. Data will be copied" in captured.out
 
 
 def test_string_constant_unicode():

--- a/src/bindings/python/tests/test_graph/test_constant.py
+++ b/src/bindings/python/tests/test_graph/test_constant.py
@@ -1012,20 +1012,12 @@ def test_string_constant_with_none():
     assert result == ["hello", "", "world"]
 
 
-def test_string_constant_shared_memory_warning(capfd):
+def test_string_constant_shared_memory_warning():
     """Test that shared_memory flag generates a warning for string constants."""
     strings = np.array(["hello", "world"])
-    ov_const = ops.constant(strings, shared_memory=True)
-
-    assert isinstance(ov_const, Constant)
-    assert ov_const.get_element_type() == Type.string
-    assert tuple(ov_const.shape) == (2,)
-
-    result = ov_const.get_value_strings()
-    assert result == ["hello", "world"]
-
-    captured = capfd.readouterr()
-    assert "Creating a String Constant with shared memory is not supported. Data will be copied" in captured.out
+    with pytest.warns(RuntimeWarning, match="Creating a String Constant with shared memory is not supported. Data will be copied."):
+        ops.constant(strings, shared_memory=True)
+        
 
 
 def test_string_constant_unicode():

--- a/src/bindings/python/tests/test_graph/test_constant.py
+++ b/src/bindings/python/tests/test_graph/test_constant.py
@@ -1012,11 +1012,20 @@ def test_string_constant_with_none():
     assert result == ["hello", "", "world"]
 
 
-def test_string_constant_shared_memory_warning():
+def test_string_constant_shared_memory_warning(capfd):
     """Test that shared_memory flag generates a warning for string constants."""
-    with pytest.warns(RuntimeWarning, match="Creating a String Constant with shared memory is not supported. Data will be copied."):
-        strings = np.array(["hello", "world"])
-        ops.constant(strings, shared_memory=True)
+    strings = np.array(["hello", "world"])
+    ov_const = ops.constant(strings, shared_memory=True)
+
+    assert isinstance(ov_const, Constant)
+    assert ov_const.get_element_type() == Type.string
+    assert tuple(ov_const.shape) == (2,)
+
+    result = ov_const.get_value_strings()
+    assert result == ["hello", "world"]
+
+    captured = capfd.readouterr()
+    # assert "Creating a String Constant with shared memory is not supported. Data will be copied" in captured.err
 
 
 def test_string_constant_unicode():

--- a/src/bindings/python/tests/test_graph/test_constant.py
+++ b/src/bindings/python/tests/test_graph/test_constant.py
@@ -414,7 +414,35 @@ def test_float_to_f8e5m2_constant(ov_type, numpy_dtype, opset):
 )
 def test_float_to_f8e4m3_constant(ov_type, numpy_dtype, opset):
     data = np.array(
-        [4.75, 4.5, -5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, -0.0, -0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8, -0.9, -1, 448, 512],
+        [
+            4.75,
+            4.5,
+            -5.25,
+            0.0,
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1,
+            -0.0,
+            -0.1,
+            -0.2,
+            -0.3,
+            -0.4,
+            -0.5,
+            -0.6,
+            -0.7,
+            -0.8,
+            -0.9,
+            -1,
+            448,
+            512,
+        ],
         dtype=numpy_dtype,
     )
 
@@ -533,7 +561,36 @@ def test_float_to_f8e8m0_constant(ov_type, numpy_dtype, opset):
     pytest.skip("CVS-145281 BUG: nan to inf repro. [random - depends on the device]")
 
     data = np.array(
-        [4.75, 4.5, 5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, -0.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 448, 512, np.nan],
+        [
+            4.75,
+            4.5,
+            5.25,
+            0.0,
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1,
+            -0.0,
+            1.1,
+            1.2,
+            1.3,
+            1.4,
+            1.5,
+            1.6,
+            1.7,
+            1.8,
+            1.9,
+            2.0,
+            448,
+            512,
+            np.nan,
+        ],
         dtype=numpy_dtype,
     )
 
@@ -547,7 +604,36 @@ def test_float_to_f8e8m0_constant(ov_type, numpy_dtype, opset):
     tensor = np.zeros(data.shape, dtype=numpy_dtype)
     result = compiled(tensor)[0]
 
-    target = [4.0, 4.0, 4.0, 0.0, 0.125, 0.25, 0.25, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 512, 512, np.nan]
+    target = [
+        4.0,
+        4.0,
+        4.0,
+        0.0,
+        0.125,
+        0.25,
+        0.25,
+        0.5,
+        0.5,
+        0.5,
+        0.5,
+        1.0,
+        1.0,
+        1.0,
+        0.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        512,
+        512,
+        np.nan,
+    ]
     target = np.array(target, dtype=numpy_dtype)
 
     assert np.allclose(result, target, equal_nan=True)
@@ -656,7 +742,35 @@ def test_float_to_f8e5m2_convert(ov_type, numpy_dtype, opset):
 )
 def test_float_to_f8e4m3_convert(ov_type, numpy_dtype, opset):
     data = np.array(
-        [4.75, 4.5, -5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, -0.0, -0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8, -0.9, -1, 448, 512],
+        [
+            4.75,
+            4.5,
+            -5.25,
+            0.0,
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1,
+            -0.0,
+            -0.1,
+            -0.2,
+            -0.3,
+            -0.4,
+            -0.5,
+            -0.6,
+            -0.7,
+            -0.8,
+            -0.9,
+            -1,
+            448,
+            512,
+        ],
         dtype=numpy_dtype,
     )
 
@@ -717,7 +831,36 @@ def test_float_to_f8e8m0_convert(ov_type, numpy_dtype, opset):
     pytest.skip("CVS-145281 BUG: nan to inf repro. [random - depends on the device]")
 
     data = np.array(
-        [4.75, 4.5, 5.25, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, -0.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 448, 512, np.nan],
+        [
+            4.75,
+            4.5,
+            5.25,
+            0.0,
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1,
+            -0.0,
+            1.1,
+            1.2,
+            1.3,
+            1.4,
+            1.5,
+            1.6,
+            1.7,
+            1.8,
+            1.9,
+            2.0,
+            448,
+            512,
+            np.nan,
+        ],
         dtype=numpy_dtype,
     )
 
@@ -732,7 +875,36 @@ def test_float_to_f8e8m0_convert(ov_type, numpy_dtype, opset):
     tensor = np.zeros(data.shape, dtype=numpy_dtype)
     result = compiled(tensor)[0]
 
-    target = [4.0, 4.0, 4.0, 0.0, 0.125, 0.25, 0.25, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 512, 512, np.nan]
+    target = [
+        4.0,
+        4.0,
+        4.0,
+        0.0,
+        0.125,
+        0.25,
+        0.25,
+        0.5,
+        0.5,
+        0.5,
+        0.5,
+        1.0,
+        1.0,
+        1.0,
+        0.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        512,
+        512,
+        np.nan,
+    ]
     target = np.array(target, dtype=numpy_dtype)
 
     assert np.allclose(result, target, equal_nan=True)
@@ -1015,9 +1187,10 @@ def test_string_constant_with_none():
 def test_string_constant_shared_memory_warning():
     """Test that shared_memory flag generates a warning for string constants."""
     strings = np.array(["hello", "world"])
-    with pytest.warns(RuntimeWarning, match="Creating a String Constant with shared memory is not supported. Data will be copied."):
+    with pytest.warns(
+        RuntimeWarning, match="Creating a String Constant with shared memory is not supported. Data will be copied."
+    ):
         ops.constant(strings, shared_memory=True)
-        
 
 
 def test_string_constant_unicode():


### PR DESCRIPTION
This PR fixes #23611 

- The numpy based construtor now handles numpy-array with string as elements. 
- converts None to empty string ''

Related tests have also been added to test_constant.py. 
