### PR TITLE
[NPU] Add execution context handle in npu_mlir_runtime header

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/npu_mlir_runtime.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npu_mlir_runtime.hpp
@@ -84,6 +84,10 @@ typedef struct _npu_mlir_runtime_handle_t* npu_mlir_runtime_handle_t;
 /// @brief NPU MLIR runtime MemRef handle
 typedef struct _npu_mlir_runtime_mem_ref_handle_t* npu_mlir_runtime_mem_ref_handle_t;
 
+//////////////////////////////////////////////////////////////////////////////
+/// @brief NPU MLIR runtime execution context handle
+typedef struct _npu_mlir_runtime_execution_context_handle_t* npu_mlir_runtime_execution_context_handle_t;
+
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defined Return/Error codes
 typedef enum _npu_mlir_runtime_result_t {
@@ -124,6 +128,7 @@ typedef struct _npu_mlir_runtime_execute_params_t {
     ze_command_queue_handle_t commandQueue;
     ze_fence_handle_t inferenceFence;
     ze_event_handle_t event;
+    npu_mlir_runtime_execution_context_handle_t executionContext;
 } npu_mlir_runtime_execute_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -213,6 +218,21 @@ npuMLIRRuntimeParseMemRef(npu_mlir_runtime_mem_ref_handle_t hMemRef,  ///< [in] 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// @brief Extension version 1.1
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Init MLIR runtime instance and return handle
+NPU_MLIR_RUNTIME_APIEXPORT npu_mlir_runtime_result_t NPU_MLIR_RUNTIME_APICALL npuMLIRRuntimeCreateExecutionContext(
+    npu_mlir_runtime_handle_t hRuntime,  ///< [in] handle of mlir runtime object
+    npu_mlir_runtime_execution_context_handle_t*
+        phExecutionHandle  ///< [out] pointer to handle of mlir runtime execution context created
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy MLIR runtime instance
+NPU_MLIR_RUNTIME_APIEXPORT npu_mlir_runtime_result_t NPU_MLIR_RUNTIME_APICALL npuMLIRRuntimeDestroyExecutionContext(
+    npu_mlir_runtime_execution_context_handle_t
+        phExecutionHandle  ///< [in][release] handle of execution context object to destroy
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Update mutable command list used in execution and execute


### PR DESCRIPTION
### Details:
 - *Introduces support for an execution context in the NPU MLIR runtime API, this is to support updateMutableCommandList API*
 - *Added a new handle type `npu_mlir_runtime_execution_context_handle_t` for representing execution contexts in the MLIR runtime API*
 - *Updated the `npu_mlir_runtime_execute_params_t` structure to include an `executionContext` field, allowing execution parameters to reference a specific context, this may break compatibility, not increase version number since mutableCommandList is not fully supported yet*
 - *Introduced `npuMLIRRuntimeCreateExecutionContext` and `npuMLIRRuntimeDestroyExecutionContext` API functions for creating and destroying execution context instances.*

### Tickets:
 - *E-200748*
