### PR TITLE
[PyTorch FE] Add 2-bit (u2) weight decompression subgraph support

### DIFF
--- a/src/frontends/pytorch/src/frontend.cpp
+++ b/src/frontends/pytorch/src/frontend.cpp
@@ -273,6 +273,8 @@ void FrontEnd::normalize(const std::shared_ptr<ov::Model>& model) const {
     }
     manager.register_pass<ov::frontend::pytorch::pass::U4BlockRepack>(sym);
     manager.register_pass<ov::frontend::pytorch::pass::U4ConvertReshape>();
+    manager.register_pass<ov::frontend::pytorch::pass::U2ConvertReshape>();
+    manager.register_pass<ov::frontend::pytorch::pass::MarkCompressedWeightConstants>();
 
     manager.register_pass<ov::pass::RemoveMultiSubGraphOpDanglingParamsResults>();
     manager.run_passes(model);

--- a/src/frontends/pytorch/src/op/cat.cpp
+++ b/src/frontends/pytorch/src/op/cat.cpp
@@ -187,6 +187,9 @@ OutputVector translate_stack(const NodeContext& context) {
     // GPTQ u4 decompression pattern
     if (const auto& u4_const = u4_compression_stack(stack_inputs, axis))
         return {u4_const};
+    // NNCF u2 decompression pattern
+    if (const auto& u2_const = u2_compression_stack(stack_inputs, axis))
+        return {u2_const};
     // Direct case: unsqueeze each element then concatenate
     auto dim = context.mark_node(v0::Constant::create(element::i32, Shape{}, {axis}));
     std::deque<Output<Node>> unsqueezed;
@@ -224,6 +227,10 @@ OutputVector translate_stack_fx(const NodeContext& context) {
     // returns the u4 constant if the stack operation is a part of the decompression pattern
     if (const auto& u4_const = u4_compression_stack(stack_inputs, axis))
         return {u4_const};
+
+    // returns the u2 constant if the stack operation is a part of the 2-bit decompression pattern
+    if (const auto& u2_const = u2_compression_stack(stack_inputs, axis))
+        return {u2_const};
 
     num_elements = list_elems.size();
     list_elems.clear();

--- a/src/frontends/pytorch/src/transforms/u4_block_repack.cpp
+++ b/src/frontends/pytorch/src/transforms/u4_block_repack.cpp
@@ -7,13 +7,17 @@
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/op/transpose.hpp"
+#include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/rt_info/decompression.hpp"
+#include "transformations/rt_info/keep_const_precision.hpp"
 #include "utils.hpp"
 #include "utils_quantize.hpp"
 
@@ -192,6 +196,56 @@ U4ConvertReshape::U4ConvertReshape() {
             copy_runtime_info(pattern_nodes, new_const);
             replace_node(reshape, new_const);
 
+            return true;
+        });
+};
+
+U2ConvertReshape::U2ConvertReshape() {
+    const auto& m_constant = wrap_type<v0::Constant>(type_matches(element::u2));
+    const auto& m_reshape = wrap_type<v1::Reshape>({m_constant, any_input()});
+
+    register_matcher(
+        std::make_shared<Matcher>(m_reshape, "ov::frontend::pytorch::pass::U2ConvertReshape"),
+        [=](Matcher& m) {
+            auto& pattern_to_output = m.get_pattern_value_map();
+            auto u2_const =
+                std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_to_output[m_constant].get_node_shared_ptr());
+            if (!u2_const)
+                return false;
+
+            if (u2_const->get_element_type() != element::u2)
+                return false;
+
+            auto reshape = pattern_to_output[m_reshape].get_node_shared_ptr();
+            auto dst_shape = reshape->get_output_shape(0);
+
+            auto new_const = std::make_shared<v0::Constant>(*u2_const, dst_shape);
+
+            copy_runtime_info({u2_const, reshape}, new_const);
+            replace_node(reshape, new_const);
+
+            return true;
+        });
+};
+
+MarkCompressedWeightConstants::MarkCompressedWeightConstants() {
+    auto is_compressed_type = [](const ov::Output<ov::Node>& output) -> bool {
+        auto et = output.get_element_type();
+        return et == element::u2 || et == element::u4 || et == element::i4;
+    };
+    const auto& m_constant = wrap_type<v0::Constant>(is_compressed_type);
+    const auto& m_convert = wrap_type<v0::Convert>({m_constant});
+
+    register_matcher(
+        std::make_shared<Matcher>(m_convert, "ov::frontend::pytorch::pass::MarkCompressedWeightConstants"),
+        [=](Matcher& m) {
+            auto& pattern_to_output = m.get_pattern_value_map();
+            auto const_node = pattern_to_output.at(m_constant).get_node_shared_ptr();
+            auto convert_node = pattern_to_output.at(m_convert).get_node_shared_ptr();
+
+            ov::pass::disable_constant_folding(convert_node);
+            ov::mark_as_decompression(convert_node);
+            ov::enable_keep_const_precision(const_node);
             return true;
         });
 };

