### PR TITLE
Fix unloading libopenvino_intel_npu_plugin.so library

### DIFF
--- a/src/core/dev_api/openvino/core/so_extension.hpp
+++ b/src/core/dev_api/openvino/core/so_extension.hpp
@@ -35,9 +35,7 @@ inline std::filesystem::path resolve_extension_path(const std::filesystem::path&
     }
 }
 
-inline std::vector<Extension::Ptr> load_extensions(const std::filesystem::path& path) {
-    const auto resolved_path = resolve_extension_path(path);
-    auto so = ov::util::load_shared_object(resolved_path);
+inline std::vector<Extension::Ptr> load_extensions(std::shared_ptr<void>& so) {
     using CreateFunction = void(std::vector<Extension::Ptr>&);
     std::vector<Extension::Ptr> extensions;
     reinterpret_cast<CreateFunction*>(ov::util::get_symbol(so, "create_extensions"))(extensions);
@@ -49,6 +47,12 @@ inline std::vector<Extension::Ptr> load_extensions(const std::filesystem::path& 
         so_extensions.emplace_back(std::make_shared<SOExtension>(ex, so));
     }
     return so_extensions;
+}
+
+inline std::vector<Extension::Ptr> load_extensions(const std::filesystem::path& path) {
+    const auto resolved_path = resolve_extension_path(path);
+    auto so = ov::util::load_shared_object(resolved_path);
+    return load_extensions(so);
 }
 
 template <class T>

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -275,9 +275,9 @@ std::filesystem::path get_cache_model_path(const ov::AnyMap& config) {
     return it == config.end() ? std::filesystem::path{} : it->second.as<std::filesystem::path>();
 }
 
-std::vector<ov::Extension::Ptr> try_get_extensions(const std::filesystem::path& path) {
+std::vector<ov::Extension::Ptr> try_get_extensions(std::shared_ptr<void>& so) {
     try {
-        return ov::detail::load_extensions(path);
+        return ov::detail::load_extensions(so);
     } catch (const std::runtime_error&) {
         return {};
     }
@@ -802,7 +802,7 @@ ov::Plugin ov::CoreImpl::get_plugin(const std::string& plugin_name) const {
                 // the same extension can be registered multiple times - ignore it!
             }
         } else {
-            ext = try_get_extensions(desc.m_lib_location);
+            ext = try_get_extensions(so);
         }
         std::move(ext.begin(), ext.end(), std::back_inserter(m_plugin_registry.at(device_name).m_extensions));
 

--- a/src/plugins/intel_npu/CMakeLists.txt
+++ b/src/plugins/intel_npu/CMakeLists.txt
@@ -62,6 +62,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WX")
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    ov_add_compiler_flags(-fno-gnu-unique)
+endif()
+
 if(CMAKE_COMPILE_WARNING_AS_ERROR)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
         remove_compiler_flags(-Wno-error=deprecated-declarations)

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_integration.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_integration.hpp
@@ -494,6 +494,58 @@ TEST_P(OVClassBasicTestPNPU, smoke_registerPluginsLibrariesUnicodePath) {
 }
 #endif
 
+static void checkLibrariesInProcessMemoryMap(bool checkExist) {
+#ifdef __linux__
+    std::unordered_map<const char*, bool> librariesFound = {
+        /*
+        TODO: uncomment when unloading driver and loader is fixed
+        {"libnpu_driver_compiler.so", false},
+        {"libze_intel_npu.so", false},
+        {"libze_loader.so", false},
+        */
+        {"libopenvino_intel_npu_plugin.so", false},
+    };
+    std::ifstream file("/proc/self/maps");
+    std::string line;
+    while (!file.eof()) {
+        std::getline(file, line);
+        for (auto [library, _] : librariesFound) {
+            if (strstr(line.c_str(), library)) {
+                librariesFound[library] = true;
+                break;
+            }
+        }
+    }
+    for (auto [library, found] : librariesFound) {
+        if (checkExist) {
+            EXPECT_TRUE(found) << "NPU related library (" << library << ") is not loaded";
+        } else {
+            EXPECT_FALSE(found) << "NPU related library (" << library << ") is still loaded";
+        }
+    }
+#endif
+}
+
+TEST(OVClassBaseTestNPU, UnloadPlugin) {
+    auto core = ov::test::utils::PluginCache::get().core();
+    {
+        auto model = ov::test::utils::make_conv_pool_relu();
+        auto compiled_model = core->compile_model(model, ov::test::utils::DEVICE_NPU);
+        auto req = compiled_model.create_infer_request();
+        req.infer();
+    }
+
+    checkLibrariesInProcessMemoryMap(true);
+    core->unload_plugin(ov::test::utils::DEVICE_NPU);
+    checkLibrariesInProcessMemoryMap(false);
+
+    // check if Core can load the plugin again and run the inference
+    auto model = ov::test::utils::make_conv_pool_relu();
+    auto compiled_model = core->compile_model(model, ov::test::utils::DEVICE_NPU);
+    auto req = compiled_model.create_infer_request();
+    req.infer();
+}
+
 }  // namespace behavior
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
- avoid multiple dlopens when loading the plugin - create another flavor of load_extensions function which takes DSO handle (instead of DSO name)
- add -fno-gnu-unique for NPU plugin when compiled with gcc. Unique symbols prevent the library from being unloaded.