### PR TITLE
Enable sdpa kv cache uint4

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/multi_tensor_variable_state.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/multi_tensor_variable_state.hpp
@@ -55,7 +55,8 @@ public:
                                            const std::vector<cldnn::layout>& output_layouts,
                                            size_t beam_idx,
                                            size_t concat_idx,
-                                           bool has_zp_state);
+                                           bool has_zp_state,
+                                           bool is_4bit_kv_cache = false);
     using Ptr = std::shared_ptr<VariableStateIndirectKVCacheCompressed>;
 
     void set_state(const ov::SoPtr<ov::ITensor>& state) override;
@@ -70,5 +71,6 @@ public:
 
 private:
     bool m_has_zp_state = false;
+    bool m_is_4bit_kv_cache = false;
 };
 }  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/variable_state.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/variable_state.hpp
@@ -72,6 +72,8 @@ public:
         return m_initial_layout;
     }
 
+    void set_alloc_inner_dim_divisor(size_t divisor) { m_alloc_inner_dim_divisor = divisor; }
+
     ov::element::Type get_user_specified_type() const;
 
 protected:
@@ -82,6 +84,7 @@ protected:
     cldnn::memory::ptr m_memory = nullptr;
     bool m_transpose_required = false;
     size_t actual_size = 0;
+    size_t m_alloc_inner_dim_divisor = 1;
 
     const cldnn::layout m_initial_layout;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -506,6 +506,9 @@ struct kv_cache_impl : multi_stage_primitive<kv_cache> {
         params.combine_scales_and_zp =
             primitive->quantization_attributes.output_storage_type != ov::op::internal::DynamicQuantize::OutputStorageType::Planar;
 
+        const auto kv_cache_dt = impl_param.get_program().get_config().get_kv_cache_precision();
+        params.is_int4_compressed = ov::element::Type(kv_cache_dt).bitwidth() == 4;
+
         const auto& past_kv_cache_shape = impl_param.input_layouts[0].get_partial_shape();
         params.axis_offset = past_kv_cache_shape[primitive->concat_axis].is_static() ? past_kv_cache_shape[primitive->concat_axis].get_length() : 0;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
@@ -212,6 +212,13 @@ JitConstants SDPABase::get_jit_constants(const kernel_impl_params& params) const
             jit.make("HAS_SINK_INPUT", 1);
         }
         jit.make("IS_KV_COMPRESSED", desc->is_kv_compressed);
