### PR TITLE
zero rank in reorder inputs

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -113,7 +113,6 @@ std::pair<std::shared_ptr<primitive>, bool> reorder_factory::get_weights_reorder
 }
 
 int64_t cldnn::get_convolution_channel_count(const convolution_node& conv_node, const layout& layout, bool is_input) {
-
     int64_t channel_count = -1;
     if (layout.get_partial_shape().size() > 1 && layout.get_partial_shape()[1].is_static()) {
         channel_count = layout.get_partial_shape()[1].get_length();


### PR DESCRIPTION
### Details:
 We are enabling customer model on GPU stack, the input to the conv node has zero rank.
Inside src\plugins\intel_gpu\src\graph\layout_optimizer.cpp during fuse_reorder, at line https://github.com/openvinotoolkit/openvino/blob/acffc4a409d5375ef1d037d923d926f0992d79a6/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp#L271
during the below check, we got error "Accessing out of range dimension"

https://github.com/openvinotoolkit/openvino/blob/acffc4a409d5375ef1d037d923d926f0992d79a6/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp#L116


<img width="1911" height="1177" alt="graph-ISV-model" src="https://github.com/user-attachments/assets/c618cbae-e4bc-4258-8047-c79a291fb2dd" />

### Tickets:
 - *CVS-180503*
