### PR TITLE
[GPU] Update condition of winograd kernel selection

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -500,6 +500,8 @@ bool should_use_winograd_2x3_s1(const convolution_node& node,
         || weights_layout.batch() % 64 != 0  // current algorithm is effective for ofm to be multiply of 64
         || any_not_one(prim->stride)               // stride has to be 1x1 by definition
         || any_not_one(prim->dilation)             // no support for dilation
+        || !all_zeroes(prim->padding_begin)        // no padding supported. padding could makes higher accuracy loss.
+        || !all_zeroes(prim->padding_end)          // no padding supported. padding could makes higher accuracy loss.
         || output_size_handling_enabled            // This condition is weird. Need to revise it and replace with something meaningful
         || (input_layout.count() > 3000000)        // limit max input size as winograd consumes more memory
         || (input_layout.count() < 50000)          // limit min input size as winograd is not effective for small input


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - Winograd kernel selected convolution has wrong accuracy output.
 - Padding > 0 would affect to wrong accuracy.
 - Added padding check in should_use_winograd_2x3_s1()

#### The code and line that caused this issue (if it is not changed directly)
 - https://github.com/openvinotoolkit/openvino/blob/43018d2c33bb42eb83fa35ab7ac8ab7a092a1b73/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp#L487

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - $ ./benchmark_app -d GPU.0 -m ~/task/cvs179212/ttybulew.ov.instance-segmentation-bug-001/model.xml -i ~/task/cvs179212/ttybulew.ov.instance-segmentation-bug-001/image.npy -hint none -nstreams 1 -nireq 1 -niter 1

#### Problematic graph
 - I<Winograd kernel selected convolution>
 
<img width="924" height="635" alt="image" src="https://github.com/user-attachments/assets/29cd5af7-4919-462a-8363-8af938f460d9" />


#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 179212