### PR TITLE
[Docs] Extend TopK spec with NaN handling info

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-1.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-1.rst
@@ -76,6 +76,10 @@ Sorting and minimum/maximum are controlled by ``sort`` and ``mode`` attributes:
 
 If there are several elements with the same value then their output order is not determined.
 
+**NaN Handling**
+
+For floating-point types, NaN values are treated as smaller than any valid number (consistent with NumPy behavior). In ``max`` mode, NaN values will not appear in top-K results unless fewer than K valid numbers exist. Note that this differs from PyTorch, which treats NaN as larger than all valid numbers.
+
 **Example**
 
 .. code-block:: cpp

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-1.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-1.rst
@@ -78,7 +78,7 @@ If there are several elements with the same value then their output order is not
 
 **NaN Handling**
 
-For floating-point types, NaN values are treated as smaller than any valid number (consistent with NumPy behavior). In ``max`` mode, NaN values will not appear in top-K results unless fewer than K valid numbers exist. Note that this differs from PyTorch, which treats NaN as larger than all valid numbers.
+For floating-point types, the ordering of NaN values in the output is implementation-defined. Per IEEE 754, NaN fails all ordered comparisons, so there is no single correct placement for NaN in a sorted result. Different frameworks (e.g., NumPy, PyTorch) handle NaN differently, and the TopK implementation does not guarantee a specific NaN ordering. If deterministic behavior is required, NaN values should be sanitized before the TopK operation (e.g., replaced with ``-inf`` or ``+inf`` depending on the desired placement).
 
 **Example**
 

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-11.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-11.rst
@@ -94,6 +94,11 @@ Sorting and minimum/maximum are controlled by ``sort`` and ``mode`` attributes w
 * *sort* =  ``none``  , *mode* =  ``min``  - undefined
 
 The relative order of equivalent elements is only preserved if the ``stable`` attribute is set to ``true``. This makes the implementation use stable sorting algorithm during the computation of TopK elements. Otherwise the output order is undefined.
+
+**NaN Handling**
+
+For floating-point types, NaN values are treated as smaller than any valid number (consistent with NumPy behavior). In ``max`` mode, NaN values will not appear in top-K results unless fewer than K valid numbers exist. Note that this differs from PyTorch, which treats NaN as larger than all valid numbers.
+
 The "by index" order means that the input tensor's elements are still sorted by value but their order in the output tensor is additionally determined by the indices of those elements in the input tensor. This might yield multiple correct results though. For example if the input tensor contains the following elements:
 
 .. code-block:: cpp

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-11.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-11.rst
@@ -97,7 +97,7 @@ The relative order of equivalent elements is only preserved if the ``stable`` at
 
 **NaN Handling**
 
-For floating-point types, NaN values are treated as smaller than any valid number (consistent with NumPy behavior). In ``max`` mode, NaN values will not appear in top-K results unless fewer than K valid numbers exist. Note that this differs from PyTorch, which treats NaN as larger than all valid numbers.
+For floating-point types, the ordering of NaN values in the output is implementation-defined. Per IEEE 754, NaN fails all ordered comparisons, so there is no single correct placement for NaN in a sorted result. Different frameworks (e.g., NumPy, PyTorch) handle NaN differently, and the TopK implementation does not guarantee a specific NaN ordering. If deterministic behavior is required, NaN values should be sanitized before the TopK operation (e.g., replaced with ``-inf`` or ``+inf`` depending on the desired placement).
 
 The "by index" order means that the input tensor's elements are still sorted by value but their order in the output tensor is additionally determined by the indices of those elements in the input tensor. This might yield multiple correct results though. For example if the input tensor contains the following elements:
 

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-3.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-3.rst
@@ -83,6 +83,10 @@ Sorting and minimum/maximum are controlled by ``sort`` and ``mode`` attributes:
 
 If there are several elements with the same value then their output order is not determined.
 