+        {
+            // const bool is_int4 = ov::element::Type(desc->quantization_attributes.quantization_dt).bitwidth() == 4;
+            const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
+            const bool is_int4 = ov::element::Type(kv_cache_dt).bitwidth() == 4;
+            // std::cout << ">> get_sdpa_jit_constants: is_int4_compressed = " << is_int4 << std::endl;
+            jit.make("IS_INT4_COMPRESSED", is_int4);
+        }
         GPU_DEBUG_TRACE_DETAIL << "desc->is_kv_compressed = " << desc->is_kv_compressed << std::endl;
 
         const auto& in_offsets_map = params.in_port_to_shape_info_offset;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -359,7 +359,7 @@ KERNEL(sdpa_opt)(
 
                     uint query_offset = head_idx_index + sglid;
                     unroll_for (uint seq_idx = 0; seq_idx < TARGET_SEQ_LEN_BLOCK_SIZE; seq_idx++) {
-                        query_offset + = seq_idx * K_HEAD_SIZE;
+                        query_offset += seq_idx * K_HEAD_SIZE;
                         INPUT0_TYPE q_val0 = query_local[query_offset];
                         INPUT0_TYPE q_val1 = query_local[query_offset+ SUBGROUP_SIZE];
                         acc[seq_idx] = mad(TO_SOFTMAX_ACCUMULATOR_TYPE(q_val0), TO_SOFTMAX_ACCUMULATOR_TYPE(key_val0), acc[seq_idx]);
@@ -380,7 +380,7 @@ KERNEL(sdpa_opt)(
 
                     uint query_offset = head_idx_index + sglid;
                     unroll_for (uint seq_idx = 0; seq_idx < TARGET_SEQ_LEN_BLOCK_SIZE; seq_idx++) {
-                        query_offset + = seq_idx * K_HEAD_SIZE;
+                        query_offset += seq_idx * K_HEAD_SIZE;
                         INPUT0_TYPE q_val0 = query_local[query_offset];
                         acc[seq_idx] = mad(TO_SOFTMAX_ACCUMULATOR_TYPE(q_val0), TO_SOFTMAX_ACCUMULATOR_TYPE(key_val0), acc[seq_idx]);
                     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -4,6 +4,7 @@
 
 #include "include/batch_headers/fetch_data.cl"
 #include "include/batch_headers/common.cl"
+#include "include/batch_headers/int4_utils.cl"
 #include "include/batch_headers/sub_group_block_read.cl"
 #include "include/batch_headers/sub_group_block_write.cl"
 #include "include/batch_headers/sub_group_shuffle.cl"
@@ -289,10 +290,79 @@ KERNEL(sdpa_opt)(
 #if IS_KV_COMPRESSED
                 const uint comp_offset = GET_COMPRESSION_INDEX(KEY_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, start_partition_idx + seq_len, 0);
                 KEY_COMPRESSION_SCALE_TYPE comp_scale = GET_SCALE(key_zp, key_scale, comp_offset);
-#if USE_ASYMMETRIC_QUANTIZATION
+#if USE_ASYMMETRIC_QUANTIZATION || IS_INT4_COMPRESSED
                 KEY_COMPRESSION_SCALE_TYPE comp_zp = GET_ZP(key_zp, key_scale, comp_offset);
 #endif
 #endif
+
+#if IS_KV_COMPRESSED && IS_INT4_COMPRESSED
+                // Original logic
+                ////////////////////////////////////////////////////////////////////////////////////
+                {
+                #if 0
+                    #define KEY_BLOCK_SIZE 1
+                    for (; head_idx_index + (KEY_BLOCK_SIZE * SUBGROUP_SIZE) <= K_HEAD_SIZE; head_idx_index += SUBGROUP_SIZE * KEY_BLOCK_SIZE) {
+                        #define KEY_BLOCK_READ(ptr, offset) BLOCK_READN(INPUT1_TYPE, KEY_BLOCK_SIZE, ptr, offset);
+                        #define KEY_BLOCK MAKE_VECTOR_TYPE(INPUT1_TYPE, KEY_BLOCK_SIZE)
+                        #define KEY_BLOCK_UNCOMPRESSED MAKE_VECTOR_TYPE(KEY_COMPRESSION_SCALE_TYPE, KEY_BLOCK_SIZE)
+                        #define TO_KEY_BLOCK_UNCOMPRESSED_TYPE(val) CAT(convert_, KEY_BLOCK_UNCOMPRESSED)(val)
+                        #define QUERY_BLOCK MAKE_VECTOR_TYPE(INPUT0_TYPE, KEY_BLOCK_SIZE)
+
+                        KEY_BLOCK key_vec_packed = KEY_BLOCK_READ(key_input, key_offset + head_idx_index);
+                        KEY_BLOCK_UNCOMPRESSED key_vals = (TO_KEY_BLOCK_UNCOMPRESSED_TYPE(key_vec_packed) - comp_zp) * comp_scale;
+
+                        uint query_offset = head_idx_index + sglid;
+                        unroll_for (uint seq_idx = 0; seq_idx < TARGET_SEQ_LEN_BLOCK_SIZE; seq_idx++) {
+                            QUERY_BLOCK query_vals_reg;
+                            // KEY_BLOCK_SIZE 1
+                            // unroll_for(uint i = 0; i < KEY_BLOCK_SIZE; i++) {
+                            //     query_vals_reg = query_local[query_offset + i * SUBGROUP_SIZE];
+                            // }
+                            query_vals_reg = query_local[query_offset];
+
+                            acc[seq_idx] = mad(TO_SOFTMAX_ACCUMULATOR_TYPE(query_vals_reg), TO_SOFTMAX_ACCUMULATOR_TYPE(key_vals), acc[seq_idx]);
+                            query_offset += K_HEAD_SIZE;
+                        }
+                    }
+                    // Sum up all accumulators accross single SG and save result to SLM
+                    unroll_for (uint seq_idx = 0; seq_idx < TARGET_SEQ_LEN_BLOCK_SIZE; seq_idx++) {
+                        acc[seq_idx] = sub_group_reduce_add(acc[seq_idx]);
+                        qk_local[seq_idx * SEQ_LEN_PARTITION_SIZE + seq_len] = acc[seq_idx];
+                    }
+                #endif
+                }
+                ////////////////////////////////////////////////////////////////////////////////////
+
+                // 4-bit KV cache: physical key size is K_HEAD_SIZE/2 bytes per sequence position.
+                // Packing: consecutive pairs of SUBGROUP_SIZE-wide groups share one physical byte:
+                //   byte at phys_offset = (head_idx_index/2 + sglid) holds:
+                //     lo order_in_packed -> key val at head dim [head_idx_index + sglid]
+                //     hi order_in_packed -> key val at head dim [head_idx_index + SUBGROUP_SIZE + sglid]
+                for (uint head_idx_index = 0; head_idx_index < K_HEAD_SIZE; head_idx_index += 2 * SUBGROUP_SIZE) {
+                    #define KEY_BLOCK_READ_1(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset)
+                    INPUT1_TYPE packed_byte = KEY_BLOCK_READ_1(key_input, key_offset + head_idx_index / 2);
+                    char2 unpacked = unpack_to_char(*(uint4x2_t*)&packed_byte);
+
+                    KEY_COMPRESSION_SCALE_TYPE key_val0 = (CAT(convert_, KEY_COMPRESSION_SCALE_TYPE)(unpacked.s0) - comp_zp) * comp_scale;
+                    KEY_COMPRESSION_SCALE_TYPE key_val1 = (CAT(convert_, KEY_COMPRESSION_SCALE_TYPE)(unpacked.s1) - comp_zp) * comp_scale;
+
+                    uint query_offset = head_idx_index + sglid;
+                    unroll_for (uint seq_idx = 0; seq_idx < TARGET_SEQ_LEN_BLOCK_SIZE; seq_idx++) {
+                        query_offset + = seq_idx * K_HEAD_SIZE;
+                        INPUT0_TYPE q_val0 = query_local[query_offset];
+                        INPUT0_TYPE q_val1 = query_local[query_offset+ SUBGROUP_SIZE];
+                        acc[seq_idx] = mad(TO_SOFTMAX_ACCUMULATOR_TYPE(q_val0), TO_SOFTMAX_ACCUMULATOR_TYPE(key_val0), acc[seq_idx]);
+                        acc[seq_idx] = mad(TO_SOFTMAX_ACCUMULATOR_TYPE(q_val1), TO_SOFTMAX_ACCUMULATOR_TYPE(key_val1), acc[seq_idx]);
+                    }
+                    #undef KEY_BLOCK_READ_1
+                }
+
+                // Sum up all accumulators accross SG and save result to SLM
+                unroll_for (uint seq_idx = 0; seq_idx < TARGET_SEQ_LEN_BLOCK_SIZE; seq_idx++) {
+                    acc[seq_idx] = sub_group_reduce_add(acc[seq_idx]);
+                    qk_local[seq_idx * SEQ_LEN_PARTITION_SIZE + seq_len] = acc[seq_idx];
+                }
+#else  // !(IS_KV_COMPRESSED && IS_INT4_COMPRESSED) — original INT8 path
                 uint head_idx_index = 0;
                 #define KEY_BLOCK_SIZE 8
                 for (; head_idx_index + (KEY_BLOCK_SIZE * SUBGROUP_SIZE) <= K_HEAD_SIZE; head_idx_index += SUBGROUP_SIZE * KEY_BLOCK_SIZE) {
@@ -424,6 +494,7 @@ KERNEL(sdpa_opt)(
                     acc[seq_idx] = sub_group_reduce_add(acc[seq_idx]);
                     qk_local[seq_idx * SEQ_LEN_PARTITION_SIZE + seq_len] = acc[seq_idx];
                 }
+#endif  // IS_KV_COMPRESSED && IS_INT4_COMPRESSED
             }
 
             {
@@ -643,7 +714,12 @@ KERNEL(sdpa_opt)(
         uint value_offset_next_seq = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0);
         const uint value_pitch = value_offset_next_seq - value_offset;
 #else
+#if IS_INT4_COMPRESSED
+        // INT4: GET_INDEX returns element-level offsets; rows are V_HEAD_SIZE apart
         const uint value_pitch = V_HEAD_SIZE;
+#else
+        const uint value_pitch = V_HEAD_SIZE;
+#endif
 #endif
 #endif
 
@@ -661,17 +737,28 @@ KERNEL(sdpa_opt)(
             uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE) + sglid, sgid * SUBGROUP_SIZE);
 #else
             const uint b_idx = b0_idx;
-#ifdef INPUT2_DIMS_ORDER
-            uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
-#else
-            uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
-#endif
+    #if IS_INT4_COMPRESSED
+                const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
+    #endif
+    #ifdef INPUT2_DIMS_ORDER
+        #if IS_INT4_COMPRESSED
+                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
+        #else
+                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
+        #endif
+    #else
+        #if IS_INT4_COMPRESSED
+                    uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
+        #else
+                    uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
+        #endif
+    #endif
 #endif
 
 #if IS_KV_COMPRESSED
             const uint comp_offset = GET_COMPRESSION_INDEX(VALUE_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, start_partition_idx + (seq_len * SUBGROUP_SIZE) + sglid, 0);
             VALUE_COMPRESSION_SCALE_TYPE comp_scale = GET_SCALE(val_zp, val_scale, comp_offset);
-#if USE_ASYMMETRIC_QUANTIZATION
+#if USE_ASYMMETRIC_QUANTIZATION || IS_INT4_COMPRESSED
             VALUE_COMPRESSION_SCALE_TYPE comp_zp = GET_ZP(val_zp, val_scale, comp_offset);
 #endif
 #endif
@@ -688,7 +775,14 @@ KERNEL(sdpa_opt)(
                 const INPUT2_TYPE value_packed = VALUE_BLOCK_READ(value_input, value_offset);
 #endif
 
-#if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
+#if IS_KV_COMPRESSED && IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+                // INT4: unpack the order_in_packed for this lane's head dim from the packed byte.
+                char2 v_unpacked = unpack_to_char(*(uint4x2_t*)&value_packed);
+                VALUE_COMPRESSION_SCALE_TYPE value_val = (order_in_packed == 0 ?
+                    CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked.s0) :
+                    CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked.s1));
+                value_val = (value_val - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
+#elif IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                 VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
 #elif IS_KV_COMPRESSED
                 VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed * sub_group_broadcast(comp_scale, i));
@@ -717,16 +811,27 @@ KERNEL(sdpa_opt)(
             const uint b_idx = b0_idx;
 #endif
 
+#if IS_INT4_COMPRESSED
+            const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
+#endif
 #ifdef INPUT2_DIMS_ORDER
+#if IS_INT4_COMPRESSED
+            const uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + seq_len, (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
+#else
             const uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + seq_len, head_size_idx);
+#endif
+#else
+#if IS_INT4_COMPRESSED
+            const uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + seq_len, (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
 #else
             const uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + seq_len, head_size_idx);
+#endif
 #endif
 
 #if IS_KV_COMPRESSED
             const uint comp_offset = GET_COMPRESSION_INDEX(VALUE_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, start_partition_idx + seq_len, 0);
             VALUE_COMPRESSION_SCALE_TYPE comp_scale = GET_SCALE(val_zp, val_scale, comp_offset);
-#if USE_ASYMMETRIC_QUANTIZATION
+#if USE_ASYMMETRIC_QUANTIZATION || IS_INT4_COMPRESSED
             VALUE_COMPRESSION_SCALE_TYPE comp_zp = GET_ZP(val_zp, val_scale, comp_offset);
 #endif
 #endif
@@ -737,7 +842,13 @@ KERNEL(sdpa_opt)(
             }
 
             const INPUT2_TYPE value_packed = VALUE_BLOCK_READ(value_input, value_offset);
-#if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
+#if IS_KV_COMPRESSED && IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+            char2 v_rem_unpacked = unpack_to_char(*(uint4x2_t*)&value_packed);
+            VALUE_COMPRESSION_SCALE_TYPE value_val = (order_in_packed == 0 ?
+                CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_rem_unpacked.s0) :
+                CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_rem_unpacked.s1));
+            value_val = (value_val - comp_zp) * comp_scale;
+#elif IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
             const VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed - comp_zp) * comp_scale;
 #elif IS_KV_COMPRESSED
             const VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed * comp_scale);
@@ -1247,10 +1358,39 @@ KERNEL(sdpa_opt)(
 #if IS_KV_COMPRESSED
                 const uint comp_offset = GET_COMPRESSION_INDEX(KEY_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, seq_len + sglid, 0);
                 KEY_COMPRESSION_SCALE_TYPE comp_scale = GET_SCALE(key_zp, key_scale, comp_offset);
-#if USE_ASYMMETRIC_QUANTIZATION
+#if USE_ASYMMETRIC_QUANTIZATION || IS_INT4_COMPRESSED
                 KEY_COMPRESSION_SCALE_TYPE comp_zp = GET_ZP(key_zp, key_scale, comp_offset);
 #endif
 #endif
+#if IS_KV_COMPRESSED && IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+                {
+                    // INT4: process 2*SUBGROUP_SIZE logical head dims per iteration (one packed byte per lane per token row)
+                    #define KEY_BLOCK_READ(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset);
+                    #define QUERY_VEC MAKE_VECTOR_TYPE(INPUT0_TYPE, TARGET_SEQ_LEN_BLOCK_SIZE)
+                    const uint key_pitch_int4 = K_HEAD_SIZE;
+                    for (uint hi = 0; hi < K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
+                        QUERY_VEC qvec_lo, qvec_hi;
+                        uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
+                        uint qhi_off = (hi + SUBGROUP_SIZE) * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
+                        unroll_for (uint q_row = 0; q_row < TARGET_SEQ_LEN_BLOCK_SIZE; q_row++) {
+                            qvec_lo[q_row] = slm_query[qlo];
+                            qvec_hi[q_row] = slm_query[qhi_off];
+                            qlo += TARGET_SEQ_LEN_BLOCK_SIZE;
+                            qhi_off += TARGET_SEQ_LEN_BLOCK_SIZE;
+                        }
+                        unroll_for (uint key_row_idx = 0; key_row_idx < TARGET_SEQ_LEN_BLOCK_SIZE; key_row_idx++) {
+                            const INPUT1_TYPE packed_byte = KEY_BLOCK_READ(key_input, key_offset + key_row_idx * key_pitch_int4 + hi / 2);
+                            char2 unpacked = unpack_to_char(*(uint4x2_t*)&packed_byte);
+                            KEY_COMPRESSION_SCALE_TYPE key_lo = (TO_KEY_COMPRESSION_SCALE_TYPE(unpacked.s0) - sub_group_broadcast(comp_zp, key_row_idx)) * sub_group_broadcast(comp_scale, key_row_idx);
+                            KEY_COMPRESSION_SCALE_TYPE key_hi = (TO_KEY_COMPRESSION_SCALE_TYPE(unpacked.s1) - sub_group_broadcast(comp_zp, key_row_idx)) * sub_group_broadcast(comp_scale, key_row_idx);
+                            unroll_for (uint i = 0; i < SUBGROUP_SIZE; i++) {
+                                qk_acc[key_row_idx] = mad(sub_group_broadcast(key_lo, i), qvec_lo[i], qk_acc[key_row_idx]);
+                                qk_acc[key_row_idx] = mad(sub_group_broadcast(key_hi, i), qvec_hi[i], qk_acc[key_row_idx]);
+                            }
+                        }
+                    }
+                }
+#else  // !IS_INT4_COMPRESSED
                 uint head_idx_index = 0;
                 __attribute__((opencl_unroll_hint(1)))
                 for (; head_idx_index + SUBGROUP_SIZE <= K_HEAD_SIZE; head_idx_index += SUBGROUP_SIZE) {
@@ -1309,15 +1449,49 @@ KERNEL(sdpa_opt)(
                         }
                     }
                 #endif
+#endif  // !IS_INT4_COMPRESSED
             } else if (seq_len_calc_size > 0) {
 #if IS_KV_COMPRESSED
                 const uint comp_offset = GET_COMPRESSION_INDEX(KEY_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, seq_len + min(sglid, (uint)seq_len_calc_size - 1), 0);
                 // const uint comp_offset = GET_COMPRESSION_INDEX(KEY_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, seq_len + sglid, 0);
                 KEY_COMPRESSION_SCALE_TYPE comp_scale = GET_SCALE(key_zp, key_scale, comp_offset);
-#if USE_ASYMMETRIC_QUANTIZATION
+#if USE_ASYMMETRIC_QUANTIZATION || IS_INT4_COMPRESSED
                 KEY_COMPRESSION_SCALE_TYPE comp_zp = GET_ZP(key_zp, key_scale, comp_offset);
 #endif
 #endif
+#if IS_KV_COMPRESSED && IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+                {
+                    // INT4 partial block: process 2*SUBGROUP_SIZE logical head dims per iteration
+                    #define KEY_BLOCK_READ(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset)
+                    #define QUERY_VEC_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, TARGET_SEQ_LEN_BLOCK_SIZE)
+                    const uint key_pitch_int4 = K_HEAD_SIZE;
+                    for (uint hi = 0; hi < K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
+                        QUERY_VEC_TYPE qvec_lo, qvec_hi;
+                        uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
+                        uint qhi_off = (hi + SUBGROUP_SIZE) * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
+                        unroll_for (uint q_row = 0; q_row < TARGET_SEQ_LEN_BLOCK_SIZE; q_row++) {
+                            qvec_lo[q_row] = slm_query[qlo];
+                            qvec_hi[q_row] = slm_query[qhi_off];
+                            qlo += TARGET_SEQ_LEN_BLOCK_SIZE;
+                            qhi_off += TARGET_SEQ_LEN_BLOCK_SIZE;
+                        }
+                        unroll_for (uint key_row_idx = 0; key_row_idx < TARGET_SEQ_LEN_BLOCK_SIZE; key_row_idx++) {
+                            KEY_COMPRESSION_SCALE_TYPE key_lo = 0;
+                            KEY_COMPRESSION_SCALE_TYPE key_hi = 0;
+                            if (key_row_idx < seq_len_calc_size) {
+                                const INPUT1_TYPE packed_byte = KEY_BLOCK_READ(key_input, key_offset + key_row_idx * key_pitch_int4 + hi / 2);
+                                char2 unpacked = unpack_to_char(*(uint4x2_t*)&packed_byte);
+                                key_lo = (TO_KEY_COMPRESSION_SCALE_TYPE(unpacked.s0) - sub_group_broadcast(comp_zp, key_row_idx)) * sub_group_broadcast(comp_scale, key_row_idx);
+                                key_hi = (TO_KEY_COMPRESSION_SCALE_TYPE(unpacked.s1) - sub_group_broadcast(comp_zp, key_row_idx)) * sub_group_broadcast(comp_scale, key_row_idx);
+                            }
+                            unroll_for (uint i = 0; i < SUBGROUP_SIZE; i++) {
+                                qk_acc[key_row_idx] = mad(sub_group_broadcast(key_lo, i), qvec_lo[i], qk_acc[key_row_idx]);
+                                qk_acc[key_row_idx] = mad(sub_group_broadcast(key_hi, i), qvec_hi[i], qk_acc[key_row_idx]);
+                            }
+                        }
+                    }
+                }
+#else  // !IS_INT4_COMPRESSED
                 uint head_idx_index = 0;
                 __attribute__((opencl_unroll_hint(1)))
                 for (; head_idx_index + SUBGROUP_SIZE <= K_HEAD_SIZE; head_idx_index += SUBGROUP_SIZE) {
@@ -1405,6 +1579,7 @@ KERNEL(sdpa_opt)(
                         }
                     }
                 #endif // K_HEAD_SIZE_LEFTOVER
