### PR TITLE
[TRANSFORMATIONS] Support new GPU RoPE pattern of glm-4-9b-chat-hf for RoPEFusion 

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -779,7 +779,7 @@ RoPEFusionChatGLM::RoPEFusionChatGLM(const bool support_2d_rope) {
 static std::shared_ptr<ov::Node> build_ChatGLMHF_interleave_pattern(std::shared_ptr<ov::Node> cos_or_sin) {
     auto transpose = pattern::wrap_type<v1::Transpose>({cos_or_sin, pattern::any_input()});
     auto reshape = pattern::wrap_type<v1::Reshape>({transpose, pattern::any_input()});
-    auto multiply = pattern::wrap_type<v1::Multiply, v3::Broadcast>({reshape, pattern::any_input()});
+    auto multiply = pattern::wrap_type<v1::Multiply, ov::op::util::BroadcastBase>({reshape, pattern::any_input()});
     auto gather_nd = pattern::wrap_type<v8::GatherND>({multiply, pattern::any_input()});
     auto transpose_1 = pattern::wrap_type<v1::Transpose>({gather_nd, pattern::any_input()});
 


### PR DESCRIPTION
### Details:
The previous fix 55eda000c262e4d22e7151981b94894187b07637 for the model didn't account for GPU, which has a different model graph, so needs additional support as well.

### Tickets:
 - [CVS-178113](https://jira.devtools.intel.com/browse/CVS-178113)

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>