### PR TITLE
fallback to pa opt kernel in case of micro gemm solution fails

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1243,7 +1243,7 @@ public:
             return pa_sdpa_micro->kd.micro_kernels.size() > 0;
         else if (stage == PagedAttentionStage::MIXED)
             return pa_sdpa_micro_mixed->kd.micro_kernels.size() > 0;
-        else if (stage == PagedAttentionStage::GQA_SINGLE_TOKEN)
+        else if (stage == PagedAttentionStage::GENERATE)
             return pa_sdpa_micro_gqa_single_token->kd.micro_kernels.size() > 0;
         return false;
     }


### PR DESCRIPTION
### Details:
 - currently sdpa micro allows kernel fails in build time, but still use it in runtime
 - this PR allows the fallback to use pa opt kernel in this case

### Tickets:
 - *CVS-182481*
