### PR TITLE
[GPU] Relax rank limit for FC implementation pre-selection

### DIFF
--- a/src/plugins/intel_gpu/src/graph/registry/fully_connected_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/fully_connected_impls.cpp
@@ -23,7 +23,7 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<fully
             [](const program_node& node) {
                 if (node.can_use(impl_types::onednn))
                     return false;
-                return node.get_output_pshape().size() <= 3;
+                return node.get_output_pshape().size() <= 4;
         })
     };
 


### PR DESCRIPTION
### Details:
 - Allows fully_connected nodes with 4D outputs to pre-select OCL implementations for dynamic shapes where no oneDNN implementation is available
 - Is intended to reduce execution-time weight updates and their associated memory usage in cases of 4D dynamic shapes

### Tickets:
 - CVS-182319

### AI Assistance:
 - AI assistance used: no
