### PR TITLE
[PT FE] Added support for quantized::linear_dynamic

### DIFF
--- a/src/frontends/pytorch/src/op/quantized_linear.cpp
+++ b/src/frontends/pytorch/src/op/quantized_linear.cpp
@@ -39,6 +39,32 @@ OutputVector translate_quantized_linear(const NodeContext& context) {
     return {quantize(context, linear, scale, zero_point, x)};
 };
 
+OutputVector translate_quantized_linear_dynamic(const NodeContext& context) {
+    // "quantized::linear_dynamic(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack,
+    // bool reduce_range=False) -> Tensor Y"
+    // Dynamic quantization: output is a float tensor, not quantized
+    num_inputs_check(context, 2, 3);
+    auto x = context.get_input(0);
+    auto packed_params_node = ov::as_type_ptr<ov::op::util::FrameworkNode>(context.get_input(1).get_node_shared_ptr());
+    PYTORCH_OP_CONVERSION_CHECK(packed_params_node, "Packed params input node type is required to be FrameworkNode.");
+    const auto& attrs = packed_params_node->get_attrs();
+    PYTORCH_OP_CONVERSION_CHECK((attrs.find(PtFrameworkNode::op_type_key) != attrs.end()),
+                                "Packed params input node does not contain information about op type.");
+    PYTORCH_OP_CONVERSION_CHECK((attrs.at(PtFrameworkNode::op_type_key) == "prim::GetAttr"),
+                                "Incorrect packed params input node operator type, expected prim::GetAttr.");
+
+    auto packed_params = packed_params_node->inputs();
+    PYTORCH_OP_CONVERSION_CHECK(packed_params.size() == 2,
+                                "Packed parameters for quantized linear should contain 2 items.");
+    auto weights = packed_params[0].get_source_output();
+    auto bias = packed_params[1].get_source_output();
+
+    auto linear = context.mark_node(std::make_shared<ov::op::v0::MatMul>(x, weights, false, true));
+    linear = context.mark_node(std::make_shared<ov::op::v1::Add>(linear, bias));
+    // Dynamic quantization returns float tensor directly, no output quantization
+    return {linear};
+};
+
 }  // namespace op
 }  // namespace pytorch
 }  // namespace frontend

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -291,6 +291,7 @@ OP_CONVERTER(translate_quantized_cat);
 OP_CONVERTER(translate_quantized_convnd);
 OP_CONVERTER(translate_quantized_convnd_relu);
 OP_CONVERTER(translate_quantized_linear);
+OP_CONVERTER(translate_quantized_linear_dynamic);
 OP_CONVERTER(translate_xor);
 // Torch FX Translations
 OP_CONVERTER(translate_adaptive_max_pool1d_fx);
@@ -813,6 +814,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"quantized::conv2d_relu", op::translate_quantized_convnd_relu},
         {"quantized::hardswish", op::translate_quantized_hardswish},
         {"quantized::linear", op::translate_quantized_linear},
+        {"quantized::linear_dynamic", op::translate_quantized_linear_dynamic},
         {"quantized::mul", op::translate_quantized_mul},
         {"torchvision::deform_conv2d", op::translate_deform_conv},
         {"torchvision::nms", op::translate_nms},


### PR DESCRIPTION
Fixes #29732

quantized::linear_dynamic performs dynamic quantization of the input tensor at runtime and returns a float tensor. Unlike quantized::linear which requires pre-computed output scale and zero_point, this operation determines quantization parameters dynamically.

The implementation unpacks the weights and bias from the packed params and performs MatMul + Add, returning the float result directly without output quantization.


