### PR TITLE
[CPU] Add ACL split executor path

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_split.cpp
@@ -1,0 +1,245 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "acl_split.hpp"
+
+#include <arm_compute/core/CoreTypes.h>
+#include <arm_compute/core/Error.h>
+#include <arm_compute/core/ITensor.h>
+#include <arm_compute/core/TensorInfo.h>
+#include <arm_compute/core/TensorShape.h>
+#include <arm_compute/core/Types.h>
+#include <arm_compute/runtime/IFunction.h>
+#include <arm_compute/runtime/NEON/functions/NESplit.h>
+#include <arm_compute/runtime/Tensor.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <oneapi/dnnl/dnnl.hpp>
+#include <utility>
+#include <vector>
+
+#include "acl_utils.hpp"
+#include "cpu_memory.h"
+#include "cpu_types.h"
+#include "memory_desc/cpu_memory_desc.h"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/split.hpp"
+#include "utils/debug_capabilities.h"
+
+namespace ov::intel_cpu {
+
+AclSplitExecutor::AclSplitExecutor(ExecutorContext::CPtr context) : SplitExecutor(std::move(context)) {}
+
+bool AclSplitExecutor::init(const SplitAttrs& splitAttrs,
+                            const std::vector<MemoryDescPtr>& srcDescs,
+                            const std::vector<MemoryDescPtr>& dstDescs,
+                            [[maybe_unused]] const dnnl::primitive_attr& attr) {
+    if (srcDescs.empty() || dstDescs.size() < 2) {
+        return false;
+    }
+
+    const auto& srcDesc = srcDescs[0];
+    const auto rank = srcDesc->getShape().getRank();
+    if (rank == 0 || rank > 4) {
+        DEBUG_LOG("ACL Split supports up to 4D tensors. Rank=", rank);
+        return false;
+    }
+
+    const auto aclDataType = precisionToAclDataType(srcDesc->getPrecision());
+    if (aclDataType == arm_compute::DataType::UNKNOWN) {
+        DEBUG_LOG("Unsupported precision for ACL Split: ", srcDesc->getPrecision());
+        return false;
+    }
+
+    auto srcLayout = getAclDataLayoutByMemoryDesc(srcDesc);
+    if (srcLayout == arm_compute::DataLayout::UNKNOWN) {
+        DEBUG_LOG("Unsupported layout for ACL Split");
+        return false;
+    }
+
+    bool hasNspcLayout = srcDesc->hasLayoutType(LayoutType::nspc);
+    aclAxis = axisCast(splitAttrs.axis, rank, hasNspcLayout ? NHWC_TO_NCHW : NO_LAYOUT_CONVERSION);
+    if (aclAxis == static_cast<unsigned>(-1)) {
+        DEBUG_LOG("Axis cast failed for ACL Split. axis=", splitAttrs.axis);
+        return false;
+    }
+
+    auto srcShape = shapeCast(srcDesc->getShape().getStaticDims());
+    std::vector<arm_compute::TensorShape> dstShapes;
+    dstShapes.reserve(dstDescs.size());
+    for (const auto& dstDesc : dstDescs) {
+        dstShapes.emplace_back(shapeCast(dstDesc->getShape().getStaticDims()));
+    }
+
+    if (hasNspcLayout) {
+        std::vector<arm_compute::TensorShape*> shapes;
+        shapes.reserve(dstShapes.size() + 1);
+        shapes.push_back(&srcShape);
+        for (auto& s : dstShapes) {
+            shapes.push_back(&s);
+        }
+        changeLayoutToNH_C(shapes);
+    }
+
+    arm_compute::TensorInfo srcInfo(srcShape, 1, aclDataType, srcLayout);
+    std::vector<arm_compute::TensorInfo> dstInfos;
+    dstInfos.reserve(dstDescs.size());
+    for (size_t i = 0; i < dstDescs.size(); ++i) {
+        auto dstLayout = getAclDataLayoutByMemoryDesc(dstDescs[i]);
+        if (dstLayout != srcLayout) {
+            DEBUG_LOG("ACL Split requires the same layout on input and output. src=",
+                      static_cast<int>(srcLayout),
+                      " dst=",
+                      static_cast<int>(dstLayout));
+            return false;
+        }
+        const auto dstDataType = precisionToAclDataType(dstDescs[i]->getPrecision());
+        if (dstDataType != aclDataType) {
+            DEBUG_LOG("ACL Split requires equal precisions on input and outputs");
+            return false;
+        }
+        dstInfos.emplace_back(dstShapes[i], 1, dstDataType, dstLayout);
+    }
+
+    std::vector<arm_compute::ITensorInfo*> dstInfoPtrs;
+    dstInfoPtrs.reserve(dstInfos.size());
+    for (auto& info : dstInfos) {
+        dstInfoPtrs.push_back(&info);
+    }
+
+    arm_compute::Status status = arm_compute::NESplit::validate(&srcInfo, dstInfoPtrs, aclAxis);
+    if (!status) {
+        DEBUG_LOG("NESplit validation failed: ", status.error_description());
+        return false;
+    }
+
+    srcTensor.allocator()->init(srcInfo);
+    dstTensors.resize(dstInfos.size());
+    for (size_t i = 0; i < dstInfos.size(); ++i) {
+        dstTensors[i].allocator()->init(dstInfos[i]);
+    }
+
+    configureThreadSafe([&] {
+        std::vector<arm_compute::ITensor*> outputs;
+        outputs.reserve(dstTensors.size());
+        for (auto& t : dstTensors) {
+            outputs.push_back(&t);
+        }
+
+        auto fn = std::make_unique<arm_compute::NESplit>();
+        fn->configure(&srcTensor, outputs, aclAxis);
+        acl_split = std::move(fn);
+    });
+
+    this->splitAttrs = splitAttrs;
+    return true;
+}
+
+void AclSplitExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) {
+    srcTensor.allocator()->import_memory(src[0]->getData());
+    for (size_t i = 0; i < dstTensors.size(); ++i) {
+        dstTensors[i].allocator()->import_memory(dst[i]->getData());
+    }
+
+    acl_split->run();
+
+    srcTensor.allocator()->free();
+    for (auto& t : dstTensors) {
+        t.allocator()->free();
+    }
+}
+
+bool AclSplitExecutorBuilder::isSupported(const SplitAttrs& splitAttrs,
+                                          const std::vector<MemoryDescPtr>& srcDescs,
+                                          const std::vector<MemoryDescPtr>& dstDescs) const {
+    if (srcDescs.empty() || dstDescs.size() < 2) {
+        return false;
+    }
+
+    const auto& srcDesc = srcDescs[0];
+    if (!srcDesc->getShape().isStatic()) {
+        DEBUG_LOG("ACL Split requires static input shape");
+        return false;
+    }
+
+    const auto& srcDims = srcDesc->getShape().getDims();
+    if (std::any_of(srcDims.begin(), srcDims.end(), [](size_t d) {
+            return d == Shape::UNDEFINED_DIM;
+        })) {
+        DEBUG_LOG("ACL Split requires defined dimensions");
+        return false;
+    }
+
+    const auto rank = srcDesc->getShape().getRank();
+    if (rank == 0 || rank > 4) {
+        DEBUG_LOG("ACL Split supports tensors up to 4D");
+        return false;
+    }
+
+    if (splitAttrs.axis >= rank) {
+        DEBUG_LOG("Axis is out of range for ACL Split: axis=", splitAttrs.axis, " rank=", rank);
+        return false;
+    }
+
+    if (precisionToAclDataType(srcDesc->getPrecision()) == arm_compute::DataType::UNKNOWN) {
+        DEBUG_LOG("Unsupported precision for ACL Split");
+        return false;
+    }
+
+    auto layout = getAclDataLayoutByMemoryDesc(srcDesc);
+    if (layout == arm_compute::DataLayout::UNKNOWN) {
+        DEBUG_LOG("Unsupported layout for ACL Split");
+        return false;
+    }
+
+    // All outputs must match input layout and precision and be static
+    for (const auto& dstDesc : dstDescs) {
+        if (!dstDesc->getShape().isStatic()) {
+            return false;
+        }
+        const auto& dstDims = dstDesc->getShape().getDims();
+        if (std::any_of(dstDims.begin(), dstDims.end(), [](size_t d) {
+                return d == Shape::UNDEFINED_DIM;
+            })) {
+            return false;
+        }
+        if (getAclDataLayoutByMemoryDesc(dstDesc) != layout) {
+            DEBUG_LOG("ACL Split expects identical layouts for input and outputs");
+            return false;
+        }
+        if (dstDesc->getPrecision() != srcDesc->getPrecision()) {
+            DEBUG_LOG("ACL Split expects identical precisions for input and outputs");
+            return false;
+        }
+        if (dstDesc->getShape().getRank() != rank) {
+            DEBUG_LOG("Rank mismatch between input and outputs for ACL Split");
+            return false;
+        }
+    }
+
+    bool hasNspcLayout = srcDesc->hasLayoutType(LayoutType::nspc);
+    int aclAxis = axisCast(splitAttrs.axis, rank, hasNspcLayout ? NHWC_TO_NCHW : NO_LAYOUT_CONVERSION);
+    if (aclAxis == -1) {
+        DEBUG_LOG("Axis cast failed during ACL Split support check");
+        return false;
+    }
+
+    // Check that sum of output slices matches input along axis
+    size_t inputAxisDim = srcDesc->getShape().getStaticDims()[splitAttrs.axis];
+    size_t sumAxis = 0;
+    for (const auto& dstDesc : dstDescs) {
+        sumAxis += dstDesc->getShape().getStaticDims()[splitAttrs.axis];
+    }
+    if (inputAxisDim != sumAxis) {
+        DEBUG_LOG("Output slices along axis do not match input size for ACL Split");
+        return false;
+    }
+
+    return true;
+}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_split.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_split.hpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <arm_compute/runtime/NEON/NEFunctions.h>
+
+#include <memory>
+#include <vector>
+
+#include "acl_utils.hpp"
+#include "nodes/executors/split.hpp"
+#include "utils/debug_capabilities.h"
+
+namespace ov::intel_cpu {
+
+class AclSplitExecutor : public SplitExecutor {
+public:
+    explicit AclSplitExecutor(ExecutorContext::CPtr context);
+
+    bool init(const SplitAttrs& splitAttrs,
+              const std::vector<MemoryDescPtr>& srcDescs,
+              const std::vector<MemoryDescPtr>& dstDescs,
+              const dnnl::primitive_attr& attr) override;
+
+    void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) override;
+
+    [[nodiscard]] impl_desc_type getImplType() const override {
+        return implType;
+    }
+
+private:
+    impl_desc_type implType = impl_desc_type::acl;
+    std::unique_ptr<arm_compute::IFunction> acl_split;
+    arm_compute::Tensor srcTensor;
+    std::vector<arm_compute::Tensor> dstTensors;
+    unsigned int aclAxis = 0;
+};
+
+class AclSplitExecutorBuilder : public SplitExecutorBuilder {
+public:
+    [[nodiscard]] bool isSupported(const SplitAttrs& splitAttrs,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override;
+
+    [[nodiscard]] SplitExecutorPtr makeExecutor(ExecutorContext::CPtr context) const override {
+        return std::make_shared<AclSplitExecutor>(context);
+    }
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/split.cpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "split.hpp"
+
+#include <utility>
+
+#include "executor.hpp"
+
+namespace ov::intel_cpu {
+
+SplitExecutor::SplitExecutor(ExecutorContext::CPtr context) : context(std::move(context)) {}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/split.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/split.hpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <oneapi/dnnl/dnnl.hpp>
+#include <vector>
+
+#include "cpu_types.h"
+#include "executor.hpp"
+#include "memory_desc/cpu_memory_desc.h"
+
+namespace ov::intel_cpu {
+
+struct SplitAttrs {
+    size_t axis = 0;
+};
+
+class SplitExecutor {
+public:
+    explicit SplitExecutor(ExecutorContext::CPtr context);
+    virtual ~SplitExecutor() = default;
+
+    virtual bool init(const SplitAttrs& splitAttrs,
+                      const std::vector<MemoryDescPtr>& srcDescs,
+                      const std::vector<MemoryDescPtr>& dstDescs,
+                      const dnnl::primitive_attr& attr) = 0;
+
+    virtual void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) = 0;
+
+    [[nodiscard]] virtual impl_desc_type getImplType() const = 0;
+
+protected:
+    SplitAttrs splitAttrs;
+    const ExecutorContext::CPtr context;
+};
+
+using SplitExecutorPtr = std::shared_ptr<SplitExecutor>;
+using SplitExecutorCPtr = std::shared_ptr<const SplitExecutor>;
+
+class SplitExecutorBuilder {
+public:
+    virtual ~SplitExecutorBuilder() = default;
+
+    [[nodiscard]] virtual bool isSupported(const SplitAttrs& splitAttrs,
+                                           const std::vector<MemoryDescPtr>& srcDescs,
+                                           const std::vector<MemoryDescPtr>& dstDescs) const = 0;
+
+    [[nodiscard]] virtual SplitExecutorPtr makeExecutor(ExecutorContext::CPtr context) const = 0;
+};
+
+using SplitExecutorBuilderPtr = std::shared_ptr<SplitExecutorBuilder>;
+using SplitExecutorBuilderCPtr = std::shared_ptr<const SplitExecutorBuilder>;
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/split_list.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/split_list.cpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "split_list.hpp"
+
+#include <memory>
+#include <oneapi/dnnl/dnnl.hpp>
+#include <vector>
+
+#include "executor.hpp"
+#include "memory_desc/cpu_memory_desc.h"
+#include "openvino/core/except.hpp"
+#include "split.hpp"
+#if defined(OV_CPU_WITH_ACL)
+#    include "acl/acl_split.hpp"
+#endif
+#include "utils/arch_macros.h"
+
+namespace ov::intel_cpu {
+
+const std::vector<SplitExecutorDesc>& getSplitExecutorsList() {
+    static const std::vector<SplitExecutorDesc> descs = {
+        OV_CPU_INSTANCE_ACL(ExecutorType::Acl, std::make_shared<AclSplitExecutorBuilder>())};
+    return descs;
+}
+
+SplitExecutorPtr SplitExecutorFactory::makeExecutor(const SplitAttrs& splitAttrs,
+                                                    const std::vector<MemoryDescPtr>& srcDescs,
+                                                    const std::vector<MemoryDescPtr>& dstDescs,
+                                                    const dnnl::primitive_attr& attr) {
+    auto build = [&](const SplitExecutorDesc* desc) {
+        auto executor = desc->builder->makeExecutor(context);
+        if (executor->init(splitAttrs, srcDescs, dstDescs, attr)) {
+            return executor;
+        }
+        return SplitExecutorPtr{};
+    };
+
+    if (chosenDesc) {
+        if (auto executor = build(chosenDesc)) {
+            return executor;
+        }
+    }
+
+    for (const auto& sd : supportedDescs) {
+        if (auto executor = build(&sd)) {
+            chosenDesc = &sd;
+            return executor;
+        }
+    }
+
+    OPENVINO_THROW("Supported Split executor is not found");
+}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/split_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/split_list.hpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <oneapi/dnnl/dnnl.hpp>
+#include <vector>
+
+#include "executor.hpp"
+#include "memory_desc/cpu_memory_desc.h"
+#include "split.hpp"
+#if defined(OV_CPU_WITH_ACL)
+#    include "acl/acl_split.hpp"
+#endif
+
+namespace ov::intel_cpu {
+
+struct SplitExecutorDesc {
+    ExecutorType executorType;
+    SplitExecutorBuilderCPtr builder;
+};
+
+const std::vector<SplitExecutorDesc>& getSplitExecutorsList();
+
+class SplitExecutorFactory : public ExecutorFactoryLegacy {
+public:
+    SplitExecutorFactory(const SplitAttrs& splitAttrs,
+                         const std::vector<MemoryDescPtr>& srcDescs,
+                         const std::vector<MemoryDescPtr>& dstDescs,
+                         const ExecutorContext::CPtr& context)
+        : ExecutorFactoryLegacy(context) {
+        for (const auto& desc : getSplitExecutorsList()) {
+            if (desc.builder->isSupported(splitAttrs, srcDescs, dstDescs)) {
+                supportedDescs.push_back(desc);
+            }
+        }
+    }
+
+    ~SplitExecutorFactory() override = default;
+
+    SplitExecutorPtr makeExecutor(const SplitAttrs& splitAttrs,
+                                  const std::vector<MemoryDescPtr>& srcDescs,
+                                  const std::vector<MemoryDescPtr>& dstDescs,
+                                  const dnnl::primitive_attr& attr);
+
+    [[nodiscard]] bool isEmpty() const {
+        return supportedDescs.empty();
+    }
+
+private:
+    std::vector<SplitExecutorDesc> supportedDescs;
+    const SplitExecutorDesc* chosenDesc = nullptr;
+};
+
+using SplitExecutorFactoryPtr = std::shared_ptr<SplitExecutorFactory>;
+using SplitExecutorFactoryCPtr = std::shared_ptr<const SplitExecutorFactory>;
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/split.h
+++ b/src/plugins/intel_cpu/src/nodes/split.h
@@ -17,6 +17,10 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
+#if defined(OV_CPU_WITH_ACL)
+#    include "nodes/executors/split.hpp"
+#endif
+
 namespace ov::intel_cpu::node {
 
 class Split : public Node {
@@ -76,6 +80,12 @@ private:
     size_t INPUTS_NUM = 2;
     bool constSplitLengths = true;
     std::vector<int> splitLengths;
+
+#if defined(OV_CPU_WITH_ACL)
+    ov::intel_cpu::SplitAttrs splitAttrs;
+    bool canUseAclExecutor = false;
+    ov::intel_cpu::SplitExecutorPtr aclExecPtr = nullptr;
+#endif
 };
 
 }  // namespace ov::intel_cpu::node


### PR DESCRIPTION
### Details:
- introduce Split executor interface/factory and register ACL builder entry
- add ACL NESplit backend for static <=4D tensors with matching layout/precision
- wire ACL split configs into CPU node setup/execute to use nspc/ncsp paths when available

### Tickets:
 - N/A
