### PR TITLE
Add handling of fused swiglu in calc_output_layout

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -133,14 +133,15 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
         weights_layout.set_partial_shape(reshape_to_2d(weights_pshape, feature));
     }
 
+    format output_format = get_preferred_format(node, impl_param);
+
     auto& fused_prims = node.get_fused_primitives();
-    for (auto f : fused_prims) {
+    for (const auto& f : fused_prims) {
         if (f.is_type<swiglu>()) {
             OPENVINO_ASSERT(fused_prims.size() == 1, "Other operation is fused in addition to swiglu!");
             ov::PartialShape out_pshape = f.output_layout.get_partial_shape();
             GPU_DEBUG_TRACE_DETAIL << impl_param.desc->id << " fused with swiglu so override with its output layout: " << out_pshape.to_string()
                                     << std::endl;
-            format output_format = get_preferred_format(node, impl_param);
             return layout(out_pshape, output_type, output_format);
         }
     }
@@ -159,8 +160,6 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
                           input_layout.spatial(2), input_layout.spatial(1), out_features};
         }
 
-        format output_format = get_preferred_format(node, impl_param);
-
         return layout(out_pshape, output_type, output_format);
     } else {
         if (desc->input_size > 5) {
@@ -176,8 +175,6 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
         } else if (desc->input_size == 5) {
             output_size = tensor(input_layout.batch(), input_layout.feature(), out_features, input_layout.spatial(1), input_layout.spatial(2));
         }
-
-        format output_format = get_preferred_format(node, impl_param);
 
         return layout(output_type, output_format, output_size);
     }

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -133,6 +133,18 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
         weights_layout.set_partial_shape(reshape_to_2d(weights_pshape, feature));
     }
 
+    auto& fused_prims = node.get_fused_primitives();
+    for (auto f : fused_prims) {
+        if (f.is_type<swiglu>()) {
+            OPENVINO_ASSERT(fused_prims.size() == 1, "Other operation is fused in addition to swiglu!");
+            ov::PartialShape out_pshape = f.output_layout.get_partial_shape();
+            GPU_DEBUG_TRACE_DETAIL << impl_param.desc->id << " fused with swiglu so override with its output layout: " << out_pshape.to_string()
+                                    << std::endl;
+            format output_format = get_preferred_format(node, impl_param);
+            return layout(out_pshape, output_type, output_format);
+        }
+    }
+
     if (supports_immad) {
         auto out_features = desc->weights_transposed ? weights_layout.batch() : weights_layout.feature();
         ov::PartialShape out_pshape = {input_layout.batch(), out_features, 1, 1};

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -138,7 +138,8 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
     auto& fused_prims = node.get_fused_primitives();
     for (const auto& f : fused_prims) {
         if (f.is_type<swiglu>()) {
-            OPENVINO_ASSERT(fused_prims.size() == 1, "Other operation is fused in addition to swiglu!");
+            OPENVINO_ASSERT(fused_prims.size() == 1, "[GPU] Other operation is fused in addition to swiglu!");
+            OPENVINO_ASSERT(fused_prims[0].typed_desc<swiglu>()->glu_type == ov::op::internal::GLU::GluType::Swish);
             ov::PartialShape out_pshape = f.output_layout.get_partial_shape();
             GPU_DEBUG_TRACE_DETAIL << impl_param.desc->id << " fused with swiglu so override with its output layout: " << out_pshape.to_string()
                                     << std::endl;

--- a/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
@@ -225,7 +225,7 @@ public:
 
 #define CASE_FC_FP16_INT4_SWIGLU_1 { 1, 64 }, { 1, 64 }, { 64, 64 }, data_types::f16, format::bfyx, data_types::u4, format::oiyx, data_types::f16, format::bfyx
 #define CASE_FC_FP16_INT4_SWIGLU_2 { 1, 64}, { 1, 128 }, { 128, 64 }, data_types::f16, format::bfyx, data_types::u4, format::oiyx, data_types::f16, format::bfyx
-#define CASE_FC_FP16_INT4_SWIGLU_3 { 1, 312 }, { 1, 128 }, { 128, 312 }, data_types::f16, format::bfyx, data_types::u4, format::oiyx, data_types::f16, format::bfyx
+#define CASE_FC_FP16_INT4_SWIGLU_3 { 1, 320 }, { 1, 128 }, { 128, 320 }, data_types::f16, format::bfyx, data_types::u4, format::oiyx, data_types::f16, format::bfyx
 #define CASE_FC_FP16_INT4_SWIGLU_4 { 8, 1, 64}, { 8, 1, 128 }, { 128, 64 }, data_types::f16, format::bfyx, data_types::u4, format::oiyx, data_types::f16, format::bfyx
 
 /* ----------------------------------------------------------------------------------------------------- */
@@ -1204,14 +1204,13 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_fp16_eltwise_add_ocl_dynamic, ::testing
     fully_connected_test_params{ DYN_CASE_FC_FP16_3D_2, 2, 3 },
 }));
 
