### PR TITLE
[NPU][NPUW] Fix UAF in pyramid attention shared tensor buffer.

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
@@ -1115,6 +1115,13 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
     if (is_recreate) {
         submodel_desc.pyramid_infer_requests.clear();
         submodel_desc.pyramid_pipeline_requests.clear();
+        // Also release anchor tensors for this submodel so stale buffers are not retained
+        m_pyramid_anchor_tensors.erase(std::remove_if(m_pyramid_anchor_tensors.begin(),
+                                                      m_pyramid_anchor_tensors.end(),
+                                                      [real_idx](const auto& e) {
+                                                          return e.first == real_idx;
+                                                      }),
+                                       m_pyramid_anchor_tensors.end());
     }
 
     // Allocate storage for infer requests
@@ -1175,6 +1182,17 @@ void ov::npuw::JustInferRequest::setup_pyramid_infer_requests(std::size_t real_i
         submodel_desc.pyramid_infer_requests[last_model_idx] = m_subrequests[real_idx];
         if (is_piped) {
             submodel_desc.pyramid_pipeline_requests[last_model_idx] = m_funcall_pipeline[real_idx].subrequest;
+        }
+
+        // Anchor input tensors here; see m_pyramid_anchor_tensors.
+        const size_t num_inputs = submodel_desc.compiled_model->inputs().size();
+        for (size_t input_idx = 0; input_idx < num_inputs; ++input_idx) {
+            auto main_input = submodel_desc.compiled_model->inputs()[input_idx];
+            m_pyramid_anchor_tensors.emplace_back(real_idx, m_subrequests[real_idx]->get_tensor(main_input));
+            if (is_piped) {
+                m_pyramid_anchor_tensors.emplace_back(real_idx,
+                                                      m_funcall_pipeline[real_idx].subrequest->get_tensor(main_input));
+            }
         }
     }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.hpp
@@ -184,6 +184,14 @@ protected:
 
     // MoE executor (encapsulates MoE inference logic and profiling)
     std::unique_ptr<ov::npuw::moe::MoEExecutor> m_moe_executor;
+
+    // Anchor tensors that keep pyramid shared buffers alive.
+    // The pyramid infer requests share memory via raw pointers wrapped in ov::Tensor.
+    // Without these anchors the original tensor SoPtr can drop to zero when
+    // bind_pyramid_attention_inputs calls set_tensor on m_subrequests for the last chunk,
+    // freeing the buffer while pyramid requests still hold raw pointers into it.
+    // Each entry is {real_idx, tensor} so recreate can selectively remove by submodel.
+    std::vector<std::pair<std::size_t, ov::SoPtr<ov::ITensor>>> m_pyramid_anchor_tensors;
 };
 
 }  // namespace npuw


### PR DESCRIPTION
### Details:
- In `setup_pyramid_infer_requests`, non-last pyramid infer requests share memory with `m_subrequests[real_idx]` via raw pointers wrapped in `ov::Tensor`. (see [here](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp#L1157))
- When `bind_pyramid_attention_inputs` calls `set_tensor` on `m_subrequests` for the last chunk (see the [fast path](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp#L848)), the original tensor SoPtr refcount drops to zero, freeing the buffer while pyramid requests still hold raw pointers into it.
- The next round inference then aborts when accessing the freed memory.
- Fix: add `m_pyramid_anchor_tensors` to `JustInferRequest`, so that the shared tensor and `JustInferRequest` have the same life cycle.

### Tickets:
 - *[CVS-183325](https://jira.devtools.intel.com/browse/CVS-183325)*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*