### PR TITLE
Fix itt resource memory leak issue

### DIFF
--- a/cmake/developer_package/frontends/frontends.cmake
+++ b/cmake/developer_package/frontends/frontends.cmake
@@ -203,7 +203,7 @@ macro(ov_add_frontend)
 
     # Shutdown protobuf when unloading the frontend dynamic library
     if(OV_FRONTEND_PROTOBUF_REQUIRED AND BUILD_SHARED_LIBS)
-        target_link_libraries(${TARGET_NAME} PRIVATE openvino::protobuf_shutdown)
+        target_link_libraries(${TARGET_NAME} PRIVATE openvino::protobuf_shutdown openvino::shutdown)
     endif()
 
     if(NOT BUILD_SHARED_LIBS)

--- a/cmake/developer_package/plugins/plugins.cmake
+++ b/cmake/developer_package/plugins/plugins.cmake
@@ -72,7 +72,9 @@ function(ov_add_plugin)
         endif()
 
         target_compile_definitions(${OV_PLUGIN_NAME} PRIVATE IMPLEMENT_OPENVINO_RUNTIME_PLUGIN)
-        if(NOT BUILD_SHARED_LIBS)
+        if(BUILD_SHARED_LIBS)
+            target_link_libraries(${OV_PLUGIN_NAME} PRIVATE openvino::shutdown)
+        else()
             # to distinguish functions creating plugin objects
             target_compile_definitions(${OV_PLUGIN_NAME} PRIVATE
                 OV_CREATE_PLUGIN=create_plugin_engine_${OV_PLUGIN_DEVICE_NAME})

--- a/src/cmake/openvino.cmake
+++ b/src/cmake/openvino.cmake
@@ -58,6 +58,10 @@ target_link_libraries(${TARGET_NAME}
     PUBLIC $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.1>>:stdc++fs>
     $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:c++fs>)
 
+if(BUILD_SHARED_LIBS)
+    target_link_libraries(${TARGET_NAME} PRIVATE openvino::shutdown)
+endif()
+
 if (TBBBIND_2_5_FOUND)
     target_link_libraries(${TARGET_NAME} PRIVATE ${TBBBIND_2_5_IMPORTED_TARGETS})
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+add_subdirectory(shutdown)
+
 add_subdirectory(itt)
 add_subdirectory(conditional_compilation)
 add_subdirectory(util)

--- a/src/common/itt/CMakeLists.txt
+++ b/src/common/itt/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(${TARGET_NAME} STATIC ${SOURCES})
 add_library(openvino::itt ALIAS ${TARGET_NAME})
 set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME itt)
 
-target_link_libraries(${TARGET_NAME} PUBLIC openvino::util)
+target_link_libraries(${TARGET_NAME} PUBLIC openvino::util openvino::shutdown)
 
 if(NOT ENABLE_PROFILING_ITT STREQUAL "OFF")
     if(TARGET ittapi::ittnotify)

--- a/src/common/itt/include/openvino/itt.hpp
+++ b/src/common/itt/include/openvino/itt.hpp
@@ -48,6 +48,7 @@ void taskEnd(domain_t d);
 void threadName(const char* name);
 void regionBegin(domain_t d, handle_t t);
 void regionEnd(domain_t d);
