### PR TITLE
Eliminate gold linker usage

### DIFF
--- a/cmake/developer_package/compile_flags/functions.cmake
+++ b/cmake/developer_package/compile_flags/functions.cmake
@@ -400,24 +400,6 @@ function(ov_link_system_libraries TARGET_NAME)
 endfunction()
 
 #
-# ov_try_use_gold_linker()
-#
-# Tries to use gold linker in current scope (directory, function)
-#
-function(ov_try_use_gold_linker)
-    # don't use the gold linker, if the mold linker is set
-    if(CMAKE_EXE_LINKER_FLAGS MATCHES "mold" OR CMAKE_MODULE_LINKER_FLAGS MATCHES "mold" OR CMAKE_SHARED_LINKER_FLAGS MATCHES "mold")
-        return()
-    endif()
-
-    # gold linker on ubuntu20.04 may fail to link binaries build with sanitizer
-    if(CMAKE_COMPILER_IS_GNUCXX AND NOT ENABLE_SANITIZER AND NOT CMAKE_CROSSCOMPILING)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold" PARENT_SCOPE)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold" PARENT_SCOPE)
-    endif()
-endfunction()
-
-#
 # ov_target_link_libraries_as_system(<TARGET NAME> <PUBLIC | PRIVATE | INTERFACE> <target1 target2 ...>)
 #
 function(ov_target_link_libraries_as_system TARGET_NAME LINK_TYPE)

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -7,8 +7,6 @@ set(TARGET_NAME ov_core_unit_tests)
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
 
-ov_try_use_gold_linker()
-
 add_definitions(-DSERIALIZED_ZOO=\"${TEST_MODEL_ZOO}/core/models\")
 
 # For type relaxed types

--- a/src/frontends/onnx/tests/CMakeLists.txt
+++ b/src/frontends/onnx/tests/CMakeLists.txt
@@ -4,8 +4,6 @@
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
 
-ov_try_use_gold_linker()
-
 ov_deprecated_no_errors()
 
 message(STATUS "ONNX frontend test enabled")


### PR DESCRIPTION
### Details:
 - Eliminate gold linker usage due to its obsolescence and conflict with new cmake versions
 - *...*

### Tickets:
 - CVS-180354

### AI Assistance:
 - *AI assistance used: no *
