### PR TITLE
Turn on debug logs for `pip install` on Windows to troubleshoot `Content-Type: Unknown` error

### DIFF
--- a/.github/workflows/job_build_windows.yml
+++ b/.github/workflows/job_build_windows.yml
@@ -118,23 +118,23 @@ jobs:
       - name: Install python dependencies
         run: |
           # For Python API: build and wheel packaging
-          python3 -m pip install -r ${{ env.OPENVINO_REPO }}/src/bindings/python/wheel/requirements-dev.txt
+          python3 -m pip install -vv -r ${{ env.OPENVINO_REPO }}/src/bindings/python/wheel/requirements-dev.txt
 
           # For running ONNX frontend unit tests
-          python3 -m pip install --force-reinstall -r ${{ env.OPENVINO_REPO }}/src/frontends/onnx/tests/requirements.txt
+          python3 -m pip install -vv --force-reinstall -r ${{ env.OPENVINO_REPO }}/src/frontends/onnx/tests/requirements.txt
 
           # For running TensorFlow frontend unit tests
-          python3 -m pip install -r ${{ env.OPENVINO_REPO }}/src/frontends/tensorflow/tests/requirements.txt
+          python3 -m pip install -vv -r ${{ env.OPENVINO_REPO }}/src/frontends/tensorflow/tests/requirements.txt
 
           # For running TensorFlow Lite frontend unit tests
-          python3 -m pip install -r ${{ env.OPENVINO_REPO }}/src/frontends/tensorflow_lite/tests/requirements.txt
+          python3 -m pip install -vv -r ${{ env.OPENVINO_REPO }}/src/frontends/tensorflow_lite/tests/requirements.txt
 
           # Disabled because of CVS-95904
           # For running Paddle frontend unit tests
-          # python3 -m pip install -r ${{ env.OPENVINO_REPO }}/src/frontends/paddle/tests/requirements.txt
+          # python3 -m pip install -vv -r ${{ env.OPENVINO_REPO }}/src/frontends/paddle/tests/requirements.txt
 
           # For getting rid of SSL issues during model downloading for unit tests
-          python3 -m pip install certifi
+          python3 -m pip install -vv certifi
 
       #
       # Build
@@ -216,7 +216,7 @@ jobs:
           pip-cache-path: ${{ env.PIP_CACHE_PATH }}
           should-setup-pip-paths: 'true'
           self-hosted-runner: 'true'
-        
+
       # Setup additional Python versions for wheels building
       - name: Setup Python 3.14
         if: ${{ inputs.build-additional-python-wheels }}
@@ -244,7 +244,7 @@ jobs:
             Write-Host "Using pip version: $pipVersion for $pyVersion"
             $env:PIP_CACHE_DIR="${{ env.PIP_CACHE_PATH }}/$pipVersion"
 
