### PR TITLE
[GPU] Enable SDPA 4D gpu test

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -249,7 +249,6 @@ std::vector<std::string> disabledTestPatterns() {
         returnVal.push_back(R"(.*smoke_ConvolutionLayerGPUTest_3D_tensor_basic/ConvolutionLayerGPUTest..*)");
         returnVal.push_back(R"(.*smoke_MatmulWeightsDecompressionQuantizeConvolution_basic.*)");
         returnVal.push_back(R"(.*smoke_Nms9LayerTest/Nms9LayerTest.Inference/num_batches=2_num_boxes=50.*)");
-        returnVal.push_back(R"(.*smoke_ScaledAttnDynamic4D_GPU/ScaledAttnLayerGPUTest.CompareWithRefs/n.*)");
     } else {
         // CVS-172342
         returnVal.push_back(R"(.*smoke_MatMulCompressedWeights_3D_weight.*)");


### PR DESCRIPTION
### Details:
Enable SDPA 4D tests for XMX capable GPUs

### Tickets:
 - N/A
