### PR TITLE
[GPU] serializing kernel_arguments_desc.local_memory_args

### DIFF
--- a/src/plugins/intel_gpu/src/graph/common_utils/kernel_generator_base.cpp
+++ b/src/plugins/intel_gpu/src/graph/common_utils/kernel_generator_base.cpp
@@ -29,6 +29,7 @@ void KernelData::save(cldnn::BinaryOutputBuffer& ob) const {
         microkernel->save(ob);
     }
 #endif
+    ob << params.local_memory_args;
 }
 
 void KernelData::load(cldnn::BinaryInputBuffer& ib) {
@@ -60,6 +61,7 @@ void KernelData::load(cldnn::BinaryInputBuffer& ib) {
         micro_kernels.push_back(microkernel);
     }
 #endif
+    ib >> params.local_memory_args;
 }
 
 }  // namespace ov::intel_gpu


### PR DESCRIPTION
### Details:
 - This PR updates `KernelData` to serialize `local_memory_args`.
   - It resolves a functional issue of the gpt-oss model when model caching is used.
 - backport of https://github.com/openvinotoolkit/openvino/pull/33897