--- a/src/frontends/pytorch/src/transforms/u4_block_repack.hpp
+++ b/src/frontends/pytorch/src/transforms/u4_block_repack.hpp
@@ -24,6 +24,20 @@ public:
     U4ConvertReshape();
 };
 
+class U2ConvertReshape : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::U2ConvertReshape");
+    U2ConvertReshape();
+};
+
+/// \brief Marks Convert nodes consuming u2/u4 Constants with disable_constant_folding
+///        and mark_as_decompression to prevent MOC from folding compressed weight constants.
+class MarkCompressedWeightConstants : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::MarkCompressedWeightConstants");
+    MarkCompressedWeightConstants();
+};
+
 }  // namespace pass
 }  // namespace pytorch
 }  // namespace frontend

--- a/src/frontends/pytorch/src/utils_quantize.cpp
+++ b/src/frontends/pytorch/src/utils_quantize.cpp
@@ -282,6 +282,93 @@ std::shared_ptr<Node> u4_compression_stack(const OutputVector& list_elems, int64
     return new_const;
 }
 
+std::shared_ptr<Node> u2_compression_stack(const OutputVector& list_elems, int64_t axis) {
+    // Part 1: Detect pattern
+    // unpack_uint2 produces stack of 4 elements:
+    //   bitwise_and(packed, 3)
+    //   bitwise_and(bitwise_right_shift(packed, 2), 3)
+    //   bitwise_and(bitwise_right_shift(packed, 4), 3)
+    //   bitwise_and(bitwise_right_shift(packed, 6), 3)
+
+    if (list_elems.size() != 4)
+        return nullptr;
+
+    // Element 0: bitwise_and(packed, 3) - lowest 2 bits
+    auto bitwise_and_0_candidate = list_elems[0].get_node_shared_ptr();
+    std::shared_ptr<Node> bitwise_and_0 = cast_fw_node(bitwise_and_0_candidate, "aten::bitwise_and");
+    if (!bitwise_and_0) {
+        bitwise_and_0 = std::dynamic_pointer_cast<v13::BitwiseAnd>(bitwise_and_0_candidate);
+        if (!bitwise_and_0)
+            return nullptr;
+    }
+
+    auto weights_u8 = std::dynamic_pointer_cast<v0::Constant>(bitwise_and_0->get_input_node_shared_ptr(0));
+    if (!weights_u8)
+        return nullptr;
+
+    if (weights_u8->get_output_element_type(0) != element::u8)
+        return nullptr;
+
+    if (axis != -1 && static_cast<uint64_t>(axis) != weights_u8->get_shape().size() - 1)
+        return nullptr;
+
+    if (!ov::op::util::has_constant_value<uint64_t>(ov::util::get_constant_from_source(bitwise_and_0->input_value(1)),
+                                                    0x03))
+        return nullptr;
+
+    // Elements 1..3: bitwise_and(bitwise_right_shift(packed, shift), 3) for shift = 2, 4, 6
+    const uint64_t expected_shifts[] = {2, 4, 6};
+    NodeVector all_nodes = {weights_u8, bitwise_and_0};
+
+    for (int i = 1; i <= 3; ++i) {
+        auto bitwise_and_i_candidate = list_elems[i].get_node_shared_ptr();
+        std::shared_ptr<Node> bitwise_and_i = cast_fw_node(bitwise_and_i_candidate, "aten::bitwise_and");
+        if (!bitwise_and_i) {
+            bitwise_and_i = std::dynamic_pointer_cast<v13::BitwiseAnd>(bitwise_and_i_candidate);
+            if (!bitwise_and_i)
+                return nullptr;
+        }
+
+        if (!ov::op::util::has_constant_value<uint64_t>(
+                ov::util::get_constant_from_source(bitwise_and_i->input_value(1)), 0x03))
+            return nullptr;
+
+        auto bitwise_shift_node =
+            cast_fw_node(bitwise_and_i->get_input_node_shared_ptr(0),
+                         {"aten::bitwise_right_shift", "aten.bitwise_right_shift.Tensor_Scalar"});
+        if (!bitwise_shift_node)
+            return nullptr;
+
+        auto weights_u8_shift =
+            std::dynamic_pointer_cast<v0::Constant>(bitwise_shift_node->get_input_node_shared_ptr(0));
+        if (!weights_u8_shift || weights_u8->get_data_ptr() != weights_u8_shift->get_data_ptr())
+            return nullptr;
+
+        if (!ov::op::util::has_constant_value<uint64_t>(bitwise_shift_node->get_input_node_shared_ptr(1),
+                                                        expected_shifts[i - 1]))
+            return nullptr;
+
+        all_nodes.push_back(bitwise_shift_node);
+        all_nodes.push_back(bitwise_and_i);
+    }
+
+    // Pattern detected, weights_u8 is target u8 packed constant with weights (4 x uint2 per byte)
+
+    // Part 2: Form u2 constant by repacking of the original weights_u8
+    const auto& u8_shape = weights_u8->get_shape();
+    size_t full_size = shape_size(u8_shape);
+    auto src = weights_u8->get_data_ptr<uint8_t>();
+
+    auto u2_shape = u8_shape;
+    u2_shape.push_back(4);
+    auto new_const = std::make_shared<v0::Constant>(element::u2, u2_shape);
+    auto dst = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(new_const->get_data_ptr()));
+
+    std::copy(src, src + full_size, dst);  // Both PyTorch and OV pack u2 as LSB-first, no reordering needed
+    copy_runtime_info_and_name(weights_u8, {new_const}, all_nodes);
+    return new_const;
+}
+
 }  // namespace pytorch
 }  // namespace frontend
 }  // namespace ov

