### PR TITLE
draft , moe otd weightless

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/program_builder.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/program_builder.hpp
@@ -143,6 +143,7 @@ public:
 
     std::shared_ptr<ov::threading::IStreamsExecutor> get_task_executor() const { return m_task_executor; }
     std::shared_ptr<cldnn::ICompilationContext> get_compilation_context() const { return m_compilation_context; }
+    std::shared_ptr<ov::Model> get_model() { return m_model; }
 
 private:
     static factories_map_t factories_map;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -138,7 +138,7 @@ struct weightless_cache_manager {
             do_precision_conversion = true;
         }
     }
-
+    
     void apply_reorder(std::shared_ptr<layout> input_layout, std::shared_ptr<reorder> reorder) {
         reorder_rep = {input_layout, reorder};
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_3gemm_fused_compressed.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_3gemm_fused_compressed.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 #include <vector>
+#include <string>
 
 #include "intel_gpu/op/moe_3gemm_fused_compressed.hpp"
 #include "intel_gpu/runtime/engine.hpp"
@@ -12,10 +13,40 @@
 namespace cldnn {
 using MOE3GemmFusedCompressed = ov::intel_gpu::op::MOE3GemmFusedCompressed;
 
+struct moe_weights {
+    cldnn::memory::ptr gate_w = nullptr;
+    cldnn::memory::ptr gate_s = nullptr;
+    cldnn::memory::ptr gate_z = nullptr;
+    cldnn::memory::ptr up_w = nullptr;
+    cldnn::memory::ptr up_s = nullptr;
+    cldnn::memory::ptr up_z = nullptr;
+    cldnn::memory::ptr down_w = nullptr;
+    cldnn::memory::ptr down_s = nullptr;
+    cldnn::memory::ptr down_z = nullptr;
+};
+
 /// @brief moe compressed primitive
 /// @details Performs moe compressed
 struct moe_3gemm_fused_compressed : public primitive_base<moe_3gemm_fused_compressed> {
     CLDNN_DECLARE_PRIMITIVE(moe_3gemm_fused_compressed)
+
+    static constexpr size_t serialized_weight_offset_count = 9;
+
+    enum class input_index : size_t {
+        hidden_states = 0,
+        routing_weights,
+        weight_0,
+        scale_0,
+        zp_0,
+        weight_1,
+        scale_1,
+        zp_1,
+        weight_2,
+        scale_2,
+        zp_2,
+        count
+    };
+    static constexpr size_t input_count = static_cast<size_t>(input_index::count);
 
     moe_3gemm_fused_compressed() : primitive_base("", {}) {}
 
@@ -70,11 +101,22 @@ struct moe_3gemm_fused_compressed : public primitive_base<moe_3gemm_fused_compre
     //                   22: shared_gate_gate_weight - shared expert gate weight for gating,
     //                      shape [hidden_size]
     //
-    moe_3gemm_fused_compressed(const primitive_id& id, const std::vector<input_info>& inputs, const MOE3GemmFusedCompressed::Config& config)
+        moe_3gemm_fused_compressed(const primitive_id& id,
+                                                             const std::vector<input_info>& inputs,
+                                                             const MOE3GemmFusedCompressed::Config& config,
+                                                             const std::vector<size_t>& weight_bin_offsets = {},
+                                                             const std::string& weights_path = "",
+                                                             size_t lru_expert_num = 0)
         : primitive_base(id, inputs, 1, {optional_data_type()}),
-          _config(config) {}
+                    _config(config),
+                    _weight_bin_offsets(weight_bin_offsets),
+                    _weights_path(weights_path),
+                    _lru_expert_num(lru_expert_num) {}
 
     MOE3GemmFusedCompressed::Config _config;
+        std::vector<size_t> _weight_bin_offsets;
+        std::string _weights_path;
+        size_t _lru_expert_num = 0;
 
     bool operator==(const primitive& rhs) const override {
         if (!compare_common_params(rhs))
@@ -82,17 +124,26 @@ struct moe_3gemm_fused_compressed : public primitive_base<moe_3gemm_fused_compre
 
         auto rhs_casted = downcast<const moe_3gemm_fused_compressed>(rhs);
 
-        return std::memcmp(&_config, &rhs_casted._config, sizeof(_config)) == 0;
+         return std::memcmp(&_config, &rhs_casted._config, sizeof(_config)) == 0 &&
+             _weight_bin_offsets == rhs_casted._weight_bin_offsets &&
+             _weights_path == rhs_casted._weights_path &&
+             _lru_expert_num == rhs_casted._lru_expert_num;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
         primitive_base<moe_3gemm_fused_compressed>::save(ob);
         ob << make_data(&_config, sizeof(_config));
+        ob << _weight_bin_offsets;
+        ob << _weights_path;
+        ob << _lru_expert_num;
     }
 
     void load(BinaryInputBuffer& ib) override {
         primitive_base<moe_3gemm_fused_compressed>::load(ib);
         ib >> make_data(&_config, sizeof(_config));
+        ib >> _weight_bin_offsets;
+        ib >> _weights_path;
+        ib >> _lru_expert_num;
     }
 };
 

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
@@ -133,6 +133,7 @@ static constexpr Property<ImplForcingMap, PropertyMutability::RW> force_implemen
 static constexpr Property<std::string, PropertyMutability::RW> config_file{"CONFIG_FILE"};
 static constexpr Property<float, PropertyMutability::RW> buffers_preallocation_ratio{"GPU_BUFFERS_PREALLOCATION_RATIO"};
 static constexpr Property<size_t, PropertyMutability::RW> max_kernels_per_batch{"GPU_MAX_KERNELS_PER_BATCH"};
+static constexpr Property<size_t, PropertyMutability::RW> moe_offload_max_experts{"MOE_OFFLOAD_MAX_EXPERTS"};
 static constexpr Property<bool, PropertyMutability::RW> use_onednn{"GPU_USE_ONEDNN"};
 static constexpr Property<bool, PropertyMutability::RW> use_cm{"GPU_USE_CM"};
 

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -39,6 +39,7 @@ OV_CONFIG_RELEASE_OPTION(ov::hint, model, nullptr, "Shared pointer to the ov::Mo
 OV_CONFIG_RELEASE_OPTION(ov::internal, key_cache_quant_mode, ov::internal::CacheQuantMode::BY_CHANNEL, "AUTO or BY_CHANNEL or BY_TOKEN")
 OV_CONFIG_RELEASE_OPTION(ov::internal, value_cache_quant_mode, ov::internal::CacheQuantMode::BY_TOKEN, "AUTO or BY_CHANNEL or BY_TOKEN")
 OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, mem_pool_util_threshold, 0.5, "Minimum utilization threshold (0.0~1.0) for reusable memory in the pool")
+OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, moe_offload_max_experts, 0, "Maximum number of MoE experts to keep resident on device for offload")
 OV_CONFIG_RELEASE_OPTION(ov, enable_weightless, false, "Enable/Disable weightless blob")
 
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, shape_predictor_settings, {10, 16 * 1024, 2, 1.1f}, "Preallocation settings")

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/LRUCache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/LRUCache.cpp
@@ -1,0 +1,54 @@
+#include "LRUCache.hpp"
+
+#include <cstdlib>
+
+
+LRUCache::LRUCache(size_t max_total_experts, EvictCallback cb)
+    : m_max_total_experts(max_total_experts),
+      m_total_experts(0),
+      m_to_filled_lru_expert_no(0),
+      m_on_evict(std::move(cb)) {
+        m_filled_list.resize(max_total_experts, false);
+      }
+
+void LRUCache::move_to_end(std::list<Node>::iterator it) {
+    if (std::next(it) == m_list.end())
+        return;
+    m_list.splice(m_list.end(), m_list, it);
+}
+
+void LRUCache::evict_one() {
+    if (m_list.empty()) return;
+
+    auto& oldest = m_list.front();
+
+    m_filled_list[oldest.lru_expert_no] = false;
+    m_to_filled_lru_expert_no = oldest.lru_expert_no;
+    Key key{oldest.layer, oldest.expert};
+    m_map.erase(key);
+    m_list.pop_front();
+    --m_total_experts;
+}
+
+std::pair<size_t, bool> LRUCache::get_lru_item(size_t layer, size_t expert) {
+   Key key{layer, expert};
+   auto it = m_map.find(key);
+   if (it == m_map.end()) {
+       size_t to_filled_no = 0; 
+       if (m_total_experts >= m_max_total_experts) {
+           evict_one();
+           to_filled_no = m_to_filled_lru_expert_no;
+       } else {
+           to_filled_no = m_total_experts;
+       }
+       m_list.push_back(Node{layer, expert, to_filled_no});
+       auto new_it = std::prev(m_list.end());
+       m_map[key] = new_it;
+       ++m_total_experts;
+       return { to_filled_no, false };
+   } else {
+       move_to_end(it->second);
+       const bool is_hit = m_filled_list[it->second->lru_expert_no];
+       return { it->second->lru_expert_no, is_hit };
+   }
+}

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/LRUCache.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/LRUCache.hpp
@@ -1,0 +1,69 @@
+#pragma once
+#include <functional>
+#include <unordered_map>
+#include <list>
+#include <utility>
+#include "intel_gpu/runtime/engine.hpp"
+#include <memory>
+
+class LRUCache {
+public:
+    using EvictCallback = std::function<void(size_t layer, size_t expert, void* addr, void* params)>;
+
+    enum NodeAction {
+        INSERT,
+        REFRESH
+    };
+
+    LRUCache(size_t max_total_experts, EvictCallback cb = nullptr);
+    NodeAction insert_or_refresh(size_t layer, size_t expert, void* addr, void* params = nullptr);
+
+    std::pair<size_t, bool> get_lru_item(size_t layer, size_t expert);
+    size_t get_total_experts() const { return m_total_experts; }
+
+    void evict_one();
+
+    size_t size() const { return m_total_experts; }
+    std::pair<size_t, bool> get_item(size_t layer, size_t expert);
+
+    void set_filled(size_t lru_expert_no) {
+        if (lru_expert_no >= m_filled_list.size()) {
+            return;
+        }
+        m_filled_list[lru_expert_no] = true;
+    }
+
+    bool m_initialized = false;
+private:
+    struct Key {
+        size_t layer;
+        size_t expert;
+        bool operator==(const Key& other) const noexcept {
+            return layer == other.layer && expert == other.expert;
+        }
+    };
+
+    struct KeyHash {
+        std::size_t operator()(const Key& k) const noexcept {
+            return std::hash<size_t>()(k.layer * 131ULL + k.expert);
+        }
+    };
+
+    struct Node {
+        size_t layer;
+        size_t expert;
+        size_t lru_expert_no;
+    };
+
+    size_t m_max_total_experts;
+    size_t m_per_expert_size;
+    size_t m_total_experts;
+    size_t m_to_filled_lru_expert_no;
+    EvictCallback m_on_evict;
+
+    std::list<Node> m_list;
+    std::vector<bool> m_filled_list;
+    std::unordered_map<Key, std::list<Node>::iterator, KeyHash> m_map;
+
+    void move_to_end(std::list<Node>::iterator it);
+};

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
@@ -5,17 +5,47 @@
 // clang-format off
 #include "moe_3gemm_gen_micro.hpp"
 #include "moe_3gemm_swiglu_opt.hpp"
