### PR TITLE
Fix ConcatReduceFusion to skip when concat inputs have different shapes

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/concat_reduce_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/concat_reduce_fusion.cpp
@@ -116,7 +116,7 @@ ReplaceConcatReduceByMinOrMax::ReplaceConcatReduceByMinOrMax() {
         // This is only valid when all Concat inputs have identical shapes,
         // so that the elementwise operation produces the same result as the Concat+Reduce.
         // If inputs have different shapes, the elementwise op would broadcast them, producing
-        // a different result. See CVS-179011.
+        // a different result.
         //
         // Example of the bug: Concat([2], [1]) -> ReduceMin(axis=0, keepdims=false) should produce scalar []
         // But the incorrect transformation produces: Minimum([2], [1]) -> [2] (broadcast) -> Squeeze -> [2]


### PR DESCRIPTION
### Details:
The ReplaceConcatReduceByMinOrMax transformation replaces the pattern
Concat(A, B, axis=k) -> ReduceMin/Max(axis=k) with Minimum/Maximum(A, B) -> Squeeze(axis=k).

This transformation is only valid when both concat inputs have identical shapes.
When inputs have different shapes, the elementwise Minimum/Maximum operation
broadcasts them according to numpy rules, producing a different output shape
than the original Concat+Reduce pattern.

Example of the incorrect behavior:
- Concat([2], [1], axis=0) produces shape [3]
- ReduceMin(axis=0, keepdims=false) produces scalar []

But the transformation was producing:
- Minimum([2], [1]) broadcasts to [2]
- Squeeze([2], axis=0) produces [2] (not scalar)

This caused shape mismatch errors in downstream operations like Select/Where
that expected a scalar condition but received shape [2].

The fix adds a check to skip the transformation when concat input shapes differ.

### Tickets:
 - 179011
