### PR TITLE
[GPU] Enable 5d output shape of random_uniform createOp

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/random_uniform.cpp
@@ -21,8 +21,10 @@ void CreateRandomUniformOp(ProgramBuilder &p, const std::shared_ptr<ov::op::v8::
 
     if (output_pshape.is_static() && !p.use_new_shape_infer()) {
         auto output_shape = output_pshape.get_shape();
-        // Extend to 4D shape
-        output_shape.insert(output_shape.end(), 4 - output_shape.size(), 1ul);
+        if (output_shape.size() < 4) {
+            // Extend to 4D shape
+            output_shape.insert(output_shape.end(), 4 - output_shape.size(), 1ul);
+        }
 
         auto random_uniform_prim = cldnn::random_uniform(layer_type_name_ID(op),
                                                          inputs,

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/random_uniform.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/random_uniform.cpp
@@ -24,7 +24,8 @@ const std::vector<int64_t> op_seeds = {10, 50};
 const std::vector<ov::Shape> output_shapes = {
         {1, 3, 3,  3},
         {1, 1, 5,  5},
-        {2, 1, 10, 10}
+        {2, 1, 10, 10},
+        {1, 3, 1, 512, 512}
 };
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - The customer model has 5d output shape in random_uniform. In CreateRandomUniformOp, 4d extension makes "vector too long" error.
 - output_shape.insert(output_shape.end(), 4 - output_shape.size(), 1ul);  -> when output_shape_size()=5, size_t(-1) happens.

#### The code and line that caused this issue (if it is not changed directly)
 - ihttps://github.com/openvinotoolkit/openvino/blob/3d81cc84c32fa8c8ab04ee7820a9c7543b511885/src/plugins/intel_gpu/src/plugin/ops/random_uniform.cpp#L25

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - $ benchmark_app -d GPU.1 -m ~/task/cvs179162/irwn_enc-v2-fp32-512x512-ox.onnx -hint latency
 
#### Problematic graph
 - onnx model graph
 
<img width="361" height="168" alt="image" src="https://github.com/user-attachments/assets/41c790c1-6cf6-4b87-907c-2264e4a21ad5" />


#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 179162