### PR TITLE
[GPU] Fix TopK radix kernel priority for small sort sizes and k=1

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_topk_radix.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_topk_radix.cpp
@@ -188,7 +188,17 @@ KernelsData ArgMaxMinKernelTopKRadix::GetKernelsData(const Params& params) const
     return {kd};
 }
 
-KernelsPriority ArgMaxMinKernelTopKRadix::GetKernelsPriority(const Params&) const {
+KernelsPriority ArgMaxMinKernelTopKRadix::GetKernelsPriority(const Params& p) const {
+    const auto& params = static_cast<const arg_max_min_params&>(p);
+    const size_t sort_size = GetSortSize(params);
+
+    // Radix sort excels at large sort sizes with large k (e.g., N=8400+, k=300).
+    // For k=1 (pure argmax/argmin) or small sort sizes, the axis kernel's
+    // simple reduction is more efficient — especially when there are many
+    // independent operations that amplify per-WG overhead.
+    if (params.topK == 1 || sort_size < 256)
+        return FORCE_PRIORITY_5;
+
     return FORCE_PRIORITY_1;
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
@@ -1314,3 +1314,32 @@ TEST(arg_max_gpu_topk_radix, f16_max_duplicates_n70_k5_indices_tiebreak) {
         }
     }
 }
+
+// Verify that arg_max_min_axis is selected over radix for small sort_size and k=1
+TEST(arg_max_gpu_topk_radix, fallback_to_axis_for_small_sort_size_and_topk1) {
+    auto& engine = get_test_engine();
+
+    // sort_size=8 (< 256) + topK=1 → both conditions trigger axis fallback
+    auto input = engine.allocate_memory({data_types::f16, format::bfyx, {1, 8, 1, 1}});
+    set_values(input, {ov::float16(1.f), ov::float16(5.f), ov::float16(3.f), ov::float16(9.f),
+                       ov::float16(2.f), ov::float16(7.f), ov::float16(4.f), ov::float16(8.f)});
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(arg_max_min("arg_max", {input_info("input")},
+                             ov::op::TopKMode::MAX, 1, 1,
+                             ov::op::TopKSortType::SORT_VALUES, true, false, data_types::f16, 2));
+
+    auto config = get_test_default_config(engine);
+    network network(engine, topology, config);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+
+    auto info = network.get_primitive_info("arg_max");
+    ASSERT_TRUE(info.find("arg_max_min_axis") != std::string::npos)
+        << "Expected arg_max_min_axis, got: " << info;
+
+    auto output = outputs.at("arg_max").get_memory();
+    cldnn::mem_lock<ov::float16> out_ptr(output, get_test_stream());
+    ASSERT_NEAR(static_cast<float>(out_ptr[0]), 9.0f, 0.01f);
+}


### PR DESCRIPTION
backport: https://github.com/openvinotoolkit/openvino/pull/34778

### Description of the issue(symptom, root-cause, how it was resolved)
#### Symptom
After https://github.com/openvinotoolkit/openvino/pull/34539,
deeplabv3 and efficientdet-d0 has huge Perf degradation, related to topK.

#### Root cause
arg_max_min_topk_radix was unconditionally given the highest kernel priority.

Radix kernel: two-level histogram radix select+SLM bitonic sort: effective for large sort sizes and large k.
Small sort sizes or small k fixed overhead of multiple full-data passes (caching, coarse/fine histogram, gather) and WG-level barriers dominates slower than arg_max_min_axis.

This caused regressions when topK == 1
(argma: multi-pass radix is overkill vs. simple reduction) or sort_size < 256
(below WG_SIZE, most threads idle while paying full barrier and global memory overhead per pass).

#### Resolution
This patch lowers radix priority below arg_max_min_axis for these two cases.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model) 
$  ./benchmark_app -m deeplabv3.xml -d GPU.1 -t 5
$  ./benchmark_app -m efficientdet-d0.xml -d GPU.1 -t 5

#### Checklist 
 - [x] Is it a proper fix?
 - [x] Did you include test case for this fix, if necessary? 
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *CVS-183209*

