### PR TITLE
[GPU][Skills] Extend MoE3GeMMFusedCompressed

### DIFF
--- a/.github/skills/gpu-extend-moe3gemm-fused-compressed/SKILL.md
+++ b/.github/skills/gpu-extend-moe3gemm-fused-compressed/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: gpu-extend-moe3gemm-fused-compressed
+description: 'Guide for extending MOE3GemmFusedCompressed with new routing pattern support in the OpenVINO GPU plugin. Use when asked to support a new MoE model in GPU plugin, add a new MoE routing variant (e.g. sigmoid-bias), extend MOE3GemmFusedCompressed, add a new MOE pattern, or debug MOE fusion failures. Covers analysis, decomposition, transformation patterns, OpenCL kernels, and test strategy.'
+---
+
+# Extending MOE3GemmFusedCompressed with New Pattern Support (GPU Plugin)
+
+This skill describes the complete workflow for adding support for a new MoE (Mixture-of-Experts) routing pattern to the `MOE3GemmFusedCompressed` fused operation in the OpenVINO GPU plugin.
+
+The reference implementation — adding Sigmoid+Bias routing support — was merged at commit [`b3175eb`](https://github.com/openvinotoolkit/openvino/commit/b3175eb70da72304f035045f5a5d23ea628b45c2). It serves as a concrete example of the end-to-end change set required for this type of work. When in doubt about what a specific file change should look like (new enum values, pattern branch, kernel stage, test parametrization), fetch the diff of that commit and use it as a reference.
+
+## When to Use This Skill
+
+- A new model uses an MoE routing pattern not yet fused by `FuseMOE3GemmCompressed`
+- You need to add a new routing variant (e.g. sigmoid+bias)
+- The GPU plugin falls back to unfused per-expert execution for a model that should use the optimized fused path
+- You see `MOECompressed` nodes in the execution graph instead of `moe_3gemm_fused_compressed`
+
+## Prerequisites
+
+### Required Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `MODEL_PATH` | Yes | Absolute path to the MoE LLM model `.xml` (OpenVINO IR format). The model must exhibit the routing pattern you are trying to support. Used in all `benchmark_app` commands (Steps 1–2). |
+
+Collect this from the user before starting. Steps 1–2 cannot be executed without it.
+
+> **Device requirement:** `FuseVectorizedMOE3GEMM` (and the entire 3-GEMM fused pipeline) is gated on `device_info.supports_immad` — it is disabled at runtime on non-systolic-array architectures. All steps in this skill require a GPU with IMMAD support.
+
+### Build Environment Setup
+
+Helper scripts live in [`scripts/`](scripts/) and auto-detect the OpenVINO source root from their location. Override `SRC_DIR` or `BUILD_DIR` if needed.
+
+#### 1. CMake Configuration
+
+Run once (or after `CMakeLists.txt` changes):
+
+```bash
+./scripts/configure.sh
+```
+
+Key flags enabled: `ENABLE_INTEL_GPU`, `ENABLE_TESTS`, `ENABLE_DEBUG_CAPS`, `ENABLE_GPU_DEBUG_CAPS`.
+
+#### 2. Build
+
+Pass the CMake target name directly:
+
+```bash
+./scripts/build.sh openvino_intel_gpu_plugin   # to run a MoE model
+./scripts/build.sh ov_gpu_unit_tests            # GPU unit tests
+./scripts/build.sh ov_gpu_func_tests            # GPU functional tests
+```
+
+For multiple targets, build them in sequence or as a single `cmake --build` call.
+
+#### 3. Run Tests
+
+```bash
+# Kernel-level accuracy tests (requires IMMAD GPU)
+./scripts/run_tests.sh ov_gpu_unit_tests --gtest_filter='*moe_3gemm*'
+
+# Fusion/transformation tests only (no GPU hardware needed)
+./scripts/run_tests.sh ov_gpu_unit_tests --gtest_filter='*FuseMOE3GemmCompressed*'
+
+# Full subgraph functional tests (requires IMMAD GPU)
+./scripts/run_tests.sh ov_gpu_func_tests --gtest_filter='*MoE3GemmCompressed*'
+```
+
+#### 4. Run a Model with benchmark_app
+
+```bash
+<build_dir>/bin/benchmark_app \
+    -m <path_to_model.xml> \
+    -d GPU \
+    -niter 1 \
+    -inference_precision f16 \
+    -hint latency \
+    -data_shape "input_ids[1,1],input_ids_1[1,1],793[1,1,2048],647[1,1,2048]" \ # note: data shape or input names may be different
+```
+
+## Architecture Overview
+
+`MOE3GemmFusedCompressed` is a GPU-plugin internal operation produced by the `FuseMOE3GemmCompressed` transformation. At runtime it is executed entirely by an OpenCL kernel implementation (`moe_3gemm_swiglu_fuse.cl`) which handles routing, expert gather/scatter, gate/up projections, SwiGLU activation, and down projection in a single fused dispatch.
+
+### Transformation Pipeline
+
+The four passes that form the compressed MoE 3-GEMM pipeline run in this order inside `TransformationsPipeline::apply()` (see `src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp`):
+
+```
+Input IR (standard MoE ops)
+        │
+        ▼
+1. FuseVectorizedMOE3GEMM          [ov::pass::FuseVectorizedMOE3GEMM]
+   Fuses the three expert GEMMs (gate/up/down) and the SwiGLU
+   activation into a single internal ov::op::internal::MOE node.
+   ⚠ Disabled on non-IMMAD platforms (callback returns true).
+        │
+        ▼
+2. ConvertMOEToMOECompressed       [ov::intel_gpu::ConvertMOEToMOECompressed]
+   Converts MOE → MOECompressed when expert weights are
+   weight-compressed (u4/u8 with scale/zp). Attaches decompression
+   metadata to the config.
+        │
+        ▼
+3. FuseMOE3GemmCompressed          [ov::intel_gpu::FuseMOE3GemmCompressed]
+   Pattern-matches the routing subgraph (Softmax or Sigmoid+Bias)
+   in front of MOECompressed and replaces the whole subgraph with
+   a single MOE3GemmFusedCompressed node.
+   ← THIS IS THE PASS YOU EXTEND FOR A NEW ROUTING PATTERN →
+        │
+        ▼
+5. KeepMOE3GemmConstPrecision      [ov::intel_gpu::KeepMOE3GemmConstPrecision]
+   Marks the newly constant-folded weight constants so that a
+   subsequent ConvertPrecision pass does not change their dtype
+   (u4/u8 must stay as-is for the kernel). Note: it is needed only for u4 weights
+```
+
+## Workflow
+
+- [ ] Step 1: Run model with matcher logging — see [workflow-diagnosis.md](./references/workflow-diagnosis.md#step-1-run-with-matcher-logging)
+- [ ] Step 2: Analyze logs (routes to Step 3 or Step 5) — see [workflow-diagnosis.md](./references/workflow-diagnosis.md#step-2-analyze-the-logs)
+- [ ] Step 3: Reproduce transformation failure as a unit test — see [workflow-transformation.md](./references/workflow-transformation.md#step-3-create-test-cases-from-the-new-model)
+- [ ] Step 4: Extend the transformation until unit tests pass — see [workflow-transformation.md](./references/workflow-transformation.md#step-4-extend-the-transformation-and-make-tests-pass)
+- [ ] Step 5: Extend the end-to-end functional test — see [workflow-testing.md](./references/workflow-testing.md#step-5-extend-the-end-to-end-functional-test)
+- [ ] Step 6: Fix the OpenCL kernel (only if Step 5 has accuracy failures) — see [workflow-testing.md](./references/workflow-testing.md#step-6-fix-the-opencl-kernel)
+- [ ] Step 7: Done — verify all acceptance criteria below
+
+## Step 7: Done
+
+All of the following should hold:
+
+- [ ] Matcher log (Step 1) shows all four passes firing on the real model
+- [ ] `moe_3gemm_fused_compressed` appears in the runtime model
+- [ ] `FuseMOE3GemmCompressed` unit test passes for all routing types (Step 4)
+- [ ] `smoke_MoE3GemmCompressedFusion` functional test passes for all routing types and weight precisions (Step 5)
+
+## File Modification Checklist
+
+| Area | Files | Purpose |
+|------|-------|---------|
+| **Test builders** | `common_test_utils/.../moe_builders.hpp` / `.cpp` | New routing subgraph builder |
+| **Internal Op** | `intel_gpu/op/moe_compressed.hpp` | `RoutingType` enum value |
+| **Internal Op** | `intel_gpu/op/moe_3gemm_fused_compressed.hpp` / `.cpp` | New inputs, validation |
+| **Op serialization** | `transformations/op/moe_compressed.cpp` | `EnumNames`, `visit_attributes` |
+| **Fusion transformation** | `transformations/fuse_moe_3gemm_compressed.cpp` / `.hpp` | Pattern branch via `Or` |
+| **Const precision** | `transformations/keep_moe_3gemm_const_precision.cpp` | Handle new input count |
+| **Graph registration** | `plugin/ops/moe.cpp` | Dynamic input validation |
+| **Kernel indices** | `impls/ocl_v2/moe/moe_3gemm_base.hpp` | New input enum values |
+| **Kernel impl** | `impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp` | Stage registration, dispatch |
+| **OpenCL kernel** | `impls/ocl_v2/moe_3gemm_swiglu_fuse.cl` | New routing kernel stage |
+| **Kernel unit tests** | `tests/unit/test_cases/moe_3gemm_gpu_test.cpp` | Kernel accuracy (routing reference + parametrize) |
+| **Kernel test data** | `tests/unit/test_cases/moe_3gemm_test_data.h` | Reference outputs for new routing type |
+| **Transf. tests** | `tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp` | Fusion correctness |
+| **Functional tests** | `tests/functional/subgraph_tests/dynamic/moe.cpp` | End-to-end |
+| **Skip config** | `tests/functional/.../skip_tests_config.cpp` | Platform gating |
+
+## Step 8: Debug Capabilities
+
+See `src/plugins/intel_gpu/docs/gpu_debug_utils.md` for the full reference. Most relevant capabilities for MoE kernel work:
+
+- **`OV_GPU_DUMP_GRAPHS_PATH`** — verify `moe_3gemm_fused_compressed` is present in the compiled GPU graph
+- **`OV_GPU_DUMP_TENSORS_PATH`** — inspect intermediate tensor values when a kernel produces wrong results (Step 6)
+- **`OV_GPU_DUMP_SOURCES_PATH`** — inspect the expanded OpenCL kernel source to confirm a new JIT branch compiled correctly (Step 6)
+
+## Troubleshooting
+
+| Issue | See |
+|-------|-----|
+| `FuseVectorizedMOE3GEMM` does not fire despite expected MoE subgraph | [Known Issues → MatMul attribute mismatch](./references/workflow-diagnosis.md#known-issues) |
+
+## References
+
+### Skill Workflow Files
+
+- [workflow-diagnosis.md](./references/workflow-diagnosis.md) — Steps 1–2: matcher logging setup and log analysis
+- [workflow-transformation.md](./references/workflow-transformation.md) — Steps 3–4: transformation unit tests and extension
+- [workflow-testing.md](./references/workflow-testing.md) — Steps 5–6: end-to-end functional tests and OpenCL kernel fixes
+
+### GPU Plugin Documentation
+
+- [`gpu_debug_utils.md`](../../../../src/plugins/intel_gpu/docs/gpu_debug_utils.md) — Debug environment variables (`OV_GPU_DUMP_*`, `OV_VERBOSE`)
+- [`gpu_kernels.md`](../../../../src/plugins/intel_gpu/docs/gpu_kernels.md) — KernelSelector architecture for implementing a new routing `KernelGenerator`
+- [`gpu_plugin_unit_test.md`](../../../../src/plugins/intel_gpu/docs/gpu_plugin_unit_test.md) — Unit test directory structure (`fusions/`, `test_cases/`, `module_tests/`)
+- [`graph_optimization_passes.md`](../../../../src/plugins/intel_gpu/docs/graph_optimization_passes.md) — cldnn graph optimization pass sequence (background for how GPU-level fusion interacts with OV-level passes)
+
+### Transformation Infrastructure
+
+- [`matcher_logging.md`](../../../../src/common/transformations/docs/debug_capabilities/matcher_logging.md) — `OV_MATCHER_LOGGING` / `OV_MATCHERS_TO_LOG` usage
+
+### Reference Implementation
+
+- Commit [`b3175eb`](https://github.com/openvinotoolkit/openvino/commit/b3175eb70da72304f035045f5a5d23ea628b45c2) — Complete diff for Sigmoid+Bias routing support; use as a template for any new routing type
+

--- a/.github/skills/gpu-extend-moe3gemm-fused-compressed/references/workflow-diagnosis.md
+++ b/.github/skills/gpu-extend-moe3gemm-fused-compressed/references/workflow-diagnosis.md
@@ -1,0 +1,66 @@
+# Workflow: Diagnosis
+
+## Step 1: Run with Matcher Logging
+
+Build `openvino_intel_gpu_plugin`, `openvino_ir_frontend`, and `benchmark_app`, then run the model with transformation logging enabled to observe whether the expected pipeline fires.
+
+**Enable matcher logging** (see `src/common/transformations/docs/debug_capabilities/matcher_logging.md`):
+
+```bash
+# Build
+./scripts/build.sh openvino_intel_gpu_plugin
+./scripts/build.sh openvino_ir_frontend
+./scripts/build.sh benchmark_app
+
+# Run with logging enabled – redirect to .json for VS Code collapsible view
+OV_MATCHER_LOGGING=true \
+OV_MATCHERS_TO_LOG=FuseVectorizedMOE3GEMM,ConvertMOEToMOECompressed,FuseMOE3GemmCompressed,KeepMOE3GemmConstPrecision \
+<build_dir>/bin/benchmark_app \
+    -m <path_to_model.xml> \
+    -d GPU \
+    -niter 1 \
+    -inference_precision f16 \
+    2>matcher_log.json
+```
+
+For verbose output with per-node details:
+
+```bash
+OV_MATCHER_LOGGING=true OV_VERBOSE_LOGGING=true ...
+```
+
+## Step 2: Analyze the Logs
+
+Check whether each pass in the pipeline fired successfully:
+
+| Pass | Expected outcome |
+|------|------------------|
+| `FuseVectorizedMOE3GEMM` | `MOE` op appears in graph |
+| `ConvertMOEToMOECompressed` | `MOECompressed` op appears |
+| `FuseMOE3GemmCompressed` | `MOE3GemmFusedCompressed` op appears |
+| `KeepMOE3GemmConstPrecision` | Weight constants stay u4 |
+
+Look for `match succeeded` vs `match failed` entries for each matcher name. Confirm the runtime model contains `moe_3gemm_fused_compressed` layer type.
+
+- If **all passes fired** → proceed to **Step 5** in [workflow-testing.md](./workflow-testing.md#step-5-extend-the-end-to-end-functional-test)
+- If **any pass did not fire** → proceed to **Step 3** in [workflow-transformation.md](./workflow-transformation.md#step-3-create-test-cases-from-the-new-model)
+
+## Known Issues
+
+### `FuseVectorizedMOE3GEMM` does not fire — MatMul attribute mismatch
+
+**Symptom:** Step 2 log shows `FuseVectorizedMOE3GEMM` never matching, even though the model visually contains the expected 3-GEMM MoE subgraph.
+
+**Root cause:** The pattern in `FuseVectorizedMOE3GEMM` (`matmul_experts_fusion.cpp`) hard-codes attribute constraints on all three MatMuls:
+
+```
+gate_matmul:  transpose_a=false, transpose_b=true
+up_matmul:    transpose_a=false, transpose_b=true
+down_matmul:  transpose_a=false, transpose_b=true
+```
+
+If any MatMul has a different combination, the pattern match silently fails and the entire fusion chain never runs.
+
+> ⛔ **This is not a skill bug — it is an IR conversion error.**
+>
+> **Required action:** Stop work on the GPU plugin and report back to the user that the model has been incorrectly converted to OpenVINO IR. All MoE expert MatMuls **must** be exported with `transpose_a=false` and `transpose_b=true`. The model conversion pipeline (frontend or export script) must be fixed before this skill can proceed. Do not attempt to work around this by modifying the pattern — the fix belongs at the IR level.

--- a/.github/skills/gpu-extend-moe3gemm-fused-compressed/references/workflow-testing.md
+++ b/.github/skills/gpu-extend-moe3gemm-fused-compressed/references/workflow-testing.md
@@ -1,0 +1,84 @@
+# Workflow: Testing
+
+## Step 5: Extend the End-to-End Functional Test
+
+Once the transformation pipeline fires correctly on the real model, extend `MoE3GemmCompressedFusionTest` (see `src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/moe.cpp`) to cover the new routing type.
+
+Add the new `MoERoutingType` value to the `routing_types` vector in the instantiation:
+
+```cpp
+const std::vector<MoERoutingType> routing_types = {
+    MoERoutingType::SOFTMAX,
+    MoERoutingType::SIGMOID_BIAS,  // ← new
+};
+```
+
+The test already:
+- Compiles the full model on GPU with f16 inference precision
+- Validates numerical accuracy against CPU reference
+- Asserts `moe_3gemm_fused_compressed` is present in the runtime model
+
+Run it:
+
+```bash
+./scripts/build.sh ov_gpu_func_tests
+./scripts/run_tests.sh ov_gpu_func_tests --gtest_filter='*smoke_MoE3GemmCompressedFusion*'
+```
+
+- If the test **passes** → proceed to **Step 7** (done)
+- If the test **fails with accuracy errors** → proceed to **Step 6**
+
+## Step 6: Fix the OpenCL Kernel
+
+Accuracy failures in `MoE3GemmCompressedFusionTest` indicate the kernel stage for the new routing type is missing or incorrect. Always fix at the kernel-level unit test layer first — do not iterate directly on the slower e2e test.
+
+### 6.1 Reproduce in Kernel-Level Unit Tests
+
+> **Reference:** [`gpu_plugin_unit_test.md`](../../../../src/plugins/intel_gpu/docs/gpu_plugin_unit_test.md) — explains the `fusions/`, `test_cases/`, and `module_tests/` subdirectory structure under `tests/unit/`.
+
+**File:** `src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp`
+
+Add a test case for the new routing type:
+1. Add a C++ reference implementation of the new routing logic (e.g. `run_reference_sigmoid()`) that computes expected outputs in float
+2. Parametrize the existing tests by routing type and add the new variant
+3. Add reference output data for hardcoded weight cases (see `moe_3gemm_test_data.h`)
+4. Adjust numerical tolerance if needed — new routing types may diverge slightly in f16
+
+```bash
+./scripts/build.sh ov_gpu_unit_tests
+./scripts/run_tests.sh ov_gpu_unit_tests --gtest_filter='*moe_3gemm*'
+```
+
+The new test case is **expected to fail**, confirming the kernel gap is reproduced at unit level.
+
+### 6.2 Fix the Kernel
+
+> **Reference:** [`gpu_kernels.md`](../../../../src/plugins/intel_gpu/docs/gpu_kernels.md) — explains the KernelSelector architecture: `kernel_selector` base class, params descriptor, and per-kernel selection heuristics that the new routing `KernelGenerator` must follow.
+
+**Files:**
+- `src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp` — stage registration and dispatch by routing type
+- `src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_fuse.cl` — OpenCL routing kernel stage
+
+Key points:
+- Create a new `KernelGenerator` subclass for the routing stage
+- Guard the `.cl` kernel block with a new JIT constant (e.g. `#elif SIGMOID_BIAS_TOPK_ENABLE`)
+- Handle both f16 and f32 paths
+- Fix shape helpers if needed (e.g. `get_seq_len()` for inputs with rank ≠ 4)
+
+Rebuild and run the unit tests after each change:
+
+```bash
+./scripts/build.sh ov_gpu_unit_tests
+./scripts/run_tests.sh ov_gpu_unit_tests --gtest_filter='*moe_3gemm*'
+```
+
+Only proceed once **all kernel-level unit tests pass**.
+
+### 6.3 Re-run the End-to-End Test
+
+```bash
+./scripts/build.sh ov_gpu_func_tests
+./scripts/run_tests.sh ov_gpu_func_tests --gtest_filter='*smoke_MoE3GemmCompressedFusion*'
+```
+
+Return to Step 6.1 if accuracy issues persist; return to Step 5 once the test passes.

--- a/.github/skills/gpu-extend-moe3gemm-fused-compressed/references/workflow-transformation.md
+++ b/.github/skills/gpu-extend-moe3gemm-fused-compressed/references/workflow-transformation.md
@@ -1,0 +1,104 @@
+# Workflow: Transformation
+
+## Step 3: Create Test Cases from the New Model
+
+Before modifying any transformation code, reproduce the failure as a unit test. These tests run without GPU hardware and give the fastest feedback.
+
+### 3.1 Understand the New Routing Subgraph
+
+Serialize the model (e.g. using `ov::pass::Serialize`) and trace the routing path from router logits to the `MOECompressed` input. Identify:
+
+- **New operations** compared to existing patterns (e.g. `Sigmoid`, `Add(bias)`, `GatherElements`, `Slice`, `Add(eps)`)
+- **New inputs** the fused op will need (e.g. `routing_bias`, `routing_eps`)
+- **Shared tail** — the ScatterElementsUpdate → Transpose → Reshape → Unsqueeze chain is typically reused across routing variants
+
+Existing patterns for reference:
+
+**Softmax routing:**
+```
+MatMul → Softmax → TopK → ReduceSum → Divide(normalize)
+                        ↘ ShapeOf → Gather → Unsqueeze ─┐
+                                                         ├→ Concat → Broadcast
+                                                         │
+         ScatterElementsUpdate ← TopK_indices            │
+              ↓                                          │
+         Transpose → Reshape → Unsqueeze → MOECompressed
+```
+
+**Sigmoid+Bias routing:**
+```
+MatMul → Sigmoid → Add(bias) → TopK → Convert(i32) → GatherElements(sigmoid_out)
+                                    ↘ ReduceSum → Add(eps) → Divide(normalize)
+                                      → Slice → ScatterElementsUpdate
+                                                     ↓
+                                              Transpose → Reshape → Unsqueeze → MOECompressed
+```
+
+### 3.2 Add a Routing Type and Builder
+
+**Files:**
+- `src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/moe_builders.hpp`
+- `src/tests/test_utils/common_test_utils/src/node_builders/moe_builders.cpp`
+
+1. Add a new value to `MoERoutingType` (e.g. `SIGMOID_BIAS`)
+2. Implement `build_<routing_name>_routing_subgraph()` returning the unsqueeze_moe output and topk_indices output
+3. Dispatch on the new type in `initMoE3GeMMSubgraph()`
+
+### 3.3 Write the Transformation Unit Test
+
+**File:** `src/plugins/intel_gpu/tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp`
+
+Build a test that:
+1. Constructs the input graph (routing subgraph + `MOECompressed`) using the builder from 3.2
+2. Runs `FuseMOE3GemmCompressed`
+3. Compares against an expected graph containing `MOE3GemmFusedCompressed` with the correct routing type and input count
+
+Parametrize over all routing types so existing cases stay covered:
+
+```cpp
+INSTANTIATE_TEST_SUITE_P(smoke, FuseMOE3GemmCompressedTest,
+    ::testing::Values(MoERoutingType::SOFTMAX, MoERoutingType::SIGMOID_BIAS));
+```
+
+Run immediately — the new case is **expected to fail**, confirming you have reproduced the gap:
+
+```bash
+./scripts/build.sh ov_gpu_unit_tests
+./scripts/run_tests.sh ov_gpu_unit_tests --gtest_filter='*FuseMOE3GemmCompressed*'
+```
+
+## Step 4: Extend the Transformation and Make Tests Pass
+
+Extend all layers touched by the new routing pattern until the unit test from Step 3.3 passes.
+
+### 4.1 Extend the Internal Operation
+
+**Files:**
+- `src/plugins/intel_gpu/include/intel_gpu/op/moe_compressed.hpp` — add `RoutingType` enum value to `MOECompressed::Config`
+- `src/plugins/intel_gpu/include/intel_gpu/op/moe_3gemm_fused_compressed.hpp` — document new inputs
+- `src/plugins/intel_gpu/src/plugin/transformations/op/moe_compressed.cpp` — add `EnumNames` specialization and `visit_attributes` entry
+- `src/plugins/intel_gpu/src/plugin/transformations/op/moe_3gemm_fused_compressed.cpp` — validate input count against routing type
+
+### 4.2 Extend the Fusion Pattern
+
+**Files:**
+- `src/plugins/intel_gpu/src/plugin/transformations/fuse_moe_3gemm_compressed.cpp` / `.hpp`
+- `src/plugins/intel_gpu/src/plugin/transformations/keep_moe_3gemm_const_precision.cpp`
+- `src/plugins/intel_gpu/src/plugin/ops/moe.cpp`
+
+Use `ov::pass::pattern::op::Or` to branch on the new routing subgraph. Detect the matched branch in the callback and push the extra inputs (e.g. `routing_bias`, `routing_eps`) into the fused op's argument list.
+
+### 4.3 Extend Primitive Input Indices
+
+**File:** `src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_base.hpp`
+
+Add enum values for the new inputs (e.g. `ROUTING_BIAS = 11`, `ROUTING_EPS = 12`).
+
+### 4.4 Verify and Loop
+
+```bash
+./scripts/build.sh ov_gpu_unit_tests
+./scripts/run_tests.sh ov_gpu_unit_tests --gtest_filter='*FuseMOE3GemmCompressed*'
+```
+
+When the test passes, return to **Step 1** in [workflow-diagnosis.md](./workflow-diagnosis.md#step-1-run-with-matcher-logging) to confirm the transformation fires on the real model.

--- a/.github/skills/gpu-extend-moe3gemm-fused-compressed/scripts/build.sh
+++ b/.github/skills/gpu-extend-moe3gemm-fused-compressed/scripts/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build a CMake target for GPU plugin MoE development.
+#
+# Usage:  ./build.sh <target>
+#   e.g.: ./build.sh openvino_intel_gpu_plugin
+#         ./build.sh ov_gpu_unit_tests
+#         ./build.sh ov_gpu_func_tests
+#
+# Set BUILD_DIR to override the build directory (default: $SRC_DIR/build/Release).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="${SRC_DIR:-$(cd "$SCRIPT_DIR/../../../.." && pwd)}"
+BUILD_DIR="${BUILD_DIR:-$SRC_DIR/build/Release}"
+
+cmake --build "$BUILD_DIR" --config Release --target "${1:?Usage: $0 <target>}" -j 24

--- a/.github/skills/gpu-extend-moe3gemm-fused-compressed/scripts/configure.sh
+++ b/.github/skills/gpu-extend-moe3gemm-fused-compressed/scripts/configure.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Configure CMake build for GPU plugin MoE development.
+# Run once from the OpenVINO source root, or set SRC_DIR / BUILD_DIR as needed.
+#
+# Usage:  SRC_DIR=/path/to/openvino BUILD_DIR=/path/to/build ./configure.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Script lives at .github/skills/<skill>/scripts/ → source root is 4 levels up
+SRC_DIR="${SRC_DIR:-$(cd "$SCRIPT_DIR/../../../.." && pwd)}"
+BUILD_DIR="${BUILD_DIR:-$SRC_DIR/build/Release}"
+
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=/usr/local/bin/gcc \
+    -DCMAKE_CXX_COMPILER=/usr/local/bin/g++ \
+    -DENABLE_INTEL_GPU=TRUE \
+    -DENABLE_INTEL_NPU=FALSE \
+    -DENABLE_TESTS=TRUE \
+    -DENABLE_PYTHON=TRUE \
+    -DENABLE_DEBUG_CAPS=TRUE \
+    -DENABLE_GPU_DEBUG_CAPS=TRUE \
+    -DENABLE_CPPLINT=FALSE \
+    -DENABLE_CLANG_FORMAT=FALSE \
+    -DENABLE_OPENVINO_DEBUG=FALSE \
+    -DPYTHON_EXECUTABLE=/usr/bin/python3 \
+    "-DCMAKE_CXX_FLAGS=-Wno-deprecated -Wno-deprecated-declarations" \
+    "-DCMAKE_C_FLAGS=-Wno-deprecated -Wno-deprecated-declarations" \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE \
+    --no-warn-unused-cli \
+    -S "$SRC_DIR" \
+    -B "$BUILD_DIR" \
+    -G Ninja

--- a/.github/skills/gpu-extend-moe3gemm-fused-compressed/scripts/run_tests.sh
+++ b/.github/skills/gpu-extend-moe3gemm-fused-compressed/scripts/run_tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run GPU plugin test binaries for MoE development.
+# All arguments are forwarded to the test binary.
+#
+# Usage:  ./run_tests.sh <binary> [gtest_args...]
+#   e.g.: ./run_tests.sh ov_gpu_unit_tests
+#         ./run_tests.sh ov_gpu_unit_tests --gtest_filter='*moe_3gemm*'
+#         ./run_tests.sh ov_gpu_func_tests --gtest_filter='*MoE3GemmCompressed*'
+#
+# Set BUILD_DIR to override the build directory (default: $SRC_DIR/build/Release).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="${SRC_DIR:-$(cd "$SCRIPT_DIR/../../../.." && pwd)}"
+BUILD_DIR="${BUILD_DIR:-$SRC_DIR/build/Release}"
+
+BINARY="${1:?Usage: $0 <binary> [gtest_args...]}"
+shift
+
+"$BUILD_DIR/bin/$BINARY" "$@"


### PR DESCRIPTION
### Details:

Adds a new Agent Skill that teaches GitHub Copilot how to extend `MOE3GemmFusedCompressed` with support for a new MoE routing pattern in the OpenVINO GPU plugin.

The skill covers the full development workflow — from diagnosing a fusion miss with matcher logging, through extending the transformation and OpenCL kernel, to verifying the result with unit and functional tests.

The reference implementation (Sigmoid+Bias routing, commit `b3175eb`) is linked and can be used by the agent as a concrete diff to follow.

### Example Usage

> I have a new LLM model with MoE which should be supported by GPU plugin. The model is at `/new_llm_model/openvino_model.xml`. Add support for it using gpu-extend-moe3gemm-fused-compressed skill.

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
