### PR TITLE
Fix for Visual Studio 2026

### DIFF
--- a/src/plugins/intel_npu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/functional/CMakeLists.txt
@@ -67,8 +67,9 @@ if(WIN32)
     target_link_libraries(${TARGET_NAME} PRIVATE d3d12)
 endif()
 
+file(RELATIVE_PATH _folder "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 set_target_properties(
-  ${TARGET_NAME} PROPERTIES FOLDER ${CMAKE_CURRENT_SOURCE_DIR} CXX_STANDARD 17)
+  ${TARGET_NAME} PROPERTIES FOLDER "${_folder}" CXX_STANDARD 17)
 
 if(MSVC)
   # Enforce standards conformance on MSVC

--- a/src/plugins/intel_npu/tools/common/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/common/CMakeLists.txt
@@ -9,8 +9,9 @@ file(GLOB_RECURSE SOURCES "*.cpp" "*.hpp")
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})
 
 add_library(${TARGET_NAME} STATIC EXCLUDE_FROM_ALL ${SOURCES})
+file(RELATIVE_PATH _folder "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 set_target_properties(${TARGET_NAME} PROPERTIES
-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
+                          FOLDER "${_folder}"
                           CXX_STANDARD 17)
 
 target_include_directories(${TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")

--- a/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
@@ -30,8 +30,9 @@ ov_add_target(TYPE EXECUTABLE
                       Threads::Threads
                       npu_tools_utils)
 
+file(RELATIVE_PATH _folder "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 set_target_properties(${TARGET_NAME} PROPERTIES
-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
+                          FOLDER "${_folder}"
                           CXX_STANDARD 17)
 
 # TODO: fix warnings and remove this exception

--- a/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
@@ -66,8 +66,9 @@ ov_add_target(TYPE EXECUTABLE
               INCLUDES ${PROTOPIPE_SOURCE_DIR} "${CMAKE_CURRENT_BINARY_DIR}/version"
               LINK_LIBRARIES PRIVATE ${DEPENDENCIES})
 
+file(RELATIVE_PATH _folder "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 set_target_properties(${TARGET_NAME} PROPERTIES
-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
+                          FOLDER "${_folder}"
                           CXX_STANDARD 17)
 
 if (WIN32)

--- a/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
@@ -52,8 +52,9 @@ ov_add_target(TYPE EXECUTABLE
 
 ov_set_threading_interface_for(${TARGET_NAME})
 
+file(RELATIVE_PATH _folder "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 set_target_properties(${TARGET_NAME} PROPERTIES
-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
+                          FOLDER "${_folder}"
                           CXX_STANDARD 17)
 
 # TODO: fix warnings and remove this exception


### PR DESCRIPTION
### Details:
 - Don't use absolute path in cmake folder properties

### Tickets:
 - CVS-182973

### AI Assistance:
 - *AI assistance used: yes