### PR TITLE
Paddle FE: Add support for PIR JSON models (inference.json)

### DIFF
--- a/src/frontends/paddle/src/CMakeLists.txt
+++ b/src/frontends/paddle/src/CMakeLists.txt
@@ -7,6 +7,6 @@ ov_add_frontend(NAME paddle
                 PROTOBUF_REQUIRED
                 PROTOBUF_LITE
                 FILEDESCRIPTION "FrontEnd to load and convert PaddlePaddle file format"
-                LINK_LIBRARIES openvino::util openvino::core::dev)
+                LINK_LIBRARIES openvino::util openvino::core::dev nlohmann_json::nlohmann_json)
 
 ov_build_target_faster(openvino_paddle_frontend PCH)

--- a/src/frontends/paddle/src/frontend.cpp
+++ b/src/frontends/paddle/src/frontend.cpp
@@ -382,8 +382,24 @@ bool FrontEnd::supported_impl(const std::vector<ov::Any>& variants) const {
     // Validating first path, it must contain a model
     if (variants[0].is<std::string>()) {
         std::string suffix = ".pdmodel";
+        std::string json_suffix = ".json";
         std::string model_path = variants[0].as<std::string>();
         FRONT_END_GENERAL_CHECK(util::file_exists(model_path), "Could not open the file: \"", model_path, '"');
+        if (ov::util::ends_with(model_path, json_suffix)) {
+            std::ifstream model_str(model_path, std::ios::binary);
+            if (!model_str.is_open())
+                return false;
+
+            std::string header(2048, '\0');
+            model_str.read(&header[0], 2048);
+
+            if (header.find("\"program\":") != std::string::npos) {
+                return true;
+            }
+            return false;
+        }
+
+        // For pdmodel or directory-based models
         if (!ov::util::ends_with(model_path, suffix)) {
             model_path += paddle::get_path_sep<char>() + "__model__";
         }
@@ -395,11 +411,28 @@ bool FrontEnd::supported_impl(const std::vector<ov::Any>& variants) const {
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
     else if (variants[0].is<std::wstring>()) {
         std::wstring suffix = L".pdmodel";
+        std::wstring json_suffix = L".json";
         std::wstring model_path = variants[0].as<std::wstring>();
         FRONT_END_GENERAL_CHECK(util::file_exists(model_path),
                                 "Could not open the file: \"",
                                 util::path_to_string(model_path),
                                 '"');
+
+        if (ov::util::ends_with(model_path, json_suffix)) {
+            std::ifstream model_str(model_path.c_str(), std::ios::binary);
+            if (!model_str.is_open())
+                return false;
+
+            std::string header(2048, '\0');
+            model_str.read(&header[0], 2048);
+
+            if (header.find("\"program\":") != std::string::npos) {
+                return true;
+            }
+            return false;
+        }
+
+        // For pdmodel or directory-based models
         if (!ov::util::ends_with(model_path, suffix)) {
             model_path += paddle::get_path_sep<wchar_t>() + L"__model__";
         }

--- a/src/frontends/paddle/src/input_model.cpp
+++ b/src/frontends/paddle/src/input_model.cpp
@@ -13,6 +13,7 @@
 #include "decoder_proto.hpp"
 #include "framework.pb.h"
 #include "input_model.hpp"
+#include "json_to_proto.hpp"
 #include "openvino/core/log_util.hpp"
 #include "openvino/frontend/paddle/node_context.hpp"
 #include "openvino/opsets/opset7.hpp"
@@ -20,6 +21,7 @@
 #include "openvino/util/file_util.hpp"
 #include "paddle_utils.hpp"
 #include "place.hpp"
+
 
 namespace ov {
 namespace frontend {
@@ -182,10 +184,22 @@ bool is_pdmodel(const std::basic_string<T>& path) {
     return ov::util::ends_with(path, ext);
 }
 
+template <typename T>
+bool is_json_model(const std::basic_string<T>& path) {
+    std::string ext = ".json";
+    return ov::util::ends_with(path, ext);
+}
+
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
 template <>
 bool is_pdmodel(const std::basic_string<wchar_t>& path) {
     std::wstring ext = L".pdmodel";
+    return ov::util::ends_with(path, ext);
+}
+
+template <>
+bool is_json_model(const std::basic_string<wchar_t>& path) {
+    std::wstring ext = L".json";
     return ov::util::ends_with(path, ext);
 }
 #endif
@@ -193,14 +207,20 @@ bool is_pdmodel(const std::basic_string<wchar_t>& path) {
 template <typename T>
 std::basic_string<T> get_model_path(const std::basic_string<T>& path, std::ifstream* weights_stream) {
     std::string model_file{path};
-    std::string ext = ".pdmodel";
-    if (ov::util::ends_with(model_file, ext)) {
+    std::string pdmodel_ext = ".pdmodel";
+    std::string json_ext = ".json";
+    if (ov::util::ends_with(model_file, pdmodel_ext)) {
         std::string params_ext = ".pdiparams";
         std::string weights_file{path};
-        weights_file.replace(weights_file.size() - ext.size(), ext.size(), params_ext);
+        weights_file.replace(weights_file.size() - pdmodel_ext.size(), pdmodel_ext.size(), params_ext);
         weights_stream->open(weights_file, std::ios::binary);
         // Don't throw error if file isn't opened
         // It may mean that model don't have constants
+    } else if (ov::util::ends_with(model_file, json_ext)) {
+        std::string params_ext = ".pdiparams";
+        std::string weights_file{path};
+        weights_file.replace(weights_file.size() - json_ext.size(), json_ext.size(), params_ext);
+        weights_stream->open(weights_file, std::ios::binary);
     } else {
         model_file += paddle::get_path_sep<T>() + "__model__";
     }
@@ -211,14 +231,20 @@ std::basic_string<T> get_model_path(const std::basic_string<T>& path, std::ifstr
 template <>
 std::basic_string<wchar_t> get_model_path(const std::basic_string<wchar_t>& path, std::ifstream* weights_stream) {
     std::wstring model_file{path};
-    std::wstring ext = L".pdmodel";
-    if (ov::util::ends_with(model_file, ext)) {
+    std::wstring pdmodel_ext = L".pdmodel";
+    std::wstring json_ext = L".json";
+    if (ov::util::ends_with(model_file, pdmodel_ext)) {
         std::wstring params_ext = L".pdiparams";
         std::wstring weights_file{path};
-        weights_file.replace(weights_file.size() - ext.size(), ext.size(), params_ext);
+        weights_file.replace(weights_file.size() - pdmodel_ext.size(), pdmodel_ext.size(), params_ext);
         weights_stream->open(weights_file.c_str(), std::ios::binary);
         // Don't throw error if file isn't opened
         // It may mean that model don't have constants
+    } else if (ov::util::ends_with(model_file, json_ext)) {
+        std::wstring params_ext = L".pdiparams";
+        std::wstring weights_file{path};
+        weights_file.replace(weights_file.size() - json_ext.size(), json_ext.size(), params_ext);
+        weights_stream->open(weights_file.c_str(), std::ios::binary);
     } else {
         model_file += paddle::get_path_sep<wchar_t>() + L"__model__";
     }
@@ -398,13 +424,26 @@ InputModel::InputModelImpl::InputModelImpl(const std::basic_string<T>& path,
       m_input_model(input_model),
       m_telemetry(telemetry) {
     std::ifstream weights_stream;
-    std::ifstream pb_stream(get_model_path<T>(path, &weights_stream).c_str(), std::ios::in | std::ifstream::binary);
 
-    FRONT_END_GENERAL_CHECK(pb_stream && pb_stream.is_open(),
-                            "Could not open the file: \"",
-                            util::path_to_string(path),
-                            '"');
-    FRONT_END_GENERAL_CHECK(m_fw_ptr->ParseFromIstream(&pb_stream), "Model can't be parsed");
+    if (is_json_model(path)) {
+        // PP-OCRv5 / PIR JSON format: convert JSON → ProgramDesc in memory
+        // get_model_path handles opening the weights stream for .json paths
+        auto model_path = get_model_path<T>(path, &weights_stream);
+        std::ifstream json_stream(model_path.c_str(), std::ios::in);
+        FRONT_END_GENERAL_CHECK(json_stream && json_stream.is_open(),
+                                "Could not open the JSON model file: \"",
+                                util::path_to_string(path),
+                                '"');
+        m_fw_ptr = paddle::json_to_program_desc(json_stream);
+    } else {
+        std::ifstream pb_stream(get_model_path<T>(path, &weights_stream).c_str(), std::ios::in | std::ifstream::binary);
+        FRONT_END_GENERAL_CHECK(pb_stream && pb_stream.is_open(),
+                                "Could not open the file: \"",
+                                util::path_to_string(path),
+                                '"');
+        FRONT_END_GENERAL_CHECK(m_fw_ptr->ParseFromIstream(&pb_stream), "Model can't be parsed");
+    }
+
     // According to Paddle, the saved model has the framework version
     // For example Paddle 2.1.0 is encoded as 2001000. 0 means the latest framework.
     // https://github.com/paddle/Paddle/blob/develop/cmake/version.cmake
@@ -414,7 +453,7 @@ InputModel::InputModelImpl::InputModelImpl(const std::basic_string<T>& path,
         version >= 2000000 || version == 0,
         "[Frontend]Only Support Paddle greater than 2.0.0, current version " + std::to_string(version));
     load_places();
-    if (is_pdmodel(path)) {
+    if (is_pdmodel(path) || is_json_model(path)) {
         load_consts(&weights_stream);
     } else {
         load_consts(path);

--- a/src/frontends/paddle/src/json_to_proto.cpp
+++ b/src/frontends/paddle/src/json_to_proto.cpp
@@ -1,0 +1,553 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "json_to_proto.hpp"
+
+#include <algorithm>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "framework.pb.h"
+#include "nlohmann/json.hpp"
+#include "openvino/frontend/exception.hpp"
+
+namespace ov {
+namespace frontend {
+namespace paddle {
+
+using json = nlohmann::json;
+using namespace ::paddle::framework::proto;
+
+static std::string var_name(int id) {
+    return "v_" + std::to_string(id);
+}
+
+static std::string strip_op_name(const std::string& raw) {
+    if (raw == "p")
+        return "p";
+    auto dot = raw.find('.');
+    if (dot != std::string::npos) {
+        std::string name = raw.substr(dot + 1);
+        if (!name.empty() && name.back() == '_')
+            name.pop_back();
+        return name;
+    }
+    return raw;
+}
+
+static VarType_Type dtype_to_proto(const std::string& dtype) {
+    static const std::map<std::string, VarType_Type> m{
+        {"float32", VarType_Type_FP32},
+        {"float64", VarType_Type_FP64},
+        {"float16", VarType_Type_FP16},
+        {"int32", VarType_Type_INT32},
+        {"int64", VarType_Type_INT64},
+        {"int16", VarType_Type_INT16},
+        {"int8", VarType_Type_INT8},
+        {"uint8", VarType_Type_UINT8},
+        {"bool", VarType_Type_BOOL},
+        {"bfloat16", VarType_Type_BF16},
+    };
+    auto it = m.find(dtype);
+    FRONT_END_GENERAL_CHECK(it != m.end(), "Unknown PIR dtype: ", dtype);
+    return it->second;
+}
+
+static VarType_Type type_tag_to_proto(const std::string& tag) {
+    static const std::map<std::string, VarType_Type> m{
+        {"0.t_f32", VarType_Type_FP32},
+        {"0.t_f64", VarType_Type_FP64},
+        {"0.t_f16", VarType_Type_FP16},
+        {"0.t_i32", VarType_Type_INT32},
+        {"0.t_i64", VarType_Type_INT64},
+        {"0.t_i16", VarType_Type_INT16},
+        {"0.t_i8", VarType_Type_INT8},
+        {"0.t_ui8", VarType_Type_UINT8},
+        {"0.t_bool", VarType_Type_BOOL},
+        {"0.t_bf16", VarType_Type_BF16},
+    };
+    auto it = m.find(tag);
+    if (it != m.end())
+        return it->second;
+    // Unknown type tag — fall back to FP32; this is safe for most cases
+    return VarType_Type_FP32;
+}
+
+static const std::map<std::string, std::vector<std::string>>& op_input_names() {
+    static const std::map<std::string, std::vector<std::string>> m{
+        {"conv2d", {"Input", "Filter"}},
+        {"depthwise_conv2d", {"Input", "Filter"}},
+        {"conv2d_transpose", {"Input", "Filter"}},
+        {"batch_norm", {"X", "Mean", "Variance", "Scale", "Bias"}},
+        {"pool2d", {"X"}},
+        {"relu", {"X"}},
+        {"hardswish", {"X"}},
+        {"hardsigmoid", {"X"}},
+        {"sigmoid", {"X"}},
+        {"add", {"X", "Y"}},
+        {"subtract", {"X", "Y"}},
+        {"multiply", {"X", "Y"}},
+        {"divide", {"X", "Y"}},
+        {"elementwise_add", {"X", "Y"}},
+        {"elementwise_mul", {"X", "Y"}},
+        {"reshape", {"X", "ShapeTensor"}},
+        {"reshape2", {"X", "ShapeTensor"}},
+        {"concat", {"X"}},
+        {"flatten_contiguous_range", {"X"}},
+        {"matmul_v2", {"X", "Y"}},
+        {"softmax", {"X"}},
+        {"scale", {"X"}},
+        {"flatten2", {"X"}},
+        {"transpose2", {"X"}},
+        {"unsqueeze2", {"X"}},
+        {"squeeze2", {"X"}},
+        {"layer_norm", {"X", "Scale", "Bias"}},
+        {"leaky_relu", {"X"}},
+        {"gelu", {"X"}},
+        {"slice", {"Input"}},
+    };
+    return m;
+}
+
+static const std::map<std::string, std::vector<std::string>>& op_output_names() {
+    static const std::map<std::string, std::vector<std::string>> m{
+        {"batch_norm", {"Y", "MeanOut", "VarianceOut", "SavedMean", "SavedVariance", "ReserveSpace"}},
+        {"pool2d", {"Out"}},
+        {"conv2d", {"Output"}},
+        {"depthwise_conv2d", {"Output"}},
+        {"conv2d_transpose", {"Output"}},
+        {"add", {"Out"}},
+        {"subtract", {"Out"}},
+        {"multiply", {"Out"}},
+        {"divide", {"Out"}},
+        {"relu", {"Out"}},
+        {"hardswish", {"Out"}},
+        {"hardsigmoid", {"Out"}},
+        {"sigmoid", {"Out"}},
+        {"reshape", {"Out"}},
+        {"reshape2", {"Out", "XShape"}},
+        {"concat", {"Out"}},
+        {"softmax", {"Out"}},
+        {"scale", {"Out"}},
+        {"elementwise_add", {"Out"}},
+        {"elementwise_mul", {"Out"}},
+        {"flatten_contiguous_range", {"Out"}},
+        {"flatten2", {"Out", "XShape"}},
+        {"matmul_v2", {"Out"}},
+        {"transpose2", {"Out", "XShape"}},
+        {"unsqueeze2", {"Out", "XShape"}},
+        {"squeeze2", {"Out", "XShape"}},
+        {"layer_norm", {"Y", "Mean", "Variance"}},
+        {"leaky_relu", {"Out"}},
+        {"gelu", {"Out"}},
+        {"slice", {"Out"}},
+    };
+    return m;
+}
+
+static std::vector<std::string> get_input_port_names(const std::string& op_name, size_t count) {
+    auto it = op_input_names().find(op_name);
+    if (it != op_input_names().end() && it->second.size() >= count) {
+        return std::vector<std::string>(it->second.begin(), it->second.begin() + count);
+    }
+    std::vector<std::string> names;
+    for (size_t i = 0; i < count; ++i)
+        names.push_back("I_" + std::to_string(i));
+    return names;
+}
+
+static std::vector<std::string> get_output_port_names(const std::string& op_name, size_t count) {
+    auto it = op_output_names().find(op_name);
+    if (it != op_output_names().end() && it->second.size() >= count) {
+        return std::vector<std::string>(it->second.begin(), it->second.begin() + count);
+    }
+    std::vector<std::string> names;
+    for (size_t i = 0; i < count; ++i)
+        names.push_back("O_" + std::to_string(i));
+    return names;
+}
+
+static void set_attr(OpDesc::Attr* attr, const json& a_obj) {
+    const auto& at_node = a_obj.at("AT");
+    const std::string at_type = at_node.at("#").get<std::string>();
+
+    if (at_type == "0.a_str") {
+        attr->set_type(AttrType::STRING);
+        attr->set_s(at_node.at("D").get<std::string>());
+    } else if (at_type == "0.a_i32") {
+        attr->set_type(AttrType::INT);
+        attr->set_i(at_node.at("D").get<int32_t>());
+    } else if (at_type == "0.a_i64") {
+        attr->set_type(AttrType::LONG);
+        attr->set_l(at_node.at("D").get<int64_t>());
+    } else if (at_type == "0.a_f32") {
+        attr->set_type(AttrType::FLOAT);
+        attr->set_f(at_node.at("D").get<float>());
+    } else if (at_type == "0.a_bool") {
+        attr->set_type(AttrType::BOOLEAN);
+        attr->set_b(at_node.at("D").get<bool>());
+    } else if (at_type == "0.a_array") {
+        const auto& arr = at_node.at("D");
+        if (arr.empty()) {
+            attr->set_type(AttrType::INTS);
+            return;
+        }
+        const std::string elem_type = arr[0].at("#").get<std::string>();
+        if (elem_type == "0.a_i32") {
+            attr->set_type(AttrType::INTS);
+            for (auto& e : arr)
+                attr->add_ints(e.at("D").get<int32_t>());
+        } else if (elem_type == "0.a_i64") {
+            attr->set_type(AttrType::LONGS);
+            for (auto& e : arr)
+                attr->add_longs(e.at("D").get<int64_t>());
+        } else if (elem_type == "0.a_f32") {
+            attr->set_type(AttrType::FLOATS);
+            for (auto& e : arr)
+                attr->add_floats(e.at("D").get<float>());
+        } else if (elem_type == "0.a_bool") {
+            attr->set_type(AttrType::BOOLEANS);
+            for (auto& e : arr)
+                attr->add_bools(e.at("D").get<bool>());
+        } else if (elem_type == "0.a_str") {
+            attr->set_type(AttrType::STRINGS);
+            for (auto& e : arr)
+                attr->add_strings(e.at("D").get<std::string>());
+        }
+    } else if (at_type == "1.a_intarray") {
+        attr->set_type(AttrType::INTS);
+        const auto& d = at_node.at("D");
+        if (d.is_array()) {
+            for (auto& e : d)
+                attr->add_ints(e.get<int32_t>());
+        }
+    } else if (at_type == "1.a_dtype") {
+        attr->set_type(AttrType::INT);
+        attr->set_i(static_cast<int>(dtype_to_proto(at_node.at("D").get<std::string>())));
+    } else if (at_type == "1.a_place") {
+        attr->set_type(AttrType::INT);
+        attr->set_i(0);
+    }
+}
+
+static void fill_var_desc_from_output(VarDesc* var, const json& output_node) {
+    var->set_name(var_name(output_node.at("%").get<int>()));
+    auto* var_type = var->mutable_type();
+    var_type->set_type(VarType_Type_LOD_TENSOR);
+    auto* lod = var_type->mutable_lod_tensor();
+    auto* tensor = lod->mutable_tensor();
+
+    if (output_node.contains("TT")) {
+        const auto& tt = output_node.at("TT");
+        const auto& d = tt.at("D");
+        if (d.is_array() && d.size() >= 2) {
+            if (d[0].is_object() && d[0].contains("#")) {
+                tensor->set_data_type(type_tag_to_proto(d[0].at("#").get<std::string>()));
+            }
+            // d[1] = shape array  [N, C, H, W] or [-1, 3, -1, -1]
+            if (d[1].is_array()) {
+                for (auto& dim : d[1]) {
+                    tensor->add_dims(dim.get<int64_t>());
+                }
+            }
+        }
+    }
+}
+
+struct FullIntArrayConst {
+    std::vector<int64_t> values;
+};
+
+static std::map<int, FullIntArrayConst> scan_full_int_arrays(const json& ops) {
+    std::map<int, FullIntArrayConst> m;
+    for (auto& op : ops) {
+        const std::string raw_name = op.at("#").get<std::string>();
+        if (strip_op_name(raw_name) != "full_int_array")
+            continue;
+        // Get output value ID
+        const auto& outputs = op.at("O");
+        int out_id = -1;
+        if (outputs.is_array() && !outputs.empty()) {
+            out_id = outputs[0].at("%").get<int>();
+        } else if (outputs.is_object()) {
+            out_id = outputs.at("%").get<int>();
+        }
+        if (out_id < 0)
+            continue;
+        FullIntArrayConst c;
+        if (op.contains("A") && op.at("A").is_array()) {
+            for (auto& attr : op.at("A")) {
+                if (attr.contains("N") && attr.at("N").get<std::string>() == "value") {
+                    const auto& at_node = attr.at("AT");
+                    if (at_node.at("#").get<std::string>() == "0.a_array") {
+                        for (auto& e : at_node.at("D")) {
+                            if (e.contains("D"))
+                                c.values.push_back(e.at("D").get<int64_t>());
+                        }
+                    }
+                }
+            }
+        }
+        m[out_id] = c;
+    }
+    return m;
+}
+
+std::shared_ptr<ProgramDesc> json_to_program_desc(std::istream& json_stream) {
+    json root = json::parse(json_stream);
+
+    FRONT_END_GENERAL_CHECK(root.contains("program"), "PIR JSON has no 'program' key");
+    const auto& program = root.at("program");
+    FRONT_END_GENERAL_CHECK(program.contains("regions") && program.at("regions").is_array(),
+                            "PIR JSON has no 'regions' array");
+    const auto& regions = program.at("regions");
+
+    auto desc = std::make_shared<ProgramDesc>();
+
+    for (auto& region : regions) {
+        if (!region.contains("blocks") || !region.at("blocks").is_array())
+            continue;
+        for (auto& block_json : region.at("blocks")) {
+            if (!block_json.contains("ops") || !block_json.at("ops").is_array())
+                continue;
+
+            auto* block = desc->add_blocks();
+            block->set_idx(desc->blocks_size() - 1);
+            block->set_parent_idx(0);
+
+            const auto& ops_json = block_json.at("ops");
+
+            auto fia_map = scan_full_int_arrays(ops_json);
+
+            std::map<int, std::string> param_vars;
+            for (auto& op_json : ops_json) {
+                std::string raw = op_json.at("#").get<std::string>();
+                if (raw != "p")
+                    continue;
+
+                std::string weight_name;
+                const auto& a_field = op_json.at("A");
+                if (a_field.is_array() && a_field.size() >= 4 && a_field[3].is_string()) {
+                    weight_name = a_field[3].get<std::string>();
+                }
+
+                const auto& o = op_json.at("O");
+                int out_id = o.at("%").get<int>();
+
+                param_vars[out_id] = weight_name;
+
+                auto* var = block->add_vars();
+                var->set_name(weight_name);
+                var->set_persistable(true);
+
+                auto* var_type = var->mutable_type();
+                var_type->set_type(VarType_Type_LOD_TENSOR);
+                auto* lod = var_type->mutable_lod_tensor();
+                auto* tensor = lod->mutable_tensor();
+
+                if (o.contains("TT")) {
+                    const auto& tt = o.at("TT");
+                    const auto& d = tt.at("D");
+                    if (d.is_array() && d.size() >= 2) {
+                        if (d[0].is_object() && d[0].contains("#"))
+                            tensor->set_data_type(type_tag_to_proto(d[0].at("#").get<std::string>()));
+                        if (d[1].is_array()) {
+                            for (auto& dim : d[1])
+                                tensor->add_dims(dim.get<int64_t>());
+                        }
+                    }
+                }
+            }
+
+            std::map<int, std::string> value_to_var;
+            for (auto& [id, wname] : param_vars) {
+                value_to_var[id] = wname;
+            }
+
+            for (auto& op_json : ops_json) {
+                std::string raw = op_json.at("#").get<std::string>();
+                std::string name = strip_op_name(raw);
+
+                if (raw == "p")
+                    continue;
+
+                if (name == "full_int_array") {
+                    const auto& outputs = op_json.at("O");
+                    if (outputs.is_array()) {
+                        for (auto& o : outputs) {
+                            int oid = o.at("%").get<int>();
+                            std::string vname = var_name(oid);
+                            value_to_var[oid] = vname;
+                            auto* var = block->add_vars();
+                            var->set_name(vname);
+                            var->set_persistable(false);
+                            fill_var_desc_from_output(var, o);
+                        }
+                    } else if (outputs.is_object()) {
+                        int oid = outputs.at("%").get<int>();
+                        std::string vname = var_name(oid);
+                        value_to_var[oid] = vname;
+                        auto* var = block->add_vars();
+                        var->set_name(vname);
+                        var->set_persistable(false);
+                        fill_var_desc_from_output(var, outputs);
+                    }
+                    continue;
+                }
+
+                std::string proto_op_type = name;
+                if (name == "data") {
+                    proto_op_type = "feed";
+                } else if (name == "fetch") {
+                    proto_op_type = "fetch";
+                }
+
+                auto* op_desc = block->add_ops();
+                op_desc->set_type(proto_op_type);
+
+                std::vector<int> input_ids;
+                if (op_json.contains("I") && op_json.at("I").is_array()) {
+                    for (auto& i_item : op_json.at("I")) {
+                        if (i_item.is_object() && i_item.contains("%")) {
+                            input_ids.push_back(i_item.at("%").get<int>());
+                        }
+                    }
+                }
+
+                if (proto_op_type == "pool2d" && input_ids.size() == 2) {
+                    int fia_id = input_ids[1];
+                    auto fia_it = fia_map.find(fia_id);
+                    if (fia_it != fia_map.end()) {
+                        auto* ksize_attr = op_desc->add_attrs();
+                        ksize_attr->set_name("ksize");
+                        ksize_attr->set_type(AttrType::INTS);
+                        for (auto v : fia_it->second.values)
+                            ksize_attr->add_ints(static_cast<int32_t>(v));
+                    }
+                    input_ids.resize(1);
+                }
+
+                auto in_names = get_input_port_names(proto_op_type, input_ids.size());
+                if (proto_op_type == "feed") {
+                } else if (proto_op_type == "fetch") {
+                    if (!input_ids.empty()) {
+                        auto* inp = op_desc->add_inputs();
+                        inp->set_parameter("X");
+                        std::string vname;
+                        auto vit = value_to_var.find(input_ids[0]);
+                        if (vit != value_to_var.end())
+                            vname = vit->second;
+                        else
+                            vname = var_name(input_ids[0]);
+                        inp->add_arguments(vname);
+                    }
+                } else {
+                    for (size_t i = 0; i < input_ids.size(); ++i) {
+                        auto* inp = op_desc->add_inputs();
+                        inp->set_parameter(in_names[i]);
+                        std::string vname;
+                        auto vit = value_to_var.find(input_ids[i]);
+                        if (vit != value_to_var.end())
+                            vname = vit->second;
+                        else
+                            vname = var_name(input_ids[i]);
+                        inp->add_arguments(vname);
+                    }
+                }
+
+                std::vector<int> output_ids;
+                const auto& outputs = op_json.contains("O") ? op_json.at("O") : json();
+                if (outputs.is_array()) {
+                    for (auto& o : outputs)
+                        output_ids.push_back(o.at("%").get<int>());
+                } else if (outputs.is_object() && outputs.contains("%")) {
+                    output_ids.push_back(outputs.at("%").get<int>());
+                }
+
+                if (proto_op_type == "feed") {
+                    if (!output_ids.empty()) {
+                        int oid = output_ids[0];
+                        std::string out_vname = var_name(oid);
+                        value_to_var[oid] = out_vname;
+
+                        auto* outp = op_desc->add_outputs();
+                        outp->set_parameter("Out");
+                        outp->add_arguments(out_vname);
+
+                        auto* var = block->add_vars();
+                        var->set_name(out_vname);
+                        var->set_persistable(false);
+                        if (outputs.is_array() && !outputs.empty())
+                            fill_var_desc_from_output(var, outputs[0]);
+                        else if (outputs.is_object())
+                            fill_var_desc_from_output(var, outputs);
+                    }
+                } else if (proto_op_type == "fetch") {
+                } else {
+                    auto out_names = get_output_port_names(proto_op_type, output_ids.size());
+                    for (size_t i = 0; i < output_ids.size(); ++i) {
+                        int oid = output_ids[i];
+                        std::string out_vname = var_name(oid);
+                        value_to_var[oid] = out_vname;
+
+                        auto* outp = op_desc->add_outputs();
+                        outp->set_parameter(out_names[i]);
+                        outp->add_arguments(out_vname);
+
+                        auto* var = block->add_vars();
+                        var->set_name(out_vname);
+                        var->set_persistable(false);
+                        if (outputs.is_array() && i < outputs.size())
+                            fill_var_desc_from_output(var, outputs[i]);
+                    }
+                }
+
+                if (op_json.contains("A") && op_json.at("A").is_array()) {
+                    for (auto& a : op_json.at("A")) {
+                        if (!a.is_object() || !a.contains("N") || !a.contains("AT"))
+                            continue;
+                        auto* attr = op_desc->add_attrs();
+                        attr->set_name(a.at("N").get<std::string>());
+                        set_attr(attr, a);
+                    }
+                }
+
+                // OA (output attributes) are informational in PIR JSON; not needed for conversion
+
+                if (proto_op_type == "feed") {
+                    if (op_json.contains("A") && op_json.at("A").is_array()) {
+                        for (auto& a : op_json.at("A")) {
+                            if (!a.is_object())
+                                continue;
+                            if (a.contains("N") && a.at("N").get<std::string>() == "name") {
+                                if (!output_ids.empty()) {
+                                    const auto& at_node = a.at("AT");
+                                    std::string feed_name = at_node.at("D").get<std::string>();
+                                    int oid = output_ids[0];
+                                    for (int vi = 0; vi < block->vars_size(); ++vi) {
+                                        if (block->vars(vi).name() == var_name(oid)) {
+                                            block->mutable_vars(vi)->set_name(feed_name);
+                                        }
+                                    }
+                                    if (op_desc->outputs_size() > 0) {
+                                        op_desc->mutable_outputs(0)->set_arguments(0, feed_name);
+                                    }
+                                    value_to_var[oid] = feed_name;
+                                }
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+
+    return desc;
+}
+}  // namespace paddle
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/paddle/src/json_to_proto.hpp
+++ b/src/frontends/paddle/src/json_to_proto.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <istream>
+#include <memory>
+
+namespace paddle {
+namespace framework {
+namespace proto {
+class ProgramDesc;
+}
+}  // namespace framework
+}  // namespace paddle
+
+namespace ov {
+namespace frontend {
+namespace paddle {
+
+/// Convert a PIR JSON model (inference.json) to an in-memory ProgramDesc protobuf.
+/// This allows PP-OCRv5 and newer Paddle models that use the PIR JSON format
+/// to be loaded through the existing protobuf-based pipeline without changes.
+std::shared_ptr<::paddle::framework::proto::ProgramDesc> json_to_program_desc(std::istream& json_stream);
+
+}  // namespace paddle
+}  // namespace frontend
+}  // namespace ov


### PR DESCRIPTION
## Description
Fixes #30911

Recent PaddlePaddle models (e.g. **PP-OCRv5**) are exported in **PIR JSON format**:

- `inference.json`
- `inference.pdiparams`
- `inference.yml`

OpenVINO's Paddle frontend previously supported only the legacy protobuf format (`.pdmodel`).  
This PR adds support for **PIR JSON models** by converting `inference.json` into an in-memory `ProgramDesc` protobuf, allowing the existing frontend pipeline to work unchanged.

`inference.yml` contains runtime metadata and is not required for model loading.

---

## Changes
- **New:** `json_to_proto.cpp/.hpp` — converts PIR JSON → `ProgramDesc`
- **frontend.cpp:** extend `supported_impl()` to detect Paddle JSON models using a 2 KB header sniff for `"program"`
- **input_model.cpp:** route `.json` models through the converter (existing `.pdmodel` path untouched)
- **CMakeLists.txt:** register `json_to_proto.cpp` in the Paddle frontend build

---

## Compatibility
Fully backwards compatible — `.pdmodel` loading behavior is unchanged.

---

## Testing
Ran full Paddle frontend test suite:

- **668 tests passed**
- **2 pre-existing failures (unrelated):**
  - `LoadModelMemoryToCore` — Windows file mode issue (`fopen("r")`)
  - `greater_equal_big_int64` — known CPU inference limitation

---

## AI Assistance
AI assistance used: **Yes**

AI tools were used to help understand the JSON to protobuf conversion and to review the structure of the implementation. Apart from that it was also used to review the PR before pushing to get a maintainer's persepective on whether the changes were correctly made and if they were under the scope. 
The core implementation, integration into the Paddle frontend (`input_model.cpp`, `frontend.cpp`), build updates, and validation were performed manually. Verification included a full Debug build and running the complete Paddle frontend test suite to confirm correctness and ensure no regressions.