--- a/src/frontends/pytorch/src/utils_quantize.hpp
+++ b/src/frontends/pytorch/src/utils_quantize.hpp
@@ -193,6 +193,15 @@ OutputVector quantizable_op(const NodeContext& context) {
  */
 std::shared_ptr<Node> u4_compression_stack(const OutputVector& list_elems, int64_t axis);
 
+/**
+ * Captures aten::stack([aten::bitwise_and(Constant(u8), 3),
+ *                       aten::bitwise_and(aten::bitwise_right_shift(Constant(u8), 2), 3),
+ *                       aten::bitwise_and(aten::bitwise_right_shift(Constant(u8), 4), 3),
+ *                       aten::bitwise_and(aten::bitwise_right_shift(Constant(u8), 6), 3)], dim=-1).
+ * This pattern is transformed to a single Constant with element_type=u2.
+ */
+std::shared_ptr<Node> u2_compression_stack(const OutputVector& list_elems, int64_t axis);
+
 }  // namespace pytorch
 }  // namespace frontend
 }  // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -533,7 +533,8 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
                               {ov::element::f64, ov::element::f32},
                               {ov::element::boolean, ov::element::u8},
                               {ov::element::u4, ov::element::u8},
-                              {ov::element::i4, ov::element::i8}};
+                              {ov::element::i4, ov::element::i8},
+                              {ov::element::u2, ov::element::u8}};
 
         // @todo should we always convert to f32 regardless of hardware support, as it is done for f16?
         if (!hasHardwareSupport(ov::element::bf16)) {

--- a/tests/layer_tests/pytorch_tests/test_compressed_mm.py
+++ b/tests/layer_tests/pytorch_tests/test_compressed_mm.py
@@ -11,12 +11,43 @@ from pytorch_layer_test_class import PytorchLayerTest
 def pack_uint4(tensor):
     packed_tensor = tensor.contiguous()
     packed_tensor = packed_tensor.reshape(-1, 2)
-    packed_tensor = torch.bitwise_and(packed_tensor[..., ::2], 15) | packed_tensor[..., 1::2] << 4
+    packed_tensor = (
+        torch.bitwise_and(packed_tensor[..., ::2], 15) | packed_tensor[..., 1::2] << 4
+    )
     return packed_tensor
 
 
 def unpack_uint4(packed_tensor):
-    return torch.stack((torch.bitwise_and(packed_tensor, 15), torch.bitwise_right_shift(packed_tensor, 4)), dim=-1)
+    return torch.stack(
+        (
+            torch.bitwise_and(packed_tensor, 15),
+            torch.bitwise_right_shift(packed_tensor, 4),
+        ),
+        dim=-1,
+    )
+
+
+def pack_uint2(tensor):
+    packed_tensor = tensor.contiguous().reshape(-1, 4)
+    packed_tensor = (
+        torch.bitwise_and(packed_tensor[..., 0], 3)
+        | (torch.bitwise_and(packed_tensor[..., 1], 3) << 2)
+        | (torch.bitwise_and(packed_tensor[..., 2], 3) << 4)
+        | (torch.bitwise_and(packed_tensor[..., 3], 3) << 6)
+    )
+    return packed_tensor
+
+
+def unpack_uint2(packed_tensor):
+    return torch.stack(
+        (
+            torch.bitwise_and(packed_tensor, 3),
+            torch.bitwise_and(torch.bitwise_right_shift(packed_tensor, 2), 3),
+            torch.bitwise_and(torch.bitwise_right_shift(packed_tensor, 4), 3),
+            torch.bitwise_and(torch.bitwise_right_shift(packed_tensor, 6), 3),
+        ),
+        dim=-1,
+    )
 
 
 def pack_int4(tensor):
@@ -43,7 +74,6 @@ def decompress_symmetric(input, scale):
 
 
 class TestMatMulU4Weights(PytorchLayerTest):
-
     def _prepare_input(self):
         return (np.round(5.00 * self.random.rand(2, 4) - 2.50, 4),)
 
@@ -52,7 +82,9 @@ class TestMatMulU4Weights(PytorchLayerTest):
             def __init__(self, compressed_weight, scale, zero_point, weight_shape):
                 super().__init__()
                 self.compressed_weight_shape = compressed_weight.shape
-                self.packed_weight = torch.nn.Parameter(pack_uint4(compressed_weight), requires_grad=False)
+                self.packed_weight = torch.nn.Parameter(
+                    pack_uint4(compressed_weight), requires_grad=False
+                )
 
                 self.register_buffer("_scale", scale.type(dtype=torch.float16))
 
@@ -65,24 +97,29 @@ class TestMatMulU4Weights(PytorchLayerTest):
                 # NNCF UINT4 asymmetric decompression pattern
                 # https://github.com/openvinotoolkit/nncf/blob/develop/nncf/torch/quantization/layers.py
                 compressed_weight = unpack_uint4(self.packed_weight)
-                compressed_weight = compressed_weight.reshape(self.compressed_weight_shape)
+                compressed_weight = compressed_weight.reshape(
+                    self.compressed_weight_shape
+                )
 
                 zero_point = unpack_uint4(self._zero_point)
                 zero_point = zero_point.reshape(self.zero_point_shape)
 
-                weight = decompress_asymmetric(compressed_weight, self._scale, zero_point)
+                weight = decompress_asymmetric(
+                    compressed_weight, self._scale, zero_point
+                )
                 weight = weight.reshape(self.weight_shape)
                 weight = weight.type(dtype=torch.float32)
 
                 return torch.matmul(x, weight)
-
 
         weight_shape = (4, 2)
         ngroups = weight_shape[0] // group_size
         compressed_weight_shape = (ngroups, group_size, weight_shape[1])
         zero_point_shape = scale_shape = (ngroups, 1, weight_shape[1])
 
-        compressed_weight = self.random.randint(0, 16, size=compressed_weight_shape, dtype=np.uint8)
+        compressed_weight = self.random.randint(
+            0, 16, size=compressed_weight_shape, dtype=np.uint8
+        )
         scale = self.random.randint(-5, 6, size=scale_shape, dtype=np.int32)
         zero_point = self.random.randint(0, 16, size=zero_point_shape, dtype=np.uint8)
 
@@ -90,7 +127,9 @@ class TestMatMulU4Weights(PytorchLayerTest):
         t_scale = torch.from_numpy(scale)
         t_zero_point = torch.from_numpy(zero_point)
 
-        return aten_mm_u4(t_compressed_weight, t_scale, t_zero_point, weight_shape), ["aten::matmul"]
+        return aten_mm_u4(t_compressed_weight, t_scale, t_zero_point, weight_shape), [
+            "aten::matmul"
+        ]
 
     @pytest.mark.nightly
     @pytest.mark.precommit
@@ -103,12 +142,11 @@ class TestMatMulU4Weights(PytorchLayerTest):
             precision,
             ir_version,
             trace_model=True,
-            dynamic_quantization_group_size=0
+            dynamic_quantization_group_size=0,
         )
 
 
 class TestMatMulI4Weights(PytorchLayerTest):
