### PR TITLE
[CPU][Snippets] Fix FP16 enablement for AArch64 GEMM KleidiAI emitters

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_copy_b_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_copy_b_emitter.cpp
@@ -15,8 +15,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include <iostream>
-
 #include "cache/multi_cache.h"
 #include "emitters/snippets/aarch64/jit_binary_call_emitter.hpp"
 #include "emitters/snippets/aarch64/kernel_executors/gemm_copy_b.hpp"
@@ -49,13 +47,11 @@ jit_gemm_copy_b_emitter::jit_gemm_copy_b_emitter(
     OV_CPU_JIT_EMITTER_ASSERT(gemm_repack, "expects GemmCopyB node");
     const auto& input_prc = gemm_repack->get_input_element_type(0);
     if (input_prc == element::f16) {
-        std::cout << "[GemmCopyB] Registering FP16 KleidiAI kernel executor" << std::endl;
         m_kernel_executor =
             kernel_table->register_kernel<GemmCopyBF16KaiKernelExecutor>(expr, GemmCopyBKernelKaiConfig());
         m_is_f16 = true;
     } else {
         OV_CPU_JIT_EMITTER_ASSERT(input_prc == element::f32, "Unexpected precision for GemmCopyB executor");
-        std::cout << "[GemmCopyB] Registering FP32 KleidiAI kernel executor" << std::endl;
         m_kernel_executor =
             kernel_table->register_kernel<GemmCopyBF32KaiKernelExecutor>(expr, GemmCopyBKernelKaiConfig());
         m_is_f16 = false;

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
@@ -13,8 +13,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include <iostream>
-
 #include "cache/multi_cache.h"
 #include "emitters/snippets/aarch64/jit_binary_call_emitter.hpp"
 #include "emitters/snippets/aarch64/kernel_executors/gemm.hpp"
@@ -51,12 +49,10 @@ jit_gemm_emitter::jit_gemm_emitter(jit_generator* h,
     OV_CPU_JIT_EMITTER_ASSERT(gemm_node, "Expected GemmCPU node");
     const auto& input_prc = gemm_node->get_input_element_type(0);
     if (input_prc == element::f16) {
-        std::cout << "[GEMM] Registering FP16 KleidiAI kernel executor" << std::endl;
         m_kernel_executor_kai = kernel_table->register_kernel<GemmF16KaiKernelExecutor>(expr, kernel_config);
         m_is_f16 = true;
     } else {
         OV_CPU_JIT_EMITTER_ASSERT(input_prc == element::f32, "Unexpected precision for GemmKai executor");
-        std::cout << "[GEMM] Registering FP32 KleidiAI kernel executor" << std::endl;
         m_kernel_executor_kai = kernel_table->register_kernel<GemmF32KaiKernelExecutor>(expr, kernel_config);
         m_is_f16 = false;
     }


### PR DESCRIPTION
### Details:
 - Remove the `-march=armv8.2-a+fp16` compiler flag that was applied to `jit_gemm_emitter.cpp` and `jit_gemm_copy_b_emitter.cpp` in https://github.com/openvinotoolkit/openvino/pull/34227
 - The flag is unnecessary for these files because KleidiAI micro-kernel implementations are compiled by KleidiAI's own `CMakeLists.txt` with appropriate per-file `-march` flags.
 - The flag `-march=armv8.2-a+fp16` causes crashes on ARMv8.0-A targets (e.g., Raspberry Pi 4).

### Tickets:
 - CVS-177544
