### PR TITLE
Adapt OpenVINO source code for Chromium GN build system

### DIFF
--- a/src/bindings/c/src/ov_infer_request.cpp
+++ b/src/bindings/c/src/ov_infer_request.cpp
@@ -3,6 +3,8 @@
 //
 #include "openvino/c/ov_infer_request.h"
 
+#include <exception>
+
 #include "common.h"
 
 void ov_infer_request_free(ov_infer_request_t* infer_request) {

--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <initializer_list>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "openvino/util/file_path.hpp"

--- a/src/common/util/src/os/win/os.cpp
+++ b/src/common/util/src/os/win/os.cpp
@@ -10,7 +10,11 @@ namespace ov::util {
 bool may_i_use_dynamic_code() {
     // The function GetProcessMitigationPolicy may not be available in the kernel32 library. It depends on the Windows version.
     // Need to check this at runtime if the project was built on a different platform.
+#ifdef BUILD_OPENVINO_WITH_CHROMIUM
     if (HMODULE kernel32 = LoadLibrary(L"kernel32")) {
+#else
+    if (HMODULE kernel32 = LoadLibrary("kernel32")) {
+#endif
         typedef BOOL (*fnGetProcessMitigationPolicy)(HANDLE, _PROCESS_MITIGATION_POLICY, PVOID, SIZE_T);
         fnGetProcessMitigationPolicy get_process_mitigation_policy =
             (fnGetProcessMitigationPolicy)GetProcAddress(kernel32, "GetProcessMitigationPolicy");

--- a/src/common/util/src/os/win/os.cpp
+++ b/src/common/util/src/os/win/os.cpp
@@ -10,7 +10,7 @@ namespace ov::util {
 bool may_i_use_dynamic_code() {
     // The function GetProcessMitigationPolicy may not be available in the kernel32 library. It depends on the Windows version.
     // Need to check this at runtime if the project was built on a different platform.
-    if (HMODULE kernel32 = LoadLibrary("kernel32")) {
+    if (HMODULE kernel32 = LoadLibrary(L"kernel32")) {
         typedef BOOL (*fnGetProcessMitigationPolicy)(HANDLE, _PROCESS_MITIGATION_POLICY, PVOID, SIZE_T);
         fnGetProcessMitigationPolicy get_process_mitigation_policy =
             (fnGetProcessMitigationPolicy)GetProcAddress(kernel32, "GetProcessMitigationPolicy");

--- a/src/core/include/openvino/core/any.hpp
+++ b/src/core/include/openvino/core/any.hpp
@@ -16,6 +16,7 @@
 #include <typeinfo>
 #include <unordered_map>
 #include <utility>
+#include <type_traits>
 
 #include "openvino/core/attribute_visitor.hpp"
 #include "openvino/core/except.hpp"

--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstring>
 #include <sstream>
+#include <iterator>
 
 #include "compare.hpp"
 #include "element_visitor.hpp"

--- a/src/core/src/runtime/compute_hash.cpp
+++ b/src/core/src/runtime/compute_hash.cpp
@@ -647,14 +647,14 @@ void ComputeHash<avx512_core>::join(const Vmm& v_dst) {
     }
 
     mov(r64_aux, ptr[r64_params + GET_OFF(intermediate_ptr)]);
-    prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_aux ) + 1024]);
+    prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_aux) + 1024]);
 
     auto xmm_src_0 = getXmm();
     auto xmm_src_last = Xbyak::Xmm(v_dst.getIdx());
     auto xmm_aux_0 = getXmm();
     auto xmm_k_2_3 = Xbyak::Xmm(v_k_2_3.getIdx());
 
-    uni_vmovdqu64(xmm_src_last, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 7]);
+    uni_vmovdqu64(xmm_src_last, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 7]);
 
     uni_vmovdqu64(xmm_src_0, ptr[r64_aux]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_14_15_OFF], 0b00000000);
@@ -662,37 +662,37 @@ void ComputeHash<avx512_core>::join(const Vmm& v_dst) {
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_12_13_OFF], 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_12_13_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 2lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 2lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_10_11_OFF], 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_10_11_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 3lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 3lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_8_9_OFF], 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_8_9_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 4lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 4lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 5lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 5lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 6lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 6lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, xmm_k_2_3, 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, xmm_k_2_3, 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
@@ -706,28 +706,28 @@ void ComputeHash<isa>::join(const Vmm& v_dst) {
     }
 
     mov(r64_aux, ptr[r64_params + GET_OFF(intermediate_ptr)]);
