### PR TITLE
[GPU] Skip CoreThreadingTestsWithIter func tests

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -62,6 +62,8 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*smoke.*BehaviorTests.*InferFullyDynamicNetworkWith(S|G)etTensor.*)",
             R"(.*smoke.*BehaviorTests.*DynamicOutputToDynamicInput.*)",
             R"(.*smoke.*BehaviorTests.*DynamicInputToDynamicOutput.*)",
+            // TODO: Issue: 180519
+            R"(.*CoreThreadingTestsWithIter.*)",
             // TODO: Issue: 145926
             R"(.*CoreThreadingTest.smoke_QueryModel.*)",
             // Assign-3/ReadValue-3 does not have evaluate() methods; ref implementation does not save the value across the inferences.


### PR DESCRIPTION
### Details:
 - `CoreThreadingTestsWithIter` functional tests had been disabled, but they were enabled in #33862.
 - However, these tests are still showing sporadic failures, and the issue has not been resolved.
 - Therefore, they are added back to the skip list.

### Tickets:
 - *180519*
