### PR TITLE
[GPU] Disable FP16 Compression for if and gather for FP16 Detectron2 MaskRCNN model inference accuracy

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_gather_if.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_gather_if.cpp
@@ -35,7 +35,7 @@ DisableFP16CompForDetectron2MaskRCNNGatherIfPattern::DisableFP16CompForDetectron
                     disable_fp16_compression(if_op);
                     return true;
                 }
-            }   
+            }
 
             // check gather -> gather pattern
             auto gather_op = std::dynamic_pointer_cast<ov::op::v8::Gather>(matched_node);
@@ -50,7 +50,7 @@ DisableFP16CompForDetectron2MaskRCNNGatherIfPattern::DisableFP16CompForDetectron
                     disable_fp16_compression(gather_op);
                     return true;
                 }
-            }   
+            }
         }
 
         return false;

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_gather_if.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_gather_if.cpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "disable_fp16_comp_gather_if.hpp"
+
+#include "openvino/op/gather.hpp"
+#include "openvino/op/gather_nd.hpp"
+#include "openvino/op/if.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace ov::intel_gpu {
+
+DisableFP16CompForDetectron2MaskRCNNGatherIfPattern::DisableFP16CompForDetectron2MaskRCNNGatherIfPattern() {
+
+    auto root_pattern = ov::pass::pattern::wrap_type<ov::op::v8::If, ov::op::v8::Gather>();
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(root_pattern, "DisableFP16CompForDetectron2MaskRCNNGatherIfPattern");
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        auto matched_node = m.get_match_root();
+
+        if (matched_node) {
+            // check gather_nd -> if pattern
+            auto if_op = std::dynamic_pointer_cast<ov::op::v8::If>(matched_node);
+            if (if_op) {
+                for (auto& input : if_op->inputs()) {
+                    auto src_node = input.get_source_output().get_node_shared_ptr();
+
+                    auto gather_nd = std::dynamic_pointer_cast<ov::op::v8::GatherND>(src_node);
+                    if (!gather_nd || !gather_nd->get_element_type().is_real())
+                        continue;
+
+                    disable_fp16_compression(if_op);
+                    return true;
+                }
+            }   
+
+            // check gather -> gather pattern
+            auto gather_op = std::dynamic_pointer_cast<ov::op::v8::Gather>(matched_node);
+            if (gather_op) {
+                for (auto& input : gather_op->inputs()) {
+                    auto src_node = input.get_source_output().get_node_shared_ptr();
+
+                    auto gather = std::dynamic_pointer_cast<ov::op::v8::Gather>(src_node);
+                    if (!gather || !gather->get_element_type().is_real())
+                        continue;
+
+                    disable_fp16_compression(gather_op);
+                    return true;
+                }
+            }   
+        }
+
+        return false;
+    };
+
+    this->register_matcher(m, callback);
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_gather_if.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_gather_if.hpp
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/pass.hpp"
+
+namespace ov::intel_gpu {
+
+class DisableFP16CompForDetectron2MaskRCNNGatherIfPattern: public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("DisableFP16CompForDetectron2MaskRCNNGatherIfPattern");
+    DisableFP16CompForDetectron2MaskRCNNGatherIfPattern();
+};
+
+}   // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -99,6 +99,7 @@
 #include "plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.hpp"
 #include "plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.hpp"
 #include "plugin/transformations/disable_fp16_comp_rms.hpp"
+#include "plugin/transformations/disable_fp16_comp_gather_if.hpp"
 #include "plugin/transformations/swiglu_fusion_with_clamp.hpp"
 #include "transformations/common_optimizations/activations_scaling.hpp"
 #include "transformations/common_optimizations/broadcast_elementwise_fusion.hpp"
@@ -539,6 +540,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             return static_cast<int32_t>((gamma_shape.back() / vec_size)) > static_cast<int32_t>(device_info.max_work_group_size);
         });
         manager.register_pass<ov::pass::RMSFusion>(false, true);
+        manager.register_pass<DisableFP16CompForDetectron2MaskRCNNGatherIfPattern>();
         manager.register_pass<DisableFP16CompForGemma3RMSPattern>();
         manager.register_pass<DisableFP16ComForGPTOSSROPEPattern>();
         const bool keep_precision_sensitive_in_fp32_1 = true;

