### PR TITLE
[GPU][PTL] WA: Set max WG size to 512 for reduce_ref kernel in PTL

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_ref.cpp
@@ -43,7 +43,14 @@ CommonDispatchData ReduceKernelRef::SetDefault(const reduce_params& params) cons
     dispatchData.gws = { params.outputs[0].X().v * params.outputs[0].Y().v,
                          params.outputs[0].Z().v * params.outputs[0].W().v * params.outputs[0].U().v * params.outputs[0].V().v,
                          params.outputs[0].Batch().v * params.outputs[0].Feature().v };
-    dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo, in_layout, out_layout, dims_by_gws);
+
+    // [WA] PTL (Panther Lake, xe3p) IGC may allocate more than 128 GRF per thread,
+    // which reduces the per-kernel max work-group size below the device max reported at query time.
+    // Enqueuing with the original max WGS then triggers CL_INVALID_WORK_GROUP_SIZE (-54).
+    // Limit to 512 on PTL to stay within the reduced per-kernel limit.
+    auto engineInfo = params.engineInfo;
+    engineInfo.maxWorkGroupSize = std::min(engineInfo.maxWorkGroupSize, static_cast<uint64_t>(512));
+    dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, engineInfo, in_layout, out_layout, dims_by_gws);
 
     return dispatchData;
 }


### PR DESCRIPTION
### Description of the issue (symptom, root-cause, how it was resolved)

**Reduce kernel CL_INVALID_WORK_GROUP_SIZE on PTL (-54)**
 - **Symptom**: Reduce kernel fails with `CL_INVALID_WORK_GROUP_SIZE` (-54) on Panther Lake (xe3 integrated GPU)
 - **Root-cause**: IGC may allocate more than 128 GRF per thread on PTL, which reduces the per-kernel max work-group size below the device-reported max. The runtime dispatches with the original (larger) WGS, causing the OpenCL error.
 - **Resolution**: Limit `maxWorkGroupSize` to 512 before computing optimal LWS in `reduce_kernel_ref.cpp`

#### The code and line that caused this issue (if it is not changed directly)
 - `intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_ref.cpp`

#### Checklist
 - [ ] Is it a proper fix? (not a workaround)
   - Add WA code for CL_INVALID_WORK_GROUP_SIZE.
   - This workaround will be removed after the IGC driver issue is fixed.
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *183530*