### PR TITLE
Fix compilation errors for Visual Studio 2026

### DIFF
--- a/src/plugins/intel_cpu/tests/unit/rt_cache.cpp
+++ b/src/plugins/intel_cpu/tests/unit/rt_cache.cpp
@@ -323,7 +323,7 @@ class ScopedThread {
 public:
     explicit ScopedThread(std::thread t) : _t(std::move(t)) {
         if (!_t.joinable()) {
-            std::logic_error("Thread is not joinable!");
+            throw std::logic_error("Thread is not joinable!");
         }
     }
     ~ScopedThread() {

--- a/src/plugins/template/tests/functional/op_reference/roi_align_rotated.cpp
+++ b/src/plugins/template/tests/functional/op_reference/roi_align_rotated.cpp
@@ -52,8 +52,8 @@ ROIAlignRotatedParams PrepareTestCaseParams(const PartialShape& inputShape,
     const auto elementType = element::from<T>();
 
     ret.inputShape = inputShape;
-    ret.pooledH = pooledH;
-    ret.pooledW = pooledW;
+    ret.pooledH = static_cast<int32_t>(pooledH);
+    ret.pooledW = static_cast<int32_t>(pooledW);
     ret.spatialScale = spatialScale;
     ret.samplingRatio = samplingRatio;
     ret.clockwise = clockwise;


### PR DESCRIPTION
### Details:
 - Fix compilation errors for Visual Studio 2026

### Tickets:
 - CVS-182973

### AI Assistance:
 - *AI assistance used: no *
