### PR TITLE
[SDL438] Add nosec B404 to subprocess imports for Bandit compliance

### DIFF
--- a/scripts/utils/utils.py
+++ b/scripts/utils/utils.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import subprocess
+import subprocess  # nosec B404
 import tarfile
 from datetime import datetime
 from shutil import copyfile, copytree, rmtree

--- a/tools/commit_slider/commit_slider.py
+++ b/tools/commit_slider/commit_slider.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess
+import subprocess  # nosec B404
 import os
 import shutil
 import sys

--- a/tools/commit_slider/utils/e2e_preparator.py
+++ b/tools/commit_slider/utils/e2e_preparator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 try:
     import yaml
 except:
-    import subprocess
+    import subprocess  # nosec B404
     import sys
     p = subprocess.Popen('{} -m pip install pyyaml'.format(
             sys.executable

--- a/tools/commit_slider/utils/helpers.py
+++ b/tools/commit_slider/utils/helpers.py
@@ -5,7 +5,7 @@ import importlib
 import shutil
 import os
 import sys
-import subprocess
+import subprocess  # nosec B404
 from enum import Enum
 import re
 import json


### PR DESCRIPTION
Fix Bandit B404 security warning by adding nosec B404 comments to subprocess imports. Addresses SDL438 - Align Use of Python with Bandit Guidance. Ticket: CVS-177660