### PR TITLE
[DRAFT][AI] GatedDeltaNet fusion transformation

### DIFF
--- a/src/common/transformations/include/ov_ops/gated_delta_net.hpp
+++ b/src/common/transformations/include/ov_ops/gated_delta_net.hpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/op.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov {
+namespace op {
+namespace internal {
+
+/// \brief GatedDeltaNet - linear recurrent sequence processing operation.
+///
+/// \note Implements the recurrence from arXiv:2412.06464. Processes a sequence using
+///       the delta rule to update a hidden state matrix, controlled by a per-token
+///       forget gate and a per-token write gate (beta). Queries are scaled internally
+///       by 1 / sqrt(key_head_dim).
+///
+/// Inputs (6):
+///   query           [batch, seq_len, num_heads, key_head_dim]
+///   key             [batch, seq_len, num_heads, key_head_dim]
+///   value           [batch, seq_len, num_heads, value_head_dim]
+///   recurrent_state [batch, num_heads, key_head_dim, value_head_dim]
+///   gate            [batch, seq_len, num_heads]  (log-space forget gate)
+///   beta            [batch, seq_len, num_heads]  (write gate)
+///
+/// Outputs (2):
+///   output_attn             [batch, seq_len, num_heads, value_head_dim]
+///   output_recurrent_state  [batch, num_heads, key_head_dim, value_head_dim]
+class TRANSFORMATIONS_API GatedDeltaNet : public ov::op::Op {
+public:
+    OPENVINO_OP("GatedDeltaNet", "ie_internal_opset");
+
+    GatedDeltaNet() = default;
+
+    /// \brief Constructs a GatedDeltaNet operation.
+    ///
+    /// \param query           4D tensor [batch, seq_len, num_heads, key_head_dim]
+    /// \param key             4D tensor [batch, seq_len, num_heads, key_head_dim]
+    /// \param value           4D tensor [batch, seq_len, num_heads, value_head_dim]
+    /// \param recurrent_state 4D tensor [batch, num_heads, key_head_dim, value_head_dim]
+    /// \param gate            3D tensor [batch, seq_len, num_heads] (log-space)
+    /// \param beta            3D tensor [batch, seq_len, num_heads]
+    GatedDeltaNet(const Output<Node>& query,
+                  const Output<Node>& key,
+                  const Output<Node>& value,
+                  const Output<Node>& recurrent_state,
+                  const Output<Node>& gate,
+                  const Output<Node>& beta);
+
+    bool visit_attributes(AttributeVisitor& visitor) override;
+    void validate_and_infer_types() override;
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+};
+
+}  // namespace internal
+}  // namespace op
+}  // namespace ov

--- a/src/common/transformations/include/ov_ops/opset_private_tbl.hpp
+++ b/src/common/transformations/include/ov_ops/opset_private_tbl.hpp
@@ -9,4 +9,5 @@
 
 _OPENVINO_OP_REG(AUGRUCell, ov::op::internal)
 _OPENVINO_OP_REG(AUGRUSequence, ov::op::internal)
+_OPENVINO_OP_REG(GatedDeltaNet, ov::op::internal)
 _OPENVINO_OP_REG(RMS, ov::op::internal)

--- a/src/common/transformations/include/transformations/common_optimizations/gated_delta_net_fusion.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/gated_delta_net_fusion.hpp
@@ -4,11 +4,14 @@
 
 #pragma once
 
