### PR TITLE
[PT FE]: add support for aten::_sparse_mm and aten::sparse_coo_…

### DIFF
--- a/src/frontends/common/include/openvino/frontend/sparse_type_mark.hpp
+++ b/src/frontends/common/include/openvino/frontend/sparse_type_mark.hpp
@@ -1,0 +1,100 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/frontend/exception.hpp"
+#include "openvino/frontend/node_context.hpp"
+#include "openvino/frontend/visibility.hpp"
+#include "openvino/op/util/framework_node.hpp"
+
+namespace ov {
+namespace frontend {
+
+/// \brief SparseTypeMark serves to mark sparse tensor representations.
+///
+/// This marker defers the conversion from sparse to dense, allowing
+/// operations to work directly with sparse data (indices, values).
+///
+/// Represents:
+/// - indices: [ndim, nnz] (canonical COO layout)
+/// - values: [nnz]
+/// - shape: [ndim]
+///
+/// Usage:
+///   auto sparse_mark = std::make_shared<SparseTypeMark>(indices, values, shape);
+///   auto result = SparseTypeMark::sparse_mm(context, sparse_mark, dense);
+///
+class FRONTEND_API SparseTypeMark : public ov::op::util::FrameworkNode {
+public:
+    OPENVINO_OP("SparseTypeMark", "util", ov::op::util::FrameworkNode);
+
+    /// \brief Construct a SparseTypeMark from sparse COO representation
+    /// \param indices Tensor of indices in canonical layout [ndim, nnz]
+    /// \param values Tensor of values at those indices, shape [nnz]
+    /// \param shape Tensor describing the dense shape, shape [ndim]
+    /// \param value_type Element type of the values
+    SparseTypeMark(const ov::Output<ov::Node>& indices,
+                   const ov::Output<ov::Node>& values,
+                   const ov::Output<ov::Node>& shape,
+                   const ov::element::Type& value_type = ov::element::dynamic);
+
+    ~SparseTypeMark() override;
+
+    void validate_and_infer_types() override {
+        set_output_type(0, ov::element::dynamic, ov::PartialShape::dynamic());
+    }
+
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& inputs) const override {
+        OPENVINO_ASSERT(inputs.size() == 3, "SparseTypeMark expects 3 inputs");
+        auto sparse_mark = std::make_shared<SparseTypeMark>(inputs[0], inputs[1], inputs[2], m_value_type);
+        sparse_mark->set_attrs(get_attrs());
+        return sparse_mark;
+    }
+
+    /// \brief Get the element type of the sparse tensor values
+    ov::element::Type get_value_type() const {
+        return m_value_type;
+    }
+
+    /// \brief Get the indices tensor
+    /// \return Indices tensor in canonical layout [ndim, nnz]
+    ov::Output<ov::Node> get_indices();
+
+    /// \brief Get the values tensor (lazy accessor)
+    /// \return Values tensor, shape [nnz]
+    ov::Output<ov::Node> get_values();
+
+    /// \brief Get the shape tensor (lazy accessor)
+    /// \return Shape tensor, shape [ndim]
+    ov::Output<ov::Node> get_shape();
+
+    /// \brief Convert sparse representation to dense tensor
+    /// This is the fallback for operations that don't have sparse-aware implementations
+    /// \param context Node context for creating operations
+    /// \return Dense tensor with the same values as the sparse representation
+    ov::Output<ov::Node> to_dense(const NodeContext& context);
+
+    /// \brief Sparse-aware matrix multiplication: sparse @ dense -> dense, sparse @ sparse -> dense
+    /// \param context Node context for creating operations
+    /// \param sparse Sparse matrix (SparseTypeMark or dense)
+    /// \param dense Dense matrix
+    /// \return Result of matrix multiplication
+    static ov::Output<ov::Node> sparse_mm(const NodeContext& context,
+                                          const ov::Output<ov::Node>& sparse,
+                                          const ov::Output<ov::Node>& dense);
+
+private:
+    ov::Output<ov::Node> m_indices;
+    ov::Output<ov::Node> m_values;
+    ov::Output<ov::Node> m_shape;
+    ov::element::Type m_value_type;
+
+    // Cached dense representation (lazy, only created when needed)
+    mutable ov::Output<ov::Node> m_dense;
+};
+
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/common/src/sparse_type_mark.cpp
+++ b/src/frontends/common/src/sparse_type_mark.cpp
@@ -81,7 +81,8 @@ ov::Output<ov::Node> SparseTypeMark::sparse_mm(const NodeContext& context,
         return context.mark_node(std::make_shared<v0::MatMul>(dense_sparse, matrix, false, false));
     }
 
-    FRONT_END_OP_CONVERSION_CHECK(!matrix_mark, "aten::_sparse_mm does not support Dense x Sparse matrix multiplication.");
+    FRONT_END_OP_CONVERSION_CHECK(!matrix_mark,
+                                  "aten::_sparse_mm does not support Dense x Sparse matrix multiplication.");
 
     return context.mark_node(std::make_shared<v0::MatMul>(sparse, matrix, false, false));
 }

