### PR TITLE
[NPU] Fix TileCount default value in device_desc

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
@@ -390,7 +390,7 @@ VCLCompilerImpl::VCLCompilerImpl() : _logHandle(nullptr), _logger("VCLCompilerIm
     vcl_device_desc_t device_desc = {sizeof(vcl_device_desc_t),
                                      0x00,
                                      static_cast<uint16_t>(-1),
-                                     static_cast<uint16_t>(-1)};
+                                     static_cast<uint32_t>(-1)};
     THROW_ON_FAIL_FOR_VCL("vclCompilerCreate",
                           vclCompilerCreate(&compilerDesc, &device_desc, &_compilerHandle, &_logHandle),
                           nullptr);


### PR DESCRIPTION
### Details:
 - Fix default value setting for tileCount in [plugin compiler](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp#L393) to match the [default format defined](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/compiler_adapter/include/compiler.h#L148). 

### Tickets:
 - *CVS-180596*