-
     def _prepare_input(self):
         return (np.round(5.00 * self.random.rand(2, 4) - 2.50, 4),)
 
@@ -117,7 +155,9 @@ class TestMatMulI4Weights(PytorchLayerTest):
             def __init__(self, compressed_weight, scale, weight_shape):
                 super().__init__()
                 self.compressed_weight_shape = compressed_weight.shape
-                self.packed_weight = torch.nn.Parameter(pack_int4(compressed_weight), requires_grad=False)
+                self.packed_weight = torch.nn.Parameter(
+                    pack_int4(compressed_weight), requires_grad=False
+                )
 
                 self.register_buffer("_scale", scale.type(dtype=torch.float16))
 
@@ -127,7 +167,9 @@ class TestMatMulI4Weights(PytorchLayerTest):
                 # NNCF INT4 symmetric decompression pattern
                 # https://github.com/openvinotoolkit/nncf/blob/develop/nncf/torch/quantization/layers.py
                 compressed_weight = unpack_int4(self.packed_weight)
-                compressed_weight = compressed_weight.reshape(self.compressed_weight_shape)
+                compressed_weight = compressed_weight.reshape(
+                    self.compressed_weight_shape
+                )
 
                 weight = decompress_symmetric(compressed_weight, self._scale)
                 weight = weight.reshape(self.weight_shape)