+#include "openvino/runtime/shared_buffer.hpp"
+#include "LRUCache.hpp"
 // clang-format on
 
 #define DEBUG_MOE_LOG 0
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
+#    include <chrono>
 #    include <initializer_list>
+#    include <cstdlib>
+#    include <cstdint>
+#    include <fstream>
+#    include <iostream>
+#    include <limits>
+#    include <mutex>
 #    include <oneapi/dnnl/dnnl.hpp>
 #    include <sstream>
 #    include <string_view>
+#    include <thread>
 #    include <tuple>
 #    include <utility>
+
+#    ifdef _WIN32
+#        ifndef NOMINMAX
+#            define NOMINMAX
+#        endif
+#        ifndef WIN32_LEAN_AND_MEAN
+#            define WIN32_LEAN_AND_MEAN
+#        endif
+#        include <windows.h>
+#        ifdef min
+#            undef min
+#        endif
+#        ifdef max
+#            undef max
+#        endif
+#    else
+#        include <fcntl.h>
+#        include <sys/stat.h>
+#        include <unistd.h>
+#    endif
 
 #    include "../primitive_ocl_base.hpp"
 #    include "../utils/kernel_generator.hpp"
@@ -897,6 +927,8 @@ public:
         moe_fusion_weights_base_addr moe_fusion_wei_addr;
         memory::ptr input_routing_weights;
         memory::ptr input_router_topk_idx;
+        memory::ptr _expert_index_buffer;
+        bool _index_initialized = false;
     };
 
     std::vector<std::vector<dnnl_weights>> _dnnl_weights;
@@ -905,6 +937,7 @@ public:
     int _shared_intermediate_size;
     int _gate_up_group_size;
     int _down_group_size;
+    size_t _lru_expert_num = 0;
 
     bool _has_shared_expert = false;
     // Shared expert primitives
@@ -954,6 +987,14 @@ public:
         const auto& weight_dt = params.get_input_layout(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_0)).data_type;
         if (weight_dt != data_types::u4 && use_micro_gemm_prefill) {
             use_micro_gemm_prefill = false;
+        }
+
+        // OTD relies on runtime weight streaming in oneDNN path.
+        _lru_expert_num = params.typed_desc<moe_3gemm_fused_compressed>()->_lru_expert_num;
+        if (_lru_expert_num > 0 && use_micro_gemm_prefill) {
+            use_micro_gemm_prefill = false;
+            GPU_DEBUG_TRACE_DETAIL << "[DEBUG] moe_3gemm_swiglu_opt_impl(): force disable micro_gemm prefill in OTD mode, lru_expert_num="
+                                   << _lru_expert_num << std::endl;
         }
 
         // Don't change the order of stages
@@ -1028,27 +1069,29 @@ public:
             dnnl_weights[2].ic = _intermediate_size;
             dnnl_weights[2].ic_group_size = _down_group_size;
             dnnl_weights[2].oc = _hidden_size;
-            for (int i = 0; i < 3; i++) {
-                // weight shape: [ic, oc], type: u4/i8
-                int64_t wei_offset = j * get_bytes_count(dnnl_weights[i].ic * dnnl_weights[i].oc, moe_fusion_wei_addr.weight[i]->get_layout());
-                dnnl_weights[i].weight =
-                    convert2dnnl(moe_fusion_wei_addr.weight[i], {dnnl_weights[i].ic, dnnl_weights[i].oc}, dnnl::memory::format_tag::ba, wei_offset);
+            if (!_lru_expert_num) {
+                for (int i = 0; i < 3; i++) {
+                    // weight shape: [ic, oc], type: u4/i8
+                    int64_t wei_offset = j * get_bytes_count(dnnl_weights[i].ic * dnnl_weights[i].oc, moe_fusion_wei_addr.weight[i]->get_layout());
+                    dnnl_weights[i].weight =
+                        convert2dnnl(moe_fusion_wei_addr.weight[i], {dnnl_weights[i].ic, dnnl_weights[i].oc}, dnnl::memory::format_tag::ba, wei_offset);
 
-                // scale shape: [ic / ic_group_size, oc], type: f16
-                int64_t scale_offset =
-                    j * get_bytes_count(dnnl_weights[i].ic * dnnl_weights[i].oc / dnnl_weights[i].ic_group_size, moe_fusion_wei_addr.scale[i]->get_layout());
-                dnnl_weights[i].scale = convert2dnnl(moe_fusion_wei_addr.scale[i],
-                                                     {dnnl_weights[i].ic / dnnl_weights[i].ic_group_size, dnnl_weights[i].oc},
-                                                     dnnl::memory::format_tag::ab,
-                                                     scale_offset);
+                    // scale shape: [ic / ic_group_size, oc], type: f16
+                    int64_t scale_offset =
+                        j * get_bytes_count(dnnl_weights[i].ic * dnnl_weights[i].oc / dnnl_weights[i].ic_group_size, moe_fusion_wei_addr.scale[i]->get_layout());
+                    dnnl_weights[i].scale = convert2dnnl(moe_fusion_wei_addr.scale[i],
+                                                        {dnnl_weights[i].ic / dnnl_weights[i].ic_group_size, dnnl_weights[i].oc},
+                                                        dnnl::memory::format_tag::ab,
+                                                        scale_offset);
 
-                // zp shape: [ic / ic_group_size, oc], type: u4/i8
-                int64_t zp_offset =
-                    j * get_bytes_count(dnnl_weights[i].ic * dnnl_weights[i].oc / dnnl_weights[i].ic_group_size, moe_fusion_wei_addr.zp[i]->get_layout());
-                dnnl_weights[i].zp = convert2dnnl(moe_fusion_wei_addr.zp[i],
-                                                  {dnnl_weights[i].ic / dnnl_weights[i].ic_group_size, dnnl_weights[i].oc},
-                                                  dnnl::memory::format_tag::ab,
-                                                  zp_offset);
+                    // zp shape: [ic / ic_group_size, oc], type: u4/i8
+                    int64_t zp_offset =
+                        j * get_bytes_count(dnnl_weights[i].ic * dnnl_weights[i].oc / dnnl_weights[i].ic_group_size, moe_fusion_wei_addr.zp[i]->get_layout());
+                    dnnl_weights[i].zp = convert2dnnl(moe_fusion_wei_addr.zp[i],
+                                                    {dnnl_weights[i].ic / dnnl_weights[i].ic_group_size, dnnl_weights[i].oc},
+                                                    dnnl::memory::format_tag::ab,
+                                                    zp_offset);
+                }
             }
         }
     }
@@ -1188,6 +1231,7 @@ public:
         cur_moe->_intermediate_size = _intermediate_size;
         cur_moe->_gate_up_group_size = _gate_up_group_size;
         cur_moe->_down_group_size = _down_group_size;
+        cur_moe->_lru_expert_num = _lru_expert_num;
         return cur_moe;
     }
 
@@ -1266,41 +1310,43 @@ public:
             }
         }
 
-        // gate
-        scratch.moe_fusion_wei_addr.weight[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_0));
-        scratch.moe_fusion_wei_addr.scale[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SCALE_0));
-        scratch.moe_fusion_wei_addr.zp[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::ZP_0));
+        if (!_lru_expert_num) {
+            // gate
+            scratch.moe_fusion_wei_addr.weight[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_0));
+            scratch.moe_fusion_wei_addr.scale[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SCALE_0));
+            scratch.moe_fusion_wei_addr.zp[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::ZP_0));
 
-        // up
-        scratch.moe_fusion_wei_addr.weight[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_1));
-        scratch.moe_fusion_wei_addr.scale[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SCALE_1));
-        scratch.moe_fusion_wei_addr.zp[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::ZP_1));
+            // up
+            scratch.moe_fusion_wei_addr.weight[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_1));
+            scratch.moe_fusion_wei_addr.scale[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SCALE_1));
+            scratch.moe_fusion_wei_addr.zp[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::ZP_1));
 
-        // down
-        scratch.moe_fusion_wei_addr.weight[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_2));
-        scratch.moe_fusion_wei_addr.scale[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SCALE_2));
-        scratch.moe_fusion_wei_addr.zp[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::ZP_2));
+            // down
+            scratch.moe_fusion_wei_addr.weight[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_2));
+            scratch.moe_fusion_wei_addr.scale[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SCALE_2));
+            scratch.moe_fusion_wei_addr.zp[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::ZP_2));
 
-        // shared expert
-        size_t dep_count = instance.dependencies().size();
-        if (dep_count >= static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_GATE_WEIGHT) + 1) {
-            // Gate
-            scratch.moe_fusion_wei_addr.shared_weight[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_WEIGHT));
-            scratch.moe_fusion_wei_addr.shared_scale[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_SCALE));
-            scratch.moe_fusion_wei_addr.shared_zp[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_ZP));
+            // shared expert
+            size_t dep_count = instance.dependencies().size();
+            if (dep_count >= static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_GATE_WEIGHT) + 1) {
+                // Gate
+                scratch.moe_fusion_wei_addr.shared_weight[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_WEIGHT));
+                scratch.moe_fusion_wei_addr.shared_scale[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_SCALE));
+                scratch.moe_fusion_wei_addr.shared_zp[0] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_ZP));
 
