### PR TITLE
fixed memory accumulation in jaxpr_Decoder

### DIFF
--- a/src/bindings/python/src/openvino/frontend/jax/jaxpr_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/jax/jaxpr_decoder.py
@@ -144,6 +144,9 @@ class JaxprPythonDecoder(Decoder):
         return PartialShape(self.jaxpr.outvars[index].aval.shape)
 
     def visit_subgraph(self, node_visitor) -> None:
+        #Fix : clear the list to prevent accumalation of decoders on multiple calls
+        self.m_decoders.clear()
+        
         if isinstance(self.jaxpr, jex.core.JaxprEqn):
             return
         for _, decoder in self.params.items():


### PR DESCRIPTION
### Problem
The `JaxprPythonDecoder` accumulates decoder objects in `self.m_decoders` indefinitely upon repeated calls to `visit_subgraph`. This causes unbounded memory growth during multi-pass graph analysis.

### Solution
Explicitly clear `self.m_decoders` at the start of `visit_subgraph` to ensure only decoders for the current traversal are retained.

### Testing
Verified locally with a reproduction script.
- Before fix: m_decoders length grew 2 -> 4 -> 6
- After fix: m_decoders length remained stable 2 -> 2 -> 2

### Related Issue
Fixes #33745