### PR TITLE
Fix broken documentation links in README (404 error) resolves #34550

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Open-source software toolkit for optimizing and deploying deep learning models.
 </h3>
 
 <p align="center">
- <a href="https://docs.openvino.ai/2026/index.html"><b>Documentation</b></a> • <a href="https://blog.openvino.ai"><b>Blog</b></a> • <a href="https://docs.openvino.ai/2026/about-openvino/key-features.html"><b>Key Features</b></a> • <a href="https://docs.openvino.ai/2026/get-started/learn-openvino.html"><b>Tutorials</b></a> • <a href="https://docs.openvino.ai/2026/documentation/openvino-ecosystem.html"><b>Integrations</b></a> • <a href="https://www.intel.com/content/www/us/en/developer/tools/openvino-toolkit/model-hub.html"><b>Benchmarks</b></a> • <a href="https://github.com/openvinotoolkit/openvino.genai"><b>Generative AI</b></a>
+ <a href="https://docs.openvino.ai/2026/index.html"><b>Documentation</b></a> • <a href="https://blog.openvino.ai"><b>Blog</b></a> • <a href="https://docs.openvino.ai/2026/about-openvino/key-features.html"><b>Key Features</b></a> • <a href="https://docs.openvino.ai/2026/get-started/learn-openvino.html"><b>Tutorials</b></a> • <a href="https://docs.openvino.ai/2026/about-openvino/openvino-ecosystem/openvino-integrations.html"><b>Integrations</b></a> • <a href="https://www.intel.com/content/www/us/en/developer/tools/openvino-toolkit/model-hub.html"><b>Benchmarks</b></a> • <a href="https://github.com/openvinotoolkit/openvino.genai"><b>Generative AI</b></a>
 </p>
 
 [![PyPI Status](https://badge.fury.io/py/openvino.svg)](https://badge.fury.io/py/openvino)
@@ -100,7 +100,7 @@ OpenVINO supports the CPU, GPU, and NPU [devices](https://docs.openvino.ai/2026/
 
 ## Generative AI with OpenVINO
 
-Get started with the OpenVINO GenAI [installation](https://docs.openvino.ai/2026/get-started/install-openvino/install-openvino-genai.html) and refer to the [detailed guide](https://docs.openvino.ai/2026/openvino-workflow-generative/generative-inference.html) to explore the capabilities of Generative AI using OpenVINO.
+Get started with the OpenVINO GenAI [installation](https://docs.openvino.ai/2026/get-started/install-openvino/install-openvino-genai.html) and refer to the [detailed guide](https://docs.openvino.ai/2026/openvino-workflow-generative/inference-with-genai.html) to explore the capabilities of Generative AI using OpenVINO.
 
 Learn how to run LLMs and GenAI with [Samples](https://github.com/openvinotoolkit/openvino.genai/tree/master/samples) in the [OpenVINO™ GenAI repo](https://github.com/openvinotoolkit/openvino.genai). See GenAI in action with Jupyter notebooks: [LLM-powered Chatbot](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/llm-chatbot) and [LLM Instruction-following pipeline](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/llm-question-answering).
 


### PR DESCRIPTION
## Broken links :
README.md(line-9)----> [Integrations](https://docs.openvino.ai/2026/documentation/openvino-ecosystem.html)
README.md(line-103)----> [Detailed Guide](https://docs.openvino.ai/2026/openvino-workflow-generative/generative-inference.html)

## Fixed these linked links to ---> 
[Integrations](https://docs.openvino.ai/2026/about-openvino/openvino-ecosystem/openvino-integrations.html)
[Detailed Guide](https://docs.openvino.ai/2026/openvino-workflow-generative/inference-with-genai.html)


Resolves issue #34550