### PR TITLE
removed steps mapping in Cleanup_HF_Cache_Linux

### DIFF
--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -46,7 +46,6 @@ jobs:
     env:
       HF_CACHE_PATH: /mount/caches/huggingface
     steps:
-      steps:
       - name: Pre-Collecting Cache Info
         run: |
           echo "Cache info: "


### PR DESCRIPTION
### Details:
 - Removed extra mapping of steps from cleanup_caches.yml becasue of failing workflow

<img width="700" height="192" alt="image" src="https://github.com/user-attachments/assets/0d23437e-6dac-4ba3-9f96-9316ed969fa7" />


### Tickets:
 - #34719

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