@@ -135,13 +177,14 @@ class TestMatMulI4Weights(PytorchLayerTest):
 
                 return torch.matmul(x, weight)
 
-
         weight_shape = (4, 2)
         ngroups = weight_shape[0] // group_size
         compressed_weight_shape = (ngroups, group_size, weight_shape[1])
         scale_shape = (ngroups, 1, weight_shape[1])
 
-        compressed_weight = self.random.randint(-8, 8, size=compressed_weight_shape, dtype=np.int8)
+        compressed_weight = self.random.randint(
+            -8, 8, size=compressed_weight_shape, dtype=np.int8
+        )
         scale = self.random.randint(-5, 6, size=scale_shape, dtype=np.int32)
 
         t_compressed_weight = torch.from_numpy(compressed_weight)
@@ -160,5 +203,80 @@ class TestMatMulI4Weights(PytorchLayerTest):
             precision,
             ir_version,
             trace_model=True,
-            dynamic_quantization_group_size=0
+            dynamic_quantization_group_size=0,
+        )
+
+
+class TestMatMulU2Weights(PytorchLayerTest):
+    def _prepare_input(self):
+        return (np.round(5.00 * self.random.rand(2, 8) - 2.50, 4),)
+
+    def create_model(self, group_size):
+        class aten_mm_u2(torch.nn.Module):
+            def __init__(
+                self, compressed_weight, scale, zero_point, weight_shape, result_dtype
+            ):
+                super(aten_mm_u2, self).__init__()
+                self.compressed_weight_shape = compressed_weight.shape
+                self.packed_weight = torch.nn.Parameter(
+                    pack_uint2(compressed_weight), requires_grad=False
+                )
+
+                self.register_buffer("_scale", scale.type(dtype=torch.float16))
+
+                self.zero_point_shape = zero_point.shape
+                self.register_buffer("_zero_point", zero_point.type(dtype=torch.uint8))
+
+                self.weight_shape = weight_shape
+                self.result_dtype = result_dtype
+
+            def forward(self, x):
+                # NNCF INT2 symmetric decompression pattern
+                # https://github.com/openvinotoolkit/nncf/blob/develop/nncf/torch/quantization/layers.py
+                compressed_weight = unpack_uint2(self.packed_weight)
+                compressed_weight = compressed_weight.reshape(
+                    self.compressed_weight_shape
+                )
+
+                compressed_weight = compressed_weight.type(
+                    dtype=self.result_dtype
+                ) - self._zero_point.type(dtype=self.result_dtype)
+
+                weight = decompress_symmetric(compressed_weight, self._scale)
+                weight = weight.reshape(self.weight_shape)
+                weight = weight.type(dtype=torch.float32)
+
+                return torch.matmul(x, weight)
+
+        weight_shape = (8, 4)
+        ngroups = weight_shape[0] // group_size
+        compressed_weight_shape = (ngroups, group_size, weight_shape[1])
+        zero_point_shape = scale_shape = (ngroups, 1, weight_shape[1])
+
+        compressed_weight = self.random.randint(
+            0, 4, size=compressed_weight_shape, dtype=np.uint8
+        )
+        scale = self.random.randint(-5, 6, size=scale_shape, dtype=np.int32)
+        zero_point = np.full(zero_point_shape, 2, dtype=np.uint8)
+
+        t_compressed_weight = torch.from_numpy(compressed_weight)
+        t_scale = torch.from_numpy(scale)
+        t_zero_point = torch.from_numpy(zero_point)
+
+        return aten_mm_u2(
+            t_compressed_weight, t_scale, t_zero_point, weight_shape, torch.float32
+        ), ["aten::matmul"]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_fx_backend
+    @pytest.mark.parametrize("group_size", [2, 4])
+    def test_matmul_u2(self, group_size, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model(group_size),
+            ie_device,
+            precision,
+            ir_version,
+            trace_model=True,
+            dynamic_quantization_group_size=0,
         )

