### PR TITLE
[GPU] Check static impl cache before compiling new one

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -3051,13 +3051,13 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
     }
 
     // 1. If we have static impl in the cache - use it
-    if (use_async_compilation && ((inst.get_impl() && inst.get_impl()->is_dynamic()) || inst.get_flag(ExecutionFlags::SHAPE_CHANGED))) {
-        auto cached_impl = m_static_impls_cache.get(updated_params);
-        if (cached_impl) {
-            return cached_impl->clone();
-        }
+    auto cached_impl = m_static_impls_cache.get(updated_params);
+    if (cached_impl) {
+        return cached_impl->clone();
+    }
 
-        // 1.1. Static impl not found - run async compilation
+    // 2. If async compilation is enabled and dynamic impl exists or shape changed - try to compile asynchronously
+    if (use_async_compilation && ((inst.get_impl() && inst.get_impl()->is_dynamic()) || inst.get_flag(ExecutionFlags::SHAPE_CHANGED))) {
         auto& compilation_context = prog.get_compilation_context();
         compilation_context.push_task(updated_params, [&inst, &compilation_context, updated_params, find_impl]() {
             if (compilation_context.is_stopped())
@@ -3082,7 +3082,7 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
     }
 
     std::shared_ptr<primitive_impl> dynamic_impl = nullptr;
-    // 2. Try to find existing dynamic impl which supports given shapes
+    // 3. Try to find existing dynamic impl which supports given shapes
     for (auto& impl : m_dynamic_impls_cache) {
         if (impl->m_manager->support_shapes(params)) {
             dynamic_impl = impl;
@@ -3090,7 +3090,7 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
         }
     }
 
-    // 3. Try to create new shape agnostic impl & cache it
+    // 4. Try to create new shape agnostic impl & cache it
     if (!dynamic_impl) {
         dynamic_impl = find_impl(node, params, shape_types::dynamic_shape);
         if (dynamic_impl && !inst.can_be_optimized()) {
@@ -3101,17 +3101,10 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
         }
     }
 
-    // 4. If we have any dynamic impl, do adjustment for new shape before returning in back
+    // 5. If we have any dynamic impl, do adjustment for new shape before returning in back
     if (dynamic_impl) {
         dynamic_impl->update(inst, params);
         return dynamic_impl;
-    }
-
-    // 5. Check static impl cache before compiling new one
-    {
-        auto cached_impl = m_static_impls_cache.get(updated_params);
-        if (cached_impl)
-            return cached_impl->clone();
     }
 
     // 6. Finally, if no impl found so far, we just enforce static impl compilation


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - TTFT(Iteration) latency of OPTIMIZE_SIZE cache is slow than NoCache due to load the cache file is too slow.
 - OneDNN FC does not support the shape agnostic kernel. But it's choosed in dynamic llm model. The primitive cache manager (static) in ImplementationsFactory does not manage OneDNN FC.

#### The code and line that caused this issue (if it is not changed directly)
 - src/plugins/intel_gpu/src/graph/registry/fully_connected_impls.cpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
reproducer is attached at the ticket.
 - $ python benchmark_genai_model_cache.py -m Qwen2-0.5B-Instruct_int4_sym_mixed_group-1 ^
       -d GPU --apply_chat_template -n 3 -pf flores-devtest.h10.int3.en-zh.jsonl -c -cm 0

### Tickets:
 - 179467