-#include "openvino/pass/matcher_pass.hpp"
+#include "openvino/pass/graph_rewrite.hpp"
 #include "transformations_visibility.hpp"
 
 namespace ov {
 namespace pass {
+
+class TRANSFORMATIONS_API GatedDeltaNetLoopFusion;
+class TRANSFORMATIONS_API GatedDeltaNetOutputLayoutProcessing;
 
 /// \brief GatedDeltaNetFusion replaces the Loop-based recurrent attention graph
 ///        emitted by optimum-intel with one GatedDeltaNet internal operation.
@@ -27,9 +30,21 @@ namespace pass {
 /// The fusion transposes external inputs to the seq-first layout required by
 /// GatedDeltaNet, creates the internal op, then transposes and reshapes its
 /// outputs back so the original flattened concat interface is preserved.
-class TRANSFORMATIONS_API GatedDeltaNetFusion : public ov::pass::MatcherPass {
+class TRANSFORMATIONS_API GatedDeltaNetLoopFusion : public ov::pass::MatcherPass {
 public:
-    OPENVINO_MATCHER_PASS_RTTI("GatedDeltaNetFusion", "0");
+    OPENVINO_MATCHER_PASS_RTTI("GatedDeltaNetLoopFusion", "0");
+    GatedDeltaNetLoopFusion();
+};
+
+class TRANSFORMATIONS_API GatedDeltaNetOutputLayoutProcessing : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("GatedDeltaNetOutputLayoutProcessing", "0");
+    GatedDeltaNetOutputLayoutProcessing();
+};
+
+class TRANSFORMATIONS_API GatedDeltaNetFusion : public ov::pass::GraphRewrite {
+public:
+    OPENVINO_GRAPH_REWRITE_RTTI("GatedDeltaNetFusion", "0");
     GatedDeltaNetFusion();
 };
 

--- a/src/common/transformations/include/transformations/common_optimizations/gated_delta_net_fusion.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/gated_delta_net_fusion.hpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov {
+namespace pass {
+
+/// \brief GatedDeltaNetFusion replaces the Loop-based recurrent attention graph
+///        emitted by optimum-intel with one GatedDeltaNet internal operation.
+///
+/// The matched graph has head-first inputs [batch, num_heads, seq_len, dim] and
+/// is wrapped as:
+///
+///   Concat(
+///       Reshape(Loop(...).output(0), [-1]),
+///       Reshape(Loop(...).output(1), [-1]),
+///       axis=0)
+///
+/// The Loop body slices axis 2 one token at a time and applies the recurrent
+/// update with ScatterUpdate-based accumulation of the full attention output.
+///
+/// The fusion transposes external inputs to the seq-first layout required by
+/// GatedDeltaNet, creates the internal op, then transposes and reshapes its
+/// outputs back so the original flattened concat interface is preserved.
+class TRANSFORMATIONS_API GatedDeltaNetFusion : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("GatedDeltaNetFusion", "0");
+    GatedDeltaNetFusion();
+};
+
+}  // namespace pass
+}  // namespace ov

--- a/src/common/transformations/src/ov_ops/gated_delta_net.cpp
+++ b/src/common/transformations/src/ov_ops/gated_delta_net.cpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ov_ops/gated_delta_net.hpp"
+
+#include "itt.hpp"
+
+using namespace std;
+
+ov::op::internal::GatedDeltaNet::GatedDeltaNet(const Output<Node>& query,
+                                                const Output<Node>& key,
+                                                const Output<Node>& value,
+                                                const Output<Node>& recurrent_state,
+                                                const Output<Node>& gate,
+                                                const Output<Node>& beta)
+    : Op({query, key, value, recurrent_state, gate, beta}) {
+    constructor_validate_and_infer_types();
+}
+
+bool ov::op::internal::GatedDeltaNet::visit_attributes(AttributeVisitor& visitor) {
+    INTERNAL_OP_SCOPE(internal_GatedDeltaNet_visit_attributes);
+    return true;
+}
+
+void ov::op::internal::GatedDeltaNet::validate_and_infer_types() {
+    INTERNAL_OP_SCOPE(internal_GatedDeltaNet_validate_and_infer_types);
+
+    // Validate element types (all must be floating-point and compatible)
+    auto result_et = element::dynamic;
+    for (size_t i = 0; i < 6; ++i) {
+        NODE_VALIDATION_CHECK(this,
+                              element::Type::merge(result_et, result_et, get_input_element_type(i)),
+                              "Element types for all inputs must be compatible floating-point types.");
+        NODE_VALIDATION_CHECK(this,
+                              get_input_element_type(i).is_dynamic() || get_input_element_type(i).is_real(),
+                              "Input ",
+                              i,
+                              " must be a floating-point type, got: ",
+                              get_input_element_type(i));
+    }
+
+    // query: [batch, seq_len, num_heads, key_head_dim]
+    const auto& query_shape = get_input_partial_shape(0);
+    // key: [batch, seq_len, num_heads, key_head_dim]
+    const auto& key_shape = get_input_partial_shape(1);
+    // value: [batch, seq_len, num_heads, value_head_dim]
+    const auto& value_shape = get_input_partial_shape(2);
+    // recurrent_state: [batch, num_heads, key_head_dim, value_head_dim]
+    const auto& state_shape = get_input_partial_shape(3);
+    // gate: [batch, seq_len, num_heads]
+    const auto& gate_shape = get_input_partial_shape(4);
+    // beta: [batch, seq_len, num_heads]
+    const auto& beta_shape = get_input_partial_shape(5);
+
+    NODE_VALIDATION_CHECK(this,
+                          query_shape.rank().is_dynamic() || query_shape.rank().get_length() == 4,
+                          "query must be a 4D tensor, got rank: ",
+                          query_shape.rank());
+    NODE_VALIDATION_CHECK(this,
+                          key_shape.rank().is_dynamic() || key_shape.rank().get_length() == 4,
+                          "key must be a 4D tensor, got rank: ",
+                          key_shape.rank());
+    NODE_VALIDATION_CHECK(this,
+                          value_shape.rank().is_dynamic() || value_shape.rank().get_length() == 4,
+                          "value must be a 4D tensor, got rank: ",
+                          value_shape.rank());
+    NODE_VALIDATION_CHECK(this,
+                          state_shape.rank().is_dynamic() || state_shape.rank().get_length() == 4,
+                          "recurrent_state must be a 4D tensor, got rank: ",
+                          state_shape.rank());
+    NODE_VALIDATION_CHECK(this,
+                          gate_shape.rank().is_dynamic() || gate_shape.rank().get_length() == 3,
+                          "gate must be a 3D tensor, got rank: ",
+                          gate_shape.rank());
+    NODE_VALIDATION_CHECK(this,
+                          beta_shape.rank().is_dynamic() || beta_shape.rank().get_length() == 3,
+                          "beta must be a 3D tensor, got rank: ",
+                          beta_shape.rank());
+
+    // Infer output shapes
+    // output_attn: [batch, seq_len, num_heads, value_head_dim]
+    ov::PartialShape attn_shape = ov::PartialShape::dynamic(4);
+    // output_recurrent_state: [batch, num_heads, key_head_dim, value_head_dim]
+    ov::PartialShape out_state_shape = ov::PartialShape::dynamic(4);
+
+    if (query_shape.rank().is_static() && value_shape.rank().is_static()) {
+        // batch from query[0], seq_len from query[1], num_heads from query[2]
+        // value_head_dim from value[3]
+        attn_shape = ov::PartialShape{query_shape[0], query_shape[1], query_shape[2], value_shape[3]};
+    }
+
+    if (state_shape.rank().is_static()) {
+        // batch, num_heads, key_head_dim, value_head_dim all from recurrent_state
+        out_state_shape = state_shape;
+    }
+
+    set_output_type(0, result_et, attn_shape);
+    set_output_type(1, result_et, out_state_shape);
+}
+
+shared_ptr<ov::Node> ov::op::internal::GatedDeltaNet::clone_with_new_inputs(const OutputVector& new_args) const {
+    INTERNAL_OP_SCOPE(internal_GatedDeltaNet_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    return make_shared<GatedDeltaNet>(new_args.at(0),
+                                      new_args.at(1),
+                                      new_args.at(2),
+                                      new_args.at(3),
+                                      new_args.at(4),
+                                      new_args.at(5));
+}

--- a/src/common/transformations/src/transformations/common_optimizations/common_optimizations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/common_optimizations.cpp
@@ -26,6 +26,7 @@
 #include "transformations/common_optimizations/eliminate_unsqueeze_gather.hpp"
 #include "transformations/common_optimizations/fq_mul_fusion.hpp"
 #include "transformations/common_optimizations/fq_reshape_fusion.hpp"
+#include "transformations/common_optimizations/gated_delta_net_fusion.hpp"
 #include "transformations/common_optimizations/gelu_fusion.hpp"
 #include "transformations/common_optimizations/hsigmoid_fusion.hpp"
 #include "transformations/common_optimizations/hswish_fusion.hpp"
@@ -151,6 +152,7 @@ bool ov::pass::CommonOptimizations::run_on_model(const std::shared_ptr<ov::Model
     ADD_MATCHER(common_fusions, InterpolateSequenceFusion)
     ADD_MATCHER(common_fusions, SkipGatherBeforeTransposeAndReshape)
     ADD_MATCHER(common_fusions, ReduceMerge)
+    ADD_MATCHER(common_fusions, GatedDeltaNetFusion)
     common_fusions->set_name("ov::pass::CommonFusions");
 
     manager.register_pass<ConcatReduceFusion>();

--- a/src/common/transformations/src/transformations/common_optimizations/gated_delta_net_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/gated_delta_net_fusion.cpp
@@ -1,0 +1,386 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/gated_delta_net_fusion.hpp"
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/exp.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/loop.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/scatter_update.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/multi_subgraph_base.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/util/pp.hpp"
+#include "ov_ops/gated_delta_net.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace ov::pass {
+
+namespace {
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+namespace v3 = ov::op::v3;
+namespace v5 = ov::op::v5;
+namespace v8 = ov::op::v8;
+
+using MergedD = op::util::MultiSubGraphOp::MergedInputDescription;
+using SlicedD = op::util::MultiSubGraphOp::SliceInputDescription;
+
+bool is_constant_vector(const std::shared_ptr<Node>& node, const std::vector<int64_t>& expected) {
+    const auto constant = ov::as_type_ptr<v0::Constant>(node);
+    if (!constant || shape_size(constant->get_shape()) != expected.size()) {
+        return false;
+    }
+
+    return constant->cast_vector<int64_t>() == expected;
+}
+
+bool is_true_constant(const std::shared_ptr<Node>& node) {
+    const auto constant = ov::as_type_ptr<v0::Constant>(node);
+    if (!constant || shape_size(constant->get_shape()) != 1) {
+        return false;
+    }
+
+    return constant->cast_vector<char>()[0] != 0;
+}
+
+bool is_reduce_sum(const std::shared_ptr<Node>& node, int64_t axis, bool keep_dims) {
+    const auto rs = ov::as_type_ptr<v1::ReduceSum>(node);
+    if (!rs || rs->get_keep_dims() != keep_dims) {
+        return false;
+    }
+
+    return is_constant_vector(rs->get_input_node_shared_ptr(1), {axis});
+}
+
+bool is_flatten_reshape(const std::shared_ptr<Node>& node) {
+    const auto reshape = ov::as_type_ptr<v1::Reshape>(node);
+    if (!reshape || reshape->get_special_zero()) {
+        return false;
+    }
+
+    return is_constant_vector(reshape->get_input_node_shared_ptr(1), {-1});
+}
+
+bool is_exporter_zero_broadcast(const Output<Node>& value, const Output<Node>& init_attn) {
+    const auto broadcast = ov::as_type_ptr<v3::Broadcast>(init_attn.get_node_shared_ptr());
+    if (!broadcast) {
+        return false;
+    }
+
+    const auto zero = ov::as_type_ptr<v0::Constant>(broadcast->get_input_node_shared_ptr(0));
+    const auto value_shape = ov::as_type_ptr<v3::ShapeOf>(broadcast->get_input_node_shared_ptr(1));
+    if (!zero || !value_shape) {
+        return false;
+    }
+
+    if (shape_size(zero->get_shape()) != 1 || zero->cast_vector<float>()[0] != 0.0f) {
+        return false;
+    }
+
+    return value_shape->input_value(0) == value;
+}
+
+struct LoopMatch {
+    Output<Node> query;
+    Output<Node> key;
+    Output<Node> value;
+    Output<Node> gate;
+    Output<Node> beta;
+    Output<Node> recurrent_state;
+};
+
+bool is_expected_sliced_input(const std::shared_ptr<SlicedD>& desc) {
+    return desc && desc->m_axis == 2 && desc->m_start == 0 && desc->m_stride == 1 && desc->m_part_size == 1 &&
+           desc->m_end == -1;
+}
+
+bool match_recurrent_attention_loop(const std::shared_ptr<v5::Loop>& loop, LoopMatch& match) {
+    if (!loop) {
+        return false;
+    }
+
+    const auto& body = loop->get_function();
+    const auto& body_parameters = body->get_parameters();
+    const auto& body_results = body->get_results();
+    const auto& special_ports = loop->get_special_body_ports();
+    const auto& input_descs = loop->get_input_descriptions();
+
+    if (!body || body_parameters.size() != 8 || body_results.size() != 3 || special_ports.current_iteration_input_idx != 0 ||
+        special_ports.body_condition_output_idx != 0) {
+        return false;
+    }
+
+    if (!is_true_constant(body_results[0]->get_input_node_shared_ptr(0))) {
+        return false;
+    }
+
+    const auto state_out = ov::as_type_ptr<v1::Add>(body_results[1]->get_input_node_shared_ptr(0));
+    const auto scatter = ov::as_type_ptr<v3::ScatterUpdate>(body_results[2]->get_input_node_shared_ptr(0));
+    if (!state_out || !scatter || !is_constant_vector(scatter->get_input_node_shared_ptr(3), {2})) {
+        return false;
+    }
+
+    const auto timestep_unsqueeze = ov::as_type_ptr<v0::Unsqueeze>(scatter->get_input_node_shared_ptr(1));
+    const auto core_attn_update = ov::as_type_ptr<v1::ReduceSum>(scatter->get_input_node_shared_ptr(2));
+    if (!timestep_unsqueeze || !core_attn_update || !is_constant_vector(timestep_unsqueeze->get_input_node_shared_ptr(1), {0}) ||
+        !is_reduce_sum(core_attn_update, -2, true)) {
+        return false;
+    }
+
+    const auto timestep_param = ov::as_type_ptr<v0::Parameter>(timestep_unsqueeze->get_input_node_shared_ptr(0));
+    const auto core_attn_state_param = ov::as_type_ptr<v0::Parameter>(scatter->get_input_node_shared_ptr(0));
+    if (!timestep_param || !core_attn_state_param) {
+        return false;
+    }
+
+    const auto core_attn_mul = ov::as_type_ptr<v1::Multiply>(core_attn_update->get_input_node_shared_ptr(0));
+    const auto query_unsqueeze = ov::as_type_ptr<v0::Unsqueeze>(core_attn_mul ? core_attn_mul->get_input_node_shared_ptr(1) : nullptr);
+    const auto query_squeeze = ov::as_type_ptr<v0::Squeeze>(query_unsqueeze ? query_unsqueeze->get_input_node_shared_ptr(0) : nullptr);
+    const auto query_param = ov::as_type_ptr<v0::Parameter>(query_squeeze ? query_squeeze->get_input_node_shared_ptr(0) : nullptr);
+    if (!core_attn_mul || !query_unsqueeze || !query_squeeze || !query_param ||
+        core_attn_mul->input_value(0) != state_out->output(0) || !is_constant_vector(query_unsqueeze->get_input_node_shared_ptr(1), {-1}) ||
+        !is_constant_vector(query_squeeze->get_input_node_shared_ptr(1), {2})) {
+        return false;
+    }
+
+    const auto state_decay = ov::as_type_ptr<v1::Multiply>(state_out->get_input_node_shared_ptr(0));
+    const auto state_delta = ov::as_type_ptr<v1::Multiply>(state_out->get_input_node_shared_ptr(1));
+    if (!state_decay || !state_delta) {
+        return false;
+    }
+
+    const auto recurrent_state_param = ov::as_type_ptr<v0::Parameter>(state_decay->get_input_node_shared_ptr(0));
+    const auto gate_unsqueeze = ov::as_type_ptr<v0::Unsqueeze>(state_decay->get_input_node_shared_ptr(1));
+    const auto gate_exp = ov::as_type_ptr<v0::Exp>(gate_unsqueeze ? gate_unsqueeze->get_input_node_shared_ptr(0) : nullptr);
+    const auto gate_param = ov::as_type_ptr<v0::Parameter>(gate_exp ? gate_exp->get_input_node_shared_ptr(0) : nullptr);
+    if (!recurrent_state_param || !gate_unsqueeze || !gate_exp || !gate_param ||
+        !is_constant_vector(gate_unsqueeze->get_input_node_shared_ptr(1), {-1})) {
+        return false;
+    }
+
+    const auto key_unsqueeze_outer = ov::as_type_ptr<v0::Unsqueeze>(state_delta->get_input_node_shared_ptr(0));
+    const auto delta_unsqueeze = ov::as_type_ptr<v0::Unsqueeze>(state_delta->get_input_node_shared_ptr(1));
+    const auto key_squeeze = ov::as_type_ptr<v0::Squeeze>(key_unsqueeze_outer ? key_unsqueeze_outer->get_input_node_shared_ptr(0) : nullptr);
+    const auto key_param = ov::as_type_ptr<v0::Parameter>(key_squeeze ? key_squeeze->get_input_node_shared_ptr(0) : nullptr);
+    const auto delta = ov::as_type_ptr<v1::Multiply>(delta_unsqueeze ? delta_unsqueeze->get_input_node_shared_ptr(0) : nullptr);
+    const auto beta_param = ov::as_type_ptr<v0::Parameter>(delta ? delta->get_input_node_shared_ptr(1) : nullptr);
+    if (!key_unsqueeze_outer || !delta_unsqueeze || !key_squeeze || !key_param || !delta || !beta_param ||
+        !is_constant_vector(key_unsqueeze_outer->get_input_node_shared_ptr(1), {-1}) ||
+        !is_constant_vector(key_squeeze->get_input_node_shared_ptr(1), {2}) ||
+        !is_constant_vector(delta_unsqueeze->get_input_node_shared_ptr(1), {-2})) {
+        return false;
+    }
+
+    const auto value_minus_kv = ov::as_type_ptr<v1::Subtract>(delta->get_input_node_shared_ptr(0));
+    const auto value_squeeze = ov::as_type_ptr<v0::Squeeze>(value_minus_kv ? value_minus_kv->get_input_node_shared_ptr(0) : nullptr);
+    const auto value_param = ov::as_type_ptr<v0::Parameter>(value_squeeze ? value_squeeze->get_input_node_shared_ptr(0) : nullptr);
+    const auto kv_mem = value_minus_kv ? value_minus_kv->get_input_node_shared_ptr(1) : nullptr;
+    if (!value_minus_kv || !value_squeeze || !value_param || !is_constant_vector(value_squeeze->get_input_node_shared_ptr(1), {2})) {
+        return false;
+    }
+
+    const auto kv_reduce = ov::as_type_ptr<v1::ReduceSum>(kv_mem);
+    const auto kv_mul = ov::as_type_ptr<v1::Multiply>(kv_reduce ? kv_reduce->get_input_node_shared_ptr(0) : nullptr);
+    const auto key_unsqueeze_inner = ov::as_type_ptr<v0::Unsqueeze>(kv_mul ? kv_mul->get_input_node_shared_ptr(1) : nullptr);
+    if (!kv_reduce || !kv_mul || !key_unsqueeze_inner || kv_mul->input_value(0) != state_decay->output(0) ||
+        !is_reduce_sum(kv_reduce, -2, false) || key_unsqueeze_inner->input_value(0) != key_squeeze->output(0) ||
+        !is_constant_vector(key_unsqueeze_inner->get_input_node_shared_ptr(1), {-1})) {
+        return false;
+    }
+
+    if (scatter->input_value(2).get_node_shared_ptr() != core_attn_update) {
+        return false;
+    }
+
+    const auto trip_count = loop->get_input_node_shared_ptr(0);
+    const auto exec_cond = loop->get_input_node_shared_ptr(1);
+    const auto trip_count_convert = ov::as_type_ptr<v0::Convert>(trip_count);
+    const auto trip_count_gather = ov::as_type_ptr<v8::Gather>(trip_count_convert ? trip_count_convert->get_input_node_shared_ptr(0) : nullptr);
+    const auto trip_count_shape = ov::as_type_ptr<v3::ShapeOf>(trip_count_gather ? trip_count_gather->get_input_node_shared_ptr(0) : nullptr);
+    if (!trip_count_convert || !trip_count_gather || !trip_count_shape || !is_true_constant(exec_cond) ||
+        !is_constant_vector(trip_count_gather->get_input_node_shared_ptr(1), {2}) ||
+        !is_constant_vector(trip_count_gather->get_input_node_shared_ptr(2), {0})) {
+        return false;
+    }
+
+    bool has_query = false;
+    bool has_key = false;
+    bool has_value = false;
+    bool has_gate = false;
+    bool has_beta = false;
+    bool has_state = false;
+    bool has_core_attn = false;
+    Output<Node> core_attn_init;
+
+    for (const auto& desc : input_descs) {
+        const auto& body_param = body_parameters[desc->m_body_parameter_index];
+        if (body_param == query_param) {
+            const auto sliced = ov::as_type_ptr<SlicedD>(desc);
+            if (!is_expected_sliced_input(sliced)) {
+                return false;
+            }
+            match.query = loop->input_value(desc->m_input_index);
+            has_query = true;
+        } else if (body_param == key_param) {
+            const auto sliced = ov::as_type_ptr<SlicedD>(desc);
+            if (!is_expected_sliced_input(sliced)) {
+                return false;
+            }
+            match.key = loop->input_value(desc->m_input_index);
+            has_key = true;
+        } else if (body_param == value_param) {
+            const auto sliced = ov::as_type_ptr<SlicedD>(desc);
+            if (!is_expected_sliced_input(sliced)) {
+                return false;
+            }
+            match.value = loop->input_value(desc->m_input_index);
+            has_value = true;
+        } else if (body_param == gate_param) {
+            const auto sliced = ov::as_type_ptr<SlicedD>(desc);
+            if (!is_expected_sliced_input(sliced)) {
+                return false;
+            }
+            match.gate = loop->input_value(desc->m_input_index);
+            has_gate = true;
+        } else if (body_param == beta_param) {
+            const auto sliced = ov::as_type_ptr<SlicedD>(desc);
+            if (!is_expected_sliced_input(sliced)) {
+                return false;
+            }
+            match.beta = loop->input_value(desc->m_input_index);
+            has_beta = true;
+        } else if (body_param == recurrent_state_param) {
+            const auto merged = ov::as_type_ptr<MergedD>(desc);
+            if (!merged || body_results[merged->m_body_value_index]->input_value(0) != state_out->output(0)) {
+                return false;
+            }
+            match.recurrent_state = loop->input_value(desc->m_input_index);
+            has_state = true;
+        } else if (body_param == core_attn_state_param) {
+            const auto merged = ov::as_type_ptr<MergedD>(desc);
+            if (!merged || body_results[merged->m_body_value_index]->input_value(0) != scatter->output(0)) {
+                return false;
+            }
+            core_attn_init = loop->input_value(desc->m_input_index);
+            has_core_attn = true;
+        } else if (body_param == timestep_param) {
+            if (!ov::as_type_ptr<MergedD>(desc)) {
+                return false;
+            }
+        }
+    }
+
+    if (!(has_query && has_key && has_value && has_gate && has_beta && has_state && has_core_attn)) {
+        return false;
+    }
+
+    return trip_count_shape->input_value(0) == match.value && is_exporter_zero_broadcast(match.value, core_attn_init);
+}
+}  // namespace
+
+/// Matches the graph emitted by optimum-intel's RecurrentAttentionCell conversion:
+///
+///   Concat(
+///       Reshape(Loop(...).output(0), [-1]),
+///       Reshape(Loop(...).output(1), [-1]),
+///       axis=0)
+///
+/// where Loop iterates over sequence axis 2 of head-first inputs [B, H, S, D].
+/// The loop body implements one recurrent attention step and accumulates the full
+/// attention tensor with ScatterUpdate. The fused replacement inserts GatedDeltaNet
+/// in seq-first layout [B, S, H, D], then transposes outputs back and rebuilds the
+/// original flat concat so downstream consumers remain unchanged.
+
+GatedDeltaNetFusion::GatedDeltaNetFusion() {
+    MATCHER_SCOPE(GatedDeltaNetFusion);
+
+    auto loop = pattern::wrap_type<v5::Loop>();
+    auto attn_flat = pattern::wrap_type<v1::Reshape>({loop, pattern::any_input()});
+    auto state_flat = pattern::wrap_type<v1::Reshape>({loop, pattern::any_input()});
+    auto concat = pattern::wrap_type<v0::Concat>({attn_flat, state_flat});
+
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
+        auto concat_node = ov::as_type_ptr<v0::Concat>(m.get_match_root());
+        if (!concat_node || concat_node->get_axis() != 0 || concat_node->inputs().size() != 2) {
+            return false;
+        }
+
+        if (transformation_callback(concat_node)) {
+            return false;
+        }
+
+        auto attn_reshape = ov::as_type_ptr<v1::Reshape>(concat_node->get_input_node_shared_ptr(0));
+        auto state_reshape = ov::as_type_ptr<v1::Reshape>(concat_node->get_input_node_shared_ptr(1));
+        if (!is_flatten_reshape(attn_reshape) || !is_flatten_reshape(state_reshape)) {
+            return false;
+        }
+
+        if (attn_reshape->input_value(0).get_node() != state_reshape->input_value(0).get_node()) {
+            return false;
+        }
+
+        auto loop_node = ov::as_type_ptr<v5::Loop>(attn_reshape->get_input_node_shared_ptr(0));
+        if (!loop_node || loop_node->output(0).get_target_inputs().size() != 1 || loop_node->output(1).get_target_inputs().size() != 1) {
+            return false;
+        }
+
+        LoopMatch match;
+        if (!match_recurrent_attention_loop(loop_node, match)) {
+            return false;
+        }
+
+        const auto q_perm = v0::Constant::create(element::i64, Shape{4}, {0, 2, 1, 3});
+        const auto g_perm = v0::Constant::create(element::i64, Shape{3}, {0, 2, 1});
+        const auto q_back_perm = v0::Constant::create(element::i64, Shape{4}, {0, 2, 1, 3});
+        const auto flatten_shape = v0::Constant::create(element::i32, Shape{1}, {-1});
+
+        auto q_seq = std::make_shared<v1::Transpose>(match.query, q_perm);
+        auto k_seq = std::make_shared<v1::Transpose>(match.key, q_perm);
+        auto v_seq = std::make_shared<v1::Transpose>(match.value, q_perm);
+        auto g_seq = std::make_shared<v1::Transpose>(match.gate, g_perm);
+        auto beta_seq = std::make_shared<v1::Transpose>(match.beta, g_perm);
+
+        auto gdn = std::make_shared<ov::op::internal::GatedDeltaNet>(q_seq,
+                                                                     k_seq,
+                                                                     v_seq,
+                                                                     match.recurrent_state,
+                                                                     g_seq,
+                                                                     beta_seq);
+
+        auto attn_head_first = std::make_shared<v1::Transpose>(gdn->output(0), q_back_perm);
+        auto attn_flat_new = std::make_shared<v1::Reshape>(attn_head_first, flatten_shape, false);
+        auto state_flat_new = std::make_shared<v1::Reshape>(gdn->output(1), flatten_shape, false);
+        auto concat_new = std::make_shared<v0::Concat>(OutputVector{attn_flat_new, state_flat_new}, 0);
+        concat_new->set_friendly_name(concat_node->get_friendly_name());
+
+        ov::copy_runtime_info(NodeVector{concat_node, attn_reshape, state_reshape, loop_node},
+                              NodeVector{q_seq, k_seq, v_seq, g_seq, beta_seq, gdn, attn_head_first, attn_flat_new, state_flat_new, concat_new});
+        register_new_node(gdn);
+        ov::replace_node(concat_node, concat_new);
+        return true;
+    };
+
+    auto matcher = std::make_shared<pattern::Matcher>(concat, matcher_name);
+    register_matcher(matcher, callback);
+}
+
+}  // namespace ov::pass

--- a/src/common/transformations/src/transformations/common_optimizations/gated_delta_net_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/gated_delta_net_fusion.cpp
@@ -108,106 +108,153 @@ struct LoopMatch {
     Output<Node> recurrent_state;
 };
 
+struct LoopBodyMatch {
+    std::shared_ptr<v0::Parameter> timestep_param;
+    std::shared_ptr<v0::Parameter> query_param;
+    std::shared_ptr<v0::Parameter> key_param;
+    std::shared_ptr<v0::Parameter> value_param;
+    std::shared_ptr<v0::Parameter> gate_param;
+    std::shared_ptr<v0::Parameter> beta_param;
+    std::shared_ptr<v0::Parameter> recurrent_state_param;
+    std::shared_ptr<v0::Parameter> core_attn_state_param;
+    std::shared_ptr<v1::Add> state_out;
+    std::shared_ptr<v3::ScatterUpdate> scatter;
+};
+
 bool is_expected_sliced_input(const std::shared_ptr<SlicedD>& desc) {
     return desc && desc->m_axis == 2 && desc->m_start == 0 && desc->m_stride == 1 && desc->m_part_size == 1 &&
            desc->m_end == -1;
 }
 
+bool match_loop_signature(const std::shared_ptr<v5::Loop>& loop) {
+    auto loop_pattern = pattern::wrap_type<v5::Loop>([](const Output<Node>& out) {
+        const auto loop_node = ov::as_type_ptr<v5::Loop>(out.get_node_shared_ptr());
+        if (!loop_node) {
+            return false;
+        }
+
+        const auto& body = loop_node->get_function();
+        if (!body) {
+            return false;
+        }
+
+        const auto& body_parameters = body->get_parameters();
+        const auto& body_results = body->get_results();
+        const auto& special_ports = loop_node->get_special_body_ports();
+        return body_parameters.size() == 8 && body_results.size() == 3 && special_ports.current_iteration_input_idx == 0 &&
+               special_ports.body_condition_output_idx == 0;
+    });
+
+    pattern::Matcher loop_matcher(loop_pattern, "GatedDeltaNetFusionLoopMatcher");
+    return loop_matcher.match(std::static_pointer_cast<Node>(loop));
+}
+
+std::shared_ptr<Node> make_const_pattern(const std::vector<int64_t>& values) {
+    return pattern::wrap_type<v0::Constant>([values](const Output<Node>& out) {
+        return is_constant_vector(out.get_node_shared_ptr(), values);
+    });
+}
+
+bool match_loop_body_pattern(const std::shared_ptr<v5::Loop>& loop, LoopBodyMatch& body_match) {
+    const auto& body = loop->get_function();
+    const auto& body_results = body->get_results();
+    if (body_results.size() != 3 || !is_true_constant(body_results[0]->get_input_node_shared_ptr(0))) {
+        return false;
+    }
+
+    auto c_m1 = make_const_pattern({-1});
+    auto c_m2 = make_const_pattern({-2});
+    auto c_0 = make_const_pattern({0});
+    auto c_2 = make_const_pattern({2});
+
+    auto timestep_param = pattern::wrap_type<v0::Parameter>();
+    auto query_param = pattern::wrap_type<v0::Parameter>();
+    auto key_param = pattern::wrap_type<v0::Parameter>();
+    auto value_param = pattern::wrap_type<v0::Parameter>();
+    auto gate_param = pattern::wrap_type<v0::Parameter>();
+    auto beta_param = pattern::wrap_type<v0::Parameter>();
+    auto recurrent_state_param = pattern::wrap_type<v0::Parameter>();
+    auto core_attn_state_param = pattern::wrap_type<v0::Parameter>();
+
+    auto gate_exp = pattern::wrap_type<v0::Exp>({gate_param});
+    auto gate_unsqueeze = pattern::wrap_type<v0::Unsqueeze>({gate_exp, c_m1});
+    auto state_decay = pattern::wrap_type<v1::Multiply>({recurrent_state_param, gate_unsqueeze});
+
+    auto key_squeeze = pattern::wrap_type<v0::Squeeze>({key_param, c_2});
+    auto key_unsqueeze_inner = pattern::wrap_type<v0::Unsqueeze>({key_squeeze, c_m1});
+    auto kv_mul = pattern::wrap_type<v1::Multiply>({state_decay, key_unsqueeze_inner});
+    auto kv_reduce = pattern::wrap_type<v1::ReduceSum>({kv_mul, c_m2});
+
+    auto value_squeeze = pattern::wrap_type<v0::Squeeze>({value_param, c_2});
+    auto value_minus_kv = pattern::wrap_type<v1::Subtract>({value_squeeze, kv_reduce});
+    auto delta = pattern::wrap_type<v1::Multiply>({value_minus_kv, beta_param});
+    auto delta_unsqueeze = pattern::wrap_type<v0::Unsqueeze>({delta, c_m2});
+    auto key_unsqueeze_outer = pattern::wrap_type<v0::Unsqueeze>({key_squeeze, c_m1});
+    auto state_delta = pattern::wrap_type<v1::Multiply>({key_unsqueeze_outer, delta_unsqueeze});
+    auto state_out = pattern::wrap_type<v1::Add>({state_decay, state_delta});
+
+    auto query_squeeze = pattern::wrap_type<v0::Squeeze>({query_param, c_2});
+    auto query_unsqueeze = pattern::wrap_type<v0::Unsqueeze>({query_squeeze, c_m1});
+    auto core_attn_mul = pattern::wrap_type<v1::Multiply>({state_out, query_unsqueeze});
+    auto core_attn_update = pattern::wrap_type<v1::ReduceSum>({core_attn_mul, c_m2});
+    auto timestep_unsqueeze = pattern::wrap_type<v0::Unsqueeze>({timestep_param, c_0});
+    auto scatter = pattern::wrap_type<v3::ScatterUpdate>({core_attn_state_param, timestep_unsqueeze, core_attn_update, c_2});
+
+    pattern::Matcher body_matcher(scatter, "GatedDeltaNetFusionBodyMatcher");
+    if (!body_matcher.match(body_results[2]->input_value(0))) {
+        return false;
+    }
+
+    const auto& p_map = body_matcher.get_pattern_value_map();
+    auto matched_scatter = ov::as_type_ptr<v3::ScatterUpdate>(p_map.at(scatter).get_node_shared_ptr());
+    auto matched_state_out = ov::as_type_ptr<v1::Add>(p_map.at(state_out).get_node_shared_ptr());
+    auto matched_core_attn_update = ov::as_type_ptr<v1::ReduceSum>(p_map.at(core_attn_update).get_node_shared_ptr());
+    auto matched_kv_reduce = ov::as_type_ptr<v1::ReduceSum>(p_map.at(kv_reduce).get_node_shared_ptr());
+
+    if (!matched_scatter || !matched_state_out || !matched_core_attn_update || !matched_kv_reduce) {
+        return false;
+    }
+
+    if (body_results[1]->input_value(0).get_node_shared_ptr() != matched_state_out ||
+        body_results[2]->input_value(0).get_node_shared_ptr() != matched_scatter) {
+        return false;
+    }
+
+    if (matched_scatter->input_value(2).get_node_shared_ptr() != matched_core_attn_update || !is_reduce_sum(matched_core_attn_update, -2, true) ||
+        !is_reduce_sum(matched_kv_reduce, -2, false)) {
+        return false;
+    }
+
+    if (matched_state_out->output(0) != matched_core_attn_update->get_input_node_shared_ptr(0)->input_value(0)) {
+        return false;
+    }
+
+    body_match.timestep_param = ov::as_type_ptr<v0::Parameter>(p_map.at(timestep_param).get_node_shared_ptr());
+    body_match.query_param = ov::as_type_ptr<v0::Parameter>(p_map.at(query_param).get_node_shared_ptr());
+    body_match.key_param = ov::as_type_ptr<v0::Parameter>(p_map.at(key_param).get_node_shared_ptr());
+    body_match.value_param = ov::as_type_ptr<v0::Parameter>(p_map.at(value_param).get_node_shared_ptr());
+    body_match.gate_param = ov::as_type_ptr<v0::Parameter>(p_map.at(gate_param).get_node_shared_ptr());
+    body_match.beta_param = ov::as_type_ptr<v0::Parameter>(p_map.at(beta_param).get_node_shared_ptr());
+    body_match.recurrent_state_param = ov::as_type_ptr<v0::Parameter>(p_map.at(recurrent_state_param).get_node_shared_ptr());
+    body_match.core_attn_state_param = ov::as_type_ptr<v0::Parameter>(p_map.at(core_attn_state_param).get_node_shared_ptr());
+    body_match.state_out = matched_state_out;
+    body_match.scatter = matched_scatter;
+
+    return body_match.timestep_param && body_match.query_param && body_match.key_param && body_match.value_param && body_match.gate_param &&
+           body_match.beta_param && body_match.recurrent_state_param && body_match.core_attn_state_param;
+}
+
 bool match_recurrent_attention_loop(const std::shared_ptr<v5::Loop>& loop, LoopMatch& match) {
-    if (!loop) {
+    if (!match_loop_signature(loop)) {
         return false;
     }
 
     const auto& body = loop->get_function();
     const auto& body_parameters = body->get_parameters();
-    const auto& body_results = body->get_results();
-    const auto& special_ports = loop->get_special_body_ports();
     const auto& input_descs = loop->get_input_descriptions();
 
-    if (!body || body_parameters.size() != 8 || body_results.size() != 3 || special_ports.current_iteration_input_idx != 0 ||
-        special_ports.body_condition_output_idx != 0) {
-        return false;
-    }
-
-    if (!is_true_constant(body_results[0]->get_input_node_shared_ptr(0))) {
-        return false;
-    }
-
-    const auto state_out = ov::as_type_ptr<v1::Add>(body_results[1]->get_input_node_shared_ptr(0));
-    const auto scatter = ov::as_type_ptr<v3::ScatterUpdate>(body_results[2]->get_input_node_shared_ptr(0));
-    if (!state_out || !scatter || !is_constant_vector(scatter->get_input_node_shared_ptr(3), {2})) {
-        return false;
-    }
-
-    const auto timestep_unsqueeze = ov::as_type_ptr<v0::Unsqueeze>(scatter->get_input_node_shared_ptr(1));
-    const auto core_attn_update = ov::as_type_ptr<v1::ReduceSum>(scatter->get_input_node_shared_ptr(2));
-    if (!timestep_unsqueeze || !core_attn_update || !is_constant_vector(timestep_unsqueeze->get_input_node_shared_ptr(1), {0}) ||
-        !is_reduce_sum(core_attn_update, -2, true)) {
-        return false;
-    }
-
-    const auto timestep_param = ov::as_type_ptr<v0::Parameter>(timestep_unsqueeze->get_input_node_shared_ptr(0));
-    const auto core_attn_state_param = ov::as_type_ptr<v0::Parameter>(scatter->get_input_node_shared_ptr(0));
-    if (!timestep_param || !core_attn_state_param) {
-        return false;
-    }
-
-    const auto core_attn_mul = ov::as_type_ptr<v1::Multiply>(core_attn_update->get_input_node_shared_ptr(0));
-    const auto query_unsqueeze = ov::as_type_ptr<v0::Unsqueeze>(core_attn_mul ? core_attn_mul->get_input_node_shared_ptr(1) : nullptr);
-    const auto query_squeeze = ov::as_type_ptr<v0::Squeeze>(query_unsqueeze ? query_unsqueeze->get_input_node_shared_ptr(0) : nullptr);
-    const auto query_param = ov::as_type_ptr<v0::Parameter>(query_squeeze ? query_squeeze->get_input_node_shared_ptr(0) : nullptr);
-    if (!core_attn_mul || !query_unsqueeze || !query_squeeze || !query_param ||
-        core_attn_mul->input_value(0) != state_out->output(0) || !is_constant_vector(query_unsqueeze->get_input_node_shared_ptr(1), {-1}) ||
-        !is_constant_vector(query_squeeze->get_input_node_shared_ptr(1), {2})) {
-        return false;
-    }
-
-    const auto state_decay = ov::as_type_ptr<v1::Multiply>(state_out->get_input_node_shared_ptr(0));
-    const auto state_delta = ov::as_type_ptr<v1::Multiply>(state_out->get_input_node_shared_ptr(1));
-    if (!state_decay || !state_delta) {
-        return false;
-    }
-
-    const auto recurrent_state_param = ov::as_type_ptr<v0::Parameter>(state_decay->get_input_node_shared_ptr(0));
-    const auto gate_unsqueeze = ov::as_type_ptr<v0::Unsqueeze>(state_decay->get_input_node_shared_ptr(1));
-    const auto gate_exp = ov::as_type_ptr<v0::Exp>(gate_unsqueeze ? gate_unsqueeze->get_input_node_shared_ptr(0) : nullptr);
-    const auto gate_param = ov::as_type_ptr<v0::Parameter>(gate_exp ? gate_exp->get_input_node_shared_ptr(0) : nullptr);
-    if (!recurrent_state_param || !gate_unsqueeze || !gate_exp || !gate_param ||
-        !is_constant_vector(gate_unsqueeze->get_input_node_shared_ptr(1), {-1})) {
-        return false;
-    }
-
-    const auto key_unsqueeze_outer = ov::as_type_ptr<v0::Unsqueeze>(state_delta->get_input_node_shared_ptr(0));
-    const auto delta_unsqueeze = ov::as_type_ptr<v0::Unsqueeze>(state_delta->get_input_node_shared_ptr(1));
-    const auto key_squeeze = ov::as_type_ptr<v0::Squeeze>(key_unsqueeze_outer ? key_unsqueeze_outer->get_input_node_shared_ptr(0) : nullptr);
-    const auto key_param = ov::as_type_ptr<v0::Parameter>(key_squeeze ? key_squeeze->get_input_node_shared_ptr(0) : nullptr);
-    const auto delta = ov::as_type_ptr<v1::Multiply>(delta_unsqueeze ? delta_unsqueeze->get_input_node_shared_ptr(0) : nullptr);
-    const auto beta_param = ov::as_type_ptr<v0::Parameter>(delta ? delta->get_input_node_shared_ptr(1) : nullptr);
-    if (!key_unsqueeze_outer || !delta_unsqueeze || !key_squeeze || !key_param || !delta || !beta_param ||
-        !is_constant_vector(key_unsqueeze_outer->get_input_node_shared_ptr(1), {-1}) ||
-        !is_constant_vector(key_squeeze->get_input_node_shared_ptr(1), {2}) ||
-        !is_constant_vector(delta_unsqueeze->get_input_node_shared_ptr(1), {-2})) {
-        return false;
-    }
-
-    const auto value_minus_kv = ov::as_type_ptr<v1::Subtract>(delta->get_input_node_shared_ptr(0));
-    const auto value_squeeze = ov::as_type_ptr<v0::Squeeze>(value_minus_kv ? value_minus_kv->get_input_node_shared_ptr(0) : nullptr);
-    const auto value_param = ov::as_type_ptr<v0::Parameter>(value_squeeze ? value_squeeze->get_input_node_shared_ptr(0) : nullptr);
-    const auto kv_mem = value_minus_kv ? value_minus_kv->get_input_node_shared_ptr(1) : nullptr;
-    if (!value_minus_kv || !value_squeeze || !value_param || !is_constant_vector(value_squeeze->get_input_node_shared_ptr(1), {2})) {
-        return false;
-    }
-
-    const auto kv_reduce = ov::as_type_ptr<v1::ReduceSum>(kv_mem);
-    const auto kv_mul = ov::as_type_ptr<v1::Multiply>(kv_reduce ? kv_reduce->get_input_node_shared_ptr(0) : nullptr);
-    const auto key_unsqueeze_inner = ov::as_type_ptr<v0::Unsqueeze>(kv_mul ? kv_mul->get_input_node_shared_ptr(1) : nullptr);
-    if (!kv_reduce || !kv_mul || !key_unsqueeze_inner || kv_mul->input_value(0) != state_decay->output(0) ||
-        !is_reduce_sum(kv_reduce, -2, false) || key_unsqueeze_inner->input_value(0) != key_squeeze->output(0) ||
-        !is_constant_vector(key_unsqueeze_inner->get_input_node_shared_ptr(1), {-1})) {
-        return false;
-    }
-
-    if (scatter->input_value(2).get_node_shared_ptr() != core_attn_update) {
+    LoopBodyMatch body_match;
+    if (!match_loop_body_pattern(loop, body_match)) {
         return false;
     }
 
@@ -233,56 +280,56 @@ bool match_recurrent_attention_loop(const std::shared_ptr<v5::Loop>& loop, LoopM
 
     for (const auto& desc : input_descs) {
         const auto& body_param = body_parameters[desc->m_body_parameter_index];
-        if (body_param == query_param) {
+        if (body_param == body_match.query_param) {
             const auto sliced = ov::as_type_ptr<SlicedD>(desc);
             if (!is_expected_sliced_input(sliced)) {
                 return false;
             }
             match.query = loop->input_value(desc->m_input_index);
             has_query = true;
-        } else if (body_param == key_param) {
+        } else if (body_param == body_match.key_param) {
             const auto sliced = ov::as_type_ptr<SlicedD>(desc);
             if (!is_expected_sliced_input(sliced)) {
                 return false;
             }
             match.key = loop->input_value(desc->m_input_index);
             has_key = true;
-        } else if (body_param == value_param) {
+        } else if (body_param == body_match.value_param) {
             const auto sliced = ov::as_type_ptr<SlicedD>(desc);
             if (!is_expected_sliced_input(sliced)) {
                 return false;
             }
             match.value = loop->input_value(desc->m_input_index);
             has_value = true;
-        } else if (body_param == gate_param) {
+        } else if (body_param == body_match.gate_param) {
             const auto sliced = ov::as_type_ptr<SlicedD>(desc);
             if (!is_expected_sliced_input(sliced)) {
                 return false;
             }
             match.gate = loop->input_value(desc->m_input_index);
             has_gate = true;
-        } else if (body_param == beta_param) {
+        } else if (body_param == body_match.beta_param) {
             const auto sliced = ov::as_type_ptr<SlicedD>(desc);
             if (!is_expected_sliced_input(sliced)) {
                 return false;
             }
             match.beta = loop->input_value(desc->m_input_index);
             has_beta = true;
-        } else if (body_param == recurrent_state_param) {
+        } else if (body_param == body_match.recurrent_state_param) {
             const auto merged = ov::as_type_ptr<MergedD>(desc);
-            if (!merged || body_results[merged->m_body_value_index]->input_value(0) != state_out->output(0)) {
+            if (!merged || body->get_results()[merged->m_body_value_index]->input_value(0) != body_match.state_out->output(0)) {
                 return false;
             }
             match.recurrent_state = loop->input_value(desc->m_input_index);
             has_state = true;
-        } else if (body_param == core_attn_state_param) {
+        } else if (body_param == body_match.core_attn_state_param) {
             const auto merged = ov::as_type_ptr<MergedD>(desc);
-            if (!merged || body_results[merged->m_body_value_index]->input_value(0) != scatter->output(0)) {
+            if (!merged || body->get_results()[merged->m_body_value_index]->input_value(0) != body_match.scatter->output(0)) {
                 return false;
             }
             core_attn_init = loop->input_value(desc->m_input_index);
             has_core_attn = true;
-        } else if (body_param == timestep_param) {
+        } else if (body_param == body_match.timestep_param) {
             if (!ov::as_type_ptr<MergedD>(desc)) {
                 return false;
             }

--- a/src/common/transformations/src/transformations/common_optimizations/gated_delta_net_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/gated_delta_net_fusion.cpp
@@ -342,51 +342,63 @@ bool match_recurrent_attention_loop(const std::shared_ptr<v5::Loop>& loop, LoopM
 
     return trip_count_shape->input_value(0) == match.value && is_exporter_zero_broadcast(match.value, core_attn_init);
 }
+
+bool get_exporter_concat_context(const std::shared_ptr<v5::Loop>& loop,
+                                 std::shared_ptr<v1::Reshape>& attn_reshape,
+                                 std::shared_ptr<v1::Reshape>& state_reshape,
+                                 std::shared_ptr<v0::Concat>& concat) {
+    if (!loop || loop->get_output_size() < 2) {
+        return false;
+    }
+
+    const auto& out0_targets = loop->output(0).get_target_inputs();
+    const auto& out1_targets = loop->output(1).get_target_inputs();
+    if (out0_targets.size() != 1 || out1_targets.size() != 1) {
+        return false;
+    }
+
+    attn_reshape = ov::as_type_ptr<v1::Reshape>(out0_targets.begin()->get_node()->shared_from_this());
+    state_reshape = ov::as_type_ptr<v1::Reshape>(out1_targets.begin()->get_node()->shared_from_this());
+    if (!is_flatten_reshape(attn_reshape) || !is_flatten_reshape(state_reshape)) {
+        return false;
+    }
+
+    const auto& attn_targets = attn_reshape->output(0).get_target_inputs();
+    const auto& state_targets = state_reshape->output(0).get_target_inputs();
+    if (attn_targets.size() != 1 || state_targets.size() != 1) {
+        return false;
+    }
+
+    concat = ov::as_type_ptr<v0::Concat>(attn_targets.begin()->get_node()->shared_from_this());
+    auto concat_from_state = ov::as_type_ptr<v0::Concat>(state_targets.begin()->get_node()->shared_from_this());
+    if (!concat || !concat_from_state || concat != concat_from_state || concat->get_axis() != 0 || concat->inputs().size() != 2) {
+        return false;
+    }
+
+    return concat->input_value(0).get_node_shared_ptr() == attn_reshape &&
+           concat->input_value(1).get_node_shared_ptr() == state_reshape;
+}
 }  // namespace
 
-/// Matches the graph emitted by optimum-intel's RecurrentAttentionCell conversion:
-///
-///   Concat(
-///       Reshape(Loop(...).output(0), [-1]),
-///       Reshape(Loop(...).output(1), [-1]),
-///       axis=0)
-///
-/// where Loop iterates over sequence axis 2 of head-first inputs [B, H, S, D].
-/// The loop body implements one recurrent attention step and accumulates the full
-/// attention tensor with ScatterUpdate. The fused replacement inserts GatedDeltaNet
-/// in seq-first layout [B, S, H, D], then transposes outputs back and rebuilds the
-/// original flat concat so downstream consumers remain unchanged.
-
-GatedDeltaNetFusion::GatedDeltaNetFusion() {
-    MATCHER_SCOPE(GatedDeltaNetFusion);
+GatedDeltaNetLoopFusion::GatedDeltaNetLoopFusion() {
+    MATCHER_SCOPE(GatedDeltaNetLoopFusion);
 
     auto loop = pattern::wrap_type<v5::Loop>();
-    auto attn_flat = pattern::wrap_type<v1::Reshape>({loop, pattern::any_input()});
-    auto state_flat = pattern::wrap_type<v1::Reshape>({loop, pattern::any_input()});
-    auto concat = pattern::wrap_type<v0::Concat>({attn_flat, state_flat});
 
     matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
-        auto concat_node = ov::as_type_ptr<v0::Concat>(m.get_match_root());
-        if (!concat_node || concat_node->get_axis() != 0 || concat_node->inputs().size() != 2) {
+        auto loop_node = ov::as_type_ptr<v5::Loop>(m.get_match_root());
+        if (!loop_node || transformation_callback(loop_node)) {
+            return false;
+        }
+
+        std::shared_ptr<v1::Reshape> attn_reshape;
+        std::shared_ptr<v1::Reshape> state_reshape;
+        std::shared_ptr<v0::Concat> concat_node;
+        if (!get_exporter_concat_context(loop_node, attn_reshape, state_reshape, concat_node)) {
             return false;
         }
 
         if (transformation_callback(concat_node)) {
-            return false;
-        }
-
-        auto attn_reshape = ov::as_type_ptr<v1::Reshape>(concat_node->get_input_node_shared_ptr(0));
-        auto state_reshape = ov::as_type_ptr<v1::Reshape>(concat_node->get_input_node_shared_ptr(1));
-        if (!is_flatten_reshape(attn_reshape) || !is_flatten_reshape(state_reshape)) {
-            return false;
-        }
-
-        if (attn_reshape->input_value(0).get_node() != state_reshape->input_value(0).get_node()) {
-            return false;
-        }
-
-        auto loop_node = ov::as_type_ptr<v5::Loop>(attn_reshape->get_input_node_shared_ptr(0));
-        if (!loop_node || loop_node->output(0).get_target_inputs().size() != 1 || loop_node->output(1).get_target_inputs().size() != 1) {
             return false;
         }
 
@@ -397,8 +409,6 @@ GatedDeltaNetFusion::GatedDeltaNetFusion() {
 
         const auto q_perm = v0::Constant::create(element::i64, Shape{4}, {0, 2, 1, 3});
         const auto g_perm = v0::Constant::create(element::i64, Shape{3}, {0, 2, 1});
-        const auto q_back_perm = v0::Constant::create(element::i64, Shape{4}, {0, 2, 1, 3});
-        const auto flatten_shape = v0::Constant::create(element::i32, Shape{1}, {-1});
 
         auto q_seq = std::make_shared<v1::Transpose>(match.query, q_perm);
         auto k_seq = std::make_shared<v1::Transpose>(match.key, q_perm);
@@ -412,22 +422,64 @@ GatedDeltaNetFusion::GatedDeltaNetFusion() {
                                                                      match.recurrent_state,
                                                                      g_seq,
                                                                      beta_seq);
+        gdn->set_friendly_name(loop_node->get_friendly_name());
 
-        auto attn_head_first = std::make_shared<v1::Transpose>(gdn->output(0), q_back_perm);
-        auto attn_flat_new = std::make_shared<v1::Reshape>(attn_head_first, flatten_shape, false);
-        auto state_flat_new = std::make_shared<v1::Reshape>(gdn->output(1), flatten_shape, false);
-        auto concat_new = std::make_shared<v0::Concat>(OutputVector{attn_flat_new, state_flat_new}, 0);
+        ov::copy_runtime_info(NodeVector{loop_node, attn_reshape, state_reshape, concat_node},
+                              NodeVector{q_seq, k_seq, v_seq, g_seq, beta_seq, gdn});
+        register_new_node(gdn);
+        ov::replace_node(loop_node, gdn);
+        return true;
+    };
+
+    auto matcher = std::make_shared<pattern::Matcher>(loop, matcher_name);
+    register_matcher(matcher, callback);
+}
+
+GatedDeltaNetOutputLayoutProcessing::GatedDeltaNetOutputLayoutProcessing() {
+    MATCHER_SCOPE(GatedDeltaNetOutputLayoutProcessing);
+
+    auto gdn = pattern::wrap_type<ov::op::internal::GatedDeltaNet>();
+    auto attn_flat = pattern::wrap_type<v1::Reshape>({gdn, pattern::any_input()});
+    auto state_flat = pattern::wrap_type<v1::Reshape>({gdn, pattern::any_input()});
+    auto concat = pattern::wrap_type<v0::Concat>({attn_flat, state_flat});
+
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
+        auto concat_node = ov::as_type_ptr<v0::Concat>(m.get_match_root());
+        if (!concat_node || concat_node->get_axis() != 0 || concat_node->inputs().size() != 2 || transformation_callback(concat_node)) {
+            return false;
+        }
+
+        auto attn_reshape = ov::as_type_ptr<v1::Reshape>(concat_node->get_input_node_shared_ptr(0));
+        auto state_reshape = ov::as_type_ptr<v1::Reshape>(concat_node->get_input_node_shared_ptr(1));
+        if (!is_flatten_reshape(attn_reshape) || !is_flatten_reshape(state_reshape)) {
+            return false;
+        }
+
+        auto gdn_node = ov::as_type_ptr<ov::op::internal::GatedDeltaNet>(attn_reshape->get_input_node_shared_ptr(0));
+        if (!gdn_node || state_reshape->get_input_node_shared_ptr(0) != gdn_node || attn_reshape->input_value(0).get_index() != 0 ||
+            state_reshape->input_value(0).get_index() != 1) {
+            return false;
+        }
+
+        const auto q_back_perm = v0::Constant::create(element::i64, Shape{4}, {0, 2, 1, 3});
+        auto attn_head_first = std::make_shared<v1::Transpose>(gdn_node->output(0), q_back_perm);
+        auto attn_flat_new = std::make_shared<v1::Reshape>(attn_head_first, attn_reshape->input_value(1), attn_reshape->get_special_zero());
+        auto concat_new = std::make_shared<v0::Concat>(OutputVector{attn_flat_new, state_reshape}, 0);
         concat_new->set_friendly_name(concat_node->get_friendly_name());
 
-        ov::copy_runtime_info(NodeVector{concat_node, attn_reshape, state_reshape, loop_node},
-                              NodeVector{q_seq, k_seq, v_seq, g_seq, beta_seq, gdn, attn_head_first, attn_flat_new, state_flat_new, concat_new});
-        register_new_node(gdn);
+        ov::copy_runtime_info(NodeVector{concat_node, attn_reshape, state_reshape, gdn_node},
+                              NodeVector{attn_head_first, attn_flat_new, concat_new});
         ov::replace_node(concat_node, concat_new);
         return true;
     };
 
     auto matcher = std::make_shared<pattern::Matcher>(concat, matcher_name);
     register_matcher(matcher, callback);
+}
+
+GatedDeltaNetFusion::GatedDeltaNetFusion() {
+    add_matcher<ov::pass::GatedDeltaNetLoopFusion>();
+    add_matcher<ov::pass::GatedDeltaNetOutputLayoutProcessing>();
 }
 
 }  // namespace ov::pass

--- a/src/common/transformations/tests/common_optimizations/gated_delta_net_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/gated_delta_net_fusion_test.cpp
@@ -1,0 +1,225 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/gated_delta_net_fusion.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/exp.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/loop.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/scatter_update.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/pass/manager.hpp"
+#include "ov_ops/gated_delta_net.hpp"
+
+using namespace testing;
+using namespace ov;
+using namespace ov::pass;
+
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+namespace v3 = ov::op::v3;
+namespace v5 = ov::op::v5;
+namespace v8 = ov::op::v8;
+
+static constexpr int64_t B = 2;
+static constexpr int64_t H = 4;
+static constexpr int64_t S = 3;
+static constexpr int64_t Dk = 8;
+static constexpr int64_t Dv = 16;
+
+static std::shared_ptr<Node> build_exporter_concat_output(const Output<Node>& query,
+                                                          const Output<Node>& key,
+                                                          const Output<Node>& value,
+                                                          const Output<Node>& recurrent_state,
+                                                          const Output<Node>& gate,
+                                                          const Output<Node>& beta,
+                                                          bool core_attn_keep_dims = true,
+                                                          bool flatten_outputs = true) {
+    const auto const_zero_i32 = v0::Constant::create(element::i32, Shape{}, {0});
+    const auto const_two_i32 = v0::Constant::create(element::i32, Shape{}, {2});
+    const auto const_minus_one = v0::Constant::create(element::i32, Shape{}, {-1});
+    const auto const_minus_two = v0::Constant::create(element::i32, Shape{}, {-2});
+    const auto flatten_shape = flatten_outputs ? v0::Constant::create(element::i32, Shape{1}, {-1})
+                                               : v0::Constant::create(element::i32, Shape{2}, {-1, 1});
+
+    const auto value_shape = std::make_shared<v3::ShapeOf>(value, element::i32);
+    const auto zero_f32 = v0::Constant::create(element::f32, Shape{}, {0.0f});
+    const auto core_attn_out = std::make_shared<v3::Broadcast>(zero_f32, value_shape);
+    const auto seq_len = std::make_shared<v8::Gather>(value_shape, const_two_i32, const_zero_i32);
+    const auto seq_len_i32 = std::make_shared<v0::Convert>(seq_len, element::i32);
+    const auto exec_cond = v0::Constant::create(element::boolean, Shape{}, {true});
+
+    auto timestep_param = std::make_shared<v0::Parameter>(element::i32, PartialShape{});
+    auto q_t_param = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, -1, 1, -1});
+    auto k_t_param = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, -1, 1, -1});
+    auto v_t_param = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, -1, 1, -1});
+    auto g_t_param = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, -1, 1});
+    auto beta_t_param = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, -1, 1});
+    auto last_state_param = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1});
+    auto core_attn_param = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1});
+
+    auto q_t = std::make_shared<v0::Squeeze>(q_t_param, const_two_i32);
+    auto k_t = std::make_shared<v0::Squeeze>(k_t_param, const_two_i32);
+    auto v_t = std::make_shared<v0::Squeeze>(v_t_param, const_two_i32);
+    auto g_t = std::make_shared<v0::Unsqueeze>(std::make_shared<v0::Exp>(g_t_param), const_minus_one);
+
+    auto last_state_in = std::make_shared<v1::Multiply>(last_state_param, g_t);
+    std::shared_ptr<Node> kv_mem =
+        std::make_shared<v1::Multiply>(last_state_in, std::make_shared<v0::Unsqueeze>(k_t, const_minus_one));
+    kv_mem = std::make_shared<v1::ReduceSum>(kv_mem, const_minus_two, false);
+
+    auto delta = std::make_shared<v1::Multiply>(std::make_shared<v1::Subtract>(v_t, kv_mem), beta_t_param);
+    auto last_state_delta = std::make_shared<v1::Multiply>(std::make_shared<v0::Unsqueeze>(k_t, const_minus_one),
+                                                           std::make_shared<v0::Unsqueeze>(delta, const_minus_two));
+    auto last_state_next = std::make_shared<v1::Add>(last_state_in, last_state_delta);
+    std::shared_ptr<Node> core_attn_update =
+        std::make_shared<v1::Multiply>(last_state_next, std::make_shared<v0::Unsqueeze>(q_t, const_minus_one));
+    core_attn_update = std::make_shared<v1::ReduceSum>(core_attn_update, const_minus_two, core_attn_keep_dims);
+
+    auto timestep = std::make_shared<v0::Unsqueeze>(timestep_param, const_zero_i32);
+    auto core_attn_res = std::make_shared<v3::ScatterUpdate>(core_attn_param, timestep, core_attn_update, const_two_i32);
+    auto body_cond = v0::Constant::create(element::boolean, Shape{1}, {true});
+    auto last_state_result = std::make_shared<v0::Result>(last_state_next);
+    auto core_attn_result = std::make_shared<v0::Result>(core_attn_res);
+
+    auto body = std::make_shared<Model>(OutputVector{body_cond, last_state_result, core_attn_result},
+                                        ParameterVector{timestep_param,
+                                                        q_t_param,
+                                                        k_t_param,
+                                                        v_t_param,
+                                                        g_t_param,
+                                                        beta_t_param,
+                                                        last_state_param,
+                                                        core_attn_param},
+                                        "body_model");
+
+    auto loop = std::make_shared<v5::Loop>(seq_len_i32, exec_cond);
+    loop->set_function(body);
+    loop->set_special_body_ports({0, 0});
+    loop->set_sliced_input(q_t_param, query, 0, 1, 1, -1, 2);
+    loop->set_sliced_input(k_t_param, key, 0, 1, 1, -1, 2);
+    loop->set_sliced_input(v_t_param, value, 0, 1, 1, -1, 2);
+    loop->set_sliced_input(g_t_param, gate, 0, 1, 1, -1, 2);
+    loop->set_sliced_input(beta_t_param, beta, 0, 1, 1, -1, 2);
+    loop->set_merged_input(last_state_param, recurrent_state, last_state_result);
+    loop->set_merged_input(core_attn_param, core_attn_out, core_attn_result);
+
+    auto core_attn_last = loop->get_iter_value(core_attn_result, -1);
+    auto last_state_last = loop->get_iter_value(last_state_result, -1);
+    auto core_attn_flat = std::make_shared<v1::Reshape>(core_attn_last, flatten_shape, false);
+    auto last_state_flat = std::make_shared<v1::Reshape>(last_state_last, flatten_shape, false);
+    return std::make_shared<v0::Concat>(OutputVector{core_attn_flat, last_state_flat}, 0);
+}
+
+static std::shared_ptr<Node> build_fused_concat_output(const Output<Node>& query,
+                                                       const Output<Node>& key,
+                                                       const Output<Node>& value,
+                                                       const Output<Node>& recurrent_state,
+                                                       const Output<Node>& gate,
+                                                       const Output<Node>& beta) {
+    const auto q_perm = v0::Constant::create(element::i64, Shape{4}, {0, 2, 1, 3});
+    const auto g_perm = v0::Constant::create(element::i64, Shape{3}, {0, 2, 1});
+    const auto flatten_shape = v0::Constant::create(element::i32, Shape{1}, {-1});
+
+    auto q_seq = std::make_shared<v1::Transpose>(query, q_perm);
+    auto k_seq = std::make_shared<v1::Transpose>(key, q_perm);
+    auto v_seq = std::make_shared<v1::Transpose>(value, q_perm);
+    auto g_seq = std::make_shared<v1::Transpose>(gate, g_perm);
+    auto beta_seq = std::make_shared<v1::Transpose>(beta, g_perm);
+
+    auto gdn = std::make_shared<ov::op::internal::GatedDeltaNet>(q_seq, k_seq, v_seq, recurrent_state, g_seq, beta_seq);
+    auto attn_head_first = std::make_shared<v1::Transpose>(gdn->output(0), q_perm);
+    auto attn_flat = std::make_shared<v1::Reshape>(attn_head_first, flatten_shape, false);
+    auto state_flat = std::make_shared<v1::Reshape>(gdn->output(1), flatten_shape, false);
+    return std::make_shared<v0::Concat>(OutputVector{attn_flat, state_flat}, 0);
+}
+
+TEST_F(TransformationTestsF, GatedDeltaNetFusion_ExporterLoopStaticShapes) {
+    {
+        auto query = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S, Dk});
+        auto key = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S, Dk});
+        auto value = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S, Dv});
+        auto recurrent_state = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, Dk, Dv});
+        auto gate = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S});
+        auto beta = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S});
+
+        auto concat_out = build_exporter_concat_output(query, key, value, recurrent_state, gate, beta);
+        model = std::make_shared<Model>(OutputVector{concat_out},
+                                        ParameterVector{query, key, value, recurrent_state, gate, beta});
+        manager.register_pass<GatedDeltaNetFusion>();
+    }
+    {
+        auto query = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S, Dk});
+        auto key = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S, Dk});
+        auto value = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S, Dv});
+        auto recurrent_state = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, Dk, Dv});
+        auto gate = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S});
+        auto beta = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S});
+
+        auto concat_out = build_fused_concat_output(query, key, value, recurrent_state, gate, beta);
+        model_ref = std::make_shared<Model>(OutputVector{concat_out},
+                                            ParameterVector{query, key, value, recurrent_state, gate, beta});
+    }
+}
+
+TEST_F(TransformationTestsF, GatedDeltaNetFusion_ExporterLoopDynamicShapes) {
+    {
+        auto query = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1, Dk});
+        auto key = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1, Dk});
+        auto value = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1, Dv});
+        auto recurrent_state = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, Dk, Dv});
+        auto gate = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1});
+        auto beta = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1});
+
+        auto concat_out = build_exporter_concat_output(query, key, value, recurrent_state, gate, beta);
+        model = std::make_shared<Model>(OutputVector{concat_out},
+                                        ParameterVector{query, key, value, recurrent_state, gate, beta});
+        manager.register_pass<GatedDeltaNetFusion>();
+    }
+    {
+        auto query = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1, Dk});
+        auto key = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1, Dk});
+        auto value = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1, Dv});
+        auto recurrent_state = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, Dk, Dv});
+        auto gate = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1});
+        auto beta = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, H, -1});
+
+        auto concat_out = build_fused_concat_output(query, key, value, recurrent_state, gate, beta);
+        model_ref = std::make_shared<Model>(OutputVector{concat_out},
+                                            ParameterVector{query, key, value, recurrent_state, gate, beta});
+    }
+}
+
+TEST_F(TransformationTestsF, GatedDeltaNetFusion_NegativeNonFlatOutputReshape) {
+    auto query = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S, Dk});
+    auto key = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S, Dk});
+    auto value = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S, Dv});
+    auto recurrent_state = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, Dk, Dv});
+    auto gate = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S});
+    auto beta = std::make_shared<v0::Parameter>(element::f32, Shape{B, H, S});
+
+    auto concat_out = build_exporter_concat_output(query, key, value, recurrent_state, gate, beta, true, false);
+    model = std::make_shared<Model>(OutputVector{concat_out},
+                                    ParameterVector{query, key, value, recurrent_state, gate, beta});
+    manager.register_pass<GatedDeltaNetFusion>();
+}