--- a/tests/layer_tests/pytorch_tests/test_compressed_mm.py
+++ b/tests/layer_tests/pytorch_tests/test_compressed_mm.py
@@ -213,9 +213,9 @@ class TestMatMulU2Weights(PytorchLayerTest):
 
     def create_model(self, group_size):
         class aten_mm_u2(torch.nn.Module):
-            def __init__(
-                self, compressed_weight, scale, zero_point, weight_shape, result_dtype
-            ):
+            ZERO_POINT_VALUE = 2
+
+            def __init__(self, compressed_weight, scale, weight_shape, result_dtype):
                 super(aten_mm_u2, self).__init__()
                 self.compressed_weight_shape = compressed_weight.shape
                 self.packed_weight = torch.nn.Parameter(
@@ -223,9 +223,10 @@ class TestMatMulU2Weights(PytorchLayerTest):
                 )
 
                 self.register_buffer("_scale", scale.type(dtype=torch.float16))
-
-                self.zero_point_shape = zero_point.shape
-                self.register_buffer("_zero_point", zero_point.type(dtype=torch.uint8))
+                self.register_buffer(
+                    "_zero_point",
+                    torch.tensor(self.ZERO_POINT_VALUE, dtype=torch.uint8),
+                )
 
                 self.weight_shape = weight_shape
                 self.result_dtype = result_dtype
