### PR TITLE
Allocate page aligned memory to avoid ASAN change memory attribute

### DIFF
--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -265,6 +265,8 @@ public:
 
             static jit_convert_array generator(context);
 
+            // Since the JIT code always resides in memory, and ASAN's memory management may remove executable
+            // permissions, we need to restore executable permissions for the generated code.
             generator.setProtectModeRE(false);
             return (fn_t)generator.getCode();
         }
@@ -471,6 +473,8 @@ public:
 
             static jit_count_out_of_range generator(context);
 
+            // Since the JIT code always resides in memory, and ASAN's memory management may remove executable
+            // permissions, we need to restore executable permissions for the generated code.
             generator.setProtectModeRE(false);
             return (fn_t)generator.getCode();
         }

--- a/src/core/src/runtime/compute_hash.cpp
+++ b/src/core/src/runtime/compute_hash.cpp
@@ -117,6 +117,8 @@ public:
     virtual void generate() = 0;
 
     void operator()(const ComputeHashCallArgs* args) {
+        // Since the JIT code always resides in memory, and ASAN's memory management may remove executable
+        // permissions, we need to restore executable permissions for the generated code.
         setProtectModeRE(false);
         ker_fn(args);
     }


### PR DESCRIPTION

### Details:
 - Avoid static memory to keep the allocated memory and asan will change the static objects' memory attribute.
 - Update the memory's attribute before execute.

#### Backup
 - The kernel and heap memory may share 1 page memory.
 - The asan will change the memory's attribute to `RW` and that operates 1 page memory. Then the kernel's execution attributes lost. It will cause the access violation when fetch the instruction.

### Tickets:
 - [CVS-182324](https://jira.devtools.intel.com/browse/CVS-182324)

### AI Assistance:
 - *AI assistance used: yes*
 - Give the callstack, asm code and input pointers. It gives a solution only for windows with MACRO.
 - After understand the problem, then create new chat to describe the problem and let it give the solution. The solution fixed in 3rd part `xbyak`.
 - Due to this is a memory issue then request to change in the `jit_generator.cpp`
