### PR TITLE
Pin Keras to workaround Tensorflow Lite Layer Tests failure

### DIFF
--- a/tests/layer_tests/requirements.txt
+++ b/tests/layer_tests/requirements.txt
@@ -14,5 +14,7 @@ packaging
 pillow
 pytest
 defusedxml
+# Tensorflow depends on Keras without version constraint, Keras update to 3.14.0 caused Tensorflow Lite Layer Tests failure
+keras<=3.13.2
 tensorflow
 tensorflow-addons; python_version <= '3.10'


### PR DESCRIPTION
### Details:
New version of Keras released on April 3rd (in the middle of the night UTC 🥲), Tensorflow depends on it without using version constraints, this caused an error in Tensorflow Lite Layer Tests:

```
=================================== FAILURES ===================================
_ TestTFLiteTransposeConvWithBiasLayerTest.test_transpose_conv_with_bias[ ie_device:CPU - precision:FP16 - params:{'shape': [1, 22, 22, 3], 'filters': 6, 'kernel_size': (1, 1), 'strides': (1, 1), 'padding': 'valid'} ] _
[gw1] linux -- Python 3.12.3 /venv/bin/python3

self = <test_tfl_TransposeConv.TestTFLiteTransposeConvWithBiasLayerTest object at 0x7fd31d9802c0>
params = {'filters': 6, 'kernel_size': (1, 1), 'padding': 'valid', 'shape': [1, 22, 22, 3], ...}
ie_device = 'CPU', precision = 'FP16'
temp_dir = '/__w/openvino/openvino/install/tests/layer_tests/common/out/CPU_test_transpose_conv_with_biash5dwegtm'

    @pytest.mark.parametrize("params", test_params_with_bias)
    @pytest.mark.nightly
    @pytest.mark.precommit
    def test_transpose_conv_with_bias(self, params, ie_device, precision, temp_dir):
>       self._test(ie_device, precision, temp_dir, params)

install/tests/layer_tests/tensorflow_lite_tests/test_tfl_TransposeConv.py:100: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
install/tests/layer_tests/common/tflite_layer_test_class.py:78: in _test
    self.model_path = self.produce_tflite_model(model, temp_dir)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
install/tests/layer_tests/tensorflow_lite_tests/test_tfl_TransposeConv.py:89: in produce_tflite_model
    tflite_model = converter.convert()
                   ^^^^^^^^^^^^^^^^^^^
/venv/lib/python3.12/site-packages/tensorflow/lite/python/lite.py:1254: in wrapper
    return self._convert_and_export_metrics(convert_func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/venv/lib/python3.12/site-packages/tensorflow/lite/python/lite.py:1206: in _convert_and_export_metrics
    result = convert_func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/venv/lib/python3.12/site-packages/tensorflow/lite/python/lite.py:1777: in convert
    self._freeze_keras_model()
/venv/lib/python3.12/site-packages/tensorflow/lite/python/convert_phase.py:215: in wrapper
    raise error from None  # Re-throws the exception.
    ^^^^^^^^^^^^^^^^^^^^^
/venv/lib/python3.12/site-packages/tensorflow/lite/python/convert_phase.py:205: in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
/venv/lib/python3.12/site-packages/tensorflow/lite/python/lite.py:1724: in _freeze_keras_model
    concrete_func = func.get_concrete_function()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/venv/lib/python3.12/site-packages/tensorflow/python/eager/polymorphic_function/polymorphic_function.py:1256: in get_concrete_function
    concrete = self._get_concrete_function_garbage_collected(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/venv/lib/python3.12/site-packages/tensorflow/python/eager/polymorphic_function/polymorphic_function.py:1226: in _get_concrete_function_garbage_collected
    self._initialize(args, kwargs, add_initializers_to=initializers)
/venv/lib/python3.12/site-packages/tensorflow/python/eager/polymorphic_function/polymorphic_function.py:696: in _initialize
    self._concrete_variable_creation_fn = tracing_compilation.trace_function(
/venv/lib/python3.12/site-packages/tensorflow/python/eager/polymorphic_function/tracing_compilation.py:178: in trace_function
    concrete_function = _maybe_define_function(
/venv/lib/python3.12/site-packages/tensorflow/python/eager/polymorphic_function/tracing_compilation.py:283: in _maybe_define_function
    concrete_function = _create_concrete_function(
/venv/lib/python3.12/site-packages/tensorflow/python/eager/polymorphic_function/tracing_compilation.py:310: in _create_concrete_function
    traced_func_graph = func_graph_module.func_graph_from_py_func(
/venv/lib/python3.12/site-packages/tensorflow/python/framework/func_graph.py:1060: in func_graph_from_py_func
    func_outputs = python_func(*func_args, **func_kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/venv/lib/python3.12/site-packages/tensorflow/python/eager/polymorphic_function/polymorphic_function.py:599: in wrapped_fn
    out = weak_wrapped_fn().__wrapped__(*args, **kwds)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = (<tf.Tensor 'Input:0' shape=(None, 22, 22, 3) dtype=float32>,)
inputs = <tf.Tensor 'Input:0' shape=(None, 22, 22, 3) dtype=float32>

    @def_function.function(input_signature=input_signature, autograph=False)
    def _wrapped_model(*args):
      """A concrete tf.function that wraps the model's call function."""
      # When given a single input, Keras models will call the model on the tensor
      # rather than a list consisting of the single tensor.
      inputs = args[0] if len(input_signature) == 1 else list(args)
    
>     with keras_deps.get_call_context_function()().enter(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          model,
          inputs=inputs,
          build_graph=False,
          call_context_args={'training': False},
          saving=True,
      ):
E     TypeError: 'NoneType' object is not callable

/venv/lib/python3.12/site-packages/tensorflow/lite/python/tflite_keras_util.py:223: TypeError
_ TestTFLiteTransposeConvWithBiasLayerTest.test_transpose_conv_with_bias[ ie_device:CPU - precision:FP16 - params:{'shape': [1, 3, 4, 1], 'filters': 1, 'kernel_size': (1, 1), 'strides': (1, 1), 'padding': 'same'} ] _
[gw0] linux -- Python 3.12.3 /venv/bin/python3

self = <test_tfl_TransposeConv.TestTFLiteTransposeConvWithBiasLayerTest object at 0x7fea25f9fd10>
params = {'filters': 1, 'kernel_size': (1, 1), 'padding': 'same', 'shape': [1, 3, 4, 1], ...}
ie_device = 'CPU', precision = 'FP16'
temp_dir = '/__w/openvino/openvino/install/tests/layer_tests/common/out/CPU_test_transpose_conv_with_biaszc38mked'

    @pytest.mark.parametrize("params", test_params_with_bias)
    @pytest.mark.nightly
    @pytest.mark.precommit
    def test_transpose_conv_with_bias(self, params, ie_device, precision, temp_dir):
>       self._test(ie_device, precision, temp_dir, params)
```