-            & $pythonExecutablePath -m pip install -r ${{ env.OPENVINO_REPO }}/src/bindings/python/wheel/requirements-dev.txt
+            & $pythonExecutablePath -m pip install -vv -r ${{ env.OPENVINO_REPO }}/src/bindings/python/wheel/requirements-dev.txt
 
             if ($pyVersion -eq '3.14t') {
               cmake -DPython3_EXECUTABLE="$pythonExecutablePath" -DENABLE_GIL_PYTHON_API=OFF -DENABLE_PYTHON=ON -DENABLE_WHEEL=ON -DOpenVINODeveloperPackage_DIR=${{ env.BUILD_DIR }} -S ${{ env.OPENVINO_REPO }}/src/bindings/python -B "$pyBuildDir"
@@ -273,7 +273,7 @@ jobs:
           should-setup-pip-paths: 'true'
           self-hosted-runner: 'true'
           allow-prereleases: 'true'
-      
+
       - name: Build additional Python wheels - Python 3.14t
         if: ${{ inputs.build-additional-python-wheels }}
         run: |
@@ -290,7 +290,7 @@ jobs:
           Write-Host "Using pip version: $pipVersion for $pyVersion"
           $env:PIP_CACHE_DIR="${{ env.PIP_CACHE_PATH }}/$pipVersion"
 
-          & $pythonExecutablePath -m pip install -r ${{ env.OPENVINO_REPO }}/src/bindings/python/wheel/requirements-dev.txt
+          & $pythonExecutablePath -m pip install -vv -r ${{ env.OPENVINO_REPO }}/src/bindings/python/wheel/requirements-dev.txt
 
           cmake -DPython3_EXECUTABLE="$pythonExecutablePath" -DENABLE_GIL_PYTHON_API=OFF -DENABLE_PYTHON=ON -DENABLE_WHEEL=ON -DOpenVINODeveloperPackage_DIR=${{ env.BUILD_DIR }} -S ${{ env.OPENVINO_REPO }}/src/bindings/python -B "$pyBuildDir"
 

--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -123,20 +123,20 @@ jobs:
       - name: Install python dependencies
         run: |
           # For running ONNX frontend unit tests
-          python3 -m pip install --force-reinstall -r ${{ env.OPENVINO_REPO }}/src/frontends/onnx/tests/requirements.txt
+          python3 -m pip install -vv --force-reinstall -r ${{ env.OPENVINO_REPO }}/src/frontends/onnx/tests/requirements.txt
 
           # For running TensorFlow frontend unit tests
-          python3 -m pip install -r ${{ env.OPENVINO_REPO }}/src/frontends/tensorflow/tests/requirements.txt
+          python3 -m pip install -vv -r ${{ env.OPENVINO_REPO }}/src/frontends/tensorflow/tests/requirements.txt
 
           # For running TensorFlow Lite frontend unit tests
-          python3 -m pip install -r ${{ env.OPENVINO_REPO }}/src/frontends/tensorflow_lite/tests/requirements.txt
+          python3 -m pip install -vv -r ${{ env.OPENVINO_REPO }}/src/frontends/tensorflow_lite/tests/requirements.txt
 
           # For getting rid of SSL issues during model downloading for unit tests
-          python3 -m pip install certifi
+          python3 -m pip install -vv certifi
 
           # Disabled because of CVS-95904
           # For running Paddle frontend unit tests
-          # python3 -m pip install -r ${{ env.OPENVINO_REPO }}/src/frontends/paddle/tests/requirements.txt
+          # python3 -m pip install -vv -r ${{ env.OPENVINO_REPO }}/src/frontends/paddle/tests/requirements.txt
 
       #
       # Build
@@ -433,7 +433,7 @@ jobs:
           self-hosted-runner: 'false'
 
       - name: Install python dependencies for run_parallel.py
-        run: python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/layer_tests_summary/requirements.txt
+        run: python3 -m pip install -vv -r ${{ env.INSTALL_TEST_DIR }}/layer_tests_summary/requirements.txt
 
       - name: Restore tests execution time
         uses: actions/cache/restore@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Samples tests
         run: |
-          python3 -m pip install --ignore-installed PyYAML -r ./tests/smoke_tests/requirements.txt
+          python3 -m pip install -vv --ignore-installed PyYAML -r ./tests/smoke_tests/requirements.txt
           . "./setupvars.ps1"
           $Env:PYTHONCOERCECLOCALE="warn"
           python3 -bb -W error -X dev -X warn_default_encoding -m pytest ./tests/smoke_tests --numprocesses auto
@@ -330,25 +330,25 @@ jobs:
       - name: Install Python API tests dependencies
         run: |
           # To enable pytest parallel features
-          python3 -m pip install pytest-xdist[psutil]
+          python3 -m pip install -vv pytest-xdist[psutil]
 
           # For torchvision to OpenVINO preprocessing converter
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/python/preprocess/torchvision/requirements.txt
+          python3 -m pip install -vv -r ${{ env.INSTALL_TEST_DIR }}/python/preprocess/torchvision/requirements.txt
 
           # For validation of Python API
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
+          python3 -m pip install -vv -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
 
           #  ONNX tests requirements
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/requirements_onnx
+          python3 -m pip install -vv -r ${{ env.INSTALL_TEST_DIR }}/requirements_onnx
 
           # For getting rid of SSL issues during model downloading for unit tests
-          python3 -m pip install certifi
+          python3 -m pip install -vv certifi
 
       - name: Set SSL_CERT_FILE for model downloading for unit tests
         run: echo SSL_CERT_FILE=$(python3 -m certifi) >> $env:GITHUB_ENV
 
       - name: Install Python Layer tests dependencies
-        run: python3 -m pip install -r ${{ env.LAYER_TESTS_INSTALL_DIR }}/requirements.txt
+        run: python3 -m pip install -vv -r ${{ env.LAYER_TESTS_INSTALL_DIR }}/requirements.txt
 
       - name: Python API Tests
         #if: fromJSON(needs.smart_ci.outputs.affected_components).Python_API.test # Ticket: 127101
@@ -472,7 +472,7 @@ jobs:
           free-threaded-python: ${{ contains(matrix.python-version, 't') }}
 
       - name: Install Python API tests dependencies
-        run: python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
+        run: python3 -m pip install -vv -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
 
       - name: Python API Tests
         shell: cmd
@@ -484,8 +484,8 @@ jobs:
         shell: cmd
         run: |
           python3 -m pip uninstall -y numpy
-          python3 -m pip install "numpy>=2.0.0,<2.1.0"
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
+          python3 -m pip install -vv "numpy>=2.0.0,<2.1.0"
+          python3 -m pip install -vv -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
           # for 'template' extension
           set PYTHONPATH=${{ env.INSTALL_TEST_DIR }};%PYTHONPATH%
           set PATH=${{ env.INSTALL_TEST_DIR }};%PATH%
@@ -605,7 +605,7 @@ jobs:
           self-hosted-runner: 'true'
 
       - name: Install python dependencies
-        run: python3 -m pip install -r ${{ github.workspace }}\install\tests\functional_test_utils\layer_tests_summary\requirements.txt
+        run: python3 -m pip install -vv -r ${{ github.workspace }}\install\tests\functional_test_utils\layer_tests_summary\requirements.txt
 
       - name: Restore tests execution time
         uses: actions/cache/restore@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2


### PR DESCRIPTION
### Details:
There's an increase in failures during `pip install` on Windows with the following message:
```
WARNING: Skipping page https://pypi.org/simple/pip/ because the GET request got Content-Type: Unknown. The only supported Content-Types are application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html, and text/html
```

There are a few GitHub issues describing this problem (https://github.com/pypa/cibuildwheel/issues/1254 for example), but all of them claim the issue is solved by using different directories for different Python versions, which we already do.

I suspect the issue occurs in this line https://github.com/pypa/pip/blob/545eda389c41478e2f99d23212254d757d8c2cef/src/pip/_internal/index/collector.py#L71 - `Unknown` is what we see when there's no such header at all. Without debug logs it is impossible to find out why we get an HTTP response without `Content-Type` header.

### Tickets:
 - *CVS-158400*
