### PR TITLE
[GPU] fix dGPU QDQStrippingTest.Inference testcase

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
@@ -55,10 +55,13 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
         bool grouped = scale_shape.size() == weight_shape.size() + 1;
 
         bool weight_u8 = false;
+        bool weight_i8 = false;
         std::shared_ptr<ov::Node> weight_ptr =
             pattern_map.count(weights_const_m) ? pattern_map.at(weights_const_m).get_node_shared_ptr() : pattern_map.at(weights_param_m).get_node_shared_ptr();
         if (weight_ptr->get_element_type() == ov::element::u8)
             weight_u8 = true;
+        else if (weight_ptr->get_element_type() == ov::element::i8)
+            weight_i8 = true;
 
         auto reshape_const = [has_transpose, grouped, is_weight_3d](std::shared_ptr<ov::Node> node) {
             auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);
@@ -95,6 +98,8 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
                 result = std::dynamic_pointer_cast<ov::Node>(std::make_shared<ov::op::v0::Convert>(node, ov::element::u8));
             else if (weight_u8 && sub_with_convert)
                 result = std::dynamic_pointer_cast<ov::Node>(std::make_shared<ov::op::v0::Convert>(node, ov::element::u8));
+            else if (weight_i8 && sub_with_convert)
+                result = std::dynamic_pointer_cast<ov::Node>(std::make_shared<ov::op::v0::Convert>(node, ov::element::i8));
             else
                 result = std::dynamic_pointer_cast<ov::Node>(constant);
 


### PR DESCRIPTION
### Details

`smoke_QDQStripping_BothPrecisions/QDQStrippingTest.Inference/input_shape=[?.?.?.?]_([1.3.128.128])_input_precision=f32_quantization_precision=i16_inference_precision=f16_pattern=NeedScalingForwardBias` testcase failed on dGPU.

### Description of the issue
#### Symptom

The testcase can be passed on iGPU, but will be failed on dGPU.

#### Root cause

The MatMul with i8 weights zero_point (-128) is wrongly converted to u8 (128) for dGPU, during the ConvertFullyConnectedToFullyConnectedCompressed pass.

#### How to fix it

Prevent the unnecessary i8 to u8 conversion in the pass. 

#### The code and line that caused this issue

https://github.com/openvinotoolkit/openvino/blob/468f32a646aed975b730d21e31f39c1044c5dee9/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp#L96-L99

#### Reproduction step and snapshot

./ov_gpu_func_tests --device_suffix=<dGPU_INDEX> --gtest_filter='smoke_QDQStripping_BothPrecisions/QDQStrippingTest.Inference/input_shape=[?.?.?.?]_([1.3.128.128])_input_precision=f32_quantization_precision=i16_inference_precision=f16_pattern=NeedScalingForwardBias'

#### Problematic graph

<img width="830" height="442" alt="image" src="https://github.com/user-attachments/assets/b9e4653e-8277-4a31-9b6c-6f79d7485e6b" />

#### Checklist 
 - [x] Is it a proper fix? (not a workaround) 
 - [ ] Did you include test case for this fix, if necessary? The testcase itself can cover this issue.
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? QDQStrippingTest.Inference with NeedScalingForwardBias.

### Tickets:
 - *CVS-182520*

### AI Assistance:
 - *AI assistance used: yes*
 - *Asked AI model to find out the reason why i8 (-128) was converted to u8 (128).*