### PR TITLE
[GPU][TESTS] KVCacheTests: fixed sign-compare warning

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/kv_cache.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/kv_cache.cpp
@@ -363,7 +363,7 @@ class KVCacheTests: public ::testing::Test {
                     seq_len.data<int32_t>()[0] = trim.trim_seq;
                     return trim.trim_seq;
                 } else {
-                    OPENVINO_ASSERT(past_seq_len < std::numeric_limits<int32_t>::max());
+                    OPENVINO_ASSERT(past_seq_len < static_cast<uint32_t>(std::numeric_limits<int32_t>::max()));
                     seq_len.data<int32_t>()[0] = static_cast<int32_t>(past_seq_len);
                     return std::nullopt;
                 }


### PR DESCRIPTION
### Details:
 - *`KVCacheTests`: fixed sign-compare warning to avoid compilation errors in debug build*

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: no*
