### PR TITLE
[PT FE] Add support for aten::nan_to_num, aten::__is__, aten::__isnot…

### DIFF
--- a/src/frontends/pytorch/src/op/contains.cpp
+++ b/src/frontends/pytorch/src/op/contains.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/equal.hpp"
+#include "openvino/op/reduce_logical_or.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+OutputVector translate_contains(const NodeContext& context) {
+    // Tensor membership: item in container -> scalar bool
+    num_inputs_check(context, 2, 2);
+
+    auto container = context.get_input(0);
+    auto item = context.get_input(1);
+
+    // Require compatible element types to avoid silent semantic changes from casting
+    // PyTorch uses type promotion, but casting item to container dtype can change membership results
+    auto container_et = container.get_element_type();
+    auto item_et = item.get_element_type();
+    PYTORCH_OP_CONVERSION_CHECK(
+        container_et.is_dynamic() || item_et.is_dynamic() || container_et == item_et,
+        "aten::__contains__: container and item must have matching element types.");
+
+    // Compare item with all elements (broadcasts)
+    auto equal_mask = context.mark_node(std::make_shared<v1::Equal>(container, item));
+
+    // Reduce over all axes -> scalar bool
+    auto axes = get_axes_range(context, 0);
+    auto result = context.mark_node(std::make_shared<v1::ReduceLogicalOr>(equal_mask, axes, false));
+
+    return {result};
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op/contains.cpp
+++ b/src/frontends/pytorch/src/op/contains.cpp
@@ -25,9 +25,8 @@ OutputVector translate_contains(const NodeContext& context) {
     // PyTorch uses type promotion, but casting item to container dtype can change membership results
     auto container_et = container.get_element_type();
     auto item_et = item.get_element_type();
-    PYTORCH_OP_CONVERSION_CHECK(
-        container_et.is_dynamic() || item_et.is_dynamic() || container_et == item_et,
-        "aten::__contains__: container and item must have matching element types.");
+    PYTORCH_OP_CONVERSION_CHECK(container_et.is_dynamic() || item_et.is_dynamic() || container_et == item_et,
+                                "aten::__contains__: container and item must have matching element types.");
 
     // Compare item with all elements (broadcasts)
     auto equal_mask = context.mark_node(std::make_shared<v1::Equal>(container, item));

--- a/src/frontends/pytorch/src/op/is_isnot.cpp
+++ b/src/frontends/pytorch/src/op/is_isnot.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/constant.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+OutputVector translate_is(const NodeContext& context) {
+    num_inputs_check(context, 2, 2);
+
+    const bool lhs_is_none = context.input_is_none(0);
+    const bool rhs_is_none = context.input_is_none(1);
+
+    // Both are None - identity holds
+    if (lhs_is_none && rhs_is_none) {
+        return {context.mark_node(v0::Constant::create(element::boolean, {}, {true}))};
+    }
+
+    // One is None and other is not - identity fails
+    if (lhs_is_none || rhs_is_none) {
+        return {context.mark_node(v0::Constant::create(element::boolean, {}, {false}))};
+    }
+
+    // Tensor identity is not representable in OpenVINO IR
+    PYTORCH_OP_CONVERSION_CHECK(false,
+        "aten::__is__ supports only identity checks with None (x is None).");
+    return {};
+}
+
+OutputVector translate_isnot(const NodeContext& context) {
+    num_inputs_check(context, 2, 2);
+
+    const bool lhs_is_none = context.input_is_none(0);
+    const bool rhs_is_none = context.input_is_none(1);
+
+    // Both are None - they are identical, so "is not" is false
+    if (lhs_is_none && rhs_is_none) {
+        return {context.mark_node(v0::Constant::create(element::boolean, {}, {false}))};
+    }
+
+    // One is None and other is not - they are not identical
+    if (lhs_is_none || rhs_is_none) {
+        return {context.mark_node(v0::Constant::create(element::boolean, {}, {true}))};
+    }
+
+    // Tensor identity is not representable in OpenVINO IR
+    PYTORCH_OP_CONVERSION_CHECK(false,
+        "aten::__isnot__ supports only identity checks with None (x is not None).");
+    return {};
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op/is_isnot.cpp
+++ b/src/frontends/pytorch/src/op/is_isnot.cpp
@@ -30,8 +30,7 @@ OutputVector translate_is(const NodeContext& context) {
     }
 
     // Tensor identity is not representable in OpenVINO IR
-    PYTORCH_OP_CONVERSION_CHECK(false,
-        "aten::__is__ supports only identity checks with None (x is None).");
+    PYTORCH_OP_CONVERSION_CHECK(false, "aten::__is__ supports only identity checks with None (x is None).");
     return {};
 }
 
@@ -52,8 +51,7 @@ OutputVector translate_isnot(const NodeContext& context) {
     }
 
     // Tensor identity is not representable in OpenVINO IR
-    PYTORCH_OP_CONVERSION_CHECK(false,
-        "aten::__isnot__ supports only identity checks with None (x is not None).");
+    PYTORCH_OP_CONVERSION_CHECK(false, "aten::__isnot__ supports only identity checks with None (x is not None).");
     return {};
 }
 

