### PR TITLE
[NPU] Fix Memory Leak test

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_integration.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_integration.hpp
@@ -383,6 +383,13 @@ TEST_P(OVClassGetMetricAndPrintNoThrow, NpuDeviceAllocMemSizeSameAfterDestroyInf
     ov::CompiledModel compiledModel;
     auto model = createModelWithLargeSize();
 
+    //Warm up inference to initialize driver scratch buffers
+    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(model, target_device));
+    auto inferRequest = compiledModel.create_infer_request();
+    inferRequest.infer();
+    inferRequest = {};
+    compiledModel = {};
+
     OV_ASSERT_NO_THROW(deviceAllocMemSizeAny =
                            core.get_property(target_device, ov::intel_npu::device_alloc_mem_size.name()));
     uint64_t deviceAllocMemSize = deviceAllocMemSizeAny.as<uint64_t>();

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -844,17 +844,6 @@ Example:
         </filters>
     </skip_config>
 
-    <!-- E#190990-->
-    <skip_config>
-        <message>Skip test-cases failing with Win Drv UD48 RC5</message>
-        <enable_rules>
-            <operating_system>windows</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*NpuDeviceAllocMemSizeSameAfterDestroyInferRequestGetTensor.*</filter>
-        </filters>
-    </skip_config>
-
     <skip_config>
         <message>Set of caching properties that are not suported by PV driver</message>
         <enable_rules>


### PR DESCRIPTION
### Details:
 - Unskip NpuDeviceAllocMemSizeSameAfterDestroyInf test
 - Test needed a warm up inference to setup driver scratch buffers which would otherwise be miscounted in the memory usage comparisons

### Tickets:
 - E-190990
