### PR TITLE
[DOCS] Fix formatting issues in documentation_build_instructions.md

### DIFF
--- a/docs/documentation_build_instructions.md
+++ b/docs/documentation_build_instructions.md
@@ -4,7 +4,7 @@
 
 1. Clone the OpenVINO repository and setup its submodules
 ```
-$ git clone <openvino_repository_url> <repository_path>
+$ git clone https://github.com/openvinotoolkit/openvino.git <repository_path>
 $ cd <repository_path>
 $ git submodule update --init --recursive
 ```
@@ -27,11 +27,11 @@ $ source env/bin/activate
 5. Install the sphinx theme
 ```
 (env) $ python -m pip install docs/openvino_sphinx_theme
-``````
+```
 6. Install the custom sphinx sitemap
 ```
 (env) $ pip install docs/openvino_custom_sphinx_sitemap
-``````
+```
 7. Create build folder:
 ```
 (env) $ mkdir build && cd build
@@ -48,5 +48,5 @@ Depending on the needs, following variables can be added to first cmake call:
 - building Notebooks:  `-DENABLE_NOTEBOOKS=ON`
 - building OVMS:       `-DENABLE_OVMS=ON -DOVMS_DOCS_DIR=<path_to_OVMS_repo>`
 
-> > **Note:** When building the Python API documentation, the OpenVINO package version specified in [conf.py](./sphinx_setup/conf.py) is automatically downloaded using the [installation script](./scripts/install_appropriate_openvino_version.py).  
+> **Note:** When building the Python API documentation, the OpenVINO package version specified in [conf.py](./sphinx_setup/conf.py) is automatically downloaded using the [installation script](./scripts/install_appropriate_openvino_version.py).  
 > If you need a specific version or want to use an already installed OpenVINO package, modify these files accordingly.


### PR DESCRIPTION
### Details:  
 - Fix placeholder `<openvino_repository_url>` with actual URL `https://github.com/openvinotoolkit/openvino.git`  
 - Fix malformed six-backtick (``````...``````) code fences in steps 5 and 6 to standard three-backtick fences  
 - Fix double blockquote `> >` formatting on the final Note to a single `>`  
  
### Tickets:  
 - N/A  
  
### AI Assistance:  
 - AI assistance used: yes  
 - AI was used to identify the formatting inconsistencies