-class fc_fp16_swiglu_ocl_dynamic : public FullyConnectedFusingTest {
-public:
-    void run_test(bool is_per_channel_quan) {
+class fc_fp16_swiglu_ocl : public FullyConnectedFusingTest {
+protected:
+    void run_test(bool is_dynamic, bool is_per_channel_quan) {
         auto p = GetParam();
         auto test_input_layout = get_input_layout(p);
-        auto dynamic_input_layout = layout{ov::PartialShape::dynamic(test_input_layout.get_partial_shape().size()),
-                                           test_input_layout.data_type,
-                                           test_input_layout.format};
+        auto dynamic_input_layout =
+            layout{ov::PartialShape::dynamic(test_input_layout.get_partial_shape().size()), test_input_layout.data_type, test_input_layout.format};
         int64_t swiglu_length = p.weights_shape[0].get_length()/2;
         auto fc_prim = fully_connected("fc_prim",
                                        input_info("input"),
@@ -1227,7 +1226,7 @@ public:
         auto groups_num = p.in_shape.size() == 3 ? p.in_shape[2] / group_size : p.in_shape[1] / group_size;
         auto scale_shape = p.out_shape.size() == 3 ? ov::PartialShape{p.out_shape[2], groups_num} : ov::PartialShape{p.out_shape[1], groups_num};
 
-        create_topologies(input_layout("input", dynamic_input_layout),
+        create_topologies(input_layout("input", is_dynamic ? dynamic_input_layout : test_input_layout),
                           data("weights", get_mem(get_weights_layout(p))),
                           data("scale", get_mem(layout{scale_shape, p.default_type, p.default_format}, 0.1)),
                           fc_prim,
@@ -1241,7 +1240,46 @@ public:
                           reorder("reorder_bfyx", input_info("swiglu"), p.default_format, data_types::f32));
 
         tolerance = 1.0f;
-        execute(p, true);
+        execute(p, is_dynamic);
+    }
+};
+
+class fc_fp16_swiglu_ocl_static : public fc_fp16_swiglu_ocl {
+public:
+    void run_test(bool is_per_channel_quan) {
+        fc_fp16_swiglu_ocl::run_test(false, is_per_channel_quan);
+    }
+};
+
+TEST_P(fc_fp16_swiglu_ocl_static, basic) {
+    if (engine.get_device_info().supports_immad)
+        return;
+
+    if (engine.get_device_info().execution_units_count < 128)
+        return;
+    run_test(false);
+}
+
+TEST_P(fc_fp16_swiglu_ocl_static, per_channel_quan) {
+    if (engine.get_device_info().supports_immad)
+        return;
+
+    if (engine.get_device_info().execution_units_count < 128)
+        return;
+    run_test(true);
+}
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_fp16_swiglu_ocl_static, ::testing::ValuesIn(std::vector<fully_connected_test_params>{
+    fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_1, 2, 3 },
+    fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_2, 2, 3 },
+    fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_3, 2, 3 },
+    fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_4, 2, 3 },
+}));
+
+class fc_fp16_swiglu_ocl_dynamic : public fc_fp16_swiglu_ocl {
+public:
+    void run_test(bool is_per_channel_quan) {
+        fc_fp16_swiglu_ocl::run_test(true, is_per_channel_quan);
     }
 };
 