+void shutdown();
 }  // namespace internal
 /**
  * @endcond

--- a/src/common/itt/src/itt.cpp
+++ b/src/common/itt/src/itt.cpp
@@ -9,6 +9,8 @@
 #include <mutex>
 #include <vector>
 
+#include "openvino/shutdown.hpp"
+
 #ifdef ENABLE_PROFILING_ITT
 #    include <ittnotify.h>
 #endif
@@ -108,6 +110,10 @@ void regionEnd(domain_t d) {
     current_region_handle = nullptr;
 }
 
+void shutdown() {
+    __itt_release_resources();
+}
+
 #else
 
 domain_t domain(const char*) {
@@ -128,8 +134,16 @@ void regionBegin(domain_t, handle_t) {}
 
 void regionEnd(domain_t) {}
 
+void shutdown() {}
+
 #endif  // ENABLE_PROFILING_ITT
 
 }  // namespace internal
 }  // namespace itt
 }  // namespace openvino
+
+static void shutdown_itt_resources() {
+    openvino::itt::internal::shutdown();
+}
+
+OV_REGISTER_SHUTDOWN_CALLBACK(shutdown_itt_resources)

--- a/src/common/shutdown/CMakeLists.txt
+++ b/src/common/shutdown/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(TARGET_NAME openvino_shutdown)
+
+add_library(${TARGET_NAME} STATIC shutdown.cpp)
+
+add_library(openvino::shutdown ALIAS ${TARGET_NAME})
+target_include_directories(${TARGET_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME shutdown)
+ov_add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})
+
+# install & export
+ov_install_static_lib(${TARGET_NAME} ${OV_CPACK_COMP_CORE})
+ov_developer_package_export_targets(TARGET openvino::shutdown
+                                    INSTALL_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include/")

--- a/src/common/shutdown/include/openvino/shutdown.hpp
+++ b/src/common/shutdown/include/openvino/shutdown.hpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+#include <functional>
+#include <vector>
+
+namespace ov {
+    // Registers a shutdown callback
+    bool register_shutdown_callback(const std::function<void()>& func);
+}
+
+#define OV_REGISTER_SHUTDOWN_CALLBACK(func) \
+    namespace { \
+        static bool ov_shutdown_register_##func = ov::register_shutdown_callback(func); \
+    }

--- a/src/common/shutdown/shutdown.cpp
+++ b/src/common/shutdown/shutdown.cpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "openvino/shutdown.hpp"
+
+#include <functional>
+#include <vector>
+
+namespace ov {
+
+class ShutdownRegistry {
+private:
+    std::vector<std::function<void()>> m_callbacks;
+    ShutdownRegistry() = default;
+public:
+
+    static ShutdownRegistry& get() {
+        static ShutdownRegistry instance;
+        return instance;
+    }
+
+    bool register_callback(const std::function<void()>& func) {
+        if (!func) {
+            return false;
+        }
+        m_callbacks.emplace_back(func);
+        return true;
+    }
+
+    ~ShutdownRegistry() {
+        for (auto& func : m_callbacks) {
+            func();
+        }
+        m_callbacks.clear();
+    }
+};
+
+bool register_shutdown_callback(const std::function<void()>& func) {
+    return ShutdownRegistry::get().register_callback(func);
+}
+
+}  // namespace ov

--- a/src/frontends/common/shutdown_protobuf/CMakeLists.txt
+++ b/src/frontends/common/shutdown_protobuf/CMakeLists.txt
@@ -14,3 +14,4 @@ target_include_directories(${TARGET_NAME} SYSTEM PRIVATE
     $<BUILD_INTERFACE:$<TARGET_PROPERTY:protobuf::libprotobuf,INTERFACE_INCLUDE_DIRECTORIES>>)
 set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 target_compile_features(${TARGET_NAME} PRIVATE $<TARGET_PROPERTY:protobuf::libprotobuf,INTERFACE_COMPILE_FEATURES>)
+target_link_libraries(${TARGET_NAME} PRIVATE openvino::shutdown)

--- a/src/frontends/common/shutdown_protobuf/shutdown_protobuf.cpp
+++ b/src/frontends/common/shutdown_protobuf/shutdown_protobuf.cpp
@@ -4,28 +4,10 @@
 
 #include <google/protobuf/stubs/common.h>
 
-#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
-#    include <windows.h>
-BOOL WINAPI DllMain(HINSTANCE hinstDLL,  // handle to DLL module
-                    DWORD fdwReason,     // reason for calling function
-                    LPVOID lpReserved)   // reserved
-{
-    // Perform actions based on the reason for calling.
-    switch (fdwReason) {
-    case DLL_PROCESS_ATTACH:
-    case DLL_THREAD_ATTACH:
-    case DLL_THREAD_DETACH:
-        break;
+#include "openvino/shutdown.hpp"
 
-    case DLL_PROCESS_DETACH:
-        google::protobuf::ShutdownProtobufLibrary();
-        break;
-    }
-    return TRUE;  // Successful DLL_PROCESS_ATTACH.
-}
-#elif defined(__linux__) || defined(__APPLE__)
-extern "C" __attribute__((destructor)) void library_unload();
-void library_unload() {
+static void shutdown_frontend_resources() {
     google::protobuf::ShutdownProtobufLibrary();
 }
-#endif
+
+OV_REGISTER_SHUTDOWN_CALLBACK(shutdown_frontend_resources)


### PR DESCRIPTION
### Details:
 - The ITT allocate memory from the below call stack.
 ```
000001d4`82618d30  00007ffd`12845ff9 vfbasics!AVrfpInitializeCriticalSectionCommon+0x13d
000001d4`82618d38  00007ffc`d277ac4c openvino!__itt_get_collection_state+0x2c [C:\Jenkins\workspace\private-ci\ie\build-windows-vs2022@2\b\repos\openvino\thirdparty\ittapi\ittapi\src\ittnotify\ittnotify_static.c @ 1665]
000001d4`82618d40  00007ffc`d1d68949 openvino!openvino::itt::internal::`dynamic initializer for 'state''+0x9 [src\common\itt\src\itt.cpp @ 22]
000001d4`82618d48  00007ffd`2f8de716 ucrtbase!initterm+0x36
000001d4`82618d50  00007ffc`d2782eea openvino!dllmain_crt_process_attach+0x9a [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\dll_dllmain.cpp @ 66]
000001d4`82618d58  00007ffc`d2783057 openvino!dllmain_dispatch+0x6f [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\dll_dllmain.cpp @ 276]
000001d4`82618d60  00007ffd`13d20ec4 verifier!AVrfpStandardDllEntryPointRoutine+0xf4
000001d4`82618d68  00007ffd`20dfb704 vrfcore!VfCoreStandardDllEntryPointRoutine+0x184
000001d4`82618d70  00007ffd`12848694 vfbasics!AVrfpStandardDllEntryPointRoutine+0xf4
000001d4`82618d78  00007ffd`322df86e ntdll!LdrpCallInitRoutineInternal+0x22
000001d4`82618d80  00007ffd`3218bcae ntdll!LdrpCallInitRoutine+0x10e
000001d4`82618d88  00007ffd`321897ac ntdll!LdrpInitializeNode+0x19c
000001d4`82618d90  00007ffd`322176ea ntdll!LdrpInitializeGraphRecurse+0x6a
000001d4`82618d98  00007ffd`32217716 ntdll!LdrpInitializeGraphRecurse+0x96
```
 - Need to call `__itt_release_resources` when unload `openvino.dll`.

 - The solutions
Here is the solution: we create a class used to store all resource deallocation methods, then create a static object. The release method will register to the static object; this object will be released when the dll unload, all release functions will be called in the destructor. In this way, we didn't need to change any code in DLLMain/unload_library. Just use a MACRO to define the function pointer, like the code below.
```
static void shutdown_frontend_resources() {
    google::protobuf::ShutdownProtobufLibrary();
}

OV_REGISTER_SHUTDOWN_CALLBACK(shutdown_frontend_resources)
```
Port https://github.com/openvinotoolkit/openvino/pull/33887 to 2026.0

### Tickets:
 - [CVS-179009](https://jira.devtools.intel.com/browse/CVS-179009)
 - [CVS-180657](https://jira.devtools.intel.com/browse/CVS-180657)
