### PR TITLE
misc: Fixed incorrect escape sequences in string literals

### DIFF
--- a/.github/github_org_control/check_pr.py
+++ b/.github/github_org_control/check_pr.py
@@ -30,11 +30,7 @@ class PrType(Enum):
 
 def get_pr_labels(pull):
     """Gets PR labels as set"""
-    pr_lables = set()
-    for label in pull.labels:
-        pr_lables.add(label.name)
-    return pr_lables
-
+    return set([label.name for label in pull.labels])
 
 def set_pr_labels(pull, labels):
     """Sets new PR labels (all previously set labels are removed)"""
@@ -56,9 +52,9 @@ def add_pr_labels(pull, labels):
 
 def get_pr_type_by_labels(pull):
     """Gets PR type using labels"""
-    pr_lables = get_pr_labels(pull)
+    pr_labels = get_pr_labels(pull)
     pr_types = set(type.value for type in PrType)
-    pr_types_labels = pr_lables & pr_types
+    pr_types_labels = pr_labels & pr_types
     if not pr_types_labels:
         return None
     if len(pr_types_labels) > 1:
@@ -68,7 +64,7 @@ def get_pr_type_by_labels(pull):
 
 
 def get_label_by_team_name_re(team_name):
-    """Generates label by PR reviwer team name using regular expressions"""
+    """Generates label by PR reviewer team name using regular expressions"""
     if "admins" in team_name:
         return "category: ci"
     re_compile_label = re.compile(rf"{Config().GITHUB_REPO}-(.+)-maintainers")
@@ -79,17 +75,17 @@ def get_label_by_team_name_re(team_name):
 
 
 def get_label_by_team_name_map(team_name):
-    """Generates label by PR reviwer team name using config map"""
+    """Generates label by PR reviewer team name using config map"""
     return Config().TEAM_TO_LABEL.get(team_name)
 
 
 def get_category_labels(pull):
-    """Gets list of category labels by all PR reviwer teams"""
+    """Gets list of category labels by all PR reviewer teams"""
     labels = []
-    pr_lables = get_pr_labels(pull)
+    pr_labels = get_pr_labels(pull)
     for reviewer_team in pull.get_review_requests()[1]:
         reviewer_label = get_label_by_team_name_map(reviewer_team.name)
-        if reviewer_label and reviewer_label not in pr_lables:
+        if reviewer_label and reviewer_label not in pr_labels:
             labels.append(reviewer_label)
     return labels
 
@@ -171,7 +167,7 @@ def get_wrong_commits(pull):
                 commit.raw_data["commit"]["verification"]["reason"],
             )
             if pr_author_email != commit_author_email or pr_author_email != commit_committer_email:
-                print("    WARNING: Commit emails and GitHub PR author public email are differnt")
+                print("    WARNING: Commit emails and GitHub PR author public email are different")
     return wrong_commits
 
 

--- a/src/plugins/intel_cpu/tools/dump_jit_disassm/__main__.py
+++ b/src/plugins/intel_cpu/tools/dump_jit_disassm/__main__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import re
 import argparse

--- a/src/plugins/intel_cpu/tools/dump_jit_disassm/__main__.py
+++ b/src/plugins/intel_cpu/tools/dump_jit_disassm/__main__.py
@@ -40,8 +40,8 @@ if __name__ == "__main__":
     print(f"load {args.trace}...")
     addr2check = {}
     offset2addr = {}
-    pattern = re.compile("(.*)\(\+(0x[0-9a-f]*)\).*")  # xxx.so(+0x1234) [] 
-    pattern2 = re.compile("(.*)\(\) \[(0x[0-9a-f]*)\].*") # xxx() [0x1234]
+    pattern = re.compile(r'(.*)\(\+(0x[0-9a-f]*)\).*')  # xxx.so(+0x1234) [] 
+    pattern2 = re.compile(r'(.*)\(\) \[(0x[0-9a-f]*)\].*') # xxx() [0x1234]
     with open(args.trace, "r") as f:
         for line in f.readlines():
             offset, traces = line.split(":")
@@ -74,7 +74,7 @@ if __name__ == "__main__":
         print(f"Unsupported platform for objdump: {platform.machine()}")
         sys.exit(1)
 
