### PR TITLE
[PT FE]: add support for aten::values

### DIFF
--- a/src/frontends/pytorch/src/op/values.cpp
+++ b/src/frontends/pytorch/src/op/values.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/util/framework_node.hpp"
+#include "openvino/frontend/exception.hpp"
+#include "utils.hpp"    
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+OutputVector translate_values(const NodeContext& context) {
+    // aten::values(Tensor(a) self) -> Tensor(a)
+    // aten::values(Dict(a) self) -> Tensor[] (list of dict values)
+    num_inputs_check(context, 1, 1);
+    auto input = context.get_input(0);
+    auto producer = input.get_node_shared_ptr();
+
+    if (auto dict_construct = cast_fw_node(producer, "prim::DictConstruct")) {
+        // Check if the input is produced by prim::DictConstruct (dict input)
+        // inputs are key-value pairs, we need to return the values
+        // input are stored as [key1, value1, key2, value2, ...]
+        // thus we start from the second element and step by 2
+        // we need to check if the inputs are divisible by 2
+        // if not, we throw an error
+        const auto inputs = dict_construct->input_values();
+        FRONT_END_OP_CONVERSION_CHECK(inputs.size() % 2 == 0,
+                                     "aten::values: prim::DictConstruct inputs number is not divisible by 2.");
+        OutputVector value_outputs;
+        for (size_t i = 1; i < inputs.size(); i += 2) {
+            value_outputs.push_back(inputs.at(i));
+        }
+        return {context.mark_node(make_list_construct(value_outputs))};
+    }
+    // Tensor input: aten::values(Tensor) returns the tensor itself (single value)
+    // Only sparse tensor have values() method
+    // dense tensor does not have values() method
+    if (auto tensor = cast_fw_node(producer, {"aten::sparse_coo_tensor", "aten::sparse_csr_tensor", "aten::sparse_csc_tensor", "aten::sparse_bsr_tensor", "aten::sparse_bsc_tensor"})) {
+        FRONT_END_OP_CONVERSION_CHECK(false, "aten::values: Sparse tensor input is not supported.");
+    }
+    FRONT_END_OP_CONVERSION_CHECK(false, "aten::values: input is not a sparse tensor or dict.");
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -284,6 +284,7 @@ OP_CONVERTER(translate_upsample_nearest3d);
 OP_CONVERTER(translate_upsample_trilinear3d);
 OP_CONVERTER(translate_var);
 OP_CONVERTER(translate_var_mean);
+OP_CONVERTER(translate_values);
 OP_CONVERTER(translate_view_as_complex);
 OP_CONVERTER(translate_view_as_real);
 OP_CONVERTER(translate_weight_norm);
@@ -773,6 +774,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::upsample_trilinear3d", op::translate_upsample_trilinear3d},
         {"aten::var", op::translate_var},
         {"aten::var_mean", op::translate_var_mean},
+        {"aten::values", op::translate_values},
         {"aten::view", op::quantizable_op<op::translate_reshape>},
         {"aten::view_as", op::translate_reshape_as},
         {"aten::view_as_complex", op::translate_view_as_complex},

--- a/tests/layer_tests/pytorch_tests/test_values.py
+++ b/tests/layer_tests/pytorch_tests/test_values.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import numpy as np
+import openvino as ov
+from typing import Dict, Tuple
+from pytorch_layer_test_class import PytorchLayerTest
+
+# Need to test for TorchScript and FX models with different input types for all scenarios
+
+# Scenario 1: Dict input
+# aten::values(Dict(a) self) -> Dict[a]
+# Scenario 2: Tensor input
+# aten::values(Tensor(a) self) -> Tensor(a)
+
+def make_dict(input_tensor: torch.Tensor):
+    return {0: input_tensor, 1: input_tensor + input_tensor, 2: 2 * input_tensor}
+
+class aten_values_dict_input(torch.nn.Module):
+    def forward(self, input_tensor: torch.Tensor):
+        # x : Dict[int, torch.Tensor] = {idx:tensor for idx, tensor in enumerate(input_tuple)}
+        # x : Dict[int, torch.Tensor] = {0: input_tensor, 1: input_tensor + input_tensor, 2: 2 * input_tensor}
+        x = make_dict(input_tensor)
+        return x.values()
+
+class TestDictInput(PytorchLayerTest):
+    def _generate_tensor(self):
+        return self.random.randn(2, 5, 3, 4)
+    def _prepare_input(self):
+        return (self._generate_tensor(),)
+    def create_model(self):
+        return aten_values_dict_input(), "aten::values"
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_dict_input(self, ie_device, precision, ir_version):
+        self._test(*self.create_model(), ie_device, precision,
+                   ir_version, use_convert_model=True)


### PR DESCRIPTION
## Motivation

PyTorch models that construct a Dict in TorchScript and call .values() currently fail conversion in the PyTorch frontend due to missing support for aten::values. In TorchScript, aten::values is used both for dict.values() and for sparse_tensor.values(). 

This PR adds support for only the Dict case so such models can be successfully converted via the TorchScript path. Sparse tensor inputs are intentionally not supported in this change and are handled with an explicit error. Refer to [Scope and Limitations Section](##scope-and-limitations) to understand why.

## Summary of Changes

1. aten::values Translator

Added a new translator for aten::values in:
- openvino/src/frontends/pytorch/src/op/values.cpp

Registered it in the PyTorch frontend op table at:
- openvino/src/frontends/pytorch/src/op_table.cpp

## Behavior:

1. Dict input (supported)
When the input is produced by prim::DictConstruct, the translator extracts the value tensors (inputs at indices 1, 3, 5, …) and returns them as a list using make_list_construct.
This corresponds to Python dict.values() when the dictionary is constructed in the TorchScript graph.

2. Sparse tensor input (explicitly not supported)
If the producer is one of:
- aten::sparse_coo_tensor
  - conversion fails with a clear error message indicating that sparse tensor input is not supported.

- Other inputs
   - Any other input (e.g. unsupported dict producer) results in a conversion error stating that only Dict produced by prim::DictConstruct is supported.

This change is additive and does not modify behavior of previously supported operators.

## Tests

Added layer tests in:
- tests/layer_tests/pytorch_tests/test_values.py

The tests cover the supported Dict case only:
- A TorchScript model constructs a dictionary from tensors and calls .values()

Conversion is validated using use_convert_model=True (TorchScript path)

No sparse tensor tests are included, as sparse tensor construction is not yet supported in the PyTorch frontend.

## Scope and Limitations

This PR supports aten::values only when:
- The input is a Dict produced by prim::DictConstruct.
- Sparse tensor support is intentionally not included.

In PyTorch, aten::values is also used for sparse tensors (e.g. sparse_tensor.values()), but:
- aten::sparse_coo_tensor and other sparse constructors are not yet implemented in the OpenVINO PyTorch frontend.
- Conversion currently fails earlier on sparse construction ops.
- Therefore, aten::values for sparse inputs cannot be meaningfully supported at this time.

Sparse COO support is under development in a separate PR:
#33768 

Once sparse tensors are represented in the frontend graph, support for aten::values on sparse inputs can be added in a follow-up change.

This PR enables successful conversion of TorchScript models that use dict.values() while keeping sparse behavior explicit and well-defined for future extension.

## Tickets:
 - closes #29718  
 - parent isse #28584 
 
 