### PR TITLE
[NPUW]Introduce block based KV cache.

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
@@ -63,6 +63,7 @@ INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_ENABLE_PREFIX_CACHING, bool, false, ov::intel
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_PREFIX_CACHING_BLOCK_SIZE, uint64_t, 256, ov::intel_npu::npuw::llm, prefix_caching_block_size, "NPUW_LLM_PREFIX_CACHING_BLOCK_SIZE", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_PREFIX_CACHING_MAX_NUM_BLOCKS, uint64_t, 128, ov::intel_npu::npuw::llm, prefix_caching_max_num_blocks, "NPUW_LLM_PREFIX_CACHING_MAX_NUM_BLOCKS", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_CACHE_ROPE, bool, true, ov::intel_npu::npuw::llm, cache_rope, "NPUW_LLM_CACHE_ROPE", LLM, EXPOSED, CACHED, ALL)
+INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE, bool, false, ov::intel_npu::npuw::llm, enable_block_based_kv_cache, "NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_STRING_ENUM_OPT(NPUW_LLM_PREFILL_MOE_HINT, ::intel_npu::npuw::llm::MoEHint, MoEHintOptionTraits, ov::intel_npu::npuw::llm, prefill_moe_hint, "NPUW_LLM_PREFILL_MOE_HINT", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_STRING_ENUM_OPT(NPUW_LLM_GENERATE_MOE_HINT, ::intel_npu::npuw::llm::MoEHint, MoEHintOptionTraits, ov::intel_npu::npuw::llm, generate_moe_hint, "NPUW_LLM_GENERATE_MOE_HINT", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_STRING_ENUM_OPT(NPUW_LLM_PREFILL_HINT, ::intel_npu::npuw::llm::PrefillHint, PrefillHintOptionTraits, ov::intel_npu::npuw::llm, prefill_hint, "NPUW_LLM_PREFILL_HINT", LLM, EXPOSED, CACHED, ALL)

--- a/src/plugins/intel_npu/src/plugin/npuw/attention.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/attention.hpp
@@ -35,7 +35,7 @@ struct Attention {
     PPtr _mask;
     ov::Shape _mask_shape;
 
-    // Per-variant KV block parameter indices (populated by process_pyramid_model in block-split mode).
+    // Per-variant KV block parameter indices.
     // Ordered by Concat input order: [block_0_idx, ..., block_{M-1}_idx] in this variant's model.
     // Empty in the non-block (contiguous KV) case.
     std::vector<size_t> past_key_block_variant_param_indices;

--- a/src/plugins/intel_npu/src/plugin/npuw/attention.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/attention.hpp
@@ -35,6 +35,12 @@ struct Attention {
     PPtr _mask;
     ov::Shape _mask_shape;
 
+    // Per-variant KV block parameter indices (populated by process_pyramid_model in block-split mode).
+    // Ordered by Concat input order: [block_0_idx, ..., block_{M-1}_idx] in this variant's model.
+    // Empty in the non-block (contiguous KV) case.
+    std::vector<size_t> past_key_block_variant_param_indices;
+    std::vector<size_t> past_value_block_variant_param_indices;
+
     std::size_t query_len() const {
         // Put the mask's innermost dimension dynamic
         NPUW_ASSERT(_mask_shape.size() == 4);

--- a/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
@@ -553,11 +553,24 @@ void ov::npuw::IBaseInferRequest::bind_global_params(std::size_t idx, RqPtr requ
             return false;  // Early return
         }
 
+        const auto& pyramid_top = proto_comp_model_desc.pyramid_attention.value();
         auto pyramid_id = m_pyramid_selector->pyramid_id();
-        auto& pyramid_attn = proto_comp_model_desc.pyramid_attention.value()._attention_infos[pyramid_id];
-        return std::any_of(pyramid_attn.params.begin(), pyramid_attn.params.end(), [&](const auto& p) -> bool {
-            return p.idx == sub_in_idx;
-        });
+        const auto& pyramid_attn = pyramid_top._attention_infos[pyramid_id];
+
+        // Check spatial KV params (non-block, used for view/copy binding).
+        if (std::any_of(pyramid_attn.params.begin(), pyramid_attn.params.end(), [&](const auto& p) -> bool {
+                return p.idx == sub_in_idx;
+            }))
+            return true;
+
+        // Check KV block params using the *full-model* block index space.
+        // past_key/value_block_param_indices hold the main model's parameter indices (block0..blockN).
+        // (per-variant past_key/value_block_variant_param_indices don't match sub_in_idx.)
+        auto is_block = [&](const std::vector<size_t>& indices) {
+            return std::find(indices.begin(), indices.end(), sub_in_idx) != indices.end();
+        };
+        return is_block(pyramid_top.past_key_block_global_param_indices) ||
+               is_block(pyramid_top.past_value_block_global_param_indices);
     };
 
     auto is_hfa_attn_param = [&](std::size_t sub_in_idx) -> bool {
@@ -873,7 +886,37 @@ void ov::npuw::IBaseInferRequest::bind_pyramid_attention_inputs(std::size_t idx,
                                                static_cast<uint32_t>(param.dim),
                                                static_cast<uint32_t>(param.dim));
         }
+
+        // Bind KV block port tensors (block-split mode only, PREFILL path).
+        // bind_global_params stored each block tensor into m_attention_io at the full-model param index.
+        // main_block_indices[m] = full-model index (lookup key in m_attention_io).
+        // variant_port_indices[m] = this variant's compiled-model port (set_tensor target).
+        // M (variant block count) <= N (full-model block count).
+        // TODO (Phase C): replace with BlockKVCacheExtension::bind_pyramid_prefill_blocks().
+        auto bind_block_ports = [&](const std::vector<size_t>& main_block_indices,
+                                    const std::vector<size_t>& variant_port_indices) {
+            NPUW_ASSERT(variant_port_indices.size() <= main_block_indices.size());
+            for (size_t m = 0; m < variant_port_indices.size(); ++m) {
+                const auto& iport = pyramid_model->inputs()[variant_port_indices[m]];
+                const auto& tensor = m_attention_io[idx].inputs.at(main_block_indices[m]);
+                if (tensor) {
+                    request->set_tensor(iport, tensor);
+                }
+            }
+        };
+        bind_block_ports(pyramid_attention.past_key_block_global_param_indices,
+                         attention_info.past_key_block_variant_param_indices);
+        bind_block_ports(pyramid_attention.past_value_block_global_param_indices,
+                         attention_info.past_value_block_variant_param_indices);
     } else if (infer_case == pyramid_attention::Selector::Case::GENERATE) {
+        // Guard: block KV cache + pyramid GENERATE is not validated.
+        // Use NPUW_LLM_GENERATE_PYRAMID=YES for block KV cache instead of
+        // NPUW_LLM_GENERATE_ATTENTION_HINT=PYRAMID, which routes through this path.
+        NPUW_ASSERT(pyramid_attention.past_key_block_global_param_indices.empty() &&
+                    "Pyramid GENERATE with block KV cache is not supported. "
+                    "Use NPUW_LLM_GENERATE_PYRAMID=YES instead of "
+                    "NPUW_LLM_GENERATE_ATTENTION_HINT=PYRAMID when block KV cache is enabled.");
+
         // GENERATE: Set or copy past KV, preserving existing data
         for (auto&& param : attention_info.params) {
             const auto& iport = pyramid_model->inputs()[param.idx];

--- a/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
@@ -554,23 +554,21 @@ void ov::npuw::IBaseInferRequest::bind_global_params(std::size_t idx, RqPtr requ
         }
 
         const auto& pyramid_top = proto_comp_model_desc.pyramid_attention.value();
-        auto pyramid_id = m_pyramid_selector->pyramid_id();
-        const auto& pyramid_attn = pyramid_top._attention_infos[pyramid_id];
 
-        // Check spatial KV params (non-block, used for view/copy binding).
-        if (std::any_of(pyramid_attn.params.begin(), pyramid_attn.params.end(), [&](const auto& p) -> bool {
-                return p.idx == sub_in_idx;
-            }))
-            return true;
+        // Block KV mode: params list is empty; check full-model block index space only.
+        if (!pyramid_top.past_key_block_global_param_indices.empty()) {
+            auto in_vec = [&](const std::vector<size_t>& v) {
+                return std::find(v.begin(), v.end(), sub_in_idx) != v.end();
+            };
+            return in_vec(pyramid_top.past_key_block_global_param_indices) ||
+                   in_vec(pyramid_top.past_value_block_global_param_indices);
+        }
 
-        // Check KV block params using the *full-model* block index space.
-        // past_key/value_block_param_indices hold the main model's parameter indices (block0..blockN).
-        // (per-variant past_key/value_block_variant_param_indices don't match sub_in_idx.)
-        auto is_block = [&](const std::vector<size_t>& indices) {
-            return std::find(indices.begin(), indices.end(), sub_in_idx) != indices.end();
-        };
-        return is_block(pyramid_top.past_key_block_global_param_indices) ||
-               is_block(pyramid_top.past_value_block_global_param_indices);
+        // Contiguous KV mode: check per-variant params list.
+        const auto& pyramid_attn = pyramid_top._attention_infos[m_pyramid_selector->pyramid_id()];
+        return std::any_of(pyramid_attn.params.begin(), pyramid_attn.params.end(), [&](const auto& p) -> bool {
+            return p.idx == sub_in_idx;
+        });
     };
 
     auto is_hfa_attn_param = [&](std::size_t sub_in_idx) -> bool {
@@ -832,16 +830,40 @@ void ov::npuw::IBaseInferRequest::bind_pyramid_attention_inputs(std::size_t idx,
     const auto& attention_info = pyramid_attention._attention_infos[pyramid_id];
     const auto& pyramid_model = pyramid_attention._compiled_models[pyramid_id];
 
+    const bool block_mode = !pyramid_attention.past_key_block_global_param_indices.empty();
+
+    // Bind pre-allocated block tensors to this variant's compiled-model ports.
+    // bind_global_params stored each block tensor in m_attention_io at the full-model index.
+    // main_block_indices[m] = full-model lookup key; variant_port_indices[m] = set_tensor target.
+    // M (variant block count) <= N (full-model block count).
+    auto bind_block_ports = [&](const std::vector<size_t>& main_block_indices,
+                                const std::vector<size_t>& variant_port_indices) {
+        NPUW_ASSERT(variant_port_indices.size() <= main_block_indices.size());
+        for (size_t m = 0; m < variant_port_indices.size(); ++m) {
+            const auto& iport = pyramid_model->inputs()[variant_port_indices[m]];
+            const auto& tensor = m_attention_io[idx].inputs.at(main_block_indices[m]);
+            if (tensor) {
+                request->set_tensor(iport, tensor);
+            }
+        }
+    };
+
     const auto pos_id = m_pyramid_selector->length();
     if (pos_id == -1) {
         // Pyramid dynamic range couldn't be identified - fallback to the default
-        // (worst case) behavior
-        for (auto&& param : attention_info.params) {
-            const auto& iport = pyramid_model->inputs()[param.idx];
-            const auto& input = m_attention_io[idx].inputs.at(param.idx);
-            request->set_tensor(iport, input);
+        // (worst case) behavior: use pyramid_id variant as-is (typically the full/last variant).
+        if (block_mode) {
+            bind_block_ports(pyramid_attention.past_key_block_global_param_indices,
+                             attention_info.past_key_block_variant_param_indices);
+            bind_block_ports(pyramid_attention.past_value_block_global_param_indices,
+                             attention_info.past_value_block_variant_param_indices);
+        } else {
+            for (auto&& param : attention_info.params) {
+                const auto& iport = pyramid_model->inputs()[param.idx];
+                const auto& input = m_attention_io[idx].inputs.at(param.idx);
+                request->set_tensor(iport, input);
+            }
         }
-
         return;
     }
 
@@ -853,61 +875,46 @@ void ov::npuw::IBaseInferRequest::bind_pyramid_attention_inputs(std::size_t idx,
 
     // Process each KV parameter based on inference case
     if (infer_case == pyramid_attention::Selector::Case::PREFILL) {
-        // PREFILL: Set or copy past KV to destination tensors
-        for (auto&& param : attention_info.params) {
-            const auto& iport = pyramid_model->inputs()[param.idx];
-            const auto& input = m_attention_io[idx].inputs.at(param.idx);
-            const auto& input_shape = input->get_shape();
+        if (block_mode) {
+            bind_block_ports(pyramid_attention.past_key_block_global_param_indices,
+                             attention_info.past_key_block_variant_param_indices);
+            bind_block_ports(pyramid_attention.past_value_block_global_param_indices,
+                             attention_info.past_value_block_variant_param_indices);
+        } else {
+            // Contiguous KV mode: view/copy the right slice of each past KV tensor.
+            for (auto&& param : attention_info.params) {
+                const auto& iport = pyramid_model->inputs()[param.idx];
+                const auto& input = m_attention_io[idx].inputs.at(param.idx);
+                const auto& input_shape = input->get_shape();
 
-            LOG_DEBUG(iport);
-            LOG_BLOCK();
+                LOG_DEBUG(iport);
+                LOG_BLOCK();
 
-            // Optimization for the last chunk: Direct tensor reuse when shapes match
-            if (static_cast<int64_t>(input_shape[param.dim]) == past_len) {
-                request->set_tensor(iport, input);
-                continue;
-            }
-
-            // Create view of past KV data
-            const auto& view = ov::npuw::util::view(input, param.dim, 0, past_len);
-            const auto& shape = view->get_shape();
-
-            // Handle empty shape case (first chunk)
-            if (ov::shape_size(shape) == 0) {
-                request->get_tensor(iport)->set_shape(shape);
-                continue;
-            }
-
-            // Copy past KV to full destination tensor
-            LOG_DEBUG("Do copy: " << shape << "...");
-            const auto& dst = request->get_tensor(iport);
-            ov::npuw::util::copy_tensor_by_dim(view,
-                                               dst,
-                                               static_cast<uint32_t>(param.dim),
-                                               static_cast<uint32_t>(param.dim));
-        }
-
-        // Bind KV block port tensors (block-split mode only, PREFILL path).
-        // bind_global_params stored each block tensor into m_attention_io at the full-model param index.
-        // main_block_indices[m] = full-model index (lookup key in m_attention_io).
-        // variant_port_indices[m] = this variant's compiled-model port (set_tensor target).
-        // M (variant block count) <= N (full-model block count).
-        // TODO (Phase C): replace with BlockKVCacheExtension::bind_pyramid_prefill_blocks().
-        auto bind_block_ports = [&](const std::vector<size_t>& main_block_indices,
-                                    const std::vector<size_t>& variant_port_indices) {
-            NPUW_ASSERT(variant_port_indices.size() <= main_block_indices.size());
-            for (size_t m = 0; m < variant_port_indices.size(); ++m) {
-                const auto& iport = pyramid_model->inputs()[variant_port_indices[m]];
-                const auto& tensor = m_attention_io[idx].inputs.at(main_block_indices[m]);
-                if (tensor) {
-                    request->set_tensor(iport, tensor);
+                // Optimization for the last chunk: Direct tensor reuse when shapes match
+                if (static_cast<int64_t>(input_shape[param.dim]) == past_len) {
+                    request->set_tensor(iport, input);
+                    continue;
                 }
+
+                // Create view of past KV data
+                const auto& view = ov::npuw::util::view(input, param.dim, 0, past_len);
+                const auto& shape = view->get_shape();
+
+                // Handle empty shape case (first chunk)
+                if (ov::shape_size(shape) == 0) {
+                    request->get_tensor(iport)->set_shape(shape);
+                    continue;
+                }
+
+                // Copy past KV to full destination tensor
+                LOG_DEBUG("Do copy: " << shape << "...");
+                const auto& dst = request->get_tensor(iport);
+                ov::npuw::util::copy_tensor_by_dim(view,
+                                                   dst,
+                                                   static_cast<uint32_t>(param.dim),
+                                                   static_cast<uint32_t>(param.dim));
             }
-        };
-        bind_block_ports(pyramid_attention.past_key_block_global_param_indices,
-                         attention_info.past_key_block_variant_param_indices);
-        bind_block_ports(pyramid_attention.past_value_block_global_param_indices,
-                         attention_info.past_value_block_variant_param_indices);
+        }
     } else if (infer_case == pyramid_attention::Selector::Case::GENERATE) {
         // Guard: block KV cache + pyramid GENERATE is not validated.
         // Use NPUW_LLM_GENERATE_PYRAMID=YES for block KV cache instead of

--- a/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
@@ -567,9 +567,15 @@ void ov::npuw::IBaseInferRequest::bind_global_params(std::size_t idx, RqPtr requ
         // Check if sub_in_idx matches any SDPA parameter index
         auto& hfa_attn = proto_comp_model_desc.host_flash_attention.value()._sdpa_attention_info;
         const auto& sdpa_in = hfa_attn._sdpa_indices;
-        return sub_in_idx == sdpa_in.query || sub_in_idx == sdpa_in.past_key || sub_in_idx == sdpa_in.past_value ||
-               sub_in_idx == sdpa_in.present_key || sub_in_idx == sdpa_in.present_value ||
-               sub_in_idx == sdpa_in.attention_mask;
+
+        // Check if sub_in_idx is in past_key_blocks or past_value_blocks vectors
+        auto is_past_kv = [&](const std::vector<std::size_t>& blocks) {
+            return std::find(blocks.begin(), blocks.end(), sub_in_idx) != blocks.end();
+        };
+
+        return sub_in_idx == sdpa_in.query || is_past_kv(sdpa_in.past_key_blocks) ||
+               is_past_kv(sdpa_in.past_value_blocks) || sub_in_idx == sdpa_in.present_key ||
+               sub_in_idx == sdpa_in.present_value || sub_in_idx == sdpa_in.attention_mask;
     };
 
     for (auto&& it : iodesc.global_params) {

--- a/src/plugins/intel_npu/src/plugin/npuw/host_flash_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/host_flash_attention.cpp
@@ -718,31 +718,69 @@ static void build_sdpa_param_mapping(HostFlashAttention& hfa,
         hfa._sdpa_param_index_map[SDPAInputId::QUERY] = q_idx;
     }
 
-    // Extract past_key parameter - input 0 of past_key_concat
+    // Extract past_key parameters - all inputs of past_key_concat except the last (present_key)
     if (pattern_nodes.past_key_concat_node) {
-        if (auto past_k_param = extract_param(pattern_nodes.past_key_concat_node->get_input_node_shared_ptr(0))) {
-            std::size_t past_k_idx = model->get_parameter_index(past_k_param);
-            hfa._sdpa_param_index_map[SDPAInputId::PAST_KEY] = past_k_idx;
+        size_t num_inputs = pattern_nodes.past_key_concat_node->get_input_size();
+
+        // Clear and reserve space for blocks
+        hfa._past_key_block_indices.clear();
+        hfa._past_key_block_indices.reserve(num_inputs - 1);
+
+        // Extract all past_key block parameters (all inputs except the last one)
+        for (size_t i = 0; i < num_inputs - 1; ++i) {
+            if (auto past_k_block_param =
+                    extract_param(pattern_nodes.past_key_concat_node->get_input_node_shared_ptr(i))) {
+                std::size_t block_idx = model->get_parameter_index(past_k_block_param);
+                hfa._past_key_block_indices.push_back(block_idx);
+                LOG_DEBUG("  Found past_key block[" << i << "] at parameter index " << block_idx);
+
+                // Keep first block in map for backward compatibility (default continuous past_key input)
+                if (i == 0) {
+                    hfa._sdpa_param_index_map[SDPAInputId::PAST_KEY] = block_idx;
+                }
+            }
         }
 
-        // Extract present_key parameter - input 1 of past_key_concat
-        if (auto present_k_param = extract_param(pattern_nodes.past_key_concat_node->get_input_node_shared_ptr(1))) {
+        // Extract present_key parameter - last input of past_key_concat
+        size_t last_input_idx = num_inputs - 1;
+        if (auto present_k_param =
+                extract_param(pattern_nodes.past_key_concat_node->get_input_node_shared_ptr(last_input_idx))) {
             std::size_t present_k_idx = model->get_parameter_index(present_k_param);
             hfa._sdpa_param_index_map[SDPAInputId::PRESENT_KEY] = present_k_idx;
+            LOG_DEBUG("  Found present_key at parameter index " << present_k_idx);
         }
     }
 
-    // Extract past_value parameter - input 0 of past_value_concat
+    // Extract past_value parameters - all inputs of past_value_concat except the last (present_value)
     if (pattern_nodes.past_value_concat_node) {
-        if (auto past_v_param = extract_param(pattern_nodes.past_value_concat_node->get_input_node_shared_ptr(0))) {
-            std::size_t past_v_idx = model->get_parameter_index(past_v_param);
-            hfa._sdpa_param_index_map[SDPAInputId::PAST_VALUE] = past_v_idx;
+        size_t num_inputs = pattern_nodes.past_value_concat_node->get_input_size();
+
+        // Clear and reserve space for blocks
+        hfa._past_value_block_indices.clear();
+        hfa._past_value_block_indices.reserve(num_inputs - 1);
+
+        // Extract all past_value block parameters (all inputs except the last one)
+        for (size_t i = 0; i < num_inputs - 1; ++i) {
+            if (auto past_v_block_param =
+                    extract_param(pattern_nodes.past_value_concat_node->get_input_node_shared_ptr(i))) {
+                std::size_t block_idx = model->get_parameter_index(past_v_block_param);
+                hfa._past_value_block_indices.push_back(block_idx);
+                LOG_DEBUG("  Found past_value block[" << i << "] at parameter index " << block_idx);
+
+                // Keep first block in map for backward compatibility (default continuous past_value input)
+                if (i == 0) {
+                    hfa._sdpa_param_index_map[SDPAInputId::PAST_VALUE] = block_idx;
+                }
+            }
         }
 
-        // Extract present_value parameter - input 1 of past_value_concat
-        if (auto present_v_param = extract_param(pattern_nodes.past_value_concat_node->get_input_node_shared_ptr(1))) {
+        // Extract present_value parameter - last input of past_value_concat
+        size_t last_input_idx = num_inputs - 1;
+        if (auto present_v_param =
+                extract_param(pattern_nodes.past_value_concat_node->get_input_node_shared_ptr(last_input_idx))) {
             std::size_t present_v_idx = model->get_parameter_index(present_v_param);
             hfa._sdpa_param_index_map[SDPAInputId::PRESENT_VALUE] = present_v_idx;
+            LOG_DEBUG("  Found present_value at parameter index " << present_v_idx);
         }
     }
 
@@ -753,6 +791,8 @@ static void build_sdpa_param_mapping(HostFlashAttention& hfa,
     }
 
     LOG_INFO("Built SDPA input mapping with " << hfa._sdpa_param_index_map.size() << " entries");
+    LOG_INFO("  Past key blocks: " << hfa._past_key_block_indices.size());
+    LOG_INFO("  Past value blocks: " << hfa._past_value_block_indices.size());
 
     // Print the complete mapping table
     LOG_DEBUG("");
@@ -762,6 +802,18 @@ static void build_sdpa_param_mapping(HostFlashAttention& hfa,
     for (const auto& [input_id, param_idx] : hfa._sdpa_param_index_map) {
         LOG_DEBUG("  " << sdpa_input_id_to_string(input_id) << " -> parameter[" << param_idx << "]");
     }
+
+    // Print KV cache blocks
+    LOG_DEBUG("Past key blocks (" << hfa._past_key_block_indices.size() << "):");
+    for (size_t i = 0; i < hfa._past_key_block_indices.size(); ++i) {
+        LOG_DEBUG("  block[" << i << "] -> parameter[" << hfa._past_key_block_indices[i] << "]");
+    }
+
+    LOG_DEBUG("Past value blocks (" << hfa._past_value_block_indices.size() << "):");
+    for (size_t i = 0; i < hfa._past_value_block_indices.size(); ++i) {
+        LOG_DEBUG("  block[" << i << "] -> parameter[" << hfa._past_value_block_indices[i] << "]");
+    }
+
     LOG_DEBUG("=============================================");
 }
 
@@ -1076,8 +1128,11 @@ HostFlashAttention::HostFlashAttention(const function::HostFlashAttention& func_
     };
 
     _sdpa_attention_info._sdpa_indices.query = get_sdpa_param_idx(SDPAInputId::QUERY);
-    _sdpa_attention_info._sdpa_indices.past_key = get_sdpa_param_idx(SDPAInputId::PAST_KEY);
-    _sdpa_attention_info._sdpa_indices.past_value = get_sdpa_param_idx(SDPAInputId::PAST_VALUE);
+
+    // Copy all KV cache block indices
+    _sdpa_attention_info._sdpa_indices.past_key_blocks = func_hfa._past_key_block_indices;
+    _sdpa_attention_info._sdpa_indices.past_value_blocks = func_hfa._past_value_block_indices;
+
     _sdpa_attention_info._sdpa_indices.present_key = get_sdpa_param_idx(SDPAInputId::PRESENT_KEY);
     _sdpa_attention_info._sdpa_indices.present_value = get_sdpa_param_idx(SDPAInputId::PRESENT_VALUE);
     _sdpa_attention_info._sdpa_indices.attention_mask = get_sdpa_param_idx(SDPAInputId::ATTENTION_MASK);
@@ -1114,11 +1169,12 @@ HostFlashAttention::HostFlashAttention(const function::HostFlashAttention& func_
     _sdpa_attention_info._tile_output_indices.d = get_tile_output_idx(HFATileOutputId::D);
 
     LOG_INFO("Pre-cached SDPA indices: [query="
-             << _sdpa_attention_info._sdpa_indices.query << ", past_key=" << _sdpa_attention_info._sdpa_indices.past_key
-             << ", past_value=" << _sdpa_attention_info._sdpa_indices.past_value
+             << _sdpa_attention_info._sdpa_indices.query
              << ", present_key=" << _sdpa_attention_info._sdpa_indices.present_key
              << ", present_value=" << _sdpa_attention_info._sdpa_indices.present_value
              << ", attention_mask=" << _sdpa_attention_info._sdpa_indices.attention_mask << "]");
+    LOG_INFO("  Past key blocks: " << _sdpa_attention_info._sdpa_indices.past_key_blocks.size());
+    LOG_INFO("  Past value blocks: " << _sdpa_attention_info._sdpa_indices.past_value_blocks.size());
     LOG_INFO("Attention configuration: query_size="
              << _sdpa_attention_info._query_size << ", context_size=" << _sdpa_attention_info._context_size
              << ", k_seq_dim=" << _sdpa_attention_info._k_seq_dim << ", v_seq_dim=" << _sdpa_attention_info._v_seq_dim);

--- a/src/plugins/intel_npu/src/plugin/npuw/host_flash_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/host_flash_attention.cpp
@@ -15,7 +15,7 @@
 #include "openvino/op/ops.hpp"
 #include "openvino/openvino.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
-#include "pyramid_attention.hpp"
+#include "sdpa_utils.hpp"
 #include "util.hpp"
 
 namespace ov {

--- a/src/plugins/intel_npu/src/plugin/npuw/host_flash_attention.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/host_flash_attention.hpp
@@ -146,6 +146,12 @@ struct HostFlashAttention {
     // This is created during pattern analysis in from() method
     std::map<SDPAInputId, std::size_t> _sdpa_param_index_map;
 
+    // KV cache block parameter indices (for split KV cache support)
+    // After SplitKVCacheIntoBlocks transformation, KV cache is split into multiple block parameters
+    // These vectors store all block parameter indices in order
+    std::vector<std::size_t> _past_key_block_indices;    // [block_0_idx, block_1_idx, ..., block_N_idx]
+    std::vector<std::size_t> _past_value_block_indices;  // [block_0_idx, block_1_idx, ..., block_N_idx]
+
     // Tile model parameter index mapping
     // Maps tile parameter IDs (PAST_ACC, K_TILE, Q, etc.) to actual input indices
     // Tile model I/O: Inputs[past_acc, past_max, past_d, k_tile, v_tile, q, mask_tile]
@@ -191,8 +197,9 @@ struct HostFlashAttentionInfo {
     // Pre-cached SDPA parameter indices
     struct {
         std::size_t query = 0u;
-        std::size_t past_key = 0u;
-        std::size_t past_value = 0u;
+        // Support multiple KV cache blocks after split transformation
+        std::vector<std::size_t> past_key_blocks;    // All past_key block parameter indices
+        std::vector<std::size_t> past_value_blocks;  // All past_value block parameter indices
         std::size_t present_key = 0u;
         std::size_t present_value = 0u;
         std::size_t attention_mask = 0u;

--- a/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
@@ -1138,13 +1138,15 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
     auto alias_blocks_to_block0 = [&](ov::SoPtr<ov::IAsyncInferRequest>& req) {
         if (!pyr_attn.past_key_block_global_param_indices.empty()) {
             auto key_block0 = req->get_tensor(main_inputs[pyr_attn.past_key_block_global_param_indices[0]]);
-            for (size_t i = 1; i < pyr_attn.past_key_block_global_param_indices.size(); ++i)
+            for (size_t i = 1; i < pyr_attn.past_key_block_global_param_indices.size(); ++i) {
                 req->set_tensor(main_inputs[pyr_attn.past_key_block_global_param_indices[i]], key_block0);
+            }
         }
         if (!pyr_attn.past_value_block_global_param_indices.empty()) {
             auto val_block0 = req->get_tensor(main_inputs[pyr_attn.past_value_block_global_param_indices[0]]);
-            for (size_t i = 1; i < pyr_attn.past_value_block_global_param_indices.size(); ++i)
+            for (size_t i = 1; i < pyr_attn.past_value_block_global_param_indices.size(); ++i) {
                 req->set_tensor(main_inputs[pyr_attn.past_value_block_global_param_indices[i]], val_block0);
+            }
         }
     };
 
@@ -1156,10 +1158,10 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
     // Build a name→main-port map once for sharing non-block inputs into pyramid variants.
     // (This is one-time setup cost, not per-inference.)
     std::unordered_map<std::string, ov::Output<const ov::Node>> main_name_to_port;
-    main_name_to_port.reserve(main_inputs.size() * 2);
+    main_name_to_port.reserve(main_inputs.size());
     for (const auto& inp : main_inputs) {
-        for (const auto& n : inp.get_names()) {
-            main_name_to_port[n] = inp;
+        if (!inp.get_names().empty()) {
+            main_name_to_port[inp.get_any_name()] = inp;
         }
     }
 
@@ -1183,46 +1185,47 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
         }
 
         // Share inputs into this pyramid variant:
-        //   • Block ports (K/V): after aliasing, main block_N already holds block_0's tensor →
+        //   Block ports (K/V): after aliasing, main block_N already holds block_0's tensor →
         //     only need to get key_block_0 / value_block_0 from main and set_tensor directly
         //     (shapes match since all block slots are the same size).
-        //   • Non-block ports: may have different shapes (e.g. attention mask) → share buffer
+        //   Non-block ports: may have different shapes (e.g. attention mask) → share buffer
         //     pointer with the variant's own (possibly smaller) shape.
         const auto& info = pyr_attn._attention_infos[model_idx];
         const auto& variant_inputs = pyramid_models[model_idx]->inputs();
 
         // Build O(1) lookup sets for key/value block port indices of this variant.
-        const std::unordered_set<size_t> key_block_ports(info.past_key_block_variant_param_indices.begin(),
-                                                         info.past_key_block_variant_param_indices.end());
-        const std::unordered_set<size_t> val_block_ports(info.past_value_block_variant_param_indices.begin(),
-                                                         info.past_value_block_variant_param_indices.end());
+        const std::unordered_set<size_t> key_block_port_indices(info.past_key_block_variant_param_indices.begin(),
+                                                                info.past_key_block_variant_param_indices.end());
+        const std::unordered_set<size_t> val_block_port_indices(info.past_value_block_variant_param_indices.begin(),
+                                                                info.past_value_block_variant_param_indices.end());
 
         auto share_inputs_for_request = [&](ov::SoPtr<ov::IAsyncInferRequest>& req,
                                             ov::SoPtr<ov::IAsyncInferRequest>& main_req) {
             // Cache block_0 tensors from the (aliased) main request.
             ov::SoPtr<ov::ITensor> key_block0, val_block0;
-            if (!pyr_attn.past_key_block_global_param_indices.empty())
+            if (!pyr_attn.past_key_block_global_param_indices.empty()) {
                 key_block0 = main_req->get_tensor(main_inputs[pyr_attn.past_key_block_global_param_indices[0]]);
-            if (!pyr_attn.past_value_block_global_param_indices.empty())
+            }
+            if (!pyr_attn.past_value_block_global_param_indices.empty()) {
                 val_block0 = main_req->get_tensor(main_inputs[pyr_attn.past_value_block_global_param_indices[0]]);
+            }
 
             for (size_t j = 0; j < variant_inputs.size(); ++j) {
-                if (key_block_ports.count(j)) {
+                if (key_block_port_indices.count(j)) {
                     // Key block: share block_0 tensor directly (shapes match).
-                    if (key_block0)
-                        req->set_tensor(variant_inputs[j], key_block0);
-                } else if (val_block_ports.count(j)) {
+                    req->set_tensor(variant_inputs[j], key_block0);
+                } else if (val_block_port_indices.count(j)) {
                     // Value block: share block_0 tensor directly (shapes match).
-                    if (val_block0)
-                        req->set_tensor(variant_inputs[j], val_block0);
+                    req->set_tensor(variant_inputs[j], val_block0);
                 } else {
                     // Non-block input: share buffer pointer with variant's own shape.
-                    const auto& names = variant_inputs[j].get_names();
-                    if (names.empty())
+                    if (variant_inputs[j].get_names().empty()) {
                         continue;
-                    const auto it = main_name_to_port.find(*names.begin());
-                    if (it == main_name_to_port.end())
+                    }
+                    const auto it = main_name_to_port.find(variant_inputs[j].get_any_name());
+                    if (it == main_name_to_port.end()) {
                         continue;
+                    }
                     auto main_tensor = main_req->get_tensor(it->second);
                     auto pyr_tensor = req->get_tensor(variant_inputs[j]);
                     auto shared = ov::get_tensor_impl(
@@ -1233,7 +1236,6 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
         };
 
         share_inputs_for_request(submodel_desc.pyramid_infer_requests[model_idx], m_subrequests[real_idx]);
-
         if (is_piped) {
             share_inputs_for_request(submodel_desc.pyramid_pipeline_requests[model_idx],
                                      m_funcall_pipeline[real_idx].subrequest);

--- a/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
@@ -1133,9 +1133,9 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
     const auto& pyr_attn = submodel_desc.pyramid_attention.value();
     const auto& main_inputs = submodel_desc.compiled_model->inputs();
 
-    // Alias block_N (N>0) tensors to block_0 in each main request.
-    // Uses HFA-style pre-parsed past_key/value_block_indices (built in set_compiled_models).
-    auto alias_blocks_to_block0 = [&](ov::SoPtr<ov::IAsyncInferRequest>& req) {
+    // Share KV block buffers across all block ports of the main request.
+    // bind_pyramid_attention_inputs() will set the real per-block tensors at inference time.
+    auto share_kv_block_buffers = [&](ov::SoPtr<ov::IAsyncInferRequest>& req) {
         if (!pyr_attn.past_key_block_global_param_indices.empty()) {
             auto key_block0 = req->get_tensor(main_inputs[pyr_attn.past_key_block_global_param_indices[0]]);
             for (size_t i = 1; i < pyr_attn.past_key_block_global_param_indices.size(); ++i) {
@@ -1150,9 +1150,9 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
         }
     };
 
-    alias_blocks_to_block0(m_subrequests[real_idx]);
+    share_kv_block_buffers(m_subrequests[real_idx]);
     if (is_piped) {
-        alias_blocks_to_block0(m_funcall_pipeline[real_idx].subrequest);
+        share_kv_block_buffers(m_funcall_pipeline[real_idx].subrequest);
     }
 
     // Build a name→main-port map once for sharing non-block inputs into pyramid variants.

--- a/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
@@ -1130,6 +1130,39 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
         submodel_desc.pyramid_pipeline_requests.resize(num_pyramid_models);
     }
 
+    const auto& pyr_attn = submodel_desc.pyramid_attention.value();
+    const auto& main_inputs = submodel_desc.compiled_model->inputs();
+
+    // Alias block_N (N>0) tensors to block_0 in each main request.
+    // Uses HFA-style pre-parsed past_key/value_block_indices (built in set_compiled_models).
+    auto alias_blocks_to_block0 = [&](ov::SoPtr<ov::IAsyncInferRequest>& req) {
+        if (!pyr_attn.past_key_block_global_param_indices.empty()) {
+            auto key_block0 = req->get_tensor(main_inputs[pyr_attn.past_key_block_global_param_indices[0]]);
+            for (size_t i = 1; i < pyr_attn.past_key_block_global_param_indices.size(); ++i)
+                req->set_tensor(main_inputs[pyr_attn.past_key_block_global_param_indices[i]], key_block0);
+        }
+        if (!pyr_attn.past_value_block_global_param_indices.empty()) {
+            auto val_block0 = req->get_tensor(main_inputs[pyr_attn.past_value_block_global_param_indices[0]]);
+            for (size_t i = 1; i < pyr_attn.past_value_block_global_param_indices.size(); ++i)
+                req->set_tensor(main_inputs[pyr_attn.past_value_block_global_param_indices[i]], val_block0);
+        }
+    };
+
+    alias_blocks_to_block0(m_subrequests[real_idx]);
+    if (is_piped) {
+        alias_blocks_to_block0(m_funcall_pipeline[real_idx].subrequest);
+    }
+
+    // Build a name→main-port map once for sharing non-block inputs into pyramid variants.
+    // (This is one-time setup cost, not per-inference.)
+    std::unordered_map<std::string, ov::Output<const ov::Node>> main_name_to_port;
+    main_name_to_port.reserve(main_inputs.size() * 2);
+    for (const auto& inp : main_inputs) {
+        for (const auto& n : inp.get_names()) {
+            main_name_to_port[n] = inp;
+        }
+    }
+
     // Create infer requests for all but the last pyramid model
     for (size_t model_idx = 0; model_idx + 1 < num_pyramid_models; ++model_idx) {
         try {
@@ -1149,28 +1182,61 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
             NPUW_ASSERT(false && "Pyramid model infer request creation/recreation failed with unknown error");
         }
 
-        // Share input tensors between pyramid and main infer requests
-        const size_t num_inputs = pyramid_models[model_idx]->inputs().size();
-        NPUW_ASSERT(num_inputs == submodel_desc.compiled_model->inputs().size());
-        for (size_t input_idx = 0; input_idx < num_inputs; ++input_idx) {
-            auto pyramid_input = pyramid_models[model_idx]->inputs()[input_idx];
-            auto main_input = submodel_desc.compiled_model->inputs()[input_idx];
+        // Share inputs into this pyramid variant:
+        //   • Block ports (K/V): after aliasing, main block_N already holds block_0's tensor →
+        //     only need to get key_block_0 / value_block_0 from main and set_tensor directly
+        //     (shapes match since all block slots are the same size).
+        //   • Non-block ports: may have different shapes (e.g. attention mask) → share buffer
+        //     pointer with the variant's own (possibly smaller) shape.
+        const auto& info = pyr_attn._attention_infos[model_idx];
+        const auto& variant_inputs = pyramid_models[model_idx]->inputs();
 
-            // Get tensor from main infer request and share its memory with the pyramid infer request
-            auto main_tensor_ptr = m_subrequests[real_idx]->get_tensor(main_input)->data();
-            auto pyramid_tensor = submodel_desc.pyramid_infer_requests[model_idx]->get_tensor(pyramid_input);
-            auto shared_tensor = ov::get_tensor_impl(
-                ov::Tensor(pyramid_tensor->get_element_type(), pyramid_tensor->get_shape(), main_tensor_ptr));
-            submodel_desc.pyramid_infer_requests[model_idx]->set_tensor(pyramid_input, shared_tensor);
+        // Build O(1) lookup sets for key/value block port indices of this variant.
+        const std::unordered_set<size_t> key_block_ports(info.past_key_block_variant_param_indices.begin(),
+                                                         info.past_key_block_variant_param_indices.end());
+        const std::unordered_set<size_t> val_block_ports(info.past_value_block_variant_param_indices.begin(),
+                                                         info.past_value_block_variant_param_indices.end());
 
-            // Repeat for pipeline infer request if pipelined
-            if (is_piped) {
-                auto pipeline_tensor = submodel_desc.pyramid_pipeline_requests[model_idx]->get_tensor(pyramid_input);
-                auto pipeline_tensor_ptr = m_funcall_pipeline[real_idx].subrequest->get_tensor(main_input)->data();
-                auto shared_pipeline_tensor = ov::get_tensor_impl(
-                    ov::Tensor(pipeline_tensor->get_element_type(), pipeline_tensor->get_shape(), pipeline_tensor_ptr));
-                submodel_desc.pyramid_pipeline_requests[model_idx]->set_tensor(pyramid_input, shared_pipeline_tensor);
+        auto share_inputs_for_request = [&](ov::SoPtr<ov::IAsyncInferRequest>& req,
+                                            ov::SoPtr<ov::IAsyncInferRequest>& main_req) {
+            // Cache block_0 tensors from the (aliased) main request.
+            ov::SoPtr<ov::ITensor> key_block0, val_block0;
+            if (!pyr_attn.past_key_block_global_param_indices.empty())
+                key_block0 = main_req->get_tensor(main_inputs[pyr_attn.past_key_block_global_param_indices[0]]);
+            if (!pyr_attn.past_value_block_global_param_indices.empty())
+                val_block0 = main_req->get_tensor(main_inputs[pyr_attn.past_value_block_global_param_indices[0]]);
+
+            for (size_t j = 0; j < variant_inputs.size(); ++j) {
+                if (key_block_ports.count(j)) {
+                    // Key block: share block_0 tensor directly (shapes match).
+                    if (key_block0)
+                        req->set_tensor(variant_inputs[j], key_block0);
+                } else if (val_block_ports.count(j)) {
+                    // Value block: share block_0 tensor directly (shapes match).
+                    if (val_block0)
+                        req->set_tensor(variant_inputs[j], val_block0);
+                } else {
+                    // Non-block input: share buffer pointer with variant's own shape.
+                    const auto& names = variant_inputs[j].get_names();
+                    if (names.empty())
+                        continue;
+                    const auto it = main_name_to_port.find(*names.begin());
+                    if (it == main_name_to_port.end())
+                        continue;
+                    auto main_tensor = main_req->get_tensor(it->second);
+                    auto pyr_tensor = req->get_tensor(variant_inputs[j]);
+                    auto shared = ov::get_tensor_impl(
+                        ov::Tensor(pyr_tensor->get_element_type(), pyr_tensor->get_shape(), main_tensor->data()));
+                    req->set_tensor(variant_inputs[j], shared);
+                }
             }
+        };
+
+        share_inputs_for_request(submodel_desc.pyramid_infer_requests[model_idx], m_subrequests[real_idx]);
+
+        if (is_piped) {
+            share_inputs_for_request(submodel_desc.pyramid_pipeline_requests[model_idx],
+                                     m_funcall_pipeline[real_idx].subrequest);
         }
     }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
@@ -1568,8 +1568,20 @@ void ov::npuw::JustInferRequest::run_hfa_tiled_inference(std::size_t real_idx, s
     // Use pre-cached SDPA indices
     const auto& sdpa_in = sdpa_info._sdpa_indices;
 
-    auto past_key_tensor = hfa_inputs.at(sdpa_in.past_key);
-    auto past_value_tensor = hfa_inputs.at(sdpa_in.past_value);
+    std::vector<ov::SoPtr<ov::ITensor>> past_key_blocks;
+    std::vector<ov::SoPtr<ov::ITensor>> past_value_blocks;
+
+    NPUW_ASSERT(!sdpa_in.past_key_blocks.empty() && !sdpa_in.past_value_blocks.empty() &&
+                "SDPA indices must have at least one past_key/value block");
+    NPUW_ASSERT(sdpa_in.past_key_blocks.size() == sdpa_in.past_value_blocks.size() &&
+                "Number of past key blocks must match number of past value blocks");
+
+    // Collect all KV block tensors (works for both single-block and multi-block cases)
+    for (size_t i = 0; i < sdpa_in.past_key_blocks.size(); ++i) {
+        past_key_blocks.push_back(hfa_inputs.at(sdpa_in.past_key_blocks[i]));
+        past_value_blocks.push_back(hfa_inputs.at(sdpa_in.past_value_blocks[i]));
+    }
+
     auto query_tensor = hfa_inputs.at(sdpa_in.query);
     auto present_key_tensor = hfa_inputs.at(sdpa_in.present_key);
     auto attention_mask_tensor = hfa_inputs.at(sdpa_in.attention_mask);
@@ -1751,22 +1763,49 @@ void ov::npuw::JustInferRequest::run_hfa_tiled_inference(std::size_t real_idx, s
     };
 
     int64_t mask_tile_offset = 0;
-    int64_t kv_tile_offset = 0;
+    int64_t global_kv_offset = 0;  // Global KV offset across all blocks
 
-    // Process regular tiles (all but the last one)
+    // Process regular tiles (all but the last one) - iterate through past KV blocks
     // Each regular tile processes past KV cache and outputs intermediate states (acc, max, d)
-    for (int64_t tile_idx = 0; tile_idx < num_tiles - 1; ++tile_idx) {
-        process_tile(regular_tile_request,
-                     hfa_desc._compiled_tile_model,
-                     past_key_tensor,
-                     past_value_tensor,
-                     kv_tile_offset,
-                     mask_tile_offset,
-                     tile_size);
+    int64_t past_kv_tiles = num_tiles - 1;  // Exclude final tile (present KV)
 
-        kv_tile_offset += tile_size;
-        mask_tile_offset += tile_size;
+    for (size_t block_idx = 0; block_idx < past_key_blocks.size() && past_kv_tiles > 0; ++block_idx) {
+        const auto& k_block = past_key_blocks[block_idx];
+        const auto& v_block = past_value_blocks[block_idx];
+
+        // Get block size from tensor shape
+        const int64_t block_size = static_cast<int64_t>(k_block->get_shape()[K_SEQ_DIM]);
+        NPUW_ASSERT(block_size % tile_size == 0 && "HFA block size must be a multiple of tile size for correct tiling");
+
+        // Calculate number of tiles in this block
+        // Example: 8K total tokens (7K past + 1K present), tile_size = 1K
+        //   - Single-block mode: past KV block_size = 7K → tiles_in_block = 7 (process 7 past tiles in this block)
+        //   - Multi-block mode (1K split): 7 blocks × 1K each, block_size = 1K → tiles_in_block = 1 (process 1 past
+        //   tile per block)
+        // Note: The present KV tile is processed after this loop completes
+        const int64_t tiles_in_block = block_size / tile_size;
+
+        // Process all tiles in this block (but only up to past_kv_tiles remaining)
+        for (int64_t tile_in_block = 0; tile_in_block < tiles_in_block && past_kv_tiles > 0; ++tile_in_block) {
+            const int64_t kv_offset_in_block = tile_in_block * tile_size;
+
+            // Process this tile directly from the block (no extraction needed)
+            process_tile(regular_tile_request,
+                         hfa_desc._compiled_tile_model,
+                         k_block,
+                         v_block,
+                         kv_offset_in_block,
+                         mask_tile_offset,
+                         tile_size);
+
+            mask_tile_offset += tile_size;
+            global_kv_offset += tile_size;
+            past_kv_tiles--;
+        }
     }
+
+    // Verify that all past tiles were processed correctly
+    NPUW_ASSERT(past_kv_tiles == 0 && "HFA: All past KV blocks should contain exactly (num_tiles - 1) tiles in total");
 
     // Process final tile separately
     // Final tile processes present KV tokens and produces final attention output

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
@@ -4,8 +4,6 @@
 
 #include "kv_cache_block_manager.hpp"
 
-#include <algorithm>
-
 #include "logging.hpp"
 #include "util.hpp"
 
@@ -28,15 +26,16 @@ KVCacheBlockManager::KVCacheBlockManager(uint32_t block_size,
     // For Value (transposed): [batch, num_heads, head_dim, seq_len] e.g., [1, 8, 128, 1024]
     // The seq_len dimension already equals block_size, no modification needed
     block_shape_ = base_shape;
-    OPENVINO_ASSERT(std::any_of(base_shape.begin(),
-                                base_shape.end(),
-                                [block_size](size_t dim) {
-                                    return dim == block_size;
-                                }),
+    // The sequence dimension must equal block_size.
+    // For non-transposed tensors (K, and V when !v_transposed) it is dim 2,
+    // for transposed V it is dim 3. Only these two positions are valid; checking
+    // all four dims would also accept shapes where head_dim == block_size by accident.
+    OPENVINO_ASSERT(base_shape.size() == 4 && (base_shape[2] == block_size || base_shape[3] == block_size),
                     "KVCacheBlockManager: base_shape ",
                     base_shape,
-                    " does not contain a dimension equal to block_size=",
-                    block_size);
+                    " does not have block_size=",
+                    block_size,
+                    " in sequence dimension (expected at dim 2 or 3)");
 
     // Initialize block pool (lazy memory allocation)
     blocks_.reserve(max_blocks);
@@ -119,12 +118,9 @@ void KVCacheBlockManager::update_block_tokens(uint32_t block_id, uint32_t num_to
     auto& block = blocks_[block_id];
     block.num_tokens = num_tokens;
 
-    // Update state
-    if (num_tokens >= block_size_) {
-        block.state = Block::State::FULL;
-    } else if (num_tokens > 0) {
-        block.state = Block::State::ALLOCATED;
-    }
+    // Update state: FULL when the block is filled, ALLOCATED otherwise
+    // (num_tokens==0 is valid after a reset).
+    block.state = (num_tokens >= block_size_) ? Block::State::FULL : Block::State::ALLOCATED;
 
     LOG_VERB("KVCacheBlockManager: Updated block " << block_id << " tokens: " << num_tokens << "/" << block_size_);
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
@@ -1,0 +1,179 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "kv_cache_block_manager.hpp"
+
+#include <algorithm>
+
+#include "logging.hpp"
+#include "util.hpp"
+
+namespace ov {
+namespace npuw {
+
+KVCacheBlockManager::KVCacheBlockManager(uint32_t block_size,
+                                         uint32_t max_blocks,
+                                         const ov::Shape& base_shape,
+                                         ov::element::Type elem_type,
+                                         const std::string& device,
+                                         const std::shared_ptr<const ov::IPlugin>& plugin)
+    : block_size_(block_size),
+      max_blocks_(max_blocks),
+      element_type_(elem_type),
+      device_(device),
+      plugin_(plugin) {
+    // Set block shape: base_shape already contains the full block shape from model
+    // For Key:   [batch, num_heads, seq_len, head_dim] e.g., [1, 8, 1024, 128]
+    // For Value (transposed): [batch, num_heads, head_dim, seq_len] e.g., [1, 8, 128, 1024]
+    // The seq_len dimension already equals block_size, no modification needed
+    block_shape_ = base_shape;
+    OPENVINO_ASSERT(std::any_of(base_shape.begin(),
+                                base_shape.end(),
+                                [block_size](size_t dim) {
+                                    return dim == block_size;
+                                }),
+                    "KVCacheBlockManager: base_shape ",
+                    base_shape,
+                    " does not contain a dimension equal to block_size=",
+                    block_size);
+
+    // Initialize block pool (lazy memory allocation)
+    blocks_.reserve(max_blocks);
+    for (uint32_t i = 0; i < max_blocks; ++i) {
+        Block block;
+        block.id = i;
+        // block.tensor defaults to empty SoPtr (allocate on-demand)
+        block.num_tokens = 0;
+        block.state = Block::State::FREE;
+
+        blocks_.push_back(std::move(block));
+    }
+
+    // Push block IDs to stack in reverse order (so block 0 is on top)
+    for (int32_t i = max_blocks - 1; i >= 0; --i) {
+        free_block_ids_.push(static_cast<uint32_t>(i));
+    }
+
+    LOG_INFO("KVCacheBlockManager initialized: " << "block_size=" << block_size << ", max_blocks=" << max_blocks
+                                                 << ", total_capacity=" << (block_size * max_blocks) << " tokens"
+                                                 << ", device=" << device);
+}
+
+std::optional<uint32_t> KVCacheBlockManager::allocate_block() {
+    if (free_block_ids_.empty()) {
+        LOG_WARN("KVCacheBlockManager: No free blocks available! " << "All " << max_blocks_ << " blocks are in use.");
+        return std::nullopt;
+    }
+
+    uint32_t block_id = free_block_ids_.top();
+    free_block_ids_.pop();
+
+    auto& block = blocks_[block_id];
+
+    // Allocate actual memory on-demand
+    if (!block.tensor) {
+        block.tensor = ov::npuw::util::allocMem(element_type_, block_shape_, device_, plugin_);
+        LOG_DEBUG("KVCacheBlockManager: Allocated memory for block " << block_id << " (shape=" << block_shape_
+                                                                     << ", device=" << device_ << ")");
+    }
+
+    // Reset block state
+    block.num_tokens = 0;
+    block.state = Block::State::ALLOCATED;
+
+    LOG_VERB("KVCacheBlockManager: Allocated block " << block_id
+                                                     << " (free blocks remaining: " << free_block_ids_.size() << ")");
+
+    return block_id;
+}
+
+ov::SoPtr<ov::ITensor> KVCacheBlockManager::get_block_tensor(uint32_t block_id) {
+    validate_block_id(block_id);
+
+    auto& block = blocks_[block_id];
+
+    if (!block.tensor) {
+        OPENVINO_THROW("KVCacheBlockManager: Block ",
+                       block_id,
+                       " has no allocated tensor. "
+                       "Call allocate_block() first.");
+    }
+
+    return block.tensor;
+}
+
+void KVCacheBlockManager::update_block_tokens(uint32_t block_id, uint32_t num_tokens) {
+    validate_block_id(block_id);
+
+    if (num_tokens > block_size_) {
+        OPENVINO_THROW("KVCacheBlockManager: Cannot set ",
+                       num_tokens,
+                       " tokens in block ",
+                       block_id,
+                       " (capacity: ",
+                       block_size_,
+                       ")");
+    }
+
+    auto& block = blocks_[block_id];
+    block.num_tokens = num_tokens;
+
+    // Update state
+    if (num_tokens >= block_size_) {
+        block.state = Block::State::FULL;
+    } else if (num_tokens > 0) {
+        block.state = Block::State::ALLOCATED;
+    }
+
+    LOG_VERB("KVCacheBlockManager: Updated block " << block_id << " tokens: " << num_tokens << "/" << block_size_);
+}
+
+uint32_t KVCacheBlockManager::get_block_tokens(uint32_t block_id) const {
+    validate_block_id(block_id);
+    return blocks_[block_id].num_tokens;
+}
+
+std::vector<uint32_t> KVCacheBlockManager::get_allocated_blocks() const {
+    std::vector<uint32_t> allocated;
+    allocated.reserve(max_blocks_);
+
+    for (const auto& block : blocks_) {
+        if (block.state != Block::State::FREE) {
+            allocated.push_back(block.id);
+        }
+    }
+
+    return allocated;
+}
+
+void KVCacheBlockManager::clear_all() {
+    LOG_DEBUG("KVCacheBlockManager: Clearing all blocks");
+
+    // Free all allocated blocks
+    for (auto& block : blocks_) {
+        if (block.state != Block::State::FREE) {
+            block.num_tokens = 0;
+            block.state = Block::State::FREE;
+        }
+    }
+
+    // Rebuild free stack (push in reverse order so block 0 is on top)
+    std::stack<uint32_t> empty;
+    free_block_ids_.swap(empty);
+
+    for (int32_t i = max_blocks_ - 1; i >= 0; --i) {
+        free_block_ids_.push(static_cast<uint32_t>(i));
+    }
+
+    LOG_DEBUG("KVCacheBlockManager: All blocks cleared");
+}
+
+void KVCacheBlockManager::validate_block_id(uint32_t block_id) const {
+    if (block_id >= max_blocks_) {
+        OPENVINO_THROW("KVCacheBlockManager: Invalid block ID ", block_id, " (valid range: 0-", max_blocks_ - 1, ")");
+    }
+}
+
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
@@ -21,15 +21,9 @@ KVCacheBlockManager::KVCacheBlockManager(uint32_t block_size,
       element_type_(elem_type),
       device_(device),
       plugin_(plugin) {
-    // Set block shape: base_shape already contains the full block shape from model
-    // For Key:   [batch, num_heads, seq_len, head_dim] e.g., [1, 8, 1024, 128]
-    // For Value (transposed): [batch, num_heads, head_dim, seq_len] e.g., [1, 8, 128, 1024]
-    // The seq_len dimension already equals block_size, no modification needed
     block_shape_ = base_shape;
-    // The sequence dimension must equal block_size.
-    // For non-transposed tensors (K, and V when !v_transposed) it is dim 2,
-    // for transposed V it is dim 3. Only these two positions are valid; checking
-    // all four dims would also accept shapes where head_dim == block_size by accident.
+    // Check that the sequence dimension (dim 2 for K/non-transposed-V, dim 3 for transposed V)
+    // equals block_size. Checking only dim 2/3 avoids false positives when head_dim == block_size.
     OPENVINO_ASSERT(base_shape.size() == 4 && (base_shape[2] == block_size || base_shape[3] == block_size),
                     "KVCacheBlockManager: base_shape ",
                     base_shape,
@@ -37,16 +31,10 @@ KVCacheBlockManager::KVCacheBlockManager(uint32_t block_size,
                     block_size,
                     " in sequence dimension (expected at dim 2 or 3)");
 
-    // Initialize block pool (lazy memory allocation)
+    // Initialize block pool (tensors allocated on-demand, not here)
     blocks_.reserve(max_blocks);
     for (uint32_t i = 0; i < max_blocks; ++i) {
-        Block block;
-        block.id = i;
-        // block.tensor defaults to empty SoPtr (allocate on-demand)
-        block.num_tokens = 0;
-        block.state = Block::State::FREE;
-
-        blocks_.push_back(std::move(block));
+        blocks_.push_back({});
     }
 
     // Push block IDs to stack in reverse order (so block 0 is on top)
@@ -132,11 +120,11 @@ uint32_t KVCacheBlockManager::get_block_tokens(uint32_t block_id) const {
 
 std::vector<uint32_t> KVCacheBlockManager::get_allocated_blocks() const {
     std::vector<uint32_t> allocated;
-    allocated.reserve(max_blocks_);
+    allocated.reserve(max_blocks_ - free_block_ids_.size());
 
-    for (const auto& block : blocks_) {
-        if (block.state != Block::State::FREE) {
-            allocated.push_back(block.id);
+    for (uint32_t i = 0; i < blocks_.size(); ++i) {
+        if (blocks_[i].state != Block::State::FREE) {
+            allocated.push_back(i);
         }
     }
 
@@ -146,23 +134,17 @@ std::vector<uint32_t> KVCacheBlockManager::get_allocated_blocks() const {
 void KVCacheBlockManager::clear_all() {
     LOG_DEBUG("KVCacheBlockManager: Clearing all blocks");
 
-    // Free all allocated blocks
     for (auto& block : blocks_) {
-        if (block.state != Block::State::FREE) {
-            block.num_tokens = 0;
-            block.state = Block::State::FREE;
-        }
+        block.num_tokens = 0;
+        block.state = Block::State::FREE;
     }
 
     // Rebuild free stack (push in reverse order so block 0 is on top)
     std::stack<uint32_t> empty;
     free_block_ids_.swap(empty);
-
     for (int32_t i = max_blocks_ - 1; i >= 0; --i) {
         free_block_ids_.push(static_cast<uint32_t>(i));
     }
-
-    LOG_DEBUG("KVCacheBlockManager: All blocks cleared");
 }
 
 void KVCacheBlockManager::validate_block_id(uint32_t block_id) const {

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
@@ -1,0 +1,170 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <stack>
+#include <string>
+#include <vector>
+
+#include "openvino/runtime/iplugin.hpp"
+#include "openvino/runtime/itensor.hpp"
+#include "openvino/runtime/so_ptr.hpp"
+
+namespace ov {
+namespace npuw {
+
+/**
+ * @brief Block-based KV Cache Manager
+ *
+ * Manages KV cache memory using fixed-size blocks instead of a single continuous buffer.
+ * This approach significantly reduces memory waste when actual prompt length is much smaller
+ * than the configured max_prompt_size.
+ *
+ * Key benefits:
+ * - Memory efficiency: Only allocate blocks as needed (83%+ memory savings for short prompts)
+ * - Improved concurrency: 6-8x more concurrent requests with the same memory budget
+ * - Flexible allocation: Adapt to variable-length prompts without pre-allocating max buffer
+ *
+ * Example usage:
+ *   KVCacheBlockManager manager(512, 16, shape, type, "NPU", plugin);
+ *   auto block_id = manager.allocate_block();
+ *   auto tensor = manager.get_block_tensor(block_id.value());
+ *   manager.update_block_tokens(block_id.value(), 256);
+ *   manager.free_block(block_id.value());
+ */
+class KVCacheBlockManager {
+public:
+    /**
+     * @brief Represents a single block of KV cache memory
+     */
+    struct Block {
+        uint32_t id;                    ///< Unique block identifier
+        ov::SoPtr<ov::ITensor> tensor;  ///< Block memory tensor
+        uint32_t num_tokens;            ///< Number of tokens stored in this block
+
+        enum class State {
+            FREE,       ///< Block is free and available for allocation
+            ALLOCATED,  ///< Block is allocated but not yet filled
+            FULL,       ///< Block is completely filled
+        };
+        State state;
+    };
+
+    /**
+     * @brief Construct a new KV Cache Block Manager
+     *
+     * @param block_size Number of tokens per block (recommended: 512)
+     * @param max_blocks Maximum number of blocks in the pool
+     * @param base_shape Base shape for block tensors [batch, num_heads, seq_len, head_dim]
+     * @param elem_type Element type (e.g., fp16, fp32)
+     * @param device Target device for memory allocation ("NPU", "CPU")
+     * @param plugin Plugin instance for memory allocation
+     */
+    KVCacheBlockManager(uint32_t block_size,
+                        uint32_t max_blocks,
+                        const ov::Shape& base_shape,
+                        ov::element::Type elem_type,
+                        const std::string& device,
+                        const std::shared_ptr<const ov::IPlugin>& plugin);
+
+    ~KVCacheBlockManager() = default;
+
+    // Disable copy
+    KVCacheBlockManager(const KVCacheBlockManager&) = delete;
+    KVCacheBlockManager& operator=(const KVCacheBlockManager&) = delete;
+
+    // Allow move
+    KVCacheBlockManager(KVCacheBlockManager&&) = default;
+    KVCacheBlockManager& operator=(KVCacheBlockManager&&) = default;
+
+    /**
+     * @brief Allocate a new block from the free pool
+     *
+     * @return Block ID if successful, std::nullopt if no free blocks available
+     */
+    std::optional<uint32_t> allocate_block();
+
+    /**
+     * @brief Get the tensor associated with a block
+     *
+     * @param block_id Block ID
+     * @return Tensor for the block
+     */
+    ov::SoPtr<ov::ITensor> get_block_tensor(uint32_t block_id);
+
+    /**
+     * @brief Update the number of tokens stored in a block
+     *
+     * @param block_id Block ID
+     * @param num_tokens New token count (must be <= block_size)
+     */
+    void update_block_tokens(uint32_t block_id, uint32_t num_tokens);
+
+    /**
+     * @brief Get the number of tokens in a block
+     *
+     * @param block_id Block ID
+     * @return Number of tokens
+     */
+    uint32_t get_block_tokens(uint32_t block_id) const;
+
+    /**
+     * @brief Get list of all currently allocated block IDs
+     *
+     * @return Vector of block IDs
+     */
+    std::vector<uint32_t> get_allocated_blocks() const;
+
+    /**
+     * @brief Clear all blocks and reset to initial state
+     *
+     * Frees all allocated blocks and resets token counts
+     */
+    void clear_all();
+
+    /**
+     * @brief Get block size (tokens per block)
+     */
+    uint32_t get_block_size() const {
+        return block_size_;
+    }
+
+    /**
+     * @brief Get maximum number of blocks
+     */
+    uint32_t get_max_blocks() const {
+        return max_blocks_;
+    }
+
+    /**
+     * @brief Pair of key/value block managers for one transformer layer
+     */
+    struct LayerBlockManagers {
+        std::unique_ptr<KVCacheBlockManager> key_manager;
+        std::unique_ptr<KVCacheBlockManager> value_manager;
+    };
+
+private:
+    uint32_t block_size_;                  ///< Number of tokens per block
+    uint32_t max_blocks_;                  ///< Maximum blocks in pool
+    std::vector<Block> blocks_;            ///< All blocks (free + allocated)
+    std::stack<uint32_t> free_block_ids_;  ///< Stack of free block IDs (LIFO for better reuse)
+
+    ov::element::Type element_type_;             ///< Element type for tensors
+    ov::Shape block_shape_;                      ///< Shape for block tensors
+    std::string device_;                         ///< Target device
+    std::shared_ptr<const ov::IPlugin> plugin_;  ///< Plugin for memory allocation
+
+    /**
+     * @brief Validate block ID
+     */
+    void validate_block_id(uint32_t block_id) const;
+};
+
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
@@ -35,7 +35,7 @@ namespace npuw {
  *   auto block_id = manager.allocate_block();
  *   auto tensor = manager.get_block_tensor(block_id.value());
  *   manager.update_block_tokens(block_id.value(), 256);
- *   manager.free_block(block_id.value());
+ *   manager.clear_all();
  */
 class KVCacheBlockManager {
 public:
@@ -43,16 +43,15 @@ public:
      * @brief Represents a single block of KV cache memory
      */
     struct Block {
-        uint32_t id;                    ///< Unique block identifier
-        ov::SoPtr<ov::ITensor> tensor;  ///< Block memory tensor
-        uint32_t num_tokens;            ///< Number of tokens stored in this block
+        ov::SoPtr<ov::ITensor> tensor;  ///< Block memory tensor (allocated on-demand)
+        uint32_t num_tokens = 0;        ///< Number of tokens stored in this block
 
         enum class State {
             FREE,       ///< Block is free and available for allocation
             ALLOCATED,  ///< Block is allocated but not yet filled
             FULL,       ///< Block is completely filled
         };
-        State state;
+        State state = State::FREE;
     };
 
     /**

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
@@ -1,0 +1,868 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "llm_block_kvcache_extension.hpp"
+
+#include <regex>
+
+#include "infer_request_utils.hpp"
+#include "llm_compiled_model.hpp"
+#include "llm_infer_base_request.hpp"
+#include "logging.hpp"
+#include "util.hpp"
+
+namespace {
+
+// Construct numbered block input name: e.g. "past_key_values.5.key_block_2"
+std::string make_numbered_block_input_name(const std::string& kv_type, const std::string& layer_idx, size_t block_idx) {
+    return "past_key_values." + layer_idx + "." + kv_type + "_block_" + std::to_string(block_idx);
+}
+
+// Construct block_tail input name: e.g. "past_key_values.5.key_block_tail"
+std::string make_block_tail_input_name(const std::string& kv_type, const std::string& layer_idx) {
+    return "past_key_values." + layer_idx + "." + kv_type + "_block_tail";
+}
+
+// Set dummy tensors on all numbered block inputs in a ports map.
+// Returns the count of block inputs that were set.
+template <typename PortMapType, typename SetTensorFn>
+size_t set_dummy_block_tensors(const PortMapType& ports_map,
+                               SetTensorFn&& set_tensor_fn,
+                               const ov::SoPtr<ov::ITensor>& dummy_key_tensor,
+                               const ov::SoPtr<ov::ITensor>& dummy_value_tensor) {
+    size_t block_count = 0;
+    for (const auto& [name, port] : ports_map) {
+        if (name.find("block_tail") != std::string::npos) {
+            continue;
+        }
+        if (name.find("_block_") != std::string::npos) {
+            bool is_key_block = (name.find("key_block") != std::string::npos);
+            set_tensor_fn(port, is_key_block ? dummy_key_tensor : dummy_value_tensor);
+            block_count++;
+        }
+    }
+    return block_count;
+}
+
+// Pre-categorised block ports for one layer, ready for BlockBindingHelper::from_ports().
+struct LayerBlockPorts {
+    std::vector<ov::Output<const ov::Node>> numbered;  // block_0, block_1, …
+    std::optional<ov::Output<const ov::Node>> tail;    // block_tail (nullopt if absent)
+};
+
+// Partition block input ports for one layer into numbered (block_0, block_1, …) and tail.
+LayerBlockPorts partition_layer_block_ports(
+    const std::string& kv_type,
+    const std::string& layer_idx,
+    const std::unordered_map<std::string, ov::Output<const ov::Node>>& ports_map,
+    uint32_t max_blocks) {
+    LayerBlockPorts result;
+    result.numbered.reserve(max_blocks);
+
+    for (uint32_t idx = 0; idx < max_blocks; ++idx) {
+        auto it = ports_map.find(make_numbered_block_input_name(kv_type, layer_idx, static_cast<size_t>(idx)));
+        if (it != ports_map.end()) {
+            result.numbered.push_back(it->second);
+        } else {
+            break;  // This variant has fewer blocks than max_blocks
+        }
+    }
+
+    auto tail_it = ports_map.find(make_block_tail_input_name(kv_type, layer_idx));
+    if (tail_it != ports_map.end()) {
+        result.tail = tail_it->second;
+    }
+
+    return result;
+}
+
+// Copy a block tensor (or a slice of it) into the tail input port, handling padding correctly.
+void copy_block_to_tail_input(const ov::SoPtr<ov::ITensor>& block_tensor,
+                              uint32_t start_token,
+                              uint32_t end_token,
+                              uint32_t kv_dim,
+                              const ov::Output<const ov::Node>& tail_input_port,
+                              std::shared_ptr<ov::IAsyncInferRequest> request) {
+    namespace uu = ov::npuw::util;
+    NPUW_ASSERT(start_token <= end_token);
+
+    auto tail_input_tensor = request->get_tensor(tail_input_port);
+    NPUW_ASSERT(end_token <= static_cast<uint32_t>(tail_input_tensor->get_shape()[kv_dim]));
+
+    auto src_slice = uu::make_tensor_slice(block_tensor, kv_dim, start_token, end_token);
+    auto dst_slice = uu::make_tensor_slice(tail_input_tensor, kv_dim, start_token, end_token);
+    uu::copy_tensor_by_dim(src_slice, dst_slice, kv_dim, kv_dim);
+}
+
+}  // anonymous namespace
+
+// ============================================================================
+// BlockKVCacheExtension — public methods
+// ============================================================================
+
+namespace ov {
+namespace npuw {
+
+bool BlockKVCacheExtension::initialize(
+    const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+    const std::vector<std::shared_ptr<ov::IAsyncInferRequest>>& generate_requests,
+    const PortsMap& prefill_in_ports,
+    const PortsMap& prefill_out_ports,
+    const std::unordered_map<std::shared_ptr<ov::IAsyncInferRequest>, PortsMap>& gen_variant_in_ports,
+    const std::string& device,
+    const std::shared_ptr<LLMCompiledModel>& compiled_model) {
+    m_compiled_model = compiled_model;
+    m_device = device;
+
+    if (!m_compiled_model->m_cfg.get<::intel_npu::NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE>()) {
+        return false;
+    }
+
+    LOG_INFO("=== Initializing Block-based KV Cache Managers ===");
+
+    // Phase 2: Dummy tensor optimization — share dummy tensors across all block inputs
+    auto block_shapes = find_block_shapes(prefill_in_ports);
+    if (block_shapes.found_key) {
+        auto dummy_tensors = allocate_dummy_block_tensors(block_shapes);
+        set_dummy_tensors_to_all_requests(dummy_tensors,
+                                          prefill_request,
+                                          generate_requests,
+                                          prefill_in_ports,
+                                          gen_variant_in_ports);
+    }
+
+    // Phase 3: Parse structure
+    auto layer_blocks = parse_block_inputs_structure(prefill_in_ports);
+
+    // Phase 4: Create managers and pre-compute binding helpers
+    create_block_managers_and_helpers(layer_blocks, prefill_in_ports, generate_requests, gen_variant_in_ports);
+
+    // Phase 5: Snapshot original prefill output tensors for restore_prefill_output_buffers().
+    // These are the model-owned buffers that exist before any zero-copy redirect happens.
+    for (const auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
+        const std::string layer_str = std::to_string(layer_idx);
+        for (const char* kv_type : {"key", "value"}) {
+            std::string output_name = "present." + layer_str + "." + kv_type;
+            auto port_it = prefill_out_ports.find(output_name);
+            if (port_it != prefill_out_ports.end()) {
+                m_prefill_original_output_tensors[output_name] = prefill_request->get_tensor(port_it->second);
+            }
+        }
+    }
+    LOG_INFO("Snapshotted " << m_prefill_original_output_tensors.size() << " original prefill output tensors");
+
+    LOG_INFO("=== Block-based KV Cache Initialization Complete ===");
+
+    m_enabled = true;
+    return true;
+}
+
+uint32_t BlockKVCacheExtension::get_block_size() const {
+    OPENVINO_ASSERT(!m_kv_cache_block_managers.empty());
+    return m_kv_cache_block_managers.begin()->second.key_manager->get_block_size();
+}
+
+void BlockKVCacheExtension::reset() {
+    if (m_kv_cache_block_managers.empty()) {
+        return;
+    }
+    for (auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
+        layer_managers.key_manager->clear_all();
+        layer_managers.value_manager->clear_all();
+    }
+}
+
+// ============================================================================
+// Prefill path
+// ============================================================================
+
+void BlockKVCacheExtension::load_past_kv_blocks_to_prefill(
+    const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+    const PortsMap& prefill_in_ports) {
+    if (m_kv_cache_block_managers.empty()) {
+        return;
+    }
+
+    LOG_DEBUG("=== Binding Block Tensors to Prefill Model Inputs ===");
+
+    for (const auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
+        const std::string layer_idx_str = std::to_string(layer_idx);
+
+        auto bind_kv_blocks = [&](KVCacheBlockManager* manager, const char* kv_type) {
+            if (!manager) {
+                return;
+            }
+            auto allocated_blocks = manager->get_allocated_blocks();
+            for (size_t block_idx = 0; block_idx < allocated_blocks.size(); ++block_idx) {
+                std::string input_name = make_numbered_block_input_name(kv_type, layer_idx_str, block_idx);
+                auto port_it = prefill_in_ports.find(input_name);
+                if (port_it != prefill_in_ports.end()) {
+                    prefill_request->set_tensor(port_it->second,
+                                                manager->get_block_tensor(allocated_blocks[block_idx]));
+                    LOG_VERB("Bound " << kv_type << " block layer " << layer_idx_str << " block_" << block_idx);
+                }
+            }
+        };
+
+        bind_kv_blocks(layer_managers.key_manager.get(), "key");
+        bind_kv_blocks(layer_managers.value_manager.get(), "value");
+    }
+}
+
+bool BlockKVCacheExtension::redirect_prefill_outputs_to_new_blocks(
+    const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+    const PortsMap& prefill_out_ports,
+    uint32_t num_new_tokens) {
+    if (m_kv_cache_block_managers.empty()) {
+        return false;
+    }
+
+    // Zero-copy optimisation: bind prefill output ports directly to fresh blocks BEFORE inference.
+    // This lets the model write KV cache straight into BlockManager memory with no post-inference copy.
+    //
+    // Steps:
+    //   1. Pre-allocate one block per layer to hold the new tokens.
+    //   2. Redirect that output port to the block tensor (present.N.key / present.N.value).
+    //   3. Update block metadata immediately (token count is known before inference).
+    //   After infer(), data and metadata are already in place — no additional work needed.
+    //
+    // CONSTRAINT: Only valid when the chunk writes into exactly ONE block:
+    //   - current_position must be block-aligned (start of a block boundary).
+    //   - num_new_tokens must not span across a block boundary.
+    // When these constraints are not met, callers must call restore_prefill_output_buffers() instead
+    // and fall back to the copy-based copy_prefill_outputs_to_blocks() path.
+
+    auto& kvcache_desc = m_compiled_model->m_kvcache_desc;
+    uint32_t current_position = kvcache_desc.num_stored_tokens;
+
+    // Verify block-alignment (caller should have checked, but assert for safety)
+    uint32_t first_block_size = m_kv_cache_block_managers.begin()->second.key_manager->get_block_size();
+    if (current_position % first_block_size != 0) {
+        return false;
+    }
+
+    LOG_DEBUG("=== Redirecting Prefill Outputs to New Blocks (Zero-Copy) ===");
+    LOG_DEBUG("Pre-allocating blocks for " << num_new_tokens << " new tokens");
+
+    size_t total_blocks_allocated = 0;
+    size_t total_outputs_bound = 0;
+
+    auto process_kv_blocks = [&](uint32_t layer_idx, KVCacheBlockManager* manager, const char* kv_type_name) -> bool {
+        uint32_t block_size = manager->get_block_size();
+        uint32_t start_pos = current_position;
+        uint32_t end_pos = current_position + num_new_tokens;
+        uint32_t start_block_idx = start_pos / block_size;
+        uint32_t end_block_idx = (end_pos - 1) / block_size;
+
+        // Alignment postconditions for zero-copy
+        OPENVINO_ASSERT(start_pos % block_size == 0,
+                        "Zero-copy prefill requires block-aligned position. ",
+                        "current_position=",
+                        start_pos,
+                        ", block_size=",
+                        block_size);
+        OPENVINO_ASSERT(start_block_idx == end_block_idx,
+                        "Zero-copy prefill requires writing to a single block. ",
+                        "start_block=",
+                        start_block_idx,
+                        ", end_block=",
+                        end_block_idx,
+                        ", num_new_tokens=",
+                        num_new_tokens,
+                        ", block_size=",
+                        block_size);
+
+        uint32_t tokens_in_block = end_pos - (start_block_idx * block_size);
+        OPENVINO_ASSERT(tokens_in_block == block_size || tokens_in_block == num_new_tokens,
+                        "Zero-copy prefill requires writing full blocks. ",
+                        "tokens_in_block=",
+                        tokens_in_block,
+                        ", block_size=",
+                        block_size,
+                        ", num_new_tokens=",
+                        num_new_tokens);
+
+        // Ensure the target block is allocated
+        uint32_t blocks_needed = end_block_idx + 1;
+        auto allocated_blocks = manager->get_allocated_blocks();
+        while (allocated_blocks.size() < blocks_needed) {
+            auto new_block_id = manager->allocate_block();
+            OPENVINO_ASSERT(new_block_id.has_value(),
+                            "Failed to allocate ",
+                            kv_type_name,
+                            " block for layer ",
+                            layer_idx);
+            total_blocks_allocated++;
+            allocated_blocks = manager->get_allocated_blocks();
+        }
+
+        std::string output_name = "present." + std::to_string(layer_idx) + "." + kv_type_name;
+        auto port_it = prefill_out_ports.find(output_name);
+        if (port_it != prefill_out_ports.end()) {
+            uint32_t target_block_id = allocated_blocks[start_block_idx];
+            auto target_block_tensor = manager->get_block_tensor(target_block_id);
+            prefill_request->set_tensor(port_it->second, target_block_tensor);
+
+            // Update metadata immediately — we know how many tokens will be written
+            uint32_t block_start_pos = start_block_idx * block_size;
+            manager->update_block_tokens(target_block_id, end_pos - block_start_pos);
+            total_outputs_bound++;
+            LOG_VERB("Bound " << kv_type_name << " output layer " << layer_idx << " to block_" << start_block_idx
+                              << " (zero-copy, " << num_new_tokens << " tokens, metadata updated)");
+        }
+        return true;
+    };
+
+    for (const auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
+        if (layer_managers.key_manager) {
+            process_kv_blocks(layer_idx, layer_managers.key_manager.get(), "key");
+        }
+        if (layer_managers.value_manager) {
+            process_kv_blocks(layer_idx, layer_managers.value_manager.get(), "value");
+        }
+    }
+
+    LOG_DEBUG("Pre-binding complete: allocated=" << total_blocks_allocated << " blocks, bound=" << total_outputs_bound
+                                                 << " outputs");
+    m_prefill_outputs_redirected = true;
+    return true;
+}
+
+void BlockKVCacheExtension::restore_prefill_output_buffers(
+    const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+    const PortsMap& prefill_out_ports) {
+    if (m_kv_cache_block_managers.empty()) {
+        return;
+    }
+
+    // CRITICAL: Must be called before any non-aligned prefill chunk to prevent silent block corruption.
+    //
+    // Failure scenario without this restore:
+    //   Chunk 1: zero-copy binds "present.0.key" output → block 0 (block-aligned, works correctly).
+    //   Chunk 2: chunk is NOT block-aligned, so zero-copy is skipped.
+    //   But "present.0.key" is STILL bound to block 0 from the previous chunk.
+    //   infer() now overwrites block 0 with misaligned data → silent data corruption.
+    //
+    // Fix: restore the original model output buffers (snapshotted in initialize()).
+    // The model then writes into its own buffers, and copy_prefill_outputs_to_blocks() copies
+    // the result into the correct blocks afterwards.
+
+    if (!m_prefill_outputs_redirected) {
+        LOG_VERB("Prefill outputs already pointing to original tensors - no restore needed");
+        return;
+    }
+    OPENVINO_ASSERT(!m_prefill_original_output_tensors.empty(),
+                    "Original output tensors were not snapshotted during initialize().");
+
+    LOG_DEBUG("=== Restoring Original Output Tensors (Non-Zero-Copy Path) ===");
+
+    size_t total_restored = 0;
+    for (const auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
+        const std::string layer_str = std::to_string(layer_idx);
+        for (const char* kv_type : {"key", "value"}) {
+            std::string output_name = "present." + layer_str + "." + kv_type;
+            auto orig_it = m_prefill_original_output_tensors.find(output_name);
+            auto port_it = prefill_out_ports.find(output_name);
+            if (orig_it == m_prefill_original_output_tensors.end() || port_it == prefill_out_ports.end()) {
+                continue;
+            }
+            auto current_tensor = prefill_request->get_tensor(port_it->second);
+            if (current_tensor->data() != orig_it->second->data()) {
+                prefill_request->set_tensor(port_it->second, orig_it->second);
+                total_restored++;
+                LOG_VERB("Restored original buffer for " << output_name);
+            }
+        }
+    }
+
+    LOG_DEBUG("Restore complete: restored=" << total_restored << " tensors");
+    m_prefill_outputs_redirected = false;
+}
+
+// ============================================================================
+// Generate path
+// ============================================================================
+
+void BlockKVCacheExtension::init_generate_kv_block_bindings(
+    const std::shared_ptr<ov::IAsyncInferRequest>& kvcache_request,
+    const PortsMap& kvcache_in_ports,
+    uint32_t num_stored_tokens) {
+    if (m_kv_cache_block_managers.empty()) {
+        return;
+    }
+
+    // Initial block binding strategy (called once per conversation on the first generate step):
+    //
+    //  Numbered blocks (indices within BlockBindingHelper::non_tail_capacity):
+    //    → Zero-copy: set_tensor() shares the BlockManager buffer with the model input.
+    //      Future writes by copy_outputs_to_blocks() go directly into the shared tensor,
+    //      so subsequent generate steps need no re-binding for these blocks.
+    //
+    //  Tail block (index >= non_tail_capacity, handled via a separate "_block_tail" port):
+    //    → Copy-based: block data is copied into the tail input with padding.
+    //      Must be explicitly refreshed by update_generate_bindings() after every infer().
+
+    LOG_DEBUG("=== Initial Block Binding for Generate Model ===");
+    LOG_BLOCK();
+
+    auto& kvcache_desc = m_compiled_model->m_kvcache_desc;
+    const auto& variant_layer_helpers = m_variant_block_binding_helpers.at(kvcache_request);
+
+    size_t total_numbered_bound = 0;
+    size_t total_tail_copied = 0;
+
+    auto process_blocks = [&](uint32_t layer_idx,
+                              KVCacheBlockManager* manager,
+                              const BlockBindingHelper& helper,
+                              uint32_t kv_dim,
+                              const char* kv_type_name) {
+        auto allocated_blocks = manager->get_allocated_blocks();
+        if (allocated_blocks.empty()) {
+            return;
+        }
+        for (size_t block_idx = 0; block_idx < allocated_blocks.size(); ++block_idx) {
+            uint32_t block_id = allocated_blocks[block_idx];
+            auto block_tensor = manager->get_block_tensor(block_id);
+            uint32_t tokens_in_block = manager->get_block_tokens(block_id);
+            bool is_tail = helper.should_treat_as_tail(static_cast<uint32_t>(block_idx));
+            if (is_tail) {
+                copy_block_to_tail_input(block_tensor,
+                                         0u,
+                                         tokens_in_block,
+                                         kv_dim,
+                                         helper.tail_input_port.value(),
+                                         kvcache_request);
+                total_tail_copied++;
+                LOG_VERB("Bound tail " << kv_type_name << " layer_" << layer_idx << " block_" << block_idx);
+            } else {
+                if (block_idx < helper.numbered_input_ports.size()) {
+                    kvcache_request->set_tensor(helper.numbered_input_ports[block_idx], block_tensor);
+                    total_numbered_bound++;
+                    LOG_VERB("Bound numbered " << kv_type_name << " layer_" << layer_idx << " block_" << block_idx);
+                }
+            }
+        }
+    };
+
+    for (const auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
+        const auto& layer_helpers = variant_layer_helpers.at(layer_idx);
+        if (layer_managers.key_manager) {
+            process_blocks(layer_idx,
+                           layer_managers.key_manager.get(),
+                           layer_helpers.key_helper,
+                           kvcache_desc.dim,
+                           "key");
+        }
+        if (layer_managers.value_manager) {
+            const uint32_t kv_dim = kvcache_desc.v_tensors_transposed_gen ? 3u : kvcache_desc.dim;
+            process_blocks(layer_idx, layer_managers.value_manager.get(), layer_helpers.value_helper, kv_dim, "value");
+        }
+    }
+
+    LOG_DEBUG("Initial binding complete: numbered=" << total_numbered_bound << ", tail=" << total_tail_copied);
+}
+
+void BlockKVCacheExtension::update_generate_bindings(uint32_t old_num_tokens,
+                                                     uint32_t new_num_tokens,
+                                                     const std::shared_ptr<ov::IAsyncInferRequest>& kvcache_request,
+                                                     const PortsMap& kvcache_in_ports) {
+    if (m_kv_cache_block_managers.empty()) {
+        return;
+    }
+
+    LOG_DEBUG("=== Update Block Bindings After Generate ===");
+    LOG_BLOCK();
+
+    auto& kvcache_desc = m_compiled_model->m_kvcache_desc;
+    const auto& variant_layer_helpers = m_variant_block_binding_helpers.at(kvcache_request);
+
+    size_t total_tail_updates = 0;
+    size_t total_new_bindings = 0;
+
+    auto update_blocks = [&](uint32_t layer_idx,
+                             KVCacheBlockManager* manager,
+                             const BlockBindingHelper& helper,
+                             uint32_t kv_dim,
+                             const char* kv_type_name) {
+        auto allocated_blocks = manager->get_allocated_blocks();
+        if (allocated_blocks.empty()) {
+            return;
+        }
+
+        // update_generate_bindings is only called after at least one prefill has run,
+        // so old_num_tokens must be positive.
+        NPUW_ASSERT(old_num_tokens > 0);
+
+        uint32_t final_block_idx = helper.get_block_index_for_position(new_num_tokens - 1);
+        uint32_t old_block_idx = helper.get_block_index_for_position(old_num_tokens - 1);
+
+        // Bind every block that was newly entered during this step (boundary crossings).
+        // In standard decoding (input_tokens_len=1) this loop runs 0 or 1 times.
+        // In speculative decoding it may run more times if input_tokens_len > block_size.
+        for (uint32_t bidx = old_block_idx + 1; bidx <= final_block_idx; ++bidx) {
+            if (bidx >= static_cast<uint32_t>(allocated_blocks.size())) {
+                break;
+            }
+            bool block_is_tail = helper.should_treat_as_tail(bidx);
+            if (block_is_tail) {
+                uint32_t block_id = allocated_blocks[bidx];
+                copy_block_to_tail_input(manager->get_block_tensor(block_id),
+                                         0u,
+                                         manager->get_block_tokens(block_id),
+                                         kv_dim,
+                                         helper.tail_input_port.value(),
+                                         kvcache_request);
+                total_tail_updates++;
+                LOG_VERB("Updated tail " << kv_type_name << " layer_" << layer_idx << " block_" << bidx
+                                         << " (crossed block boundary)");
+            } else if (bidx < helper.numbered_input_ports.size()) {
+                uint32_t block_id = allocated_blocks[bidx];
+                kvcache_request->set_tensor(helper.numbered_input_ports[bidx], manager->get_block_tensor(block_id));
+                total_new_bindings++;
+                LOG_VERB("Bound new numbered " << kv_type_name << " layer_" << layer_idx << " block_" << bidx);
+            }
+        }
+
+        // If the final block is a tail block and was NOT newly entered by the loop above
+        // (i.e., old and new tokens are in the same block), incrementally copy only the
+        // tokens added this step. Numbered blocks share memory with BlockManager and need
+        // no explicit update.
+        bool final_is_tail = helper.should_treat_as_tail(final_block_idx);
+        if (final_is_tail && final_block_idx == old_block_idx) {
+            uint32_t block_id = allocated_blocks[final_block_idx];
+            uint32_t block_start_pos = final_block_idx * helper.block_size;
+            uint32_t prev_tokens_in_block = old_num_tokens - block_start_pos;
+            uint32_t new_tokens_in_block = manager->get_block_tokens(block_id);
+            copy_block_to_tail_input(manager->get_block_tensor(block_id),
+                                     prev_tokens_in_block,
+                                     new_tokens_in_block,
+                                     kv_dim,
+                                     helper.tail_input_port.value(),
+                                     kvcache_request);
+            total_tail_updates++;
+            LOG_VERB("Refreshed tail " << kv_type_name << " layer_" << layer_idx << " block_" << final_block_idx << " ["
+                                       << prev_tokens_in_block << ".." << new_tokens_in_block << "]");
+        }
+    };
+
+    for (const auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
+        const auto& layer_helpers = variant_layer_helpers.at(layer_idx);
+        if (layer_managers.key_manager) {
+            update_blocks(layer_idx,
+                          layer_managers.key_manager.get(),
+                          layer_helpers.key_helper,
+                          kvcache_desc.dim,
+                          "key");
+        }
+        if (layer_managers.value_manager) {
+            const uint32_t kv_dim = kvcache_desc.v_tensors_transposed_gen ? 3u : kvcache_desc.dim;
+            update_blocks(layer_idx, layer_managers.value_manager.get(), layer_helpers.value_helper, kv_dim, "value");
+        }
+    }
+
+    LOG_DEBUG("Update complete: tail_updates=" << total_tail_updates << ", new_bindings=" << total_new_bindings);
+}
+
+// ============================================================================
+// KV copy engine — shared by prefill (copy-path) and generate
+// ============================================================================
+
+void BlockKVCacheExtension::copy_outputs_to_blocks(const std::shared_ptr<ov::IAsyncInferRequest>& request,
+                                                   const PortsMap& src_ports,
+                                                   uint32_t num_tokens,
+                                                   bool v_transposed,
+                                                   uint32_t current_kv_position) {
+    namespace uu = ov::npuw::util;
+    auto& kvcache_desc = m_compiled_model->m_kvcache_desc;
+    auto& compiled = request->get_compiled_model();
+
+    for (std::size_t i = LLMInferBaseRequest::layer_ids::kStartOutputKVCacheLayers; i < compiled->outputs().size();
+         ++i) {
+        const auto& output_name = compiled->outputs()[i].get_any_name();
+
+        bool is_key = (output_name.find("key") != std::string::npos);
+        bool is_value = (output_name.find("value") != std::string::npos);
+        if (!is_key && !is_value) {
+            continue;
+        }
+
+        // Parse layer index from output name (e.g., "present.0.key" → layer 0)
+        std::regex layer_regex(R"(present\.(\d+)\.)");
+        std::smatch match;
+        uint32_t layer_idx = 0;
+        if (std::regex_search(output_name, match, layer_regex) && match.size() > 1) {
+            layer_idx = static_cast<uint32_t>(std::stoi(match[1].str()));
+        }
+
+        auto it = m_kv_cache_block_managers.find(layer_idx);
+        if (it == m_kv_cache_block_managers.end()) {
+            continue;
+        }
+
+        auto& layer_managers = it->second;
+        auto& block_manager = is_key ? layer_managers.key_manager : layer_managers.value_manager;
+
+        const uint32_t kv_dim = (is_value && v_transposed) ? 3u : kvcache_desc.dim;
+
+        auto src_tensor = request->get_tensor(src_ports.at(output_name));
+        uint32_t src_seq_len = static_cast<uint32_t>(src_tensor->get_shape()[kv_dim]);
+        OPENVINO_ASSERT(num_tokens <= src_seq_len, "num_tokens (", num_tokens, ") > src_seq_len (", src_seq_len, ")");
+
+        auto src_to_copy = src_tensor;
+        if (src_seq_len > num_tokens) {
+            src_to_copy = uu::make_tensor_slice(src_tensor, kv_dim, src_seq_len - num_tokens, src_seq_len);
+        }
+
+        uint32_t block_size = block_manager->get_block_size();
+        uint32_t start_pos = current_kv_position;
+        uint32_t end_pos = current_kv_position + num_tokens;
+        uint32_t start_block_idx = start_pos / block_size;
+        uint32_t end_block_idx = (end_pos - 1) / block_size;
+
+        auto allocated_blocks = block_manager->get_allocated_blocks();
+        uint32_t blocks_needed = end_block_idx + 1;
+        while (allocated_blocks.size() < blocks_needed) {
+            auto new_block_id = block_manager->allocate_block();
+            OPENVINO_ASSERT(new_block_id.has_value(), "Failed to allocate block for KV cache — pool exhausted");
+            allocated_blocks = block_manager->get_allocated_blocks();
+        }
+
+        uint32_t tokens_written = 0;
+        for (uint32_t block_idx = start_block_idx; block_idx <= end_block_idx; ++block_idx) {
+            uint32_t block_id = allocated_blocks[block_idx];
+            auto block_tensor = block_manager->get_block_tensor(block_id);
+
+            uint32_t block_start_pos = block_idx * block_size;
+            uint32_t write_start_in_block = (start_pos > block_start_pos) ? (start_pos - block_start_pos) : 0;
+            uint32_t write_end_in_block = std::min(end_pos - block_start_pos, block_size);
+            uint32_t tokens_in_this_block = write_end_in_block - write_start_in_block;
+
+            auto dst_slice = uu::make_tensor_slice(block_tensor, kv_dim, write_start_in_block, write_end_in_block);
+            auto src_slice =
+                uu::make_tensor_slice(src_to_copy, kv_dim, tokens_written, tokens_written + tokens_in_this_block);
+            uu::copy_tensor_by_dim(src_slice, dst_slice, kv_dim, kv_dim);
+
+            tokens_written += tokens_in_this_block;
+            block_manager->update_block_tokens(block_id, write_end_in_block);
+        }
+        OPENVINO_ASSERT(tokens_written == num_tokens, "Mismatch: wrote ", tokens_written, " but expected ", num_tokens);
+    }
+}
+
+void BlockKVCacheExtension::copy_prefill_outputs_to_blocks(
+    const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+    const PortsMap& prefill_out_ports,
+    uint32_t num_tokens,
+    bool v_transposed,
+    uint32_t kv_position) {
+    LOG_DEBUG("Copying prefill outputs to blocks: num_tokens=" << num_tokens << " kv_position=" << kv_position);
+    copy_outputs_to_blocks(prefill_request, prefill_out_ports, num_tokens, v_transposed, kv_position);
+}
+
+void BlockKVCacheExtension::commit_generate_kv_and_rebind(
+    uint32_t old_num_tokens,
+    uint32_t new_num_tokens,
+    uint32_t input_tokens_len,
+    const std::shared_ptr<ov::IAsyncInferRequest>& kvcache_request,
+    const PortsMap& kvcache_out_ports,
+    const PortsMap& kvcache_in_ports) {
+    // Step 1: Write the newly generated token(s) into block storage (partial block, copy-based)
+    copy_outputs_to_blocks(kvcache_request,
+                           kvcache_out_ports,
+                           input_tokens_len,
+                           m_compiled_model->m_kvcache_desc.v_tensors_transposed_gen,
+                           old_num_tokens);
+
+    // Step 2: Re-bind model inputs if we crossed a block boundary or need tail update
+    update_generate_bindings(old_num_tokens, new_num_tokens, kvcache_request, kvcache_in_ports);
+}
+
+// ============================================================================
+// Private initialization helpers
+// ============================================================================
+
+BlockKVCacheExtension::BlockShapeInfo BlockKVCacheExtension::find_block_shapes(const PortsMap& prefill_in_ports) const {
+    BlockShapeInfo shapes;
+    for (const auto& [name, port] : prefill_in_ports) {
+        if (name.find("block_tail") != std::string::npos) {
+            continue;
+        }
+        if (name.find("_block_") != std::string::npos) {
+            if (!shapes.found_key && name.find("key_block") != std::string::npos) {
+                shapes.key_shape = port.get_shape();
+                shapes.elem_type = port.get_element_type();
+                shapes.found_key = true;
+                LOG_DEBUG("Detected key block shape: " << shapes.key_shape << ", type: " << shapes.elem_type);
+            }
+            if (!shapes.found_value && name.find("value_block") != std::string::npos) {
+                shapes.value_shape = port.get_shape();
+                shapes.found_value = true;
+                LOG_DEBUG("Detected value block shape: " << shapes.value_shape);
+            }
+            if (shapes.found_key && shapes.found_value) {
+                break;
+            }
+        }
+    }
+    return shapes;
+}
+
+BlockKVCacheExtension::DummyTensors BlockKVCacheExtension::allocate_dummy_block_tensors(
+    const BlockShapeInfo& shapes) const {
+    DummyTensors dummies;
+    dummies.key_tensor =
+        ov::npuw::util::allocMem(shapes.elem_type, shapes.key_shape, "NPU", m_compiled_model->get_plugin());
+    LOG_INFO("Allocated shared dummy key tensor: " << shapes.key_shape << " (" << dummies.key_tensor->get_byte_size()
+                                                   << " bytes)");
+
+    if (shapes.found_value && shapes.value_shape != shapes.key_shape) {
+        dummies.value_tensor =
+            ov::npuw::util::allocMem(shapes.elem_type, shapes.value_shape, "NPU", m_compiled_model->get_plugin());
+        LOG_INFO("Allocated shared dummy value tensor: " << shapes.value_shape << " ("
+                                                         << dummies.value_tensor->get_byte_size() << " bytes)");
+    } else {
+        dummies.value_tensor = dummies.key_tensor;  // Reuse key tensor
+    }
+    return dummies;
+}
+
+void BlockKVCacheExtension::set_dummy_tensors_to_all_requests(
+    const DummyTensors& dummies,
+    const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+    const std::vector<std::shared_ptr<ov::IAsyncInferRequest>>& generate_requests,
+    const PortsMap& prefill_in_ports,
+    const std::unordered_map<std::shared_ptr<ov::IAsyncInferRequest>, PortsMap>& gen_variant_in_ports) {
+    size_t prefill_block_count = set_dummy_block_tensors(
+        prefill_in_ports,
+        [&prefill_request](const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) {
+            prefill_request->set_tensor(port, tensor);
+        },
+        dummies.key_tensor,
+        dummies.value_tensor);
+    LOG_INFO("Set " << prefill_block_count << " prefill numbered block inputs to shared dummy tensors");
+
+    size_t generate_block_count = 0;
+    for (auto& generate_request : generate_requests) {
+        generate_block_count += set_dummy_block_tensors(
+            gen_variant_in_ports.at(generate_request),
+            [&generate_request](const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) {
+                generate_request->set_tensor(port, tensor);
+            },
+            dummies.key_tensor,
+            dummies.value_tensor);
+    }
+    LOG_INFO("Set " << generate_block_count << " generate numbered block inputs to shared dummy tensors");
+}
+
+BlockKVCacheExtension::LayerBlockNames BlockKVCacheExtension::parse_block_inputs_structure(
+    const PortsMap& prefill_in_ports) const {
+    LayerBlockNames layer_blocks;
+
+    for (const auto& [name, port] : prefill_in_ports) {
+        if (name.find("_block_") == std::string::npos) {
+            continue;
+        }
+        std::regex layer_regex(R"(past_key_values\.(\d+)\.)");
+        std::smatch match;
+        uint32_t layer_idx = 0;
+        if (std::regex_search(name, match, layer_regex) && match.size() > 1) {
+            layer_idx = static_cast<uint32_t>(std::stoi(match[1].str()));
+        } else {
+            LOG_DEBUG("WARNING: Could not parse layer index from " << name << ", using default 0");
+        }
+
+        bool is_key = (name.find("key_block") != std::string::npos);
+        if (is_key) {
+            layer_blocks[layer_idx].first.push_back(name);
+        } else {
+            layer_blocks[layer_idx].second.push_back(name);
+        }
+    }
+    return layer_blocks;
+}
+
+void BlockKVCacheExtension::create_block_managers_and_helpers(
+    const LayerBlockNames& layer_blocks,
+    const PortsMap& prefill_in_ports,
+    const std::vector<std::shared_ptr<ov::IAsyncInferRequest>>& generate_requests,
+    const std::unordered_map<std::shared_ptr<ov::IAsyncInferRequest>, PortsMap>& gen_variant_in_ports) {
+    const uint32_t block_size = static_cast<uint32_t>(m_compiled_model->m_prefill_chunk_size);
+    const uint32_t max_blocks = m_compiled_model->m_kvcache_desc.total_size / block_size;
+
+    LOG_INFO("Block configuration: size=" << block_size << " tokens, max_blocks=" << max_blocks);
+
+    for (const auto& [layer_idx, block_names_pair] : layer_blocks) {
+        const auto& key_block_names = block_names_pair.first;
+        const auto& value_block_names = block_names_pair.second;
+
+        if (key_block_names.empty() && value_block_names.empty()) {
+            continue;
+        }
+
+        KVCacheBlockManager::LayerBlockManagers layer_managers;
+        // Use block_0 name specifically to deterministically get the full-block shape.
+        const std::string layer_idx_str_local = std::to_string(layer_idx);
+
+        if (!key_block_names.empty()) {
+            // Deterministically pick block_0 (full-block shape, not a smaller tail block)
+            const std::string key_block0_name = make_numbered_block_input_name("key", layer_idx_str_local, 0);
+            auto first_key_port = prefill_in_ports.at(key_block0_name);
+            layer_managers.key_manager = std::make_unique<KVCacheBlockManager>(block_size,
+                                                                               max_blocks,
+                                                                               first_key_port.get_shape(),
+                                                                               first_key_port.get_element_type(),
+                                                                               "NPU",
+                                                                               m_compiled_model->get_plugin());
+        }
+
+        if (!value_block_names.empty()) {
+            // Deterministically pick block_0 (full-block shape, not a smaller tail block)
+            const std::string value_block0_name = make_numbered_block_input_name("value", layer_idx_str_local, 0);
+            auto first_value_port = prefill_in_ports.at(value_block0_name);
+            layer_managers.value_manager = std::make_unique<KVCacheBlockManager>(block_size,
+                                                                                 max_blocks,
+                                                                                 first_value_port.get_shape(),
+                                                                                 first_value_port.get_element_type(),
+                                                                                 "NPU",
+                                                                                 m_compiled_model->get_plugin());
+        }
+
+        m_kv_cache_block_managers[layer_idx] = std::move(layer_managers);
+
+        // Pre-compute BlockBindingHelpers for this layer × all generate variants
+        const std::string layer_idx_str = std::to_string(layer_idx);
+        const auto& layer_managers_ref = m_kv_cache_block_managers.at(layer_idx);
+
+        for (const auto& generate_request : generate_requests) {
+            const auto& variant_in_ports = gen_variant_in_ports.at(generate_request);
+            auto& variant_layer_helpers = m_variant_block_binding_helpers[generate_request];
+
+            LayerBlockBindingHelpers layer_helpers;
+
+            if (layer_managers_ref.key_manager) {
+                uint32_t max_blocks_key = layer_managers_ref.key_manager->get_max_blocks();
+                auto key_ports = partition_layer_block_ports("key", layer_idx_str, variant_in_ports, max_blocks_key);
+                layer_helpers.key_helper =
+                    BlockBindingHelper::from_ports(std::move(key_ports.numbered),
+                                                   std::move(key_ports.tail),
+                                                   layer_managers_ref.key_manager->get_block_size());
+            }
+
+            if (layer_managers_ref.value_manager) {
+                uint32_t max_blocks_value = layer_managers_ref.value_manager->get_max_blocks();
+                auto value_ports =
+                    partition_layer_block_ports("value", layer_idx_str, variant_in_ports, max_blocks_value);
+                layer_helpers.value_helper =
+                    BlockBindingHelper::from_ports(std::move(value_ports.numbered),
+                                                   std::move(value_ports.tail),
+                                                   layer_managers_ref.value_manager->get_block_size());
+            }
+
+            variant_layer_helpers[layer_idx] = std::move(layer_helpers);
+        }
+    }
+}
+
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
@@ -588,7 +588,7 @@ void BlockKVCacheExtension::copy_outputs_to_blocks(const std::shared_ptr<ov::IAs
         }
 
         // Parse layer index from output name (e.g., "present.0.key" → layer 0)
-        std::regex layer_regex(R"(present\.(\d+)\.)");
+        static const std::regex layer_regex(R"(present\.(\d+)\.)");
         std::smatch match;
         uint32_t layer_idx = 0;
         if (std::regex_search(output_name, match, layer_regex) && match.size() > 1) {
@@ -712,13 +712,13 @@ BlockKVCacheExtension::DummyTensors BlockKVCacheExtension::allocate_dummy_block_
     const BlockShapeInfo& shapes) const {
     DummyTensors dummies;
     dummies.key_tensor =
-        ov::npuw::util::allocMem(shapes.elem_type, shapes.key_shape, "NPU", m_compiled_model->get_plugin());
+        ov::npuw::util::allocMem(shapes.elem_type, shapes.key_shape, m_device, m_compiled_model->get_plugin());
     LOG_INFO("Allocated shared dummy key tensor: " << shapes.key_shape << " (" << dummies.key_tensor->get_byte_size()
                                                    << " bytes)");
 
     if (shapes.found_value && shapes.value_shape != shapes.key_shape) {
         dummies.value_tensor =
-            ov::npuw::util::allocMem(shapes.elem_type, shapes.value_shape, "NPU", m_compiled_model->get_plugin());
+            ov::npuw::util::allocMem(shapes.elem_type, shapes.value_shape, m_device, m_compiled_model->get_plugin());
         LOG_INFO("Allocated shared dummy value tensor: " << shapes.value_shape << " ("
                                                          << dummies.value_tensor->get_byte_size() << " bytes)");
     } else {
@@ -763,7 +763,7 @@ BlockKVCacheExtension::LayerBlockNames BlockKVCacheExtension::parse_block_inputs
         if (name.find("_block_") == std::string::npos) {
             continue;
         }
-        std::regex layer_regex(R"(past_key_values\.(\d+)\.)");
+        static const std::regex layer_regex(R"(past_key_values\.(\d+)\.)");
         std::smatch match;
         uint32_t layer_idx = 0;
         if (std::regex_search(name, match, layer_regex) && match.size() > 1) {
@@ -812,7 +812,7 @@ void BlockKVCacheExtension::create_block_managers_and_helpers(
                                                                                max_blocks,
                                                                                first_key_port.get_shape(),
                                                                                first_key_port.get_element_type(),
-                                                                               "NPU",
+                                                                               m_device,
                                                                                m_compiled_model->get_plugin());
         }
 
@@ -824,7 +824,7 @@ void BlockKVCacheExtension::create_block_managers_and_helpers(
                                                                                  max_blocks,
                                                                                  first_value_port.get_shape(),
                                                                                  first_value_port.get_element_type(),
-                                                                                 "NPU",
+                                                                                 m_device,
                                                                                  m_compiled_model->get_plugin());
         }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
@@ -788,7 +788,7 @@ void BlockKVCacheExtension::create_block_managers_and_helpers(
     const std::vector<std::shared_ptr<ov::IAsyncInferRequest>>& generate_requests,
     const std::unordered_map<std::shared_ptr<ov::IAsyncInferRequest>, PortsMap>& gen_variant_in_ports) {
     const uint32_t block_size = static_cast<uint32_t>(m_compiled_model->m_prefill_chunk_size);
-    const uint32_t max_blocks = m_compiled_model->m_kvcache_desc.total_size / block_size;
+    const uint32_t max_blocks = (m_compiled_model->m_kvcache_desc.total_size + block_size - 1) / block_size;
 
     LOG_INFO("Block configuration: size=" << block_size << " tokens, max_blocks=" << max_blocks);
 

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
@@ -24,6 +24,26 @@ std::string make_block_tail_input_name(const std::string& kv_type, const std::st
     return "past_key_values." + layer_idx + "." + kv_type + "_block_tail";
 }
 
+// Classify a port name as a numbered block KV param (non-contiguous, non-tail).
+// Returns: true  => numbered key block (key_block_N)
+//          false => numbered value block (value_block_N)
+//          nullopt => skip (not a KV param, contiguous, or tail)
+std::optional<bool> classify_numbered_block_param(const std::string& name) {
+    namespace uu = ov::npuw::util;
+    const bool is_key = uu::isPastKeyParam(name);
+    const bool is_value = uu::isPastValueParam(name);
+    if (!is_key && !is_value) {
+        return std::nullopt;
+    }
+    if (uu::isPastKeyParamContiguous(name) || uu::isPastValueParamContiguous(name)) {
+        return std::nullopt;
+    }
+    if (name.find("block_tail") != std::string::npos) {
+        return std::nullopt;
+    }
+    return is_key;
+}
+
 // Set dummy tensors on all numbered block inputs in a ports map.
 // Returns the count of block inputs that were set.
 template <typename PortMapType, typename SetTensorFn>
@@ -33,14 +53,12 @@ size_t set_dummy_block_tensors(const PortMapType& ports_map,
                                const ov::SoPtr<ov::ITensor>& dummy_value_tensor) {
     size_t block_count = 0;
     for (const auto& [name, port] : ports_map) {
-        if (name.find("block_tail") != std::string::npos) {
+        const auto kv_type = classify_numbered_block_param(name);
+        if (!kv_type.has_value()) {
             continue;
         }
-        if (name.find("_block_") != std::string::npos) {
-            bool is_key_block = (name.find("key_block") != std::string::npos);
-            set_tensor_fn(port, is_key_block ? dummy_key_tensor : dummy_value_tensor);
-            block_count++;
-        }
+        set_tensor_fn(port, kv_type.value() ? dummy_key_tensor : dummy_value_tensor);
+        block_count++;
     }
     return block_count;
 }
@@ -139,11 +157,14 @@ bool BlockKVCacheExtension::initialize(
     create_block_managers_and_helpers(layer_blocks, prefill_in_ports, generate_requests, gen_variant_in_ports);
 
     // Phase 5: Snapshot original prefill output tensors for restore_prefill_output_buffers().
-    // These are the model-owned buffers that exist before any zero-copy redirect happens.
+    // Also build m_output_kv_info (output_name → layer/kv classification) to avoid per-call
+    // regex in copy_outputs_to_blocks().
     for (const auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
         const std::string layer_str = std::to_string(layer_idx);
-        for (const char* kv_type : {"key", "value"}) {
-            std::string output_name = "present." + layer_str + "." + kv_type;
+        for (const bool is_key : {true, false}) {
+            const std::string kv_type = is_key ? "key" : "value";
+            const std::string output_name = "present." + layer_str + "." + kv_type;
+            m_output_kv_info[output_name] = {layer_idx, is_key};
             auto port_it = prefill_out_ports.find(output_name);
             if (port_it != prefill_out_ports.end()) {
                 m_prefill_original_output_tensors[output_name] = prefill_request->get_tensor(port_it->second);
@@ -581,19 +602,14 @@ void BlockKVCacheExtension::copy_outputs_to_blocks(const std::shared_ptr<ov::IAs
          ++i) {
         const auto& output_name = compiled->outputs()[i].get_any_name();
 
-        bool is_key = (output_name.find("key") != std::string::npos);
-        bool is_value = (output_name.find("value") != std::string::npos);
-        if (!is_key && !is_value) {
+        // Classify output port via pre-computed map (avoids per-call regex).
+        auto info_it = m_output_kv_info.find(output_name);
+        if (info_it == m_output_kv_info.end()) {
             continue;
         }
-
-        // Parse layer index from output name (e.g., "present.0.key" → layer 0)
-        static const std::regex layer_regex(R"(present\.(\d+)\.)");
-        std::smatch match;
-        uint32_t layer_idx = 0;
-        if (std::regex_search(output_name, match, layer_regex) && match.size() > 1) {
-            layer_idx = static_cast<uint32_t>(std::stoi(match[1].str()));
-        }
+        const bool is_key = info_it->second.is_key;
+        const bool is_value = !is_key;
+        const uint32_t layer_idx = info_it->second.layer_idx;
 
         auto it = m_kv_cache_block_managers.find(layer_idx);
         if (it == m_kv_cache_block_managers.end()) {
@@ -685,24 +701,25 @@ void BlockKVCacheExtension::commit_generate_kv_and_rebind(
 BlockKVCacheExtension::BlockShapeInfo BlockKVCacheExtension::find_block_shapes(const PortsMap& prefill_in_ports) const {
     BlockShapeInfo shapes;
     for (const auto& [name, port] : prefill_in_ports) {
-        if (name.find("block_tail") != std::string::npos) {
+        const auto kv_type = classify_numbered_block_param(name);
+        if (!kv_type.has_value()) {
             continue;
         }
-        if (name.find("_block_") != std::string::npos) {
-            if (!shapes.found_key && name.find("key_block") != std::string::npos) {
-                shapes.key_shape = port.get_shape();
-                shapes.elem_type = port.get_element_type();
-                shapes.found_key = true;
-                LOG_DEBUG("Detected key block shape: " << shapes.key_shape << ", type: " << shapes.elem_type);
-            }
-            if (!shapes.found_value && name.find("value_block") != std::string::npos) {
-                shapes.value_shape = port.get_shape();
-                shapes.found_value = true;
-                LOG_DEBUG("Detected value block shape: " << shapes.value_shape);
-            }
-            if (shapes.found_key && shapes.found_value) {
-                break;
-            }
+        const bool is_key = kv_type.value();
+        const bool is_value = !is_key;
+        if (!shapes.found_key && is_key) {
+            shapes.key_shape = port.get_shape();
+            shapes.elem_type = port.get_element_type();
+            shapes.found_key = true;
+            LOG_DEBUG("Detected key block shape: " << shapes.key_shape << ", type: " << shapes.elem_type);
+        }
+        if (!shapes.found_value && is_value) {
+            shapes.value_shape = port.get_shape();
+            shapes.found_value = true;
+            LOG_DEBUG("Detected value block shape: " << shapes.value_shape);
+        }
+        if (shapes.found_key && shapes.found_value) {
+            break;
         }
     }
     return shapes;
@@ -760,7 +777,9 @@ BlockKVCacheExtension::LayerBlockNames BlockKVCacheExtension::parse_block_inputs
     LayerBlockNames layer_blocks;
 
     for (const auto& [name, port] : prefill_in_ports) {
-        if (name.find("_block_") == std::string::npos) {
+        const bool is_key = ov::npuw::util::isPastKeyParam(name);
+        const bool is_value = ov::npuw::util::isPastValueParam(name);
+        if (!is_key && !is_value) {
             continue;
         }
         static const std::regex layer_regex(R"(past_key_values\.(\d+)\.)");
@@ -772,7 +791,6 @@ BlockKVCacheExtension::LayerBlockNames BlockKVCacheExtension::parse_block_inputs
             LOG_DEBUG("WARNING: Could not parse layer index from " << name << ", using default 0");
         }
 
-        bool is_key = (name.find("key_block") != std::string::npos);
         if (is_key) {
             layer_blocks[layer_idx].first.push_back(name);
         } else {

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.hpp
@@ -237,6 +237,13 @@ private:
     // layer_idx → {key_block_names, value_block_names}
     using LayerBlockNames = std::unordered_map<uint32_t, std::pair<std::vector<std::string>, std::vector<std::string>>>;
 
+    // Pre-computed classification for each KV output port (e.g. "present.0.key").
+    // Built once in initialize(); used by copy_outputs_to_blocks() to avoid per-call regex.
+    struct OutputKVInfo {
+        uint32_t layer_idx;
+        bool is_key;  // false → value port
+    };
+
     // -------------------------------------------------------------------------
     // Initialization helpers (called once from initialize())
     // -------------------------------------------------------------------------
@@ -285,6 +292,9 @@ private:
     // Pre-computed binding helpers: variant_request → layer_idx → {key_helper, value_helper}
     std::unordered_map<std::shared_ptr<ov::IAsyncInferRequest>, std::unordered_map<uint32_t, LayerBlockBindingHelpers>>
         m_variant_block_binding_helpers;
+
+    // output_name → {layer_idx, is_key}: pre-computed in initialize(), used in copy_outputs_to_blocks()
+    std::unordered_map<std::string, OutputKVInfo> m_output_kv_info;
 
     // Zero-copy prefill output state
     std::unordered_map<std::string, ov::SoPtr<ov::ITensor>> m_prefill_original_output_tensors;

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.hpp
@@ -1,0 +1,295 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "kv_cache_block_manager.hpp"
+#include "openvino/runtime/iasync_infer_request.hpp"
+#include "openvino/runtime/itensor.hpp"
+#include "openvino/runtime/so_ptr.hpp"
+
+// Forward declaration
+namespace ov {
+namespace npuw {
+class LLMCompiledModel;
+}
+}  // namespace ov
+
+namespace ov {
+namespace npuw {
+
+// Helper for block binding: determines whether a block uses zero-copy numbered binding
+// or copy-based tail binding, and stores the pre-parsed input ports for fast access.
+struct BlockBindingHelper {
+    uint32_t block_size;  ///< Tokens per block (e.g., 1024)
+
+    std::vector<ov::Output<const ov::Node>> numbered_input_ports;  ///< block_0, block_1, …
+    std::optional<ov::Output<const ov::Node>> tail_input_port;     ///< block_tail (nullopt if absent)
+
+    static BlockBindingHelper from_ports(std::vector<ov::Output<const ov::Node>> numbered_ports,
+                                         std::optional<ov::Output<const ov::Node>> tail_port,
+                                         uint32_t block_size_param) {
+        BlockBindingHelper helper;
+        helper.block_size = block_size_param;
+        helper.numbered_input_ports = std::move(numbered_ports);
+        helper.tail_input_port = std::move(tail_port);
+        return helper;
+    }
+
+    bool has_tail_input() const {
+        return tail_input_port.has_value();
+    }
+
+    // Returns true when block_idx is beyond the numbered range and should use the tail port.
+    // Callers may unconditionally dereference tail_input_port.value() when this returns true.
+    bool should_treat_as_tail(uint32_t block_idx) const {
+        return has_tail_input() && block_idx >= numbered_input_ports.size();
+    }
+
+    uint32_t get_block_index_for_position(uint32_t token_position) const {
+        return token_position / block_size;
+    }
+};
+
+/**
+ * @brief Encapsulates all block-based KV cache logic for LLMInferRequest.
+ *
+ * This class is a value member of LLMInferRequest (like Eagle3Extension), keeping the
+ * block-KV-cache feature cleanly decoupled from the main inference flow.
+ *
+ * Lifecycle:
+ *   1. initialize() - detects block format, sets up managers and pre-computed helpers
+ *   2. reset()      - called at the start of each new conversation
+ *   3. load_past_kv_blocks_to_prefill / redirect_prefill_outputs_to_new_blocks / restore_prefill_output_buffers - per
+ * prefill chunk
+ *   4. init_generate_kv_block_bindings - called once on the first generate step
+ *   5. update_generate_bindings - called after every generate inference
+ */
+class BlockKVCacheExtension {
+public:
+    // Reuse the PortsMap type alias from the base class for consistency
+    using PortsMap = std::unordered_map<std::string, ov::Output<const ov::Node>>;
+
+    // Pre-computed binding helpers for one layer (key + value)
+    struct LayerBlockBindingHelpers {
+        BlockBindingHelper key_helper;
+        BlockBindingHelper value_helper;
+    };
+
+    BlockKVCacheExtension() = default;
+
+    // -------------------------------------------------------------------------
+    // Initialization
+    // -------------------------------------------------------------------------
+
+    /**
+     * @brief Detect block-based KV cache layout and set up all managers / helpers.
+     *
+     * Must be called once in LLMInferRequest constructor after prefill/generate requests
+     * and port maps are ready.
+     *
+     * @return true if block-based KV cache was detected and initialized.
+     */
+    bool initialize(const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+                    const std::vector<std::shared_ptr<ov::IAsyncInferRequest>>& generate_requests,
+                    const PortsMap& prefill_in_ports,
+                    const PortsMap& prefill_out_ports,
+                    const std::unordered_map<std::shared_ptr<ov::IAsyncInferRequest>, PortsMap>& gen_variant_in_ports,
+                    const std::string& device,
+                    const std::shared_ptr<LLMCompiledModel>& compiled_model);
+
+    // -------------------------------------------------------------------------
+    // State queries
+    // -------------------------------------------------------------------------
+
+    bool is_enabled() const {
+        return m_enabled;
+    }
+
+    bool is_empty() const {
+        return m_kv_cache_block_managers.empty();
+    }
+
+    uint32_t get_block_size() const;
+
+    // -------------------------------------------------------------------------
+    // Conversation boundary
+    // -------------------------------------------------------------------------
+
+    /**
+     * @brief Clear all block managers, called at the start of each new conversation.
+     */
+    void reset();
+
+    // -------------------------------------------------------------------------
+    // Prefill path
+    // -------------------------------------------------------------------------
+
+    /**
+     * @brief Load previously-computed KV blocks into prefill model inputs.
+     *
+     * Called before each prefill chunk inference so the model can read past KV cache.
+     */
+    void load_past_kv_blocks_to_prefill(const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+                                        const PortsMap& prefill_in_ports);
+
+    /**
+     * @brief Redirect prefill output ports to fresh blocks before inference (zero-copy optimisation).
+     *
+     * Call BEFORE prefill inference when the chunk is block-aligned.
+     * Model will write directly into blocks — no post-inference copy is needed.
+     *
+     * @param num_new_tokens Tokens that will be written by this inference pass.
+     * @return true if redirect was applied (block-aligned); call restore_prefill_output_buffers()
+     *         before inference when this returns false.
+     */
+    bool redirect_prefill_outputs_to_new_blocks(const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+                                                const PortsMap& prefill_out_ports,
+                                                uint32_t num_new_tokens);
+
+    bool prefill_outputs_redirected() const {
+        return m_prefill_outputs_redirected;
+    }
+
+    /**
+     * @brief Restore original output buffers when zero-copy cannot be used.
+     *
+     * Must be called before non-aligned prefill chunks to prevent block corruption.
+     */
+    void restore_prefill_output_buffers(const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+                                        const PortsMap& prefill_out_ports);
+
+    // -------------------------------------------------------------------------
+    // Generate path
+    // -------------------------------------------------------------------------
+
+    /**
+     * @brief Perform initial block→input binding for the first generate step.
+     *
+     * Called once per conversation when m_generate_initialized is false.
+     * Numbered blocks get zero-copy binding; tail blocks are copied in.
+     *
+     * @param num_stored_tokens Total tokens in KV cache at call time.
+     */
+    void init_generate_kv_block_bindings(const std::shared_ptr<ov::IAsyncInferRequest>& kvcache_request,
+                                         const PortsMap& kvcache_in_ports,
+                                         uint32_t num_stored_tokens);
+
+    /**
+     * @brief Copy prefill outputs into blocks after inference (zero-copy fallback).
+     *
+     * Called when the zero-copy path was not applicable — specifically when kv_position
+     * is not block-aligned (kv_position % block_size != 0, e.g. not enough tokens to fill a block in the last chunk).
+     * Reads present.N.key/value outputs and copies tokens into the block managers
+     * starting at kv_position.
+     *
+     * @param kv_position  kvcache_desc.num_stored_tokens value BEFORE this chunk was inferred.
+     */
+    void copy_prefill_outputs_to_blocks(const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+                                        const PortsMap& prefill_out_ports,
+                                        uint32_t num_tokens,
+                                        bool v_transposed,
+                                        uint32_t kv_position);
+
+    /**
+     * @brief Copy generate output into the current (partial) block, then re-bind inputs.
+     *
+     * Combines the two post-generate steps into one call:
+     *   1. copy_outputs_to_blocks() — writes the newly generated token(s) into block storage.
+     *   2. update_generate_bindings() — re-binds model inputs if a block transition occurred.
+     *
+     * @param old_num_tokens  kvcache_desc.num_stored_tokens BEFORE this generate step.
+     * @param new_num_tokens  kvcache_desc.num_stored_tokens AFTER this generate step.
+     * @param input_tokens_len  Number of tokens actually generated (usually 1).
+     */
+    void commit_generate_kv_and_rebind(uint32_t old_num_tokens,
+                                       uint32_t new_num_tokens,
+                                       uint32_t input_tokens_len,
+                                       const std::shared_ptr<ov::IAsyncInferRequest>& kvcache_request,
+                                       const PortsMap& kvcache_out_ports,
+                                       const PortsMap& kvcache_in_ports);
+
+private:
+    // -------------------------------------------------------------------------
+    // Private helper structs (used only during initialize())
+    // -------------------------------------------------------------------------
+
+    struct BlockShapeInfo {
+        ov::Shape key_shape;
+        ov::Shape value_shape;
+        ov::element::Type elem_type;
+        bool found_key = false;
+        bool found_value = false;
+    };
+
+    struct DummyTensors {
+        ov::SoPtr<ov::ITensor> key_tensor;
+        ov::SoPtr<ov::ITensor> value_tensor;
+    };
+
+    // layer_idx → {key_block_names, value_block_names}
+    using LayerBlockNames = std::unordered_map<uint32_t, std::pair<std::vector<std::string>, std::vector<std::string>>>;
+
+    // -------------------------------------------------------------------------
+    // Initialization helpers (called once from initialize())
+    // -------------------------------------------------------------------------
+
+    BlockShapeInfo find_block_shapes(const PortsMap& prefill_in_ports) const;
+    DummyTensors allocate_dummy_block_tensors(const BlockShapeInfo& shapes) const;
+    void set_dummy_tensors_to_all_requests(
+        const DummyTensors& dummies,
+        const std::shared_ptr<ov::IAsyncInferRequest>& prefill_request,
+        const std::vector<std::shared_ptr<ov::IAsyncInferRequest>>& generate_requests,
+        const PortsMap& prefill_in_ports,
+        const std::unordered_map<std::shared_ptr<ov::IAsyncInferRequest>, PortsMap>& gen_variant_in_ports);
+    LayerBlockNames parse_block_inputs_structure(const PortsMap& prefill_in_ports) const;
+    void create_block_managers_and_helpers(
+        const LayerBlockNames& layer_blocks,
+        const PortsMap& prefill_in_ports,
+        const std::vector<std::shared_ptr<ov::IAsyncInferRequest>>& generate_requests,
+        const std::unordered_map<std::shared_ptr<ov::IAsyncInferRequest>, PortsMap>& gen_variant_in_ports);
+
+    // Core KV copy engine shared by both prefill and generate copy-paths.
+    // Reads present.N.key/value outputs from request and writes tokens into block_managers
+    // starting at current_kv_position.
+    void copy_outputs_to_blocks(const std::shared_ptr<ov::IAsyncInferRequest>& request,
+                                const PortsMap& src_ports,
+                                uint32_t num_tokens,
+                                bool v_transposed,
+                                uint32_t current_kv_position);
+
+    // Re-bind model inputs after a generate step (called by commit_generate_kv_and_rebind).
+    void update_generate_bindings(uint32_t old_num_tokens,
+                                  uint32_t new_num_tokens,
+                                  const std::shared_ptr<ov::IAsyncInferRequest>& kvcache_request,
+                                  const PortsMap& kvcache_in_ports);
+
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    bool m_enabled = false;
+    std::shared_ptr<LLMCompiledModel> m_compiled_model;
+    std::string m_device;
+
+    // Block managers: layer_idx → {key_manager, value_manager}
+    std::unordered_map<uint32_t, KVCacheBlockManager::LayerBlockManagers> m_kv_cache_block_managers;
+
+    // Pre-computed binding helpers: variant_request → layer_idx → {key_helper, value_helper}
+    std::unordered_map<std::shared_ptr<ov::IAsyncInferRequest>, std::unordered_map<uint32_t, LayerBlockBindingHelpers>>
+        m_variant_block_binding_helpers;
+
+    // Zero-copy prefill output state
+    std::unordered_map<std::string, ov::SoPtr<ov::ITensor>> m_prefill_original_output_tensors;
+    bool m_prefill_outputs_redirected = false;
+};
+
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -39,6 +39,7 @@
 #include "partitioning/patterns/pre_compute.hpp"
 #include "partitioning/patterns/sdpa.hpp"
 #include "serialization.hpp"
+#include "split_kvcache_into_blocks.hpp"
 #include "transformations/convert_precision.hpp"
 #include "util.hpp"
 #include "whisper/prepare_whisper_model.hpp"
@@ -1046,6 +1047,37 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
         }
     }
 
+    // Apply block-based KV cache transformation for chunk prefill after ShapeOfParameter
+    // This ensures ShapeOf nodes are already regularized before transformation
+    // Only support HFA for now, but PYRAMID can be supported as well with some extra work
+    // TODO: support block-based KV cache for PYRAMID attention
+    if (m_cfg.get<::intel_npu::NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE>() && m_use_chunk_prefill && !m_is_embedding &&
+        prefill_attn_hfa) {
+        const uint32_t block_size = static_cast<uint32_t>(m_prefill_chunk_size);
+
+        LOG_DEBUG("Applying SplitKVCacheIntoBlocks (block_size=" << block_size << ")");
+        LOG_BLOCK();
+
+        auto apply_block_kv_transform =
+            [&](std::shared_ptr<ov::Model>& model, bool v_transposed, const std::string& tag) {
+                ov::pass::Manager mgr(tag);
+                mgr.register_pass<ov::npuw::pass::SplitKVCacheIntoBlocks>(block_size, v_transposed);
+                if (mgr.run_passes(model)) {
+                    LOG_INFO("SplitKVCacheIntoBlocks applied: " << tag);
+                } else {
+                    LOG_WARN("SplitKVCacheIntoBlocks had no effect: " << tag);
+                }
+            };
+
+        apply_block_kv_transform(prefill_model, m_kvcache_desc.v_tensors_transposed_pre, "prefill");
+
+        for (size_t i = 0; i < generate_model_variants.size(); ++i) {
+            apply_block_kv_transform(generate_model_variants[i],
+                                     m_kvcache_desc.v_tensors_transposed_gen,
+                                     "generate_" + std::to_string(i));
+        }
+    }
+
     // Compile multiple generate model variants with different sizes
     compile_generate_model_variants(generate_model_variants, plugin, generate_config);
 
@@ -1523,6 +1555,7 @@ void ov::npuw::LLMCompiledModel::implement_properties() {
                           BIND(npuw::llm::optimize_v_tensors, NPUW_LLM_OPTIMIZE_V_TENSORS, get),
                           BIND(npuw::llm::optimize_fp8, NPUW_LLM_OPTIMIZE_FP8, get),
                           BIND(npuw::llm::cache_rope, NPUW_LLM_CACHE_ROPE, get),
+                          BIND(npuw::llm::enable_block_based_kv_cache, NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE, get),
                           BIND(npuw::llm::prefill_moe_hint, NPUW_LLM_PREFILL_MOE_HINT, get),
                           BIND(npuw::llm::generate_moe_hint, NPUW_LLM_GENERATE_MOE_HINT, get),
                           BIND(npuw::llm::generate_pyramid, NPUW_LLM_GENERATE_PYRAMID, get),

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -1049,10 +1049,8 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
 
     // Apply block-based KV cache transformation for chunk prefill after ShapeOfParameter
     // This ensures ShapeOf nodes are already regularized before transformation
-    // Only support HFA for now, but PYRAMID can be supported as well with some extra work
-    // TODO: support block-based KV cache for PYRAMID attention
     if (m_cfg.get<::intel_npu::NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE>() && m_use_chunk_prefill && !m_is_embedding &&
-        prefill_attn_hfa) {
+        (prefill_attn_hfa || prefill_attn_pyramid)) {
         const uint32_t block_size = static_cast<uint32_t>(m_prefill_chunk_size);
 
         LOG_DEBUG("Applying SplitKVCacheIntoBlocks (block_size=" << block_size << ")");

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -14,6 +14,7 @@ namespace npuw {
 
 class LLMInferRequest;
 class WhisperInferRequest;
+class BlockKVCacheExtension;
 struct PrefixCacheRestorationContext;
 class LLMCompiledModel : public ov::npuw::ICompiledModel {
     using GetPropertiesMap =
@@ -75,6 +76,7 @@ private:
     friend class LLMInferRequest;
     friend class WhisperInferRequest;
     friend class EmbeddingInferRequest;
+    friend class BlockKVCacheExtension;
 
     std::shared_ptr<ov::ISyncInferRequest> create_llm_infer_request();
     std::shared_ptr<ov::ISyncInferRequest> create_whisper_infer_request();

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -154,8 +154,17 @@ ov::npuw::LLMInferRequest::LLMInferRequest(const std::shared_ptr<ov::npuw::LLMCo
 
     m_eagle3_ext.initialize(m_npuw_llm_compiled_model->m_is_eagle, m_prefill_in_ports, m_prefill_out_ports);
 
+    // Initialize multi-block KV cache managers if needed
+    m_block_kvcache_ext.initialize(m_prefill_request,
+                                   m_generate_requests,
+                                   m_prefill_in_ports,
+                                   m_prefill_out_ports,
+                                   m_generate_variant_in_ports,
+                                   m_pre_alloc_device,
+                                   m_npuw_llm_compiled_model);
+
     const bool use_chunk_prefill = m_npuw_llm_compiled_model->m_use_chunk_prefill;
-    if (use_chunk_prefill) {
+    if (use_chunk_prefill && !m_block_kvcache_ext.is_enabled()) {
         // FIXME: enable w/o chunking as well. Although need to align the paddings beforehand
         bind_past_kv();
         clear_chunk_prefill_kv_cache();
@@ -277,65 +286,103 @@ void ov::npuw::LLMInferRequest::create_generate_request_variants(
     // Create multiple generate model variants' requests
     m_generate_requests.reserve(compiled_model->m_generate_compiled_variants.size());
 
-    // First, create the largest variant request (last one in the list)
-    auto largest_generate_request = compiled_model->m_generate_compiled_variants.back()->create_infer_request();
+    const bool is_block_based_kvcache = compiled_model->m_cfg.get<::intel_npu::NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE>();
 
-    // Store past KV tensors from the largest variant for sharing
-    std::unordered_map<std::string, ov::SoPtr<ov::ITensor>> largest_past_kv_tensors;
-    for (const auto& input_port : largest_generate_request->get_compiled_model()->inputs()) {
-        const auto& input_name = input_port.get_any_name();
-        if (input_name.find(layer_names::past_key_values) != std::string::npos) {
-            largest_past_kv_tensors[input_name] = largest_generate_request->get_tensor(input_port);
-        }
-    }
+    if (is_block_based_kvcache) {
+        // ========================================================================
+        // Block-based KV Cache Mode: No buffer pre-allocation needed
+        // ========================================================================
+        // In block mode, KV cache blocks are dynamically allocated by BlockManager
+        // and bound to model inputs via init_generate_kv_block_bindings()
+        // before the first generate inference. No need to pre-allocate large continuous buffers.
+        // ========================================================================
 
-    // Create all variant requests and share past KV tensors
-    for (size_t i = 0; i < compiled_model->m_generate_compiled_variants.size(); ++i) {
-        std::shared_ptr<ov::IAsyncInferRequest> generate_request;
+        for (size_t i = 0; i < compiled_model->m_generate_compiled_variants.size(); ++i) {
+            auto generate_request = compiled_model->m_generate_compiled_variants[i]->create_infer_request();
+            m_generate_requests.push_back(generate_request);
 
-        if (i == compiled_model->m_generate_compiled_variants.size() - 1) {
-            // Use the already created largest variant
-            generate_request = largest_generate_request;
-        } else {
-            // Create smaller variant
-            generate_request = compiled_model->m_generate_compiled_variants[i]->create_infer_request();
+            // Build input/output ports mapping for this variant
+            std::unordered_map<std::string, ov::Output<const ov::Node>> variant_in_ports;
+            std::unordered_map<std::string, ov::Output<const ov::Node>> variant_out_ports;
 
-            // Share past KV tensors from the largest variant
             for (const auto& input_port : generate_request->get_compiled_model()->inputs()) {
-                const auto& input_name = input_port.get_any_name();
-                if (input_name.find(layer_names::past_key_values) != std::string::npos) {
-                    if (largest_past_kv_tensors.find(input_name) != largest_past_kv_tensors.end()) {
-                        auto largest_tensor = largest_past_kv_tensors[input_name];
-                        auto small_shape = input_port.get_shape();
+                variant_in_ports.emplace(input_port.get_any_name(), input_port);
+            }
+            for (const auto& output_port : generate_request->get_compiled_model()->outputs()) {
+                variant_out_ports.emplace(output_port.get_any_name(), output_port);
+            }
 
-                        // Wrap the largest tensor's data pointer with smaller shape
-                        auto shared_tensor = ov::SoPtr<ov::ITensor>(
-                            ov::make_tensor(input_port.get_element_type(), small_shape, largest_tensor->data()),
-                            nullptr);
+            m_generate_variant_in_ports.emplace(generate_request, std::move(variant_in_ports));
+            m_generate_variant_out_ports.emplace(generate_request, std::move(variant_out_ports));
+        }
+    } else {
+        // ========================================================================
+        // Legacy Continuous Buffer Mode: Pre-allocate and share KV buffer
+        // ========================================================================
+        // For non-block mode, create the largest variant first and share its
+        // KV buffer with smaller variants to save memory.
+        // ========================================================================
 
-                        generate_request->set_tensor(input_port, shared_tensor);
-                    } else {
-                        OPENVINO_ASSERT(false, "Unexpected input name: ", input_name);
-                    }
-                }
+        // First, create the largest variant request (last one in the list)
+        auto largest_generate_request = compiled_model->m_generate_compiled_variants.back()->create_infer_request();
+
+        // Store past KV tensors from the largest variant for sharing
+        std::unordered_map<std::string, ov::SoPtr<ov::ITensor>> largest_past_kv_tensors;
+        for (const auto& input_port : largest_generate_request->get_compiled_model()->inputs()) {
+            const auto& input_name = input_port.get_any_name();
+            if (input_name.find(layer_names::past_key_values) != std::string::npos) {
+                largest_past_kv_tensors[input_name] = largest_generate_request->get_tensor(input_port);
             }
         }
 
-        m_generate_requests.push_back(generate_request);
+        // Create all variant requests and share past KV tensors
+        for (size_t i = 0; i < compiled_model->m_generate_compiled_variants.size(); ++i) {
+            std::shared_ptr<ov::IAsyncInferRequest> generate_request;
 
-        // Build input/output ports mapping for this variant
-        std::unordered_map<std::string, ov::Output<const ov::Node>> variant_in_ports;
-        std::unordered_map<std::string, ov::Output<const ov::Node>> variant_out_ports;
+            if (i == compiled_model->m_generate_compiled_variants.size() - 1) {
+                // Use the already created largest variant
+                generate_request = largest_generate_request;
+            } else {
+                // Create smaller variant
+                generate_request = compiled_model->m_generate_compiled_variants[i]->create_infer_request();
 
-        for (const auto& input_port : generate_request->get_compiled_model()->inputs()) {
-            variant_in_ports.emplace(input_port.get_any_name(), input_port);
+                // Share past KV tensors from the largest variant
+                for (const auto& input_port : generate_request->get_compiled_model()->inputs()) {
+                    const auto& input_name = input_port.get_any_name();
+                    if (input_name.find(layer_names::past_key_values) != std::string::npos) {
+                        if (largest_past_kv_tensors.find(input_name) != largest_past_kv_tensors.end()) {
+                            auto largest_tensor = largest_past_kv_tensors[input_name];
+                            auto small_shape = input_port.get_shape();
+
+                            // Wrap the largest tensor's data pointer with smaller shape
+                            auto shared_tensor = ov::SoPtr<ov::ITensor>(
+                                ov::make_tensor(input_port.get_element_type(), small_shape, largest_tensor->data()),
+                                nullptr);
+
+                            generate_request->set_tensor(input_port, shared_tensor);
+                        } else {
+                            OPENVINO_ASSERT(false, "Unexpected input name: ", input_name);
+                        }
+                    }
+                }
+            }
+
+            m_generate_requests.push_back(generate_request);
+
+            // Build input/output ports mapping for this variant
+            std::unordered_map<std::string, ov::Output<const ov::Node>> variant_in_ports;
+            std::unordered_map<std::string, ov::Output<const ov::Node>> variant_out_ports;
+
+            for (const auto& input_port : generate_request->get_compiled_model()->inputs()) {
+                variant_in_ports.emplace(input_port.get_any_name(), input_port);
+            }
+            for (const auto& output_port : generate_request->get_compiled_model()->outputs()) {
+                variant_out_ports.emplace(output_port.get_any_name(), output_port);
+            }
+
+            m_generate_variant_in_ports.emplace(generate_request, std::move(variant_in_ports));
+            m_generate_variant_out_ports.emplace(generate_request, std::move(variant_out_ports));
         }
-        for (const auto& output_port : generate_request->get_compiled_model()->outputs()) {
-            variant_out_ports.emplace(output_port.get_any_name(), output_port);
-        }
-
-        m_generate_variant_in_ports.emplace(generate_request, std::move(variant_in_ports));
-        m_generate_variant_out_ports.emplace(generate_request, std::move(variant_out_ports));
     }
 
     // Set default to the largest variant for backward compatibility
@@ -481,6 +528,11 @@ void ov::npuw::LLMInferRequest::prepare_for_new_conversation(int64_t prompt_leng
     }
 
     m_npuw_llm_compiled_model->m_kvcache_desc.num_stored_tokens = 0u;
+
+    // Clear all blocks for new conversation
+    if (m_block_kvcache_ext.is_enabled()) {
+        m_block_kvcache_ext.reset();
+    }
 
     // Select the appropriate generate inference request variant based on prompt length
     // The function internally calculates expected total tokens (prompt + min_response_len)
@@ -726,6 +778,34 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
             m_prefill_base_request->update_history_size(kvcache_desc.num_stored_tokens);
         });
 
+        // Load previously-computed KV blocks into prefill model inputs before inference.
+        // This ensures the model reads from past KV cache in subsequent chunks.
+        if (m_block_kvcache_ext.is_enabled()) {
+            m_block_kvcache_ext.load_past_kv_blocks_to_prefill(m_prefill_request, m_prefill_in_ports);
+        }
+
+        // Zero-copy optimization: pre-allocate blocks and bind output tensors to them BEFORE inference,
+        // so the model writes KV cache directly into block memory with no post-inference copy.
+        //
+        // Constraint: only valid when the chunk is block-aligned (current_prompts_len % block_size == 0).
+        // Prefill uses left-padding, so a non-aligned chunk would write padding data into the block.
+        // In that case we restore the original output buffers and fall back to the copy path.
+        if (m_block_kvcache_ext.is_enabled()) {
+            uint32_t block_size = m_block_kvcache_ext.get_block_size();
+            if (current_prompts_len % block_size == 0) {
+                // Zero-copy path: redirect outputs directly to new blocks before infer()
+                m_block_kvcache_ext.redirect_prefill_outputs_to_new_blocks(m_prefill_request,
+                                                                           m_prefill_out_ports,
+                                                                           static_cast<uint32_t>(current_prompts_len));
+            } else {
+                LOG_DEBUG("Chunk not block-aligned (" << current_prompts_len << " % " << block_size
+                                                      << " != 0), falling back to copy path");
+                // CRITICAL: restore original output buffers so the model does not write into
+                // blocks that were redirected by a previous zero-copy chunk.
+                m_block_kvcache_ext.restore_prefill_output_buffers(m_prefill_request, m_prefill_out_ports);
+            }
+        }
+
         m_llm_profile["1/prefill:3b.infer"].record([&]() {
             m_prefill_request->infer();
         });
@@ -746,6 +826,24 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
             }
         });
 
+        // Update KV cache blocks after inference
+        if (m_block_kvcache_ext.is_enabled()) {
+            if (m_block_kvcache_ext.prefill_outputs_redirected()) {
+                // Zero-copy path: model wrote KV cache directly into blocks during infer().
+                // redirect_prefill_outputs_to_new_blocks() already pre-allocated blocks,
+                // redirected output tensors, and updated block metadata — nothing left to do.
+                LOG_DEBUG("Zero-copy prefill complete - no post-inference work needed");
+            } else {
+                // Copy path: copy from the model's output buffer into blocks.
+                uint32_t kv_position_before = kvcache_desc.num_stored_tokens;
+                m_block_kvcache_ext.copy_prefill_outputs_to_blocks(m_prefill_request,
+                                                                   m_prefill_out_ports,
+                                                                   static_cast<uint32_t>(current_prompts_len),
+                                                                   kvcache_desc.v_tensors_transposed_pre,
+                                                                   kv_position_before);
+            }
+        }
+
         remaining_prompts -= current_prompts_len;
         kvcache_desc.num_stored_tokens += static_cast<uint32_t>(current_prompts_len);
 
@@ -758,11 +856,13 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
 
         m_llm_profile["1/prefill:3d.update_kvcache"].record([&]() {
             // Copy calculated key/values chunk from present k/v layer to past k/v layer for storage
-            update_kvcache_for(m_prefill_request,
-                               m_prefill_in_ports,
-                               m_prefill_out_ports,
-                               static_cast<uint32_t>(current_prompts_len),
-                               kvcache_desc.v_tensors_transposed_pre);
+            if (!m_block_kvcache_ext.is_enabled()) {
+                update_kvcache_for(m_prefill_request,
+                                   m_prefill_in_ports,
+                                   m_prefill_out_ports,
+                                   static_cast<uint32_t>(current_prompts_len),
+                                   kvcache_desc.v_tensors_transposed_pre);
+            }
 
             // Update attention mask for the next iteration
             std::copy_n(attn_mask_in_tensor->data<int64_t>() + attn_mask_in_tensor->get_size() - current_prompts_len,
@@ -902,9 +1002,19 @@ void ov::npuw::LLMInferRequest::infer_generate(ov::SoPtr<ov::ITensor> input_ids,
     // prepare_for_new_conversation()
     m_llm_profile["N/generate:1.prepare"].record([&]() {
         if (!m_generate_initialized) {
-            LOG_DEBUG("Copy kv-cache from prefill to generate model.");
+            LOG_DEBUG("First generate call - initialize inputs.");
+
             if (kvcache_desc.num_stored_tokens > 0) {
-                copy_kvcache();
+                if (!m_block_kvcache_ext.is_enabled()) {
+                    // For non-block mode, copy KV cache from prefill to generate's continuous buffer
+                    copy_kvcache();
+                } else {
+                    // For block mode, perform initial binding of blocks to model inputs
+                    // This establishes zero-copy binding for numbered blocks and copies tail blocks
+                    m_block_kvcache_ext.init_generate_kv_block_bindings(m_kvcache_request,
+                                                                        m_kvcache_in_ports,
+                                                                        kvcache_desc.num_stored_tokens);
+                }
             }
 
             LOG_DEBUG("Prepare inputs.");
@@ -970,22 +1080,39 @@ void ov::npuw::LLMInferRequest::infer_generate(ov::SoPtr<ov::ITensor> input_ids,
         }
     });
 
+    uint32_t tokens_before_infer = kvcache_desc.num_stored_tokens;
+
     m_llm_profile["N/generate:2.infer"].record([&]() {
         m_kvcache_request->infer();
     });
     kvcache_desc.num_stored_tokens += input_tokens_len;
 
+    auto post_infer = [&]() {
+        if (kvcache_desc.num_stored_tokens >= kvcache_desc.total_size) {
+            return;
+        }
+        if (m_block_kvcache_ext.is_enabled()) {
+            m_block_kvcache_ext.commit_generate_kv_and_rebind(tokens_before_infer,
+                                                              kvcache_desc.num_stored_tokens,
+                                                              input_tokens_len,
+                                                              m_kvcache_request,
+                                                              m_kvcache_out_ports,
+                                                              m_kvcache_in_ports);
+        } else {
+            // Legacy non-block mode
+            update_kvcache_for(m_kvcache_request,
+                               m_kvcache_in_ports,
+                               m_kvcache_out_ports,
+                               input_tokens_len,
+                               kvcache_desc.v_tensors_transposed_gen);
+        }
+    };
+
     if (m_lm_head_request) {
         LOG_DEBUG("Calling inference for LM head model asynchronously");
         m_lm_head_request->start_async();
         m_llm_profile["N/generate:3.update_kvcache"].record([&]() {
-            if (kvcache_desc.num_stored_tokens < kvcache_desc.total_size) {
-                update_kvcache_for(m_kvcache_request,
-                                   m_kvcache_in_ports,
-                                   m_kvcache_out_ports,
-                                   input_tokens_len,
-                                   kvcache_desc.v_tensors_transposed_gen);
-            }
+            post_infer();
         });
         m_llm_profile["N/generate:4.lm_head"].record([&]() {
             m_lm_head_request->wait();
@@ -995,13 +1122,7 @@ void ov::npuw::LLMInferRequest::infer_generate(ov::SoPtr<ov::ITensor> input_ids,
         });
     } else {
         m_llm_profile["N/generate:3.update_kvcache"].record([&]() {
-            if (kvcache_desc.num_stored_tokens < kvcache_desc.total_size) {
-                update_kvcache_for(m_kvcache_request,
-                                   m_kvcache_in_ports,
-                                   m_kvcache_out_ports,
-                                   input_tokens_len,
-                                   kvcache_desc.v_tensors_transposed_gen);
-            }
+            post_infer();
         });
 
         m_logits = m_kvcache_request->get_tensor(m_kvcache_out_ports.at(layer_names::logits));

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -149,7 +149,7 @@ ov::npuw::LLMInferRequest::LLMInferRequest(const std::shared_ptr<ov::npuw::LLMCo
         m_prefill_out_ports.emplace(output_port.get_any_name(), output_port);
     }
 
-    init_pre_alloc_device();
+    m_pre_alloc_device = init_pre_alloc_device();
     init_lora_states();
 
     m_eagle3_ext.initialize(m_npuw_llm_compiled_model->m_is_eagle, m_prefill_in_ports, m_prefill_out_ports);

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "base_sync_infer_request.hpp"
+#include "llm_block_kvcache_extension.hpp"
 #include "llm_compiled_model.hpp"
 #include "llm_eagle3_extension.hpp"
 #include "llm_infer_base_request.hpp"
@@ -127,6 +128,9 @@ protected:
     // LLM-level profiling for 1st token generation analysis
     using MS = ov::npuw::perf::metric<ov::npuw::perf::MSec>;
     ov::npuw::perf::Profile<MS> m_llm_profile;
+
+    // Support multi-block KV cache (all logic encapsulated in extension)
+    BlockKVCacheExtension m_block_kvcache_ext;
 
     // Friend declarations for PrefixCachingHelper to access protected members
     friend class PrefixCachingHelper;

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
@@ -425,12 +425,13 @@ void Group::setRepeated(const std::shared_ptr<Repeated>& rep) {
 PairMICSetIO Group::metaInterconnect(const Group::GPtr& gptr_prod) const {
     MICSet mics;
 
+    auto locked_snapshot = m_snapshot.lock();
     auto ics = interconnect(gptr_prod);
     for (const auto& ic : ics) {
-        mics.insert({ov::npuw::online::util::getMetaDesc(ic.input_node),
+        mics.insert({locked_snapshot->getMetaDesc(ic.input_node),
                      gptr_prod->m_reptrack.at(ic.input_node),
                      ic.input_port,
-                     ov::npuw::online::util::getMetaDesc(ic.output_node),
+                     locked_snapshot->getMetaDesc(ic.output_node),
                      m_reptrack.at(ic.output_node),
                      ic.output_port});
     }
@@ -441,10 +442,10 @@ PairMICSetIO Group::metaInterconnect(const Group::GPtr& gptr_prod) const {
     if (!m_mic_io_valid) {
         m_cached_mic_io = MetaInterconnectIO{};
         for (const auto& oi : m_input_layers) {
-            m_cached_mic_io.output_imeta.insert(ov::npuw::online::util::getMetaDesc(oi));
+            m_cached_mic_io.output_imeta.insert(locked_snapshot->getMetaDesc(oi));
         }
         for (const auto& oo : m_output_layers) {
-            m_cached_mic_io.output_ometa.insert(ov::npuw::online::util::getMetaDesc(oo));
+            m_cached_mic_io.output_ometa.insert(locked_snapshot->getMetaDesc(oo));
         }
         m_mic_io_valid = true;
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
@@ -145,10 +145,12 @@ const std::unordered_set<std::shared_ptr<ov::Node>>& Group::getOutputs() const {
 
 void Group::addInput(const std::shared_ptr<ov::Node>& node) {
     m_input_layers.insert(node);
+    m_mic_io_valid = false;
 }
 
 void Group::addOutput(const std::shared_ptr<ov::Node>& node) {
     m_output_layers.insert(node);
+    m_mic_io_valid = false;
 }
 
 void Group::addContent(const std::shared_ptr<ov::Node>& node) {
@@ -173,6 +175,7 @@ own::ade::NodeHandle Group::getHandle() const {
 
 // Not every input should be included - those layers which contained inside merging group are not inputs anymore
 void Group::updateInputLayers(const Group::GPtr& gptr_other) {
+    m_mic_io_valid = false;
     detail::OVNodeSet combined_input;
     combined_input.insert(m_input_layers.begin(), m_input_layers.end());
     combined_input.insert(gptr_other->m_input_layers.begin(), gptr_other->m_input_layers.end());
@@ -199,6 +202,7 @@ void Group::updateInputLayers(const Group::GPtr& gptr_other) {
 // Not every output should be included - those layers which are consumed _ONLY_ by the merged group are not outputs
 // anymore
 void Group::updateOutputLayers(const Group::GPtr& gptr_other) {
+    m_mic_io_valid = false;
     detail::OVNodeSet combined_output;
     combined_output.insert(m_output_layers.begin(), m_output_layers.end());
     combined_output.insert(gptr_other->m_output_layers.begin(), gptr_other->m_output_layers.end());
@@ -333,21 +337,26 @@ void Group::takeFlags(const Group::GPtr& gptr_other) {
 
 // Check if there is indirect path from this to gptr_cons
 bool Group::hasCycle(const Group::GPtr& gptr_cons) const {
-    std::unordered_set<own::ade::NodeHandle> visited;
+    // Fast-path: if this group has at most 1 consumer, there is no alternative path
+    // to gptr_cons and therefore no cycle.
+    if (m_nh->dstNodes().size() <= 1) {
+        return false;
+    }
 
+    std::unordered_set<own::ade::NodeHandle> visited;
     std::stack<own::ade::NodeHandle> st;
 
     for (const auto& prod : gptr_cons->srcNodes()) {
         // skip self during this iter
         if (!(m_nh == prod)) {
             st.push(prod);
+            visited.insert(prod);  // mark at push time to avoid duplicate pushes
         }
     }
 
     while (!st.empty()) {
         auto nh = st.top();
         st.pop();
-        visited.insert(nh);
 
         if (nh == m_nh) {
             // Found another path from self to gptr_cons
@@ -355,8 +364,9 @@ bool Group::hasCycle(const Group::GPtr& gptr_cons) const {
         }
 
         for (const auto& prod : nh->srcNodes()) {
-            if (visited.find(prod) == visited.end()) {
+            if (!visited.count(prod)) {
                 st.push(prod);
+                visited.insert(prod);  // mark at push time
             }
         }
     }
@@ -425,23 +435,28 @@ PairMICSetIO Group::metaInterconnect(const Group::GPtr& gptr_prod) const {
                      ic.output_port});
     }
 
-    MetaInterconnectIO mic_io;
-    auto locked_snapshot = m_snapshot.lock();
-    for (const auto& oi : m_input_layers) {
-        mic_io.output_imeta.insert(ov::npuw::online::util::getMetaDesc(oi));
-    }
-    for (const auto& oo : m_output_layers) {
-        mic_io.output_ometa.insert(ov::npuw::online::util::getMetaDesc(oo));
+    // Cache the MetaInterconnectIO part — it only depends on m_input_layers /
+    // m_output_layers which are invalidated (m_mic_io_valid = false) whenever
+    // those sets change (addInput / addOutput / updateInputLayers / updateOutputLayers).
+    if (!m_mic_io_valid) {
+        m_cached_mic_io = MetaInterconnectIO{};
+        for (const auto& oi : m_input_layers) {
+            m_cached_mic_io.output_imeta.insert(ov::npuw::online::util::getMetaDesc(oi));
+        }
+        for (const auto& oo : m_output_layers) {
+            m_cached_mic_io.output_ometa.insert(ov::npuw::online::util::getMetaDesc(oo));
+        }
+        m_mic_io_valid = true;
     }
 
-    return {mics, mic_io};
+    return {mics, m_cached_mic_io};
 }
 
 std::unordered_set<Interconnect> Group::interconnect(const Group::GPtr& gptr_prod) const {
     std::unordered_set<Interconnect> ics;
 
     auto locked_snapshot = m_snapshot.lock();
-    auto ports_map = locked_snapshot->getPortsMap();
+    const auto& ports_map = locked_snapshot->getPortsMap();
 
     for (const auto& layer : m_content) {
         for (const auto& input_layer : locked_snapshot->getNodeProducers(layer)) {

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.hpp
@@ -11,6 +11,7 @@
 
 #include "graph.hpp"
 #include "openvino/openvino.hpp"
+#include "repeated.hpp"
 #include "utils/utils.hpp"
 
 namespace ov {
@@ -119,6 +120,11 @@ private:
     std::shared_ptr<Repeated> m_repeated = nullptr;
     // For each layer inside group, store it's history of repeated groups
     detail::ReptrackMap m_reptrack;
+
+    // Cache for the MetaInterconnectIO part of metaInterconnect().
+    // Invalidated whenever m_input_layers or m_output_layers change.
+    mutable bool m_mic_io_valid = false;
+    mutable MetaInterconnectIO m_cached_mic_io;
 };
 
 }  // namespace online

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
@@ -1014,6 +1014,28 @@ void Snapshot::mergeUniques() {
     LOG_INFO("Online partitioning: executing mergeUniques pass...");
     LOG_BLOCK();
 
+    // Pre-build a rep-tag → GPtrSet index to replace the O(V) scan inside
+    // getRepGroups(). Without this, getRepGroups() is called once per distinct rep
+    // tag and each call scans all V graph nodes → O(V × nRepTags) = O(V²) total.
+    // With small chunk sizes (many KV blocks → large V), this dominates compilation.
+    //
+    // Correctness: each rep tag is visited at most once (merged_this_time guard).
+    // During the loop, tryMergeRepeating() may:
+    //   - re-tag consumer groups (they get a new_rep) → stale entries in the index
+    //   - remove producer groups from the graph
+    // Both cases are handled by the staleness filter below (rep-tag and graph checks).
+    std::unordered_map<Repeated*, GPtrSet> rep_index;
+    for (const auto& nh_i : m_graph->sorted()) {
+        if (!m_graph->contains(nh_i)) {
+            continue;
+        }
+        const Group::GPtr& g = m_graph->meta(nh_i).get<Group::GPtr>();
+        const auto& rep_i = g->repeated();
+        if (rep_i && !g->isFrozen()) {
+            rep_index[rep_i.get()].insert(g);
+        }
+    }
+
     std::unordered_set<std::shared_ptr<Repeated>> merged_this_time;
 
     for (const auto& nh : m_graph->sorted()) {
@@ -1026,7 +1048,17 @@ void Snapshot::mergeUniques() {
         GPtrSet repeating_groups;
 
         if (rep && rep->openForMerge() && merged_this_time.count(rep) == 0) {
-            repeating_groups = getRepGroups(group);
+            // Use the prebuilt index (O(|rep_set|)) instead of the O(V) graph scan.
+            // Apply a staleness filter: a group's rep tag may have changed if it was
+            // merged in an earlier iteration of this same mergeUniques() call.
+            auto it = rep_index.find(rep.get());
+            if (it != rep_index.end()) {
+                for (const auto& g : it->second) {
+                    if (m_graph->contains(g->getHandle()) && g->repeated().get() == rep.get() && !g->isFrozen()) {
+                        repeating_groups.insert(g);
+                    }
+                }
+            }
         }
 
         if (!repeating_groups.empty()) {
@@ -1079,26 +1111,29 @@ std::shared_ptr<Repeated> Snapshot::tryGrowRepeatingGroups(const GPtrSet& repeat
             Group::GPtr prod_group = m_graph->meta(prod_nh).get<Group::GPtr>();
             LOG_DEBUG("prod_group:");
             prod_group->dump();
-            if (prod_group->repeated() && !prod_group->hasCycle(group) && prod_group->repeated() != this_rep_tag &&
-                prod_group->avoidedTargets() == this_avoided && prod_group->specialTags() == this_special) {
-                auto meta_interconnect = group->metaInterconnect(prod_group);
+            if (prod_group->repeated()) {
+                bool cycle = prod_group->hasCycle(group);
+                if (!cycle && prod_group->repeated() != this_rep_tag && prod_group->avoidedTargets() == this_avoided &&
+                    prod_group->specialTags() == this_special) {
+                    auto meta_interconnect = group->metaInterconnect(prod_group);
 
-                // FIXME: find a better way to reduce time complexity
-                // Need to align interconnects in the same format via sort, so they could be compared later
-                MICVec mic_sorted_key(meta_interconnect.first.begin(), meta_interconnect.first.end());
-                std::sort(mic_sorted_key.begin(), mic_sorted_key.end());
-                mics[{mic_sorted_key, meta_interconnect.second}].push_back({prod_group, group});
-                LOG_DEBUG("Add the pair to the merge vector!");
-            } else if (ov::npuw::debug_groups()) {
-                LOG_DEBUG("Couldn't add the pair to the merge vector due to failed checks:");
-                LOG_BLOCK();
+                    // FIXME: find a better way to reduce time complexity
+                    // Need to align interconnects in the same format via sort, so they could be compared later
+                    MICVec mic_sorted_key(meta_interconnect.first.begin(), meta_interconnect.first.end());
+                    std::sort(mic_sorted_key.begin(), mic_sorted_key.end());
+                    mics[{mic_sorted_key, meta_interconnect.second}].push_back({prod_group, group});
+                    LOG_DEBUG("Add the pair to the merge vector!");
+                } else if (ov::npuw::debug_groups()) {
+                    LOG_DEBUG("Couldn't add the pair to the merge vector due to failed checks:");
+                    LOG_BLOCK();
 #define INSPECT(x) LOG_DEBUG(#x " = " << (x))
-                INSPECT(prod_group->specialTags());
-                INSPECT(prod_group->repeated() != this_rep_tag);
-                INSPECT(prod_group->hasCycle(group));
-                INSPECT(prod_group->avoidedTargets() == this_avoided);
-                INSPECT(prod_group->specialTags() == this_special);
+                    INSPECT(prod_group->specialTags());
+                    INSPECT(prod_group->repeated() != this_rep_tag);
+                    INSPECT(cycle);
+                    INSPECT(prod_group->avoidedTargets() == this_avoided);
+                    INSPECT(prod_group->specialTags() == this_special);
 #undef INSPECT
+                }
             }
         }
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
@@ -754,7 +754,7 @@ void Snapshot::identifyUniques() {
         // This pass should only be called at the very beginning,
         // thus check and use only the single initial layer
         auto ov_node = group->getInitialNode();
-        auto metadesc = ov::npuw::online::util::getMetaDesc(ov_node);
+        auto metadesc = getMetaDesc(ov_node);
         const auto& avoids = group->avoidedTargets();
         const auto& special_tags = group->specialTags();
         uniques[{metadesc, avoids, special_tags}].insert(group);
@@ -1347,7 +1347,7 @@ void Snapshot::completeRepeating(const std::shared_ptr<Repeated>& reptag, const 
 
     for (const auto& gptr : gset) {
         for (const auto& layer : gptr->getContent()) {  // FIXME: should it be a part of group's API instead?
-            const auto& metadesc = ov::npuw::online::util::getMetaDesc(layer);
+            const auto& metadesc = getMetaDesc(layer);
             const auto& archetype = gptr->getReptrack(layer);
             matches[{std::move(metadesc), std::move(archetype)}].insert(layer);
         }
@@ -1430,6 +1430,17 @@ std::shared_ptr<own::ade::Graph> Snapshot::getGraph() const {
 
 size_t Snapshot::graphSize() const {
     return m_graph->nodes().size();
+}
+
+std::string Snapshot::getMetaDesc(const std::shared_ptr<ov::Node>& node) const {
+    auto id = node->get_instance_id();
+    auto it = m_metadesc_cache.find(id);
+    if (it != m_metadesc_cache.end()) {
+        return it->second;
+    }
+    auto result = util::getMetaDesc(node);
+    m_metadesc_cache.emplace(id, result);
+    return result;
 }
 
 const OVPortsMap& Snapshot::getPortsMap() const {

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.hpp
@@ -67,6 +67,7 @@ public:
     void repeat(detail::Pass&& pass);
     void setCtx(const PassContext& ctx);
     size_t graphSize() const;
+    std::string getMetaDesc(const std::shared_ptr<ov::Node>& node) const;
 
 private:
     detail::GPtrSet getRepGroups(const std::shared_ptr<Group>& group) const;
@@ -100,6 +101,7 @@ private:
 
     detail::OVPortsMap m_ports_map;
     std::map<std::string, std::vector<std::set<std::string>>> m_layer_matches;
+    mutable std::unordered_map<size_t, std::string> m_metadesc_cache;
 };
 
 }  // namespace online

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/utils/utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/utils/utils.cpp
@@ -4,8 +4,6 @@
 
 #include "utils.hpp"
 
-#include <unordered_map>
-
 #include "../../../logging.hpp"
 #include "intel_npu/config/npuw.hpp"
 
@@ -14,14 +12,6 @@ using ov::npuw::online::util::ReadAttributes;
 
 // FIXME: metadesc should be hash of layer's meta, not string
 std::string ov::npuw::online::util::getMetaDesc(const std::shared_ptr<ov::Node>& ov_node) {
-    // Cache the result per node pointer: the node's structure is fixed once created.
-    static thread_local std::unordered_map<ov::Node*, std::string> s_metadesc_cache;
-    auto* raw = ov_node.get();
-    auto it = s_metadesc_cache.find(raw);
-    if (it != s_metadesc_cache.end()) {
-        return it->second;
-    }
-
     std::stringstream ss;
     ss << ov_node->description() << ' ';
 
@@ -42,9 +32,7 @@ std::string ov::npuw::online::util::getMetaDesc(const std::shared_ptr<ov::Node>&
 
     // FIXME: should be { self type. self inputs. self outputs. self attrs. self data }
     //        can't extract data here?
-    auto result = ss.str();
-    s_metadesc_cache.emplace(raw, result);
-    return result;
+    return ss.str();
 }
 
 std::tuple<ov::npuw::online::PatternType, std::string, std::string> ov::npuw::online::util::parse(

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/utils/utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/utils/utils.cpp
@@ -4,6 +4,8 @@
 
 #include "utils.hpp"
 
+#include <unordered_map>
+
 #include "../../../logging.hpp"
 #include "intel_npu/config/npuw.hpp"
 
@@ -12,6 +14,14 @@ using ov::npuw::online::util::ReadAttributes;
 
 // FIXME: metadesc should be hash of layer's meta, not string
 std::string ov::npuw::online::util::getMetaDesc(const std::shared_ptr<ov::Node>& ov_node) {
+    // Cache the result per node pointer: the node's structure is fixed once created.
+    static thread_local std::unordered_map<ov::Node*, std::string> s_metadesc_cache;
+    auto* raw = ov_node.get();
+    auto it = s_metadesc_cache.find(raw);
+    if (it != s_metadesc_cache.end()) {
+        return it->second;
+    }
+
     std::stringstream ss;
     ss << ov_node->description() << ' ';
 
@@ -32,7 +42,9 @@ std::string ov::npuw::online::util::getMetaDesc(const std::shared_ptr<ov::Node>&
 
     // FIXME: should be { self type. self inputs. self outputs. self attrs. self data }
     //        can't extract data here?
-    return ss.str();
+    auto result = ss.str();
+    s_metadesc_cache.emplace(raw, result);
+    return result;
 }
 
 std::tuple<ov::npuw::online::PatternType, std::string, std::string> ov::npuw::online::util::parse(

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/sdpa.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/sdpa.cpp
@@ -106,16 +106,16 @@ SDPA::SDPA(const std::shared_ptr<ov::npuw::online::Snapshot>& snapshot, const st
 
 SDPADecomposed::SDPADecomposed(const std::shared_ptr<ov::npuw::online::Snapshot>& snapshot,
                                const std::string& isol_tag) {
-    auto convert1 = opp::wrap_type<ov::op::v0::Convert>({opp::any_input()});
-    auto concat1 = opp::wrap_type<ov::op::v0::Concat>({convert1, opp::any_input()});
+    // Match Concat with any number of inputs (including multi-input from KV cache block split)
+    // Don't constrain the number of inputs - just match any Concat node
+    auto concat1 = opp::wrap_type<ov::op::v0::Concat>();
 
     // GQA optional nodes
     auto unsqueeze1 = opp::optional<ov::op::v0::Unsqueeze>({concat1, opp::any_input()});
     auto broadcast1 = opp::optional<ov::op::v3::Broadcast>({unsqueeze1, opp::any_input()});
     auto reshape1 = opp::optional<ov::op::v1::Reshape>({broadcast1, opp::any_input()});
 
-    auto convert2 = opp::wrap_type<ov::op::v0::Convert>({opp::any_input()});
-    auto concat2 = opp::wrap_type<ov::op::v0::Concat>({convert2, opp::any_input()});
+    auto concat2 = opp::wrap_type<ov::op::v0::Concat>();
 
     // GQA optional nodes
     auto unsqueeze2 = opp::optional<ov::op::v0::Unsqueeze>({concat2, opp::any_input()});
@@ -147,15 +147,34 @@ SDPADecomposed::SDPADecomposed(const std::shared_ptr<ov::npuw::online::Snapshot>
             }
         };
 
-        // Isolate all matched nodes in the pattern
-        isolate_matched(convert1);
-        isolate_matched(concat1);
+        // Isolate concat nodes and their Convert inputs (if any)
+        auto isolate_concat_with_inputs = [&](const auto& concat_pattern) {
+            auto concat_iter = node_to_output.find(concat_pattern);
+            if (concat_iter != node_to_output.end()) {
+                auto concat_node = concat_iter->second.get_node_shared_ptr();
+                node_to_gptr->at(concat_node)->isolate(isol_tag);
+
+                // Also isolate all Convert inputs to this Concat
+                for (size_t i = 0; i < concat_node->get_input_size(); ++i) {
+                    auto input_node = concat_node->get_input_node_shared_ptr(i);
+                    if (auto convert_node = std::dynamic_pointer_cast<ov::op::v0::Convert>(input_node)) {
+                        if (node_to_gptr->count(convert_node)) {
+                            node_to_gptr->at(convert_node)->isolate(isol_tag);
+                        }
+                    }
+                }
+            }
+        };
+
+        // Isolate Concat nodes with all their Convert inputs
+        isolate_concat_with_inputs(concat1);
+        isolate_concat_with_inputs(concat2);
+
+        // Isolate all other matched nodes in the pattern
         isolate_matched(unsqueeze1);
         isolate_matched(broadcast1);
         isolate_matched(reshape1);
 
-        isolate_matched(convert2);
-        isolate_matched(concat2);
         isolate_matched(unsqueeze2);
         isolate_matched(broadcast2);
         isolate_matched(reshape2);
@@ -253,7 +272,7 @@ AttentionBroadcast2::AttentionBroadcast2() {
 
 ShapeOfParameter::ShapeOfParameter() {
     auto param_in = opp::wrap_type<ov::op::v0::Parameter>();
-    auto param_cvt = opp::wrap_type<ov::op::v0::Convert>({param_in});
+    auto param_cvt = opp::optional<ov::op::v0::Convert>({param_in});
     auto param_shp = opp::wrap_type<ov::op::v3::ShapeOf>({param_cvt});
 
     // Note: Use [=] to make sure the above objects stay alive in the callback

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
@@ -27,30 +27,6 @@ namespace ov {
 namespace npuw {
 namespace function {
 
-// Helper function to find mask parameter by traversing from Add node
-std::shared_ptr<ov::op::v0::Parameter> find_mask_parameter(const std::shared_ptr<ov::Node>& add_node) {
-    if (!add_node || add_node->get_input_size() < 2) {
-        return nullptr;
-    }
-
-    // Traverse the Add node's mask input (input 1) upwards to find the proper Parameter
-    // Only unary ops are allowed along the way
-    auto mask_in_node = add_node->input(1).get_source_output().get_node_shared_ptr();
-    while (mask_in_node && !ov::op::util::is_parameter(mask_in_node)) {
-        if (mask_in_node->inputs().size() != 1) {
-            LOG_WARN("Non-unary or disconnected op on the way from Add to input mask");
-            return nullptr;
-        }
-        mask_in_node = mask_in_node->inputs()[0].get_source_output().get_node_shared_ptr();
-    }
-
-    if (mask_in_node && ov::op::util::is_parameter(mask_in_node)) {
-        return std::static_pointer_cast<ov::op::v0::Parameter>(mask_in_node);
-    }
-
-    return nullptr;
-}
-
 // Helper function to create Attention instance from a model
 std::optional<ov::npuw::function::Attention> create_attention_from_model(
     const std::shared_ptr<ov::Model>& model,
@@ -323,99 +299,6 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
                                    full_context_length,
                                    past_key_sequence_dims,
                                    past_value_sequence_dims};
-}
-
-SDPAPatternNodes find_sdpa_pattern_nodes(const std::shared_ptr<ov::Model>& model) {
-    // Find decomposed SDPA pattern components
-    SDPAPatternNodes pattern_nodes;
-
-    // Find all past key and value parameter nodes (support multiple blocks after split)
-    for (auto input : model->inputs()) {
-        auto input_node = input.get_node();
-        auto input_name = input_node->get_friendly_name();
-        if (ov::npuw::util::isPastKeyValuesKey(input_name)) {
-            pattern_nodes.past_key_param_nodes.push_back(input_node->shared_from_this());
-        } else if (ov::npuw::util::isPastKeyValuesValue(input_name)) {
-            pattern_nodes.past_value_param_nodes.push_back(input_node->shared_from_this());
-        }
-    }
-
-    // Helper lambda to trace from MatMul to find Concat node
-    auto find_concat_from_matmul = [](const std::shared_ptr<ov::Node>& matmul_node,
-                                      size_t input_idx) -> std::shared_ptr<ov::Node> {
-        if (!matmul_node)
-            return nullptr;
-
-        auto current_node = matmul_node->input(input_idx).get_source_output().get_node_shared_ptr();
-
-        // Traverse backwards through reshape/transpose operations to find Concat
-        while (current_node) {
-            if (ov::is_type<ov::op::v0::Concat>(current_node)) {
-                return current_node;
-            }
-
-            // Allow traversing through Reshape and Transpose
-            if (ov::is_type<ov::op::v1::Reshape>(current_node) || ov::is_type<ov::op::v3::Broadcast>(current_node) ||
-                ov::is_type<ov::op::v0::Unsqueeze>(current_node)) {
-                if (current_node->get_input_size() > 0) {
-                    current_node = current_node->input(0).get_source_output().get_node_shared_ptr();
-                } else {
-                    break;
-                }
-            } else {
-                // Stop at other operations
-                break;
-            }
-        }
-
-        return nullptr;
-    };
-
-    // Search for the pattern: MatMul -> Add -> Softmax -> MatMul
-    auto ops = model->get_ordered_ops();
-    for (auto&& node : ops) {
-        if (ov::is_type<ov::op::v8::Softmax>(node)) {
-            pattern_nodes.softmax_node = node;
-
-            // Check if softmax is fed by Add
-            auto softmax_input = node->input(0).get_source_output().get_node_shared_ptr();
-            if (ov::is_type<ov::op::v1::Add>(softmax_input)) {
-                pattern_nodes.add_node = softmax_input;
-
-                // Check if add is fed by MatMul (first MatMul)
-                auto add_input0 = pattern_nodes.add_node->input(0).get_source_output().get_node_shared_ptr();
-                if (ov::is_type<ov::op::v0::MatMul>(add_input0)) {
-                    pattern_nodes.matmul1_node = add_input0;
-
-                    // Find Concat node for past key (input 1 of MatMul1)
-                    pattern_nodes.past_key_concat_node = find_concat_from_matmul(pattern_nodes.matmul1_node, 1);
-                }
-            }
-
-            // Check if softmax feeds into MatMul (second MatMul)
-            for (auto&& output : node->outputs()) {
-                for (auto&& target_input : output.get_target_inputs()) {
-                    auto target_node = target_input.get_node()->shared_from_this();
-                    if (ov::is_type<ov::op::v0::MatMul>(target_node)) {
-                        pattern_nodes.matmul2_node = target_node;
-
-                        // Find Concat node for past value (input 1 of MatMul2)
-                        pattern_nodes.past_value_concat_node = find_concat_from_matmul(pattern_nodes.matmul2_node, 1);
-                        break;
-                    }
-                }
-                if (pattern_nodes.matmul2_node)
-                    break;
-            }
-
-            if (pattern_nodes.is_valid()) {
-                pattern_nodes.log_pattern();
-                break;  // Found complete pattern
-            }
-        }
-    }
-
-    return pattern_nodes;
 }
 
 std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov::Model>& model) {

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
@@ -5,6 +5,7 @@
 #include "pyramid_attention.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <utility>
 
 #include "openvino/core/validation_util.hpp"
@@ -79,7 +80,8 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                                                         size_t full_past_kv_length,
                                                         size_t full_context_length,
                                                         const std::map<std::string, size_t>& past_key_sequence_dims,
-                                                        const std::map<std::string, size_t>& past_value_sequence_dims) {
+                                                        const std::map<std::string, size_t>& past_value_sequence_dims,
+                                                        bool has_block_layout) {
     // Clone the original model for modification
     auto cloned_model = original_model->clone();
 
@@ -105,6 +107,194 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
     LOG_DEBUG("Model " << model_idx << ":");
     LOG_DEBUG("  Context length: " << current_context_length);
     LOG_DEBUG("  Past length: " << current_past_length);
+
+    // -------------------------------------------------------------------------
+    // Block-split KV cache path (has_block_layout == true)
+    //
+    // The model has already been through SplitKVCacheIntoBlocks. The KV Concat
+    // now has the form:
+    //   Concat([past_key_block_0, ..., past_key_block_{N-2}, present_key])
+    // For pyramid model[idx] we only need `idx` past blocks, so we replace the
+    // Concat with a smaller one and remove the surplus block Parameters.
+    //   model[0]  -> Concat([present_key])           (0 past blocks)
+    //   model[1]  -> Concat([block_0, present_key])  (1 past block)
+    //   model[idx]-> Concat([block_0..block_{idx-1}, present_key])
+    // -------------------------------------------------------------------------
+    if (has_block_layout) {
+        std::cout << "Processing block-mode pyramid model[" << model_idx << "], query_length=" << query_length
+                  << ", full_past_kv_length=" << full_past_kv_length << std::endl;
+        const size_t num_blocks_needed = model_idx;  // model[idx] needs exactly idx past blocks
+
+        // Lambda: shrink one Concat (key or value) to keep only num_blocks_needed past inputs.
+        // Returns false on error.
+        auto shrink_concat_inputs = [&](const std::shared_ptr<ov::Node>& concat_node) -> bool {
+            auto concat = std::dynamic_pointer_cast<ov::op::v0::Concat>(concat_node);
+            if (!concat) {
+                LOG_WARN("  Block shrink: expected a Concat node, got something else");
+                return false;
+            }
+
+            const size_t total_inputs = concat->get_input_size();
+            // The last input is always present_key/value (SplitKVCacheIntoBlocks convention).
+            const size_t num_global_past_blocks = total_inputs - 1u;
+
+            if (num_blocks_needed > num_global_past_blocks) {
+                LOG_WARN("  Block shrink: model[" << model_idx << "] needs " << num_blocks_needed
+                                                  << " blocks but global model only has " << num_global_past_blocks);
+                return false;
+            }
+
+            std::cout << "  Shrinking Concat inputs, global past blocks=" << num_global_past_blocks
+                      << ", needed past blocks=" << num_blocks_needed << std::endl;
+
+            ov::OutputVector new_inputs;
+            new_inputs.reserve(num_blocks_needed + 1u);
+            std::vector<std::shared_ptr<ov::op::v0::Parameter>> params_to_remove;
+
+            for (size_t i = 0; i < num_global_past_blocks; ++i) {
+                auto src_output = concat->input_value(i);
+                auto src_node = src_output.get_node_shared_ptr();
+
+                // SplitKVCacheIntoBlocks may insert a Convert node between the block
+                // Parameter and the Concat; unwrap it to reach the Parameter.
+                std::shared_ptr<ov::op::v0::Parameter> block_param;
+                if (auto cvt = std::dynamic_pointer_cast<ov::op::v0::Convert>(src_node)) {
+                    block_param =
+                        std::dynamic_pointer_cast<ov::op::v0::Parameter>(cvt->input_value(0).get_node_shared_ptr());
+                } else {
+                    block_param = std::dynamic_pointer_cast<ov::op::v0::Parameter>(src_node);
+                }
+
+                if (i < num_blocks_needed) {
+                    new_inputs.push_back(src_output);  // keep
+                } else {
+                    if (block_param) {
+                        params_to_remove.push_back(block_param);
+                        LOG_DEBUG("  Dropping block param: " << block_param->get_friendly_name());
+                        std::cout << "  Dropping block param: " << block_param->get_friendly_name() << std::endl;
+                    }
+                }
+            }
+            // Always keep the present_key/value (last input).
+            new_inputs.push_back(concat->input_value(total_inputs - 1u));
+
+            auto new_concat = std::make_shared<ov::op::v0::Concat>(new_inputs, concat->get_axis());
+            new_concat->set_friendly_name(concat->get_friendly_name());
+            concat->output(0).replace(new_concat->output(0));
+
+            for (const auto& param : params_to_remove) {
+                cloned_model->remove_parameter(param);
+            }
+
+            LOG_DEBUG("  Concat shrunken: " << total_inputs << " inputs -> " << new_inputs.size() << " inputs");
+            return true;
+        };
+
+        // Find SDPA pattern in the cloned model.
+        auto cloned_pattern = find_sdpa_pattern_nodes(cloned_model);
+        if (!cloned_pattern.is_valid()) {
+            LOG_WARN("Could not find SDPA pattern in block-mode cloned model (model_idx=" << model_idx << ")");
+            return std::nullopt;
+        }
+
+        // Capture value Concat axis before shrinking — needed for patch_reshape_constants below.
+        int64_t value_concat_axis = 0;
+        if (auto vc = std::dynamic_pointer_cast<ov::op::v0::Concat>(cloned_pattern.past_value_concat_node)) {
+            const auto& out_shape = vc->get_output_partial_shape(0);
+            value_concat_axis = ov::util::try_normalize_axis(vc->get_axis(), out_shape.rank(), *vc);
+        }
+
+        if (!shrink_concat_inputs(cloned_pattern.past_key_concat_node) ||
+            !shrink_concat_inputs(cloned_pattern.past_value_concat_node)) {
+            LOG_WARN("Failed to shrink Concat nodes for block-mode pyramid model[" << model_idx << "]");
+            return std::nullopt;
+        }
+
+        LOG_DEBUG("  Concat nodes shrunk successfully for model[" << model_idx << "]");
+        std::cout << "  Concat nodes shrunk successfully for model[" << model_idx << "]" << std::endl;
+
+        // Apply the same pre-reshape patching + reshape sequence as the non-block path:
+        //   1. patch_broadcast_constants — fix Broadcast shape constants referencing full_context_length
+        //   2. patch_reshape_constants  — set seq dim to -1 in value-path Reshape shape constant
+        //                                 (pattern: value_Concat → Reshape → MatMul2 ← Softmax)
+        //   3. reshape(new_shapes)      — apply mask shape update and propagate all shapes
+        //   4. validate_nodes_and_infer_types
+        ov::npuw::function::patch_broadcast_constants(cloned_model, full_context_length);
+        // The map key is unused by patch_reshape_constants; only the dim-index value matters.
+        ov::npuw::function::patch_reshape_constants(cloned_model, {{"", static_cast<size_t>(value_concat_axis)}});
+
+        // Directly set partial shape on the Parameter node — bypasses reshape() name/pointer
+        // lookup entirely. reshape(Output<Node>) can silently miss, reshape(string) uses
+        // tensor names (not friendly names), so set_partial_shape() is the safest path.
+        auto mask_param = find_mask_parameter(cloned_pattern.add_node);
+        if (mask_param) {
+            ov::PartialShape new_mask_shape = mask_param->get_partial_shape();
+            if (new_mask_shape.rank().is_static() && new_mask_shape.rank().get_length() > 0) {
+                new_mask_shape[new_mask_shape.rank().get_length() - 1] = current_context_length;
+                mask_param->set_partial_shape(new_mask_shape);
+                LOG_INFO("  Set mask '" << mask_param->get_friendly_name() << "' partial shape -> " << new_mask_shape);
+                std::cout << "  Set mask '" << mask_param->get_friendly_name() << "' partial shape -> "
+                          << new_mask_shape << std::endl;
+            }
+        } else {
+            LOG_WARN("  No mask parameter found in block-mode cloned model (model_idx=" << model_idx << ")");
+        }
+
+        cloned_model->validate_nodes_and_infer_types();
+
+        if (1) {
+            const std::string ir_path = "pyramid_block_variant_" + std::to_string(model_idx) + ".xml";
+            ov::save_model(cloned_model, ir_path);
+            LOG_INFO("Saved block-mode pyramid variant[" << model_idx << "] to " << ir_path);
+            std::cout << "Saved block-mode pyramid variant[" << model_idx << "] to " << ir_path << std::endl;
+        }
+
+        // Build a minimal Attention descriptor for block mode.
+        // Cannot use create_attention_from_model() because is_valid() requires past_key_param_nodes
+        // to be non-empty — model[0] has 0 past block params after shrinking, so it always fails.
+        // Call find_sdpa_pattern_nodes() unconditionally and extract mask + block params directly.
+        ov::npuw::function::Attention block_attention;
+        {
+            auto post_pattern = find_sdpa_pattern_nodes(cloned_model);
+            auto mask_p = (post_pattern.add_node ? find_mask_parameter(post_pattern.add_node)
+                                                 : find_mask_parameter(cloned_pattern.add_node));
+            if (!mask_p) {
+                LOG_WARN("Could not find mask parameter for block-mode pyramid model[" << model_idx << "]");
+                return std::nullopt;
+            }
+            block_attention._mask = mask_p;
+            block_attention._mask_shape = mask_p->get_shape();
+
+            // Collect past key/value block parameter indices from the (shrunk) Concat inputs.
+            // All inputs except the last (present KV) are past block params.
+            auto collect_block_param_indices = [&](const std::shared_ptr<ov::Node>& concat_node,
+                                                   std::vector<size_t>& out) {
+                if (!concat_node)
+                    return;
+                const size_t n = concat_node->get_input_size();
+                for (size_t i = 0; i + 1 < n; ++i) {
+                    auto node = concat_node->get_input_node_shared_ptr(i);
+                    // SplitKVCacheIntoBlocks may insert a Convert; unwrap it.
+                    if (auto cvt = std::dynamic_pointer_cast<ov::op::v0::Convert>(node))
+                        node = cvt->input_value(0).get_node_shared_ptr();
+                    if (auto param = std::dynamic_pointer_cast<ov::op::v0::Parameter>(node))
+                        out.push_back(cloned_model->get_parameter_index(param));
+                }
+            };
+            collect_block_param_indices(post_pattern.past_key_concat_node,
+                                        block_attention.past_key_block_variant_param_indices);
+            collect_block_param_indices(post_pattern.past_value_concat_node,
+                                        block_attention.past_value_block_variant_param_indices);
+        }
+
+        LOG_INFO("Block-mode pyramid model[" << model_idx << "] ready: " << num_blocks_needed
+                                             << " past block(s), context=" << current_context_length);
+
+        return PyramidModelResult{cloned_model, std::move(block_attention)};
+    }
+    // -------------------------------------------------------------------------
+    // End block-split path
+    // -------------------------------------------------------------------------
 
     // Create initial Attention instance to get mask parameter for reshaping
     auto initial_attention =
@@ -237,6 +427,49 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
         return std::nullopt;
     }
 
+    // Detect block-split KV cache layout.
+    // After SplitKVCacheIntoBlocks the single past_key param becomes N block params named
+    // "{original_name}_block_{i}". We detect this by either count > 1 or the name suffix.
+    const bool has_block_layout =
+        !pattern_nodes.past_key_param_nodes.empty() &&
+        (pattern_nodes.past_key_param_nodes.size() > 1 ||
+         pattern_nodes.past_key_param_nodes[0]->get_friendly_name().find("_block_") != std::string::npos);
+
+    if (has_block_layout) {
+        LOG_INFO("Detected block-split KV cache (" << pattern_nodes.past_key_param_nodes.size()
+                                                   << " past key block(s)): using Concat-shrink path");
+        // Compute full-model block param indices from the **Concat input order** (block_0, block_1, ..., present).
+        // This is the same order used by process_pyramid_model / collect_block_param_indices, so
+        // global and variant indices are always aligned for bind_block_ports.
+        // Do NOT use past_key_param_nodes order (model parameter list) — it may differ.
+        auto collect_global_indices = [&](const std::shared_ptr<ov::Node>& concat_node, std::vector<size_t>& out) {
+            if (!concat_node)
+                return;
+            const size_t n = concat_node->get_input_size();
+            // All inputs except the last (present_key/value) are past block params.
+            for (size_t i = 0; i + 1 < n; ++i) {
+                auto node = concat_node->get_input_node_shared_ptr(i);
+                if (auto cvt = std::dynamic_pointer_cast<ov::op::v0::Convert>(node))
+                    node = cvt->input_value(0).get_node_shared_ptr();
+                if (auto param = std::dynamic_pointer_cast<ov::op::v0::Parameter>(node))
+                    out.push_back(model->get_parameter_index(param));
+            }
+        };
+        std::vector<size_t> full_key_indices, full_val_indices;
+        collect_global_indices(pattern_nodes.past_key_concat_node, full_key_indices);
+        collect_global_indices(pattern_nodes.past_value_concat_node, full_val_indices);
+        // Sequence-dim maps are not needed in block mode; process_pyramid_model() uses
+        // direct Concat-shrinking instead of per-parameter reshape.
+        return PyramidValidationResult{query_length,
+                                       0u,
+                                       full_context_length,
+                                       {},
+                                       {},
+                                       true,
+                                       std::move(full_key_indices),
+                                       std::move(full_val_indices)};
+    }
+
     // Pre-analyze original model to find sequence dimensions for past key/value parameters
     // This avoids repeated analysis in each cloned model
     std::map<std::string, size_t> past_key_sequence_dims;
@@ -298,7 +531,8 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
                                    past_kv_length,
                                    full_context_length,
                                    past_key_sequence_dims,
-                                   past_value_sequence_dims};
+                                   past_value_sequence_dims,
+                                   false};  // has_block_layout
 }
 
 std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov::Model>& model) {
@@ -313,6 +547,7 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
     size_t full_context_length = validation_result->full_context_length;
     const auto& past_key_sequence_dims = validation_result->past_key_sequence_dims;
     const auto& past_value_sequence_dims = validation_result->past_value_sequence_dims;
+    const bool has_block_layout = validation_result->has_block_layout;
 
     std::vector<std::shared_ptr<ov::Model>> pyramid_models;
 
@@ -342,6 +577,16 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
                 return std::nullopt;
             }
 
+            // In block mode the last model IS the full/original model (N blocks).
+            // Propagate the full-model block indices into this variant's attention so
+            // compiled::PyramidAttentionInfo can copy them without re-scanning the graph.
+            if (has_block_layout) {
+                last_attention->past_key_block_variant_param_indices =
+                    validation_result->past_key_block_global_param_indices;
+                last_attention->past_value_block_variant_param_indices =
+                    validation_result->past_value_block_global_param_indices;
+            }
+
             pyramid_attentions.push_back(std::move(*last_attention));
             LOG_INFO("Successfully setup attention for original model[" << model_idx << "]");
         } else {
@@ -353,7 +598,8 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
                                                 full_past_kv_length,
                                                 full_context_length,
                                                 past_key_sequence_dims,
-                                                past_value_sequence_dims);
+                                                past_value_sequence_dims,
+                                                has_block_layout);
             if (!result) {
                 return std::nullopt;
             }
@@ -372,6 +618,11 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
     pyramid_attention._models = pyramid_models;
     pyramid_attention._attentions = pyramid_attentions;
 
+    // In block mode, propagate the full-model block param indices computed during validation.
+    // All variant attentions already carry their per-variant slice; this level holds the global N.
+    pyramid_attention.past_key_block_global_param_indices = validation_result->past_key_block_global_param_indices;
+    pyramid_attention.past_value_block_global_param_indices = validation_result->past_value_block_global_param_indices;
+
     LOG_INFO("Returning pyramid attention with " << pyramid_models.size() << " models");
     LOG_INFO("  Query length: " << pyramid_attention._query_length);
     LOG_INFO("  Full context length: " << pyramid_attention._full_context_length);
@@ -383,7 +634,9 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
 
 namespace compiled {
 
-// Constructor implementation - extracts metadata and stores models for compilation
+// Constructor implementation - extracts metadata and stores models for compilation.
+// KV block parameter indices are read from function::Attention._past_key/value_block_params,
+// which were populated in process_pyramid_model (block path) from the Concat inputs.
 PyramidAttention::PyramidAttention(const function::PyramidAttention& func_pyramid)
     : query_size(func_pyramid._query_length),
       full_context_size(func_pyramid._full_context_length),
@@ -414,14 +667,27 @@ PyramidAttention::PyramidAttention(const function::PyramidAttention& func_pyrami
         attention_info.query_size = func_attn.query_len();
         attention_info.context_length = func_attn.context_len();
 
+        // Block parameter indices are pre-computed by process_pyramid_model / from().
+        // Simple copy; no model->get_parameter_index() needed for blocks.
+        attention_info.past_key_block_variant_param_indices = func_attn.past_key_block_variant_param_indices;
+        attention_info.past_value_block_variant_param_indices = func_attn.past_value_block_variant_param_indices;
+
         _attention_infos.push_back(std::move(attention_info));
         _context_lengths.push_back(_attention_infos.back().context_length);
     }
 
-    LOG_INFO("compiled::PyramidAttention metadata extracted, models stored for compilation");
+    // Full-model block indices are pre-computed in function::PyramidAttention::from().
+    // Simple copy; no further graph traversal needed.
+    past_key_block_global_param_indices = func_pyramid.past_key_block_global_param_indices;
+    past_value_block_global_param_indices = func_pyramid.past_value_block_global_param_indices;
+
+    LOG_INFO("compiled::PyramidAttention metadata extracted, "
+             << past_key_block_global_param_indices.size() << " K blocks / "
+             << past_value_block_global_param_indices.size() << " V blocks in full model");
 }
 
-// Set compiled models after parallel compilation and clear temporary storage
+// Set compiled models after parallel compilation and clear temporary storage.
+// Block indices are already populated in the constructor from the graph.
 void PyramidAttention::set_compiled_models(std::vector<ov::SoPtr<ov::ICompiledModel>>&& compiled_models) {
     NPUW_ASSERT(compiled_models.size() == _attention_infos.size() && "Compiled models count must match metadata count");
     _compiled_models = std::move(compiled_models);
@@ -430,7 +696,7 @@ void PyramidAttention::set_compiled_models(std::vector<ov::SoPtr<ov::ICompiledMo
     _models_to_compile.clear();
     _models_to_compile.shrink_to_fit();
 
-    LOG_INFO("compiled::PyramidAttention compiled models set successfully (" << _compiled_models.size() << " models)");
+    LOG_INFO("compiled::PyramidAttention compiled models set (" << _compiled_models.size() << " models)");
 }
 
 }  // namespace compiled

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
@@ -5,7 +5,6 @@
 #include "pyramid_attention.hpp"
 
 #include <algorithm>
-#include <cstdlib>
 #include <utility>
 
 #include "openvino/core/validation_util.hpp"
@@ -72,6 +71,24 @@ std::optional<ov::npuw::function::Attention> create_attention_from_model(
     return attention;
 }
 
+// Collect past KV block parameter indices from a Concat node in Concat input order.
+// All inputs except the last (present_key/value) are past block params.
+// SplitKVCacheIntoBlocks may insert a Convert between each block Parameter and the Concat.
+static void collect_concat_block_indices(const std::shared_ptr<ov::Model>& model,
+                                         const std::shared_ptr<ov::Node>& concat_node,
+                                         std::vector<size_t>& out) {
+    if (!concat_node)
+        return;
+    const size_t n = concat_node->get_input_size();
+    for (size_t i = 0; i + 1 < n; ++i) {
+        auto node = concat_node->get_input_node_shared_ptr(i);
+        if (auto cvt = std::dynamic_pointer_cast<ov::op::v0::Convert>(node))
+            node = cvt->input_value(0).get_node_shared_ptr();
+        if (auto param = std::dynamic_pointer_cast<ov::op::v0::Parameter>(node))
+            out.push_back(model->get_parameter_index(param));
+    }
+}
+
 // Helper function to process a single pyramid model (clone, reshape, patch, optimize)
 std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov::Model>& original_model,
                                                         size_t model_idx,
@@ -121,8 +138,6 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
     //   model[idx]-> Concat([block_0..block_{idx-1}, present_key])
     // -------------------------------------------------------------------------
     if (has_block_layout) {
-        std::cout << "Processing block-mode pyramid model[" << model_idx << "], query_length=" << query_length
-                  << ", full_past_kv_length=" << full_past_kv_length << std::endl;
         const size_t num_blocks_needed = model_idx;  // model[idx] needs exactly idx past blocks
 
         // Lambda: shrink one Concat (key or value) to keep only num_blocks_needed past inputs.
@@ -143,9 +158,6 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                                                   << " blocks but global model only has " << num_global_past_blocks);
                 return false;
             }
-
-            std::cout << "  Shrinking Concat inputs, global past blocks=" << num_global_past_blocks
-                      << ", needed past blocks=" << num_blocks_needed << std::endl;
 
             ov::OutputVector new_inputs;
             new_inputs.reserve(num_blocks_needed + 1u);
@@ -171,7 +183,6 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                     if (block_param) {
                         params_to_remove.push_back(block_param);
                         LOG_DEBUG("  Dropping block param: " << block_param->get_friendly_name());
-                        std::cout << "  Dropping block param: " << block_param->get_friendly_name() << std::endl;
                     }
                 }
             }
@@ -211,7 +222,6 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
         }
 
         LOG_DEBUG("  Concat nodes shrunk successfully for model[" << model_idx << "]");
-        std::cout << "  Concat nodes shrunk successfully for model[" << model_idx << "]" << std::endl;
 
         // Apply the same pre-reshape patching + reshape sequence as the non-block path:
         //   1. patch_broadcast_constants — fix Broadcast shape constants referencing full_context_length
@@ -233,21 +243,12 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                 new_mask_shape[new_mask_shape.rank().get_length() - 1] = current_context_length;
                 mask_param->set_partial_shape(new_mask_shape);
                 LOG_INFO("  Set mask '" << mask_param->get_friendly_name() << "' partial shape -> " << new_mask_shape);
-                std::cout << "  Set mask '" << mask_param->get_friendly_name() << "' partial shape -> "
-                          << new_mask_shape << std::endl;
             }
         } else {
             LOG_WARN("  No mask parameter found in block-mode cloned model (model_idx=" << model_idx << ")");
         }
 
         cloned_model->validate_nodes_and_infer_types();
-
-        if (1) {
-            const std::string ir_path = "pyramid_block_variant_" + std::to_string(model_idx) + ".xml";
-            ov::save_model(cloned_model, ir_path);
-            LOG_INFO("Saved block-mode pyramid variant[" << model_idx << "] to " << ir_path);
-            std::cout << "Saved block-mode pyramid variant[" << model_idx << "] to " << ir_path << std::endl;
-        }
 
         // Build a minimal Attention descriptor for block mode.
         // Cannot use create_attention_from_model() because is_valid() requires past_key_param_nodes
@@ -266,25 +267,12 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
             block_attention._mask_shape = mask_p->get_shape();
 
             // Collect past key/value block parameter indices from the (shrunk) Concat inputs.
-            // All inputs except the last (present KV) are past block params.
-            auto collect_block_param_indices = [&](const std::shared_ptr<ov::Node>& concat_node,
-                                                   std::vector<size_t>& out) {
-                if (!concat_node)
-                    return;
-                const size_t n = concat_node->get_input_size();
-                for (size_t i = 0; i + 1 < n; ++i) {
-                    auto node = concat_node->get_input_node_shared_ptr(i);
-                    // SplitKVCacheIntoBlocks may insert a Convert; unwrap it.
-                    if (auto cvt = std::dynamic_pointer_cast<ov::op::v0::Convert>(node))
-                        node = cvt->input_value(0).get_node_shared_ptr();
-                    if (auto param = std::dynamic_pointer_cast<ov::op::v0::Parameter>(node))
-                        out.push_back(cloned_model->get_parameter_index(param));
-                }
-            };
-            collect_block_param_indices(post_pattern.past_key_concat_node,
-                                        block_attention.past_key_block_variant_param_indices);
-            collect_block_param_indices(post_pattern.past_value_concat_node,
-                                        block_attention.past_value_block_variant_param_indices);
+            collect_concat_block_indices(cloned_model,
+                                         post_pattern.past_key_concat_node,
+                                         block_attention.past_key_block_variant_param_indices);
+            collect_concat_block_indices(cloned_model,
+                                         post_pattern.past_value_concat_node,
+                                         block_attention.past_value_block_variant_param_indices);
         }
 
         LOG_INFO("Block-mode pyramid model[" << model_idx << "] ready: " << num_blocks_needed
@@ -439,29 +427,16 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
         LOG_INFO("Detected block-split KV cache (" << pattern_nodes.past_key_param_nodes.size()
                                                    << " past key block(s)): using Concat-shrink path");
         // Compute full-model block param indices from the **Concat input order** (block_0, block_1, ..., present).
-        // This is the same order used by process_pyramid_model / collect_block_param_indices, so
+        // This is the same order used by process_pyramid_model / collect_concat_block_indices, so
         // global and variant indices are always aligned for bind_block_ports.
         // Do NOT use past_key_param_nodes order (model parameter list) — it may differ.
-        auto collect_global_indices = [&](const std::shared_ptr<ov::Node>& concat_node, std::vector<size_t>& out) {
-            if (!concat_node)
-                return;
-            const size_t n = concat_node->get_input_size();
-            // All inputs except the last (present_key/value) are past block params.
-            for (size_t i = 0; i + 1 < n; ++i) {
-                auto node = concat_node->get_input_node_shared_ptr(i);
-                if (auto cvt = std::dynamic_pointer_cast<ov::op::v0::Convert>(node))
-                    node = cvt->input_value(0).get_node_shared_ptr();
-                if (auto param = std::dynamic_pointer_cast<ov::op::v0::Parameter>(node))
-                    out.push_back(model->get_parameter_index(param));
-            }
-        };
         std::vector<size_t> full_key_indices, full_val_indices;
-        collect_global_indices(pattern_nodes.past_key_concat_node, full_key_indices);
-        collect_global_indices(pattern_nodes.past_value_concat_node, full_val_indices);
+        collect_concat_block_indices(model, pattern_nodes.past_key_concat_node, full_key_indices);
+        collect_concat_block_indices(model, pattern_nodes.past_value_concat_node, full_val_indices);
         // Sequence-dim maps are not needed in block mode; process_pyramid_model() uses
         // direct Concat-shrinking instead of per-parameter reshape.
         return PyramidValidationResult{query_length,
-                                       0u,
+                                       0u,  // past_kv_length: unused in block mode
                                        full_context_length,
                                        {},
                                        {},
@@ -635,7 +610,7 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
 namespace compiled {
 
 // Constructor implementation - extracts metadata and stores models for compilation.
-// KV block parameter indices are read from function::Attention._past_key/value_block_params,
+// KV block parameter indices are read from function::Attention::past_key/value_block_variant_param_indices,
 // which were populated in process_pyramid_model (block path) from the Concat inputs.
 PyramidAttention::PyramidAttention(const function::PyramidAttention& func_pyramid)
     : query_size(func_pyramid._query_length),

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
@@ -329,14 +329,14 @@ SDPAPatternNodes find_sdpa_pattern_nodes(const std::shared_ptr<ov::Model>& model
     // Find decomposed SDPA pattern components
     SDPAPatternNodes pattern_nodes;
 
-    // Find past key and value parameter nodes
+    // Find all past key and value parameter nodes (support multiple blocks after split)
     for (auto input : model->inputs()) {
         auto input_node = input.get_node();
         auto input_name = input_node->get_friendly_name();
         if (ov::npuw::util::isPastKeyValuesKey(input_name)) {
-            pattern_nodes.past_key_param_node = input_node->shared_from_this();
+            pattern_nodes.past_key_param_nodes.push_back(input_node->shared_from_this());
         } else if (ov::npuw::util::isPastKeyValuesValue(input_name)) {
-            pattern_nodes.past_value_param_node = input_node->shared_from_this();
+            pattern_nodes.past_value_param_nodes.push_back(input_node->shared_from_this());
         }
     }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
@@ -77,15 +77,18 @@ std::optional<ov::npuw::function::Attention> create_attention_from_model(
 static void collect_concat_block_indices(const std::shared_ptr<ov::Model>& model,
                                          const std::shared_ptr<ov::Node>& concat_node,
                                          std::vector<size_t>& out) {
-    if (!concat_node)
+    if (!concat_node) {
         return;
+    }
     const size_t n = concat_node->get_input_size();
     for (size_t i = 0; i + 1 < n; ++i) {
         auto node = concat_node->get_input_node_shared_ptr(i);
-        if (auto cvt = std::dynamic_pointer_cast<ov::op::v0::Convert>(node))
+        if (auto cvt = std::dynamic_pointer_cast<ov::op::v0::Convert>(node)) {
             node = cvt->input_value(0).get_node_shared_ptr();
-        if (auto param = std::dynamic_pointer_cast<ov::op::v0::Parameter>(node))
+        }
+        if (auto param = std::dynamic_pointer_cast<ov::op::v0::Parameter>(node)) {
             out.push_back(model->get_parameter_index(param));
+        }
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
@@ -55,12 +55,12 @@ std::optional<ov::npuw::function::Attention> create_attention_from_model(
     const auto& params = model->get_parameters();
     for (const auto& param : params) {
         const std::string param_name = param->get_friendly_name();
-        if (ov::npuw::util::isPastKeyValuesKey(param_name)) {
+        if (ov::npuw::util::isPastKeyParamContiguous(param_name)) {
             auto dim_iter = past_key_sequence_dims.find(param_name);
             if (dim_iter != past_key_sequence_dims.end()) {
                 attention._inputs.push_back(ov::npuw::function::Attention::Param{param, dim_iter->second});
             }
-        } else if (ov::npuw::util::isPastKeyValuesValue(param_name)) {
+        } else if (ov::npuw::util::isPastValueParamContiguous(param_name)) {
             auto dim_iter = past_value_sequence_dims.find(param_name);
             if (dim_iter != past_value_sequence_dims.end()) {
                 attention._inputs.push_back(ov::npuw::function::Attention::Param{param, dim_iter->second});
@@ -101,7 +101,7 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                                                         size_t full_context_length,
                                                         const std::map<std::string, size_t>& past_key_sequence_dims,
                                                         const std::map<std::string, size_t>& past_value_sequence_dims,
-                                                        bool has_block_layout) {
+                                                        bool is_block_split) {
     // Clone the original model for modification
     auto cloned_model = original_model->clone();
 
@@ -129,7 +129,7 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
     LOG_DEBUG("  Past length: " << current_past_length);
 
     // -------------------------------------------------------------------------
-    // Block-split KV cache path (has_block_layout == true)
+    // Block-split KV cache path (is_block_split == true)
     //
     // The model has already been through SplitKVCacheIntoBlocks. The KV Concat
     // now has the form:
@@ -140,7 +140,7 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
     //   model[1]  -> Concat([block_0, present_key])  (1 past block)
     //   model[idx]-> Concat([block_0..block_{idx-1}, present_key])
     // -------------------------------------------------------------------------
-    if (has_block_layout) {
+    if (is_block_split) {
         const size_t num_blocks_needed = model_idx;  // model[idx] needs exactly idx past blocks
 
         // Lambda: shrink one Concat (key or value) to keep only num_blocks_needed past inputs.
@@ -315,7 +315,7 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                 new_shapes[param->output(0)] = new_shape;
                 LOG_DEBUG("  Mask param '" << param_name << "' shape: " << original_shape << " -> " << new_shape);
             }
-        } else if (ov::npuw::util::isPastKeyValuesKey(param_name)) {
+        } else if (ov::npuw::util::isPastKeyParamContiguous(param_name)) {
             // Handle past key parameters
             // Use pre-analyzed sequence dimension information
             auto dim_iter = past_key_sequence_dims.find(param_name);
@@ -330,7 +330,7 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                 LOG_WARN("No pre-analyzed sequence dimension for past key param: " << param_name);
                 return std::nullopt;
             }
-        } else if (ov::npuw::util::isPastKeyValuesValue(param_name)) {
+        } else if (ov::npuw::util::isPastValueParamContiguous(param_name)) {
             // Handle past value parameters
             // Use pre-analyzed sequence dimension information
             auto dim_iter = past_value_sequence_dims.find(param_name);
@@ -396,7 +396,6 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
     // Extract query_length and full_context_length from Softmax output shape
     auto softmax_output_shape = pattern_nodes.softmax_node->get_output_shape(0);
     size_t query_length = 0;
-    size_t past_kv_length = 0;
     size_t full_context_length = 0;
 
     if (softmax_output_shape.size() >= 2) {
@@ -421,12 +420,12 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
     // Detect block-split KV cache layout.
     // After SplitKVCacheIntoBlocks the single past_key param becomes N block params named
     // "{original_name}_block_{i}". We detect this by either count > 1 or the name suffix.
-    const bool has_block_layout =
+    const bool is_block_split =
         !pattern_nodes.past_key_param_nodes.empty() &&
         (pattern_nodes.past_key_param_nodes.size() > 1 ||
-         pattern_nodes.past_key_param_nodes[0]->get_friendly_name().find("_block_") != std::string::npos);
+         !ov::npuw::util::isPastKeyParamContiguous(pattern_nodes.past_key_param_nodes[0]->get_friendly_name()));
 
-    if (has_block_layout) {
+    if (is_block_split) {
         LOG_INFO("Detected block-split KV cache (" << pattern_nodes.past_key_param_nodes.size()
                                                    << " past key block(s)): using Concat-shrink path");
         // Compute full-model block param indices from the **Concat input order** (block_0, block_1, ..., present).
@@ -436,20 +435,15 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
         std::vector<size_t> full_key_indices, full_val_indices;
         collect_concat_block_indices(model, pattern_nodes.past_key_concat_node, full_key_indices);
         collect_concat_block_indices(model, pattern_nodes.past_value_concat_node, full_val_indices);
-        // Sequence-dim maps are not needed in block mode; process_pyramid_model() uses
-        // direct Concat-shrinking instead of per-parameter reshape.
-        return PyramidValidationResult{query_length,
-                                       0u,  // past_kv_length: unused in block mode
-                                       full_context_length,
-                                       {},
-                                       {},
-                                       true,
-                                       std::move(full_key_indices),
-                                       std::move(full_val_indices)};
+        return PyramidValidationResult::make_block(query_length,
+                                                   full_context_length,
+                                                   std::move(full_key_indices),
+                                                   std::move(full_val_indices));
     }
 
     // Pre-analyze original model to find sequence dimensions for past key/value parameters
     // This avoids repeated analysis in each cloned model
+    size_t past_kv_length = 0;
     std::map<std::string, size_t> past_key_sequence_dims;
     std::map<std::string, size_t> past_value_sequence_dims;
 
@@ -474,8 +468,8 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
         const auto& original_params = model->get_parameters();
         for (const auto& param : original_params) {
             const std::string param_name = param->get_friendly_name();
-            bool is_target_param = is_key ? ov::npuw::util::isPastKeyValuesKey(param_name)
-                                          : ov::npuw::util::isPastKeyValuesValue(param_name);
+            bool is_target_param = is_key ? ov::npuw::util::isPastKeyParamContiguous(param_name)
+                                          : ov::npuw::util::isPastValueParamContiguous(param_name);
 
             if (is_target_param) {
                 sequence_dims[param_name] = concat_axis;
@@ -505,12 +499,11 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
         return std::nullopt;
     }
 
-    return PyramidValidationResult{query_length,
-                                   past_kv_length,
-                                   full_context_length,
-                                   past_key_sequence_dims,
-                                   past_value_sequence_dims,
-                                   false};  // has_block_layout
+    return PyramidValidationResult::make_contiguous(query_length,
+                                                    full_context_length,
+                                                    past_kv_length,
+                                                    past_key_sequence_dims,
+                                                    past_value_sequence_dims);
 }
 
 std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov::Model>& model) {
@@ -525,7 +518,7 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
     size_t full_context_length = validation_result->full_context_length;
     const auto& past_key_sequence_dims = validation_result->past_key_sequence_dims;
     const auto& past_value_sequence_dims = validation_result->past_value_sequence_dims;
-    const bool has_block_layout = validation_result->has_block_layout;
+    const bool is_block_split = validation_result->is_block_split;
 
     std::vector<std::shared_ptr<ov::Model>> pyramid_models;
 
@@ -558,7 +551,7 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
             // In block mode the last model IS the full/original model (N blocks).
             // Propagate the full-model block indices into this variant's attention so
             // compiled::PyramidAttentionInfo can copy them without re-scanning the graph.
-            if (has_block_layout) {
+            if (is_block_split) {
                 last_attention->past_key_block_variant_param_indices =
                     validation_result->past_key_block_global_param_indices;
                 last_attention->past_value_block_variant_param_indices =
@@ -577,7 +570,7 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
                                                 full_context_length,
                                                 past_key_sequence_dims,
                                                 past_value_sequence_dims,
-                                                has_block_layout);
+                                                is_block_split);
             if (!result) {
                 return std::nullopt;
             }
@@ -595,9 +588,7 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
     pyramid_attention._full_context_length = full_context_length;
     pyramid_attention._models = pyramid_models;
     pyramid_attention._attentions = pyramid_attentions;
-
-    // In block mode, propagate the full-model block param indices computed during validation.
-    // All variant attentions already carry their per-variant slice; this level holds the global N.
+    // Block indices are empty in contiguous mode; assigned unconditionally for simplicity.
     pyramid_attention.past_key_block_global_param_indices = validation_result->past_key_block_global_param_indices;
     pyramid_attention.past_value_block_global_param_indices = validation_result->past_value_block_global_param_indices;
 

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "attention.hpp"
+#include "sdpa_utils.hpp"
 
 namespace ov {
 namespace npuw {
@@ -59,42 +60,6 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
 
 // Helper function to validate model and extract necessary information for pyramid attention
 std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(const std::shared_ptr<ov::Model>& model);
-
-// Structure to hold SDPA pattern nodes
-struct SDPAPatternNodes {
-    std::shared_ptr<ov::Node> matmul1_node = nullptr;
-    std::shared_ptr<ov::Node> matmul2_node = nullptr;
-    std::shared_ptr<ov::Node> softmax_node = nullptr;
-    std::shared_ptr<ov::Node> add_node = nullptr;
-    // Support multiple block parameters after KV cache split
-    std::vector<std::shared_ptr<ov::Node>> past_key_param_nodes;
-    std::vector<std::shared_ptr<ov::Node>> past_value_param_nodes;
-    std::shared_ptr<ov::Node> past_key_concat_node = nullptr;
-    std::shared_ptr<ov::Node> past_value_concat_node = nullptr;
-
-    bool is_valid() const {
-        return matmul1_node && matmul2_node && softmax_node && add_node && !past_key_param_nodes.empty() &&
-               !past_value_param_nodes.empty() && past_key_concat_node && past_value_concat_node;
-    }
-
-    // Log pattern information for debugging
-    void log_pattern() const {
-        LOG_DEBUG("SDPA Pattern nodes:");
-        LOG_DEBUG("  MatMul1: " << (matmul1_node ? matmul1_node->get_friendly_name() : "null"));
-        LOG_DEBUG("  Add: " << (add_node ? add_node->get_friendly_name() : "null"));
-        LOG_DEBUG("  Softmax: " << (softmax_node ? softmax_node->get_friendly_name() : "null"));
-        LOG_DEBUG("  MatMul2: " << (matmul2_node ? matmul2_node->get_friendly_name() : "null"));
-        LOG_DEBUG("  Key Concat: " << (past_key_concat_node ? past_key_concat_node->get_friendly_name() : "null"));
-        LOG_DEBUG(
-            "  Value Concat: " << (past_value_concat_node ? past_value_concat_node->get_friendly_name() : "null"));
-    }
-};
-
-// Function to find SDPA pattern nodes in the model
-SDPAPatternNodes find_sdpa_pattern_nodes(const std::shared_ptr<ov::Model>& model);
-
-// Function to find mask parameter by traversing from Add node
-std::shared_ptr<ov::op::v0::Parameter> find_mask_parameter(const std::shared_ptr<ov::Node>& add_node);
 
 // PyramidAttention structure definition
 struct PyramidAttention {

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
@@ -24,9 +24,23 @@ struct PyramidValidationResult {
     size_t full_context_length = 0;
     std::map<std::string, size_t> past_key_sequence_dims;
     std::map<std::string, size_t> past_value_sequence_dims;
+    // True when the model has already been processed by SplitKVCacheIntoBlocks.
+    // In this case past_key_sequence_dims / past_value_sequence_dims are empty;
+    // process_pyramid_model() uses the Concat-shrink path instead of per-param reshape.
+    bool has_block_layout = false;
+
+    // In block-split mode: parameter indices for all N past-key/value blocks in the full (original)
+    // model. Populated by validate_and_setup_pyramid_attention() so that from() can propagate them
+    // into function::Attention (variant) and function::PyramidAttention (global). Empty otherwise.
+    std::vector<size_t> past_key_block_global_param_indices;
+    std::vector<size_t> past_value_block_global_param_indices;
 
     // Validation helper
     bool is_valid() const {
+        if (has_block_layout) {
+            // Block mode: dim maps are intentionally empty; only sizes must be sane.
+            return query_length > 0 && full_context_length > 0 && full_context_length >= query_length;
+        }
         return query_length > 0 && full_context_length > 0 && full_context_length >= query_length &&
                !past_key_sequence_dims.empty() && !past_value_sequence_dims.empty();
     }
@@ -48,7 +62,9 @@ std::optional<ov::npuw::function::Attention> create_attention_from_model(
     const std::map<std::string, size_t>& past_key_sequence_dims,
     const std::map<std::string, size_t>& past_value_sequence_dims);
 
-// Helper function to process a single pyramid model (clone, reshape, patch, optimize)
+// Helper function to process a single pyramid model (clone, reshape, patch, optimize).
+// When has_block_layout is true the model has already been processed by SplitKVCacheIntoBlocks;
+// in this case the function shrinks the KV Concat inputs rather than reshaping parameters.
 std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov::Model>& original_model,
                                                         size_t model_idx,
                                                         size_t pyramid_step,
@@ -56,7 +72,8 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                                                         size_t full_past_kv_length,
                                                         size_t full_context_length,
                                                         const std::map<std::string, size_t>& past_key_sequence_dims,
-                                                        const std::map<std::string, size_t>& past_value_sequence_dims);
+                                                        const std::map<std::string, size_t>& past_value_sequence_dims,
+                                                        bool has_block_layout = false);
 
 // Helper function to validate model and extract necessary information for pyramid attention
 std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(const std::shared_ptr<ov::Model>& model);
@@ -67,6 +84,11 @@ struct PyramidAttention {
     std::vector<std::shared_ptr<ov::Model>> _models;
     size_t _query_length = 0;
     size_t _full_context_length = 0;
+
+    // Global (full-model) KV block parameter indices (block0..blockN).
+    // Populated by from() in block-split mode from the PyramidValidationResult; empty otherwise.
+    std::vector<size_t> past_key_block_global_param_indices;
+    std::vector<size_t> past_value_block_global_param_indices;
 
     // Validation helpers
     bool is_valid() const {
@@ -96,6 +118,12 @@ struct PyramidAttentionInfo {
     std::size_t mask_idx = 0u;
     std::size_t query_size = 0u;      // Added for PositionIDs selector compatibility
     std::size_t context_length = 0u;  // Context length this pyramid model supports
+
+    // Per-variant KV block parameter indices (block0..blockM, M <= N).
+    // Copied from function::Attention::past_key/value_block_variant_param_indices by
+    // the compiled::PyramidAttention constructor.
+    std::vector<size_t> past_key_block_variant_param_indices;
+    std::vector<size_t> past_value_block_variant_param_indices;
 };
 
 // Compile-time pyramid attention information
@@ -116,8 +144,14 @@ struct PyramidAttention {
     // Compiled models are set later via set_compiled_models()
     explicit PyramidAttention(const function::PyramidAttention& func_pyramid);
 
-    // Set compiled models after parallel compilation completes
-    // Also clears _models_to_compile to free memory
+    // Global (full-model) KV block parameter indices (block0..blockN).
+    // Copied from function::PyramidAttention::past_key/value_block_global_param_indices by the constructor.
+    std::vector<size_t> past_key_block_global_param_indices;
+    std::vector<size_t> past_value_block_global_param_indices;
+
+    // Set compiled models after parallel compilation completes.
+    // Clears _models_to_compile to free memory.
+    // Block indices are already populated in the constructor from the graph.
     void set_compiled_models(std::vector<ov::SoPtr<ov::ICompiledModel>>&& compiled_models);
 
     // Return number of pyramid models

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
@@ -19,25 +19,57 @@ namespace function {
 
 // Helper struct to hold validation and setup results
 struct PyramidValidationResult {
+    // ── Shared ───────────────────────────────────────────────────────────────────
     size_t query_length = 0;
-    size_t past_kv_length = 0;
     size_t full_context_length = 0;
+    // True when the model has already been processed by SplitKVCacheIntoBlocks.
+    // Determines which of the two mode-specific field groups below is populated.
+    bool is_block_split = false;
+
+    // ── Contiguous mode only ─────────────────────────────────────────────────────
+    // Empty when is_block_split == true.
+    size_t past_kv_length = 0;
     std::map<std::string, size_t> past_key_sequence_dims;
     std::map<std::string, size_t> past_value_sequence_dims;
-    // True when the model has already been processed by SplitKVCacheIntoBlocks.
-    // In this case past_key_sequence_dims / past_value_sequence_dims are empty;
-    // process_pyramid_model() uses the Concat-shrink path instead of per-param reshape.
-    bool has_block_layout = false;
 
-    // In block-split mode: parameter indices for all N past-key/value blocks in the full (original)
-    // model. Populated by validate_and_setup_pyramid_attention() so that from() can propagate them
-    // into function::Attention (variant) and function::PyramidAttention (global). Empty otherwise.
+    static PyramidValidationResult make_contiguous(size_t query_len,
+                                                   size_t ctx_len,
+                                                   size_t past_kv_len,
+                                                   std::map<std::string, size_t> key_seq_dims,
+                                                   std::map<std::string, size_t> val_seq_dims) {
+        PyramidValidationResult r;
+        r.query_length = query_len;
+        r.full_context_length = ctx_len;
+        r.past_kv_length = past_kv_len;
+        r.past_key_sequence_dims = std::move(key_seq_dims);
+        r.past_value_sequence_dims = std::move(val_seq_dims);
+        return r;
+    }
+
+    // ── Block mode only ──────────────────────────────────────────────────────────
+    // Parameter indices for all N past-key/value blocks in the full (original) model.
+    // Populated by validate_and_setup_pyramid_attention() so that from() can propagate
+    // them into function::Attention (variant) and function::PyramidAttention (global).
+    // Empty when is_block_split == false.
     std::vector<size_t> past_key_block_global_param_indices;
     std::vector<size_t> past_value_block_global_param_indices;
 
+    static PyramidValidationResult make_block(size_t query_len,
+                                              size_t ctx_len,
+                                              std::vector<size_t> key_block_indices,
+                                              std::vector<size_t> val_block_indices) {
+        PyramidValidationResult r;
+        r.query_length = query_len;
+        r.full_context_length = ctx_len;
+        r.is_block_split = true;
+        r.past_key_block_global_param_indices = std::move(key_block_indices);
+        r.past_value_block_global_param_indices = std::move(val_block_indices);
+        return r;
+    }
+
     // Validation helper
     bool is_valid() const {
-        if (has_block_layout) {
+        if (is_block_split) {
             // Block mode: dim maps are intentionally empty; only sizes must be sane.
             return query_length > 0 && full_context_length > 0 && full_context_length >= query_length;
         }
@@ -63,7 +95,7 @@ std::optional<ov::npuw::function::Attention> create_attention_from_model(
     const std::map<std::string, size_t>& past_value_sequence_dims);
 
 // Helper function to process a single pyramid model (clone, reshape, patch, optimize).
-// When has_block_layout is true the model has already been processed by SplitKVCacheIntoBlocks;
+// When is_block_split is true the model has already been processed by SplitKVCacheIntoBlocks;
 // in this case the function shrinks the KV Concat inputs rather than reshaping parameters.
 std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov::Model>& original_model,
                                                         size_t model_idx,
@@ -73,20 +105,22 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                                                         size_t full_context_length,
                                                         const std::map<std::string, size_t>& past_key_sequence_dims,
                                                         const std::map<std::string, size_t>& past_value_sequence_dims,
-                                                        bool has_block_layout = false);
+                                                        bool is_block_split = false);
 
 // Helper function to validate model and extract necessary information for pyramid attention
 std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(const std::shared_ptr<ov::Model>& model);
 
 // PyramidAttention structure definition
 struct PyramidAttention {
+    // ── Shared ───────────────────────────────────────────────────────────────────
     std::vector<Attention> _attentions;
     std::vector<std::shared_ptr<ov::Model>> _models;
     size_t _query_length = 0;
     size_t _full_context_length = 0;
 
+    // ── Block mode only ──────────────────────────────────────────────────────────
     // Global (full-model) KV block parameter indices (block0..blockN).
-    // Populated by from() in block-split mode from the PyramidValidationResult; empty otherwise.
+    // Populated by from() when is_block_split; empty in contiguous mode.
     std::vector<size_t> past_key_block_global_param_indices;
     std::vector<size_t> past_value_block_global_param_indices;
 
@@ -114,20 +148,27 @@ struct PyramidAttentionInfo {
         std::size_t idx;  // function input index for this spatial parameter
         std::size_t dim;
     };
-    std::vector<Param> params;
+
+    // ── Shared ───────────────────────────────────────────────────────────────────
     std::size_t mask_idx = 0u;
     std::size_t query_size = 0u;      // Added for PositionIDs selector compatibility
     std::size_t context_length = 0u;  // Context length this pyramid model supports
 
+    // ── Contiguous mode only ─────────────────────────────────────────────────────
+    // Used during both PREFILL and GENERATE to bind per-step KV slices. Empty in block mode.
+    std::vector<Param> params;
+
+    // ── Block mode only ──────────────────────────────────────────────────────────
     // Per-variant KV block parameter indices (block0..blockM, M <= N).
     // Copied from function::Attention::past_key/value_block_variant_param_indices by
-    // the compiled::PyramidAttention constructor.
+    // the compiled::PyramidAttention constructor. Empty in contiguous mode.
     std::vector<size_t> past_key_block_variant_param_indices;
     std::vector<size_t> past_value_block_variant_param_indices;
 };
 
 // Compile-time pyramid attention information
 struct PyramidAttention {
+    // ── Shared ───────────────────────────────────────────────────────────────────
     std::vector<PyramidAttentionInfo> _attention_infos;
     std::vector<ov::SoPtr<ov::ICompiledModel>> _compiled_models;
     std::vector<std::size_t> _context_lengths;
@@ -144,8 +185,10 @@ struct PyramidAttention {
     // Compiled models are set later via set_compiled_models()
     explicit PyramidAttention(const function::PyramidAttention& func_pyramid);
 
+    // ── Block mode only ──────────────────────────────────────────────────────────
     // Global (full-model) KV block parameter indices (block0..blockN).
-    // Copied from function::PyramidAttention::past_key/value_block_global_param_indices by the constructor.
+    // Copied from function::PyramidAttention::past_key/value_block_global_param_indices
+    // by the constructor. Empty in contiguous mode.
     std::vector<size_t> past_key_block_global_param_indices;
     std::vector<size_t> past_value_block_global_param_indices;
 

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #pragma once
 
@@ -65,14 +66,15 @@ struct SDPAPatternNodes {
     std::shared_ptr<ov::Node> matmul2_node = nullptr;
     std::shared_ptr<ov::Node> softmax_node = nullptr;
     std::shared_ptr<ov::Node> add_node = nullptr;
-    std::shared_ptr<ov::Node> past_key_param_node = nullptr;
-    std::shared_ptr<ov::Node> past_value_param_node = nullptr;
+    // Support multiple block parameters after KV cache split
+    std::vector<std::shared_ptr<ov::Node>> past_key_param_nodes;
+    std::vector<std::shared_ptr<ov::Node>> past_value_param_nodes;
     std::shared_ptr<ov::Node> past_key_concat_node = nullptr;
     std::shared_ptr<ov::Node> past_value_concat_node = nullptr;
 
     bool is_valid() const {
-        return matmul1_node && matmul2_node && softmax_node && add_node && past_key_param_node &&
-               past_value_param_node && past_key_concat_node && past_value_concat_node;
+        return matmul1_node && matmul2_node && softmax_node && add_node && !past_key_param_nodes.empty() &&
+               !past_value_param_nodes.empty() && past_key_concat_node && past_value_concat_node;
     }
 
     // Log pattern information for debugging

--- a/src/plugins/intel_npu/src/plugin/npuw/sdpa_utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/sdpa_utils.cpp
@@ -57,9 +57,9 @@ SDPAPatternNodes find_sdpa_pattern_nodes(const std::shared_ptr<ov::Model>& model
     for (auto input : model->inputs()) {
         auto input_node = input.get_node();
         auto input_name = input_node->get_friendly_name();
-        if (ov::npuw::util::isPastKeyValuesKey(input_name)) {
+        if (ov::npuw::util::isPastKeyParam(input_name)) {
             pattern_nodes.past_key_param_nodes.push_back(input_node->shared_from_this());
-        } else if (ov::npuw::util::isPastKeyValuesValue(input_name)) {
+        } else if (ov::npuw::util::isPastValueParam(input_name)) {
             pattern_nodes.past_value_param_nodes.push_back(input_node->shared_from_this());
         }
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/sdpa_utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/sdpa_utils.cpp
@@ -1,0 +1,145 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "sdpa_utils.hpp"
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/softmax.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/op_types.hpp"
+#include "util.hpp"  // isPastKeyValuesKey, isPastKeyValuesValue
+
+namespace ov {
+namespace npuw {
+namespace function {
+
+// ----------------------------------------------------------------------------
+// find_mask_parameter
+// ----------------------------------------------------------------------------
+
+std::shared_ptr<ov::op::v0::Parameter> find_mask_parameter(const std::shared_ptr<ov::Node>& add_node) {
+    if (!add_node || add_node->get_input_size() < 2) {
+        return nullptr;
+    }
+
+    // Traverse the Add node's mask input (input 1) upwards to find the proper Parameter.
+    // Only unary ops are allowed along the way.
+    auto mask_in_node = add_node->input(1).get_source_output().get_node_shared_ptr();
+    while (mask_in_node && !ov::op::util::is_parameter(mask_in_node)) {
+        if (mask_in_node->inputs().size() != 1) {
+            LOG_WARN("Non-unary or disconnected op on the way from Add to input mask");
+            return nullptr;
+        }
+        mask_in_node = mask_in_node->inputs()[0].get_source_output().get_node_shared_ptr();
+    }
+
+    if (mask_in_node && ov::op::util::is_parameter(mask_in_node)) {
+        return std::static_pointer_cast<ov::op::v0::Parameter>(mask_in_node);
+    }
+
+    return nullptr;
+}
+
+// ----------------------------------------------------------------------------
+// find_sdpa_pattern_nodes
+// ----------------------------------------------------------------------------
+
+SDPAPatternNodes find_sdpa_pattern_nodes(const std::shared_ptr<ov::Model>& model) {
+    SDPAPatternNodes pattern_nodes;
+
+    // Collect all past key / value parameter nodes (supports multiple blocks
+    // after SplitKVCacheIntoBlocks transformation).
+    for (auto input : model->inputs()) {
+        auto input_node = input.get_node();
+        auto input_name = input_node->get_friendly_name();
+        if (ov::npuw::util::isPastKeyValuesKey(input_name)) {
+            pattern_nodes.past_key_param_nodes.push_back(input_node->shared_from_this());
+        } else if (ov::npuw::util::isPastKeyValuesValue(input_name)) {
+            pattern_nodes.past_value_param_nodes.push_back(input_node->shared_from_this());
+        }
+    }
+
+    // Helper: walk backwards from a MatMul input through Reshape/Broadcast/Unsqueeze
+    // intermediates until a Concat node is found (or the chain ends).
+    auto find_concat_from_matmul = [](const std::shared_ptr<ov::Node>& matmul_node,
+                                      size_t input_idx) -> std::shared_ptr<ov::Node> {
+        if (!matmul_node)
+            return nullptr;
+
+        auto current_node = matmul_node->input(input_idx).get_source_output().get_node_shared_ptr();
+
+        while (current_node) {
+            if (ov::is_type<ov::op::v0::Concat>(current_node)) {
+                return current_node;
+            }
+
+            if (ov::is_type<ov::op::v1::Reshape>(current_node) || ov::is_type<ov::op::v3::Broadcast>(current_node) ||
+                ov::is_type<ov::op::v0::Unsqueeze>(current_node)) {
+                if (current_node->get_input_size() > 0) {
+                    current_node = current_node->input(0).get_source_output().get_node_shared_ptr();
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        return nullptr;
+    };
+
+    // Search for the canonical pattern: MatMul(Q,K) -> Add(mask) -> Softmax -> MatMul(·,V)
+    auto ops = model->get_ordered_ops();
+    for (auto&& node : ops) {
+        if (!ov::is_type<ov::op::v8::Softmax>(node)) {
+            continue;
+        }
+
+        pattern_nodes.softmax_node = node;
+
+        // Softmax <- Add?
+        auto softmax_input = node->input(0).get_source_output().get_node_shared_ptr();
+        if (ov::is_type<ov::op::v1::Add>(softmax_input)) {
+            pattern_nodes.add_node = softmax_input;
+
+            // Add <- MatMul (first)?
+            auto add_input0 = pattern_nodes.add_node->input(0).get_source_output().get_node_shared_ptr();
+            if (ov::is_type<ov::op::v0::MatMul>(add_input0)) {
+                pattern_nodes.matmul1_node = add_input0;
+                // Find past_key Concat (input 1 of MatMul1)
+                pattern_nodes.past_key_concat_node = find_concat_from_matmul(pattern_nodes.matmul1_node, 1);
+            }
+        }
+
+        // Softmax -> MatMul (second)?
+        for (auto&& output : node->outputs()) {
+            for (auto&& target_input : output.get_target_inputs()) {
+                auto target_node = target_input.get_node()->shared_from_this();
+                if (ov::is_type<ov::op::v0::MatMul>(target_node)) {
+                    pattern_nodes.matmul2_node = target_node;
+                    // Find past_value Concat (input 1 of MatMul2)
+                    pattern_nodes.past_value_concat_node = find_concat_from_matmul(pattern_nodes.matmul2_node, 1);
+                    break;
+                }
+            }
+            if (pattern_nodes.matmul2_node)
+                break;
+        }
+
+        if (pattern_nodes.is_valid()) {
+            pattern_nodes.log_pattern();
+            break;
+        }
+    }
+
+    return pattern_nodes;
+}
+
+}  // namespace function
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/sdpa_utils.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/sdpa_utils.hpp
@@ -1,0 +1,70 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+// Shared SDPA (Scaled Dot-Product Attention) graph-analysis utilities.
+//
+// This header intentionally has NO dependency on pyramid_attention.hpp or
+// host_flash_attention.hpp so that both can include it independently.
+// The two attention strategies (Pyramid and HFA) both need to analyse the
+// same decomposed-SDPA graph pattern, so the detection logic lives here.
+
+#include <memory>
+#include <vector>
+
+#include "logging.hpp"
+#include "openvino/openvino.hpp"
+
+namespace ov {
+namespace npuw {
+namespace function {
+
+// Structure to hold SDPA pattern nodes.
+//
+// After SplitKVCacheIntoBlocks transformation the single past_key / past_value
+// parameter is replaced by N block parameters, so both fields are vectors.
+// For the unmodified (non-block) case each vector will contain exactly one
+// element (the original parameter node).
+struct SDPAPatternNodes {
+    std::shared_ptr<ov::Node> matmul1_node = nullptr;
+    std::shared_ptr<ov::Node> matmul2_node = nullptr;
+    std::shared_ptr<ov::Node> softmax_node = nullptr;
+    std::shared_ptr<ov::Node> add_node = nullptr;
+    std::vector<std::shared_ptr<ov::Node>> past_key_param_nodes;    // 1 (contiguous) or N (block-split) elements
+    std::vector<std::shared_ptr<ov::Node>> past_value_param_nodes;  // 1 (contiguous) or N (block-split) elements
+    std::shared_ptr<ov::Node> past_key_concat_node = nullptr;
+    std::shared_ptr<ov::Node> past_value_concat_node = nullptr;
+
+    bool is_valid() const {
+        return matmul1_node && matmul2_node && softmax_node && add_node && !past_key_param_nodes.empty() &&
+               !past_value_param_nodes.empty() && past_key_concat_node && past_value_concat_node;
+    }
+
+    // Log pattern information for debugging
+    void log_pattern() const {
+        LOG_DEBUG("SDPA Pattern nodes:");
+        LOG_DEBUG("  MatMul1: " << (matmul1_node ? matmul1_node->get_friendly_name() : "null"));
+        LOG_DEBUG("  Add: " << (add_node ? add_node->get_friendly_name() : "null"));
+        LOG_DEBUG("  Softmax: " << (softmax_node ? softmax_node->get_friendly_name() : "null"));
+        LOG_DEBUG("  MatMul2: " << (matmul2_node ? matmul2_node->get_friendly_name() : "null"));
+        LOG_DEBUG("  Key Concat: " << (past_key_concat_node ? past_key_concat_node->get_friendly_name() : "null"));
+        LOG_DEBUG(
+            "  Value Concat: " << (past_value_concat_node ? past_value_concat_node->get_friendly_name() : "null"));
+    }
+};
+
+// Find the decomposed SDPA sub-graph pattern (MatMul->Add->Softmax->MatMul) in
+// a model and return all relevant nodes.  Returns an invalid result if the
+// pattern is not found.
+SDPAPatternNodes find_sdpa_pattern_nodes(const std::shared_ptr<ov::Model>& model);
+
+// Traverse upward from an Add node's mask input to find the Parameter that
+// supplies the attention mask.  Only unary ops are traversed; returns nullptr
+// if the traversal fails.
+std::shared_ptr<ov::op::v0::Parameter> find_mask_parameter(const std::shared_ptr<ov::Node>& add_node);
+
+}  // namespace function
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
@@ -142,8 +142,8 @@ void ov::npuw::s11n::write(std::ostream& stream, const ov::npuw::compiled::HostF
 
     // Serialize SDPA indices from _sdpa_attention_info
     write(stream, var._sdpa_attention_info._sdpa_indices.query);
-    write(stream, var._sdpa_attention_info._sdpa_indices.past_key);
-    write(stream, var._sdpa_attention_info._sdpa_indices.past_value);
+    write(stream, var._sdpa_attention_info._sdpa_indices.past_key_blocks);
+    write(stream, var._sdpa_attention_info._sdpa_indices.past_value_blocks);
     write(stream, var._sdpa_attention_info._sdpa_indices.present_key);
     write(stream, var._sdpa_attention_info._sdpa_indices.present_value);
     write(stream, var._sdpa_attention_info._sdpa_indices.attention_mask);
@@ -371,8 +371,8 @@ void ov::npuw::s11n::read(std::istream& stream, ov::npuw::compiled::HostFlashAtt
 
     // Deserialize SDPA indices into _sdpa_attention_info
     read(stream, var._sdpa_attention_info._sdpa_indices.query);
-    read(stream, var._sdpa_attention_info._sdpa_indices.past_key);
-    read(stream, var._sdpa_attention_info._sdpa_indices.past_value);
+    read(stream, var._sdpa_attention_info._sdpa_indices.past_key_blocks);
+    read(stream, var._sdpa_attention_info._sdpa_indices.past_value_blocks);
     read(stream, var._sdpa_attention_info._sdpa_indices.present_key);
     read(stream, var._sdpa_attention_info._sdpa_indices.present_value);
     read(stream, var._sdpa_attention_info._sdpa_indices.attention_mask);

--- a/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.cpp
@@ -4,8 +4,6 @@
 
 #include "split_kvcache_into_blocks.hpp"
 
-#include <algorithm>
-#include <cctype>
 #include <memory>
 #include <string>
 #include <vector>
@@ -17,14 +15,13 @@
 #include "openvino/op/concat.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/parameter.hpp"
+#include "util.hpp"
 
 namespace ov {
 namespace npuw {
 namespace pass {
 
 namespace {
-
-static constexpr const char* past_key_values = "past_key_values";
 
 /**
  * @brief Structure to hold parameter and its associated Concat node
@@ -35,59 +32,6 @@ struct KVCacheTransformInfo {
     ov::Output<ov::Node> present_kv_input;
     std::shared_ptr<ov::Node> convert_node;  // Convert node between param and concat (if exists)
 };
-
-/**
- * @brief Check if parameter is K (key) tensor
- * Matches: "past_key.0", "past_key_values.0.key", etc.
- */
-bool is_key_parameter(const std::shared_ptr<ov::op::v0::Parameter>& param) {
-    std::string name = param->get_friendly_name();
-    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-
-    // Match "past_key_values.X.key" pattern
-    if (name.find(past_key_values) != std::string::npos && name.find(".key") != std::string::npos) {
-        return true;
-    }
-    // Match "past_key.X" pattern (but not "past_key_values")
-    if (name.find("past_key") != std::string::npos && name.find(past_key_values) == std::string::npos) {
-        return true;
-    }
-    return false;
-}
-
-/**
- * @brief Check if parameter is V (value) tensor
- * Matches: "past_value.0", "past_key_values.0.value", etc.
- */
-bool is_value_parameter(const std::shared_ptr<ov::op::v0::Parameter>& param) {
-    std::string name = param->get_friendly_name();
-    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-
-    // Match "past_key_values.X.value" pattern
-    if (name.find(past_key_values) != std::string::npos && name.find(".value") != std::string::npos) {
-        return true;
-    }
-    // Match "past_value.X" pattern
-    if (name.find("past_value") != std::string::npos) {
-        return true;
-    }
-    return false;
-}
-
-/**
- * @brief Check if parameter name indicates KV cache
- *
- * KV cache parameters typically have names like:
- * - "past_key.0", "past_value.0" (standard naming)
- * - "past_key_values.0.key", "past_key_values.0.value" (alternative naming)
- */
-bool is_kv_cache_parameter(const std::shared_ptr<ov::op::v0::Parameter>& param) {
-    std::string name = param->get_friendly_name();
-    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-
-    return (name.find("past_key") != std::string::npos || name.find("past_value") != std::string::npos ||
-            name.find(past_key_values) != std::string::npos);
-}
 
 }  // namespace
 
@@ -103,7 +47,11 @@ bool SplitKVCacheIntoBlocks::run_on_model(const std::shared_ptr<ov::Model>& mode
     std::vector<std::shared_ptr<ov::op::v0::Parameter>> params_to_remove;
 
     for (const auto& param : model->get_parameters()) {
-        if (!is_kv_cache_parameter(param)) {
+        const std::string& param_name = param->get_friendly_name();
+
+        // Only process contiguous past key/value params (not already-split block params).
+        if (!ov::npuw::util::isPastKeyParamContiguous(param_name) &&
+            !ov::npuw::util::isPastValueParamContiguous(param_name)) {
             continue;
         }
 
@@ -202,10 +150,10 @@ bool SplitKVCacheIntoBlocks::run_on_model(const std::shared_ptr<ov::Model>& mode
         // For Key: always [B, H, S, D]
         // For Value transposed: [B, H, D, S]
         // For Value not transposed: [B, H, S, D]
-        if (is_key_parameter(param)) {
+        if (ov::npuw::util::isPastKeyParamContiguous(param->get_friendly_name())) {
             seq_len = orig_shape[2].is_static() ? orig_shape[2].get_length() : -1;
             head_dim = orig_shape[3].is_static() ? orig_shape[3].get_length() : -1;
-        } else if (is_value_parameter(param) && m_v_transposed) {
+        } else if (ov::npuw::util::isPastValueParamContiguous(param->get_friendly_name()) && m_v_transposed) {
             head_dim = orig_shape[2].is_static() ? orig_shape[2].get_length() : -1;
             seq_len = orig_shape[3].is_static() ? orig_shape[3].get_length() : -1;
         } else {
@@ -223,12 +171,10 @@ bool SplitKVCacheIntoBlocks::run_on_model(const std::shared_ptr<ov::Model>& mode
 
         // Determine concat axis based on parameter type
         int64_t concat_axis = -1;
-        if (is_key_parameter(param)) {
+        if (ov::npuw::util::isPastKeyParamContiguous(param->get_friendly_name())) {
             concat_axis = 2;  // K: [B, H, S, D] concat on S
-        } else if (is_value_parameter(param)) {
-            concat_axis = m_v_transposed
-                              ? 3
-                              : 2;  // V transposed: [B, H, D, S] concat on S; not transposed: [B, H, S, D] concat on S
+        } else if (ov::npuw::util::isPastValueParamContiguous(param->get_friendly_name())) {
+            concat_axis = m_v_transposed ? 3 : 2;  // V transposed: [B,H,D,S]; not transposed: [B,H,S,D]
         } else {
             concat_axis = concat->get_axis();
         }

--- a/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.cpp
@@ -1,0 +1,358 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "split_kvcache_into_blocks.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "logging.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/node.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/parameter.hpp"
+
+namespace ov {
+namespace npuw {
+namespace pass {
+
+namespace {
+
+static constexpr const char* past_key_values = "past_key_values";
+
+/**
+ * @brief Structure to hold parameter and its associated Concat node
+ */
+struct KVCacheTransformInfo {
+    std::shared_ptr<ov::op::v0::Parameter> param;
+    std::shared_ptr<ov::op::v0::Concat> concat;
+    ov::Output<ov::Node> present_kv_input;
+    std::shared_ptr<ov::Node> convert_node;  // Convert node between param and concat (if exists)
+};
+
+/**
+ * @brief Check if parameter is K (key) tensor
+ * Matches: "past_key.0", "past_key_values.0.key", etc.
+ */
+bool is_key_parameter(const std::shared_ptr<ov::op::v0::Parameter>& param) {
+    std::string name = param->get_friendly_name();
+    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+
+    // Match "past_key_values.X.key" pattern
+    if (name.find(past_key_values) != std::string::npos && name.find(".key") != std::string::npos) {
+        return true;
+    }
+    // Match "past_key.X" pattern (but not "past_key_values")
+    if (name.find("past_key") != std::string::npos && name.find(past_key_values) == std::string::npos) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @brief Check if parameter is V (value) tensor
+ * Matches: "past_value.0", "past_key_values.0.value", etc.
+ */
+bool is_value_parameter(const std::shared_ptr<ov::op::v0::Parameter>& param) {
+    std::string name = param->get_friendly_name();
+    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+
+    // Match "past_key_values.X.value" pattern
+    if (name.find(past_key_values) != std::string::npos && name.find(".value") != std::string::npos) {
+        return true;
+    }
+    // Match "past_value.X" pattern
+    if (name.find("past_value") != std::string::npos) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @brief Check if parameter name indicates KV cache
+ *
+ * KV cache parameters typically have names like:
+ * - "past_key.0", "past_value.0" (standard naming)
+ * - "past_key_values.0.key", "past_key_values.0.value" (alternative naming)
+ */
+bool is_kv_cache_parameter(const std::shared_ptr<ov::op::v0::Parameter>& param) {
+    std::string name = param->get_friendly_name();
+    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+
+    return (name.find("past_key") != std::string::npos || name.find("past_value") != std::string::npos ||
+            name.find(past_key_values) != std::string::npos);
+}
+
+}  // namespace
+
+SplitKVCacheIntoBlocks::SplitKVCacheIntoBlocks(uint32_t block_size, bool v_transposed)
+    : m_block_size(block_size),
+      m_v_transposed(v_transposed) {}
+
+bool SplitKVCacheIntoBlocks::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    bool model_changed = false;
+
+    // Collect all KV cache parameters and their associated Concat nodes
+    std::vector<KVCacheTransformInfo> params_to_transform;
+    std::vector<std::shared_ptr<ov::op::v0::Parameter>> params_to_remove;
+
+    for (const auto& param : model->get_parameters()) {
+        if (!is_kv_cache_parameter(param)) {
+            continue;
+        }
+
+        // Find the Concat that uses this parameter
+        // Pattern: Parameter -> Concat or Parameter -> Convert -> Concat
+        std::shared_ptr<ov::op::v0::Concat> concat = nullptr;
+        std::shared_ptr<ov::Node> convert_node = nullptr;
+
+        for (const auto& output : param->outputs()) {
+            for (const auto& input : output.get_target_inputs()) {
+                auto node = input.get_node()->shared_from_this();
+
+                // Check if direct consumer is Concat
+                if (auto concat_node = ov::as_type_ptr<ov::op::v0::Concat>(node)) {
+                    concat = concat_node;
+                    break;
+                }
+
+                // Check if consumer is Convert, then check Convert's consumers for Concat
+                if (node->get_type_name() == std::string("Convert")) {
+                    for (const auto& convert_output : node->outputs()) {
+                        for (const auto& convert_target : convert_output.get_target_inputs()) {
+                            auto next_node = convert_target.get_node()->shared_from_this();
+                            if (auto concat_node = ov::as_type_ptr<ov::op::v0::Concat>(next_node)) {
+                                concat = concat_node;
+                                convert_node = node;  // Record the Convert node
+                                break;
+                            }
+                        }
+                        if (concat)
+                            break;
+                    }
+                }
+            }
+            if (concat) {
+                break;
+            }
+        }
+
+        if (!concat) {
+            continue;
+        }
+
+        // Find present_key/value input (the other input to concat)
+        ov::Output<ov::Node> present_kv_input;
+        bool found_present_kv = false;
+        for (size_t i = 0; i < concat->get_input_size(); ++i) {
+            const auto& input = concat->input(i);
+            auto input_node = input.get_source_output().get_node_shared_ptr();
+
+            // Check if input comes from our parameter (directly or through Convert)
+            bool is_from_param = false;
+            if (input_node == param) {
+                is_from_param = true;
+            } else if (input_node->get_type_name() == std::string("Convert")) {
+                // Check if Convert's input is our parameter
+                auto convert_input = input_node->input(0).get_source_output().get_node_shared_ptr();
+                if (convert_input == param) {
+                    is_from_param = true;
+                }
+            }
+
+            if (!is_from_param) {
+                present_kv_input = input.get_source_output();
+                found_present_kv = true;
+                break;
+            }
+        }
+
+        if (found_present_kv) {
+            params_to_transform.push_back({param, concat, present_kv_input, convert_node});
+        }
+    }
+
+    // Transform each KV cache parameter
+    for (auto& info : params_to_transform) {
+        auto& param = info.param;
+        auto& concat = info.concat;
+        auto& present_kv_input = info.present_kv_input;
+        auto& convert_node = info.convert_node;
+
+        // Get original KV cache shape
+        const auto& orig_shape = param->get_partial_shape();
+        if (orig_shape.rank().is_dynamic() || orig_shape.rank().get_length() != 4) {
+            LOG_WARN("SplitKVCacheIntoBlocks: Skipping parameter "
+                     << param->get_friendly_name() << " - invalid rank (expected 4D, got " << orig_shape << ")");
+            continue;
+        }
+
+        // Extract dimensions based on parameter type
+        int64_t batch = orig_shape[0].is_static() ? orig_shape[0].get_length() : 1;
+        int64_t num_heads = orig_shape[1].is_static() ? orig_shape[1].get_length() : -1;
+        int64_t head_dim = -1;
+        int64_t seq_len = -1;
+
+        // For Key: always [B, H, S, D]
+        // For Value transposed: [B, H, D, S]
+        // For Value not transposed: [B, H, S, D]
+        if (is_key_parameter(param)) {
+            seq_len = orig_shape[2].is_static() ? orig_shape[2].get_length() : -1;
+            head_dim = orig_shape[3].is_static() ? orig_shape[3].get_length() : -1;
+        } else if (is_value_parameter(param) && m_v_transposed) {
+            head_dim = orig_shape[2].is_static() ? orig_shape[2].get_length() : -1;
+            seq_len = orig_shape[3].is_static() ? orig_shape[3].get_length() : -1;
+        } else {
+            seq_len = orig_shape[2].is_static() ? orig_shape[2].get_length() : -1;
+            head_dim = orig_shape[3].is_static() ? orig_shape[3].get_length() : -1;
+        }
+
+        if (num_heads <= 0 || head_dim <= 0 || seq_len <= 0) {
+            LOG_WARN("SplitKVCacheIntoBlocks: Skipping parameter " << param->get_friendly_name()
+                                                                   << " - invalid or dynamic dimensions");
+            continue;
+        }
+
+        LOG_INFO("SplitKVCacheIntoBlocks: Transforming " << param->get_friendly_name() << " from shape " << orig_shape);
+
+        // Determine concat axis based on parameter type
+        int64_t concat_axis = -1;
+        if (is_key_parameter(param)) {
+            concat_axis = 2;  // K: [B, H, S, D] concat on S
+        } else if (is_value_parameter(param)) {
+            concat_axis = m_v_transposed
+                              ? 3
+                              : 2;  // V transposed: [B, H, D, S] concat on S; not transposed: [B, H, S, D] concat on S
+        } else {
+            concat_axis = concat->get_axis();
+        }
+
+        // Calculate number of blocks
+        uint32_t num_full_blocks = static_cast<uint32_t>(seq_len) / m_block_size;
+        uint32_t tail_size = static_cast<uint32_t>(seq_len) % m_block_size;
+        uint32_t total_blocks = num_full_blocks + (tail_size > 0 ? 1 : 0);
+
+        LOG_INFO("SplitKVCacheIntoBlocks: block_size=" << m_block_size << ", num_full_blocks=" << num_full_blocks
+                                                       << ", tail_size=" << tail_size
+                                                       << ", total_blocks=" << total_blocks);
+
+        // Create block parameters
+        ov::OutputVector block_params;
+        std::vector<std::shared_ptr<ov::op::v0::Parameter>> new_params;
+        block_params.reserve(total_blocks);
+        new_params.reserve(total_blocks);
+
+        // Create full blocks
+        for (uint32_t i = 0; i < num_full_blocks; ++i) {
+            ov::Shape block_shape;
+            if (concat_axis == 2) {
+                block_shape = {static_cast<size_t>(batch),
+                               static_cast<size_t>(num_heads),
+                               m_block_size,
+                               static_cast<size_t>(head_dim)};
+            } else {
+                block_shape = {static_cast<size_t>(batch),
+                               static_cast<size_t>(num_heads),
+                               static_cast<size_t>(head_dim),
+                               m_block_size};
+            }
+            auto block_param = std::make_shared<ov::op::v0::Parameter>(param->get_element_type(), block_shape);
+            std::string block_name = param->get_friendly_name() + "_block_" + std::to_string(i);
+            block_param->set_friendly_name(block_name);
+            // CRITICAL: Set tensor names so compiled model ports have names
+            block_param->output(0).set_names({block_name});
+            block_params.push_back(block_param);
+            new_params.push_back(block_param);
+        }
+
+        // Create tail block if needed
+        if (tail_size > 0) {
+            ov::Shape tail_shape;
+            if (concat_axis == 2) {
+                tail_shape = {static_cast<size_t>(batch),
+                              static_cast<size_t>(num_heads),
+                              tail_size,
+                              static_cast<size_t>(head_dim)};
+            } else {
+                tail_shape = {static_cast<size_t>(batch),
+                              static_cast<size_t>(num_heads),
+                              static_cast<size_t>(head_dim),
+                              tail_size};
+            }
+            auto tail_param = std::make_shared<ov::op::v0::Parameter>(param->get_element_type(), tail_shape);
+            std::string tail_name = param->get_friendly_name() + "_block_tail";
+            tail_param->set_friendly_name(tail_name);
+            // CRITICAL: Set tensor names so compiled model ports have names
+            tail_param->output(0).set_names({tail_name});
+            block_params.push_back(tail_param);
+            new_params.push_back(tail_param);
+        }
+
+        // Add new block parameters to model
+        model->add_parameters(new_params);
+
+        // If original path had Convert, create Convert for each block parameter
+        ov::OutputVector inputs_for_concat;
+        inputs_for_concat.reserve(block_params.size() + 1);
+
+        if (convert_node) {
+            // Get the target type from original Convert node
+            auto target_type = convert_node->get_output_element_type(0);
+
+            // Create Convert for each block parameter
+            for (const auto& block_param : block_params) {
+                auto convert = std::make_shared<ov::op::v0::Convert>(block_param, target_type);
+                convert->set_friendly_name(block_param.get_node()->get_friendly_name() + "_convert");
+                inputs_for_concat.push_back(convert);
+            }
+        } else {
+            // No Convert needed, use block parameters directly
+            inputs_for_concat = block_params;
+        }
+
+        // Add present_kv_input to concat inputs
+        inputs_for_concat.push_back(present_kv_input);
+
+        // Create new Concat
+        auto new_concat = std::make_shared<ov::op::v0::Concat>(inputs_for_concat, concat_axis);
+        new_concat->set_friendly_name(concat->get_friendly_name());
+
+        LOG_DEBUG("SplitKVCacheIntoBlocks: Created new concat with output shape "
+                  << new_concat->get_output_partial_shape(0));
+
+        // Copy runtime info
+        ov::NodeVector new_nodes{new_concat};
+        for (const auto& p : new_params) {
+            new_nodes.push_back(p);
+        }
+        copy_runtime_info({param, concat}, new_nodes);
+
+        // Replace concat's output with new_concat
+        concat->output(0).replace(new_concat->output(0));
+
+        // Mark old parameter for removal
+        params_to_remove.push_back(param);
+
+        LOG_INFO("SplitKVCacheIntoBlocks: Successfully replaced " << param->get_friendly_name() << " with "
+                                                                  << total_blocks << " block parameters");
+
+        model_changed = true;
+    }
+
+    // Remove all old parameters after transformations are complete
+    for (const auto& param : params_to_remove) {
+        model->remove_parameter(param);
+    }
+
+    return model_changed;
+}
+
+}  // namespace pass
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.cpp
@@ -4,8 +4,6 @@
 
 #include "split_kvcache_into_blocks.hpp"
 
-#include <memory>
-#include <string>
 #include <vector>
 
 #include "logging.hpp"
@@ -23,15 +21,52 @@ namespace pass {
 
 namespace {
 
-/**
- * @brief Structure to hold parameter and its associated Concat node
- */
+// Information collected in the scan phase; all fields are pre-computed so the
+// transform phase never needs to re-query the parameter name.
 struct KVCacheTransformInfo {
     std::shared_ptr<ov::op::v0::Parameter> param;
     std::shared_ptr<ov::op::v0::Concat> concat;
     ov::Output<ov::Node> present_kv_input;
-    std::shared_ptr<ov::Node> convert_node;  // Convert node between param and concat (if exists)
+    std::shared_ptr<ov::Node> convert_node;  // nullptr when Parameter→Concat directly
+    bool is_key;                             // true = K tensor
+    bool is_value;                           // true = V tensor
+    int64_t concat_axis;                     // sequence dimension index in the concat
 };
+
+// Walk a parameter's consumers to find the Concat it feeds (directly or via Convert).
+// Returns {concat, convert_node}; concat is nullptr if the pattern is not found.
+std::pair<std::shared_ptr<ov::op::v0::Concat>, std::shared_ptr<ov::Node>> find_concat_for_param(
+    const std::shared_ptr<ov::op::v0::Parameter>& param) {
+    for (const auto& output : param->outputs()) {
+        for (const auto& target : output.get_target_inputs()) {
+            auto node = target.get_node()->shared_from_this();
+            if (auto concat = ov::as_type_ptr<ov::op::v0::Concat>(node)) {
+                return {concat, nullptr};
+            }
+            if (ov::is_type<ov::op::v0::Convert>(node)) {
+                for (const auto& cvt_out : node->outputs()) {
+                    for (const auto& cvt_target : cvt_out.get_target_inputs()) {
+                        auto next = cvt_target.get_node()->shared_from_this();
+                        if (auto concat = ov::as_type_ptr<ov::op::v0::Concat>(next)) {
+                            return {concat, node};
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return {nullptr, nullptr};
+}
+
+// Build a 4D block shape.  seq_dim is the axis holding the sequence (2 or 3);
+// all other dims are copied from orig_shape.
+ov::Shape make_block_shape(const ov::PartialShape& orig_shape, int64_t seq_dim, size_t seq_size) {
+    ov::Shape s(4);
+    for (int i = 0; i < 4; ++i) {
+        s[i] = (i == seq_dim) ? seq_size : static_cast<size_t>(orig_shape[i].get_length());
+    }
+    return s;
+}
 
 }  // namespace
 
@@ -42,258 +77,132 @@ SplitKVCacheIntoBlocks::SplitKVCacheIntoBlocks(uint32_t block_size, bool v_trans
 bool SplitKVCacheIntoBlocks::run_on_model(const std::shared_ptr<ov::Model>& model) {
     bool model_changed = false;
 
-    // Collect all KV cache parameters and their associated Concat nodes
+    // --- Phase 1: Scan — collect parameters that need to be split ----------
     std::vector<KVCacheTransformInfo> params_to_transform;
-    std::vector<std::shared_ptr<ov::op::v0::Parameter>> params_to_remove;
 
     for (const auto& param : model->get_parameters()) {
-        const std::string& param_name = param->get_friendly_name();
+        const std::string& name = param->get_friendly_name();
 
-        // Only process contiguous past key/value params (not already-split block params).
-        if (!ov::npuw::util::isPastKeyParamContiguous(param_name) &&
-            !ov::npuw::util::isPastValueParamContiguous(param_name)) {
+        const bool is_key = ov::npuw::util::isPastKeyParamContiguous(name);
+        const bool is_value = ov::npuw::util::isPastValueParamContiguous(name);
+        if (!is_key && !is_value) {
+            continue;  // not a contiguous KV cache parameter
+        }
+
+        // Shape must be 4D and fully static before we can proceed.
+        const auto& orig_shape = param->get_partial_shape();
+        if (orig_shape.rank().is_dynamic() || orig_shape.rank().get_length() != 4) {
+            LOG_WARN("SplitKVCacheIntoBlocks: Skipping " << name << " — expected 4D shape, got " << orig_shape);
+            continue;
+        }
+        if (!orig_shape[0].is_static() || !orig_shape[1].is_static() || !orig_shape[2].is_static() ||
+            !orig_shape[3].is_static()) {
+            LOG_WARN("SplitKVCacheIntoBlocks: Skipping " << name << " — dynamic dimensions not supported");
             continue;
         }
 
-        // Find the Concat that uses this parameter
-        // Pattern: Parameter -> Concat or Parameter -> Convert -> Concat
-        std::shared_ptr<ov::op::v0::Concat> concat = nullptr;
-        std::shared_ptr<ov::Node> convert_node = nullptr;
-
-        for (const auto& output : param->outputs()) {
-            for (const auto& input : output.get_target_inputs()) {
-                auto node = input.get_node()->shared_from_this();
-
-                // Check if direct consumer is Concat
-                if (auto concat_node = ov::as_type_ptr<ov::op::v0::Concat>(node)) {
-                    concat = concat_node;
-                    break;
-                }
-
-                // Check if consumer is Convert, then check Convert's consumers for Concat
-                if (node->get_type_name() == std::string("Convert")) {
-                    for (const auto& convert_output : node->outputs()) {
-                        for (const auto& convert_target : convert_output.get_target_inputs()) {
-                            auto next_node = convert_target.get_node()->shared_from_this();
-                            if (auto concat_node = ov::as_type_ptr<ov::op::v0::Concat>(next_node)) {
-                                concat = concat_node;
-                                convert_node = node;  // Record the Convert node
-                                break;
-                            }
-                        }
-                        if (concat)
-                            break;
-                    }
-                }
-            }
-            if (concat) {
-                break;
-            }
-        }
-
+        // Locate the Concat this parameter feeds (directly or via Convert).
+        auto [concat, convert_node] = find_concat_for_param(param);
         if (!concat) {
             continue;
         }
 
-        // Find present_key/value input (the other input to concat)
+        // Locate the "present_kv" input — the non-param input of the Concat.
         ov::Output<ov::Node> present_kv_input;
-        bool found_present_kv = false;
+        bool found = false;
         for (size_t i = 0; i < concat->get_input_size(); ++i) {
-            const auto& input = concat->input(i);
-            auto input_node = input.get_source_output().get_node_shared_ptr();
-
-            // Check if input comes from our parameter (directly or through Convert)
-            bool is_from_param = false;
-            if (input_node == param) {
-                is_from_param = true;
-            } else if (input_node->get_type_name() == std::string("Convert")) {
-                // Check if Convert's input is our parameter
-                auto convert_input = input_node->input(0).get_source_output().get_node_shared_ptr();
-                if (convert_input == param) {
-                    is_from_param = true;
-                }
-            }
-
-            if (!is_from_param) {
-                present_kv_input = input.get_source_output();
-                found_present_kv = true;
+            auto src = concat->input(i).get_source_output().get_node_shared_ptr();
+            bool from_param = (src == param) || (ov::is_type<ov::op::v0::Convert>(src) &&
+                                                 src->input(0).get_source_output().get_node_shared_ptr() == param);
+            if (!from_param) {
+                present_kv_input = concat->input(i).get_source_output();
+                found = true;
                 break;
             }
         }
-
-        if (found_present_kv) {
-            params_to_transform.push_back({param, concat, present_kv_input, convert_node});
+        if (!found) {
+            continue;
         }
+
+        // Pre-compute the concat axis (sequence dimension) once.
+        const int64_t concat_axis = (is_key || (is_value && !m_v_transposed)) ? 2 : 3;
+
+        params_to_transform.push_back({param, concat, present_kv_input, convert_node, is_key, is_value, concat_axis});
     }
 
-    // Transform each KV cache parameter
+    // --- Phase 2: Transform — replace each collected parameter with blocks --
     for (auto& info : params_to_transform) {
         auto& param = info.param;
         auto& concat = info.concat;
-        auto& present_kv_input = info.present_kv_input;
-        auto& convert_node = info.convert_node;
 
-        // Get original KV cache shape
         const auto& orig_shape = param->get_partial_shape();
-        if (orig_shape.rank().is_dynamic() || orig_shape.rank().get_length() != 4) {
-            LOG_WARN("SplitKVCacheIntoBlocks: Skipping parameter "
-                     << param->get_friendly_name() << " - invalid rank (expected 4D, got " << orig_shape << ")");
-            continue;
-        }
+        const int64_t seq_len = orig_shape[info.concat_axis].get_length();
+        const uint32_t num_full_blocks = static_cast<uint32_t>(seq_len) / m_block_size;
+        const uint32_t tail_size = static_cast<uint32_t>(seq_len) % m_block_size;
+        const uint32_t total_blocks = num_full_blocks + (tail_size > 0 ? 1 : 0);
 
-        // Extract dimensions based on parameter type
-        int64_t batch = orig_shape[0].is_static() ? orig_shape[0].get_length() : 1;
-        int64_t num_heads = orig_shape[1].is_static() ? orig_shape[1].get_length() : -1;
-        int64_t head_dim = -1;
-        int64_t seq_len = -1;
+        LOG_INFO("SplitKVCacheIntoBlocks: Transforming " << param->get_friendly_name() << " shape=" << orig_shape
+                                                         << " → " << total_blocks << " blocks (tail=" << tail_size
+                                                         << ")");
 
-        // For Key: always [B, H, S, D]
-        // For Value transposed: [B, H, D, S]
-        // For Value not transposed: [B, H, S, D]
-        if (ov::npuw::util::isPastKeyParamContiguous(param->get_friendly_name())) {
-            seq_len = orig_shape[2].is_static() ? orig_shape[2].get_length() : -1;
-            head_dim = orig_shape[3].is_static() ? orig_shape[3].get_length() : -1;
-        } else if (ov::npuw::util::isPastValueParamContiguous(param->get_friendly_name()) && m_v_transposed) {
-            head_dim = orig_shape[2].is_static() ? orig_shape[2].get_length() : -1;
-            seq_len = orig_shape[3].is_static() ? orig_shape[3].get_length() : -1;
-        } else {
-            seq_len = orig_shape[2].is_static() ? orig_shape[2].get_length() : -1;
-            head_dim = orig_shape[3].is_static() ? orig_shape[3].get_length() : -1;
-        }
-
-        if (num_heads <= 0 || head_dim <= 0 || seq_len <= 0) {
-            LOG_WARN("SplitKVCacheIntoBlocks: Skipping parameter " << param->get_friendly_name()
-                                                                   << " - invalid or dynamic dimensions");
-            continue;
-        }
-
-        LOG_INFO("SplitKVCacheIntoBlocks: Transforming " << param->get_friendly_name() << " from shape " << orig_shape);
-
-        // Determine concat axis based on parameter type
-        int64_t concat_axis = -1;
-        if (ov::npuw::util::isPastKeyParamContiguous(param->get_friendly_name())) {
-            concat_axis = 2;  // K: [B, H, S, D] concat on S
-        } else if (ov::npuw::util::isPastValueParamContiguous(param->get_friendly_name())) {
-            concat_axis = m_v_transposed ? 3 : 2;  // V transposed: [B,H,D,S]; not transposed: [B,H,S,D]
-        } else {
-            concat_axis = concat->get_axis();
-        }
-
-        // Calculate number of blocks
-        uint32_t num_full_blocks = static_cast<uint32_t>(seq_len) / m_block_size;
-        uint32_t tail_size = static_cast<uint32_t>(seq_len) % m_block_size;
-        uint32_t total_blocks = num_full_blocks + (tail_size > 0 ? 1 : 0);
-
-        LOG_INFO("SplitKVCacheIntoBlocks: block_size=" << m_block_size << ", num_full_blocks=" << num_full_blocks
-                                                       << ", tail_size=" << tail_size
-                                                       << ", total_blocks=" << total_blocks);
-
-        // Create block parameters
-        ov::OutputVector block_params;
+        // Build block Parameter nodes.
+        ov::OutputVector block_outputs;
         std::vector<std::shared_ptr<ov::op::v0::Parameter>> new_params;
-        block_params.reserve(total_blocks);
+        block_outputs.reserve(total_blocks);
         new_params.reserve(total_blocks);
 
-        // Create full blocks
+        auto make_block_param = [&](const std::string& suffix, size_t seq_size) {
+            auto block_shape = make_block_shape(orig_shape, info.concat_axis, seq_size);
+            auto p = std::make_shared<ov::op::v0::Parameter>(param->get_element_type(), block_shape);
+            const std::string block_name = param->get_friendly_name() + suffix;
+            p->set_friendly_name(block_name);
+            p->output(0).set_names({block_name});
+            return p;
+        };
+
         for (uint32_t i = 0; i < num_full_blocks; ++i) {
-            ov::Shape block_shape;
-            if (concat_axis == 2) {
-                block_shape = {static_cast<size_t>(batch),
-                               static_cast<size_t>(num_heads),
-                               m_block_size,
-                               static_cast<size_t>(head_dim)};
-            } else {
-                block_shape = {static_cast<size_t>(batch),
-                               static_cast<size_t>(num_heads),
-                               static_cast<size_t>(head_dim),
-                               m_block_size};
-            }
-            auto block_param = std::make_shared<ov::op::v0::Parameter>(param->get_element_type(), block_shape);
-            std::string block_name = param->get_friendly_name() + "_block_" + std::to_string(i);
-            block_param->set_friendly_name(block_name);
-            // CRITICAL: Set tensor names so compiled model ports have names
-            block_param->output(0).set_names({block_name});
-            block_params.push_back(block_param);
-            new_params.push_back(block_param);
+            new_params.push_back(make_block_param("_block_" + std::to_string(i), m_block_size));
+            block_outputs.push_back(new_params.back());
         }
-
-        // Create tail block if needed
         if (tail_size > 0) {
-            ov::Shape tail_shape;
-            if (concat_axis == 2) {
-                tail_shape = {static_cast<size_t>(batch),
-                              static_cast<size_t>(num_heads),
-                              tail_size,
-                              static_cast<size_t>(head_dim)};
-            } else {
-                tail_shape = {static_cast<size_t>(batch),
-                              static_cast<size_t>(num_heads),
-                              static_cast<size_t>(head_dim),
-                              tail_size};
-            }
-            auto tail_param = std::make_shared<ov::op::v0::Parameter>(param->get_element_type(), tail_shape);
-            std::string tail_name = param->get_friendly_name() + "_block_tail";
-            tail_param->set_friendly_name(tail_name);
-            // CRITICAL: Set tensor names so compiled model ports have names
-            tail_param->output(0).set_names({tail_name});
-            block_params.push_back(tail_param);
-            new_params.push_back(tail_param);
+            new_params.push_back(make_block_param("_block_tail", tail_size));
+            block_outputs.push_back(new_params.back());
         }
 
-        // Add new block parameters to model
         model->add_parameters(new_params);
 
-        // If original path had Convert, create Convert for each block parameter
+        // If the original path had a Convert, insert one after each block param.
         ov::OutputVector inputs_for_concat;
-        inputs_for_concat.reserve(block_params.size() + 1);
+        inputs_for_concat.reserve(total_blocks + 1);
 
-        if (convert_node) {
-            // Get the target type from original Convert node
-            auto target_type = convert_node->get_output_element_type(0);
-
-            // Create Convert for each block parameter
-            for (const auto& block_param : block_params) {
-                auto convert = std::make_shared<ov::op::v0::Convert>(block_param, target_type);
-                convert->set_friendly_name(block_param.get_node()->get_friendly_name() + "_convert");
-                inputs_for_concat.push_back(convert);
+        if (info.convert_node) {
+            const auto target_type = info.convert_node->get_output_element_type(0);
+            for (const auto& blk : block_outputs) {
+                auto cvt = std::make_shared<ov::op::v0::Convert>(blk, target_type);
+                cvt->set_friendly_name(blk.get_node()->get_friendly_name() + "_convert");
+                inputs_for_concat.push_back(cvt);
             }
         } else {
-            // No Convert needed, use block parameters directly
-            inputs_for_concat = block_params;
+            inputs_for_concat = block_outputs;
         }
+        inputs_for_concat.push_back(info.present_kv_input);
 
-        // Add present_kv_input to concat inputs
-        inputs_for_concat.push_back(present_kv_input);
-
-        // Create new Concat
-        auto new_concat = std::make_shared<ov::op::v0::Concat>(inputs_for_concat, concat_axis);
+        // Replace the old Concat.
+        auto new_concat = std::make_shared<ov::op::v0::Concat>(inputs_for_concat, info.concat_axis);
         new_concat->set_friendly_name(concat->get_friendly_name());
 
-        LOG_DEBUG("SplitKVCacheIntoBlocks: Created new concat with output shape "
-                  << new_concat->get_output_partial_shape(0));
-
-        // Copy runtime info
         ov::NodeVector new_nodes{new_concat};
         for (const auto& p : new_params) {
             new_nodes.push_back(p);
         }
         copy_runtime_info({param, concat}, new_nodes);
 
-        // Replace concat's output with new_concat
         concat->output(0).replace(new_concat->output(0));
+        model->remove_parameter(param);
 
-        // Mark old parameter for removal
-        params_to_remove.push_back(param);
-
-        LOG_INFO("SplitKVCacheIntoBlocks: Successfully replaced " << param->get_friendly_name() << " with "
-                                                                  << total_blocks << " block parameters");
+        LOG_DEBUG("SplitKVCacheIntoBlocks: new concat shape " << new_concat->get_output_partial_shape(0));
 
         model_changed = true;
-    }
-
-    // Remove all old parameters after transformations are complete
-    for (const auto& param : params_to_remove) {
-        model->remove_parameter(param);
     }
 
     return model_changed;

--- a/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.hpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/pass.hpp"
+
+namespace ov {
+namespace npuw {
+namespace pass {
+
+/**
+ * @brief Transformation pass to split KV cache access into block-based pattern
+ *
+ * This pass identifies KV cache parameters in the model and transforms their access
+ * pattern from continuous memory (batch, num_heads, seq_len, head_dim) to block-based
+ * layout (num_blocks, batch, num_heads, block_size, head_dim).
+ *
+ * Transformation pattern:
+ * Before:
+ *   Parameter(past_key)     [1, 32, 2048, 128]  \
+ *   Parameter(present_key)  [1, 32, 1, 128]      |-> Concat(axis=2) -> SDPA
+ *
+ *   Parameter(past_value)   [1, 32, 128, 2048]  \
+ *   Parameter(present_value)[1, 32, 128, 1]      |-> Concat(axis=3) -> SDPA  (if v_transposed=true)
+ *
+ * After (block_size=1024, seq_len=2048):
+ *   Parameter(past_key_block_0)   [1, 32, 1024, 128]  \
+ *   Parameter(past_key_block_1)   [1, 32, 1024, 128]   |
+ *   Parameter(present_key)        [1, 32, 1, 128]      |-> Concat(axis=2) -> SDPA
+ *
+ *   Parameter(past_value_block_0) [1, 32, 128, 1024]  \
+ *   Parameter(past_value_block_1) [1, 32, 128, 1024]   |
+ *   Parameter(present_value)      [1, 32, 128, 1]      |-> Concat(axis=3) -> SDPA  (if v_transposed=true)
+ *
+ * Note: Number of blocks is auto-calculated from original seq_len and block_size.
+ *       If seq_len % block_size != 0, a tail block with remaining tokens is created.
+ *
+ * Benefits:
+ * - Reduces memory allocation (only allocate needed blocks)
+ * - Enables memory sharing across sequences
+ * - Improves memory locality for attention operations
+ *
+ * Note: This transformation is applied to both prefill and generate (decode) models
+ * where KV cache parameters are identified by naming convention
+ * (e.g., "past_key", "past_value", "past_key_values.X.key", "past_key_values.X.value").
+ */
+class SplitKVCacheIntoBlocks : public ov::pass::ModelPass {
+public:
+    OPENVINO_RTTI("ov::npuw::pass::SplitKVCacheIntoBlocks", "0");
+
+    /**
+     * @brief Construct transformation with block configuration
+     *
+     * @param block_size Number of tokens per block (default: 1024 for efficiency)
+     * @param v_transposed Whether V tensor is transposed (true: [B,H,D,S], false: [B,H,S,D])
+     *
+     * The number of blocks is automatically calculated from the original past_key shape.
+     * If the sequence length is not evenly divisible by block_size, a tail block is created.
+     */
+    explicit SplitKVCacheIntoBlocks(uint32_t block_size = 1024, bool v_transposed = true);
+
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+
+private:
+    uint32_t m_block_size;
+    bool m_v_transposed;
+};
+
+}  // namespace pass
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -912,16 +912,27 @@ void ov::npuw::util::fill_tensor_bytes(ov::SoPtr<ov::ITensor> tensor, uint8_t fi
     std::memset(tensor_data, fill_val, byte_size);
 }
 
-bool ov::npuw::util::isPastKeyValuesKey(const std::string& str) {
-    // Match both original format and block-split format (numbered and tail blocks)
-    // Examples: "past_key_values.0.key", "past_key_values.0.key_block_3", "past_key_values.0.key_block_tail"
-    std::regex pattern(R"(past_key_values\.\d+\.key(_block_(\d+|tail))?)");
+bool ov::npuw::util::isPastKeyParam(const std::string& str) {
+    // Match any past key param: contiguous or block-split (e.g. key_block_3, key_block_tail).
+    std::regex pattern(R"(past_key_values\.\d+\.key(_block_(\d+|tail))?)" );
     return std::regex_match(str, pattern);
 }
 
-bool ov::npuw::util::isPastKeyValuesValue(const std::string& str) {
-    // Match both original format and block-split format (numbered and tail blocks)
-    // Examples: "past_key_values.0.value", "past_key_values.0.value_block_3", "past_key_values.0.value_block_tail"
-    std::regex pattern(R"(past_key_values\.\d+\.value(_block_(\d+|tail))?)");
+bool ov::npuw::util::isPastValueParam(const std::string& str) {
+    // Match any past value param: contiguous or block-split.
+    std::regex pattern(R"(past_key_values\.\d+\.value(_block_(\d+|tail))?)" );
+    return std::regex_match(str, pattern);
+}
+
+bool ov::npuw::util::isPastKeyParamContiguous(const std::string& str) {
+    // Match only the single contiguous past key param (no _block_ suffix).
+    // Use in contexts that operate exclusively on non-block-split models.
+    std::regex pattern(R"(past_key_values\.\d+\.key)" );
+    return std::regex_match(str, pattern);
+}
+
+bool ov::npuw::util::isPastValueParamContiguous(const std::string& str) {
+    // Match only the single contiguous past value param (no _block_ suffix).
+    std::regex pattern(R"(past_key_values\.\d+\.value)" );
     return std::regex_match(str, pattern);
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -914,25 +914,25 @@ void ov::npuw::util::fill_tensor_bytes(ov::SoPtr<ov::ITensor> tensor, uint8_t fi
 
 bool ov::npuw::util::isPastKeyParam(const std::string& str) {
     // Match any past key param: contiguous or block-split (e.g. key_block_3, key_block_tail).
-    std::regex pattern(R"(past_key_values\.\d+\.key(_block_(\d+|tail))?)" );
+    static const std::regex pattern(R"(past_key_values\.\d+\.key(_block_(\d+|tail))?)");
     return std::regex_match(str, pattern);
 }
 
 bool ov::npuw::util::isPastValueParam(const std::string& str) {
     // Match any past value param: contiguous or block-split.
-    std::regex pattern(R"(past_key_values\.\d+\.value(_block_(\d+|tail))?)" );
+    static const std::regex pattern(R"(past_key_values\.\d+\.value(_block_(\d+|tail))?)");
     return std::regex_match(str, pattern);
 }
 
 bool ov::npuw::util::isPastKeyParamContiguous(const std::string& str) {
     // Match only the single contiguous past key param (no _block_ suffix).
     // Use in contexts that operate exclusively on non-block-split models.
-    std::regex pattern(R"(past_key_values\.\d+\.key)" );
+    static const std::regex pattern(R"(past_key_values\.\d+\.key)");
     return std::regex_match(str, pattern);
 }
 
 bool ov::npuw::util::isPastValueParamContiguous(const std::string& str) {
     // Match only the single contiguous past value param (no _block_ suffix).
-    std::regex pattern(R"(past_key_values\.\d+\.value)" );
+    static const std::regex pattern(R"(past_key_values\.\d+\.value)");
     return std::regex_match(str, pattern);
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -913,11 +913,15 @@ void ov::npuw::util::fill_tensor_bytes(ov::SoPtr<ov::ITensor> tensor, uint8_t fi
 }
 
 bool ov::npuw::util::isPastKeyValuesKey(const std::string& str) {
-    std::regex pattern(R"(past_key_values\.\d+\.key)");
+    // Match both original format and block-split format (numbered and tail blocks)
+    // Examples: "past_key_values.0.key", "past_key_values.0.key_block_3", "past_key_values.0.key_block_tail"
+    std::regex pattern(R"(past_key_values\.\d+\.key(_block_(\d+|tail))?)");
     return std::regex_match(str, pattern);
 }
 
 bool ov::npuw::util::isPastKeyValuesValue(const std::string& str) {
-    std::regex pattern(R"(past_key_values\.\d+\.value)");
+    // Match both original format and block-split format (numbered and tail blocks)
+    // Examples: "past_key_values.0.value", "past_key_values.0.value_block_3", "past_key_values.0.value_block_tail"
+    std::regex pattern(R"(past_key_values\.\d+\.value(_block_(\d+|tail))?)");
     return std::regex_match(str, pattern);
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -243,9 +243,14 @@ private:
     mutable bool done = false;
 };
 
-bool isPastKeyValuesKey(const std::string& str);
-
-bool isPastKeyValuesValue(const std::string& str);
+// Matches any past key param: contiguous (past_key_values.N.key) or block-split (key_block_M).
+bool isPastKeyParam(const std::string& str);
+// Matches any past value param: contiguous or block-split.
+bool isPastValueParam(const std::string& str);
+// Matches only the contiguous (non-block-split) past key param.
+bool isPastKeyParamContiguous(const std::string& str);
+// Matches only the contiguous (non-block-split) past value param.
+bool isPastValueParamContiguous(const std::string& str);
 
 }  // namespace util
 }  // namespace npuw

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -69,6 +69,7 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/attention.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/sdpa_utils.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/host_flash_attention.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/perf.cpp

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -65,6 +65,9 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/util_xarch.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/v1/elements/failsafe.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/split_kvcache_into_blocks.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_extension.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/attention.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/host_flash_attention.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
@@ -1,0 +1,263 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "kv_cache_block_manager.hpp"
+
+#include <gtest/gtest.h>
+
+#include "openvino/core/shape.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+using namespace ov::npuw;
+
+namespace {
+
+// Test fixture for KVCacheBlockManager tests
+class KVCacheBlockManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Common test parameters
+        block_size = 512;
+        max_blocks = 8;
+        base_shape = ov::Shape{1, 32, block_size, 128};  // [batch, num_heads, seq_len=block_size, head_dim]
+        elem_type = ov::element::f16;
+        device = "CPU";  // Use CPU for unit tests
+
+        // Pass nullptr for plugin since CPU device doesn't need it in allocMem
+        manager = std::make_unique<KVCacheBlockManager>(block_size, max_blocks, base_shape, elem_type, device, nullptr);
+    }
+
+    void TearDown() override {
+        manager.reset();
+    }
+
+    uint32_t block_size;
+    uint32_t max_blocks;
+    ov::Shape base_shape;
+    ov::element::Type elem_type;
+    std::string device;
+    std::unique_ptr<KVCacheBlockManager> manager;
+};
+
+// Test 1: Basic Allocation
+TEST_F(KVCacheBlockManagerTest, BasicAllocation) {
+    // Allocate a block
+    auto block_id = manager->allocate_block();
+    ASSERT_TRUE(block_id.has_value()) << "Block allocation should succeed";
+    EXPECT_EQ(block_id.value(), 0u) << "First block should have ID 0";
+
+    // Get block tensor
+    auto tensor = manager->get_block_tensor(block_id.value());
+    ASSERT_NE(tensor, nullptr) << "Block tensor should not be null";
+
+    // Check tensor shape
+    auto shape = tensor->get_shape();
+    EXPECT_EQ(shape[0], base_shape[0]) << "Batch dimension should match";
+    EXPECT_EQ(shape[1], base_shape[1]) << "Num_heads dimension should match";
+    EXPECT_EQ(shape[2], block_size) << "Seq_len should be block_size";
+    EXPECT_EQ(shape[3], base_shape[3]) << "Head_dim should match";
+
+    // Check token count
+    EXPECT_EQ(manager->get_block_tokens(block_id.value()), 0u) << "Newly allocated block should have 0 tokens";
+}
+
+// Test 2: Multiple Allocations
+TEST_F(KVCacheBlockManagerTest, MultipleAllocations) {
+    std::vector<uint32_t> allocated_blocks;
+
+    // Allocate half of available blocks
+    for (uint32_t i = 0; i < max_blocks / 2; ++i) {
+        auto block_id = manager->allocate_block();
+        ASSERT_TRUE(block_id.has_value()) << "Allocation " << i << " should succeed";
+        allocated_blocks.push_back(block_id.value());
+    }
+
+    // Verify unique block IDs
+    std::set<uint32_t> unique_ids(allocated_blocks.begin(), allocated_blocks.end());
+    EXPECT_EQ(unique_ids.size(), allocated_blocks.size()) << "All allocated blocks should have unique IDs";
+
+    // Verify counts via get_allocated_blocks()
+    auto all_allocated = manager->get_allocated_blocks();
+    EXPECT_EQ(all_allocated.size(), max_blocks / 2);
+}
+
+// Test 3: Block Exhaustion
+TEST_F(KVCacheBlockManagerTest, BlockExhaustion) {
+    // Allocate all blocks
+    for (uint32_t i = 0; i < max_blocks; ++i) {
+        auto block_id = manager->allocate_block();
+        ASSERT_TRUE(block_id.has_value()) << "Allocation " << i << " should succeed";
+    }
+
+    // All blocks should be allocated
+    EXPECT_EQ(manager->get_allocated_blocks().size(), static_cast<size_t>(max_blocks));
+
+    // Try to allocate one more - should fail
+    auto extra_block = manager->allocate_block();
+    EXPECT_FALSE(extra_block.has_value()) << "Allocation should fail when all blocks are in use";
+
+    // Clear all, then allocation should succeed again
+    manager->clear_all();
+    EXPECT_TRUE(manager->get_allocated_blocks().empty());
+
+    auto new_block = manager->allocate_block();
+    ASSERT_TRUE(new_block.has_value()) << "Allocation should succeed after clearing all blocks";
+}
+
+// Test 4: Token Tracking
+TEST_F(KVCacheBlockManagerTest, TokenTracking) {
+    auto block_id = manager->allocate_block();
+    ASSERT_TRUE(block_id.has_value());
+
+    // Initially 0 tokens
+    EXPECT_EQ(manager->get_block_tokens(block_id.value()), 0u);
+
+    // Update to 256 tokens
+    manager->update_block_tokens(block_id.value(), 256);
+    EXPECT_EQ(manager->get_block_tokens(block_id.value()), 256u);
+
+    // Update to full capacity
+    manager->update_block_tokens(block_id.value(), block_size);
+    EXPECT_EQ(manager->get_block_tokens(block_id.value()), block_size);
+
+    // Allocate a second block and verify its tokens are tracked independently
+    auto block_id2 = manager->allocate_block();
+    ASSERT_TRUE(block_id2.has_value());
+    manager->update_block_tokens(block_id2.value(), 100);
+    EXPECT_EQ(manager->get_block_tokens(block_id2.value()), 100u);
+    EXPECT_EQ(manager->get_block_tokens(block_id.value()), block_size) << "First block tokens should be unchanged";
+}
+
+// Test 5: Token Count Validation
+TEST_F(KVCacheBlockManagerTest, TokenCountValidation) {
+    auto block_id = manager->allocate_block();
+    ASSERT_TRUE(block_id.has_value());
+
+    // Try to set more tokens than capacity - should throw
+    EXPECT_THROW(manager->update_block_tokens(block_id.value(), block_size + 1), ov::Exception)
+        << "Setting tokens beyond capacity should throw exception";
+}
+
+// Test 6: Memory Reuse After Clear
+TEST_F(KVCacheBlockManagerTest, MemoryReuseAfterClear) {
+    // Allocate a block and record its tensor pointer
+    auto block_id = manager->allocate_block();
+    ASSERT_TRUE(block_id.has_value());
+    auto tensor_before = manager->get_block_tensor(block_id.value());
+    ASSERT_NE(tensor_before, nullptr);
+    void* ptr_before = tensor_before->data();
+
+    // Clear and re-allocate — should reuse the same underlying memory
+    manager->clear_all();
+    auto block_id2 = manager->allocate_block();
+    ASSERT_TRUE(block_id2.has_value());
+    auto tensor_after = manager->get_block_tensor(block_id2.value());
+    ASSERT_NE(tensor_after, nullptr);
+    EXPECT_EQ(tensor_after->data(), ptr_before) << "Should reuse the same memory buffer after clear";
+}
+
+// Test 7: Allocation and Token State Consistency
+TEST_F(KVCacheBlockManagerTest, AllocationAndTokenConsistency) {
+    // Initially no blocks allocated
+    EXPECT_TRUE(manager->get_allocated_blocks().empty());
+
+    // Allocate 2 blocks with different token counts
+    auto block1 = manager->allocate_block();
+    auto block2 = manager->allocate_block();
+    ASSERT_TRUE(block1.has_value());
+    ASSERT_TRUE(block2.has_value());
+
+    manager->update_block_tokens(block1.value(), block_size);  // full block
+    manager->update_block_tokens(block2.value(), 256);         // half-full block
+
+    EXPECT_EQ(manager->get_allocated_blocks().size(), 2u);
+    EXPECT_EQ(manager->get_block_tokens(block1.value()), block_size);
+    EXPECT_EQ(manager->get_block_tokens(block2.value()), 256u);
+
+    // After clear, tokens and allocations reset
+    manager->clear_all();
+    EXPECT_TRUE(manager->get_allocated_blocks().empty());
+    // Re-allocate and verify tokens are reset to 0
+    auto block3 = manager->allocate_block();
+    ASSERT_TRUE(block3.has_value());
+    EXPECT_EQ(manager->get_block_tokens(block3.value()), 0u);
+}
+
+// Test 8: Clear All
+TEST_F(KVCacheBlockManagerTest, ClearAll) {
+    // Allocate several blocks with token counts
+    for (uint32_t i = 0; i < 5; ++i) {
+        auto block_id = manager->allocate_block();
+        ASSERT_TRUE(block_id.has_value());
+        manager->update_block_tokens(block_id.value(), 100 * (i + 1));
+    }
+
+    // Verify blocks allocated
+    EXPECT_EQ(manager->get_allocated_blocks().size(), 5u);
+
+    // Clear all
+    manager->clear_all();
+
+    // Verify all blocks freed
+    EXPECT_TRUE(manager->get_allocated_blocks().empty());
+
+    // Should be able to allocate again, and tokens reset to 0
+    auto new_block = manager->allocate_block();
+    ASSERT_TRUE(new_block.has_value());
+    EXPECT_EQ(manager->get_block_tokens(new_block.value()), 0u);
+}
+
+// Test 9: Get Allocated Blocks
+TEST_F(KVCacheBlockManagerTest, GetAllocatedBlocks) {
+    // Initially empty
+    auto allocated = manager->get_allocated_blocks();
+    EXPECT_TRUE(allocated.empty());
+
+    // Allocate some blocks
+    std::vector<uint32_t> expected_blocks;
+    expected_blocks.push_back(manager->allocate_block().value());
+    expected_blocks.push_back(manager->allocate_block().value());
+    expected_blocks.push_back(manager->allocate_block().value());
+
+    // Get allocated blocks
+    allocated = manager->get_allocated_blocks();
+    EXPECT_EQ(allocated.size(), expected_blocks.size());
+
+    // Verify all expected blocks are in the list
+    for (auto block_id : expected_blocks) {
+        EXPECT_TRUE(std::find(allocated.begin(), allocated.end(), block_id) != allocated.end())
+            << "Block " << block_id << " should be in allocated list";
+    }
+}
+
+// Test 10: Invalid Block ID
+TEST_F(KVCacheBlockManagerTest, InvalidBlockID) {
+    // Try to access block with ID >= max_blocks
+    EXPECT_THROW(manager->get_block_tensor(max_blocks), ov::Exception) << "Accessing invalid block ID should throw";
+
+    EXPECT_THROW(manager->get_block_tokens(max_blocks + 10), ov::Exception)
+        << "Accessing invalid block ID should throw";
+
+    EXPECT_THROW(manager->update_block_tokens(max_blocks, 100), ov::Exception)
+        << "Updating invalid block ID should throw";
+}
+
+// Test 11: Get Tensor After Clear (memory kept, state reset)
+TEST_F(KVCacheBlockManagerTest, GetTensorAfterClear) {
+    auto block_id = manager->allocate_block();
+    ASSERT_TRUE(block_id.has_value());
+
+    // Tensor is allocated on first allocate_block()
+    auto tensor = manager->get_block_tensor(block_id.value());
+    EXPECT_NE(tensor, nullptr) << "Tensor should be valid after allocation";
+
+    // clear_all() resets state but keeps memory for reuse
+    manager->clear_all();
+    auto block_id2 = manager->allocate_block();
+    ASSERT_TRUE(block_id2.has_value());
+    auto tensor2 = manager->get_block_tensor(block_id2.value());
+    EXPECT_NE(tensor2, nullptr) << "Tensor should still be valid after clear + re-allocate";
+}
+
+}  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
@@ -6,6 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <set>
+
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
 

--- a/src/plugins/intel_npu/tests/unit/npuw/split_kvcache_into_blocks_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/split_kvcache_into_blocks_test.cpp
@@ -1,0 +1,413 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "split_kvcache_into_blocks.hpp"
+
+#include <gtest/gtest.h>
+
+#include "openvino/op/concat.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/pass/manager.hpp"
+
+using namespace ov;
+using namespace ov::npuw::pass;
+
+class SplitKVCacheIntoBlocksTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Common test setup
+    }
+
+    // Helper: Create a simple model with KV cache parameter -> Concat
+    std::shared_ptr<ov::Model> create_kv_cache_model(const std::string& param_name,
+                                                     const ov::Shape& shape,
+                                                     int64_t concat_axis) {
+        // Create KV cache parameter
+        auto kv_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, shape);
+        kv_param->set_friendly_name(param_name);
+
+        // Create new token parameter (to concatenate with)
+        ov::Shape new_token_shape = shape;
+        new_token_shape[concat_axis] = 1;  // Single token
+        auto new_token = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, new_token_shape);
+        new_token->set_friendly_name("new_token");
+
+        // Create Concat
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{kv_param, new_token}, concat_axis);
+
+        // Create Result
+        auto result = std::make_shared<ov::op::v0::Result>(concat);
+
+        return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{kv_param, new_token});
+    }
+};
+
+TEST_F(SplitKVCacheIntoBlocksTest, TransformKeyParameter) {
+    // Test: Transform past_key parameter with axis=2
+    // Original: past_key [1, 32, 64, 128] + new_token [1, 32, 1, 128]
+    // After: 4 blocks of 16 tokens each + new_token
+    const uint32_t block_size = 16;
+    const ov::Shape orig_shape{1, 32, 64, 128};        // [B, H, S=64, D]
+    const uint32_t expected_blocks = 64 / block_size;  // 4 blocks
+
+    auto model = create_kv_cache_model("past_key.0", orig_shape, 2);
+
+    // Apply transformation (max_blocks removed, auto-calculated from shape)
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.run_passes(model);
+
+    // Verify: Should have expected_blocks + 1 parameters (blocks + new_token)
+    EXPECT_EQ(model->get_parameters().size(), expected_blocks + 1);
+
+    // Verify: Each block parameter has correct shape [1, 32, 16, 128]
+    uint32_t block_count = 0;
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name().find("_block_") != std::string::npos) {
+            block_count++;
+            auto block_shape = param->get_shape();
+            EXPECT_EQ(block_shape[0], 1);           // batch
+            EXPECT_EQ(block_shape[1], 32);          // num_heads
+            EXPECT_EQ(block_shape[2], block_size);  // block_size
+            EXPECT_EQ(block_shape[3], 128);         // head_dim
+        }
+    }
+    EXPECT_EQ(block_count, expected_blocks);
+
+    // Verify: Concat has blocks + new_token input (CRITICAL: present_key preserved!)
+    bool found_concat = false;
+    for (const auto& op : model->get_ops()) {
+        if (ov::is_type<ov::op::v0::Concat>(op)) {
+            found_concat = true;
+            auto concat = ov::as_type_ptr<ov::op::v0::Concat>(op);
+            EXPECT_EQ(concat->get_axis(), 2);
+            EXPECT_EQ(concat->get_input_size(), expected_blocks + 1);  // blocks + present_key
+        }
+    }
+    EXPECT_TRUE(found_concat);
+}
+
+TEST_F(SplitKVCacheIntoBlocksTest, TransformValueParameterTransposed) {
+    // Test: Transform past_value parameter with v_transposed=true (axis=3)
+    const uint32_t block_size = 16;
+    const ov::Shape orig_shape{1, 32, 128, 64};  // [B, H, D, S] - transposed
+
+    auto model = create_kv_cache_model("past_value.0", orig_shape, 3);
+
+    // Apply transformation with v_transposed=true
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.run_passes(model);
+
+    const uint32_t expected_blocks = 64 / block_size;  // 4 blocks
+
+    // Verify: Block parameters have correct shape [1, 32, 128, 16]
+    uint32_t block_count = 0;
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name().find("_block_") != std::string::npos) {
+            block_count++;
+            auto block_shape = param->get_shape();
+            EXPECT_EQ(block_shape[0], 1);           // batch
+            EXPECT_EQ(block_shape[1], 32);          // num_heads
+            EXPECT_EQ(block_shape[2], 128);         // head_dim
+            EXPECT_EQ(block_shape[3], block_size);  // block_size
+        }
+    }
+    EXPECT_EQ(block_count, expected_blocks);
+
+    // Verify: Concat axis=3 and has blocks + present_value
+    for (const auto& op : model->get_ops()) {
+        if (ov::is_type<ov::op::v0::Concat>(op)) {
+            auto concat = ov::as_type_ptr<ov::op::v0::Concat>(op);
+            EXPECT_EQ(concat->get_axis(), 3);
+            EXPECT_EQ(concat->get_input_size(), expected_blocks + 1);
+        }
+    }
+}
+
+TEST_F(SplitKVCacheIntoBlocksTest, TransformValueParameterNotTransposed) {
+    // Test: Transform past_value parameter with v_transposed=false (axis=2)
+    const uint32_t block_size = 16;
+    const ov::Shape orig_shape{1, 32, 64, 128};  // [B, H, S, D] - same as K
+
+    auto model = create_kv_cache_model("past_value.0", orig_shape, 2);
+
+    // Apply transformation with v_transposed=false
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, false);
+    manager.run_passes(model);
+
+    const uint32_t expected_blocks = 64 / block_size;  // 4 blocks
+
+    // Verify: Block parameters have correct shape [1, 32, 16, 128]
+    uint32_t block_count = 0;
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name().find("_block_") != std::string::npos) {
+            block_count++;
+            auto block_shape = param->get_shape();
+            EXPECT_EQ(block_shape[0], 1);           // batch
+            EXPECT_EQ(block_shape[1], 32);          // num_heads
+            EXPECT_EQ(block_shape[2], block_size);  // block_size (at axis=2)
+            EXPECT_EQ(block_shape[3], 128);         // head_dim
+        }
+    }
+    EXPECT_EQ(block_count, expected_blocks);
+
+    // Verify: Concat axis=2 (same as K) and has blocks + present_value
+    for (const auto& op : model->get_ops()) {
+        if (ov::is_type<ov::op::v0::Concat>(op)) {
+            auto concat = ov::as_type_ptr<ov::op::v0::Concat>(op);
+            EXPECT_EQ(concat->get_axis(), 2);
+            EXPECT_EQ(concat->get_input_size(), expected_blocks + 1);
+        }
+    }
+}
+
+TEST_F(SplitKVCacheIntoBlocksTest, AlternativeNaming) {
+    // Test: Transform past_key_values.0.key naming convention
+    const uint32_t block_size = 16;
+    const ov::Shape orig_shape{1, 32, 64, 128};
+
+    auto model = create_kv_cache_model("past_key_values.0.key", orig_shape, 2);
+
+    const uint32_t expected_blocks = 64 / block_size;  // 4 blocks
+
+    // Apply transformation
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.run_passes(model);
+
+    // Verify: Should have transformed
+    EXPECT_EQ(model->get_parameters().size(), expected_blocks + 1);
+
+    bool found_blocks = false;
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name().find("_block_") != std::string::npos) {
+            found_blocks = true;
+        }
+    }
+    EXPECT_TRUE(found_blocks);
+}
+
+TEST_F(SplitKVCacheIntoBlocksTest, SkipNonKVCacheParameter) {
+    // Test: Should NOT transform non-KV cache parameters
+    const uint32_t block_size = 16;
+    const ov::Shape orig_shape{1, 32, 64, 128};
+
+    auto model = create_kv_cache_model("hidden_states", orig_shape, 2);
+
+    size_t orig_param_count = model->get_parameters().size();
+
+    // Apply transformation
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.run_passes(model);
+
+    // Verify: Parameter count unchanged (not transformed)
+    EXPECT_EQ(model->get_parameters().size(), orig_param_count);
+
+    // Verify: No block parameters created
+    for (const auto& param : model->get_parameters()) {
+        EXPECT_EQ(param->get_friendly_name().find("_block_"), std::string::npos);
+    }
+}
+
+TEST_F(SplitKVCacheIntoBlocksTest, InvalidRank) {
+    // Test: Should skip parameters with invalid rank (not 4D)
+    const uint32_t block_size = 16;
+    const ov::Shape invalid_shape{1, 32, 64};  // 3D instead of 4D
+
+    auto kv_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, invalid_shape);
+    kv_param->set_friendly_name("past_key.0");
+
+    ov::Shape new_token_shape{1, 32, 1};
+    auto new_token = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, new_token_shape);
+
+    auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{kv_param, new_token}, 2);
+    auto result = std::make_shared<ov::op::v0::Result>(concat);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{kv_param, new_token});
+
+    size_t orig_param_count = model->get_parameters().size();
+
+    // Apply transformation
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.run_passes(model);
+
+    // Verify: Not transformed due to invalid rank
+    EXPECT_EQ(model->get_parameters().size(), orig_param_count);
+}
+
+TEST_F(SplitKVCacheIntoBlocksTest, MultipleKVParameters) {
+    // Test: Transform multiple KV cache parameters in one model
+    const uint32_t block_size = 16;
+    const uint32_t expected_blocks = 64 / block_size;  // 4 blocks per parameter
+
+    // Create model with both past_key and past_value
+    auto key_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 32, 64, 128});
+    key_param->set_friendly_name("past_key.0");
+
+    auto value_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 32, 128, 64});
+    value_param->set_friendly_name("past_value.0");
+
+    auto new_k = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 32, 1, 128});
+    auto new_v = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 32, 128, 1});
+
+    auto concat_k = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{key_param, new_k}, 2);
+    auto concat_v = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{value_param, new_v}, 3);
+
+    auto result_k = std::make_shared<ov::op::v0::Result>(concat_k);
+    auto result_v = std::make_shared<ov::op::v0::Result>(concat_v);
+
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result_k, result_v},
+                                             ov::ParameterVector{key_param, value_param, new_k, new_v});
+
+    // Apply transformation
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.run_passes(model);
+
+    // Verify: Should have (expected_blocks * 2) + 2 parameters (K blocks + V blocks + new_k + new_v)
+    EXPECT_EQ(model->get_parameters().size(), (expected_blocks * 2) + 2);
+
+    // Count block parameters
+    size_t key_blocks = 0, value_blocks = 0;
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name().find("past_key") != std::string::npos &&
+            param->get_friendly_name().find("_block_") != std::string::npos) {
+            key_blocks++;
+        }
+        if (param->get_friendly_name().find("past_value") != std::string::npos &&
+            param->get_friendly_name().find("_block_") != std::string::npos) {
+            value_blocks++;
+        }
+    }
+
+    EXPECT_EQ(key_blocks, expected_blocks);
+    EXPECT_EQ(value_blocks, expected_blocks);
+}
+
+TEST_F(SplitKVCacheIntoBlocksTest, TailBlockHandling) {
+    // Test: Handle non-evenly divisible seq_len (creates tail block)
+    // seq_len=70, block_size=16 -> 4 full blocks (64 tokens) + 1 tail block (6 tokens)
+    const uint32_t block_size = 16;
+    const ov::Shape orig_shape{1, 32, 70, 128};                                                      // [B, H, S=70, D]
+    const uint32_t expected_full_blocks = 70 / block_size;                                           // 4
+    const uint32_t expected_tail_size = 70 % block_size;                                             // 6
+    const uint32_t expected_total_blocks = expected_full_blocks + (expected_tail_size > 0 ? 1 : 0);  // 5
+
+    auto model = create_kv_cache_model("past_key.0", orig_shape, 2);
+
+    // Apply transformation
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.run_passes(model);
+
+    // Verify: Should have 5 block parameters + 1 new_token = 6 total
+    EXPECT_EQ(model->get_parameters().size(), expected_total_blocks + 1);
+
+    // Verify: 4 full blocks + 1 tail block
+    uint32_t full_block_count = 0;
+    bool found_tail_block = false;
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name().find("_block_tail") != std::string::npos) {
+            found_tail_block = true;
+            auto tail_shape = param->get_shape();
+            EXPECT_EQ(tail_shape[2], expected_tail_size);  // tail block has 6 tokens
+        } else if (param->get_friendly_name().find("_block_") != std::string::npos) {
+            full_block_count++;
+            auto block_shape = param->get_shape();
+            EXPECT_EQ(block_shape[2], block_size);  // full block has 16 tokens
+        }
+    }
+    EXPECT_EQ(full_block_count, expected_full_blocks);
+    EXPECT_TRUE(found_tail_block);
+
+    // Verify: Concat has all blocks + present_key
+    for (const auto& op : model->get_ops()) {
+        if (ov::is_type<ov::op::v0::Concat>(op)) {
+            auto concat = ov::as_type_ptr<ov::op::v0::Concat>(op);
+            EXPECT_EQ(concat->get_input_size(), expected_total_blocks + 1);  // 5 blocks + present_key
+        }
+    }
+}
+
+TEST_F(SplitKVCacheIntoBlocksTest, WithConvertNode) {
+    // Test: Transform KV cache with Convert node between Parameter and Concat
+    // Pattern: Parameter(f16) -> Convert(f32) -> Concat
+    const uint32_t block_size = 16;
+    const ov::Shape orig_shape{1, 32, 64, 128};  // [B, H, S=64, D]
+
+    // Create KV cache parameter
+    auto kv_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, orig_shape);
+    kv_param->set_friendly_name("past_key.0");
+
+    // Create Convert node (f16 -> f32)
+    auto convert = std::make_shared<ov::op::v0::Convert>(kv_param, ov::element::f32);
+
+    // Create new token parameter
+    ov::Shape new_token_shape = orig_shape;
+    new_token_shape[2] = 1;  // Single token
+    auto new_token = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, new_token_shape);
+    new_token->set_friendly_name("new_token");
+
+    // Create Concat with Convert output and new_token
+    auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{convert, new_token}, 2);
+
+    // Create Result
+    auto result = std::make_shared<ov::op::v0::Result>(concat);
+
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{kv_param, new_token});
+
+    // Apply transformation
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.run_passes(model);
+
+    // Verify: Should have 4 block parameters + 1 new_token
+    EXPECT_EQ(model->get_parameters().size(), 5);
+
+    // Verify: Each block parameter should be followed by a Convert node
+    uint32_t block_count = 0;
+    uint32_t convert_count = 0;
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name().find("_block_") != std::string::npos) {
+            block_count++;
+            // Check that parameter is f16
+            EXPECT_EQ(param->get_element_type(), ov::element::f16);
+
+            // Check that it's followed by a Convert node
+            for (const auto& output : param->outputs()) {
+                for (const auto& input : output.get_target_inputs()) {
+                    auto node = input.get_node()->shared_from_this();
+                    if (ov::is_type<ov::op::v0::Convert>(node)) {
+                        auto cvt = ov::as_type_ptr<ov::op::v0::Convert>(node);
+                        EXPECT_EQ(cvt->get_destination_type(), ov::element::f32);
+                        convert_count++;
+                    }
+                }
+            }
+        }
+    }
+    EXPECT_EQ(block_count, 4);
+    EXPECT_EQ(convert_count, 4);  // Each block should have a Convert
+
+    // Verify: Concat receives f32 inputs from Convert nodes
+    bool found_concat = false;
+    for (const auto& op : model->get_ops()) {
+        if (ov::is_type<ov::op::v0::Concat>(op)) {
+            found_concat = true;
+            auto concat_node = ov::as_type_ptr<ov::op::v0::Concat>(op);
+            EXPECT_EQ(concat_node->get_input_size(), 5);  // 4 blocks + new_token
+
+            // Verify all concat inputs are f32
+            for (size_t i = 0; i < concat_node->get_input_size(); ++i) {
+                EXPECT_EQ(concat_node->get_input_element_type(i), ov::element::f32);
+            }
+        }
+    }
+    EXPECT_TRUE(found_concat);
+}

--- a/src/plugins/intel_npu/tests/unit/npuw/split_kvcache_into_blocks_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/split_kvcache_into_blocks_test.cpp
@@ -53,7 +53,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, TransformKeyParameter) {
     const ov::Shape orig_shape{1, 32, 64, 128};        // [B, H, S=64, D]
     const uint32_t expected_blocks = 64 / block_size;  // 4 blocks
 
-    auto model = create_kv_cache_model("past_key.0", orig_shape, 2);
+    auto model = create_kv_cache_model("past_key_values.0.key", orig_shape, 2);
 
     // Apply transformation (max_blocks removed, auto-calculated from shape)
     ov::pass::Manager manager;
@@ -95,7 +95,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, TransformValueParameterTransposed) {
     const uint32_t block_size = 16;
     const ov::Shape orig_shape{1, 32, 128, 64};  // [B, H, D, S] - transposed
 
-    auto model = create_kv_cache_model("past_value.0", orig_shape, 3);
+    auto model = create_kv_cache_model("past_key_values.0.value", orig_shape, 3);
 
     // Apply transformation with v_transposed=true
     ov::pass::Manager manager;
@@ -133,7 +133,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, TransformValueParameterNotTransposed) {
     const uint32_t block_size = 16;
     const ov::Shape orig_shape{1, 32, 64, 128};  // [B, H, S, D] - same as K
 
-    auto model = create_kv_cache_model("past_value.0", orig_shape, 2);
+    auto model = create_kv_cache_model("past_key_values.0.value", orig_shape, 2);
 
     // Apply transformation with v_transposed=false
     ov::pass::Manager manager;
@@ -248,10 +248,10 @@ TEST_F(SplitKVCacheIntoBlocksTest, MultipleKVParameters) {
 
     // Create model with both past_key and past_value
     auto key_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 32, 64, 128});
-    key_param->set_friendly_name("past_key.0");
+    key_param->set_friendly_name("past_key_values.0.key");
 
     auto value_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 32, 128, 64});
-    value_param->set_friendly_name("past_value.0");
+    value_param->set_friendly_name("past_key_values.0.value");
 
     auto new_k = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 32, 1, 128});
     auto new_v = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 32, 128, 1});
@@ -276,11 +276,11 @@ TEST_F(SplitKVCacheIntoBlocksTest, MultipleKVParameters) {
     // Count block parameters
     size_t key_blocks = 0, value_blocks = 0;
     for (const auto& param : model->get_parameters()) {
-        if (param->get_friendly_name().find("past_key") != std::string::npos &&
+        if (param->get_friendly_name().find(".key") != std::string::npos &&
             param->get_friendly_name().find("_block_") != std::string::npos) {
             key_blocks++;
         }
-        if (param->get_friendly_name().find("past_value") != std::string::npos &&
+        if (param->get_friendly_name().find(".value") != std::string::npos &&
             param->get_friendly_name().find("_block_") != std::string::npos) {
             value_blocks++;
         }
@@ -299,7 +299,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, TailBlockHandling) {
     const uint32_t expected_tail_size = 70 % block_size;                                             // 6
     const uint32_t expected_total_blocks = expected_full_blocks + (expected_tail_size > 0 ? 1 : 0);  // 5
 
-    auto model = create_kv_cache_model("past_key.0", orig_shape, 2);
+    auto model = create_kv_cache_model("past_key_values.0.key", orig_shape, 2);
 
     // Apply transformation
     ov::pass::Manager manager;
@@ -343,7 +343,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, WithConvertNode) {
 
     // Create KV cache parameter
     auto kv_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, orig_shape);
-    kv_param->set_friendly_name("past_key.0");
+    kv_param->set_friendly_name("past_key_values.0.key");
 
     // Create Convert node (f16 -> f32)
     auto convert = std::make_shared<ov::op::v0::Convert>(kv_param, ov::element::f32);


### PR DESCRIPTION
### Details

Introduces opt-in block-based KV cache management for the NPUW LLM inference path, enabled via a new runtime property:

```
NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE=YES
```

**Impact:**
- Blocked-based KV cache can improve memory footprint significantly.
- Blocked-based KV cache can improve TTFT slightly - directly KV cache update without copy
- Blocked-based KV cache leads to 1~2 tks/s drop for 8K & 16K context cases. - More DMA workloads are introduced when KV are split. Expect to be optimized in NPU compiler.
<img width="1374" height="821" alt="image" src="https://github.com/user-attachments/assets/7e40276d-cfac-4354-bd17-3b08ef800fa3" />

**Key changes:**

- **`SplitKVCacheIntoBlocks` pass** - rewrites each continuous `past_key`/`past_value` parameter into `N` fixed-size block parameters (`_block_0`, `_block_1`, ...) plus an optional smaller tail block (`_block_tail`). Applied to both prefill and generate models at compile time.

- **`KVCacheBlockManager`** - fixed-size block pool with lazy tensor allocation. Manages token-count metadata per block; blocks are reused across conversations via `clear_all()`.

- **`BlockKVCacheExtension`** - encapsulates all per-request block KV cache logic as a value member of `LLMInferRequest`:
  - *Prefill*: loads past blocks into model inputs; uses a **zero-copy path** (redirect output port directly to a fresh block) when the chunk is block-aligned, and a **copy path** otherwise.
  - *Generate*: numbered blocks share memory with `BlockManager` (zero-copy); the tail block is refreshed by copying incrementally after each step.

- **`Others`**:
  - *HFA* - SDPA indices changed from scalar `past_key`/`past_value` to `std::vector<size_t>` (`past_key_blocks`/`past_value_blocks`)
  - *SDPA pattern matching* - `SDPADecomposed` pattern relaxed to match `Concat` with any number of inputs; `ShapeOfParameter` pattern makes the intermediate `Convert` optional.
  - *Unit tests*

### Tickets
 - [EISW-206740](https://jira.devtools.intel.com/browse/EISW-206740)

### AI Assistance
 - AI assistance used: yes
 - Copilot used for code review comment resolution, clang-format execution, and PR description drafting. All logic changes reviewed and validated manually.