### PR TITLE
Fix broken documentation link in README (404 error) resolves #34340

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ OpenVINO supports the CPU, GPU, and NPU [devices](https://docs.openvino.ai/2025/
 
 ## Generative AI with OpenVINO
 
-Get started with the OpenVINO GenAI [installation](https://docs.openvino.ai/2025/get-started/install-openvino/install-openvino-genai.html) and refer to the [detailed guide](https://docs.openvino.ai/2025/openvino-workflow-generative/generative-inference.html) to explore the capabilities of Generative AI using OpenVINO.
+Get started with the OpenVINO GenAI [installation](https://docs.openvino.ai/2025/get-started/install-openvino/install-openvino-genai.html) and refer to the [detailed guide](https://docs.openvino.ai/2025/openvino-workflow-generative/inference-with-genai.html) to explore the capabilities of Generative AI using OpenVINO.
 
 Learn how to run LLMs and GenAI with [Samples](https://github.com/openvinotoolkit/openvino.genai/tree/master/samples) in the [OpenVINO™ GenAI repo](https://github.com/openvinotoolkit/openvino.genai). See GenAI in action with Jupyter notebooks: [LLM-powered Chatbot](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/llm-chatbot) and [LLM Instruction-following pipeline](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/llm-question-answering).
 


### PR DESCRIPTION
This PR fixes a broken link in the documentation README
[here](https://github.com/openvinotoolkit/openvino?tab=readme-ov-file#generative-ai-with-openvino)
broken link --> [detailed guide](https://docs.openvino.ai/2025/openvino-workflow-generative/generative-inference.html)(https://docs.openvino.ai/2025/openvino-workflow-generative/generative-inference.html)
that was returning a 404 error.

Updated the link to [detailed guide](https://docs.openvino.ai/2025/openvino-workflow-generative/inference-with-genai.html)

No functional changes.

Resolves issue #34340