### PR TITLE
Fixed the circular refernece between CPUStreamsExecutor and ExecuterManager

### DIFF
--- a/src/inference/src/dev/threading/cpu_streams_executor.cpp
+++ b/src/inference/src/dev/threading/cpu_streams_executor.cpp
@@ -360,7 +360,6 @@ struct CPUStreamsExecutor::Impl {
                   return std::make_shared<Impl::Stream>(this);
               },
               this) {
-        _exectorMgr = executor_manager();
         auto numaNodes = get_available_numa_nodes();
         int streams_num = _config.get_streams();
         auto processor_ids = _config.get_stream_processor_ids();
@@ -478,7 +477,6 @@ struct CPUStreamsExecutor::Impl {
     bool _isStopped = false;
     std::vector<int> _usedNumaNodes;
     CustomThreadLocal _streams;
-    std::shared_ptr<ExecutorManager> _exectorMgr;
     bool _isExit = false;
     std::vector<int> _cpu_ids_all;
     std::mutex _cpu_ids_mutex;


### PR DESCRIPTION

### Details:

<img width="1178" height="572" alt="image" src="https://github.com/user-attachments/assets/706377a9-6a53-43d9-8341-675ef8d0df3d" />

The `CPUStreamsExecutor `: 
```
 explicit Impl(const Config& config)
        : _config{config},
          _streams(
              [this] {
                  return std::make_shared<Impl::Stream>(this);
              },
              this) {
        _exectorMgr = executor_manager();
```
The `ExecutorManagerImpl`:
```
std::shared_ptr<ov::threading::ITaskExecutor> ExecutorManagerImpl::get_executor(const std::string& id) {
    std::lock_guard<std::mutex> guard(taskExecutorMutex);
    auto foundEntry = executors.find(id);
    if (foundEntry == executors.end()) {
        auto newExec = std::make_shared<ov::threading::CPUStreamsExecutor>(ov::threading::IStreamsExecutor::Config{id});
        tbbThreadsCreated = true;
        executors[id] = newExec;
        return newExec;
    }
    return foundEntry->second;
}
```


### Tickets:
 - [CVS-179009](https://jira.devtools.intel.com/browse/CVS-179009)
