### PR TITLE
[NPU] Fix serialize arguments

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
@@ -477,6 +477,10 @@ std::vector<std::shared_ptr<NetworkDescription>> VCLCompilerImpl::compileWsOneSh
     const FilteredConfig& config) const {
     _logger.debug("compileWsOneShot start");
 
+    /// Check the linked vcl version whether supported in plugin
+    UsedVersion usedVersion = getUsedVclVersion(VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR, _vclVersion);
+    _logger.debug("the finally used compiler vcl version is %d.%d", usedVersion.Major, usedVersion.Minor);
+
     const auto maxOpsetVersion = _compilerProperties.supportedOpsets;
     _logger.info("getSupportedOpsetVersion Max supported version of opset in CiD: %d", maxOpsetVersion);
 
@@ -486,7 +490,7 @@ std::vector<std::shared_ptr<NetworkDescription>> VCLCompilerImpl::compileWsOneSh
     compilerVersion.minor = _compilerProperties.version.minor;
 
     bool useBaseModelSerializer = true;
-    useBaseModelSerializer = isUseBaseModelSerializer({7, 5}, config);
+    useBaseModelSerializer = isUseBaseModelSerializer(usedVersion, config);
     _logger.debug("serialize IR method is %s",
                   useBaseModelSerializer ? "base vcl serializer" : "vcl serializer (not copy weights)");
     auto serializedIR =

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -134,8 +134,8 @@ std::shared_ptr<IGraph> DriverCompilerAdapter::compileWS(std::shared_ptr<ov::Mod
                                                     compilerVersion,
                                                     maxOpsetVersion,
                                                     useBaseModelSerializer(updatedConfig),
-                                                    true,
-                                                    _zeGraphExt->isPluginModelHashSupported());
+                                                    _zeGraphExt->isPluginModelHashSupported(),
+                                                    true);
 
     std::string buildFlags;
     const bool useIndices = !((compilerVersion.major < 5) || (compilerVersion.major == 5 && compilerVersion.minor < 9));


### PR DESCRIPTION
### Details:
* Updated the logic for selecting the IR serializer method to use the determined `usedVersion` instead of a hardcoded version in `VCLCompilerImpl::compileWsOneShot`.
* Fixed the argument order when calling a function in `DriverCompilerAdapter::compileWS` to ensure that `isPluginModelHashSupported()` and the boolean flag are passed in the correct order

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
