### PR TITLE
[GPU] Provide a value for `default_value` in primitive constructor

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/sparse_fill_empty_rows.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/sparse_fill_empty_rows.hpp
@@ -25,7 +25,7 @@ struct sparse_fill_empty_rows : public primitive_base<sparse_fill_empty_rows> {
     std::vector<float> values;
     std::vector<int64_t> dense_shape;
     std::vector<int64_t> indices;
-    float default_value;
+    float default_value = 0.0f;
 
     sparse_fill_empty_rows(const primitive_id& id,
                           const std::vector<input_info>& inputs,


### PR DESCRIPTION
### Details:
 - `PARAMETER` test cases sporadically fail for `SparseFillEmprtRows`
 - In `PARAMETER` test case there's currently no initial value for `default_value`
 - It can cause issues in
https://github.com/openvinotoolkit/openvino/blob/178f7fc352400d830c23e64386b3bb90e333a891/src/plugins/intel_gpu/include/intel_gpu/primitives/sparse_fill_empty_rows.hpp#L58-L66
Because if, sporadically, random memory assigned to `default_value` is a `NaN`, then there's a `NaN == NaN -> false`. In case the random memory is a trash `float == 42`, then in `PARAMETER` case, both `rhs` and `lhs` will hold `42`, making kernel discovery work (but rather by accident).
 - This can cause sporadic errors mentioned in the ticket
 - Adding an init value is aligned with how other operators are specified in GPU Plugin
 - This is aligned with the spec, since `default_value` is a required input, but in `PARAMETER` case the actual input is grabbed directly from memory
 - I was not able to reproduce the issue locally, the only way to check if it works is to merge and see if there are any new reproductions

### Tickets:
 - CVS-181097

### AI Assistance:
 - AI was used to help me follow the logic of the code and identify possible issues
