### PR TITLE
Clean up cmake/features.cmake

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -117,7 +117,6 @@ else()
 endif()
 
 ov_dependent_option (ENABLE_TBBBIND_2_5 "Enable TBBBind_2_5 static usage in OpenVINO runtime" ${ENABLE_TBBBIND_2_5_DEFAULT} "THREADING MATCHES TBB; NOT APPLE" OFF)
-ov_dependent_option (ENABLE_TBB_RELEASE_ONLY "Only Release TBB libraries are linked to the OpenVINO Runtime binaries" ON "THREADING MATCHES TBB;LINUX" OFF)
 
 ov_option (ENABLE_MULTI "Enables MULTI Device Plugin" ON)
 ov_option (ENABLE_AUTO "Enables AUTO Device Plugin" ON)
@@ -144,7 +143,6 @@ ov_option(ENABLE_OV_PADDLE_FRONTEND "Enable PaddlePaddle FrontEnd" ON)
 ov_option(ENABLE_OV_IR_FRONTEND "Enable IR FrontEnd" ON)
 ov_option(ENABLE_OV_PYTORCH_FRONTEND "Enable PyTorch FrontEnd" ON)
 ov_option(ENABLE_OV_JAX_FRONTEND "Enable JAX FrontEnd" ON)
-ov_option(ENABLE_OV_IR_FRONTEND "Enable IR FrontEnd" ON)
 ov_option(ENABLE_OV_TF_FRONTEND "Enable TensorFlow FrontEnd" ON)
 ov_option(ENABLE_OV_TF_LITE_FRONTEND "Enable TensorFlow Lite FrontEnd" ON)
 
@@ -222,10 +220,6 @@ endif()
 
 if(ENABLE_OPENVINO_DEBUG)
     add_definitions(-DENABLE_OPENVINO_DEBUG)
-endif()
-
-if (ENABLE_PROFILING_RAW)
-    add_definitions(-DENABLE_PROFILING_RAW=1)
 endif()
 
 if (ENABLE_SNIPPETS_DEBUG_CAPS)


### PR DESCRIPTION
### Details:
 - `ENABLE_TBB_RELEASE_ONLY` and `ENABLE_PROFILING_RAW` are defined, but never used
 - `ENABLE_OV_IR_FRONTEND` is defined twice

### Tickets:
 - N/A
