### PR TITLE
[GPU] fix bug: miss dynamic_quantized_precomputed_reduction to save/load cache in fully_connected

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
@@ -216,6 +216,7 @@ struct fully_connected : public primitive_base<fully_connected> {
         ob << weights_rank;
         ob << dynamic_quantized_activation;
         ob << dynamic_quantized_activation_zp;
+        ob << dynamic_quantized_precomputed_reduction;
 
         if (decompression_zero_point_scalar.has_value()) {
             ob << true;
@@ -240,6 +241,7 @@ struct fully_connected : public primitive_base<fully_connected> {
         ib >> weights_rank;
         ib >> dynamic_quantized_activation;
         ib >> dynamic_quantized_activation_zp;
+        ib >> dynamic_quantized_precomputed_reduction;
 
         bool has_value;
         ib >> has_value;


### PR DESCRIPTION
### Details:
 - add dynamic_quantized_precomputed_reduction to save/load cache

### Tickets:
 - 183252

### AI Assistance:
 - AI assistance used: yes
 - AI: find a root-cause
 - human: build/tests/manual checks on PTL
