### PR TITLE
[SIT] Extend I/O precision support

### DIFF
--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -2953,7 +2953,8 @@ static int runSingleImageTest() {
                         inputBinPrecisionForOneInfer[inferIdx][precisionIdx] = ov::element::f8e4m3;
                     } else {
                         std::cout << "WARNING: Unhandled precision '" << precision
-                                << "'! Only FP32, FP16, I32, I64, U8, U16, I16, U4, I4, U2, BF8 and HF8 can be currently converted to the network's";
+                                << "'! Only FP32, FP16, I32, I64, U8, U16, I16, U4, I4, U2, BF8 and HF8 "
+                                << "can be currently converted to the network's input tensor precision.";
                     }
                     ++precisionIdx;
                 }


### PR DESCRIPTION
### Details:
 - *Extends single-image-test tool to support additional OpenVINO element types:*
    - *New integer precisions: U16, I16, U4, I4, U2*
    - *New FP8 precisions: BF8 (f8e5m2), HF8 (f8e4m3)*
 - *Note: Image-based inputs still require standard precisions (U8, FP32, etc.) due to OpenCV limitations. New precisions work only with binary inputs `--img_as_bin`*

### Tickets:
 - *EISW-183469*
