### PR TITLE
[GHA] [Sanitizers] Transformations func tests show leaks

### DIFF
--- a/src/core/include/openvino/core/graph_util.hpp
+++ b/src/core/include/openvino/core/graph_util.hpp
@@ -236,13 +236,17 @@ std::vector<std::shared_ptr<Node>> topological_sort(T root_nodes) {
         Node* node = nodes_to_do.top();
         if (nodes_done.count(node) == 0) {
             bool can_add = true;
-            if (++nodes_visited[node] > 2)
+            if (++nodes_visited[node] > 2) {
+                // break circular dependencies to release memory
+                node->set_arguments(OutputVector{});
+                node->clear_control_dependencies();
                 // Node may be at the top of `nodes_to_do` not more than twice before it's added to `nodes_done` -
                 // when visited and placed in `nodes_to_do` and after the subtree traversal is finished.
                 // Otherwise it's a loop.
                 OPENVINO_THROW("Loop detected during topological sort starting from '",
                                node->get_friendly_name(),
                                "' node.");
+            }
 
             size_t arg_count = node->get_input_size();
             for (size_t i = 0; i < arg_count; ++i) {

--- a/src/core/include/openvino/core/graph_util.hpp
+++ b/src/core/include/openvino/core/graph_util.hpp
@@ -221,7 +221,23 @@ void replace_nodes(const std::shared_ptr<Model>& f,
                        parameter_replacement_map,
                    const std::unordered_map<std::shared_ptr<Node>, std::shared_ptr<Node>>& body_replacement_map);
 
-/// Topological sort of nodes needed to compute root_nodes
+/// \brief Performs a topological sort on a graph of nodes.
+///
+/// \tparam T A container type (e.g., std::vector, std::deque) of shared_ptr<Node> or Node*.
+/// \param root_nodes The starting nodes from which to begin the topological sort traversal.
+///
+/// \return A vector of nodes sorted in topological order, where dependencies come before dependents.
+///
+/// \details
+/// This function performs a depth-first traversal of the computation graph starting from the given root nodes.
+/// It produces an ordering where each node appears after all of its input dependencies.
+///
+/// \note If a circular dependency is detected (a node is visited more than twice during traversal),
+///       the function clears the offending node's arguments and control dependencies, then throws
+///       an OPENVINO_THROW exception with details about the loop source.
+///
+/// \warning The caller is responsible for providing valid, acyclic graph structures. Circular
+///          dependencies will result in an exception being thrown.
 template <typename T>
 std::vector<std::shared_ptr<Node>> topological_sort(T root_nodes) {
     std::stack<Node*, std::vector<Node*>> nodes_to_do;

--- a/src/core/include/openvino/core/graph_util.hpp
+++ b/src/core/include/openvino/core/graph_util.hpp
@@ -233,11 +233,9 @@ void replace_nodes(const std::shared_ptr<Model>& f,
 /// It produces an ordering where each node appears after all of its input dependencies.
 ///
 /// \note If a circular dependency is detected (a node is visited more than twice during traversal),
-///       the function clears the offending node's arguments and control dependencies, then throws
-///       an OPENVINO_THROW exception with details about the loop source.
+///       the function throws an OPENVINO_THROW exception with details about the loop source.
 ///
-/// \warning The caller is responsible for providing valid, acyclic graph structures. Circular
-///          dependencies will result in an exception being thrown.
+/// \warning The caller is responsible for clean-up the model connections when circular dependencies are present.
 template <typename T>
 std::vector<std::shared_ptr<Node>> topological_sort(T root_nodes) {
     std::stack<Node*, std::vector<Node*>> nodes_to_do;
@@ -253,9 +251,6 @@ std::vector<std::shared_ptr<Node>> topological_sort(T root_nodes) {
         if (nodes_done.count(node) == 0) {
             bool can_add = true;
             if (++nodes_visited[node] > 2) {
-                // break circular dependencies to release memory
-                node->set_arguments(OutputVector{});
-                node->clear_control_dependencies();
                 // Node may be at the top of `nodes_to_do` not more than twice before it's added to `nodes_done` -
                 // when visited and placed in `nodes_to_do` and after the subtree traversal is finished.
                 // Otherwise it's a loop.

--- a/src/core/include/openvino/core/node.hpp
+++ b/src/core/include/openvino/core/node.hpp
@@ -451,8 +451,8 @@ private:
     mutable std::string m_unique_name;
     mutable std::atomic_bool m_name_changing{false};
     static std::atomic<size_t> m_next_instance_id;
-    std::deque<descriptor::Input> m_inputs;
     std::deque<descriptor::Output> m_outputs;
+    std::deque<descriptor::Input> m_inputs;
     RTMap m_rt_info;
 
     // The vector of SharedRTInfo attributes associated to Functions

--- a/src/core/include/openvino/core/node.hpp
+++ b/src/core/include/openvino/core/node.hpp
@@ -451,8 +451,8 @@ private:
     mutable std::string m_unique_name;
     mutable std::atomic_bool m_name_changing{false};
     static std::atomic<size_t> m_next_instance_id;
-    std::deque<descriptor::Output> m_outputs;
     std::deque<descriptor::Input> m_inputs;
+    std::deque<descriptor::Output> m_outputs;
     RTMap m_rt_info;
 
     // The vector of SharedRTInfo attributes associated to Functions

--- a/src/core/src/descriptor/input.cpp
+++ b/src/core/src/descriptor/input.cpp
@@ -45,7 +45,11 @@ void ov::descriptor::Input::replace_output(Output& new_output) {
     }
     new_output.add_input(this);
     m_output = &new_output;
-    m_src_node = std::shared_ptr<ov::Node>(new_output.get_node());
+    m_output->add_input(this);
+    // there is no need to tak ownership to itself
+    if (m_node != new_output.get_node().get()) {
+        m_src_node = new_output.get_node();
+    }
 
     // Output replacement may change the topological order of nodes,
     // so we have to reset cache by setting a flag into shared node info.

--- a/src/core/src/descriptor/input.cpp
+++ b/src/core/src/descriptor/input.cpp
@@ -45,11 +45,7 @@ void ov::descriptor::Input::replace_output(Output& new_output) {
     }
     new_output.add_input(this);
     m_output = &new_output;
-    m_output->add_input(this);
-    // there is no need to tak ownership to itself
-    if (m_node != new_output.get_node().get()) {
-        m_src_node = new_output.get_node();
-    }
+    m_src_node = new_output.get_node();
 
     // Output replacement may change the topological order of nodes,
     // so we have to reset cache by setting a flag into shared node info.

--- a/src/core/tests/conditional_compilation/ov_cc_collect.cpp
+++ b/src/core/tests/conditional_compilation/ov_cc_collect.cpp
@@ -43,12 +43,16 @@ TEST(conditional_compilation, collect_ops_in_opset) {
 #define ov_opset_test_opset1_Abs 1
     ov::OpSet opset("test_opset1");
     INSERT_OP(test_opset1, Abs, ov::op::v0);
-    EXPECT_NE(opset.create("Abs"), nullptr);
-    EXPECT_NE(opset.create_insensitive("Abs"), nullptr);
+    auto node = std::shared_ptr<ov::Node>(opset.create("Abs"));
+    EXPECT_NE(node.get(), nullptr);
+    node = std::shared_ptr<ov::Node>(opset.create_insensitive("Abs"));
+    EXPECT_NE(node.get(), nullptr);
 
     INSERT_OP(test_opset1, Constant, ov::op::v0);
-    EXPECT_NE(opset.create("Constant"), nullptr);
-    EXPECT_NE(opset.create_insensitive("Constant"), nullptr);
+    node = std::shared_ptr<ov::Node>(opset.create("Constant"));
+    EXPECT_NE(node.get(), nullptr);
+    node = std::shared_ptr<ov::Node>(opset.create_insensitive("Constant"));
+    EXPECT_NE(node.get(), nullptr);
 #undef ov_opset_test_opset1_Abs
 }
 

--- a/src/core/tests/conditional_compilation/ov_cc_off.cpp
+++ b/src/core/tests/conditional_compilation/ov_cc_off.cpp
@@ -38,12 +38,16 @@ TEST(conditional_compilation, op_scope_with_disabled_cc) {
 TEST(conditional_compilation, all_ops_enabled_in_opset) {
     ov::OpSet opset("test_opset2");
     INSERT_OP(test_opset2, Abs, ov::op::v0);
-    EXPECT_NE(opset.create("Abs"), nullptr);
-    EXPECT_NE(opset.create_insensitive("Abs"), nullptr);
+    auto node = std::shared_ptr<ov::Node>(opset.create("Abs"));
+    EXPECT_NE(node.get(), nullptr);
+    node = std::shared_ptr<ov::Node>(opset.create_insensitive("Abs"));
+    EXPECT_NE(node.get(), nullptr);
 
     INSERT_OP(test_opset2, Constant, ov::op::v0);
-    EXPECT_NE(opset.create("Constant"), nullptr);
-    EXPECT_NE(opset.create_insensitive("Constant"), nullptr);
+    node = std::shared_ptr<ov::Node>(opset.create("Constant"));
+    EXPECT_NE(node.get(), nullptr);
+    node = std::shared_ptr<ov::Node>(opset.create_insensitive("Constant"));
+    EXPECT_NE(node.get(), nullptr);
 }
 
 namespace {

--- a/src/core/tests/conditional_compilation/ov_cc_on.cpp
+++ b/src/core/tests/conditional_compilation/ov_cc_on.cpp
@@ -41,12 +41,16 @@ TEST(conditional_compilation, disabled_Constant_in_opset) {
 #define ov_opset_test_opset3_Abs 1
     ov::OpSet opset("test_opset3");
     INSERT_OP(test_opset3, Abs, ov::op::v0);
-    EXPECT_NE(opset.create("Abs"), nullptr);
-    EXPECT_NE(opset.create_insensitive("Abs"), nullptr);
+    auto node = std::shared_ptr<ov::Node>(opset.create("Abs"));
+    EXPECT_NE(node.get(), nullptr);
+    node = std::shared_ptr<ov::Node>(opset.create_insensitive("Abs"));
+    EXPECT_NE(node.get(), nullptr);
 
     INSERT_OP(test_opset3, Constant, ov::op::v0);
-    EXPECT_EQ(opset.create("Constant"), nullptr);
-    EXPECT_EQ(opset.create_insensitive("Constant"), nullptr);
+    node = std::shared_ptr<ov::Node>(opset.create("Constant"));
+    EXPECT_EQ(node.get(), nullptr);
+    node = std::shared_ptr<ov::Node>(opset.create_insensitive("Constant"));
+    EXPECT_EQ(node.get(), nullptr);
 #undef ov_opset_test_opset3_Abs
 }
 

--- a/src/core/tests/model.cpp
+++ b/src/core/tests/model.cpp
@@ -1540,6 +1540,18 @@ TEST(model, topological_sort_throws_if_loop_with_one_node) {
                  ov::Exception);
 }
 
+TEST(model, topological_sort_throws_if_loop_with_two_node) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    // Loop relu1->relu2->relu1
+    relu1->input(0).replace_source_output(relu2->output(0));
+
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
+                 ov::Exception);
+}
+
 TEST(model, topological_sort_throws_if_loop_with_several_nodes) {
     auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
     auto relu1 = std::make_shared<ov::op::v0::Relu>(arg0);

--- a/src/core/tests/model.cpp
+++ b/src/core/tests/model.cpp
@@ -1534,6 +1534,7 @@ TEST(model, topological_sort_throws_if_loop_with_one_node) {
 
         // Loop relu1->relu1
         relu1->input(0).replace_source_output(relu1->output(0));
+        nodes = {arg0, relu1};
 
         auto result = std::make_shared<ov::op::v0::Result>(relu1);
         ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
@@ -1573,6 +1574,7 @@ TEST(model, topological_sort_throws_if_loop_with_several_nodes) {
         // Loop relu2->relu3->relu2
         auto relu2 = std::make_shared<ov::op::v0::Relu>(relu1->output(0));
         auto relu3 = std::make_shared<ov::op::v0::Relu>(relu2);
+        nodes = {arg0, relu1, relu2, relu3};
         ov::replace_node(relu1, relu3);
 
         ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
@@ -1590,6 +1592,7 @@ TEST(model, topological_sort_throws_if_loop_with_control_dependency) {
         auto relu1 = std::make_shared<ov::op::v0::Relu>(arg0);
         auto relu2 = std::make_shared<ov::op::v0::Relu>(relu1);
         auto result = std::make_shared<ov::op::v0::Result>(relu2);
+        nodes = {arg0, relu1, relu2};
 
         // Loop relu1->relu2->relu1
         relu1->add_control_dependency(relu2);
@@ -1612,6 +1615,7 @@ TEST(model, topological_sort_throws_if_loop_with_control_dependency_only) {
         auto arg1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
         auto relu1 = std::make_shared<ov::op::v0::Relu>(arg1);
         auto result1 = std::make_shared<ov::op::v0::Result>(relu1);
+        nodes = {arg0, relu0, arg1, relu1};
 
         // Loop relu0->relu1->relu0
         relu0->add_control_dependency(relu1);

--- a/src/core/tests/model.cpp
+++ b/src/core/tests/model.cpp
@@ -22,10 +22,8 @@
 #include "openvino/op/subtract.hpp"
 #include "shared_node_info.hpp"
 
-using ov::op::util::Variable;
-using ov::op::util::VariableInfo;
-using ov::op::v0::Parameter;
-using ov::op::v0::Result;
+using ov::op::util::Variable, ov::op::util::VariableInfo;
+using ov::op::v0::Parameter, ov::op::v0::Result, ov::op::v0::Relu;
 
 TEST(model, get_input_by_tensor_name) {
     auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
@@ -1541,13 +1539,13 @@ TEST(model, topological_sort_throws_if_loop_with_one_node) {
 }
 
 TEST(model, topological_sort_throws_if_loop_with_two_node) {
-    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
-    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
-    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto arg0 = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<Relu>(arg0);
+    auto relu2 = std::make_shared<Relu>(relu1);
     // Loop relu1->relu2->relu1
     relu1->input(0).replace_source_output(relu2->output(0));
 
-    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto result = std::make_shared<Result>(relu2);
     ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
                  ov::Exception);
 }

--- a/src/core/tests/model.cpp
+++ b/src/core/tests/model.cpp
@@ -1527,72 +1527,104 @@ bool all_ops_have_same_info(const std::shared_ptr<ov::Model>& f) {
 }  // namespace
 
 TEST(model, topological_sort_throws_if_loop_with_one_node) {
-    auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
-    auto relu1 = std::make_shared<ov::op::v0::Relu>(arg0);
+    std::vector<std::weak_ptr<ov::Node>> nodes;
+    {
+        auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
+        auto relu1 = std::make_shared<ov::op::v0::Relu>(arg0);
 
-    // Loop relu1->relu1
-    relu1->input(0).replace_source_output(relu1->output(0));
+        // Loop relu1->relu1
+        relu1->input(0).replace_source_output(relu1->output(0));
 
-    auto result = std::make_shared<ov::op::v0::Result>(relu1);
-    ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
-                 ov::Exception);
+        auto result = std::make_shared<ov::op::v0::Result>(relu1);
+        ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
+                     ov::Exception);
+        // break circular dependency to release all nodes
+        relu1->set_arguments(ov::OutputVector{});
+    }
+    EXPECT_THAT(nodes, testing::Each(testing::Property(&std::weak_ptr<ov::Node>::expired, true)));
 }
 
 TEST(model, topological_sort_throws_if_loop_with_two_node) {
-    auto arg0 = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape{1});
-    auto relu1 = std::make_shared<Relu>(arg0);
-    auto relu2 = std::make_shared<Relu>(relu1);
-    // Loop relu1->relu2->relu1
-    relu1->input(0).replace_source_output(relu2->output(0));
+    std::vector<std::weak_ptr<ov::Node>> nodes;
+    {
+        auto arg0 = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape{1});
+        auto relu1 = std::make_shared<Relu>(arg0);
+        auto relu2 = std::make_shared<Relu>(relu1);
+        nodes = {arg0, relu1, relu2};
+        // Loop relu1->relu2->relu1
+        relu1->input(0).replace_source_output(relu2->output(0));
 
-    auto result = std::make_shared<Result>(relu2);
-    ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
-                 ov::Exception);
+        auto result = std::make_shared<Result>(relu2);
+        ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
+                     ov::Exception);
+        // break circular dependency to release all nodes
+        relu1->set_arguments(ov::OutputVector{});
+    }
+    EXPECT_THAT(nodes, testing::Each(testing::Property(&std::weak_ptr<ov::Node>::expired, true)));
 }
 
 TEST(model, topological_sort_throws_if_loop_with_several_nodes) {
-    auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
-    auto relu1 = std::make_shared<ov::op::v0::Relu>(arg0);
-    auto result = std::make_shared<ov::op::v0::Result>(relu1);
+    std::vector<std::weak_ptr<ov::Node>> nodes;
+    {
+        auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
+        auto relu1 = std::make_shared<ov::op::v0::Relu>(arg0);
+        auto result = std::make_shared<ov::op::v0::Result>(relu1);
 
-    // Loop relu2->relu3->relu2
-    auto relu2 = std::make_shared<ov::op::v0::Relu>(relu1->output(0));
-    auto relu3 = std::make_shared<ov::op::v0::Relu>(relu2);
-    ov::replace_node(relu1, relu3);
+        // Loop relu2->relu3->relu2
+        auto relu2 = std::make_shared<ov::op::v0::Relu>(relu1->output(0));
+        auto relu3 = std::make_shared<ov::op::v0::Relu>(relu2);
+        ov::replace_node(relu1, relu3);
 
-    ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
-                 ov::Exception);
+        ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
+                     ov::Exception);
+        // break circular dependency to release all nodes
+        relu2->set_arguments(ov::OutputVector{});
+    }
+    EXPECT_THAT(nodes, testing::Each(testing::Property(&std::weak_ptr<ov::Node>::expired, true)));
 }
 
 TEST(model, topological_sort_throws_if_loop_with_control_dependency) {
-    auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
-    auto relu1 = std::make_shared<ov::op::v0::Relu>(arg0);
-    auto relu2 = std::make_shared<ov::op::v0::Relu>(relu1);
-    auto result = std::make_shared<ov::op::v0::Result>(relu2);
+    std::vector<std::weak_ptr<ov::Node>> nodes;
+    {
+        auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
+        auto relu1 = std::make_shared<ov::op::v0::Relu>(arg0);
+        auto relu2 = std::make_shared<ov::op::v0::Relu>(relu1);
+        auto result = std::make_shared<ov::op::v0::Result>(relu2);
 
-    // Loop relu1->relu2->relu1
-    relu1->add_control_dependency(relu2);
+        // Loop relu1->relu2->relu1
+        relu1->add_control_dependency(relu2);
 
-    ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
-                 ov::Exception);
+        ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
+                     ov::Exception);
+        // break circular dependency to release all nodes
+        relu1->remove_control_dependency(relu2);
+    }
+    EXPECT_THAT(nodes, testing::Each(testing::Property(&std::weak_ptr<ov::Node>::expired, true)));
 }
 
 TEST(model, topological_sort_throws_if_loop_with_control_dependency_only) {
-    auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
-    auto relu0 = std::make_shared<ov::op::v0::Relu>(arg0);
-    auto result0 = std::make_shared<ov::op::v0::Result>(relu0);
+    std::vector<std::weak_ptr<ov::Node>> nodes;
+    {
+        auto arg0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
+        auto relu0 = std::make_shared<ov::op::v0::Relu>(arg0);
+        auto result0 = std::make_shared<ov::op::v0::Result>(relu0);
 
-    auto arg1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
-    auto relu1 = std::make_shared<ov::op::v0::Relu>(arg1);
-    auto result1 = std::make_shared<ov::op::v0::Result>(relu1);
+        auto arg1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
+        auto relu1 = std::make_shared<ov::op::v0::Relu>(arg1);
+        auto result1 = std::make_shared<ov::op::v0::Result>(relu1);
 
-    // Loop relu0->relu1->relu0
-    relu0->add_control_dependency(relu1);
-    relu1->add_control_dependency(relu0);
+        // Loop relu0->relu1->relu0
+        relu0->add_control_dependency(relu1);
+        relu1->add_control_dependency(relu0);
 
-    ASSERT_THROW(
-        std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result0, result1}, ov::ParameterVector{arg0, arg1}),
-        ov::Exception);
+        ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result0, result1},
+                                                               ov::ParameterVector{arg0, arg1}),
+                     ov::Exception);
+        // break circular dependency to release all nodes
+        relu0->remove_control_dependency(relu1);
+        relu1->remove_control_dependency(relu0);
+    }
+    EXPECT_THAT(nodes, testing::Each(testing::Property(&std::weak_ptr<ov::Node>::expired, true)));
 }
 
 TEST(model, topological_sort_caching_basic) {

--- a/src/core/tests/node_input_output.cpp
+++ b/src/core/tests/node_input_output.cpp
@@ -436,6 +436,8 @@ TEST(node_input_output, output_replace_bidirectional_connection) {
 
     // create model from incorrect net (cycles) to release nodes without leaking memory
     OV_EXPECT_THROW(ov::Model(OutputVector{mul}, ParameterVector{param}), ov::Exception, _);
+    // break circular dependency to release all nodes
+    relu->set_arguments(ov::OutputVector{});
 }
 
 TEST(node_input_output, output_replace_empty_targets) {

--- a/src/core/tests/node_input_output.cpp
+++ b/src/core/tests/node_input_output.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "common_test_utils/test_assertions.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/convert.hpp"
@@ -18,9 +19,11 @@
 #include "openvino/op/relu.hpp"
 #include "transformations/utils/utils.hpp"
 
-using namespace ov;
-using namespace std;
+namespace ov::test {
+
 using ov::op::util::disconnect_output_from_consumers;
+using std::make_shared;
+using testing::_;
 
 TEST(node_input_output, input_create) {
     auto x = make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 3, 4});
@@ -430,6 +433,11 @@ TEST(node_input_output, output_replace_bidirectional_connection) {
     EXPECT_EQ(mul_count, 2) << "mul should have exactly 2 connections from add2";
 
     EXPECT_EQ(add1->output(0).get_target_inputs().size(), 0) << "add1 should have no targets";
+
+    // create model from incorrect net (cycles) to release nodes without leaking memory
+    OV_EXPECT_THROW(std::ignore = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{param}),
+                    ov::Exception,
+                    _);
 }
 
 TEST(node_input_output, output_replace_empty_targets) {
@@ -475,3 +483,4 @@ TEST(node_input_output, output_replace_cascade) {
     EXPECT_EQ(add2->output(0).get_target_inputs().size(), 0);
     EXPECT_EQ(add3->output(0).get_target_inputs().size(), 0);
 }
+}  // namespace ov::test

--- a/src/core/tests/node_input_output.cpp
+++ b/src/core/tests/node_input_output.cpp
@@ -435,9 +435,7 @@ TEST(node_input_output, output_replace_bidirectional_connection) {
     EXPECT_EQ(add1->output(0).get_target_inputs().size(), 0) << "add1 should have no targets";
 
     // create model from incorrect net (cycles) to release nodes without leaking memory
-    OV_EXPECT_THROW(std::ignore = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{param}),
-                    ov::Exception,
-                    _);
+    OV_EXPECT_THROW(ov::Model(OutputVector{mul}, ParameterVector{param}), ov::Exception, _);
 }
 
 TEST(node_input_output, output_replace_empty_targets) {

--- a/src/core/tests/ov_default_allocator_test.cpp
+++ b/src/core/tests/ov_default_allocator_test.cpp
@@ -30,7 +30,9 @@ TEST_F(OVDefaultAllocatorTest, canAllocateAndDeallocate) {
 
 TEST_F(OVDefaultAllocatorTest, alignedAllocationNotThrow) {
     ov::Allocator allocator;
-    OV_ASSERT_NO_THROW(allocator.allocate(64, 64));
+    void* ptr = nullptr;
+    OV_ASSERT_NO_THROW(ptr = allocator.allocate(64, 64));
+    OV_ASSERT_NO_THROW(allocator.deallocate(ptr, 64, 64));
 }
 
 TEST_F(OVDefaultAllocatorTest, sizedAndAlignedDeallocationNotThrow) {


### PR DESCRIPTION
### Details:
 - Fix model validation in topological sort when exception throw force unlink nodes to removed dependencies (circular) which allow release nodes without leak.

### Tickets:
 - CVS-143900

### AI Assistance:
 - *AI assistance used: yes*
 - *Support analyze sanitizers errors to identify issues*