+#endif  // !IS_INT4_COMPRESSED
             }
 
             // softmax_scale
@@ -1676,7 +1851,12 @@ KERNEL(sdpa_opt)(
             uint value_offset_next_seq = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0);
             const uint value_pitch = value_offset_next_seq - value_offset_base;
 #else
+#if IS_INT4_COMPRESSED
+            // INT4: GET_INDEX returns element-level offsets; rows are V_HEAD_SIZE apart
             const uint value_pitch = V_HEAD_SIZE;
+#else
+            const uint value_pitch = V_HEAD_SIZE;
+#endif
 #endif
 #endif
 
@@ -1700,10 +1880,21 @@ KERNEL(sdpa_opt)(
                     const uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len) + sglid, sgid * SUBGROUP_SIZE);
 #else
                     const uint b_idx = b0_idx;
+    #if IS_INT4_COMPRESSED
+                    const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
+    #endif
     #ifdef INPUT2_DIMS_ORDER
+    #if IS_INT4_COMPRESSED
+                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (seq_len), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
+    #else
                     uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (seq_len), head_size_idx);
+    #endif
+    #else
+    #if IS_INT4_COMPRESSED
+                    uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + (seq_len), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
     #else
                     uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + (seq_len), head_size_idx);
+    #endif
     #endif
 #endif
 #endif
@@ -1714,7 +1905,7 @@ KERNEL(sdpa_opt)(
 #if IS_KV_COMPRESSED
                     const uint comp_offset = GET_COMPRESSION_INDEX(VALUE_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, start_partition_idx + seq_len + sglid, 0);
                     VALUE_COMPRESSION_SCALE_TYPE comp_scale = GET_SCALE(val_zp, val_scale, comp_offset);
-#if USE_ASYMMETRIC_QUANTIZATION
+#if USE_ASYMMETRIC_QUANTIZATION || IS_INT4_COMPRESSED
                     VALUE_COMPRESSION_SCALE_TYPE comp_zp = GET_ZP(val_zp, val_scale, comp_offset);
 #endif
 #endif
@@ -1730,7 +1921,13 @@ KERNEL(sdpa_opt)(
                         const INPUT2_TYPE value_packed = VALUE_BLOCK_READ(value_input, value_offset);
                         #endif
 
-                        #if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
+                        #if IS_KV_COMPRESSED && IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+                        char2 v_unpacked = unpack_to_char(*(uint4x2_t*)&value_packed);
+                        VALUE_COMPRESSION_SCALE_TYPE value_val = (order_in_packed == 0 ?
+                            CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked.s0) :
+                            CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked.s1));
+                        value_val = (value_val - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
+                        #elif IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                         VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
                         #elif IS_KV_COMPRESSED
                         VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed * sub_group_broadcast(comp_scale, i));
@@ -1753,7 +1950,13 @@ KERNEL(sdpa_opt)(
                         #else
                             const INPUT2_TYPE value_packed = value_input[value_offset];
                         #endif
-                        #if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
+                        #if IS_KV_COMPRESSED && IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+                            char2 v_unpacked_elt = unpack_to_char(*(uint4x2_t*)&value_packed);
+                            VALUE_COMPRESSION_SCALE_TYPE value_val = (order_in_packed == 0 ?
+                                CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked_elt.s0) :
+                                CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked_elt.s1));
+                            value_val = (value_val - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
+                        #elif IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                             VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
                         #elif IS_KV_COMPRESSED
                             VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed * sub_group_broadcast(comp_scale, i));
@@ -1793,10 +1996,21 @@ KERNEL(sdpa_opt)(
                     uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE) + sglid, sgid * SUBGROUP_SIZE);
                 #else
                     const uint b_idx = b0_idx;
+                #if IS_INT4_COMPRESSED
+                    const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
+                #endif
                 #ifdef INPUT2_DIMS_ORDER
+                #if IS_INT4_COMPRESSED
+                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
+                #else
                     uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
+                #endif
+                #else
+                #if IS_INT4_COMPRESSED
+                    uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
                 #else
                     uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
+                #endif
                 #endif
             #endif
 #endif
@@ -1804,7 +2018,7 @@ KERNEL(sdpa_opt)(
 #if IS_KV_COMPRESSED
                     const uint comp_offset = GET_COMPRESSION_INDEX(VALUE_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, start_partition_idx + (seq_len * SUBGROUP_SIZE) + sglid, 0);
                     VALUE_COMPRESSION_SCALE_TYPE comp_scale = GET_SCALE(val_zp, val_scale, comp_offset);
-#if USE_ASYMMETRIC_QUANTIZATION
+#if USE_ASYMMETRIC_QUANTIZATION || IS_INT4_COMPRESSED
                     VALUE_COMPRESSION_SCALE_TYPE comp_zp = GET_ZP(val_zp, val_scale, comp_offset);
 #endif
 #endif // IS_KV_COMPRESSED
@@ -1825,7 +2039,13 @@ KERNEL(sdpa_opt)(
                         const INPUT2_TYPE value_packed = VALUE_BLOCK_READ(value_input, value_offset);
                 #endif
 
-                #if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
+                #if IS_KV_COMPRESSED && IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+                        char2 v_unpacked = unpack_to_char(*(uint4x2_t*)&value_packed);
+                        VALUE_COMPRESSION_SCALE_TYPE value_val = (order_in_packed == 0 ?
+                            CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked.s0) :
+                            CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked.s1));
+                        value_val = (value_val - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
+                #elif IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                         VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
                 #elif IS_KV_COMPRESSED
                         VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed * sub_group_broadcast(comp_scale, i));
