### PR TITLE
[TFL FE] Add STABLEHLO_COMPOSITE odml.rms_norm translation

### DIFF
--- a/src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp
+++ b/src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp
@@ -265,6 +265,15 @@ ov::Any DecoderFlatBuffer::get_attribute(const std::string& name) const {
         return this->get_attribute(&tflite::WhileOptions::cond_subgraph_index);
     } else if (name == "body_subgraph_index" && m_type == "WHILE") {
         return this->get_attribute(&tflite::WhileOptions::body_subgraph_index);
+    } else if (name == "composite_name" && m_type == "STABLEHLO_COMPOSITE") {
+        const auto opts = m_node_def->builtin_options_2_as<tflite::StableHLOCompositeOptions>();
+        FRONT_END_GENERAL_CHECK(opts != nullptr, "StableHLOCompositeOptions not found for STABLEHLO_COMPOSITE op");
+        FRONT_END_GENERAL_CHECK(opts->name() != nullptr, "composite_name is missing in STABLEHLO_COMPOSITE op");
+        return std::string(opts->name()->str());
+    } else if (name == "decomposition_subgraph_index" && m_type == "STABLEHLO_COMPOSITE") {
+        const auto opts = m_node_def->builtin_options_2_as<tflite::StableHLOCompositeOptions>();
+        FRONT_END_GENERAL_CHECK(opts != nullptr, "StableHLOCompositeOptions not found for STABLEHLO_COMPOSITE op");
+        return static_cast<int32_t>(opts->decomposition_subgraph_index());
     } else if (name == "strides" && m_type == "CONV_2D") {
         return std::vector<int64_t>{1,
                                     this->get_attribute(&tflite::Conv2DOptions::stride_h),
@@ -389,6 +398,22 @@ ov::Any DecoderFlatBuffer::get_attribute(const std::string& name) const {
         } else {
             return {};
         }
+    }
+
+    // For STABLEHLO_COMPOSITE, look up unknown attributes in composite_attributes FlexBuffer.
+    // Missing keys return empty ov::Any (not an error) — callers must use the two-argument
+    // get_attribute(name, default) overload for optional attributes, matching the custom_options
+    // contract below.
+    if (m_type == "STABLEHLO_COMPOSITE") {
+        const auto opts = m_node_def->builtin_options_2_as<tflite::StableHLOCompositeOptions>();
+        if (opts != nullptr) {
+            const auto attrs = opts->composite_attributes();
+            if (attrs != nullptr) {
+                const flexbuffers::Map& m = flexbuffers::GetRoot(attrs->Data(), attrs->size()).AsMap();
+                return get_value_as_ov_any(m[name]);
+            }
+        }
+        return {};
     }
 
     const auto opts = m_node_def->custom_options();

--- a/src/frontends/tensorflow_lite/src/op/stablehlo_composite.cpp
+++ b/src/frontends/tensorflow_lite/src/op/stablehlo_composite.cpp
@@ -1,0 +1,61 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <memory>
+#include <string>
+
+#include "op_translation_utils.hpp"
+#include "openvino/core/node_vector.hpp"
+#include "openvino/frontend/tensorflow_lite/decoder.hpp"
+#include "openvino/frontend/tensorflow_lite/node_context.hpp"
+#include "ov_ops/rms.hpp"
+
+namespace ov {
+namespace frontend {
+namespace tensorflow_lite {
+namespace op {
+
+/// \brief Translate odml.rms_norm composite op.
+/// The composite encodes RMS normalization with learnable gamma (scale).
+/// Expected inputs: [data, gamma]
+/// Attributes: epsilon value
+OutputVector translate_odml_rms_norm(const ov::frontend::tensorflow_lite::NodeContext& node) {
+    auto inputs = node.get_inputs();
+    FRONT_END_GENERAL_CHECK(inputs.size() == 2,
+                            "STABLEHLO_COMPOSITE odml.rms_norm expects 2 inputs (data, gamma), got ",
+                            inputs.size());
+
+    const auto& data = inputs[0];
+    const auto& gamma = inputs[1];
+
+    double epsilon = static_cast<double>(node.get_attribute<float>("epsilon", 1e-6f));
+
+    auto rms = std::make_shared<ov::op::internal::RMS>(data, gamma, epsilon);
+    return ov::OutputVector{rms->output(0)};
+}
+
+/// \brief Dispatcher for STABLEHLO_COMPOSITE operations.
+/// Routes to specific composite translators based on the composite name.
+OutputVector stablehlo_composite(const ov::frontend::tensorflow_lite::NodeContext& node) {
+    const auto decoder = node.get_decoder();
+    FRONT_END_GENERAL_CHECK(decoder != nullptr, "Decoder is required for STABLEHLO_COMPOSITE translation");
+
+    auto composite_name = decoder->get_attribute("composite_name").as<std::string>();
+
+    // Dispatch to appropriate translator based on composite name
+    if (composite_name == "odml.rms_norm") {
+        return translate_odml_rms_norm(node);
+    }
+
+    // Unsupported composite operation
+    FRONT_END_OP_CONVERSION_CHECK(false,
+                                  "Unsupported STABLEHLO_COMPOSITE operation: ",
+                                  composite_name,
+                                  ". Currently only odml.rms_norm is supported.");
+}
+
+}  // namespace op
+}  // namespace tensorflow_lite
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/tensorflow_lite/src/op_table.cpp
+++ b/src/frontends/tensorflow_lite/src/op_table.cpp
@@ -172,6 +172,7 @@ std::map<std::string, CreatorFunction> get_supported_ops() {
         {"SQUARE", DEQUANTIZE_INPUTS(translate_square_op)},
         {"SQUARED_DIFFERENCE", translate_binary<opset10::SquaredDifference>},
         {"SQUEEZE", DEQUANTIZE_INPUTS(translate_squeeze_op)},
+        {"STABLEHLO_COMPOSITE", stablehlo_composite},
         {"STRIDED_SLICE", DEQUANTIZE_INPUTS(translate_strided_slice_op)},
         {"SUB", translate_binary_op_with_activation<opset10::Subtract>},
         {"SUM", translate_reduce_op<opset10::ReduceSum>},

--- a/src/frontends/tensorflow_lite/src/op_table.hpp
+++ b/src/frontends/tensorflow_lite/src/op_table.hpp
@@ -41,6 +41,7 @@ TFL_OP_CONVERTER(quantize);
 TFL_OP_CONVERTER(reshape);
 TFL_OP_CONVERTER(rfft2d);
 TFL_OP_CONVERTER(softmax);
+TFL_OP_CONVERTER(stablehlo_composite);
 TFL_OP_CONVERTER(transpose_conv);
 TFL_OP_CONVERTER(unique);
 TFL_OP_CONVERTER(while_op);

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_StableHLOComposite.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_StableHLOComposite.py
@@ -1,0 +1,216 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import numpy as np
+import pytest
+from flatbuffers import flexbuffers
+from tensorflow.lite.python import schema_py_generated as schema_fb
+from tensorflow.lite.tools import flatbuffer_utils as fb_utils
+
+import openvino as ov
+
+test_params = [
+    {'shape': [1, 3, 32], 'epsilon': 1e-6},
+    {'shape': [2, 64], 'epsilon': 1e-5},
+    {'shape': [1, 4, 8, 16], 'epsilon': 1e-6},
+]
+
+
+def _make_gamma(last_dim, seed=123):
+    """Generate deterministic non-trivial gamma weights for testing."""
+    rng = np.random.default_rng(seed)
+    return rng.uniform(0.5, 2.0, [last_dim]).astype(np.float32)
+
+
+def build_stablehlo_composite_rms_norm_model(input_shape, epsilon):
+    """Build a TFLite flatbuffer model with STABLEHLO_COMPOSITE odml.rms_norm op.
+
+    The model has one dynamic input (data) and a constant gamma (non-trivial values).
+    """
+    last_dim = input_shape[-1]
+    gamma_data = _make_gamma(last_dim)
+
+    model = schema_fb.ModelT()
+    model.version = 3
+    model.description = "StableHLO Composite RMS Norm test model"
+
+    # Buffers: [0]=null, [1]=input (empty), [2]=gamma weights, [3]=output (empty)
+    buf_null = schema_fb.BufferT()
+    buf_input = schema_fb.BufferT()
+    buf_gamma = schema_fb.BufferT()
+    buf_output = schema_fb.BufferT()
+
+    buf_gamma.data = list(gamma_data.tobytes())
+    model.buffers = [buf_null, buf_input, buf_gamma, buf_output]
+
+    # Operator code for STABLEHLO_COMPOSITE (opcode 206)
+    op_code = schema_fb.OperatorCodeT()
+    op_code.builtinCode = schema_fb.BuiltinOperator.STABLEHLO_COMPOSITE
+    op_code.deprecatedBuiltinCode = schema_fb.BuiltinOperator.PLACEHOLDER_FOR_GREATER_OP_CODES
+    op_code.version = 1
+    model.operatorCodes = [op_code]
+
+    # Tensor 0: input
+    t_input = schema_fb.TensorT()
+    t_input.shape = list(input_shape)
+    t_input.type = schema_fb.TensorType.FLOAT32
+    t_input.buffer = 1
+    t_input.name = b"Input"
+
+    # Tensor 1: gamma (constant, non-trivial values to verify correct wiring)
+    t_gamma = schema_fb.TensorT()
+    t_gamma.shape = [last_dim]
+    t_gamma.type = schema_fb.TensorType.FLOAT32
+    t_gamma.buffer = 2
+    t_gamma.name = b"gamma"
+
+    # Tensor 2: output
+    t_output = schema_fb.TensorT()
+    t_output.shape = list(input_shape)
+    t_output.type = schema_fb.TensorType.FLOAT32
+    t_output.buffer = 3
+    t_output.name = b"RmsNormOutput"
+
+    # STABLEHLO_COMPOSITE operator with odml.rms_norm options
+    op = schema_fb.OperatorT()
+    op.opcodeIndex = 0
+    op.inputs = [0, 1]
+    op.outputs = [2]
+    op.builtinOptionsType = 0
+    op.builtinOptions = None
+    op.builtinOptions2Type = schema_fb.BuiltinOptions2.StableHLOCompositeOptions
+
+    composite_opts = schema_fb.StableHLOCompositeOptionsT()
+    composite_opts.name = "odml.rms_norm"
+    composite_opts.decompositionSubgraphIndex = 1
+    composite_opts.version = 1
+
+    # Encode epsilon as FlexBuffer map
+    fbb = flexbuffers.Builder()
+    fbb.MapFromElements({"epsilon": float(epsilon)})
+    composite_opts.compositeAttributes = list(fbb.Finish())
+    composite_opts.compositeAttributesFormat = schema_fb.CustomOptionsFormat.FLEXBUFFERS
+    op.builtinOptions2 = composite_opts
+
+    # Main subgraph
+    main_subgraph = schema_fb.SubGraphT()
+    main_subgraph.tensors = [t_input, t_gamma, t_output]
+    main_subgraph.inputs = [0]
+    main_subgraph.outputs = [2]
+    main_subgraph.operators = [op]
+    main_subgraph.name = b"main"
+
+    # Decomposition subgraph placeholder (required by schema)
+    decomp_subgraph = schema_fb.SubGraphT()
+    decomp_subgraph.name = b"odml.rms_norm_decomposition"
+    t_decomp = schema_fb.TensorT()
+    t_decomp.shape = list(input_shape)
+    t_decomp.type = schema_fb.TensorType.FLOAT32
+    t_decomp.buffer = 0
+    t_decomp.name = b"decomp_placeholder"
+    decomp_subgraph.tensors = [t_decomp]
+    decomp_subgraph.inputs = [0]
+    decomp_subgraph.outputs = [0]
+    decomp_subgraph.operators = []
+
+    model.subgraphs = [main_subgraph, decomp_subgraph]
+    return model
+
+
+def rms_norm_reference(input_data, gamma, epsilon):
+    """Compute RMS normalization reference: x / sqrt(mean(x^2) + eps) * gamma."""
+    mean_sq = np.mean(np.square(input_data), axis=-1, keepdims=True)
+    rms = np.sqrt(mean_sq + epsilon)
+    return (input_data / rms) * gamma
+
+
+class TestTFLiteStableHLOCompositeRmsNorm:
+    """Layer test for STABLEHLO_COMPOSITE odml.rms_norm op translation.
+
+    This test builds a TFLite model containing a STABLEHLO_COMPOSITE operator
+    with odml.rms_norm composite name, loads it directly via OV read_model
+    (bypassing IR serialization since RMS is an internal op), runs inference,
+    and compares against a NumPy reference implementation.
+    """
+
+    @pytest.mark.parametrize("params", test_params)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_stablehlo_composite_rms_norm(self, params, ie_device, precision, temp_dir):
+        shape = params['shape']
+        epsilon = params['epsilon']
+
+        # Build and write the TFLite model
+        model_obj = build_stablehlo_composite_rms_norm_model(shape, epsilon)
+        model_path = os.path.join(temp_dir, 'stablehlo_composite_rms_norm.tflite')
+        fb_utils.write_model(model_obj, model_path)
+
+        # Load directly via OV frontend (no IR serialization needed for internal RMS op)
+        core = ov.Core()
+        ov_model = core.read_model(model_path)
+
+        # Verify the model was translated to contain an RMS op
+        op_types = [op.get_type_name() for op in ov_model.get_ordered_ops()]
+        assert "RMS" in op_types, (
+            f"Expected RMS op in translated model, got: {op_types}"
+        )
+
+        # Compile and infer
+        config = {}
+        if ie_device == 'GPU' and precision == 'FP32':
+            config = {'INFERENCE_PRECISION_HINT': 'f32'}
+        compiled_model = core.compile_model(ov_model, ie_device, config)
+
+        # Generate random input
+        rng = np.random.default_rng(42)
+        input_data = rng.uniform(-1.0, 1.0, shape).astype(np.float32)
+        gamma = _make_gamma(shape[-1])
+
+        # Run OV inference
+        result = compiled_model([input_data])
+        ov_output = result[compiled_model.output(0)]
+
+        # Compute reference
+        expected = rms_norm_reference(input_data, gamma, epsilon)
+
+        # Compare
+        custom_eps = 1e-4 if precision == 'FP32' else 5e-2
+        assert np.allclose(ov_output, expected, atol=custom_eps), (
+            f"RMS norm output mismatch. Max diff: {np.max(np.abs(ov_output - expected)):.2e}, "
+            f"tolerance: {custom_eps:.2e}"
+        )
+
+    @pytest.mark.parametrize("params", test_params)
+    @pytest.mark.nightly
+    def test_stablehlo_composite_rms_norm_model_structure(self, params, ie_device, precision,
+                                                          temp_dir):
+        """Verify OV frontend correctly translates the STABLEHLO_COMPOSITE model structure."""
+        shape = params['shape']
+        epsilon = params['epsilon']
+
+        model_obj = build_stablehlo_composite_rms_norm_model(shape, epsilon)
+        model_path = os.path.join(temp_dir, 'stablehlo_composite_rms_norm.tflite')
+        fb_utils.write_model(model_obj, model_path)
+
+        core = ov.Core()
+        ov_model = core.read_model(model_path)
+
+        # Verify input/output shapes
+        assert len(ov_model.inputs) == 1
+        assert list(ov_model.inputs[0].shape) == shape
+
+        assert len(ov_model.outputs) == 1
+        assert list(ov_model.outputs[0].shape) == shape
+
+        # Verify RMS op has correct epsilon
+        for op in ov_model.get_ordered_ops():
+            if op.get_type_name() == "RMS":
+                attrs = op.get_attributes()
+                assert abs(attrs['epsilon'] - epsilon) < 1e-10, (
+                    f"Expected epsilon={epsilon}, got {attrs['epsilon']}"
+                )
+                break
+        else:
+            pytest.fail("RMS op not found in the model")


### PR DESCRIPTION
### Details:
 - Add STABLEHLO_COMPOSITE odml.rms_norm translation
 - Reference for stablehlo.composite : https://openxla.org/stablehlo/spec#composite
 - Reference for `odml.rms_norm` (RMS Normalization) : https://github.com/google-ai-edge/litert-torch/blob/main/litert_torch/generative/layers/normalization.py#L193
 - This op is widely used in genai tflite/litert models like gemma3, gemma3n, gemma4.

### Tickets:
 - CVS-182852

### AI Assistance:
 - *AI assistance used: yes*
  - *Copilot was used to generate test code, and to fix errors in code*
  - *Manually reviewed the changes, and verified the test cases by running the tests*