### PR TITLE
[GPU] Fix non-deterministic MVN results

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_b_fs_yx_fsv16_imad.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_b_fs_yx_fsv16_imad.cl
@@ -370,6 +370,7 @@ KERNEL(mvn_mean_var_bsv32)(
 #if NORMALIZE_VARIANCE
     MEAN_PACKED_TYPE partial_dev = FUNC_CALL(accumulate_sum_sq_dev)(input, data_sets_offset, get_local_id(0), mean);
     #if SG_NUM != 1
+        barrier(CLK_LOCAL_MEM_FENCE);
         MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev, slm_acc);
     #else
         MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev);
@@ -474,6 +475,7 @@ KERNEL(mvn_final)(
 #   else
     MEAN_PACKED_TYPE partial_dev = FUNC_CALL(accumulate_sum_sq_dev)(input, data_sets_offset, get_local_id(0), mean);
 #       if SG_NUM != 1
+    barrier(CLK_LOCAL_MEM_FENCE);
     MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev, slm_acc);
 #       else
     MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_b_fs_yx_fsv16_imad.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_b_fs_yx_fsv16_imad.cl
@@ -356,13 +356,10 @@ KERNEL(mvn_mean_var_bsv32)(
     const uint sglid = get_sub_group_local_id();
     const uint data_sets_offset = INPUT0_GET_INDEX(b, f, 0, 0);
 
-#if SG_NUM != 1
-    __local MEAN_TYPE slm_acc[(SG_NUM - 1) * FSV];
-#endif
-
     ACC_PACKED_TYPE partial_sum = FUNC_CALL(accumulate_sum_input)(input, data_sets_offset, get_local_id(0));
 #if SG_NUM != 1
-    MEAN_TYPE mean = FUNC_CALL(reduce_mean)(TO_MEAN_PACKED_TYPE(partial_sum), slm_acc);
+    __local MEAN_TYPE slm_mean_acc[(SG_NUM - 1) * FSV];
+    MEAN_TYPE mean = FUNC_CALL(reduce_mean)(TO_MEAN_PACKED_TYPE(partial_sum), slm_mean_acc);
 #else
     MEAN_TYPE mean = FUNC_CALL(reduce_mean)(TO_MEAN_PACKED_TYPE(partial_sum));
 #endif
@@ -370,8 +367,8 @@ KERNEL(mvn_mean_var_bsv32)(
 #if NORMALIZE_VARIANCE
     MEAN_PACKED_TYPE partial_dev = FUNC_CALL(accumulate_sum_sq_dev)(input, data_sets_offset, get_local_id(0), mean);
     #if SG_NUM != 1
-        barrier(CLK_LOCAL_MEM_FENCE);
-        MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev, slm_acc);
+        __local MEAN_TYPE slm_var_acc[(SG_NUM - 1) * FSV];
+        MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev, slm_var_acc);
     #else
         MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev);
     #endif
@@ -454,16 +451,13 @@ KERNEL(mvn_final)(
 #endif
     uint input_offset;
 
-#if (!PRECALC_MEAN || (NORMALIZE_VARIANCE && !PRECALC_VARIANCE)) && SG_NUM != 1
-    __local MEAN_TYPE slm_acc[(SG_NUM - 1) * FSV];
-#endif
-
 #if PRECALC_MEAN
     MEAN_TYPE mean = means[flat_data_set_group * FSV + sglid];
 #else
     INT_PACKED_TYPE partial_sum = FUNC_CALL(accumulate_sum_input)(input, data_sets_offset, get_local_id(0));
 #   if SG_NUM != 1
-    MEAN_TYPE mean = FUNC_CALL(reduce_mean)(TO_MEAN_PACKED_TYPE(partial_sum), slm_acc);
+    __local MEAN_TYPE slm_mean_acc[(SG_NUM - 1) * FSV];
+    MEAN_TYPE mean = FUNC_CALL(reduce_mean)(TO_MEAN_PACKED_TYPE(partial_sum), slm_mean_acc);
 #   else
     MEAN_TYPE mean = FUNC_CALL(reduce_mean)(TO_MEAN_PACKED_TYPE(partial_sum));
 #   endif
@@ -475,10 +469,10 @@ KERNEL(mvn_final)(
 #   else
     MEAN_PACKED_TYPE partial_dev = FUNC_CALL(accumulate_sum_sq_dev)(input, data_sets_offset, get_local_id(0), mean);
 #       if SG_NUM != 1
-    barrier(CLK_LOCAL_MEM_FENCE);
-    MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev, slm_acc);
+            __local MEAN_TYPE slm_var_acc[(SG_NUM - 1) * FSV];
+            MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev, slm_var_acc);
 #       else
-    MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev);
+            MEAN_TYPE inv_variance = FUNC_CALL(reduce_inverse_variance)(partial_dev);
 #       endif
 #   endif
 #else


### PR DESCRIPTION
### Issue:
 - MVN execution on Intel GPU shows non-deterministic results for blocked layouts (e.g. bs_fs_yx_bsv32_fsv32) even with identical inputs.
 - This PR addresses a missing work-group level synchronization when reusing local (SLM) memory across consecutive reductions inside a single kernel.

### Symptom:
- MVN output becomes randomly corrupted on certain (batch, feature) tiles.
- The corruption occurs with identical inputs, varies from run to run, looks like value collapse rather than small numerical drift.
- The issue is observed when local memory, `slm_acc`, is shared between mean and variance reductions.

### Root cause:
- The root cause is missing synchronization when reusing the same local (SLM) buffer for two consecutive reductions (`reduce_mean` → `reduce_inverse_variance`) inside the `mvn_mean_var_bsv32` kernel.
- Although `reduce_*` functions contain internal barriers, those barriers only guarantee correctness inside a single reduction.
- They do not guarantee that all sub-groups have completed reading the broadcasted result after the function returns.
- This leads to corrupted mean or variance, undefined behavior, non-deterministic results.

### How to fix:
- Use separate local variables for each `reduce_mean` and `reduce_inverse_variance`.


### Tickets:
 - CVS-115729
