### PR TITLE
[Draft] [CPU][ARM] Enable sequential post-ops (Activation + FakeQuantize) for ACL Convolution

### DIFF
--- a/src/common/low_precision_transformations/src/convolution.cpp
+++ b/src/common/low_precision_transformations/src/convolution.cpp
@@ -22,6 +22,7 @@
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/group_conv.hpp"
+#include "openvino/op/swish.hpp"
 
 namespace ov {
 namespace pass {
@@ -33,7 +34,8 @@ ConvolutionTransformation::ConvolutionTransformation(const Params& params) : Wei
         ov::pass::pattern::wrap_type<ov::opset1::Multiply>(),
         std::make_shared<pass::pattern::op::Or>(OutputVector {
             pattern::wrap_type<ov::opset1::Multiply>(),
-            pattern::wrap_type<ov::opset1::FakeQuantize>()
+            pattern::wrap_type<ov::opset1::FakeQuantize>(),
+            pattern::wrap_type<ov::op::v4::Swish>()
         })
     });
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -69,13 +69,13 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
                                                arm_compute::DimensionRoundingType::FLOOR);
     dilation = arm_compute::Size2D(attrs.dilation[1] + 1, attrs.dilation[0] + 1);
 
-    if (attrs.postOps.size() == 1) {
-        if (const auto* const activation = std::any_cast<ActivationPostOp>(attrs.postOps.data())) {
+    for (const auto& postOp : attrs.postOps) {
+        if (const auto* const activation = std::any_cast<ActivationPostOp>(&postOp)) {
             activationLayerInfo = getActivationLayerInfo(convertToEltwiseAlgorithm(activation->type()),
                                                          activation->alpha(),
                                                          activation->beta(),
                                                          activation->gamma());
-        } else if (const auto* const fq = std::any_cast<FakeQuantizePostOp>(attrs.postOps.data())) {
+        } else if (const auto* const fq = std::any_cast<FakeQuantizePostOp>(&postOp)) {
             fqInputScale = fq->inputScale();
             fqInputShift = fq->inputShift();
             fqOutputScale = fq->outputScale();
@@ -112,13 +112,11 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
         } else {
             OPENVINO_THROW("ACLConvolutionExecutor: the executor supports FakeQuantize and Activation post ops only");
         }
-    } else if (attrs.postOps.size() > 1) {
-        OPENVINO_THROW("ACLConvolutionExecutor: ACL does not support more than 1 post op");
     }
 }
 
 bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
-    VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
+    VERIFY(config.attrs.postOps.size() <= 2U, UNSUPPORTED_BY_EXECUTOR);
 
     const auto& srcDesc = config.descs.at(ARG_SRC);
     const auto& weiDesc = config.descs.at(ARG_WEI);
@@ -128,7 +126,13 @@ bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
     VERIFY(srcDesc->getShape().getRank() == 4 && weiDesc->getShape().getRank() == 4, UNSUPPORTED_BY_EXECUTOR);
     // isQuantized verifies whether src is u8/i8, weights is i8 and FQ is fused if dst is u8/i8
     // the last requirement is due to ACL int32 accumulation that needs to be requantized by non-trivial scales
-    const bool hasQuantizationPostOp = std::any_cast<FakeQuantizePostOp>(config.attrs.postOps.data()) != nullptr;
+    bool hasQuantizationPostOp = false;
+    for (const auto& postOp : config.attrs.postOps) {
+        if (std::any_cast<FakeQuantizePostOp>(&postOp) != nullptr) {
+            hasQuantizationPostOp = true;
+            break;
+        }
+    }
     const bool isQuantizedU8 = srcDesc->getPrecision() == ov::element::u8 &&
                                any_of(weiDesc->getPrecision(), ov::element::u8, ov::element::i8) &&
                                dstDesc->getPrecision() == ov::element::u8 && hasQuantizationPostOp;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/conv_mul_add_fq_block.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/conv_mul_add_fq_block.cpp
@@ -13,6 +13,7 @@
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/fake_quantize.hpp"
 #include "openvino/op/multiply.hpp"
+#include "openvino/op/swish.hpp"
 #include "openvino/pass/pattern/op/block.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
@@ -39,10 +40,14 @@ ov::intel_cpu::ConvMulAddFQBlock::ConvMulAddFQBlock(const bool require_int_fq_ou
     });
     auto add = wrap_type<ov::op::v1::Add>({multiply, bias_const});
 
