### PR TITLE
Remove gemm_tiled_opt separate batches workaround since this compilat…

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
@@ -149,35 +149,10 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
                 current_bucket.push_back(batch_program(bucket_id, batch_id, options, batch_headers, kernel_string->language));
             }
 
-            // This is a temporary walk-around to avoid severe performance drop.
-            // It will be removed after OpenCL compiler is updated.
-            auto need_separate_batch = [&](std::string& unique_kernel_name) -> bool {
-                const std::vector<std::string> special_kernels = {"gemm_tiled_opt"};
-
-                if (current_bucket.back().kernels_counter > 0) {
-                    // check if the current kernel name is in special_kernels
-                    for (auto& special_kernel : special_kernels) {
-                        if (entry_point.find(special_kernel) != std::string::npos)
-                            return true;
-                    }
-                }
-
-                // check if the current_batch has one of special_kernels
-                if (current_bucket.back().kernels_counter == 1) {
-                    auto& kernel_in_current_batch = current_bucket.back().entry_point_to_id.begin()->first;
-                    for (auto& special_kernel : special_kernels) {
-                        if (kernel_in_current_batch.find(special_kernel) != std::string::npos)
-                            return true;
-                    }
-                }
-                return false;
-            };
-
             // Create new kernels batch when the limit is reached
             // and current kernel's entry_point is duplicated in this kernels batch
             if (current_bucket.back().kernels_counter >= _config.get_max_kernels_per_batch()
-                || current_bucket.back().entry_point_to_id.find(entry_point) != current_bucket.back().entry_point_to_id.end()
-                || need_separate_batch(entry_point)) {
+                || current_bucket.back().entry_point_to_id.find(entry_point) != current_bucket.back().entry_point_to_id.end()) {
                 const auto& batch_id = static_cast<int32_t>(current_bucket.size());
                 current_bucket.push_back(batch_program(bucket_id, batch_id, options, batch_headers, kernel_string->language));
             }


### PR DESCRIPTION
…ion error has been fixed in driver

### Details:
In PR https://github.com/openvinotoolkit/openvino/pull/24499, a workaround was added, and the driver issue has been fixed since 32.0.101.5989, so remove the workaround for driver versions >= 32.0.101.5989. With this patch, there will be performance improvement for some fp32 models running in ACCURACY mode.

### Tickets:
 - *CVS-183761*

