### PR TITLE
[core] Fix for nullptr bin_path in read_model()

### DIFF
--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -121,7 +121,6 @@ public:
                                           const Path& bin_path = {},
                                           const ov::AnyMap& properties = {}) const {
         if constexpr (std::is_pointer_v<Path>) {
-            // For pointer types (const char*, const wchar_t*), {} initializes to nullptr.
             if constexpr (std::is_constructible_v<std::string, Path>) {
                 return read_model(std::string(model_path),
                                   bin_path ? std::string(bin_path) : std::string{},

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -187,7 +187,27 @@ TEST_F(CoreBaseTest, read_model_with_std_fs_path_unicode) {
         }
     }
 }
+
+TEST_F(CoreBaseTest, read_model_with_const_wchar_path) {
+    generate_test_model_files("test-model");
+
+    ov::Core core;
+    const std::wstring model_path_w = ov::util::string_to_wstring(model_file_name);
+    const wchar_t* model_path = model_path_w.c_str();
+    const auto model = core.read_model(model_path);
+    EXPECT_NE(model, nullptr);
+}
 #endif
+
+TEST_F(CoreBaseTest, read_model_with_const_char_path) {
+    generate_test_model_files("test-model");
+
+    ov::Core core;
+    const char* model_path = model_file_name.c_str();
+    const auto model = core.read_model(model_path);
+    EXPECT_NE(model, nullptr);
+}
+
 namespace ov::test {
 TEST_F(CoreBaseTest, read_model_with_std_fs_path) {
     generate_test_model_files("test-model");
@@ -205,27 +225,6 @@ TEST_F(CoreBaseTest, read_model_with_std_fs_path) {
         EXPECT_NE(model, nullptr);
     }
 }
-
-TEST_F(CoreBaseTest, read_model_with_const_char_path) {
-    generate_test_model_files("test-model");
-
-    ov::Core core;
-    const char* model_path = model_file_name.c_str();
-    const auto model = core.read_model(model_path);
-    EXPECT_NE(model, nullptr);
-}
-
-#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-TEST_F(CoreBaseTest, read_model_with_const_wchar_path) {
-    generate_test_model_files("test-model");
-
-    ov::Core core;
-    const std::wstring model_path_w = ov::util::string_to_wstring(model_file_name);
-    const wchar_t* model_path = model_path_w.c_str();
-    const auto model = core.read_model(model_path);
-    EXPECT_NE(model, nullptr);
-}
-#endif
 
 TEST_F(CoreBaseTest, read_model_variadic_properties_std_string) {
     generate_test_model_files("test-model-variadic");


### PR DESCRIPTION
### Details:
 - Fix support for default value of bin_path in read_model(), when `model_path` is  `const char*` or `const wchar_t*`
 

> const char* path = "mobilenet-v2.xml";
    const auto model = core.read_model(path);

 - Add unit tests 


### Tickets:
 - *ticket-id*