### PR TITLE
[GPU] Fix accuracy issues for Qwen2.5-VL-3B-instruct (#33491)

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -35,6 +35,7 @@
 #include "transformations/utils/utils.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "transformations/symbolic_transformations/symbolic_optimizations.hpp"
+#include "utils.hpp"
 
 namespace ov::intel_gpu {
 
@@ -329,53 +330,6 @@ IncreasePositionIdsPrecisionForGPTOSS::IncreasePositionIdsPrecisionForGPTOSS() {
     this->register_matcher(m, callback);
 }
 
-bool IncreasePositionIdsPrecisionForRoPE::insert_converts_before_if_needed(const std::shared_ptr<ov::Node>& node,
-                                                                const ov::element::Type desired_et, size_t& input_idx) {
-    bool is_changed = false;
-    for (const auto& input : node->inputs()) {
-        const auto& incoming_output = input.get_source_output();
-        const auto& incoming_node = incoming_output.get_node_shared_ptr();
-        const auto input_et = incoming_output.get_element_type();
-
-        if (input_et == desired_et)
-            continue;
-
-        auto in_convert = ov::as_type_ptr<ov::op::v0::Convert>(incoming_node);
-
-        if (in_convert && in_convert->get_users().size() == 1 && input_et.bitwidth() <= desired_et.bitwidth()) {
-            auto convert = std::make_shared<ov::op::v0::Convert>(incoming_node->input_value(0), desired_et);
-            convert->set_friendly_name(in_convert->get_friendly_name() + "_increase_precision_" + std::to_string(input_idx));
-            copy_runtime_info(incoming_node, convert);
-            ov::replace_node(incoming_node, convert);
-        } else {
-            auto convert = std::make_shared<ov::op::v0::Convert>(incoming_output, desired_et);
-            convert->set_friendly_name(incoming_node->get_friendly_name() + "_increase_precision_" + std::to_string(input_idx));
-            copy_runtime_info(incoming_node, convert);
-            input.replace_source_output(convert);
-        }
-
-        input_idx++;
-        is_changed = true;
-    }
-
-    return is_changed;
-}
-
-void IncreasePositionIdsPrecisionForRoPE::insert_converts_after_if_needed(const std::shared_ptr<ov::Node>& node,
-                                                            const ov::element::Type original_et, size_t& output_idx) {
-    for (const auto& output : node->outputs()) {
-        for (const auto& out_inputs : output.get_target_inputs()) {
-            auto out_node = out_inputs.get_node()->shared_from_this();
-
-            auto convert = std::make_shared<ov::op::v0::Convert>(output, original_et);
-            auto convert_name = out_node->get_friendly_name() + "_restore_precision_" + std::to_string(output_idx);
-            convert->set_friendly_name(convert_name);
-            copy_runtime_info(node, convert);
-            out_inputs.replace_source_output(convert);
-            output_idx++;
-        }
-    }
-}
 
 IncreasePositionIdsPrecision::IncreasePositionIdsPrecision() {}
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
@@ -12,24 +12,21 @@ class IncreasePositionIdsPrecisionForRoPE : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("IncreasePositionIdsPrecisionBase");
     IncreasePositionIdsPrecisionForRoPE();
-protected:
-    bool insert_converts_before_if_needed(const std::shared_ptr<ov::Node>& node, const ov::element::Type desired_et, size_t& input_idx);
-    void insert_converts_after_if_needed(const std::shared_ptr<ov::Node>& node, const ov::element::Type original_et, size_t& output_idx);
 };
 
-class IncreasePositionIdsPrecisionForQwen25VL : public IncreasePositionIdsPrecisionForRoPE {
+class IncreasePositionIdsPrecisionForQwen25VL : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("IncreasePositionIdsPrecisionForQwen25VL");
     IncreasePositionIdsPrecisionForQwen25VL();
 };
 
-class IncreasePositionIdsPrecisionForLtxVideo : public IncreasePositionIdsPrecisionForRoPE {
+class IncreasePositionIdsPrecisionForLtxVideo : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("IncreasePositionIdsPrecisionForLtxVideo");
     IncreasePositionIdsPrecisionForLtxVideo();
 };
 
-class IncreasePositionIdsPrecisionForGPTOSS : public IncreasePositionIdsPrecisionForRoPE {
+class IncreasePositionIdsPrecisionForGPTOSS : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("IncreasePositionIdsPrecisionForGPTOSS");
     IncreasePositionIdsPrecisionForGPTOSS();

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_rms_input_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_rms_input_precision.cpp
@@ -1,0 +1,107 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "increase_rms_input_precision.hpp"
+
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/gelu.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/softmax.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/swish.hpp"
+#include "openvino/pass/pattern/op/or.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "ov_ops/rms.hpp"
+#include "transformations/symbolic_transformations/symbolic_optimizations.hpp"
+#include "transformations/utils/utils.hpp"
+#include "utils.hpp"
+
+namespace ov::intel_gpu {
+
+IncreaseRMSInputPrecision::IncreaseRMSInputPrecision() {}
+
+bool IncreaseRMSInputPrecision::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    using namespace ov::pass;
+    SymbolicOptimizations symbolic_optimizations(false, get_pass_config());
+    auto symbolic_ctx_manager = symbolic_optimizations.get_manager();
+    symbolic_ctx_manager->register_pass<IncreasePrecisionForQwenVLMerger>();
+    symbolic_ctx_manager->register_pass<Validate>();
+    return symbolic_optimizations.run_on_model(model);
+}
+
+IncreasePrecisionForQwenVLMerger::IncreasePrecisionForQwenVLMerger() {
+    using namespace ov::op;
+    using namespace ov::pass::pattern;
+    using namespace ov::pass::pattern::op;
+
+    // Pattern: Qwen2.5-VL Vision Embedings Merger last block (blocks.31) + Merger MLP
+    // Target: down_proj MatMul -> Add -> aten_add -> RMS -> Reshape -> merger_mlp
+    auto attn_proj = wrap_type<v0::MatMul>({any_input(), any_input()}, type_matches(ov::element::f16) && consumers_count(1));
+    auto attn_proj_add = wrap_type<ov::op::v1::Add>({attn_proj, any_input()}, type_matches(element::f16));
+    auto attn_add = wrap_type<ov::op::v1::Add>({any_input(), attn_proj_add}, type_matches(element::f16));
+    auto rms_post_m = wrap_type<ov::op::internal::RMS>({attn_add, wrap_type<ov::op::v0::Constant>()}, type_matches(element::f16));
+    auto gate_proj = wrap_type<v0::MatMul>({rms_post_m, any_input()}, type_matches(ov::element::f16) && consumers_count(1));
+    auto up_proj = wrap_type<v0::MatMul>({rms_post_m, any_input()}, type_matches(ov::element::f16) && consumers_count(1));
+    auto gate_proj_add = wrap_type<ov::op::v1::Add>({gate_proj, any_input()}, type_matches(element::f16));
+    auto up_proj_add = wrap_type<ov::op::v1::Add>({up_proj, any_input()}, type_matches(element::f16));
+    auto act_silu = wrap_type<ov::op::v4::Swish>({gate_proj_add}, type_matches(ov::element::f16) && consumers_count(1));
+    auto aten_mul = wrap_type<ov::op::v1::Multiply>({act_silu, up_proj_add}, type_matches(ov::element::f16) && consumers_count(1));
+    auto down_proj = wrap_type<v0::MatMul>({aten_mul, any_input()}, type_matches(ov::element::f16) && consumers_count(1));
+    auto down_proj_add = wrap_type<ov::op::v1::Add>({down_proj, any_input()}, type_matches(element::f16));
+    auto aten_add = wrap_type<v1::Add>({attn_add, down_proj_add}, type_matches(element::f16));
+    auto rms_m = wrap_type<internal::RMS>({aten_add, wrap_type<v0::Constant>()}, type_matches(element::f16));
+    auto aten_view = wrap_type<v1::Reshape>({rms_m, any_input()}, type_matches(ov::element::f16) && consumers_count(1));
+    auto merger_mlp0 = wrap_type<v0::MatMul>({aten_view, any_input()}, type_matches(ov::element::f16) && consumers_count(1));
+    auto merger_mlp0_add = wrap_type<v1::Add>({merger_mlp0, any_input()}, type_matches(element::f16));
+    auto merger_mlp1_gelu = wrap_type<v7::Gelu>({merger_mlp0_add}, type_matches(ov::element::f16) && consumers_count(1));
+    auto merger_mlp2 = wrap_type<v0::MatMul>({merger_mlp1_gelu, any_input()}, type_matches(ov::element::f16) && consumers_count(1));
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto matmul = ov::as_type_ptr<v0::MatMul>(pattern_map.at(down_proj).get_node_shared_ptr());
+        auto add_1 = ov::as_type_ptr<v1::Add>(pattern_map.at(down_proj_add).get_node_shared_ptr());
+        auto add_2 = ov::as_type_ptr<v1::Add>(pattern_map.at(aten_add).get_node_shared_ptr());
+        auto rms = ov::as_type_ptr<internal::RMS>(pattern_map.at(rms_m).get_node_shared_ptr());
+
+        if (!rms || !add_1 || !add_2 || !matmul || transformation_callback(rms)) {
+            return false;
+        }
+
+        const auto desired_et = ov::element::f32;
+        const auto original_et = matmul->get_output_element_type(0);
+        if (original_et == desired_et) {
+            return false;
+        }
+
+        size_t input_idx = 0;
+        bool is_changed = insert_converts_before_if_needed(matmul, desired_et, input_idx);
+        if (!is_changed)
+            return false;
+        is_changed = insert_converts_before_if_needed(add_1, desired_et, input_idx);
+        if (!is_changed)
+            return false;
+        is_changed = insert_converts_before_if_needed(add_2, desired_et, input_idx, {1});
+        if (!is_changed)
+            return false;
+        is_changed = insert_converts_before_if_needed(rms, desired_et, input_idx, {0});
+        if (!is_changed)
+            return false;
+
+        size_t output_idx = 0;
+        insert_converts_after_if_needed(rms, original_et, output_idx);
+
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(merger_mlp2, "IncreasePrecisionForQwenVLMerger");
+    this->register_matcher(m, callback);
+}
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_rms_input_precision.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_rms_input_precision.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/pass.hpp"
+
+namespace ov::intel_gpu {
+
+class IncreaseRMSInputPrecision: public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("IncreaseRMSInputPrecision");
+    IncreaseRMSInputPrecision();
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+};
+
+class IncreasePrecisionForQwenVLMerger: public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("IncreasePrecisionForQwenVLMerger");
+    IncreasePrecisionForQwenVLMerger();
+};
+
+
+}   // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/utils.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/utils.hpp
@@ -1,10 +1,12 @@
-// Copyright (C) 2018-2026 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
 #pragma once
 
 #include "ov_ops/type_relaxed.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/core/graph_util.hpp"
 
 namespace ov::intel_gpu {
 
@@ -15,4 +17,57 @@ std::shared_ptr<T> make_type_relaxed(const element::TypeVector& input_data_types
     return std::make_shared<ov::op::TypeRelaxed<T>>(std::forward<Args>(args)...);
 }
 
+inline bool insert_converts_before_if_needed(const std::shared_ptr<ov::Node>& node,
+                                                                const ov::element::Type desired_et,
+                                                                size_t& input_idx,
+                                                                const std::vector<size_t>& skip_inputs = {}) {
+    bool is_changed = false;
+    for (const auto& input : node->inputs()) {
+        const auto& incoming_output = input.get_source_output();
+        const auto& incoming_node = incoming_output.get_node_shared_ptr();
+        const auto input_et = incoming_output.get_element_type();
+
+        if (input_et == desired_et)
+            continue;
+
+        if (std::find(skip_inputs.begin(), skip_inputs.end(), input.get_index()) != skip_inputs.end()) {
+            continue;
+        }
+
+        auto in_convert = ov::as_type_ptr<ov::op::v0::Convert>(incoming_node);
+
+        if (in_convert && in_convert->get_users().size() == 1 && input_et.bitwidth() <= desired_et.bitwidth()) {
+            auto convert = std::make_shared<ov::op::v0::Convert>(incoming_node->input_value(0), desired_et);
+            convert->set_friendly_name(in_convert->get_friendly_name() + "_increase_precision_" + std::to_string(input_idx));
+            ov::copy_runtime_info(incoming_node, convert);
+            ov::replace_node(incoming_node, convert);
+        } else {
+            auto convert = std::make_shared<ov::op::v0::Convert>(incoming_output, desired_et);
+            convert->set_friendly_name(incoming_node->get_friendly_name() + "_increase_precision_" + std::to_string(input_idx));
+            ov::copy_runtime_info(incoming_node, convert);
+            input.replace_source_output(convert);
+        }
+
+        input_idx++;
+        is_changed = true;
+    }
+
+    return is_changed;
+}
+
+inline void insert_converts_after_if_needed(const std::shared_ptr<ov::Node>& node,
+                                                            const ov::element::Type original_et, size_t& output_idx) {
+    for (const auto& output : node->outputs()) {
+        for (const auto& out_inputs : output.get_target_inputs()) {
+            auto out_node = out_inputs.get_node()->shared_from_this();
+
+            auto convert = std::make_shared<ov::op::v0::Convert>(output, original_et);
+            auto convert_name = out_node->get_friendly_name() + "_restore_precision_" + std::to_string(output_idx);
+            convert->set_friendly_name(convert_name);
+            ov::copy_runtime_info(node, convert);
+            out_inputs.replace_source_output(convert);
+            output_idx++;
+        }
+    }
+}
 }  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -102,6 +102,7 @@
 #include "plugin/transformations/disable_fp16_comp_rms.hpp"
 #include "plugin/transformations/swiglu_fusion_with_clamp.hpp"
 #include "plugin/transformations/disable_fp16_comp_sin_gen.hpp"