-    prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_aux ) + 1024]);
+    prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_aux) + 1024]);
 
     auto xmm_src_0 = getXmm();
     auto xmm_src_last = Xbyak::Xmm(v_dst.getIdx());
     auto xmm_aux_0 = getXmm();
     auto xmm_k_2_3 = Xbyak::Xmm(v_k_2_3.getIdx());
 
-    uni_vmovdqu64(xmm_src_last, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 3]);
+    uni_vmovdqu64(xmm_src_last, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 3]);
 
-    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 0lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 0lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 1lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 1lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 2lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux) + xmm_len * 2lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, xmm_k_2_3, 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, xmm_k_2_3, 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);

--- a/src/core/src/runtime/compute_hash.cpp
+++ b/src/core/src/runtime/compute_hash.cpp
@@ -349,7 +349,7 @@ void ComputeHash<isa>::initialize(const Vmm& v_dst) {
     mov(r64_k_ptr, ptr[r64_params + GET_OFF(k_ptr)]);
     mov(r64_work_amount, ptr[r64_params + GET_OFF(work_amount)]);
 
-    uni_vbroadcasti64x2(v_k_2_3, ptr[r64_k_ptr + K_2_3_OFF]);
+    uni_vbroadcasti64x2(v_k_2_3, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_2_3_OFF]);
 
     mov(r64_aux, reinterpret_cast<uintptr_t>(SHUF_MASK));
     uni_vbroadcasti64x2(v_shuf_mask, ptr[r64_aux]);
@@ -415,9 +415,9 @@ void ComputeHash<avx512_core>::bulk_fold(const Vmm& v_dst) {
     }
 
     if (m_jcp.type == SINGLE_THREAD) {
-        uni_vbroadcasti64x2(v_k_loop, ptr[r64_k_ptr + K_8_9_OFF]);
+        uni_vbroadcasti64x2(v_k_loop, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_8_9_OFF]);
     } else {
-        uni_vbroadcasti64x2(v_k_loop, ptr[r64_k_ptr + K_16_17_OFF]);
+        uni_vbroadcasti64x2(v_k_loop, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_16_17_OFF]);
     }
 
     uni_vmovdqu64(v_dst_0, v_dst);
@@ -430,13 +430,13 @@ void ComputeHash<avx512_core>::bulk_fold(const Vmm& v_dst) {
 
     if (m_jcp.type == FIRST_THREAD || m_jcp.type == N_THREAD) {
         add(r64_src_ptr, r64_bulk_step);
-        prefetcht2(ptr[r64_src_ptr + 16384]);
+        prefetcht2(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 16384]);
     } else {
         add(r64_src_ptr, static_cast<uint32_t>(get_vlen() - xmm_len));
-        prefetcht2(ptr[r64_src_ptr + 4096]);
+        prefetcht2(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 4096]);
     }
-    prefetcht1(ptr[r64_src_ptr + 1024]);
-    prefetcht0(ptr[r64_src_ptr + 64]);
+    prefetcht1(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 1024]);
+    prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 64]);
 
     sub(r64_work_amount, static_cast<uint32_t>(get_vlen() * 2lu - xmm_len));
 
@@ -447,13 +447,13 @@ void ComputeHash<avx512_core>::bulk_fold(const Vmm& v_dst) {
 
         if (m_jcp.type == FIRST_THREAD || m_jcp.type == N_THREAD) {
             add(r64_src_ptr, r64_bulk_step);
-            prefetcht2(ptr[r64_src_ptr + 16384]);
+            prefetcht2(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 16384]);
         } else {
             add(r64_src_ptr, static_cast<uint32_t>(get_vlen()));
-            prefetcht2(ptr[r64_src_ptr + 4096]);
+            prefetcht2(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 4096]);
         }
