### PR TITLE
Fix missing transpose check and reshape handling in ConvertWeightCompressedConv1x1ToMatmul

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
@@ -111,37 +111,35 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
         auto zp = (pattern_map.count(weights_zp_m) > 0) ? pattern_map.at(weights_zp_m).get_node_shared_ptr() : nullptr;
         auto activation = pattern_map.at(first_input_m).get_node_shared_ptr();
 
-        // expects NHWC -> NCHW transpose on activation
-        const auto act_order = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(a_order_m).get_node_shared_ptr());
-        OPENVINO_ASSERT(act_order);
-        const auto act_order_data = act_order->cast_vector<int64_t>();
-        const auto act_rank = act_order_data.size();
-        const auto is_act_transpose = pattern_map.count(transpose_activations_m) > 0;
-        if (is_act_transpose) {
+        const auto ensure_transpose_order = [](const std::shared_ptr<ov::op::v0::Constant>& order_node,
+                                               const std::array<size_t, 3>& order_offset) {
+            OPENVINO_ASSERT(order_node);
+            const auto order_data = order_node->cast_vector<int64_t>();
+            const auto order_rank = order_data.size();
+            OPENVINO_ASSERT(order_rank >= 3);  // to make an input to conv2/3d, rank should be at least 3
             // 0,3,1,2
-            if (act_rank < 3 || act_order_data[act_rank - 1] != act_rank - 2 ||
-                act_order_data[act_rank - 2] != act_rank - 3 || act_order_data[act_rank - 3] != act_rank - 1) {
+            if (order_data[order_rank - 3] != static_cast<int64_t>(order_rank - order_offset[0]) ||
+                order_data[order_rank - 2] != static_cast<int64_t>(order_rank - order_offset[1]) ||
+                order_data[order_rank - 1] != static_cast<int64_t>(order_rank - order_offset[2])) {
                 return false;
             }
-        } else {
-            // reshape is not transposing, so expects C==1 or HW==1
-            const auto act_reshape =
-                ov::as_type_ptr<ov::op::v1::Reshape>(pattern_map.at(reshape_activations_m).get_node_shared_ptr());
-            const auto& dimC = act_order_data[act_rank - 3];
-            const auto& dimH = act_order_data[act_rank - 2];
-            const auto& dimW = act_order_data[act_rank - 1];
-            if (act_rank < 3 || !((dimH == 1 && dimW == 1) || dimC == 1)) {
+            return true;
+        };
+        if (pattern_map.count(transpose_activations_m) > 0) {
+            const auto act_order =
+                ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(a_order_m).get_node_shared_ptr());
+            // expects NHWC -> NCHW transpose on activation, 4 - [0,3,1,2]
+            if (!ensure_transpose_order(act_order, {1, 3, 2})) {
                 return false;
             }
-            // not eliminate reshape, simply replace with NHWC to avoid incompatible activation shape
-            auto new_order_data = act_order_data;
-            new_order_data[act_rank - 1] = dimC;  // C
-            new_order_data[act_rank - 2] = dimW;  // W
-            new_order_data[act_rank - 3] = dimH;  // H
-            const auto new_order = ov::op::v0::Constant::create(element::i64, Shape{act_rank}, new_order_data);
-            const auto new_reshape =
-                std::make_shared<ov::op::v1::Reshape>(activation, new_order, act_reshape->get_special_zero());
-            activation = new_reshape;
+        }
+        if (pattern_map.count(transpose_output_m) > 0) {
+            const auto out_order =
+                ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(c_order_m).get_node_shared_ptr());
+            // expects NCHW -> NHWC transpose on result, 4 - [0,2,3,1]
+            if (!ensure_transpose_order(out_order, {2, 1, 3})) {
+                return false;
+            }
         }
 
         auto reshape_const_to_2d = [](std::shared_ptr<ov::Node> node) {

--- a/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
@@ -29,6 +29,7 @@
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/util/common_util.hpp"
 #include "transformations/utils/utils.hpp"
 
 using namespace ov::pass::pattern;
@@ -109,6 +110,39 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
         auto scale = pattern_map.at(weights_scales_m).get_node_shared_ptr();
         auto zp = (pattern_map.count(weights_zp_m) > 0) ? pattern_map.at(weights_zp_m).get_node_shared_ptr() : nullptr;
         auto activation = pattern_map.at(first_input_m).get_node_shared_ptr();
+
+        // expects NHWC -> NCHW transpose on activation
+        const auto act_order = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(a_order_m).get_node_shared_ptr());
+        OPENVINO_ASSERT(act_order);
+        const auto act_order_data = act_order->cast_vector<int64_t>();
+        const auto act_rank = act_order_data.size();
+        const auto is_act_transpose = pattern_map.count(transpose_activations_m) > 0;
+        if (is_act_transpose) {
+            // 0,3,1,2
+            if (act_rank < 3 || act_order_data[act_rank - 1] != act_rank - 2 ||
+                act_order_data[act_rank - 2] != act_rank - 3 || act_order_data[act_rank - 3] != act_rank - 1) {
+                return false;
+            }
+        } else {
+            // reshape is not transposing, so expects C==1 or HW==1
+            const auto act_reshape =
+                ov::as_type_ptr<ov::op::v1::Reshape>(pattern_map.at(reshape_activations_m).get_node_shared_ptr());
+            const auto& dimC = act_order_data[act_rank - 3];
+            const auto& dimH = act_order_data[act_rank - 2];
+            const auto& dimW = act_order_data[act_rank - 1];
+            if (act_rank < 3 || !((dimH == 1 && dimW == 1) || dimC == 1)) {
+                return false;
+            }
+            // not eliminate reshape, simply replace with NHWC to avoid incompatible activation shape
+            auto new_order_data = act_order_data;
+            new_order_data[act_rank - 1] = dimC;  // C
+            new_order_data[act_rank - 2] = dimW;  // W
+            new_order_data[act_rank - 3] = dimH;  // H
+            const auto new_order = ov::op::v0::Constant::create(element::i64, Shape{act_rank}, new_order_data);
+            const auto new_reshape =
+                std::make_shared<ov::op::v1::Reshape>(activation, new_order, act_reshape->get_special_zero());
+            activation = new_reshape;
+        }
 
         auto reshape_const_to_2d = [](std::shared_ptr<ov::Node> node) {
             auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);

--- a/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
@@ -53,6 +53,9 @@ std::shared_ptr<ov::Model> gen_model(const Conv1x1ToMatmulTestParams& p) {
     if (p.activation_op_type == "Transpose") {
         auto transpose_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {0, 3, 1, 2});
         act_node = std::make_shared<ov::opset1::Transpose>(input, transpose_const);
+    } else if (p.activation_op_type == "TransposeWrong") {
+        auto transpose_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {0, 3, 1, 2});
+        act_node = std::make_shared<ov::opset1::Transpose>(input, transpose_const);
     } else {
         auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {1, 10, 1, 1});
         act_node = std::make_shared<ov::opset1::Reshape>(input, reshape_const, false);
