### PR TITLE
[GPU] Move data_flow marking for const-convert-gemm pattern to reorder_inputs

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -232,6 +232,7 @@ public:
     void mark_if_constant(program_node& node);
     // mark if the node is in data flow assuming that all dependencies are marked properly
     void mark_if_data_flow(program_node& node);
+    void mark_if_gemm_data_flow();
     // Reverses connection - user becomes dependency.
 
     void remove_nodes(std::vector<program_node*>& to_remove);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -512,6 +512,8 @@ void insert_reorders(program& p, const std::map<program_node*, format::type>& fm
 }  // namespace
 
 void reorder_inputs::run(program& p, reorder_factory& rf) {
+    p.mark_if_gemm_data_flow();
+
     auto& lo = p.get_layout_optimizer();
 
     auto fmt_map = get_preferred_formats(p, lo);

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -517,12 +517,11 @@ void program::init_graph() {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, "Program::init_graph");
     apply_opt_pass<graph_initializations>();
 
+    apply_opt_pass<mark_nodes>();
     for (auto& node : processing_order) {
         if (!node->is_type<data>())
             node->get_output_layouts();
     }
-
-    apply_opt_pass<mark_nodes>();
 
     // Perform initial shape_of subgraphs markup
     apply_opt_pass<mark_shape_of_subgraphs>();
@@ -666,29 +665,36 @@ void program::mark_if_data_flow(program_node& node) {
             }
         }
     }
+}
 
-    // Rank promotion for data_flow in static shape models:
-    // - In static-shape models, patterns like Constant -> Convert -> Gemm can
-    //   leave the Convert node non-data_flow even when its output rank (e.g. bfyx)
-    //   is lower than the rank required by the Gemm inputs/outputs (e.g. bfzyx).
-    // - In such cases input_reorder may skip inserting a reorder after Convert,
-    //   which later leads to input dimension mismatch in gemm::calc_output_layout.
-    // - To avoid this, if any Gemm user has an output rank greater than the current
-    //   node rank, we promote this node to data_flow so that required reorders are
-    //   inserted on the legacy path.
-    if (!is_new_shape_infer() && !node.data_flow) {
-        const size_t current_rank = node.get_output_layout().get_rank();
-        for (auto* user : node.get_users()) {
-            if (!user->is_type<gemm>())
-                continue;
-            int port = user->get_port_from_deps(node.id());
-            if (port < 0 || port >= 2)
-                continue;
+// Rank promotion for data_flow in static shape models:
+// - In static-shape models, patterns like Constant -> Convert -> Gemm can
+//   leave the Convert node non-data_flow even when its output rank (e.g. bfyx)
+//   is lower than the rank required by the Gemm inputs/outputs (e.g. bfzyx).
+// - In such cases input_reorder may skip inserting a reorder after Convert,
+//   which later leads to input dimension mismatch in gemm::calc_output_layout.
+// - To avoid this, if any Gemm user has an output rank greater than the current
+//   node rank, we promote this node to data_flow so that required reorders are
+//   inserted on the legacy path.
+void program::mark_if_gemm_data_flow() {
+    if (is_new_shape_infer())
+        return;
 
-            size_t user_rank = user->get_output_layout().get_rank();
-            if (user_rank > current_rank) {
-                node.data_flow = true;
-                break;
+    for (const auto& node : get_processing_order()) {
+        if (!node->data_flow) {
+            const size_t current_rank = node->get_output_layout().get_rank();
+            for (auto* user : node->get_users()) {
+                if (!user->is_type<gemm>())
+                    continue;
+                int port = user->get_port_from_deps(node->id());
+                if (port < 0 || port >= 2)
+                    continue;
+
+                size_t user_rank = user->get_output_layout().get_rank();
+                if (user_rank > current_rank) {
+                    node->data_flow = true;
+                    break;
+                }
             }
         }
     }

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -517,11 +517,13 @@ void program::init_graph() {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, "Program::init_graph");
     apply_opt_pass<graph_initializations>();
 
-    apply_opt_pass<mark_nodes>();
     for (auto& node : processing_order) {
         if (!node->is_type<data>())
             node->get_output_layouts();
     }
+
+    apply_opt_pass<mark_nodes>();
+
     // Perform initial shape_of subgraphs markup
     apply_opt_pass<mark_shape_of_subgraphs>();
 }


### PR DESCRIPTION
### Issue:
- `user->get_output_layout()` in `mark_if_data_flow()` is being called before user layouts are calculated. 
- In large graphs, this can trigger deep recursive layout computation from mid‑graph nodes back to inputs, which may lead to stack overflow.

### Root Cause:
- `mark_if_data_flow()` runs during `mark_nodes` traversal and can evaluate GEMM users whose layouts are not yet cached. 
- When `get_output_layout()` is called on such nodes, it falls back to `calc_output_layouts()` and recursively requests input layouts, causing a deep call chain in large models.

### Fix:
- Create a separate function, `mark_if_gemm_data_flow()` to mark `data_flow` for the case of `Constant -> Convert -> Gemm` pattern.
- The function should be called from `reorder_inputs`.
- For information on the pattern`, please refer [PR#32817](https://github.com/openvinotoolkit/openvino/pull/32817)

#### Checklist
 - [x] Is it a proper fix?
 - [ ] Did you include test case for this fix, if necessary? 
 - [ ] Did you review existing test that can be extended to cover this scenario?
 
### Tickets:
 - 178999
