### PR TITLE
TF FE: support non-static rank BiasAdd for NCHW layout

### DIFF
--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -135,6 +135,59 @@ TEST(FrontEndConvertTrickyModels, model_with_output_shapes) {
     }
 }
 
+TEST(FrontEndConvertTrickyModels, bias_add_nchw_non_static_rank) {
+    shared_ptr<Model> model;
+    try {
+        model = convert_model("bias_add_nchw_non_static_rank/bias_add_nchw_non_static_rank.pbtxt",
+                              nullptr,
+                              {"x", "bias"},
+                              {},
+                              {PartialShape::dynamic(), PartialShape{3}});
+    } catch (const std::exception& ex) {
+        FAIL() << ex.what();
+    }
+
+    ASSERT_NE(model, nullptr);
+
+    bool x_rank_dynamic = false;
+    for (const auto& parameter : model->get_parameters()) {
+        if (parameter->get_friendly_name() == "x") {
+            x_rank_dynamic = parameter->get_output_partial_shape(0).rank().is_dynamic();
+        }
+    }
+    ASSERT_TRUE(x_rank_dynamic);
+}
+
+TEST(FrontEndConvertTrickyModels, bias_add_nchw_static_rank_regression) {
+    shared_ptr<Model> model;
+    try {
+        model = convert_model("bias_add_nchw_non_static_rank/bias_add_nchw_non_static_rank.pbtxt",
+                              nullptr,
+                              {"x", "bias"},
+                              {},
+                              {PartialShape{1, 3, 4, 4}, PartialShape{3}});
+    } catch (const std::exception& ex) {
+        FAIL() << ex.what();
+    }
+
+    ASSERT_NE(model, nullptr);
+}
+
+TEST(FrontEndConvertTrickyModels, bias_add_nhwc_regression) {
+    shared_ptr<Model> model;
+    try {
+        model = convert_model("bias_add_nhwc_regression/bias_add_nhwc_regression.pbtxt",
+                              nullptr,
+                              {"x", "bias"},
+                              {},
+                              {PartialShape{1, 4, 4, 3}, PartialShape{3}});
+    } catch (const std::exception& ex) {
+        FAIL() << ex.what();
+    }
+
+    ASSERT_NE(model, nullptr);
+}
+
 TEST_F(FrontEndConversionWithReferenceTestsF, AssertAndStringTensors) {
     {
         model = convert_model("string_tensors_model/string_tensors_model.pbtxt");

--- a/src/frontends/tensorflow/tests/test_models/models_pbtxt/bias_add_nchw_non_static_rank.pbtxt
+++ b/src/frontends/tensorflow/tests/test_models/models_pbtxt/bias_add_nchw_non_static_rank.pbtxt
@@ -1,0 +1,56 @@
+node {
+  name: "x"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        unknown_rank: true
+      }
+    }
+  }
+}
+node {
+  name: "bias"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "bias_add_nchw"
+  op: "BiasAdd"
+  input: "x"
+  input: "bias"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NCHW"
+    }
+  }
+}

--- a/src/frontends/tensorflow/tests/test_models/models_pbtxt/bias_add_nhwc_regression.pbtxt
+++ b/src/frontends/tensorflow/tests/test_models/models_pbtxt/bias_add_nhwc_regression.pbtxt
@@ -1,0 +1,67 @@
+node {
+  name: "x"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 1
+        }
+        dim {
+          size: 4
+        }
+        dim {
+          size: 4
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "bias"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "bias_add_nhwc"
+  op: "BiasAdd"
+  input: "x"
+  input: "bias"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}

--- a/src/frontends/tensorflow_common/src/op/bias_add.cpp
+++ b/src/frontends/tensorflow_common/src/op/bias_add.cpp
@@ -2,11 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <limits>
+
 #include "common_op_table.hpp"
 #include "helper_ops/complex_type_mark.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/subtract.hpp"
 #include "openvino/op/unsqueeze.hpp"
+#include "utils.hpp"
 
 using namespace std;
 using namespace ov::op;
