### PR TITLE
Fix buffer overflow in FakeQuantize reference implementation

### DIFF
--- a/src/core/reference/include/openvino/reference/fake_quantize.hpp
+++ b/src/core/reference/include/openvino/reference/fake_quantize.hpp
@@ -310,7 +310,7 @@ void fake_quantize(const T* arg,
                               *(in_low + in_low_stride),
                               *(in_high + in_high_stride),
                               *(out_low + out_low_stride),
-                              *(out_high + out_low_stride),
+                              *(out_high + out_high_stride),
                               levels_minus_one);
         }
     }

--- a/src/plugins/template/tests/functional/op_reference/fake_quantize.cpp
+++ b/src/plugins/template/tests/functional/op_reference/fake_quantize.cpp
@@ -268,7 +268,21 @@ std::vector<FakeQuantizeParams> generateParamsForFakeQuantize() {
             op::v0::Constant::create(IN_ET, Shape{2, 1, 1}, {0.f, 20.f}),
             op::v0::Constant::create(IN_ET, Shape{1}, {35.f}),
             5),
-
+        FakeQuantizeParams(
+            ov::Shape{1, 2, 4, 4},
+            ov::Shape{1, 2, 4, 4},
+            IN_ET,
+            IN_ET,
+            iota_vector<T>(shape_size(Shape{1, 2, 4, 4})),
+            std::vector<T>{
+                0,     0,     0,    0,    0,    0,    0,    0,     0,     8.75,  8.75,  8.75,  8.75, 8.75, 8.75, 17.5,
+                23.75, 23.75, 27.5, 27.5, 27.5, 27.5, 27.5, 31.25, 31.25, 31.25, 31.25, 31.25, 35,   35,   35,   35,
+            },
+            op::v0::Constant::create(IN_ET, Shape{1, 2, 1, 1}, {5.f, 10.f}),
+            op::v0::Constant::create(IN_ET, Shape{1, 1}, {30.f}),
+            op::v0::Constant::create(IN_ET, Shape{2, 1, 4}, {0.f, 0.f, 0.f, 0.f, 20.f, 20.f, 20.f, 20.f}),
+            op::v0::Constant::create(IN_ET, Shape{1}, {35.f}),
+            5),
     };
     return params;
 }


### PR DESCRIPTION
out_high can be read of out bounds because of incorrect stride

CVS-181020