### PR TITLE
[DRAFT][ConstantFoldng] Check node that it could be evaluated

### DIFF
--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -702,7 +702,7 @@ bool ov::Node::evaluate_symbol(TensorSymbolVector& output_symbols) const {
 bool ov::Node::can_constant_fold(const OutputVector& input_values) const {
     OV_ITT_SCOPED_TASK(ov::itt::domains::ov_core, "Node::can_constant_fold");
 
-    if (is_const_fold_disabled()) {
+    if (is_const_fold_disabled() || !has_evaluate()) {
         return false;
     }
 

--- a/src/core/tests/pass/serialization/custom_ops.cpp
+++ b/src/core/tests/pass/serialization/custom_ops.cpp
@@ -135,6 +135,8 @@ public:
             output.copy_to(outputs[0]);
             return true;
         });
+        
+        ON_CALL(*this, has_evaluate).WillByDefault(::testing::Return(true));
     };
 
     void validate_and_infer_types() override {
@@ -150,6 +152,8 @@ public:
                 evaluate,
                 (ov::TensorVector & output_values, const ov::TensorVector& input_values),
                 (const, override));
+    
+    MOCK_METHOD(bool, has_evaluate, (), (const, override));
 };
 
 TEST(PostponedOpSerializationTest, CorrectRtInfo) {

--- a/src/core/tests/pass/serialization/custom_ops.cpp
+++ b/src/core/tests/pass/serialization/custom_ops.cpp
@@ -135,7 +135,7 @@ public:
             output.copy_to(outputs[0]);
             return true;
         });
-        
+
         ON_CALL(*this, has_evaluate).WillByDefault(::testing::Return(true));
     };
 
@@ -152,7 +152,7 @@ public:
                 evaluate,
                 (ov::TensorVector & output_values, const ov::TensorVector& input_values),
                 (const, override));
-    
+
     MOCK_METHOD(bool, has_evaluate, (), (const, override));
 };
 


### PR DESCRIPTION
### Details:
 - Updated the `can_constant_fold` method in `node.cpp` to check both if constant folding is disabled and if the node supports evaluation before allowing constant folding.

### Tickets:
 - *CVS-176571*


