### PR TITLE
[GPU] Fix ReduceMean axis element type

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_pooling_to_reduce.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_pooling_to_reduce.cpp
@@ -50,7 +50,7 @@ ov::intel_gpu::ConvertAvgPoolingToReduce::ConvertAvgPoolingToReduce() {
 
         auto reduce = std::make_shared<ov::op::v1::ReduceMean>(
             pool->input_value(0),
-            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{axes_shape.size()}, axes_shape),
+            ov::op::v0::Constant::create(ov::element::i32, ov::Shape{axes_shape.size()}, axes_shape),
             true);
 
         reduce->set_friendly_name(pool->get_friendly_name());


### PR DESCRIPTION
## Details
Regression introduced by PR #34777  where affected models are as following:
 - common-sign-language-0002
 - mobilenet-v2-1.0-224
 - deeplabv3
 - semantic-segmentation-adas-0001
 - se-resnet-50
 
Those models fail on dGPU with:
`Axis 12884901890 out of the tensor rank range [-5, 4].`

## Root Cause
- `ConvertAvgPoolingToReduce` (dGPU-only, gated by `supports_immad`) creates a `ReduceMean` axes constant as `element::i64`. This transformation runs inside the main pass manager, but after the `ConvertPrecision(i64→i32)` pass has already been registered and executed within the same manager. The axes constant therefore survives as i64.
- PR #34777 added a blanket `ConvertPrecision({i64→i32})` pass after `UnrollTensorIterator`. This second pass converts the `ReduceMean` axes constant's underlying storage from i64 to i32. However, `ReduceMean`'s shape inference still reads the axes data as `i64`, reinterpreting two adjacent `i32` values `[2, 3]` as one `i64` value `0x00000003'00000002 = 12884901890`, which exceeds the valid axis range.
- This only affects dGPU because `ConvertAvgPoolingToReduce` is registered only when `device_info.supports_immad == true`.

## How to fix
- Change `ConvertAvgPoolingToReduce` to create the axes constant as `element::i32` instead of `element::i64`. 
- This aligns with the GPU pipeline convention that all integer constants should be `i32`, and eliminates the `i64` constant that was being corrupted by the post-unroll precision conversion pass.

## Tickets:
 - CVS-183375