### PR TITLE
[CPU] Cache FullyConnected weigths in scope of compile model

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.cpp
@@ -384,18 +384,19 @@ static VectorDims makeDummyInputDims(const Shape& inShape, const Shape& wShape) 
 }
 
 static VectorDims makeDummyOutputDims(const VectorDims& inShape, const VectorDims& wShape, const size_t out_rank) {
-    size_t activationRank = inShape.size();
-    size_t channelRank = wShape.size() - 1;
+    const auto wShape2D = reshapeDownToRank<2>(wShape);
+    const size_t activationRank = inShape.size();
+    const size_t channelRank = 1;
     // activation   weight    output_shape
     // NCHW         CoCHW     NCo
     // TNC          CoC       TNCo
     // NC           CoC       NCo
     VectorDims outputShape(out_rank, 1);
     // set Co
-    outputShape.back() = wShape[0];
+    outputShape.back() = wShape2D[0];
     // set batch dims
-    size_t batchRank = activationRank - channelRank;
-    size_t startIdx = out_rank - batchRank - 1;
+    const size_t batchRank = activationRank - channelRank;
+    const size_t startIdx = out_rank - batchRank - 1;
     for (size_t i = 0; i < batchRank; i++) {
         outputShape[i + startIdx] = inShape[i];
     }

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -451,7 +451,7 @@ const std::vector<ExecutorImplementation<FCAttrs>>& getImplementations() {
                                                  fcMappingNotation);
             },
             AcceptsAnyShape<FCAttrs>,
-            CreateDnnlDefault<DnnlFCPrimitive, FCAttrs>{false, true}
+            CreateDnnlDefault<DnnlFCPrimitive, FCAttrs>{true, true}
             )
     };
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -652,8 +652,8 @@ void FullyConnected::needSplitMemoryForTensorParallel() {
         }
         memory[ARG_BIAS] = tp_cfg.cached_splited_bias;
         // dst
-        memory[ARG_DST] = getDstMemoryAtPort(0);
         tp_cfg.cached_dst = split_horizontal(context->getEngine(), dst, -1, tp_cfg.w_rank, tp_cfg.w_size, false);
+        memory[ARG_DST] = tp_cfg.cached_dst;
 
         if (auto it = memory.find(ARG_DST | ARG_ATTR_SCALES); it != memory.end()) {
             it->second = split_horizontal(context->getEngine(), it->second, 0, tp_cfg.w_rank, tp_cfg.w_size);


### PR DESCRIPTION
This moves it out of the first inference and significantly improves
first token latency on LLMs

Also, it reduces peak memory usage a lot, since most of the weights
where transposed in scope of compile_model call anyway

The current state of test infrastructure does not allow to have a test for this logic

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*

<!-- Message of single commit: -->