--- a/src/tests/functional/base_func_tests/src/base/utils/compare_results.cpp
+++ b/src/tests/functional/base_func_tests/src/base/utils/compare_results.cpp
@@ -7,6 +7,7 @@
 #include "openvino/op/ops.hpp"
 #include "ov_ops/augru_cell.hpp"
 #include "ov_ops/augru_sequence.hpp"
+#include "ov_ops/gated_delta_net.hpp"
 #include "ov_ops/rms.hpp"
 
 #include "shared_test_classes/base/utils/compare_results.hpp"

--- a/src/tests/functional/base_func_tests/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/base_func_tests/src/base/utils/generate_inputs.cpp
@@ -10,6 +10,7 @@
 
 #include "ov_ops/augru_cell.hpp"
 #include "ov_ops/augru_sequence.hpp"
+#include "ov_ops/gated_delta_net.hpp"
 #include "ov_ops/rms.hpp"
 
 #include "common_test_utils/ov_tensor_utils.hpp"


### PR DESCRIPTION
### Details:
This pull request introduces a new internal operator, `GatedDeltaNet`, for efficient linear recurrent sequence processing, and adds a graph optimization pass to fuse certain recurrent attention patterns into this new operator. This enhances model optimization and execution by simplifying complex recurrent attention subgraphs into a single, purpose-built operation.

