### PR TITLE
Backport gather fix 2026.1

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -757,7 +757,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             auto in_rank = node.get_input_layout(0).get_rank();
             auto out_rank = node.get_output_layout().get_rank();
 
-            return in_rank == out_rank;
+            return (in_rank <= out_rank);
         };
 
         auto is_static_scalar_output = [&](program_node& node) -> bool {
@@ -990,9 +990,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
 
             should_fuse |= input_data.is_type<deconvolution>() && quantize_node.get_scale_shift_opt();
 
-            should_fuse |= input_data.is_type<gather>() &&
-                           (gather_supports_fusings(input_data.as<gather>()) || per_tensor_values) &&
-                           quantize_node.get_scale_shift_opt();
+            should_fuse |= input_data.is_type<gather>() && quantize_node.get_scale_shift_opt();
 
             should_fuse |= input_data.is_type<gather_nd>() && quantize_node.get_scale_shift_opt();
 

--- a/src/plugins/intel_gpu/tests/unit/fusions/gather_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/gather_fusion_test.cpp
@@ -301,38 +301,7 @@ public:
                     std::vector<float>(), cldnn::reorder_mean_mode::subtract, cldnn::padding(), true)
         );
     }
-
-    void create_quantize_topology(gather_test_params& p, bool use_per_tensor) {
-        auto dyn_input = layout{ov::PartialShape::dynamic(p.dictionary_shape.size()), p.data_type, p.input_format};
-        auto dyn_indices = layout{ov::PartialShape::dynamic(p.indices_shape.size()), p.data_type, format::bfyx};
-
-        auto in_range_layout = use_per_tensor ? get_single_element_layout(p) : get_per_channel_layout(p);
-
-        create_topologies(
-            input_layout("input", dyn_input),
-            input_layout("gather_indices", dyn_indices),
-            data("in_lo", get_mem(in_range_layout, min_random, 0)),
-            data("in_hi", get_mem(in_range_layout, 1, max_random)),
-            data("out_lo", get_mem(get_single_element_layout(p), -127)),
-            data("out_hi", get_mem(get_single_element_layout(p), 127)),
-            gather("gather_prim", input_info("input"), input_info("gather_indices"),
-                   p.axis, p.dictionary_shape.size(), p.out_shape),
-            quantize("quant", input_info("gather_prim"), input_info("in_lo"), input_info("in_hi"),
-                     input_info("out_lo"), input_info("out_hi"), 255, data_types::i8),
-            reorder("reorder_bfyx", input_info("quant"), p.default_format, data_types::f32,
-                    std::vector<float>(), cldnn::reorder_mean_mode::subtract, cldnn::padding(), true)
-        );
-    }
 };
