### PR TITLE
problem 23074 fix-include HW plugin properties in supported_properties

### DIFF
--- a/src/plugins/auto_batch/src/compiled_model.cpp
+++ b/src/plugins/auto_batch/src/compiled_model.cpp
@@ -207,12 +207,28 @@ ov::Any CompiledModel::get_property(const std::string& name) const {
         } else if (name == ov::loaded_from_cache) {
             return m_compiled_model_without_batch->get_property(ov::loaded_from_cache.name());
         } else if (name == ov::supported_properties) {
-            return std::vector<ov::PropertyName>{
+            std::set<std::string> batch_props_set;
+            std::vector<ov::PropertyName> supported_props = {
                 ov::PropertyName{ov::supported_properties.name(), ov::PropertyMutability::RO},
                 ov::PropertyName{ov::optimal_number_of_infer_requests.name(), ov::PropertyMutability::RO},
                 ov::PropertyName{ov::model_name.name(), ov::PropertyMutability::RO},
                 ov::PropertyName{ov::execution_devices.name(), ov::PropertyMutability::RO},
                 ov::PropertyName{ov::auto_batch_timeout.name(), ov::PropertyMutability::RW}};
+            for (const auto& p : supported_props)
+                batch_props_set.insert(p);
+            // include HW plugin compiled model properties, skipping duplicates
+            try {
+                auto hw_props =
+                    m_compiled_model_without_batch->get_property(ov::supported_properties.name())
+                        .as<std::vector<ov::PropertyName>>();
+                for (auto&& hw_prop : hw_props) {
+                    if (batch_props_set.count(hw_prop) == 0) {
+                        supported_props.push_back(hw_prop);
+                    }
+                }
+            } catch (const ov::Exception&) {
+            }
+            return supported_props;
         } else if (name == ov::auto_batch_timeout) {
             uint32_t time_out = m_time_out;
             return time_out;

--- a/src/plugins/auto_batch/tests/unit/compile_model_get_property_test.cpp
+++ b/src/plugins/auto_batch/tests/unit/compile_model_get_property_test.cpp
@@ -136,3 +136,18 @@ INSTANTIATE_TEST_SUITE_P(smoke_AutoBatch_BehaviorTests,
                          CompileModelGetPropertyTest,
                          ::testing::ValuesIn(compile_model_get_property_param_test),
                          CompileModelGetPropertyTest::getTestCaseName);
+
+TEST_P(CompileModelGetPropertyTest, SupportedPropertiesIncludesHWPluginProperties) {
+    auto result = auto_batch_compile_model->get_property(ov::supported_properties.name());
+    auto supported = result.as<std::vector<ov::PropertyName>>();
+    std::set<std::string> names;
+    for (const auto& p : supported)
+        names.insert(p);
+    // batch-specific properties must be present
+    EXPECT_TRUE(names.count(ov::supported_properties.name()));
+    EXPECT_TRUE(names.count(ov::optimal_number_of_infer_requests.name()));
+    EXPECT_TRUE(names.count(ov::auto_batch_timeout.name()));
+    // HW plugin properties (optimal_batch_size, cache_dir) must also be present
+    EXPECT_TRUE(names.count(ov::optimal_batch_size.name()));
+    EXPECT_TRUE(names.count(ov::cache_dir.name()));
+}


### PR DESCRIPTION
### Details:
 - BATCH plugin's `supported_properties` only returned a hardcoded list of batch-specific properties, hiding the underlying HW plugin's compiled model properties
 - Now queries HW plugin's `supported_properties` via `m_compiled_model_without_batch`
  and merges them into the returned list, skipping duplicates.
-Added unit test to verify HW plugin properties appear in the merged list.

### Tickets:
 -  CVS-133381

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).
 -  AI helped refine the PR description and suggested an approach for merging `supported_properties` while avoiding duplicates.
- Human validation: verified logic against existing test structure and mock setup, confirmed the fallback path in `get_property()` already handles value retrieval for HW plugin properties.`.
