### PR TITLE
[GPU]Fix moe kernel build failure issue

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.cpp
@@ -83,7 +83,7 @@ JitConstants MoE3GemmMicroGenerator::get_jit_constants(const kernel_impl_params&
         jit.make("WEIGHT_COMPRESSED_ZP_INT4", 0);
     }
 
-    jit.make("IS_GENERATE", 0);    // only for prefill
+    // "IS_GENERATE" is for generate stage, and prefill stage doesn't need set it.
     jit.make("INPUT_SEQ_LEN", 4);  // prefill not use it
     jit.make("SCALE_ZP_NO_TRANSPOSE", 1);
 


### PR DESCRIPTION
### Details:
 - Fix below error when run qwen3_moe model:
    [GPU] ProgramBuilder build failed!
    Program build failed(4_part_0):
    16:539:2: error: too many arguments to function call, expected 16, have 17
       ,scale_zp_leading_dim
    ^~~~~~~~~~~~~~~~~~~~
    16:185:18: note: 'ugemm_moe' declared here
 - Comes from *https://github.com/openvinotoolkit/openvino/pull/33752*

### Tickets:
 - *ticket-id*
