### PR TITLE
[GPU] Fix onednn concat validation for non-block-aligned feature in blocked formats

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
@@ -96,7 +96,7 @@ struct ConcatenationImplementationManager : public ImplementationManager {
             if (!one_of(in_layout.format.value, supported_in_fmts))
                 return false;
 
-            if (!is_feature_aligned(in_layout))
+            if (node.is_dynamic() && !is_feature_aligned(in_layout))
                 return false;
         }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -1701,7 +1701,7 @@ TEST(concat_gpu_onednn, impl_selection_unaligned_feature_axis) {
     ASSERT_NO_THROW(network.execute());
 }
 
-TEST(concat_gpu_onednn, impl_selection_non_block_aligned_feature) {
+TEST(concat_gpu_onednn, dynamic_non_block_aligned_feature) {
     auto& engine = get_test_engine();
     if (!engine.get_device_info().supports_immad)
         return;
@@ -1713,9 +1713,27 @@ TEST(concat_gpu_onednn, impl_selection_non_block_aligned_feature) {
     const int32_t f_slices = (f + fsv - 1) / fsv;
     const int32_t f_real_in_last = f - (f_slices - 1) * fsv;
 
-    layout in_layout = { data_types::f16, format::b_fs_yx_fsv16, { b, f, x, y } };
-    auto input0 = engine.allocate_memory(in_layout);
-    auto input1 = engine.allocate_memory(in_layout);
+    layout in_layout_dyn = { ov::PartialShape{ -1, f, x, y }, data_types::f16, format::b_fs_yx_fsv16 };
+
+    topology topology(
+            input_layout("input0", in_layout_dyn),
+            input_layout("input1", in_layout_dyn),
+            concatenation("concat",
+                          { input_info("input0"), input_info("input1") },
+                          1,
+                          data_types::f16),
+            reorder("reorder_out", input_info("concat"), { ov::PartialShape{ -1, f * 2, x, y }, data_types::f16, format::bfyx })
+    );
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    auto network = cldnn::network::build_network(engine, topology, config);
+
+    layout actual_layout = { data_types::f16, format::b_fs_yx_fsv16, { b, f, x, y } };
+    auto input0 = engine.allocate_memory(actual_layout);
+    auto input1 = engine.allocate_memory(actual_layout);
 
     auto data0_5d = rg.generate_random_5d<ov::float16>(b, f_slices, y, x, fsv, -1, 1);
     auto data1_5d = rg.generate_random_5d<ov::float16>(b, f_slices, y, x, fsv, -1, 1);
@@ -1735,33 +1753,19 @@ TEST(concat_gpu_onednn, impl_selection_non_block_aligned_feature) {
     set_values<ov::float16>(input0, flatten_5d(format::bfzyx, data0_5d));
     set_values<ov::float16>(input1, flatten_5d(format::bfzyx, data1_5d));
 
-    layout reorder_layout = { data_types::f16, format::bfyx, { b, f * 2, x, y } };
+    network->set_input_data("input0", input0);
+    network->set_input_data("input1", input1);
 
-    topology topology(
-            input_layout("input0", in_layout),
-            input_layout("input1", in_layout),
-            concatenation("concat",
-                          { input_info("input0"), input_info("input1") },
-                          1,
-                          data_types::f16),
-            reorder("reorder", input_info("concat"), reorder_layout)
-    );
+    auto outputs = network->execute();
 
-    ExecutionConfig config = get_test_default_config(engine);
-    config.set_property(ov::intel_gpu::optimize_data(true));
-
-    network network(engine, topology, config);
-    network.set_input_data("input0", input0);
-    network.set_input_data("input1", input1);
-
-    auto concat_inst = network.get_primitive("concat");
+    auto concat_inst = network->get_primitive("concat");
     auto impl = concat_inst->get_impl();
     ASSERT_TRUE(impl != nullptr);
     ASSERT_TRUE(impl->m_manager != nullptr);
-    EXPECT_EQ(impl->m_manager->get_impl_type(), impl_types::ocl);
+    EXPECT_NE(impl->m_manager->get_impl_type(), impl_types::onednn)
+        << "Dynamic non-block-aligned concat should NOT use onednn";
 
-    auto outputs = network.execute();
-    auto output_memory = outputs.at("reorder").get_memory();
+    auto output_memory = outputs.at("reorder_out").get_memory();
     cldnn::mem_lock<ov::float16> output_ptr(output_memory, get_test_stream());
 
     for (size_t i = 0; i < output_memory->get_layout().count(); ++i) {


### PR DESCRIPTION
### Details:
  - Fix NaN output in onednn concat layer when input feature dimension is not aligned to the block size in blocked memory formats.

### Description of the issue(symptom, root-cause, how it was resolved)
  - **Symptom**: TF_Separate_Bass model produces NaN values on GPU with FP16 precision at concat:Transpose_125956059 layer inside Loop sub-graph. Two clean inputs [2,24,16,256] with f16 b_fs_yx_fsv16 format are concatenated along feature axis to [2,48,16,256], but output contain more than 8 hundred NaN values.
 
  - **Root Cause**: 
    - The concat layer's two inputs have feature=24 in b_fs_yx_fsv16 (block size=16) format, where 24 % 16 != 0 (not block-aligned)
    - The validate_impl() in concatenation_onednn.hpp checks output feature alignment (is_feature_aligned(out_layout)) but does not check input feature alignment
    - Output feature 48 is aligned (48 % 16 == 0), so the check passes, and onednn concat is selected
    - The onednn concat kernel has a bug handling non-block-aligned input features in blocked formats, causing data corruption at block boundaries
    - Static models are not affected: build-time allocation always zero-fills padding, so padding is safe.


 - **Resolution**:
    - In concatenation_onednn.hpp validate_impl(), add ` if (node.is_dynamic() && !is_feature_aligned(in_layout))` check for all input layouts inside the dependency loop, consistent with the existing output layout check
    - This ensures onednn concat is rejected only when the combination of dynamic memory reuse (no zero-fill) and non-block-aligned input features would produce incorrect results. Static models retain the onednn path and are unaffected performance-wise.
    - When onednn is rejected for non-block-aligned inputs, the framework falls back to OCL concat which correctly handles this case
    - Added unit test concat_gpu_onednn.dynamic_non_block_aligned_feature to verify the fix
   
#### The code and line that caused this issue (if it is not changed directly)
https://github.com/openvinotoolkit/openvino/blob/81bb2f9d63fefa933a5aec40a6560364bb392a2b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp#L87-L100

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
python -m pytest test_ovc_mo.py \
    -n 2 \
    --tb=native \
    --env_conf=.automation/env_config.yml \
    --test_conf=.automation/test_configs/desktop_test_config_gpu_llm.yml \
    -m "not launch_only_if_manually_specified" \
    --pregen_irs=models/irs_mapping.csv \
    --tf_models_version=1.15.2 \
    --modules pipelines/production/tf/light \
    -k "TF_Ssd_Inception_v2_coco_api_2_True" \
    --dynamism_type=None \
    --log-cli-level INFO

#### Problematic graph
 - Original IR
<img width="2761" height="1138" alt="image" src="https://github.com/user-attachments/assets/3c005f57-f204-483a-96c5-bed751ca56ff" />

 - Current IR
<img width="3157" height="1123" alt="image" src="https://github.com/user-attachments/assets/3650ab8d-987c-4598-91c0-dcacf7b046bb" />

#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [v] Did you include test case for this fix, if necessary?
 - [v] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *CVS-181149*


