### PR TITLE
[GPU] Add block2d compatibility guard for SDPA micro kernel BLOCK_2D_A

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1169,8 +1169,8 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
         // tile element vector = sg_tile_m * max_BC / sg_size; must be <= 16 (max defined vl).
         const bool block2d_compatible = (sg_tile_m * 8 / sg_size) <= 16;  // sg_tile_m <= 32
         const bool use_block2d = lda % 16 == 0 && vbytes % 4 == 0 && block2d_compatible;
-        GPU_DEBUG_INFO << "BLOCK_2D_A check: sg_tile_m=" << sg_tile_m << " sg_size=" << sg_size << " lda=" << lda << " vbytes=" << vbytes
-                       << " block2d_compatible=" << block2d_compatible << " => " << (use_block2d ? "enabled" : "disabled") << std::endl;
+        GPU_DEBUG_TRACE_DETAIL << "BLOCK_2D_A check: sg_tile_m=" << sg_tile_m << " sg_size=" << sg_size << " lda=" << lda << " vbytes=" << vbytes
+                               << " block2d_compatible=" << block2d_compatible << " => " << (use_block2d ? "enabled" : "disabled") << std::endl;
         if (use_block2d)
             jit.make("BLOCK_2D_A", 1);
     }


### PR DESCRIPTION
### Description of the issue (symptom, root-cause, how it was resolved)

**SDPA micro kernel BLOCK_2D_A enablement without block2d compatibility check**
 - **Symptom**: `BLOCK_2D_A` could be enabled for configurations where `sg_tile_m` exceeds the supported range of `DEF_BLOCK2D_LOAD_STORE` definitions in `tile_ops.cl`, potentially leading to compilation failures or incorrect behavior
 - **Root-cause**: The original condition (`lda % 16 == 0 && vbytes % 4 == 0`) did not verify that the tile element vector length (`sg_tile_m * max_BC / sg_size`) falls within the defined `DEF_BLOCK2D_LOAD_STORE` variants (max vl=16 for half)
 - **Resolution**: Added `block2d_compatible` guard ensuring `sg_tile_m <= 32` (i.e., vl ≤ 16) before enabling `BLOCK_2D_A` in `sdpa_gen_micro.cpp`

#### The code and line that caused this issue (if it is not changed directly)
 - `intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp`

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *183530*