### PR TITLE
[GPU] Fix LoRA adapter accuracy by enabling LoRA horizontal fusion and adjusting activation scaling

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
@@ -17,7 +17,6 @@
 #include "openvino/core/graph_util.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/concat.hpp"
-#include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/variadic_split.hpp"
@@ -121,33 +120,7 @@ FullyConnectedHorizontalFusion::FullyConnectedHorizontalFusion(bool fuse_mlp_swi
                     zp_nodes.push_back(fc_user->get_input_node_shared_ptr(4));
             }
         }
-        // Skip FC horizontal fusion when LoRA consumers are detected.
-        // LoRA pattern: FC -> Add(FC_output, MatMul(Multiply(alpha, lora_A), lora_B))
-        // Fusing QKV FCs into a single large FC causes numerical divergence in FP16
-        // due to different GEMM tiling/accumulation in the larger fused kernel.
-        auto has_lora_consumer = [](const std::shared_ptr<ov::Node>& fc_node) {
-            for (const auto& consumer : fc_node->get_users()) {
-                const auto& add = ov::as_type_ptr<ov::op::v1::Add>(consumer);
-                if (!add)
-                    continue;
-                for (size_t i = 0; i < 2; ++i) {
-                    const auto& matmul = ov::as_type_ptr<ov::op::v0::MatMul>(add->get_input_node_shared_ptr(i));
-                    if (!matmul)
-                        continue;
-                    if (ov::is_type<ov::op::v1::Multiply>(matmul->get_input_node_shared_ptr(0)))
-                        return true;
-                }
-            }
-            return false;
-        };
-        for (const auto& fc : fc_nodes) {
-            if (has_lora_consumer(fc)) {
-                GPU_DEBUG_TRACE_DETAIL << "Skip FC horizontal fusion: LoRA consumer detected for "
-                                       << fc->get_friendly_name() << std::endl;
-                return false;
-            }
-        }
-
+        // fc weight is already transposed to [N, K]
         const size_t weight_idx = 1;
         if (fc_nodes[0]->get_input_shape(weight_idx).size() != 2)
             return false;

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1429,7 +1429,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             }
 
             // Temporary disabling for BMG due to regression
-            if (device_info.arch != cldnn::gpu_arch::xe2 && !config.get_enable_lora_operation()) {
+            if (device_info.arch != cldnn::gpu_arch::xe2 && (!config.get_enable_lora_operation() || device_info.supports_immad)) {
                 manager.register_pass<ov::intel_gpu::LoRAHorizontalFusion>();
             }
         }

--- a/src/plugins/intel_gpu/tests/unit/transformations/horizontal_fc_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/horizontal_fc_fusion_test.cpp
@@ -18,7 +18,6 @@
 #include "openvino/op/variadic_split.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/add.hpp"
-#include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/pass/manager.hpp"
 
