### PR TITLE
[GPU] Add MVN BFYX fallback for devices without work_group collectives

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_bfyx_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_bfyx_opt.cl
@@ -32,13 +32,37 @@ KERNEL (mvn_gpu_bfyx_opt)(
     float my_sum = 0;
     float tmp;
 
+#if !USE_WORK_GROUP_COLLECTIVES
+    __local float lg_storage[SLM_SIZE];
+#endif
+
     //each WI reads items_num consecutive items from batch*feature
     for (uint i=0; i<iters_num; ++i)
     {
         my_sum += (float)input[my_data_offset + i * workers_per_data_set];
     }
 
+#if USE_WORK_GROUP_COLLECTIVES
     my_sum = work_group_reduce_add(my_sum) / data_set_size;
+#else
+    lg_storage[in_data_set_idx] = my_sum;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (uint offset = workers_per_data_set / 2; offset > 0; offset /= 2) {
+        if (in_data_set_idx < offset) {
+            lg_storage[in_data_set_idx] += lg_storage[in_data_set_idx + offset];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (in_data_set_idx == 0)
+    {
+        lg_storage[0] /= data_set_size;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    my_sum = lg_storage[0];
+#endif
 
 #if NORMALIZE_VARIANCE == 0
     for (uint i=0; i<iters_num; ++i) {
@@ -62,6 +86,7 @@ KERNEL (mvn_gpu_bfyx_opt)(
         my_variance = fma(tmp, tmp, my_variance);
     }
 
+#if USE_WORK_GROUP_COLLECTIVES
     my_variance = work_group_reduce_add(my_variance);
 
     if (in_data_set_idx == 0)
@@ -76,6 +101,33 @@ KERNEL (mvn_gpu_bfyx_opt)(
     }
 
     my_variance = work_group_broadcast(my_variance, 0);
+#else
+    lg_storage[in_data_set_idx] = my_variance;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (uint offset = workers_per_data_set / 2; offset > 0; offset /= 2) {
+        if (in_data_set_idx < offset) {
+            lg_storage[in_data_set_idx] += lg_storage[in_data_set_idx + offset];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (in_data_set_idx == 0)
+    {
+        my_variance = lg_storage[0] / data_set_size;
+
+#   if defined EPS_OUTSIDE_SQRT
+        lg_storage[0] = native_powr(native_sqrt(my_variance) + (float)EPSILON, -1.f);
+#   elif defined EPS_INSIDE_SQRT
+        lg_storage[0] = native_powr(my_variance + (float)EPSILON, -0.5f);
+#   endif
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    my_variance = lg_storage[0];
+#endif
 
     for (uint i=0; i<iters_num; ++i) {
         uint iteration_in_data_set_offset = i * workers_per_data_set;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bfyx_opt.cpp
@@ -77,6 +77,7 @@ MVNKernelBfyxOpt::Parent::DispatchData MVNKernelBfyxOpt::SetDefault(const mvn_pa
 
 JitConstants MVNKernelBfyxOpt::GetJitConstants(const mvn_params& params, MVNKernelBase::DispatchData dispatchData) const {
     auto jit = MVNKernelBase::GetJitConstants(params, dispatchData);
+    const int use_work_group_collectives = static_cast<int>(params.engineInfo.supports_work_group_collective_functions);
 
     if (params.has_dynamic_tensors()) {
         const auto& input = params.inputs[0];
@@ -92,13 +93,17 @@ JitConstants MVNKernelBfyxOpt::GetJitConstants(const mvn_params& params, MVNKern
         }
         const std::string lws_0 = "get_local_size(0)";
         jit.AddConstants({
+            MakeJitConstant("USE_WORK_GROUP_COLLECTIVES", use_work_group_collectives),
             MakeJitConstant("LWS", lws_0),
+            MakeJitConstant("SLM_SIZE", dispatchData.maxSlmSize),
             MakeJitConstant("DATA_SET_SIZE", data_set_size),
             MakeJitConstant("DATA_SETS_COUNT", data_set_count),
         });
     } else {
         jit.AddConstants({
+            MakeJitConstant("USE_WORK_GROUP_COLLECTIVES", use_work_group_collectives),
             MakeJitConstant("LWS", dispatchData.lws[0]),
+            MakeJitConstant("SLM_SIZE", dispatchData.lws[0]),
             MakeJitConstant("DATA_SETS_COUNT", dispatchData.dataSetsCount),
             MakeJitConstant("DATA_SET_SIZE", dispatchData.dataSetSize),
         });


### PR DESCRIPTION
### Details:
 - *Background: PR #26346 (`fee50b0b6b`, [GPU] Improve MVN BFYX OPT kernel sum reductions) optimized `mvn_gpu_bfyx_opt` using `work_group_reduce_add` / `work_group_broadcast`.*
 - *On some OpenCL targets, work-group collective functions are unavailable, so this path is not portable to all supported devices.*
 - *Observed on target hardware: CPU `Intel Pentium Silver N6005`, iGPU `Intel Jasper Lake UHD` (no work-group collective support in the target environment).*
 - *This PR adds capability-based routing in MVN BFYX OPT via JIT constant `USE_WORK_GROUP_COLLECTIVES` from `params.engineInfo.supports_work_group_collective_functions`.*
 - *If collectives are supported, existing fast path is kept unchanged; otherwise, kernel uses local-memory tree reduction + barrier-based broadcast-equivalent fallback.*
 - *`SLM_SIZE` JIT constant is restored for static and dynamic shape flows to support the fallback local-memory path.*

### Tickets:
 - *N/A*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used to inspect upstream history, locate relevant work-group usage, and draft a guarded fast/fallback implementation for MVN BFYX OPT.*
 - *Human validation performed: reviewed the final diff manually and validated behavior on target hardware without work-group collective support.*
