### PR TITLE
[GPU] Enable mmap for loading model weights​ on iGPUs

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
@@ -13,46 +13,101 @@
 #include "bind.hpp"
 
 namespace cldnn {
+
+/// @brief Page size alignment constant for cache blob serialization.
+/// This value (4KB) matches the typical OS page size on Windows, Linux, and macOS.
+inline constexpr uint32_t CACHE_PAGE_SIZE = 4096;
+
+/// @brief Alignment requirement for individual weight buffers within cache blobs.
+/// This alignment (128 bytes) ensures optimal GPU memory access patterns for weight data.
+inline constexpr uint32_t CACHE_SUB_BUFFER_ALIGNMENT = 128;
 struct memory;
 
 class BinaryOutputBuffer : public OutputBuffer<BinaryOutputBuffer> {
 public:
-    BinaryOutputBuffer(std::ostream& stream)
-    : OutputBuffer<BinaryOutputBuffer>(this), stream(stream), _impl_params(nullptr), _strm(nullptr) {}
+    BinaryOutputBuffer(std::ostream& stream, bool encrypted = false)
+        : OutputBuffer<BinaryOutputBuffer>(this),
+          stream(stream),
+          _impl_params(nullptr),
+          _strm(nullptr),
+          _is_encrypted(encrypted),
+          _offset(0) {}
 
     virtual ~BinaryOutputBuffer() = default;
 
-    virtual void write(void const* data, std::streamsize size) {
-        auto const written_size = stream.rdbuf()->sputn(reinterpret_cast<const char*>(data), size);
-        OPENVINO_ASSERT(written_size == size,
-                        "[GPU] Failed to write " + std::to_string(size) + " bytes to stream! Wrote " +
-                            std::to_string(written_size));
+    virtual void write(const void* data, std::streamsize size) {
+        const auto written_size = stream.rdbuf()->sputn(reinterpret_cast<const char*>(data), size);
+        OPENVINO_ASSERT(written_size == size, "[GPU] Failed to write " + std::to_string(size) + " bytes to stream! Wrote " + std::to_string(written_size));
+        _offset += written_size;
     }
 
     virtual void flush() {}
 
-    void setKernelImplParams(void* impl_params) { _impl_params = impl_params; }
-    void* getKernelImplParams() const { return _impl_params; }
-    void set_stream(void* strm) { _strm = strm; }
-    void* get_stream() const { return _strm; }
+    void setKernelImplParams(void* impl_params) {
+        _impl_params = impl_params;
+    }
+    void* getKernelImplParams() const {
+        return _impl_params;
+    }
+    void set_stream(void* strm) {
+        _strm = strm;
+    }
+    void* get_stream() const {
+        return _strm;
+    }
+    bool is_encrypted() const {
+        return _is_encrypted;
+    }
+    size_t get_offset() const {
+        return _offset;
+    }
+    bool is_offset_page_aligned() const {
+        return (get_offset() % CACHE_PAGE_SIZE == 0);
+    }
+
+    size_t get_bytes_to_page_boundary() const {
+        return CACHE_PAGE_SIZE - (get_offset() % CACHE_PAGE_SIZE);
+    }
+
+    bool is_offset_sub_buffer_aligned() const {
+        return (get_offset() % CACHE_SUB_BUFFER_ALIGNMENT == 0);
+    }
+
+    size_t get_bytes_to_sub_buffer_boundary() const {
+        return CACHE_SUB_BUFFER_ALIGNMENT - (get_offset() % CACHE_SUB_BUFFER_ALIGNMENT);
+    }
 
 private:
     std::ostream& stream;
     void* _impl_params;
     void* _strm;
+    bool _is_encrypted;
+    size_t _offset;
 };
 
 class BinaryInputBuffer : public InputBuffer<BinaryInputBuffer> {
 public:
-    BinaryInputBuffer(std::istream& stream, engine& engine)
-    : InputBuffer<BinaryInputBuffer>(this, engine), _stream(stream), _impl_params(nullptr) {}
+    BinaryInputBuffer(std::istream& stream, engine& engine, bool encrypted = false)
+        : InputBuffer<BinaryInputBuffer>(this, engine),
+          _stream(stream),
+          _impl_params(nullptr),
+          _tensor_base_ptr(nullptr),
+          _is_encrypted(encrypted),
+          _offset(0) {}
+    BinaryInputBuffer(std::istream& stream, engine& engine, const size_t* _tensor_bp, bool encrypted = false)
+        : InputBuffer<BinaryInputBuffer>(this, engine),
+          _stream(stream),
+          _impl_params(nullptr),
+          _tensor_base_ptr(_tensor_bp),
+          _is_encrypted(encrypted),
+          _offset(0) {}
 
     virtual ~BinaryInputBuffer() = default;
 
     virtual void read(void* const data, std::streamsize size) {
-        auto const read_size = _stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
-        OPENVINO_ASSERT(read_size == size,
-            "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
+        const auto read_size = _stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
+        OPENVINO_ASSERT(read_size == size, "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
+        _offset += read_size;
     }
 
     /// Access the underlying streambuf. Callers that know their backing buffer
@@ -62,19 +117,76 @@ public:
     std::streambuf* get_streambuf() const {
         return _stream.rdbuf();
     }
+    bool has_mmap_tensor() const {
+        return _tensor_base_ptr != nullptr;
+    }
 
-    void setKernelImplParams(void* impl_params) { _impl_params = impl_params; }
-    void* getKernelImplParams() const { return _impl_params; }
+    bool is_mmap_tensor_4K_aligned() const {
+        return has_mmap_tensor() && (reinterpret_cast<std::uintptr_t>(_tensor_base_ptr) % CACHE_PAGE_SIZE == 0);
+    }
+
+    const size_t* get_mmap_tensor() const {
+        return _tensor_base_ptr;
+    }
+
+    size_t get_stream_size() const {
+        std::streampos current_pos = _stream.tellg();
+        _stream.seekg(0, std::ios::end);
+        std::streampos end_pos = _stream.tellg();
+        _stream.seekg(0, std::ios::beg);
+        std::streampos start_pos = _stream.tellg();
+        _stream.seekg(current_pos);
+        return static_cast<size_t>(end_pos) - static_cast<size_t>(start_pos);
+    }
+
+    size_t get_offset() const {
+        return _offset;
+    }
+
+    void seek_current_ptr(std::streamsize size) {
+        // Get current stream position
+        std::streampos current_pos = _stream.tellg();
+        // Advance stream position
+        _stream.seekg(current_pos + static_cast<std::streampos>(size));
+        _offset += size;
+    }
+    bool is_offset_page_aligned() const {
+        return (get_offset() % CACHE_PAGE_SIZE == 0);
+    }
+
+    size_t get_bytes_to_page_boundary() const {
+        return CACHE_PAGE_SIZE - (get_offset() % CACHE_PAGE_SIZE);
+    }
+
+    bool is_offset_sub_buffer_aligned() const {
+        return (get_offset() % CACHE_SUB_BUFFER_ALIGNMENT == 0);
+    }
+
+    size_t get_bytes_to_sub_buffer_boundary() const {
+        return CACHE_SUB_BUFFER_ALIGNMENT - (get_offset() % CACHE_SUB_BUFFER_ALIGNMENT);
+    }
+    void setKernelImplParams(void* impl_params) {
+        _impl_params = impl_params;
+    }
+    void* getKernelImplParams() const {
+        return _impl_params;
+    }
+    bool is_encrypted() const {
+        return _is_encrypted;
+    }
 
 private:
     std::istream& _stream;
     void* _impl_params;
+    const size_t* _tensor_base_ptr;
+    bool _is_encrypted;
+    size_t _offset;
 };
 
 class EncryptedBinaryOutputBuffer : public BinaryOutputBuffer {
 public:
     EncryptedBinaryOutputBuffer(std::ostream& stream, std::function<std::string(const std::string&)> encrypt)
-        : BinaryOutputBuffer(stream),
+        : BinaryOutputBuffer(stream, true),
           encrypt(encrypt) {
         OPENVINO_ASSERT(encrypt);
     }
@@ -100,10 +212,8 @@ private:
 
 class EncryptedBinaryInputBuffer : public BinaryInputBuffer {
 public:
-    EncryptedBinaryInputBuffer(std::istream& stream,
-                               engine& engine,
-                               std::function<std::string(const std::string&)> decrypt)
-        : BinaryInputBuffer(stream, engine),
+    EncryptedBinaryInputBuffer(std::istream& stream, engine& engine, std::function<std::string(const std::string&)> decrypt)
+        : BinaryInputBuffer(stream, engine, true),
           decrypt(decrypt) {
         OPENVINO_ASSERT(decrypt);
 
@@ -113,19 +223,15 @@ public:
         // Not reading directly to plaintext_stream because decrypt(plaintext_stream.str()) would create an additional
         // copy.
         std::string str(bytes, 0);
-        BinaryInputBuffer::read(
-            make_data(const_cast<void*>(reinterpret_cast<const void*>(str.c_str())), str.size()).data,
-            str.size());
+        BinaryInputBuffer::read(make_data(const_cast<void*>(reinterpret_cast<const void*>(str.c_str())), str.size()).data, str.size());
         plaintext_stream.str(decrypt(str));
     }
 
     ~EncryptedBinaryInputBuffer() override = default;
 
     void read(void* const data, std::streamsize size) override {
-        auto const read_size = plaintext_stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
-        OPENVINO_ASSERT(
-            read_size == size,
-            "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
+        const auto read_size = plaintext_stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
+        OPENVINO_ASSERT(read_size == size, "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
     }
 
 private:

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/compiled_model.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/compiled_model.hpp
@@ -71,6 +71,9 @@ public:
     std::shared_ptr<Graph> get_graph(size_t n) const;
 
     void release_memory() override;
+    void set_backing_tensor(const std::shared_ptr<ov::Tensor>& tensor) {
+        _backing_tensor = tensor;
+    }
 
 private:
     RemoteContextImpl::Ptr m_context;
@@ -81,6 +84,7 @@ private:
     std::vector<ov::Output<const ov::Node>> m_outputs;
     std::vector<std::shared_ptr<Graph>> m_graphs;
     bool m_loaded_from_cache;
+    std::shared_ptr<ov::Tensor> _backing_tensor;
 };
 
 }  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <climits>
 #include <variant>
-
 #include "intel_gpu/graph/network.hpp"
 #include "intel_gpu/primitives/input_layout.hpp"
 #include "intel_gpu/primitives/reorder.hpp"
@@ -28,7 +27,6 @@ using weights_memory_ptr = std::variant<std::shared_ptr<ov::MappedMemory>, std::
 using offset_const_map_t = std::map<size_t, std::shared_ptr<ov::op::v0::Constant>>;
 using shared_mapped_memory_ptr = std::shared_ptr<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>;
 using constant_memory_ptr = std::variant<shared_mapped_memory_ptr, std::shared_ptr<ov::op::v0::Constant>>;
-
 namespace {
 
 bool is_alloc_host_accessible(const cldnn::allocation_type& alloc_type) {
@@ -173,8 +171,8 @@ struct weightless_cache_manager {
         return true;
     }
 
-    bool load(BinaryInputBuffer& ib, memory::ptr dst_mem, std::shared_ptr<WeightsMemory> weights_memory) {
-        ib >> do_weightless_caching;
+    bool load(BinaryInputBuffer& ib, memory::ptr dst_mem, std::shared_ptr<WeightsMemory> weights_memory, bool weightless_caching) {
+        do_weightless_caching = weightless_caching;
         if (!do_weightless_caching) {
             return false;
         }
@@ -193,7 +191,6 @@ struct weightless_cache_manager {
         } else {
             original_size = dst_mem->size();
         }
-
         bool do_reorder = false;
         ib >> do_reorder;
         if (do_reorder) {
@@ -389,6 +386,10 @@ struct data : public primitive_base<data> {
         bool do_weightless_caching = cache_info->save(ob, data_size);
         if (!do_weightless_caching) {
             if (is_alloc_host_accessible(_allocation_type)) {
+                if (!ob.is_encrypted() && !ob.is_offset_sub_buffer_aligned()) {
+                    std::vector<uint8_t> pad(ob.get_bytes_to_sub_buffer_boundary(), 0);
+                    ob << make_data(pad.data(), pad.size());
+                }
                 ob << make_data(mem->buffer_ptr(), data_size);
             } else {
                 std::vector<uint8_t> _buf;
@@ -404,23 +405,40 @@ struct data : public primitive_base<data> {
         primitive_base<data>::load(ib);
     }
 
-    void load_weights(BinaryInputBuffer& ib, std::shared_ptr<WeightsMemory> weights_memory) {
+    void load_weights(BinaryInputBuffer& ib, std::shared_ptr<WeightsMemory> weights_memory, memory_ptr model_tensor_base) {
         layout output_layout = layout();
         ib >> output_layout;
 
         allocation_type _allocation_type = allocation_type::unknown;
         ib >> make_data(&_allocation_type, sizeof(_allocation_type));
-
+        
         size_t data_size = 0;
         ib >> make_data(&data_size, sizeof(size_t));
 
-        mem = ib.get_engine().allocate_memory(output_layout, _allocation_type, false);
+        bool weightless_caching = false;
+        ib >> weightless_caching;
 
-        bool is_weightless_caching = cache_info->load(ib, mem, weights_memory);
+        bool enable_zero_copy_mode = ib.is_mmap_tensor_4K_aligned() && ib.get_engine().get_device_info().arch >= gpu_arch::xe2 &&
+                                     ib.get_engine().get_device_info().dev_type == device_type::integrated_gpu &&
+                                     _allocation_type == allocation_type::usm_host && !weightless_caching;
+        if (!enable_zero_copy_mode) {
+            mem = ib.get_engine().allocate_memory(output_layout, _allocation_type, false);
+        }
+        
+        bool is_weightless_caching = cache_info->load(ib, mem, weights_memory, weightless_caching);
 
         if (!is_weightless_caching) {
             if (is_alloc_host_accessible(_allocation_type)) {
-                ib >> make_data(mem->buffer_ptr(), data_size);
+                if (!ib.is_encrypted() && !ib.is_offset_sub_buffer_aligned()) {
+                    std::vector<uint8_t> pad(ib.get_bytes_to_sub_buffer_boundary(), 0);
+                    ib >> make_data(pad.data(), pad.size());
+                }
+                if (enable_zero_copy_mode) {
+                    mem = ib.get_engine().create_subbuffer(*model_tensor_base, output_layout, ib.get_offset());
+                    ib.seek_current_ptr(data_size);
+                } else {
+                    ib >> make_data(std::move(mem->buffer_ptr()), data_size);
+                }
             } else {
                 const size_t DATA_BLOCK_SIZE = 4 * 1024 * 1024;
                 auto& eng = ib.get_engine();
@@ -490,8 +508,7 @@ struct data : public primitive_base<data> {
                     while (dst_offset < data_size) {
                         const bool is_blocking = false;
                         const size_t src_offset = 0;
-                        size_t copy_size =
-                            (data_size > (dst_offset + DATA_BLOCK_SIZE)) ? DATA_BLOCK_SIZE : (data_size - dst_offset);
+                        size_t copy_size = (data_size > (dst_offset + DATA_BLOCK_SIZE)) ? DATA_BLOCK_SIZE : (data_size - dst_offset);
                         if (buf_flag) {
                             ib >> make_data(_buf1.data(), copy_size);
                             if (ev2 != nullptr) {

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
@@ -63,6 +63,9 @@ public:
     /// Created subbuffer memory object from the other @p memory and reinterpred the data using specified @p new_layout
     virtual memory_ptr create_subbuffer(const memory& memory, const layout& new_layout, size_t byte_offset) = 0;
 
+    /// Created memory object by wrapping a host-allocated, memory-mapped layout region
+    virtual memory_ptr create_mmap_hostbuffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) = 0;
+
     /// Created memory object from the other @p memory and reinterpred the data using specified @p new_layout
     virtual memory_ptr reinterpret_buffer(const memory& memory, const layout& new_layout) = 0;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -25,6 +25,7 @@ OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, enable_loop_unrolling, true, "Enable/Dis
 OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, disable_winograd_convolution, false, "Enable/Disable winograd convolution implementation if available")
 OV_CONFIG_RELEASE_OPTION(ov::internal, exclusive_async_requests, false, "")
 OV_CONFIG_RELEASE_OPTION(ov::internal, query_model_ratio, 1.0f, "")
+OV_CONFIG_RELEASE_OPTION(ov::internal, cache_header_alignment, 4096, "Header Alignment in bytes for cache blob")
 OV_CONFIG_RELEASE_OPTION(ov, cache_mode, ov::CacheMode::OPTIMIZE_SPEED, "Cache mode defines the trade-off between the model compilation time and the disk space required for the cache")
 OV_CONFIG_RELEASE_OPTION(ov, cache_encryption_callbacks, ov::EncryptionCallbacks{}, "Callbacks used to encrypt/decrypt the model")
 OV_CONFIG_RELEASE_OPTION(ov::hint, dynamic_quantization_group_size, 0, "Dynamic quantization group size")

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -19,6 +19,7 @@
 #include "intel_gpu/runtime/compilation_context.hpp"
 #include "intel_gpu/graph/program.hpp"
 
+
 #include "layout_optimizer.h"
 #include "pass_manager.h"
 #include "primitive_type.h"
@@ -1953,7 +1954,7 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     }
 
     ob << allocating_order.size();
-    for (auto const& node_id : allocating_order) {
+    for (const auto& node_id : allocating_order) {
         ob << node_id;
     }
 
@@ -1961,6 +1962,11 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     for (auto& state_initializer : state_initializers) {
         ob << state_initializer.first;
         ob << state_initializer.second;
+    }
+
+    if (!ob.is_encrypted() && !ob.is_offset_page_aligned()) {
+        std::vector<uint8_t> pad(ob.get_bytes_to_page_boundary(), 0);
+        ob << make_data(pad.data(), pad.size());
     }
 }
 
@@ -1987,6 +1993,17 @@ void program::load(cldnn::BinaryInputBuffer& ib,
         } else {
             OPENVINO_THROW("Weights path or model is required for cache mode OPTIMIZE_SIZE");
         }
+    }
+
+    const bool can_use_mmap_zero_copy = ib.is_mmap_tensor_4K_aligned() && _engine.get_device_info().arch >= gpu_arch::xe2 &&
+                                        _engine.get_device_info().dev_type == device_type::integrated_gpu && !_config.get_enable_weightless();
+    memory_ptr model_tensor_base_ptr = nullptr;
+    if (can_use_mmap_zero_copy) {
+        model_tensor_base_ptr =
+            ib.get_engine().create_mmap_hostbuffer(ib.get_mmap_tensor(),
+                                                   ib.get_stream_size(),
+                                                   allocation_type::usm_host,
+                                                   layout({{static_cast<tensor::value_type>(ib.get_stream_size()), 1, 1, 1}, data_types::u8, format::bfyx}));
     }
 
     size_t num_nodes;
@@ -2016,11 +2033,10 @@ void program::load(cldnn::BinaryInputBuffer& ib,
         std::shared_ptr<cldnn::primitive> prim;
         ib >> prim;
         if (auto data_prim = dynamic_cast<cldnn::data*>(prim.get())) {
-            data_prim->load_weights(ib, weights_memory);
+            data_prim->load_weights(ib, weights_memory, model_tensor_base_ptr);
         }
         get_or_create(prim);
     }
-
     size_t num_output_sharing_mutable_datas;
     ib >> num_output_sharing_mutable_datas;
     for (size_t i = 0; i < num_output_sharing_mutable_datas; ++i) {
@@ -2175,4 +2191,11 @@ void program::load(cldnn::BinaryInputBuffer& ib,
         ib >> initializers;
         state_initializers[variable_id] = initializers;
     }
+
+    // At the end of load
+    if (!ib.is_encrypted() && !ib.is_offset_page_aligned()) {
+        std::vector<uint8_t> pad(ib.get_bytes_to_page_boundary(), 0);
+        ib >> make_data(pad.data(), pad.size());
+    }
 }
+

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -54,6 +54,7 @@
 
 using ms = std::chrono::duration<double, std::ratio<1, 1000>>;
 using Time = std::chrono::high_resolution_clock;
+thread_local const size_t* g_current_tensor_base = nullptr;
 
 namespace ov::intel_gpu {
 
@@ -427,10 +428,9 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model,
     ov::EncryptionCallbacks encryption_callbacks = config.get_cache_encryption_callbacks();
 
     std::unique_ptr<cldnn::BinaryInputBuffer> ib_ptr =
-        encryption_callbacks.decrypt ? std::make_unique<cldnn::EncryptedBinaryInputBuffer>(model,
-                                                                                 context_impl->get_engine(),
-                                                                                 encryption_callbacks.decrypt)
-                           : std::make_unique<cldnn::BinaryInputBuffer>(model, context_impl->get_engine());
+        encryption_callbacks.decrypt
+            ? std::make_unique<cldnn::EncryptedBinaryInputBuffer>(model, context_impl->get_engine(), encryption_callbacks.decrypt)
+            : std::make_unique<cldnn::BinaryInputBuffer>(model, context_impl->get_engine(), g_current_tensor_base);
     auto& ib = *ib_ptr;
 
     ov::CacheMode loaded_cache_mode = ov::CacheMode::OPTIMIZE_SPEED;
@@ -474,9 +474,22 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model
 std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model,
                                                          const ov::SoPtr<ov::IRemoteContext>& context,
                                                          const ov::AnyMap& config) const{
+    // Store tensor base in thread-local storage
+    g_current_tensor_base = static_cast<const size_t*>(model.data());
     ov::intel_gpu::ParallelMemStreamBuf par_buf(model.data(), model.get_byte_size());
     std::istream stream(&par_buf);
-    return import_model(stream, context, config);
+    auto compiled_model = import_model(stream, context, config);
+
+    // Clear thread-local storage
+    g_current_tensor_base = nullptr;
+
+    // Ensure the tensor stays alive as long as the compiled model
+    auto* gpu_model = dynamic_cast<CompiledModel*>(compiled_model.get());
+    if (gpu_model) {
+        gpu_model->set_backing_tensor(std::make_shared<ov::Tensor>(model));
+    }
+
+    return compiled_model;
 }
 
 ov::Any Plugin::get_property(const std::string& name, const ov::AnyMap& options) const {
@@ -686,6 +699,8 @@ ov::Any Plugin::get_metric(const std::string& name, const ov::AnyMap& options) c
         info.device = device_info.pci_info.pci_device;
         info.function = device_info.pci_info.pci_function;
         return decltype(ov::device::pci_info)::value_type {info};
+    } else if (name == ov::internal::cache_header_alignment) {
+        return decltype(ov::internal::cache_header_alignment)::value_type{4096};
     } else {
         OPENVINO_THROW("Unsupported metric key ", name);
     }
@@ -771,7 +786,8 @@ std::vector<ov::PropertyName> Plugin::get_supported_internal_properties() const 
             ov::PropertyName{ov::internal::compiled_model_runtime_properties.name(), ov::PropertyMutability::RO},
             ov::PropertyName{ov::internal::compiled_model_runtime_properties_supported.name(), ov::PropertyMutability::RO},
             ov::PropertyName{ov::internal::query_model_ratio.name(), PropertyMutability::RW},
-            ov::PropertyName{ov::internal::caching_with_mmap.name(), PropertyMutability::RO}};
+            ov::PropertyName{ov::internal::caching_with_mmap.name(), PropertyMutability::RO},
+            ov::PropertyName{ov::internal::cache_header_alignment.name(), PropertyMutability::RO}};
     return supported_internal_properties;
 }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
@@ -4,6 +4,8 @@
 
 #include "ocl_engine.hpp"
 #include "intel_gpu/runtime/utils.hpp"
+#include "intel_gpu/graph/serialization/binary_buffer.hpp"  // For CACHE_PAGE_SIZE
+
 #include "ocl_kernel.hpp"
 #include "ocl_kernel_builder.hpp"
 #include "ocl_common.hpp"
@@ -148,7 +150,7 @@ memory::ptr ocl_engine::create_subbuffer(const memory& memory, const layout& new
                                      memory.get_mem_tracker());
         } else {
             auto buffer = reinterpret_cast<const ocl::gpu_buffer&>(memory).get_buffer();
-            cl_buffer_region sub_buffer_region = { byte_offset, new_layout.get_linear_size() };
+            cl_buffer_region sub_buffer_region = {byte_offset, new_layout.get_linear_size()};
             auto sub_buffer = buffer.createSubBuffer({}, CL_BUFFER_CREATE_TYPE_REGION, &sub_buffer_region);
 
             return std::make_shared<ocl::gpu_buffer>(this,
@@ -160,6 +162,26 @@ memory::ptr ocl_engine::create_subbuffer(const memory& memory, const layout& new
         OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
     }
 }
+
+memory_ptr ocl_engine::create_mmap_hostbuffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) {
+    auto tracker = std::make_shared<MemoryTracker>(this,
+                                                   const_cast<void*>(mmapped_address),  // Point directly to mmap'd memory
+                                                   data_size,
+                                                   _allocation_type);
+    std::uintptr_t mmap_address = reinterpret_cast<std::uintptr_t>(mmapped_address);
+    std::uintptr_t aligned_addr = mmap_address & ~(static_cast<std::uintptr_t>(cldnn::CACHE_PAGE_SIZE) - 1);
+    void* mmap_aligned_address = reinterpret_cast<void*>(aligned_addr);
+
+    cl_int err = CL_SUCCESS;
+    cl_mem_flags flags = CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR;
+#ifdef CL_MEM_FORCE_HOST_MEMORY_INTEL
+    flags |= CL_MEM_FORCE_HOST_MEMORY_INTEL;
+#endif
+    cl::Buffer buffer(get_cl_context(), flags, data_size, mmap_aligned_address, &err);
+    OPENVINO_ASSERT(err == CL_SUCCESS, "clcreatebuffer with CL_MEM_USE_HOST_PTR and CL_MEM_FORCE_HOST_MEMORY_INTEL failed!");
+    return std::make_shared<ocl::gpu_buffer>(this, output_layout, buffer, tracker);
+}
+
 memory::ptr ocl_engine::reinterpret_buffer(const memory& memory, const layout& new_layout) {
     OPENVINO_ASSERT(memory.get_engine() == this, "[GPU] trying to reinterpret buffer allocated by a different engine");
     OPENVINO_ASSERT(new_layout.format.is_image() == memory.get_layout().format.is_image(),
@@ -286,3 +308,7 @@ std::shared_ptr<cldnn::engine> create_ocl_engine(const device::ptr device, runti
 
 }  // namespace ocl
 }  // namespace cldnn
+
+
+
+

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp
@@ -28,6 +28,7 @@ public:
     memory_ptr allocate_memory(const layout& layout, allocation_type type, bool reset = true) override;
     memory_ptr reinterpret_handle(const layout& new_layout, shared_mem_params params) override;
     memory_ptr create_subbuffer(const memory& memory, const layout& new_layout, size_t offset) override;
+    memory_ptr create_mmap_hostbuffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) override;
     memory_ptr reinterpret_buffer(const memory& memory, const layout& new_layout) override;
     bool is_the_same_buffer(const memory& mem1, const memory& mem2) override;
 

--- a/src/plugins/intel_gpu/src/runtime/ze/ze_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_engine.cpp
@@ -157,6 +157,10 @@ memory_ptr ze_engine::create_subbuffer(const memory& memory, const layout& new_l
                              memory.get_mem_tracker());
 }
 
+memory_ptr ze_engine::create_mmap_hostbuffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) {
+    OPENVINO_NOT_IMPLEMENTED;
+}
+
 bool ze_engine::is_the_same_buffer(const memory& mem1, const memory& mem2) {
     if (mem1.get_engine() != this || mem2.get_engine() != this)
         return false;

--- a/src/plugins/intel_gpu/src/runtime/ze/ze_engine.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_engine.hpp
@@ -25,6 +25,7 @@ public:
     memory_ptr allocate_memory(const layout& layout, allocation_type type, bool reset = true) override;
     memory_ptr reinterpret_handle(const layout& new_layout, shared_mem_params params) override;
     memory_ptr create_subbuffer(const memory& memory, const layout& new_layout, size_t byte_offset) override;
+    memory_ptr create_mmap_hostbuffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) override;
     memory_ptr reinterpret_buffer(const memory& memory, const layout& new_layout) override;
     bool is_the_same_buffer(const memory& mem1, const memory& mem2) override;
 


### PR DESCRIPTION
[GPU] Enable mmap for loading model weights​ on iGPUs and eliminate host to device copying of weights (LNL+)

Description of the issue(symptom, root-cause, how it was resolved)
- On iGPUs enable mmap feature to access model weights directly on iGPUs.
- OCL provides ::clcreatebuffer API which can take a host_buffer_ptr and map it for direct GPU access.
- Each model Node's weight is mapped with OCL buffer.createsubbuffer API.
- While creating model blob ensure 4096 aligned header(metadata) and 128B aligned individual per-node weights.

The code and line that caused this issue (if it is not changed directly)
src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
src/plugins/intel_gpu/include/intel_gpu/plugin/compiled_model.hpp                                                       src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
src/plugins/intel_gpu/src/graph/program.cpp
src/plugins/intel_gpu/src/plugin/plugin.cpp
src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp
src/plugins/intel_gpu/src/runtime/ze/ze_engine.cpp
src/plugins/intel_gpu/src/runtime/ze/ze_engine.hpp

Reproduction step and snapshot (if applicable. Do not attach for customer model)
STEP-1: Create a blob in the model cache directory.
STEP-2: Load from the blob to use the mmap feature which maps the blob to host virtual address space.

Problematic graph
NA

Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary? NA
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? NA

Tickets:
CVS-177982

### AI Assistance:
 - AI assistance used: Yes, For Fixing Regressions and Bugs in the PR