+**NaN Handling**
+
+For floating-point types, NaN values are treated as smaller than any valid number (consistent with NumPy behavior). In ``max`` mode, NaN values will not appear in top-K results unless fewer than K valid numbers exist. Note that this differs from PyTorch, which treats NaN as larger than all valid numbers.
+
 **Example**
 
 .. code-block:: cpp

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-3.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sort/top-k-3.rst
@@ -85,7 +85,7 @@ If there are several elements with the same value then their output order is not
 
 **NaN Handling**
 
-For floating-point types, NaN values are treated as smaller than any valid number (consistent with NumPy behavior). In ``max`` mode, NaN values will not appear in top-K results unless fewer than K valid numbers exist. Note that this differs from PyTorch, which treats NaN as larger than all valid numbers.
+For floating-point types, the ordering of NaN values in the output is implementation-defined. Per IEEE 754, NaN fails all ordered comparisons, so there is no single correct placement for NaN in a sorted result. Different frameworks (e.g., NumPy, PyTorch) handle NaN differently, and the TopK implementation does not guarantee a specific NaN ordering. If deterministic behavior is required, NaN values should be sanitized before the TopK operation (e.g., replaced with ``-inf`` or ``+inf`` depending on the desired placement).
 
 **Example**
 

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -2511,7 +2511,7 @@ void TopK::topk_ref_process(const float* src_data,
         }
         for (int i2 = 0; i2 < top_k - 1; i2++) {
             for (int i3 = top_k - 1; i3 > i2; i3--) {
-                if (compare(max_values[i3], max_values[i3 - 1])) {
+                if (std::isnan(max_values[i3 - 1]) || compare(max_values[i3], max_values[i3 - 1])) {
                     swap_func(i3, i3 - 1);
                 }
             }
@@ -2520,7 +2520,7 @@ void TopK::topk_ref_process(const float* src_data,
             max_values[top_k] = src_data[s_index];
             max_indexes[top_k] = i2;
             for (int i3 = top_k; i3 > 0; i3--) {
-                if (compare(max_values[i3], max_values[i3 - 1])) {
+                if (std::isnan(max_values[i3 - 1]) || compare(max_values[i3], max_values[i3 - 1])) {
                     swap_func(i3, i3 - 1);
                 } else {
                     break;

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -2511,7 +2511,7 @@ void TopK::topk_ref_process(const float* src_data,
         }
         for (int i2 = 0; i2 < top_k - 1; i2++) {
             for (int i3 = top_k - 1; i3 > i2; i3--) {
-                if (std::isnan(max_values[i3 - 1]) || compare(max_values[i3], max_values[i3 - 1])) {
+                if (compare(max_values[i3], max_values[i3 - 1])) {
                     swap_func(i3, i3 - 1);
                 }
             }
@@ -2520,7 +2520,7 @@ void TopK::topk_ref_process(const float* src_data,
             max_values[top_k] = src_data[s_index];
             max_indexes[top_k] = i2;
             for (int i3 = top_k; i3 > 0; i3--) {
-                if (std::isnan(max_values[i3 - 1]) || compare(max_values[i3], max_values[i3 - 1])) {
+                if (compare(max_values[i3], max_values[i3 - 1])) {
                     swap_func(i3, i3 - 1);
                 } else {
                     break;


### PR DESCRIPTION
**Details:**

Extends the TopK operation specs (TopK-1, TopK-3, TopK-11) with documentation on NaN handling behavior.

**What this PR does:**
- Documents that NaN ordering in TopK results is implementation-defined, consistent with IEEE 754 semantics
- Notes that different frameworks (NumPy, PyTorch) handle NaN ordering differently
- Provides guidance for users who need deterministic behavior: sanitize NaN values before TopK (e.g. replace with -inf or +inf)

This is a docs-only change with no code modifications. The code fix for NaN handling was reverted per reviewer feedback -- a new TopK version with configurable NaN handling (nan_mode attribute) is planned as a follow-up.

**Tickets:**
- Related to #33626