### PR TITLE
[CPU] Remove duplicate join/split functions and use `ov::util::join` instead

### DIFF
--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
@@ -501,7 +501,7 @@ public:
     template <class Container>
     std::string join(const Container& strs) {
         std::stringstream ss;
-        ss << "[" << ov::intel_cpu::join(strs, ',') << "]";
+        ss << "[" << ov::util::join(strs, ",") << "]";
         return ss.str();
     }
 };

--- a/src/plugins/intel_cpu/src/utils/general_utils.h
+++ b/src/plugins/intel_cpu/src/utils/general_utils.h
@@ -166,31 +166,6 @@ inline ov::element::Type getMaxPrecision(const std::vector<ov::element::Type>& p
     return ov::element::dynamic;
 }
 
-inline std::vector<std::string> split(const std::string& str, char delim) {
-    std::stringstream ss(str);
-    std::string item;
-    std::vector<std::string> elements;
-    while (std::getline(ss, item, delim)) {
-        elements.emplace_back(item);
-    }
-    return elements;
-}
-
-template <class Container>
-inline std::string join(const Container& strs, char delim) {
-    if (strs.empty()) {
-        return {};
-    }
-
-    std::stringstream result;
-    auto it = strs.begin();
-    result << *it++;
-    for (; it != strs.end(); it++) {
-        result << delim << *it;
-    }
-    return result.str();
-}
-
 template <typename Container, typename T>
 inline bool any_of_values(const Container& container, const T& value) {
     return std::find(container.begin(), container.end(), value) != container.end();


### PR DESCRIPTION
### Tickets:
 - N/A