-            // Up
-            scratch.moe_fusion_wei_addr.shared_weight[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_UP_WEIGHT));
-            scratch.moe_fusion_wei_addr.shared_scale[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_UP_SCALE));
-            scratch.moe_fusion_wei_addr.shared_zp[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_UP_ZP));
+                // Up
+                scratch.moe_fusion_wei_addr.shared_weight[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_UP_WEIGHT));
+                scratch.moe_fusion_wei_addr.shared_scale[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_UP_SCALE));
+                scratch.moe_fusion_wei_addr.shared_zp[1] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_UP_ZP));
 
-            // Down
-            scratch.moe_fusion_wei_addr.shared_weight[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_DOWN_WEIGHT));
-            scratch.moe_fusion_wei_addr.shared_scale[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_DOWN_SCALE));
-            scratch.moe_fusion_wei_addr.shared_zp[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_DOWN_ZP));
+                // Down
+                scratch.moe_fusion_wei_addr.shared_weight[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_DOWN_WEIGHT));
+                scratch.moe_fusion_wei_addr.shared_scale[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_DOWN_SCALE));
+                scratch.moe_fusion_wei_addr.shared_zp[2] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_DOWN_ZP));
 
-            // Scalar Gate - f16
-            scratch.moe_fusion_wei_addr.shared_weight[3] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_GATE_WEIGHT));
+                // Scalar Gate - f16
+                scratch.moe_fusion_wei_addr.shared_weight[3] = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SHARED_GATE_GATE_WEIGHT));
+            }
         }
     }
 
@@ -1432,9 +1478,413 @@ public:
         return std::make_tuple(mem, layout);
     }
 
