### PR TITLE
[NPUW] Add wall-clock timestamps to LLM execution profiling

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -222,6 +222,7 @@ ov::npuw::LLMInferRequest::LLMInferRequest(const std::shared_ptr<ov::npuw::LLMCo
     m_generate_initialized = false;
 
     m_llm_profile.report_on_die = ov::npuw::profiling_enabled();
+    m_llm_profile.emit_timestamps = ov::npuw::profiling_enabled();
     m_llm_profile.area = "LLM/execution";
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
@@ -5,7 +5,10 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
+#include <ctime>
 #include <functional>
+#include <iomanip>
 #include <limits>
 #include <ostream>
 #include <string>
@@ -64,15 +67,22 @@ private:
     T total = 0;
     std::string name;
     bool enabled = false;
+    bool emit_timestamps = false;
 
 public:
     metric() = default;
-    metric(metric&& m) : records(std::move(m.records)), name(std::move(m.name)), enabled(m.enabled) {}
+    metric(metric&& m)
+        : records(std::move(m.records)), name(std::move(m.name)),
+          enabled(m.enabled), emit_timestamps(m.emit_timestamps) {}
 
     explicit metric(const std::string& named, bool active = false) : name(named), enabled(active) {}
 
     void enable() {
         enabled = true;
+    }
+
+    void set_timestamps(bool v) {
+        emit_timestamps = v;
     }
 
     void operator+=(T&& t) {
@@ -105,8 +115,28 @@ public:
     void record(F&& f) {
         if (!enabled) {
             f();
-        } else {
+        } else if (!emit_timestamps) {
             *this += U::sample(f);
+        } else {
+            auto t_start = std::chrono::system_clock::now();
+            auto start_us =
+                std::chrono::duration_cast<std::chrono::microseconds>(t_start.time_since_epoch()).count();
+            std::time_t start_tt = std::chrono::system_clock::to_time_t(t_start);
+            std::tm start_tm = *std::localtime(&start_tt);
+            LOG_INFO("PROF " << name << " START @ "
+                             << std::put_time(&start_tm, "%H:%M:%S") << "."
+                             << std::setfill('0') << std::setw(6) << (start_us % 1000000));
+            *this += U::sample(f);
+            auto t_end = std::chrono::system_clock::now();
+            auto end_us =
+                std::chrono::duration_cast<std::chrono::microseconds>(t_end.time_since_epoch()).count();
+            std::time_t end_tt = std::chrono::system_clock::to_time_t(t_end);
+            std::tm end_tm = *std::localtime(&end_tt);
+            LOG_INFO("PROF " << name << " END   @ "
+                             << std::put_time(&end_tm, "%H:%M:%S") << "."
+                             << std::setfill('0') << std::setw(6) << (end_us % 1000000)
+                             << " (took " << std::fixed << std::setprecision(3)
+                             << ((end_us - start_us) / 1000.0) << " ms)");
         }
     }
 
@@ -151,6 +181,8 @@ public:
         enabled = true;
     }
 
+    void set_timestamps(bool) {}  // no-op for counters
+
     void operator+=(T&& t) {
         if (enabled) {
             total += t;
@@ -178,12 +210,15 @@ struct Profile {
     std::map<std::string, Metric> metrics;
     std::string area;
     bool report_on_die = false;
+    bool emit_timestamps = false;
 
     Metric& operator[](const std::string& tag) {
         auto iter = metrics.find(tag);
         if (iter == metrics.end()) {
-            // Use report_on_die as a "enabled" marker here
             auto [new_iter, unused] = metrics.insert({tag, Metric(tag, report_on_die)});
+            if (emit_timestamps) {
+                new_iter->second.set_timestamps(true);
+            }
             return new_iter->second;
         }
         return iter->second;


### PR DESCRIPTION
Expands on 04293e6 by adding HH:MM:SS.microsecond timestamps to LLM execution profiling points only (prefill/generate phases), for correlation with external voltage measurements on NPU. Gated behind OPENVINO_NPUW_PROF=1 and OPENVINO_NPUW_LOG_LEVEL=INFO.

### Details:
 - *item1*
 - *...*

### Tickets:
 - EISW-202385

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
