### PR TITLE
[CPU] Add BF16 RoPE and remove Gather skip to reduce reorders

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -2019,7 +2019,8 @@ void Graph::EnforceInferencePrecision() const {
                       Type::ScaledDotProductAttention,
                       Type::QKVProjection,
                       Type::GatherMatmul,
-                      Type::LLMMLP);
+                      Type::LLMMLP,
+                      Type::RoPE);
     };
 
     // Backward DFS: traverse from node to its parents, stopping at mandatory BF16 nodes
@@ -2105,22 +2106,6 @@ void Graph::EnforceInferencePrecision() const {
                             forwardSkipSearch(node, nodesToSkip);
                         }
                     }
-                }
-            }
-
-            // Pattern 2: Gather with an integer type on data input is usually encountered in token embeddings (when
-            // compressed). It's better to preserve token embeddings preprocessing (e.g., normalization) in fp32
-            if (node->getType() == Type::Gather) {
-                // Note: ShapeOf subgraphs are excluded from skipping markup
-                // since they are always kept in integer precision
-                const bool shapeOfSubgraph = node->getParentEdgeAt(0)->getParent()->getType() == Type::ShapeOf;
-                const auto inputPrec = node->getOriginalInputPrecisionAtPort(0);
-                if (!shapeOfSubgraph && inputPrec.is_integral_number()) {
-                    // Add Gather node to nodesToSkip
-                    nodesToSkip.insert(node);
-
-                    // keep the child subtree in the original precision
-                    forwardSkipSearch(node, nodesToSkip);
                 }
             }
         }


### PR DESCRIPTION

### Details:
 - *Mark RoPE as mandatory BF16 and remove the Gather integer-input skip pattern in BF16 enforcement, reducing extra reorders to fix LLM performance degradation on Xeon platforms*


### Tickets:
 - *CVS-179127*
