### PR TITLE
[GPU] Fix conditions for selecting gqa kernel

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1343,12 +1343,14 @@ public:
         rt_params->query_block_size = get_query_block_size(rt_params->stage, rt_params->use_micro_sdpa);
 
         if (rt_params->stage == PagedAttentionStage::GENERATE) {
+            const bool allow_gqa = can_use_gqa_kernel(params, PagedAttentionStage::GENERATE, rt_params->max_context_len);
             if (rt_params->use_micro_sdpa) {
                 size_t kv_group_size = desc->heads_num / desc->kv_heads_num;
-                rt_params->use_gqa_kernel = (kv_group_size == 8 && desc->k_head_size == 64);
-                rt_params->use_micro_sdpa = rt_params->use_gqa_kernel;
+                const bool allow_micro_gqa = allow_gqa && kv_group_size == 8 && desc->k_head_size == 64;
+                rt_params->use_gqa_kernel = allow_micro_gqa;
+                rt_params->use_micro_sdpa = allow_micro_gqa;
             } else {
-                rt_params->use_gqa_kernel = can_use_gqa_kernel(params, PagedAttentionStage::GENERATE, rt_params->max_context_len);
+                rt_params->use_gqa_kernel = allow_gqa;
             }
         } else {
             rt_params->use_gqa_kernel = false;


### PR DESCRIPTION
### Details:
 - *When enabling `sdpa_micro_gqa_single_token` https://github.com/openvinotoolkit/openvino/pull/33204, a check for `GQA` `can_use_gqa_kernel(...)` was missed, which resulted in the kernel being used in an unsupported case, which led to accuracy issues*

### Tickets:
 - *[181161](https://jira.devtools.intel.com/browse/CVS-181161)*
