### PR TITLE
[TF FE][Tests] Fix non-deterministic FILM model test failure

### DIFF
--- a/tests/model_hub_tests/tensorflow/test_tf_hub_api_notebooks.py
+++ b/tests/model_hub_tests/tensorflow/test_tf_hub_api_notebooks.py
@@ -37,10 +37,7 @@ class TestTFHubApiNotebooks(TestConvertModel):
             )
             film_layer = hub.KerasLayer(
                 "https://www.kaggle.com/models/google/film/frameworks/tensorFlow2/variations/film/versions/1")(inputs)
-            # Use 'image' output which is the interpolated frame - the main result of FILM model.
-            # Using list(film_layer.values())[0] is incorrect because dict iteration order
-            # is non-deterministic and may return different outputs (like flow pyramids)
-            # on different runs, causing shape mismatch errors.
+            # Select 'image' output - the interpolated frame
             film_model = tf.keras.Model(inputs=inputs, outputs=film_layer['image'])
             return film_model
         else:


### PR DESCRIPTION
### Details:
The test `test_tf_hub_api_notebook1[CPU-film]` was failing randomly in CI with shape mismatch error:
ValueError: operands could not be broadcast together with shapes (1,200,200,2) (1,6,6,2)

Root cause: The test used `list(film_layer.values())[0]` to select the model output. This is incorrect because:

1. Python dict iteration order depends on hash randomization (PYTHONHASHSEED), which is random by default since Python 3.3
2. The FILM model returns 7 different outputs including flow pyramids with various shapes
3. When dict iteration returns a flow pyramid instead of 'image', the shapes don't match

The fix selects the output by name (`film_layer['image']`) instead of by position.

### Why the fix is in the test, not in OpenVINO TF Frontend

Fixing this in OpenVINO is not possible because TensorFlow itself does not guarantee output order:

1. SavedModel signature uses protobuf `map<string, TensorInfo>` for outputs, which has no defined iteration order per protobuf specification
2. TensorFlow documentation states that signature inputs/outputs are "identified by string names", not by position
3. Even within pure TensorFlow (without OpenVINO), the dict key order changes between runs depending on PYTHONHASHSEED

OpenVINO cannot preserve an order that TensorFlow does not define. The only reliable way to select a specific output is by name.

### Tickets:
 - 180301