@@ -116,6 +119,9 @@ std::shared_ptr<ov::Model> gen_model(const Conv1x1ToMatmulTestParams& p) {
     std::shared_ptr<ov::Node> out_node;
     if (p.activation_op_type == "Transpose") {
         auto transpose_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {0, 2, 3, 1});
+        out_node = std::make_shared<ov::opset1::Transpose>(current_node, transpose_const);
+    } else if (p.activation_op_type == "TransposeWrong") {
+        auto transpose_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {0, 1, 3, 2});
         out_node = std::make_shared<ov::opset1::Transpose>(current_node, transpose_const);
     } else {
         auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {1, 1, 1, 15});
@@ -239,23 +245,26 @@ protected:
                                          with_act_new_reshape,
                                          activation_op_type};
         model = gen_model(params);
-        model_ref = gen_model_ref(params);
+        if (activation_op_type != "TransposeWrong") {
+            model_ref = gen_model_ref(params);
+        }
         manager.register_pass<ov::pass::ConvertWeightCompressedConv1x1ToMatmul>();
     }
 };
 
 TEST_P(ConvertWeightCompressedConv1x1ToMatmulTest, CompareFunctions) {}
 
-INSTANTIATE_TEST_SUITE_P(TransformationTests,
-                         ConvertWeightCompressedConv1x1ToMatmulTest,
-                         ::testing::Combine(::testing::Bool(),
-                                            ::testing::Bool(),
-                                            ::testing::Bool(),
-                                            ::testing::Bool(),
-                                            ::testing::Bool(),
-                                            ::testing::Bool(),
-                                            ::testing::Values("Transpose", "Reshape")),
-                         ConvertWeightCompressedConv1x1ToMatmulTest::get_test_case_name);
+INSTANTIATE_TEST_SUITE_P(
+    TransformationTests,
+    ConvertWeightCompressedConv1x1ToMatmulTest,
+    ::testing::Combine(::testing::Bool(),
+                       ::testing::Bool(),
+                       ::testing::Bool(),
+                       ::testing::Bool(),
+                       ::testing::Bool(),
+                       ::testing::Bool(),
+                       ::testing::Values("Transpose", "TransposeWrong", "Reshape")),
+    ConvertWeightCompressedConv1x1ToMatmulTest::get_test_case_name);
 
 // Checked blocked cases
 class ConvertWeightCompressedConv1x1ToMatmulTest_Blocked : public TransformationTestsF {


### PR DESCRIPTION
### Details:
Current `ConvertWeightCompressedConv1x1ToMatmul` expects activation has a transpose before so that converting to matmul could eliminate that transpose.

But actual code is only matching the pattern, not really doing transpose layout check (only NHWC->NCHW transpose is capable for elimination).

Reshape case is even worse, since eliminating it blindly could get totally incompatible input shape for the newly added matmul (and trigger assert).

sample failure case:
<img width="384" height="362" alt="image" src="https://github.com/user-attachments/assets/03c191c2-50db-4eea-bdc1-cf850a9240ad" />


This PR simply added transpose check, and for reshape it's overwrite it rather than removing it, hope later passes will do no-op eliminations.

### Tickets:
 - *[CVS-183223](https://jira.devtools.intel.com/browse/CVS-183223)*

### AI Assistance:
 - *AI assistance used: no*

