### PR TITLE
[PT FE] add support for aten::ravel

### DIFF
--- a/src/frontends/pytorch/src/op/ravel.cpp
+++ b/src/frontends/pytorch/src/op/ravel.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/reshape.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+OutputVector translate_ravel(const NodeContext& context) {
+    // aten::ravel(input)
+    // "Return a contiguous flattened tensor."
+    // Equivalent to input.reshape(-1)
+    
+    num_inputs_check(context, 1, 1);
+    auto input = context.get_input(0);
+    
+    auto shape = context.mark_node(v0::Constant::create(element::i32, Shape{1}, {-1}));
+    auto reshape = context.mark_node(std::make_shared<v1::Reshape>(input, shape, false));
+    
+    return {reshape};
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -65,6 +65,7 @@ OP_CONVERTER(translate_cdist);
 OP_CONVERTER(translate_celu);
 OP_CONVERTER(translate_channel_shuffle);
 OP_CONVERTER(translate_clamp);
+OP_CONVERTER(translate_ravel);
 OP_CONVERTER(translate_col2im);
 OP_CONVERTER(translate_constant);
 OP_CONVERTER(translate_conv_transposend);
@@ -674,6 +675,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::randint", op::translate_randint},
         {"aten::randn", op::translate_randn},
         {"aten::randn_like", op::translate_randn_like},
+        {"aten::ravel", op::translate_ravel},
         {"aten::real", common_translators::translate_real},
         {"aten::reciprocal", op::optional_out<op::translate_reciprocal, 1>},
         {"aten::reciprocal_", op::inplace_op<op::translate_reciprocal>},

--- a/tests/layer_tests/pytorch_tests/test_ravel.py
+++ b/tests/layer_tests/pytorch_tests/test_ravel.py
@@ -1,0 +1,19 @@
+
+import pytest
+import torch
+import numpy as np
+from pytorch_layer_test_class import PytorchLayerTest
+
+class TestRavel(PytorchLayerTest):
+
+    def _prepare_input(self):
+        return (np.random.randn(2, 3, 4).astype(np.float32),)
+
+    class RavelModel(torch.nn.Module):
+        def forward(self, x):
+            return torch.ravel(x)
+
+    def test_ravel(self, ie_device, precision, ir_version):
+        model = self.RavelModel()
+        self._test(model, None, "aten::ravel", 
+                   ie_device, precision, ir_version)


### PR DESCRIPTION
## Changes
- **Implemented `translate_ravel`**:
  - **File**: `src/frontends/pytorch/src/op/ravel.cpp`
  - **Logic**: Maps `aten::ravel` to `v1::Reshape` with shape `[-1]`, producing a contiguous flattened tensor.
- **Registered Operation**:
  - Added `aten::ravel` to `src/frontends/pytorch/src/op_table.cpp`.

## Verification
- **Automated Tests**:
  - Added `tests/layer_tests/pytorch_tests/test_ravel.py`.
  - verified on CPU.
  
Closes #28902 
Parent Issue #28584 