### PR TITLE
[GPU] Fixed ScatterUpdate kernel for input with padding

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
@@ -25,7 +25,7 @@
     #define ORDER b,f,w,z,y,x
 #endif
 
-#ifdef BLOCKED_LAYOUT
+#ifdef USE_LAYOUT_AWARE_INDEXING
 inline void FUNC(planar_to_bfyx)(const uint planar_index,
                                  const uint batch_num, const uint channel_num, const uint height, const uint width,
                                  uint* dst_b, uint* dst_f, uint* dst_y, uint* dst_x)
@@ -88,7 +88,7 @@ inline void FUNC(planar_to_bfwzyx)(const uint planar_index,
     *dst_x = dst_xy % width;
 }
 #endif // INPUT2_DIMS
-#endif // BLOCKED_LAYOUT
+#endif // USE_LAYOUT_AWARE_INDEXING
 
 KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
                    const __global INPUT0_TYPE* dictionary,
@@ -190,7 +190,7 @@ KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
         #endif
     #endif
 
-    #ifdef BLOCKED_LAYOUT
+    #ifdef USE_LAYOUT_AWARE_INDEXING
         const uint planar_axis_idx = OUTPUT_INDEX_ON_AXIS;
         uint b_b, b_f, b_w, b_z, b_y, b_x;
         FUNC_CALL(planar_to_bfyx)(planar_axis_idx, INPUT1_BATCH_NUM, INPUT1_FEATURE_NUM, INPUT1_SIZE_Y, INPUT1_SIZE_X,
@@ -203,7 +203,7 @@ KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
 
     const uint output_idx = GET_OUTPUT_INDEX(SECOND_ITER_OUTPUT_INDEX_ORDER);
 
-    #ifdef BLOCKED_LAYOUT
+    #ifdef USE_LAYOUT_AWARE_INDEXING
         const uint planar_updates_idx = GET_UPDATES_INDEX(UPDATES_INDEX_ORDER);
 
         #if INPUT2_DIMS == 4

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
@@ -238,6 +238,8 @@ KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 }
 
+#undef INDICES_SIZE
+#undef GET_UPDATES_INDEX
 #undef GET_OUTPUT_INDEX
 #undef GET_INPUT_INDEX
 #undef ORDER

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
@@ -13,6 +13,9 @@
 
 #define GET_OUTPUT_INDEX(idx_order) OUTPUT_GET_INDEX(idx_order)
 #define GET_INPUT_INDEX(idx_order) INPUT0_GET_INDEX(idx_order)
+#define GET_UPDATES_INDEX(idx_order) UPDATES_GET_INDEX(idx_order)
+
+#define INDICES_SIZE INPUT1_LENGTH
 
 #if OUTPUT_DIMS == 4
     #define ORDER b,f,y,x

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -186,13 +186,13 @@ JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params
 
     const auto input2_has_padding = params.inputs[2].has_dynamic_pad() || params.inputs[2].PitchesDifferFromLogicalDims();
 
-    // In case of padded input2 (updates), we also need blocked layout, because UPDATES_INDEX is calculated based on output sizes
-    const auto blocked_layout = !(SimpleLayout(params.inputs[0].GetLayout()) &&
-                                  SimpleLayout(params.inputs[1].GetLayout()) &&
-                                  SimpleLayout(params.inputs[2].GetLayout())) || input2_has_padding;
+    // In case of padded input2 (updates), we also need non-planar indexing, because UPDATES_INDEX is calculated based on output sizes
+    const auto use_layout_aware_indexing = !(SimpleLayout(params.inputs[0].GetLayout()) &&
+                                             SimpleLayout(params.inputs[1].GetLayout()) &&
+                                             SimpleLayout(params.inputs[2].GetLayout())) || input2_has_padding;
 
