### PR TITLE
Prevent silent failures of steps in Windows jobs

### DIFF
--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -32,6 +32,10 @@ env:
   PYTHON_VERSION: '3.11'
   TARGET_BRANCH: ${{ inputs.target-branch || github.base_ref || github.event.merge_group.base_ref || github.ref }}
 
+defaults:
+  run:
+    shell: pwsh -NoProfile -NonInteractive -Command "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"
+
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
@@ -62,9 +66,6 @@ jobs:
   Build:
     needs: Smart_CI
     timeout-minutes: 300 # 5 hours without cache
-    defaults:
-      run:
-        shell: pwsh
     runs-on: aks-win-32-cores-128gb-build
     env:
       CMAKE_BUILD_TYPE: 'Release'
@@ -314,9 +315,6 @@ jobs:
     name: Conditional Compilation
     timeout-minutes: 40
     needs: [Build, Smart_CI]
-    defaults:
-      run:
-        shell: pwsh
     runs-on: aks-win-16-cores-32gb-build
     env:
       CMAKE_BUILD_TYPE: 'Release'
@@ -395,9 +393,6 @@ jobs:
     name: CPU functional tests
     needs: [Build, Smart_CI]
     timeout-minutes: 85
-    defaults:
-      run:
-        shell: pwsh
     runs-on: aks-win-8-cores-16gb-test
     env:
       OPENVINO_REPO: "${{ github.workspace }}\\openvino"

--- a/.github/workflows/windows_vs2022_debug.yml
+++ b/.github/workflows/windows_vs2022_debug.yml
@@ -27,6 +27,10 @@ permissions: read-all
 env:
   TARGET_BRANCH: ${{ inputs.target-branch || github.base_ref || github.event.merge_group.base_ref || github.ref }}
 
+defaults:
+  run:
+    shell: pwsh -NoProfile -NonInteractive -Command "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"
+
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -29,6 +29,10 @@ env:
 
 permissions: read-all
 
+defaults:
+  run:
+    shell: pwsh -NoProfile -NonInteractive -Command "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"
+
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest
@@ -86,9 +90,6 @@ jobs:
     needs: [ Build, Smart_CI ]
     if: fromJSON(needs.smart_ci.outputs.affected_components).samples
     timeout-minutes: 20
-    defaults:
-      run:
-        shell: pwsh
     runs-on: aks-win-4-cores-8gb
     env:
       CMAKE_COMPILE_WARNING_AS_ERROR: 'ON'
@@ -184,9 +185,6 @@ jobs:
   JS_API:
     name: JS API
     needs: [ Build, Smart_CI ]
-    defaults:
-      run:
-        shell: pwsh
     runs-on: 'aks-win-4-cores-8gb'
     env:
       OPENVINO_JS_DIR: "${{ github.workspace }}\\openvino\\src\\bindings\\js\\node"
@@ -272,9 +270,6 @@ jobs:
     name: Python unit tests
     needs: [ Build, Smart_CI ]
     timeout-minutes: 75
-    defaults:
-      run:
-        shell: pwsh
     runs-on: aks-win-8-cores-16gb-test
     env:
       OPENVINO_REPO: "${{ github.workspace }}\\openvino"
@@ -417,9 +412,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
-    defaults:
-      run:
-        shell: pwsh
     runs-on: aks-win-8-cores-16gb-test
     env:
       OPENVINO_REPO: "${{ github.workspace }}\\openvino"
@@ -555,9 +547,6 @@ jobs:
     name: CPU functional tests
     needs: [ Build, Smart_CI ]
     timeout-minutes: 70
-    defaults:
-      run:
-        shell: pwsh
     runs-on: aks-win-8-cores-16gb-test
     env:
       OPENVINO_REPO: "${{ github.workspace }}\\openvino"


### PR DESCRIPTION
### Details:
Some Windows jobs have hidden failures, because Powershell continues execution on non-zero code exit of a command. This PR attempts to fix it.

Here's an example: https://github.com/openvinotoolkit/openvino/actions/runs/21655086502/job/62430978057 . The failure is actually in "Install Python API tests dependencies" step.