### PR TITLE
[PyTorch FE] Support aten::_to_copy operation

### DIFF
--- a/src/frontends/pytorch/src/op/to.cpp
+++ b/src/frontends/pytorch/src/op/to.cpp
@@ -46,6 +46,14 @@ OutputVector translate_to(const NodeContext& context) {
             // Cast only to device without changing dtype. Return input node unchanged.
             return {context.get_input(0)};
         }
+    } else if (context.get_input_size() == 7) {
+        // aten::_to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None,
+        //                bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor
+        dtype_idx = 1;
+        if (context.input_is_none(dtype_idx)) {
+            // No dtype change requested. Return input node unchanged.
+            return {context.get_input(0)};
+        }
     } else if (context.get_input_size() == 8) {
         // aten::to(Tensor(a) self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool?
         // pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None)

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -391,6 +391,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::_pad_packed_sequence", op::translate_pad_packed_sequence},
         {"aten::_set_item", op::translate_set_item},
         {"aten::_shape_as_tensor", op::translate_shape_as_tensor},
+        {"aten::_to_copy", op::translate_to},
         {"aten::_unique2", op::translate_unique2},
         {"aten::_upsample_bicubic2d_aa", op::translate_upsample_bicubic2d_aa},
         {"aten::_upsample_bilinear2d_aa", op::translate_upsample_bilinear2d_aa},

--- a/tests/layer_tests/pytorch_tests/test_to.py
+++ b/tests/layer_tests/pytorch_tests/test_to.py
@@ -228,3 +228,72 @@ class TestAtenToFromComplexTensor(PytorchLayerTest):
     def test_aten_to_from_complex(self, dtype, ie_device, precision, ir_version):
         self._test(*self.create_model(dtype), ie_device, precision,
                    ir_version)
+
+
+class TestAtenToCopy(PytorchLayerTest):
+    def _prepare_input(self):
+        return (np.array([0.0, 1.5, 2.0, 3.0, 4.0], dtype=np.float32),)
+
+    def create_model(self, dtype):
+        import torch
+
+        class aten_to_copy(torch.nn.Module):
+            def __init__(self, dtype):
+                super(aten_to_copy, self).__init__()
+                self.dtype = dtype
+
+            def forward(self, x):
+                return torch.ops.aten._to_copy(x, dtype=self.dtype)
+
+        return aten_to_copy(dtype), "aten::_to_copy"
+
+    @pytest.mark.parametrize("output_type", [
+        torch.uint8, torch.int8, torch.int16, torch.int32,
+        torch.int64, torch.float16, torch.float32, torch.float64,
+    ])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_aten_to_copy(self, output_type, ie_device, precision, ir_version):
+        self.input_type = np.float32
+        self._test(*self.create_model(output_type),
+                   ie_device, precision, ir_version, trace_model=True)
+
+
+class TestAtenToCopyNoDtype(PytorchLayerTest):
+    def _prepare_input(self):
+        return (np.array([0.0, 1.5, 2.0], dtype=np.float32),)
+
+    def create_model(self):
+        import torch
+
+        class aten_to_copy_no_dtype(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten._to_copy(x)
+
+        return aten_to_copy_no_dtype(), "aten::_to_copy"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_aten_to_copy_no_dtype(self, ie_device, precision, ir_version):
+        self._test(*self.create_model(),
+                   ie_device, precision, ir_version, trace_model=True)
+
+
+class TestAtenToCopyPrimDtype(PytorchLayerTest):
+    def _prepare_input(self):
+        return (np.array([0.0, 1.5, -2.0], dtype=np.float32),
+                np.array([0.0], dtype=np.float16))
+
+    def create_model(self):
+        import torch
+
+        class aten_to_copy_prim_dtype(torch.nn.Module):
+            def forward(self, x, d):
+                return torch.ops.aten._to_copy(x, dtype=d.dtype)
+
+        return aten_to_copy_prim_dtype(), "aten::_to_copy"
+
+    @pytest.mark.nightly
+    def test_aten_to_copy_prim_dtype(self, ie_device, precision, ir_version):
+        self._test(*self.create_model(),
+                   ie_device, precision, ir_version)


### PR DESCRIPTION
### [PyTorch FE] Support `aten::_to_copy` operation

This PR teaches the PyTorch Frontend (TorchScript path) how to convert graphs that contain `aten::_to_copy`. Recent PyTorch versions increasingly lower `Tensor.to(...)` into `_to_copy` when a real copy and/or dtype conversion is needed, and without this support the conversion fails with an “unsupported op” error.

Registered ops:
- `aten::_to_copy` (TorchScript) → `op::translate_to`

Closes #29687

### Details

#### PyTorch reference

PyTorch schema (kwarg-only args):

```text
_to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None,
         bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor
```

`aten::_to_copy` is the internal “do the work” op used by `at::to()` when something must change (copy and/or dtype). See: [Deep dive into `at::to()`, `at::copy_` and memory format](https://dev-discuss.pytorch.org/t/deep-dive-into-at-to-at-copy-and-memory-format/826).

#### What was broken

We already had `translate_to` handling several `aten::to*` variants, but:
- `_to_copy` wasn’t registered in the TorchScript op table, so the frontend rejected it as unsupported.
- `_to_copy` shows up as a **7-input** schema in TorchScript graphs, and `translate_to` didn’t have a branch for that arity.

#### Why we reuse `translate_to` (instead of adding a new file)

It’s tempting to add a standalone `translate_to_copy`, but that tends to start “simple” and then slowly re-implements the same tricky logic we already have in `translate_to`. Reusing the existing translator keeps behavior consistent and avoids duplication.

In particular, `translate_to` already correctly handles:
- dynamic dtype through `prim::dtype` (`ConvertLike`)
- constant dtype casts (`Convert`)
- complex type bookkeeping (`ComplexTypeMark`)
- the existing frontend policy for `to`-family ops (ignore non-functional kwargs like `non_blocking` / `memory_format` in OpenVINO IR)

So the smallest and safest fix is: **incorporate `translate_to` about the 7-input `_to_copy` schema and register `_to_copy` to that translator**.

#### Semantics (what we model)

OpenVINO IR is functional and doesn’t model storage aliasing, so `_to_copy` is represented as:
- **Identity** when `dtype=None` (no dtype change requested)
- **Convert / ConvertLike** when a dtype conversion is requested

Other kwargs (layout/device/pin_memory/non_blocking/memory_format) are handled the same way we already handle them for `aten::to`.

#### Implementation

- `src/frontends/pytorch/src/op/to.cpp`
  - Add a new `input_size == 7` branch for `_to_copy`
  - Treat `dtype=None` as an early identity return

- `src/frontends/pytorch/src/op_table.cpp`
  - Register `aten::_to_copy` → `op::translate_to` in the TorchScript op map

#### Tests

Adds deterministic TorchScript layer tests that directly emit `_to_copy` using `torch.ops.aten._to_copy(...)`:

- `TestAtenToCopy`: covers common target dtypes (u8/i*/f16/f32/f64)
- `TestAtenToCopyNoDtype`: verifies the dtype=None case
- `TestAtenToCopyPrimDtype`: uses `dtype=ref.dtype` with `trace_model=False` to exercise the `prim::dtype` path

Tests are added to:
- `tests/layer_tests/pytorch_tests/test_to.py`



Requesting ### [PyTorch FE] Support `aten::_to_copy` operation

This PR teaches the PyTorch Frontend (TorchScript path) how to convert graphs that contain `aten::_to_copy`. Recent PyTorch versions increasingly lower `Tensor.to(...)` into `_to_copy` when a real copy and/or dtype conversion is needed, and without this support the conversion fails with an “unsupported op” error.

Registered ops:
- `aten::_to_copy` (TorchScript) → `op::translate_to`

Closes #29687

### Details

#### PyTorch reference

PyTorch schema (kwarg-only args):

```text
_to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None,
         bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor
```

`aten::_to_copy` is the internal “do the work” op used by `at::to()` when something must change (copy and/or dtype). See: [Deep dive into `at::to()`, `at::copy_` and memory format](https://dev-discuss.pytorch.org/t/deep-dive-into-at-to-at-copy-and-memory-format/826).

#### What was broken

We already had `translate_to` handling several `aten::to*` variants, but:
- `_to_copy` wasn’t registered in the TorchScript op table, so the frontend rejected it as unsupported.
- `_to_copy` shows up as a **7-input** schema in TorchScript graphs, and `translate_to` didn’t have a branch for that arity.

#### Why we reuse `translate_to` (instead of adding a new file)

It’s tempting to add a standalone `translate_to_copy`, but that tends to start “simple” and then slowly re-implements the same tricky logic we already have in `translate_to`. Reusing the existing translator keeps behavior consistent and avoids duplication.

In particular, `translate_to` already correctly handles:
- dynamic dtype through `prim::dtype` (`ConvertLike`)
- constant dtype casts (`Convert`)
- complex type bookkeeping (`ComplexTypeMark`)
- the existing frontend policy for `to`-family ops (ignore non-functional kwargs like `non_blocking` / `memory_format` in OpenVINO IR)

So the smallest and safest fix is: **teach `translate_to` about the 7-input `_to_copy` schema and register `_to_copy` to that translator**.

#### Semantics (what we model)

OpenVINO IR is functional and doesn’t model storage aliasing, so `_to_copy` is represented as:
- **Identity** when `dtype=None` (no dtype change requested)
- **Convert / ConvertLike** when a dtype conversion is requested

Other kwargs (layout/device/pin_memory/non_blocking/memory_format) are handled the same way we already handle them for `aten::to`.

#### Implementation

- `src/frontends/pytorch/src/op/to.cpp`
  - Add a new `input_size == 7` branch for `_to_copy`
  - Treat `dtype=None` as an early identity return

- `src/frontends/pytorch/src/op_table.cpp`
  - Register `aten::_to_copy` → `op::translate_to` in the TorchScript op map

#### Tests

Adds deterministic TorchScript layer tests that directly emit `_to_copy` using `torch.ops.aten._to_copy(...)`:

- `TestAtenToCopy`: covers common target dtypes (u8/i*/f16/f32/f64)
- `TestAtenToCopyNoDtype`: verifies the dtype=None case
- `TestAtenToCopyPrimDtype`: uses `dtype=ref.dtype` with `trace_model=False` to exercise the `prim::dtype` path

Tests are added to:
- `tests/layer_tests/pytorch_tests/test_to.py`

### References
- Issue: #29687
- Example PR: openvinotoolkit/openvino#18998