-    if (blocked_layout) {
-        jit.AddConstant(MakeJitConstant("BLOCKED_LAYOUT", "1"));
+    if (use_layout_aware_indexing) {
+        jit.AddConstant(MakeJitConstant("USE_LAYOUT_AWARE_INDEXING", "1"));
     }
 
     jit.AddConstant(MakeJitConstant("UPDATES_INDEX_ORDER", GetUpdatesIndexOrder(params)));
@@ -205,8 +205,10 @@ JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params
     auto default_order = GetDefaultOrder(output.GetDims().size());
 
     size_t dims = default_order.size();
-    // For blocked layout, this is just planar index, offset will be added later
-    std::string get_update_idx = blocked_layout ? "0" : "(INPUT2_OFFSET)";
+    // UPDATES_GET_INDEX just calculates planar index
+    // In case of simple planar layout, this index will be used directly, so need to add INPUT2_OFFSET
+    // In case of non-planar layout, INPUT2_GET_INDEX macro will be used, which adds the offset internally
+    std::string get_update_idx = use_layout_aware_indexing ? "0" : "(INPUT2_OFFSET)";
     std::string get_update_idx_src = "UPDATES_GET_INDEX(";
     for (size_t i = 0; i < dims; ++i) {
         if (i == dims-1) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -180,39 +180,13 @@ static std::string GetSecondIterOutputIndexOrder(const scatter_update_params& pa
     return GetOrderString(output_order);
 }
 
-static std::vector<std::string> GetPlanarPitches(const Tensor::NDims& dims) {
-    const auto ndims = dims.size();
-    std::vector<std::string> pitches(ndims);
-    size_t pitch = 1;
-    for (size_t i = 0; i < ndims; ++i) {
-        pitches[i] = std::to_string(pitch);
-        pitch *= dims[i].v;
-    }
-    std::reverse(pitches.begin(), pitches.end());
-    return pitches;
-}
-
-static std::vector<std::string> GetDynamicPitches(const Tensor::NDims& dims, size_t tensor_idx) {
-    std::vector<std::string> pitches(dims.size());
-    size_t shape_info_rank = DataTensor::max_rank();
-    std::string pitch = "1";
-    for (size_t i = 0; i < pitches.size(); ++i) {
-        size_t bf_idx = dims.size() - i - 1;
-        size_t dim_offset = bf_idx > 1 ? shape_info_rank - i - 1 : bf_idx;
-
-        pitches[i] = pitch;
-        pitch += "*" + toCodeString(dims[i], tensor_idx * shape_info_rank + dim_offset);
-    }
-    std::reverse(pitches.begin(), pitches.end());
-    return pitches;
-}
-
 JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params& params) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
     size_t axis_value = GetScatterUpdateChannelIndex(params);
 
     const auto input2_has_padding = params.inputs[2].has_dynamic_pad() || params.inputs[2].PitchesDifferFromLogicalDims();
 
+    // In case of padded input2 (updates), we also need blocked layout, because UPDATES_INDEX is calculated based on output sizes
     const auto blocked_layout = !(SimpleLayout(params.inputs[0].GetLayout()) &&
                                   SimpleLayout(params.inputs[1].GetLayout()) &&
                                   SimpleLayout(params.inputs[2].GetLayout())) || input2_has_padding;
@@ -227,54 +201,26 @@ JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params
     jit.AddConstant(MakeJitConstant("OUTPUT_INDEX_ON_AXIS", GetOutputIndexOnAxis(params, GetScatterUpdateChannelIndex(params))));
     jit.AddConstant(MakeJitConstant("AXIS_VALUE", axis_value));
 
-    const auto& input1 = params.inputs[1];
-    if (input1.is_dynamic()) {
-        const auto& input1_dims = input1.GetDims();
-        size_t input_offset = DataTensor::max_rank();
-        std::string indices_size = "(";
-
-        for (size_t i = 0; i < input1_dims.size(); ++i) {
-            size_t bf_idx = input1_dims.size() - i - 1;
-            size_t dim_offset = bf_idx > 1 ? input_offset - i - 1 : bf_idx;
-
-            indices_size += toCodeString(input1_dims[i], input_offset + dim_offset) + "*";
-        }
-        indices_size.back() = ')';
-        jit.AddConstant(MakeJitConstant("INDICES_SIZE", indices_size));
-    } else {
-        jit.AddConstant(MakeJitConstant("INDICES_SIZE", params.inputs[1].LogicalSize()));
-    }
-
-    std::vector<std::string> pitches;
     const auto& output = params.outputs[0];
-    if (output.is_dynamic()) {
-        size_t tensor_idx = params.inputs.size() + GetFusedPrimitiveInputsCount(params);
-        for (auto input : params.inputs) {
-            if (!input.is_dynamic())
-                tensor_idx--;
-        }
-        for (auto fused_op : params.fused_ops) {
-            if (!fused_op.output_tensor.is_dynamic())
-                tensor_idx--;
-        }
-        pitches = GetDynamicPitches(output.GetDims(), tensor_idx);
-    } else {
-        pitches = GetPlanarPitches(output.GetDims());
-    }
     auto default_order = GetDefaultOrder(output.GetDims().size());
 
     size_t dims = default_order.size();
+    // For blocked layout, this is just planar index, offset will be added later
     std::string get_update_idx = blocked_layout ? "0" : "(INPUT2_OFFSET)";
+    std::string get_update_idx_src = "UPDATES_GET_INDEX(";
     for (size_t i = 0; i < dims; ++i) {
-        if (i >= axis_value) {
+        if (i == dims-1) {
+            get_update_idx_src += default_order[i] + ")";
             std::string def_pitch = "UPDATES_" + GetAxisName(dims, i) + "_PITCH";
-            std::string src_pitch = "(" + pitches[i] + ")";
+            std::string src_pitch = "1";
             jit.AddConstant(MakeJitConstant(def_pitch, src_pitch));
         } else if (i == (axis_value - 1)) {
+            get_update_idx_src += default_order[i] + ", ";
             std::string def_pitch = "UPDATES_" + GetAxisName(dims, i) + "_PITCH";
-            std::string src_pitch = "(" + pitches[i + 1] + " * INDICES_SIZE)";
+            std::string src_pitch = "(UPDATES_" + GetAxisName(dims, i + 1) + "_PITCH * INDICES_SIZE)";
             jit.AddConstant(MakeJitConstant(def_pitch, src_pitch));
-        } else { // i < axis_value - 1
+        } else {
+            get_update_idx_src += default_order[i] + ", ";
             std::string def_pitch = "UPDATES_" + GetAxisName(dims, i) + "_PITCH" + "";
             std::string output_size_name;
             if (i == 0)
@@ -286,7 +232,7 @@ JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params
         }
         get_update_idx = get_update_idx + " + (" + default_order[i] + ")*(UPDATES_" + GetAxisName(dims, i) + "_PITCH)";
     }
-    jit.AddConstant(MakeJitConstant("GET_UPDATES_INDEX(idx_order)", get_update_idx));
+    jit.AddConstant(MakeJitConstant(get_update_idx_src, get_update_idx));
 
     if (!params.fused_ops.empty()) {
         FusedOpsConfiguration conf1 = { "_FIRST_KERNEL", GetDefaultOrder(output.GetDims().size()), "val", params.inputs[0].GetDType() };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -211,9 +211,11 @@ JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params
     JitConstants jit = MakeBaseParamsJitConstants(params);
     size_t axis_value = GetScatterUpdateChannelIndex(params);
 
+    const auto input2_has_padding = params.inputs[2].has_dynamic_pad() || params.inputs[2].PitchesDifferFromLogicalDims();
+
     const auto blocked_layout = !(SimpleLayout(params.inputs[0].GetLayout()) &&
                                   SimpleLayout(params.inputs[1].GetLayout()) &&
-                                  SimpleLayout(params.inputs[2].GetLayout()));
+                                  SimpleLayout(params.inputs[2].GetLayout())) || input2_has_padding;
 
     if (blocked_layout) {
         jit.AddConstant(MakeJitConstant("BLOCKED_LAYOUT", "1"));
@@ -262,7 +264,7 @@ JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params
     auto default_order = GetDefaultOrder(output.GetDims().size());
 
     size_t dims = default_order.size();
-    std::string get_update_idx = "(INPUT2_OFFSET)";
+    std::string get_update_idx = blocked_layout ? "0" : "(INPUT2_OFFSET)";
     for (size_t i = 0; i < dims; ++i) {
         if (i >= axis_value) {
             std::string def_pitch = "UPDATES_" + GetAxisName(dims, i) + "_PITCH";

--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_update_gpu_test.cpp
@@ -1683,6 +1683,90 @@ TEST(scatter_update_gpu_fp32, dynamic) {
     }
 }
 
+TEST(scatter_update_gpu_fp32, dynamic_with_input_padding) {
+    //  Dictionary : 1x2x5x2
+    //  Indexes : 2x1x2x1
+    //  Updates : 1x2x2x1x2x2
+    //  Axis : 2
+    //  Output : 1x2x5x2
+    //  Input values in fp32
+
+    auto& engine = get_test_engine();
+
+    auto input1_layout = layout{ ov::PartialShape::dynamic(4), data_types::f32, format::bfyx };
+    auto input2_layout = layout{ ov::PartialShape::dynamic(4), data_types::f32, format::bfyx };
+    padding::DynamicDimsMask mask;
+    mask.set(5);
+    auto input3_layout = layout{ov::PartialShape::dynamic(6), data_types::f32, format::bfwzyx, padding({}, mask)};
+
+    auto input1 = engine.allocate_memory({{1, 2, 5, 2},       data_types::f32, format::bfyx});   // Dictionary
+    auto input2 = engine.allocate_memory({{2, 1, 2, 1},       data_types::f32, format::bfyx});   // Indices
+    auto input3 = engine.allocate_memory({{1, 2, 2, 1, 2, 2}, data_types::f32, format::bfwzyx, padding({0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0})});  // Updates
+    auto axis = 2;
+
+    set_values(input1, {
+        0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f,
+        10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f
+    });
+
+    set_values(input2, {
+        2.f, 0.f,
+        3.f, 4.f
+    });
+
+    set_values(input3, {
+        0.f, 20.f, 30.f,
+        0.f, 40.f, 50.f,
+        0.f, 60.f, 70.f,
+        0.f, 80.f, 90.f,
+        0.f, 100.f, 110.f,
+        0.f, 120.f, 130.f,
+        0.f, 140.f, 150.f,
+        0.f, 160.f, 170.f
+    });
+
+    topology topology;
+    topology.add(input_layout("InputDictionary", input1_layout));
+    topology.add(input_layout("InputText", input2_layout));
+    topology.add(input_layout("InputUpdates", input3_layout));
+
+    topology.add(reorder("DictionaryReordered", input_info("InputDictionary"), format::bfyx, data_types::f32));
+    topology.add(reorder("TextReordered", input_info("InputText"), format::bfyx, data_types::f32));
+    topology.add(scatter_update("scatter_update",
+                                input_info("DictionaryReordered"),
+                                input_info("TextReordered"),
+                                input_info("InputUpdates"),
+                                axis)
+    );
+    topology.add(reorder("out", input_info("scatter_update"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, config);
+
+    network.set_input_data("InputDictionary", input1);
+    network.set_input_data("InputText", input2);
+    network.set_input_data("InputUpdates", input3);
+
+    auto inst = network.get_primitive("scatter_update");
+    auto impl = inst->get_impl();
+    ASSERT_TRUE(impl != nullptr);
+    ASSERT_TRUE(impl->is_dynamic());
+
+    auto outputs = network.execute();
+    auto output = outputs.at("out").get_memory();
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+
+    std::vector<float> expected_results = {
+        40.f, 50.f, 2.f, 3.f, 20.f, 30.f, 60.f, 70.f, 80.f, 90.f,
+        120.f, 130.f, 12.f, 13.f, 100.f, 110.f, 140.f, 150.f, 160.f, 170.f
+    };
+
+    for (size_t i = 0; i < expected_results.size(); ++i) {
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
+    }
+}
+
 TEST(scatter_update_gpu_fp32, mixed_input_with_dynamic_static) {
     //  Dictionary : 1x2x5x2
     //  Indexes : 2x1x2x1

--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_update_gpu_test.cpp
@@ -1683,7 +1683,170 @@ TEST(scatter_update_gpu_fp32, dynamic) {
     }
 }
 
-TEST(scatter_update_gpu_fp32, dynamic_with_input_padding) {
+TEST(scatter_update_gpu_fp32, static_input_padding) {
+    //  Dictionary : 1x2x5x2
+    //  Indexes : 2x1x2x1
+    //  Updates : 1x2x2x1x2x2
+    //  Axis : 2
+    //  Output : 1x2x5x2
+    //  Input values in fp32
+
+    auto& engine = get_test_engine();
+
+    auto input1_layout = layout{ov::PartialShape{1, 2, 5, 2}, data_types::f32, format::bfyx};
+    auto input2_layout = layout{ov::PartialShape{2, 1, 2, 1}, data_types::f32, format::bfyx};
+    auto input3_layout = layout{ov::PartialShape{1, 2, 2, 1, 2, 2}, data_types::f32, format::bfwzyx, padding({0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0})};
+
+    auto input1 = engine.allocate_memory({{1, 2, 5, 2},       data_types::f32, format::bfyx});   // Dictionary
+    auto input2 = engine.allocate_memory({{2, 1, 2, 1},       data_types::f32, format::bfyx});   // Indices
+    auto input3 = engine.allocate_memory({{1, 2, 2, 1, 2, 2}, data_types::f32, format::bfwzyx, padding({0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0})});  // Updates
+    auto axis = 2;
+
+    set_values(input1, {
+        0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f,
+        10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f
+    });
+
+    set_values(input2, {
+        2.f, 0.f,
+        3.f, 4.f
+    });
+
+    set_values(input3, {
+        0.f, 20.f, 30.f,
+        0.f, 40.f, 50.f,
+        0.f, 60.f, 70.f,
+        0.f, 80.f, 90.f,
+        0.f, 100.f, 110.f,
+        0.f, 120.f, 130.f,
+        0.f, 140.f, 150.f,
+        0.f, 160.f, 170.f
+    });
+
+    topology topology;
+    topology.add(input_layout("InputDictionary", input1_layout));
+    topology.add(input_layout("InputText", input2_layout));
+    topology.add(input_layout("InputUpdates", input3_layout));
+
+    topology.add(reorder("DictionaryReordered", input_info("InputDictionary"), format::bfyx, data_types::f32));
+    topology.add(reorder("TextReordered", input_info("InputText"), format::bfyx, data_types::f32));
+    topology.add(scatter_update("scatter_update",
+                                input_info("DictionaryReordered"),
+                                input_info("TextReordered"),
+                                input_info("InputUpdates"),
+                                axis)
+    );
+    topology.add(reorder("out", input_info("scatter_update"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, config);
+
+    network.set_input_data("InputDictionary", input1);
+    network.set_input_data("InputText", input2);
+    network.set_input_data("InputUpdates", input3);
+
+    auto inst = network.get_primitive("scatter_update");
+    auto impl = inst->get_impl();
+    ASSERT_TRUE(impl != nullptr);
+
+    auto outputs = network.execute();
+    auto output = outputs.at("out").get_memory();
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+
+    std::vector<float> expected_results = {
+        40.f, 50.f, 2.f, 3.f, 20.f, 30.f, 60.f, 70.f, 80.f, 90.f,
+        120.f, 130.f, 12.f, 13.f, 100.f, 110.f, 140.f, 150.f, 160.f, 170.f
+    };
+
+    for (size_t i = 0; i < expected_results.size(); ++i) {
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
+    }
+}
+
+TEST(scatter_update_gpu_fp32, dynamic_with_static_input_padding) {
+    //  Dictionary : 1x2x5x2
+    //  Indexes : 2x1x2x1
+    //  Updates : 1x2x2x1x2x2
+    //  Axis : 2
+    //  Output : 1x2x5x2
+    //  Input values in fp32
+
+    auto& engine = get_test_engine();
+
+    auto input1_layout = layout{ ov::PartialShape::dynamic(4), data_types::f32, format::bfyx };
+    auto input2_layout = layout{ ov::PartialShape::dynamic(4), data_types::f32, format::bfyx };
+    auto input3_layout = layout{ov::PartialShape::dynamic(6), data_types::f32, format::bfwzyx, padding({0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0})};
+
+    auto input1 = engine.allocate_memory({{1, 2, 5, 2},       data_types::f32, format::bfyx});   // Dictionary
+    auto input2 = engine.allocate_memory({{2, 1, 2, 1},       data_types::f32, format::bfyx});   // Indices
+    auto input3 = engine.allocate_memory({{1, 2, 2, 1, 2, 2}, data_types::f32, format::bfwzyx, padding({0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0})});  // Updates
+    auto axis = 2;
+
+    set_values(input1, {
+        0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f,
+        10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f
+    });
+
+    set_values(input2, {
+        2.f, 0.f,
+        3.f, 4.f
+    });
+
+    set_values(input3, {
+        0.f, 20.f, 30.f,
+        0.f, 40.f, 50.f,
+        0.f, 60.f, 70.f,
+        0.f, 80.f, 90.f,
+        0.f, 100.f, 110.f,
+        0.f, 120.f, 130.f,
+        0.f, 140.f, 150.f,
+        0.f, 160.f, 170.f
+    });
+
+    topology topology;
+    topology.add(input_layout("InputDictionary", input1_layout));
+    topology.add(input_layout("InputText", input2_layout));
+    topology.add(input_layout("InputUpdates", input3_layout));
+
+    topology.add(reorder("DictionaryReordered", input_info("InputDictionary"), format::bfyx, data_types::f32));
+    topology.add(reorder("TextReordered", input_info("InputText"), format::bfyx, data_types::f32));
+    topology.add(scatter_update("scatter_update",
+                                input_info("DictionaryReordered"),
+                                input_info("TextReordered"),
+                                input_info("InputUpdates"),
+                                axis)
+    );
+    topology.add(reorder("out", input_info("scatter_update"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, config);
+
+    network.set_input_data("InputDictionary", input1);
+    network.set_input_data("InputText", input2);
+    network.set_input_data("InputUpdates", input3);
+
+    auto inst = network.get_primitive("scatter_update");
+    auto impl = inst->get_impl();
+    ASSERT_TRUE(impl != nullptr);
+    ASSERT_TRUE(impl->is_dynamic());
+
+    auto outputs = network.execute();
+    auto output = outputs.at("out").get_memory();
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+
+    std::vector<float> expected_results = {
+        40.f, 50.f, 2.f, 3.f, 20.f, 30.f, 60.f, 70.f, 80.f, 90.f,
+        120.f, 130.f, 12.f, 13.f, 100.f, 110.f, 140.f, 150.f, 160.f, 170.f
+    };
+
+    for (size_t i = 0; i < expected_results.size(); ++i) {
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
+    }
+}
+
+TEST(scatter_update_gpu_fp32, dynamic_with_dynamic_input_padding) {
     //  Dictionary : 1x2x5x2
     //  Indexes : 2x1x2x1
     //  Updates : 1x2x2x1x2x2
@@ -1701,7 +1864,7 @@ TEST(scatter_update_gpu_fp32, dynamic_with_input_padding) {
 
     auto input1 = engine.allocate_memory({{1, 2, 5, 2},       data_types::f32, format::bfyx});   // Dictionary
     auto input2 = engine.allocate_memory({{2, 1, 2, 1},       data_types::f32, format::bfyx});   // Indices
-    auto input3 = engine.allocate_memory({{1, 2, 2, 1, 2, 2}, data_types::f32, format::bfwzyx, padding({0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0})});  // Updates
+    auto input3 = engine.allocate_memory({{1, 2, 2, 1, 2, 2}, data_types::f32, format::bfwzyx, padding({0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0}, mask)});  // Updates
     auto axis = 2;
 
     set_values(input1, {


### PR DESCRIPTION
### Details:
 - This PR enables proper support for input padding for the ScatterUpdate reference kernel.
 - Unit tests for static and dynamic padding were added.

### Description of the issue(symptom, root-cause, how it was resolved)
- Scatter update doesn't give correct output when the "updates" input tensor has padding.
- Code for calculation of pitches was incorrect in case of dynamic padding
- Issue was resolved by modifying the GET_UPDATES_INDEX code and using blocked path in case of padding.
 
#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
 
### Tickets:
 - CVS-173392

### AI Assistance:
 - AI assistance used: no
