### PR TITLE
Info -> warning: Override performance mode to THROUGHPUT for compilation

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -693,19 +693,6 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
         const bool shouldWarnAboutLatency = successfullyDebatched && performanceHintSetByUser &&
                                             localConfig.get<PERFORMANCE_HINT>() == ov::hint::PerformanceMode::LATENCY;
 
-        std::optional<FilteredConfig> modifiedConfig;
-        const FilteredConfig* configToCompile = &localConfig;
-
-        if (shouldForceThroughput) {
-            _logger.info("Setting performance mode to THROUGHPUT for batched model compilation.");
-
-            modifiedConfig = localConfig;  // Copy only when needed
-            std::stringstream strStream;
-            strStream << ov::hint::PerformanceMode::THROUGHPUT;
-            modifiedConfig->update({{ov::hint::performance_mode.name(), strStream.str()}});
-            configToCompile = &modifiedConfig.value();
-        }
-
         if (shouldWarnAboutLatency) {
             _logger.warning("PERFORMANCE_HINT is explicitly set to LATENCY mode, but batch dimension (N) is "
                             "detected in the model. The NPU Plugin will reshape the model to batch size 1 and "
@@ -716,7 +703,17 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
                             "configured properly.");
         }
 
-        graph = compileWithConfig(std::move(modelToCompile), *configToCompile);
+        if (shouldForceThroughput) {
+            _logger.info("Setting performance mode to THROUGHPUT for batched model compilation.");
+
+            auto modifiedConfig = localConfig;  // Copy only when needed
+            std::stringstream strStream;
+            strStream << ov::hint::PerformanceMode::THROUGHPUT;
+            modifiedConfig.update({{ov::hint::performance_mode.name(), strStream.str()}});
+            graph = compileWithConfig(std::move(modelToCompile), modifiedConfig);
+        } else {
+            graph = compileWithConfig(std::move(modelToCompile), localConfig);
+        }
     } catch (const std::exception& ex) {
         OPENVINO_THROW(ex.what());
     } catch (...) {

--- a/src/plugins/intel_npu/src/plugin/src/transformations.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/transformations.cpp
@@ -243,6 +243,7 @@ std::tuple<std::shared_ptr<ov::Model>, bool> handlePluginBatching(
         if (batchModeIsAvailable) {
             // If we have successfully debatched the model on the PLUGIN side, we should
             // avoid repeating the same in the compiler by resetting the batch mode
+            logger.info("The model was reshaped to batch size 1 on the plugin side.");
             updateBatchMode(ov::intel_npu::BatchMode::COMPILER);
         }
     } catch (const std::exception& ex) {


### PR DESCRIPTION
### Details:
 - Switching performance mode to `THROUGHPUT` during compilation when `PLUGIN batching` is applicable is a non-obvious behavior change, we should warn about it.

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
