### PR TITLE
[NPUW] Model builder: fix Whisper decoder synthetic model

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
@@ -1543,9 +1543,9 @@ std::shared_ptr<ov::Model> ModelBuilder::build_llm(const LLMConfig& config_in) {
     return make_model(final_norm, "last_hidden_state", model_name);
 }
 
-std::shared_ptr<ov::Model> ModelBuilder::build_whisper_encoder(const WhisperEncoderConfig& config_in) {
+std::shared_ptr<ov::Model> ModelBuilder::build_whisper_encoder(const WhisperConfig& config_in) {
     clear();
-    WhisperEncoderConfig config = config_in;
+    WhisperConfig config = config_in;
     if (!config.norm)
         config.norm = LayerNorm(config.hidden_size, config.precision);
     if (!config.ffn)
@@ -1796,9 +1796,9 @@ static ov::Output<ov::Node> make_whisper_positional_embedding(const ov::Output<o
     return hidden_states->output(0);
 }
 
-std::shared_ptr<ov::Model> ModelBuilder::build_whisper_decoder(const WhisperDecoderConfig& config_in) {
+std::shared_ptr<ov::Model> ModelBuilder::build_whisper_decoder(const WhisperConfig& config_in) {
     clear();
-    WhisperDecoderConfig config = config_in;
+    WhisperConfig config = config_in;
     if (!config.norm)
         config.norm = LayerNorm(config.hidden_size, config.precision);
     if (!config.ffn)
@@ -1810,7 +1810,9 @@ std::shared_ptr<ov::Model> ModelBuilder::build_whisper_decoder(const WhisperDeco
 
     auto input_ids = parameter(ov::element::i64, ov::PartialShape{-1, -1}, "input_ids");
     auto encoder_hidden_states =
-        parameter(ov::element::f32, ov::PartialShape{-1, -1, static_cast<int64_t>(d)}, "encoder_hidden_states");
+        parameter(ov::element::f32,
+                  ov::PartialShape{-1, static_cast<int64_t>(config.get_encoder_seq_len()), static_cast<int64_t>(d)},
+                  "encoder_hidden_states");
     auto beam_idx = parameter(ov::element::i32, ov::PartialShape{-1}, "beam_idx");
 
     ov::Output<ov::Node> enc_hs = encoder_hidden_states->output(0);

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
@@ -405,22 +405,22 @@ struct LLMConfig : public BaseModelConfig {
     bool pre_norm = true;
 };
 
-struct WhisperEncoderConfig : public BaseModelConfig {
+struct WhisperConfig : public BaseModelConfig {
     size_t encoder_layers = 0;
+    size_t decoder_layers = 0;
     size_t num_mel_bins = 80;
     size_t max_source_positions = 1500;
+    size_t max_target_positions = 448;
 
     size_t get_encoder_layers() const {
         return encoder_layers == 0 ? num_layers : encoder_layers;
     }
-};
-
-struct WhisperDecoderConfig : public BaseModelConfig {
-    size_t decoder_layers = 0;
-    size_t max_target_positions = 448;
-
     size_t get_decoder_layers() const {
         return decoder_layers == 0 ? num_layers : decoder_layers;
+    }
+    /// Encoder output sequence length after Conv1D preprocessing (stride=2 on 2*max_source_positions).
+    size_t get_encoder_seq_len() const {
+        return max_source_positions;
     }
 };
 
@@ -454,8 +454,8 @@ public:
                                                      const std::string& name);
 
     std::shared_ptr<ov::Model> build_llm(const LLMConfig& config);
-    std::shared_ptr<ov::Model> build_whisper_encoder(const WhisperEncoderConfig& config);
-    std::shared_ptr<ov::Model> build_whisper_decoder(const WhisperDecoderConfig& config);
+    std::shared_ptr<ov::Model> build_whisper_encoder(const WhisperConfig& config);
+    std::shared_ptr<ov::Model> build_whisper_decoder(const WhisperConfig& config);
     std::shared_ptr<ov::Model> build_embedding_encoder(const BertConfig& config);
 
     void clear();

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
@@ -428,13 +428,17 @@ TEST_F(LLMCompiledModelFactoryOptionsTest, CacheRopeDisabledRoundsTripThroughCom
     EXPECT_EQ(recorder.count_contains("_kv"), 1u);
 }
 
-TEST_F(LLMCompiledModelFactoryOptionsTest, WhisperOptionRejectsCurrentSyntheticDecoderModel) {
+TEST_F(LLMCompiledModelFactoryOptionsTest, WhisperOptionCompilesSyntheticDecoderModel) {
     RecordingFactory recorder;
     std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
 
-    EXPECT_ANY_THROW(compiled = create_compiled_model(build_whisper_decoder_model(),
-                                                      {{"NPUW_WHISPER", "YES"}, {"NPUW_WHISPER_EOS_TOKEN", "42"}},
-                                                      recorder));
+    ASSERT_NO_THROW(compiled = create_compiled_model(build_whisper_decoder_model(),
+                                                     {{"NPUW_WHISPER", "YES"}, {"NPUW_WHISPER_EOS_TOKEN", "42"}},
+                                                     recorder));
+    ASSERT_NE(compiled, nullptr);
+    EXPECT_GE(recorder.calls().size(), 2u);
+    EXPECT_NE(recorder.find_suffix("_prefill"), nullptr);
+    EXPECT_EQ(recorder.count_contains("_kv"), 1u);
 }
 
 TEST_F(LLMCompiledModelFactoryOptionsTest, WhisperPreparationAddsKvCacheInputsAndPresentOutputs) {
@@ -462,7 +466,9 @@ TEST_F(LLMCompiledModelFactoryOptionsTest, WhisperPrefillPreparationAddsCrossAtt
     ov::pass::StatefulToStateless().run_on_model(model);
     model = model->clone();
 
-    EXPECT_TRUE(ov::npuw::util::PrepareWhisperPrefillModel(128, 256).run_on_model(model));
+    EXPECT_TRUE(ov::npuw::util::PrepareWhisperPrefillModel(
+                    128, static_cast<uint32_t>(ov::test::npuw::WhisperConfig{}.max_source_positions))
+                    .run_on_model(model));
     auto prepared = model;
 
     EXPECT_TRUE(has_input_name(prepared, "attention_mask"));

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
@@ -38,7 +38,7 @@ inline std::shared_ptr<ov::Model> build_llm_test_model() {
 
 inline std::shared_ptr<ov::Model> build_whisper_decoder_test_model() {
     ModelBuilder mb;
-    return mb.build_whisper_decoder(make_test_model_config<WhisperDecoderConfig>());
+    return mb.build_whisper_decoder(make_test_model_config<WhisperConfig>());
 }
 
 inline std::shared_ptr<ov::Model> build_embedding_test_model() {


### PR DESCRIPTION
### Details:
 - Unify WhisperEncoderConfig and WhisperDecoderConfig into a single WhisperConfig struct so encoder and decoder share the same source of truth for encoder / decoder. Update tests to expect a success not failure.
 
### Tickets:
 - *EISW-209517*

### AI Assistance:
 - *AI assistance used: yes*
 - *Claude Code used for review, refactoring suggestions, and test updates. All changes validated by build + unit tests locally.*