--- a/src/frontends/common/src/sparse_type_mark.cpp
+++ b/src/frontends/common/src/sparse_type_mark.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/sparse_type_mark.hpp"
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/scatter_nd_update.hpp"
+#include "openvino/op/transpose.hpp"
+
+using namespace ov::frontend;
+using namespace ov::op;
+
+SparseTypeMark::SparseTypeMark(const ov::Output<ov::Node>& indices,
+                               const ov::Output<ov::Node>& values,
+                               const ov::Output<ov::Node>& shape,
+                               const ov::element::Type& value_type)
+    : ov::op::util::FrameworkNode(ov::OutputVector{indices, values, shape}, 1),
+      m_indices(indices),
+      m_values(values),
+      m_shape(shape),
+      m_value_type(value_type),
+      m_dense{} {
+    validate_and_infer_types();
+
+    if (m_value_type.is_dynamic()) {
+        m_value_type = m_values.get_element_type();
+    }
+}
+
+SparseTypeMark::~SparseTypeMark() = default;
+
+ov::Output<ov::Node> SparseTypeMark::get_indices() {
+    return m_indices;
+}
+
+ov::Output<ov::Node> SparseTypeMark::get_values() {
+    return m_values;
+}
+
+ov::Output<ov::Node> SparseTypeMark::get_shape() {
+    return m_shape;
+}
+
+ov::Output<ov::Node> SparseTypeMark::to_dense(const NodeContext& context) {
+    if (m_dense.get_node_shared_ptr()) {
+        return m_dense;
+    }
+
+    auto zero_const = context.mark_node(v0::Constant::create(m_value_type, Shape{}, {0}));
+    auto dense_zero = context.mark_node(std::make_shared<v3::Broadcast>(zero_const, m_shape));
+
+    // m_indices is stored in canonical [ndim, nnz] layout; transpose to [nnz, ndim] for ScatterNDUpdate
+    // Note: m_indices is always a 2D tensor (shape [ndim, nnz]) regardless of the sparse tensor's rank.
+    // Therefore, the permutation order to swap its two dimensions is always {1, 0}.
+    auto perm_order = context.mark_node(v0::Constant::create(element::i32, Shape{2}, {1, 0}));
+    auto permuted_indices = context.mark_node(std::make_shared<v1::Transpose>(m_indices, perm_order));
+
+    m_dense = context.mark_node(std::make_shared<v3::ScatterNDUpdate>(dense_zero, permuted_indices, m_values));
+
+    return m_dense;
+}
+
+ov::Output<ov::Node> SparseTypeMark::sparse_mm(const NodeContext& context,
+                                               const ov::Output<ov::Node>& sparse,
+                                               const ov::Output<ov::Node>& matrix) {
+    auto sparse_mark = as_type_ptr<SparseTypeMark>(sparse.get_node_shared_ptr());
+    auto matrix_mark = as_type_ptr<SparseTypeMark>(matrix.get_node_shared_ptr());
+
+    if (sparse_mark && matrix_mark) {
+        auto lhs_dense = sparse_mark->to_dense(context);
+        auto rhs_dense = matrix_mark->to_dense(context);
+        return context.mark_node(std::make_shared<v0::MatMul>(lhs_dense, rhs_dense, false, false));
+    }
+
+    if (sparse_mark) {
+        auto dense_sparse = sparse_mark->to_dense(context);
+        return context.mark_node(std::make_shared<v0::MatMul>(dense_sparse, matrix, false, false));
+    }
+
+    FRONT_END_OP_CONVERSION_CHECK(!matrix_mark, "aten::_sparse_mm does not support Dense x Sparse matrix multiplication.");
+
+    return context.mark_node(std::make_shared<v0::MatMul>(sparse, matrix, false, false));
+}

