### PR TITLE
[GPU] reconstruct precomputed_reduction flag on cache load

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
@@ -212,11 +212,11 @@ struct fully_connected : public primitive_base<fully_connected> {
         ob << activation_scale;
         ob << activation_zero_point;
         ob << activation_precomputed_reduction;
-        ob << dynamic_quantized_precomputed_reduction;
         ob << input_size;
         ob << weights_rank;
         ob << dynamic_quantized_activation;
         ob << dynamic_quantized_activation_zp;
+        ob << dynamic_quantized_precomputed_reduction;
 
         if (decompression_zero_point_scalar.has_value()) {
             ob << true;
@@ -237,11 +237,11 @@ struct fully_connected : public primitive_base<fully_connected> {
         ib >> activation_scale;
         ib >> activation_zero_point;
         ib >> activation_precomputed_reduction;
-        ib >> dynamic_quantized_precomputed_reduction;
         ib >> input_size;
         ib >> weights_rank;
         ib >> dynamic_quantized_activation;
         ib >> dynamic_quantized_activation_zp;
+        ib >> dynamic_quantized_precomputed_reduction;
 
         bool has_value;
         ib >> has_value;


### PR DESCRIPTION
### Details:
 - add dynamic_quantized_precomputed_reduction to save/load cache

### Tickets:
 - 183252

### AI Assistance:
 - AI assistance used: yes
 - AI: find a root-cause
 - human: build/tests/manual checks on PTL
