### PR TITLE
Fix MVNFusion logic for handling square operation with self-multiply

### DIFF
--- a/src/common/transformations/tests/common_optimizations/mvn_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mvn_fusion_test.cpp
@@ -189,6 +189,35 @@ TEST_F(TransformationTestsF, MVNFusionTestAltDiv) {
     }
 }
 
+TEST_F(TransformationTestsF, MVNFusionTestSelfMultiply) {
+    {
+        auto input = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 16, 409600, 1});
+        auto mean1_axes = opset6::Constant::create(element::i32, Shape{1}, {2});
+        auto mean1 = std::make_shared<opset6::ReduceMean>(input, mean1_axes, true);
+        auto sub1 = std::make_shared<opset6::Subtract>(input, mean1);
+        auto self_multiply = std::make_shared<opset6::Multiply>(sub1, sub1);
+        auto mean3_axes = opset6::Constant::create(element::i32, Shape{1}, {2});
+        auto mean3 = std::make_shared<opset6::ReduceMean>(self_multiply, mean3_axes, true);
+        auto const_0_5 = opset6::Constant::create(element::f32, Shape{}, {0.5});
+        auto power_sqrt = std::make_shared<opset6::Power>(mean3, const_0_5);
+        auto eps = opset6::Constant::create(element::f32, Shape{}, {1e-9});
+        auto add_eps = std::make_shared<opset6::Add>(power_sqrt, eps);
+        auto div = std::make_shared<opset6::Divide>(sub1, add_eps);
+
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
+
+        manager.register_pass<ov::pass::MVNFusion>();
+    }
+
+    {
+        auto input = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 16, 409600, 1});
+        auto axes = opset6::Constant::create(element::i32, Shape{1}, {2});
+        auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::OUTSIDE_SQRT);
+
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
+    }
+}
+
 TEST_F(TransformationTestsF, MVNFusionTestInsideSqrt) {
     {
         auto input = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 3, 224, 224});


### PR DESCRIPTION
### Details:

- MVNFusion replaces the operator sequence [Reshape] → ReduceMean(mean) → ElementWise(Sub: x-mean) → Square(Mul self/Pow^2) → ReduceMean(variance) → ElementWise(Add: +epsilon) → ElementWise(Sqrt) → ElementWise(Div: (x-mean)/sqrt(variance+eps)) [→ Reshape] with a single optimized "MVN" OP.
- The current logic does not handle square operation when implemented using Multiply OP(i.e., self-multiply).
- Fixed match pattern in MVNFusionWithoutConstants to handle square operation implemented using self-multiply.

The code and line that caused this issue (if it is not changed directly) intel_gpu/src/kernel_selector/cl_kernels/reduce_simple.cl common/transformations/src/transformations/common_optimizations/mvn_fusion.cpp

Reproduction step and snapshot (if applicable. Do not attach for customer model) NA

Problematic graph
<img width="1240" height="764" alt="image" src="https://github.com/user-attachments/assets/2e77aa2c-86a8-4a7a-9847-4abae2d1bea8" />

Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary? Yes
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? NA

### Tickets:
 - *CVS-132495*