@@ -251,21 +252,19 @@ class TestMatMulU2Weights(PytorchLayerTest):
         weight_shape = (8, 4)
         ngroups = weight_shape[0] // group_size
         compressed_weight_shape = (ngroups, group_size, weight_shape[1])
-        zero_point_shape = scale_shape = (ngroups, 1, weight_shape[1])
+        scale_shape = (ngroups, 1, weight_shape[1])
 
         compressed_weight = self.random.randint(
             0, 4, size=compressed_weight_shape, dtype=np.uint8
         )
         scale = self.random.randint(-5, 6, size=scale_shape, dtype=np.int32)
-        zero_point = np.full(zero_point_shape, 2, dtype=np.uint8)
 
         t_compressed_weight = torch.from_numpy(compressed_weight)
         t_scale = torch.from_numpy(scale)
-        t_zero_point = torch.from_numpy(zero_point)
 
-        return aten_mm_u2(
-            t_compressed_weight, t_scale, t_zero_point, weight_shape, torch.float32
-        ), ["aten::matmul"]
+        return aten_mm_u2(t_compressed_weight, t_scale, weight_shape, torch.float32), [
+            "aten::matmul"
+        ]
 
     @pytest.mark.nightly
     @pytest.mark.precommit


### PR DESCRIPTION
### Details:
- Added `u2_compression_stack` pattern matcher in `utils_quantize.cpp` that detects the NNCF
	`unpack_uint2` subgraph: `aten::stack([bitwise_and(packed, 3), bitwise_and(bitwise_right_shift(packed, 2), 3),
	bitwise_and(bitwise_right_shift(packed, 4), 3), bitwise_and(bitwise_right_shift(packed, 6), 3)], dim=-1)`
	and replaces it with a single `element::u2` constant.
- Added `U2ConvertReshape` transformation pass that folds `Reshape` on u2 constants
	into the constant itself (analogous to `U4ConvertReshape` for u4).
- Added `MarkCompressedWeightConstants` transformation pass that marks `Convert` nodes
	consuming u2/u4/i4 constants with `disable_constant_folding` and `mark_as_decompression`
	to prevent MOC from expanding compressed weight constants.
- Integrated u2 pattern detection in both `translate_stack` (TorchScript) and
	`translate_stack_fx` (torch.compile) code paths.
- Added `u2 → u8` type promotion in CPU plugin's `transformation_pipeline.cpp`.
- No need for a standalone `aten::bitwise_right_shift` op converter — the pattern matcher
	consumes the entire unpack subgraph at the `aten::stack` level.

This enables export of NNCF models with `INT2SymmetricWeightsDecompressor` to OpenVINO IR,
following the same approach used for INT4 decompression patterns (PR #27048).
	
### Tickets:
- Depends on NNCF PR: openvinotoolkit/nncf#3971 (INT2SymmetricWeightsDecompressor)
- ref: openvinotoolkit/openvino#27048 (INT4 decompression patterns)

### AI Assistance:
 - *AI assistance used: yes*
 - *manually converted u2/u4 qwen/qwen3-4b and evaluated in openvino
 
lm_eval \
--model openvino \
--model_args pretrained=$IR_DIR \
--device cpu \
--tasks lambada_openai

model | quant_config | group_size | Lambada,   acc | Lambada   ppl | Lambada      OV acc | Lambada   OV ppl
-- | -- | -- | -- | -- | -- | --
Qwen/Qwen3-4B | FQ_LORA   (avg 3bit - mix of 2/4 bit) | 128/64 | 0.5604 | 9.6826 | 0.5572 | 9.6666


