### PR TITLE
Set FOLDER property for NPU tools correctly

### DIFF
--- a/src/plugins/intel_npu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/functional/CMakeLists.txt
@@ -68,7 +68,7 @@ if(WIN32)
 endif()
 
 set_target_properties(
-  ${TARGET_NAME} PROPERTIES FOLDER ${CMAKE_CURRENT_SOURCE_DIR} CXX_STANDARD 17)
+  ${TARGET_NAME} PROPERTIES CXX_STANDARD 17)
 
 if(MSVC)
   # Enforce standards conformance on MSVC

--- a/src/plugins/intel_npu/tools/common/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/common/CMakeLists.txt
@@ -10,7 +10,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})
 
 add_library(${TARGET_NAME} STATIC EXCLUDE_FROM_ALL ${SOURCES})
 set_target_properties(${TARGET_NAME} PROPERTIES
-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
+                          FOLDER intel_npu_tools
                           CXX_STANDARD 17)
 
 target_include_directories(${TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")

--- a/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
@@ -31,8 +31,8 @@ ov_add_target(TYPE EXECUTABLE
                       npu_tools_utils)
 
 set_target_properties(${TARGET_NAME} PROPERTIES
-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
-                          CXX_STANDARD 17)
+                      FOLDER intel_npu_tools
+                      CXX_STANDARD 17)
 
 # TODO: fix warnings and remove this exception
 if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)

--- a/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
@@ -67,8 +67,8 @@ ov_add_target(TYPE EXECUTABLE
               LINK_LIBRARIES PRIVATE ${DEPENDENCIES})
 
 set_target_properties(${TARGET_NAME} PROPERTIES
-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
-                          CXX_STANDARD 17)
+                      FOLDER intel_npu_tools
+                      CXX_STANDARD 17)
 
 if (WIN32)
     target_link_options(${TARGET_NAME} PRIVATE "/MANIFESTINPUT:${CMAKE_SOURCE_DIR}/protopipe.exe.manifest")

--- a/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
@@ -53,8 +53,8 @@ ov_add_target(TYPE EXECUTABLE
 ov_set_threading_interface_for(${TARGET_NAME})
 
 set_target_properties(${TARGET_NAME} PROPERTIES
-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
-                          CXX_STANDARD 17)
+                      FOLDER intel_npu_tools
+                      CXX_STANDARD 17)
 
 # TODO: fix warnings and remove this exception
 if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)


### PR DESCRIPTION
As per CMake documentation (see
https://cmake.org/cmake/help/v3.31/prop_tgt/FOLDER.html), FOLDER property controls how the respective targets are viewed in IDEs that support this property (e.g. in Visual Studio, in XCode).

As there are multiple Intel NPU specific tools, they can be combined under a local folder. Unlike with the previously used CMAKE_CURRENT_SOURCE_DIR, this makes these tools actually visible in Visual Studio (tested with Visual Studio 2022). Graphically, consider:

(now)
```
- intel_npu_tools
  |- compile_tool
  |- protopipe
  |- single-image-test
```
vs
(before)
```
- C: (not found)
```
(Note: before, the tools would not appear in Solutions Explorer)

Additionally, this seems to fix the native debugging experience.

As a drive by, remove FOLDER property for ov_npu_func_tests to align the target to ov_npu_unit_tests, ov_cpu_func_tests, and other targets that do not have this property set.

### Tickets:
* [CVS-182973](https://jira.devtools.intel.com/browse/CVS-182973)