### PR TITLE
[FE] Coverity move instead of copy fix

### DIFF
--- a/src/frontends/pytorch/src/op/loop.cpp
+++ b/src/frontends/pytorch/src/op/loop.cpp
@@ -199,7 +199,7 @@ OutputVector translate_while_loop_fx(const NodeContext& context) {
         if (node_map.count(source_node)) {
             cloned_body_outputs.push_back(node_map[source_node]->output(source.get_index()));
         } else {
-            cloned_body_outputs.push_back(std::move(source));
+            cloned_body_outputs.push_back(source);
         }
     }
 


### PR DESCRIPTION
### Details:
Fix Coverity defect type: Variable copied when it could be moved, for: src/frontends/pytorch/src/op/loop.cpp
Coiverity issues id: 
 - 2536356 
 - 2536355
 - 2536354
 - 2536353
 - 2536352

### Tickets:
 - *ticket-id*
