### PR TITLE
[OVC] Fix freeze_placeholder_with_value parameter handling via input

### DIFF
--- a/tools/ovc/openvino/tools/ovc/cli_parser.py
+++ b/tools/ovc/openvino/tools/ovc/cli_parser.py
@@ -132,7 +132,11 @@ def input_to_input_cut_info(input: [dict, tuple, list]):
 
         inputs = []
         for inp in input:
-            inputs.append(single_input_to_input_cut_info(inp))
+            # If input is already an InputCutInfo, use it directly
+            if isinstance(inp, _InputCutInfo):
+                inputs.append(inp)
+            else:
+                inputs.append(single_input_to_input_cut_info(inp))
         return inputs
 
     if isinstance(input, dict):

--- a/tools/ovc/openvino/tools/ovc/convert_impl.py
+++ b/tools/ovc/openvino/tools/ovc/convert_impl.py
@@ -361,6 +361,12 @@ def normalize_inputs(argv: argparse.Namespace):
                 data_type_dict[inp.name] = to_ov_type(inp.type)
         argv.placeholder_shapes = shape_dict if shape_dict else None
         argv.placeholder_data_types = data_type_dict if data_type_dict else {}
+        # Extract freeze_placeholder values from input
+        freeze_placeholder_dict = {}
+        for inp in inputs:
+            if inp.value is not None:
+                freeze_placeholder_dict[inp.name] = inp.value
+        argv.freeze_placeholder_with_value = freeze_placeholder_dict
     else:
         # Unnamed inputs case
         shape_list = []
@@ -374,6 +380,11 @@ def normalize_inputs(argv: argparse.Namespace):
                 data_type_list.append(to_ov_type(inp.type))
         argv.placeholder_shapes = shape_list if shape_list else None
         argv.placeholder_data_types = data_type_list if data_type_list else {}
+        # For unnamed inputs, freeze_placeholder is empty (values require names)
+        argv.freeze_placeholder_with_value = {}
+    # Fallback: ensure freeze_placeholder_with_value always exists
+    if not hasattr(argv, 'freeze_placeholder_with_value'):
+        argv.freeze_placeholder_with_value = {}
     if hasattr(argv, "framework") and argv.framework == "pytorch" and getattr(argv, "example_input", None) is not None:
         extract_input_info_from_example(argv, inputs)
 

--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pipeline.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pipeline.py
@@ -145,9 +145,10 @@ def moc_pipeline(argv: argparse.Namespace, moc_front_end: FrontEnd):
     argv.placeholder_shapes, argv.placeholder_data_types = convert_params_lists_to_dicts(
         input_model, argv.placeholder_shapes, argv.placeholder_data_types)
 
+    freeze_placeholder_with_value = getattr(argv, 'freeze_placeholder_with_value', {})
     user_shapes, outputs, freeze_placeholder = fe_user_data_repack(
         input_model, argv.placeholder_shapes, argv.placeholder_data_types,
-        argv.output, {}, moc_front_end.get_name())
+        argv.output, freeze_placeholder_with_value, moc_front_end.get_name())
 
     def add_names_to_tensors(model: InputModel, places: list[Place]):
         """
@@ -204,7 +205,7 @@ def moc_pipeline(argv: argparse.Namespace, moc_front_end: FrontEnd):
 
             user_shapes, outputs, _ = fe_user_data_repack(
                 input_model, placeholder_shapes, argv.placeholder_data_types,
-                new_output_places_name, {}, moc_front_end.get_name())
+                new_output_places_name, freeze_placeholder_with_value, moc_front_end.get_name())
     elif not inputs_equal:
         log.debug('Using override_all_inputs')
         add_names_to_tensors(input_model, user_shapes)
@@ -216,7 +217,7 @@ def moc_pipeline(argv: argparse.Namespace, moc_front_end: FrontEnd):
 
             user_shapes, outputs, _ = fe_user_data_repack(
                 input_model, placeholder_shapes, argv.placeholder_data_types,
-                argv.output, {}, moc_front_end.get_name())
+                argv.output, freeze_placeholder_with_value, moc_front_end.get_name())
     elif not outputs_equal:
         log.debug('Using override_all_outputs')
         add_names_to_tensors(input_model, user_shapes)


### PR DESCRIPTION
### Summary
Fix `_InputCutInfo.value` field being ignored during model conversion, which prevented freezing placeholder inputs with constant values.

### Problem
When using `convert_model()` with `_InputCutInfo` containing a `value` field, the value was silently ignored. This broke models that require freezing placeholder inputs (e.g., training/inference mode flags).

Affected E2E tests: TF_Shufflenet, TF_FaceNet (all variants).

### Root Cause
1. `cli_parser.py:input_to_input_cut_info()` didn't recognize pre-constructed `_InputCutInfo` objects in input list
2. `convert_impl.py:normalize_inputs()` extracted shape and type but ignored the `value` field
3. `pipeline.py:moc_pipeline()` passed empty `{}` instead of actual freeze_placeholder values to `fe_user_data_repack()`

### Changes
- `cli_parser.py`: Pass through `_InputCutInfo` objects directly instead of re-parsing them
- `convert_impl.py`: Extract `value` from `_InputCutInfo` into `argv.freeze_placeholder_with_value`
- `pipeline.py`: Pass `freeze_placeholder_with_value` to `fe_user_data_repack()` in all 3 call sites

### Tickets:
 - 155709
