### PR TITLE
fix : Improve Test coverage for  tools/ovc/unit_tests

### DIFF
--- a/tools/ovc/unit_tests/moc_tf_fe/check_info_messages_test.py
+++ b/tools/ovc/unit_tests/moc_tf_fe/check_info_messages_test.py
@@ -12,50 +12,75 @@ from openvino.tools.ovc.main import main
 from openvino.tools.ovc.get_ov_update_message import get_compression_message
 
 
-def arg_parse_helper(input_model,
-                     use_legacy_frontend,
-                     use_new_frontend,
-                     input_model_is_text,
-                     framework,
-                     compress_to_fp16=False):
+def arg_parse_helper(input_model, use_legacy_frontend, use_new_frontend, input_model_is_text, framework, compress_to_fp16=False):
     path = os.path.dirname(__file__)
     input_model = os.path.join(path, "test_models", input_model)
 
     return argparse.Namespace(
         input_model=input_model,
-        log_level='INFO',
+        log_level="INFO",
         verbose=False,
         output_model=None,
         transform=[],
         output=None,
         input=None,
         compress_to_fp16=compress_to_fp16,
-        extension=None
+        extension=None,
     )
 
 
-class TestInfoMessagesTFFE(unittest.TestCase):
-    @patch('argparse.ArgumentParser.parse_args',
-           return_value=arg_parse_helper(input_model="model_int32.pbtxt",
-                                         use_legacy_frontend=False, use_new_frontend=True,
-                                         framework=None, input_model_is_text=True))
-    @patch('openvino.tools.ovc.convert_impl.driver', side_effect=Exception('MESSAGE'))
-    def run_fail_tf_fe(self, mock_driver):
+class TestInfoMessagesTFFE(unittest.TestCase):  # test: If TensorFlow frontend conversion fails, does the system properly throw an exception?
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=arg_parse_helper(
+            input_model="model_int32.pbtxt", use_legacy_frontend=False, use_new_frontend=True, framework=None, input_model_is_text=True
+        ),
+    )
+    @patch("openvino.tools.ovc.convert_impl.driver", side_effect=Exception("MESSAGE"))
+    def test_fail_tf_fe(self, mock_driver, mock_parse_args):
         from openvino.tools.ovc import convert_model
+
         path = os.path.dirname(__file__)
-        convert_model(os.path.join(path, "test_models", "model_int32.pbtxt"), verbose=True)
+        with self.assertRaises(Exception):
+            convert_model(
+                os.path.join(path, "test_models", "model_int32.pbtxt"),
+                verbose=True,
+            )
 
 
 class TestInfoMessagesCompressFP16(unittest.TestCase):
-    @patch('argparse.ArgumentParser.parse_args',
-           return_value=arg_parse_helper(input_model="model_int32.pbtxt",
-                                         use_legacy_frontend=False, use_new_frontend=True,
-                                         compress_to_fp16=True,
-                                         framework=None, input_model_is_text=True))
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=arg_parse_helper(
+            input_model="model_int32.pbtxt", use_legacy_frontend=False, use_new_frontend=True, compress_to_fp16=True, framework=None, input_model_is_text=True
+        ),
+    )
     def test_compress_to_fp16(self, mock_argparse):
         f = io.StringIO()
         with redirect_stdout(f):
             main()
             std_out = f.getvalue()
         fp16_compression_message_found = get_compression_message() in std_out
-        assert fp16_compression_message_found
+        self.assertTrue(
+            fp16_compression_message_found,
+            "Expected FP16 compression message not found in stdout when compress_to_fp16=True",
+        )
+
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=arg_parse_helper(
+            input_model="model_int32.pbtxt",
+            use_legacy_frontend=False,
+            use_new_frontend=True,
+            input_model_is_text=True,
+            framework=None,
+            compress_to_fp16=False,
+        ),
+    )
+    def test_no_fp16_message_when_not_compressed(self, mock_argparse):
+        f = io.StringIO()
+        with redirect_stdout(f):
+            main()
+            std_out = f.getvalue()
+        expected_message = get_compression_message()
+        self.assertNotIn(expected_message, std_out, "FP16 compression message should not appear when compress_to_fp16=False")


### PR DESCRIPTION
### Details:
- Added missing negative test to verify FP16 compression message behavior
- Improved existing test by using proper unittest assertions (`assertIn`, `assertNotIn`)
- Fixed fuction's parameters to the mocks in `test_fail_tf_fe`
- Ensured message is shown only when `compress_to_fp16=True`
- Ensured message is NOT shown when `compress_to_fp16=False`

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used:  yes
 - Used Ai to understand the codebase faster,  and understand OpenVINO test structure
 - all code is tested locally using pytest  and validated by fixing runtime errors
