### PR TITLE
[GPU] Fix i64 index type error in ScatterUpdate inside Loop

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -427,28 +427,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
     enableInt8 = config.get_enable_lp_transformations() && is_model_quantized;
 
     {
-        OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "TransformationsPipeline::apply::run_passes");
-        ov::pass::Manager manager("GPU:UnrollTensorIterator");
-        // This ConstantFolding pass is added to fold reshapes added for constant inputs on NMS internal operation which prevents upper-bound calculation
-        // TODO: check why we have these reshapes
-        manager.register_pass<ov::pass::ConstantFolding>();
-
-        manager.register_pass<ov::pass::UnrollTensorIterator>();
-        auto pass_config = manager.get_pass_config();
-        pass_config->set_callback<ov::pass::UnrollTensorIterator>(
-            [unroll_loop](const std::shared_ptr<const ov::Node> &node) -> bool {
-                auto sub_graph_op = ov::as_type_ptr<const ov::op::util::SubGraphOp>(node);
-                int64_t num_iter = sub_graph_op->get_num_iterations();
-                std::cout << "num_iter : " << num_iter << std::endl;
-                if (!unroll_loop)
-                    return num_iter != 1;
-                return num_iter >= 16;
-            });
-
-        manager.run_passes(func);
-    }
-
-    {
         ov::pass::Manager manager("Plugin:GPU");
         auto pass_config = manager.get_pass_config();
         manager.set_per_pass_validation(false);
@@ -1297,6 +1275,41 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         auto params = LayerTransformation::Params(true, element::f32, defaultPrecisions, reshapeIgnorePerTensorQuantizationCheck);
         lptManager.register_pass<LowPrecision>(supportedPrecisions, perTensorQuantization, params);
         lptManager.run_passes(func);
+    }
+
+    {
+        OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "TransformationsPipeline::apply::run_passes");
+        ov::pass::Manager manager("GPU:UnrollTensorIterator");
+        // This ConstantFolding pass is added to fold reshapes added for constant inputs on NMS internal operation which prevents upper-bound calculation
+        // TODO: check why we have these reshapes
+        manager.register_pass<ov::pass::ConstantFolding>();
+
+        manager.register_pass<ov::pass::UnrollTensorIterator>();
+        auto pass_config = manager.get_pass_config();
+        pass_config->set_callback<ov::pass::UnrollTensorIterator>(
+            [unroll_loop](const std::shared_ptr<const ov::Node> &node) -> bool {
+                auto sub_graph_op = ov::as_type_ptr<const ov::op::util::SubGraphOp>(node);
+                int64_t num_iter = sub_graph_op->get_num_iterations();
+                if (!unroll_loop)
+                    return num_iter != 1;
+                return num_iter >= 16;
+            });
+
+        manager.run_passes(func);
+    }
+
+    {
+        // Re-apply i64->i32 conversion after loop unrolling.
+        // UnrollTensorIterator replaces the current_iteration Parameter with a
+        // Constant(i64) regardless of the original parameter type. GPU kernels
+        // do not support i64 operands (e.g. ScatterUpdate indices),
+        // so convert these newly introduced i64 nodes to i32.
+        OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "TransformationsPipeline::apply::post_unroll_convert_precision");
+        ov::pass::Manager manager("GPU:PostUnrollConvertPrecision");
+        precisions_map post_unroll_int_map{{ov::element::i64, ov::element::i32}};
+        type_to_fuse_map post_unroll_type_to_fuse = {};
+        manager.register_pass<ov::pass::ConvertPrecision>(post_unroll_int_map, post_unroll_type_to_fuse, false, false);
+        manager.run_passes(func);
     }
 
     {

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1299,6 +1299,20 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
     }
 
     {
+        // Re-apply i64->i32 conversion after loop unrolling.
+        // UnrollTensorIterator replaces the current_iteration Parameter with a
+        // Constant(i64) regardless of the original parameter type. GPU kernels
+        // do not support i64 operands (e.g. ScatterUpdate indices),
+        // so convert these newly introduced i64 nodes to i32.
+        OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "TransformationsPipeline::apply::post_unroll_convert_precision");
+        ov::pass::Manager manager("GPU:PostUnrollConvertPrecision");
+        precisions_map post_unroll_int_map{{ov::element::i64, ov::element::i32}};
+        type_to_fuse_map post_unroll_type_to_fuse = {};
+        manager.register_pass<ov::pass::ConvertPrecision>(post_unroll_int_map, post_unroll_type_to_fuse, false, false);
+        manager.run_passes(func);
+    }
+
+    {
         OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "TransformationsPipeline::apply::activations_scaling");
         ov::pass::Manager manager("GPU:ActivationsScaling");
         manager.set_per_pass_validation(false);

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -427,6 +427,28 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
     enableInt8 = config.get_enable_lp_transformations() && is_model_quantized;
 
     {
+        OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "TransformationsPipeline::apply::run_passes");
+        ov::pass::Manager manager("GPU:UnrollTensorIterator");
+        // This ConstantFolding pass is added to fold reshapes added for constant inputs on NMS internal operation which prevents upper-bound calculation
+        // TODO: check why we have these reshapes
+        manager.register_pass<ov::pass::ConstantFolding>();
+
+        manager.register_pass<ov::pass::UnrollTensorIterator>();
+        auto pass_config = manager.get_pass_config();
+        pass_config->set_callback<ov::pass::UnrollTensorIterator>(
+            [unroll_loop](const std::shared_ptr<const ov::Node> &node) -> bool {
+                auto sub_graph_op = ov::as_type_ptr<const ov::op::util::SubGraphOp>(node);
+                int64_t num_iter = sub_graph_op->get_num_iterations();
+                std::cout << "num_iter : " << num_iter << std::endl;
+                if (!unroll_loop)
+                    return num_iter != 1;
+                return num_iter >= 16;
+            });
+
+        manager.run_passes(func);
+    }
+
+    {
         ov::pass::Manager manager("Plugin:GPU");
         auto pass_config = manager.get_pass_config();
         manager.set_per_pass_validation(false);
@@ -1275,41 +1297,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         auto params = LayerTransformation::Params(true, element::f32, defaultPrecisions, reshapeIgnorePerTensorQuantizationCheck);
         lptManager.register_pass<LowPrecision>(supportedPrecisions, perTensorQuantization, params);
         lptManager.run_passes(func);
-    }
-
-    {
-        OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "TransformationsPipeline::apply::run_passes");
-        ov::pass::Manager manager("GPU:UnrollTensorIterator");
-        // This ConstantFolding pass is added to fold reshapes added for constant inputs on NMS internal operation which prevents upper-bound calculation
-        // TODO: check why we have these reshapes
-        manager.register_pass<ov::pass::ConstantFolding>();
-
-        manager.register_pass<ov::pass::UnrollTensorIterator>();
-        auto pass_config = manager.get_pass_config();
-        pass_config->set_callback<ov::pass::UnrollTensorIterator>(
-            [unroll_loop](const std::shared_ptr<const ov::Node> &node) -> bool {
-                auto sub_graph_op = ov::as_type_ptr<const ov::op::util::SubGraphOp>(node);
-                int64_t num_iter = sub_graph_op->get_num_iterations();
-                if (!unroll_loop)
-                    return num_iter != 1;
-                return num_iter >= 16;
-            });
-
-        manager.run_passes(func);
-    }
-
-    {
-        // Re-apply i64->i32 conversion after loop unrolling.
-        // UnrollTensorIterator replaces the current_iteration Parameter with a
-        // Constant(i64) regardless of the original parameter type. GPU kernels
-        // do not support i64 operands (e.g. ScatterUpdate indices),
-        // so convert these newly introduced i64 nodes to i32.
-        OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "TransformationsPipeline::apply::post_unroll_convert_precision");
-        ov::pass::Manager manager("GPU:PostUnrollConvertPrecision");
-        precisions_map post_unroll_int_map{{ov::element::i64, ov::element::i32}};
-        type_to_fuse_map post_unroll_type_to_fuse = {};
-        manager.register_pass<ov::pass::ConvertPrecision>(post_unroll_int_map, post_unroll_type_to_fuse, false, false);
-        manager.run_passes(func);
     }
 
     {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/loop.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/loop.cpp
@@ -16,6 +16,8 @@
 #include "openvino/op/maximum.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/shape_of.hpp"
+#include "openvino/op/scatter_update.hpp"
+#include "openvino/op/unsqueeze.hpp"
 
 namespace {
 using ov::test::InputShape;
@@ -504,4 +506,100 @@ INSTANTIATE_TEST_SUITE_P(smoke_DynamicShapeLoop_conflict_dynamic, DynamicShapeLo
                         /* device */ testing::Values<std::string>(ov::test::utils::DEVICE_GPU),
                         /* freeze_input */ testing::Values(true)),
                         DynamicShapeLoopDynamicInputTest::getTestCaseName);
+
+// Regression test for Loop body containing ScatterUpdate with i32 current_iteration index.
+// UnrollTensorIterator replaces the current_iteration Parameter with Constant(i64),
+// which the GPU OCL ScatterUpdate kernel does not support as an index type.
+// The GPU plugin must convert such i64 constants to i32 after unrolling.
+class LoopWithScatterUpdateTest : public testing::WithParamInterface<ov::element::Type>,
+                                  virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<ov::element::Type>& obj) {
+        std::ostringstream result;
+        result << "data_type=" << obj.param;
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+        const auto data_type = GetParam();
+
+        // Outer model inputs
+        //   data:    [num_iter, feature_sz] – accumulation buffer
+        //   updates: [1, feature_sz]        – single row written each iteration
+        const size_t num_iter   = 8;
+        const size_t feature_sz = 4;
+        const ov::Shape data_shape   {num_iter,  feature_sz};
+        const ov::Shape update_shape {1,         feature_sz};
+
+        auto outer_data    = std::make_shared<ov::op::v0::Parameter>(data_type, data_shape);
+        auto outer_updates = std::make_shared<ov::op::v0::Parameter>(data_type, update_shape);
+        outer_data->set_friendly_name("outer_data");
+        outer_updates->set_friendly_name("outer_updates");
+
+        // Loop control inputs
+        auto trip_count = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{}, num_iter);
+        auto exec_cond  = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{}, true);
+
+        // ---- Body ----
+        // b_timestep is declared as i32 – the key point of this regression test.
+        // UnrollTensorIterator will replace it with Constant(i64), which the GPU
+        // OCL ScatterUpdate kernel cannot handle as an index type without the fix.
+        auto b_timestep = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{});
+        auto b_data     = std::make_shared<ov::op::v0::Parameter>(data_type, data_shape);
+        auto b_updates  = std::make_shared<ov::op::v0::Parameter>(data_type, update_shape);
+        b_timestep->set_friendly_name("timestep");
+        b_data->set_friendly_name("b_data");
+        b_updates->set_friendly_name("b_updates");
+
+        // Unsqueeze scalar timestep to shape [1] for use as ScatterUpdate indices
+        auto axis_const  = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{0});
+        auto timestep_1d = std::make_shared<ov::op::v0::Unsqueeze>(b_timestep, axis_const);
+        timestep_1d->set_friendly_name("timestep_1d");
+
+        // ScatterUpdate: b_data[timestep, :] = b_updates[0, :]
+        // indices shape [1] requires updates shape [1, feature_sz] — satisfied by b_updates
+        auto scatter_axis = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, 0);
+        auto b_scatter    = std::make_shared<ov::op::v3::ScatterUpdate>(b_data, timestep_1d, b_updates, scatter_axis);
+        b_scatter->set_friendly_name("scatter_update");
+
+        auto b_cond = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{}, true);
+
+        auto body = std::make_shared<ov::Model>(
+            ov::OutputVector{b_cond, b_scatter},
+            ov::ParameterVector{b_timestep, b_data, b_updates});
+
+        // ---- Loop ----
+        auto loop = std::make_shared<ov::op::v5::Loop>(trip_count, exec_cond);
+        loop->set_function(body);
+        // {0, 0}: b_timestep (param[0]) is current_iteration; body result[0] (b_cond) is the exit condition.
+        // body_condition_output_idx must be >= 0, otherwise Loop::validate_and_infer_types() returns
+        // early without setting output shapes, leaving the Loop output with a dynamic PartialShape.
+        loop->set_special_body_ports({0, 0});
+        loop->set_merged_input(b_data, outer_data, b_scatter);
+        loop->set_invariant_input(b_updates, outer_updates);
+        loop->get_iter_value(b_scatter, -1);
+
+        auto result = std::make_shared<ov::op::v0::Result>(loop->output(0));
+        function = std::make_shared<ov::Model>(ov::ResultVector{result},
+                                               ov::ParameterVector{outer_data, outer_updates});
+
+        // All shapes are fully static; set targetStaticShapes directly so that
+        // compile_model compiles the function as-is without a reshape pass.
+        // Calling init_input_shapes() would populate inputDynamicShapes and
+        // trigger a reshape of the cloned model, which can cause the Loop op's
+        // shape re-inference to produce a dynamic output dimension.
+        targetStaticShapes = {{data_shape, update_shape}};
+    }
+};
+
+TEST_P(LoopWithScatterUpdateTest, Inference) {
+    run();
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_LoopWithScatterUpdate, LoopWithScatterUpdateTest,
+                         testing::Values(ov::element::f32, ov::element::f16),
+                         LoopWithScatterUpdateTest::getTestCaseName);
+
 } // namespace


