### PR TITLE
[CPU] Allow Gather on KV cache paths in MatchSdpaKvCache

### DIFF
--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -3168,7 +3168,7 @@ void GraphOptimizer::MatchSdpaKvCache(Graph& graph) {
         auto&& childEdges = node->getChildEdgesAtPort(0);
         for (auto&& item : childEdges) {
             auto childNode = item->getChild();
-            if (none_of(childNode->getType(), Type::ScaledDotProductAttention, Type::ShapeOf)) {
+            if (none_of(childNode->getType(), Type::ScaledDotProductAttention, Type::ShapeOf, Type::Gather)) {
                 return false;
             }
 


### PR DESCRIPTION
### Details:
MatchSdpaKvCache is not executed due to the presence of Gather among the Concat's children on KV cache paths after StatefulSDPAFusion. This prevents `MemoryInputSDPA` creation, leaving KV states unassigned and causing
a null state crash at inference.

```
          ┌─────────┐               
    ┌─────┤ReadValue├────┐          
    │     └────┬────┘    │          
    │          │         │          
    ▼          ▼         ▼          
┌────────┐ ┌───────┐ ┌──────┐       
│SDPAWith│ │ShapeOf│ │Gather│       
│KVCache │ └───────┘ └──────┘       
└────────┘            //Not Expected
```

### Tickets:
 - [CVS-183493](https://jira.devtools.intel.com/browse/CVS-183493)

### AI Assistance:
 - *AI assistance used: yes*

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>