### PR TITLE
[TRANSFORMATIONS] Coverity move instead of copy fix

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -148,11 +148,11 @@ RoPEFusionFlux::RoPEFusionFlux(bool num_heads_transposed) {
         config.output_trans0213 = false;
 
         OutputVector new_args;
-        new_args.push_back(pattern_map.at(x));
-        new_args.push_back(pattern_map.at(t_cos));
-        new_args.push_back(pattern_map.at(t_sin));
+        new_args.push_back(std::move(pattern_map.at(x)));
+        new_args.push_back(std::move(pattern_map.at(t_cos)));
+        new_args.push_back(std::move(pattern_map.at(t_sin)));
 
-        auto old_node = root;
+        auto old_node = std::move(root);
         auto new_node = std::make_shared<ov::op::internal::RoPE>(new_args, config);
         new_node->set_friendly_name(old_node->get_friendly_name());
         ov::copy_runtime_info({pattern_map.at(x1).get_node_shared_ptr(),
@@ -1184,16 +1184,18 @@ RoPEFusionGPTOSS::RoPEFusionGPTOSS() {
 
         new_args.push_back(x_val);
         new_args.push_back(v_cos);
-        new_args.push_back(pattern_map.at(t_sin));
+
+        new_args.push_back(pattern_map.at(std::move(t_sin)));
         auto new_node = std::make_shared<ov::op::internal::RoPE>(new_args, config);
+
         new_node->set_friendly_name(root->get_friendly_name());
-        ov::copy_runtime_info({pattern_map.at(neg).get_node_shared_ptr(),
-                               pattern_map.at(sub_Subtract).get_node_shared_ptr(),
-                               pattern_map.at(first_half_mul_cos).get_node_shared_ptr(),
-                               pattern_map.at(first_half_mul_sin).get_node_shared_ptr(),
-                               pattern_map.at(second_half_mul_cos).get_node_shared_ptr(),
-                               pattern_map.at(second_half_mul_sin).get_node_shared_ptr(),
-                               pattern_map.at(add_Add).get_node_shared_ptr(),
+        ov::copy_runtime_info({pattern_map.at(std::move(neg)).get_node_shared_ptr(),
+                               pattern_map.at(std::move(sub_Subtract)).get_node_shared_ptr(),
+                               pattern_map.at(std::move(first_half_mul_cos)).get_node_shared_ptr(),
+                               pattern_map.at(std::move(first_half_mul_sin)).get_node_shared_ptr(),
+                               pattern_map.at(std::move(second_half_mul_cos)).get_node_shared_ptr(),
+                               pattern_map.at(std::move(second_half_mul_sin)).get_node_shared_ptr(),
+                               pattern_map.at(std::move(add_Add)).get_node_shared_ptr(),
                                pattern_map.at(result).get_node_shared_ptr()},
                               new_node);
         ov::replace_node(root, new_node);


### PR DESCRIPTION
### Details:
Fix Coverity defect type: Variable copied when it could be moved, for: fuse_rotary_positional_embeddings.cpp
Coiverity issues id:
 - 2535304
 - 2535315
 - 2535312
 - 2535311
 - 2535308
 - 2535305
 - 2535309
 - 2535306
 - 2535307
 - 2535316
 - 2534917
 - 2534916
 - 2534942
 - 2534936
 - 2534933
 - 2534915
 - 2534931
 - 2534938
 - 2534940
 - 2534919
 - 2534928
