### PR TITLE
[OVC] Allow output cut at intermediate nodes in TensorFlow models

### DIFF
--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pipeline.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pipeline.py
@@ -176,9 +176,8 @@ def moc_pipeline(argv: argparse.Namespace, moc_front_end: FrontEnd):
 
     outputs_equal = True
     if outputs:
-        # TODO: Remove this line when new 'cut' helper is introduced
-        raise_exception_for_input_output_cut(input_model.get_outputs(), outputs, False)
-
+        # Note: unlike inputs, we don't check if outputs exist in model.get_outputs()
+        # because user may want to cut the graph at any intermediate node (like MO does)
         outputs_equal = check_places_are_same(input_model.get_outputs(), outputs)
     log.debug('Inputs are same: {}, outputs are same: {}'.format(
         inputs_equal, outputs_equal))


### PR DESCRIPTION
### Details:
This PR removes the restriction that prevented users from specifying intermediate graph nodes as outputs when converting TensorFlow models with OVC.

Problem:
When using `convert_model()` with the `output` parameter pointing to an intermediate node (not a terminal output), OVC raised an error:
"Name <node_name> is not found among model outputs."

This behavior differed from Model Optimizer, which allowed cutting the graph at any node by specifying it as an output.

Root cause:
In `moc_frontend/pipeline.py`, the function `raise_exception_for_input_output_cut()` was called for outputs, which validated that all specified outputs must exist in `input_model.get_outputs()`. This check is too restrictive because users may legitimately want to extract intermediate tensors.

Solution:
Removed the validation check for outputs while keeping the existing logic that compares user-specified outputs with model outputs to determine if graph modification is needed.

Example that now works:
```python
from openvino import convert_model

model = convert_model(
    "model.pb",
    input=[1, 720, 1280, 1],
    output=["pred/simple_nms/Select_2", "local_descriptors", "global_descriptor"]
)
This fixes E2E test failures for TF_xj_feature_model_v2 where the test needed to cut the graph at specific intermediate nodes.

### Tickets:
 - 155709
