### PR TITLE
[NPU] Update test config for `WeightsSeparationTests`

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/weights_separation.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/weights_separation.hpp
@@ -179,6 +179,7 @@ protected:
  */
 TEST_P(WeightsSeparationTests, CheckOneShotVersionThrows) {
     model = createTestModel();
+    configuration.insert(ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER));
     configuration.insert(ov::intel_npu::weightless_blob(true));
     configuration.insert(ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ONE_SHOT));
     OV_EXPECT_THROW(compiled_model = core->compile_model(model, target_device, configuration), ov::Exception, _);


### PR DESCRIPTION
### Details:
 - *NPU default compiler type was recently updated (DRIVER is not default compiler type anymore)*
 - *Need to specify compiler-in-driver for `WeightsSeparationTests/CheckOneShotVersionThrows` (test designed for compiler-in-driver scenario).*

### Tickets:
 - *ticket-id*