+#include "plugin/transformations/increase_rms_input_precision.hpp"
 #include "transformations/common_optimizations/activations_scaling.hpp"
 #include "transformations/common_optimizations/broadcast_elementwise_fusion.hpp"
 #include "transformations/common_optimizations/broadcast_transition.hpp"
@@ -1374,6 +1375,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.set_per_pass_validation(false);
 
         manager.register_pass<ov::pass::ConvertWeightCompressedConv1x1ToMatmul>();
+        manager.register_pass<ov::intel_gpu::IncreaseRMSInputPrecision>();
         manager.register_pass<ov::intel_gpu::ClampFP16Output>();
         manager.register_pass<ov::intel_gpu::ConvertMatMulToFullyConnected>(device_info.supports_immad);
         manager.register_pass<ov::intel_gpu::MoveFCReshapeToWeights>();


### PR DESCRIPTION
This PR is backport PR for #33491

### Description of the issue:
#### Issues
The result of inference on GPU plugin has a failure of "!" repeated output for Qwen2.5-VL-3B-Instruct model, resulting in low accuracy (similarity ~0.78-0.95 depending on architecture).

**Symptom:**
- 5 out of 24 WWB prompts (P11, P19, P20, P21, P22) produce `!!!!!!!!!!!!!!!!!!!!!!!!` instead of meaningful text
- NaN values detected in VLSDPA CM kernel output at specific iteration
- 100% reproducible on certain images/prompts
- Example of issued output:

