### PR TITLE
[PyOV] Disable ARMv8.1+ instructions in `numpy` for Python tests

### DIFF
--- a/src/bindings/python/tests/conftest.py
+++ b/src/bindings/python/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 # https://numpy.org/devdocs/reference/simd/build-options.html
 _npy_cpu_features_original = os.environ.get("NPY_DISABLE_CPU_FEATURES")
 if platform.machine() == "aarch64" and platform.system() == "Linux":
-    os.environ["NPY_DISABLE_CPU_FEATURES"] = "ASIMDDP"
+    os.environ["NPY_DISABLE_CPU_FEATURES"] = "ASIMDDP,ASIMDFHM"
 
 
 def pytest_sessionfinish(session, exitstatus):


### PR DESCRIPTION
### Details:
 - This fix regards `Illegal instruction` error, which is thrown when an invalid instruction is issued to CPU.
 - Disable `numpy` ARMv8.1+ instructions in CI pipelines. Our machines have Cortex-A72 CPUs, which only support ARMv8.0 instructions.
 - `numpy` should automatically use available features only, but that may fail (example in sources)
 - In case this does not fix the sporadic `Illegal instruction` errors, the PR will be reverted and I'll investigate further.
 - The environment variable is set only for the test suite duration and is reset after it finishes by using `pytest_sessionfinish` hook.

### Sources:
 - https://stackoverflow.com/questions/76668304/confusion-regarding-arm-architecture-used-in-raspberry-pi-4-model-b
 - https://discourse.mozilla.org/t/deepspeech-python-illegal-instruction-core-dumped-with-jetson-nano-2-gb/74392/7

### Tickets:
 - 179098
