### PR TITLE
[NPU] Update skip config for func tests before driver update

### DIFF
--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -851,4 +851,15 @@ Example:
         </filters>
     </skip_config>
 
+    <!-- E#190990-->
+    <skip_config>
+        <message>Skip test-cases failing with Win Drv UD48 RC5</message>
+        <enable_rules>
+            <operating_system>windows</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*NpuDeviceAllocMemSizeSameAfterDestroyInferRequestGetTensor.*</filter>
+        </filters>
+    </skip_config>
+
 </skip_configs>


### PR DESCRIPTION
### Details:
 - *Disable test `nightly_BehaviorTests_OVClassGetMetricTest/OVClassGetMetricAndPrintNoThrow.NpuDeviceAllocMemSizeSameAfterDestroyInferRequestGetTensor` which fails when updating NPU driver to UD48 RC5 in ov integration* 
 - *...*

### Tickets:
 - *E-190990*