--- a/src/frontends/pytorch/src/op/sparse_coo_tensor.cpp
+++ b/src/frontends/pytorch/src/op/sparse_coo_tensor.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/frontend/sparse_type_mark.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+OutputVector translate_sparse_coo_tensor(const NodeContext& context) {
+    // aten::sparse_coo_tensor(indices, values, size, dtype=None, layout=None, device=None, pin_memory=False)
+    num_inputs_check(context, 3, 7);
+    auto indices = context.get_input(0);  // [ndim, nnz]
+    auto values = context.get_input(1);   // [nnz]
+    auto size = context.get_input(2);     // [ndim] - shape of dense tensor
+
+    // Note: Shape validation (indices vs values) is deferred to the execution stage 
+    // (ScatterNDUpdate in to_dense()) to allow dynamic shapes to propagate correctly.
+    // Defer dense conversion via SparseTypeMark
+    auto sparse_mark = context.mark_node(
+        std::make_shared<ov::frontend::SparseTypeMark>(indices, values, size, values.get_element_type()));
+
+    return {sparse_mark};
+};
+
+OutputVector translate_to_dense(const NodeContext& context) {
+    // aten::to_dense(Tensor self, ScalarType? dtype=None, bool? masked_grad=None) -> Tensor
+    num_inputs_check(context, 1, 3);
+    auto input = context.get_input(0);
+    auto sparse_mark = std::dynamic_pointer_cast<ov::frontend::SparseTypeMark>(input.get_node_shared_ptr());
+    if (sparse_mark) {
+        return {sparse_mark->to_dense(context)};
+    }
+    // Already dense, return as-is
+    return {input};
+};
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op/sparse_coo_tensor.cpp
+++ b/src/frontends/pytorch/src/op/sparse_coo_tensor.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #include "openvino/frontend/pytorch/node_context.hpp"
 #include "openvino/frontend/sparse_type_mark.hpp"
@@ -19,14 +20,14 @@ OutputVector translate_sparse_coo_tensor(const NodeContext& context) {
     auto values = context.get_input(1);   // [nnz]
     auto size = context.get_input(2);     // [ndim] - shape of dense tensor
 
-    // Note: Shape validation (indices vs values) is deferred to the execution stage 
+    // Note: Shape validation (indices vs values) is deferred to the execution stage
     // (ScatterNDUpdate in to_dense()) to allow dynamic shapes to propagate correctly.
     // Defer dense conversion via SparseTypeMark
     auto sparse_mark = context.mark_node(
         std::make_shared<ov::frontend::SparseTypeMark>(indices, values, size, values.get_element_type()));
 
     return {sparse_mark};
-};
+}
 
 OutputVector translate_to_dense(const NodeContext& context) {
     // aten::to_dense(Tensor self, ScalarType? dtype=None, bool? masked_grad=None) -> Tensor
@@ -38,7 +39,7 @@ OutputVector translate_to_dense(const NodeContext& context) {
     }
     // Already dense, return as-is
     return {input};
-};
+}
 
 }  // namespace op
 }  // namespace pytorch