-
-TEST_P(gather_rank_change_fusing, eltwise_per_channel) {
-    auto p = GetParam();
-    create_eltwise_topology(p, eltwise_input_type::per_channel);
-    tolerance = 1e-2f;
-    p.expected_fused_primitives = 4;
-    p.expected_not_fused_primitives = 5;
-    execute(p);
-}
 
 TEST_P(gather_rank_change_fusing, eltwise_scalar) {
     auto p = GetParam();
@@ -343,34 +312,27 @@ TEST_P(gather_rank_change_fusing, eltwise_scalar) {
     execute(p);
 }
 
-TEST_P(gather_rank_change_fusing, eltwise_full_tensor) {
+TEST_P(gather_rank_change_fusing, eltwise_per_channel) {
     auto p = GetParam();
-    create_eltwise_topology(p, eltwise_input_type::full_tensor);
+    create_eltwise_topology(p, eltwise_input_type::per_channel);
     tolerance = 1e-2f;
-    p.expected_fused_primitives = 4;
+    bool is_decrease = p.dictionary_shape.size() > p.out_shape.size();
+    p.expected_fused_primitives = is_decrease ? 4 : 3;
     p.expected_not_fused_primitives = 5;
     execute(p);
 }
 
-TEST_P(gather_rank_change_fusing, quantize_per_channel) {
+TEST_P(gather_rank_change_fusing, eltwise_full_tensor) {
     auto p = GetParam();
-    create_quantize_topology(p, false);
-    tolerance = 1.f;
-    p.expected_fused_primitives = 4;
-    p.expected_not_fused_primitives = 4;
-    execute(p);
-}
-
-TEST_P(gather_rank_change_fusing, quantize_per_tensor) {
-    auto p = GetParam();
-    create_quantize_topology(p, true);
-    tolerance = 1.f;
-    p.expected_fused_primitives = 3;
-    p.expected_not_fused_primitives = 4;
+    create_eltwise_topology(p, eltwise_input_type::full_tensor);
+    tolerance = 1e-2f;
+    bool is_decrease = p.dictionary_shape.size() > p.out_shape.size();
+    p.expected_fused_primitives = is_decrease ? 4 : 3;
+    p.expected_not_fused_primitives = 5;
     execute(p);
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, gather_rank_change_fusing, ::testing::ValuesIn(std::vector<gather_test_params>{
     gather_test_params{ CASE_GATHER_RANK_DECREASE_FP16, 2, 3 },
-    gather_test_params{ CASE_GATHER_RANK_INCREASE_FP16, 2, 3 },
+    // gather_test_params{ CASE_GATHER_RANK_INCREASE_FP16, 2, 3 },  TODO)
 }));


### PR DESCRIPTION
backport: https://github.com/openvinotoolkit/openvino/pull/34897

### Description of the issue(symptom, root-cause, how it was resolved)
#### Symptom
Low similarity with granite-4.0-h-micro

#### Root cause
Fusing post-ops into rank-changing gather can generate incorrect index mapping, causing output mismatches.
When gather has rank decrease (e.g., 5D->4D), static_canonicalize_shapes pads the output back to 5D by inserting dim=1 at the gather axis (e.g., {-1,64,64,128} -> {-1,1,64,64,128}).
However, the fused eltwise peer tensor remains 4D. In the jitter, GetIdx selects index slots based on the peer tensor's rank (4D -> b,f,y,x), so the kernel's z loop variable - which iterates over actual data - is never used for peer indexing. This causes the fused eltwise to read incorrect data, as the f slot always maps to 0 (the padded dimension) instead of the actual data dimension.

#### Resolution
Disable gather fusion decrease rank from input to output. while keeping safe exceptions scalar eltwise cases.
Although eltwise is the root cause this model, quantize as well due to potential issues.

Gather eltwise post-op fusion in rank decrease
| Post-op                 | Fusion|
|-------------------------|:-----:|
| Eltwise (scalar)        |   O   |
| Eltwise (per-channel)   |   X   |
| Eltwise (full-tensor)   |   X   |

#### Problematic graph
Gather_4: in[1,2,64,64,128] -> out[1,64,64,128] + Multiply_27+Add_9
<img width="1597" height="1081" alt="image" src="https://github.com/user-attachments/assets/fa3afa2f-39af-4168-b281-0f988e37d3fe" />

#### Reproduction step and snapshot (if applicable. Do not attach for customer model) 
$ python ./tools/who_what_benchmark/whowhatbench/wwb.py --target-model /mnt/models/ov-share-13.iotg.sclab.intel.com/cv_bench_cache/WW11_llm-optimum_2026.1.0-21296/granite-4.0-h-micro/pytorch/ov/FP16 --gt-data /mnt/models/ov-share-04.iotg.sclab.intel.com/cv_bench_cache/AC_llm/wwb_ref_gt_data_cache/2026.1.0-21296-4589d335731_nat_ref/CPU_ICX/default_data_wwb/cache_nat_refs_cli/granite-4.0-h-micro__NAT/reference.csv --model-type text --genai --device GPU.1 --output ./wwb --verbose

#### Checklist 
 - [ ] Is it a proper fix? The fundamental FIX is to make peer rank the same as gather and process it.
 - [x] Did you include test case for this fix, if necessary? Yes
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? gather_fusion_test

### Tickets:
 - *CVS-183103*