### PR TITLE
[GPU] Enable fusion of gathers with different I/O ranks.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -753,18 +753,6 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             return lora_is_single_user && is_simple_lora;
         };
 
-        auto gather_supports_fusings = [&](gather_node& node) -> bool {
-            auto in_rank = node.get_input_layout(0).get_rank();
-            auto out_rank = node.get_output_layout().get_rank();
-
-            return (in_rank <= out_rank);
-        };
-
-        auto is_static_scalar_output = [&](program_node& node) -> bool {
-            const auto& out_layout = node.get_output_layout();
-            return out_layout.is_static() && out_layout.count() == 1;
-        };
-
         auto broadcast_supports_fusings = [&](broadcast_node& bcast_node) -> bool {
             if (bcast_node.get_outputs_count() != 1)
                 return false;
@@ -1078,9 +1066,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                                       (parents[i].first->is_type<pooling>()) ||
                                       (parents[i].first->is_type<depth_to_space>() &&
                                        dts_supports_fusings(parents[i].first->as<depth_to_space>())) ||
-                                      (parents[i].first->is_type<gather>() &&
-                                       (gather_supports_fusings(parents[i].first->as<gather>()) ||
-                                       is_static_scalar_output(*parents[(i == 0) ? 1u : 0u].first))) ||
+                                      (parents[i].first->is_type<gather>()) ||
                                       (parents[i].first->is_type<reduce>() &&
                                        reduce_supports_fusings(parents[i].first->as<reduce>())) ||
                                       (parents[i].first->is_type<lrn>()) ||

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -102,20 +102,6 @@ public:
         params.support_neg_ind = primitive->support_neg_ind;
 
         auto output_layout = impl_param.get_output_layout(0);
-        auto in_rank = input_layout.get_partial_shape().size();
-        auto out_rank = output_layout.get_partial_shape().size();
-
-        if (in_rank > 4 && in_rank > out_rank) { // if in_rank <= 4, the dims are to be adjusted to 4 by convert_data_tensor
-            auto output_shape = output_layout.get_partial_shape();
-            ov::PartialShape new_output_shape({output_shape[0], output_shape[1]});
-            for (size_t i = 0; i < in_rank - out_rank; ++i)
-                new_output_shape.push_back(1);
-
-            for (size_t i = 2; i < out_rank; ++i) {
-                new_output_shape.push_back(output_shape[i]);
-            }
-            output_layout = layout(new_output_shape, output_layout.data_type, format::get_default_format(new_output_shape.size()));
-        }
 
         params.outputs[0] = convert_data_tensor(output_layout);
         params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(1)));
@@ -153,6 +139,36 @@ public:
             output_pshape.insert(output_pshape.begin() + prim->axis, ov::Dimension(1));
             out_layout.set_partial_shape(output_pshape);
             out_layout.format = format::adjust_to_rank(out_layout.format, output_pshape.size());
+
+            // Insert a dimension of size 1 at the gather axis for fused op tensors
+            // so that the jitter's GetIdx maps dimensions correctly after rank change.
+            for (size_t fi = 0; fi < updated_impl_params.fused_desc.size(); fi++) {
+                auto& fd = updated_impl_params.fused_desc[fi];
+                // Extend fused op output_layout rank to match the restored output rank
+                auto fd_out_pshape = fd.output_layout.get_partial_shape();
+                if (fd_out_pshape.size() < output_pshape.size()) {
+                    fd_out_pshape.insert(fd_out_pshape.begin() + prim->axis, ov::Dimension(1));
+                    fd.output_layout.set_partial_shape(fd_out_pshape);
+                    fd.output_layout.format = format::adjust_to_rank(fd.output_layout.format, fd_out_pshape.size());
+                }
+
+                // Extend all fused op peer dependency tensor ranks (quantize has multiple: in_lo, in_hi, out_lo, out_hi)
+                if (fd.has_outer_dep()) {
+                    size_t num_outer_deps = fd.total_num_deps > 0 ? fd.total_num_deps - 1 : 0;
+                    for (size_t di = 0; di < num_outer_deps; di++) {
+                        size_t dep_idx = static_cast<size_t>(fd.outer_dep_start_idx) + di;
+                        if (dep_idx >= updated_impl_params.input_layouts.size())
+                            break;
+                        auto& dep_layout = updated_impl_params.input_layouts[dep_idx];
+                        auto dep_pshape = dep_layout.get_partial_shape();
+                        if (dep_pshape.size() < output_pshape.size()) {
+                            dep_pshape.insert(dep_pshape.begin() + prim->axis, ov::Dimension(1));
+                            dep_layout.set_partial_shape(dep_pshape);
+                            dep_layout.format = format::adjust_to_rank(dep_layout.format, dep_pshape.size());
+                        }
+                    }
+                }
+            }
         }
 
         for (auto& input_layout : updated_impl_params.input_layouts) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
@@ -212,12 +212,6 @@ static std::string GetIndicesIdxOrder(const gather_params& params, size_t axis, 
     return GetOrderString(idx_order);
 }
 
