### PR TITLE
[cmake] WA to fix issue with new No module named 'wheel.vendored'

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -12,7 +12,7 @@ build<1.5
 pygments>=2.8.1
 setuptools>=77,<80.10
 sympy>=1.10
-wheel>=0.38.1
+wheel>=0.38.1,<0.46.2
 patchelf<=0.17.2.4
 packaging>=22.0
 


### PR DESCRIPTION
New wheel package release 22.01.2026:
https://pypi.org/project/wheel/#history
https://wheel.readthedocs.io/en/stable/news.html

Seems it is causing a problem on cmake stage:
```
[2026-01-22T07:01:16.417Z] -- Performing Test HAS_FLTO
[2026-01-22T07:01:16.417Z] -- Performing Test HAS_FLTO - Success
[2026-01-22T07:01:16.417Z] Traceback (most recent call last):
[2026-01-22T07:01:16.418Z]   File "<string>", line 1, in <module>
[2026-01-22T07:01:16.418Z] ModuleNotFoundError: No module named 'wheel.vendored'
[2026-01-22T07:01:16.418Z] CMake Error at wheel/CMakeLists.txt:12 (message):
[2026-01-22T07:01:16.418Z]   Failed to detect Python Tag via wheel.vendored.packaging.tags.  Please,
[2026-01-22T07:01:16.418Z]   check 'wheel' dependency version update
[2026-01-22T07:01:16.418Z] 
[2026-01-22T07:01:16.418Z] 
[2026-01-22T07:01:16.418Z] -- Configuring incomplete, errors occurred!
[2026-01-22T07:01:16.418Z] 
[2026-01-22T07:01:16.418Z] [2026-01-22 08:01:15,525] [123145498882048] cmake python_api python3.10  INFO: 
```