### PR TITLE
[GPU] Fix unused lambda capture 'this' in random_uniform_kernel_ref

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/random_uniform/random_uniform_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/random_uniform/random_uniform_kernel_ref.cpp
@@ -22,14 +22,14 @@ size_t GetGwsSize(const random_uniform_params &params) {
     return CeilDiv(shapeSize, step);
 }
 
-CommonDispatchData SetDefault(const random_uniform_params &params) {
+}  // namespace
+
+CommonDispatchData RandomUniformKernelRef::SetDefault(const random_uniform_params &params) const {
     CommonDispatchData dispatchData;
     dispatchData.gws = {GetGwsSize(params), 1, 1};
     dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo);
     return dispatchData;
 }
-
-}  // namespace
 
 JitConstants RandomUniformKernelRef::GetJitConstants(const random_uniform_params &params) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
@@ -98,7 +98,7 @@ ParamsKey RandomUniformKernelRef::GetSupportedKey() const {
 }
 
 void RandomUniformKernelRef::GetUpdateDispatchDataFunc(KernelData& kd) const {
-    kd.update_dispatch_data_func = [](const Params& params, KernelData& kd) {
+    kd.update_dispatch_data_func = [this](const Params& params, KernelData& kd) {
         const auto& prim_params = static_cast<const random_uniform_params&>(params);
         auto dispatchData = SetDefault(prim_params);
         OPENVINO_ASSERT(kd.kernels.size() == 1, "[GPU] Invalid kernels size for update dispatch data func");

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/random_uniform/random_uniform_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/random_uniform/random_uniform_kernel_ref.h
@@ -44,6 +44,8 @@ private:
     void GetUpdateDispatchDataFunc(KernelData& kd) const override;
 
     JitConstants GetJitConstants(const random_uniform_params &params) const;
+
+    CommonDispatchData SetDefault(const random_uniform_params &params) const;
 };
 
 } /* namespace kernel_selector */


### PR DESCRIPTION
### Details:
 - SetDefault is a free function, not a member method, so capturing 'this' in the update_dispatch_data_func lambda is unnecessary. Remove it to fix -Werror,-Wunused-lambda-capture error when building with -DENABLE_FUZZING=ON (clang + sanitizer flags).

### Tickets:
 - 181419