+    static size_t get_layer(typed_primitive_inst<moe_3gemm_fused_compressed>& instance) {
+        auto cur_moe = instance.get_typed_desc<moe_3gemm_fused_compressed>();
+        auto& id = cur_moe->id;
+        size_t layer = 0;
+        if (id == "moe:moe_router") {
+            layer = 0;
+        } else {
+            size_t pos = id.rfind('_');
+            if (pos != std::string::npos && pos + 1 < id.size()) {
+                std::string numStr = id.substr(pos + 1);
+                layer = atoi(numStr.c_str());
+            } 
+        }
+        return layer;
+    }
+
+    class otd_parallel_weight_reader {
+    public:
+        explicit otd_parallel_weight_reader(const std::string& weights_path) : _weights_path(weights_path) {
+            open_shared_handle();
+        }
+
+        ~otd_parallel_weight_reader() {
+            close_shared_handle();
+        }
+
+        const std::string& path() const {
+            return _weights_path;
+        }
+
+        void read(char* dst, size_t size, size_t file_offset) {
+            if (!single_read(get_shared_handle(), dst, size, file_offset)) {
+                throw std::runtime_error("Failed to read enough bytes from OTD weight file");
+            }
+        }
+
+    private:
+#ifdef _WIN32
+        using native_handle_t = HANDLE;
+        static constexpr native_handle_t invalid_handle() {
+            return INVALID_HANDLE_VALUE;
+        }
+
+        static native_handle_t open_native_handle(const std::string& weights_path) {
+            auto path = std::filesystem::path(weights_path);
+            auto handle = CreateFileW(path.native().c_str(),
+                                      GENERIC_READ,
+                                      FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                      nullptr,
+                                      OPEN_EXISTING,
+                                      FILE_ATTRIBUTE_NORMAL,
+                                      nullptr);
+            if (handle == INVALID_HANDLE_VALUE) {
+                throw std::runtime_error("Failed to open weight file for OTD streaming read");
+            }
+            return handle;
+        }
+
+        static void close_native_handle(native_handle_t handle) {
+            if (handle != INVALID_HANDLE_VALUE) {
+                CloseHandle(handle);
+            }
+        }
+
+        static bool single_read(native_handle_t handle, char* dst, size_t size, size_t file_offset) {
+            char* current = dst;
+            size_t remaining = size;
+            size_t current_offset = file_offset;
+            while (remaining > 0) {
+                const DWORD to_read = static_cast<DWORD>(std::min(remaining, static_cast<size_t>(UINT_MAX - 1024u)));
+                LARGE_INTEGER li = {};
+                li.QuadPart = static_cast<LONGLONG>(current_offset);
+                if (!SetFilePointerEx(handle, li, nullptr, FILE_BEGIN)) {
+                    return false;
+                }
+                DWORD bytes_read = 0;
+                if (!ReadFile(handle, current, to_read, &bytes_read, nullptr) || bytes_read == 0) {
+                    return false;
+                }
+                current += bytes_read;
+                current_offset += bytes_read;
+                remaining -= bytes_read;
+            }
+            return true;
+        }
+#else
+        using native_handle_t = int;
+        static constexpr native_handle_t invalid_handle() {
+            return -1;
+        }
+
+        static native_handle_t open_native_handle(const std::string& weights_path) {
+            auto fd = ::open(weights_path.c_str(), O_RDONLY | O_CLOEXEC);
+            if (fd == -1) {
+                throw std::runtime_error("Failed to open weight file for OTD streaming read");
+            }
+            return fd;
+        }
+
+        static void close_native_handle(native_handle_t handle) {
+            if (handle != -1) {
+                ::close(handle);
+            }
+        }
+
+        static bool single_read(native_handle_t handle, char* dst, size_t size, size_t file_offset) {
+            char* current = dst;
+            size_t remaining = size;
+            off_t current_offset = static_cast<off_t>(file_offset);
+            while (remaining > 0) {
+                const ssize_t bytes_read = ::pread(handle, current, remaining, current_offset);
+                if (bytes_read <= 0) {
+                    return false;
+                }
+                current += bytes_read;
+                current_offset += bytes_read;
+                remaining -= static_cast<size_t>(bytes_read);
+            }
+            return true;
+        }
+#endif
+
+        void open_shared_handle() {
+            _shared_handle = open_native_handle(_weights_path);
+        }
+
+        void close_shared_handle() {
+            close_native_handle(_shared_handle);
+            _shared_handle = invalid_handle();
+        }
+
+        native_handle_t get_shared_handle() const {
+            return _shared_handle;
+        }
+
+        std::string _weights_path;
+        native_handle_t _shared_handle = invalid_handle();
+    };
+
+    static otd_parallel_weight_reader& get_thread_local_weight_reader(const std::string& weights_path) {
+        thread_local std::unique_ptr<otd_parallel_weight_reader> reader;
+        if (!reader || reader->path() != weights_path) {
+            reader = std::make_unique<otd_parallel_weight_reader>(weights_path);
+        }
+        return *reader;
+    }
+
+    static void fill_weights_memory(cldnn::stream& exec_stream,
+        const cldnn::moe_3gemm_fused_compressed& desc,
+        cldnn::moe_weights& wei_mem, const std::vector<uint32_t>& experts_list, const std::vector<uint32_t>& lru_experts) {
+        const auto num_expert = static_cast<size_t>(desc._config.num_expert);
+        const auto& weight_bin_offsets = desc._weight_bin_offsets;
+        const auto& weights_path = desc._weights_path;
+
+        OPENVINO_ASSERT(!weights_path.empty(), "weights path is empty for OTD weight loading");
+        OPENVINO_ASSERT(weight_bin_offsets.size() == cldnn::moe_3gemm_fused_compressed::serialized_weight_offset_count,
+                "Unexpected number of MOE weight offsets");
+
+        static std::once_flag file_size_flag;
+        static size_t weight_file_size = 0;
+        std::call_once(file_size_flag, [&] {
+            std::ifstream size_file(weights_path.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
+            OPENVINO_ASSERT(size_file.is_open(), "Failed to open weight file to query size: ", weights_path);
+            auto end_pos = size_file.tellg();
+            OPENVINO_ASSERT(end_pos >= 0, "Failed to query weight file size: ", weights_path);
+            weight_file_size = static_cast<size_t>(end_pos);
+        });
+
+        static const std::array<const char*, cldnn::moe_3gemm_fused_compressed::serialized_weight_offset_count> tensor_names = {{
+            "gate_w", "up_w", "down_w", "gate_s", "up_s", "down_s", "gate_z", "up_z", "down_z"
+        }};
+
+        const bool transpose_scale_zp = std::getenv("MOE_OTD_DISABLE_SCALE_ZP_TRANSPOSE") == nullptr;
+        auto maybe_transpose_scale_zp = [&](const char* tensor_name,
+                                            const cldnn::layout& layout,
+                                            std::vector<uint8_t>& payload,
+                                            size_t per_expert_size) {
+            if (!transpose_scale_zp || tensor_name == nullptr) {
+                return;
+            }
+
+            const std::string_view name(tensor_name);
+            const bool is_scale = name.find("_s") != std::string_view::npos;
+            const bool is_zp = name.find("_z") != std::string_view::npos;
+            if (!is_scale && !is_zp) {
+                return;
+            }
+
+            size_t oc = 0;
+            size_t ic = 0;
+            if (name.rfind("down_", 0) == 0) {
+                oc = static_cast<size_t>(desc._config.hidden_size);
+                ic = static_cast<size_t>(desc._config.inter_size);
+            } else {
+                oc = static_cast<size_t>(desc._config.inter_size);
+                ic = static_cast<size_t>(desc._config.hidden_size);
+            }
+
+            const size_t group_size = static_cast<size_t>(desc._config.group_size);
+            size_t group_count = 1;
+            if (group_size != 0 && group_size != std::numeric_limits<size_t>::max()) {
+                OPENVINO_ASSERT(ic % group_size == 0,
+                                "Invalid group_size for OTD transpose: tensor=",
+                                tensor_name,
+                                ", ic=",
+                                ic,
+                                ", group_size=",
+                                group_size);
+                group_count = ic / group_size;
+            }
+
+            OPENVINO_ASSERT(oc > 0 && group_count > 0,
+                            "Invalid dims for OTD transpose: tensor=",
+                            tensor_name,
+                            ", oc=",
+                            oc,
+                            ", group_count=",
+                            group_count);
+
+            const size_t elem_count = oc * group_count;
+            if (is_scale) {
+                const size_t elem_size = static_cast<size_t>(data_type_traits::size_of(layout.data_type));
+                OPENVINO_ASSERT(elem_size > 0, "Invalid scale element size for tensor=", tensor_name);
+                OPENVINO_ASSERT(elem_count * elem_size == per_expert_size,
+                                "Unexpected scale payload size for tensor=",
+                                tensor_name,
+                                ", expected=",
+                                elem_count * elem_size,
+                                ", got=",
+                                per_expert_size);
+
+                std::vector<uint8_t> transposed(per_expert_size, 0);
+                for (size_t o = 0; o < oc; o++) {
+                    for (size_t g = 0; g < group_count; g++) {
+                        const size_t src_elem_idx = o * group_count + g;
+                        const size_t dst_elem_idx = g * oc + o;
+                        std::memcpy(transposed.data() + dst_elem_idx * elem_size,
+                                    payload.data() + src_elem_idx * elem_size,
+                                    elem_size);
+                    }
+                }
+                payload.swap(transposed);
+                return;
+            }
+
+            // ZP is packed as 4-bit values (low nibble first). Unpack -> transpose -> repack.
+            OPENVINO_ASSERT(elem_count % 2 == 0,
+                            "Unexpected odd element count for packed zp tensor=",
+                            tensor_name,
+                            ", elem_count=",
+                            elem_count);
+            OPENVINO_ASSERT(elem_count / 2 == per_expert_size,
+                            "Unexpected zp payload size for tensor=",
+                            tensor_name,
+                            ", expected=",
+                            elem_count / 2,
+                            ", got=",
+                            per_expert_size);
+
+            std::vector<uint8_t> unpacked(elem_count, 0);
+            for (size_t i = 0; i < per_expert_size; i++) {
+                const uint8_t byte = payload[i];
+                unpacked[2 * i] = static_cast<uint8_t>(byte & 0x0F);
+                unpacked[2 * i + 1] = static_cast<uint8_t>((byte >> 4) & 0x0F);
+            }
+
+            std::vector<uint8_t> transposed_unpacked(elem_count, 0);
+            for (size_t o = 0; o < oc; o++) {
+                for (size_t g = 0; g < group_count; g++) {
+                    const size_t src_idx = o * group_count + g;
+                    const size_t dst_idx = g * oc + o;
+                    transposed_unpacked[dst_idx] = unpacked[src_idx];
+                }
+            }
+
+            std::vector<uint8_t> repacked(per_expert_size, 0);
+            for (size_t i = 0; i < per_expert_size; i++) {
+                repacked[i] = static_cast<uint8_t>((transposed_unpacked[2 * i] & 0x0F) |
+                                                   ((transposed_unpacked[2 * i + 1] & 0x0F) << 4));
+            }
+            payload.swap(repacked);
+        };
+
+        struct tensor_fill_plan {
+            size_t per_expert_size = 0;
+            size_t src_offset = 0;
+            size_t dst_offset = 0;
+        };
+
+        auto make_tensor_fill_plan = [&] (size_t base_offset,
+                                          cldnn::memory_ptr mem,
+                                          size_t expert_no,
+                                          size_t lru_expert_no,
+                                          const char* tensor_name) {
+            tensor_fill_plan plan;
+            if (!mem)
+                return plan;
+
+            const auto total_bytes = mem->get_layout().bytes_count();
+            OPENVINO_ASSERT(num_expert > 0, "Invalid expert count");
+
+            plan.per_expert_size = total_bytes / num_expert;
+            plan.src_offset = base_offset + expert_no * plan.per_expert_size;
+            plan.dst_offset = lru_expert_no * plan.per_expert_size;
+
+            OPENVINO_ASSERT(plan.src_offset <= weight_file_size, "Invalid src_offset out of file: ", plan.src_offset, ", file_size=", weight_file_size);
+            OPENVINO_ASSERT(plan.per_expert_size <= weight_file_size - plan.src_offset,
+                            "Read range out of file for tensor ",
+                            tensor_name,
+                            ": src_offset=",
+                            plan.src_offset,
+                            ", per_expert_size=",
+                            plan.per_expert_size,
+                            ", file_size=",
+                            weight_file_size,
+                            ", base_offset=",
+                            base_offset,
+                            ", expert=",
+                            expert_no);
+            return plan;
+        };
+
+        auto copy_tensor_to_memory = [&] (cldnn::memory_ptr mem,
+                                          const tensor_fill_plan& plan,
+                                          std::vector<uint8_t>& payload,
+                                          const char* tensor_name) {
+            if (!mem || plan.per_expert_size == 0) {
+                return;
+            }
+
+            maybe_transpose_scale_zp(tensor_name, mem->get_layout(), payload, plan.per_expert_size);
+
+            // ---- 3. GPU copy (safe) ----
+            mem->copy_from(exec_stream,
+                           payload.data(),
+                           0,  // src offset
+                           plan.dst_offset,
+                           plan.per_expert_size,
+                           true);
+        };
+
+        const std::array<cldnn::memory_ptr, cldnn::moe_3gemm_fused_compressed::serialized_weight_offset_count> tensors_by_offset = {{
+            wei_mem.gate_w,
+            wei_mem.up_w,
+            wei_mem.down_w,
+            wei_mem.gate_s,
+            wei_mem.up_s,
+            wei_mem.down_s,
+            wei_mem.gate_z,
+            wei_mem.up_z,
+            wei_mem.down_z
+        }};
+
+        size_t i = 0;
+        for (uint32_t expert: experts_list) {
+            auto& weight_reader = get_thread_local_weight_reader(weights_path);
+
+            for (size_t offset_pos = 0;
+                 offset_pos < static_cast<size_t>(cldnn::moe_3gemm_fused_compressed::serialized_weight_offset_count);
+                 offset_pos++) {
+                auto plan = make_tensor_fill_plan(weight_bin_offsets[offset_pos],
+                                                  tensors_by_offset[offset_pos],
+                                                  expert,
+                                                  lru_experts[i],
+                                                  tensor_names[offset_pos]);
+                std::vector<uint8_t> payload;
+
+                if (plan.per_expert_size != 0) {
+                    payload.resize(plan.per_expert_size);
+                    weight_reader.read(reinterpret_cast<char*>(payload.data()), plan.per_expert_size, plan.src_offset);
+                }
+
+                copy_tensor_to_memory(tensors_by_offset[offset_pos], plan, payload, tensor_names[offset_pos]);
+            }
+            i++;
+        }
+
+    }
+
+    static uint32_t get_lru_expert_no(typed_primitive_inst<moe_3gemm_fused_compressed>& instance, uint32_t expert, LRUCache& cache) {
+        auto cur_moe = instance.get_typed_desc<moe_3gemm_fused_compressed>();
+        auto& stream = instance.get_network().get_stream();
+        size_t layer = get_layer(instance);
+        auto item = cache.get_lru_item(layer, expert);
+        OPENVINO_ASSERT(item.first <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()),
+                        "LRU slot index overflow: ",
+                        item.first);
+        const auto lru_slot = static_cast<uint32_t>(item.first);
+        if(!item.second) {
+            std::vector<uint32_t> experts_list_single;
+            experts_list_single.push_back(expert);
+            std::vector<uint32_t> lru_experts_list_single;
+            lru_experts_list_single.push_back(lru_slot);
+            fill_weights_memory(stream, *cur_moe, instance._weights, experts_list_single, lru_experts_list_single);
+            cache.set_filled(lru_slot);
+        }
+        return lru_slot;
+    }
     cldnn::event::ptr exec_single_token(const std::vector<cldnn::event::ptr>& events,
                                         typed_primitive_inst<moe_3gemm_fused_compressed>& instance,
-                                        scratch_buffers& scratch) {
+                                        scratch_buffers& scratch,
+                                        LRUCache& cache) {
+        auto& cur_net = instance.get_network();
+        auto& stream = cur_net.get_stream();
+        if(_lru_expert_num) {
+            stream.finish();
+        }
         auto cur_moe = instance.get_typed_desc<moe_3gemm_fused_compressed>();
         int max_topk = static_cast<int>(cur_moe->_config.top_k);
 
@@ -1447,6 +1897,42 @@ public:
 
         const size_t subgroup_size = instance.get_impl_params()->get_device_info().arch >= gpu_arch::xe2 ? 32 : 16;
         const size_t max_work_group_size = instance.get_impl_params()->get_device_info().max_work_group_size;
+
+        if(_lru_expert_num) {
+            cldnn::moe_weights shell_params = instance._weights;
+            auto& engine = instance.get_network().get_engine();
+            uint32_t* p_expert = (uint32_t*)batch_mem_ptr->buffer_ptr();
+            std::vector<uint32_t> experts_list;
+            for (int i = 0; i < max_topk; i++) {
+                experts_list.push_back(*p_expert++);
+            }
+            if (!scratch._index_initialized) {
+                size_t experts_index_size = 4 * max_topk; // each expert has 4 bytes
+                auto layout_expert = cldnn::layout({1, 1, 1, static_cast<ov::Dimension::value_type>(experts_index_size)}, ov::element::i8, cldnn::format::bfyx);
+                // auto alloc_type = engine.get_preferred_memory_allocation_type(false);
+                scratch._expert_index_buffer = engine.allocate_memory(layout_expert, allocation_type::usm_host, false);
+                // instance._expert_index_buffer = engine.allocate_memory(layout_expert, alloc_type, false);
+                scratch._index_initialized = true;
+            } 
+            uint32_t* p_expert_index = (uint32_t*)scratch._expert_index_buffer->buffer_ptr();
+            for (int i = 0; i < max_topk; i++) {
+                auto expert_no = experts_list[i];
+                auto lru_expert_no = get_lru_expert_no(instance, static_cast<uint32_t>(expert_no), cache);
+                *p_expert_index++ = lru_expert_no;  // update batch_mem_ptr as re-map
+            }
+            batch_mem_ptr = scratch._expert_index_buffer;
+            scratch.moe_fusion_wei_addr.weight[0] = shell_params.gate_w;
+            scratch.moe_fusion_wei_addr.scale[0] = shell_params.gate_s;
+            scratch.moe_fusion_wei_addr.zp[0] = shell_params.gate_z;
+
+            scratch.moe_fusion_wei_addr.weight[1] = shell_params.up_w;
+            scratch.moe_fusion_wei_addr.scale[1] = shell_params.up_s;
+            scratch.moe_fusion_wei_addr.zp[1] = shell_params.up_z;
+
+            scratch.moe_fusion_wei_addr.weight[2] = shell_params.down_w;
+            scratch.moe_fusion_wei_addr.scale[2] = shell_params.down_s;
+            scratch.moe_fusion_wei_addr.zp[2] = shell_params.down_z;
+        }
 
         // gate
         const auto& mlp_gate_wei_mem = scratch.moe_fusion_wei_addr.weight[0];
@@ -1534,6 +2020,7 @@ public:
     cldnn::event::ptr exec_prefill_micro_gemm(const std::vector<cldnn::event::ptr>& events,
                                               typed_primitive_inst<moe_3gemm_fused_compressed>& instance,
                                               scratch_buffers& scratch,
+                                              LRUCache& cache,
                                               const bool use_gpu_mask_gen) {
         auto cur_moe = instance.get_typed_desc<moe_3gemm_fused_compressed>();
         int max_topk = static_cast<int>(cur_moe->_config.top_k);
@@ -1558,6 +2045,40 @@ public:
         auto& stream = instance.get_network().get_stream();
         auto num_total_experts = static_cast<int>(cur_moe->_config.num_expert);
         int num_actually_used_experts = 0;
+
+        if (_lru_expert_num) {
+            auto& stream = instance.get_network().get_stream();
+            auto& engine = instance.get_network().get_engine();
+            auto topk_count = token_num * static_cast<size_t>(max_topk);
+            auto topk_bytes = topk_count * sizeof(uint32_t);
+
+            std::vector<uint32_t> expert_ids(topk_count);
+            batch_mem_ptr->copy_to(stream, expert_ids.data(), 0, 0, topk_bytes, true);
+
+            std::unordered_map<uint32_t, uint32_t> expert_to_lru;
+            expert_to_lru.reserve(topk_count);
+            for (size_t i = 0; i < topk_count; i++) {
+                auto expert_no = expert_ids[i];
+                OPENVINO_ASSERT(expert_no < static_cast<uint32_t>(num_total_experts),
+                                "expert_no ",
+                                expert_no,
+                                " exceed max_expert_num ",
+                                num_total_experts);
+                auto it = expert_to_lru.find(expert_no);
+                if (it == expert_to_lru.end()) {
+                    auto lru_expert_no = get_lru_expert_no(instance, expert_no, cache);
+                    it = expert_to_lru.emplace(expert_no, lru_expert_no).first;
+                }
+                expert_ids[i] = it->second;
+            }
+
+            auto remap_layout = batch_mem_ptr->get_layout();
+            if (!scratch._expert_index_buffer || scratch._expert_index_buffer->size() < topk_bytes) {
+                scratch._expert_index_buffer = engine.allocate_memory(remap_layout, allocation_type::usm_host, false);
+            }
+            scratch._expert_index_buffer->copy_from(stream, expert_ids.data(), 0, 0, topk_bytes, true);
+            batch_mem_ptr = scratch._expert_index_buffer;
+        }
 
         // step 1: generate 4 mask data for following kernel execution
         // input: topk output, [token_len, expert_topk]
@@ -1823,6 +2344,7 @@ public:
 
     using lru_cache_hash = LruCache<std::pair<int, int>, std::shared_ptr<onednn_kernel>, PairHash>;
     lru_cache_hash _kernels = lru_cache_hash(1024);
+    std::shared_ptr<onednn_kernel> _otd_kernel_holder;
     onednn_kernel& get_kernel(int n_token, int expert_no, typed_primitive_inst<moe_3gemm_fused_compressed>& instance) {
         auto key = std::make_pair(n_token, expert_no);
         if (_kernels.has(key)) {
@@ -1879,6 +2401,12 @@ public:
                                              dnnl_weights[2].weight,
                                              dnnl_weights[2].scale,
                                              dnnl_weights[2].zp);
+        // each time dnnl_weights updated need refresh kernel cache in OTD mode, if not, the stream engine context and memory storage engine context will mismatch,
+        // dnnl kernel will report invalid_arguments and fail or compute wrong and output wrong tokens. if any perf concerns, need deep dive here.
+        if (_lru_expert_num) {
+            _otd_kernel_holder = kernel;
+            return *_otd_kernel_holder;
+        }
         _kernels.add(key, kernel);
         return *_kernels.get(key);
     }
@@ -1900,7 +2428,8 @@ public:
     cldnn::event::ptr exec_prefill_onednn(const std::vector<cldnn::event::ptr>& events,
                                           cldnn::stream& stream,
                                           typed_primitive_inst<moe_3gemm_fused_compressed>& instance,
-                                          scratch_buffers& scratch) {
+                                          scratch_buffers& scratch,
+                                                                                    LRUCache& cache) {
         auto cur_moe = instance.get_typed_desc<moe_3gemm_fused_compressed>();
         const auto& config = cur_moe->_config;
         auto& dnn_stream = stream.get_onednn_stream();
@@ -1936,6 +2465,32 @@ public:
             auto can_skip_subgraph = !expert_mask.pred_flag[expert_no];
             if (can_skip_subgraph) {
                 continue;
+            }
+
+            if (_lru_expert_num) {
+                // Ensure previous oneDNN work is completed before any potential
+                // LRU slot overwrite in get_lru_expert_no/fill_weights_memory.
+                dnn_stream.wait();
+
+                auto& dnnl_weights = _dnnl_weights[expert_no];
+                auto lru_expert_no = get_lru_expert_no(instance, static_cast<uint32_t>(expert_no), cache);
+                auto& params = instance._weights;
+
+                #define CONVERT_DNNL(name, i)  \
+                    int64_t wei_offset##i = lru_expert_no * dnnl_weights[i].ic * dnnl_weights[i].oc / 2; \
+                    int64_t scale_offset##i = lru_expert_no * dnnl_weights[i].ic * dnnl_weights[i].oc / dnnl_weights[i].ic_group_size * 2; \
+                    int64_t zp_offset##i = lru_expert_no * dnnl_weights[i].ic * dnnl_weights[i].oc / dnnl_weights[i].ic_group_size / 2; \
+                    dnnl_weights[i].weight = convert2dnnl(params.name##_w, {dnnl_weights[i].ic, dnnl_weights[i].oc}, dnnl::memory::format_tag::ba, wei_offset##i); \
+                    dnnl_weights[i].scale = convert2dnnl(params.name##_s, \
+                                                        {dnnl_weights[i].ic / dnnl_weights[i].ic_group_size, dnnl_weights[i].oc}, \
+                                                        dnnl::memory::format_tag::ab, scale_offset##i); \
+                    dnnl_weights[i].zp = convert2dnnl(params.name##_z, \
+                                                    {dnnl_weights[i].ic / dnnl_weights[i].ic_group_size, dnnl_weights[i].oc}, \
+                                                    dnnl::memory::format_tag::ab, zp_offset##i);
+                CONVERT_DNNL(gate, 0)
+                CONVERT_DNNL(up, 1)
+                CONVERT_DNNL(down, 2)
+                #undef CONVERT_DNNL
             }
             auto& dnnl_weights = _dnnl_weights[expert_no];
 
@@ -2004,6 +2559,11 @@ public:
         const auto& config = cur_moe->_config;
         auto& cur_net = instance.get_network();
         auto& stream = cur_net.get_stream();
+        static std::map<cldnn::primitive_id, LRUCache> multi_layer_caches;
+        auto [it, _] = multi_layer_caches.try_emplace(cur_moe->id, _lru_expert_num);
+
+        auto& cache = it->second;
+
         cldnn::event::ptr ret_env = nullptr;
         _has_shared_expert = (config.num_shared_expert > 0);
 
@@ -2019,6 +2579,24 @@ public:
 
         auto [hidden_states_mem_ptr, hidden_states_layout] = get_input_info(instance, static_cast<size_t>(MOE3GemmInputIndex::HIDDEN_STATES));
         size_t token_num = get_seq_len(hidden_states_layout);
+
+        if (_lru_expert_num) {
+            if (!cache.m_initialized) {
+                instance._weights.gate_w = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_0));
+                instance._weights.gate_z = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::ZP_0));
+                instance._weights.gate_s = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SCALE_0));
+
+                instance._weights.up_w = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_1));
+                instance._weights.up_z = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::ZP_1));
+                instance._weights.up_s = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SCALE_1));
+
+                instance._weights.down_w = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_2));
+                instance._weights.down_z = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::ZP_2));
+                instance._weights.down_s = instance.input_memory_ptr(static_cast<size_t>(MOE3GemmInputIndex::SCALE_2));
+                cache.m_initialized = true;
+            }
+        }
+
         scratch_buffers scratch;
         prepare_internal_buffers(instance, scratch, token_num);
 