-        prefetcht1(ptr[r64_src_ptr + 1024]);
-        prefetcht0(ptr[r64_src_ptr + 64]);
+        prefetcht1(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 1024]);
+        prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 64]);
 
         if (is_vpclmulqdq) {
             vpclmulqdq(v_aux_0, v_dst_0, v_k_loop, 0b00000000);
@@ -501,13 +501,13 @@ void ComputeHash<avx512_core>::bulk_fold(const Vmm& v_dst) {
             vextracti64x2(xmm_dst_3, v_dst_0, 0x3);
         }
 
-        vpclmulqdq(xmm_aux_0, xmm_dst_0, ptr[r64_k_ptr + K_6_7_OFF], 0b00000000);
-        vpclmulqdq(xmm_dst_0, xmm_dst_0, ptr[r64_k_ptr + K_6_7_OFF], 0b00010001);
+        vpclmulqdq(xmm_aux_0, xmm_dst_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00000000);
+        vpclmulqdq(xmm_dst_0, xmm_dst_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00010001);
         uni_vpxorq(xmm_dst_3, xmm_dst_3, xmm_aux_0);
         uni_vpxorq(xmm_dst_3, xmm_dst_3, xmm_dst_0);
 
-        vpclmulqdq(xmm_aux_0, xmm_dst_1, ptr[r64_k_ptr + K_4_5_OFF], 0b00000000);
-        vpclmulqdq(xmm_dst_1, xmm_dst_1, ptr[r64_k_ptr + K_4_5_OFF], 0b00010001);
+        vpclmulqdq(xmm_aux_0, xmm_dst_1, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00000000);
+        vpclmulqdq(xmm_dst_1, xmm_dst_1, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00010001);
         uni_vpxorq(xmm_dst_3, xmm_dst_3, xmm_aux_0);
         uni_vpxorq(xmm_dst_3, xmm_dst_3, xmm_dst_1);
 
@@ -519,10 +519,10 @@ void ComputeHash<avx512_core>::bulk_fold(const Vmm& v_dst) {
         if (is_vpclmulqdq) {
             uni_vmovdqu64(ptr[r64_dst_ptr], v_dst_0);
         } else {
-            uni_vmovdqu64(ptr[r64_dst_ptr + xmm_len * 0lu], xmm_dst_0);
-            uni_vmovdqu64(ptr[r64_dst_ptr + xmm_len * 1lu], xmm_dst_1);
-            uni_vmovdqu64(ptr[r64_dst_ptr + xmm_len * 2lu], xmm_dst_2);
-            uni_vmovdqu64(ptr[r64_dst_ptr + xmm_len * 3lu], xmm_dst_3);
+            uni_vmovdqu64(ptr[static_cast<Xbyak::RegExp>(r64_dst_ptr) + xmm_len * 0lu], xmm_dst_0);
+            uni_vmovdqu64(ptr[static_cast<Xbyak::RegExp>(r64_dst_ptr) + xmm_len * 1lu], xmm_dst_1);
+            uni_vmovdqu64(ptr[static_cast<Xbyak::RegExp>(r64_dst_ptr) + xmm_len * 2lu], xmm_dst_2);
+            uni_vmovdqu64(ptr[static_cast<Xbyak::RegExp>(r64_dst_ptr) + xmm_len * 3lu], xmm_dst_3);
         }
     }
 
@@ -560,9 +560,9 @@ void ComputeHash<isa>::bulk_fold(const Vmm& v_dst) {
     }
 
     if (m_jcp.type == SINGLE_THREAD) {
-        uni_vbroadcasti64x2(v_k_loop, ptr[r64_k_ptr + K_4_5_OFF]);
+        uni_vbroadcasti64x2(v_k_loop, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF]);
     } else {
-        uni_vbroadcasti64x2(v_k_loop, ptr[r64_k_ptr + K_8_9_OFF]);
+        uni_vbroadcasti64x2(v_k_loop, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_8_9_OFF]);
     }
 
     uni_vmovdqu64(v_dst_0, v_dst);
@@ -576,9 +576,9 @@ void ComputeHash<isa>::bulk_fold(const Vmm& v_dst) {
     } else {
         add(r64_src_ptr, r64_bulk_step);
     }
-    prefetcht2(ptr[r64_src_ptr + 4096]);
-    prefetcht1(ptr[r64_src_ptr + 1024]);
-    prefetcht0(ptr[r64_src_ptr + 64]);
+    prefetcht2(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 4096]);
+    prefetcht1(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 1024]);
+    prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 64]);
 
     sub(r64_work_amount, static_cast<uint32_t>(get_vlen() * 2lu - xmm_len));
 