```
INFO:whowhatbench.wwb:   similarity
0    0.949354
INFO:whowhatbench.wwb:=======================================================================================================
INFO:whowhatbench.wwb:## Prompt 1:
What is the name of the user with a rose in their profile picture?

INFO:whowhatbench.wwb:## Metric value:0.0923

INFO:whowhatbench.wwb:## Reference text:
The user with a rose in their profile picture is "dukeofdumbass".


INFO:whowhatbench.wwb:## Actual text:
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


INFO:whowhatbench.wwb:## Diff:
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!The user with a rose in their profile picture is "dukeofdumbass".


```

#### Root causes

Two distinct issues were identified:

**Issue 1: FP16 overflow in Vision Embeddings Merger (RMS input precision)**
- In `blocks.31` of Vision Embeddings Merger, `gate_proj` FC produces large values (min/max = -4224, 2858)
- After SwiGLU operation (`gate * up`), FP16 overflow occurs in `down_proj` FC resulting in `inf`
- `inf` propagates through `merger.ln_q` (RMSNorm), producing `nan` which corrupts the entire output

**Issue 2: CM SDPA kernel garbage data in unused KV cache positions (NaN propagation)**

- VLSDPA CM kernel loads K/V data in kv_step=16 units for DPAS hardware optimization
- When remaining KV tokens < 16 (e.g., kv_tokens=8), the loaded block contains garbage/stale data in positions beyond valid tokens
- Note: This is NOT out-of-bounds memory access — data is still within KV cache page bounds, but contains invalid values
- These garbage values (potentially NaN or extreme values) propagate through attention computation: Q × garbage_K → garbage_scores → softmax → garbage × V → NaN output

