### PR TITLE
[GPU] Handle negative indices values for scatter_nd_update_opt

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/scatter_nd_update_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/scatter_nd_update_opt.cl
@@ -89,7 +89,8 @@ KERNEL(scatter_nd_update_opt)(OPTIONAL_SHAPE_INFO_ARG
 
     for (uint i = 0; i < INDICES_LAST_DIM; ++i) {
         indices_coord[INDICES_RANK - 1] = i;
-        target_coord[i] = indices[GET_INDICES_INDEX(INPUT1_ORDER)];
+        int indices_val = indices[GET_INDICES_INDEX(INPUT1_ORDER)];
+        target_coord[i] = indices_val + (INPUT0_DIMS * (indices_val < 0));
     }
 
     for (uint i = INDICES_LAST_DIM; i < OUTPUT_DIMS; ++i) {


### PR DESCRIPTION
### Details:
scatter_nd_udpate_opt doesn't handle negative indices value causing data copy to wrong location

*Fix - To handle negative indices, add input/data dimension to the indices to position to correct positive indices location.

### Tickets:
 - CVS-182012

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, understand how scatter_nd_update work.
