### PR TITLE
[NPUW] Enable strided tensor support by removing continuous tensor restriction

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
@@ -243,14 +243,9 @@ void ov::npuw::IBaseInferRequest::handle_set_remote_input(const ov::Output<const
                 if (::intel_npu::zeroUtils::get_l0_context_memory_allocation_id(
                         static_cast<ze_context_handle_t>(zrh.as<void*>()),
                         tensor->data()) > 0) {
-                    if (tensor->is_continuous()) {
                         // Note: no need for locking as it's internal method that should
                         // only be called from set_tensor()
-                        m_input_allocated.insert(tensor->data());
-                    } else {
-                        LOG_WARN("Strided remote tensor is not supported on the device! Expect worse performance due "
-                                 "to CPU runtime copy.");
-                    }
+                    m_input_allocated.insert(tensor->data());
                 }
             }
         }


### PR DESCRIPTION
### Details:
 - *Previously, strided remote tensors were rejected and fell back to slower
CPU runtime copy. Remove the continuous tensor check to allow strided
tensors to be processed directly on the device.*

### Tickets:
 - *CVS-183225*

### AI Assistance:
 - *AI assistance used: no*