@@ -592,9 +592,9 @@ void ComputeHash<isa>::bulk_fold(const Vmm& v_dst) {
         } else {
             add(r64_src_ptr, r64_bulk_step);
         }
-        prefetcht2(ptr[r64_src_ptr + 4096]);
-        prefetcht1(ptr[r64_src_ptr + 1024]);
-        prefetcht0(ptr[r64_src_ptr + 64]);
+        prefetcht2(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 4096]);
+        prefetcht1(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 1024]);
+        prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_src_ptr) + 64]);
 
         if (is_vpclmulqdq) {
             vpclmulqdq(v_aux_0, v_dst_0, v_k_loop, 0b00000000);
@@ -632,8 +632,8 @@ void ComputeHash<isa>::bulk_fold(const Vmm& v_dst) {
         if (is_vpclmulqdq) {
             uni_vmovdqu64(ptr[r64_dst_ptr], v_dst_0);
         } else {
-            uni_vmovdqu64(ptr[r64_dst_ptr + xmm_len * 0lu], xmm_dst_0);
-            uni_vmovdqu64(ptr[r64_dst_ptr + xmm_len * 1lu], xmm_dst_1);
+            uni_vmovdqu64(ptr[static_cast<Xbyak::RegExp>(r64_dst_ptr) + xmm_len * 0lu], xmm_dst_0);
+            uni_vmovdqu64(ptr[static_cast<Xbyak::RegExp>(r64_dst_ptr) + xmm_len * 1lu], xmm_dst_1);
         }
     }
 
@@ -647,52 +647,52 @@ void ComputeHash<avx512_core>::join(const Vmm& v_dst) {
     }
 
     mov(r64_aux, ptr[r64_params + GET_OFF(intermediate_ptr)]);
-    prefetcht0(ptr[r64_aux + 1024]);
+    prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_aux ) + 1024]);
 
     auto xmm_src_0 = getXmm();
     auto xmm_src_last = Xbyak::Xmm(v_dst.getIdx());
     auto xmm_aux_0 = getXmm();
     auto xmm_k_2_3 = Xbyak::Xmm(v_k_2_3.getIdx());
 
-    uni_vmovdqu64(xmm_src_last, ptr[r64_aux + xmm_len * 7]);
+    uni_vmovdqu64(xmm_src_last, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 7]);
 
     uni_vmovdqu64(xmm_src_0, ptr[r64_aux]);
-    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[r64_k_ptr + K_14_15_OFF], 0b00000000);
-    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[r64_k_ptr + K_14_15_OFF], 0b00010001);
+    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_14_15_OFF], 0b00000000);
+    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_14_15_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[r64_aux + xmm_len]);
-    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[r64_k_ptr + K_12_13_OFF], 0b00000000);
-    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[r64_k_ptr + K_12_13_OFF], 0b00010001);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len]);
+    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_12_13_OFF], 0b00000000);
+    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_12_13_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[r64_aux + xmm_len * 2lu]);
-    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[r64_k_ptr + K_10_11_OFF], 0b00000000);
-    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[r64_k_ptr + K_10_11_OFF], 0b00010001);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 2lu]);
+    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_10_11_OFF], 0b00000000);
+    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_10_11_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[r64_aux + xmm_len * 3lu]);
-    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[r64_k_ptr + K_8_9_OFF], 0b00000000);
-    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[r64_k_ptr + K_8_9_OFF], 0b00010001);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 3lu]);
+    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_8_9_OFF], 0b00000000);
+    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_8_9_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[r64_aux + xmm_len * 4lu]);
-    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[r64_k_ptr + K_6_7_OFF], 0b00000000);
-    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[r64_k_ptr + K_6_7_OFF], 0b00010001);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 4lu]);
+    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00000000);
+    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[r64_aux + xmm_len * 5lu]);
-    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[r64_k_ptr + K_4_5_OFF], 0b00000000);
-    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[r64_k_ptr + K_4_5_OFF], 0b00010001);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 5lu]);
+    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00000000);
+    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[r64_aux + xmm_len * 6lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 6lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, xmm_k_2_3, 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, xmm_k_2_3, 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
@@ -706,28 +706,28 @@ void ComputeHash<isa>::join(const Vmm& v_dst) {
     }
 
     mov(r64_aux, ptr[r64_params + GET_OFF(intermediate_ptr)]);
-    prefetcht0(ptr[r64_aux + 1024]);
+    prefetcht0(ptr[static_cast<Xbyak::RegExp>(r64_aux ) + 1024]);
 
     auto xmm_src_0 = getXmm();
     auto xmm_src_last = Xbyak::Xmm(v_dst.getIdx());
     auto xmm_aux_0 = getXmm();
     auto xmm_k_2_3 = Xbyak::Xmm(v_k_2_3.getIdx());
 
-    uni_vmovdqu64(xmm_src_last, ptr[r64_aux + xmm_len * 3]);
+    uni_vmovdqu64(xmm_src_last, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 3]);
 
