### PR TITLE
SDL512: Fix npm audit vulnerabilities in package-lock.json

### DIFF
--- a/.github/actions/cache/package-lock.json
+++ b/.github/actions/cache/package-lock.json
@@ -4721,9 +4721,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
       "dev": true
     },
     "node_modules/for-each": {

--- a/.github/actions/wait-for-check-completion/package-lock.json
+++ b/.github/actions/wait-for-check-completion/package-lock.json
@@ -1352,9 +1352,9 @@
             "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",

--- a/src/bindings/js/node/package-lock.json
+++ b/src/bindings/js/node/package-lock.json
@@ -2011,9 +2011,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Details:

Bump vulnerable npm dependencies to patched versions in package-lock.json files (SDL512 npm security audit).

### Changes:
- **brace-expansion** 1.1.12 → 1.1.13 (CVE-2026-33750)
- **flatted** 3.3.3 → 3.3.4 (CVE-2026-32141, CVE-2026-33228)
- **picomatch** 4.0.3 → 4.0.4 (CVE-2026-33671, CVE-2026-33672)

### Files changed:
- `.github/actions/wait-for-check-completion/package-lock.json` - brace-expansion
- `.github/actions/cache/package-lock.json` - flatted
- `src/bindings/js/node/package-lock.json` - picomatch

Note: `serialize-javascript` was already at 7.0.5 (above the vulnerable 7.0.4).