@@ -1848,7 +2068,13 @@ KERNEL(sdpa_opt)(
                         #else
                             const INPUT2_TYPE value_packed = value_input[value_offset];
                         #endif
-                        #if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
+                        #if IS_KV_COMPRESSED && IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+                            char2 v_unpacked_elt = unpack_to_char(*(uint4x2_t*)&value_packed);
+                            VALUE_COMPRESSION_SCALE_TYPE value_val = (order_in_packed == 0 ?
+                                CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked_elt.s0) :
+                                CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_unpacked_elt.s1));
+                            value_val = (value_val - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
+                        #elif IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                             VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
                         #elif IS_KV_COMPRESSED
                             VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed * sub_group_broadcast(comp_scale, i));
@@ -1891,10 +2117,21 @@ KERNEL(sdpa_opt)(
                     const uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + seq_len_leftovers_start + sglid, sgid * SUBGROUP_SIZE);
 #else
                     const uint b_idx = b0_idx;
+    #if IS_INT4_COMPRESSED
+                    const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
+    #endif
     #ifdef INPUT2_DIMS_ORDER
+    #if IS_INT4_COMPRESSED
+                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + seq_len_leftovers_start, (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
+    #else
                     uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + seq_len_leftovers_start, head_size_idx);
+    #endif
+    #else
+    #if IS_INT4_COMPRESSED
+                    uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + seq_len_leftovers_start, (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
     #else
                     uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + seq_len_leftovers_start, head_size_idx);
+    #endif
     #endif
 #endif
 #endif
@@ -1903,7 +2140,7 @@ KERNEL(sdpa_opt)(
                     const uint comp_offset = GET_COMPRESSION_INDEX(VALUE_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, start_partition_idx + min(seq_len_leftovers_start + sglid, seq_len_end - 1), 0);
                     // const uint comp_offset = GET_COMPRESSION_INDEX(VALUE_COMPRESSION_SCALE, b_idx, b1_idx / BROADCAST_GROUP_SIZE, start_partition_idx + seq_len_leftovers_start + sglid, 0);
                     VALUE_COMPRESSION_SCALE_TYPE comp_scale = GET_SCALE(val_zp, val_scale, comp_offset);
-#if USE_ASYMMETRIC_QUANTIZATION
+#if USE_ASYMMETRIC_QUANTIZATION || IS_INT4_COMPRESSED
                     VALUE_COMPRESSION_SCALE_TYPE comp_zp = GET_ZP(val_zp, val_scale, comp_offset);
 #endif
 #endif
@@ -1929,7 +2166,13 @@ KERNEL(sdpa_opt)(
                         #endif
                     #endif // V_HEAD_SIZE_LEFTOVER
 
-#if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
+#if IS_KV_COMPRESSED && IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+                        char2 v_left_unpacked = unpack_to_char(*(uint4x2_t*)&value_packed);
+                        VALUE_COMPRESSION_SCALE_TYPE value_val = (order_in_packed == 0 ?
+                            CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_left_unpacked.s0) :
+                            CAT(convert_, VALUE_COMPRESSION_SCALE_TYPE)(v_left_unpacked.s1));
+                        value_val = (value_val - sub_group_broadcast(comp_zp, seq_len_idx)) * sub_group_broadcast(comp_scale, seq_len_idx);
+#elif IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                         VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed - sub_group_broadcast(comp_zp, seq_len_idx)) * sub_group_broadcast(comp_scale, seq_len_idx);
 #elif IS_KV_COMPRESSED
                         VALUE_COMPRESSION_SCALE_TYPE value_val = (value_packed * sub_group_broadcast(comp_scale, seq_len_idx));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -349,7 +349,7 @@ KERNEL(sdpa_opt)(
                 //   byte at phys_offset = (head_idx_index/2 + sglid) holds:
                 //     lo order_in_packed -> key val at head dim [head_idx_index + sglid]
                 //     hi order_in_packed -> key val at head dim [head_idx_index + SUBGROUP_SIZE + sglid]
-                for (uint head_idx_index = 0; head_idx_index < K_HEAD_SIZE; head_idx_index += 2 * SUBGROUP_SIZE) {
+                for (uint head_idx_index = 0; head_idx_index + 2 * SUBGROUP_SIZE <= K_HEAD_SIZE; head_idx_index += 2 * SUBGROUP_SIZE) {
                     #define KEY_BLOCK_READ_1(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset)
                     INPUT1_TYPE packed_byte = KEY_BLOCK_READ_1(key_input, key_offset + head_idx_index / 2);
                     char2 unpacked = unpack_to_char(*(uint4x2_t*)&packed_byte);
@@ -367,6 +367,26 @@ KERNEL(sdpa_opt)(
                     }
                     #undef KEY_BLOCK_READ_1
                 }
+                // Handle leftover chunk when K_HEAD_SIZE is not a multiple of 2*SUBGROUP_SIZE
+#if (K_HEAD_SIZE % (2 * SUBGROUP_SIZE)) != 0
+                {
+                    const uint head_idx_index = (K_HEAD_SIZE / (2 * SUBGROUP_SIZE)) * (2 * SUBGROUP_SIZE);
+                    #define KEY_BLOCK_READ_1(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset)
+                    INPUT1_TYPE packed_byte = KEY_BLOCK_READ_1(key_input, key_offset + head_idx_index / 2);
+                    char2 unpacked = unpack_to_char(*(uint4x2_t*)&packed_byte);
+
+                    // Only the lo nibble is valid for the leftover chunk
+                    KEY_COMPRESSION_SCALE_TYPE key_val0 = (CAT(convert_, KEY_COMPRESSION_SCALE_TYPE)(unpacked.s0) - comp_zp) * comp_scale;
+
+                    uint query_offset = head_idx_index + sglid;
+                    unroll_for (uint seq_idx = 0; seq_idx < TARGET_SEQ_LEN_BLOCK_SIZE; seq_idx++) {
+                        query_offset + = seq_idx * K_HEAD_SIZE;
+                        INPUT0_TYPE q_val0 = query_local[query_offset];
+                        acc[seq_idx] = mad(TO_SOFTMAX_ACCUMULATOR_TYPE(q_val0), TO_SOFTMAX_ACCUMULATOR_TYPE(key_val0), acc[seq_idx]);
+                    }
+                    #undef KEY_BLOCK_READ_1
+                }
+#endif
 
                 // Sum up all accumulators accross SG and save result to SLM
                 unroll_for (uint seq_idx = 0; seq_idx < TARGET_SEQ_LEN_BLOCK_SIZE; seq_idx++) {
@@ -1389,7 +1409,7 @@ KERNEL(sdpa_opt)(
                     #define KEY_BLOCK_READ(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset);
                     #define QUERY_VEC MAKE_VECTOR_TYPE(INPUT0_TYPE, TARGET_SEQ_LEN_BLOCK_SIZE)
                     const uint key_pitch_int4 = K_HEAD_SIZE;
-                    for (uint hi = 0; hi < K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
+                    for (uint hi = 0; hi + 2 * SUBGROUP_SIZE <= K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
                         QUERY_VEC qvec_lo, qvec_hi;
                         uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
                         uint qhi_off = (hi + SUBGROUP_SIZE) * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
@@ -1410,6 +1430,26 @@ KERNEL(sdpa_opt)(
                             }
                         }
                     }
+                    // Handle leftover chunk when K_HEAD_SIZE is not a multiple of 2*SUBGROUP_SIZE
+#if (K_HEAD_SIZE % (2 * SUBGROUP_SIZE)) != 0
+                    {
+                        const uint hi = (K_HEAD_SIZE / (2 * SUBGROUP_SIZE)) * (2 * SUBGROUP_SIZE);
+                        QUERY_VEC qvec_lo;
+                        uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
+                        unroll_for (uint q_row = 0; q_row < TARGET_SEQ_LEN_BLOCK_SIZE; q_row++) {
+                            qvec_lo[q_row] = slm_query[qlo];
+                            qlo += TARGET_SEQ_LEN_BLOCK_SIZE;
+                        }
+                        unroll_for (uint key_row_idx = 0; key_row_idx < TARGET_SEQ_LEN_BLOCK_SIZE; key_row_idx++) {
+                            const INPUT1_TYPE packed_byte = KEY_BLOCK_READ(key_input, key_offset + key_row_idx * key_pitch_int4 + hi / 2);
+                            char2 unpacked = unpack_to_char(*(uint4x2_t*)&packed_byte);
+                            KEY_COMPRESSION_SCALE_TYPE key_lo = (TO_KEY_COMPRESSION_SCALE_TYPE(unpacked.s0) - sub_group_broadcast(comp_zp, key_row_idx)) * sub_group_broadcast(comp_scale, key_row_idx);
+                            unroll_for (uint i = 0; i < SUBGROUP_SIZE; i++) {
+                                qk_acc[key_row_idx] = mad(sub_group_broadcast(key_lo, i), qvec_lo[i], qk_acc[key_row_idx]);
+                            }
+                        }
+                    }
+#endif
                 }
 #else  // !IS_INT4_COMPRESSED
                 uint head_idx_index = 0;
@@ -1486,7 +1526,7 @@ KERNEL(sdpa_opt)(
                     #define KEY_BLOCK_READ(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset)
                     #define QUERY_VEC_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, TARGET_SEQ_LEN_BLOCK_SIZE)
                     const uint key_pitch_int4 = K_HEAD_SIZE;
-                    for (uint hi = 0; hi < K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
+                    for (uint hi = 0; hi + 2 * SUBGROUP_SIZE <= K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
                         QUERY_VEC_TYPE qvec_lo, qvec_hi;
                         uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
                         uint qhi_off = (hi + SUBGROUP_SIZE) * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
@@ -1511,6 +1551,29 @@ KERNEL(sdpa_opt)(
                             }
                         }
                     }
+                    // Handle leftover chunk when K_HEAD_SIZE is not a multiple of 2*SUBGROUP_SIZE
+#if (K_HEAD_SIZE % (2 * SUBGROUP_SIZE)) != 0
+                    {
+                        const uint hi = (K_HEAD_SIZE / (2 * SUBGROUP_SIZE)) * (2 * SUBGROUP_SIZE);
+                        QUERY_VEC_TYPE qvec_lo;
+                        uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
+                        unroll_for (uint q_row = 0; q_row < TARGET_SEQ_LEN_BLOCK_SIZE; q_row++) {
+                            qvec_lo[q_row] = slm_query[qlo];
+                            qlo += TARGET_SEQ_LEN_BLOCK_SIZE;
+                        }
+                        unroll_for (uint key_row_idx = 0; key_row_idx < TARGET_SEQ_LEN_BLOCK_SIZE; key_row_idx++) {
+                            KEY_COMPRESSION_SCALE_TYPE key_lo = 0;
+                            if (key_row_idx < seq_len_calc_size) {
+                                const INPUT1_TYPE packed_byte = KEY_BLOCK_READ(key_input, key_offset + key_row_idx * key_pitch_int4 + hi / 2);
+                                char2 unpacked = unpack_to_char(*(uint4x2_t*)&packed_byte);
+                                key_lo = (TO_KEY_COMPRESSION_SCALE_TYPE(unpacked.s0) - sub_group_broadcast(comp_zp, key_row_idx)) * sub_group_broadcast(comp_scale, key_row_idx);
+                            }
+                            unroll_for (uint i = 0; i < SUBGROUP_SIZE; i++) {
+                                qk_acc[key_row_idx] = mad(sub_group_broadcast(key_lo, i), qvec_lo[i], qk_acc[key_row_idx]);
+                            }
+                        }
+                    }
+#endif
                 }
 #else  // !IS_INT4_COMPRESSED
                 uint head_idx_index = 0;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -275,10 +275,10 @@ KERNEL(sdpa_opt)(
 #if IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
     #ifdef INPUT1_DIMS_ORDER
             const uint key_base_p0 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, 0);
-            const uint key_packed_pitch_p0 = (FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0) - key_base_p0) / 2;
+            const uint key_packed_pitch_p0 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0) - key_base_p0;
     #else
             const uint key_base_p0 = INPUT1_GET_INDEX(b0_idx, b1_idx, 0, 0);
-            const uint key_packed_pitch_p0 = K_HEAD_SIZE / 2;
+            const uint key_packed_pitch_p0 = K_HEAD_SIZE;
     #endif
 #endif
             for (uint seq_len = sgid; seq_len < partition_seq_len; seq_len += SUBGROUPS_PER_WG) {
@@ -724,13 +724,13 @@ KERNEL(sdpa_opt)(
         uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, 0);
         uint value_offset_next_seq = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0);
     #if IS_INT4_COMPRESSED
-        const uint value_pitch = (value_offset_next_seq - value_offset) / 2;
+        const uint value_pitch = value_offset_next_seq - value_offset;
     #else
         const uint value_pitch = value_offset_next_seq - value_offset;
     #endif
 #else
     #if IS_INT4_COMPRESSED
-        const uint value_pitch = V_HEAD_SIZE / 2;
+        const uint value_pitch = V_HEAD_SIZE;
     #else
         const uint value_pitch = V_HEAD_SIZE;
     #endif
@@ -1311,10 +1311,10 @@ KERNEL(sdpa_opt)(
 #if IS_INT4_COMPRESSED && !defined(IS_PAGED_ATTENTION) && !defined(BEAM_TABLE_TYPE)
     #ifdef INPUT1_DIMS_ORDER
     const uint key_base_s1 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, 0);
-    const uint key_packed_pitch_s1 = (FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0) - key_base_s1) / 2;
+    const uint key_packed_pitch_s1 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0) - key_base_s1;
     #else
     const uint key_base_s1 = INPUT1_GET_INDEX(b0_idx, b1_idx, 0, 0);
