### PR TITLE
change memory dependencies from hashMap to vector

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
@@ -43,7 +43,7 @@ class memory_restricter {
         // Insert into set2 (set1 is read-only)
         void insert(const Key& key) {
             auto it = std::lower_bound(ordered_keys_set1->begin(), ordered_keys_set1->end(), key);
-            if (it != ordered_keys_set1->end() && *it == key) {
+            if (it == ordered_keys_set1->end() || *it != key) {
                 auto it2 = std::lower_bound(ordered_keys_set2.begin(), ordered_keys_set2.end(), key);
                 if (it2 == ordered_keys_set2.end() || *it2 != key) {
                     ordered_keys_set2.insert(it2, key);

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
@@ -29,41 +29,52 @@ using memory_ptr = std::shared_ptr<memory>;
 template<typename Key, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>>
 class memory_restricter {
     private:
-        const std::unordered_set<Key, Hash, KeyEqual>* set1;  // Const reference to immutable set
-        std::unordered_set<Key, Hash, KeyEqual> set2;         // Internal mutable set
+        const std::vector<Key>* ordered_keys_set1;  // Const reference to immutable set
+        std::vector<Key> ordered_keys_set2;         // Internal mutable set
 
     public:
-        memory_restricter() : set1(nullptr) {};
+        memory_restricter() : ordered_keys_set1(nullptr) {};
 
         // Constructor to initialize with a const reference for set1
-        explicit memory_restricter(const std::unordered_set<Key, Hash, KeyEqual>* externalSet)
-            : set1(externalSet) {}
+        explicit memory_restricter(const std::vector<Key>* externalSet)
+            : ordered_keys_set1(externalSet) {
+        }
 
         // Insert into set2 (set1 is read-only)
         void insert(const Key& key) {
-            if (set1->find(key) == set1->end())
-                set2.insert(key);
+            auto it = std::lower_bound(ordered_keys_set1->begin(), ordered_keys_set1->end(), key);
+            if (it != ordered_keys_set1->end() && *it == key) {
+                auto it2 = std::lower_bound(ordered_keys_set2.begin(), ordered_keys_set2.end(), key);
+                if (it2 == ordered_keys_set2.end() || *it2 != key) {
+                    ordered_keys_set2.insert(it2, key);
+                }
+            }
         }
 
         // Check existence in either set
-        bool contains(const Key& key) const {
-            return set1->find(key) != set1->end() || set2.find(key) != set2.end();
+        bool contains(const Key & key) const {
+            if (ordered_keys_set1 && !ordered_keys_set1->empty()) {
+                if (std::binary_search(ordered_keys_set1->begin(), ordered_keys_set1->end(), key)) {
+                    return true;
+                }
+            }
+            return std::binary_search(ordered_keys_set2.begin(), ordered_keys_set2.end(), key);
         }
 
         // Total size of both sets
         size_t size() const {
-            return set1->size() + set2.size();
+            return ordered_keys_set1->size() + ordered_keys_set2.size();
         }
 
         // Check if both sets are empty
         bool empty() const {
-            return set1->empty() && set2.empty();
+            return ordered_keys_set1->empty() && ordered_keys_set2.empty();
         }
 
         // Iterate over both sets
         void for_each(void(*func)(const Key&)) const {
-            for (const auto& key : set1) func(key);
-            for (const auto& key : set2) func(key);
+            for (const auto& key : ordered_keys_set1) func(key);
+            for (const auto& key : ordered_keys_set2) func(key);
         }
 }; // end of memory_restricter
 

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
@@ -26,7 +26,7 @@ class engine;
 using primitive_id = std::string;
 using memory_ptr = std::shared_ptr<memory>;
 
-template<typename Key, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>>
+template<typename Key>
 class memory_restricter {
     private:
         const std::vector<Key>* ordered_keys_set1;  // Const reference to immutable set
@@ -42,17 +42,19 @@ class memory_restricter {
 
         // Insert into set2 (set1 is read-only)
         void insert(const Key& key) {
-            auto it = std::lower_bound(ordered_keys_set1->begin(), ordered_keys_set1->end(), key);
-            if (it == ordered_keys_set1->end() || *it != key) {
-                auto it2 = std::lower_bound(ordered_keys_set2.begin(), ordered_keys_set2.end(), key);
-                if (it2 == ordered_keys_set2.end() || *it2 != key) {
-                    ordered_keys_set2.insert(it2, key);
-                }
+            if (ordered_keys_set1) {
+                auto it = std::lower_bound(ordered_keys_set1->begin(), ordered_keys_set1->end(), key);
+                if (it != ordered_keys_set1->end() && *it == key)
+                    return;
+            }
+            auto it2 = std::lower_bound(ordered_keys_set2.begin(), ordered_keys_set2.end(), key);
+            if (it2 == ordered_keys_set2.end() || *it2 != key) {
+                ordered_keys_set2.insert(it2, key);
             }
         }
 
         // Check existence in either set
-        bool contains(const Key & key) const {
+        bool contains(const Key& key) const {
             if (ordered_keys_set1 && !ordered_keys_set1->empty()) {
                 if (std::binary_search(ordered_keys_set1->begin(), ordered_keys_set1->end(), key)) {
                     return true;
@@ -63,17 +65,19 @@ class memory_restricter {
 
         // Total size of both sets
         size_t size() const {
-            return ordered_keys_set1->size() + ordered_keys_set2.size();
+            return (ordered_keys_set1 ? ordered_keys_set1->size() : 0) + ordered_keys_set2.size();
         }
 
         // Check if both sets are empty
         bool empty() const {
-            return ordered_keys_set1->empty() && ordered_keys_set2.empty();
+            return (!ordered_keys_set1 || ordered_keys_set1->empty()) && ordered_keys_set2.empty();
         }
 
         // Iterate over both sets
         void for_each(void(*func)(const Key&)) const {
-            for (const auto& key : ordered_keys_set1) func(key);
+            if (ordered_keys_set1) {
+                for (const auto& key : *ordered_keys_set1) func(key);
+            }
             for (const auto& key : ordered_keys_set2) func(key);
         }
 }; // end of memory_restricter

--- a/src/plugins/intel_gpu/src/graph/include/pass_manager.h
+++ b/src/plugins/intel_gpu/src/graph/include/pass_manager.h
@@ -328,7 +328,8 @@ public:
 
         // If this dependency is already there, exit early
         const auto& mem_deps = node->get_memory_dependencies();
-        if (mem_deps.find(static_cast<uint32_t>(dep->get_unique_id())) != mem_deps.end()) {
+        auto it = std::lower_bound(mem_deps.begin(), mem_deps.end(), static_cast<uint32_t>(dep->get_unique_id()));
+        if (it != mem_deps.end() && *it == static_cast<uint32_t>(dep->get_unique_id())) {
             return;
         }
 

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -210,7 +210,7 @@ public:
     size_t get_dependency_index(const program_node& node) const;
     size_t get_user_index(const program_node& node) const;
 
-    const std::unordered_set<uint32_t>& get_memory_dependencies() const;
+    const std::vector<uint32_t>& get_memory_dependencies() const;
 
     void add_memory_dependency(std::vector<size_t>);
     void add_memory_dependency(const program_node& node);
@@ -506,7 +506,7 @@ protected:
     std::list<program_node*> users;
 
     // list of primitives that can reuse same memory buffers due to execution order conflicts
-    std::unordered_set<uint32_t> memory_dependencies;
+    std::vector<uint32_t> memory_dependencies;
 
     impl_types impl_type = impl_types::any;
     impl_types forced_impl_type = impl_types::any;

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -195,17 +195,27 @@ void program_node::remove_dependency(size_t idx) {
     dependencies.erase(dependencies.begin() + idx);
 }
 
-const std::unordered_set<uint32_t>& program_node::get_memory_dependencies() const { return memory_dependencies; }
+const std::vector<uint32_t>& program_node::get_memory_dependencies() const { return memory_dependencies; }
 
 void program_node::add_memory_dependency(std::vector<size_t> prim_list) {
     for (size_t val : prim_list) {
-        memory_dependencies.insert(static_cast<uint32_t>(val));
+        OPENVINO_ASSERT(val <= std::numeric_limits<uint32_t>::max(),
+            "[GPU] Memory dependency id is out of uint32_t range: ", std::to_string(val));
+        const auto v32 = static_cast<uint32_t>(val);
+        auto it = std::lower_bound(memory_dependencies.begin(), memory_dependencies.end(), v32);
+        if (it == memory_dependencies.end() || *it != v32) {
+            memory_dependencies.insert(it, v32);
+        }
     }
 }
 
 void program_node::add_memory_dependency(const program_node& dep) {
-    if (dep.may_use_mempool() && may_use_mempool())
-        memory_dependencies.insert(static_cast<uint32_t>(dep.get_unique_id()));
+    if (dep.may_use_mempool() && may_use_mempool()) {
+        auto it = std::lower_bound(memory_dependencies.begin(), memory_dependencies.end(), static_cast<uint32_t>(dep.get_unique_id()));
+        if (it == memory_dependencies.end() || *it != static_cast<uint32_t>(dep.get_unique_id())) {
+            memory_dependencies.insert(it, static_cast<uint32_t>(dep.get_unique_id()));
+        }
+    }
 }
 
 std::unique_ptr<json_composite> program_node::desc_to_json() const {


### PR DESCRIPTION
### Details:
 - Currently node.memory_dependecy information is stored in unordered_set<uint32_t>, which is very consuming of the memory, for example ~200 KB of memory allocated for a std::unordered_set<uint32_t> with 4031 elements. 
 For a customer model, memory usage for memory dependencies is around 480 MB.
 By replacing unordered_set with vector, we could reduce memory usage for memory dependencies down to 40-50 MB.

 


<img width="1146" height="374" alt="mem-reduction" src="https://github.com/user-attachments/assets/f2f7fcba-da03-43f7-bccd-1c608788a592" />


<img width="1890" height="1002" alt="PSD5-wcl" src="https://github.com/user-attachments/assets/635e13a3-2ae5-457c-bd99-8e43fa3d09cd" />

<img width="1968" height="987" alt="PSD5-vector-vs-map" src="https://github.com/user-attachments/assets/1de48ca9-1a4c-49f8-a2a3-a5e33dc6d4fd" />

### Tickets:
 - *CVS-182164*



### AI Assistance:
 - *AI assistance used: no *