--- a/src/frontends/pytorch/src/op/sparse_mm.cpp
+++ b/src/frontends/pytorch/src/op/sparse_mm.cpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/frontend/sparse_type_mark.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+OutputVector translate_sparse_mm(const NodeContext& context) {
+    // aten::_sparse_mm(Tensor sparse, Tensor matrix) -> Tensor
+    num_inputs_check(context, 2, 2);
+    auto sparse_mat = context.get_input(0);
+    auto mat2 = context.get_input(1);
+
+    // Delegate to SparseTypeMark aware implementation
+    return {ov::frontend::SparseTypeMark::sparse_mm(context, sparse_mat, mat2)};
+};
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op/sparse_mm.cpp
+++ b/src/frontends/pytorch/src/op/sparse_mm.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #include "openvino/frontend/pytorch/node_context.hpp"
 #include "openvino/frontend/sparse_type_mark.hpp"
@@ -18,7 +19,7 @@ OutputVector translate_sparse_mm(const NodeContext& context) {
 
     // Delegate to SparseTypeMark aware implementation
     return {ov::frontend::SparseTypeMark::sparse_mm(context, sparse_mat, mat2)};
-};
+}
 
 }  // namespace op
 }  // namespace pytorch

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -259,6 +259,8 @@ OP_CONVERTER(translate_std_mean);
 OP_CONVERTER(translate_stft);
 OP_CONVERTER(translate_sub);
 OP_CONVERTER(translate_sub_);
+OP_CONVERTER(translate_sparse_mm);
+OP_CONVERTER(translate_sparse_coo_tensor);
 OP_CONVERTER(translate_sum);
 OP_CONVERTER(translate_t);
 OP_CONVERTER(translate_take_along_dim);
@@ -351,6 +353,7 @@ OP_CONVERTER(translate_sub_fx);
 OP_CONVERTER(translate_sum_fx);
 OP_CONVERTER(translate_std_fx);
 OP_CONVERTER(translate_topk_fx);
+OP_CONVERTER(translate_to_dense);
 OP_CONVERTER(translate_to_fx);
 OP_CONVERTER(translate_quantize_per_channel_fx);
 OP_CONVERTER(translate_quantize_per_tensor_fx);
@@ -391,6 +394,8 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::_pad_packed_sequence", op::translate_pad_packed_sequence},
         {"aten::_set_item", op::translate_set_item},
         {"aten::_shape_as_tensor", op::translate_shape_as_tensor},
+        {"aten::sparse_coo_tensor", op::translate_sparse_coo_tensor},
+        {"aten::_sparse_mm", op::translate_sparse_mm},
         {"aten::_unique2", op::translate_unique2},
         {"aten::_upsample_bicubic2d_aa", op::translate_upsample_bicubic2d_aa},
         {"aten::_upsample_bilinear2d_aa", op::translate_upsample_bilinear2d_aa},
@@ -754,6 +759,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         // aten::tensor_split - Supported in limited set of patterns
         {"aten::tile", op::translate_1to1_match_2_inputs<opset10::Tile>},
         {"aten::to", op::translate_to},
+        {"aten::to_dense", op::translate_to_dense},
         {"aten::topk", op::translate_topk},
         {"aten::transpose", op::quantizable_op<op::translate_transpose>},
         {"aten::tril", op::translate_tril},

