### PR TITLE
SDL436: Harden DLL loading against injection attacks on Windows

### DIFF
--- a/src/common/util/src/os/win/os.cpp
+++ b/src/common/util/src/os/win/os.cpp
@@ -10,7 +10,9 @@ namespace ov::util {
 bool may_i_use_dynamic_code() {
     // The function GetProcessMitigationPolicy may not be available in the kernel32 library. It depends on the Windows version.
     // Need to check this at runtime if the project was built on a different platform.
-    if (HMODULE kernel32 = LoadLibrary("kernel32")) {
+    // Use GetModuleHandleW instead of LoadLibrary — kernel32.dll is always loaded in every Windows process.
+    // This avoids DLL search path concerns entirely (SDL436).
+    if (HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll")) {
         typedef BOOL (*fnGetProcessMitigationPolicy)(HANDLE, _PROCESS_MITIGATION_POLICY, PVOID, SIZE_T);
         fnGetProcessMitigationPolicy get_process_mitigation_policy =
             (fnGetProcessMitigationPolicy)GetProcAddress(kernel32, "GetProcessMitigationPolicy");

--- a/src/common/util/src/os/win/win_shared_object_loader.cpp
+++ b/src/common/util/src/os/win/win_shared_object_loader.cpp
@@ -45,6 +45,15 @@
 
 #include <windows.h>
 
+// Verify that LOAD_LIBRARY_SEARCH_* flags are available.
+// These require _WIN32_WINNT >= 0x0602 (Windows 8) in the Windows SDK headers.
+// OpenVINO minimum supported platform is Windows 10, so this should always hold.
+#if !defined(LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR) || !defined(LOAD_LIBRARY_SEARCH_SYSTEM32) || \
+    !defined(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
+#    error \
+        "LOAD_LIBRARY_SEARCH_* flags not available. Ensure _WIN32_WINNT >= 0x0602 (Windows 8) or use a Windows 10+ SDK."
+#endif
+
 namespace ov::util {
 
 std::shared_ptr<void> load_shared_object(const std::filesystem::path& path) {

--- a/src/common/util/src/os/win/win_shared_object_loader.cpp
+++ b/src/common/util/src/os/win/win_shared_object_loader.cpp
@@ -8,7 +8,7 @@
 #include "openvino/util/shared_object.hpp"
 
 //
-// LoadLibraryA, LoadLibraryW:
+// LoadLibraryExW:
 //  WINAPI_FAMILY_DESKTOP_APP - OK (default)
 //  WINAPI_FAMILY_PC_APP - FAIL ?? (defined by cmake)
 //  WINAPI_FAMILY_PHONE_APP - FAIL ??
@@ -32,38 +32,12 @@
 //  WINAPI_FAMILY_SERVER - OK
 //  WINAPI_FAMILY_SYSTEM - OK
 //
-// SetDllDirectoryA, SetDllDirectoryW:
-//  WINAPI_FAMILY_DESKTOP_APP - OK (default)
-//  WINAPI_FAMILY_PC_APP - FAIL ?? (defined by cmake)
-//  WINAPI_FAMILY_PHONE_APP - FAIL ??
-//  WINAPI_FAMILY_GAMES - OK
-//  WINAPI_FAMILY_SERVER - FAIL
-//  WINAPI_FAMILY_SYSTEM - FAIL
-//
-// GetDllDirectoryA, GetDllDirectoryW:
-//  WINAPI_FAMILY_DESKTOP_APP - FAIL
-//  WINAPI_FAMILY_PC_APP - FAIL (defined by cmake)
-//  WINAPI_FAMILY_PHONE_APP - FAIL
-//  WINAPI_FAMILY_GAMES - FAIL
-//  WINAPI_FAMILY_SERVER - FAIL
-//  WINAPI_FAMILY_SYSTEM - FAIL
-//
-// SetupDiGetClassDevsA, SetupDiEnumDeviceInfo, SetupDiGetDeviceInstanceIdA, SetupDiDestroyDeviceInfoList:
-//  WINAPI_FAMILY_DESKTOP_APP - FAIL (default)
-//  WINAPI_FAMILY_PC_APP - FAIL (defined by cmake)
-//  WINAPI_FAMILY_PHONE_APP - FAIL
-//  WINAPI_FAMILY_GAMES - FAIL
-//  WINAPI_FAMILY_SERVER - FAIL
-//  WINAPI_FAMILY_SYSTEM - FAIL
-//
 
 #if defined(WINAPI_FAMILY) && !WINAPI_PARTITION_DESKTOP
-#    error "Only WINAPI_PARTITION_DESKTOP is supported, because of LoadLibrary[A|W]"
+#    error "Only WINAPI_PARTITION_DESKTOP is supported, because of LoadLibraryEx[A|W]"
 #endif
 
 #include <direct.h>
-
-#include <mutex>
 
 #ifndef NOMINMAX
 #    define NOMINMAX
@@ -75,30 +49,28 @@ namespace ov::util {
 
 std::shared_ptr<void> load_shared_object(const std::filesystem::path& path) {
     void* shared_object = nullptr;
-    using GetDllDirectoryW_Fnc = DWORD (*)(DWORD, LPWSTR);
-    static GetDllDirectoryW_Fnc IEGetDllDirectoryW = nullptr;
-    if (HMODULE hm = GetModuleHandleW(L"kernel32.dll")) {
-        IEGetDllDirectoryW = reinterpret_cast<GetDllDirectoryW_Fnc>(GetProcAddress(hm, "GetDllDirectoryW"));
-    }
-    // ExcludeCurrentDirectory
-#    if !WINAPI_PARTITION_SYSTEM
-    if (IEGetDllDirectoryW && IEGetDllDirectoryW(0, NULL) <= 1) {
-        SetDllDirectoryW(L"");
-    }
-    if (IEGetDllDirectoryW) {
-        DWORD nBufferLength = IEGetDllDirectoryW(0, NULL);
-        std::vector<WCHAR> lpBuffer(nBufferLength);
-        IEGetDllDirectoryW(nBufferLength, &lpBuffer.front());
-        const auto& dir_name = path.has_parent_path() ? path.parent_path() : path;
-        SetDllDirectoryW(dir_name.c_str());
-        shared_object = LoadLibraryW(path.c_str());
 
-        SetDllDirectoryW(&lpBuffer.front());
+    // SDL436: Use LoadLibraryExW with restricted search flags to mitigate DLL injection.
+    // LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR — searches the directory containing the DLL (requires absolute path).
+    // LOAD_LIBRARY_SEARCH_SYSTEM32 — allows loading system dependencies from System32.
+    // This approach is thread-safe, unlike the previous SetDllDirectoryW-based method which modified
+    // process-wide state and was susceptible to race conditions.
+    if (path.is_absolute()) {
+        shared_object = LoadLibraryExW(
+            path.c_str(), NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
+    } else if (path.has_parent_path()) {
+        auto abs_path = std::filesystem::absolute(path);
+        shared_object = LoadLibraryExW(
+            abs_path.c_str(), NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
     }
-#    endif
+
     if (!shared_object) {
-        shared_object = LoadLibraryW(path.c_str());
+        // Fallback for bare filenames or if the previous attempt failed.
+        // LOAD_LIBRARY_SEARCH_DEFAULT_DIRS searches: application directory, System32, and user-added directories.
+        // This avoids the insecure default search order (which includes CWD).
+        shared_object = LoadLibraryExW(path.c_str(), NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
     }
+
     if (!shared_object) {
         std::stringstream ss;
         ss << "Cannot load library \"" << path_to_string(path) << "\": " << GetLastError()


### PR DESCRIPTION
﻿## Details

**SDL436 compliance**: Replace insecure DLL loading pattern with hardened LoadLibraryExW + restricted search flags to mitigate DLL hijacking/injection on Windows.

### Problem

The central ov::util::load_shared_object() function used LoadLibraryW combined with process-wide SetDllDirectoryW calls to load plugin DLLs. This approach had several security issues:

1. **Insecure default search order** - LoadLibraryW uses the Windows default DLL search order, which includes the current working directory (CWD). An attacker could place a malicious DLL in CWD to hijack plugin loading.
2. **Race condition** - SetDllDirectoryW modifies process-wide state. In multithreaded scenarios, another thread could exploit the temporarily modified search path between SetDllDirectoryW(dir_name) and the restore call.
3. **Unmitigated fallback** - if the first load attempt failed, the code fell back to plain LoadLibraryW with no security flags at all.

### Solution

**win_shared_object_loader.cpp**:
- Use LoadLibraryExW with LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32 for paths with directory components. This ensures only the DLL's own directory and System32 are searched.
- Fallback uses LOAD_LIBRARY_SEARCH_DEFAULT_DIRS (application dir + System32 + user-added dirs) instead of the insecure default order.
- Completely remove SetDllDirectoryW usage, eliminating the process-wide race condition.
- Remove unused GetDllDirectoryW runtime resolution and mutex include.

**os.cpp**:
- Replace LoadLibrary("kernel32") with GetModuleHandleW(L"kernel32.dll") since kernel32 is always loaded in every Windows process, avoiding DLL search entirely.

### SDL436 Compliance Mapping

| SDL436 Requirement | Status |
|---|---|
| Optimal #1: Fully Qualified Path loading | Now used via LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
| Sub-optimal: SetDllDirectory | Removed (upgraded to optimal) |
| No use of SearchPath() | Confirmed - not used |
| Fallback uses safe search flags | Yes - LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |

### Compatibility

- LOAD_LIBRARY_SEARCH_* flags require Windows 8+ (KB2533623 on Windows 7). OpenVINO minimum supported platform is Windows 10, so no compatibility issues.
- LoadLibraryExW has the same WINAPI family availability as LoadLibraryW.


Fixes: CVS-183861