### PR TITLE
Pin samples test data files and rerun jobs on downloading error

### DIFF
--- a/.github/scripts/workflow_rerun/errors_to_look_for.json
+++ b/.github/scripts/workflow_rerun/errors_to_look_for.json
@@ -158,5 +158,9 @@
     {
         "error_text": "CERT_TRUST_REVOCATION_STATUS_UNKNOWN",
         "ticket": 177273
+    },
+    {
+        "error_text": "urllib3.exceptions.IncompleteRead",
+        "ticket": 173184
     }
 ]

--- a/tests/samples_tests/smoke_tests/common/samples_common_test_class.py
+++ b/tests/samples_tests/smoke_tests/common/samples_common_test_class.py
@@ -58,11 +58,11 @@ def download(test_data_dir, file_path):
             with lock_path.open('bx'):
                 if not file_path.exists():
                     if test_data_dir / 'bvlcalexnet-12.onnx' == file_path:
-                        response = requests.get("https://github.com/onnx/models/raw/main/validated/vision/classification/alexnet/model/bvlcalexnet-12.onnx?download=")
+                        response = requests.get("https://media.githubusercontent.com/media/onnx/models/4c46cd00fbdb7cd30b6c1c17ab54f2e1f4f7b177/validated/vision/classification/alexnet/model/bvlcalexnet-12.onnx?download=true")
                         with file_path.open('wb') as nfnet:
                             nfnet.write(response.content)
                     elif test_data_dir / 'efficientnet-lite4-11-qdq.onnx' == file_path:
-                        response = requests.get("https://github.com/onnx/models/raw/main/validated/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11-qdq.onnx?download=")
+                        response = requests.get("https://media.githubusercontent.com/media/onnx/models/4c46cd00fbdb7cd30b6c1c17ab54f2e1f4f7b177/validated/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11-qdq.onnx?download=true")
                         with file_path.open('wb') as nfnet:
                             nfnet.write(response.content)
                     else:


### PR DESCRIPTION
### Details:
Mitigating `IncompleteRead` errors in samples test data download method

### Tickets:
 - *CVS-173184*