#### How to fix it
**Fix 1: Increase RMS input precision (increase_rms_input_precision transformation)**
- Added new graph transformation to upgrade precision for Vision Encoder's problematic path
- Inserts Convert(f16→f32) before `down_proj MatMul` and RMSNorm operations
- Adds Convert(f32→f16) after operations to restore expected precision for downstream nodes

**Fix 2: Zero out unused K/V rows after loading**

- K/V load masking in load_slm_KV lambda: After cm_load_2d, zero out rows where r >= kv_valid_rows before writing to SLM
```C++
int kv_valid_rows = (kv_tokens >= kv_step) ? kv_step : kv_tokens;

// After K load:
for (int r = kv_valid_rows; r < kv_step; r++) temp.row(r) = 0;

// After V load:
for (int r = kv_valid_rows; r < kv_step; r++) temp2.row(r) = 0;
```
- This ensures garbage data is replaced with zeros at load time, preventing NaN propagation


#### Problematic data flow (before fix) in Vision Embeddings Merger <img width="2043" height="1936" alt="image"
src="https://github.com/user-attachments/assets/e49d9716-1bf9-4625-bed6-40648ad34d26" />


#### VLSDPA NaN occurrence detail
```
Seq 329 (last sequence):
  - Length: 8 (< kv_step=16)
  - V range: [19600, 19608)  ← valid data ends here
  - V buffer end: 19608

CM kernel behavior:
  - Loads in kv_step=16 units
  - Attempted read range: V[19600:19616]  ← loads 16 elements

Problem:
  - V[19600:19608] = valid ✓
  - V[19608:19616] = out-of-bounds memory (garbage/NaN) ✗
```

#### Reproduction step and snapshot
```bash
wwb  --target-model \models\cv_bench_cache\WW50_llm-optimum_2025.4.1-20426-RC1\qwen2.5-vl-3b-instruct\pytorch\ov\FP16\  --model-type visual-text --genai --device GPU      --gt-data \qwen2.5-vl-3b-instruct__NAT\reference.csv  --output outs\issue_2026.0.0-20771-3dd813954d1-pull_33491_head --verbose
```


#### Checklist
 - [x] Is it a proper fix?
 - [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario?


### Tickets:
 - *CVS-178472*
