### PR TITLE
[GPU] Fix PRelu 1D tensor support and Sign activation for integer types

### DIFF
--- a/src/plugins/intel_gpu/src/graph/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/activation.cpp
@@ -27,7 +27,8 @@ layout activation_inst::calc_output_layout(activation_node const& node, kernel_i
         activation_func::relu,
         activation_func::floor,
         activation_func::clamp,
-        activation_func::abs };
+        activation_func::abs,
+        activation_func::sign };  // Add sign activation for integer types
 
     if (input_node_layout.data_type == data_types::i8 || input_node_layout.data_type == data_types::u8 ||
         input_node_layout.data_type == data_types::i32) {

--- a/src/plugins/intel_gpu/src/plugin/ops/unary.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/unary.cpp
@@ -77,14 +77,24 @@ static void CreatePReluOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::P
 
     auto slope_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
     auto slope_shape = op->get_input_partial_shape(1);
-    auto out_shape = op->get_output_partial_shape(0);
 
+    // Check if slope is a scalar constant (single element)
     if (slope_node && ov::shape_size(slope_shape.to_shape()) == 1) {
+        // Scalar slope case: Extract the slope value and embed it as a constant parameter
+        // This path handles:
+        // - 0D scalar tests (shape [], size 1)
+        // - 1D constant tensors with shape [1]
+        // - Any constant slope with exactly 1 element
         float slope;
         OPENVINO_ASSERT(ov::op::util::get_single_value(slope_node, slope),
                         "[GPU] Unsupported parameter size in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
         CreateUnaryEltwiseOp(p, op, cldnn::activation_func::relu_negative_slope, {slope});
-    } else if (out_shape.size() >= 2) {
+    } else {
+        // Non-scalar slope case: Use slope as a second input to the activation primitive
+        // This path handles:
+        // - Multi-element constant slopes (e.g., per-channel slopes)
+        // - Non-constant (dynamic) slopes
+        // - ALL dimensionalities (1D, 2D, 3D, 4D, 5D, etc.)
         auto inputs = p.GetInputInfo(op);
         std::string layerName = layer_type_name_ID(op);
         auto activationPrimitive = cldnn::activation(layerName,


### PR DESCRIPTION
## Description

This PR fixes two related issues in the Intel GPU plugin's activation operations:

### 1. PRelu 1D Tensor Support (WebNN Tests)

**Problem:**
- PRelu operations with 1D tensors and non-scalar slopes were falling through both conditional branches in `CreatePReluOp`
- No primitive was being created, causing error: "Input prelu:preluOutput_0 hasn't been found in primitive_ids map"

**Root Cause:**
- 1D tensors with non-scalar or non-constant slopes had no code path to create primitives

**Solution:**
- Removed the `out_shape.size() >= 2` restriction
- Simplified to two-branch logic: scalar constant vs. everything else
- Now handles all dimensionalities (1D, 2D, 3D, 4D, 5D, etc.) uniformly

**Affected Tests (Now Passing):**
- ✅ prelu float32 1D tensors
- ✅ prelu float32 1D non-constant slope
- ✅ prelu float16 1D constant tensors
- ✅ prelu float16 1D tensors
- ✅ prelu float16 1D non-constant slope

### 2. Sign Activation Integer Type Support (WebNN Tests)

**Problem:**
- Sign activation with integer types (int8, uint8, int32) threw error: "Requested activation is not supported for integer type"

**Root Cause:**
- `activation_func::sign` was missing from the `activations_int8` whitelist in `activation.cpp`
- Sign operation is mathematically valid and well-defined for integers

**Solution:**
- Added `activation_func::sign` to the integer type whitelist
- Aligns GPU plugin with CPU/template backends which already support Sign for integers

**Affected Tests (Now Passing):**
- ✅ sign int32 2D tensor
- ✅ sign int64 3D tensor
- ✅ sign int8 4D tensor

## Testing

### Verified Passing Tests:
- All previously passing PRelu tests (0D scalar, 2D-5D tensors, broadcast cases) ✅
- All previously passing Sign tests (float32/float16 constant and dynamic) ✅
- Newly fixed PRelu 1D tests (5 tests) ✅
- Newly fixed Sign integer tests (3 tests) ✅

### No Regressions:
- PRelu scalar constant path unchanged
- PRelu 2D+ behavior unchanged
- No impact on other activation types

## Checklist

- [x] Code changes follow OpenVINO coding standards
- [x] All affected tests now pass
- [x] No regressions in previously passing tests
- [x] Changes are minimal and focused on the specific issues
- [x] Code comments added to explain the logic
- [x] Tested with WebNN test suite

### Tickets:
- https://jira.devtools.intel.com/browse/CVS-176948
- https://jira.devtools.intel.com/browse/CVS-176951