### PR TITLE
[GPU] Fix custom format handling for 3D weights in oneDNN

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -431,6 +431,8 @@ private:
                 auto it = format_map_cldnn_4d_to_onednn_3d.find(_layout.format);
                 if (it != format_map_cldnn_4d_to_onednn_3d.end()) {
                     fmt_tag = it->second;
+                } else if (_layout.format == cldnn::format::custom) {
+                    fmt_tag = dnnl::memory::format_tag::any;
                 } else {
                     OPENVINO_THROW("[GPU] Unexpected layout format " + _layout.to_short_string());
                 }

--- a/src/plugins/intel_gpu/src/runtime/format.cpp
+++ b/src/plugins/intel_gpu/src/runtime/format.cpp
@@ -205,10 +205,11 @@ format format::get_default_format(size_t rank, bool is_weights, bool is_grouped)
                 default_fmt = cldnn::format::goizyx;
             }
         } else {
-            if (rank == 4) {
-                default_fmt = cldnn::format::oiyx;
-            } else if (rank == 5) {
+            if (rank == 5) {
                 default_fmt = cldnn::format::oizyx;
+            } else {
+                // Default format for non-grouped weights: oiyx for rank!=5 (including 3D and 4D)
+                default_fmt = cldnn::format::oiyx;
             }
         }
     } else {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -27,6 +27,9 @@
 #include <tuple>
 
 #include "convolution_inst.h"
+#ifdef ENABLE_ONEDNN_FOR_GPU
+#include "graph/impls/onednn/utils.hpp"
+#endif
 
 using namespace cldnn;
 using namespace ::tests;
@@ -12602,3 +12605,38 @@ TEST_P(conv_3d_test_mmad, convolution_gpu_b_fs_zyx_mmad) {
         ASSERT_EQ(output_ptr[i], output_ptr_ref[i]);
     }
 }
+
+#ifdef ENABLE_ONEDNN_FOR_GPU
+TEST(convolution_gpu, onednn_custom_format_3d_weights) {
+    auto& engine = get_test_engine();
+
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    ov::PartialShape weights_shape{192, 1, 1};
+
+    format_traits custom_traits;
+    custom_traits.str = "custom";
+    custom_traits.order = "oiy";
+    custom_traits.internal_order = "oixyz";
+    custom_traits.batch_num = 0;
+    custom_traits.feature_num = 1;
+    custom_traits.spatial_num = 1;
+    custom_traits.group_num = 0;
+    custom_traits._order = {0, 1, 2};
+    custom_traits.block_sizes = {};
+    custom_traits.logic_block_sizes = {};
+
+    cldnn::format custom_fmt(format::custom);
+    custom_fmt.custom_traits = custom_traits;
+    layout custom_layout(weights_shape, data_types::f16, custom_fmt);
+
+    ASSERT_NO_THROW({
+        auto md = onednn::layout_to_memory_desc(custom_layout, dnnl::memory::format_tag::undef);
+        ASSERT_EQ(md.get_ndims(), 3);
+        ASSERT_EQ(md.get_dims()[0], 192);
+        ASSERT_EQ(md.get_dims()[1], 1);
+        ASSERT_EQ(md.get_dims()[2], 1);
+    });
+}
+#endif  // ENABLE_ONEDNN_FOR_GPU


### PR DESCRIPTION
### Details:
  - Fix "[GPU] Unexpected layout format f16:custom:192x1x1:nopad" error when oneDNN creates custom format for shared 3D weights in convolution operations

### Description of the issue(symptom, root-cause, how it was resolved)
   - In OpenVoice model, a convolution layer Conv_42 has the weights node with shape [192,1,1]. During oneDNN optimization, a custom format is created for the 3D weights. When MemoryDescriptorBuilder::calculate_dims() processes layout with shape_rank==3 and custom format, it fails because custom format was not explicitly handled in the 3D conversion path and throws exception.

  - Modified `utils.cpp::calculate_dims()` to explicitly handle custom format when `shape_rank==3` by setting `fmt_tag = dnnl::memory::format_tag::any`. This allows oneDNN to determine the optimal format based on the actual memory layout, which is semantically correct since custom formats are dynamically created by oneDNN's optimization passes.

  - Created unit test that directly constructs custom format layout with order="oiy" and calls layout_to_memory_desc(). Test reproduces the exact error without the fix and passes with the fix. Verified OpenVoice model runs successfully with benchmark_app

#### The code and line that caused this issue (if it is not changed directly)
https://github.com/openvinotoolkit/openvino/blob/00f0d3fb4c18b6b0af4331cb9b29fe3a030f45f5/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp#L432-L436


#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
* benchmark_app \
  -m models/Pytorch_OpenVoice_BaseSpeakerTTS_EN_api_2_True_batch_1_device_CPU_precision_FP16okrolwhn/Pytorch_OpenVoice_BaseSpeakerTTS_EN_IR_v11_FP16_batch_1.xml \
  -nstreams 1 \
  -nireq 1 \
  -b 1 \
  -infer_precision f16 \
  -d GPU \
  -hint none \
  -shape "x[1,91],x_lengths[1],sid[1]"


#### Problematic graph
<img width="1951" height="1659" alt="image" src="https://github.com/user-attachments/assets/9d1feb9b-22ba-4479-b49c-37497eec305d" />

#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [v] Did you include test case for this fix, if necessary?
 - [v] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *CVS-177098*




