### PR TITLE
[GPU] Fix reshape in-place optimization with feature padding

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -112,7 +112,8 @@ public:
 
         // Expected a padded input of only batch axis with 'bxxx' format
         if (input_layout.format.dims_order()[0] != 0 ||
-            input_pad._lower_size[1] != 0)
+            input_pad._lower_size[1] != 0 ||
+            input_pad._upper_size[1] != 0)
             return false;
 
         if (format::is_multi_blocked(input_layout.format))


### PR DESCRIPTION
### Details:
  - Fix batch inconsistency error in reshape layer when input tensor has feature dimension padding during in-place optimization.

### Description of the issue(symptom, root-cause, how it was resolved)
  - **Symptom**: TF_Ssd_Inception_v2_coco model produces incorrect inference results for batch=2 at BoxPredictor_5/Reshape layer [2,24,1,1]→[2,6,1,4].
 
  - **Root Cause**: 
    - BoxPredictor_5/Reshape receives input with feature dimension upper padding (upper_pad=[0,8,0,0]) from upstream convolution layer
    - The has_outer_padding_offset() function in reshape_inst.h only checks input_pad._lower_size[1] != 0 for feature dimension.
    - It misses the upper padding case (input_pad._upper_size[1] != 0), and returns true.
    - In-place optimization reinterprets memory buffer directly, causing reshape to read data from wrong memory offsets due to padding.
   
 - **Resolution**:
    - Modified reshape_inst.h::has_outer_padding_offset() to also check input_pad._upper_size[1] != 0.
    - Ensures feature dimension with any padding (lower or upper) prevents in-place optimization.
   
#### The code and line that caused this issue (if it is not changed directly)
https://github.com/openvinotoolkit/openvino/blob/849a12753d8fb63d576571309e24c990dfe6c565/src/plugins/intel_gpu/src/graph/include/reshape_inst.h#L113-L116


#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
python -m pytest test_ovc_mo.py \
    -n 2 \
    --tb=native \
    --env_conf=.automation/env_config.yml \
    --test_conf=.automation/test_configs/desktop_test_config_gpu_llm.yml \
    -m "not launch_only_if_manually_specified" \
    --pregen_irs=models/irs_mapping.csv \
    --tf_models_version=1.15.2 \
    --modules pipelines/production/tf/light \
    -k "TF_Ssd_Inception_v2_coco_api_2_True" \
    --dynamism_type=None \
    --log-cli-level INFO

#### Problematic graph
<img width="1716" height="1182" alt="image" src="https://github.com/user-attachments/assets/03f06b4e-9348-477c-ad8c-088f631631c4" />

#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [v] Did you include test case for this fix, if necessary?
 - [v] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *CVS-175476*