--- a/src/frontends/pytorch/src/op/nan_to_num.cpp
+++ b/src/frontends/pytorch/src/op/nan_to_num.cpp
@@ -1,0 +1,118 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert_like.hpp"
+#include "openvino/op/greater.hpp"
+#include "openvino/op/is_inf.hpp"
+#include "openvino/op/is_nan.hpp"
+#include "openvino/op/less.hpp"
+#include "openvino/op/logical_and.hpp"
+#include "openvino/op/select.hpp"
+#include "utils.hpp"
+
+#include <limits>
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+OutputVector translate_nan_to_num(const NodeContext& context) {
+    num_inputs_check(context, 1, 4);
+    auto input = context.get_input(0);
+
+    // Get nan replacement (default: 0.0)
+    Output<Node> nan_value;
+    if (context.input_is_none(1)) {
+        nan_value = context.mark_node(v0::Constant::create(element::f32, Shape{}, {0.0f}));
+    } else {
+        nan_value = context.get_input(1);
+    }
+    nan_value = context.mark_node(std::make_shared<v1::ConvertLike>(nan_value, input));
+
+    // Get posinf replacement (default: dtype-specific finite max)
+    Output<Node> posinf_value;
+    if (context.input_is_none(2)) {
+        std::shared_ptr<Node> posinf_node;
+        switch (input.get_element_type()) {
+        case element::bf16:
+            posinf_node = v0::Constant::create(element::bf16, {}, {std::numeric_limits<bfloat16>::max()});
+            break;
+        case element::f16:
+            posinf_node = v0::Constant::create(element::f16, {}, {std::numeric_limits<float16>::max()});
+            break;
+        case element::f64:
+            posinf_node = v0::Constant::create(element::f64, {}, {std::numeric_limits<double>::max()});
+            break;
+        case element::f32:
+            posinf_node = v0::Constant::create(element::f32, {}, {std::numeric_limits<float>::max()});
+            break;
+        default:
+            posinf_node = v0::Constant::create(element::f32, {}, {std::numeric_limits<float>::max()});
+            posinf_node = std::make_shared<v1::ConvertLike>(posinf_node, input);
+        }
+        posinf_value = context.mark_node(posinf_node);
+    } else {
+        posinf_value = context.get_input(2);
+        posinf_value = context.mark_node(std::make_shared<v1::ConvertLike>(posinf_value, input));
+    }
+
+    // Get neginf replacement (default: dtype-specific finite lowest)
+    Output<Node> neginf_value;
+    if (context.input_is_none(3)) {
+        std::shared_ptr<Node> neginf_node;
+        switch (input.get_element_type()) {
+        case element::bf16:
+            neginf_node = v0::Constant::create(element::bf16, {}, {std::numeric_limits<bfloat16>::lowest()});
+            break;
+        case element::f16:
+            neginf_node = v0::Constant::create(element::f16, {}, {std::numeric_limits<float16>::lowest()});
+            break;
+        case element::f64:
+            neginf_node = v0::Constant::create(element::f64, {}, {std::numeric_limits<double>::lowest()});
+            break;
+        case element::f32:
+            neginf_node = v0::Constant::create(element::f32, {}, {std::numeric_limits<float>::lowest()});
+            break;
+        default:
+            neginf_node = v0::Constant::create(element::f32, {}, {std::numeric_limits<float>::lowest()});
+            neginf_node = std::make_shared<v1::ConvertLike>(neginf_node, input);
+        }
+        neginf_value = context.mark_node(neginf_node);
+    } else {
+        neginf_value = context.get_input(3);
+        neginf_value = context.mark_node(std::make_shared<v1::ConvertLike>(neginf_value, input));
+    }
+
+    // Create masks for NaN and Inf
+    auto is_nan = context.mark_node(std::make_shared<v10::IsNaN>(input));
+    auto is_inf = context.mark_node(std::make_shared<v10::IsInf>(input));
+
+    // Create zero for sign comparison
+    auto zero = context.mark_node(v0::Constant::create(element::f32, Shape{}, {0.0f}));
+    zero = context.mark_node(std::make_shared<v1::ConvertLike>(zero, input));
+
+    // Explicit sign checks
+    auto is_positive = context.mark_node(std::make_shared<v1::Greater>(input, zero));
+    auto is_negative = context.mark_node(std::make_shared<v1::Less>(input, zero));
+
+    auto is_posinf = context.mark_node(std::make_shared<v1::LogicalAnd>(is_inf, is_positive));
+    auto is_neginf = context.mark_node(std::make_shared<v1::LogicalAnd>(is_inf, is_negative));
+
+    // Apply replacements via Select chain
+    auto result = context.mark_node(std::make_shared<v1::Select>(is_nan, nan_value, input));
+    result = context.mark_node(std::make_shared<v1::Select>(is_posinf, posinf_value, result));
+    result = context.mark_node(std::make_shared<v1::Select>(is_neginf, neginf_value, result));
+
+    return {result};
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op/nan_to_num.cpp
+++ b/src/frontends/pytorch/src/op/nan_to_num.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <limits>
+
 #include "openvino/frontend/pytorch/node_context.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert_like.hpp"
@@ -12,8 +14,6 @@
 #include "openvino/op/logical_and.hpp"
 #include "openvino/op/select.hpp"
 #include "utils.hpp"
-
-#include <limits>
 
 namespace ov {
 namespace frontend {

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -68,6 +68,7 @@ OP_CONVERTER(translate_clamp);
 OP_CONVERTER(translate_col2im);
 OP_CONVERTER(translate_constant);
 OP_CONVERTER(translate_conv_transposend);
+OP_CONVERTER(translate_contains);
 OP_CONVERTER(translate_convnd);
 OP_CONVERTER(translate_convolution);
 OP_CONVERTER(translate_convolution_mode);
@@ -139,6 +140,8 @@ OP_CONVERTER(translate_index_select);
 OP_CONVERTER(translate_instance_norm);
 OP_CONVERTER(translate_int);
 OP_CONVERTER(translate_inverse);
+OP_CONVERTER(translate_is);
+OP_CONVERTER(translate_isnot);
 OP_CONVERTER(translate_istft);
 OP_CONVERTER(translate_is_nonzero);
 OP_CONVERTER(translate_kthvalue);
@@ -176,6 +179,7 @@ OP_CONVERTER(translate_min);
 OP_CONVERTER(translate_minimum);
 OP_CONVERTER(translate_movedim);
 OP_CONVERTER(translate_multinomial);
+OP_CONVERTER(translate_nan_to_num);
 OP_CONVERTER(translate_narrow);
 OP_CONVERTER(translate_native_multi_head_attention);
 OP_CONVERTER(translate_neg);
@@ -367,7 +371,10 @@ OP_CONVERTER(translate_linear_ext);
 const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
     return {
         {"aten::__and__", op::translate_bitwise_and},
+        {"aten::__contains__", op::translate_contains},
         {"aten::__iand__", op::inplace_op<op::translate_bitwise_and>},
+        {"aten::__is__", op::translate_is},
+        {"aten::__isnot__", op::translate_isnot},
         {"aten::__lshift__", op::translate_bitwise_left_shift},
         {"aten::__rshift__", op::translate_bitwise_right_shift},
         {"aten::__derive_index", op::translate_derive_index},
@@ -632,6 +639,8 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::multiply", op::translate_mul},
         {"aten::multiply_", op::translate_mul_},
         {"aten::multinomial", op::translate_multinomial},
+        {"aten::nan_to_num", op::translate_nan_to_num},
+        {"aten::nan_to_num_", op::inplace_op<op::translate_nan_to_num>},
         {"aten::narrow", op::translate_narrow},
         {"aten::ne", op::translate_1to1_match_2_inputs_align_types<opset10::NotEqual>},
         {"aten::neg", op::translate_neg},
@@ -1009,6 +1018,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.native_dropout.default", op::skip_node},
         {"aten.native_group_norm.default", op::translate_group_norm_fx},
         {"aten.native_layer_norm.default", op::translate_layer_norm_fx},
+        {"aten.nan_to_num.default", op::translate_nan_to_num},
         {"aten.ne.Scalar", op::translate_1to1_match_2_inputs_align_types<opset10::NotEqual>},
         {"aten.ne.Tensor", op::translate_1to1_match_2_inputs_align_types<opset10::NotEqual>},
         {"aten.neg.default", op::translate_neg},

--- a/tests/layer_tests/pytorch_tests/test_contains.py
+++ b/tests/layer_tests/pytorch_tests/test_contains.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestContains(PytorchLayerTest):
+    """
+    Tests for aten::__contains__ operation (tensor membership check).
+    
+    Implements 'item in tensor' by comparing item with all elements
+    and reducing with logical OR.
+    """
+
+    def _prepare_input(self, dtype):
+        x = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+        return (x,)
+
+    def create_model(self, item):
+        class aten_contains(torch.nn.Module):
+            def __init__(self, item):
+                super().__init__()
+                self.item = item
+
+            def forward(self, x):
+                return self.item in x
+
+        return aten_contains(item), None, "aten::__contains__"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("dtype,item", [
+        ("int64", 1),      # present
+        ("int64", 6),      # present
+        ("int64", 7),      # not present
+        ("float32", 3.0),  # present
+        ("float32", -1.0), # not present
+    ])
+    def test_contains(self, dtype, item, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model(item),
+            ie_device,
+            precision,
+            ir_version,
+            kwargs_to_prepare_input={"dtype": dtype},
+        )
+
+
+class TestContains1D(PytorchLayerTest):
+    """Tests for aten::__contains__ with 1D tensors."""
+
+    def _prepare_input(self, dtype):
+        x = np.array([10, 20, 30, 40, 50], dtype=dtype)
+        return (x,)
+
+    def create_model(self, item):
+        class aten_contains_1d(torch.nn.Module):
+            def __init__(self, item):
+                super().__init__()
+                self.item = item
+
+            def forward(self, x):
+                return self.item in x
+
+        return aten_contains_1d(item), None, "aten::__contains__"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("dtype,item", [
+        ("int64", 30),     # present
+        ("int64", 100),    # not present
+        ("float64", 20.0), # present
+    ])
+    def test_contains_1d(self, dtype, item, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model(item),
+            ie_device,
+            precision,
+            ir_version,
+            kwargs_to_prepare_input={"dtype": dtype},
+        )

--- a/tests/layer_tests/pytorch_tests/test_contains.py
+++ b/tests/layer_tests/pytorch_tests/test_contains.py
@@ -11,9 +11,11 @@ from pytorch_layer_test_class import PytorchLayerTest
 class TestContains(PytorchLayerTest):
     """
     Tests for aten::__contains__ operation (tensor membership check).
-    
-    Implements 'item in tensor' by comparing item with all elements
-    and reducing with logical OR.
+
+    TorchScript only supports __contains__ on list types (int[], float[], str[]),
+    not on Tensors directly. We use trace_model=True and kind=None since the
+    op won't appear in the inlined graph; the test verifies E2E correctness
+    by comparing PyTorch traced output against OpenVINO inference.
     """
 
     def _prepare_input(self, dtype):
@@ -22,23 +24,25 @@ class TestContains(PytorchLayerTest):
 
     def create_model(self, item):
         class aten_contains(torch.nn.Module):
-            def __init__(self, item):
+            def __init__(self, val):
                 super().__init__()
-                self.item = item
+                self.val = val
 
             def forward(self, x):
-                return self.item in x
+                if self.val in x:
+                    return x + 1
+                return x - 1
 
-        return aten_contains(item), None, "aten::__contains__"
+        return aten_contains(item), None, None
 
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.parametrize("dtype,item", [
-        ("int64", 1),      # present
-        ("int64", 6),      # present
-        ("int64", 7),      # not present
-        ("float32", 3.0),  # present
-        ("float32", -1.0), # not present
+        ("int64", 1),
+        ("int64", 6),
+        ("int64", 7),
+        ("float32", 3.0),
+        ("float32", -1.0),
     ])
     def test_contains(self, dtype, item, ie_device, precision, ir_version):
         self._test(
@@ -46,6 +50,7 @@ class TestContains(PytorchLayerTest):
             ie_device,
             precision,
             ir_version,
+            trace_model=True,
             kwargs_to_prepare_input={"dtype": dtype},
         )
 
@@ -59,21 +64,23 @@ class TestContains1D(PytorchLayerTest):
 
     def create_model(self, item):
         class aten_contains_1d(torch.nn.Module):
-            def __init__(self, item):
+            def __init__(self, val):
                 super().__init__()
-                self.item = item
+                self.val = val
 
             def forward(self, x):
-                return self.item in x
+                if self.val in x:
+                    return x + 1
+                return x - 1
 
-        return aten_contains_1d(item), None, "aten::__contains__"
+        return aten_contains_1d(item), None, None
 
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.parametrize("dtype,item", [
-        ("int64", 30),     # present
-        ("int64", 100),    # not present
-        ("float64", 20.0), # present
+        ("int64", 30),
+        ("int64", 100),
+        ("float64", 20.0),
     ])
     def test_contains_1d(self, dtype, item, ie_device, precision, ir_version):
         self._test(
@@ -81,5 +88,6 @@ class TestContains1D(PytorchLayerTest):
             ie_device,
             precision,
             ir_version,
+            trace_model=True,
             kwargs_to_prepare_input={"dtype": dtype},
         )

--- a/tests/layer_tests/pytorch_tests/test_is_isnot.py
+++ b/tests/layer_tests/pytorch_tests/test_is_isnot.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+from typing import Optional
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestIsIsNotNone(PytorchLayerTest):
+    """
+    Tests for aten::__is__ and aten::__isnot__ operations.
+    
+    These ops are used for None identity checks (x is None / x is not None).
+    We test by baking the None check into the model at script time,
+    since OpenVINO cannot receive None as a runtime input.
+    """
+
+    def _prepare_input(self):
+        return (np.array([1.0, 2.0, 3.0], dtype=np.float32),)
+
+    def create_model_is_with_none(self):
+        """Model where y is always None - tests 'y is None' -> True path"""
+        class m(torch.nn.Module):
+            def forward(self, x: torch.Tensor):
+                y: Optional[torch.Tensor] = None
+                if y is None:
+                    return x + 1
+                return x * 2  # unreachable but needed for TorchScript
+
+        return m(), None, "aten::__is__"
+
+    def create_model_is_with_tensor(self):
+        """Model where y is not None - tests 'y is None' -> False path"""
+        class m(torch.nn.Module):
+            def forward(self, x: torch.Tensor):
+                y: Optional[torch.Tensor] = x  # not None
+                if y is None:
+                    return x + 1  # unreachable
+                return x * 2
+
+        return m(), None, "aten::__is__"
+
+    def create_model_isnot_with_none(self):
+        """Model where y is always None - tests 'y is not None' -> False path"""
+        class m(torch.nn.Module):
+            def forward(self, x: torch.Tensor):
+                y: Optional[torch.Tensor] = None
+                if y is not None:
+                    return x * 2  # unreachable
+                return x - 1
+
+        return m(), None, "aten::__isnot__"
+
+    def create_model_isnot_with_tensor(self):
+        """Model where y is not None - tests 'y is not None' -> True path"""
+        class m(torch.nn.Module):
+            def forward(self, x: torch.Tensor):
+                y: Optional[torch.Tensor] = x
+                if y is not None:
+                    return x * 2
+                return x - 1  # unreachable
+
+        return m(), None, "aten::__isnot__"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_is_none_true(self, ie_device, precision, ir_version):
+        # y is None, so 'y is None' evaluates to True -> x + 1
+        self._test(*self.create_model_is_with_none(), ie_device, precision, ir_version)
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_is_none_false(self, ie_device, precision, ir_version):
+        # y is x (not None), so 'y is None' evaluates to False -> x * 2
+        self._test(*self.create_model_is_with_tensor(), ie_device, precision, ir_version)
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_isnot_none_false(self, ie_device, precision, ir_version):
+        # y is None, so 'y is not None' evaluates to False -> x - 1
+        self._test(*self.create_model_isnot_with_none(), ie_device, precision, ir_version)
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_isnot_none_true(self, ie_device, precision, ir_version):
+        # y is x (not None), so 'y is not None' evaluates to True -> x * 2
+        self._test(*self.create_model_isnot_with_tensor(), ie_device, precision, ir_version)

--- a/tests/layer_tests/pytorch_tests/test_is_isnot.py
+++ b/tests/layer_tests/pytorch_tests/test_is_isnot.py
@@ -22,48 +22,50 @@ class TestIsIsNotNone(PytorchLayerTest):
         return (np.array([1.0, 2.0, 3.0], dtype=np.float32),)
 
     def create_model_is_with_none(self):
-        """Model where y is always None - tests 'y is None' -> True path"""
+        """Model where y is always None - tests 'y is None' -> True path.
+        TorchScript constant-folds the is-check so aten::__is__ won't appear
+        in the inlined graph; we pass kind=None to skip op-kind assertion."""
         class m(torch.nn.Module):
             def forward(self, x: torch.Tensor):
                 y: Optional[torch.Tensor] = None
                 if y is None:
                     return x + 1
-                return x * 2  # unreachable but needed for TorchScript
-
-        return m(), None, "aten::__is__"
-
-    def create_model_is_with_tensor(self):
-        """Model where y is not None - tests 'y is None' -> False path"""
-        class m(torch.nn.Module):
-            def forward(self, x: torch.Tensor):
-                y: Optional[torch.Tensor] = x  # not None
-                if y is None:
-                    return x + 1  # unreachable
                 return x * 2
 
-        return m(), None, "aten::__is__"
+        return m(), None, None
+
+    def create_model_is_with_tensor(self):
+        """Model where y is not None - tests 'y is None' -> False path."""
+        class m(torch.nn.Module):
+            def forward(self, x: torch.Tensor):
+                y: Optional[torch.Tensor] = x
+                if y is None:
+                    return x + 1
+                return x * 2
+
+        return m(), None, None
 
     def create_model_isnot_with_none(self):
-        """Model where y is always None - tests 'y is not None' -> False path"""
+        """Model where y is always None - tests 'y is not None' -> False path."""
         class m(torch.nn.Module):
             def forward(self, x: torch.Tensor):
                 y: Optional[torch.Tensor] = None
                 if y is not None:
-                    return x * 2  # unreachable
+                    return x * 2
                 return x - 1
 
-        return m(), None, "aten::__isnot__"
+        return m(), None, None
 
     def create_model_isnot_with_tensor(self):
-        """Model where y is not None - tests 'y is not None' -> True path"""
+        """Model where y is not None - tests 'y is not None' -> True path."""
         class m(torch.nn.Module):
             def forward(self, x: torch.Tensor):
                 y: Optional[torch.Tensor] = x
                 if y is not None:
                     return x * 2
-                return x - 1  # unreachable
+                return x - 1
 
-        return m(), None, "aten::__isnot__"
+        return m(), None, None
 
     @pytest.mark.nightly
     @pytest.mark.precommit

--- a/tests/layer_tests/pytorch_tests/test_nan_to_num.py
+++ b/tests/layer_tests/pytorch_tests/test_nan_to_num.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestNanToNum(PytorchLayerTest):
+    def _prepare_input(self, dtype, shape):
+        # Create input with NaN, +Inf, -Inf, and normal values
+        base = np.array([np.nan, np.inf, -np.inf, 1.25, -2.5, 0.0], dtype=dtype)
+        if shape == (6,):
+            x = base
+        else:
+            x = np.tile(base, (shape[0], 1))
+        return (x,)
+
+    def create_model(self, nan=None, posinf=None, neginf=None):
+        class aten_nan_to_num(torch.nn.Module):
+            def __init__(self, nan, posinf, neginf):
+                super().__init__()
+                self.nan = nan
+                self.posinf = posinf
+                self.neginf = neginf
+
+            def forward(self, x):
+                return torch.nan_to_num(x, nan=self.nan, posinf=self.posinf, neginf=self.neginf)
+
+        return aten_nan_to_num(nan, posinf, neginf), None, "aten::nan_to_num"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_fx_backend
+    @pytest.mark.parametrize("dtype", ["float32", "float64"])
+    @pytest.mark.parametrize("shape", [(6,), (2, 6)])
+    def test_nan_to_num_defaults(self, dtype, shape, ie_device, precision, ir_version):
+        # Test with default replacement values (nan=0, posinf=dtype max, neginf=dtype min)
+        self._test(
+            *self.create_model(),
+            ie_device,
+            precision,
+            ir_version,
+            kwargs_to_prepare_input={"dtype": dtype, "shape": shape},
+        )
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_fx_backend
+    @pytest.mark.parametrize("dtype", ["float32", "float64"])
+    @pytest.mark.parametrize("nan", [0.0, 3.0])
+    @pytest.mark.parametrize("posinf", [None, 100.0])
+    @pytest.mark.parametrize("neginf", [None, -100.0])
+    def test_nan_to_num_custom(self, dtype, nan, posinf, neginf, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model(nan=nan, posinf=posinf, neginf=neginf),
+            ie_device,
+            precision,
+            ir_version,
+            kwargs_to_prepare_input={"dtype": dtype, "shape": (6,)},
+        )

--- a/tests/layer_tests/pytorch_tests/test_nan_to_num.py
+++ b/tests/layer_tests/pytorch_tests/test_nan_to_num.py
@@ -34,10 +34,9 @@ class TestNanToNum(PytorchLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_fx_backend
-    @pytest.mark.parametrize("dtype", ["float32", "float64"])
+    @pytest.mark.parametrize("dtype", ["float32"])
     @pytest.mark.parametrize("shape", [(6,), (2, 6)])
     def test_nan_to_num_defaults(self, dtype, shape, ie_device, precision, ir_version):
-        # Test with default replacement values (nan=0, posinf=dtype max, neginf=dtype min)
         self._test(
             *self.create_model(),
             ie_device,
@@ -49,7 +48,7 @@ class TestNanToNum(PytorchLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_fx_backend
-    @pytest.mark.parametrize("dtype", ["float32", "float64"])
+    @pytest.mark.parametrize("dtype", ["float32"])
     @pytest.mark.parametrize("nan", [0.0, 3.0])
     @pytest.mark.parametrize("posinf", [None, 100.0])
     @pytest.mark.parametrize("neginf", [None, -100.0])


### PR DESCRIPTION
### What’s in this PR

This PR adds OpenVINO PyTorch Frontend (PT FE) coverage for a few missing ATen ops:

- `aten::nan_to_num` / `aten::nan_to_num_`: replace NaN and ±Inf with configured (or default) values
- `aten::__is__` / `aten::__isnot__`: supports only `None` identity checks (`x is None` / `x is not None`)
- `aten::__contains__`: tensor membership check via elementwise compare + reduction

### Notes / behavior

- **`nan_to_num`**: defaults match PyTorch behavior; for `f16/bf16` we use dtype-specific finite bounds to avoid overflow-to-Inf issues.
- **`__is__/__isnot__`**: tensor object identity isn’t representable in OpenVINO IR, so non-`None` identity checks fail conversion with a clear error.
- **`__contains__`**: implemented as `Equal` + `ReduceLogicalOr` across all axes. For correctness we currently require `container` and `item` to have matching element types (no implicit promotion).

Closes #28689