### PR TITLE
Add support for prim::ceil operator in PyTorch frontend

### DIFF
--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -791,6 +791,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"ov_ext::conv1d", op::translate_conv1d_ext},
         {"ov_ext::linear", op::translate_linear_ext},
         {"prim::abs", op::translate_1to1_match_1_inputs<opset10::Abs>},
+        {"prim::ceil", op::translate_1to1_match_1_inputs<opset10::Ceiling>},
         {"prim::Constant", op::translate_constant},
         {"prim::device", op::translate_constant},
         // prim::DictConstruct - Supported in limited set of patterns


### PR DESCRIPTION
### Details
This pull request adds support for the `prim::ceil` operator in the PyTorch frontend of OpenVINO.

Currently, the PyTorch frontend supports `aten::ceil` but does not explicitly support `prim::ceil`.  
This change introduces a mapping for `prim::ceil` to the OpenVINO `Ceiling` operation.

Implementation:
- Added mapping in `op_table.cpp`
- `prim::ceil` → `op::translate_1to1_match_1_inputs<opset10::Ceiling>`

This ensures that models containing `prim::ceil` nodes can be correctly translated to OpenVINO IR.

### Tickets
N/A

### AI Assistance
AI assistance used: yes

AI was used to assist with understanding the repository structure and locating the correct operator mapping location.  
The implementation and validation were reviewed manually before submission.