@@ -42,22 +51,45 @@ OutputVector translate_bias_add_op(const NodeContext& node) {
     // in case NCHW layout bias must be reshaped to have a shape (1, C, 1, ...)
     // for further correct use of Add operation
     if (data_format == "NCHW") {
-        // TODO: add support for dynamic rank in case NCHW layout
         auto value_shape = value.get_partial_shape();
-        TENSORFLOW_OP_VALIDATION(node,
-                                 value_shape.rank().is_static(),
-                                 "Value of dynamic rank for BiasAdd in NCHW layout is not supported.");
-        auto value_rank = complex_type_inputs ? value_shape.rank().get_length() - 1 : value_shape.rank().get_length();
+        if (value_shape.rank().is_static()) {
+            auto value_rank =
+                complex_type_inputs ? value_shape.rank().get_length() - 1 : value_shape.rank().get_length();
 
-        std::vector<int64_t> axes_unsqueeze;
-        for (int64_t dim_ind = 0; dim_ind < value_rank; ++dim_ind) {
-            if (dim_ind != 1) {
-                axes_unsqueeze.push_back(dim_ind);
+            std::vector<int64_t> axes_unsqueeze;
+            for (int64_t dim_ind = 0; dim_ind < value_rank; ++dim_ind) {
+                if (dim_ind != 1) {
+                    axes_unsqueeze.push_back(dim_ind);
+                }
             }
+            auto axes_unsqueeze_node =
+                make_shared<v0::Constant>(element::i64, Shape{axes_unsqueeze.size()}, axes_unsqueeze);
+            bias_reshaped = make_shared<v0::Unsqueeze>(bias, axes_unsqueeze_node);
+        } else {
+            // TensorFlow BiasAdd in NCHW layout assumes rank(value) >= 2.
+            auto one_scalar = make_shared<v0::Constant>(element::i64, Shape{}, 1);
+            auto two_scalar = make_shared<v0::Constant>(element::i64, Shape{}, 2);
+            auto zero_vec = make_shared<v0::Constant>(element::i64, Shape{1}, 0);
+            auto one_vec = make_shared<v0::Constant>(element::i64, Shape{1}, 1);
+            auto max_i64 = make_shared<v0::Constant>(element::i64, Shape{1}, std::numeric_limits<int64_t>::max());
+
+            auto value_rank = compute_subgraph_scalar_rank(value, element::i64, true);
+            if (complex_type_inputs) {
+                value_rank = make_shared<v1::Subtract>(value_rank, one_scalar);
+            }
+
+            auto tail_len = make_shared<v1::Subtract>(value_rank, two_scalar);
+            auto tail_len_1d = make_shared<v0::Unsqueeze>(tail_len, zero_vec);
+            auto ones_tail = make_shared<v3::Broadcast>(one_scalar, tail_len_1d);
+
+            auto bias_shape = make_shared<v3::ShapeOf>(bias, element::i64);
+            auto bias_channel = make_shared<v8::Slice>(bias_shape, zero_vec, one_vec, one_vec);
+            auto bias_suffix = make_shared<v8::Slice>(bias_shape, one_vec, max_i64, one_vec);
+
+            auto target_shape =
+                make_shared<v0::Concat>(OutputVector{one_vec, bias_channel, ones_tail, bias_suffix}, 0);
+            bias_reshaped = make_shared<v1::Reshape>(bias, target_shape, false);
         }
-        auto axes_unsqueeze_node =
-            make_shared<v0::Constant>(element::i64, Shape{axes_unsqueeze.size()}, axes_unsqueeze);
-        bias_reshaped = make_shared<v0::Unsqueeze>(bias, axes_unsqueeze_node);
     }
 
     auto res = make_shared<v1::Add>(value, bias_reshaped);


### PR DESCRIPTION
### Details:
- Fixed TensorFlow FE `BiasAdd` for `data_format="NCHW"` when input has non-static rank (rank is dynamic).
- Kept existing behavior unchanged for:
  - NCHW with static rank
  - NHWC path
- Preserved complex handling flow; only bias alignment graph was adjusted for non-static-rank NCHW.
- Implemented dynamic bias alignment via shape-subgraph + `Reshape` (`i64` shape ops).
- Added/updated regression coverage:
  - `bias_add_nchw_non_static_rank`
  - `bias_add_nchw_static_rank_regression`
  - `bias_add_nhwc_regression`

### Tickets:
- ticket-id: N/A

### AI Assistance:
- AI assistance used: yes
- AI was used only as coding assistance (editing/refactoring support).
- The solution idea, design decisions, and validation strategy were done by the author.
- Build and test execution, result checking, and final verification were performed manually by the author.