-static bool OutputBiasPositionCompatible(const gather_params& params) {
-    auto out = params.outputs[0];
-    auto bias = params.fused_ops[0].output_tensor;
-    return out.SameDims(bias);
-}
-
 CommonDispatchData GatherKernelRef::SetDefault(const gather_params& params) const {
     CommonDispatchData dispatchData;
     const auto& output = params.outputs[0];
@@ -276,16 +270,7 @@ JitConstants GatherKernelRef::GetJitConstants(const gather_params& params) const
 
     if (!params.fused_ops.empty()) {
         std::vector<std::string> idx_order;
-        if (params.inputs[0].GetDims().size() == 4 && GetGatherIndexDim(params).v == 0 && !params.inputs[1].is_dynamic() &&
-            params.inputs[1].LogicalSize() == 1) {
-            idx_order = {"(f)", "(y)", "(x)", "(1)"};
-        } else if (params.inputs[0].GetDims().size() == 4 && GetGatherChannelIndex(params) == 1 && !params.inputs[1].is_dynamic() &&
-                   params.inputs[1].LogicalSize() == 1 && !OutputBiasPositionCompatible(params)) {
-            idx_order = {"(b)", "(y)", "(x)", "(1)"};
-        } else {
-            idx_order = GetOrder(params.inputs[0].GetDims().size());
-        }
-
+        idx_order = GetOrder(params.outputs[0].GetDims().size());
         FusedOpsConfiguration conf = { "", idx_order, "val", params.inputs[0].GetDType() };
         jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
     }

--- a/src/plugins/intel_gpu/tests/unit/fusions/gather_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/gather_fusion_test.cpp
@@ -301,6 +301,28 @@ public:
                     std::vector<float>(), cldnn::reorder_mean_mode::subtract, cldnn::padding(), true)
         );
     }
+
+    void create_quantize_topology(gather_test_params& p, bool use_per_tensor) {
+        auto dyn_input = layout{ov::PartialShape::dynamic(p.dictionary_shape.size()), p.data_type, p.input_format};
+        auto dyn_indices = layout{ov::PartialShape::dynamic(p.indices_shape.size()), p.data_type, format::bfyx};
+
+        auto in_range_layout = use_per_tensor ? get_single_element_layout(p) : get_per_channel_layout(p);
+
+        create_topologies(
+            input_layout("input", dyn_input),
+            input_layout("gather_indices", dyn_indices),
+            data("in_lo", get_mem(in_range_layout, min_random, 0)),
+            data("in_hi", get_mem(in_range_layout, 1, max_random)),
+            data("out_lo", get_mem(get_single_element_layout(p), -127)),
+            data("out_hi", get_mem(get_single_element_layout(p), 127)),
+            gather("gather_prim", input_info("input"), input_info("gather_indices"),
+                   p.axis, p.dictionary_shape.size(), p.out_shape),
+            quantize("quant", input_info("gather_prim"), input_info("in_lo"), input_info("in_hi"),
+                     input_info("out_lo"), input_info("out_hi"), 255, data_types::i8),
+            reorder("reorder_bfyx", input_info("quant"), p.default_format, data_types::f32,
+                    std::vector<float>(), cldnn::reorder_mean_mode::subtract, cldnn::padding(), true)
+        );
+    }
 };
 
 TEST_P(gather_rank_change_fusing, eltwise_scalar) {
@@ -316,8 +338,7 @@ TEST_P(gather_rank_change_fusing, eltwise_per_channel) {
     auto p = GetParam();
     create_eltwise_topology(p, eltwise_input_type::per_channel);
     tolerance = 1e-2f;
-    bool is_decrease = p.dictionary_shape.size() > p.out_shape.size();
-    p.expected_fused_primitives = is_decrease ? 4 : 3;
+    p.expected_fused_primitives = 3;
     p.expected_not_fused_primitives = 5;
     execute(p);
 }
@@ -326,13 +347,30 @@ TEST_P(gather_rank_change_fusing, eltwise_full_tensor) {
     auto p = GetParam();
     create_eltwise_topology(p, eltwise_input_type::full_tensor);
     tolerance = 1e-2f;
-    bool is_decrease = p.dictionary_shape.size() > p.out_shape.size();
-    p.expected_fused_primitives = is_decrease ? 4 : 3;
+    p.expected_fused_primitives = 3;
     p.expected_not_fused_primitives = 5;
+    execute(p);
+}
+
+TEST_P(gather_rank_change_fusing, quantize_per_channel) {
+    auto p = GetParam();
+    create_quantize_topology(p, false);
+    tolerance = 1.f;
+    p.expected_fused_primitives = 3;
+    p.expected_not_fused_primitives = 4;
+    execute(p);
+}
+
+TEST_P(gather_rank_change_fusing, quantize_per_tensor) {
+    auto p = GetParam();
+    create_quantize_topology(p, true);
+    tolerance = 1.f;
+    p.expected_fused_primitives = 3;
+    p.expected_not_fused_primitives = 4;
     execute(p);
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, gather_rank_change_fusing, ::testing::ValuesIn(std::vector<gather_test_params>{
     gather_test_params{ CASE_GATHER_RANK_DECREASE_FP16, 2, 3 },
-    // gather_test_params{ CASE_GATHER_RANK_INCREASE_FP16, 2, 3 },  TODO)
+    gather_test_params{ CASE_GATHER_RANK_INCREASE_FP16, 2, 3 },
 }));


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
#### Symptom
Disable gather fusion when input and output are different ranks.

#### Root cause
When gather has 5D input and 4D output, static_canonicalize_shapes() sets the output back to 5D by inserting dim=1 at the gather axis (e.g., {-1,64,64,128} -> {-1,1,64,64,128}).
However, the fused eltwise peer tensor remains 4D.
In the jitter, GetIdx selects index slots based on the peer tensor's rank (4D -> b,f,y,x)
So the kernel's z loop variable - which iterates over actual data - is never used for peer indexing.
This causes the fused eltwise to read incorrect data

#### Resolution
Apply the logic from gather canonicalize shape to fused peers as well and remove W.A code.

#### Checklist 
 - [x] Is it a proper fix?
 - [x] Did you include test case for this fix, if necessary? 
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *CVS-183596*