### PR TITLE
[DOCS] Add AI usage policy and PR disclosure guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,6 @@
 ### Tickets:
  - *ticket-id*
 
-### AI Assistance (if applicable):
- - *AI assistance level: none / limited / substantial*
- - *Tools used: [tool names]*
- - *How used: [brainstorming / snippet drafting / refactoring / docs]*
- - *Human validation performed: [build/tests/manual checks]*
+### AI Assistance:
+ - *AI assistance used: no / yes*
+ - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*

--- a/AI_USAGE_POLICY.md
+++ b/AI_USAGE_POLICY.md
@@ -19,7 +19,7 @@ This policy applies to:
 
 ## Allowed AI Assistance
 
-You may use AI tools to assist your work, including:
+You may use AI tools to assist your work, including but not limited to:
 
 - Brainstorming and research
 - Explaining APIs, language features, and error messages
@@ -43,9 +43,8 @@ If you use AI in any meaningful way, you must:
 Suggested disclosure format:
 
 ```text
-AI assistance: <none | limited | substantial>
-Tools used: <tool names>
-How used: <e.g., brainstorming, snippet drafting, refactoring, docs>
+AI assistance used: <no | yes>
+If yes: <how AI was used>
 Human validation performed: <build/tests/manual checks>
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ product better.
 ## Forms of contribution
 
 See also: [AI Usage Policy](./AI_USAGE_POLICY.md).
+If you use AI assistance for any contribution activity (code, docs, issues,
+discussions, or PR communication), read and follow this policy.
 
 ### Provide Feedback
 

--- a/CONTRIBUTING_PR.md
+++ b/CONTRIBUTING_PR.md
@@ -21,9 +21,8 @@
   OpenVINO, provide the information in proper articles. You can do it yourself, 
   or contact one of OpenVINO documentation contributors to work together on
   developing the right content. 
-* If your PR includes meaningful AI assistance, disclose it in the PR description
-  using the AI section in the [PR template](./.github/pull_request_template.md)
-  and follow the [AI Usage Policy](./AI_USAGE_POLICY.md).
+* Complete the AI section in the [PR template](./.github/pull_request_template.md)
+  for every PR and follow the [AI Usage Policy](./AI_USAGE_POLICY.md).
 * For Work In Progress, or checking test results early, use a Draft PR.
 
 


### PR DESCRIPTION
### Details:
- add new AI usage policy document (AI_USAGE_POLICY.md)

- add policy link in CONTRIBUTING.md
- add AI-assistance disclosure section in .github/pull_request_template.md
- add reminder in CONTRIBUTING_PR.md to disclose meaningful AI assistance

### Tickets:
- N/A

### AI Assistance (if applicable):
- AI assistance level: substantial
- Tools used: GitHub Copilot (GPT-5.3-Codex)
- How used: drafting and editing policy/documentation text
- Human validation performed: repository context review and markdown diagnostics checks