### PR TITLE
[GPU] Fix rank-changing reorder fusion for depth_to_space

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -174,8 +174,16 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
         }
     }
 
-    // Ref kernels are the main for depth_to_space and region_yolo and strided_slice. It can do anything.
-    if (next.is_type<depth_to_space>() || next.is_type<region_yolo>() ||
+    // depth_to_space is rank-preserving by op semantics.
+    // Allow fusing only when the reorder does not change input rank for depth_to_space.
+    if (next.is_type<depth_to_space>()) {
+        const auto prev_rank = prev.get_output_layout().get_rank();
+        const auto next_input_rank = next.get_input_layout(0).get_rank();
+        return prev_rank == next_input_rank;
+    }
+
+    // Ref kernels are the main for region_yolo and strided_slice. It can do anything.
+    if (next.is_type<region_yolo>() ||
         (next.is_type<strided_slice>() && next.get_preferred_impl_type() != cldnn::impl_types::cpu))
         return true;
 
@@ -400,8 +408,16 @@ bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, reorder_node
         is_dynamic = true;
     }
 
-    // Ref kernels are the main for depth_to_space, region_yolo and detection_output. It can do anything. Should not see next.
-    if (prev.is_type<depth_to_space>() || prev.is_type<region_yolo>()
+    // depth_to_space is rank-preserving by op semantics.
+    // Allow fusing only when the reorder does not change output rank.
+    if (prev.is_type<depth_to_space>()) {
+        const auto prev_rank = prev.get_output_layout().get_rank();
+        const auto reordered_rank = node.get_output_layout().get_rank();
+        return prev_rank == reordered_rank;
+    }
+
+    // Ref kernels are the main for region_yolo and detection_output. It can do anything. Should not see next.
+    if (prev.is_type<region_yolo>()
         || (prev.is_type<detection_output>() && prev.get_preferred_impl_type() != cldnn::impl_types::cpu))
         return true;
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/depth_to_space_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/depth_to_space_gpu_test.cpp
@@ -479,3 +479,110 @@ static void test_depth_to_space_fp16_input_fp32_output(bool is_caching_test) {
 TEST(depth_to_space_gpu, fp16_input_fp32_output) {
     test_depth_to_space_fp16_input_fp32_output(false);
 }
+
+// Verify that depth_to_space output preserves 4D rank when followed by a
+// rank-changing reorder (bfyx -> bfzyx).  The rank-changing reorder must NOT
+// be fused into depth_to_space; instead it should remain as a separate
+// (possibly optimized) node so that the kernel sees matching input/output dims.
+TEST(depth_to_space_fp32_gpu, d1811_bs2_no_rank_changing_fusion) {
+    //  Input  : 1x8x1x1  (4D, bfyx)
+    //  Block size : 2
+    //  Output : 1x2x2x2  (4D, bfyx) -> reorder to bfzyx (5D)
+    //
+    //  With optimize_data enabled, the graph optimizer should NOT fuse the
+    //  bfyx->bfzyx reorder into depth_to_space because that would change
+    //  the output rank of a rank-preserving operation.
+
+    auto& engine = get_test_engine();
+
+    auto input = engine.allocate_memory({ data_types::f32, format::bfyx, tensor{ 1, 8, 1, 1 } });
+    size_t block_size = 2;
+
+    // blocks_first: feature 0..7 -> spatially rearranged
+    set_values(input, { 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f });
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(depth_to_space("depth_to_space", input_info("input"), block_size, depth_to_space_mode::blocks_first));
+    // Rank-changing reorder: 4D bfyx -> 5D bfzyx
+    topology.add(reorder("reorder_bfzyx", input_info("depth_to_space"), format::bfzyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    network network(engine, topology, config);
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+    auto output = outputs.at("reorder_bfzyx").get_memory();
+    auto out_layout = output->get_layout();
+
+    // Output should be 5D bfzyx
+    ASSERT_EQ(out_layout.format, format::bfzyx);
+
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    std::vector<float> expected = { 0.f, 2.f, 4.f, 6.f, 1.f, 3.f, 5.f, 7.f };
+
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_FLOAT_EQ(expected[i], output_ptr[i]) << "i=" << i;
+    }
+}
+
+TEST(depth_to_space_fp16_gpu, d8_12_576x672_bs2_with_eltwise_and_bfzyx_reshape) {
+    auto& engine = get_test_engine();
+
+    // Use small spatial dims to keep memory manageable in unit tests,
+    // but preserve the essential structure: 4D b_fs_yx_fsv16 input, eltwise
+    // fused, followed by reshape requiring 5D.
+    auto input = engine.allocate_memory({ data_types::f16, format::bfyx, tensor{ 1, 12, 4, 4 } });
+    auto eltw_data = engine.allocate_memory({ data_types::f16, format::bfyx, tensor{ 1, 3, 8, 8 } });
+
+    size_t block_size = 2;
+
+    // Fill with sequential values
+    std::vector<ov::float16> input_vals(1 * 12 * 4 * 4);
+    for (size_t i = 0; i < input_vals.size(); ++i)
+        input_vals[i] = ov::float16(static_cast<float>(i));
+    set_values(input, input_vals);
+
+    std::vector<ov::float16> eltw_vals(1 * 3 * 8 * 8);
+    for (size_t i = 0; i < eltw_vals.size(); ++i)
+        eltw_vals[i] = ov::float16(1.0f);
+    set_values(eltw_data, eltw_vals);
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(data("eltw_data", eltw_data));
+    // Reorder to b_fs_yx_fsv16 to match the production scenario
+    topology.add(reorder("reorder_fsv16", input_info("input"), format::b_fs_yx_fsv16, data_types::f16));
+    topology.add(depth_to_space("depth_to_space", input_info("reorder_fsv16"), block_size, depth_to_space_mode::blocks_first));
+    // Eltwise add (this gets fused into depth_to_space)
+    topology.add(eltwise("add", { input_info("depth_to_space"), input_info("eltw_data") }, eltwise_mode::sum));
+    // Reorder to bfzyx (rank-changing) - must NOT be fused into depth_to_space
+    topology.add(reorder("reorder_bfzyx", input_info("add"), format::bfzyx, data_types::f16));
+    // Final reorder back to bfyx for easy verification
+    topology.add(reorder("output", input_info("reorder_bfzyx"), format::bfyx, data_types::f16));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    // The key assertion: this must not crash during kernel compilation.
+    // Previously clBuildProgram would fail because of INPUT0_GET_INDEX
+    // macro argument mismatch when the reorder was fused.
+    ASSERT_NO_THROW({
+        network network(engine, topology, config);
+        network.set_input_data("input", input);
+        auto outputs = network.execute();
+        auto output = outputs.at("output").get_memory();
+
+        // Verify output is valid (non-zero, correct shape)
+        auto out_layout = output->get_layout();
+        ASSERT_EQ(out_layout.format, format::bfyx);
+
+        cldnn::mem_lock<ov::float16> output_ptr(output, get_test_stream());
+        // depth_to_space output: 1x3x8x8, eltwise adds 1.0 to each element
+        // Check a few samples are within reasonable range
+        ASSERT_GT(static_cast<float>(output_ptr[0]), -1000.f);
+        ASSERT_LT(static_cast<float>(output_ptr[0]), 1000.f);
+    });
+}


### PR DESCRIPTION

### Description of the issue:
#### Issues
**Symptom:**

`clBuildProgram` kernel compilation failure when running super-resolution model (`pnat-v1-fp16-576x672-2x-ox.onnx`) on GPU. The failing node is `depthtospace:/gnet/DepthToSpace` with `depth_to_space_ref` implementation.

```
compile_graph: depthtospace:/gnet/DepthToSpace
  Type: depth_to_space
  Input layout 0: f16:b_fs_yx_fsv16:8x12x576x672 (4D)
  Input layout 1: f16:bfyx:8x3x1152x1344:nopad (4D)
  Output layout 0: f16:bfzyx:8x3x1x1152x1344 (5D)   ← problem here
  Selected impl: depth_to_space_ref
```

```
error: too many arguments provided to function-like macro invocation
  INPUT0_GET_INDEX(batch, input_feature, input_z, input_y, input_x)  ← 5 args
note: macro 'INPUT0_GET_INDEX' defined here
  #define INPUT0_GET_INDEX(b, f, y, x)  ← only accepts 4 args
```

#### Root causes

`depth_to_space` is rank-preserving by op semantics — input and output must have the same number of dimensions. However, `can_fuse_reorder()` and `can_fuse_reorder_to_prev()` in `layout_optimizer.cpp` unconditionally returned `true` for `depth_to_space`, allowing a rank-changing reorder (bfyx → bfzyx) to be fused in.

The fusion chain:
1. `reorder_inputs` pass inserts reorder_42 (bfyx → bfzyx) after depth_to_space for downstream Reshape_2
2. `remove_redundant_reorders` pass calls `can_fuse_reorder_to_prev()` which returns `true` unconditionally
3. reorder_42 is fused into depth_to_space, changing its output from 4D (bfyx) to 5D (bfzyx)
4. Kernel compilation: INPUT0 is 4D (b_fs_yx_fsv16) but OUTPUT is now 5D (bfzyx) → `INPUT0_GET_INDEX` macro argument count mismatch → `clBuildProgram` crash

#### How to fix it

Add a rank equality guard in two functions of `layout_optimizer.cpp` — separate `depth_to_space` from the blanket "return true" group and allow reorder fusion only when source and target ranks match:

Same-rank reorder fusion (e.g., bfyx → b_fs_yx_fsv16) remains allowed. The rank-changing reorder stays as a separate optimized node with memory sharing (zero-copy), so there is no performance penalty.

##### After fix rank-changing reorder fusion
<img width="1773" height="1402" alt="image" src="https://github.com/user-attachments/assets/78bbc9bc-f8a0-4237-8558-dac1ac09bf2c" />
Reorder and Reshape nodes behind of depth_to_space are optimized out.

#### Reproduced steps

```
benchmark_app -d GPU -m pnat-v1-fp16-576x672-2x-ox.onnx -nireq 1 -nstreams 1 -hint none
```

### Tickets:
 - *CVS-179965*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used for debug log analysis (identifying the reorder fusion chain through 130K-line GPU debug logs), OpenVINO op spec audit (confirming depth_to_space is rank-preserving), and drafting test cases. All code changes were reviewed, the fix was validated by running the model end-to-end (121 iterations, 2.00 FPS), and unit tests were manually verified.*