-    pattern = re.compile("^\s*([\da-f]*):.*")
+    pattern = re.compile(r'^\s*([\da-f]*):.*')
     print("parsing...")
 
     rm_prefixes = [

--- a/src/plugins/intel_gpu/src/kernel_selector/primitive_db_gen.py
+++ b/src/plugins/intel_gpu/src/kernel_selector/primitive_db_gen.py
@@ -136,7 +136,7 @@ class Kernels2CHeaders(object):
             if line.find(macro) >= 0:
                 return True
             if line.find("CAT") >= 0:
-                words = ' '.join(re.split("(\W)", line)).split()
+                words = ' '.join(re.split(r'(\W)', line)).split()
                 iter_w = 0
                 while iter_w < len(words):
                     if words[iter_w]  != "CAT":
@@ -154,11 +154,11 @@ class Kernels2CHeaders(object):
         idx = 0
         while idx < len(contents_list):
             line = contents_list[idx]
-            is_macro = re.search('#\s*define', line)
+            is_macro = re.search(r'#\s*define', line)
             macro = ""
 
             if is_macro:
-                words = ' '.join(re.split("(\W)", line)).split()
+                words = ' '.join(re.split(r'(\W)', line)).split()
                 macro = words[words.index("define") + 1]
 
             if len(macro) == 0 or self.found_potential_macro_user(macro, contents_list):

--- a/src/plugins/intel_gpu/src/kernel_selector/primitive_db_gen.py
+++ b/src/plugins/intel_gpu/src/kernel_selector/primitive_db_gen.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python3
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+
 # To add new kernel please add a .cl file to kernels directory
 # the database name will be the part of the file name up to first '.' character
 # the trailing characters are a tag to allow multiple primitive implementations

--- a/tests/e2e_tests/common/logger.py
+++ b/tests/e2e_tests/common/logger.py
@@ -82,7 +82,7 @@ class SensitiveKeysStrippingFilter(logging.Filter):
         return cls.instance
 
     @classmethod
-    def build_sensitive_values_regexp(cls) -> re:
+    def build_sensitive_values_regexp(cls) -> re.Pattern:
         return re.compile(
             "|".join([r"{value}".format(value=var)
                       for var in cls.sensitive_pairs.values()]))

--- a/tests/stress_tests/scripts/memcheck_upload.py
+++ b/tests/stress_tests/scripts/memcheck_upload.py
@@ -34,8 +34,7 @@ DB_COLLECTIONS = ["commit", "nightly", "weekly"]
 PRODUCT_NAME = 'dldt'  # product name from build manifest
 RE_GTEST_MODEL_XML = re.compile(r'<model[^>]*>')
 RE_GTEST_CUR_MEASURE = re.compile(r'\[\s*MEASURE\s*\]')
-RE_GTEST_REF_MEASURE = re.compile(
-    r'Reference values of virtual memory consumption')
+RE_GTEST_REF_MEASURE = re.compile(r'Reference values of virtual memory consumption')
 RE_GTEST_PASSED = re.compile(r'\[\s*PASSED\s*\]')
 RE_GTEST_FAILED = re.compile(r'\[\s*FAILED\s*\]')
 GTEST_INFO = '[ INFO ]'

--- a/tests/stress_tests/scripts/memcheck_upload.py
+++ b/tests/stress_tests/scripts/memcheck_upload.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
-
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+
 
 """
 Upload metrics gathered by MemCheckTests into Mongo DB

--- a/tools/commit_slider/utils/log_parser.py
+++ b/tools/commit_slider/utils/log_parser.py
@@ -32,7 +32,7 @@ def extractPatterns(dirName):
 
     with open(os.path.join(dirName, "logcommon_log.log")) as file:
         data = file.read()
-    intervalPattern = "[A-Za-z0-9]*\.\.[A-Za-z0-9]*"
+    intervalPattern = r'[A-Za-z0-9]*\.\.[A-Za-z0-9]*'
 
     pattern = "Check commits {}".format(intervalPattern)
     stats_re = re.compile(pattern, re.MULTILINE | re.DOTALL)
@@ -45,7 +45,7 @@ def extractPatterns(dirName):
     return hashPatternList, intervalPatternList
 
 def prepareCSVData(hashMap, dirName):
-    throughputPattern = "Throughput:\s*([0-9]*[.][0-9]*)\s*FPS"
+    throughputPattern = r'Throughput:\s*([0-9]*[.][0-9]*)\s*FPS'
     csvData = []
 
     for k, v in hashMap.items():


### PR DESCRIPTION
First spotted when attempting to compile 2026.1 release: a number of warnings about `src/plugins/intel_gpu/src/kernel_selector/primitive_db_gen.py` using invalid escape sequences in string literals. 
Turned out a few regular expressions didn't use Raw strings, and thus regexes were invalid. Surprisingly that did not stopped the compilation.

As a result I went through most of the pylance identified issues where incorrect escape sequences in string literals were present and fixed them.
... and a few obvious typos.

### Details:
 - Bunches of .py code where invalid escape sequences in string literals were found.
 - A few typos.

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used:* No
