### PR TITLE
[GPU] Extending the pattern for the IncreasePositionIdsPrecisionForQwen3VL transformation

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -198,7 +198,7 @@ IncreasePositionIdsPrecisionForQwen3VL::IncreasePositionIdsPrecisionForQwen3VL()
     //   -> Sin/Cos -> Reshape(unsqueeze) -> RoPE
     //
     // The intermediate path between MatMul and Sin/Cos is too complex to pattern-match,
-    // so we match the beginning (up to MatMul) and use graph traversal to find downstream Sin/Cos.
+    // so we match the beginning (up to MatMul->Reshape/Transpose) and use graph traversal to find downstream Sin/Cos.
     // Key difference from Qwen2.5-VL: Unsqueeze is decomposed to Reshape.
     auto position_ids = any_input();
     auto convert_to_i32 = wrap_type<ov::op::v0::Convert>({position_ids});
@@ -209,6 +209,10 @@ IncreasePositionIdsPrecisionForQwen3VL::IncreasePositionIdsPrecisionForQwen3VL()
 
     auto broadcast_freq = wrap_type<ov::op::v3::Broadcast>({any_input(), any_input()});
     auto matmul = wrap_type<ov::op::v0::MatMul>({broadcast_freq, convert_to_f16});
+
+    auto reshape = wrap_type<ov::op::v1::Reshape>({matmul, any_input()});
+    auto transpose = wrap_type<ov::op::v1::Transpose>({matmul, any_input()});
+    auto reshape_or_transpose = std::make_shared<Or>(OutputVector{reshape, transpose});
 
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
@@ -291,7 +295,7 @@ IncreasePositionIdsPrecisionForQwen3VL::IncreasePositionIdsPrecisionForQwen3VL()
         return true;
     };
 
-    auto m = std::make_shared<ov::pass::pattern::Matcher>(matmul, "IncreasePositionIdsPrecisionForQwen3VL");
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(reshape_or_transpose, "IncreasePositionIdsPrecisionForQwen3VL");
     this->register_matcher(m, callback);
 }
 


### PR DESCRIPTION
### Details:
 - *The `IncreasePositionIdsPrecisionForQwen3VL` pattern was extended due to a match with Gemma4, which caused data type mismatches*
 - *The current Gemma4 pipeline already decompresses RoPE subgraph in FP32 (only `MatMul` is not included), apparently due to the mark decomposed RoPE subgraph as precision sensitive and propagation of the subgraph above.
     So perhaps this is enough for the accuracy of the model without additional processing*

### AI Assistance:
 - *AI assistance used: no*
