### PR TITLE
[GPU] Fix crash in onednn impl with rank-3 blocked layout

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
@@ -54,8 +54,8 @@ protected:
         dnnl::memory::dims pad_r(pads_end_shape.begin(), pads_end_shape.end());
         dnnl::memory::dims dilation(dilation_shape.begin(), dilation_shape.end());
 
-        auto input_md = onednn::layout_to_memory_desc(input_layout);
-        auto output_md = onednn::layout_to_memory_desc(output_layout);
+        auto input_md = onednn::layout_to_memory_desc(input_layout, false, format::is_blocked(input_layout.format));
+        auto output_md = onednn::layout_to_memory_desc(output_layout, false, format::is_blocked(output_layout.format));
 
         if (auto_pad == ov::op::PadType::SAME_UPPER || auto_pad == ov::op::PadType::SAME_LOWER) {
             ov::op::v8::MaxPool op;


### PR DESCRIPTION
### Issue:
 - When using oneDNN implementation on GPU, the program may terminate with a message `Unexpected layout format`.
 - The issue is reproducible when layout format is blocked, logical shape rank is 3, and `keep_rank` is not enabled during `layout_to_memory_desc()`.
 - In this case, the conversion path attempts to map a 4D blocked format to a 3D oneDNN format tag, which is unsupported and triggers an exception.

> Traceback (most recent call last):
  File "C:\Users\helena\code\cica-quantization-failed-exp\Test_Suite\quan-ravi\src\cica_resnetrf_issue.py", line 26, in <module>
    infer_request.infer()
  File "C:\Users\helena\venvs\cica_simple_env\lib\site-packages\openvino\_ov_api.py", line 202, in infer
    return OVDict(super().infer(_data_dispatch(
RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:224:
Exception from src\plugins\intel_gpu\src\graph\impls\onednn\utils.cpp:408:
[GPU] Unexpected layout format f16:b_fs_yx_fsv16:32x32x4098:nopad

### Root cause:
- `MemoryDescriptorBuilder::calculate_dims()` contains a special path for `shape_rank == 3` when `keep_rank == false`.
https://github.com/openvinotoolkit/openvino/blob/1869d0becde02ff4b8ab9d378a6861afd9217edd/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp#L399-L415
- In that path, the builder tries to convert a 4D clDNN format into a 3D oneDNN format tag.
- This conversion relies on `format_map_cldnn_4d_to_onednn_3d`, where blocked formats such as `b_fs_yx_fsv16` are not present in this map.
- As a result, the lookup fails and `OPENVINO_THROW("[GPU] Unexpected layout format ...")` is triggered.

### How to fix:
- Blocked layouts cannot be safely reduced from 4D to 3D format tags, so that rank must be preserved for such layouts.
- Enable `keep_rank` for blocked layouts during oneDNN memory descriptor creation.
- This ensures that blocked layouts preserve their original rank, and the invalid 4D→3D format conversion path is skipped.

### Tickets:
 - CVS-181412
