### PR TITLE
[GPU] Fix q_state value in case of 3 horizontal fused LoRA

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora.cpp
@@ -542,8 +542,7 @@ protected:
                 if (lora_count == 2) {
                     output_state = fused_mlp_output;
                 } else {
-                    size_t q_state = extract_channel(ChannelName::FEATURE, params.input_layouts[2]);
-                    output_state = fused_mlp_output + q_state;
+                    output_state += fused_mlp_output;
                 }
             }
 
@@ -736,7 +735,7 @@ protected:
                 size_t fused_output = kv_state * 2;
 
                 if (lora_count == 3) {
-                    size_t q_state = extract_channel(ChannelName::FEATURE, params.input_layouts[2]);
+                    size_t q_state = extract_channel(ChannelName::BATCH, params.input_layouts[4]);
                     fused_output += q_state;
                 }
 


### PR DESCRIPTION
### Details:
- *In case of QKV horizontal fused LoRA `q_state` was assigned from an incorrect dimension; previously, in models like Qwen2.5/Qwen3-8b or Llama, these values ​​were the same, but in Qwen3-4b they began to differ, which led to an incorrect implementation setup and accuracy errors*

### Tickets:
 - *[180107](https://jira.devtools.intel.com/browse/CVS-180107)*
