### PR TITLE
Revert "[PyOV] Disable ARMv8.1+ instructions in `numpy` for Python te…

### DIFF
--- a/src/bindings/python/tests/conftest.py
+++ b/src/bindings/python/tests/conftest.py
@@ -3,23 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import platform
-
 import pytest
-
-# Workaround for NumPy 2.x on RPi ARMv8.0 CPUs, ticket 179098
-# https://numpy.org/devdocs/reference/simd/build-options.html
-_npy_cpu_features_original = os.environ.get("NPY_DISABLE_CPU_FEATURES")
-if platform.machine() == "aarch64" and platform.system() == "Linux":
-    os.environ["NPY_DISABLE_CPU_FEATURES"] = "ASIMDDP,ASIMDFHM"
-
-
-def pytest_sessionfinish(session, exitstatus):
-    """Restore NPY_DISABLE_CPU_FEATURES after test session completes."""
-    if _npy_cpu_features_original is None:
-        os.environ.pop("NPY_DISABLE_CPU_FEATURES", None)
-    else:
-        os.environ["NPY_DISABLE_CPU_FEATURES"] = _npy_cpu_features_original
 
 
 def pytest_configure(config):


### PR DESCRIPTION
### Details:
 - This reverts https://github.com/openvinotoolkit/openvino/pull/33705
 - That PR was a "best guess" at what's causing sporadic illegal instruction failure
 - It did not fix the issue, so I borrowed an RPi from precommit pool and debugged locally
 - The issue turned out to be not in numpy, but in OpenVINO itself, which is compiled with features unavailable on our precommit hardware (SVE instructions to be exact)
 - Debugging results and further steps are in the ticket

### Tickets:
 - 179098
