### PR TITLE
[NPU] Add main.cpp for unit tests

### DIFF
--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -30,11 +30,7 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/utils/include
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/include
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/al/include
-            ${OpenVINO_SOURCE_DIR}/src/tests/test_utils/functional_test_utils/include
         OBJECT_FILES
-            ${OpenVINO_SOURCE_DIR}/src/tests/test_utils/functional_test_utils/src/summary/op_summary.cpp
-            ${OpenVINO_SOURCE_DIR}/src/tests/test_utils/functional_test_utils/src/summary/summary.cpp
-            ${OpenVINO_SOURCE_DIR}/src/tests/test_utils/functional_test_utils/src/summary/op_info.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/src/metadata.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model_utils.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/logging.cpp

--- a/src/plugins/intel_npu/tests/unit/main.cpp
+++ b/src/plugins/intel_npu/tests/unit/main.cpp
@@ -4,7 +4,6 @@
 
 #include <signal.h>
 
-#include <functional_test_utils/summary/op_summary.hpp>
 #include <sstream>
 #ifdef WIN32
 #    include <process.h>
@@ -14,8 +13,6 @@
 void sigsegv_handler(int errCode);
 
 void sigsegv_handler(int errCode) {
-    auto& s = ov::test::utils::OpSummary::getInstance();
-    s.saveReport();
     std::cerr << "Unexpected application crash with code: " << errCode << std::endl;
     std::abort();
 }


### PR DESCRIPTION
### Details:
 - it is helpful to have the environment variables printed at the beginning of the test run.

### Tickets:
 - *-*
