### PR TITLE
[ONNX FE] Add ONNX tests for RELU-6,13,14 with different input precision

### DIFF
--- a/src/frontends/onnx/frontend/src/op/relu.cpp
+++ b/src/frontends/onnx/frontend/src/op/relu.cpp
@@ -16,6 +16,10 @@ ov::OutputVector relu(const ov::frontend::onnx::Node& node) {
     return {std::make_shared<ov::op::v0::Relu>(ov_inputs.at(0))};
 }
 
+// Opset version differences (same conversion applies to all):
+//   opset 6:  removed 'consumed_inputs' attribute; added shape inference
+//   opset 13: extended type T to include bfloat16
+//   opset 14: extended type T to include int8, int16, int32, int64
 ONNX_OP("Relu", OPSET_SINCE(1), ai_onnx::opset_1::relu);
 }  // namespace opset_1
 }  // namespace ai_onnx

--- a/src/frontends/onnx/tests/models/relu_opset13.prototxt
+++ b/src/frontends/onnx/tests/models/relu_opset13.prototxt
@@ -1,0 +1,39 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "Relu"
+  }
+  name: "test_relu_opset13"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/src/frontends/onnx/tests/models/relu_opset14_int16.prototxt
+++ b/src/frontends/onnx/tests/models/relu_opset14_int16.prototxt
@@ -1,0 +1,39 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "Relu"
+  }
+  name: "test_relu_opset14_int16"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 5
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 5
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 14
+}

--- a/src/frontends/onnx/tests/models/relu_opset14_int32.prototxt
+++ b/src/frontends/onnx/tests/models/relu_opset14_int32.prototxt
@@ -1,0 +1,39 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "Relu"
+  }
+  name: "test_relu_opset14_int32"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 14
+}

--- a/src/frontends/onnx/tests/models/relu_opset14_int64.prototxt
+++ b/src/frontends/onnx/tests/models/relu_opset14_int64.prototxt
@@ -1,0 +1,39 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "Relu"
+  }
+  name: "test_relu_opset14_int64"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 14
+}

--- a/src/frontends/onnx/tests/models/relu_opset14_int8.prototxt
+++ b/src/frontends/onnx/tests/models/relu_opset14_int8.prototxt
@@ -1,0 +1,39 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "Relu"
+  }
+  name: "test_relu_opset14_int8"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 14
+}

--- a/src/frontends/onnx/tests/models/relu_opset6.prototxt
+++ b/src/frontends/onnx/tests/models/relu_opset6.prototxt
@@ -1,0 +1,39 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "Relu"
+  }
+  name: "test_relu_opset6"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 6
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -484,6 +484,33 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_relu_opset14_int8) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_relu_opset14_int16) {
+    auto model = convert_model("relu_opset14_int16.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<int16_t>({-300, -1, 0, 1, 200, 500});
+    test_case.add_expected_output<int16_t>({0, 0, 0, 1, 200, 500});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_relu_opset14_int32) {
+    auto model = convert_model("relu_opset14_int32.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<int32_t>({-100000, -1, 0, 1, 200000, 500000});
+    test_case.add_expected_output<int32_t>({0, 0, 0, 1, 200000, 500000});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_relu_opset14_int64) {
+    auto model = convert_model("relu_opset14_int64.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<int64_t>({-1000000000LL, -1, 0, 1, 1000000000LL, 2000000000LL});
+    test_case.add_expected_output<int64_t>({0, 0, 0, 1, 1000000000LL, 2000000000LL});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_sum_opset1) {
     // Simple Sum test for opset1.
     auto model = convert_model("sum_opset1.onnx");

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -455,6 +455,35 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_relu) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_relu_opset6) {
+    auto model = convert_model("relu_opset6.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({-1, -2, 0, 1, 2, 3});
+    test_case.add_expected_output<float>({0, 0, 0, 1, 2, 3});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_relu_opset13) {
+    auto model = convert_model("relu_opset13.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<ov::bfloat16>(
+        {ov::bfloat16(-1), ov::bfloat16(-2), ov::bfloat16(0), ov::bfloat16(1), ov::bfloat16(2), ov::bfloat16(3)});
+    test_case.add_expected_output<ov::bfloat16>(
+        {ov::bfloat16(0), ov::bfloat16(0), ov::bfloat16(0), ov::bfloat16(1), ov::bfloat16(2), ov::bfloat16(3)});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_relu_opset14_int8) {
+    auto model = convert_model("relu_opset14_int8.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<int8_t>({-3, -1, 0, 1, 2, 5});
+    test_case.add_expected_output<int8_t>({0, 0, 0, 1, 2, 5});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_sum_opset1) {
     // Simple Sum test for opset1.
     auto model = convert_model("sum_opset1.onnx");


### PR DESCRIPTION
### Details

- Documented per-opset type constraint changes in relu.cpp.
- Added ONNX test models
- Added tests verifying correct inference across all opsets.

Note: the  conversion to ov::op::v0::Relu is identical for all opset versions since the op semantics (max(0, x)) do not change. 

Closes #20564