### PR TITLE
resolve duplication fqs and nans

### DIFF
--- a/src/common/low_precision_transformations/src/qdq_stripping.cpp
+++ b/src/common/low_precision_transformations/src/qdq_stripping.cpp
@@ -46,7 +46,7 @@
 namespace ov {
 namespace pass {
 namespace low_precision {
-    std::unordered_map<std::string, std::vector<ov::Input<ov::Node>>> m_adjusted_map;
+std::map<std::vector<float>, std::vector<ov::Input<ov::Node>>> m_adjusted_map_fq_values;
 
 namespace {
 // Motivation: if the stripped FQ's dequantization scale (y_scale) is large,
@@ -58,14 +58,38 @@ namespace {
 // Note: Such scaling is possible only if all downstream paths go to scale-invariant nodes (such as MVN or Softmax).
 class ScaleAdjuster {
 public:
-    ScaleAdjuster(float scale_divisor, const std::shared_ptr<ov::Node>& fq, bool duplication)
+    ScaleAdjuster(float scale_divisor, const std::shared_ptr<ov::Node>& fq)
         : m_scale_divisor(scale_divisor),
-          m_fq(fq.get()),
-          m_duplication(duplication){}
+          m_fq(fq.get()){}
 
     void adjust() {
         propagate_backward(m_fq);
         propagate_forward(m_fq);
+
+        bool m_duplication = false;
+        auto input_low_node = m_fq->input_value(1).get_node_shared_ptr();
+        auto input_high_node = m_fq->input_value(2).get_node_shared_ptr();
+
+        // Cast to Constant if possible
+        auto input_low_const = std::dynamic_pointer_cast<ov::op::v0::Constant>(input_low_node);
+        auto input_high_const = std::dynamic_pointer_cast<ov::op::v0::Constant>(input_high_node);
+
+        // Now extract the values (example for float)
+        std::vector<float> fq_values;
+        std::vector<float> input_low_values, input_high_values;
+        if (input_low_const) {
+            input_low_values = input_low_const->cast_vector<float>();
+            fq_values.push_back(input_low_values[0]);
+        }
+        if (input_high_const) {
+            input_high_values = input_high_const->cast_vector<float>();
+            fq_values.push_back(input_high_values[0]);
+        }
+
+        auto it = m_adjusted_map_fq_values.find(fq_values);
+        if (it != m_adjusted_map_fq_values.end()) {
+            m_duplication = true;
+        }
         if (scale_adjustment_possible() && m_duplication == false) {
             for (auto& input : m_pending_adjustments) {
                 auto original_const = input.get_source_output();
@@ -77,33 +101,22 @@ public:
                 input.replace_source_output(new_const);
                 nodes_to_adjust.push_back(input);
             }
-            m_adjusted_map.emplace(m_fq->get_friendly_name(), nodes_to_adjust);
+            m_adjusted_map_fq_values.emplace(fq_values, nodes_to_adjust);
         }
         if (scale_adjustment_possible() && m_duplication == true) {
             //get nodes adjusted for org fq name and skip them from scaling
             auto fq = m_fq->get_friendly_name();
-            std::string wo_duplicated_fq_name, duplicated_fq_name;
-            std::vector<ov::Input<ov::Node>> nodes;
-            if (fq.find("/duplicated") != std::string::npos) {
-                wo_duplicated_fq_name = fq.substr(0, fq.find("/duplicated"));
-                nodes = m_adjusted_map.find(wo_duplicated_fq_name) != m_adjusted_map.end()
-                            ? m_adjusted_map[wo_duplicated_fq_name]
-                            : std::vector<ov::Input<ov::Node>>{};
-            } else {
-                duplicated_fq_name = fq + "/duplicated";
-                nodes = m_adjusted_map.find(duplicated_fq_name) != m_adjusted_map.end()
-                    ? m_adjusted_map[duplicated_fq_name]
-                    : std::vector<ov::Input<ov::Node>>{};
-            }
+            const std::vector<ov::Input<ov::Node>>& inputs = it->second;
             for (auto& input : m_pending_adjustments) {
-                if (std::find_if(nodes.begin(), nodes.end(), [&input](const ov::Input<ov::Node>& n) {
-                        return n.get_node() == input.get_node();
-                    }) != nodes.end()) {
+
+                if (std::find_if(inputs.begin(), inputs.end(), [&input](const ov::Input<ov::Node>& n) {
+                    return n.get_node() == input.get_node();
+                    }) != inputs.end()) {
                     continue;
                 }
                 auto original_const = input.get_source_output();
                 auto divisor_const =
-                    ov::op::v0::Constant::create(original_const.get_element_type(), {}, {m_scale_divisor});
+                    ov::op::v0::Constant::create(original_const.get_element_type(), {}, { m_scale_divisor });
                 auto new_const = ov::op::util::make_try_fold<ov::op::v1::Divide>(original_const, divisor_const);
                 OPENVINO_ASSERT(new_const, "Adjusted scale must be constant");
                 ov::copy_runtime_info(original_const.get_node_shared_ptr(), new_const);
@@ -118,7 +131,6 @@ private:
     float m_scale_divisor;
     ov::Node* m_fq;
     bool m_scale_adjustment_possible = true;
-    bool m_duplication = false;
 
     std::unordered_set<ov::Node*> m_visited;
     std::vector<ov::Input<ov::Node>> m_pending_adjustments;
@@ -237,7 +249,6 @@ FQStrippingTransformation::FQStrippingTransformation(const std::set<size_t>& lev
 
 bool FQStrippingTransformation::run_on_model(const std::shared_ptr<ov::Model>& f) {
     RUN_ON_FUNCTION_SCOPE(FQStrippingTransformation);
-    bool duplication = false;
     if (levels_to_strip.empty()) {
         return false;
     }
@@ -290,25 +301,8 @@ bool FQStrippingTransformation::run_on_model(const std::shared_ptr<ov::Model>& f
         constexpr auto threshold = 1.0f;
 
         if (need_weights_adjustment && max_dq_scale > threshold) {
-
-            std::string wo_duplicated_fq_name, duplicated_fq_name;
-            auto fq_name = fq->get_friendly_name();
-            if (fq_name.find("/duplicated") != std::string::npos) {
-                wo_duplicated_fq_name = fq_name.substr(0, fq_name.find("/duplicated"));
-                duplicated_fq_name = fq_name;
-                if (m_adjusted_map.count(wo_duplicated_fq_name) != 0) {
-                    duplication = true;
-                }
-            }
-            else {
-                wo_duplicated_fq_name = fq_name;
-                duplicated_fq_name = fq_name + "/duplicated";
-                if (m_adjusted_map.count(duplicated_fq_name) != 0) {
-                    duplication = true;
-                }
-            }
             constexpr auto ratio = 10.0f;
-            ScaleAdjuster adjuster(max_dq_scale * ratio, fq, duplication);
+            ScaleAdjuster adjuster(max_dq_scale * ratio, fq);
             adjuster.adjust();
         }
 


### PR DESCRIPTION
### Details:
 - The problem is that latest onnxruntime performs minor modifications to the model, which aren't processed properly in the OpenVINO LPT portion. Specifically, it converts a DQ node with multiple consumers into duplicated DQ nodes (original model on the left, ORT model passed to OV on the right):
 - 
![graph-ort-ov](https://github.com/user-attachments/assets/68d75f5c-548f-48ea-bb88-6f0f8ca5964e)

### Tickets:
 - *180573*