-    const uint key_packed_pitch_s1 = K_HEAD_SIZE / 2;
+    const uint key_packed_pitch_s1 = K_HEAD_SIZE;
     #endif
 #endif
 
@@ -1388,7 +1388,7 @@ KERNEL(sdpa_opt)(
                     // INT4: process 2*SUBGROUP_SIZE logical head dims per iteration (one packed byte per lane per token row)
                     #define KEY_BLOCK_READ(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset);
                     #define QUERY_VEC MAKE_VECTOR_TYPE(INPUT0_TYPE, TARGET_SEQ_LEN_BLOCK_SIZE)
-                    const uint key_pitch_int4 = K_HEAD_SIZE / 2;
+                    const uint key_pitch_int4 = K_HEAD_SIZE;
                     for (uint hi = 0; hi < K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
                         QUERY_VEC qvec_lo, qvec_hi;
                         uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
@@ -1485,7 +1485,7 @@ KERNEL(sdpa_opt)(
                     // INT4 partial block: process 2*SUBGROUP_SIZE logical head dims per iteration
                     #define KEY_BLOCK_READ(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset)
                     #define QUERY_VEC_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, TARGET_SEQ_LEN_BLOCK_SIZE)
-                    const uint key_pitch_int4 = K_HEAD_SIZE / 2;
+                    const uint key_pitch_int4 = K_HEAD_SIZE;
                     for (uint hi = 0; hi < K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
                         QUERY_VEC_TYPE qvec_lo, qvec_hi;
                         uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
@@ -1871,13 +1871,13 @@ KERNEL(sdpa_opt)(
             uint value_offset_base = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, 0);
             uint value_offset_next_seq = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0);
     #if IS_INT4_COMPRESSED
-            const uint value_pitch = (value_offset_next_seq - value_offset_base) / 2;
+            const uint value_pitch = value_offset_next_seq - value_offset_base;
     #else
             const uint value_pitch = value_offset_next_seq - value_offset_base;
     #endif
 #else
     #if IS_INT4_COMPRESSED
-            const uint value_pitch = V_HEAD_SIZE / 2;
+            const uint value_pitch = V_HEAD_SIZE;
     #else
             const uint value_pitch = V_HEAD_SIZE;
     #endif

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -272,6 +272,15 @@ KERNEL(sdpa_opt)(
             // Main Gemm1 calculation loop
             // Each SG performs element-wise multiplications of Q[HEAD_SIZE]xK[HEAD_SIZE] values
             // HEAD_SIZE / SUBGROUPS_PER_WG times in the loop and saves the result to the qk_local SLM buffer
+#if IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+    #ifdef INPUT1_DIMS_ORDER
+            const uint key_base_p0 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, 0);
+            const uint key_packed_pitch_p0 = (FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0) - key_base_p0) / 2;
+    #else
+            const uint key_base_p0 = INPUT1_GET_INDEX(b0_idx, b1_idx, 0, 0);
+            const uint key_packed_pitch_p0 = K_HEAD_SIZE / 2;
+    #endif
+#endif
             for (uint seq_len = sgid; seq_len < partition_seq_len; seq_len += SUBGROUPS_PER_WG) {
 #ifdef BEAM_TABLE_TYPE
                 const uint b_idx = beam_table[FUNC_CALL(get_bt_index_key)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + seq_len, 0)];
@@ -279,7 +288,9 @@ KERNEL(sdpa_opt)(
                 const uint b_idx = b0_idx;
 #endif
 
-#ifdef INPUT1_DIMS_ORDER
+#if IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+                uint key_offset = key_base_p0 + (start_partition_idx + seq_len) * key_packed_pitch_p0;
+#elif defined(INPUT1_DIMS_ORDER)
                 uint key_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + seq_len, 0);
 #else
                 uint key_offset = INPUT1_GET_INDEX(b_idx, b1_idx, start_partition_idx + seq_len, 0);
@@ -712,15 +723,28 @@ KERNEL(sdpa_opt)(
 #ifdef INPUT2_DIMS_ORDER
         uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, 0);
         uint value_offset_next_seq = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0);
+    #if IS_INT4_COMPRESSED
+        const uint value_pitch = (value_offset_next_seq - value_offset) / 2;
+    #else
         const uint value_pitch = value_offset_next_seq - value_offset;
+    #endif
 #else
-#if IS_INT4_COMPRESSED
-        // INT4: GET_INDEX returns element-level offsets; rows are V_HEAD_SIZE apart
+    #if IS_INT4_COMPRESSED
+        const uint value_pitch = V_HEAD_SIZE / 2;
+    #else
         const uint value_pitch = V_HEAD_SIZE;
-#else
-        const uint value_pitch = V_HEAD_SIZE;
+    #endif
 #endif
 #endif
+
+#if IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+        const uint val_packed_x = (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE;
+        const uint order_in_packed_p0 = (head_size_idx / SUBGROUP_SIZE) & 1;
+    #ifdef INPUT2_DIMS_ORDER
+        const uint value_base_p0 = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, val_packed_x);
+    #else
+        const uint value_base_p0 = INPUT2_GET_INDEX(b0_idx, b1_idx, 0, val_packed_x);
+    #endif
 #endif
 
 #if SG_SCALE_FACTOR > 1
