### PR TITLE
[POC][GPU] Support broadcast mul and reduce to matmul.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -1140,6 +1140,13 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                             compatible &= od.get_length() == id.get_length();
                         } else if (id.is_static()) {
                             compatible &= id.get_length() != 1;
+                        } else if (od.is_static() && id.is_dynamic()) {
+                            // If parent dim is dynamic with upper bound smaller than the expected output dim,
+                            // it can never match at runtime, so fusion would always fail in is_valid_fusion()
+                            auto id_max = id.get_max_length();
+                            if (id_max > 0 && static_cast<int64_t>(id_max) < static_cast<int64_t>(od.get_length())) {
+                                compatible = false;
+                            }
                         }
                     }
                     return compatible;

--- a/src/plugins/intel_gpu/src/plugin/transformations/broadcast_mul_reduce_to_matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/broadcast_mul_reduce_to_matmul.cpp
@@ -1,0 +1,235 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "broadcast_mul_reduce_to_matmul.hpp"
+
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace ov::intel_gpu {
+
+BroadcastMulReduceToMatMul::BroadcastMulReduceToMatMul() {
+    using namespace ov::pass::pattern;
+
+    // Match: any_input -> Multiply -> ReduceSum
+    // Validate that Multiply inputs are Unsqueeze in the callback.
+    auto multiply_in_a = any_input();
+    auto multiply_in_b = any_input();
+    auto multiply_m = wrap_type<ov::op::v1::Multiply>({multiply_in_a, multiply_in_b});
+    auto reduce_axis_m = wrap_type<ov::op::v0::Constant>();
+    auto reduce_sum_m = wrap_type<ov::op::v1::ReduceSum>({multiply_m, reduce_axis_m});
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        if (transformation_callback(m.get_match_root())) {
+            return false;
+        }
+
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto reduce_sum = ov::as_type_ptr<ov::op::v1::ReduceSum>(m.get_match_root());
+        auto multiply = ov::as_type_ptr<ov::op::v1::Multiply>(
+            pattern_map.at(multiply_m).get_node_shared_ptr());
+
+        if (!reduce_sum || !multiply)
+            return false;
+
+        // ReduceSum must have keep_dims=false
+        if (reduce_sum->get_keep_dims())
+            return false;
+
+        // Multiply should have exactly one consumer (the ReduceSum)
+        if (multiply->get_output_target_inputs(0).size() != 1)
+            return false;
+
+        // Both Multiply inputs must be Unsqueeze
+        auto unsqueeze_a = ov::as_type_ptr<ov::op::v0::Unsqueeze>(multiply->get_input_node_shared_ptr(0));
+        auto unsqueeze_b = ov::as_type_ptr<ov::op::v0::Unsqueeze>(multiply->get_input_node_shared_ptr(1));
+
+        if (!unsqueeze_a || !unsqueeze_b)
+            return false;
+
+        // Get unsqueeze axes (must be constant single values)
+        auto axis_a_const = ov::as_type_ptr<ov::op::v0::Constant>(unsqueeze_a->get_input_node_shared_ptr(1));
+        auto axis_b_const = ov::as_type_ptr<ov::op::v0::Constant>(unsqueeze_b->get_input_node_shared_ptr(1));
+        auto axis_r_const = ov::as_type_ptr<ov::op::v0::Constant>(reduce_sum->get_input_node_shared_ptr(1));
+
+        if (!axis_a_const || !axis_b_const || !axis_r_const)
+            return false;
+
+        auto axis_a_vals = axis_a_const->cast_vector<int64_t>();
+        auto axis_b_vals = axis_b_const->cast_vector<int64_t>();
+        auto axis_r_vals = axis_r_const->cast_vector<int64_t>();
+
+        // Each must be a single axis
+        if (axis_a_vals.size() != 1 || axis_b_vals.size() != 1 || axis_r_vals.size() != 1)
+            return false;
+
+        // Get the rank of the expanded intermediate from the Multiply output.
+        // Each input is R dimensional; after two Unsqueezes, the Multiply output is (R+1) dimensional.
+        auto mul_out_pshape = multiply->get_output_partial_shape(0);
+        if (mul_out_pshape.rank().is_dynamic())
+            return false;
+
+        const int64_t rank_expanded = mul_out_pshape.rank().get_length();
+
+        // Normalize negative axes
+        int64_t axis_a = axis_a_vals[0];
+        int64_t axis_b = axis_b_vals[0];
+        int64_t axis_r = axis_r_vals[0];
+        if (axis_a < 0) axis_a += rank_expanded;
+        if (axis_b < 0) axis_b += rank_expanded;
+        if (axis_r < 0) axis_r += rank_expanded;
+
+        // Validate axes are in range and all different
+        if (axis_a < 0 || axis_a >= rank_expanded ||
+            axis_b < 0 || axis_b >= rank_expanded ||
+            axis_r < 0 || axis_r >= rank_expanded)
+            return false;
+
+        if (axis_a == axis_b || axis_a == axis_r || axis_b == axis_r)
+            return false;
+
+        // Need at least 3D intermediate
+        if (rank_expanded < 3)
+            return false;
+
+        // Compute batch axes in the expanded (R+1) dim space.
+        // In MatMul terms: axis_b maps to M, axis_a maps to N, axis_r maps to K.
+        // Everything else is a batch dimension.
+        std::vector<int64_t> batch_axes;
+        for (int64_t d = 0; d < rank_expanded; d++) {
+            if (d != axis_a && d != axis_b && d != axis_r)
+                batch_axes.push_back(d);
+        }
+
+        // Map expanded (R+1) dim axis to A's original R dim axis (A is missing axis_a)
+        auto map_to_a = [axis_a](int64_t d_exp) -> int64_t {
+            return d_exp < axis_a ? d_exp : d_exp - 1;
+        };
+        // Map expanded (R+1) dim axis to B's original R dim axis (B is missing axis_b)
+        auto map_to_b = [axis_b](int64_t d_exp) -> int64_t {
+            return d_exp < axis_b ? d_exp : d_exp - 1;
+        };
+
+        // Transpose order for A: [...batch, M, K]
+        // M = axis unique to A (axis_b position in expanded space)
+        // K = reduced axis (axis_r, summed out by ReduceSum)
+        std::vector<int64_t> transpose_a;
+        for (auto bd : batch_axes)
+            transpose_a.push_back(map_to_a(bd));
+        transpose_a.push_back(map_to_a(axis_b));   // M (axis unique to A)
+        transpose_a.push_back(map_to_a(axis_r));   // K (reduced axis)
+
+        // Transpose order for B: [...batch, N, K]
+        // N = axis unique to B (axis_a position in expanded space)
+        // K = reduced axis (axis_r, summed out by ReduceSum)
+        std::vector<int64_t> transpose_b;
+        for (auto bd : batch_axes)
+            transpose_b.push_back(map_to_b(bd));
+        transpose_b.push_back(map_to_b(axis_a));   // N (axis unique to B)
+        transpose_b.push_back(map_to_b(axis_r));   // K (reduced axis)
+
+        // Output transpose: MatMul output [...batch, M, N] expected ReduceSum output order.
+        // Axis labels below use expanded (R+1) dim numbering for bookkeeping.
+        std::vector<int64_t> matmul_output_order;
+        for (auto bd : batch_axes)
+            matmul_output_order.push_back(bd);
+        matmul_output_order.push_back(axis_b);
+        matmul_output_order.push_back(axis_a);
+
+        std::vector<int64_t> expected_output_order;
+        for (int64_t d = 0; d < rank_expanded; d++) {
+            if (d != axis_r)
+                expected_output_order.push_back(d);
+        }
+
+        const int64_t rank_input = rank_expanded - 1;
+
+        std::vector<int64_t> transpose_out(rank_input);
+        for (int64_t i = 0; i < rank_input; i++) {
+            for (int64_t j = 0; j < rank_input; j++) {
+                if (matmul_output_order[j] == expected_output_order[i]) {
+                    transpose_out[i] = j;
+                    break;
+                }
+            }
+        }
+
+        auto is_identity = [](const std::vector<int64_t>& perm) {
+            for (size_t i = 0; i < perm.size(); i++) {
+                if (perm[i] != static_cast<int64_t>(i))
+                    return false;
+            }
+            return true;
+        };
+
+        auto input_a = unsqueeze_a->input_value(0);
+        auto input_b = unsqueeze_b->input_value(0);
+
+        ov::NodeVector new_nodes;
+
+        // Transpose A if needed: [...batch, M, K]
+        ov::Output<ov::Node> a_prepared = input_a;
+        if (!is_identity(transpose_a)) {
+            auto perm_a = ov::op::v0::Constant::create(ov::element::i64, {transpose_a.size()}, transpose_a);
+            auto tr_a = std::make_shared<ov::op::v1::Transpose>(input_a, perm_a);
+            new_nodes.push_back(tr_a);
+            a_prepared = tr_a->output(0);
+        }
+
+        // Transpose B if needed: [...batch, N, K]
+        ov::Output<ov::Node> b_prepared = input_b;
+        if (!is_identity(transpose_b)) {
+            auto perm_b = ov::op::v0::Constant::create(ov::element::i64, {transpose_b.size()}, transpose_b);
+            auto tr_b = std::make_shared<ov::op::v1::Transpose>(input_b, perm_b);
+            new_nodes.push_back(tr_b);
+            b_prepared = tr_b->output(0);
+        }
+
+        // MatMul with transpose_b=true (batched):
+        // A: [...batch, M, K]
+        // B: [...batch, N, K]  →  transpose_b swaps last 2: [...batch, K, N]
+        // Result: [...batch, M, N]
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(a_prepared, b_prepared, false, true);
+        new_nodes.push_back(matmul);
+
+        ov::Output<ov::Node> result = matmul->output(0);
+
+        // Transpose output to expected order if needed
+        if (!is_identity(transpose_out)) {
+            auto perm_out = ov::op::v0::Constant::create(ov::element::i64, {transpose_out.size()}, transpose_out);
+            auto tr_out = std::make_shared<ov::op::v1::Transpose>(result, perm_out);
+            new_nodes.push_back(tr_out);
+            result = tr_out->output(0);
+        }
+
+        // Ensure output data type matches the original ReduceSum output.
+        // GPU Gemm may compute in f32 while the graph expects f16.
+        auto expected_et = reduce_sum->get_output_element_type(0);
+        if (result.get_element_type() != expected_et) {
+            auto cvt = std::make_shared<ov::op::v0::Convert>(result, expected_et);
+            new_nodes.push_back(cvt);
+            result = cvt->output(0);
+        }
+
+        result.get_node_shared_ptr()->set_friendly_name(reduce_sum->get_friendly_name());
+        ov::copy_runtime_info(m.get_matched_nodes(), new_nodes);
+        ov::replace_node(reduce_sum, result.get_node_shared_ptr());
+
+        return true;
+    };
+
+    auto matcher = std::make_shared<ov::pass::pattern::Matcher>(reduce_sum_m, "BroadcastMulReduceToMatMul");
+    this->register_matcher(matcher, callback);
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/broadcast_mul_reduce_to_matmul.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/broadcast_mul_reduce_to_matmul.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov::intel_gpu {
+
+/// Converts Unsqueeze + Unsqueeze + Multiply + ReduceSum patterns into MatMul.
+///
+/// Matches the pattern where two N Dims inputs are each unsqueezed on different axes,
+/// broadcast-multiplied to produce an (N+1) Dims intermediate, and then reduced by
+/// ReduceSum on a third axis that is neither of the unsqueeze axes. This is
+/// mathematically equivalent to a batched MatMul with optional transposes.
+///
+/// Example (Mamba2 SSD naive):
+///   A:[b,g,L,H,N] --Unsqueeze(3)--> [b,g,L,1,H,N]
+///   B:[b,g,L,H,N] --Unsqueeze(2)--> [b,g,1,L,H,N]
+///   Multiply --> [b,g,L,L,H,N]
+///   ReduceSum(axis=5) --> [b,g,L,L,H]
+///   == Batched MatMul: [b*g*H, L, N] x [b*g*H, N, L] -> [b*g*H, L, L]
+class BroadcastMulReduceToMatMul : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("BroadcastMulReduceToMatMul");
+    BroadcastMulReduceToMatMul();
+};
+
+}   // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -108,6 +108,7 @@
 #include "plugin/transformations/print_model_statistics.hpp"
 #include "plugin/transformations/sink_reshape.hpp"
 #include "plugin/transformations/transpose_fusion.hpp"