The most important changes are:

**New Operator Implementation:**
* Added the `GatedDeltaNet` operator, including its interface (`gated_delta_net.hpp`) and implementation (`gated_delta_net.cpp`). This operator processes sequences using a delta rule with per-token gates, as described in arXiv:2412.06464, and supports efficient recurrent attention. [[1]](diffhunk://#diff-60245b328641df95ce683a8ce061e34c2e2835fdf359e2943d34a71e835c6554R1-R60) [[2]](diffhunk://#diff-d5fcbc1cb50f979a6b20452565a505c168b8739ee8c04bb36b8a521fbf6e672cR1-R111)

**Operator Registration:**
* Registered `GatedDeltaNet` in the internal opset registry to make it available for graph transformations and model execution. (`opset_private_tbl.hpp`)

**Graph Transformation / Fusion Pass:**
* Introduced the `GatedDeltaNetFusion` matcher pass, which detects recurrent attention subgraphs (typically emitted by optimum-intel) and replaces them with a single `GatedDeltaNet` node for improved efficiency. (`gated_delta_net_fusion.hpp`)
* Integrated the new fusion pass into the common optimizations pipeline, ensuring it is applied during model optimization. (`common_optimizations.cpp`) [[1]](diffhunk://#diff-2ed72810580174cd45592b5336384f0dad9c9dd47904be56373376d057fd022fR29) [[2]](diffhunk://#diff-2ed72810580174cd45592b5336384f0dad9c9dd47904be56373376d057fd022fR155)

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used:  yes*
 - *fully generated transformation*
