### PR TITLE
[GPU] Fix OCL kernel builder error handling

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
@@ -73,6 +73,9 @@ class ocl_kernel_builder : public kernel_builder{
                 OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
             } catch (const cl::Error& err) {
                 OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
+            } catch (...) {
+                // We should never hit this catch block
+                OPENVINO_THROW("[GPU] Unknown error during kernel build process");
             }
             for (auto& k : kernels) {
                 const auto &entry_point = k.getInfo<CL_KERNEL_FUNCTION_NAME>();


### PR DESCRIPTION
### Details:
 - CL_HPP_ENABLE_EXCEPTIONS macro causes OpenCL C++ bindings API to throw exceptions instead of returning error values. Because of this we should use try&catch to handle possible errors.

### Tickets:
 - ...

### AI Assistance:
 - AI assistance used: no
