### PR TITLE
Fixed webnn test crash issue (#34708)

### DIFF
--- a/src/core/include/openvino/core/any.hpp
+++ b/src/core/include/openvino/core/any.hpp
@@ -483,7 +483,7 @@ class OPENVINO_API Any {
         virtual bool equal(const Base& rhs) const = 0;
         virtual void print(std::ostream& os) const = 0;
         virtual void read(std::istream& os) = 0;
-        void read_to(Base& other) const;
+        virtual void read_from(const Base& other);
 
         virtual const DiscreteTypeInfo& get_type_info() const = 0;
         virtual std::shared_ptr<RuntimeAttribute> as_runtime_attribute() const;
@@ -683,6 +683,16 @@ class OPENVINO_API Any {
             read_impl(is, value);
         }
 
+        void read_from(const Base& other) override {
+            if constexpr (std::is_same<T, std::string>::value) {
+                std::stringstream strm;
+                other.print(strm);
+                value = strm.str();
+            } else {
+                Base::read_from(other);
+            }
+        }
+
         T value;
     };
 
@@ -704,7 +714,7 @@ class OPENVINO_API Any {
                 return _impl->as<T>();
             } else {
                 _temp = std::make_shared<Impl<std::string>>();
-                _impl->read_to(*_temp);
+                _temp->read_from(*_impl);
                 return _temp->as<std::string>();
             }
         } else {
@@ -765,7 +775,7 @@ class OPENVINO_API Any {
             return _impl->as<T>();
         } else if (_impl->is<std::string>()) {
             _temp = std::make_shared<Impl<decay_t<T>>>();
-            _impl->read_to(*_temp);
+            _temp->read_from(*_impl);
             return _temp->as<T>();
         }
 
@@ -979,7 +989,7 @@ T& Any::as_impl(int) {
         return _impl->as<T>();
     } else if (util::Readable<T>::value && _impl->is<std::string>()) {
         _temp = std::make_shared<Impl<decay_t<T>>>();
-        _impl->read_to(*_temp);
+        _temp->read_from(*_impl);
         return _temp->as<T>();
     } else if (_impl->is_signed_integral()) {
         auto value = _impl->convert<long long>();

--- a/src/core/src/any.cpp
+++ b/src/core/src/any.cpp
@@ -74,14 +74,15 @@ bool Any::Base::visit_attributes(AttributeVisitor& visitor) const {
     return const_cast<Any::Base*>(this)->visit_attributes(visitor);
 }
 
-void Any::Base::read_to(Base& other) const {
+void Any::Base::read_from(const Base& other) {
+    OPENVINO_ASSERT(!is<std::string>(),
+                    "Any::Base::read_from does not handle std::string type. std::string must be processed by the "
+                    "derived specialization.");
+
     std::stringstream strm;
-    print(strm);
-    if (other.is<std::string>()) {
-        *static_cast<std::string*>(other.addressof()) = strm.str();
-    } else {
-        if (!strm.str().empty())
-            other.read(strm);
+    other.print(strm);
+    if (strm.peek() != std::char_traits<char>::eof()) {
+        read(strm);
     }
 }
 


### PR DESCRIPTION
### Details:
 - In the debugger, I found the `read_to` located at `openvino.dll`. All other plugin call the `read_to` method to construct a string will allocate the memory in `openvino.dll`
 - The `onnxruntime_providers_openvino_plugin_impl.dll`'s new feature will convert `float` map to `std::string`. The `float` map `Any` object was created at `openvino_intel_npu_plugin.dll`. So the `_impl` in `Any` is `openvino_intel_npu_plugin`'s type. `_temp` is `onnxruntime_providers_openvino_plugin_impl`'s `string` type. Then the `Any`'s dtor will call the `onnxruntime_providers_openvino_plugin_impl`'s `string` dtor. That caused the memory issue.

### Solution:
- Create a virtual method `read_from` and let the copy call the real type's method. In this way, it can call the `onnxruntime_providers_openvino_plugin_impl`'s ctor and dtor.
- Port https://github.com/openvinotoolkit/openvino/pull/34708

### Tickets:
 - [CVS-182610](https://jira.devtools.intel.com/browse/CVS-182610)

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
