### PR TITLE
[NPU] Acknowledge OV model compression in weightless compilation

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/model_serializer.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/model_serializer.cpp
@@ -185,7 +185,9 @@ void storeWeightsPointerAttribute(const std::shared_ptr<ov::Model>& model) {
  * @param model Both source and target.
  */
 void storeWeightlessCacheAttribute(const std::shared_ptr<ov::Model>& model) {
+    std::unordered_map<size_t, size_t> wca_offset_to_size;
     size_t constantId = 0;
+
     for (auto&& node : model->get_ordered_ops()) {
         if (ov::is_type<ov::op::v0::Constant>(node)) {
             ov::RTMap& runtimeInfoMap = node->get_rt_info();
@@ -195,6 +197,16 @@ void storeWeightlessCacheAttribute(const std::shared_ptr<ov::Model>& model) {
             const std::string constantIdString = std::to_string(constantId++);
             if (weightlessCacheAttrIt != runtimeInfoMap.end()) {
                 auto& weightlessCacheAttr = weightlessCacheAttrIt->second.as<ov::WeightlessCacheAttribute>();
+
+                if (!wca_offset_to_size.count(weightlessCacheAttr.bin_offset)) {
+                    wca_offset_to_size[weightlessCacheAttr.bin_offset] = weightlessCacheAttr.original_size;
+                } else {
+                    OPENVINO_ASSERT(
+                        wca_offset_to_size.at(weightlessCacheAttr.bin_offset) == weightlessCacheAttr.original_size,
+                        "The WeightlessCacheAttribute of at least two Constant nodes use the same offset, but "
+                        "different sizes");
+                }
+
                 model->set_rt_info(weightlessCacheAttr.bin_offset, "ws_bin_offset_" + constantIdString);
                 model->set_rt_info(weightlessCacheAttr.original_size, "ws_original_size_" + constantIdString);
                 model->set_rt_info(weightlessCacheAttr.original_dtype, "ws_original_dtype_" + constantIdString);

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -43,7 +43,7 @@ std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_consta
             auto& weightlessCacheAttr = weightlessCacheAttrIt->second.as<ov::WeightlessCacheAttribute>();
 
             auto& constant = constants[weightlessCacheAttr.bin_offset];
-            if (bool foundDuplicate = (constant != nullptr); foundDuplicate) {
+            if (constant != nullptr) {
                 // if multiple constants point to the same buffer, ensure that
                 // their binary sizes are the same
                 OPENVINO_ASSERT(constant->get_byte_size() == constantNode->get_byte_size(),


### PR DESCRIPTION
### Details:
 - OV model compression may produce models with multiple constants pointing to the same binary data. If this is the case, rely on compiler to provide actual constant description (shape and precision), keeping the plugin code simple. Additionally, introduce several checks to ensure that the buffer sizes are the same. They are relatively cheap computation-wise, yet allow to ensure model invariants.
 - Changes and description by @andrey-golubev, small addition by me.

### Tickets:
 - *EISW-204968*

### AI Assistance:
 - *AI assistance used: no*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
