### PR TITLE
[TEST] Selective parallelization. Time optimization.

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/prior_box.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/prior_box.cpp
@@ -82,6 +82,7 @@ public:
 
 protected:
     void SetUp() override {
+        m_parallel_validation = true;
         const auto& [specParams, netPrecision, inPrc, outPrc, inputShapes, imageShapes, _targetDevice] = GetParam();
         targetDevice = _targetDevice;
         selectedType = makeSelectedTypeStr("ref_any", ov::test::ElementType::i32);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_dw_conv.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_dw_conv.cpp
@@ -22,6 +22,7 @@ class ConvDWConv : public testing::WithParamInterface<ConvDWConvTestParams>,
                    public CPUTestUtils::CpuTestWithFusing {
 protected:
     void SetUp() override {
+        m_parallel_validation = true;
         targetDevice = utils::DEVICE_CPU;
         const auto& [precision, input_shape, out_channels, fusing_params] = this->GetParam();
         std::tie(postOpMgrPtr, fusedOps) = fusing_params;

--- a/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_subgraph.hpp
@@ -88,6 +88,7 @@ protected:
     bool is_report_stages = false;
     bool is_reported = false;
     double rel_influence_coef = 1.f;
+    bool m_parallel_validation = false;
 
     virtual std::vector<ov::Tensor> calculate_refs();
     virtual std::vector<ov::Tensor> get_plugin_outputs();

--- a/src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp
@@ -464,36 +464,41 @@ std::vector<ov::Tensor> SubgraphBaseTest::get_plugin_outputs() {
 
 void SubgraphBaseTest::validate() {
     std::vector<ov::Tensor> expectedOutputs, actualOutputs;
-    std::exception_ptr expected_outputs_error, actual_output_error;
 
 #ifndef NDEBUG
     actualOutputs = get_plugin_outputs();
     expectedOutputs = calculate_refs();
 #else
-    std::thread t_device([this, &actualOutputs, &actual_output_error] {
-        // The try ... catch block is required to handle exceptions during output calculations and report as test fail.
-        // If exception is not caught then application would be terminated with crash. (CVS-133676)
-        try {
-            actualOutputs = get_plugin_outputs();
-        } catch (...) {
-            actual_output_error = std::current_exception();
-        }
-    });
-    std::thread t_ref([this, &expectedOutputs, &expected_outputs_error] {
-        try {
-            expectedOutputs = calculate_refs();
-        } catch (...) {
-            expected_outputs_error = std::current_exception();
-        }
-    });
-    t_device.join();
-    t_ref.join();
+    if (m_parallel_validation) {
+        std::exception_ptr expected_outputs_error, actual_output_error;
+        std::thread t_device([this, &actualOutputs, &actual_output_error] {
+            // The try ... catch block is required to handle exceptions during output calculations and report as test fail.
+            // If exception is not caught then application would be terminated with crash. (CVS-133676)
+            try {
+                actualOutputs = get_plugin_outputs();
+            } catch (...) {
+                actual_output_error = std::current_exception();
+            }
+        });
+        std::thread t_ref([this, &expectedOutputs, &expected_outputs_error] {
+            try {
+                expectedOutputs = calculate_refs();
+            } catch (...) {
+                expected_outputs_error = std::current_exception();
+            }
+        });
+        t_device.join();
+        t_ref.join();
 
-    if (actual_output_error) {
-        std::rethrow_exception(actual_output_error);
-    }
-    if (expected_outputs_error) {
-        std::rethrow_exception(expected_outputs_error);
+        if (actual_output_error) {
+            std::rethrow_exception(actual_output_error);
+        }
+        if (expected_outputs_error) {
+            std::rethrow_exception(expected_outputs_error);
+        }
+    } else {
+        actualOutputs = get_plugin_outputs();
+        expectedOutputs = calculate_refs();
     }
 #endif
 

--- a/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
@@ -123,6 +123,7 @@ uint64_t clip(uint64_t n, uint64_t lower, uint64_t upper) {
 }
 
 void ReadIRTest::SetUp() {
+    m_parallel_validation = true;
     std::pair<std::string, std::string> model_pair;
     targetDevice = ov::test::utils::target_device;
     configuration = ov::test::utils::global_plugin_config;

--- a/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_roifeatureextractor.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_roifeatureextractor.cpp
@@ -37,6 +37,7 @@ std::string ExperimentalDetectronROIFeatureExtractorLayerTest::getTestCaseName(
 }
 
 void ExperimentalDetectronROIFeatureExtractorLayerTest::SetUp() {
+    m_parallel_validation = true;
     const auto& [shapes, outputSize, sampling_ratio, pyramid_scales, aligned, model_type, targetName] =
         this->GetParam();
 

--- a/src/tests/functional/plugin/shared/src/single_op/prior_box.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/prior_box.cpp
@@ -65,6 +65,7 @@ std::string PriorBoxLayerTest::getTestCaseName(const testing::TestParamInfo<prio
 }
 
 void PriorBoxLayerTest::SetUp() {
+    m_parallel_validation = true;
     const auto& [spec_params, model_type, shapes, _targetDevice] = GetParam();
     targetDevice = _targetDevice;
 

--- a/src/tests/functional/plugin/shared/src/subgraph/shared_matmul_gather_weights_decompression.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/shared_matmul_gather_weights_decompression.cpp
@@ -65,6 +65,7 @@ std::shared_ptr<ov::Model> SharedMatmulAndGatherWeightsDecompression::initSubgra
 }
 
 void SharedMatmulAndGatherWeightsDecompression::SetUp() {
+    m_parallel_validation = true;
     const auto& [_targetDevice,
                  shape_params,
                  weights_precision,


### PR DESCRIPTION
### Details:
 - *Parallelism in the fn `SubgraphBaseTest::validate` slows down `ov_cpu_func_tests`.*
 - *There is no difference between parallel and sequence execution for `ov_gpu_func_tests`.*
 - *Solution: disable this parallelism by default and enable in cases where it can improve execution time.*

### Tickets:
 - *98677*

### AI Assistance:
 - *AI assistance used: no*
