### PR TITLE
[GPU] add virtual destructor to kernel_builder and ocl_kernel_builder

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/kernel_builder.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/kernel_builder.hpp
@@ -21,6 +21,7 @@ enum class KernelFormat {
 /// @brief Interface for building the GPU kernels. Implementations must be thread-safe to support case where multiple threads use single builder.
 class kernel_builder {
 public:
+    virtual ~kernel_builder() = default;
     virtual void build_kernels(const void *src, size_t src_bytes, KernelFormat src_format, const std::string &options, std::vector<kernel::ptr> &out) const = 0;
 };
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
@@ -17,6 +17,7 @@ namespace ocl {
 class ocl_kernel_builder : public kernel_builder{
     public:
         ocl_kernel_builder(const ocl_device &device) : m_device(device) {}
+        virtual ~ocl_kernel_builder() = default;
 
         void build_kernels(const void *src,
             size_t src_bytes,


### PR DESCRIPTION
Fix fuzzing build failure on Ubuntu 22.04 caused by -Wdelete-non-abstract-non-virtual-dtor warning promoted to error via -Werror when using Clang with GCC 11 libstdc++ headers.

### Tickets:
 - 183571

### AI Assistance:
 - AI assistance used: yes
 - AI: issue check & create patch
 - user: reproduce issue and check PR on ubuntu