@@ -336,66 +335,6 @@ TEST_F(TransformationTestsF, FullyConnectedHorizontalFusion_eltwise_bias_zp_scal
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
-
-TEST_F(TransformationTestsF, FullyConnectedHorizontalFusion_skip_lora_consumers) {
-    std::vector<int64_t> pattern = {7, -1};
-    size_t hidden_size = 4096;
-    size_t lora_rank = 128;
-    {
-        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 7, static_cast<int64_t>(hidden_size)});
-        auto weight_q = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{4096, hidden_size});
-        auto weight_k = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, hidden_size});
-        auto weight_v = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, hidden_size});
-        auto bias_q = std::make_shared<ov::intel_gpu::op::Placeholder>();
-        auto bias_k = std::make_shared<ov::intel_gpu::op::Placeholder>();
-        auto bias_v = std::make_shared<ov::intel_gpu::op::Placeholder>();
-        auto scale_q = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{4096, 32});
-        auto scale_k = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 32});
-        auto scale_v = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 32});
-        auto fc_q = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weight_q, bias_q, scale_q);
-        auto fc_k = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weight_k, bias_k, scale_k);
-        auto fc_v = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weight_v, bias_v, scale_v);
-
-        // LoRA subgraph for Q: input -> MatMul(A) -> Multiply(alpha) -> MatMul(B) -> Add(FC_out, ...)
-        auto lora_a_q = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{hidden_size, lora_rank});
-        auto lora_matmul1_q = std::make_shared<ov::op::v0::MatMul>(input, lora_a_q, false, false);
-        auto lora_alpha_q = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, lora_rank});
-        auto lora_mul_q = std::make_shared<ov::op::v1::Multiply>(lora_matmul1_q, lora_alpha_q);
-        auto lora_b_q = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{lora_rank, 4096});
-        auto lora_matmul2_q = std::make_shared<ov::op::v0::MatMul>(lora_mul_q, lora_b_q, false, false);
-        auto lora_add_q = std::make_shared<ov::op::v1::Add>(fc_q, lora_matmul2_q);
-
-        // LoRA subgraph for K
-        auto lora_a_k = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{hidden_size, lora_rank});
-        auto lora_matmul1_k = std::make_shared<ov::op::v0::MatMul>(input, lora_a_k, false, false);
-        auto lora_alpha_k = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, lora_rank});
-        auto lora_mul_k = std::make_shared<ov::op::v1::Multiply>(lora_matmul1_k, lora_alpha_k);
-        auto lora_b_k = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{lora_rank, 1024});
-        auto lora_matmul2_k = std::make_shared<ov::op::v0::MatMul>(lora_mul_k, lora_b_k, false, false);
-        auto lora_add_k = std::make_shared<ov::op::v1::Add>(fc_k, lora_matmul2_k);
-
-        // LoRA subgraph for V
-        auto lora_a_v = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{hidden_size, lora_rank});
-        auto lora_matmul1_v = std::make_shared<ov::op::v0::MatMul>(input, lora_a_v, false, false);
-        auto lora_alpha_v = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, lora_rank});
-        auto lora_mul_v = std::make_shared<ov::op::v1::Multiply>(lora_matmul1_v, lora_alpha_v);
-        auto lora_b_v = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{lora_rank, 1024});
-        auto lora_matmul2_v = std::make_shared<ov::op::v0::MatMul>(lora_mul_v, lora_b_v, false, false);
-        auto lora_add_v = std::make_shared<ov::op::v1::Add>(fc_v, lora_matmul2_v);
-
-        auto reshape_pattern = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{2}, pattern);
-        auto reshape1 = std::make_shared<ov::op::v1::Reshape>(lora_add_q, reshape_pattern, true);
-        auto reshape2 = std::make_shared<ov::op::v1::Reshape>(lora_add_k, reshape_pattern, true);
-        auto reshape3 = std::make_shared<ov::op::v1::Reshape>(lora_add_v, reshape_pattern, true);
-        auto result1 = std::make_shared<ov::op::v0::Result>(reshape1);
-        auto result2 = std::make_shared<ov::op::v0::Result>(reshape2);
-        auto result3 = std::make_shared<ov::op::v0::Result>(reshape3);
-        model = std::make_shared<ov::Model>(ov::ResultVector{result1, result2, result3}, ov::ParameterVector{input});
-        manager.register_pass<FullyConnectedHorizontalFusion>();
-    }
-    // model_ref is not set => expects no transformation (model unchanged)
-}
-
 }  // namespace intel_gpu
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - **Problem**
   - LoRA-adapted LLM models (e.g., Qwen3-VL-4B-Instruct) produce incorrect results on GPU due to two FP16 precision issues:
   - **FC horizontal fusion numerical divergence**: Merging QKV FCs into a single large FC changes GEMM tiling/accumulation order, producing different FP16 results. Without LoRA this is tolerable, but with LoRA each FC output is consumed individually by `Add(FC, MatMul(Multiply(alpha, A), B))` before concatenation, so the numerical error propagates through LoRA ops and amplifies across layers.
   - **Missing activation scaling**: `activations_scale_factor` is skipped for LLM models, but LoRA-adapted models can produce larger activation ranges that overflow FP16 on non-IMMAD platforms.
- **Solution**
  - **Enabling LoRA horizontal fusion** on IMMAD platforms resolves this by fusing LoRA Add as post-sum into the fused FC kernel.
  - **Enable activation scaling for LLM+LoRA on non-IMMAD platforms** by detecting `lora_state_` model variables.

### Tickets:
 - [CVS-183147](https://jira.devtools.intel.com/browse/CVS-183147)

### AI Assistance:
 - *AI assistance used: no*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
