### PR TITLE
[NPU] Disable func tests `ZeroGraphTest.SetAlignedBlob`

### DIFF
--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -879,4 +879,16 @@ Example:
         </filters>
     </skip_config>
 
+    <!-- E#206393 -->
+    <skip_config>
+        <message>Skip memory standard allocation tests for Win NPU3720 due to OS issue, E#206393.</message>
+        <enable_rules>
+            <operating_system>windows</operating_system>
+            <device>3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*ZeroGraphTest.SetAlignedBlob.*zeGraphNpuExtVersion=(1.13|1.14|1.15|1.16).*</filter>
+        </filters>
+    </skip_config>
+
 </skip_configs>


### PR DESCRIPTION
### Details:
 - *Skip memory standard allocation tests for Windows NPU3720 due to OS issue which occurs for recent NPU Windows drivers.*
 - *PR needs to be merged before NPU driver update to UD12.*

### Tickets:
 - *E#206393*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
