### PR TITLE
[GPU] fix debug configuration

### DIFF
--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -44,20 +44,24 @@ size_t get_x_pitch(const layout& layout) {
 }
 
 template <class T>
-void __validate_data_range(memory::ptr mem, stream& stream, std::string &info) {
+void __validate_data_range(memory::ptr mem, stream& stream, const layout& data_layout, std::string &info) {
     if (!mem)
         return;
-    auto&& size = mem->get_layout().get_tensor();
-    mem_lock<T, mem_lock_type::read> lock(mem, stream);
+
+    // Reinterpret buffer to represent actual data layout (same as log_memory_to_file)
+    auto actual_mem = mem->get_engine()->reinterpret_buffer(*mem, data_layout);
+
+    auto&& size = actual_mem->get_layout().get_tensor();
+    mem_lock<T, mem_lock_type::read> lock(actual_mem, stream);
     auto mem_ptr = lock.data();
-    auto x_pitch = get_x_pitch(mem->get_layout());
+    auto x_pitch = get_x_pitch(actual_mem->get_layout());
     std::stringstream buffer;
     float val_min = std::numeric_limits<float>::max();
     float val_max = std::numeric_limits<float>::lowest();
-    const bool is_memory_packed = !mem->is_memory_reset_needed(mem->get_layout());
+    const bool is_memory_packed = !actual_mem->is_memory_reset_needed(actual_mem->get_layout());
 
     if (is_memory_packed) {
-        for (size_t i = 0; i < mem->count(); ++i) {
+        for (size_t i = 0; i < actual_mem->count(); ++i) {
             auto val = convert_element(mem_ptr[i]);
             if (std::isinf(val) || std::isnan(val)) {
                 std::string err_str = std::isinf(val) ? "inf" : "nan";
@@ -77,7 +81,7 @@ void __validate_data_range(memory::ptr mem, stream& stream, std::string &info) {
                         for (ov::Dimension::value_type z = 0; z < size.spatial[2]; ++z) {
                             for (ov::Dimension::value_type y = 0; y < size.spatial[1]; ++y) {
                                 cldnn::tensor t(cldnn::group(g), cldnn::batch(b), cldnn::feature(f), cldnn::spatial(0, y, z, w));
-                                size_t input_it = mem->get_layout().get_linear_offset(t);
+                                size_t input_it = actual_mem->get_layout().get_linear_offset(t);
 
                                 for (ov::Dimension::value_type x = 0; x < size.spatial[0]; ++x, input_it += x_pitch) {
                                     auto val = convert_element(mem_ptr[input_it]);
@@ -101,15 +105,16 @@ void __validate_data_range(memory::ptr mem, stream& stream, std::string &info) {
     GPU_DEBUG_INFO << "min, max = " << val_min << ", " << val_max << "  : " << info << "  is_packed " << is_memory_packed << std::endl;
 }
 
-void validate_data_range(memory::ptr mem, stream& stream, ov::element::Type_t data_type, std::string &info) {
-    if (data_type == ov::element::Type_t::f32)
-        __validate_data_range<float>(mem, stream, info);
-    else if (data_type == ov::element::Type_t::f16)
-        __validate_data_range<ov::float16>(mem, stream, info);
-    else if (data_type == ov::element::Type_t::i8)
-        __validate_data_range<int8_t>(mem, stream, info);
-    else if (data_type == ov::element::Type_t::u8)
-        __validate_data_range<uint8_t>(mem, stream, info);
+void validate_data_range(memory::ptr mem, stream& stream, const layout& data_layout, std::string &info) {
+    auto data_type = data_layout.data_type;
+    if (data_type == cldnn::data_types::f32)
+        __validate_data_range<float>(mem, stream, data_layout, info);
+    else if (data_type == cldnn::data_types::f16)
+        __validate_data_range<ov::float16>(mem, stream, data_layout, info);
+    else if (data_type == cldnn::data_types::i8)
+        __validate_data_range<int8_t>(mem, stream, data_layout, info);
+    else if (data_type == cldnn::data_types::u8)
+        __validate_data_range<uint8_t>(mem, stream, data_layout, info);
     else
         GPU_DEBUG_INFO << "Unsupport data type for validating data range " << data_type << std::endl;
 }
@@ -504,7 +509,7 @@ NodeDebugHelper::~NodeDebugHelper() {
         for (size_t i = 0; i < m_inst.outputs_memory_count(); i++) {
             auto output_mem = m_inst.output_memory_ptr(i);
             std::string info = m_inst.id() + "(" + std::to_string(i) + ") at iteration " + std::to_string(m_network.get_current_iteration_num());
-            validate_data_range(output_mem, m_stream, m_inst.get_output_layout(i).data_type, info);
+            validate_data_range(output_mem, m_stream, m_inst.get_output_layout(i), info);
         }
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
@@ -286,7 +286,8 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
 
             // Add -g -s to build options to allow IGC assembly dumper to associate assembler sources with corresponding OpenCL kernel code lines
             // Should be used with the IGC_ShaderDump option
-            if (!dump_sources_dir.empty()) {
+            // Note: Skip adding -g -s for CM kernels as these options are not supported by CM compiler
+            if (!dump_sources_dir.empty() && b.language != kernel_language::CM) {
                 std::string current_dump_file_name = std::move(dump_sources_dir);
                 if (!current_dump_file_name.empty() && current_dump_file_name.back() != '/')
                     current_dump_file_name += '/';
@@ -349,8 +350,10 @@ void kernels_cache::build_batch(const batch_program& batch, compiled_kernels& co
         if (!current_dump_file_name.empty() && current_dump_file_name.back() != '/')
             current_dump_file_name += '/';
 
+        // Use .cm extension for CM kernels, .cl for OpenCL kernels
+        std::string ext = (batch.language == kernel_language::CM) ? ".cm" : ".cl";
         current_dump_file_name += "clDNN_program_" + std::to_string(_prog_id) + "_bucket_" + std::to_string(batch.bucket_id)
-                               + "_part_" + std::to_string(batch.batch_id) + "_" + std::to_string(batch.hash_value) + ".cl";
+                               + "_part_" + std::to_string(batch.batch_id) + "_" + std::to_string(batch.hash_value) + ext;
     }
 
     std::ofstream dump_file;


### PR DESCRIPTION
### Details:

- Reinterpret buffer to represent actual data layout for validate output buffer

  -  This prevents the validate function from accessing data outside the region that is actually used when the allocated buffer size is larger than the actual layout. Without reinterpreting the buffer, validation may read undefined or unintended data that lies outside the valid layout region.

- Skip adding -g -s for CM kernels as these options are not supported by CM compiler

  - This avoids build failures during kernel dumping when GPU_DUMP_SOURCES_PATH is set. If unsupported options are added for CM kernels, the kernel build may fail, which in turn disables VLSDPA.


### Tickets:
 - *CVS-178472*