--- a/src/plugins/intel_gpu/tests/unit/transformations/disable_fp16_compression_gather_if_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/disable_fp16_compression_gather_if_test.cpp
@@ -1,0 +1,118 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include <openvino/core/model.hpp>
+#include <openvino/pass/manager.hpp>
+#include <transformations/utils/utils.hpp>
+#include <transformations/convert_precision.hpp>
+
+#include "plugin/transformations/disable_fp16_comp_gather_if.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/gather_nd.hpp"
+#include "openvino/op/if.hpp"
+#include "openvino/op/add.hpp"
+
+using namespace testing;
+using namespace ov::intel_gpu;
+
+static const std::string name_if = "prim::If/If";
+static const std::string name_gather = "__module.model.roi_heads.mask_pooler/aten::select/Gather";
+
+// This model creates the exact pattern that DisableFP16CompForDetectron2MaskRCNNGatherIfPattern is looking for.
+static std::shared_ptr<ov::Model> create_model_to_match(bool use_convert = false) {
+
+    // Gather_ND -> If
+    auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{4});
+    auto pred = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, ov::Shape{});
+    auto indices_nd = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{2, 1});
+    auto gather_nd = std::make_shared<ov::op::v8::GatherND>(data, indices_nd, 0);
+    auto gather_nd_out_shape = gather_nd->get_output_shape(0);
+
+    auto then_gather = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, gather_nd->get_output_partial_shape(0));
+    auto then_const = ov::op::v0::Constant::create(ov::element::f16,
+        gather_nd_out_shape, std::vector<float>(ov::shape_size(gather_nd_out_shape), 1.0f));
+    auto then_add = std::make_shared<ov::op::v1::Add>(then_gather, then_const);
+    auto then_result = std::make_shared<ov::op::v0::Result>(then_add);
+    auto then_body = std::make_shared<ov::Model>(
+        ov::ResultVector{then_result},
+        ov::ParameterVector{then_gather});
+
+    auto else_gather = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, gather_nd->get_output_partial_shape(0));
+    auto else_const = ov::op::v0::Constant::create(ov::element::f16,
+        gather_nd_out_shape, std::vector<float>(ov::shape_size(gather_nd_out_shape), 2.0f));
+    auto else_add = std::make_shared<ov::op::v1::Add>(else_gather, else_const);
+    auto else_result = std::make_shared<ov::op::v0::Result>(else_add);
+    auto else_body = std::make_shared<ov::Model>(
+        ov::ResultVector{else_result},
+        ov::ParameterVector{else_gather});
+
+    auto if_node = std::make_shared<ov::op::v8::If>(pred);
+    if_node->set_then_body(then_body);
+    if_node->set_else_body(else_body);
+    if_node->set_friendly_name(name_if);
+
+    if_node->set_input(gather_nd->output(0), then_gather, else_gather);
+    if_node->set_output(then_result, else_result);
+
+    auto if_result = std::make_shared<ov::op::v0::Result>(if_node->output(0));
+
+    // Gather -> Gather
+    auto indices0  = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{2});
+    auto indices1  = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
+
+    auto axis0 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0});
+    auto axis1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0});
+
+    auto gather0_node = std::make_shared<ov::op::v8::Gather>(data, indices0, axis0);
+    auto gather1_node = std::make_shared<ov::op::v8::Gather>(gather0_node, indices1, axis1);
+    gather1_node->set_friendly_name(name_gather);
+
+    auto gather_result = std::make_shared<ov::op::v0::Result>(gather1_node);
+
+    return std::make_shared<ov::Model>(
+        ov::ResultVector{if_result, gather_result},
+        ov::ParameterVector{pred, data, indices_nd, indices0, indices1});
+}
+
+static void run_test(std::shared_ptr<ov::Model> model,
+                     const std::unordered_map<std::string, bool>& expected_fp16_disabled_status) {
+    ov::pass::Manager manager;
+    manager.register_pass<DisableFP16CompForDetectron2MaskRCNNGatherIfPattern>();
+
+    precisions_map fp_convert_precision_map = {
+        {ov::element::f32, ov::element::f16}
+    };
+    manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map);
+
+    manager.run_passes(model);
+
+    for (const auto& op : model->get_ops()) {
+        auto it = expected_fp16_disabled_status.find(op->get_friendly_name());
+        if (it != expected_fp16_disabled_status.end()) {
+            bool expected_status = it->second;
+            if (expected_status) {
+                ASSERT_TRUE(ov::fp16_compression_is_disabled(op))
+                    << "FP16 compression is not disabled for node: " << op->get_friendly_name();
+            } else {
+                ASSERT_FALSE(ov::fp16_compression_is_disabled(op))
+                    << "FP16 compression is unexpectedly disabled for node: " << op->get_friendly_name();
+            }
+        }
+    }
+}
+
+TEST(TransformationTests, DisableFP16CompForDetectron2MaskRCNNGatherIf) {
+    auto model = create_model_to_match();
+    // In the matching pattern, 'If' and 'Gather' should have FP16 compression disabled.
+    std::unordered_map<std::string, bool> expected_status = {
+        {name_if, true},
+        {name_gather, true},
+    };
+    run_test(model, expected_status);
+}


### PR DESCRIPTION
### Details
Disabled FP16 compression for if and gather to keep FP32 precision during FP16 inference of Detectron2 MaskRCNN model.

### Description of the issue

#### Symptom
FP16 E2E test for Detectron2 MaskRCNN model will be failed at "crop", which has input shape of 1x1x28x28 while want to get 2x1x28x28 shape output.

#### Root cause
FP32 inference has input shape of 2x1x28x28 and can pass E2E accuracy testing. The root cause is FP16 precision resolution is not enough to get correct results and thus the shape is changed after ops like gather_nonzero (NonZero) and condition (If).

#### How to fix it
Disable FP16 Compression for gather and if in specific pattern in the GPU Plugin transformation pipeline can make them keep FP32 precision, and get correct final result to pass the accuracy testing.

#### The code and line that caused this issue
- Added DisableFP16CompForDetectron2MaskRCNNGatherIfPattern for Detectron2 MaskRCNN

https://github.com/openvinotoolkit/openvino/blob/a7a983b6eebb86ea8718e6c87c1747182e13d02f/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp#L543

#### Reproduction step and snapshot
```python -m pytest test_ovc_mo.py  --tb=native --env_conf=.automation/env_config.yml --test_conf=.automation/test_configs/desktop_test_config_gpu.yml -m "not launch_only_if_manually_specified " --pregen_irs=irs_mapping.csv --tf_models_version=1.15.2 --modules pipelines/production/pytorch/light/detectron2_mask_rcnn.py -k "Pytorch_Detectron2_MaskRCNN_api_2_True" --dynamism_type=None --log-cli-level INFO```

#### Problematic graph
- crop (__module.model.roi_heads.mask_head/aten::split_with_sizes/VariadicSplit)
<img width="432" height="293" alt="image" src="https://github.com/user-attachments/assets/544a58d1-1fa0-49dd-860d-6e5d3e5f3504" />

#### Checklist 
 - [x] Is it a proper fix? (not a workaround) 
 - [x] Did you include test case for this fix, if necessary? 
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - CVS-123423