### PR TITLE
[PT FE]: Add support for quantized_conv1d and quantized_conv1d_relu

### DIFF
--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -809,6 +809,8 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"quantized::add", op::translate_quantized_add},
         {"quantized::add_relu", op::translate_quantized_add_relu},
         {"quantized::cat", op::translate_quantized_cat},
+        {"quantized::conv1d", op::translate_quantized_convnd},
+        {"quantized::conv1d_relu", op::translate_quantized_convnd_relu},
         {"quantized::conv2d", op::translate_quantized_convnd},
         {"quantized::conv2d_relu", op::translate_quantized_convnd_relu},
         {"quantized::hardswish", op::translate_quantized_hardswish},

--- a/tests/layer_tests/pytorch_tests/test_quantized_convnd.py
+++ b/tests/layer_tests/pytorch_tests/test_quantized_convnd.py
@@ -12,6 +12,82 @@ from openvino.frontend.pytorch.ts_decoder import TorchScriptPythonDecoder
 from pytorch_layer_test_class import PytorchLayerTest
 
 
+class TestQuantizedConv1D(PytorchLayerTest):
+    rng = np.random.default_rng(seed=123)
+
+    def _prepare_input(self):
+        return (np.round(self.rng.random([2, 3, 25], dtype=np.float32), 4),)
+
+    def create_model(self, weights_shape, strides, pads, dilations, groups, bias, relu, scale, zero_point):
+        class quantized_conv1d(torch.nn.Module):
+            def __init__(self):
+                super(quantized_conv1d, self).__init__()
+                if not relu:
+                    conv_func = torch.ao.nn.quantized.Conv1d
+                else:
+                    conv_func = torch.ao.nn.intrinsic.quantized.ConvReLU1d
+                self.conv = conv_func(
+                    weights_shape[1] * groups,
+                    weights_shape[0],
+                    weights_shape[2],
+                    strides,
+                    pads,
+                    dilations,
+                    groups,
+                    bias,
+                )
+                if bias:
+                    torch.nn.init.normal_(self.conv.bias())
+                self.conv.scale = float(scale)
+                self.conv.zero_point = int(zero_point)
+
+            def forward(self, x):
+                x_quantized = torch.quantize_per_tensor(
+                    x, 1.0, 0, torch.quint8)
+                conv = self.conv(x_quantized)
+                return torch.dequantize(conv)
+
+        ref_net = None
+        if not relu:
+            op_name = "quantized::conv1d"
+        else:
+            op_name = "quantized::conv1d_relu"
+
+        return quantized_conv1d(), ref_net, op_name
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"weights_shape": [1, 3, 3], "strides": 1,
+                "pads": 0, "dilations": 1, "groups": 1},
+            {"weights_shape": [2, 3, 3], "strides": 1,
+                "pads": 0, "dilations": 1, "groups": 1},
+            {"weights_shape": [2, 3, 3], "strides": 2,
+                "pads": 0, "dilations": 1, "groups": 1},
+            {"weights_shape": [2, 3, 3], "strides": 1,
+                "pads": 1, "dilations": 1, "groups": 1},
+            {"weights_shape": [2, 3, 3], "strides": 1,
+                "pads": 0, "dilations": 2, "groups": 1},
+            {"weights_shape": [3, 1, 3], "strides": 1,
+                "pads": 0, "dilations": 1, "groups": 3},
+        ],
+    )
+    @pytest.mark.parametrize("bias", [True, False])
+    @pytest.mark.parametrize("relu", [True, False])
+    @pytest.mark.parametrize("scale", [1, 0.3, 1.3])
+    @pytest.mark.parametrize("zero_point", [0, 1])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
+                       reason='Ticket - 122715')
+    def test_quantized_conv1d(self, params, bias, relu, scale, zero_point, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model(**params, bias=bias, relu=relu,
+                               scale=scale, zero_point=zero_point),
+            ie_device, precision, ir_version, trace_model=True, freeze_model=False, quantized_ops=True, quant_size=scale
+        )
+
+
 class TestQuantizedConv2D(PytorchLayerTest):
     rng = np.random.default_rng(seed=123)
 


### PR DESCRIPTION

### Details:
 - *This PR enables support for quantized::conv1d and quantized::conv1d_relu operations in the PyTorch Frontend. It extends the existing quantized convolution translation logic to correctly handle 1D tensor shapes and weight formats.*

### Tickets:
 - *closes [#29730](https://github.com/openvinotoolkit/openvino/issues/29730) and #29729*
