### PR TITLE
[JS API] Fix js api unit test to not use exact names of ops

### DIFF
--- a/src/bindings/js/node/tests/unit/model.test.js
+++ b/src/bindings/js/node/tests/unit/model.test.js
@@ -288,12 +288,10 @@ describe("ov.Model tests", () => {
 
     it("should return node names expected in the calling model", () => {
       const model = core.readModelSync(addModel.xml);
-      const modelOps = model.getOps();
-      const nodeNames = ["Parameter_7674", "Parameter_7672", "Result_7678", "Add_7676"];
-      assert.deepStrictEqual(modelOps.length, nodeNames.length);
-      for (const [index, node] of nodeNames.entries()) {
-        assert.deepStrictEqual(modelOps[index].getName(), node);
-      }
+      const expectedOps = ["Parameter", "Result", "Add"];
+      const modelOperators = model.getOps().map((op) => op.getName().split("_")[0]);
+
+      assert.ok(expectedOps.every((op) => modelOperators.includes(op)));
     });
 
     it("should not accept any arguments", () => {


### PR DESCRIPTION
### Details:
 - Now the test checks only the first part of its autogenerated name and if op appeared at least once in model

### Tickets:
 - [CVS-179371](https://jira.devtools.intel.com/browse/CVS-179371)
