### PR TITLE
[OV JS] Skip basics test

### DIFF
--- a/src/bindings/js/node/tests/unit/basic.test.js
+++ b/src/bindings/js/node/tests/unit/basic.test.js
@@ -16,8 +16,8 @@ const {
   generateImage,
 } = require("../utils.js");
 
-// Tests on non-Linux platforms are skipped until CVS-180810 is fixed.
-describe("ov basic tests.", { skip: process.platform !== "linux" }, () => {
+// Tests are skipped until CVS-180810 is fixed.
+describe("ov basic tests.", { skip: true }, () => {
   const { testModelFP32 } = testModels;
   let core = null;
   let model = null;


### PR DESCRIPTION
Basics unit tests are skipped until CVS-180810 is fixed.