### PR TITLE
[PT FE] Support aten::binary_cross_entropy_with_logits

### DIFF
--- a/src/frontends/pytorch/src/op/binary_cross_entropy_with_logits.cpp
+++ b/src/frontends/pytorch/src/op/binary_cross_entropy_with_logits.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2025 Intel Corporation
+// Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/src/frontends/pytorch/src/op/binary_cross_entropy_with_logits.cpp
+++ b/src/frontends/pytorch/src/op/binary_cross_entropy_with_logits.cpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert_like.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reduce_mean.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/softplus.hpp"
+#include "openvino/op/subtract.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+// Negate a tensor using Multiply by -1 (same pattern as translate_neg).
+// Avoids v0::Negative which can fail in ConvertNegative pass when element type is dynamic.
+static Output<Node> negate(const NodeContext& context, const Output<Node>& x) {
+    auto const_neg_1 = context.mark_node(v0::Constant::create(element::i32, Shape{}, {-1}));
+    auto cast = context.mark_node(std::make_shared<v1::ConvertLike>(const_neg_1, x));
+    return context.mark_node(std::make_shared<v1::Multiply>(x, cast));
+}
+
+OutputVector translate_binary_cross_entropy_with_logits(const NodeContext& context) {
+    // aten::binary_cross_entropy_with_logits(Tensor self, Tensor target,
+    //     Tensor? weight=None, Tensor? pos_weight=None, int reduction=1) -> Tensor
+    num_inputs_check(context, 2, 5);
+
+    auto input = get_input_with_floating_type(context, 0);
+    auto target = context.get_input(1);
+    target = context.mark_node(std::make_shared<v1::ConvertLike>(target, input));
+
+    // Numerically stable log_sigmoid(x) = -softplus(-x)
+    auto neg_input = negate(context, input);
+    auto softplus_neg = context.mark_node(std::make_shared<v4::SoftPlus>(neg_input));
+    Output<Node> log_sigmoid_input = negate(context, softplus_neg);
+
+    // Optional pos_weight (index 3): log_weight = (pos_weight - 1) * target + 1
+    if (context.get_input_size() > 3 && !context.input_is_none(3)) {
+        auto pos_weight = context.get_input(3);
+        pos_weight = context.mark_node(std::make_shared<v1::ConvertLike>(pos_weight, input));
+
+        auto one = context.mark_node(v0::Constant::create(element::f32, Shape{}, {1.0f}));
+        one = context.mark_node(std::make_shared<v1::ConvertLike>(one, input));
+
+        auto pw_minus_one = context.mark_node(std::make_shared<v1::Subtract>(pos_weight, one));
+        auto pw_times_target = context.mark_node(std::make_shared<v1::Multiply>(pw_minus_one, target));
+        auto log_weight = context.mark_node(std::make_shared<v1::Add>(pw_times_target, one));
+
+        log_sigmoid_input = context.mark_node(std::make_shared<v1::Multiply>(log_sigmoid_input, log_weight));
+    }
+
+    // loss = (1 - target) * input - log_sigmoid_input
+    auto one = context.mark_node(v0::Constant::create(element::f32, Shape{}, {1.0f}));
+    one = context.mark_node(std::make_shared<v1::ConvertLike>(one, input));
+    auto one_minus_target = context.mark_node(std::make_shared<v1::Subtract>(one, target));
+    auto term1 = context.mark_node(std::make_shared<v1::Multiply>(one_minus_target, input));
+    Output<Node> loss = context.mark_node(std::make_shared<v1::Subtract>(term1, log_sigmoid_input));
+
+    // Optional weight (index 2): loss *= weight
+    if (context.get_input_size() > 2 && !context.input_is_none(2)) {
+        auto weight = context.get_input(2);
+        weight = context.mark_node(std::make_shared<v1::ConvertLike>(weight, input));
+        loss = context.mark_node(std::make_shared<v1::Multiply>(loss, weight));
+    }
+
+    // reduction: 0=None, 1=Mean (default), 2=Sum
+    int64_t reduction = 1;
+    if (context.get_input_size() > 4 && !context.input_is_none(4)) {
+        reduction = context.const_input<int64_t>(4);
+    }
+
+    if (reduction == 0) {
+        return {loss};
+    }
+
+    auto axes = get_axes_range(context, 0);
+
+    if (reduction == 1) {
+        loss = context.mark_node(std::make_shared<v1::ReduceMean>(loss, axes, false));
+        return {loss};
+    }
+
+    if (reduction == 2) {
+        loss = context.mark_node(std::make_shared<v1::ReduceSum>(loss, axes, false));
+        return {loss};
+    }
+
+    PYTORCH_OP_CONVERSION_CHECK(false,
+                                "aten::binary_cross_entropy_with_logits: unsupported reduction value: ",
+                                reduction);
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -53,6 +53,7 @@ OP_CONVERTER(translate_avg_pool3d);
 OP_CONVERTER(translate_bool);
 OP_CONVERTER(translate_batch_norm);
 OP_CONVERTER(translate_bernoulli);
+OP_CONVERTER(translate_binary_cross_entropy_with_logits);
 OP_CONVERTER(translate_bitwise_and);
 OP_CONVERTER(translate_bitwise_left_shift);
 OP_CONVERTER(translate_bitwise_not);
@@ -446,6 +447,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::baddbmm", op::translate_addmm},
         {"aten::batch_norm", op::translate_batch_norm},
         {"aten::bernoulli", op::translate_bernoulli},
+        {"aten::binary_cross_entropy_with_logits", op::translate_binary_cross_entropy_with_logits},
         {"aten::bitwise_and", op::translate_bitwise_and},
         {"aten::bitwise_left_shift", op::translate_bitwise_left_shift},
         {"aten::bitwise_not", op::translate_bitwise_not},

--- a/tests/layer_tests/pytorch_tests/test_binary_cross_entropy_with_logits.py
+++ b/tests/layer_tests/pytorch_tests/test_binary_cross_entropy_with_logits.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestBinaryCrossEntropyWithLogits(PytorchLayerTest):
+    def _prepare_input(self):
+        # Deterministic values including extremes that would produce -inf
+        # if naive Log(Sigmoid(x)) were used instead of stable -SoftPlus(-x).
+        logits = np.array([[-1000.0, 1000.0, -50.0, 50.0],
+                           [-1.0, 0.0, 1.0, 2.0]], dtype=np.float32)
+        target = np.array([[1.0, 0.0, 1.0, 0.0],
+                           [0.5, 0.5, 0.0, 1.0]], dtype=np.float32)
+        return (logits, target)
+
+    def create_model(self, reduction, with_weight, with_pos_weight):
+        import torch
+        import torch.nn.functional as F
+
+        class BCEWithLogitsModel(torch.nn.Module):
+            def __init__(self, reduction, with_weight, with_pos_weight):
+                super().__init__()
+                self.reduction = reduction
+                self.with_weight = with_weight
+                self.with_pos_weight = with_pos_weight
+
+            def forward(self, logits, target):
+                weight = torch.tensor([[2.0, 1.0, 0.5, 1.0],
+                                       [1.0, 1.5, 2.0, 0.5]]) if self.with_weight else None
+                pos_weight = torch.tensor([3.0]) if self.with_pos_weight else None
+                return F.binary_cross_entropy_with_logits(
+                    logits, target,
+                    weight=weight,
+                    pos_weight=pos_weight,
+                    reduction=self.reduction,
+                )
+
+        return BCEWithLogitsModel(reduction, with_weight, with_pos_weight), None, \
+            "aten::binary_cross_entropy_with_logits"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
+    @pytest.mark.parametrize("with_weight", [False, True])
+    @pytest.mark.parametrize("with_pos_weight", [False, True])
+    def test_binary_cross_entropy_with_logits(self, reduction, with_weight, with_pos_weight,
+                                              ie_device, precision, ir_version):
+        self._test(
+            *self.create_model(reduction, with_weight, with_pos_weight),
+            ie_device, precision, ir_version,
+            use_convert_model=True,
+            dynamic_shapes=False,
+        )

--- a/tests/layer_tests/pytorch_tests/test_binary_cross_entropy_with_logits.py
+++ b/tests/layer_tests/pytorch_tests/test_binary_cross_entropy_with_logits.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2025 Intel Corporation
+# Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
@@ -39,7 +39,7 @@ class TestBinaryCrossEntropyWithLogits(PytorchLayerTest):
                     reduction=self.reduction,
                 )
 
