### PR TITLE
[core] Add OpenVINO Runtime in model rt info when called save_model

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -27,7 +27,7 @@ from openvino import (
     save_model,
     OVAny,
 )
-from openvino import Output
+from openvino import Output, get_version
 from openvino.op.util import VariableInfo, Variable
 
 from tests.utils.helpers import (
@@ -900,6 +900,7 @@ def test_model_with_statement():
 
         with Core().read_model(f"{model_save_dir}/model.xml") as model:
             assert mem_model.friendly_name == model.friendly_name
+            assert model.get_rt_info("OpenVINO Runtime") == get_version()
 
         with pytest.raises(AttributeError):
             save_model(model, f"{model_save_dir}/model.xml")

--- a/src/core/src/graph_util.cpp
+++ b/src/core/src/graph_util.cpp
@@ -13,6 +13,7 @@
 #include "openvino/core/descriptor/tensor.hpp"
 #include "openvino/core/descriptor_tensor.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/core/version.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
@@ -316,6 +317,9 @@ void save_model(const std::shared_ptr<const ov::Model>& m,
                 const std::filesystem::path& output_model,
                 bool compress_to_fp16) {
     auto cloned = m->clone();
+    const auto& [build_number, description] = ov::get_openvino_version();
+    cloned->set_rt_info(build_number, description);
+
     if (compress_to_fp16) {
         // TODO: Implement on-the-fly compression in pass::Serialize, Ticket: 145380
         bool postponed = true;

--- a/src/core/tests/pass/serialization/serialize.cpp
+++ b/src/core/tests/pass/serialization/serialize.cpp
@@ -13,6 +13,7 @@
 #include "common_test_utils/graph_comparator.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "openvino/core/graph_util.hpp"
+#include "openvino/core/version.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/pass/serialize.hpp"
 #include "openvino/runtime/core.hpp"
@@ -617,6 +618,33 @@ TEST_F(MetaDataSerialize, set_complex_meta_information) {
         check_meta_info(s_model);
         check_rt_info(s_model);
     }
+}
+
+TEST_F(MetaDataSerialize, save_model_updates_runtime_version) {
+    auto model = ov::test::readModel(ir_with_meta);
+
+    std::string runtime_version;
+    ASSERT_NO_THROW(runtime_version = model->get_rt_info<std::string>("Runtime_version"));
+    ASSERT_EQ(runtime_version, "TestVersion");
+
+    ov::save_model(model, m_out_xml_path, false);
+
+    auto s_model = ov::test::readModel(m_out_xml_path, m_out_bin_path);
+
+    const auto& [exp_version, version_key] = ov::get_openvino_version();
+    ASSERT_TRUE(s_model->has_rt_info(version_key));
+    ASSERT_TRUE(s_model->has_rt_info(std::string{version_key}));
+
+    std::string ov_version;
+    ASSERT_NO_THROW(ov_version = s_model->get_rt_info<std::string>(version_key));
+    EXPECT_EQ(ov_version, exp_version);
+
+    ASSERT_NO_THROW(runtime_version = s_model->get_rt_info<std::string>("Runtime_version"));
+    ASSERT_EQ(runtime_version, "TestVersion");
+
+    std::string mo_version;
+    ASSERT_NO_THROW(mo_version = s_model->get_rt_info<std::string>("MO_version"));
+    EXPECT_EQ(mo_version, "TestVersion");
 }
 
 // After deprecating undefined type, test whether the serialization of replacing undefined type with dynamic type is


### PR DESCRIPTION
### Details:
 - Add OV runtime attribute with build version when using `ov::save_model`

### Tickets:
 - CVS-161877

### AI Assistance:
 - *AI assistance used: yes*
 - *Problem analysis and test generation*