--- a/tests/layer_tests/pytorch_tests/test_sparse_mm.py
+++ b/tests/layer_tests/pytorch_tests/test_sparse_mm.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import numpy as np
+import torch
+from pytorch_layer_test_class import PytorchLayerTest, skip_if_export
+
+
+class TestSparseMM(PytorchLayerTest):
+    def _prepare_input(self, dense_shape):
+        rng = np.random.default_rng(42)
+        return (rng.standard_normal(dense_shape).astype(np.float32),)
+
+    def create_model(self, sparse_shape, indices, values):
+        class aten_sparse_mm(torch.nn.Module):
+            def __init__(self, sparse_shape, indices, values):
+                super().__init__()
+                self.sparse_shape = sparse_shape
+                self.indices = indices
+                self.values = values
+
+            def forward(self, dense_mat):
+                sparse_mat = torch.sparse_coo_tensor(self.indices, self.values, self.sparse_shape)
+                return torch.sparse.mm(sparse_mat, dense_mat)
+
+        return aten_sparse_mm(sparse_shape, indices, values), "aten::_sparse_mm"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.parametrize(("sparse_shape", "dense_shape", "sparsity_mode"), [
+        skip_if_export((3, 3), (3, 2), "empty"),
+        skip_if_export((3, 3), (3, 2), "very_sparse"),
+        skip_if_export((3, 3), (3, 2), "per_row"),
+        skip_if_export((4, 5), (5, 2), "multi_per_row"),
+        skip_if_export((10, 10), (10, 10), "multi_per_row"),
+    ])
+    def test_sparse_mm(self, sparse_shape, dense_shape, sparsity_mode, ie_device, precision, ir_version):
+        rng = np.random.default_rng(42)
+        total_elements = sparse_shape[0] * sparse_shape[1]
+        
+        if sparsity_mode == "empty":
+            num_elements = 0
+        elif sparsity_mode == "very_sparse":
+            num_elements = 1
+        elif sparsity_mode == "per_row":
+            num_elements = min(sparse_shape[0], total_elements)
+        elif sparsity_mode == "multi_per_row":
+            num_elements = min(sparse_shape[0] * 2, total_elements)
+        else:
+            raise ValueError(f"Unknown sparsity_mode: {sparsity_mode}")
+
+        flat_indices = rng.choice(total_elements, num_elements, replace=False)
+        row_indices = flat_indices // sparse_shape[1]
+        col_indices = flat_indices % sparse_shape[1]
+
+        torch.manual_seed(42)
+        indices = torch.tensor(np.array([row_indices, col_indices]), dtype=torch.int64)
+        values = torch.randn(num_elements, dtype=torch.float32)
+
+        self._test(
+            *self.create_model(sparse_shape, indices, values),
+            ie_device, precision, ir_version,
+            kwargs_to_prepare_input={"dense_shape": dense_shape},
+            trace_model=True,
+        )


### PR DESCRIPTION
## Summary
This PR enables support for `aten::_sparse_mm` in the PyTorch Frontend. It also implements `aten::sparse_coo_tensor` to support the construction of sparse tensors within the graph, which is required for end-to-end testing of sparse matrix multiplication using standard dense inputs.
## Changes
- **Implemented [translate_sparse_mm](cci:1://file:///d:/codes/open-source/openvino/src/frontends/pytorch/src/op/sparse_mm.cpp:12:0-23:1)**:
  - Maps `aten::_sparse_mm` directly to `ov::op::v0::MatMul`.
  - Located in [src/frontends/pytorch/src/op/sparse_mm.cpp](cci:7://file:///d:/codes/open-source/openvino/src/frontends/pytorch/src/op/sparse_mm.cpp:0:0-0:0).
- **Implemented [translate_sparse_coo_tensor](cci:1://file:///d:/codes/open-source/openvino/src/frontends/pytorch/src/op/sparse_coo_tensor.cpp:17:0-41:1)**:
  - Maps `aten::sparse_coo_tensor` to `ov::op::v3::ScatterNDUpdate`.
  - Logic: Creates a dense zero tensor and scatters values into it based on indices.
  - Context: This op is necessary for the validation tests, as it allows constructing sparse tensors from dense inputs (indices/values) within the OpenVINO graph.
  - Located in [src/frontends/pytorch/src/op/sparse_coo_tensor.cpp](cci:7://file:///d:/codes/open-source/openvino/src/frontends/pytorch/src/op/sparse_coo_tensor.cpp:0:0-0:0).
- **Operation Registration**:
  - Registered both operations in [src/frontends/pytorch/src/op_table.cpp](cci:7://file:///d:/codes/open-source/openvino/src/frontends/pytorch/src/op_table.cpp:0:0-0:0).
## Testing
- Added [tests/layer_tests/pytorch_tests/test_sparse_mm.py](cci:7://file:///d:/codes/open-source/openvino/tests/layer_tests/pytorch_tests/test_sparse_mm.py:0:0-0:0).
- Verified correct behavior for Sparse (COO) x Dense matrix multiplication.
- Validated on CPU device.

Closes #29685 
Parent Issue #28584 