+#include "plugin/transformations/broadcast_mul_reduce_to_matmul.hpp"
 #include "plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.hpp"
 #include "plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.hpp"
 #include "plugin/transformations/disable_fp16_comp_rms.hpp"
@@ -1566,6 +1567,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         });
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
+        manager.register_pass<ov::intel_gpu::BroadcastMulReduceToMatMul>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>(device_info.supports_immad);
 
         if (!device_info.supports_immad) {

--- a/src/plugins/intel_gpu/tests/unit/transformations/broadcast_mul_reduce_to_matmul_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/broadcast_mul_reduce_to_matmul_test.cpp
@@ -1,0 +1,193 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/ov_test_utils.hpp"
+
+#include "openvino/core/model.hpp"
+#include "openvino/pass/manager.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/unsqueeze.hpp"
+
+#include "plugin/transformations/broadcast_mul_reduce_to_matmul.hpp"
+
+#include <memory>
+
+using namespace testing;
+using namespace ov::intel_gpu;
+
+namespace ov {
+namespace test {
+namespace intel_gpu {
+
+// Helper: build the Unsqueeze+Multiply+ReduceSum subgraph
+static std::shared_ptr<ov::Model> make_unsq_mul_reduce_model(
+        ov::element::Type et,
+        const ov::PartialShape& shape_a,
+        const ov::PartialShape& shape_b,
+        int64_t unsq_axis_a,
+        int64_t unsq_axis_b,
+        int64_t reduce_axis,
+        bool keep_dims = false) {
+    auto param_a = std::make_shared<ov::op::v0::Parameter>(et, shape_a);
+    auto param_b = std::make_shared<ov::op::v0::Parameter>(et, shape_b);
+
+    auto unsq_a_ax = ov::op::v0::Constant::create(ov::element::i64, {1}, {unsq_axis_a});
+    auto unsq_a = std::make_shared<ov::op::v0::Unsqueeze>(param_a, unsq_a_ax);
+
+    auto unsq_b_ax = ov::op::v0::Constant::create(ov::element::i64, {1}, {unsq_axis_b});
+    auto unsq_b = std::make_shared<ov::op::v0::Unsqueeze>(param_b, unsq_b_ax);
+
+    auto mul = std::make_shared<ov::op::v1::Multiply>(unsq_a, unsq_b);
+
+    auto red_ax = ov::op::v0::Constant::create(ov::element::i64, {1}, {reduce_axis});
+    auto reduce = std::make_shared<ov::op::v1::ReduceSum>(mul, red_ax, keep_dims);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{reduce}, ov::ParameterVector{param_a, param_b});
+}
+
+// ============================================================================
+// Pattern 1 (Mamba2 SSD typical):
+//   A:[b,g,L,H,N] --Unsqueeze(3)--> [b,g,L,1,H,N]
+//   B:[b,g,L,H,N] --Unsqueeze(2)--> [b,g,1,L,H,N]
+//   Multiply --> [b,g,L,L,H,N]
+//   ReduceSum(axis=5, keep_dims=false) --> [b,g,L,L,H]
+//   == MatMul: [...batch, L, N] x [...batch, N, L]^T -> [...batch, L, L]
+// ============================================================================
+TEST_F(TransformationTestsF, BroadcastMulReduceToMatMul_Pattern1) {
+    // Input model
+    {
+        model = make_unsq_mul_reduce_model(
+            ov::element::f16,
+            {1, 1, 256, 64, 128},  // A: [b,g,L,H,N]
+            {1, 1, 256, 64, 128},  // B: [b,g,L,H,N]
+            3,   // unsqueeze A at axis 3
+            2,   // unsqueeze B at axis 2
+            5);  // reduce axis 5
+        manager.register_pass<BroadcastMulReduceToMatMul>();
+    }
+    // Reference model: Transpose_A + Transpose_B + MatMul(transpose_b=true) + Transpose_out
+    {
+        auto param_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 1, 256, 64, 128});
+        auto param_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 1, 256, 64, 128});
+
+        // A: [b,g,L,H,N] -> [...batch, M, K] = [b,g,H, L, N]  (batch={0,1,4}, M=axis_b=2->L, K=axis_r=5->N)
+        // Expanded axes: batch={0,1,4}, axis_b=3(M), axis_a=2(N), axis_r=5(K)
+        // map_to_a: expanded -> skip axis_a=3 -> {0,1,2,3,4} mapped from {0,1,4,3,5} but let me compute properly.
+        // axis_a=3 (unsq axis for A), axis_b=2 (unsq axis for B), axis_r=5 (reduce)
+        // batch in expanded: {0,1,4}
+        // map_to_a(d) = d if d<3, d-1 if d>=3 (skip axis_a=3)
+        // transpose_a: [map_to_a(0), map_to_a(1), map_to_a(4), map_to_a(2), map_to_a(5)]
+        //            = [0, 1, 3, 2, 4]
+        auto perm_a = ov::op::v0::Constant::create(ov::element::i64, {5}, std::vector<int64_t>{0, 1, 3, 2, 4});
+        auto tr_a = std::make_shared<ov::op::v1::Transpose>(param_a, perm_a);
+
+        // B: [b,g,L,H,N] -> [...batch, N, K] = [b,g,H, L, N]
+        // map_to_b(d) = d if d<2, d-1 if d>=2 (skip axis_b=2)
+        // transpose_b: [map_to_b(0), map_to_b(1), map_to_b(4), map_to_b(3), map_to_b(5)]
+        //   but wait, axis_a=3 in expanded maps to B's N dim
+        //   transpose_b order: [batch..., map_to_b(axis_a), map_to_b(axis_r)]
+        //   = [map_to_b(0), map_to_b(1), map_to_b(4), map_to_b(3), map_to_b(5)]
+        //   = [0, 1, 3, 2, 4]
+        auto perm_b = ov::op::v0::Constant::create(ov::element::i64, {5}, std::vector<int64_t>{0, 1, 3, 2, 4});
+        auto tr_b = std::make_shared<ov::op::v1::Transpose>(param_b, perm_b);
+
+        // MatMul(transpose_b=true): [b,g,H, L, N] x [b,g,H, L, N]^T -> [b,g,H, L, L]
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(tr_a, tr_b, false, true);
+
+        // Output transpose: MatMul output is [...batch, M, N] in expanded labeling = [b(0),g(1),H(4), L(3), L(2)]
+        // Need expected order: remove axis_r(5) -> [0,1,2,3,4] -> which maps to expanded [0,1,2,3,4]
+        // matmul_output_order = [batch..., axis_b, axis_a] = [0, 1, 4, 3, 2]
+        //   (positions in expanded: batch axes are {0,1,4} in the original expanded rank-6 space,
+        //    then axis_b=3(M), axis_a=2(N) -- but in the rank-5 output we need to figure the mapping)
+        // Actually, the pass computes: matmul_output_order = [0,1,4, 3, 2]
+        //                              expected_output_order = [0,1,2,3,4]
+        // transpose_out[i] = j where matmul_output_order[j] == expected_output_order[i]
+        // expected[0]=0 -> matmul[0]=0 -> j=0; expected[1]=1 -> matmul[1]=1 -> j=1;
+        // expected[2]=2 -> matmul[4]=2 -> j=4; expected[3]=3 -> matmul[3]=3 -> j=3;
+        // expected[4]=4 -> matmul[2]=4 -> j=2;
+        // transpose_out = [0, 1, 4, 3, 2]
+        auto perm_out = ov::op::v0::Constant::create(ov::element::i64, {5}, std::vector<int64_t>{0, 1, 4, 3, 2});
+        auto tr_out = std::make_shared<ov::op::v1::Transpose>(matmul, perm_out);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{tr_out}, ov::ParameterVector{param_a, param_b});
+    }
+}
+
+// ============================================================================
+// Simple 3D case: no transpose needed for either input or output
+//   A:[M,K] --Unsqueeze(1)--> [M,1,K]
+//   B:[N,K] --Unsqueeze(0)--> [1,N,K]
+//   Multiply --> [M,N,K]
+//   ReduceSum(axis=2) --> [M,N]
+//   == MatMul(A, B^T): [M,K] x [N,K]^T -> [M,N]
+// ============================================================================
+TEST_F(TransformationTestsF, BroadcastMulReduceToMatMul_Simple3D) {
+    {
+        model = make_unsq_mul_reduce_model(
+            ov::element::f32,
+            {8, 16},   // A: [M, K]
+            {4, 16},   // B: [N, K]
+            1,   // unsqueeze A at axis 1
+            0,   // unsqueeze B at axis 0
+            2);  // reduce axis 2 (K)
+        manager.register_pass<BroadcastMulReduceToMatMul>();
+    }
+    {
+        // Expanded: axis_a=1, axis_b=0, axis_r=2
+        // batch_axes: none (all 3 dims are axis_a, axis_b, axis_r)
+        // A original: [M, K] (rank 2), map_to_a skips axis_a=1: d<1->d, d>=1->d-1
+        // transpose_a = [map_to_a(axis_b=0), map_to_a(axis_r=2)] = [0, 1] -> identity, no transpose
+        // B original: [N, K] (rank 2), map_to_b skips axis_b=0: d<0->d, d>=0->d-1
+        // transpose_b = [map_to_b(axis_a=1), map_to_b(axis_r=2)] = [0, 1] -> identity, no transpose
+        // MatMul output order: [axis_b=0, axis_a=1], expected: [0, 1] -> identity, no output transpose
+        auto param_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{8, 16});
+        auto param_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{4, 16});
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(param_a, param_b, false, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{param_a, param_b});
+    }
+}
+
+// ============================================================================
+// Batched 4D case with output transpose
+//   A:[B,M,K] --Unsqueeze(2)--> [B,M,1,K]
+//   B:[B,N,K] --Unsqueeze(1)--> [B,1,N,K]
+//   Multiply --> [B,M,N,K]
+//   ReduceSum(axis=3) --> [B,M,N]
+//   == MatMul: [B,M,K] x [B,N,K]^T -> [B,M,N]
+// ============================================================================
+TEST_F(TransformationTestsF, BroadcastMulReduceToMatMul_Batched4D) {
+    {
+        model = make_unsq_mul_reduce_model(
+            ov::element::f32,
+            {2, 8, 16},  // A: [B, M, K]
+            {2, 4, 16},  // B: [B, N, K]
+            2,   // unsqueeze A at axis 2
+            1,   // unsqueeze B at axis 1
+            3);  // reduce axis 3 (K)
+        manager.register_pass<BroadcastMulReduceToMatMul>();
+    }
+    {
+        // Expanded: axis_a=2, axis_b=1, axis_r=3, batch={0}
+        // transpose_a = [map_to_a(0), map_to_a(1), map_to_a(3)] = [0, 1, 2] -> identity
+        // transpose_b = [map_to_b(0), map_to_b(2), map_to_b(3)] = [0, 1, 2] -> identity
+        // matmul_output_order = [0, 1, 2], expected = [0, 1, 2] -> identity
+        auto param_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 8, 16});
+        auto param_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 4, 16});
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(param_a, param_b, false, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{param_a, param_b});
+    }
+}
+
+}  // namespace intel_gpu
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
Einsum in granite-4.0(mamba) is decompressed unsqueeze + eltwise(broadcast) + reducesum. It caused the main bottleneck and OOM reason because of huge intermediate buffer. Einsum in granite could be replaced to MatMul, so add convert to use MatMul instead.

### Tickets:
 - *CVS-187120*

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