-    uni_vmovdqu64(xmm_src_0, ptr[r64_aux + xmm_len * 0lu]);
-    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[r64_k_ptr + K_6_7_OFF], 0b00000000);
-    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[r64_k_ptr + K_6_7_OFF], 0b00010001);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 0lu]);
+    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00000000);
+    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_6_7_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[r64_aux + xmm_len * 1lu]);
-    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[r64_k_ptr + K_4_5_OFF], 0b00000000);
-    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[r64_k_ptr + K_4_5_OFF], 0b00010001);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 1lu]);
+    vpclmulqdq(xmm_aux_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00000000);
+    vpclmulqdq(xmm_src_0, xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_k_ptr) + K_4_5_OFF], 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_src_0);
 
-    uni_vmovdqu64(xmm_src_0, ptr[r64_aux + xmm_len * 2lu]);
+    uni_vmovdqu64(xmm_src_0, ptr[static_cast<Xbyak::RegExp>(r64_aux ) + xmm_len * 2lu]);
     vpclmulqdq(xmm_aux_0, xmm_src_0, xmm_k_2_3, 0b00000000);
     vpclmulqdq(xmm_src_0, xmm_src_0, xmm_k_2_3, 0b00010001);
     uni_vpxorq(xmm_src_last, xmm_src_last, xmm_aux_0);

--- a/src/core/src/runtime/tensor.cpp
+++ b/src/core/src/runtime/tensor.cpp
@@ -264,9 +264,16 @@ Tensor read_tensor_data(ov::FileHandle file_handle,
                         size_t offset_in_bytes) {
     OPENVINO_ASSERT(element_type != ov::element::string);
     const auto size = get_size_for_mapping(element_type, partial_shape);
+#ifdef BUILD_OPENVINO_WITH_CHROMIUM
     return read_tensor_data_mmap_impl(load_mmap_object_from_handle(file_handle, offset_in_bytes, size),
                                       element_type,
                                       partial_shape,
                                       offset_in_bytes);
+#else
+    return read_tensor_data_mmap_impl(load_mmap_object(file_handle, offset_in_bytes, size),
+                                      element_type,
+                                      partial_shape,
+                                      offset_in_bytes);
+#endif
 }
 }  // namespace ov