@@ -738,20 +762,12 @@ KERNEL(sdpa_opt)(
 #else
             const uint b_idx = b0_idx;
     #if IS_INT4_COMPRESSED
-                const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
-    #endif
-    #ifdef INPUT2_DIMS_ORDER
-        #if IS_INT4_COMPRESSED
-                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
-        #else
-                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
-        #endif
+                const uint order_in_packed = order_in_packed_p0;
+                uint value_offset = value_base_p0 + (start_partition_idx + (seq_len * SUBGROUP_SIZE)) * value_pitch;
+    #elif defined(INPUT2_DIMS_ORDER)
+                uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
     #else
-        #if IS_INT4_COMPRESSED
-                    uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
-        #else
-                    uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
-        #endif
+                uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
     #endif
 #endif
 
@@ -811,21 +827,13 @@ KERNEL(sdpa_opt)(
             const uint b_idx = b0_idx;
 #endif
 
-#if IS_INT4_COMPRESSED
-            const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
-#endif
-#ifdef INPUT2_DIMS_ORDER
-#if IS_INT4_COMPRESSED
-            const uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + seq_len, (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
-#else
+#if IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+            const uint order_in_packed = order_in_packed_p0;
+            const uint value_offset = value_base_p0 + (start_partition_idx + seq_len) * value_pitch;
+#elif defined(INPUT2_DIMS_ORDER)
             const uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + seq_len, head_size_idx);
-#endif
-#else
-#if IS_INT4_COMPRESSED
-            const uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + seq_len, (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
 #else
             const uint value_offset = INPUT2_GET_INDEX(b_idx, b1_idx, start_partition_idx + seq_len, head_size_idx);
-#endif
 #endif
 
 #if IS_KV_COMPRESSED
@@ -1300,6 +1308,16 @@ KERNEL(sdpa_opt)(
     // Q*K calculation loop
     MAKE_VECTOR_TYPE(OUTPUT_TYPE, TARGET_SEQ_LEN_BLOCK_SIZE) output_acc = OUTPUT_VAL_ZERO;
 
+#if IS_INT4_COMPRESSED && !defined(IS_PAGED_ATTENTION) && !defined(BEAM_TABLE_TYPE)
+    #ifdef INPUT1_DIMS_ORDER
+    const uint key_base_s1 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, 0);
+    const uint key_packed_pitch_s1 = (FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0) - key_base_s1) / 2;
+    #else
+    const uint key_base_s1 = INPUT1_GET_INDEX(b0_idx, b1_idx, 0, 0);
+    const uint key_packed_pitch_s1 = K_HEAD_SIZE / 2;
+    #endif
+#endif
+
     __attribute__((opencl_unroll_hint(1)))
     for (uint start_partition_idx = 0; start_partition_idx < SOURCE_SEQ_LEN; start_partition_idx += SEQ_LEN_PARTITION_SIZE) {
         const uint seq_len = start_partition_idx + sgid * SUBGROUP_SIZE;
@@ -1331,7 +1349,10 @@ KERNEL(sdpa_opt)(
             const uint key_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, seq_len + sglid, 0);
 #else
             const uint b_idx = b0_idx;
-    #ifdef INPUT1_DIMS_ORDER
+    #if IS_INT4_COMPRESSED
+            uint key_offset = key_base_s1 + seq_len * key_packed_pitch_s1;
+            const uint key_pitch = key_packed_pitch_s1;
+    #elif defined(INPUT1_DIMS_ORDER)
             uint key_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, seq_len, 0);
             uint key_offset_next_seq = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, seq_len + 1, 0);
             const uint key_pitch = key_offset_next_seq - key_offset;
@@ -1367,7 +1388,7 @@ KERNEL(sdpa_opt)(
                     // INT4: process 2*SUBGROUP_SIZE logical head dims per iteration (one packed byte per lane per token row)
                     #define KEY_BLOCK_READ(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset);
                     #define QUERY_VEC MAKE_VECTOR_TYPE(INPUT0_TYPE, TARGET_SEQ_LEN_BLOCK_SIZE)
-                    const uint key_pitch_int4 = K_HEAD_SIZE;
+                    const uint key_pitch_int4 = K_HEAD_SIZE / 2;
                     for (uint hi = 0; hi < K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
                         QUERY_VEC qvec_lo, qvec_hi;
                         uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
@@ -1464,7 +1485,7 @@ KERNEL(sdpa_opt)(
                     // INT4 partial block: process 2*SUBGROUP_SIZE logical head dims per iteration
                     #define KEY_BLOCK_READ(ptr, offset) BLOCK_READN(INPUT1_TYPE, 1, ptr, offset)
                     #define QUERY_VEC_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, TARGET_SEQ_LEN_BLOCK_SIZE)
-                    const uint key_pitch_int4 = K_HEAD_SIZE;
+                    const uint key_pitch_int4 = K_HEAD_SIZE / 2;
                     for (uint hi = 0; hi < K_HEAD_SIZE; hi += 2 * SUBGROUP_SIZE) {
                         QUERY_VEC_TYPE qvec_lo, qvec_hi;
                         uint qlo = hi * TARGET_SEQ_LEN_BLOCK_SIZE + sglid;
@@ -1849,15 +1870,28 @@ KERNEL(sdpa_opt)(
 #ifdef INPUT2_DIMS_ORDER
             uint value_offset_base = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, 0);
             uint value_offset_next_seq = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 1, 0);
+    #if IS_INT4_COMPRESSED
+            const uint value_pitch = (value_offset_next_seq - value_offset_base) / 2;
+    #else
             const uint value_pitch = value_offset_next_seq - value_offset_base;
+    #endif
 #else
-#if IS_INT4_COMPRESSED
-            // INT4: GET_INDEX returns element-level offsets; rows are V_HEAD_SIZE apart
+    #if IS_INT4_COMPRESSED
+            const uint value_pitch = V_HEAD_SIZE / 2;
+    #else
             const uint value_pitch = V_HEAD_SIZE;
-#else
-            const uint value_pitch = V_HEAD_SIZE;
+    #endif
 #endif
 #endif
+
+#if IS_INT4_COMPRESSED && !defined(IS_PAGED_ATTENTION) && !defined(BEAM_TABLE_TYPE)
+            const uint val_packed_x_s1 = (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE;
+            const uint order_in_packed_s1 = (head_size_idx / SUBGROUP_SIZE) & 1;
+    #ifdef INPUT2_DIMS_ORDER
+            const uint value_base_s1 = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, 0, val_packed_x_s1);
+    #else
+            const uint value_base_s1 = INPUT2_GET_INDEX(b0_idx, b1_idx, 0, val_packed_x_s1);
+    #endif
 #endif
 
             if (partition_seq_len == SEQ_LEN_PARTITION_SIZE) {
@@ -1881,20 +1915,12 @@ KERNEL(sdpa_opt)(
 #else
                     const uint b_idx = b0_idx;
     #if IS_INT4_COMPRESSED
-                    const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
-    #endif
-    #ifdef INPUT2_DIMS_ORDER
-    #if IS_INT4_COMPRESSED
-                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (seq_len), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
-    #else
+                    const uint order_in_packed = order_in_packed_s1;
+                    uint value_offset = value_base_s1 + (start_partition_idx + (seq_len)) * value_pitch;
+    #elif defined(INPUT2_DIMS_ORDER)
                     uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (seq_len), head_size_idx);
-    #endif
-    #else
-    #if IS_INT4_COMPRESSED
-                    uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + (seq_len), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
     #else
                     uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + (seq_len), head_size_idx);
-    #endif
     #endif
 #endif
 #endif
@@ -1997,20 +2023,12 @@ KERNEL(sdpa_opt)(
                 #else
                     const uint b_idx = b0_idx;
                 #if IS_INT4_COMPRESSED
-                    const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
-                #endif
-                #ifdef INPUT2_DIMS_ORDER
-                #if IS_INT4_COMPRESSED
-                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
-                #else
+                    const uint order_in_packed = order_in_packed_s1;
+                    uint value_offset = value_base_s1 + (start_partition_idx + (seq_len * SUBGROUP_SIZE)) * value_pitch;
+                #elif defined(INPUT2_DIMS_ORDER)
                     uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
-                #endif
-                #else
-                #if IS_INT4_COMPRESSED
-                    uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
                 #else
                     uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
-                #endif
                 #endif
             #endif
 #endif
@@ -2118,20 +2136,12 @@ KERNEL(sdpa_opt)(
 #else
                     const uint b_idx = b0_idx;
     #if IS_INT4_COMPRESSED
-                    const uint order_in_packed = (head_size_idx / SUBGROUP_SIZE) & 1;
-    #endif
-    #ifdef INPUT2_DIMS_ORDER
-    #if IS_INT4_COMPRESSED
-                    uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + seq_len_leftovers_start, (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
-    #else
+                    const uint order_in_packed = order_in_packed_s1;
+                    uint value_offset = value_base_s1 + (start_partition_idx + seq_len_leftovers_start) * value_pitch;
+    #elif defined(INPUT2_DIMS_ORDER)
                     uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + seq_len_leftovers_start, head_size_idx);
-    #endif
-    #else
-    #if IS_INT4_COMPRESSED
-                    uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + seq_len_leftovers_start, (head_size_idx / (2 * SUBGROUP_SIZE)) * SUBGROUP_SIZE);
     #else
                     uint value_offset = INPUT2_GET_INDEX(b0_idx, b1_idx, start_partition_idx + seq_len_leftovers_start, head_size_idx);
-    #endif
     #endif
 #endif
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
@@ -3,12 +3,14 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
-#include "include/batch_headers/fetch_data.cl"
 #include "include/batch_headers/common.cl"
+#include "include/batch_headers/int4_utils.cl"
 #include "include/batch_headers/sub_group_block_read.cl"
 #include "include/batch_headers/sub_group_block_write.cl"
 #include "include/batch_headers/sub_group_shuffle.cl"
 
+
+#define UINT4_RANGE 15
 
 #if OUTPUT_DIMS != 4
 #error "dynamic_quantize_gpu_kv_cache.cl: Unsupported output dimension"
@@ -73,16 +75,52 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
     const uint input_offset = INPUT0_GET_INDEX(b, f, y, x);
     unroll_for (uint i = 0; i < INNERMOST_DIM_VALUE / SUBGROUP_SIZE; i++) {
         val[i] = INPUT_BLOCK_READ(input, input_offset + i * SUBGROUP_SIZE);
-#if ASYMMETRIC_QUANTIZATION
+#if ASYMMETRIC_QUANTIZATION || IS_INT4_COMPRESSED
         max_value = fmax(max_value, val[i]);
         min_value = fmin(min_value, val[i]);
 #else
         max_value = fmax(max_value, fabs(val[i]));
 #endif
     }
-#if !ASYMMETRIC_QUANTIZATION
+#if !ASYMMETRIC_QUANTIZATION && !IS_INT4_COMPRESSED
     max_value = fmax(max_value, grp_max);
 #endif
+
+#ifdef APPEND_MODE
+    APPEND_AXIS_NAME += axis_offset;
+#endif
+
+#if IS_INT4_COMPRESSED
+    // 4-bit unsigned asymmetric quantization: map [min, max] to [0, 15].
+    // Two INT4 values are packed per byte using SUBGROUP_SIZE-stride grouping:
+    //   output byte at physical offset (k * SUBGROUP_SIZE + sglid) holds:
+    //     lo nibble = quantized val[(2k)   * SUBGROUP_SIZE + sglid]
+    //     hi nibble = quantized val[(2k+1) * SUBGROUP_SIZE + sglid]
+    min_value = work_group_reduce_min(min_value);
+    max_value = work_group_reduce_max(max_value);
+
+    ACCUMULATOR_TYPE diff_value = max_value == min_value ? (ACCUMULATOR_TYPE)(grp_max)
+                                                         : (ACCUMULATOR_TYPE)(max_value - min_value);
+    ACCUMULATOR_TYPE scale_tmp = (ACCUMULATOR_TYPE)((UINT4_RANGE) / diff_value);
+    ACCUMULATOR_TYPE zp_tmp    = (ACCUMULATOR_TYPE)(-min_value * scale_tmp); // maps min -> 0, max -> UINT4_RANGE
+
+    const uint output_offset = OUTPUT_GET_INDEX(b, f, y, x);
+    // Pairs of consecutive SUBGROUP_SIZE blocks are packed together.
+    unroll_for (uint i = 0; i < INNERMOST_DIM_VALUE / SUBGROUP_SIZE; i += 2) {
+        uchar q0 = (uchar)clamp(convert_int_rte((float)val[i]     * scale_tmp + zp_tmp), 0, UINT4_RANGE);
+        uchar q1 = (uchar)clamp(convert_int_rte((float)val[i + 1] * scale_tmp + zp_tmp), 0, UINT4_RANGE);
+        // Pack: lo nibble = q0, hi nibble = q1
+        char packed = cvt_uint8x2_to_uint4x2((uchar2)(q0, q1));
+        OUTPUT_BLOCK_WRITE(output, output_offset + (i / 2) * SUBGROUP_SIZE, packed);
+    }
+
+    const uint scale_idx = FUNC_CALL(get_scales_offset)(OPTIONAL_SHAPE_INFO_TENSOR b, f, y, x);
+    if (grouped_indexes == 0 && sglid == 0) {
+        output_scale[scale_idx]     = (OUTPUT1_TYPE)(1.0f / scale_tmp); // dequant scale
+        output_scale[scale_idx + 1] = (OUTPUT1_TYPE)(zp_tmp);           // zero-point
+    }
+
+#else  // !IS_INT4_COMPRESSED — original INT8 path
 
 #if ASYMMETRIC_QUANTIZATION
     min_value = work_group_reduce_min(min_value);
@@ -98,10 +136,6 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
 #else
     max_value = work_group_reduce_max(max_value);
     OUTPUT1_TYPE scale = 127.0h / max_value;
-#endif
-
-#ifdef APPEND_MODE
-    APPEND_AXIS_NAME += axis_offset;
 #endif
 
     const uint output_offset = OUTPUT_GET_INDEX(b, f, y, x);
@@ -134,4 +168,6 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
         output_scale[scale_idx] = 1.0h / scale;
 #endif
     }
+
+#endif  // IS_INT4_COMPRESSED
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
@@ -134,7 +134,15 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
     const uint scale_idx = FUNC_CALL(get_scales_offset)(OPTIONAL_SHAPE_INFO_TENSOR b, f, y, x);
     if (grouped_indexes == 0 && sglid == 0) {
         output_scale[scale_idx]     = (OUTPUT1_TYPE)(1.0f / scale_tmp); // dequant scale
-        output_scale[scale_idx + 1] = (OUTPUT1_TYPE)(zp_tmp);           // zero-point
+#if ASYMMETRIC_QUANTIZATION && !GROUP_SCALES_WITH_ZP
+    #if OUTPUT2_IS_FP
+        output_zp[scale_idx] = (OUTPUT2_TYPE)(zp_tmp);
+    #else
+        output_zp[scale_idx] = convert_char_rte(zp_tmp);
+    #endif
+#else
+        output_scale[scale_idx + 1] = (OUTPUT1_TYPE)(zp_tmp);           // zero-point (interleaved)
+#endif
     }
 
 #else  // !IS_INT4_COMPRESSED — original INT8 path

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
@@ -109,13 +109,27 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
     // can address rows with the standard GET_INDEX pitch.
     const uint output_offset = OUTPUT_GET_INDEX(b, f, y, x);
     // Pairs of consecutive SUBGROUP_SIZE blocks are packed together.
-    unroll_for (uint i = 0; i < INNERMOST_DIM_VALUE / SUBGROUP_SIZE; i += 2) {
+    // Process complete pairs first (handles HEAD_SIZE that is multiple of 2*SUBGROUP_SIZE).
+#define NUM_SUBGROUP_CHUNKS (INNERMOST_DIM_VALUE / SUBGROUP_SIZE)
+#define NUM_FULL_PAIRS (NUM_SUBGROUP_CHUNKS / 2)
+    unroll_for (uint i = 0; i < NUM_FULL_PAIRS * 2; i += 2) {
         uchar q0 = (uchar)clamp(convert_int_rte((float)val[i]     * scale_tmp + zp_tmp), 0, UINT4_RANGE);
         uchar q1 = (uchar)clamp(convert_int_rte((float)val[i + 1] * scale_tmp + zp_tmp), 0, UINT4_RANGE);
         // Pack: lo nibble = q0, hi nibble = q1
         char packed = cvt_uint8x2_to_uint4x2((uchar2)(q0, q1));
         OUTPUT_BLOCK_WRITE(output, output_offset + (i / 2) * SUBGROUP_SIZE, packed);
     }
+#if (NUM_SUBGROUP_CHUNKS % 2) != 0
+    // Handle the last odd chunk: pack low nibble only, zero-pad high nibble.
+    {
+        const uint i = NUM_FULL_PAIRS * 2;
+        uchar q0 = (uchar)clamp(convert_int_rte((float)val[i] * scale_tmp + zp_tmp), 0, UINT4_RANGE);
+        char packed = cvt_uint8x2_to_uint4x2((uchar2)(q0, 0));
+        OUTPUT_BLOCK_WRITE(output, output_offset + (i / 2) * SUBGROUP_SIZE, packed);
+    }
+#endif
+#undef NUM_SUBGROUP_CHUNKS
+#undef NUM_FULL_PAIRS
 
     const uint scale_idx = FUNC_CALL(get_scales_offset)(OPTIONAL_SHAPE_INFO_TENSOR b, f, y, x);
     if (grouped_indexes == 0 && sglid == 0) {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
@@ -104,7 +104,9 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
     ACCUMULATOR_TYPE scale_tmp = (ACCUMULATOR_TYPE)((UINT4_RANGE) / diff_value);
     ACCUMULATOR_TYPE zp_tmp    = (ACCUMULATOR_TYPE)(-min_value * scale_tmp); // maps min -> 0, max -> UINT4_RANGE
 
-    const uint output_offset = OUTPUT_GET_INDEX(b, f, y, x);
+    // INT4 packed buffer: the output layout uses i8 with full head_size shape,
+    // so divide by 2 to get the correct packed byte offset (2 INT4 values per byte).
+    const uint output_offset = OUTPUT_GET_INDEX(b, f, y, x) / 2;
     // Pairs of consecutive SUBGROUP_SIZE blocks are packed together.
     unroll_for (uint i = 0; i < INNERMOST_DIM_VALUE / SUBGROUP_SIZE; i += 2) {
         uchar q0 = (uchar)clamp(convert_int_rte((float)val[i]     * scale_tmp + zp_tmp), 0, UINT4_RANGE);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
@@ -104,9 +104,10 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
     ACCUMULATOR_TYPE scale_tmp = (ACCUMULATOR_TYPE)((UINT4_RANGE) / diff_value);
     ACCUMULATOR_TYPE zp_tmp    = (ACCUMULATOR_TYPE)(-min_value * scale_tmp); // maps min -> 0, max -> UINT4_RANGE
 
-    // INT4 packed buffer: the output layout uses i8 with full head_size shape,
-    // so divide by 2 to get the correct packed byte offset (2 INT4 values per byte).
-    const uint output_offset = OUTPUT_GET_INDEX(b, f, y, x) / 2;
+    // INT4 packed buffer: the output layout uses i8 with full head_size shape.
+    // Use element-level offset directly (same stride as layout) so that SDPA
+    // can address rows with the standard GET_INDEX pitch.
+    const uint output_offset = OUTPUT_GET_INDEX(b, f, y, x);
     // Pairs of consecutive SUBGROUP_SIZE blocks are packed together.
     unroll_for (uint i = 0; i < INNERMOST_DIM_VALUE / SUBGROUP_SIZE; i += 2) {
         uchar q0 = (uchar)clamp(convert_int_rte((float)val[i]     * scale_tmp + zp_tmp), 0, UINT4_RANGE);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt_kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt_kv_cache.cpp
@@ -88,6 +88,9 @@ ParamsKey DynamicQuantizeKernelKVCache::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::INT8);
+    k.EnableOutputDataType(Datatype::UINT8);
+    k.EnableOutputDataType(Datatype::INT4);
+    k.EnableOutputDataType(Datatype::UINT4);
     k.EnableDifferentTypes();
     k.EnableAllInputLayout();
     k.EnableAllOutputLayout();
@@ -141,6 +144,7 @@ JitConstants DynamicQuantizeKernelKVCache::GetJitConstants(const dynamic_quantiz
     jit.AddConstant(MakeJitConstant("ITERATIONS_NUMBER", iterations_number));
     jit.AddConstant(MakeJitConstant("ASYMMETRIC_QUANTIZATION", params.use_asymmetric_quantization));
     jit.AddConstant(MakeJitConstant("GROUP_SCALES_WITH_ZP", params.combine_scales_and_zp));
+    jit.AddConstant(MakeJitConstant("IS_INT4_COMPRESSED", params.is_int4_compressed));
 
     // Use FP32 accumulator type for scale/zp calculation
     jit.Merge(MakeTypeJitConstants(Datatype::F32, "ACCUMULATOR"));
@@ -183,6 +187,19 @@ CommonDispatchData DynamicQuantizeKernelKVCache::SetDefault(const dynamic_quanti
     const auto total_batched_elements = get_elements_number_per_batch(params);
     const auto total_grouped_elements = get_elements_number_per_group(params);
     const auto total_subgroups_number = total_grouped_elements / input_dims.back().v;
+
+    // [DEBUG]
+    // {
+    //     size_t total_elements_number = 1;
+    //     const auto& group_sizes = params.group_sizes;
+    //     for (size_t i = 0; i < group_sizes.size(); i++) {
+    //         if (group_sizes[i] != UINT64_MAX) {
+    //             total_elements_number *= input_dims[i].v;
+    //         }
+    //     }
+    //     std::cout << "  >> group_sizes : " << group_sizes[0] << ", " << group_sizes[1] << ", " << group_sizes[2] << ", " << group_sizes[3]
+    //                 << " => total_elements_number : " << total_elements_number << ", total_batched_elements : " << total_batched_elements << std::endl;
+    // }
 
     dispatchData.gws = {subgroup_size, total_subgroups_number, total_batched_elements};
     dispatchData.lws = {subgroup_size, total_subgroups_number, 1};

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_ref.h
@@ -21,6 +21,7 @@ struct dynamic_quantize_params : public base_params {
     bool use_asymmetric_quantization = false;
     bool combine_scales_and_zp = false;
     bool generate_precomputed_reduction = false;
+    bool is_int4_compressed = false;
 };
 
 class DynamicQuantizeKernelRef : public KernelBaseOpenCL {

--- a/src/plugins/intel_gpu/src/plugin/multi_tensor_variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/multi_tensor_variable_state.cpp
@@ -165,9 +165,11 @@ VariableStateIndirectKVCacheCompressed::VariableStateIndirectKVCacheCompressed(
     const std::vector<cldnn::layout>& output_layouts,
     size_t beam_idx,
     size_t concat_idx,
-    bool has_zp_state = false)
+    bool has_zp_state,
+    bool is_4bit_kv_cache)
     : VariableStateIndirectKVCache(info, context, shape_predictor, beam_idx, concat_idx),
-      m_has_zp_state(has_zp_state) {
+      m_has_zp_state(has_zp_state),
+      m_is_4bit_kv_cache(is_4bit_kv_cache) {
     OPENVINO_ASSERT((has_zp_state && output_layouts.size() == 3) ||
                     (!has_zp_state && output_layouts.size() == 2),
                     "[GPU] Unexpected number of output layouts for VariableStateIndirectKVCacheCompressed");
@@ -185,6 +187,12 @@ VariableStateIndirectKVCacheCompressed::VariableStateIndirectKVCacheCompressed(
     OPENVINO_ASSERT((!m_has_zp_state && m_hidden_states.size() == 3) || (m_has_zp_state && m_hidden_states.size() == 4),
                     "[GPU] VariableStateIndirectKVCacheCompressed expects 3 or 4 internal states to be initialized, "
                     "actual number is ", m_hidden_states.size());
+
+    // For 4-bit KV-cache, two INT4 values are packed per byte.
+    // Halve the innermost dim of the allocation to reduce physical memory usage.
+    if (m_is_4bit_kv_cache) {
+        m_hidden_states[0]->set_alloc_inner_dim_divisor(2);
+    }
 }
 
 VariableState::Ptr VariableStateIndirectKVCacheCompressed::get_compression_scale_state() const {

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -745,13 +745,16 @@ void SyncInferRequest::allocate_states() {
         }
 
         if (compressed) {
+            const auto kv_precision = m_graph->get_config().get_kv_cache_precision();
+            const bool is_4bit_kv_cache = ov::element::Type(kv_precision).bitwidth() == 4;
             m_variables.emplace(vi.first, std::make_shared<VariableStateIndirectKVCacheCompressed>(vi.second,
                                                                                                    m_context,
                                                                                                    m_shape_predictor,
                                                                                                    states_layouts,
                                                                                                    beam_axis,
                                                                                                    concat_axis,
-                                                                                                   has_zp_state));
+                                                                                                   has_zp_state,
+                                                                                                   is_4bit_kv_cache));
         } else if (indirect_kv_cache) {
             m_variables.emplace(vi.first, std::make_shared<VariableStateIndirectKVCache>(vi.second,
                                                                                          m_context,

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/kv_cache.cpp
@@ -4,6 +4,7 @@
 
 #include "intel_gpu/op/kv_cache.hpp"
 #include "intel_gpu/op/kv_cache_compressed.hpp"
+#include "intel_gpu/runtime/utils.hpp"
 #include "gather_shape_inference.hpp"
 #include "concat_shape_inference.hpp"
 #include "openvino/core/partial_shape.hpp"
@@ -207,8 +208,8 @@ KVCacheCompressed::KVCacheCompressed(const OutputVector& inputs,
     : KVCache(inputs, past_variable, true, trim, concat_axis, gather_axis, output_type)
     , m_compressed(true)
     , m_quantization_attrs(quantization_attrs) {
-    OPENVINO_ASSERT(quantization_attrs.quantization_dt == ov::element::i8,
-                    "[GPU] Only I8 data type is currently supported for KV-cache compression");
+    OPENVINO_ASSERT(cldnn::one_of(quantization_attrs.quantization_dt , {element::i8, element::i4, element::u4}),
+                    "[GPU] data type is currently not supported for KV-cache compression");
 
     m_variable = past_variable;
     size_t output_size = 3;

--- a/src/plugins/intel_gpu/src/plugin/variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/variable_state.cpp
@@ -119,10 +119,21 @@ void VariableState::update_device_buffer() {
         const auto alloc_type = m_context->get_engine().use_unified_shared_memory() ? cldnn::allocation_type::usm_device : cldnn::allocation_type::cl_mem;
         const auto current_buf_size = m_layout.get_padded_dims();
         ov::Shape current_shape(current_buf_size.begin(), current_buf_size.end());
-        const auto alloc_shape = predict_shape(m_name, cldnn::layout(current_shape, m_layout.data_type, m_layout.format), *m_shape_predictor);
-        const auto alloc_layout = cldnn::layout(alloc_shape, m_layout.data_type, m_layout.format);
-        m_memory = m_context->get_engine().allocate_memory(alloc_layout, alloc_type, false);
-        actual_size = std::max(actual_size, alloc_layout.bytes_count());
+        auto alloc_shape = predict_shape(m_name, cldnn::layout(current_shape, m_layout.data_type, m_layout.format), *m_shape_predictor);
+
+        // For INT4 packed KV-cache, halve the innermost dim to reduce physical allocation.
+        // actual_size tracks LOGICAL capacity (un-halved) for correct max_pad calculations.
+        if (m_alloc_inner_dim_divisor > 1 && !alloc_shape.empty()) {
+            auto logical_alloc_shape = alloc_shape;
+            alloc_shape.back() /= m_alloc_inner_dim_divisor;
+            const auto alloc_layout = cldnn::layout(alloc_shape, m_layout.data_type, m_layout.format);
+            m_memory = m_context->get_engine().allocate_memory(alloc_layout, alloc_type, false);
+            actual_size = std::max(actual_size, cldnn::layout(logical_alloc_shape, m_layout.data_type, m_layout.format).bytes_count());
+        } else {
+            const auto alloc_layout = cldnn::layout(alloc_shape, m_layout.data_type, m_layout.format);
+            m_memory = m_context->get_engine().allocate_memory(alloc_layout, alloc_type, false);
+            actual_size = std::max(actual_size, alloc_layout.bytes_count());
+        }
     }
 
     OPENVINO_ASSERT(m_memory != nullptr, "m_memory is nullptr!!!");


### PR DESCRIPTION
### Details:
Enable 4bit KV-cache compression of SDPA backend for peak memory reduction
Pass WWB accuracy check, no performance regression by this feature

### Reproduction step and snapshot
- Can be reproduced by wwb.py
`python openvino.genai/tools/who_what_benchmark/whowhatbench/wwb.py --genai --ov-config enable_sdpa_cache_u4.json --target-model models/WW50_llm/glm-4-9b-chat-hf/pytorch/ov/OV_FP16-4BIT_DEFAULT --device GPU --num-samples 100 --gt-data gt-data/glm-4-9b-chat-hf__NAT/reference.csv`
- `cat enable_sdpa_cache_u4.json`
`
{
    "ATTENTION_BACKEND": "SDPA",
    "KV_CACHE_PRECISION": "u4"
}
`

### Tickets:
 - CVS-182251

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).
    Resolved invalid indexing issue by code static analyzing
    Code clean up by merging seperate int4 KV-cache kernel code to legacy sdpa_opt kernel
