### PR TITLE
[GPU] Minimal support for int4 datatype in remote_tensor

### DIFF
--- a/src/inference/src/dev/make_tensor.cpp
+++ b/src/inference/src/dev/make_tensor.cpp
@@ -19,6 +19,53 @@
 namespace ov {
 
 namespace {
+size_t ceil_div(size_t value, size_t divisor) {
+    OPENVINO_ASSERT(divisor != 0, "Division by zero");
+    return (value + divisor - 1) / divisor;
+}
+
+Strides make_packed_reference_strides(const Shape& shape, const element::Type& element_type) {
+    Strides strides{};
+
+    if (shape.empty()) {
+        return strides;
+    }
+
+    strides.resize(shape.size());
+    if (element_type.bitwidth() >= 8) {
+        strides.back() = shape.back() == 0 ? 0 : element_type.size();
+        std::copy(shape.rbegin(), shape.rend() - 1, strides.rbegin() + 1);
+        std::partial_sum(strides.rbegin(), strides.rend(), strides.rbegin(), std::multiplies<size_t>());
+    } else {
+        OPENVINO_ASSERT(8 % element_type.bitwidth() == 0,
+                        "Unsupported sub-byte element type bitwidth: ",
+                        element_type.bitwidth());
+        const auto elements_per_byte = static_cast<size_t>(8 / element_type.bitwidth());
+        strides.back() = shape.back() == 0 ? 0 : 1;
+        for (size_t axis = shape.size() - 1; axis > 0; --axis) {
+            const size_t inner_elements =
+                std::accumulate(shape.begin() + axis, shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
+            strides[axis - 1] = ceil_div(inner_elements, elements_per_byte);
+        }
+    }
+
+    return strides;
+}
+
+size_t calculate_contiguous_linear_offset_in_elements(const Shape& shape, const Coordinate& coord) {
+    OPENVINO_ASSERT(shape.size() == coord.size(), "Coordinate rank mismatch");
+
+    size_t linear_offset = 0;
+    size_t axis_stride = 1;
+    for (size_t axis = shape.size(); axis > 0; --axis) {
+        const auto idx = axis - 1;
+        linear_offset += coord[idx] * axis_stride;
+        axis_stride *= shape[idx];
+    }
+
+    return linear_offset;
+}
+
 Shape make_roi_shape(const Shape& tensor_shape, const Coordinate& begin, const Coordinate& end) {
     OPENVINO_ASSERT(tensor_shape.size() == begin.size());
     OPENVINO_ASSERT(begin.size() == end.size());
@@ -39,6 +86,27 @@ Shape make_roi_shape(const Shape& tensor_shape, const Coordinate& begin, const C
 
     return roi_shape;
 }
+
+void validate_int4_roi(const std::shared_ptr<ITensor>& owner, const Coordinate& begin, const Coordinate& end) {
+    if (owner->get_element_type().bitwidth() < 8) {
+        const auto elements_per_byte = static_cast<size_t>(8 / owner->get_element_type().bitwidth());
+        const auto& owner_shape = owner->get_shape();
+        const auto& owner_strides = owner->get_strides();
+        const auto reference_strides = make_packed_reference_strides(owner_shape, owner->get_element_type());
+
+        OPENVINO_ASSERT(owner_strides == reference_strides,
+                        "Sub-byte ROI is supported only for contiguous packed tensors");
+
+        const auto begin_offset = calculate_contiguous_linear_offset_in_elements(owner_shape, begin);
+        const auto end_offset = calculate_contiguous_linear_offset_in_elements(owner_shape, end);
+
+        OPENVINO_ASSERT(begin_offset % elements_per_byte == 0,
+                        "Sub-byte ROI begin offset must be aligned to byte boundary");
+        OPENVINO_ASSERT(end_offset % elements_per_byte == 0,
+                        "Sub-byte ROI end offset must be aligned to byte boundary");
+    }
+}
+
 }  // namespace
 
 /**
@@ -113,9 +181,9 @@ public:
     }
 
     const Strides& get_strides() const override {
-        OPENVINO_ASSERT(m_element_type.bitwidth() >= 8,
+        /*OPENVINO_ASSERT(m_element_type.bitwidth() >= 8,
                         "Could not get strides for types with bitwidths less then 8 bit. Tensor type: ",
-                        m_element_type);
+                        m_element_type);*/
         std::call_once(m_strides_once, &ViewTensor::update_strides, this);
         return m_strides;
     }
@@ -136,6 +204,13 @@ protected:
             // gets type info to reduce validation to access speed, due to performance issues
             const auto& other_type_info = element::get_type_info(element_type);
             const auto& this_type_info = element::get_type_info(get_element_type());
+
+            // For sub-byte types, we need special handling
+            if (get_element_type().bitwidth() < 8 || element_type.bitwidth() < 8) {
+                // Only allow exact type matches for sub-byte types
+                return get_element_type() == element_type;
+            }
+
             return (get_element_type() != element::string && element_type != element::string &&
                     other_type_info.m_bitwidth == this_type_info.m_bitwidth &&
                     other_type_info.m_is_real == this_type_info.m_is_real) ||
@@ -144,18 +219,9 @@ protected:
     }
 
     void update_strides() const {
-        if (m_element_type.bitwidth() < 8)
-            return;
-
         auto& shape = get_shape();
         if (m_strides.empty() && !shape.empty()) {
-            m_strides.resize(shape.size());
-            m_strides.back() = shape.back() == 0 ? 0 : m_element_type.size();
-            std::transform(shape.crbegin(),
-                           shape.crend() - 1,
-                           m_strides.rbegin(),
-                           m_strides.rbegin() + 1,
-                           std::multiplies<size_t>());
+            m_strides = make_packed_reference_strides(shape, m_element_type);
         }
     }
 
@@ -195,10 +261,12 @@ class StridedViewTensor : public ViewTensor {
 public:
     StridedViewTensor(const element::Type element_type, const Shape& shape, void* ptr, const Strides& strides)
         : ViewTensor{element_type, shape, ptr} {
-        OPENVINO_ASSERT(
-            get_element_type().bitwidth() >= 8,
-            "Could not create strided access tensor for types with bitwidths less then 8 bit. Tensor type: ",
-            get_element_type());
+        // Remove the bitwidth restriction for int4 support
+        // OPENVINO_ASSERT(
+        //     get_element_type().bitwidth() >= 8,
+        //     "Could not create strided access tensor for types with bitwidths less then 8 bit. Tensor type: ",
+        //     get_element_type());
+
         // Save default strides
         auto shape_strides = get_strides();
         // Change strides
@@ -211,11 +279,20 @@ public:
                             shape_strides[i],
                             ", stride: ",
                             m_strides[i]);
-            OPENVINO_ASSERT((m_strides[i] % get_element_type().size()) == 0,
-                            "shape stride: ",
-                            shape_strides[i],
-                            ", stride: ",
-                            m_strides[i]);
+
+            // For sub-byte types, we need different validation logic
+            if (get_element_type().bitwidth() >= 8) {
+                OPENVINO_ASSERT((m_strides[i] % get_element_type().size()) == 0,
+                                "shape stride: ",
+                                shape_strides[i],
+                                ", stride: ",
+                                m_strides[i]);
+            } else {
+                // For int4, strides should be byte-aligned
+                // Since we're dealing with packed data, ensure stride alignment makes sense
+                OPENVINO_ASSERT(m_strides[i] > 0, "Invalid stride for int4 type: ", m_strides[i]);
+            }
+
             if (i) {
                 OPENVINO_ASSERT(m_strides[i - 1] >= m_strides[i] * shape[i],
                                 "Strides: ",
@@ -417,11 +494,11 @@ public:
         : m_owner{owner},
           m_shape{make_roi_shape(owner->get_shape(), begin, end)},
           m_capacity{m_shape},
-          m_offset{
-              std::inner_product(begin.begin(), begin.end(), m_owner->get_strides().begin(), static_cast<size_t>(0))} {
-        OPENVINO_ASSERT(m_owner->get_element_type().bitwidth() >= 8,
-                        "ROI Tensor for types with bitwidths less than 8 bit is not implemented. Tensor type: ",
-                        m_owner->get_element_type());
+          m_offset{calculate_roi_offset(owner, begin)} {
+        // Remove the bitwidth restriction
+        // OPENVINO_ASSERT(m_owner->get_element_type().bitwidth() >= 8,
+        //                 "ROI Tensor for types with bitwidths less than 8 bit is not implemented. Tensor type: ",
+        //                 m_owner->get_element_type());
     }
 
     void set_shape(ov::Shape new_shape) {
@@ -454,6 +531,20 @@ public:
         return m_offset;
     }
 
+private:
+    static size_t calculate_roi_offset(const std::shared_ptr<ITensor>& owner, const Coordinate& begin) {
+        if (owner->get_element_type().bitwidth() < 8) {
+            const auto elements_per_byte = static_cast<size_t>(8 / owner->get_element_type().bitwidth());
+            const auto linear_offset = calculate_contiguous_linear_offset_in_elements(owner->get_shape(), begin);
+            OPENVINO_ASSERT(linear_offset % elements_per_byte == 0,
+                            "Sub-byte ROI begin offset must be aligned to byte boundary");
+            return linear_offset / elements_per_byte;
+        } else {
+            // Original calculation for byte-aligned types
+            return std::inner_product(begin.begin(), begin.end(), owner->get_strides().begin(), static_cast<size_t>(0));
+        }
+    }
+
 protected:
     std::shared_ptr<ITensor> m_owner;
     Shape m_shape;
@@ -468,7 +559,9 @@ protected:
 class RoiTensor : public BaseRoiTensor, public ITensor {
 public:
     RoiTensor(const std::shared_ptr<ITensor>& owner, const Coordinate& begin, const Coordinate& end)
-        : BaseRoiTensor(owner, begin, end) {}
+        : BaseRoiTensor(owner, begin, end) {
+        validate_int4_roi(owner, begin, end);
+    }
 
     const element::Type& get_element_type() const override {
         return m_owner->get_element_type();
@@ -518,7 +611,9 @@ public:
 class RoiRemoteTensor : public BaseRoiTensor, public IRemoteTensor {
 public:
     RoiRemoteTensor(const std::shared_ptr<ITensor>& owner, const Coordinate& begin, const Coordinate& end)
-        : BaseRoiTensor(owner, begin, end) {}
+        : BaseRoiTensor(owner, begin, end) {
+        validate_int4_roi(owner, begin, end);
+    }
 
     const element::Type& get_element_type() const override {
         return m_owner->get_element_type();

--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -33,19 +33,81 @@ struct std::hash<ov::intel_gpu::VirtualAddressMemory> {
 namespace ov::intel_gpu {
 
 namespace {
+static size_t ceil_div(size_t value, size_t divisor) {
+    OPENVINO_ASSERT(divisor != 0, "[GPU] Division by zero");
+    return (value + divisor - 1) / divisor;
+}
+
+static size_t calculate_packed_bytes(size_t elements_count, const ov::element::Type& element_type) {
+    if (element_type.bitwidth() >= 8) {
+        return elements_count * element_type.size();
+    }
+
+    return ceil_div(elements_count * element_type.bitwidth(), static_cast<size_t>(8));
+}
+
+static size_t calculate_contiguous_chunk_size(const ov::Shape& shape,
+                                              const size_t start_axis,
+                                              const ov::element::Type& element_type) {
+    if (shape.empty()) {
+        return 0;
+    }
+
+    const size_t inner_elements = std::accumulate(shape.begin() + start_axis,
+                                                  shape.end(),
+                                                  static_cast<size_t>(1),
+                                                  std::multiplies<size_t>());
+    return calculate_packed_bytes(inner_elements, element_type);
+}
+
 static ov::Strides calculate_strides(const ov::Shape& shape, const ov::element::Type& element_type) {
     ov::Strides strides{};
-    if (element_type.bitwidth() < 8)
-        return strides;
 
-    if (!shape.empty()) {
-        strides.resize(shape.size());
+    if (shape.empty()) {
+        return strides;
+    }
+
+    strides.resize(shape.size());
+
+    if (element_type.bitwidth() >= 8) {
+        // Original logic for byte-aligned types
         strides.back() = shape.back() == 0 ? 0 : element_type.size();
         std::copy(shape.rbegin(), shape.rend() - 1, strides.rbegin() + 1);
         std::partial_sum(strides.rbegin(), strides.rend(), strides.rbegin(), std::multiplies<size_t>());
+    } else {
+        const auto bitwidth = element_type.bitwidth();
+        OPENVINO_ASSERT(8 % bitwidth == 0, "[GPU] Unsupported sub-byte element type bitwidth: ", bitwidth);
+        const auto elements_per_byte = static_cast<size_t>(8 / bitwidth);
+
+        strides.back() = shape.back() == 0 ? 0 : 1;
+        for (size_t axis = shape.size() - 1; axis > 0; --axis) {
+            const size_t inner_elements = std::accumulate(shape.begin() + axis,
+                                                          shape.end(),
+                                                          static_cast<size_t>(1),
+                                                          std::multiplies<size_t>());
+            strides[axis - 1] = ceil_div(inner_elements, elements_per_byte);
+        }
     }
 
     return strides;
+}
+
+// Helper function to validate int4 copy operations
+static void validate_int4_copy(const ov::Shape& src_shape,
+                               const ov::Shape& dst_shape,
+                               const ov::Shape& roi_shape,
+                               const ov::element::Type& element_type) {
+    const auto bitwidth = element_type.bitwidth();
+    OPENVINO_ASSERT(bitwidth < 8, "[GPU] Invalid sub-byte element type for validation");
+    OPENVINO_ASSERT(8 % bitwidth == 0, "[GPU] Unsupported sub-byte element type bitwidth: ", bitwidth);
+    const auto elements_per_byte = static_cast<size_t>(8 / bitwidth);
+
+    if (!roi_shape.empty()) {
+        OPENVINO_ASSERT(!src_shape.empty() && !dst_shape.empty(),
+                        "[GPU] Invalid ROI shape for sub-byte copy");
+        OPENVINO_ASSERT(roi_shape.back() % elements_per_byte == 0,
+                        "[GPU] Sub-byte unaligned view requires repack: innermost ROI dimension must be byte-addressable");
+    }
 }
 
 struct MemWrapper {
@@ -88,10 +150,11 @@ static void copy_roi_recursively(const MemWrapper& src_mem,
                                  const ov::Shape& roi_shape,
                                  const ov::Strides& src_strides,
                                  const ov::Strides& dst_strides,
-                                 const ov::Strides& roi_strides) {
+                                 const ov::Strides& roi_strides,
+                                 const ov::element::Type& element_type) {
     if (axis == roi_shape.size() - 1) {
         // Copy the innermost dimension
-        const auto size = roi_strides[axis] * roi_shape[axis];
+        const auto size = calculate_contiguous_chunk_size(roi_shape, axis, element_type);
         src_mem.copy_to(dst_mem, src_offset, dst_offset, size);
     } else {
         // Check if the current dimension and all inner dimensions can be copied as a single chunk
@@ -104,13 +167,22 @@ static void copy_roi_recursively(const MemWrapper& src_mem,
         }
 
         if (can_copy_as_chunk) {
-            const auto chunk_size = roi_strides[axis] * roi_shape[axis];
+            const auto chunk_size = calculate_contiguous_chunk_size(roi_shape, axis, element_type);
             src_mem.copy_to(dst_mem, src_offset, dst_offset, chunk_size);
         } else {
             for (size_t i = 0; i < roi_shape[axis]; i++) {
                 const auto src_offset_new = src_offset + i * src_strides[axis];
                 const auto dst_offset_new = dst_offset + i * dst_strides[axis];
-                copy_roi_recursively(src_mem, dst_mem, axis + 1, src_offset_new, dst_offset_new, roi_shape, src_strides, dst_strides, roi_strides);
+                copy_roi_recursively(src_mem,
+                                     dst_mem,
+                                     axis + 1,
+                                     src_offset_new,
+                                     dst_offset_new,
+                                     roi_shape,
+                                     src_strides,
+                                     dst_strides,
+                                     roi_strides,
+                                     element_type);
             }
         }
     }
@@ -123,11 +195,19 @@ static void copy_roi(const MemWrapper& src_mem,
                      const ov::Strides& src_strides,
                      const ov::Strides& dst_strides,
                      const ov::Strides& roi_strides,
-                     const ov::Shape& src_shape,
-                     const ov::Shape& dst_shape,
-                     const ov::Shape& roi_shape) {
+                     const ov::Shape& roi_shape,
+                     const ov::element::Type& element_type) {
     const size_t start_axis = 0;
-    copy_roi_recursively(src_mem, dst_mem, start_axis, src_offset, dst_offset, roi_shape, src_strides, dst_strides, roi_strides);
+    copy_roi_recursively(src_mem,
+                         dst_mem,
+                         start_axis,
+                         src_offset,
+                         dst_offset,
+                         roi_shape,
+                         src_strides,
+                         dst_strides,
+                         roi_strides,
+                         element_type);
 }
 
 static void validate_and_check_shapes(const std::shared_ptr<const ov::ITensor>& src,
@@ -139,7 +219,7 @@ static void validate_and_check_shapes(const std::shared_ptr<const ov::ITensor>& 
                     " != dst: ",
                     dst->get_element_type(),
                     ")");
-    OPENVINO_ASSERT(src->get_element_type().bitwidth() >= 8, "[GPU] Unsupported element type for copying: ", src->get_element_type());
+    //OPENVINO_ASSERT(src->get_element_type().bitwidth() >= 8, "[GPU] Unsupported element type for copying: ", src->get_element_type());
 
     // If it's a simple copy_to/copy_from call, then change dst shape
     if (roi_shape.empty()) {
@@ -211,6 +291,11 @@ void RemoteTensorImpl::copy_to(const std::shared_ptr<ov::ITensor>& dst,
                                const ov::Shape& roi_shape) const {
     validate_and_check_shapes(shared_from_this(), dst, roi_shape);
 
+    // Add int4-specific validation
+    if (m_element_type.bitwidth() < 8) {
+        validate_int4_copy(get_shape(), dst->get_shape(), roi_shape, m_element_type);
+    }
+
     auto& stream = m_context->get_engine().get_service_stream();
     auto dst_remote_tensor = std::dynamic_pointer_cast<RemoteTensorImpl>(dst);
     auto shape = roi_shape.empty() ? get_shape() : roi_shape;
@@ -224,7 +309,15 @@ void RemoteTensorImpl::copy_to(const std::shared_ptr<ov::ITensor>& dst,
         auto src_mem = MemWrapper(stream, get_memory(), nullptr);
         auto dst_mem = MemWrapper(stream, dst_remote_tensor->get_memory(), nullptr);
 
-        copy_roi(src_mem, dst_mem, src_offset, dst_offset, get_strides(), dst->get_strides(), roi_strides, get_shape(), dst->get_shape(), shape);
+        copy_roi(src_mem,
+                 dst_mem,
+                 src_offset,
+                 dst_offset,
+                 get_strides(),
+                 dst->get_strides(),
+                 roi_strides,
+                 shape,
+                 m_element_type);
     } else {
         GPU_DEBUG_TRACE_DETAIL << "Copying from RemoteTensor (" << get_memory()->get_allocation_type() << ") to host tensor, src_offset="
                                << src_offset << ", dst_offset=" << dst_offset << ", roi_shape=" << shape << ", src_shape=" << get_shape()
@@ -235,7 +328,15 @@ void RemoteTensorImpl::copy_to(const std::shared_ptr<ov::ITensor>& dst,
         auto src_mem = MemWrapper(stream, get_memory(), nullptr);
         auto dst_mem = MemWrapper(stream, nullptr, dst->data());
 
-        copy_roi(src_mem, dst_mem, src_offset, dst_offset, get_strides(), dst->get_strides(), roi_strides, get_shape(), dst->get_shape(), shape);
+        copy_roi(src_mem,
+                 dst_mem,
+                 src_offset,
+                 dst_offset,
+                 get_strides(),
+                 dst->get_strides(),
+                 roi_strides,
+                 shape,
+                 m_element_type);
     }
 }
 
@@ -244,6 +345,11 @@ void RemoteTensorImpl::copy_from(const std::shared_ptr<const ov::ITensor>& src,
                                  size_t dst_offset,
                                  const ov::Shape& roi_shape) {
     validate_and_check_shapes(src, shared_from_this(), roi_shape);
+
+    if (m_element_type.bitwidth() < 8) {
+        validate_int4_copy(src->get_shape(), get_shape(), roi_shape, m_element_type);
+    }
+
     auto shape = roi_shape.empty() ? get_shape() : roi_shape;
 
     auto& stream = m_context->get_engine().get_service_stream();
@@ -258,7 +364,15 @@ void RemoteTensorImpl::copy_from(const std::shared_ptr<const ov::ITensor>& src,
         auto src_mem = MemWrapper(stream, src_remote_tensor->get_memory(), nullptr);
         auto dst_mem = MemWrapper(stream, get_memory(), nullptr);
 
-        copy_roi(src_mem, dst_mem, src_offset, dst_offset, src->get_strides(), get_strides(), roi_strides, src->get_shape(), get_shape(), shape);
+        copy_roi(src_mem,
+                 dst_mem,
+                 src_offset,
+                 dst_offset,
+                 src->get_strides(),
+                 get_strides(),
+                 roi_strides,
+                 shape,
+                 m_element_type);
     } else {
         GPU_DEBUG_TRACE_DETAIL << "Copying from host tensor to RemoteTensor (" << get_memory()->get_allocation_type() << "), src_offset="
                                << src_offset << ", dst_offset=" << dst_offset << ", roi_shape=" << shape << ", src_shape" << src->get_shape()
@@ -270,7 +384,15 @@ void RemoteTensorImpl::copy_from(const std::shared_ptr<const ov::ITensor>& src,
         auto src_mem = MemWrapper(stream, nullptr, const_cast<void*>(src->data()));
         auto dst_mem = MemWrapper(stream, get_memory(), nullptr);
 
-        copy_roi(src_mem, dst_mem, src_offset, dst_offset, src->get_strides(), get_strides(), roi_strides, src->get_shape(), get_shape(), shape);
+        copy_roi(src_mem,
+                 dst_mem,
+                 src_offset,
+                 dst_offset,
+                 src->get_strides(),
+                 get_strides(),
+                 roi_strides,
+                 shape,
+                 m_element_type);
     }
 }
 
@@ -312,6 +434,13 @@ void RemoteTensorImpl::allocate() {
 
     if (is_surface()) {
         m_layout.format = cldnn::format::nv12;  // Other formats are not supported
+    }
+
+    // For int4, ensure we're using the correct data type in the layout
+    if (m_element_type.bitwidth() < 8) {
+        // Make sure the cldnn layout properly handles the int4 type
+        // You may need to adjust this based on how cldnn handles int4
+        m_layout = cldnn::layout{ov::PartialShape{m_shape}, m_element_type, cldnn::format::get_default_format(m_shape.size())};
     }
 
     if (enable_caching) {


### PR DESCRIPTION
During the work on Weight Sharing on GPU we hit a limitation for models that have int4 weights. When each weight is allocated separately using remote tensor, then the current implementation will report errors.

### Details

Enable packed sub-byte element types (e.g., int4) in tensor operations, including ROI views, memory copy, and GPU remote tensor handling. Update stride and offset calculations for packed layouts, add validation for byte alignment, and relax previous bitwidth restrictions. Ensure robust handling of both byte-aligned and sub-byte types across shape, stride, and memory management.

### Tickets:
 - CVS-180701

### AI Assistance:
 - AI assistance used: yes
 - AI helped with creating the initial implementation(s), then I tested it on my experimental application. But more testing and review needed.
