### PR TITLE
[NPUW] Fix Coverity null dereference

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_infer_request.cpp
@@ -187,15 +187,19 @@ void ov::npuw::KokoroInferRequest::set_tensor(const ov::Output<const ov::Node>& 
 
     // If mappings are initialized, update sub-requests
     // Model A inputs
-    for (const auto& item : m_model_a_in_map) {
-        if (item.second == port) {
-            m_model_a_request->set_tensor(item.first, tensor);
+    if (m_model_a_request) {
+        for (const auto& item : m_model_a_in_map) {
+            if (item.second == port) {
+                m_model_a_request->set_tensor(item.first, tensor);
+            }
         }
     }
     // Model B inputs
-    for (const auto& item : m_model_b_in_map) {
-        if (item.second == port) {
-            m_model_b_request->set_tensor(item.first, tensor);
+    if (m_model_b_request) {
+        for (const auto& item : m_model_b_in_map) {
+            if (item.second == port) {
+                m_model_b_request->set_tensor(item.first, tensor);
+            }
         }
     }
 }


### PR DESCRIPTION
### Details:
- Fix null dereference introduced in https://github.com/openvinotoolkit/openvino/pull/33399
- Not a real problem, since `m_model_a_in_map` and `m_model_b_in_map` will be empty thus `set_tensor` wouldn't be called, but adding check for the saKe of the check. 

### Tickets:
 - E-199864
