### PR TITLE
Fix Windows PATH separator in build documentation

### DIFF
--- a/docs/dev/build_windows.md
+++ b/docs/dev/build_windows.md
@@ -72,7 +72,7 @@ To pack PDB files, it's essential to run cmake command to create a dedicated arc
     ```
     set PYTHONPATH=<openvino_repo>/bin/<arch>/Release/python;<openvino_repo>/tools/ovc;%PYTHONPATH%
     set OPENVINO_LIB_PATHS=<openvino_repo>/bin/<arch>/Release;<openvino_repo>/temp/<platform>/tbb/bin
-    set PATH=<openvino_repo>/tools/ovc/openvino/tools/ovc:%PATH%
+    set PATH=<openvino_repo>/tools/ovc/openvino/tools/ovc;%PATH%
     ```
   or install the wheel with pip:
   ```


### PR DESCRIPTION
This PR fixes syntax error in windows build instructions.
Corrects the PATH environment variable syntax in the Windows build documentation. The PATH separator was incorrectly using a colon (:) instead of a semicolon (;).

This fixes the Python API build instructions for Windows users. Using the incorrect separator would cause the PATH to be set incorrectly, preventing users from running OpenVINO tools from the command line