### PR TITLE
Fix LLM accuracy tests: pin optimum-intel and add explicit library_name

### DIFF
--- a/tests/llm/accuracy_conformance.py
+++ b/tests/llm/accuracy_conformance.py
@@ -119,7 +119,7 @@ def setup_model(model_id):
     int8_model_path = get_model_path(model_id, PREC_INT8)
     if not os.path.exists(int8_model_path):
         logger.info(f'Creating INT8 OpenVINO model: {int8_model_path}')
-        ov_model = OVModelForCausalLM.from_pretrained(model_path, load_in_8bit=True)
+        ov_model = OVModelForCausalLM.from_pretrained(model_path, load_in_8bit=True, library_name="transformers")
         ov_model.save_pretrained(int8_model_path)
         tokenizer.save_pretrained(int8_model_path)
         del ov_model
@@ -132,7 +132,7 @@ def setup_model(model_id):
     if not os.path.exists(int4_model_path):
         logger.info(f'Creating INT4 OpenVINO model: {int4_model_path}')
         quantization_config = OVWeightQuantizationConfig(bits=4, ratio=0.8)
-        quantized_model = OVModelForCausalLM.from_pretrained(model_path, quantization_config=quantization_config)
+        quantized_model = OVModelForCausalLM.from_pretrained(model_path, quantization_config=quantization_config, library_name="transformers")
         quantized_model.save_pretrained(int4_model_path)
         tokenizer.save_pretrained(int4_model_path)
         del quantized_model

--- a/tests/llm/requirements.txt
+++ b/tests/llm/requirements.txt
@@ -1,6 +1,6 @@
 -c ../constraints.txt
 --extra-index-url https://download.pytorch.org/whl/cpu
-optimum-intel[tests,nncf]
+optimum-intel[tests,nncf]==1.27.0
 whowhatbench[llm-test-openvino] @ git+https://github.com/openvinotoolkit/openvino.genai.git#subdirectory=tools/who_what_benchmark
 pytest
 jinja2>=3.1.0


### PR DESCRIPTION
### Details

The LLM accuracy tests (`tests/llm/accuracy_conformance.py`) are failing on Jenkins CI (`ie-tests-windows-llm_accuracy`) with:

```
ValueError: The library name could not be automatically inferred.
If using the command-line, please provide the argument --library {transformers,diffusers,timm,sentence_transformers}.
```

All 4 test cases fail identically:
- `test_accuracy_conformance[TinyLlama/TinyLlama-1.1B-Chat-v1.0-INT8-CPU]`
- `test_accuracy_conformance[TinyLlama/TinyLlama-1.1B-Chat-v1.0-INT4-CPU]`
- `test_accuracy_conformance[Qwen/Qwen2-0.5B-Instruct-INT8-CPU]`
- `test_accuracy_conformance[Qwen/Qwen2-0.5B-Instruct-INT4-CPU]`

### Root Cause

`optimum-intel` is **unpinned** in `tests/llm/requirements.txt`, and a newer version of `optimum` (transitive dependency) changed the library auto-detection logic in `TasksManager._infer_library_from_model_name_or_path()`. The locally-saved model (via `model.save_pretrained()`) no longer contains enough metadata for the updated inference logic.

This is the same class of problem already solved for pytorch model hub tests in `tests/requirements_pytorch` (line 49) with a pinned commit.

### Changes

1. **Pin `optimum-intel[tests,nncf]==1.27.0`** in `tests/llm/requirements.txt` — consistent with the pin in `tests/requirements_rope.txt`, prevents breakage from unpinned transitive dependency upgrades.

2. **Add explicit `library_name='transformers'`** to both `OVModelForCausalLM.from_pretrained()` calls (INT8 and INT4 model creation) — eliminates reliance on auto-detection entirely, making the test resilient to future `optimum` API changes.

Fixes: **CVS-180061**
