### PR TITLE
Docs: Fix broken links in GPU and CPU READMEs (#34556)

### DIFF
--- a/src/plugins/intel_cpu/README.md
+++ b/src/plugins/intel_cpu/README.md
@@ -2,7 +2,7 @@
 
 ## Key Contacts
 
-For assistance regarding CPU, contact a member of [openvino-ie-cpu-maintainers](https://github.com/orgs/openvinotoolkit/teams/openvino-ie-cpu-maintainers) group.
+For assistance regarding CPU, contact a member of the [OpenVINO Maintainers](https://github.com/openvinotoolkit/openvino/blob/master/CONTRIBUTING.md) group.
 
 ## Components
 

--- a/src/plugins/intel_gpu/README.md
+++ b/src/plugins/intel_gpu/README.md
@@ -4,7 +4,7 @@ GPU plugin in [OpenVINO toolkit](https://github.com/openvinotoolkit/openvino) su
 
 ## Key Contacts
 
-For assistance regarding GPU, contact a member of [openvino-ie-gpu-maintainers](https://github.com/orgs/openvinotoolkit/teams/openvino-ie-gpu-maintainers) group.
+For assistance regarding GPU, contact a member of the [OpenVINO Maintainers](https://github.com/openvinotoolkit/openvino/blob/master/CONTRIBUTING.md) group.
 
 ## Components
 
@@ -35,10 +35,10 @@ This contents explain the internal implementation of dynamic shape support in th
 
 * [Overall flow for dynamic shape execution](./docs/dynamic_shape/overall_flow.md)
 * Implementation details
-  * [Preprocessing: Shape inference / update weight / realloc memory](./docs/dynamic_shape/preprocessing.md)
+  * Preprocessing: Shape inference / update weight / realloc memory
   * [dynamic impl of kernels](./docs/dynamic_shape/dynamic_impl.md)
   * [in-memory kernel cache](./docs/dynamic_shape/in_memory_cache.md)
-  * [async kernel compilation](./docs/dynamic_shape/async_compilation.md)
+  * async kernel compilation
   <!-- * weight compression (TBD)) -->
 * Optimization features
   * [Memory preallocation](./docs/dynamic_shape/memory_preallocation.md)


### PR DESCRIPTION
This PR addresses Issue #34556 by cleaning up several outdated links in the Intel GPU and CPU plugin README files.

Summary of changes:

Intel GPU README: Removed broken links to missing .md files and updated the maintainer contact link to the contributing guide.

Intel CPU README: Updated the outdated maintainer contact link.

As a GSoC 2026 applicant for Project #8, I noticed these while exploring the hardware-specific plugins and wanted to ensure the documentation is accurate for new contributors.

Closes #34556