@@ -2052,7 +2630,7 @@ public:
         // Single token is a special case, we don't need to do gather/scatter,
         // and we can apply optimal kernels against memory bound to improve performance.
         if (token_num == 1) {
-            return exec_single_token({topk_event}, instance, scratch);
+            return exec_single_token({topk_event}, instance, scratch, cache);
         }
 
         auto final_hidden_states_mem_ptr = instance.output_memory_ptr(0);
@@ -2070,9 +2648,9 @@ public:
                                << ", use_micro_gemm_prefill=" << use_micro_gemm_prefill << std::endl;
         update_rt_params(instance);
         if (use_micro_gemm_prefill) {
-            ret_env = exec_prefill_micro_gemm({topk_event}, instance, scratch, use_gpu_mask_gen);
+            ret_env = exec_prefill_micro_gemm({topk_event}, instance, scratch, cache, use_gpu_mask_gen);
         } else {
-            ret_env = exec_prefill_onednn({topk_event}, stream, instance, scratch);
+            ret_env = exec_prefill_onednn({topk_event}, stream, instance, scratch, cache);
         }
 
         if (_has_shared_expert) {

--- a/src/plugins/intel_gpu/src/graph/include/moe_3gemm_fused_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/moe_3gemm_fused_inst.h
@@ -47,6 +47,8 @@ public:
     static layout calc_output_layout(const moe_node& /* node */, const kernel_impl_params& impl_param);
     static std::string to_string(const moe_node& node);
     typed_primitive_inst(network& network, const moe_node& node);
+    cldnn::memory::ptr _base;
+    cldnn::moe_weights _weights;
 };
 
 using moe_inst = typed_primitive_inst<moe_3gemm_fused_compressed>;

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -18,7 +18,7 @@
 #include "intel_gpu/runtime/compilation_context.hpp"
 #include "intel_gpu/runtime/debug_configuration.hpp"
 #include "intel_gpu/runtime/itt.hpp"
