### PR TITLE
[PyTorch FE] Fix missing .lower() call in _is_testing()

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/backend_utils.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/backend_utils.py
@@ -83,6 +83,6 @@ def _get_disabled_ops(options) -> Optional[Any]:
 def _is_testing(options) -> Optional[Any]:
     if options is not None and "testing" in options:
         is_testing = options["testing"]
-        if bool(is_testing) and str(is_testing).lower not in ["false", "0"]:
+        if bool(is_testing) and str(is_testing).lower() not in ["false", "0"]:
             return True
     return False


### PR DESCRIPTION
## Summary
- `_is_testing()` in `backend_utils.py` compares `str(is_testing).lower` (a method reference) instead of `str(is_testing).lower()` (the result)
- The bound method object is never equal to `"false"` or `"0"`, so the `not in` check always returns `True`
- This causes testing mode to be enabled for any truthy input, including `"false"` and `"0"`

Closes #34563

## Test plan
- [x] Verify `_is_testing({"testing": "false"})` returns `False` (currently returns `True`)
- [ ] Verify `_is_testing({"testing": True})` still returns `True`
- [ ] Existing TorchDynamo backend tests pass (`precommit_fx_backend` marker)