### PR TITLE
[GPU] fix lstm sequence tests cm

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
@@ -153,7 +153,7 @@ TEST_P(LSTMSequenceGPUTestCM, Inference) {
     run();
 };
 
-INSTANTIATE_TEST_SUITE_P(LSTMSequenceCM, LSTMSequenceGPUTestCM,
+INSTANTIATE_TEST_SUITE_P(smoke_LSTMSequenceCM, LSTMSequenceGPUTestCM,
                         ::testing::Combine(
                                 ::testing::Values(ov::test::utils::SequenceTestsMode::PURE_SEQ),
                                 ::testing::ValuesIn(seq_lengths_cm),


### PR DESCRIPTION
### Details:
 - to get working lstm tests on long sequence is neccessary to have better precision - template plugin has same accumulator as input type so precision must be increased from f16 to f32

### Tickets:
 - part of 167904

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
