### PR TITLE
[GPU] Restrict memory reuse to layout-compatible buffers for oneDNN

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2579,10 +2579,37 @@ void primitive_inst::update_weights() {
 }
 
 static bool user_requesting_mem_reuse_false(const program_node& node) {
+    auto is_feature_aligned = [](const cldnn::layout& l) -> bool {
+        const auto& order = format::internal_order(l.format);
+        int f_bs = 1;
+        for (const auto& [dim, bs] : format::block_sizes(l.format)) {
+            if (dim < order.size() && order[dim] == 'f') {
+                f_bs = bs;
+            }
+        }
+        return l.feature() % f_bs == 0;
+    };
+
+    const auto& l_node = node.get_output_layout();
+
+    auto should_forbid_reuse_due_to_alignment = [&](const program_node& user) -> bool {
+        const auto& l_user = user.get_output_layout();
+        return format::is_blocked(l_user.format) &&
+               format::is_blocked(l_node.format) &&
+               !(is_feature_aligned(l_user) && is_feature_aligned(l_node)) &&
+               (l_user != l_node);
+    };
+
     for (auto& user : node.get_users()) {
-        if ((user->get_selected_impl() != nullptr) && (user->get_selected_impl()->can_reuse_memory == false)) {
-            return true;
-        } else if (user->get_selected_impl() == nullptr) {
+        const auto* user_impl = user->get_selected_impl();
+        if (user_impl != nullptr) {
+            if (user_impl->can_reuse_memory == false) {
+                return true;
+            }
+            if (user_impl->is_onednn() && should_forbid_reuse_due_to_alignment(*user)) {
+                return true;
+            }
+        } else {
             if (user->is_dynamic()) {
                 return true;
             }

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -159,7 +159,7 @@ static int get_feature_block_size(const cldnn::format& fmt) {
             break;
         }
     }
-    return std::max(1, f_bs);
+    return f_bs;
 }
 
 memory::ptr memory_pool::get_from_non_padded_pool(const layout& layout,
@@ -181,7 +181,7 @@ memory::ptr memory_pool::get_from_non_padded_pool(const layout& layout,
             mem_layout.format != format::fs_b_yx_fsv32 &&
             layout.format != format::fs_b_yx_fsv32 &&
             ((layout.format != format::b_fs_yx_fsv32 && layout.format != format::b_fs_zyx_fsv32) ||
-             layout.feature() % f_block_size == 0) &&
+             layout.feature() % 32 == 0) &&
 #ifdef ENABLE_ONEDNN_FOR_GPU
             (!format::is_blocked(layout.format) || layout.feature() % f_block_size == 0 ||
              (mem_layout.format == layout.format &&
@@ -229,7 +229,7 @@ memory::ptr memory_pool::get_from_padded_pool(const layout& layout,
             if (rec_list._network_id == network_id &&
                 rec_list._type == type &&
                 ((layout.format != format::b_fs_yx_fsv32 && layout.format != format::b_fs_zyx_fsv32) ||
-                 layout.feature() % f_block_size == 0) &&
+                 layout.feature() % 32 == 0) &&
 #ifdef ENABLE_ONEDNN_FOR_GPU
                 (!format::is_blocked(layout.format) || layout.feature() % f_block_size == 0 ||
                  mem_layout.feature() % f_block_size == layout.feature() % f_block_size) &&

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -181,7 +181,7 @@ memory::ptr memory_pool::get_from_non_padded_pool(const layout& layout,
             mem_layout.format != format::fs_b_yx_fsv32 &&
             layout.format != format::fs_b_yx_fsv32 &&
             ((layout.format != format::b_fs_yx_fsv32 && layout.format != format::b_fs_zyx_fsv32) ||
-             layout.feature() % 32 == 0) &&
+             (layout.feature() % 32 == 0)) &&
 #ifdef ENABLE_ONEDNN_FOR_GPU
             (!format::is_blocked(layout.format) || layout.feature() % f_block_size == 0 ||
              (mem_layout.format == layout.format &&
@@ -229,7 +229,7 @@ memory::ptr memory_pool::get_from_padded_pool(const layout& layout,
             if (rec_list._network_id == network_id &&
                 rec_list._type == type &&
                 ((layout.format != format::b_fs_yx_fsv32 && layout.format != format::b_fs_zyx_fsv32) ||
-                 layout.feature() % 32 == 0) &&
+                 (layout.feature() % 32 == 0)) &&
 #ifdef ENABLE_ONEDNN_FOR_GPU
                 (!format::is_blocked(layout.format) || layout.feature() % f_block_size == 0 ||
                  mem_layout.feature() % f_block_size == layout.feature() % f_block_size) &&

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -187,7 +187,7 @@ memory::ptr memory_pool::get_from_non_padded_pool(const layout& layout,
              feature_aligned) &&
 #ifdef ENABLE_ONEDNN_FOR_GPU
             (!format::is_blocked(layout.format) || feature_aligned ||
-             (mem_layout.format == layout.format && mem_layout.feature() == layout.feature())) &&
+             (mem_layout.format == layout.format && mem_layout.feature() % layout.feature() == 0)) &&
 #endif // ENABLE_ONEDNN_FOR_GPU
             !has_conflict(it->second._users, restrictions))) {
             it->second._users.insert(memory_user(MEM_USER(unique_id, network_id, prim_id, layout_bytes_count)));
@@ -234,7 +234,7 @@ memory::ptr memory_pool::get_from_padded_pool(const layout& layout,
                  feature_aligned) &&
 #ifdef ENABLE_ONEDNN_FOR_GPU
                 (!format::is_blocked(layout.format) || feature_aligned ||
-                 mem_layout.feature() == layout.feature()) &&
+                 mem_layout.feature() % layout.feature() == 0) &&
 #endif // ENABLE_ONEDNN_FOR_GPU
                 // TODO: check if this condition always correct
                 layout.feature() <= mem_layout.feature() &&

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -150,10 +150,8 @@ void memory_pool::release_memory(memory* mem, const size_t& unique_id, primitive
 #endif
 }
 
-static bool is_feature_aligned(const layout& l) {
-    const cldnn::format fmt = l.format;
+static int get_feature_block_size(const cldnn::format& fmt) {
     const auto& order = cldnn::format::internal_order(fmt);
-
     int f_bs = 1;
     for (const auto& [dim, bs] : cldnn::format::block_sizes(fmt)) {
         if (dim < order.size() && order[dim] == 'f') {
@@ -161,8 +159,7 @@ static bool is_feature_aligned(const layout& l) {
             break;
         }
     }
-
-    return (l.feature() % std::max(1, f_bs)) == 0;
+    return std::max(1, f_bs);
 }
 
 memory::ptr memory_pool::get_from_non_padded_pool(const layout& layout,
@@ -174,7 +171,7 @@ memory::ptr memory_pool::get_from_non_padded_pool(const layout& layout,
                                                   bool reset,
                                                   bool is_dynamic) {
     const auto layout_bytes_count = layout.bytes_count();
-    const bool feature_aligned = is_feature_aligned(layout);
+    const int f_block_size = get_feature_block_size(layout.format);
     auto it = _non_padded_pool.lower_bound(layout_bytes_count);
     while (it != _non_padded_pool.end()) {
         const auto& mem_layout = it->second._memory->get_layout();
@@ -184,10 +181,11 @@ memory::ptr memory_pool::get_from_non_padded_pool(const layout& layout,
             mem_layout.format != format::fs_b_yx_fsv32 &&
             layout.format != format::fs_b_yx_fsv32 &&
             ((layout.format != format::b_fs_yx_fsv32 && layout.format != format::b_fs_zyx_fsv32) ||
-             feature_aligned) &&
+             layout.feature() % f_block_size == 0) &&
 #ifdef ENABLE_ONEDNN_FOR_GPU
-            (!format::is_blocked(layout.format) || feature_aligned ||
-             (mem_layout.format == layout.format && mem_layout.feature() % layout.feature() == 0)) &&
+            (!format::is_blocked(layout.format) || layout.feature() % f_block_size == 0 ||
+             (mem_layout.format == layout.format &&
+              mem_layout.feature() % f_block_size == layout.feature() % f_block_size)) &&
 #endif // ENABLE_ONEDNN_FOR_GPU
             !has_conflict(it->second._users, restrictions))) {
             it->second._users.insert(memory_user(MEM_USER(unique_id, network_id, prim_id, layout_bytes_count)));
@@ -223,7 +221,7 @@ memory::ptr memory_pool::get_from_padded_pool(const layout& layout,
                                               uint32_t network_id,
                                               const memory_restricter<uint32_t>& restrictions,
                                               allocation_type type) {
-    const bool feature_aligned = is_feature_aligned(layout);
+    const int f_block_size = get_feature_block_size(layout.format);
     auto first_level_cache = _padded_pool.find(layout);
     if (first_level_cache != _padded_pool.end()) {
         for (auto& rec_list : first_level_cache->second) {
@@ -231,10 +229,10 @@ memory::ptr memory_pool::get_from_padded_pool(const layout& layout,
             if (rec_list._network_id == network_id &&
                 rec_list._type == type &&
                 ((layout.format != format::b_fs_yx_fsv32 && layout.format != format::b_fs_zyx_fsv32) ||
-                 feature_aligned) &&
+                 layout.feature() % f_block_size == 0) &&
 #ifdef ENABLE_ONEDNN_FOR_GPU
-                (!format::is_blocked(layout.format) || feature_aligned ||
-                 mem_layout.feature() % layout.feature() == 0) &&
+                (!format::is_blocked(layout.format) || layout.feature() % f_block_size == 0 ||
+                 mem_layout.feature() % f_block_size == layout.feature() % f_block_size) &&
 #endif // ENABLE_ONEDNN_FOR_GPU
                 // TODO: check if this condition always correct
                 layout.feature() <= mem_layout.feature() &&


### PR DESCRIPTION
### Issue:
- During GPU execution with oneDNN convolution in blocked layouts (e.g. fsv16), NaNs may appear in the output when the input feature dimension is not a multiple of the block size (typically 16) and memory reuse is enabled.
- The issue does not reproduce when memory pooling/reuse is disabled or when `ocl impl` for convolution is used instead of oneDNN.

### Root cause:
- oneDNN primitives assume that inputs in blocked layouts are properly zero-padded in the feature tail lanes when the feature dimension is not aligned to the block size.
- However, when memory reuse is enabled, an input buffer produced by a previous primitive may contain non-zero garbage values in the feature tail lanes.
- Because oneDNN convolution reads these tail lanes implicitly, unexpected values can propagate into computation and result in NaNs.

### How to fix:
- For oneDNN primitives with blocked layouts, memory reuse is restricted to buffers with layout-compatible feature dimensions.
- When the feature dimension is not aligned to the block size (e.g. not a multiple of 16 for fsv16), memory reuse is allowed only if the source and candidate buffers have matching feature sizes.
- This preserves memory reuse for compatible layouts while preventing unsafe reuse that can corrupt channel tail data

### Graphs:
<img width="1347" height="508" alt="image" src="https://github.com/user-attachments/assets/28d14e51-a59c-49a2-97a9-7d9bac150801" />

### Tickets:
 - CVS-179964
