### PR TITLE
[GPU][Core] Enable zero-copy input via default USM Host Tensor allocation

### DIFF
--- a/src/core/include/openvino/runtime/tensor.hpp
+++ b/src/core/include/openvino/runtime/tensor.hpp
@@ -10,8 +10,8 @@
 #pragma once
 
 #include <filesystem>
-#include <type_traits>
 #include <functional>
+#include <type_traits>
 
 #include "openvino/core/coordinate.hpp"
 #include "openvino/core/partial_shape.hpp"

--- a/src/core/include/openvino/runtime/tensor.hpp
+++ b/src/core/include/openvino/runtime/tensor.hpp
@@ -11,6 +11,7 @@
 
 #include <filesystem>
 #include <type_traits>
+#include <functional>
 
 #include "openvino/core/coordinate.hpp"
 #include "openvino/core/partial_shape.hpp"
@@ -25,8 +26,19 @@ class Tensor;
 class ITensor;
 
 namespace util {
+using TensorImplGenerator = std::function<std::shared_ptr<ITensor>(const element::Type&, const Shape&)>;
+
 ov::Tensor make_tensor(const std::shared_ptr<ov::ITensor>& tensor, const std::shared_ptr<void>& so);
 void get_tensor_impl(const ov::Tensor& tensor, std::shared_ptr<ov::ITensor>& tensor_impl, std::shared_ptr<void>& so);
+
+/// @brief Set default tensor implementation generator. This generator will be used in Tensor constructors.
+/// @param generator Tensor implementation generator or nullptr to reset to default behavior
+OPENVINO_API
+void set_custom_tensor_impl_generator(const TensorImplGenerator& generator);
+
+/// @brief Reset default tensor implementation generator to default behavior.
+OPENVINO_API
+void reset_custom_tensor_impl_generator();
 }  // namespace util
 
 namespace op {

--- a/src/core/src/runtime/tensor.cpp
+++ b/src/core/src/runtime/tensor.cpp
@@ -29,8 +29,8 @@ ov::util::TensorImplGenerator& custom_tensor_generator() {
 }
 
 std::shared_ptr<ITensor> make_tensor_with_custom_generator(const element::Type& element_type,
-                                                    const Shape& shape,
-                                                    const Allocator& allocator) {
+                                                           const Shape& shape,
+                                                           const Allocator& allocator) {
     auto& custom_generator = custom_tensor_generator();
     if (custom_generator && allocator == Allocator{}) {
         return custom_generator(element_type, shape);

--- a/src/core/src/runtime/tensor.cpp
+++ b/src/core/src/runtime/tensor.cpp
@@ -17,9 +17,40 @@
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/runtime/remote_tensor.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
+#include "openvino/util/log.hpp"
 #include "openvino/util/mmap_object.hpp"
 
 namespace ov {
+
+namespace {
+ov::util::TensorImplGenerator& custom_tensor_generator() {
+    static ov::util::TensorImplGenerator generator;
+    return generator;
+}
+
+std::shared_ptr<ITensor> make_tensor_with_custom_generator(const element::Type& element_type,
+                                                    const Shape& shape,
+                                                    const Allocator& allocator) {
+    auto& custom_generator = custom_tensor_generator();
+    if (custom_generator && allocator == Allocator{}) {
+        return custom_generator(element_type, shape);
+    }
+    return make_tensor(element_type, shape, allocator);
+}
+}  // namespace
+
+namespace util {
+void set_custom_tensor_impl_generator(const TensorImplGenerator& generator) {
+    custom_tensor_generator() = generator;
+    OPENVINO_DEBUG("Custom tensor implementation generator is set.");
+}
+
+void reset_custom_tensor_impl_generator() {
+    custom_tensor_generator() = nullptr;
+    OPENVINO_DEBUG("Custom tensor implementation generator is reset.");
+}
+
+}  // namespace util
 
 #define OV_TENSOR_STATEMENT(...)                                      \
     OPENVINO_ASSERT(_impl != nullptr, "Tensor was not initialized."); \
@@ -48,7 +79,7 @@ Tensor::Tensor(const std::shared_ptr<ITensor>& impl, const std::shared_ptr<void>
 }
 
 Tensor::Tensor(const element::Type& element_type, const Shape& shape, const Allocator& allocator)
-    : _impl{make_tensor(element_type, shape, allocator)} {}
+    : _impl{make_tensor_with_custom_generator(element_type, shape, allocator)} {}
 
 Tensor::Tensor(const element::Type& element_type, const Shape& shape, void* host_ptr, const Strides& byte_strides)
     : _impl{make_tensor(element_type, shape, host_ptr, byte_strides)} {}

--- a/src/core/tests/ov_tensor_custom_impl_test.cpp
+++ b/src/core/tests/ov_tensor_custom_impl_test.cpp
@@ -1,0 +1,341 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "openvino/core/except.hpp"
+#include "openvino/runtime/itensor.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+namespace ov::test {
+
+// Mock ITensor implementation for testing
+class MockTensorImpl : public ov::ITensor {
+public:
+    MockTensorImpl(const ov::element::Type& element_type, const ov::Shape& shape)
+        : m_element_type(element_type),
+          m_shape(shape),
+          m_byte_size(ov::shape_size(shape) * element_type.size()) {
+        if (m_byte_size > 0) {
+            m_data = std::malloc(m_byte_size);
+            if (!m_data) {
+                throw std::bad_alloc();
+            }
+        }
+    }
+
+    ~MockTensorImpl() override {
+        if (m_data) {
+            std::free(m_data);
+        }
+    }
+
+    const ov::element::Type& get_element_type() const override {
+        return m_element_type;
+    }
+
+    void set_shape(ov::Shape new_shape) override {
+        m_shape = std::move(new_shape);
+    }
+
+    const ov::Shape& get_shape() const override {
+        return m_shape;
+    }
+
+    size_t get_size() const override {
+        return ov::shape_size(m_shape);
+    }
+
+    size_t get_byte_size() const override {
+        return m_byte_size;
+    }
+
+    const ov::Strides& get_strides() const override {
+        OPENVINO_THROW("get_strides() not implemented in MockTensorImpl");
+    }
+
+    void* data() override {
+        return m_data;
+    }
+
+    const void* data() const override {
+        return m_data;
+    }
+
+    void* data_rw() override {
+        return m_data;
+    }
+
+    void* data(const ov::element::Type& element_type) override {
+        if (element_type != m_element_type && element_type.bitwidth() != 0) {
+            OPENVINO_THROW("Cannot get data with different element type");
+        }
+        return m_data;
+    }
+
+    const void* data(const ov::element::Type& element_type) const override {
+        if (element_type != m_element_type && element_type.bitwidth() != 0) {
+            OPENVINO_THROW("Cannot get data with different element type");
+        }
+        return m_data;
+    }
+
+    void* data_rw(const ov::element::Type& element_type) override {
+        if (element_type != m_element_type && element_type.bitwidth() != 0) {
+            OPENVINO_THROW("Cannot get data with different element type");
+        }
+        return m_data;
+    }
+
+private:
+    ov::element::Type m_element_type;
+    ov::Shape m_shape;
+    size_t m_byte_size;
+    void* m_data = nullptr;
+};
+
+class OVTensorCustomImplTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Reset to default state before each test
+        ov::util::reset_custom_tensor_impl_generator();
+    }
+
+    void TearDown() override {
+        // Clean up after each test
+        ov::util::reset_custom_tensor_impl_generator();
+    }
+};
+
+TEST_F(OVTensorCustomImplTest, DefaultBehaviorWithoutCustomGenerator) {
+    // Create tensor without custom generator
+    ov::Shape shape = {2, 3, 4};
+    ov::Tensor tensor(ov::element::f32, shape);
+
+    EXPECT_EQ(tensor.get_shape(), shape);
+    EXPECT_EQ(tensor.get_element_type(), ov::element::f32);
+    EXPECT_NE(tensor.data(), nullptr);
+    EXPECT_EQ(tensor.get_size(), 24);
+}
+
+TEST_F(OVTensorCustomImplTest, CustomGeneratorIsUsed) {
+    bool generator_called = false;
+    ov::Shape captured_shape;
+    ov::element::Type captured_type;
+
+    // Set custom generator
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            generator_called = true;
+            captured_type = type;
+            captured_shape = shape;
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    // Create tensor - should use custom generator
+    ov::Shape shape = {2, 3, 4};
+    ov::Tensor tensor(ov::element::f32, shape);
+
+    EXPECT_TRUE(generator_called);
+    EXPECT_EQ(captured_type, ov::element::f32);
+    EXPECT_EQ(captured_shape, shape);
+    EXPECT_EQ(tensor.get_shape(), shape);
+    EXPECT_EQ(tensor.get_element_type(), ov::element::f32);
+    EXPECT_NE(tensor.data(), nullptr);
+}
+
+TEST_F(OVTensorCustomImplTest, ResetGeneratorRestoresDefaultBehavior) {
+    bool generator_called = false;
+
+    // Set custom generator
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            generator_called = true;
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    // Create tensor - should use custom generator
+    ov::Shape shape1 = {2, 3};
+    ov::Tensor tensor1(ov::element::f32, shape1);
+    EXPECT_TRUE(generator_called);
+
+    // Reset generator
+    generator_called = false;
+    ov::util::reset_custom_tensor_impl_generator();
+
+    // Create another tensor - should use default behavior
+    ov::Shape shape2 = {4, 5};
+    ov::Tensor tensor2(ov::element::f32, shape2);
+    EXPECT_FALSE(generator_called);
+    EXPECT_EQ(tensor2.get_shape(), shape2);
+    EXPECT_NE(tensor2.data(), nullptr);
+}
+
+TEST_F(OVTensorCustomImplTest, CustomGeneratorDoesNotAffectHostPtrConstructor) {
+    bool generator_called = false;
+
+    // Set custom generator
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            generator_called = true;
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    // Create tensor with host pointer - should NOT use custom generator
+    ov::Shape shape = {2, 3, 4};
+    std::vector<float> data(ov::shape_size(shape), 1.0f);
+    ov::Tensor tensor(ov::element::f32, shape, data.data());
+
+    EXPECT_FALSE(generator_called);
+    EXPECT_EQ(tensor.data<float>(), data.data());
+}
+
+TEST_F(OVTensorCustomImplTest, CustomGeneratorDoesNotAffectCustomAllocator) {
+    bool generator_called = false;
+
+    // Set custom generator
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            generator_called = true;
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    // Create a simple custom allocator
+    struct CustomAllocator {
+        void* allocate(size_t bytes, size_t alignment) {
+            return alignment == 0 ? std::malloc(bytes) : aligned_alloc(alignment, bytes);
+        }
+        void deallocate(void* ptr, size_t, size_t) noexcept {
+            std::free(ptr);
+        }
+        bool is_equal(const CustomAllocator&) const noexcept {
+            return true;
+        }
+    };
+
+    CustomAllocator custom_alloc;
+    ov::Allocator allocator(custom_alloc);
+
+    // Create tensor with custom allocator - should NOT use custom generator
+    ov::Shape shape = {2, 3, 4};
+    ov::Tensor tensor(ov::element::f32, shape, allocator);
+
+    EXPECT_FALSE(generator_called);
+    EXPECT_NE(tensor.data(), nullptr);
+}
+
+TEST_F(OVTensorCustomImplTest, MultipleSetAndReset) {
+    bool generator1_called = false;
+    bool generator2_called = false;
+
+    // Set first generator
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            generator1_called = true;
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    ov::Shape shape = {2, 3};
+    ov::Tensor tensor1(ov::element::f32, shape);
+    EXPECT_TRUE(generator1_called);
+    EXPECT_FALSE(generator2_called);
+
+    // Set second generator (replaces first)
+    generator1_called = false;
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            generator2_called = true;
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    ov::Tensor tensor2(ov::element::f32, shape);
+    EXPECT_FALSE(generator1_called);
+    EXPECT_TRUE(generator2_called);
+
+    // Reset and verify default behavior
+    ov::util::reset_custom_tensor_impl_generator();
+    generator1_called = false;
+    generator2_called = false;
+
+    ov::Tensor tensor3(ov::element::f32, shape);
+    EXPECT_FALSE(generator1_called);
+    EXPECT_FALSE(generator2_called);
+}
+
+TEST_F(OVTensorCustomImplTest, CustomGeneratorWithDifferentElementTypes) {
+    std::vector<ov::element::Type> captured_types;
+
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            captured_types.push_back(type);
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    ov::Shape shape = {2, 3};
+    ov::Tensor tensor_f32(ov::element::f32, shape);
+    ov::Tensor tensor_i32(ov::element::i32, shape);
+    ov::Tensor tensor_u8(ov::element::u8, shape);
+
+    EXPECT_EQ(captured_types.size(), 3);
+    EXPECT_EQ(captured_types[0], ov::element::f32);
+    EXPECT_EQ(captured_types[1], ov::element::i32);
+    EXPECT_EQ(captured_types[2], ov::element::u8);
+}
+
+TEST_F(OVTensorCustomImplTest, CustomGeneratorWithDifferentShapes) {
+    std::vector<ov::Shape> captured_shapes;
+
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            captured_shapes.push_back(shape);
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    ov::Tensor tensor1(ov::element::f32, {2, 3});
+    ov::Tensor tensor2(ov::element::f32, {4, 5, 6});
+    ov::Tensor tensor3(ov::element::f32, {1});
+
+    EXPECT_EQ(captured_shapes.size(), 3);
+    EXPECT_EQ(captured_shapes[0], ov::Shape({2, 3}));
+    EXPECT_EQ(captured_shapes[1], ov::Shape({4, 5, 6}));
+    EXPECT_EQ(captured_shapes[2], ov::Shape({1}));
+}
+
+TEST_F(OVTensorCustomImplTest, EmptyShapeTensor) {
+    bool generator_called = false;
+
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            generator_called = true;
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    ov::Tensor tensor(ov::element::f32, {0});
+    EXPECT_TRUE(generator_called);
+    EXPECT_EQ(tensor.get_size(), 0);
+}
+
+TEST_F(OVTensorCustomImplTest, SetNullptrGeneratorResetsToDefault) {
+    bool generator_called = false;
+
+    // Set a generator
+    ov::util::set_custom_tensor_impl_generator(
+        [&](const ov::element::Type& type, const ov::Shape& shape) -> std::shared_ptr<ov::ITensor> {
+            generator_called = true;
+            return std::make_shared<MockTensorImpl>(type, shape);
+        });
+
+    ov::Tensor tensor1(ov::element::f32, {2, 3});
+    EXPECT_TRUE(generator_called);
+
+    // Set nullptr as generator (should reset to default)
+    generator_called = false;
+    ov::util::set_custom_tensor_impl_generator(nullptr);
+
+    ov::Tensor tensor2(ov::element::f32, {2, 3});
+    EXPECT_FALSE(generator_called);
+    EXPECT_NE(tensor2.data(), nullptr);
+}
+
+}  // namespace ov::test

--- a/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
@@ -77,6 +77,12 @@ static constexpr Property<bool> enable_loop_unrolling{"GPU_ENABLE_LOOP_UNROLLING
  */
 static constexpr Property<bool> disable_winograd_convolution{"GPU_DISABLE_WINOGRAD_CONVOLUTION"};
 
+/**
+ * @brief Property which forces all empty host tensors to be allocated as USM host tensors
+ * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
+ */
+static constexpr Property<bool> default_usm_host_tensor_allocation{"DEFAULT_USM_HOST_TENSOR_ALLOCATION"};
+
 namespace hint {
 /**
  * @brief This enum represents the possible value of ov::intel_gpu::hint::queue_throttle property:

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
@@ -49,6 +49,7 @@ private:
 
 public:
     Plugin();
+    ~Plugin();
 
     std::shared_ptr<ov::ICompiledModel> compile_model(const std::shared_ptr<const ov::Model>& model,
                                                       const ov::AnyMap& properties) const override;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -23,6 +23,7 @@ OV_CONFIG_RELEASE_OPTION(ov::intel_gpu::hint, enable_lora_operation, true, "Enab
 OV_CONFIG_RELEASE_OPTION(ov::intel_gpu::hint, enable_large_allocations, false, "Enable/Disable large buffer allocations (>4gb). Enabling this option may lead to performance degradation")
 OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, enable_loop_unrolling, true, "Enable/Disable Loop/TensorIterator operation unrolling")
 OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, disable_winograd_convolution, false, "Enable/Disable winograd convolution implementation if available")
+OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, default_usm_host_tensor_allocation, false, "Force USM Host memory allocation for default tensors")
 OV_CONFIG_RELEASE_OPTION(ov::internal, exclusive_async_requests, false, "")
 OV_CONFIG_RELEASE_OPTION(ov::internal, query_model_ratio, 1.0f, "")
 OV_CONFIG_RELEASE_OPTION(ov, cache_mode, ov::CacheMode::OPTIMIZE_SPEED, "Cache mode defines the trade-off between the model compilation time and the disk space required for the cache")

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -38,6 +38,7 @@
 #include "openvino/runtime/plugin_config.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
+#include "openvino/runtime/tensor.hpp"
 #include "openvino/runtime/weightless_properties_utils.hpp"
 #include "openvino/util/file_util.hpp"
 #include "openvino/util/weights_path.hpp"
@@ -235,6 +236,10 @@ Plugin::Plugin() {
     m_compiled_model_runtime_properties["OV_VERSION"] = ov_version.buildNumber;
 }
 
+Plugin::~Plugin() {
+    ov::util::reset_custom_tensor_impl_generator();
+}
+
 std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<const ov::Model>& model, const ov::AnyMap& orig_config) const {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "Plugin::compile_model");
     std::string device_id = get_device_id(orig_config);
@@ -327,6 +332,18 @@ void Plugin::set_property(const ov::AnyMap &config) {
             for (auto& conf : m_configs_map) {
                 update_config(conf.second, config);
             }
+        }
+    }
+
+    // handle default usm host tensor alloc
+    if (config.find(ov::intel_gpu::default_usm_host_tensor_allocation.name()) != config.end()) {
+        bool enable_usm_host_alloc = config.at(ov::intel_gpu::default_usm_host_tensor_allocation.name()).as<bool>();
+        if (enable_usm_host_alloc) {
+            auto context = get_default_context(m_default_device_id);
+            ov::util::set_custom_tensor_impl_generator([context](const element::Type& type, const Shape& shape) {
+                auto usm_host_tensor = context->create_host_tensor(type, shape);
+                return usm_host_tensor._ptr;
+            });
         }
     }
 }
@@ -712,6 +729,7 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::intel_gpu::hint::enable_lora_operation.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::enable_loop_unrolling.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::disable_winograd_convolution.name(), PropertyMutability::RW},
+        ov::PropertyName{ov::intel_gpu::default_usm_host_tensor_allocation.name(), PropertyMutability::RW},
         ov::PropertyName{ov::cache_dir.name(), PropertyMutability::RW},
         ov::PropertyName{ov::cache_mode.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::performance_mode.name(), PropertyMutability::RW},

--- a/src/plugins/intel_gpu/tests/functional/behavior/default_usm_host_tensor_test.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/default_usm_host_tensor_test.cpp
@@ -1,0 +1,335 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "openvino/runtime/core.hpp"
+#include "openvino/runtime/intel_gpu/properties.hpp"
+#include "openvino/runtime/intel_gpu/ocl/ocl.hpp"
+#include "openvino/runtime/tensor.hpp"
+#include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "remote_tensor_tests/helpers.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+namespace {
+
+using namespace ov::test::utils;
+
+class DefaultUSMHostTensorAllocationTest : public ::testing::Test {
+protected:
+    std::shared_ptr<ov::Model> model;
+    ov::Core core;
+
+    void SetUp() override {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED();
+        model = ov::test::utils::make_conv_pool_relu();
+    }
+
+    void TearDown() override {
+        // Reset the custom tensor generator after each test
+        ov::util::reset_custom_tensor_impl_generator();
+    }
+
+    bool supportsUSM() {
+        try {
+            auto context = core.get_default_context(ov::test::utils::DEVICE_GPU).as<ov::intel_gpu::ocl::ClContext>();
+            cl_context ctx = context;
+            auto ocl_instance = std::make_shared<OpenCL>(ctx);
+            return ocl_instance->supports_usm();
+        } catch (...) {
+            return false;
+        }
+    }
+};
+
+TEST_F(DefaultUSMHostTensorAllocationTest, TensorCreationWithPropertyDisabled) {
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = false;
+    
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU, config);
+    
+    // Create a regular tensor - should use default allocation
+    ov::Shape shape = {1, 3, 224, 224};
+    ov::Tensor tensor(ov::element::f32, shape);
+    
+    EXPECT_EQ(tensor.get_shape(), shape);
+    EXPECT_EQ(tensor.get_element_type(), ov::element::f32);
+    EXPECT_NE(tensor.data(), nullptr);
+}
+
+TEST_F(DefaultUSMHostTensorAllocationTest, TensorCreationWithPropertyEnabled) {
+    if (!supportsUSM()) {
+        GTEST_SKIP() << "Device does not support USM";
+    }
+
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+    
+    // Set property to enable USM host tensor allocation
+    core.set_property(ov::test::utils::DEVICE_GPU, config);
+    
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    
+    // Create a tensor - should use USM host allocation via custom generator
+    ov::Shape shape = {1, 3, 224, 224};
+    ov::Tensor tensor(ov::element::f32, shape);
+    
+    EXPECT_EQ(tensor.get_shape(), shape);
+    EXPECT_EQ(tensor.get_element_type(), ov::element::f32);
+    EXPECT_NE(tensor.data(), nullptr);
+    
+    // Verify it's actually a USM host tensor by checking allocation type
+    auto context = compiled_model.get_context().as<ov::intel_gpu::ocl::ClContext>();
+    cl_context ctx = context;
+    auto ocl_instance = std::make_shared<OpenCL>(ctx);
+    
+    void* ptr = tensor.data();
+    cl_unified_shared_memory_type_intel mem_type = ocl_instance->get_allocation_type(ptr);
+    EXPECT_EQ(mem_type, CL_MEM_TYPE_HOST_INTEL);
+}
+
+TEST_F(DefaultUSMHostTensorAllocationTest, InferenceWithUSMHostTensors) {
+    if (!supportsUSM()) {
+        GTEST_SKIP() << "Device does not support USM";
+    }
+
+    // Compile model with USM host tensor allocation enabled
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+    core.set_property(ov::test::utils::DEVICE_GPU, config);
+    
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    auto infer_request = compiled_model.create_infer_request();
+    
+    // Get input/output info
+    auto input = model->get_parameters().at(0);
+    auto output = model->get_results().at(0);
+    auto input_shape = input->get_shape();
+    auto output_shape = output->get_shape();
+    
+    // Create tensors (should be USM host tensors)
+    ov::Tensor input_tensor(input->get_element_type(), input_shape);
+    ov::Tensor output_tensor(output->get_element_type(), output_shape);
+    
+    // Fill input with test data
+    auto input_data = ov::test::utils::create_and_fill_tensor(input->get_element_type(), input_shape);
+    std::memcpy(input_tensor.data(), input_data.data(), input_tensor.get_byte_size());
+    
+    // Set tensors and run inference
+    infer_request.set_tensor(input, input_tensor);
+    infer_request.set_tensor(output, output_tensor);
+    
+    OV_ASSERT_NO_THROW(infer_request.infer());
+    
+    // Verify output tensor is valid
+    EXPECT_NE(output_tensor.data(), nullptr);
+    EXPECT_EQ(output_tensor.get_shape(), output_shape);
+}
+
+TEST_F(DefaultUSMHostTensorAllocationTest, CompareResultsWithAndWithoutUSM) {
+    if (!supportsUSM()) {
+        GTEST_SKIP() << "Device does not support USM";
+    }
+
+    auto input = model->get_parameters().at(0);
+    auto output = model->get_results().at(0);
+    auto input_shape = input->get_shape();
+    auto output_shape = output->get_shape();
+    
+    // Create test input data
+    auto input_data = ov::test::utils::create_and_fill_tensor(input->get_element_type(), input_shape);
+    
+    // Regular inference without USM
+    {
+        ov::AnyMap config;
+        config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = false;
+        auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU, config);
+        auto infer_request = compiled_model.create_infer_request();
+        
+        infer_request.set_tensor(input, input_data);
+        infer_request.infer();
+        
+        auto output_tensor_regular = infer_request.get_tensor(output);
+        
+        // Store output for comparison
+        std::vector<float> output_regular(output_tensor_regular.get_size());
+        std::memcpy(output_regular.data(), output_tensor_regular.data(), output_tensor_regular.get_byte_size());
+        
+        // Inference with USM host tensors
+        ov::AnyMap usm_config;
+        usm_config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+        core.set_property(ov::test::utils::DEVICE_GPU, usm_config);
+        
+        auto compiled_model_usm = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+        auto infer_request_usm = compiled_model_usm.create_infer_request();
+        
+        ov::Tensor input_tensor_usm(input->get_element_type(), input_shape);
+        std::memcpy(input_tensor_usm.data(), input_data.data(), input_data.get_byte_size());
+        
+        infer_request_usm.set_tensor(input, input_tensor_usm);
+        infer_request_usm.infer();
+        
+        auto output_tensor_usm = infer_request_usm.get_tensor(output);
+        
+        // Compare results
+        ASSERT_EQ(output_tensor_regular.get_size(), output_tensor_usm.get_size());
+        
+        auto* output_regular_ptr = static_cast<float*>(output_tensor_regular.data());
+        auto* output_usm_ptr = static_cast<float*>(output_tensor_usm.data());
+        
+        for (size_t i = 0; i < output_tensor_regular.get_size(); i++) {
+            EXPECT_NEAR(output_regular_ptr[i], output_usm_ptr[i], 1e-5f)
+                << "Mismatch at index " << i;
+        }
+    }
+}
+
+TEST_F(DefaultUSMHostTensorAllocationTest, USMPropertyDoesNotAffectHostPtrConstructor) {
+    if (!supportsUSM()) {
+        GTEST_SKIP() << "Device does not support USM";
+    }
+
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+    core.set_property(ov::test::utils::DEVICE_GPU, config);
+    
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    
+    // Create tensor with host pointer - should NOT use USM allocation
+    ov::Shape shape = {1, 3, 224, 224};
+    std::vector<float> data(ov::shape_size(shape), 1.0f);
+    ov::Tensor tensor(ov::element::f32, shape, data.data());
+    
+    // Verify it uses the provided pointer, not USM
+    EXPECT_EQ(tensor.data<float>(), data.data());
+}
+
+TEST_F(DefaultUSMHostTensorAllocationTest, MultipleModelsWithUSMProperty) {
+    if (!supportsUSM()) {
+        GTEST_SKIP() << "Device does not support USM";
+    }
+
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+    core.set_property(ov::test::utils::DEVICE_GPU, config);
+    
+    // Compile multiple models
+    auto compiled_model1 = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    auto compiled_model2 = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    
+    // Create tensors - all should use USM host allocation
+    ov::Shape shape = {1, 3, 224, 224};
+    ov::Tensor tensor1(ov::element::f32, shape);
+    ov::Tensor tensor2(ov::element::f32, shape);
+    
+    auto context = compiled_model1.get_context().as<ov::intel_gpu::ocl::ClContext>();
+    cl_context ctx = context;
+    auto ocl_instance = std::make_shared<OpenCL>(ctx);
+    
+    // Verify both are USM host tensors
+    EXPECT_EQ(ocl_instance->get_allocation_type(tensor1.data()), CL_MEM_TYPE_HOST_INTEL);
+    EXPECT_EQ(ocl_instance->get_allocation_type(tensor2.data()), CL_MEM_TYPE_HOST_INTEL);
+}
+
+TEST_F(DefaultUSMHostTensorAllocationTest, PropertyResetAfterPluginDestruction) {
+    if (!supportsUSM()) {
+        GTEST_SKIP() << "Device does not support USM";
+    }
+
+    ov::Shape shape = {1, 3, 224, 224};
+    
+    {
+        // Create a new core and enable USM property
+        ov::Core local_core;
+        ov::AnyMap config;
+        config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+        local_core.set_property(ov::test::utils::DEVICE_GPU, config);
+        
+        auto compiled_model = local_core.compile_model(model, ov::test::utils::DEVICE_GPU);
+        
+        ov::Tensor tensor_usm(ov::element::f32, shape);
+        
+        auto context = compiled_model.get_context().as<ov::intel_gpu::ocl::ClContext>();
+        cl_context ctx = context;
+        auto ocl_instance = std::make_shared<OpenCL>(ctx);
+        
+        // Should be USM host tensor
+        EXPECT_EQ(ocl_instance->get_allocation_type(tensor_usm.data()), CL_MEM_TYPE_HOST_INTEL);
+        
+        // local_core goes out of scope, plugin should reset the generator
+    }
+    
+    // After plugin destruction, new tensors should use default allocation
+    // Note: This test assumes the plugin properly cleans up in its destructor
+    ov::Tensor tensor_default(ov::element::f32, shape);
+    EXPECT_NE(tensor_default.data(), nullptr);
+}
+
+TEST_F(DefaultUSMHostTensorAllocationTest, ConcurrentTensorCreation) {
+    if (!supportsUSM()) {
+        GTEST_SKIP() << "Device does not support USM";
+    }
+
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+    core.set_property(ov::test::utils::DEVICE_GPU, config);
+    
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    
+    // Create multiple tensors
+    ov::Shape shape = {1, 3, 224, 224};
+    std::vector<ov::Tensor> tensors;
+    
+    for (int i = 0; i < 10; i++) {
+        tensors.emplace_back(ov::element::f32, shape);
+    }
+    
+    auto context = compiled_model.get_context().as<ov::intel_gpu::ocl::ClContext>();
+    cl_context ctx = context;
+    auto ocl_instance = std::make_shared<OpenCL>(ctx);
+    
+    // Verify all tensors are USM host tensors
+    for (const auto& tensor : tensors) {
+        EXPECT_NE(tensor.data(), nullptr);
+        EXPECT_EQ(ocl_instance->get_allocation_type(tensor.data()), CL_MEM_TYPE_HOST_INTEL);
+    }
+}
+
+TEST_F(DefaultUSMHostTensorAllocationTest, DifferentElementTypes) {
+    if (!supportsUSM()) {
+        GTEST_SKIP() << "Device does not support USM";
+    }
+
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+    core.set_property(ov::test::utils::DEVICE_GPU, config);
+    
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    auto context = compiled_model.get_context().as<ov::intel_gpu::ocl::ClContext>();
+    cl_context ctx = context;
+    auto ocl_instance = std::make_shared<OpenCL>(ctx);
+    
+    ov::Shape shape = {10, 10};
+    
+    // Test different element types
+    std::vector<ov::element::Type> types = {
+        ov::element::f32,
+        ov::element::f16,
+        ov::element::i32,
+        ov::element::u8,
+        ov::element::i8
+    };
+    
+    for (const auto& type : types) {
+        ov::Tensor tensor(type, shape);
+        EXPECT_NE(tensor.data(), nullptr);
+        EXPECT_EQ(tensor.get_element_type(), type);
+        EXPECT_EQ(ocl_instance->get_allocation_type(tensor.data()), CL_MEM_TYPE_HOST_INTEL);
+    }
+}
+
+}  // namespace

--- a/src/plugins/intel_gpu/tests/functional/behavior/properties.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/properties.cpp
@@ -104,4 +104,55 @@ TEST_F(TestPropertiesGPU, RTInfoPropertiesWithUserValuesFromCompileModel) {
     ASSERT_EQ(scale.as<float>(), 4.0f);
 }
 
+TEST_F(TestPropertiesGPU, DefaultUSMHostTensorAllocationProperty) {
+    ov::Core core;
+    ov::CompiledModel compiled_model;
+
+    // Test default value is false
+    OV_ASSERT_NO_THROW(compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU));
+    ov::Any default_value;
+    OV_ASSERT_NO_THROW(default_value = compiled_model.get_property(ov::intel_gpu::default_usm_host_tensor_allocation));
+    ASSERT_FALSE(default_value.as<bool>());
+}
+
+TEST_F(TestPropertiesGPU, SetDefaultUSMHostTensorAllocationTrue) {
+    ov::Core core;
+    ov::CompiledModel compiled_model;
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+
+    OV_ASSERT_NO_THROW(compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU, config));
+    ov::Any value;
+    OV_ASSERT_NO_THROW(value = compiled_model.get_property(ov::intel_gpu::default_usm_host_tensor_allocation));
+    ASSERT_TRUE(value.as<bool>());
+}
+
+TEST_F(TestPropertiesGPU, SetDefaultUSMHostTensorAllocationFalse) {
+    ov::Core core;
+    ov::CompiledModel compiled_model;
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = false;
+
+    OV_ASSERT_NO_THROW(compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU, config));
+    ov::Any value;
+    OV_ASSERT_NO_THROW(value = compiled_model.get_property(ov::intel_gpu::default_usm_host_tensor_allocation));
+    ASSERT_FALSE(value.as<bool>());
+}
+
+TEST_F(TestPropertiesGPU, DefaultUSMHostTensorAllocationViaSetProperty) {
+    ov::Core core;
+    
+    // Set property via core.set_property
+    ov::AnyMap config;
+    config[ov::intel_gpu::default_usm_host_tensor_allocation.name()] = true;
+    OV_ASSERT_NO_THROW(core.set_property(ov::test::utils::DEVICE_GPU, config));
+    
+    // Compile model and verify property is set
+    ov::CompiledModel compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU));
+    ov::Any value;
+    OV_ASSERT_NO_THROW(value = compiled_model.get_property(ov::intel_gpu::default_usm_host_tensor_allocation));
+    ASSERT_TRUE(value.as<bool>());
+}
+
 } // namespace


### PR DESCRIPTION
## Motivation

In integrated GPU (iGPU) scenarios, the default `ov::Tensor` allocates standard CPU memory, which typically requires an additional copy operation to transfer data to device-accessible memory during  `SyncInferRequest::prepare_input`:

https://github.com/openvinotoolkit/openvino/blob/5eca0b1e16b150d5f8ccf9846cb5e83e92562883/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp#L871-L890

By allowing `ov::Tensor` to allocate [**USM Host Tensor**](https://github.com/openvinotoolkit/openvino/blob/5eca0b1e16b150d5f8ccf9846cb5e83e92562883/src/plugins/intel_gpu/include/intel_gpu/plugin/usm_host_tensor.hpp#L16) by default, the CPU-side tensor can be directly accessed by the GPU without data copying. 

## Key Changes

1. **Core (`src/core`):**
* Introduced a mechanism to register a custom tensor generator via `ov::util::set_custom_tensor_impl_generator`.
* Modified `ov::Tensor` constructor to check for this custom generator. If set, and the allocator is default, it delegates the tensor creation to the generator.


2. **Intel GPU Plugin (`src/plugins/intel_gpu`):**
* Added a new configuration property: `DEFAULT_USM_HOST_TENSOR_ALLOCATION`.
* When enabled, the plugin registers a generator that creates USM Host Tensors using the default GPU context.
* This ensures all subsequent `ov::Tensor` creations (no host_ptr, with default allocator) result in USM-backed memory, transparent to the application.


## Performance Results (Preliminary)

Micro-benchmark evaluating the overhead of `set_input_tensor` + `infer` loop on an identity model.

```cpp
#include <openvino/openvino.hpp>
#include <chrono>
#include <ratio>

int main(int argc, char* argv[]) {
    ov::Core core;
    core.set_property("GPU", {
        {"DEFAULT_USM_HOST_TENSOR_ALLOCATION", true}
    });

    // GPU device initialization
    auto versions = core.get_versions("GPU");

    auto tensor = ov::Tensor(ov::element::f32, {1, 3, 224, 224});
    std::cout << "Tensor address: " << static_cast<void*>(tensor.data<float>()) << std::endl;

    // 1. Create an empty model (Identity: Input -> Output)
    auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 224, 224});
    auto result = std::make_shared<ov::op::v0::Result>(param);
    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param});

    // 2. Compile the model
    auto compiled_model = core.compile_model(model, "GPU");
    auto infer_request = compiled_model.create_infer_request();

    // 3. Set input tensor
    infer_request.set_input_tensor(tensor);

    for (int i = 0; i < 100; ++i) {
        infer_request.infer();
    }

    // 4. Measure execution time
    auto start = std::chrono::high_resolution_clock::now();
    for (int i = 0; i < 10000; ++i) {
        infer_request.infer();
    }
    auto end = std::chrono::high_resolution_clock::now();

    std::chrono::duration<double, std::micro> duration = end - start;
    std::cout << "Execution time: " << duration.count() / 10000 << " microseconds per inference" << std::endl;

    return 0;
}
```

* **Environment:** Debug build / Release build
* **Baseline:** ~290 μs per inference / ~225 μs per inference
* **With Optimization:** ~65 μs per inference / ~40 μs per inference

This optimization is transparent to upper-level applications. For example, it effectively eliminates the input copy overhead in OpenVINO GenAI pipelines (e.g., preparing `input_ids` for LLMs).

##  Known Limitations for Discussion

I would like to request comments on the following implementation details:

1. **Global State Safety:** The current implementation uses a global static `TensorImplGenerator`. While this is efficient, it introduces global state that affects `ov::Tensor` creation process-wide. We need to discuss if this is acceptable or if a thread-local approach is preferred to avoid side effects in multi-threaded/multi-device applications.
2. **Multi GPU Selection:** The current GPU plugin implementation captures the context of the default device (`m_default_device_id`) when enabling the property. Perhaps options should be provided for users to choose their own GPU device, but since this optimization is primarily focused on iGPU, I directly used the default device.
3. **Core Overhead:** The modified `ov::Tensor` constructor performs a check for the custom generator and allocator (`if (custom_generator && allocator == Allocator{})`). When not setting a custom generator, it may affect the tensor creating time (compare to call `make_tensor` directly).
4. **Other Tensor Constructors:** The current modification applies only to Tensor creation using `element::Type` and `Shape`. Tensors initialized with an existing `host_ptr` are not automatically converted to USM Host Tensors. Implementing this capability would require more extensive code refactoring and is therefore considered out of scope for this PR.

## Credits

This optimization is contributed by the Institute of Parallel and Distributed Systems (IPADS).

## Todo for this PR

- [x] Unit test for these two modifications.
- [x] Other code format check