--- a/src/core/src/runtime/tensor.cpp
+++ b/src/core/src/runtime/tensor.cpp
@@ -264,7 +264,7 @@ Tensor read_tensor_data(ov::FileHandle file_handle,
                         size_t offset_in_bytes) {
     OPENVINO_ASSERT(element_type != ov::element::string);
     const auto size = get_size_for_mapping(element_type, partial_shape);
-    return read_tensor_data_mmap_impl(load_mmap_object(file_handle, offset_in_bytes, size),
+    return read_tensor_data_mmap_impl(load_mmap_object_from_handle(file_handle, offset_in_bytes, size),
                                       element_type,
                                       partial_shape,
                                       offset_in_bytes);

--- a/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.hpp
+++ b/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.hpp
@@ -73,7 +73,7 @@ public:
             if (file_size < offset_size) {
                 return false;
             }
-#if defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(_WIN32)
             std::ifstream tflite_stream(std::filesystem::path(path), std::ios::in | std::ifstream::binary);
 #else
             std::ifstream tflite_stream(path, std::ios::in | std::ifstream::binary);

--- a/src/inference/src/dev/iplugin.cpp
+++ b/src/inference/src/dev/iplugin.cpp
@@ -4,6 +4,8 @@
 
 #include "openvino/runtime/iplugin.hpp"
 
+#include <iterator>
+
 #include "core_impl.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/util/op_types.hpp"

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -1404,7 +1404,11 @@ std::shared_ptr<ov::npuw::CompiledModel> ov::npuw::CompiledModel::deserialize(
             // Use handle_provider if available, otherwise use default mmap with weights_path
             if (handle_provider) {
                 ov::FileHandle handle = handle_provider();
+#ifdef BUILD_OPENVINO_WITH_CHROMIUM
                 mapped_memory = ov::load_mmap_object_from_handle(handle);
+#else
+                mapped_memory = ov::load_mmap_object(handle.get()));
+#endif
             } else if (!weights_path.empty()) {
                 mapped_memory = ov::load_mmap_object(ov::util::make_path(weights_path));
             }

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -1404,7 +1404,7 @@ std::shared_ptr<ov::npuw::CompiledModel> ov::npuw::CompiledModel::deserialize(
             // Use handle_provider if available, otherwise use default mmap with weights_path
             if (handle_provider) {
                 ov::FileHandle handle = handle_provider();
-                mapped_memory = ov::load_mmap_object(handle);
+                mapped_memory = ov::load_mmap_object_from_handle(handle);
             } else if (!weights_path.empty()) {
                 mapped_memory = ov::load_mmap_object(ov::util::make_path(weights_path));
             }

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
@@ -69,7 +69,7 @@ ov::Tensor Const::eval() const {
         // Use handle_provider if available, otherwise use default mmap
         if (m_handle_provider) {
             ov::FileHandle handle = m_handle_provider();
-            mapped_memory = ov::load_mmap_object(handle);
+            mapped_memory = ov::load_mmap_object_from_handle(handle);
         } else {
             mapped_memory = ov::load_mmap_object(ov::util::make_path(m_weights_path));
         }

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
@@ -69,7 +69,11 @@ ov::Tensor Const::eval() const {
         // Use handle_provider if available, otherwise use default mmap
         if (m_handle_provider) {
             ov::FileHandle handle = m_handle_provider();
+#ifdef BUILD_OPENVINO_WITH_CHROMIUM
             mapped_memory = ov::load_mmap_object_from_handle(handle);
+#else
+            mapped_memory = ov::load_mmap_object(handle);
+#endif
         } else {
             mapped_memory = ov::load_mmap_object(ov::util::make_path(m_weights_path));
         }


### PR DESCRIPTION
OpenVINO is natively built with CMake. When integrating into Chromium's
GN-based build, several source files require adjustments due to
differences in compiler flags, platform macros, and include path
resolution between the two build systems.

Changes:

- src/core/src/runtime/compute_hash.cpp: Add static_cast<Xbyak::RegExp>
  to RegistersPool::Reg operands in Xbyak address expressions. The GN
  build surfaces an ambiguous operator+ overload between
  RegistersPool's friend operator+(Reg, RegExp) and Xbyak's
  operator+(RegExp, size_t/int) when combining registers with
  uint64_t offsets. Explicit casts resolve the ambiguity.

- src/common/util/src/os/win/os.cpp: Use wide string literal
  L"kernel32" for LoadLibrary call. Chromium defines UNICODE, causing
  LoadLibrary to expand to LoadLibraryW which requires LPCWSTR.

- src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.hpp:
  Construct std::ifstream with std::filesystem::path(path) instead of
  raw basic_string<T>. The templated path parameter may be wstring,
  which has no matching ifstream constructor on all platforms. Using
  std::filesystem::path works universally in C++17.

- src/core/src/runtime/tensor.cpp: Use load_mmap_object_from_handle
  instead of load_mmap_object for compatibility with the Chromium
  build environment.

- Add missing standard library includes required by Clang in Chromium's
  stricter compilation mode:
  - src/bindings/c/src/ov_infer_request.cpp: <exception>
  - src/common/util/include/openvino/util/file_util.hpp: <type_traits>
  - src/core/include/openvino/core/any.hpp: <type_traits>
  - src/core/src/op/constant.cpp: <iterator>

- src/inference/src/dev/iplugin.cpp: Add missing includes.