### PR TITLE
Fix broken intel plugin links

### DIFF
--- a/src/plugins/intel_cpu/README.md
+++ b/src/plugins/intel_cpu/README.md
@@ -2,7 +2,7 @@
 
 ## Key Contacts
 
-For assistance regarding CPU, contact a member of [openvino-ie-cpu-maintainers](https://github.com/orgs/openvinotoolkit/teams/openvino-ie-cpu-maintainers) group.
+For assistance regarding CPU, open a [GitHub issue](https://github.com/openvinotoolkit/openvino/issues) and tag it with the `cpu` label, or reach out via the [OpenVINO Discussions](https://github.com/openvinotoolkit/openvino/discussions) page.
 
 ## Components
 

--- a/src/plugins/intel_cpu/README.md
+++ b/src/plugins/intel_cpu/README.md
@@ -2,7 +2,7 @@
 
 ## Key Contacts
 
-For assistance regarding CPU, open a [GitHub issue](https://github.com/openvinotoolkit/openvino/issues) and tag it with the `cpu` label, or reach out via the [OpenVINO Discussions](https://github.com/openvinotoolkit/openvino/discussions) page.
+For assistance regarding CPU, contact a member of **openvino-ie-cpu-maintainers** group, or reach out via the [OpenVINO Discussions](https://github.com/openvinotoolkit/openvino/discussions) page.
 
 ## Components
 

--- a/src/plugins/intel_gpu/README.md
+++ b/src/plugins/intel_gpu/README.md
@@ -4,7 +4,7 @@ GPU plugin in [OpenVINO toolkit](https://github.com/openvinotoolkit/openvino) su
 
 ## Key Contacts
 
-For assistance regarding GPU, contact a member of [openvino-ie-gpu-maintainers](https://github.com/orgs/openvinotoolkit/teams/openvino-ie-gpu-maintainers) group.
+For assistance regarding GPU, open a [GitHub issue](https://github.com/openvinotoolkit/openvino/issues) and tag it with the `gpu` label, or reach out via the [OpenVINO Discussions](https://github.com/openvinotoolkit/openvino/discussions) page.
 
 ## Components
 
@@ -35,10 +35,10 @@ This contents explain the internal implementation of dynamic shape support in th
 
 * [Overall flow for dynamic shape execution](./docs/dynamic_shape/overall_flow.md)
 * Implementation details
-  * [Preprocessing: Shape inference / update weight / realloc memory](./docs/dynamic_shape/preprocessing.md)
+  * Preprocessing: Shape inference / update weight / realloc memory *(documentation pending)*
   * [dynamic impl of kernels](./docs/dynamic_shape/dynamic_impl.md)
   * [in-memory kernel cache](./docs/dynamic_shape/in_memory_cache.md)
-  * [async kernel compilation](./docs/dynamic_shape/async_compilation.md)
+  * async kernel compilation *(documentation pending)*
   <!-- * weight compression (TBD)) -->
 * Optimization features
   * [Memory preallocation](./docs/dynamic_shape/memory_preallocation.md)

--- a/src/plugins/intel_gpu/README.md
+++ b/src/plugins/intel_gpu/README.md
@@ -4,7 +4,7 @@ GPU plugin in [OpenVINO toolkit](https://github.com/openvinotoolkit/openvino) su
 
 ## Key Contacts
 
-For assistance regarding GPU, open a [GitHub issue](https://github.com/openvinotoolkit/openvino/issues) and tag it with the `gpu` label, or reach out via the [OpenVINO Discussions](https://github.com/openvinotoolkit/openvino/discussions) page.
+For assistance regarding GPU, contact a member of **openvino-ie-gpu-maintainers**, or reach out via the [OpenVINO Discussions](https://github.com/openvinotoolkit/openvino/discussions) page.
 
 ## Components
 


### PR DESCRIPTION
### Details:
 - Replaced broken `openvino-ie-gpu-maintainers` team link in `intel_gpu/README.md` with a normal text **openvino-ie-gpu-maintainers** and Added a link to GitHub Discussions, as the GitHub team page returns 404.
- Replaced broken `openvino-ie-cpu-maintainers` team link in `intel_cpu/README.md` with a normal text **openvino-ie-cpu-maintainers** and Added a link to GitHub Discussions, as the GitHub team page returns 404.
 - Removed hyperlinks from `Preprocessing: Shape inference / update weight / realloc memory` and `async kernel compilation` entries in `intel_gpu/README.md`, since the referenced markdown files (`preprocessing.md`, `async_compilation.md`) do not exist in `docs/dynamic_shape/`. Appended a  `*(documentation pending)*` note.

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes
 - While AI was used to suggest best documentation practices, the execution and review process was manual