### PR TITLE
[PyTorch tests dependencies] Replace `optimum-intel` from git to the one from PyPI for better caching

### DIFF
--- a/tests/requirements_pytorch
+++ b/tests/requirements_pytorch
@@ -46,7 +46,7 @@ huggingface-hub==0.25.2
 
 # For now, we decided to pin a specific working version of optimum-intel.
 # It will be discussed in the future how to manage versioning of the components properly.
-git+https://github.com/huggingface/optimum-intel.git@8ba536cd0a2bf93e9e88408b0048a7695db5be0b; python_version < "3.12"
+optimum-intel==1.24.0; python_version < "3.12"
 # set 'export HF_HUB_ENABLE_HF_TRANSFER=1' to benefits from hf_transfer
 hf_transfer==0.1.9
 


### PR DESCRIPTION
### Details:
Some time ago we pinned the version of `optimum-intel` Python module to a specific commit. Pip can install modules directly from git repositories, but then it builds the wheel every time. It looks to me that the pinned commit is included in the version released in PyPI, this way our cache can be utilized while being functionally equal to installing the module from git.