+    // Optional Activation (Swish)
+    auto swish = wrap_type<ov::op::v4::Swish>({add});
+    auto swish_or_add = std::make_shared<ov::pass::pattern::op::Or>(ov::OutputVector{swish, add});
+
     ov::pass::pattern::op::Predicate predicate =
         require_int_fq_output ? type_matches_any({element::i8, element::u8}) : ov::pass::pattern::op::Predicate();
     auto fake_quantize =
-        wrap_type<ov::op::v0::FakeQuantize>({add, any_input(), any_input(), any_input(), any_input()}, predicate);
+        wrap_type<ov::op::v0::FakeQuantize>({swish_or_add, any_input(), any_input(), any_input(), any_input()}, predicate);
 
     m_inputs = ov::OutputVector{conv};
     m_outputs = ov::OutputVector{fake_quantize};
@@ -50,5 +55,6 @@ ov::intel_cpu::ConvMulAddFQBlock::ConvMulAddFQBlock(const bool require_int_fq_ou
     register_anchor("convolution", conv);
     register_anchor("multiply", multiply);
     register_anchor("add", add);
+    register_anchor("swish", swish);
     register_anchor("fake_quantize", fake_quantize);
 }

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -989,7 +989,7 @@ void Transformations::runLptPasses(const std::vector<ov::element::Type>& default
     CPU_DISABLE_PASS_COMMON(lptManager, MultiplyToGroupConvolutionTransformation);
 
     // ConvolutionTransformation is disabled temporary until ACL issues are fixed: #1252, #1253
-    CPU_DISABLE_PASS_ARM(lptManager, ConvolutionTransformation);
+    // CPU_DISABLE_PASS_ARM(lptManager, ConvolutionTransformation);
     CPU_DISABLE_PASS_ARM(lptManager, ConvolutionBackpropDataTransformation);
     CPU_DISABLE_PASS_ARM(lptManager, InterpolateTransformation);
     CPU_DISABLE_PASS_ARM(lptManager, GroupConvolutionTransformation);


### PR DESCRIPTION
Hi @alvoron, @v-Golubev,

Following up on our discussion regarding my GSoC 2026 proposal for Project 5, I wanted to proactively share a PoC addressing the optional technical gap: allowing the fusion of `Convolution -> Swish -> FakeQuantize` on the ARM/ACL backend.

### Details:
 - **Context:** Currently, the execution path supports fusing a single post-operation (either an `Activation` or a `FakeQuantize`). When the LPT matcher encounters complex topologies (e.g., YOLOv8/v10 or the target YOLO26), the presence of a non-linear activation like `Swish` forces a premature graph split and a fallback to FP16 (`gemm_acl_f16`), negating INT8 performance gains.
 - **LPT Layer (`convolution.cpp` / `conv_mul_add_fq_block.cpp`):** Added `ov::op::v4::Swish` into the allowable matched patterns for convolutions. By relaxing the strict `Conv -> Add -> FQ` sequence, we prevent the early fallback to FP16.
 - **ACL Convolution Executor (`acl_conv.cpp`):** Refactored the `postOps` parsing from a strict, mutually exclusive sizing condition (`attrs.postOps.size() == 1`) to an iterative check. The executor now successfully attempts to populate both `ActivationLayerInfo` (for Swish) and the `FakeQuantize` scales simultaneously when configuring the ACL backend.
 - **Structural Success (macOS M4 Pro):** The graph successfully compiles natively on my machine. The multi-post-op sequence is dispatched to the ACL executor without throwing the single-post-op exception, and the runtime precision correctly stays at `i8`.
 - **Mathematical Validation (WIP):** I am keeping this PR in `[Draft]` status as I am fine-tuning how `arm_compute::ActivationLayerInfo` interacts with the output tensor's `QuantizationInfo` to ensure the outputs match the FP32 baseline perfectly.
 - *(bonus note for macOS developers: to build the CPU plugin natively on Apple Silicon M series without Gatekeeper or Homebrew Abseil linkage issues, I used `-DENABLE_SYSTEM_PROTOBUF=OFF -DCMAKE_DISABLE_FIND_PACKAGE_ONNX=ON` and signed the dylibs with `codesign --force`. I can submit a separate documentation PR for this if the team finds it useful).*

### Tickets:
 - Related to GSoC 2026 Project 5

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks):* AI was used as a sounding board to brainstorm C++ refactoring strategies (specifically for handling the post-op parsing in `acl_conv.cpp`), locating specific pattern matcher files, and formatting this PR description. Human validation involved manually modifying the OpenVINO C++ source code, building the CPU plugin natively on my M4 Pro (ARM64) resolving CMake/Protobuf toolchain issues, running inference via `infer.py`, and profiling the dumped execution graphs (`cpu_exec_graph.xml`) using Netron to verify the successful shift from `gemm_acl_f16` to `i8`.