### PR TITLE
Integer Underflow in ONNX Scan Converter num_scan_inputs leads to Out-of-bounds Read/Crash

### DIFF
--- a/src/frontends/onnx/frontend/src/op/scan.cpp
+++ b/src/frontends/onnx/frontend/src/op/scan.cpp
@@ -6,6 +6,7 @@
 #include "core/null_node.hpp"
 #include "core/operator_set.hpp"
 #include "exceptions.hpp"
+#include "openvino/frontend/exception.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/tensor_iterator.hpp"

--- a/src/frontends/onnx/frontend/src/op/scan.cpp
+++ b/src/frontends/onnx/frontend/src/op/scan.cpp
@@ -24,13 +24,22 @@ namespace {
 ov::OutputVector scan_to_tensor_iterator(const ov::OutputVector& node_inputs,
                                          ov::ParameterVector& body_inputs,
                                          ov::OutputVector& body_outputs,
-                                         int64_t num_scan_inputs,
+                                         size_t num_scan_inputs,
                                          const std::vector<int64_t>& scan_input_axes,
                                          const std::vector<int64_t>& scan_input_directions,
                                          const std::vector<int64_t>& scan_output_axes,
                                          const std::vector<int64_t>& scan_output_directions,
-                                         int64_t in_offset = 0,
+                                         size_t in_offset = 0,
                                          const std::string& node_description = "") {
+    FRONT_END_OP_CONVERSION_CHECK(
+        node_inputs.size() >= in_offset && node_inputs.size() - in_offset >= body_inputs.size(),
+        node_description,
+        " Number of Scan node inputs (",
+        node_inputs.size(),
+        ") is less than required (",
+        in_offset + body_inputs.size(),
+        ") based on body graph parameters and in_offset");
+
     const size_t num_initial_values = body_inputs.size() - num_scan_inputs;
     const size_t num_scan_outputs = body_outputs.size() - num_initial_values;
 
@@ -38,10 +47,10 @@ ov::OutputVector scan_to_tensor_iterator(const ov::OutputVector& node_inputs,
         if (r.is_static()) {
             axis = common::normalize_axis(node_description, axis, r);
         } else {
-            FRONT_END_GENERAL_CHECK(axis >= 0,
-                                    node_description,
-                                    " Rank must be static in order to normalize negative axis=",
-                                    axis);
+            FRONT_END_OP_CONVERSION_CHECK(axis >= 0,
+                                          node_description,
+                                          " Rank must be static in order to normalize negative axis=",
+                                          axis);
         }
         return axis;
     };
@@ -56,7 +65,7 @@ ov::OutputVector scan_to_tensor_iterator(const ov::OutputVector& node_inputs,
     // but in ONNX Scan the slice of input can has one dimension less,
     // so the parameter needs to have aligned rank with 1 at sliced axis,
     // and then squeezed to restore original shape.
-    for (int64_t i = 0; i < num_scan_inputs; ++i) {
+    for (size_t i = 0; i < num_scan_inputs; ++i) {
         const auto in_idx = num_initial_values + i;
         auto axis = scan_input_axes[i];
         const auto axis_node = v0::Constant::create(ov::element::i64, ov::Shape{1}, {axis});
@@ -65,10 +74,10 @@ ov::OutputVector scan_to_tensor_iterator(const ov::OutputVector& node_inputs,
             axis = try_normalize_axis_for_static_rank(axis, shape.rank());
             shape[axis] = 1;
         } else {
-            FRONT_END_GENERAL_CHECK(axis >= 0,
-                                    node_description,
-                                    " Rank must be static in order to normalize negative axis=",
-                                    axis);
+            FRONT_END_OP_CONVERSION_CHECK(axis >= 0,
+                                          node_description,
+                                          " Rank must be static in order to normalize negative axis=",
+                                          axis);
         }
         body_inputs[in_idx]->set_partial_shape(shape);
         body_inputs[in_idx]->validate_and_infer_types();
@@ -93,7 +102,7 @@ ov::OutputVector scan_to_tensor_iterator(const ov::OutputVector& node_inputs,
     tensor_iterator->set_function(ti_body);
 
     // Set slicing for Scan (TensorIterator) inputs
-    for (int64_t i = 0; i < num_scan_inputs; ++i) {
+    for (size_t i = 0; i < num_scan_inputs; ++i) {
         const auto in_idx = num_initial_values + i;
         const auto axis =
             try_normalize_axis_for_static_rank(scan_input_axes[i],
@@ -127,8 +136,8 @@ ov::OutputVector scan_to_tensor_iterator(const ov::OutputVector& node_inputs,
 }
 
 ov::OutputVector import_onnx_scan(const ov::frontend::onnx::Node& node,
-                                  int64_t default_axis,
-                                  int64_t in_offset,
+                                  size_t default_axis,
+                                  size_t in_offset,
                                   std::string&& in_directions_attr_name) {
     const auto& node_inputs = node.get_ov_inputs();
 
@@ -147,22 +156,76 @@ ov::OutputVector import_onnx_scan(const ov::frontend::onnx::Node& node,
         }
         body_inputs = body_graph->get_parameters();
     }
-    const int64_t num_scan_inputs = node.get_attribute_value<int64_t>("num_scan_inputs");
+
+    const int64_t num_scan_inputs_signed = node.get_attribute_value<int64_t>("num_scan_inputs");
+    FRONT_END_OP_CONVERSION_CHECK(num_scan_inputs_signed >= 0,
+                                  node.get_description(),
+                                  " num_scan_inputs attribute is negative: ",
+                                  num_scan_inputs_signed);
+    const size_t num_scan_inputs = static_cast<size_t>(num_scan_inputs_signed);
+
+    FRONT_END_OP_CONVERSION_CHECK(body_inputs.size() >= num_scan_inputs,
+                                  node.get_description(),
+                                  " num_scan_inputs (",
+                                  num_scan_inputs,
+                                  ") negative or exceeds the number of body graph inputs (",
+                                  body_inputs.size(),
+                                  ")");
+
     const size_t num_initial_values = body_inputs.size() - num_scan_inputs;
+    FRONT_END_OP_CONVERSION_CHECK(body_outputs.size() >= num_initial_values,
+                                  node.get_description(),
+                                  " num_scan_outputs can't be negative: body outputs (",
+                                  body_outputs.size(),
+                                  ") is less than num_initial_values (",
+                                  num_initial_values,
+                                  ")");
+
     const size_t num_scan_outputs = body_outputs.size() - num_initial_values;
 
     std::vector<int64_t> scan_input_axes =
         node.get_attribute_value<std::vector<int64_t>>("scan_input_axes",
                                                        std::vector<int64_t>(num_scan_inputs, default_axis));
+    FRONT_END_OP_CONVERSION_CHECK(scan_input_axes.size() >= num_scan_inputs,
+                                  node.get_description(),
+                                  " num_scan_inputs (",
+                                  num_scan_inputs,
+                                  ") exceeds the number of scan_input_axes (",
+                                  scan_input_axes.size(),
+                                  ")");
+
     std::vector<int64_t> scan_input_directions =
         node.get_attribute_value<std::vector<int64_t>>(in_directions_attr_name,
                                                        std::vector<int64_t>(num_scan_inputs, 0));
+    FRONT_END_OP_CONVERSION_CHECK(scan_input_directions.size() >= num_scan_inputs,
+                                  node.get_description(),
+                                  " num_scan_inputs (",
+                                  num_scan_inputs,
+                                  ") exceeds the number of scan_input_directions (",
+                                  scan_input_directions.size(),
+                                  ")");
+
     std::vector<int64_t> scan_output_axes =
         node.get_attribute_value<std::vector<int64_t>>("scan_output_axes",
                                                        std::vector<int64_t>(num_scan_outputs, default_axis));
+    FRONT_END_OP_CONVERSION_CHECK(scan_output_axes.size() >= num_scan_outputs,
+                                  node.get_description(),
+                                  " num_scan_outputs (",
+                                  num_scan_outputs,
+                                  ") exceeds the number of scan_output_axes (",
+                                  scan_output_axes.size(),
+                                  ")");
+
     std::vector<int64_t> scan_output_directions =
         node.get_attribute_value<std::vector<int64_t>>("scan_output_directions",
                                                        std::vector<int64_t>(num_scan_outputs, 0));
+    FRONT_END_OP_CONVERSION_CHECK(scan_output_directions.size() >= num_scan_outputs,
+                                  node.get_description(),
+                                  " num_scan_outputs (",
+                                  num_scan_outputs,
+                                  ") exceeds the number of scan_output_directions (",
+                                  scan_output_directions.size(),
+                                  ")");
 
     return scan_to_tensor_iterator(node_inputs,
                                    body_inputs,

--- a/src/frontends/onnx/tests/convert_tests.cpp
+++ b/src/frontends/onnx/tests/convert_tests.cpp
@@ -9,6 +9,7 @@
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/test_assertions.hpp"
 #include "onnx_utils.hpp"
+#include "openvino/frontend/exception.hpp"
 #include "openvino/frontend/manager.hpp"
 
 using namespace ov::frontend::onnx::tests;
@@ -75,4 +76,22 @@ TEST(ONNXFeConvertException, exception_if_qlinear_concat_invalid_x_input_triplet
     OV_EXPECT_THROW(convert_model("com.microsoft/qlinear_concat_invalid_x_input_triplet.onnx"),
                     ov::AssertFailure,
                     testing::AllOf(testing::HasSubstr("expected 2 + 3*N inputs"), testing::HasSubstr(" got: 6")));
+}
+
+TEST(ONNXFeConvertException, exception_if_scan_num_scan_inputs_exceeds_body_inputs) {
+    OV_EXPECT_THROW(convert_model("scan15_num_scan_inputs_exceeds_body_inputs.onnx"),
+                    ov::frontend::OpConversionFailure,
+                    testing::HasSubstr("num_scan_inputs (10) negative or exceeds the number of body graph inputs (2)"));
+}
+
+TEST(ONNXFeConvertException, exception_if_scan_negative_num_scan_inputs) {
+    OV_EXPECT_THROW(convert_model("scan15_negative_num_scan_inputs.onnx"),
+                    ov::frontend::OpConversionFailure,
+                    testing::HasSubstr("num_scan_inputs attribute is negative: -5"));
+}
+
+TEST(ONNXFeConvertException, exception_if_scan_body_fewer_outputs_than_initial_values) {
+    OV_EXPECT_THROW(convert_model("scan15_body_fewer_outputs_than_initial_values.onnx"),
+                    ov::frontend::OpConversionFailure,
+                    testing::HasSubstr("num_scan_outputs can't be negative"));
 }

--- a/src/frontends/onnx/tests/models/scan15_body_fewer_outputs_than_initial_values.prototxt
+++ b/src/frontends/onnx/tests/models/scan15_body_fewer_outputs_than_initial_values.prototxt
@@ -1,0 +1,116 @@
+ir_version: 8
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "initial1"
+    input: "initial2"
+    input: "sequence"
+    output: "scan_end"
+    op_type: "Scan"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "state1"
+          input: "seq_elem"
+          output: "sum"
+          op_type: "Add"
+        }
+        name: "body"
+        input {
+          name: "state1"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+        input {
+          name: "state2"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+        input {
+          name: "seq_elem"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+        output {
+          name: "sum"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+    attribute {
+      name: "num_scan_inputs"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test-model-scan-fewer-body-outputs"
+  input {
+    name: "initial1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "initial2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "sequence"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_end"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 15
+}

--- a/src/frontends/onnx/tests/models/scan15_negative_num_scan_inputs.prototxt
+++ b/src/frontends/onnx/tests/models/scan15_negative_num_scan_inputs.prototxt
@@ -1,0 +1,109 @@
+ir_version: 8
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "initial"
+    input: "sequence"
+    output: "scan_end"
+    output: "scan_seq"
+    op_type: "Scan"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "state"
+          input: "seq_elem"
+          output: "sum"
+          op_type: "Add"
+        }
+        name: "body"
+        input {
+          name: "state"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+        input {
+          name: "seq_elem"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+        output {
+          name: "sum"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+    attribute {
+      name: "num_scan_inputs"
+      i: -5
+      type: INT
+    }
+  }
+  name: "test-model-scan-neg"
+  input {
+    name: "initial"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "sequence"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_end"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_seq"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 15
+}

--- a/src/frontends/onnx/tests/models/scan15_num_scan_inputs_exceeds_body_inputs.prototxt
+++ b/src/frontends/onnx/tests/models/scan15_num_scan_inputs_exceeds_body_inputs.prototxt
@@ -1,0 +1,109 @@
+ir_version: 8
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "initial"
+    input: "sequence"
+    output: "scan_end"
+    output: "scan_seq"
+    op_type: "Scan"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "state"
+          input: "seq_elem"
+          output: "sum"
+          op_type: "Add"
+        }
+        name: "body"
+        input {
+          name: "state"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+        input {
+          name: "seq_elem"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+        output {
+          name: "sum"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+    attribute {
+      name: "num_scan_inputs"
+      i: 10
+      type: INT
+    }
+  }
+  name: "test-model-scan-invalid"
+  input {
+    name: "initial"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "sequence"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_end"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_seq"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 15
+}


### PR DESCRIPTION
- Fix and tests

### Details:
 - Fixed by adding assertions

### Tickets:
 - CVS-182187
 - [PTK0006430](https://intelait.intel.com/x_volt2_csi_product_vulnerability.do?sysparm_tiny=2XQRMPMypIHMISVXAZBirXEgVUr17ZtI&sys_id=defbe40fdf577a105348b094c2388982&sysparm_record_row=31)
