### PR TITLE
[Snippets] Enable and apply 'cppcoreguidelines-avoid-do-while' clang-tidy remarks

### DIFF
--- a/src/common/snippets/.clang-tidy
+++ b/src/common/snippets/.clang-tidy
@@ -53,7 +53,6 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-const-or-ref-data-members,
-  -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-explicit-virtual-functions,
   -cppcoreguidelines-macro-usage,

--- a/src/common/snippets/src/lowered/pass/mark_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/mark_loops.cpp
@@ -58,7 +58,7 @@ bool MarkLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
         auto loop_end_pos = loop_begin_pos;
 
         bool collapse = true;
-        do {
+        while (collapse) {
             const auto& prev_expr = *loop_end_pos;
             loop_end_pos++;
             // If iterator is the last, we should finish Loop
@@ -89,7 +89,7 @@ bool MarkLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                 }
             }
             collapse = is_connected && !is_conflicted;
-        } while (collapse);
+        }
 
         loop_manager->mark_loop(loop_begin_pos, loop_end_pos, loop_depth, m_vector_size);
         expr_it = std::prev(loop_end_pos);


### PR DESCRIPTION
### Details:
Enable checking and apply 'cppcoreguidelines-avoid-do-while' clang-tidy remarks
Note: do-while loops used in macros are ignored

### Tickets:
 - N/A
