### PR TITLE
[CPU][oneDNN] enable matmul int4 and int8 decomp

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_fc_to_compressed.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_fc_to_compressed.cpp
@@ -131,7 +131,7 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
     SupportsPredicate supports_config,
     bool convert_u4zp_to_u8) {
     auto weights_block =
-        std::make_shared<pattern::op::CompressedWeightsBlock>(supported_weights_types, std::set<size_t>{2});
+        std::make_shared<pattern::op::CompressedWeightsBlock>(supported_weights_types, std::set<size_t>{2, 3});
     auto activation = pattern::any_input(pattern::type_matches_any(supported_activation_types));
     auto bias = pattern::any_input();
     auto fully_connected = pattern::wrap_type<ov::op::internal::FullyConnected>({activation, weights_block, bias});

--- a/src/inference/src/dev/threading/istreams_executor.cpp
+++ b/src/inference/src/dev/threading/istreams_executor.cpp
@@ -297,6 +297,7 @@ void IStreamsExecutor::Config::update_executor_config() {
     OPENVINO_DEBUG("[ threading ] proc_type_table:");
     for (size_t i = 0; i < proc_type_table.size(); i++) {
         OPENVINO_DEBUG(proc_type_table[i][ALL_PROC],
+                       " ",
                        proc_type_table[i][MAIN_CORE_PROC],
                        " ",
                        proc_type_table[i][EFFICIENT_CORE_PROC],

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -817,16 +817,23 @@ static dnnl::memory::dims getGroupDims(const VectorDims& weiDims, const VectorDi
         return {};
     }
 
+    const auto dim_size = scaleDims.size();
     dnnl::memory::dims groupDims(scaleDims.size(), 0);
     for (size_t i = 0; i < scaleDims.size(); ++i) {
         groupDims[i] = weiDims[i] / scaleDims[i];
     }
 
+    const int64_t k_group_size = groupDims[dim_size - 1];
+    const int64_t n_group_size = groupDims[dim_size - 2];
+    OPENVINO_ASSERT(n_group_size == 1, "n_group_size is always 1. But got ", n_group_size);
+
     if (groupDims.size() == 3) {
-        std::rotate(groupDims.begin(), groupDims.end() - 1, groupDims.end());
+        const int64_t b_group_size = groupDims[dim_size - 3];
+        OPENVINO_ASSERT(b_group_size == 1, "b_group_size is always 1. But got ", b_group_size);
+        return {k_group_size, 1, 1};
     }
 
-    return groupDims;
+    return {k_group_size, 1};
 }
 
 static int getMask(const dnnl::memory::dims& groupDims) {

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -725,10 +725,10 @@ void DnnlPostOpsComposer::appendZeroPointsLegacy(const MemoryArgs& memory) {
     }
 }
 
-static MemoryPtr prepackDecompressionParams(const MemoryCPtr& paramsPtr,
-                                            bool needTranspose,
-                                            ov::element::Type dstPrc,
-                                            const dnnl::engine& engine) {
+static MemoryPtr prepackDecompressionParamsLegacy(const MemoryCPtr& paramsPtr,
+                                                  bool needTranspose,
+                                                  ov::element::Type dstPrc,
+                                                  const dnnl::engine& engine) {
     auto shape = paramsPtr->getShape().getStaticDims();
     if (all_of(1U, shape.size(), shape[0])) {
         shape.push_back(1);
@@ -760,46 +760,109 @@ static MemoryPtr prepackDecompressionParams(const MemoryCPtr& paramsPtr,
     return dstMem;
 }
 
-static dnnl::memory::dims getGroupDims(const VectorDims& weiDims, const VectorDims& scaleDims) {
+static MemoryPtr prepackDecompressionParams(const MemoryCPtr& paramsPtr,
+                                            bool needTranspose,
+                                            ov::element::Type dstPrc,
+                                            const dnnl::engine& engine) {
+    auto shape = paramsPtr->getShape().getStaticDims();
+    if (all_of(1U, shape.size(), shape[0])) {
+        shape.push_back(1);
+    }
+
+    OPENVINO_ASSERT(any_of(shape.size(), 2U, 3U),
+                    "DnnlPostOpsComposer cannot prepack decompression params with invalid shape");
+
+    // weights without batch: (OC, G)
+    // weights with batch: (B, OC, G)
+    const size_t OC = shape[shape.size() - 2];
+    const size_t G = shape[shape.size() - 1];
+    size_t B = 1;
+
+    Shape dstShape = {};
+    dnnl::memory::format_tag dstFormat, srcFormat;
+    const bool is_3d_decomp = shape.size() == 3;
+    if (is_3d_decomp) {
+        B = shape[0];
+        dstShape = Shape({B, OC, G});
+        dstFormat = dnnl::memory::format_tag::acb;
+        srcFormat = needTranspose ? dnnl::memory::format_tag::abc : dnnl::memory::format_tag::acb;
+    } else {
+        dstShape = Shape({OC, G});
+        dstFormat = dnnl::memory::format_tag::oi;
+        srcFormat = needTranspose ? dnnl::memory::format_tag::io : dnnl::memory::format_tag::oi;
+    }
+
+    DnnlBlockedMemoryDesc dstMemoryDesc(dstShape,
+                                        DnnlExtensionUtils::ElementTypeToDataType(dstPrc),
+                                        dstFormat);
+    auto dstMem = std::make_shared<Memory>(engine, dstMemoryDesc);
+
+    DnnlBlockedMemoryDesc srcMemoryDesc(
+        dstShape,
+        DnnlExtensionUtils::ElementTypeToDataType(paramsPtr->getDescPtr()->getPrecision()),
+        srcFormat);
+    auto srcMem = std::make_shared<Memory>(engine, srcMemoryDesc, paramsPtr->getData());
+
+    dstMem->load(*srcMem, true, false);
+    return dstMem;
+}
+
+static dnnl::memory::dims getGroupDims(const VectorDims& weiDims, const VectorDims& scaleDims, bool weiNeedTranspose) {
+    OPENVINO_ASSERT(weiDims.size() == scaleDims.size(),
+                    "weiDims size ", weiDims.size(), " is NOT equal to scaleDims size ", scaleDims.size());
+
     if (all_of(1U, scaleDims[0], scaleDims[1])) {
         return {};
     }
 
-    int N = weiDims[weiDims.size() - 2];
-    int K = weiDims[weiDims.size() - 1];
-    dnnl::memory::dim groupN = N / scaleDims[0];
-    dnnl::memory::dim groupK = K / scaleDims[1];
+    dnnl::memory::dims groupDims(scaleDims.size(), 0);
+    for (size_t i = 0; i < scaleDims.size(); ++i) {
+        groupDims[i] = weiDims[i] / scaleDims[i];
+    }
 
-    return {groupK, groupN};
+    if (groupDims.size() == 3) {
+        std::rotate(groupDims.begin(), groupDims.end() - 1, groupDims.end());
+    }
+
+    return groupDims;
 }
 
-static int getMask(const VectorDims& weiDims, const dnnl::memory::dims& groupDims) {
-    const int maskN = 1 << (weiDims.size() - 1);
-    const int maskK = 1 << (weiDims.size() - 2);
-    int N = weiDims[weiDims.size() - 2];
-    int K = weiDims[weiDims.size() - 1];
+static int getMask(const dnnl::memory::dims& groupDims) {
     int mask = 0;
-    if (!groupDims.empty() && groupDims[1] != N) {
-        mask += maskN;
-    }
-    if (!groupDims.empty() && groupDims[0] != K) {
-        mask += maskK;
+    for (size_t i=0; i<groupDims.size(); ++i) {
+        if (groupDims[i] > 1) {
+            mask |= 1 << (groupDims.size() - 1 - i);
+        }
     }
 
+    if (groupDims.size() == 3) {
+        mask |= 0b10;
+    } else if (groupDims.size() == 2) {
+        mask |= 0b1;
+    }
     return mask;
 }
 
 void DnnlPostOpsComposer::appendDecompressionScales(const MemoryCPtr& scales_ptr,
-                                                    bool needTranspose,
+                                                    bool weiNeedTranspose,
                                                     ov::element::Type dstPrecision,
                                                     const VectorDims& weiDims) {
     if (scales_ptr == nullptr) {
         return;
     }
 
-    auto scaleMem = prepackDecompressionParams(scales_ptr, needTranspose, dstPrecision, engine);
-    auto groupDims = getGroupDims(weiDims, scaleMem->getStaticDims());
-    auto mask = getMask(weiDims, groupDims);
+    MemoryPtr scaleMem;
+    dnnl::memory::dims groupDims;
+    int mask;
+    if (scales_ptr->getShape().getElementsCount() == 1) {
+        scaleMem = std::make_shared<Memory>(engine, scales_ptr->getDesc(), scales_ptr->getData());
+        groupDims = {};
+        mask = 0;
+    } else {
+        scaleMem = prepackDecompressionParams(scales_ptr, weiNeedTranspose, dstPrecision, engine);
+        groupDims = getGroupDims(weiDims, scaleMem->getStaticDims(), weiNeedTranspose);
+        mask = getMask(groupDims);
+    }
 
     attr.set_scales(DNNL_ARG_WEIGHTS, mask, groupDims, DnnlExtensionUtils::ElementTypeToDataType(dstPrecision));
     cpuArgs[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = std::move(scaleMem);
@@ -808,20 +871,29 @@ void DnnlPostOpsComposer::appendDecompressionScales(const MemoryCPtr& scales_ptr
 }
 
 void DnnlPostOpsComposer::appendDecompressionZeroPoints(const MemoryCPtr& zero_points_ptr,
-                                                        bool needTranspose,
+                                                        bool weiNeedTranspose,
                                                         ov::element::Type dstPrecision,
                                                         const VectorDims& weiDims) {
     if (zero_points_ptr == nullptr) {
         return;
     }
 
-    auto zeroPointsMem = prepackDecompressionParams(zero_points_ptr, needTranspose, dstPrecision, engine);
-    auto groupDims = getGroupDims(weiDims, zeroPointsMem->getStaticDims());
-    auto mask = getMask(weiDims, groupDims);
+    MemoryPtr zpMem;
+    dnnl::memory::dims groupDims;
+    int mask;
+    if (zero_points_ptr->getShape().getElementsCount() == 1) {
+        zpMem = std::make_shared<Memory>(engine, zero_points_ptr->getDesc(), zero_points_ptr->getData());
+        groupDims = {};
+        mask = 0;
+    } else {
+        zpMem = prepackDecompressionParams(zero_points_ptr, weiNeedTranspose, dstPrecision, engine);
+        groupDims = getGroupDims(weiDims, zpMem->getStaticDims(), weiNeedTranspose);
+        mask = getMask(groupDims);
+    }
 
     attr.set_zero_points(DNNL_ARG_WEIGHTS, mask, groupDims, DnnlExtensionUtils::ElementTypeToDataType(dstPrecision));
-    cpuArgs[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS] = zeroPointsMem;
-    dnnlArgs[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS] = zeroPointsMem->getPrimitive();
+    cpuArgs[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS] = zpMem;
+    dnnlArgs[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS] = zpMem->getPrimitive();
 }
 
 void DnnlPostOpsComposer::appendDecompressionScalesLegacy(const MemoryCPtr& scales_ptr,
@@ -831,7 +903,7 @@ void DnnlPostOpsComposer::appendDecompressionScalesLegacy(const MemoryCPtr& scal
         return;
     }
 
-    auto scalesMem = prepackDecompressionParams(scales_ptr, needTranspose, dstPrecision, engine);
+    auto scalesMem = prepackDecompressionParamsLegacy(scales_ptr, needTranspose, dstPrecision, engine);
     attr.set_scales_dims(DNNL_ARG_WEIGHTS,
                          DnnlExtensionUtils::convertToDnnlDims(scalesMem->getStaticDims()),
                          DnnlExtensionUtils::ElementTypeToDataType(dstPrecision));
@@ -847,7 +919,7 @@ void DnnlPostOpsComposer::appendDecompressionZeroPointsLegacy(const MemoryCPtr& 
         return;
     }
 
-    auto zeroPointsMem = prepackDecompressionParams(zero_points_ptr, needTranspose, dstPrecision, engine);
+    auto zeroPointsMem = prepackDecompressionParamsLegacy(zero_points_ptr, needTranspose, dstPrecision, engine);
     attr.set_zero_points_dims(DNNL_ARG_WEIGHTS,
                               DnnlExtensionUtils::convertToDnnlDims(zeroPointsMem->getStaticDims()),
                               DnnlExtensionUtils::ElementTypeToDataType(dstPrecision));

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -779,7 +779,8 @@ static MemoryPtr prepackDecompressionParams(const MemoryCPtr& paramsPtr,
     size_t B = 1;
 
     Shape dstShape = {};
-    dnnl::memory::format_tag dstFormat, srcFormat;
+    dnnl::memory::format_tag dstFormat = dnnl::memory::format_tag::undef;
+    dnnl::memory::format_tag srcFormat = dnnl::memory::format_tag::undef;
     const bool is_3d_decomp = shape.size() == 3;
     if (is_3d_decomp) {
         B = shape[0];
@@ -792,9 +793,7 @@ static MemoryPtr prepackDecompressionParams(const MemoryCPtr& paramsPtr,
         srcFormat = needTranspose ? dnnl::memory::format_tag::io : dnnl::memory::format_tag::oi;
     }
 
-    DnnlBlockedMemoryDesc dstMemoryDesc(dstShape,
-                                        DnnlExtensionUtils::ElementTypeToDataType(dstPrc),
-                                        dstFormat);
+    DnnlBlockedMemoryDesc dstMemoryDesc(dstShape, DnnlExtensionUtils::ElementTypeToDataType(dstPrc), dstFormat);
     auto dstMem = std::make_shared<Memory>(engine, dstMemoryDesc);
 
     DnnlBlockedMemoryDesc srcMemoryDesc(
@@ -807,9 +806,12 @@ static MemoryPtr prepackDecompressionParams(const MemoryCPtr& paramsPtr,
     return dstMem;
 }
 
-static dnnl::memory::dims getGroupDims(const VectorDims& weiDims, const VectorDims& scaleDims, bool weiNeedTranspose) {
+static dnnl::memory::dims getGroupDims(const VectorDims& weiDims, const VectorDims& scaleDims) {
     OPENVINO_ASSERT(weiDims.size() == scaleDims.size(),
-                    "weiDims size ", weiDims.size(), " is NOT equal to scaleDims size ", scaleDims.size());
+                    "weiDims size ",
+                    weiDims.size(),
+                    " is NOT equal to scaleDims size ",
+                    scaleDims.size());
 
     if (all_of(1U, scaleDims[0], scaleDims[1])) {
         return {};
@@ -829,7 +831,7 @@ static dnnl::memory::dims getGroupDims(const VectorDims& weiDims, const VectorDi
 
 static int getMask(const dnnl::memory::dims& groupDims) {
     int mask = 0;
-    for (size_t i=0; i<groupDims.size(); ++i) {
+    for (size_t i = 0; i < groupDims.size(); ++i) {
         if (groupDims[i] > 1) {
             mask |= 1 << (groupDims.size() - 1 - i);
         }
@@ -853,14 +855,14 @@ void DnnlPostOpsComposer::appendDecompressionScales(const MemoryCPtr& scales_ptr
 
     MemoryPtr scaleMem;
     dnnl::memory::dims groupDims;
-    int mask;
+    int mask = 0;
     if (scales_ptr->getShape().getElementsCount() == 1) {
         scaleMem = std::make_shared<Memory>(engine, scales_ptr->getDesc(), scales_ptr->getData());
         groupDims = {};
         mask = 0;
     } else {
         scaleMem = prepackDecompressionParams(scales_ptr, weiNeedTranspose, dstPrecision, engine);
-        groupDims = getGroupDims(weiDims, scaleMem->getStaticDims(), weiNeedTranspose);
+        groupDims = getGroupDims(weiDims, scaleMem->getStaticDims());
         mask = getMask(groupDims);
     }
 
@@ -880,14 +882,14 @@ void DnnlPostOpsComposer::appendDecompressionZeroPoints(const MemoryCPtr& zero_p
 
     MemoryPtr zpMem;
     dnnl::memory::dims groupDims;
-    int mask;
+    int mask = 0;
     if (zero_points_ptr->getShape().getElementsCount() == 1) {
         zpMem = std::make_shared<Memory>(engine, zero_points_ptr->getDesc(), zero_points_ptr->getData());
         groupDims = {};
         mask = 0;
     } else {
         zpMem = prepackDecompressionParams(zero_points_ptr, weiNeedTranspose, dstPrecision, engine);
-        groupDims = getGroupDims(weiDims, zpMem->getStaticDims(), weiNeedTranspose);
+        groupDims = getGroupDims(weiDims, zpMem->getStaticDims());
         mask = getMask(groupDims);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.cpp
@@ -223,19 +223,20 @@ static DnnlPrimitiveAttrs createPrimitiveAttrs(const MatMulAttrs& attrs,
                                 attrs.dqScales);
 
     if (memory.count(ARG_WEI | ARG_ATTR_SCALES) != 0U) {
+        const bool transposeDecompressionParams = attrs.fcSemantic ? !weightsNonTransposed : attrs.transposeB;
         const auto maxRank =
             std::max({srcDesc->getShape().getRank(), weiDesc->getShape().getRank(), dstDesc->getShape().getRank()});
         const auto normWeiDims = normalizeToRank(weiDesc->getShape().getStaticDims(), maxRank);
         if (auto it = memory.find(ARG_WEI | ARG_ATTR_SCALES); it != memory.end()) {
             auto dstPrc = ov::element::f32;
-            dnnlpoc.appendDecompressionScales(it->second, !weightsNonTransposed, dstPrc, normWeiDims);
+            dnnlpoc.appendDecompressionScales(it->second, transposeDecompressionParams, dstPrc, normWeiDims);
         }
         if (auto it = memory.find(ARG_WEI | ARG_ATTR_ZERO_POINTS); it != memory.end()) {
             // TODO: clarify oneDNN requirements on ZP precision
             auto zp = it->second;
             auto zpPrc = zp->getPrecision();
             auto dstPrc = any_of(zpPrc, i32, i8, u8, i4, u4) ? zpPrc : i32;
-            dnnlpoc.appendDecompressionZeroPoints(zp, !weightsNonTransposed, dstPrc, normWeiDims);
+            dnnlpoc.appendDecompressionZeroPoints(zp, transposeDecompressionParams, dstPrc, normWeiDims);
         }
     }
 
@@ -580,7 +581,7 @@ DnnlShapeAgnosticDataPtr DnnlMatMulPrimitive::createShapeAgnosticData(const MatM
         const auto weightsDesc = DnnlExtensionUtils::makeDescriptor(primDesc.weights_desc());
         auto originalWeightsDesc = MemoryDescUtils::convertToDnnlMemoryDesc(weiDesc);
 
-        if (attrs.fcSemantic) {
+        if (attrs.fcSemantic && attrs.weightsNonTransposed) {
             originalWeightsDesc = makeTransposedWeightDescriptor(originalWeightsDesc, weightsDesc, attrs);
         }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -147,8 +147,8 @@ static const TypeMapping dnnlMatMulTypeMapping {
     // quantization configuration
     {{_u8 | _i8, _i8, _u8|_i8|_i32|_bf16|_f16|_f32|_dynamic, _u8|_i8|_i32|_bf16|_f16|_f32}, {bypass(), bypass(), bypass(),  bypass()}},
     {{_u8 | _i8, _i8, _any, _any},                            {bypass(), bypass(), just<f32>(), just<f32>()}},
-    // compresses int weights
-    {{_f32 | _bf16 | _f16, _u8 | _i8, _any, _any},            {bypass(), bypass(), use<0>(), use<0>()}},
+    // compresses int weights (@todo, append the nf4 support) 
+    {{_f32 | _bf16 | _f16, _u8 | _i8 | _u4 | _i4, _any, _any},            {bypass(), bypass(), use<0>(), use<0>()}},
     // @todo should we fallback to FPXX instead of _f32?
     {{_any, _any, _any, _any},                                {just<f32>(), just<f32>(), just<f32>(), just<f32>()}},
     // @todo explicitly cover configuration limitations for oneDNN on ARM
@@ -174,6 +174,10 @@ static const TypeMapping dnnlMatMulTypeMapping {
     }
     // i32 can be up converted to f32
     if (any_of(srcType(config), i32) && any_of(weiType(config), i32)) {
+        return true;
+    }
+    // decomp
+    if (any_of(srcType(config), f32, bf16, f16) && any_of(weiType(config), u8, i8, u4, i4)) {
         return true;
     }
     // support integer type quantization matmul

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -171,7 +171,9 @@ bool FullyConnected::isSupportedCompressedOperation([[maybe_unused]] const std::
         }
 
         // 3D weights decompression is not supported due to the oneDNN limitations.
-        if (op->get_input_partial_shape(WEIGHTS).rank().get_length() == 3) {
+        // @todo remove the such limitation when nf4 is enabled.
+        if (op->get_input_partial_shape(WEIGHTS).rank().get_length() == 3 &&
+            op->get_input_element_type(WEIGHTS) == ov::element::nf4) {
             return false;
         }
     } catch (...) {

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -603,7 +603,7 @@ void Reorder::reorderData(const IMemory& input,
                 };
                 auto setNibble = [](uint8_t* ptr, size_t idx, uint8_t val) {
                     auto& byte = ptr[idx / 2];
-                    const uint8_t nibble = static_cast<uint8_t>(val & 0x0F);
+                    const auto nibble = static_cast<uint8_t>(val & 0x0F);
                     if (idx % 2 == 0) {
                         byte = static_cast<uint8_t>((byte & 0xF0) | nibble);
                     } else {

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -11,6 +11,7 @@
 #include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
@@ -567,6 +568,89 @@ void Reorder::reorderData(const IMemory& input,
             cpu_memcpy(dstPtr, srcPtr, copySize);
         }
     } else {
+        auto tryReorderAcbAbc3d = [&]() {
+            const auto inputPrc = input.getDesc().getPrecision();
+            const auto outputPrc = output.getDesc().getPrecision();
+            if (inputPrc != outputPrc) {
+                return false;
+            }
+
+            const auto inFormat = input.getDesc().serializeFormat();
+            const auto outFormat = output.getDesc().serializeFormat();
+            const bool acbToAbc = inFormat == "acb" && outFormat == "abc";
+            const bool abcToAcb = inFormat == "abc" && outFormat == "acb";
+            if (!acbToAbc && !abcToAcb) {
+                return false;
+            }
+
+            const auto inDims = input.getShape().getStaticDims();
+            const auto outDims = output.getShape().getStaticDims();
+            if (inDims.size() != 3 || inDims != outDims) {
+                return false;
+            }
+
+            const size_t A = inDims[0];
+            const size_t B = inDims[1];
+            const size_t C = inDims[2];
+
+            const auto* src = static_cast<const uint8_t*>(input.getData());
+            auto* dst = static_cast<uint8_t*>(output.getData());
+
+            if (any_of(inputPrc, ov::element::i4, ov::element::u4)) {
+                auto getNibble = [](const uint8_t* ptr, size_t idx) {
+                    const auto byte = ptr[idx / 2];
+                    return static_cast<uint8_t>((idx % 2 == 0) ? (byte & 0x0F) : (byte >> 4));
+                };
+                auto setNibble = [](uint8_t* ptr, size_t idx, uint8_t val) {
+                    auto& byte = ptr[idx / 2];
+                    const uint8_t nibble = static_cast<uint8_t>(val & 0x0F);
+                    if (idx % 2 == 0) {
+                        byte = static_cast<uint8_t>((byte & 0xF0) | nibble);
+                    } else {
+                        byte = static_cast<uint8_t>((byte & 0x0F) | (nibble << 4));
+                    }
+                };
+
+                std::fill(dst, dst + output.getSize(), 0);
+
+                for (size_t a = 0; a < A; ++a) {
+                    for (size_t b = 0; b < B; ++b) {
+                        for (size_t c = 0; c < C; ++c) {
+                            const size_t abcIndex = (a * B + b) * C + c;
+                            const size_t acbIndex = (a * C + c) * B + b;
+                            const size_t srcIndex = acbToAbc ? acbIndex : abcIndex;
+                            const size_t dstIndex = acbToAbc ? abcIndex : acbIndex;
+                            setNibble(dst, dstIndex, getNibble(src, srcIndex));
+                        }
+                    }
+                }
+                return true;
+            }
+
+            const size_t elemSize = inputPrc.size();
+            if (elemSize == 0) {
+                return false;
+            }
+
+            for (size_t a = 0; a < A; ++a) {
+                for (size_t b = 0; b < B; ++b) {
+                    for (size_t c = 0; c < C; ++c) {
+                        const size_t abcIndex = (a * B + b) * C + c;
+                        const size_t acbIndex = (a * C + c) * B + b;
+                        const size_t srcIndex = acbToAbc ? acbIndex : abcIndex;
+                        const size_t dstIndex = acbToAbc ? abcIndex : acbIndex;
+                        std::memcpy(dst + dstIndex * elemSize, src + srcIndex * elemSize, elemSize);
+                    }
+                }
+            }
+
+            return true;
+        };
+
+        if (tryReorderAcbAbc3d()) {
+            return;
+        }
+
         dnnl::reorder reorder;
         std::vector<uint8_t> tmpBuff;
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_matmul_to_fc.cpp
@@ -98,8 +98,7 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
             }
             auto const_shape = const_node->get_shape();
             auto const_dtype = const_node->get_element_type();
-            return (any_of(const_dtype, ov::element::nf4) &&
-                    (const_shape.size() == 3 && const_shape[0] > 1));
+            return (any_of(const_dtype, ov::element::nf4) && (const_shape.size() == 3 && const_shape[0] > 1));
         };
 
         auto is_3d_decompression_path2 = [](const std::shared_ptr<Node>& root) {
@@ -121,8 +120,7 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
             }
             auto const_shape = const_node->get_shape();
             auto const_dtype = const_node->get_element_type();
-            return (any_of(const_dtype, ov::element::nf4) &&
-                    (const_shape.size() == 3 && const_shape[0] > 1));
+            return (any_of(const_dtype, ov::element::nf4) && (const_shape.size() == 3 && const_shape[0] > 1));
         };
 
         if (is_3d_decompression_path1(fc_input_b.get_node_shared_ptr()) ||

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/moe_matmuls_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/moe_matmuls_fusion.cpp
@@ -14,6 +14,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/node_output.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/broadcast.hpp"

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/moe_matmuls_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/moe_matmuls_fusion.cpp
@@ -41,6 +41,21 @@
 
 using namespace ov::pass;
 namespace {
+bool is_3d_bmm_matmul(const std::shared_ptr<ov::Node>& node) {
+    const auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(node);
+    if (!matmul) {
+        return false;
+    }
+
+    const auto rank_a = matmul->get_input_partial_shape(0).rank();
+    const auto rank_b = matmul->get_input_partial_shape(1).rank();
+    if (rank_a.is_static() && rank_b.is_static()) {
+        return rank_a.get_length() == 3 && rank_b.get_length() == 3;
+    }
+
+    return false;
+}
+
 // Note: intermediate nodes remain unchanged,
 // but we need to explicitly call shape inference for them to keep shapes consistency
 void validate_nodes(const pattern::PatternValueMap& map, const std::initializer_list<std::shared_ptr<ov::Node>> nodes) {
@@ -147,6 +162,10 @@ ov::intel_cpu::MoE2GeMMFusion::MoE2GeMMFusion() {
         const auto gate_up_add_node = pattern_map.at(gate_up_add).get_node_shared_ptr();
         const auto gate_up_bias_node = pattern_map.at(gate_up_bias).get_node_shared_ptr();
 
+        if (is_3d_bmm_matmul(gate_up_mm_node)) {
+            return false;
+        }
+
         // BatchGatherMatmul A shape: [n_activated_experts, batch_size * seq_length, hidden_size]
         // Number of activated experts is always 1 for the first BatchGatherMatmul
         const auto unsqueeze = introduce_n_experts_dim(experts_subgraph_input);
@@ -160,6 +179,10 @@ ov::intel_cpu::MoE2GeMMFusion::MoE2GeMMFusion() {
 
         const auto down_proj_mm_node = pattern_map.at(down_proj_matmul).get_node_shared_ptr();
         const auto down_proj_bias_node = pattern_map.at(down_proj_bias).get_node_shared_ptr();
+
+        if (is_3d_bmm_matmul(down_proj_mm_node)) {
+            return false;
+        }
 
         const auto down_gathered_mm = std::make_shared<BatchGatherMatmul>(pattern_map.at(multiply2),
                                                                           down_proj_mm_node->input_value(1),
@@ -288,6 +311,10 @@ ov::intel_cpu::MoE3GeMMFusion::MoE3GeMMFusion() {
         const auto gate_mm_node = pattern_map.at(gate_matmul).get_node_shared_ptr();
         const auto up_mm_node = pattern_map.at(up_matmul).get_node_shared_ptr();
         const auto down_mm_node = pattern_map.at(down_matmul).get_node_shared_ptr();
+
+        if (is_3d_bmm_matmul(gate_mm_node) || is_3d_bmm_matmul(up_mm_node) || is_3d_bmm_matmul(down_mm_node)) {
+            return false;
+        }
 
         // BatchGatherMatmul A shape: [n_activated_experts, batch_size * seq_length, hidden_size]
         // Number of activated experts is always 1 for the first BatchGatherMatmul

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/moe_matmuls_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/moe_matmuls_fusion.cpp
@@ -14,7 +14,6 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/node_output.hpp"
 #include "openvino/core/rt_info.hpp"
-#include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/broadcast.hpp"
@@ -42,21 +41,6 @@
 
 using namespace ov::pass;
 namespace {
-bool is_3d_bmm_matmul(const std::shared_ptr<ov::Node>& node) {
-    const auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(node);
-    if (!matmul) {
-        return false;
-    }
-
-    const auto rank_a = matmul->get_input_partial_shape(0).rank();
-    const auto rank_b = matmul->get_input_partial_shape(1).rank();
-    if (rank_a.is_static() && rank_b.is_static()) {
-        return rank_a.get_length() == 3 && rank_b.get_length() == 3;
-    }
-
-    return false;
-}
-
 // Note: intermediate nodes remain unchanged,
 // but we need to explicitly call shape inference for them to keep shapes consistency
 void validate_nodes(const pattern::PatternValueMap& map, const std::initializer_list<std::shared_ptr<ov::Node>> nodes) {
@@ -163,10 +147,6 @@ ov::intel_cpu::MoE2GeMMFusion::MoE2GeMMFusion() {
         const auto gate_up_add_node = pattern_map.at(gate_up_add).get_node_shared_ptr();
         const auto gate_up_bias_node = pattern_map.at(gate_up_bias).get_node_shared_ptr();
 
-        if (is_3d_bmm_matmul(gate_up_mm_node)) {
-            return false;
-        }
-
         // BatchGatherMatmul A shape: [n_activated_experts, batch_size * seq_length, hidden_size]
         // Number of activated experts is always 1 for the first BatchGatherMatmul
         const auto unsqueeze = introduce_n_experts_dim(experts_subgraph_input);
@@ -180,10 +160,6 @@ ov::intel_cpu::MoE2GeMMFusion::MoE2GeMMFusion() {
 
         const auto down_proj_mm_node = pattern_map.at(down_proj_matmul).get_node_shared_ptr();
         const auto down_proj_bias_node = pattern_map.at(down_proj_bias).get_node_shared_ptr();
-
-        if (is_3d_bmm_matmul(down_proj_mm_node)) {
-            return false;
-        }
 
         const auto down_gathered_mm = std::make_shared<BatchGatherMatmul>(pattern_map.at(multiply2),
                                                                           down_proj_mm_node->input_value(1),
@@ -312,10 +288,6 @@ ov::intel_cpu::MoE3GeMMFusion::MoE3GeMMFusion() {
         const auto gate_mm_node = pattern_map.at(gate_matmul).get_node_shared_ptr();
         const auto up_mm_node = pattern_map.at(up_matmul).get_node_shared_ptr();
         const auto down_mm_node = pattern_map.at(down_matmul).get_node_shared_ptr();
-
-        if (is_3d_bmm_matmul(gate_mm_node) || is_3d_bmm_matmul(up_mm_node) || is_3d_bmm_matmul(down_mm_node)) {
-            return false;
-        }
 
         // BatchGatherMatmul A shape: [n_activated_experts, batch_size * seq_length, hidden_size]
         // Number of activated experts is always 1 for the first BatchGatherMatmul

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_weights_decompression.cpp
@@ -32,6 +32,10 @@ const std::vector<ov::test::ElementType> weights_precisions = {ov::element::u8,
                                                                ov::element::i4,
                                                                ov::element::nf4};
 
+const std::vector<ov::test::ElementType> weights_3d_precisions = {ov::element::u8,
+                                                                  ov::element::u4,
+                                                                  ov::element::i4};
+
 const std::vector<ov::test::ElementType> weights_precisions_fp8 = {ov::element::f8e4m3, ov::element::f8e5m2};
 
 const std::vector<MatMulDecompressionShapeParams> input_shapes_basic = {
@@ -429,19 +433,45 @@ const std::vector<MatMulDecompressionShapeParams> input_shapes_with_3d_weight = 
     {{{}, {{3, 10, 32}}}, {3, 32, 128}},
     {{{}, {{2, 16}}}, {5, 16, 64}},
 };
+
 INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_3D_Weights,
                          MatmulWeightsDecompression,
                          ::testing::Combine(::testing::ValuesIn(input_shapes_with_3d_weight),
-                                            ::testing::ValuesIn(weights_precisions),
+                                            ::testing::ValuesIn(weights_3d_precisions),
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::dynamic),
-                                            ::testing::Values(false),
+                                            ::testing::ValuesIn(transpose_weights),
                                             ::testing::Values(DecompressionType::full),
                                             ::testing::Values(DecompressionType::empty),
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
                                             ::testing::Values(emptyFusingSpec),
-                                            ::testing::Values(false)),
+                                            ::testing::Values(true)),
+                         MatmulWeightsDecompression::getTestCaseName);
+
+// GPT-OSS tiny bmm i4-like architecture:
+// data: [B, S, K] = [32, 16, 2880]
+// matmul logical weights: [B, K, N] = [32, 2880, 5760]
+// packed i4 weights in model: [B, N, K/group_size, group_size] = [32, 5760, 90, 32], group_size = 32
+const std::vector<ov::test::ElementType> weights_3d_precisions_gptoss = {ov::element::u4,
+                                                                         ov::element::i4};
+const std::vector<MatMulDecompressionShapeParams> input_shapes_with_3d_weight_gptoss_i4 = {
+    {{{}, {{4, 4, 8}}}, {4, 8, 128}, 32ul},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_3D_Weights_GPTOSS_i4,
+                         MatmulWeightsDecompression,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_with_3d_weight_gptoss_i4),
+                                            ::testing::ValuesIn(weights_3d_precisions_gptoss),
+                                            ::testing::ValuesIn(decompression_precisions),
+                                            ::testing::Values(ov::element::dynamic),
+                                            ::testing::Values(true),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::empty),
+                                            ::testing::Values(false),
+                                            ::testing::ValuesIn(filter_additional_config_basic()),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::Values(true)),
                          MatmulWeightsDecompression::getTestCaseName);
 }  // namespace
 }  // namespace test


### PR DESCRIPTION
### Details:
 - *onednn branch: https://github.com/openvinotoolkit/oneDNN/tree/az/dnn3.10_with_decomp_matmul_feat*
 - *support matmul i8/u8 decomp*
 - *support matmul i4/u4 decomp*
 - *Such PR is dependent on https://github.com/openvinotoolkit/openvino/pull/32935.*

### Tickets:
 - *175891*