### PR DESCRIPTION
## Issue
When a `Loop` op body contains a `ScatterUpdate` with an `i32` current-iteration index parameter, the GPU plugin fails to compile the model
```
[GPU] No layout format available for scatterupdate:Loop_.../ScatterUpdate_...,
       impl_type: any (format: bfyx, data_type: f16)
```
The model runs correctly on CPU but fails on GPU. The repro is a `Loop` that writes each iteration's output into an accumulation buffer using `ScatterUpdate`, with the scatter index derived from `current_iteration` declared as `i32`.

## Root Cause
`UnrollTensorIterator` replaces the body's current_iteration Parameter with a Constant always hardcoded as `element::i64`, regardless of the original parameter's declared type
```
// src/common/transformations/src/transformations/control_flow/unroll_tensor_iterator.cpp
auto cur_iter_const = std::make_shared<v0::Constant>(ov::element::i64, Shape{}, idx);
//                                                    ^^^^^^^^^^^^^^^^ always i64
```
When the `ScatterUpdate` index was originally `i32`, after unrolling it silently becomes `i64`. The GPU OCL `ScatterUpdate` kernel only supports `{f32, f16, i32}` for the indices input -- `i64` is not in the supported type list, causing the "no layout format available" error.

The pre-existing `ConvertPrecision(i64->i32) `pass runs before `UnrollTensorIterator`, so it does not catch these newly introduced `i64` constants.

## How To Fix
Add a second, targeted `ConvertPrecision({i64 → i32})` pass immediately after the `GPU:UnrollTensorIterator` block in `transformations_pipeline.cpp`. This cleans up only the `i64` constants freshly introduced by `UnrollTensorIterator` — the map is intentionally limited to `{i64 → i32}` since `UnrollTensorIterator` exclusively generates `i64` constants for the current-iteration replacement.

## Tickets
 - CVS-183035