### PR TITLE
[OP CONFORMANCE][TEMPLATE] Fix Interpolate test fails in op conformance Fixes #23553 

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
@@ -235,6 +235,33 @@ void ReadIRTest::SetUp() {
         GTEST_SKIP() << "Static cases are skipped according `shape_mode`";
     }
 
+    auto ordered_ops = function->get_ordered_ops();
+    // Skip cases with Interpolate linear_onnx with axes [1,2] for 4D
+    for (const auto& op : ordered_ops) {
+        size_t axes_idx = 0;
+        if (ov::is_type<ov::op::v11::Interpolate>(op)) {
+            axes_idx = 2;
+        } else if (ov::is_type<ov::op::v4::Interpolate>(op)) {
+            axes_idx = 3;
+        } else {
+            continue;
+        }
+    
+        auto interp_base = ov::as_type_ptr<ov::op::util::InterpolateBase>(op);
+        if (interp_base->get_attrs().mode != ov::op::util::InterpolateBase::InterpolateMode::LINEAR_ONNX)
+            continue;
+        if (interp_base->get_input_partial_shape(0).rank().get_length() != 4)
+            continue;
+        if (interp_base->get_input_size() <= axes_idx)
+            continue;
+        auto axes_node = interp_base->get_input_node_shared_ptr(axes_idx);
+        auto axes_const = ov::as_type_ptr<ov::op::v0::Constant>(axes_node);
+        if (!axes_const)
+            continue;
+        std::vector<int64_t> axes = axes_const->cast_vector<int64_t>();
+        if (axes == std::vector<int64_t>{1, 2})
+            GTEST_SKIP() << "Interpolate linear_onnx with axes [1,2] for 4D is not supported by reference; skipping.";
+    }
     std::vector<InputShape> inputShapes;
     auto shapeMap = utils::getShapeMap();
     for (const auto& param : function -> get_parameters()) {


### PR DESCRIPTION
### Summary
This PR skips an unsupported **Interpolate-11 `linear_onnx` configuration** in op conformance tests.

The failing IR uses:

- `mode = "linear_onnx"`
- `axes = [1,2]`
- input shape `[1, 65, 65, 21]` (4D)

According to the OpenVINO Interpolate specification, when `mode="linear_onnx"` the supported axes are:

| Rank | Supported axes |
|-----|------|
| 2D | `{0,1}` |
| 3D | `{0,1,2}` |
| 4D | `{2,3}` |
| 5D | `{2,3,4}` |

For a **4D tensor**, only `{2,3}` are supported.  
The conformance IR uses `axes=[1,2]`, which is outside the documented supported configuration.
[interploate-11 documentation](https://docs.openvino.ai/2025/documentation/openvino-ir-format/operation-sets/operation-specs/image/interpolate-11.html)
[interpolate-4 documentation](https://docs.openvino.ai/2025/documentation/openvino-ir-format/operation-sets/operation-specs/image/interpolate-4.html)

The reference implementation therefore throws:
```
[ RUN      ] conformance_Interpolate/ReadIRTest.Inference/Op=Interpolate.11_Type=f32_Shape=static_IR=0f670e49f962b0a7abc6b4f1fbf9592db592a6a78eb3e083dd4027b9f9607430_Device=TEMPLATE_Config=()

MEM_USAGE=71868KB
[ CONFORMANCE ] Influence coefficient: 8.71821e-05
[ PLUGIN      ] `SubgraphBaseTest::compile_model()` is started
[ PLUGIN      ] `SubgraphBaseTest::compile_model()` is finished successfully. Duration is 0.0654674s
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is started
/home/efode/repo/openvino/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp:94: Failure
Exception from src/inference/src/cpp/infer_request.cpp:223:
Exception from src/core/reference/include/openvino/reference/interpolate.hpp:426:
Axes are not correct!


[  FAILED  ] conformance_Interpolate/ReadIRTest.Inference/Op=Interpolate.11_Type=f32_Shape=static_IR=0f670e49f962b0a7abc6b4f1fbf9592db592a6a78eb3e083dd4027b9f9607430_Device=TEMPLATE_Config=(), where GetParam() = ("/home/efode/repo/openvino/src/tests/test_utils/functional_test_utils/layer_tests_summary/temp/models/2023.3.0-13657-d5b0f4d2d73/operation/static/Interpolate-11/f32/0f670e49f962b0a7abc6b4f1fbf9592db592a6a78eb3e083dd4027b9f9607430.xml", "") (2498 ms)
```
---

### Root Cause
The failure occurs in the reference implementation:
- src/core/reference/include/openvino/reference/interpolate.hpp
`linear_onnx_func` validates the axes and throws an exception when encountering `[1,2]` for 4D input. OPENVINO_THROW("Axes are not correct!");

This causes the **Inference** test to fail during reference calculation, while `QueryModel` and `ImportExport` pass.

---

## Change

Solution was to mark the test as **SKIPPED** instead of **FAILED** so it is not reported as a plugin failure.

A check was added in:
- src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
- Inside:
  - ReadIRTest::SetUp()


If the test detects:

- `Interpolate` v4/v11
- `mode = linear_onnx`
- 4D input
- `axes = [1,2]`

the test calls:
GTEST_SKIP() with a short explanation. "Interpolate linear_onnx with axes [1,2] for 4D is not supported by reference; skipping."

---

## Alternatives Considered

**1. Extend the reference implementation**

- Support `axes=[1,2]` in `reference/interpolate.hpp`. However this would change reference behavior and a previous attempt (PR #23636) which caused additional failures.
- Supporting [1,2] would require extending the reference behavior beyond the documented specification and may introduce inconsistencies across plugins.

**2. Filter this IR during conformance IR generation**

The problematic IR could be removed from the conformance dataset so that only valid configurations are tested.

This may be a better long-term solution but requires changes to the IR generation pipeline.

---

## IMPORTANT NOTES
This PR provides a minimal solution to prevent an **out-of-spec IR configuration** from being reported as a plugin failure.

Maintainer feedback would be helpful to determine whether:
- skipping is the preferred approach or
- the IR should be removed from the conformance dataset OR
- or supporting the axes=[1,2] option by extending the reference implementation.

---

## Tickets
Fixes #23553 

---

## AI Assistance
AI was used to help navigate the OpenVINO codebase and understand the conformance testing flow.  
All code changes and final validation were implemented manually and verified by me.