### PR TITLE
[GPU] Defer allocations of inputs

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -122,7 +122,7 @@ public:
 
     memory::ptr get_output_memory(const primitive_id& output_id);
     layout get_output_layout(const primitive_id& output_id) const;
-    std::vector<layout> get_input_layouts() const;
+    std::vector<layout> get_input_layouts();
 
     /// @brief Returns the list of @ref event for the primitives that were executed in network.
     std::map<primitive_id, event::ptr> get_executed_primitives() const {

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -122,7 +122,7 @@ public:
 
     memory::ptr get_output_memory(const primitive_id& output_id);
     layout get_output_layout(const primitive_id& output_id) const;
-    std::vector<layout> get_input_layouts();
+    std::vector<layout> get_input_layouts() const;
 
     /// @brief Returns the list of @ref event for the primitives that were executed in network.
     std::map<primitive_id, event::ptr> get_executed_primitives() const {

--- a/src/plugins/intel_gpu/src/graph/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/broadcast.cpp
@@ -137,10 +137,13 @@ void broadcast_inst::on_execute() {
 void broadcast_inst::update_output_memory() {
     if (!can_be_optimized())
         return;
-    if (static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
+    build_deps();
+
+    if (input_memory_ptr() == nullptr)
         return;
 
-    build_deps();
+    if (static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
+        return;
 
     GPU_DEBUG_TRACE_DETAIL << id() << " : update_output_memory with mem of input " << get_node().get_dependency(0).id()
                            << " : " << input_memory_ptr()->buffer_ptr() << std::endl;

--- a/src/plugins/intel_gpu/src/graph/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/broadcast.cpp
@@ -137,6 +137,7 @@ void broadcast_inst::on_execute() {
 void broadcast_inst::update_output_memory() {
     if (!can_be_optimized())
         return;
+
     build_deps();
 
     if (input_memory_ptr() == nullptr)

--- a/src/plugins/intel_gpu/src/graph/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/crop.cpp
@@ -268,7 +268,7 @@ void crop_inst::update_output_memory() {
 
     build_deps();
 
-    if (get_node().get_program().is_new_shape_infer() && input_memory_ptr() == nullptr)
+    if (input_memory_ptr() == nullptr)
         return;
 
     if (_outputs[0] && get_network().get_engine().is_the_same_buffer(output_memory(), input_memory()))

--- a/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
@@ -143,6 +143,9 @@ void dynamic_quantize_inst::update_output_memory() {
     if (!can_be_optimized())
         return;
 
+    if (input_memory_ptr() == nullptr)
+        return;
+
     if (static_cast<bool>(_outputs[0])
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory())
         && output_memory().get_layout().identical(get_output_layout()))

--- a/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
@@ -143,6 +143,9 @@ void dynamic_quantize_inst::update_output_memory() {
     if (!can_be_optimized())
         return;
 
+    if (_node != nullptr)
+        build_deps();
+
     if (input_memory_ptr() == nullptr)
         return;
 
@@ -150,9 +153,6 @@ void dynamic_quantize_inst::update_output_memory() {
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory())
         && output_memory().get_layout().identical(get_output_layout()))
         return;
-
-    if (_node != nullptr)
-        build_deps();
 
     OPENVINO_ASSERT(input_memory_ptr() != nullptr, "[GPU] Failed to reuse input in ", id(), " primitive: input memory was not allocated");
 

--- a/src/plugins/intel_gpu/src/graph/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather.cpp
@@ -141,6 +141,7 @@ void gather_inst::on_execute() {
 void gather_inst::update_output_memory() {
     if (!can_be_optimized())
         return;
+
     build_deps();
 
     if (input_memory_ptr() == nullptr)

--- a/src/plugins/intel_gpu/src/graph/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather.cpp
@@ -141,10 +141,13 @@ void gather_inst::on_execute() {
 void gather_inst::update_output_memory() {
     if (!can_be_optimized())
         return;
-    if (static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
+    build_deps();
+
+    if (input_memory_ptr() == nullptr)
         return;
 
-    build_deps();
+    if (static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
+        return;
 
     GPU_DEBUG_TRACE_DETAIL << id() << " : update_output_memory with mem of input " << get_node().get_dependency(0).id()
                            << " : " << input_memory_ptr()->buffer_ptr() << std::endl;

--- a/src/plugins/intel_gpu/src/graph/input_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/input_layout.cpp
@@ -10,18 +10,6 @@
 #include <memory>
 #include <algorithm>
 
-namespace {
-bool has_optimized_users(const cldnn::input_layout_node& node) {
-    for (auto& user : node.get_users()) {
-        if (user->can_be_optimized()) {
-            return true;
-        }
-    }
-
-    return false;
-}
-}  // namespace
-
 namespace cldnn {
 GPU_DEFINE_PRIMITIVE_TYPE_ID(input_layout)
 
@@ -30,7 +18,7 @@ input_layout_node::typed_program_node(const std::shared_ptr<input_layout> dprim,
 }
 
 input_layout_inst::typed_primitive_inst(network& network, const input_layout_node& node)
-    : parent(network, node, /*allocate_mem*/ false) {  // !node.is_dynamic() && (!network.is_internal() || has_optimized_users(node))) {
+    : parent(network, node, /*allocate_mem*/ false) {
     _has_valid_input = false;                          // by default input for 'input_layout' is invalid as long as user doesn't call set_data
 }
 

--- a/src/plugins/intel_gpu/src/graph/input_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/input_layout.cpp
@@ -18,7 +18,8 @@ input_layout_node::typed_program_node(const std::shared_ptr<input_layout> dprim,
 }
 
 input_layout_inst::typed_primitive_inst(network& network, const input_layout_node& node)
-    : parent(network, node, /*allocate_mem*/ false) {
+    // allocate memory for scalars as they assume the memory is available and not lazily allocated...
+    : parent(network, node, /*allocate_mem*/ !node.is_dynamic() && node.get_output_layout().count() <= 1) {
     _has_valid_input = false;                          // by default input for 'input_layout' is invalid as long as user doesn't call set_data
 }
 

--- a/src/plugins/intel_gpu/src/graph/input_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/input_layout.cpp
@@ -36,7 +36,6 @@ event::ptr input_layout_inst::set_data(memory::ptr mem, bool need_to_check_memor
 
     // Allow to set dummy simple_attached_memory empty tensor as network input
     if (mem->is_allocated_by(engine) || mem->get_layout().count() == 0) {
-        // Direct assignment — no copy, no pre-allocation waste
         if (_outputs.empty()) {
             _outputs.resize(1);
         }

--- a/src/plugins/intel_gpu/src/graph/input_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/input_layout.cpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 
 namespace {
-bool has_optimized_users(cldnn::input_layout_node const& node) {
+bool has_optimized_users(const cldnn::input_layout_node& node) {
     for (auto& user : node.get_users()) {
         if (user->can_be_optimized()) {
             return true;
@@ -25,14 +25,13 @@ bool has_optimized_users(cldnn::input_layout_node const& node) {
 namespace cldnn {
 GPU_DEFINE_PRIMITIVE_TYPE_ID(input_layout)
 
-input_layout_node::typed_program_node(const std::shared_ptr<input_layout> dprim, program& prog)
-    : parent(dprim, prog) {
+input_layout_node::typed_program_node(const std::shared_ptr<input_layout> dprim, program& prog) : parent(dprim, prog) {
     can_share_buffer(false);
 }
 
-input_layout_inst::typed_primitive_inst(network& network, input_layout_node const& node)
-    : parent(network, node, !node.is_dynamic() && (!network.is_internal() || has_optimized_users(node))) {
-    _has_valid_input = false;  // by default input for 'input_layout' is invalid as long as user doesn't call set_data
+input_layout_inst::typed_primitive_inst(network& network, const input_layout_node& node)
+    : parent(network, node, /*allocate_mem*/ false) {  // !node.is_dynamic() && (!network.is_internal() || has_optimized_users(node))) {
+    _has_valid_input = false;                          // by default input for 'input_layout' is invalid as long as user doesn't call set_data
 }
 
 event::ptr input_layout_inst::set_data(memory::ptr mem, bool need_to_check_memory_to_set) {
@@ -49,15 +48,17 @@ event::ptr input_layout_inst::set_data(memory::ptr mem, bool need_to_check_memor
 
     // Allow to set dummy simple_attached_memory empty tensor as network input
     if (mem->is_allocated_by(engine) || mem->get_layout().count() == 0) {
-        OPENVINO_ASSERT(!_outputs.empty(), "[GPU] Can't set data for empty input memory");
+        // Direct assignment — no copy, no pre-allocation waste
+        if (_outputs.empty()) {
+            _outputs.resize(1);
+        }
         _outputs[0] = mem;
     } else {
-        if (_outputs.empty() || !_outputs[0]) {
+        if (_outputs.empty()) {
             _outputs.resize(1);
-            _outputs[0] = engine.allocate_memory(mem->get_layout(), engine.get_preferred_memory_allocation_type(), false);
         }
-
-        if (ol.is_dynamic() && _outputs[0]->size() < mem->size()) {
+        // Only allocate if needed and not already large enough
+        if (!_outputs[0] || _outputs[0]->size() < mem->size()) {
             _outputs[0] = engine.allocate_memory(mem->get_layout(), engine.get_preferred_memory_allocation_type(), false);
         }
         mem_lock<uint8_t> src(mem, stream);
@@ -78,7 +79,7 @@ void input_layout_inst::update_shape() {
     _impl_params->output_layouts[0] = mem_layout;
 }
 
-std::string input_layout_inst::to_string(input_layout_node const& node) {
+std::string input_layout_inst::to_string(const input_layout_node& node) {
     auto node_info = node.desc_to_json();
 
     std::stringstream primitive_description;

--- a/src/plugins/intel_gpu/src/graph/input_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/input_layout.cpp
@@ -54,7 +54,17 @@ event::ptr input_layout_inst::set_data(memory::ptr mem, bool need_to_check_memor
         if (_outputs.empty()) {
             _outputs.resize(1);
         }
-        set_output_memory(mem, false);
+        if (_max_output_layout_count.empty()) {
+            _max_output_layout_count.resize(1);
+        }
+
+        // Do not use set_output_memory() for externally-owned memory here.
+        // The same device buffer can be rebound with a different logical layout,
+        // and primitive_inst::set_output_memory() short-circuits on buffer identity.
+        // That keeps a stale memory object/layout on input_layout and breaks
+        // dynamic stateful flows that feed previous outputs back as inputs.
+        _outputs[0] = mem;
+        _max_output_layout_count[0] = mem->get_layout().get_linear_size();
     } else {
         if (_outputs.empty()) {
             _outputs.resize(1);

--- a/src/plugins/intel_gpu/src/graph/input_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/input_layout.cpp
@@ -10,6 +10,21 @@
 #include <memory>
 #include <algorithm>
 
+namespace {
+
+bool requires_eager_input_allocation(const cldnn::input_layout_node& node) {
+    if (node.is_dynamic()) {
+        return false;
+    }
+
+    const auto& out_layout = node.get_output_layout();
+
+    // Scalars assume input memory is always materialized. Blocked inputs still have
+    // initialization paths that depend on an eager placeholder allocation.
+    return out_layout.count() <= 1 || cldnn::format::is_blocked(out_layout.format);
+}
+}  // namespace
+
 namespace cldnn {
 GPU_DEFINE_PRIMITIVE_TYPE_ID(input_layout)
 
@@ -18,8 +33,7 @@ input_layout_node::typed_program_node(const std::shared_ptr<input_layout> dprim,
 }
 
 input_layout_inst::typed_primitive_inst(network& network, const input_layout_node& node)
-    // allocate memory for scalars as they assume the memory is available and not lazily allocated...
-    : parent(network, node, /*allocate_mem*/ !node.is_dynamic() && node.get_output_layout().count() <= 1) {
+    : parent(network, node, /*allocate_mem*/ requires_eager_input_allocation(node)) {
     _has_valid_input = false;                          // by default input for 'input_layout' is invalid as long as user doesn't call set_data
 }
 
@@ -40,14 +54,14 @@ event::ptr input_layout_inst::set_data(memory::ptr mem, bool need_to_check_memor
         if (_outputs.empty()) {
             _outputs.resize(1);
         }
-        _outputs[0] = mem;
+        set_output_memory(mem, false);
     } else {
         if (_outputs.empty()) {
             _outputs.resize(1);
         }
         // Only allocate if needed and not already large enough
         if (!_outputs[0] || _outputs[0]->size() < mem->size()) {
-            _outputs[0] = engine.allocate_memory(mem->get_layout(), engine.get_preferred_memory_allocation_type(), false);
+            set_output_memory(engine.allocate_memory(mem->get_layout(), engine.get_preferred_memory_allocation_type(), false), false);
         }
         mem_lock<uint8_t> src(mem, stream);
         ev = _outputs[0]->copy_from(stream, src.data(), false);

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -387,6 +387,10 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
     std::vector<primitive_inst*> chain;
     std::stack<const primitive_inst*> candidates;
     auto& eng = get_engine();
+
+    if (p_inst->output_memory_ptr())
+        _in_out_shared_mem_types.push_back(p_inst->output_memory_ptr()->get_internal_params().mem_type);
+
     const auto& mem_orig = p_inst->output_memory();
 
     auto add_mdata_chain = [&](primitive_inst* p_inst) {
@@ -554,6 +558,10 @@ void network::allocate_primitives() {
             if (!node->get_dependencies().empty() && opt_inst->dependencies().empty()) {
                 opt_inst->build_deps();
             }
+            // Skip if the dependency's memory is not yet allocated (e.g. lazy input_layout).
+            // The output memory will be set up at runtime when the input becomes available.
+            if (!opt_inst->dependencies().empty() && opt_inst->dep_memory_ptr(0) == nullptr)
+                continue;
             opt_inst->update_output_memory();
         }
     }
@@ -870,10 +878,15 @@ std::vector<primitive_id> network::get_input_ids() const {
     return ret;
 }
 
-std::vector<layout> network::get_input_layouts() const {
+std::vector<layout> network::get_input_layouts() {
     std::vector<layout> ret;
     ret.reserve(_inputs.size());
-    for (auto const& input : _inputs) ret.push_back(input->output_memory_ptr()->get_layout());
+    for (auto const& input : _inputs) {
+        if (input->output_memory_ptr())
+            _in_out_shared_mem_types.push_back(input->output_memory_ptr()->get_internal_params().mem_type);
+
+        ret.push_back(input->output_memory_ptr() ? input->output_memory_ptr()->get_layout() : input->get_output_layout());
+    }
     return ret;
 }
 

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -326,8 +326,14 @@ event::ptr network::set_input_data(const primitive_id& id, memory::ptr data, boo
     }
 
     auto input = std::static_pointer_cast<input_layout_inst>(primitive_inst);
+    auto ev = input->set_data(data, need_to_check_memory_to_set);
 
-    return input->set_data(data, need_to_check_memory_to_set);
+    // Lazy input_layout allocation means some static kernels may have skipped argument
+    // binding during network initialization because the input-backed dependency buffer
+    // was not available yet. Force a fresh argument binding before the next execute.
+    _reset_arguments = true;
+
+    return ev;
 }
 
 void network::add_default_output_chains() {

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -324,14 +324,14 @@ event::ptr network::set_input_data(const primitive_id& id, memory::ptr data, boo
     if (primitive_inst->type() != input_layout::type_id()) {
         CLDNN_ERROR_MESSAGE(id, "primitive " + id + " is not an input");
     }
-
     auto input = std::static_pointer_cast<input_layout_inst>(primitive_inst);
+    const bool was_unallocated = !input->output_memory_ptr();
     auto ev = input->set_data(data, need_to_check_memory_to_set);
 
-    // Lazy input_layout allocation means some static kernels may have skipped argument
-    // binding during network initialization because the input-backed dependency buffer
-    // was not available yet. Force a fresh argument binding before the next execute.
-    _reset_arguments = true;
+    // Only force rebind on the first call for a lazy-allocated input —
+    // the initial set_arguments() skipped nodes whose dep buffer was null.
+    if (was_unallocated)
+        _reset_arguments = true;
 
     return ev;
 }

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -332,10 +332,18 @@ event::ptr network::set_input_data(const primitive_id& id, memory::ptr data, boo
         // The initial set_arguments() skipped nodes whose dep buffer was null —
         // force a fresh rebind now that the buffer is available.
         _reset_arguments = true;
-        // Record the shared mem type now that the lazy input has a buffer.
-        // Non-lazy inputs are recorded at allocate_primitive_instance() time.
-        if (input->output_memory_ptr())
-            _in_out_shared_mem_types.push_back(input->output_memory_ptr()->get_internal_params().mem_type);
+    }
+
+    // Update the shared mem type hint for the surfaces lock fast-path in execute().
+    // We deduplicate by type value to prevent unbounded growth across inferences.
+    // Note: this vector is a conservative hint - false positives (stale surface types
+    // after input memory switches back to non-surface) are harmless since execute()
+    // re-checks live memory state when building in_out_mem.
+    // TODO: possibly remove or redesign _in_out_shared_mem_types solution
+    if (input->output_memory_ptr()) {
+        const auto in_mem_type = input->output_memory_ptr()->get_internal_params().mem_type;
+        if (std::find(_in_out_shared_mem_types.begin(), _in_out_shared_mem_types.end(), in_mem_type) == _in_out_shared_mem_types.end())
+            _in_out_shared_mem_types.push_back(in_mem_type);
     }
 
     return ev;

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -328,10 +328,15 @@ event::ptr network::set_input_data(const primitive_id& id, memory::ptr data, boo
     const bool was_unallocated = !input->output_memory_ptr();
     auto ev = input->set_data(data, need_to_check_memory_to_set);
 
-    // Only force rebind on the first call for a lazy-allocated input —
-    // the initial set_arguments() skipped nodes whose dep buffer was null.
-    if (was_unallocated)
+    if (was_unallocated) {
+        // The initial set_arguments() skipped nodes whose dep buffer was null —
+        // force a fresh rebind now that the buffer is available.
         _reset_arguments = true;
+        // Record the shared mem type now that the lazy input has a buffer.
+        // Non-lazy inputs are recorded at allocate_primitive_instance() time.
+        if (input->output_memory_ptr())
+            _in_out_shared_mem_types.push_back(input->output_memory_ptr()->get_internal_params().mem_type);
+    }
 
     return ev;
 }
@@ -393,9 +398,6 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
     std::vector<primitive_inst*> chain;
     std::stack<const primitive_inst*> candidates;
     auto& eng = get_engine();
-
-    if (p_inst->output_memory_ptr())
-        _in_out_shared_mem_types.push_back(p_inst->output_memory_ptr()->get_internal_params().mem_type);
 
     const auto& mem_orig = p_inst->output_memory();
 
@@ -884,15 +886,11 @@ std::vector<primitive_id> network::get_input_ids() const {
     return ret;
 }
 
-std::vector<layout> network::get_input_layouts() {
+std::vector<layout> network::get_input_layouts() const {
     std::vector<layout> ret;
     ret.reserve(_inputs.size());
-    for (auto const& input : _inputs) {
-        if (input->output_memory_ptr())
-            _in_out_shared_mem_types.push_back(input->output_memory_ptr()->get_internal_params().mem_type);
-
+    for (auto const& input : _inputs)
         ret.push_back(input->output_memory_ptr() ? input->output_memory_ptr()->get_layout() : input->get_output_layout());
-    }
     return ret;
 }
 

--- a/src/plugins/intel_gpu/src/graph/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/permute.cpp
@@ -141,11 +141,14 @@ void permute_inst::update_output_memory() {
     if (!can_be_optimized() || _impl_params->is_dynamic())
         return;
 
+    build_deps();
+
+    if (input_memory_ptr() == nullptr)
+        return;
+
     if (_outputs.size() > 0 && static_cast<bool>(_outputs[0])
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;
-
-    build_deps();
 
     GPU_DEBUG_TRACE_DETAIL << id() << " : update_output_memory with mem of input " << get_node().get_dependency(0).id()
                            << " : " << input_memory_ptr()->buffer_ptr() << std::endl;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2393,13 +2393,12 @@ primitive_inst::primitive_inst(network & network, program_node const& node, bool
             // sum post-op can use the input buffer as the output buffer
             auto& eltw_node = node.get_dependency(reused_eltwmem_idx);
             const auto& eltw_inst = _network.get_primitive(eltw_node.id());
-            if (!eltw_inst->outputs_allocated()) {
-                // Dependency memory not yet available (e.g. lazy input_layout).
-                // Force-allocate it now so the sum post-op buffer reuse works correctly.
-                auto eltw_mem = _network.get_engine().allocate_memory(eltw_node.get_output_layout(),
-                                                                      _network.get_engine().get_preferred_memory_allocation_type(),
-                                                                      false);
-                eltw_inst->set_output_memory(eltw_mem, false);
+            if (eltw_node.is_type<input_layout>() && !eltw_inst->outputs_allocated()) {
+                auto eltw_mem = _network.get_engine().allocate_memory(eltw_node.get_output_layout(), 
+                                                                      _network.get_engine().get_preferred_memory_allocation_type(), 
+                                                                      /*reset*/false);
+                eltw_inst->set_output_memory(eltw_mem, /*check*/false);
+                std::cout << "Reusing buffer from " << eltw_inst->id() << " for " << id() << " primitive." << std::endl;
             }
             auto& eltw_mem = eltw_inst->output_memory();
             auto new_mem = eltw_mem.get_engine()->reinterpret_buffer(eltw_mem, node.get_output_layout());

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2398,7 +2398,6 @@ primitive_inst::primitive_inst(network & network, program_node const& node, bool
                                                                       _network.get_engine().get_preferred_memory_allocation_type(), 
                                                                       /*reset*/false);
                 eltw_inst->set_output_memory(eltw_mem, /*check*/false);
-                std::cout << "Reusing buffer from " << eltw_inst->id() << " for " << id() << " primitive." << std::endl;
             }
             auto& eltw_mem = eltw_inst->output_memory();
             auto new_mem = eltw_mem.get_engine()->reinterpret_buffer(eltw_mem, node.get_output_layout());

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2393,6 +2393,14 @@ primitive_inst::primitive_inst(network & network, program_node const& node, bool
             // sum post-op can use the input buffer as the output buffer
             auto& eltw_node = node.get_dependency(reused_eltwmem_idx);
             const auto& eltw_inst = _network.get_primitive(eltw_node.id());
+            if (!eltw_inst->outputs_allocated()) {
+                // Dependency memory not yet available (e.g. lazy input_layout).
+                // Force-allocate it now so the sum post-op buffer reuse works correctly.
+                auto eltw_mem = _network.get_engine().allocate_memory(eltw_node.get_output_layout(),
+                                                                      _network.get_engine().get_preferred_memory_allocation_type(),
+                                                                      false);
+                eltw_inst->set_output_memory(eltw_mem, false);
+            }
             auto& eltw_mem = eltw_inst->output_memory();
             auto new_mem = eltw_mem.get_engine()->reinterpret_buffer(eltw_mem, node.get_output_layout());
             _outputs.push_back(new_mem);

--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -227,7 +227,7 @@ void resample_inst::update_output_memory() {
 
     build_deps();
 
-    if (get_node().get_program().is_new_shape_infer() && input_memory_ptr() == nullptr)
+    if (input_memory_ptr() == nullptr)
         return;
 
     if (_outputs[0] && get_network().get_engine().is_the_same_buffer(output_memory(), input_memory()))

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -334,9 +334,8 @@ void reshape_inst::update_output_memory() {
         return;
 
     build_deps();  // reshape need deps
-    if (get_node().get_program().is_new_shape_infer() && input_memory_ptr() == nullptr)
+    if (input_memory_ptr() == nullptr)
         return;
-    OPENVINO_ASSERT(input_memory_ptr() != nullptr, "[GPU] Failed to reuse input in ", id(), " primitive: input memory was not allocated");
 
     // Can_be_optimized nodes are allocating from memory_pool too. In this case,
     // we need release the legacy output memory from memory pool explicitly.

--- a/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
@@ -71,6 +71,9 @@ void scatter_elements_update_inst::update_output_memory() {
 
     build_deps();
 
+    if (input_memory_ptr() == nullptr)
+        return;
+
     // Can_be_optimized nodes are allocating from memory_pool too. In this case,
     // we need release the legacy output memory from memory pool explicitly.
     if (static_cast<bool>(_outputs[0]) &&

--- a/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
@@ -83,6 +83,9 @@ void scatter_nd_update_inst::update_output_memory() {
 
     build_deps();
 
+    if (input_memory_ptr() == nullptr)
+        return;
+
     // Can_be_optimized nodes are allocating from memory_pool too. In this case,
     // we need release the legacy output memory from memory pool explicitly.
     if (static_cast<bool>(_outputs[0]) &&

--- a/src/plugins/intel_gpu/src/graph/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_update.cpp
@@ -63,6 +63,9 @@ void scatter_update_inst::update_output_memory() {
     if (_node != nullptr)
         build_deps();
 
+    if (input_memory_ptr() == nullptr)
+        return;
+
     // Can_be_optimized nodes are allocating from memory_pool too. In this case,
     // we need release the legacy output memory from memory pool explicitly.
     if (static_cast<bool>(_outputs[0]) &&

--- a/src/plugins/intel_gpu/src/graph/slice_scatter.cpp
+++ b/src/plugins/intel_gpu/src/graph/slice_scatter.cpp
@@ -67,10 +67,13 @@ void slice_scatter_inst::update_output_memory() {
     if (!can_be_optimized() || _impl_params->is_dynamic())
         return;
 
-    if (_outputs.size() > 0 && static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
+    build_deps();
+
+    if (input_memory_ptr() == nullptr)
         return;
 
-    build_deps();
+    if (_outputs.size() > 0 && static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
+        return;
 
     if (static_cast<bool>(_outputs[0]) && get_node().get_program().get_config().get_enable_memory_pool()) {
         _network.get_memory_pool().release_memory(_outputs[0].get(), get_node().get_unique_id(), get_node().id(), _network.get_id());

--- a/src/plugins/intel_gpu/src/graph/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/strided_slice.cpp
@@ -196,7 +196,7 @@ void strided_slice_inst::update_output_memory() {
     if (!can_be_optimized())
         return;
 
-    if (get_node().get_program().is_new_shape_infer() && input_memory_ptr() == nullptr)
+    if (input_memory_ptr() == nullptr)
         return;
 
     if (static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))

--- a/src/plugins/intel_gpu/src/graph/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/strided_slice.cpp
@@ -196,13 +196,13 @@ void strided_slice_inst::update_output_memory() {
     if (!can_be_optimized())
         return;
 
+    build_deps();
+
     if (input_memory_ptr() == nullptr)
         return;
 
     if (static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;
-
-    build_deps();
 
     GPU_DEBUG_TRACE_DETAIL << id() << " : update_output_memory with mem of input " << get_node().get_dependency(0).id()
                            << " : " << input_memory_ptr()->buffer_ptr() << std::endl;

--- a/src/plugins/intel_gpu/tests/unit/module_tests/network_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/network_test.cpp
@@ -13,6 +13,7 @@
 #include "intel_gpu/primitives/reorder.hpp"
 #include "intel_gpu/primitives/reshape.hpp"
 #include "intel_gpu/primitives/fully_connected.hpp"
+#include "intel_gpu/primitives/slice_scatter.hpp"
 #include "primitive_inst.h"
 
 #include "runtime/ocl/ocl_event.hpp"
@@ -248,6 +249,47 @@ TEST(network_test, scratchpad_test) {
         ASSERT_TRUE(fc1->get_intermediates_memories()[0]->buffer_ptr() !=
                     fc2->get_intermediates_memories()[0]->buffer_ptr());
     }
+}
+
+// this test verifies the case where an example primitive - in this case it's slice_scatter
+// calls update_output_memory before buid_deps is called, in this case we expect
+// that build_deps will be called from update_output_memory before accessing calling things like input_memory_ptr
+TEST(network_test, update_output_memory_calls_build_deps) {
+    auto& engine = get_test_engine();
+
+    auto data_mem = engine.allocate_memory({data_types::f32, format::bfyx, {1, 1, 2, 3}});
+    auto updates_mem = engine.allocate_memory({data_types::f32, format::bfyx, {1, 1, 2, 3}});
+    auto start_mem = engine.allocate_memory(layout{ov::PartialShape{4}, data_types::i64, format::bfyx});
+    auto stop_mem = engine.allocate_memory(layout{ov::PartialShape{4}, data_types::i64, format::bfyx});
+    auto step_mem = engine.allocate_memory(layout{ov::PartialShape{4}, data_types::i64, format::bfyx});
+
+    set_values<float>(data_mem, {0.f, 1.f, 2.f, 3.f, 4.f, 5.f});
+    set_values<float>(updates_mem, {10.f, 20.f, 30.f, 40.f, 50.f, 60.f});
+    set_values<int64_t>(start_mem, {0, 0, 0, 0});
+    set_values<int64_t>(stop_mem, {1, 1, 2, 3});
+    set_values<int64_t>(step_mem, {1, 1, 1, 1});
+
+    topology topo;
+    topo.add(input_layout("data", data_mem->get_layout()));
+    topo.add(input_layout("updates", updates_mem->get_layout()));
+    topo.add(data("start", start_mem));
+    topo.add(data("stop", stop_mem));
+    topo.add(data("step", step_mem));
+    // slice scatter is used here, but there are other primitives that have similar logic: gather, scatter_update, etc...
+    topo.add(slice_scatter("slice_scatter", {input_info("data"), input_info("updates"), input_info("start"), input_info("stop"), input_info("step")}));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    auto prog = program::build_program(engine, topo, config);
+    auto& slice_scatter_node = prog->get_node("slice_scatter");
+    // force the flag to be true, so that it can pass the early return at the top of slice_scatter_inst::update_output_memory
+    slice_scatter_node.can_be_optimized(true);
+    ASSERT_TRUE(slice_scatter_node.can_be_optimized());
+
+    cldnn::network::ptr network;
+    ASSERT_NO_THROW(network = network::allocate_network(engine, prog));
+    ASSERT_NE(network, nullptr);
 }
 
 #endif

--- a/src/plugins/intel_gpu/tests/unit/module_tests/network_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/network_test.cpp
@@ -252,7 +252,7 @@ TEST(network_test, scratchpad_test) {
 }
 
 // this test verifies the case where an example primitive - in this case it's slice_scatter
-// calls update_output_memory before buid_deps is called, in this case we expect
+// calls update_output_memory before build_deps is called, in this case we expect
 // that build_deps will be called from update_output_memory before accessing calling things like input_memory_ptr
 TEST(network_test, update_output_memory_calls_build_deps) {
     auto& engine = get_test_engine();

--- a/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
@@ -92,8 +92,8 @@ public:
         auto outputs = network->execute();
 
         // input_layout no longer pre-allocates memory at network construction time,
-        // so the peak no longer includes the input buffer (sizeof(float) * batch_num * feature_num * x_size * y_size)
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(64 - sizeof(float) * batch_num * feature_num * x_size * y_size));
+        const uint64_t input_buf_size = sizeof(float) * batch_num * feature_num * x_size * y_size;
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(64 - input_buf_size));
     }
 
     void test_basic_non_padded_relu_and_pooling_pipe(bool is_caching_test) {
@@ -126,8 +126,8 @@ public:
         auto outputs = network->execute();
 
         // input_layout no longer pre-allocates memory at network construction time,
-        // so the peak no longer includes the input buffer (sizeof(float) * batch_num * feature_num * x_size * y_size)
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(896 - sizeof(float) * batch_num * feature_num * x_size * y_size));
+        const uint64_t input_buf_size = sizeof(float) * batch_num * feature_num * x_size * y_size;
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(896 - input_buf_size));
     }
 
     void test_multi_outputs_network(bool is_caching_test) {
@@ -163,8 +163,8 @@ public:
         auto outputs = network->execute();
 
         // input_layout no longer pre-allocates memory at network construction time,
-        // so the peak no longer includes the input buffer (sizeof(float) * batch_num * feature_num * x_size * y_size)
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(1536 - sizeof(float) * batch_num * feature_num * x_size * y_size));
+        const uint64_t input_buf_size = sizeof(float) * batch_num * feature_num * x_size * y_size;
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(1536 - input_buf_size));
     }
 
     void test_oooq(bool is_caching_test) {
@@ -203,8 +203,8 @@ public:
         auto outputs = network->execute();
 
         // input_layout no longer pre-allocates memory at network construction time,
-        // so the peak no longer includes the input buffer (sizeof(float) * batch_num * feature_num * x_size * y_size)
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(2560 - sizeof(float) * batch_num * feature_num * x_size * y_size));
+        const uint64_t input_buf_size = sizeof(float) * batch_num * feature_num * x_size * y_size;
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(2560 - input_buf_size));
     }
 
     void test_shared_mem_pool_same_topology_twice() {
@@ -413,20 +413,16 @@ public:
 
         auto dev_info = engine->get_device_info();
         // input_layout no longer pre-allocates memory at network construction time,
-        // so the peak no longer includes the input buffer (sizeof(float) * batch_8 * feature_num * inp_x_size * inp_y_size)
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(4744 - sizeof(float) * batch_8 * feature_num * inp_x_size * inp_y_size));
+        const uint64_t input_buf_size = sizeof(float) * batch_8 * feature_num * inp_x_size * inp_y_size;
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(4744 - input_buf_size));
 
         topo.change_input_layout("input", input_1->get_layout());//change input layout to batch=1
 
         network::ptr network_second = get_network(*engine, topo, config, get_test_stream_ptr(), is_caching_test);
         network_second->set_input_data("input", input_1);
         auto outputs_second = network_second->execute();
-        // Peak after both networks: old value was 5912. It is reduced by the eliminated batch_8 input_layout
-        // pre-alloc (sizeof(float)*batch_8*feature_num*inp_x_size*inp_y_size = 1536 bytes). However, in the
-        // old code that freed 1536-byte slot re-entered the memory pool and was reused to satisfy a small
-        // 16-byte allocation in network_second, avoiding a fresh alloc. Without the pre-alloc that slot never
-        // exists, so the 16 bytes are allocated fresh, adding +16 to the new peak.
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(5912 - sizeof(float) * batch_8 * feature_num * inp_x_size * inp_y_size + 16));
+
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(5928 - input_buf_size));
     }
 
     void test_shared_dep_two_output(bool is_caching_test) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
@@ -91,7 +91,9 @@ public:
         network->set_input_data("input", input);
         auto outputs = network->execute();
 
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)64);
+        // input_layout no longer pre-allocates memory at network construction time,
+        // so the peak no longer includes the input buffer (sizeof(float) * batch_num * feature_num * x_size * y_size)
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(64 - sizeof(float) * batch_num * feature_num * x_size * y_size));
     }
 
     void test_basic_non_padded_relu_and_pooling_pipe(bool is_caching_test) {
@@ -123,7 +125,9 @@ public:
         network->set_input_data("input", input);
         auto outputs = network->execute();
 
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)896);
+        // input_layout no longer pre-allocates memory at network construction time,
+        // so the peak no longer includes the input buffer (sizeof(float) * batch_num * feature_num * x_size * y_size)
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(896 - sizeof(float) * batch_num * feature_num * x_size * y_size));
     }
 
     void test_multi_outputs_network(bool is_caching_test) {
@@ -158,7 +162,9 @@ public:
         network->set_input_data("input", input);
         auto outputs = network->execute();
 
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t) 1536);
+        // input_layout no longer pre-allocates memory at network construction time,
+        // so the peak no longer includes the input buffer (sizeof(float) * batch_num * feature_num * x_size * y_size)
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(1536 - sizeof(float) * batch_num * feature_num * x_size * y_size));
     }
 
     void test_oooq(bool is_caching_test) {
@@ -196,7 +202,9 @@ public:
         network->set_input_data("input", input);
         auto outputs = network->execute();
 
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t) 2560);
+        // input_layout no longer pre-allocates memory at network construction time,
+        // so the peak no longer includes the input buffer (sizeof(float) * batch_num * feature_num * x_size * y_size)
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(2560 - sizeof(float) * batch_num * feature_num * x_size * y_size));
     }
 
     void test_shared_mem_pool_same_topology_twice() {
@@ -404,14 +412,21 @@ public:
         auto outputs = network_first->execute();
 
         auto dev_info = engine->get_device_info();
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)4744);
+        // input_layout no longer pre-allocates memory at network construction time,
+        // so the peak no longer includes the input buffer (sizeof(float) * batch_8 * feature_num * inp_x_size * inp_y_size)
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(4744 - sizeof(float) * batch_8 * feature_num * inp_x_size * inp_y_size));
 
         topo.change_input_layout("input", input_1->get_layout());//change input layout to batch=1
 
         network::ptr network_second = get_network(*engine, topo, config, get_test_stream_ptr(), is_caching_test);
         network_second->set_input_data("input", input_1);
         auto outputs_second = network_second->execute();
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)5912);
+        // Peak after both networks: old value was 5912. It is reduced by the eliminated batch_8 input_layout
+        // pre-alloc (sizeof(float)*batch_8*feature_num*inp_x_size*inp_y_size = 1536 bytes). However, in the
+        // old code that freed 1536-byte slot re-entered the memory pool and was reused to satisfy a small
+        // 16-byte allocation in network_second, avoiding a fresh alloc. Without the pre-alloc that slot never
+        // exists, so the 16 bytes are allocated fresh, adding +16 to the new peak.
+        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(5912 - sizeof(float) * batch_8 * feature_num * inp_x_size * inp_y_size + 16));
     }
 
     void test_shared_dep_two_output(bool is_caching_test) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
@@ -91,7 +91,7 @@ public:
         network->set_input_data("input", input);
         auto outputs = network->execute();
 
-        // input_layout no longer pre-allocates memory at network construction time,
+        // input_layout no longer pre-allocates memory at network construction time
         const uint64_t input_buf_size = sizeof(float) * batch_num * feature_num * x_size * y_size;
         ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(64 - input_buf_size));
     }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
@@ -15,6 +15,8 @@
 #include <intel_gpu/primitives/crop.hpp>
 #include <intel_gpu/primitives/eltwise.hpp>
 #include <intel_gpu/primitives/grid_sample.hpp>
+#include <intel_gpu/primitives/reorder.hpp>
+#include <primitive_inst.h>
 #include <fully_connected_inst.h>
 
 using namespace cldnn;
@@ -163,6 +165,15 @@ public:
         network::ptr network = get_network(*engine, topology, config, get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
         auto outputs = network->execute();
+
+        auto input_inst = network->get_primitive("input");
+        auto relu_inst  = network->get_primitive("relu");
+        auto relu2_inst = network->get_primitive("relu2");
+
+        // Both direct consumers of the lazy-allocated input must see the same external buffer.
+        ASSERT_TRUE(engine->is_the_same_buffer(*input_inst->output_memory_ptr(), *input));
+        ASSERT_TRUE(engine->is_the_same_buffer(*relu_inst->dep_memory_ptr(0),  *input));
+        ASSERT_TRUE(engine->is_the_same_buffer(*relu2_inst->dep_memory_ptr(0), *input));
 
         // input_layout no longer pre-allocates memory at network construction time,
         // The remaining peak is 1280 bytes:
@@ -430,10 +441,177 @@ public:
         network_second->set_input_data("input", input_1);
         auto outputs_second = network_second->execute();
 
-        // now we have the previous peak + another 1152 for the second network's reoder node, plus 16 bytes for
+        // now we have the previous peak + another 1152 for the second network's reorder node, plus 16 bytes for
         // convolution output, and 16 bytes for the softmax output.
         // so 3208 + 1152 + 16 + 16 = 4392, without lazy allocations for input we'd go into 5928 bytes...
         ASSERT_EQ(engine->get_max_used_device_memory(), 4392ull);
+    }
+
+    void test_rebind_external_memory_multiple_times(bool is_caching_test) {
+        auto engine = create_test_engine();
+        layout input_lay{data_types::f32, format::bfyx, {1, 1, 2, 4}};
+        auto input_first = engine->allocate_memory(input_lay);
+        auto input_second = engine->allocate_memory(input_lay);
+
+        const std::vector<float> first_values = {-1.0f, 2.0f, -3.0f, 4.0f, -5.0f, 6.0f, -7.0f, 8.0f};
+        const std::vector<float> second_values = {10.0f, -20.0f, 30.0f, -40.0f, 50.0f, -60.0f, 70.0f, -80.0f};
+        set_values(input_first, first_values);
+        set_values(input_second, second_values);
+
+        topology topology;
+        topology.add(input_layout("input", input_lay));
+        topology.add(activation("relu", input_info("input"), activation_func::relu));
+
+        ExecutionConfig config = get_test_default_config(*engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+
+        network::ptr network = get_network(*engine, topology, config, get_test_stream_ptr(), is_caching_test);
+
+        auto input_inst = network->get_primitive("input");
+        auto relu_inst = network->get_primitive("relu");
+
+        // Lazy input allocation means input_layout should stay unmaterialized until set_input_data().
+        ASSERT_EQ(input_inst->output_memory_ptr(), nullptr);
+
+        network->set_input_data("input", input_first);
+        auto outputs_first = network->execute();
+
+        // After the first bind, both input_layout and the downstream consumer must point to the
+        // external memory object passed through set_input_data().
+        ASSERT_TRUE(engine->is_the_same_buffer(*input_inst->output_memory_ptr(), *input_first));
+        ASSERT_TRUE(engine->is_the_same_buffer(*relu_inst->dep_memory_ptr(0), *input_first));
+
+        auto first_bound_input_ptr = relu_inst->dep_memory_ptr(0)->buffer_ptr();
+        {
+            cldnn::mem_lock<float> first_output_ptr(outputs_first.at("relu").get_memory(), get_test_stream());
+            ASSERT_EQ(first_output_ptr[0], 0.0f);
+            ASSERT_EQ(first_output_ptr[1], 2.0f);
+            ASSERT_EQ(first_output_ptr[2], 0.0f);
+            ASSERT_EQ(first_output_ptr[3], 4.0f);
+            ASSERT_EQ(first_output_ptr[4], 0.0f);
+            ASSERT_EQ(first_output_ptr[5], 6.0f);
+            ASSERT_EQ(first_output_ptr[6], 0.0f);
+            ASSERT_EQ(first_output_ptr[7], 8.0f);
+        }
+
+        network->set_input_data("input", input_second);
+        auto outputs_second = network->execute();
+
+        // Rebinding must refresh the consumer dependency as well, not only input_layout itself.
+        ASSERT_TRUE(engine->is_the_same_buffer(*input_inst->output_memory_ptr(), *input_second));
+        ASSERT_TRUE(engine->is_the_same_buffer(*relu_inst->dep_memory_ptr(0), *input_second));
+
+        auto second_bound_input_ptr = relu_inst->dep_memory_ptr(0)->buffer_ptr();
+        // The consumer should no longer reference the buffer from the first inference.
+        ASSERT_NE(first_bound_input_ptr, second_bound_input_ptr);
+
+        cldnn::mem_lock<float> second_output_ptr(outputs_second.at("relu").get_memory(), get_test_stream());
+        ASSERT_EQ(second_output_ptr[0], 10.0f);
+        ASSERT_EQ(second_output_ptr[1], 0.0f);
+        ASSERT_EQ(second_output_ptr[2], 30.0f);
+        ASSERT_EQ(second_output_ptr[3], 0.0f);
+        ASSERT_EQ(second_output_ptr[4], 50.0f);
+        ASSERT_EQ(second_output_ptr[5], 0.0f);
+        ASSERT_EQ(second_output_ptr[6], 70.0f);
+        ASSERT_EQ(second_output_ptr[7], 0.0f);
+    }
+
+    void test_aliasing_through_chain_of_optimized_ops(bool is_caching_test) {
+        auto engine = create_test_engine();
+        layout input_lay{ov::PartialShape{5, 6, 1, 1}, data_types::f32, format::bfyx};
+        auto input = engine->allocate_memory(input_lay);
+
+        set_values(input, { 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 
+                            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 
+                            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 
+                            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 
+                            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f });
+
+        topology topology;
+        topology.add(input_layout("input", input_lay));
+        topology.add(crop("crop1", {input_info("input")}, tensor(5, 5, 1, 1), {tensor(0, 0, 0, 0)}));
+        topology.add(crop("crop2", {input_info("crop1")}, tensor(5, 4, 1, 1), {tensor(0, 0, 0, 0)}));
+        topology.add(reorder("reorder_out", input_info("crop2"), layout{ov::PartialShape{5, 4, 1, 1}, data_types::f32, format::bfyx}));
+
+        ExecutionConfig config = get_test_default_config(*engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+
+        network::ptr network = get_network(*engine, topology, config, get_test_stream_ptr(), is_caching_test);
+
+        auto input_inst = network->get_primitive("input");
+        auto crop1_inst = network->get_primitive("crop1");
+        auto crop2_inst = network->get_primitive("crop2");
+        auto reorder_inst = network->get_primitive("reorder_out");
+
+        ASSERT_EQ(input_inst->output_memory_ptr(), nullptr);
+
+        network->set_input_data("input", input);
+        auto outputs = network->execute();
+
+        ASSERT_TRUE(crop1_inst->can_be_optimized());
+        ASSERT_TRUE(crop2_inst->can_be_optimized());
+
+        // The optimized crop chain should stay backed by the original external input buffer.
+        ASSERT_TRUE(engine->is_the_same_buffer(*input_inst->output_memory_ptr(), *input));
+        ASSERT_TRUE(engine->is_the_same_buffer(*network->get_output_memory("crop1"), *input));
+        ASSERT_TRUE(engine->is_the_same_buffer(*network->get_output_memory("crop2"), *input));
+
+        // The final consumer must receive the aliased view from the last optimized op in the chain.
+        ASSERT_TRUE(engine->is_the_same_buffer(*reorder_inst->dep_memory_ptr(0), *network->get_output_memory("crop2")));
+
+        cldnn::mem_lock<float> output_ptr(outputs.at("reorder_out").get_memory(), get_test_stream());
+        const std::vector<float> expected = { 0.0f, 1.0f, 2.0f, 3.0f, 
+                                              0.0f, 1.0f, 2.0f, 3.0f, 
+                                              0.0f, 1.0f, 2.0f, 3.0f, 
+                                              0.0f, 1.0f, 2.0f, 3.0f, 
+                                              0.0f, 1.0f, 2.0f, 3.0f };
+        for (size_t i = 0; i < expected.size(); ++i) {
+            ASSERT_EQ(output_ptr[i], expected[i]);
+        }
+    }
+
+    void test_feed_previous_output_into_next_inference_input(bool is_caching_test) {
+        auto engine = create_test_engine();
+        layout input_lay{data_types::f32, format::bfyx, {1, 1, 2, 4}};
+        auto input = engine->allocate_memory(input_lay);
+        set_values(input, {1.0f, 2.0f, 3.0f, 4.0f, -1.0f, -2.0f, -3.0f, -4.0f});
+
+        topology topology;
+        topology.add(input_layout("input", input_lay));
+        topology.add(activation("shift", input_info("input"), activation_func::linear, {1.0f, 1.0f}));
+
+        ExecutionConfig config = get_test_default_config(*engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+
+        network::ptr network = get_network(*engine, topology, config, get_test_stream_ptr(), is_caching_test);
+
+        auto input_inst = network->get_primitive("input");
+        auto shift_inst = network->get_primitive("shift");
+
+        network->set_input_data("input", input);
+        auto outputs_first = network->execute();
+        auto first_output_mem = outputs_first.at("shift").get_memory();
+
+        {
+            cldnn::mem_lock<float> first_output_ptr(first_output_mem, get_test_stream());
+            const std::vector<float> expected_first = {2.0f, 3.0f, 4.0f, 5.0f, 0.0f, -1.0f, -2.0f, -3.0f};
+            for (size_t i = 0; i < expected_first.size(); ++i) {
+                ASSERT_EQ(first_output_ptr[i], expected_first[i]);
+            }
+        } // release the mem_lock...
+
+        // Feeding the previous output back as the next input is a valid zero-copy workflow.
+        network->set_input_data("input", first_output_mem);
+        ASSERT_TRUE(engine->is_the_same_buffer(*input_inst->output_memory_ptr(), *first_output_mem));
+        ASSERT_TRUE(engine->is_the_same_buffer(*shift_inst->dep_memory_ptr(0), *first_output_mem));
+
+        auto outputs_second = network->execute();
+        cldnn::mem_lock<float> second_output_ptr(outputs_second.at("shift").get_memory(), get_test_stream());
+        const std::vector<float> expected_second = {3.0f, 4.0f, 5.0f, 6.0f, 1.0f, 0.0f, -1.0f, -2.0f};
+        // The second inference must apply the transform again, not reuse stale bindings.
+        for (size_t i = 0; i < expected_second.size(); ++i) {
+            ASSERT_EQ(second_output_ptr[i], expected_second[i]);
+        }
     }
 
     void test_shared_dep_two_output(bool is_caching_test) {
@@ -745,6 +923,18 @@ TEST_F(memory_pool, shared_mem_pool_diff_batches) {
     this->test_shared_mem_pool_diff_batches(false);
 }
 
+TEST_F(memory_pool, rebind_external_memory_multiple_times) {
+    this->test_rebind_external_memory_multiple_times(false);
+}
+
+TEST_F(memory_pool, aliasing_through_chain_of_optimized_ops) {
+    this->test_aliasing_through_chain_of_optimized_ops(false);
+}
+
+TEST_F(memory_pool, feed_previous_output_into_next_inference_input) {
+    this->test_feed_previous_output_into_next_inference_input(false);
+}
+
 TEST_F(memory_pool, shared_dep_two_output) {
     this->test_shared_dep_two_output(false);
 }
@@ -790,6 +980,18 @@ TEST_F(memory_pool, oooq_cached) {
 
 TEST_F(memory_pool, shared_mem_pool_diff_batches_cached) {
     this->test_shared_mem_pool_diff_batches(true);
+}
+
+TEST_F(memory_pool, rebind_external_memory_multiple_times_cached) {
+    this->test_rebind_external_memory_multiple_times(true);
+}
+
+TEST_F(memory_pool, aliasing_through_chain_of_optimized_ops_cached) {
+    this->test_aliasing_through_chain_of_optimized_ops(true);
+}
+
+TEST_F(memory_pool, feed_previous_output_into_next_inference_input_cached) {
+    this->test_feed_previous_output_into_next_inference_input(true);
 }
 
 TEST_F(memory_pool, shared_dep_two_output_cached) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
@@ -92,8 +92,8 @@ public:
         auto outputs = network->execute();
 
         // input_layout no longer pre-allocates memory at network construction time
-        const uint64_t input_buf_size = sizeof(float) * batch_num * feature_num * x_size * y_size;
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(64 - input_buf_size));
+        // so we have only 16 bytes usm_host for the input buffer, 16 bytes for "relu" output, and 16 bytes for "relu5" output.
+        ASSERT_EQ(engine->get_max_used_device_memory(), 48ull);
     }
 
     void test_basic_non_padded_relu_and_pooling_pipe(bool is_caching_test) {
@@ -126,8 +126,10 @@ public:
         auto outputs = network->execute();
 
         // input_layout no longer pre-allocates memory at network construction time,
-        const uint64_t input_buf_size = sizeof(float) * batch_num * feature_num * x_size * y_size;
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(896 - input_buf_size));
+        // The remaining peak is 640 bytes:
+        // 256 bytes host for the input, 256 bytes device for relu output,
+        // 64 bytes device for pool1 output, and 64 bytes host for relu5 output.
+        ASSERT_EQ(engine->get_max_used_device_memory(), 640ull);
     }
 
     void test_multi_outputs_network(bool is_caching_test) {
@@ -163,8 +165,10 @@ public:
         auto outputs = network->execute();
 
         // input_layout no longer pre-allocates memory at network construction time,
-        const uint64_t input_buf_size = sizeof(float) * batch_num * feature_num * x_size * y_size;
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(1536 - input_buf_size));
+        // The remaining peak is 1280 bytes:
+        // 256 bytes host for the input, 256 bytes host for relu4 output, 256 bytes host for relu7 output,
+        // and 256 bytes device for two outputs from the first relu on a branch
+        ASSERT_EQ(engine->get_max_used_device_memory(), 1280ull);
     }
 
     void test_oooq(bool is_caching_test) {
@@ -203,8 +207,11 @@ public:
         auto outputs = network->execute();
 
         // input_layout no longer pre-allocates memory at network construction time,
-        const uint64_t input_buf_size = sizeof(float) * batch_num * feature_num * x_size * y_size;
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(2560 - input_buf_size));
+        // The remaining peak is 2304 bytes:
+        // 256 bytes host for the input, 768 bytes host for the final relu6 output,
+        // and 1280 bytes device for intermediates: 256 bytes each for relu1,
+        // relu2, and the lower branch feeding concat2, plus 512 bytes for concat1 / relu4.
+        ASSERT_EQ(engine->get_max_used_device_memory(), 2304ull);
     }
 
     void test_shared_mem_pool_same_topology_twice() {
@@ -388,6 +395,7 @@ public:
         auto input_1 = engine->allocate_memory(lay_batch_1);
         auto input_8 = engine->allocate_memory(lay_batch_8);
         auto weights = engine->allocate_memory({ dt, fmt, { 1, 3, 3, 2 } });
+        // so far we allocated 192+1536+72 = 1800 bytes host memory
 
         std::vector<float> dummy_input_data_1 = rg.generate_random_1d<float>(batch_1 * feature_num * inp_x_size * inp_y_size, 0, 1);
         std::vector<float> dummy_input_data_8 = rg.generate_random_1d<float>(batch_8 * feature_num * inp_x_size * inp_y_size, 0, 1);
@@ -411,10 +419,10 @@ public:
         network_first->set_input_data("input", input_8);
         auto outputs = network_first->execute();
 
-        auto dev_info = engine->get_device_info();
         // input_layout no longer pre-allocates memory at network construction time,
-        const uint64_t input_buf_size = sizeof(float) * batch_8 * feature_num * inp_x_size * inp_y_size;
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(4744 - input_buf_size));
+        // the network will use 1152 bytes for weight reorder node, 128 bytes for conv output and 128 bytes for softmax output
+        // in total we have 1800 bytes + 128 + 1152 + 128 = 3208, with no lazy allocations for inputs we'd go up to 4744...
+        ASSERT_EQ(engine->get_max_used_device_memory(), 3208ull);
 
         topo.change_input_layout("input", input_1->get_layout());//change input layout to batch=1
 
@@ -422,7 +430,10 @@ public:
         network_second->set_input_data("input", input_1);
         auto outputs_second = network_second->execute();
 
-        ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)(5928 - input_buf_size));
+        // now we have the previous peak + another 1152 for the second network's reoder node, plus 16 bytes for
+        // convolution output, and 16 bytes for the softmax output.
+        // so 3208 + 1152 + 16 + 16 = 4392, without lazy allocations for input we'd go into 5928 bytes...
+        ASSERT_EQ(engine->get_max_used_device_memory(), 4392ull);
     }
 
     void test_shared_dep_two_output(bool is_caching_test) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
@@ -570,50 +570,6 @@ public:
         }
     }
 
-    void test_feed_previous_output_into_next_inference_input(bool is_caching_test) {
-        auto engine = create_test_engine();
-        layout input_lay{data_types::f32, format::bfyx, {1, 1, 2, 4}};
-        auto input = engine->allocate_memory(input_lay);
-        set_values(input, {1.0f, 2.0f, 3.0f, 4.0f, -1.0f, -2.0f, -3.0f, -4.0f});
-
-        topology topology;
-        topology.add(input_layout("input", input_lay));
-        topology.add(activation("shift", input_info("input"), activation_func::linear, {1.0f, 1.0f}));
-
-        ExecutionConfig config = get_test_default_config(*engine);
-        config.set_property(ov::intel_gpu::optimize_data(true));
-
-        network::ptr network = get_network(*engine, topology, config, get_test_stream_ptr(), is_caching_test);
-
-        auto input_inst = network->get_primitive("input");
-        auto shift_inst = network->get_primitive("shift");
-
-        network->set_input_data("input", input);
-        auto outputs_first = network->execute();
-        auto first_output_mem = outputs_first.at("shift").get_memory();
-
-        {
-            cldnn::mem_lock<float> first_output_ptr(first_output_mem, get_test_stream());
-            const std::vector<float> expected_first = {2.0f, 3.0f, 4.0f, 5.0f, 0.0f, -1.0f, -2.0f, -3.0f};
-            for (size_t i = 0; i < expected_first.size(); ++i) {
-                ASSERT_EQ(first_output_ptr[i], expected_first[i]);
-            }
-        } // release the mem_lock...
-
-        // Feeding the previous output back as the next input is a valid zero-copy workflow.
-        network->set_input_data("input", first_output_mem);
-        ASSERT_TRUE(engine->is_the_same_buffer(*input_inst->output_memory_ptr(), *first_output_mem));
-        ASSERT_TRUE(engine->is_the_same_buffer(*shift_inst->dep_memory_ptr(0), *first_output_mem));
-
-        auto outputs_second = network->execute();
-        cldnn::mem_lock<float> second_output_ptr(outputs_second.at("shift").get_memory(), get_test_stream());
-        const std::vector<float> expected_second = {3.0f, 4.0f, 5.0f, 6.0f, 1.0f, 0.0f, -1.0f, -2.0f};
-        // The second inference must apply the transform again, not reuse stale bindings.
-        for (size_t i = 0; i < expected_second.size(); ++i) {
-            ASSERT_EQ(second_output_ptr[i], expected_second[i]);
-        }
-    }
-
     void test_shared_dep_two_output(bool is_caching_test) {
         // We need a new engine here to get correct get_max_used_device_memory() result
         // If we reuse common engine, then max memory value will be taken from some previously executed tests
@@ -931,10 +887,6 @@ TEST_F(memory_pool, aliasing_through_chain_of_optimized_ops) {
     this->test_aliasing_through_chain_of_optimized_ops(false);
 }
 
-TEST_F(memory_pool, feed_previous_output_into_next_inference_input) {
-    this->test_feed_previous_output_into_next_inference_input(false);
-}
-
 TEST_F(memory_pool, shared_dep_two_output) {
     this->test_shared_dep_two_output(false);
 }
@@ -988,10 +940,6 @@ TEST_F(memory_pool, rebind_external_memory_multiple_times_cached) {
 
 TEST_F(memory_pool, aliasing_through_chain_of_optimized_ops_cached) {
     this->test_aliasing_through_chain_of_optimized_ops(true);
-}
-
-TEST_F(memory_pool, feed_previous_output_into_next_inference_input_cached) {
-    this->test_feed_previous_output_into_next_inference_input(true);
 }
 
 TEST_F(memory_pool, shared_dep_two_output_cached) {


### PR DESCRIPTION
In `input_layout_node` try to skip early mem allocations so that we can avoid mem increase for large inputs.

This optimization saves the total memory peak by the phi silica application from 10gb down to 6gb.

### Details:
Before this change the allocate_mem was skipped (set to false) for example for dynamic shapes and internal networks. The PR forces it always to be false and also handle cases where the inputs are expected to be present (check for null, or allocate temp buffer for simplicity).

See the early version of the presentation: https://intel-my.sharepoint.com/:p:/p/bartlomiej_filipek/IQCJ4tTQG0XHQYjMm_FAUlyIAf2FeLPfsthPN6xxJt4TD-I?e=DOG6DL 

### Tickets:
CVS-178139

### AI Assistance:
 - AI assistance used: yes
 - If yes, summarize how AI was used: Ai generated most of the code after several iterations. Manually tested and debugged on the phi silica script app.

## Perf/mem Comparison:

### Using benchmark_app.exe, LunarLake 5 236V, 16GB, iGPU, 

Model | PR Avg FPS | Master Avg FPS | Δ FPS | PR Compile RAM | Master Compile RAM | Δ RAM
-- | -- | -- | -- | -- | -- | --
YOLOv3 | ~115.5 | ~115.0 | ~+0.4% | ~256 MB | ~256 MB | ≈0
PSD2 | ~55.3 | ~55.9 | ~-1.1% | ~841 MB | ~825 MB | ~+16 MB PR
PSD7 | ~5.28 | ~5.27 | ~+0.2% | ~1362 MB | ~1361 MB | ≈0
PSR | ~5.45 | ~5.47 | ~-0.4% | ~5633 MB | ~5633 MB | ≈0
ResNet-50 | ~1160 | ~1158 | ~+0.2% | ~1070 MB | ~1066 MB | ≈0

PR - binaries compiled with this PR
Master - OpenVino Master, as of 14th April, 2075ff44dc539d2cadfe07ec8bea39623ad300f5

### MCT Real weight system

Results from the MTC team, running on real weight system (11th May)

"All models look accurate compared to CPU outputs", "We may still see image quality regression due to a past OV change"

| Model                     | Cosine_Sim_Avg | L2_norm_avg |
|---------------------------|----------------|-------------|
| Model_PSD1_v0_qdq         | 0.9999         | 17.9488     |
| Model_PSD2_v0_qdq         | 0.9994         | 9.6158      |
| Model_PSD3_v1_0_201_qdq   | 0.9999         | 30.0694     |
| Model_PSD4_v0_qdq         | 0.9992         | 120.0805    |
| Model_PSD5_1_v1_0_295_qdq | 0.9996         | 3.4721      |
| Model_PSD6_v0_qdq         | 0.9969         | 7.6443      |
| Model_PSD7_v0_qdq         | 1.0000         | 3.8851      |
| Model_PSD8_v1_0_297_qdq   | 0.9997         | 164.4600    |

`Cosine_Sim_Avg` and  `L2_norm_avg ` - averaged across several output for a given model

ov_4th_may_with_pr_35126 against ov_latest from early May