-
+#include "openvino/util/env_util.hpp"
 #include "intel_gpu/graph/kernel_impl_params.hpp"
 #include "intel_gpu/graph/program.hpp"
 #include "intel_gpu/graph/network.hpp"
@@ -1065,7 +1065,9 @@ void network::transfer_memory_to_device(std::shared_ptr<primitive_inst> instance
         && users.front()->is_type<reshape>()
         && users.front()->is_dynamic())
             return;
-
+    if (get_config().get_moe_offload_max_experts() > 0) {
+        return;
+    }
     // Do not transfer memory if a user requires lockable memory.
     // If memory is used in both gpu and cpu implementations, primitive itself is responsible for correct allocation type
     if (node.need_lockable_memory())

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#include <thread>
+#include <chrono>
 
 #include "intel_gpu/graph/fused_primitive_desc.hpp"
 #include "registry/implementation_manager.hpp"
@@ -9,6 +11,7 @@
 #include "openvino/runtime/system_conf.hpp"
 #include "openvino/runtime/threading/cpu_streams_info.hpp"
 #include "openvino/util/weights_path.hpp"
+#include "openvino/util/env_util.hpp"
 #include "openvino/util/file_util.hpp"
 
 #include "intel_gpu/runtime/memory.hpp"
@@ -496,7 +499,6 @@ void program::build_program(bool is_internal) {
     { pre_optimize_graph(is_internal); }
     run_graph_compilation();
     { post_optimize_graph(is_internal); }
-
 #ifdef GPU_DEBUG_CONFIG
     if (get_config().get_dry_run_path().empty() || is_internal) {
 #else
@@ -718,7 +720,7 @@ void program::transfer_memory_to_device() {
         // TODO: Do we need finish call here? Maybe call it in network::execute() ?
         get_stream().finish();
     };
-
+    auto otd = _config.get_moe_offload_max_experts();
     for (auto& node : processing_order) {
         if (node->is_shape_infer_dep()) {
             continue;
@@ -726,6 +728,10 @@ void program::transfer_memory_to_device() {
         if (node->is_type<data>() && !node->need_lockable_memory()) {
             auto& data_node = node->as<data>();
             auto data_node_layout = data_node.get_output_layout();
+            auto prim = data_node.get_primitive();
+            if (otd) {
+                continue;
+            }
             auto& mem = data_node.get_attached_memory();
             auto mem_layout = mem.get_layout();
             auto alloc_type = mem.get_allocation_type();

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -25,10 +25,23 @@
 #include "openvino/op/tensor_iterator.hpp"
 #include "openvino/op/bucketize.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/moe.hpp"
 #include "openvino/op/util/binary_elementwise_bitwise.hpp"
+
+#include "intel_gpu/op/moe_3gemm_fused_compressed.hpp"
+#include "intel_gpu/op/moe_compressed.hpp"
 
 #include "intel_gpu/primitives/data.hpp"
 #include "intel_gpu/runtime/debug_configuration.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
 
 namespace ov::intel_gpu {
 
@@ -73,6 +86,68 @@ struct ConstProperties {
     bool needsBatchInterpretation;
 };
 
+static size_t get_moe_offload_max_experts(const ExecutionConfig& config) {
+    return config.get_moe_offload_max_experts();
+}
+
+static bool is_moe_related_constant(const std::shared_ptr<ov::op::v0::Constant>& op) {
+    const auto users = op->get_output_target_inputs(0);
+    for (const auto& input : users) {
+        const auto* node = input.get_node();
+        if (ov::is_type<ov::op::internal::MOE>(node) ||
+            ov::is_type<ov::intel_gpu::op::MOECompressed>(node) ||
+            ov::is_type<ov::intel_gpu::op::MOE3GemmFusedCompressed>(node)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct PartialMoeConstUploadLogState {
+    static constexpr size_t max_detailed_logs = 3;
+
+    void log(const std::string& node_name,
+             size_t uploaded_experts,
+             size_t total_experts,
+             size_t upload_bytes,
+             size_t target_bytes) {
+        total_upload_bytes.fetch_add(static_cast<uint64_t>(upload_bytes), std::memory_order_relaxed);
+        total_target_bytes.fetch_add(static_cast<uint64_t>(target_bytes), std::memory_order_relaxed);
+
+        const size_t total = total_count.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (total <= max_detailed_logs) {
+            std::cout << "[EXPERIMENTAL] OTD partial constant allocation at compile stage: "
+                      << node_name << ", experts=" << uploaded_experts
+                      << "/" << total_experts << ", upload_bytes=" << upload_bytes
+                      << ", target_bytes=" << target_bytes << std::endl;
+        } else if (total == max_detailed_logs + 1) {
+            std::cout << "[EXPERIMENTAL] OTD partial constant allocation: suppressing further per-constant logs, "
+                      << "final summary will be printed at process exit" << std::endl;
+        }
+    }
+
+    ~PartialMoeConstUploadLogState() {
+        const size_t total = total_count.load(std::memory_order_relaxed);
+        if (total > max_detailed_logs) {
+            const size_t shown = max_detailed_logs;
+            std::cout << "[EXPERIMENTAL] OTD partial constant allocation summary: total=" << total
+                      << ", shown=" << shown << ", suppressed=" << (total - shown)
+                      << ", total_upload_bytes=" << total_upload_bytes.load(std::memory_order_relaxed)
+                      << ", total_target_bytes=" << total_target_bytes.load(std::memory_order_relaxed)
+                      << std::endl;
+        }
+    }
+
+    std::atomic<size_t> total_count{0};
+    std::atomic<uint64_t> total_upload_bytes{0};
+    std::atomic<uint64_t> total_target_bytes{0};
+};
+
+static PartialMoeConstUploadLogState& get_partial_moe_const_upload_log_state() {
+    static PartialMoeConstUploadLogState state;
+    return state;
+}
+
 static void create_data(ProgramBuilder& p, const ov::Shape& const_shape, const std::shared_ptr<ov::op::v0::Constant>& op, const ConstProperties& props) {
     cldnn::tensor constTensor = getConstTensor(const_shape);
     auto constFormat = cldnn::format::get_default_format(const_shape.size());
@@ -99,10 +174,34 @@ static void create_data(ProgramBuilder& p, const ov::Shape& const_shape, const s
         p.primitive_ids[initialconstPrimID] = constPrimID;
         p.profiling_ids.push_back(initialconstPrimID);
     } else {
+        const size_t otd_expert_num = get_moe_offload_max_experts(p.get_config());
+        const bool partial_moe_const_upload = otd_expert_num > 0 && is_moe_related_constant(op);
+
         cldnn::memory::ptr mem = nullptr;
-        if (constLayout.bytes_count() > 0) {
+        size_t upload_bytes = constLayout.bytes_count();
+        ov::Shape upload_shape = const_shape;
+
+        if (partial_moe_const_upload && constLayout.bytes_count() > 0 && !const_shape.empty() && const_shape[0] > 0) {
+            upload_shape[0] = std::min<size_t>(const_shape[0], otd_expert_num);
+            auto upload_layout = cldnn::layout(upload_shape, out_dtype, constFormat);
+            // OTD memory-saving strategy: allocate only otd_expert_num experts worth of
+            // physical memory, then reinterpret to full constLayout so that:
+            //  (a) graph compilation sees the correct full shape for shape inference, and
+            //  (b) fill_weights_memory computes per_expert_size = layout_bytes / num_expert correctly.
+            // Safety invariant: all runtime accesses use lru_expert_no as the slot index,
+            // which is bounded by LRUCache::m_max_total_experts == otd_expert_num, so
+            // max accessed byte = otd_expert_num * per_expert_size == upload_layout.bytes_count().
+            auto upload_mem = p.get_engine().allocate_memory(upload_layout, false);
+            mem = p.get_engine().reinterpret_buffer(*upload_mem, constLayout);
+            upload_bytes = upload_layout.bytes_count();
+            get_partial_moe_const_upload_log_state().log(op->get_friendly_name(),
+                                                         upload_shape[0],
+                                                         const_shape[0],
+                                                         upload_bytes,
+                                                         constLayout.bytes_count());
+        } else if (constLayout.bytes_count() > 0) {
             mem = p.get_engine().allocate_memory(constLayout, false);
-        } else {
+        } else { 
             // In the case of empty const data with {0} shape, it has zero byte.
             // To avoid zero byte memory allocation issue, reinterpret one dimension memory to zero dimension memory.
             auto one_dim_layout = cldnn::layout(ov::PartialShape({1}), constLayout.data_type, constLayout.format);
@@ -115,35 +214,41 @@ static void create_data(ProgramBuilder& p, const ov::Shape& const_shape, const s
         auto& stream = p.get_engine().get_service_stream();
         cldnn::mem_lock<char> lock{mem, stream};
         auto buf = lock.data();
-        auto bufSize = constLayout.bytes_count();
+        auto bufSize = upload_bytes;
+        auto upload_count = ov::shape_size(upload_shape);
 
-        // If a constant has element type f64 but contains no elements (empty tensor),
-        // convert it to f32 because the GPU plugin only supports the f32 data type internally.
-        if (ov::shape_size(const_shape) == 1 &&
-            out_dtype == cldnn::data_types::f32 &&
-            op->get_output_element_type(0) == ov::element::f64) {
-            const auto* f64data = op->get_data_ptr<double>();
-            auto f32buf = reinterpret_cast<float*>(buf);
-            f32buf[0] = static_cast<float>(f64data[0]);
-        } else if (out_dtype == cldnn::data_types::f32 &&
-                   (op->get_output_element_type(0) == ov::element::u16 ||
-                    op->get_output_element_type(0) == ov::element::i16)) {
-            size_t count = ov::shape_size(const_shape);
-            auto f32buf = reinterpret_cast<float*>(buf);
+        {
+            const bool skip_partial_const_memcpy = partial_moe_const_upload;
 
-            if (op->get_output_element_type(0) == ov::element::u16) {
-                const auto* u16data = op->get_data_ptr<uint16_t>();
-                for (size_t i = 0; i < count; i++) {
-                    f32buf[i] = static_cast<float>(u16data[i]);
+            // If a constant has element type f64 but contains no elements (empty tensor),
+            // convert it to f32 because the GPU plugin only supports the f32 data type internally.
+            if (skip_partial_const_memcpy) {
+            } else if (upload_count == 1 &&
+                out_dtype == cldnn::data_types::f32 &&
+                op->get_output_element_type(0) == ov::element::f64) {
+                const auto* f64data = op->get_data_ptr<double>();
+                auto f32buf = reinterpret_cast<float*>(buf);
+                f32buf[0] = static_cast<float>(f64data[0]);
+            } else if (out_dtype == cldnn::data_types::f32 &&
+                       (op->get_output_element_type(0) == ov::element::u16 ||
+                        op->get_output_element_type(0) == ov::element::i16)) {
+                size_t count = upload_count;
+                auto f32buf = reinterpret_cast<float*>(buf);
+
+                if (op->get_output_element_type(0) == ov::element::u16) {
+                    const auto* u16data = op->get_data_ptr<uint16_t>();
+                    for (size_t i = 0; i < count; i++) {
+                        f32buf[i] = static_cast<float>(u16data[i]);
+                    }
+                } else {
+                    const auto* i16data = op->get_data_ptr<int16_t>();
+                    for (size_t i = 0; i < count; i++) {
+                        f32buf[i] = static_cast<float>(i16data[i]);
+                    }
                 }
             } else {
-                const auto* i16data = op->get_data_ptr<int16_t>();
-                for (size_t i = 0; i < count; i++) {
-                    f32buf[i] = static_cast<float>(i16data[i]);
-                }
+                std::memcpy(&buf[0], &data[0], bufSize);
             }
-        } else {
-            std::memcpy(&buf[0], &data[0], bufSize);
         }
         p.add_primitive(*op, cldnn::data(initialconstPrimID, mem));
         p.blobMemCache[cache_key] = initialconstPrimID;

--- a/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
@@ -2,13 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include "openvino/op/moe.hpp"
+#include "transformations/rt_info/fused_names_attribute.hpp"
 
 #include <intel_gpu/primitives/eltwise.hpp>
 #include <intel_gpu/primitives/moe_gather.hpp>
 #include <intel_gpu/primitives/moe_scatter_reduction.hpp>
 #include <intel_gpu/primitives/swiglu.hpp>
-#include <limits>
 
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <limits>
+#include <set>
+#include <sstream>
+#include <unordered_map>
+
+#include <pugixml.hpp>
 #include "intel_gpu/op/moe_3gemm_fused_compressed.hpp"
 #include "intel_gpu/op/moe_compressed.hpp"
 #include "intel_gpu/plugin/common_utils.hpp"
@@ -31,8 +40,202 @@ namespace ov::intel_gpu {
 using namespace cldnn;
 
 static void CreateMOE3GemmFusedCompressedOp(ProgramBuilder& p, const std::shared_ptr<ov::intel_gpu::op::MOE3GemmFusedCompressed>& op) {
+    using input_idx = cldnn::moe_3gemm_fused_compressed::input_index;
     auto inputs = p.GetInputInfo(op);
     const auto& config = op->get_config();
+    const auto& model = p.get_model();
+    std::string weights_path;
+    const size_t lru_expert_num = p.get_config().get_moe_offload_max_experts();
+    const bool otd_enabled = lru_expert_num > 0;
+    if (otd_enabled) {
+        const auto& rt = model->get_rt_info();
+        auto it = rt.find("__weights_path");
+        OPENVINO_ASSERT(it != rt.end(), "Model rt_info is missing '__weights_path' required by OTD");
+        weights_path = it->second.as<std::string>();
+    }
+
+    struct XmlConstEntry {
+        size_t offset = 0;
+        size_t size = 0;
+        bool used = false;
+    };
+
+    std::unordered_map<std::string, std::vector<XmlConstEntry>> xml_const_entries_by_name;
+    bool xml_offsets_ready = false;
+
+    auto load_const_offsets_from_xml = [&]() {
+        if (xml_offsets_ready || weights_path.empty()) {
+            return;
+        }
+
+        std::filesystem::path xml_path(weights_path);
+        xml_path.replace_extension(".xml");
+        OPENVINO_ASSERT(std::filesystem::exists(xml_path), "IR xml file is not found: ", xml_path.string());
+
+        pugi::xml_document doc;
+        OPENVINO_ASSERT(doc.load_file(xml_path.string().c_str()), "Failed to parse IR xml file: ", xml_path.string());
+
+        auto net = doc.child("net");
+        auto layers = net.child("layers");
+        for (auto layer = layers.child("layer"); layer; layer = layer.next_sibling("layer")) {
+            const auto type_attr = layer.attribute("type");
+            if (!type_attr || std::string(type_attr.value()) != "Const") {
+                continue;
+            }
+
+            const auto data = layer.child("data");
+            const auto name_attr = layer.attribute("name");
+            const auto offset_attr = data.attribute("offset");
+            const auto size_attr = data.attribute("size");
+            if (!data || !name_attr || !offset_attr || !size_attr) {
+                continue;
+            }
+
+            XmlConstEntry entry;
+            entry.offset = static_cast<size_t>(std::stoull(offset_attr.value()));
+            entry.size = static_cast<size_t>(std::stoull(size_attr.value()));
+            xml_const_entries_by_name[name_attr.value()].push_back(entry);
+        }
+
+        xml_offsets_ready = true;
+    };
+
+    auto get_const_offset = [&](size_t index) -> size_t {
+        auto node = op->input_value(index).get_node_shared_ptr();
+        auto const_op = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
+        OPENVINO_ASSERT(const_op != nullptr, "Expected constant input for MOE3GemmFusedCompressed");
+        const auto& rt_info = const_op->get_rt_info();
+        auto attr_it = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
+
+        if (attr_it != rt_info.end()) {
+            return attr_it->second.as<ov::WeightlessCacheAttribute>().bin_offset;
+        }
+
+        load_const_offsets_from_xml();
+        OPENVINO_ASSERT(xml_offsets_ready,
+                        "Missing WeightlessCacheAttribute and failed to initialize xml-based offset lookup for "
+                        "MOE3GemmFusedCompressed constant input");
+
+        auto resolve_from_name = [&](const std::string& lookup_name,
+                                     const std::string& const_name,
+                                     size_t expected_size,
+                                     size_t& resolved_offset) -> bool {
+            auto by_name_it = xml_const_entries_by_name.find(lookup_name);
+            if (by_name_it == xml_const_entries_by_name.end()) {
+                return false;
+            }
+
+            size_t match_count = 0;
+            XmlConstEntry* matched_entry = nullptr;
+            for (auto& entry : by_name_it->second) {
+                if (!entry.used && entry.size == expected_size) {
+                    match_count++;
+                    if (matched_entry == nullptr) {
+                        matched_entry = &entry;
+                    }
+                }
+            }
+
+            if (match_count == 1 && matched_entry != nullptr) {
+                matched_entry->used = true;
+                resolved_offset = matched_entry->offset;
+                return true;
+            }
+
+            if (match_count > 1) {
+                OPENVINO_THROW("Ambiguous xml offset resolution for MOE3GemmFusedCompressed constant input: ",
+                               const_name,
+                               ", lookup_name=", lookup_name,
+                               ", byte_size=", expected_size,
+                               ", candidates=", match_count);
+            }
+
+            return false;
+        };
+
+        const auto& name = const_op->get_friendly_name();
+        const size_t expected_size = const_op->get_byte_size();
+        size_t resolved_offset = 0;
+        if (resolve_from_name(name, name, expected_size, resolved_offset)) {
+            return resolved_offset;
+        }
+
+        // Try original/fused names before using any size-based fallback.
+        std::set<std::string> fused_names_unique;
+        for (const auto& fused_name : ov::getFusedNamesVector(const_op)) {
+            if (!fused_name.empty() && fused_name != name) {
+                fused_names_unique.insert(fused_name);
+            }
+        }
+        for (const auto& fused_name : fused_names_unique) {
+            if (resolve_from_name(fused_name, name, expected_size, resolved_offset)) {
+                return resolved_offset;
+            }
+        }
+
+        // Fallback: allow by-size only when there is exactly one unused candidate.
+        struct SizeCandidate {
+            std::string name;
+            XmlConstEntry* entry = nullptr;
+        };
+        std::vector<SizeCandidate> size_candidates;
+        for (auto& kv : xml_const_entries_by_name) {
+            for (auto& entry : kv.second) {
+                if (!entry.used && entry.size == expected_size) {
+                    size_candidates.push_back(SizeCandidate{kv.first, &entry});
+                }
+            }
+        }
+
+        if (size_candidates.size() == 1 && size_candidates[0].entry != nullptr) {
+            size_candidates[0].entry->used = true;
+            return size_candidates[0].entry->offset;
+        }
+
+        if (size_candidates.size() > 1) {
+            std::ostringstream oss;
+            const size_t max_candidates_to_log = 8;
+            for (size_t i = 0; i < std::min(max_candidates_to_log, size_candidates.size()); i++) {
+                const auto* candidate_entry = size_candidates[i].entry;
+                if (candidate_entry == nullptr) {
+                    continue;
+                }
+                if (i > 0) {
+                    oss << ';';
+                }
+                oss << size_candidates[i].name << '@' << candidate_entry->offset;
+            }
+
+            OPENVINO_THROW("Ambiguous xml offset resolution for MOE3GemmFusedCompressed constant input: ",
+                           name,
+                           ", byte_size=", expected_size,
+                           ", size_candidates=", size_candidates.size(),
+                           ", sample_candidates=", oss.str());
+        }
+
+        OPENVINO_THROW("Unable to resolve xml offset for MOE3GemmFusedCompressed constant input: ", name,
+                       ", byte_size=", expected_size);
+    };
+
+    const std::array<size_t, cldnn::moe_3gemm_fused_compressed::serialized_weight_offset_count> const_input_idx_by_offset = {
+        static_cast<size_t>(input_idx::weight_0),
+        static_cast<size_t>(input_idx::weight_1),
+        static_cast<size_t>(input_idx::weight_2),
+        static_cast<size_t>(input_idx::scale_0),
+        static_cast<size_t>(input_idx::scale_1),
+        static_cast<size_t>(input_idx::scale_2),
+        static_cast<size_t>(input_idx::zp_0),
+        static_cast<size_t>(input_idx::zp_1),
+        static_cast<size_t>(input_idx::zp_2)
+    };
+
+    std::vector<size_t> weight_bin_offsets(cldnn::moe_3gemm_fused_compressed::serialized_weight_offset_count, 0);
+    // Serialized offsets are only needed for OTD path (weight-on-demand loading).
+    if (otd_enabled) {
+        for (size_t i = 0; i < const_input_idx_by_offset.size(); i++) {
+            weight_bin_offsets[i] = get_const_offset(const_input_idx_by_offset[i]);
+        }
+    }
     ///   0: hidden_states - input tensor with hidden representations
     ///   1: routing_weights - [num_seq, num_experts] routing weights for all experts
     ///   2: w0_weight - expert weights for first projection,
@@ -85,7 +288,7 @@ static void CreateMOE3GemmFusedCompressedOp(ProgramBuilder& p, const std::shared
     validate_inputs_count(op, {expected_inputs});
 
     const std::string layerName = layer_type_name_ID(op);
-    const cldnn::moe_3gemm_fused_compressed moe(layerName, inputs, config);
+    const cldnn::moe_3gemm_fused_compressed moe(layerName, inputs, config, weight_bin_offsets, weights_path, lru_expert_num);
 
     p.add_primitive(*op, moe);
 }

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -177,7 +177,6 @@ std::shared_ptr<ov::Model> Plugin::clone_and_transform_model(const std::shared_p
         if (!ov::util::validate_weights_path(weights_path) && !is_weightless_cache_attributes_set(cloned_model))
             set_weightless_cache_attributes(cloned_model);
     }
-
     transform_model(cloned_model, config_copy, context);
 
     // Transformations for some reason may drop output tensor names, so here we copy those from the original model
@@ -742,6 +741,7 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::cache_encryption_callbacks.name(), PropertyMutability::WO},
         ov::PropertyName{ov::hint::kv_cache_precision.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::model.name(), PropertyMutability::WO},
+        ov::PropertyName{ov::intel_gpu::moe_offload_max_experts.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::config_file.name(), PropertyMutability::RW},
     };
 

--- a/src/plugins/intel_gpu/src/plugin/program_builder.cpp
+++ b/src/plugins/intel_gpu/src/plugin/program_builder.cpp
@@ -146,6 +146,11 @@ std::shared_ptr<cldnn::program> ProgramBuilder::build(const std::vector<std::sha
     {
         GPU_DEBUG_DEFINE_MEM_LOGGER("CreateSingleLayerPrimitives");
         for (const auto& op : ops) {
+            GPU_DEBUG_LOG << "CreateSingleLayerPrimitive begin: "
+                          << op->get_type_info().version_id << "::" << op->get_type_name()
+                          << " (friendly_name=" << op->get_friendly_name() << ")" << std::endl;
+
+            GPU_DEBUG_DEFINE_MEM_LOGGER(layer_type_name_ID(op));
             CreateSingleLayerPrimitive(op);
         }
     }
@@ -311,6 +316,18 @@ void ProgramBuilder::add_primitive(const ov::Node& op, std::shared_ptr<cldnn::pr
     auto prim_id = prim->id;
     auto id = layer_type_name_ID(&op);
     primitive_ids[id] = prim_id;
+
+    // std::cout << "[PB_PRIM] add_primitive prim_id=" << prim_id
+    //           << ", prim_type=" << prim->type_string()
+    //           << ", origin_op=" << op.get_type_info().version_id << "::" << op.get_type_name()
+    //           << " (friendly_name=" << op.get_friendly_name() << ")"
+    //           << std::endl;
+
+    GPU_DEBUG_LOG << "add_primitive: prim_id=" << prim_id
+                  << ", prim_type=" << prim->type_string()
+                  << ", origin_op=" << op.get_type_info().version_id << "::" << op.get_type_name()
+                  << " (friendly_name=" << op.get_friendly_name() << ")"
+                  << std::endl;
 
     bool multi_output_case = ends_with(prim_id, ".out0") && prim_id.length() > 5 && prim_id.substr(0, prim_id.length() - 5) == id;
     if (id != prim_id) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_offload_property_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_offload_property_test.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils/test_utils.h"
+#include "intel_gpu/runtime/internal_properties.hpp"
+
+using namespace cldnn;
+using namespace tests;
+
+TEST(moe_offload_property_test, execution_config_roundtrip) {
+    auto config = get_test_default_config(get_test_engine());
+
+    ASSERT_EQ(config.get_moe_offload_max_experts(), 0U);
+
+    config.set_property(ov::intel_gpu::moe_offload_max_experts(48));
+
+    ASSERT_EQ(config.get_moe_offload_max_experts(), 48U);
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to support efficient handling of large Mixture-of-Experts (MoE) models on Intel GPUs, focusing on partial constant uploads and runtime memory optimization. The main changes include the addition of an LRU cache for expert weights, environment-variable-driven control over constant uploads, and extensions to MoE primitive structures to support these features.

**Key changes:**

### MoE Model Partial Constant Upload and LRU Caching

* Implemented an LRU cache (`LRUCache.hpp`/`LRUCache.cpp`) to manage expert weights, including statistics reporting and eviction logic, to optimize memory usage when running large MoE models. [[1]](diffhunk://#diff-27963a7b79686f541d171206b3ce56cb2b54452a19d6ba1bb41341ee8424101fR1-R69) [[2]](diffhunk://#diff-02c725adb71cdaffc6a8667ae01ee4761e1d0c9fee220f3621497854779b35d5R1-R99)
* Added logic to partially upload MoE-related constants at compile time, controlled by the `OTD` environment variable, significantly reducing initial memory footprint for large models. [[1]](diffhunk://#diff-1f23c53b8acf4288687891e0956ec8a6ab31d18ac93e34950b8f2d7aaae61ab0R86-R113) [[2]](diffhunk://#diff-1f23c53b8acf4288687891e0956ec8a6ab31d18ac93e34950b8f2d7aaae61ab0R140-R157) [[3]](diffhunk://#diff-1f23c53b8acf4288687891e0956ec8a6ab31d18ac93e34950b8f2d7aaae61ab0L118-R181) [[4]](diffhunk://#diff-1f23c53b8acf4288687891e0956ec8a6ab31d18ac93e34950b8f2d7aaae61ab0L131-R190) [[5]](diffhunk://#diff-1f23c53b8acf4288687891e0956ec8a6ab31d18ac93e34950b8f2d7aaae61ab0R207)

### MoE Primitive and Data Structure Extensions

* Extended `moe_3gemm_fused_compressed` primitive to include weight offsets and file path, and ensured serialization/deserialization of these new fields; added a `moe_weights` struct for managing MoE expert weights. [[1]](diffhunk://#diff-64c734cd0069b8483e038f792e1bb17048004f12a71aaf84fd9f086c40db8569R7-R51) [[2]](diffhunk://#diff-64c734cd0069b8483e038f792e1bb17048004f12a71aaf84fd9f086c40db8569L46-R114)
* Updated `typed_primitive_inst<moe_3gemm_fused_compressed>` to include pointers to base memory and weights, supporting the new partial upload and caching mechanisms.

### Environment Variable Integration

* Integrated environment variable checks (`OTD`) in both compile-time (constant upload) and runtime (memory transfer) logic, allowing dynamic control over memory optimization features without code changes. [[1]](diffhunk://#diff-7350deb6c926cc66c611141163e74cc9bca1068193125cd4ed743eb4f5764488L994-R997) [[2]](diffhunk://#diff-07dd612329ad00ce8c4a6e2812b1bb88e6c5cd7dc8ae548ab0632a1c140c4250L721-R734) [[3]](diffhunk://#diff-1f23c53b8acf4288687891e0956ec8a6ab31d18ac93e34950b8f2d7aaae61ab0R86-R113)

### Miscellaneous and Infrastructure

* Added includes and utility functions for environment variable handling and file utilities to support the new features. [[1]](diffhunk://#diff-7350deb6c926cc66c611141163e74cc9bca1068193125cd4ed743eb4f5764488L20-R20) [[2]](diffhunk://#diff-07dd612329ad00ce8c4a6e2812b1bb88e6c5cd7dc8ae548ab0632a1c140c4250R14) [[3]](diffhunk://#diff-21844b1a6783c0eaeebe19fd6179e4bff8aa536cb6dc656f3f55bea664c592e6R20-R35)
* Minor: Added a getter for the model in `ProgramBuilder` to facilitate access to the loaded model.

These changes collectively enable more scalable and memory-efficient deployment of large MoE models on Intel GPUs, with tunable behavior controlled via environment variables.

Tickets: CVS-176647