### PR TITLE
[NPU] Extend match pattern for `position_ids`

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/embedding_model_utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/embedding_model_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 


### PR DESCRIPTION
### Details:
The pattern for `position_ids` in text-embedding model looks like below before:
 ~~~
Unsqueeze -> Unsqueeze -> Convert-> MatMul-> ...
~~~

But there is the pattern in some models.
~~~
Unsqueeze -> Unsqueeze -> MatMul-> ...
~~~

Here there is no `Convert` Op in pattern.
So extend the match pattern to cover this scenario.

### Tickets:
 - [EISW-202829](https://jira.devtools.intel.com/browse/EISW-202829)
