### PR TITLE
[NPU] Perform constant deletion after init inputs are allocated

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -382,6 +382,9 @@ WeightlessGraph::InputData WeightlessGraph::allocate_inputs(
     const std::shared_ptr<ZeroTensor> initInputsAllocatedTensor =
         std::make_shared<ZeroTensor>(_zeroInitStruct, ov::element::Type_t::u8, ov::Shape({initInputsByteSize}), true);
 
+    std::vector<size_t> noLongerRequiredIds;
+    noLongerRequiredIds.reserve(_initsMetadata.at(initIndex).inputs.size());
+
     size_t offset = 0;
     for (const IODescriptor& descriptor : _initsMetadata.at(initIndex).inputs) {
         auto currentInputBufferLocation =
@@ -416,8 +419,15 @@ WeightlessGraph::InputData WeightlessGraph::allocate_inputs(
             ov::make_tensor(descriptor.precision, tensorShapeFromCompiler, currentInputBufferLocation));
         offset += currentInputSize;
 
+        // Note: One cannot immediately delete the constant, because there might
+        // be a duplicate. The deletion should happen once the input data for
+        // init schedule is fully set.
+        noLongerRequiredIds.push_back(id);
+    }
+
+    for (size_t id : noLongerRequiredIds) {
         // Note: By construction of the weight schedule, every constant from OV
-        // model appears exactly once across all schedules. Thus, one can delete
+        // model appears in exactly one schedule. Thus, one can delete
         // the handle to the constant memory early.
         constants.erase(id);
     }


### PR DESCRIPTION
### Details:
 - Author @andrey-golubev 
 - In the case of "duplicate" constants, because plugin holds a single constant node for all of the duplicates (as they all share the same ID), immediate deletion of the constant node is impossible. It should be delayed until init schedule's inputs are all set, as at that point there's a guarantee that the constand node with the same ID won't appear again.

### AI Assistance:
 - *AI assistance used: no*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
