### PR TITLE
[NPUW] Add timestamps to LLM execution profiling

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -231,6 +231,7 @@ ov::npuw::LLMInferRequest::LLMInferRequest(const std::shared_ptr<ov::npuw::LLMCo
     m_generate_initialized = false;
 
     m_llm_profile.report_on_die = ov::npuw::profiling_enabled();
+    m_llm_profile.emit_timestamps = ov::npuw::profiling_enabled();
     m_llm_profile.area = "LLM/execution";
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
@@ -133,7 +133,7 @@ public:
 #else
             localtime_r(&start_tt, &start_tm);
 #endif
-            LOG_INFO("PROF " << name << " START @ " << std::put_time(&start_tm, "%H:%M:%S") << "."
+            LOG_INFO("PROF " << name << " START @ " << std::put_time(&start_tm, "%Y-%m-%dT%H:%M:%S") << "."
                              << std::setfill('0') << std::setw(6) << (start_us % 1000000));
             auto sample_ms = U::sample(f);
             *this += std::move(sample_ms);
@@ -147,7 +147,7 @@ public:
 #else
             localtime_r(&end_tt, &end_tm);
 #endif
-            LOG_INFO("PROF " << name << " END   @ " << std::put_time(&end_tm, "%H:%M:%S") << "."
+            LOG_INFO("PROF " << name << " END   @ " << std::put_time(&end_tm, "%Y-%m-%dT%H:%M:%S") << "."
                              << std::setfill('0') << std::setw(6) << (end_us % 1000000) << " (took "
                              << std::fixed << std::setprecision(3) << ((end_us - start_us) / 1000.0)
                              << " ms)");

--- a/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
@@ -73,6 +73,9 @@ public:
     metric() = default;
     metric(metric&& m)
         : records(std::move(m.records)),
+          vmin(m.vmin),
+          vmax(m.vmax),
+          total(m.total),
           name(std::move(m.name)),
           enabled(m.enabled),
           emit_timestamps(m.emit_timestamps) {}
@@ -117,24 +120,33 @@ public:
     void record(F&& f) {
         if (!enabled) {
             f();
-        } else if (!emit_timestamps) {
+        } else if (!emit_timestamps || ov::npuw::get_log_level() < ov::npuw::LogLevel::Info) {
             *this += U::sample(f);
         } else {
             auto t_start = std::chrono::system_clock::now();
-            auto start_us = std::chrono::duration_cast<std::chrono::microseconds>(
-                                t_start.time_since_epoch())
-                                .count();
+            auto start_us =
+                std::chrono::duration_cast<std::chrono::microseconds>(t_start.time_since_epoch()).count();
             std::time_t start_tt = std::chrono::system_clock::to_time_t(t_start);
-            std::tm start_tm = *std::localtime(&start_tt);
+            std::tm start_tm{};
+#ifdef _WIN32
+            localtime_s(&start_tm, &start_tt);
+#else
+            localtime_r(&start_tt, &start_tm);
+#endif
             LOG_INFO("PROF " << name << " START @ " << std::put_time(&start_tm, "%H:%M:%S") << "."
                              << std::setfill('0') << std::setw(6) << (start_us % 1000000));
-            *this += U::sample(f);
+            auto sample_ms = U::sample(f);
+            *this += std::move(sample_ms);
             auto t_end = std::chrono::system_clock::now();
-            auto end_us = std::chrono::duration_cast<std::chrono::microseconds>(
-                              t_end.time_since_epoch())
-                              .count();
+            auto end_us =
+                std::chrono::duration_cast<std::chrono::microseconds>(t_end.time_since_epoch()).count();
             std::time_t end_tt = std::chrono::system_clock::to_time_t(t_end);
-            std::tm end_tm = *std::localtime(&end_tt);
+            std::tm end_tm{};
+#ifdef _WIN32
+            localtime_s(&end_tm, &end_tt);
+#else
+            localtime_r(&end_tt, &end_tm);
+#endif
             LOG_INFO("PROF " << name << " END   @ " << std::put_time(&end_tm, "%H:%M:%S") << "."
                              << std::setfill('0') << std::setw(6) << (end_us % 1000000) << " (took "
                              << std::fixed << std::setprecision(3) << ((end_us - start_us) / 1000.0)

--- a/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
@@ -5,7 +5,10 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
+#include <ctime>
 #include <functional>
+#include <iomanip>
 #include <limits>
 #include <ostream>
 #include <string>
@@ -64,15 +67,22 @@ private:
     T total = 0;
     std::string name;
     bool enabled = false;
+    bool emit_timestamps = false;
 
 public:
     metric() = default;
-    metric(metric&& m) : records(std::move(m.records)), name(std::move(m.name)), enabled(m.enabled) {}
+    metric(metric&& m)
+        : records(std::move(m.records)), name(std::move(m.name)),
+          enabled(m.enabled), emit_timestamps(m.emit_timestamps) {}
 
     explicit metric(const std::string& named, bool active = false) : name(named), enabled(active) {}
 
     void enable() {
         enabled = true;
+    }
+
+    void set_timestamps(bool v) {
+        emit_timestamps = v;
     }
 
     void operator+=(T&& t) {
@@ -105,8 +115,28 @@ public:
     void record(F&& f) {
         if (!enabled) {
             f();
-        } else {
+        } else if (!emit_timestamps) {
             *this += U::sample(f);
+        } else {
+            auto t_start = std::chrono::system_clock::now();
+            auto start_us =
+                std::chrono::duration_cast<std::chrono::microseconds>(t_start.time_since_epoch()).count();
+            std::time_t start_tt = std::chrono::system_clock::to_time_t(t_start);
+            std::tm start_tm = *std::localtime(&start_tt);
+            LOG_INFO("PROF " << name << " START @ "
+                             << std::put_time(&start_tm, "%H:%M:%S") << "."
+                             << std::setfill('0') << std::setw(6) << (start_us % 1000000));
+            *this += U::sample(f);
+            auto t_end = std::chrono::system_clock::now();
+            auto end_us =
+                std::chrono::duration_cast<std::chrono::microseconds>(t_end.time_since_epoch()).count();
+            std::time_t end_tt = std::chrono::system_clock::to_time_t(t_end);
+            std::tm end_tm = *std::localtime(&end_tt);
+            LOG_INFO("PROF " << name << " END   @ "
+                             << std::put_time(&end_tm, "%H:%M:%S") << "."
+                             << std::setfill('0') << std::setw(6) << (end_us % 1000000)
+                             << " (took " << std::fixed << std::setprecision(3)
+                             << ((end_us - start_us) / 1000.0) << " ms)");
         }
     }
 
@@ -151,6 +181,8 @@ public:
         enabled = true;
     }
 
+    void set_timestamps(bool) {}  // no-op for counters
+
     void operator+=(T&& t) {
         if (enabled) {
             total += t;
@@ -178,12 +210,15 @@ struct Profile {
     std::map<std::string, Metric> metrics;
     std::string area;
     bool report_on_die = false;
+    bool emit_timestamps = false;
 
     Metric& operator[](const std::string& tag) {
         auto iter = metrics.find(tag);
         if (iter == metrics.end()) {
-            // Use report_on_die as a "enabled" marker here
             auto [new_iter, unused] = metrics.insert({tag, Metric(tag, report_on_die)});
+            if (emit_timestamps) {
+                new_iter->second.set_timestamps(true);
+            }
             return new_iter->second;
         }
         return iter->second;

--- a/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
@@ -72,8 +72,10 @@ private:
 public:
     metric() = default;
     metric(metric&& m)
-        : records(std::move(m.records)), name(std::move(m.name)),
-          enabled(m.enabled), emit_timestamps(m.emit_timestamps) {}
+        : records(std::move(m.records)),
+          name(std::move(m.name)),
+          enabled(m.enabled),
+          emit_timestamps(m.emit_timestamps) {}
 
     explicit metric(const std::string& named, bool active = false) : name(named), enabled(active) {}
 
@@ -119,24 +121,24 @@ public:
             *this += U::sample(f);
         } else {
             auto t_start = std::chrono::system_clock::now();
-            auto start_us =
-                std::chrono::duration_cast<std::chrono::microseconds>(t_start.time_since_epoch()).count();
+            auto start_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                t_start.time_since_epoch())
+                                .count();
             std::time_t start_tt = std::chrono::system_clock::to_time_t(t_start);
             std::tm start_tm = *std::localtime(&start_tt);
-            LOG_INFO("PROF " << name << " START @ "
-                             << std::put_time(&start_tm, "%H:%M:%S") << "."
+            LOG_INFO("PROF " << name << " START @ " << std::put_time(&start_tm, "%H:%M:%S") << "."
                              << std::setfill('0') << std::setw(6) << (start_us % 1000000));
             *this += U::sample(f);
             auto t_end = std::chrono::system_clock::now();
-            auto end_us =
-                std::chrono::duration_cast<std::chrono::microseconds>(t_end.time_since_epoch()).count();
+            auto end_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                              t_end.time_since_epoch())
+                              .count();
             std::time_t end_tt = std::chrono::system_clock::to_time_t(t_end);
             std::tm end_tm = *std::localtime(&end_tt);
-            LOG_INFO("PROF " << name << " END   @ "
-                             << std::put_time(&end_tm, "%H:%M:%S") << "."
-                             << std::setfill('0') << std::setw(6) << (end_us % 1000000)
-                             << " (took " << std::fixed << std::setprecision(3)
-                             << ((end_us - start_us) / 1000.0) << " ms)");
+            LOG_INFO("PROF " << name << " END   @ " << std::put_time(&end_tm, "%H:%M:%S") << "."
+                             << std::setfill('0') << std::setw(6) << (end_us % 1000000) << " (took "
+                             << std::fixed << std::setprecision(3) << ((end_us - start_us) / 1000.0)
+                             << " ms)");
         }
     }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/perf.hpp
@@ -124,8 +124,7 @@ public:
             *this += U::sample(f);
         } else {
             auto t_start = std::chrono::system_clock::now();
-            auto start_us =
-                std::chrono::duration_cast<std::chrono::microseconds>(t_start.time_since_epoch()).count();
+            auto start_us = std::chrono::duration_cast<std::chrono::microseconds>(t_start.time_since_epoch()).count();
             std::time_t start_tt = std::chrono::system_clock::to_time_t(t_start);
             std::tm start_tm{};
 #ifdef _WIN32
@@ -138,8 +137,7 @@ public:
             auto sample_ms = U::sample(f);
             *this += std::move(sample_ms);
             auto t_end = std::chrono::system_clock::now();
-            auto end_us =
-                std::chrono::duration_cast<std::chrono::microseconds>(t_end.time_since_epoch()).count();
+            auto end_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end.time_since_epoch()).count();
             std::time_t end_tt = std::chrono::system_clock::to_time_t(t_end);
             std::tm end_tm{};
 #ifdef _WIN32
@@ -148,9 +146,8 @@ public:
             localtime_r(&end_tt, &end_tm);
 #endif
             LOG_INFO("PROF " << name << " END   @ " << std::put_time(&end_tm, "%Y-%m-%dT%H:%M:%S") << "."
-                             << std::setfill('0') << std::setw(6) << (end_us % 1000000) << " (took "
-                             << std::fixed << std::setprecision(3) << ((end_us - start_us) / 1000.0)
-                             << " ms)");
+                             << std::setfill('0') << std::setw(6) << (end_us % 1000000) << " (took " << std::fixed
+                             << std::setprecision(3) << ((end_us - start_us) / 1000.0) << " ms)");
         }
     }
 


### PR DESCRIPTION
### Details:
 - Expands on 04293e6 by adding HH:MM:SS.microsecond timestamps to LLM execution profiling points only (prefill/generate phases), for correlation with external voltage measurements on NPU. Gated behind OPENVINO_NPUW_PROF=1 and OPENVINO_NPUW_LOG_LEVEL=INFO.

### Tickets:
 - EISW-209703

### AI Assistance:
 - *AI assistance used: yes*
 - *Claude Code used for implementing timestamps on top of existing profiling. Reviewed and verified on hardware collected logs below.*

```
[ NPUW:INFO ]     PROF 1/prefill:1.prepare_for_new_conversation START @ 09:56:18.743016
[ NPUW:INFO ]     PROF 1/prefill:1.prepare_for_new_conversation END   @ 09:56:18.743558 (took 0.542 ms)
[ NPUW:INFO ]     PROF 1/prefill:2.apply_lora START @ 09:56:18.743626
[ NPUW:INFO ]     PROF 1/prefill:2.apply_lora END   @ 09:56:18.743671 (took 0.045 ms)
[ NPUW:INFO ]     PROF 1/prefill:3.infer START @ 09:56:18.743710
[ NPUW:INFO ]         PROF 1/prefill:3a.prepare START @ 09:56:18.743748
[ NPUW:INFO ]         PROF 1/prefill:3a.prepare END   @ 09:56:18.743788 (took 0.040 ms)
[ NPUW:INFO ]         PROF 1/prefill:3b.infer START @ 09:56:18.743825
[ NPUW:INFO ]         PROF 1/prefill:3b.infer END   @ 09:56:19.153621 (took 409.796 ms)
[ NPUW:INFO ]     PROF 1/prefill:3.infer END   @ 09:56:19.153834 (took 410.124 ms)
[ NPUW:INFO ]     PROF 1/prefill:4.lm_head START @ 09:56:19.154059
[ NPUW:INFO ]     PROF 1/prefill:4.lm_head END   @ 09:56:19.164822 (took 10.763 ms)
[ NPUW:INFO ]     PROF N/generate:1.prepare START @ 09:56:19.165196
[ NPUW:INFO ]     PROF N/generate:1.prepare END   @ 09:56:19.166234 (took 1.038 ms)
[ NPUW:INFO ]     PROF N/generate:2.infer START @ 09:56:19.166428
[ NPUW:INFO ]     PROF N/generate:2.infer END   @ 09:56:19.222619 (took 56.191 ms)
[ NPUW:INFO ]     PROF N/generate:3.update_kvcache START @ 09:56:19.222753
[ NPUW:INFO ]     PROF N/generate:3.update_kvcache END   @ 09:56:19.223128 (took 0.375 ms)
[ NPUW:INFO ]     PROF N/generate:4.lm_head START @ 09:56:19.223183
[ NPUW:INFO ]     PROF N/generate:4.lm_head END   @ 09:56:19.225248 (took 2.065 ms)
[ NPUW:INFO ]     PROF N/generate:1.prepare START @ 09:56:19.225482
[ NPUW:INFO ]     PROF N/generate:1.prepare END   @ 09:56:19.225546 (took 0.064 ms)
[ NPUW:INFO ]     PROF N/generate:2.infer START @ 09:56:19.225596
[ NPUW:INFO ]     PROF N/generate:2.infer END   @ 09:56:19.249015 (took 23.419 ms)
[ NPUW:INFO ]     PROF N/generate:3.update_kvcache START @ 09:56:19.249199
[ NPUW:INFO ]     PROF N/generate:3.update_kvcache END   @ 09:56:19.249571 (took 0.372 ms)
[ NPUW:INFO ]     PROF N/generate:4.lm_head START @ 09:56:19.249629
[ NPUW:INFO ]     PROF N/generate:4.lm_head END   @ 09:56:19.251631 (took 2.002 ms)
```
