### PR TITLE
OV model hashing: fix the hashing of the weights

### DIFF
--- a/src/common/transformations/tests/hash_tests.cpp
+++ b/src/common/transformations/tests/hash_tests.cpp
@@ -43,4 +43,30 @@ TEST(HashTest, same_model_hashed_without_weights) {
 
     EXPECT_EQ(hash1, hash2);
 }
+
+TEST(HashTest, same_model_struct_different_weigth) {
+    uint64_t hash1 = 0, hash2 = 0;
+
+    {
+        int data_value = 121;
+        auto out = std::make_shared<Add>(std::make_shared<Parameter>(element::i32, Shape{1}),
+                                         std::make_shared<Constant>(element::i32, Shape{1}, &data_value));
+        auto model = std::make_shared<Model>(OutputVector{out}, "TestModel");
+
+        ov::pass::Hash hasher(hash1);
+        hasher.run_on_model(model);
+    }
+    {
+        int data_value = 13;
+        auto out = std::make_shared<Add>(std::make_shared<Parameter>(element::i32, Shape{1}),
+                                         std::make_shared<Constant>(element::i32, Shape{1}, &data_value));
+        auto model = std::make_shared<Model>(OutputVector{out}, "TestModel");
+
+        ov::pass::Hash hasher(hash2);
+        hasher.run_on_model(model);
+    }
+
+    EXPECT_NE(hash1, hash2);
+}
+
 }  // namespace ov::test

--- a/src/core/src/xml_util/constant_writer.cpp
+++ b/src/core/src/xml_util/constant_writer.cpp
@@ -81,7 +81,8 @@ ConstantWriter::FilePosition ConstantWriter::write(const char* ptr,
             m_hash_to_file_positions.insert({hash, {offset, static_cast<const void*>(ptr)}});
         }
         if (m_write_hash_value) {
-            m_binary_output.get().write(reinterpret_cast<const char*>(&hash), sizeof(uint64_t));
+            // hash stored with special ostream only
+            m_binary_output.get().write(reinterpret_cast<const char*>(&hash), hash);
         } else {
             m_binary_output.get().write(ptr_to_write, new_size);
         }


### PR DESCRIPTION
### Details:
 - If my analysis is correct, before this PR, the model hashing function computes a hash for each constants buffer. The intention was then to combine these constants hashes in this `OstreamHashWrapperBin::xsputn`. But there seems to be a bug, `OstreamHashWrapperBin::xsputn` combines the _length_ of the hashes (which is `sizeof(uint64_t)`) instead of the hash values. The end result is, models that use the same graph, but different weights values, will get the same hash from OV.

### Tickets:
 - *EISW-198709*
