### PR TITLE
zero copy permute opt for conv

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
@@ -86,10 +86,10 @@ static void optimize_permute_conv(program_node& node) {
         return;
 
     auto pnode_upstream_fmt = pnode.get_dependency(0).get_preferred_output_fmt();
+    auto node_fmt = node.get_preferred_output_fmt();
 
-    bool is_compatible_format = (pnode_upstream_fmt == format::bfyx
-                                 || pnode_upstream_fmt == format::any
-    );
+    bool is_compatible_format = ((pnode_upstream_fmt == format::bfyx || pnode_upstream_fmt == format::any)
+                                && (node_fmt == format::byxf));
 
     if (!is_compatible_format)
         return;

--- a/src/plugins/intel_gpu/tests/unit/passes/select_preferred_formats_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/select_preferred_formats_test.cpp
@@ -8,9 +8,12 @@
 #include "intel_gpu/runtime/engine.hpp"
 
 #include "intel_gpu/primitives/convolution.hpp"
+#include "intel_gpu/primitives/eltwise.hpp"
+#include "intel_gpu/primitives/permute.hpp"
 #include "intel_gpu/graph/program.hpp"
 #include "data_inst.h"
 #include "convolution_inst.h"
+#include "permute_inst.h"
 #include "intel_gpu/graph/network.hpp"
 #include "pass_manager.h"
 #include "to_string_utils.h"
@@ -116,5 +119,173 @@ TEST(test_select_preferred_formats, fsv2_fallback_to_byxf) {
             ASSERT_EQ(input_fmt, format::any);
             ASSERT_EQ(output_fmt, format::any);
         }
+    }
+}
+
+TEST(test_select_preferred_formats, permute_conv_incompatible_format) {
+    // Negative tests for is_compatible_format in optimize_permute_conv:
+    //   1) node_fmt = b_fs_yx_fsv16 (not byxf) -> optimization does NOT trigger
+    //   2) upstream preferred_output_fmt = incompatible (b_fs_yx_fsv16) -> optimization does NOT trigger
+    auto& engine = get_test_engine();
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    auto build_permute_conv_program = [&engine](const std::vector<uint16_t>& permute_order, tensor input_size, tensor weight_size, format forced_fmt) {
+        auto input = engine.allocate_memory({data_types::f16, format::bfyx, input_size});
+        auto weights = engine.allocate_memory({data_types::f16, format::bfyx, weight_size});
+
+        topology topo;
+        topo.add(data("weights", weights));
+        topo.add(input_layout("input", input->get_layout()));
+        topo.add(permute("perm", input_info("input"), permute_order));
+        topo.add(convolution("conv1", input_info("perm"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+        topo.add(reorder("output_reorder", input_info("conv1"), format::bfyx, data_types::f16));
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        ov::intel_gpu::ImplementationDesc impl = {forced_fmt, std::string(""), impl_types::onednn};
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv1", impl}}));
+
+        auto prog = program::build_program(engine, topo, config, false, true);
+        prog->get_layout_optimizer().add_all_onednn_impls_optimization_attribute();
+        prog->get_node("conv1").get_output_layouts(false);
+        return prog;
+    };
+
+    // Sub-case 1: conv preferred_output_fmt not compatible -> optimization should NOT trigger
+    {
+        auto prog = build_permute_conv_program({0, 3, 1, 2}, {1, 32, 16, 8}, {32, 16, 3, 3}, format::b_fs_yx_fsv16);
+        program_wrapper::apply_opt_pass<select_preferred_formats>(*prog);
+
+        auto& conv_node = prog->get_node("conv1");
+        auto& perm_node = prog->get_node("perm");
+        ASSERT_NE(perm_node.get_preferred_output_fmt(0), format::byxf);
+        ASSERT_NE(conv_node.get_preferred_output_fmt(0), format::byxf);
+        ASSERT_FALSE(perm_node.can_be_optimized());
+    }
+
+    // Sub-case 2: upstream preferred_output_fmt = incompatible format -> optimization should NOT trigger
+    {
+        auto prog = build_permute_conv_program({0, 3, 1, 2}, {1, 32, 16, 8}, {32, 16, 3, 3}, format::byxf);
+        prog->get_node("input").set_preferred_output_fmt(0, format::b_fs_yx_fsv16);
+        program_wrapper::apply_opt_pass<select_preferred_formats>(*prog);
+
+        auto& perm_node = prog->get_node("perm");
+        ASSERT_NE(perm_node.get_preferred_output_fmt(0), format::byxf);
+        ASSERT_FALSE(perm_node.can_be_optimized());
+    }
+}
+
+TEST(test_select_preferred_formats, permute_conv_accuracy) {
+    // Verifies that optimize_permute_conv produces numerically correct output
+    // by comparing optimized path against reference, both using oneDNN conv.
+    //
+    // opt_topo: input -> permute -> conv(oneDNN, byxf) -> output_reorder
+    //           conv has 1 user -> optimize_permute_conv fires
+    //
+    // ref_topo: same as opt_topo + extra leaf reorder ("ref_tap") from conv
+    //           conv has 2 users -> node.get_users().size() != 1
+    //           blocks optimize_permute_conv, rest of the pipeline is identical
+    //
+    // Two sub-cases:
+    //   1) Unfused permute: can_be_optimized = true
+    //   2) Fused eltwise(prod) into permute: can_be_optimized = false,
+    //      but formats still set. Uses position-dependent scale values so any
+    //      layout misalignment produces detectably wrong numerical results.
+    // IMMAD-only: optimize_permute_conv only runs when oneDNN impl is selected.
+    auto& engine = get_test_engine();
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    auto input = engine.allocate_memory({data_types::f16, format::bfyx, {1, 2, 2, 16}});
+    auto weights = engine.allocate_memory({data_types::f16, format::bfyx, {2, 2, 1, 1}});
+
+    const int num_elements = 64;  // 1*2*2*16
+    std::vector<ov::float16> input_vals(num_elements);
+    for (int i = 0; i < num_elements; ++i)
+        input_vals[i] = ov::float16(static_cast<float>(i + 1));
+    set_values<ov::float16>(input, input_vals);
+
+    std::vector<ov::float16> weight_vals(2 * 2, ov::float16(0.f));
+    for (int i = 0; i < 2; ++i)
+        weight_vals[i * 2 + i] = ov::float16(1.f);
+    set_values<ov::float16>(weights, weight_vals);
+
+    // Run ref and opt networks (both oneDNN conv), verify numerical match.
+    // Returns the opt network's program for state checks.
+    auto run_and_verify = [&](const topology& opt_topo, const topology& ref_topo) -> std::shared_ptr<program> {
+        ov::intel_gpu::ImplementationDesc conv_impl = {format::byxf, std::string(""), impl_types::onednn};
+
+        ExecutionConfig ref_config = get_test_default_config(engine);
+        ref_config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        ref_config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv1", conv_impl}}));
+        network ref_net(engine, ref_topo, ref_config);
+        ref_net.set_input_data("input", input);
+        auto ref_outputs = ref_net.execute();
+        auto ref_mem = ref_outputs.at("output_reorder").get_memory();
+        cldnn::mem_lock<float, mem_lock_type::read> ref_ptr(ref_mem, get_test_stream());
+
+        ExecutionConfig opt_config = get_test_default_config(engine);
+        opt_config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        opt_config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv1", conv_impl}}));
+        network opt_net(engine, opt_topo, opt_config);
+        opt_net.set_input_data("input", input);
+        auto opt_outputs = opt_net.execute();
+        auto opt_mem = opt_outputs.at("output_reorder").get_memory();
+        cldnn::mem_lock<float, mem_lock_type::read> opt_ptr(opt_mem, get_test_stream());
+
+        EXPECT_EQ(ref_mem->get_layout().count(), opt_mem->get_layout().count());
+        for (size_t i = 0; i < ref_mem->get_layout().count(); ++i) {
+            EXPECT_NEAR(ref_ptr[i], opt_ptr[i], 1e-3f) << "Mismatch at index " << i;
+        }
+        return opt_net.get_program();
+    };
+
+    // Sub-case 1: unfused permute -> can_be_optimized = true
+    {
+        topology opt_topo;
+        opt_topo.add(data("weights", weights));
+        opt_topo.add(input_layout("input", input->get_layout()));
+        opt_topo.add(permute("perm", input_info("input"), {0, 3, 1, 2}));
+        opt_topo.add(convolution("conv1", input_info("perm"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+        opt_topo.add(reorder("output_reorder", input_info("conv1"), format::bfyx, data_types::f32));
+
+        // ref_topo = opt_topo + extra consumer on conv1 to block optimization
+        topology ref_topo(opt_topo);
+        ref_topo.add(reorder("ref_tap", input_info("conv1"), format::bfyx, data_types::f16));
+
+        auto prog = run_and_verify(opt_topo, ref_topo);
+        auto& perm_node = prog->get_node("perm");
+        ASSERT_EQ(perm_node.get_preferred_output_fmt(0), format::byxf);
+        ASSERT_FALSE(perm_node.has_fused_primitives());
+        ASSERT_TRUE(perm_node.can_be_optimized());
+    }
+
+    // Sub-case 2: fused eltwise(prod) into permute -> can_be_optimized = false
+    {
+        auto scale_data = engine.allocate_memory({data_types::f16, format::bfyx, {1, 2, 16, 2}});
+        std::vector<ov::float16> scale_vals(num_elements);
+        for (int i = 0; i < num_elements; ++i)
+            scale_vals[i] = ov::float16(static_cast<float>(i) * 0.1f + 0.5f);
+        set_values<ov::float16>(scale_data, scale_vals);
+
+        topology opt_topo;
+        opt_topo.add(data("weights", weights));
+        opt_topo.add(data("scale_data", scale_data));
+        opt_topo.add(input_layout("input", input->get_layout()));
+        opt_topo.add(permute("perm", input_info("input"), {0, 3, 1, 2}));
+        opt_topo.add(eltwise("scale", {input_info("perm"), input_info("scale_data")}, eltwise_mode::prod));
+        opt_topo.add(convolution("conv1", input_info("scale"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+        opt_topo.add(reorder("output_reorder", input_info("conv1"), format::bfyx, data_types::f32));
+
+        // ref_topo = opt_topo + extra consumer on conv1 to block optimization
+        topology ref_topo(opt_topo);
+        ref_topo.add(reorder("ref_tap", input_info("conv1"), format::bfyx, data_types::f16));
+
+        auto prog = run_and_verify(opt_topo, ref_topo);
+        auto& perm_node = prog->get_node("perm");
+        ASSERT_EQ(perm_node.get_preferred_output_fmt(0), format::byxf);
+        ASSERT_TRUE(perm_node.has_fused_primitives());
+        ASSERT_FALSE(perm_node.can_be_optimized());
     }
 }


### PR DESCRIPTION
### Summary:
- This change targets optimization for permute->convolution subgraph typical in vision transformers. By aligning the Permute output to the Convolution's Channel-Last format, we achieve two performance wins:

1. Elimination of Reorder Nodes: Removing expensive data copy operations.
2. Zero-Copy "Virtual Transpose": Converting physical data movement into a logical layout cast

### Implementation Details:
 - reorder is getting added for changing planar to blocked fmt for conv
 - existing perm->conv optimization optimize_out the permute operation and leaving the physical data in byxf. Since Input Physical == Output Physical, the Permute becomes a Zero-Copy Layout Cast.
 - enforcing byxf format for conv eliminates the reorder node and improves performance
 - for more details, kindly refer [CVS-177918](https://jira.devtools.intel.com/browse/CVS-177918)

### Graph:
<img width="1018" height="335" alt="image" src="https://github.com/user-attachments/assets/77907a54-15f3-4997-8908-e1b43227d089" />

### Performance Improvement:
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/1d6520c6-5d10-42f2-bde6-5ae5a35e3850" />

### Test details:
- EBGAN TF FP32 showed ~50% degradation, need to rerun to make sure that there was no temporary issue with machine during the run. EBGAN TF FP16 did not show such significant degradation.
- Geomean for rest of the models is fine.
- Full validation benchmark report is [here](https://benchmarks.sclab.intel.com/cmp.py?predef=ba-tput.json&order=gain/0&ref=devel_2/dev_releases_2025_4_sha_7a97517_900/DEV_W_GPU_parallel-8_windows11_ptl_ovptl32/1&target=devel_2/dev_master_sha_fdea473_907/DEV_W_GPU_parallel-8_windows11_ptl_ovptl32/1)

<img width="1817" height="416" alt="image" src="https://github.com/user-attachments/assets/0be199d0-7cf0-411e-9670-da426f30d7d5" />

### Tickets:
 - *[CVS-177918](https://jira.devtools.intel.com/browse/CVS-177918)*
