### PR TITLE
[pyapi] Fix create ov::Tensor from numpy scalar and shape

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/common.cpp
+++ b/src/bindings/python/src/pyopenvino/core/common.cpp
@@ -529,7 +529,7 @@ ov::Tensor tensor_from_pointer(py::array& array, const ov::Shape& shape, const o
     auto element_type = (type == ov::element::dynamic) ? Common::type_helpers::get_ov_type(array) : type;
 
     if (array_helpers::is_contiguous(array)) {
-        return ov::Tensor(element_type, shape, const_cast<void*>(array.data(0)), {});
+        return ov::Tensor(element_type, shape, const_cast<void*>(array.data()), {});
     }
     OPENVINO_THROW("SHARED MEMORY MODE FOR THIS TENSOR IS NOT APPLICABLE! Passed numpy array must be C contiguous.");
 }

--- a/src/bindings/python/tests/test_runtime/test_tensor.py
+++ b/src/bindings/python/tests/test_runtime/test_tensor.py
@@ -768,3 +768,11 @@ def test_pack_unpack_u6_multidimensional():
     packed = pack_data(data, ov.Type.u6)
     unpacked = unpack_data(packed, ov.Type.u6, data.shape)
     assert np.array_equal(unpacked, data)
+
+
+def test_scalar_tensor():
+    exp_data = np.array(5)
+    tensor = ov.Tensor(exp_data)
+    assert np.array_equal(tensor.data, exp_data)
+    tensor = ov.Tensor(exp_data, ov.Shape(), ov.Type.i32)
+    assert np.array_equal(tensor.data, exp_data)


### PR DESCRIPTION
### Details:
 - Fix create the ov::Tensor from numpy scalar data when scalar shape provided for Tensor

### Tickets:
 - CVS-182155