### PR TITLE
[CPU] fix zero size reorder

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
+#include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
 #include <utility>

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/loop.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/loop.cpp
@@ -477,6 +477,10 @@ TEST_F(StaticLoopDynamicSubgraphCPUTest, smoke_StaticLoopWithDynSubgraph) {
 
 TEST_F(LoopZeroDimBackEdgeCPUTest, smoke_ZeroDimBackEdgeNoCrash) {
     run();
+    ASSERT_EQ(function->get_output_size(), 1);
+    auto output_shape = function->get_output_shape(0);
+    ov::Shape expected_shape{0, 10, 10};
+    EXPECT_EQ(output_shape, expected_shape);
 }
 
 namespace {


### PR DESCRIPTION
### Details:
 - *fix the reorder with zero dim*
 - *https://github.com/openvinotoolkit/oneDNN/pull/301*

### Tickets:
 - *182176*

### AI Assistance:
 - *AI assistance used: yes*
 - *write a fix SKILL.md, which is attached in the ticket. The SKILL.md is a guide to debug from openvino to oneDNN.*
 - *root cause both cpu plugin and onednn. zero_dim should NOT be reordered in real case. So need to skip this scenario.*
 - *add a guard at openvino side.*
