### PR TITLE
[GPU] Fix select-kernel indexing mismatch for lower-rank inputs

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
@@ -46,12 +46,19 @@ struct select_impl : typed_primitive_impl_ocl<select> {
     static kernel_impl_params static_canonicalize_shapes(const kernel_impl_params& impl_params) {
         auto updated_impl_params = canonicalize_fused_shapes(impl_params);
 
+        auto& output_layout = updated_impl_params.output_layouts[0];
+        auto out_pshape = output_layout.get_partial_shape();
+        size_t target_rank = std::max<size_t>(4, out_pshape.size());
+
         for (auto& input_layout : updated_impl_params.input_layouts) {
-            input_layout.set_partial_shape(extend_shape_to_rank_from_begin(input_layout.get_partial_shape()));
+            auto input_pshape = input_layout.get_partial_shape();
+            input_pshape = extend_shape_to_rank_from_begin(input_pshape, target_rank);
+            input_layout.set_partial_shape(input_pshape);
+            input_layout.format = format::adjust_to_rank(input_layout.format, input_pshape.size());
         }
 
-        auto& output_layout = updated_impl_params.output_layouts[0];
-        output_layout.set_partial_shape(extend_shape_to_rank_from_begin(output_layout.get_partial_shape()));
+        output_layout.set_partial_shape(extend_shape_to_rank_from_begin(out_pshape, target_rank));
+        output_layout.format = format::adjust_to_rank(output_layout.format, target_rank);
 
         return updated_impl_params;
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/select_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/select_gpu_ref.cl
@@ -6,16 +6,8 @@
 
 #if OUTPUT_DIMS == 5
     #define INPUT_0 input0[INPUT0_GET_INDEX_SAFE(b, f, z, y, x)]
-    #if INPUT1_DIMS == 4
-        #define INPUT_1 input1[INPUT1_GET_INDEX_SAFE(b, f, y, x)]
-    #else
-        #define INPUT_1 input1[INPUT1_GET_INDEX_SAFE(b, f, z, y, x)]
-    #endif
-    #if INPUT2_DIMS == 4
-        #define INPUT_2 input2[INPUT2_GET_INDEX_SAFE(b, f, y, x)]
-    #else
-        #define INPUT_2 input2[INPUT2_GET_INDEX_SAFE(b, f, z, y, x)]
-    #endif
+    #define INPUT_1 input1[INPUT1_GET_INDEX_SAFE(b, f, z, y, x)]
+    #define INPUT_2 input2[INPUT2_GET_INDEX_SAFE(b, f, z, y, x)]
 #elif OUTPUT_DIMS == 4
     #define INPUT_0 input0[INPUT0_GET_INDEX_SAFE(b, f, y, x)]
     #define INPUT_1 input1[INPUT1_GET_INDEX_SAFE(b, f, y, x)]

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
@@ -47,7 +47,28 @@ const std::vector<std::vector<ov::Shape>> numpyShapes = {
     {{5, 1, 1, 1}, {5, 7, 8, 6}, {1, 8, 6}},
     {{1, 1, 3}, {1, 3, 1}, {3, 1, 1}},
     {{2, 2, 2, 2, 2}, {2, 2, 2, 2}, {2, 2, 2, 2, 2}},
-    {{2, 2, 2, 2, 2}, {2, 2, 2, 2, 2}, {2, 2, 2, 2}}
+    {{2, 2, 2, 2, 2}, {2, 2, 2, 2, 2}, {2, 2, 2, 2}},
+};
+
+const std::vector<std::vector<ov::test::InputShape>> numpyDynShapesMask4d = {
+    // mask 4D, then 5D, else 5D → output 5D
+    {
+        {{-1, -1, -1, -1}, {{2, 2, 2, 2}}},
+        {{-1, -1, -1, -1, -1}, {{2, 2, 2, 2, 2}}},
+        {{-1, -1, -1, -1, -1}, {{2, 2, 2, 2, 2}}},
+    },
+    // mask 4D, then 5D, else 4D → output 5D
+    {
+        {{-1, -1, -1, -1}, {{2, 2, 2, 2}}},
+        {{-1, -1, -1, -1, -1}, {{2, 2, 2, 2, 2}}},
+        {{-1, -1, -1, -1}, {{2, 2, 2, 2}}},
+    },
+    // mask 4D, then 4D, else 5D → output 5D
+    {
+        {{-1, -1, -1, -1}, {{2, 2, 2, 2}}},
+        {{-1, -1, -1, -1}, {{2, 2, 2, 2}}},
+        {{-1, -1, -1, -1, -1}, {{2, 2, 2, 2, 2}}},
+    },
 };
 
 const std::vector<std::vector<ov::Shape>> pdpdShapes = {
@@ -79,6 +100,14 @@ INSTANTIATE_TEST_SUITE_P(smoke_CLDNN_TestsSelect_none,
 INSTANTIATE_TEST_SUITE_P(smoke_CLDNN_TestsSelect_numpy,
                          SelectLayerTest,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(numpyShapes)),
+                                            ::testing::ValuesIn(inputPrecision),
+                                            ::testing::Values(ov::op::AutoBroadcastType::NUMPY),
+                                            ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                         SelectLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_CLDNN_TestsSelect_numpy_broadcast_mask4d,
+                         SelectLayerTest,
+                         ::testing::Combine(::testing::ValuesIn(numpyDynShapesMask4d),
                                             ::testing::ValuesIn(inputPrecision),
                                             ::testing::Values(ov::op::AutoBroadcastType::NUMPY),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),


### PR DESCRIPTION
## Issue
Building the `Select` kernel can be failed when **NUMPY broadcasting** is used with **lower-rank inputs**, particularly in the **dynamic / new shape inference path**.
```
cond: [256,256]
then: [1]
else: [?,64,?,256,256]
```
Under NUMPY broadcasting semantics this should behave as:
```
cond → [1,1,1,256,256]
then → [1,1,1,1,1]
else → [?,64,?,256,256]
```
However, some inputs may remain lower-rank during kernel JIT generation. This can lead to mismatched macro signatures in the generated OpenCL kernel, resulting in build failures such as:
```
error: too many arguments provided to function-like macro invocation
error: use of undeclared identifier 'INPUT0_GET_INDEX_SAFE'
```

## Root cause
In the dynamic/new-shape-infer path, `Select` input layouts are **not fully canonicalized to the output rank before kernel JIT generation**.

As a result:
- the `Select` kernel may assume **5D indexing**
- while the generated `INPUT*_GET_INDEX_SAFE` macros correspond to **lower-rank inputs**

This mismatch leads to **macro argument inconsistencies during OpenCL kernel compilation**.

## Solution
This PR fixes the issue in two steps:

1. **Canonicalize Select input layouts**
    - In the `Select` impl, input shapes are extended to a consistent rank based on the output rank:
`target_rank = max(4, output_rank)`
    - Shapes are extended using `extend_shape_to_rank_from_begin()` and layouts are adjusted with `format::adjust_to_rank()`.

2. **Simplify `Select` kernel indexing**
    - After canonicalization, the `Select` kernel always uses consistent **5D indexing** when `OUTPUT_DIMS == 5`.
    - This ensures that kernel indexing and generated `GET_INDEX_SAFE` macros follow the same rank contract.

## Graphs
<img width="1907" height="396" alt="image" src="https://github.com/user-attachments/assets/609b9ef4-1f15-438d-9d83-f78b8b3dc8e3" />

## Tickets
 - CVS-182255