-        return BCEWithLogitsModel(reduction, with_weight, with_pos_weight), None, \
+        return BCEWithLogitsModel(reduction, with_weight, with_pos_weight), \
             "aten::binary_cross_entropy_with_logits"
 
     @pytest.mark.nightly


### PR DESCRIPTION
## [PT FE] Support aten::binary_cross_entropy_with_logits

Closes #29690

### What

Adds a PyTorch Frontend translator for `aten::binary_cross_entropy_with_logits` with support for optional `weight`, `pos_weight`, and all three reduction modes (`none`, `mean`, `sum`).

### Why it matters

Uses numerically stable `log_sigmoid(x) = -SoftPlus(-x)` instead of naive `Log(Sigmoid(x))`, which blows up to `-inf` for large negative logits (e.g. `x = -1000`). Negation uses the `Multiply(x, -1)` pattern (same as `translate_neg`) to avoid the `ConvertNegative` pass crashing on dynamic element types.

### Changes

| File | What |
|------|------|
| `src/frontends/pytorch/src/op/binary_cross_entropy_with_logits.cpp` | New translator |
| `src/frontends/pytorch/src/op_table.cpp` | Register TorchScript op |
| `tests/layer_tests/pytorch_tests/test_binary_cross_entropy_with_logits.py` | 24 deterministic tests (3 reductions × 2 weight × 2 pos_weight × 2 precisions) with extreme logits to catch stability regressions |

### References

- PyTorch C++ impl: [Loss.cpp#L20](https://github.com/pytorch/pytorch/blob/f7734631f4e1f3a9d734951bde16bf3073b169fc/aten/src/ATen/native/Loss.cpp#L20)
- PyTorch docs: [F.binary_cross_entropy_with_logits](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.binary_cross_entropy_with_logits.html)
- Patterns followed from existing translators: [`log.cpp`](https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/pytorch/src/op/log.cpp) (log_sigmoid decomposition), [`linear.cpp`](https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/pytorch/src/op/linear.cpp) (optional Tensor? handling), [`batch_norm.cpp`](https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/pytorch/src/op/batch_norm.cpp) (multiple optionals + ConvertLike), [`mean.cpp`](https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/pytorch/src/op/mean.cpp) (ReduceMean with all axes), [`distance.cpp`](https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/pytorch/src/op/distance.cpp) (multi-op decomposition with type alignment)
- Similar PR for reference: #18998