### PR TITLE
[PT FE] Add support for aten::items

### DIFF
--- a/src/frontends/pytorch/src/op/items.cpp
+++ b/src/frontends/pytorch/src/op/items.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+OutputVector translate_items(const NodeContext& context) {
+    num_inputs_check(context, 1, 1);
+
+    auto input = context.get_input(0);
+    auto producer = input.get_node_shared_ptr();
+
+    // Only support dict values created directly by prim::DictConstruct.
+    if (auto dict_construct = cast_fw_node(producer, "prim::DictConstruct")) {
+        const auto inputs = dict_construct->input_values();
+
+        // DictConstruct inputs must be [key1, value1, key2, value2, ...]
+        PYTORCH_OP_CONVERSION_CHECK(inputs.size() % 2 == 0,
+                                    "aten::items: prim::DictConstruct inputs number is not divisible by 2.");
+
+        OutputVector item_outputs;
+        for (size_t i = 0; i < inputs.size(); i += 2) {
+            auto key = inputs.at(i);
+            auto value = inputs.at(i + 1);
+            auto tuple = context.mark_node(make_list_construct({key, value}));
+            item_outputs.push_back(tuple);
+        }
+
+        return {context.mark_node(make_list_construct(item_outputs))};
+    }
+
+    // Fail explicitly for unsupported Dict producers.
+    PYTORCH_OP_CONVERSION_CHECK(false,
+                                "aten::items: only Dict produced by prim::DictConstruct is supported.");
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -143,6 +143,7 @@ OP_CONVERTER(translate_int);
 OP_CONVERTER(translate_inverse);
 OP_CONVERTER(translate_istft);
 OP_CONVERTER(translate_is_nonzero);
+OP_CONVERTER(translate_items);
 OP_CONVERTER(translate_kthvalue);
 OP_CONVERTER(translate_layer_norm);
 OP_CONVERTER(translate_len);
@@ -574,6 +575,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::is_grad_enabled", op::return_false_scalar},
         {"aten::istft", op::translate_istft},
         {"aten::is_nonzero", op::translate_is_nonzero},
+        {"aten::items", op::translate_items},
         {"aten::kthvalue", op::translate_kthvalue},
         {"aten::isfinite", op::translate_1to1_match_1_inputs<opset10::IsFinite>},
         {"aten::isinf", op::translate_1to1_match_1_inputs<opset10::IsInf>},

--- a/tests/layer_tests/pytorch_tests/test_items.py
+++ b/tests/layer_tests/pytorch_tests/test_items.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class aten_items_dict_input(torch.nn.Module):
+    def forward(self, x):
+        d = {0: x, 1: x + x, 2: 2 * x}
+        return d.items()
+
+
+class TestItems(PytorchLayerTest):
+    def _prepare_input(self):
+        return (self.random.randn(2, 5, 3, 4),)
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_items(self, ie_device, precision, ir_version):
+        self._test(aten_items_dict_input(), "aten::items",
+                   ie_device, precision, ir_version, use_convert_model=True)


### PR DESCRIPTION
Closes #29701

### Motivation
PyTorch frontend does not support `aten::items` yet.

### Scope
This change adds support for `aten::items` when the input Dict is produced by `prim::DictConstruct`.

### Summary of changes
- Added `translate_items` implementation in PyTorch frontend
- Registered `aten::items` in `op_table.cpp`
- Added a PyTorch layer test for `d.items()`

### Tests
- `pytest pytorch_tests/test_items.py -k test_items -m precommit`