--- a/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
@@ -1244,69 +1244,49 @@ protected:
     }
 };
 
-class fc_fp16_swiglu_ocl_static : public fc_fp16_swiglu_ocl {
-public:
-    void run_test(bool is_per_channel_quan) {
-        fc_fp16_swiglu_ocl::run_test(false, is_per_channel_quan);
-    }
-};
-
-TEST_P(fc_fp16_swiglu_ocl_static, basic) {
+TEST_P(fc_fp16_swiglu_ocl, basic_static) {
     if (engine.get_device_info().supports_immad)
         return;
 
     if (engine.get_device_info().execution_units_count < 128)
         return;
-    run_test(false);
+    run_test(false, false);
 }
 
-TEST_P(fc_fp16_swiglu_ocl_static, per_channel_quan) {
+TEST_P(fc_fp16_swiglu_ocl, per_channel_quan_static) {
     if (engine.get_device_info().supports_immad)
         return;
 
     if (engine.get_device_info().execution_units_count < 128)
         return;
-    run_test(true);
+    run_test(false, true);
 }
 
-INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_fp16_swiglu_ocl_static, ::testing::ValuesIn(std::vector<fully_connected_test_params>{
+TEST_P(fc_fp16_swiglu_ocl, basic_dynamic) {
+    if (engine.get_device_info().supports_immad)
+        return;
+
+    if (engine.get_device_info().execution_units_count < 128)
+        return;
+    run_test(true, false);
+}
+
+TEST_P(fc_fp16_swiglu_ocl, per_channel_quan_dynamic) {
+    if (engine.get_device_info().supports_immad)
+        return;
+
+    if (engine.get_device_info().execution_units_count < 128)
+        return;
+    run_test(true, true);
+}
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_fp16_swiglu_ocl, ::testing::ValuesIn(std::vector<fully_connected_test_params>{
     fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_1, 2, 3 },
     fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_2, 2, 3 },
     fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_3, 2, 3 },
     fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_4, 2, 3 },
 }));
 
-class fc_fp16_swiglu_ocl_dynamic : public fc_fp16_swiglu_ocl {
-public:
-    void run_test(bool is_per_channel_quan) {
-        fc_fp16_swiglu_ocl::run_test(true, is_per_channel_quan);
-    }
-};
-
-TEST_P(fc_fp16_swiglu_ocl_dynamic, basic) {
-    if (engine.get_device_info().supports_immad)
-        return;
-
-    if (engine.get_device_info().execution_units_count < 128)
-        return;
-    run_test(false);
-}
-
-TEST_P(fc_fp16_swiglu_ocl_dynamic, per_channel_quan) {
-    if (engine.get_device_info().supports_immad)
-        return;
-
-    if (engine.get_device_info().execution_units_count < 128)
-        return;
-    run_test(true);
-}
-
-INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_fp16_swiglu_ocl_dynamic, ::testing::ValuesIn(std::vector<fully_connected_test_params>{
-    fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_1, 2, 3 },
-    fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_2, 2, 3 },
-    fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_3, 2, 3 },
-    fully_connected_test_params{ CASE_FC_FP16_INT4_SWIGLU_4, 2, 3 },
-}));
 
 class fc_imad_int8_eltwise_add_ocl_dynamic : public FullyConnectedFusingTest {
 public:


### PR DESCRIPTION
### Details:
There's a case that swiglu is being fused into fc_compressed, the swiglu will half the dimension.
For this static model, calc_output_layout is not considering any fused ops and give wrong shape.

This PR simply add logic to use fused_swiglu's ouput layout in such case.

<img width="756" height="422" alt="image" src="https://github.com/user-attachments/assets/7a76bd00-7d1b-4a87-b3a0-4c387adff9b2" />


### Tickets:
 - *[CVS-183221](https://jira.devtools.intel.com/browse/CVS-183221)*

### AI Assistance:
 - *AI assistance used: no*
