### PR TITLE
[NPUW]Optimize pipeline initialize time in online partitioner.

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
@@ -425,12 +425,13 @@ void Group::setRepeated(const std::shared_ptr<Repeated>& rep) {
 PairMICSetIO Group::metaInterconnect(const Group::GPtr& gptr_prod) const {
     MICSet mics;
 
+    auto locked_snapshot = m_snapshot.lock();
     auto ics = interconnect(gptr_prod);
     for (const auto& ic : ics) {
-        mics.insert({ov::npuw::online::util::getMetaDesc(ic.input_node),
+        mics.insert({locked_snapshot->getMetaDesc(ic.input_node),
                      gptr_prod->m_reptrack.at(ic.input_node),
                      ic.input_port,
-                     ov::npuw::online::util::getMetaDesc(ic.output_node),
+                     locked_snapshot->getMetaDesc(ic.output_node),
                      m_reptrack.at(ic.output_node),
                      ic.output_port});
     }
@@ -441,10 +442,10 @@ PairMICSetIO Group::metaInterconnect(const Group::GPtr& gptr_prod) const {
     if (!m_mic_io_valid) {
         m_cached_mic_io = MetaInterconnectIO{};
         for (const auto& oi : m_input_layers) {
-            m_cached_mic_io.output_imeta.insert(ov::npuw::online::util::getMetaDesc(oi));
+            m_cached_mic_io.output_imeta.insert(locked_snapshot->getMetaDesc(oi));
         }
         for (const auto& oo : m_output_layers) {
-            m_cached_mic_io.output_ometa.insert(ov::npuw::online::util::getMetaDesc(oo));
+            m_cached_mic_io.output_ometa.insert(locked_snapshot->getMetaDesc(oo));
         }
         m_mic_io_valid = true;
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
@@ -145,10 +145,12 @@ const std::unordered_set<std::shared_ptr<ov::Node>>& Group::getOutputs() const {
 
 void Group::addInput(const std::shared_ptr<ov::Node>& node) {
     m_input_layers.insert(node);
+    m_mic_io_valid = false;
 }
 
 void Group::addOutput(const std::shared_ptr<ov::Node>& node) {
     m_output_layers.insert(node);
+    m_mic_io_valid = false;
 }
 
 void Group::addContent(const std::shared_ptr<ov::Node>& node) {
@@ -173,6 +175,7 @@ own::ade::NodeHandle Group::getHandle() const {
 
 // Not every input should be included - those layers which contained inside merging group are not inputs anymore
 void Group::updateInputLayers(const Group::GPtr& gptr_other) {
+    m_mic_io_valid = false;
     detail::OVNodeSet combined_input;
     combined_input.insert(m_input_layers.begin(), m_input_layers.end());
     combined_input.insert(gptr_other->m_input_layers.begin(), gptr_other->m_input_layers.end());
@@ -199,6 +202,7 @@ void Group::updateInputLayers(const Group::GPtr& gptr_other) {
 // Not every output should be included - those layers which are consumed _ONLY_ by the merged group are not outputs
 // anymore
 void Group::updateOutputLayers(const Group::GPtr& gptr_other) {
+    m_mic_io_valid = false;
     detail::OVNodeSet combined_output;
     combined_output.insert(m_output_layers.begin(), m_output_layers.end());
     combined_output.insert(gptr_other->m_output_layers.begin(), gptr_other->m_output_layers.end());
@@ -333,21 +337,26 @@ void Group::takeFlags(const Group::GPtr& gptr_other) {
 
 // Check if there is indirect path from this to gptr_cons
 bool Group::hasCycle(const Group::GPtr& gptr_cons) const {
-    std::unordered_set<own::ade::NodeHandle> visited;
+    // Fast-path: if this group has at most 1 consumer, there is no alternative path
+    // to gptr_cons and therefore no cycle.
+    if (m_nh->dstNodes().size() <= 1) {
+        return false;
+    }
 
+    std::unordered_set<own::ade::NodeHandle> visited;
     std::stack<own::ade::NodeHandle> st;
 
     for (const auto& prod : gptr_cons->srcNodes()) {
         // skip self during this iter
         if (!(m_nh == prod)) {
             st.push(prod);
+            visited.insert(prod);  // mark at push time to avoid duplicate pushes
         }
     }
 
     while (!st.empty()) {
         auto nh = st.top();
         st.pop();
-        visited.insert(nh);
 
         if (nh == m_nh) {
             // Found another path from self to gptr_cons
@@ -355,8 +364,9 @@ bool Group::hasCycle(const Group::GPtr& gptr_cons) const {
         }
 
         for (const auto& prod : nh->srcNodes()) {
-            if (visited.find(prod) == visited.end()) {
+            if (!visited.count(prod)) {
                 st.push(prod);
+                visited.insert(prod);  // mark at push time
             }
         }
     }
@@ -425,23 +435,28 @@ PairMICSetIO Group::metaInterconnect(const Group::GPtr& gptr_prod) const {
                      ic.output_port});
     }
 
-    MetaInterconnectIO mic_io;
-    auto locked_snapshot = m_snapshot.lock();
-    for (const auto& oi : m_input_layers) {
-        mic_io.output_imeta.insert(ov::npuw::online::util::getMetaDesc(oi));
-    }
-    for (const auto& oo : m_output_layers) {
-        mic_io.output_ometa.insert(ov::npuw::online::util::getMetaDesc(oo));
+    // Cache the MetaInterconnectIO part — it only depends on m_input_layers /
+    // m_output_layers which are invalidated (m_mic_io_valid = false) whenever
+    // those sets change (addInput / addOutput / updateInputLayers / updateOutputLayers).
+    if (!m_mic_io_valid) {
+        m_cached_mic_io = MetaInterconnectIO{};
+        for (const auto& oi : m_input_layers) {
+            m_cached_mic_io.output_imeta.insert(ov::npuw::online::util::getMetaDesc(oi));
+        }
+        for (const auto& oo : m_output_layers) {
+            m_cached_mic_io.output_ometa.insert(ov::npuw::online::util::getMetaDesc(oo));
+        }
+        m_mic_io_valid = true;
     }
 
-    return {mics, mic_io};
+    return {mics, m_cached_mic_io};
 }
 
 std::unordered_set<Interconnect> Group::interconnect(const Group::GPtr& gptr_prod) const {
     std::unordered_set<Interconnect> ics;
 
     auto locked_snapshot = m_snapshot.lock();
-    auto ports_map = locked_snapshot->getPortsMap();
+    const auto& ports_map = locked_snapshot->getPortsMap();
 
     for (const auto& layer : m_content) {
         for (const auto& input_layer : locked_snapshot->getNodeProducers(layer)) {

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.hpp
@@ -11,6 +11,7 @@
 
 #include "graph.hpp"
 #include "openvino/openvino.hpp"
+#include "repeated.hpp"
 #include "utils/utils.hpp"
 
 namespace ov {
@@ -119,6 +120,11 @@ private:
     std::shared_ptr<Repeated> m_repeated = nullptr;
     // For each layer inside group, store it's history of repeated groups
     detail::ReptrackMap m_reptrack;
+
+    // Cache for the MetaInterconnectIO part of metaInterconnect().
+    // Invalidated whenever m_input_layers or m_output_layers change.
+    mutable bool m_mic_io_valid = false;
+    mutable MetaInterconnectIO m_cached_mic_io;
 };
 
 }  // namespace online

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
@@ -822,7 +822,7 @@ void Snapshot::identifyUniques() {
         // This pass should only be called at the very beginning,
         // thus check and use only the single initial layer
         auto ov_node = group->getInitialNode();
-        auto metadesc = ov::npuw::online::util::getMetaDesc(ov_node);
+        auto metadesc = getMetaDesc(ov_node);
         const auto& avoids = group->avoidedTargets();
         const auto& special_tags = group->specialTags();
         uniques[{metadesc, avoids, special_tags}].insert(group);
@@ -1415,7 +1415,7 @@ void Snapshot::completeRepeating(const std::shared_ptr<Repeated>& reptag, const 
 
     for (const auto& gptr : gset) {
         for (const auto& layer : gptr->getContent()) {  // FIXME: should it be a part of group's API instead?
-            const auto& metadesc = ov::npuw::online::util::getMetaDesc(layer);
+            const auto& metadesc = getMetaDesc(layer);
             const auto& archetype = gptr->getReptrack(layer);
             matches[{std::move(metadesc), std::move(archetype)}].insert(layer);
         }
@@ -1498,6 +1498,17 @@ std::shared_ptr<own::ade::Graph> Snapshot::getGraph() const {
 
 size_t Snapshot::graphSize() const {
     return m_graph->nodes().size();
+}
+
+std::string Snapshot::getMetaDesc(const std::shared_ptr<ov::Node>& node) const {
+    auto id = node->get_instance_id();
+    auto it = m_metadesc_cache.find(id);
+    if (it != m_metadesc_cache.end()) {
+        return it->second;
+    }
+    auto result = util::getMetaDesc(node);
+    m_metadesc_cache.emplace(id, result);
+    return result;
 }
 
 const OVPortsMap& Snapshot::getPortsMap() const {

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
@@ -1082,6 +1082,28 @@ void Snapshot::mergeUniques() {
     LOG_INFO("Online partitioning: executing mergeUniques pass...");
     LOG_BLOCK();
 
+    // Pre-build a rep-tag → GPtrSet index to replace the O(V) scan inside
+    // getRepGroups(). Without this, getRepGroups() is called once per distinct rep
+    // tag and each call scans all V graph nodes → O(V × nRepTags) = O(V²) total.
+    // With small chunk sizes (many KV blocks → large V), this dominates compilation.
+    //
+    // Correctness: each rep tag is visited at most once (merged_this_time guard).
+    // During the loop, tryMergeRepeating() may:
+    //   - re-tag consumer groups (they get a new_rep) → stale entries in the index
+    //   - remove producer groups from the graph
+    // Both cases are handled by the staleness filter below (rep-tag and graph checks).
+    std::unordered_map<Repeated*, GPtrSet> rep_index;
+    for (const auto& nh_i : m_graph->sorted()) {
+        if (!m_graph->contains(nh_i)) {
+            continue;
+        }
+        const Group::GPtr& g = m_graph->meta(nh_i).get<Group::GPtr>();
+        const auto& rep_i = g->repeated();
+        if (rep_i && !g->isFrozen()) {
+            rep_index[rep_i.get()].insert(g);
+        }
+    }
+
     std::unordered_set<std::shared_ptr<Repeated>> merged_this_time;
 
     for (const auto& nh : m_graph->sorted()) {
@@ -1094,7 +1116,17 @@ void Snapshot::mergeUniques() {
         GPtrSet repeating_groups;
 
         if (rep && rep->openForMerge() && merged_this_time.count(rep) == 0) {
-            repeating_groups = getRepGroups(group);
+            // Use the prebuilt index (O(|rep_set|)) instead of the O(V) graph scan.
+            // Apply a staleness filter: a group's rep tag may have changed if it was
+            // merged in an earlier iteration of this same mergeUniques() call.
+            auto it = rep_index.find(rep.get());
+            if (it != rep_index.end()) {
+                for (const auto& g : it->second) {
+                    if (m_graph->contains(g->getHandle()) && g->repeated().get() == rep.get() && !g->isFrozen()) {
+                        repeating_groups.insert(g);
+                    }
+                }
+            }
         }
 
         if (!repeating_groups.empty()) {
@@ -1147,26 +1179,29 @@ std::shared_ptr<Repeated> Snapshot::tryGrowRepeatingGroups(const GPtrSet& repeat
             Group::GPtr prod_group = m_graph->meta(prod_nh).get<Group::GPtr>();
             LOG_DEBUG("prod_group:");
             prod_group->dump();
-            if (prod_group->repeated() && !prod_group->hasCycle(group) && prod_group->repeated() != this_rep_tag &&
-                prod_group->avoidedTargets() == this_avoided && prod_group->specialTags() == this_special) {
-                auto meta_interconnect = group->metaInterconnect(prod_group);
+            if (prod_group->repeated()) {
+                bool cycle = prod_group->hasCycle(group);
+                if (!cycle && prod_group->repeated() != this_rep_tag && prod_group->avoidedTargets() == this_avoided &&
+                    prod_group->specialTags() == this_special) {
+                    auto meta_interconnect = group->metaInterconnect(prod_group);
 
-                // FIXME: find a better way to reduce time complexity
-                // Need to align interconnects in the same format via sort, so they could be compared later
-                MICVec mic_sorted_key(meta_interconnect.first.begin(), meta_interconnect.first.end());
-                std::sort(mic_sorted_key.begin(), mic_sorted_key.end());
-                mics[{mic_sorted_key, meta_interconnect.second}].push_back({prod_group, group});
-                LOG_DEBUG("Add the pair to the merge vector!");
-            } else if (ov::npuw::debug_groups()) {
-                LOG_DEBUG("Couldn't add the pair to the merge vector due to failed checks:");
-                LOG_BLOCK();
+                    // FIXME: find a better way to reduce time complexity
+                    // Need to align interconnects in the same format via sort, so they could be compared later
+                    MICVec mic_sorted_key(meta_interconnect.first.begin(), meta_interconnect.first.end());
+                    std::sort(mic_sorted_key.begin(), mic_sorted_key.end());
+                    mics[{mic_sorted_key, meta_interconnect.second}].push_back({prod_group, group});
+                    LOG_DEBUG("Add the pair to the merge vector!");
+                } else if (ov::npuw::debug_groups()) {
+                    LOG_DEBUG("Couldn't add the pair to the merge vector due to failed checks:");
+                    LOG_BLOCK();
 #define INSPECT(x) LOG_DEBUG(#x " = " << (x))
-                INSPECT(prod_group->specialTags());
-                INSPECT(prod_group->repeated() != this_rep_tag);
-                INSPECT(prod_group->hasCycle(group));
-                INSPECT(prod_group->avoidedTargets() == this_avoided);
-                INSPECT(prod_group->specialTags() == this_special);
+                    INSPECT(prod_group->specialTags());
+                    INSPECT(prod_group->repeated() != this_rep_tag);
+                    INSPECT(cycle);
+                    INSPECT(prod_group->avoidedTargets() == this_avoided);
+                    INSPECT(prod_group->specialTags() == this_special);
 #undef INSPECT
+                }
             }
         }
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.hpp
@@ -67,6 +67,7 @@ public:
     void repeat(detail::Pass&& pass);
     void setCtx(const PassContext& ctx);
     size_t graphSize() const;
+    std::string getMetaDesc(const std::shared_ptr<ov::Node>& node) const;
 
 private:
     detail::GPtrSet getRepGroups(const std::shared_ptr<Group>& group) const;
@@ -100,6 +101,7 @@ private:
 
     detail::OVPortsMap m_ports_map;
     std::map<std::string, std::vector<std::set<std::string>>> m_layer_matches;
+    mutable std::unordered_map<size_t, std::string> m_metadesc_cache;
 };
 
 }  // namespace online

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/utils/utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/utils/utils.cpp
@@ -4,8 +4,6 @@
 
 #include "utils.hpp"
 
-#include <unordered_map>
-
 #include "../../../logging.hpp"
 #include "intel_npu/config/npuw.hpp"
 
@@ -14,14 +12,6 @@ using ov::npuw::online::util::ReadAttributes;
 
 // FIXME: metadesc should be hash of layer's meta, not string
 std::string ov::npuw::online::util::getMetaDesc(const std::shared_ptr<ov::Node>& ov_node) {
-    // Cache the result per node pointer: the node's structure is fixed once created.
-    static thread_local std::unordered_map<ov::Node*, std::string> s_metadesc_cache;
-    auto* raw = ov_node.get();
-    auto it = s_metadesc_cache.find(raw);
-    if (it != s_metadesc_cache.end()) {
-        return it->second;
-    }
-
     std::stringstream ss;
     ss << ov_node->description() << ' ';
 
@@ -42,9 +32,7 @@ std::string ov::npuw::online::util::getMetaDesc(const std::shared_ptr<ov::Node>&
 
     // FIXME: should be { self type. self inputs. self outputs. self attrs. self data }
     //        can't extract data here?
-    auto result = ss.str();
-    s_metadesc_cache.emplace(raw, result);
-    return result;
+    return ss.str();
 }
 
 std::tuple<ov::npuw::online::PatternType, std::string, std::string> ov::npuw::online::util::parse(

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/utils/utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/utils/utils.cpp
@@ -4,6 +4,8 @@
 
 #include "utils.hpp"
 
+#include <unordered_map>
+
 #include "../../../logging.hpp"
 #include "intel_npu/config/npuw.hpp"
 
@@ -12,6 +14,14 @@ using ov::npuw::online::util::ReadAttributes;
 
 // FIXME: metadesc should be hash of layer's meta, not string
 std::string ov::npuw::online::util::getMetaDesc(const std::shared_ptr<ov::Node>& ov_node) {
+    // Cache the result per node pointer: the node's structure is fixed once created.
+    static thread_local std::unordered_map<ov::Node*, std::string> s_metadesc_cache;
+    auto* raw = ov_node.get();
+    auto it = s_metadesc_cache.find(raw);
+    if (it != s_metadesc_cache.end()) {
+        return it->second;
+    }
+
     std::stringstream ss;
     ss << ov_node->description() << ' ';
 
@@ -32,7 +42,9 @@ std::string ov::npuw::online::util::getMetaDesc(const std::shared_ptr<ov::Node>&
 
     // FIXME: should be { self type. self inputs. self outputs. self attrs. self data }
     //        can't extract data here?
-    return ss.str();
+    auto result = ss.str();
+    s_metadesc_cache.emplace(raw, result);
+    return result;
 }
 
 std::tuple<ov::npuw::online::PatternType, std::string, std::string> ov::npuw::online::util::parse(


### PR DESCRIPTION
### Details:
`getPartitioning` was running very slowly when the graph contained a large number of nodes.
This PR optimized several hotspots to improve performance at scale.
- `hasCycle()`: add O(1) fast-path for single-consumer producers; fix DFS to mark visited at push-time to avoid redundant stack pushes
- `mergeUniques()`: replace per-group O(V) getRepGroups() scan with a pre-built rep-tag->GPtrSet index, reducing total cost from O(V^2) to O(V)
- `interconnect()`: use const ref for ports_map to avoid deep copy on each call
- `metaInterconnect()`: cache MetaInterconnectIO; invalidate on layer changes
- `getMetaDesc()`: add cache held by snapshot, to avoid re-stringifying same node

~30x improvement for 256 chunk size:
- 16K context: 200s -> 7s
- 8K context: 58s ->2.5s

### Tickets:
 - *[EISW-209691](https://jira.devtools.intel.com/browse/EISW-209691)*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
