### PR TITLE
Add npuMLIRRuntimeUpdateMutableCommandList API

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/npu_mlir_runtime.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npu_mlir_runtime.hpp
@@ -71,7 +71,8 @@ extern "C" {
 ///       ::NPU_MLIR_RUNTIME_MAJOR_VERSION and ::NPU_MLIR_RUNTIME_MINOR_VERSION
 typedef enum _npu_mlir_runtime_version_t {
     NPU_MLIR_RUNTIME_VERSION_1_0 = ZE_MAKE_VERSION(1, 0),             ///< version 1.0
-    NPU_MLIR_RUNTIME_VERSION_CURRENT = NPU_MLIR_RUNTIME_VERSION_1_0,  ///< latest known version
+    NPU_MLIR_RUNTIME_VERSION_1_1 = ZE_MAKE_VERSION(1, 1),             ///< version 1.1
+    NPU_MLIR_RUNTIME_VERSION_CURRENT = NPU_MLIR_RUNTIME_VERSION_1_1,  ///< latest known version
     NPU_MLIR_RUNTIME_VERSION_FORCE_UINT32 = 0x7fffffff,
 } npu_mlir_runtime_version_t;
 
@@ -180,7 +181,7 @@ NPU_MLIR_RUNTIME_APIEXPORT npu_mlir_runtime_result_t NPU_MLIR_RUNTIME_APICALL np
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create MemRef handle
 NPU_MLIR_RUNTIME_APIEXPORT npu_mlir_runtime_result_t NPU_MLIR_RUNTIME_APICALL npuMLIRRuntimeCreateMemRef(
-    int64_t dimsCount,                            ///< [in] value of tensor rank
+    int64_t dimsCount,                             ///< [in] value of tensor rank
     npu_mlir_runtime_mem_ref_handle_t* phMemRef);  ///< [out] handle of mlir runtime MemRef object
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -209,6 +210,17 @@ npuMLIRRuntimeParseMemRef(npu_mlir_runtime_mem_ref_handle_t hMemRef,  ///< [in] 
                           int64_t* pSizes,                            ///< [out] pointer to tensor sizes
                           int64_t* pStrides,                          ///< [out] pointer to tensor strides
                           int64_t* pDimsCount);                       ///< [out] value of tensor rank
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @brief Extension version 1.1
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Update mutable command list used in execution and execute
+NPU_MLIR_RUNTIME_APIEXPORT npu_mlir_runtime_result_t NPU_MLIR_RUNTIME_APICALL npuMLIRRuntimeUpdateMutableCommandList(
+    npu_mlir_runtime_handle_t hRuntime,          ///< [in] handle of mlir runtime object
+    npu_mlir_runtime_execute_params_t* pParams,  ///< [in] pointer to execution parameters
+    uint64_t* argIndexArray,                     ///< [in] pointer to argument index list
+    uint64_t argIndexArraySize);                 ///< [in] size of argument index list
 
 #if defined(__cplusplus)
 }  // extern "C"


### PR DESCRIPTION
### Details:
 - *updates the Intel NPU MLIR Runtime API to introduce version 1.1*
 - Introduced the `npuMLIRRuntimeUpdateMutableCommandList` function, which allows updating a mutable command list used in execution with specified argument indices and parameters. 

### Tickets:
 - *C174100*
