### PR TITLE
[SIT] Move skip layers check to be before passing the tensor to the metrics

### DIFF
--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -3062,8 +3062,14 @@ static int runSingleImageTest() {
                         continue;
                     }
 
+                    auto refIt = referenceTensors.find(tensorName);
+                    if (refIt == referenceTensors.end()) {
+                        std::cerr << "Reference tensor not found for output layer: " << tensorName << std::endl;
+                        continue;
+                    }
+
                     filteredOutputTensors[tensorName] = tensor;
-                    filteredReferenceTensors[tensorName] = referenceTensors.at(tensorName);
+                    filteredReferenceTensors[tensorName] = refIt->second;
 
                     auto layoutIt = outputLayouts.find(tensorName);
                     if (layoutIt != outputLayouts.end()) {


### PR DESCRIPTION
### Details:
 - *Skip the output layers before passing the tensors to the metric functions, now all metrics can skip output layers*

### Tickets:
 - *[EISW-200527](https://jira.devtools.intel.com/browse/EISW-200527)*
