### PR TITLE
[Snippets][CPU][ARM] Add JIT emitters for register spilling

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_emitter.cpp
@@ -4,7 +4,6 @@
 
 #include "jit_emitter.hpp"
 
-#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h>
 #include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_reg.h>
 
 #include <algorithm>
@@ -20,7 +19,6 @@
 #include "emitters/utils.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
-#include "utils/general_utils.h"
 
 using namespace dnnl::impl::cpu;
 using namespace dnnl::impl;

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_emitter.cpp
@@ -16,6 +16,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "emitters/snippets/aarch64/utils.hpp"
 #include "emitters/utils.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
@@ -25,6 +26,29 @@ using namespace dnnl::impl::cpu;
 using namespace dnnl::impl;
 
 namespace ov::intel_cpu::aarch64 {
+
+namespace {
+
+std::vector<Xbyak_aarch64::Reg> collect_spill_regs(const std::vector<size_t>& gpr_regs,
+                                                   const std::vector<size_t>& vec_regs,
+                                                   const std::unordered_set<size_t>& ignore_vec_regs) {
+    std::vector<Xbyak_aarch64::Reg> regs_to_spill;
+    regs_to_spill.reserve(gpr_regs.size() + vec_regs.size());
+
+    for (const auto reg_idx : gpr_regs) {
+        regs_to_spill.emplace_back(Xbyak_aarch64::XReg(reg_idx));
+    }
+
+    for (const auto reg_idx : vec_regs) {
+        if (ignore_vec_regs.find(reg_idx) == ignore_vec_regs.end()) {
+            regs_to_spill.emplace_back(Xbyak_aarch64::QReg(reg_idx));
+        }
+    }
+
+    return regs_to_spill;
+}
+
+}  // namespace
 
 const std::vector<size_t> jit_emitter::store_gpr_regs = {
     // Parameter/result registers
@@ -248,64 +272,7 @@ void jit_emitter::store_context(const std::unordered_set<size_t>& ignore_registe
 void jit_emitter::store_context(const std::vector<size_t>& gpr_regs,
                                 const std::vector<size_t>& vec_regs,
                                 const std::unordered_set<size_t>& ignore_vec_regs) const {
-    const auto store_gpr_regs_size = gpr_regs.size();
-    const auto store_vec_regs_size = vec_regs.size() - ignore_vec_regs.size();
-
-    // Calculate total stack space needed for both GPR and vector registers
-    const auto total_gpr_shift =
-        store_gpr_regs_size > 0 ? ov::intel_cpu::rnd_up(get_gpr_length() * store_gpr_regs_size, sp_alignment) : 0;
-    const auto total_vec_shift =
-        store_vec_regs_size > 0 ? ov::intel_cpu::rnd_up(get_vec_length() * store_vec_regs_size, sp_alignment) : 0;
-    const auto total_shift = total_gpr_shift + total_vec_shift;
-
-    if (total_shift > 0) {
-        // Single stack allocation for both GPR and vector registers
-        h->sub(h->sp, h->sp, total_shift);
-    }
-
-    // 1. Store General-purpose Registers
-    if (store_gpr_regs_size > 0) {
-        // Store GPR registers using stack offset (preserving original order)
-        const auto last = store_gpr_regs_size % 2;
-        int32_t current_offset = 0;
-        for (size_t i = 0; i < (store_gpr_regs_size - last); i += 2) {
-            h->stp(Xbyak_aarch64::XReg(gpr_regs[i]),
-                   Xbyak_aarch64::XReg(gpr_regs[i + 1]),
-                   Xbyak_aarch64::ptr(h->sp, current_offset));
-            current_offset += static_cast<int32_t>(get_gpr_length() * 2);
-        }
-        if (last != 0) {
-            h->str(Xbyak_aarch64::XReg(gpr_regs[store_gpr_regs_size - 1]), Xbyak_aarch64::ptr(h->sp, current_offset));
-        }
-    }
-
-    // 2. Store SIMD and Floating-Point registers
-    if (store_vec_regs_size > 0) {
-        // Store vector registers using stack offset after GPR registers (preserving original order)
-        const auto last = store_vec_regs_size % 2;
-        auto current_offset = static_cast<int32_t>(total_gpr_shift);
-
-        // Collect non-ignored registers
-        std::vector<size_t> active_regs;
-        for (const auto reg_idx : vec_regs) {
-            if (ignore_vec_regs.find(reg_idx) == ignore_vec_regs.end()) {
-                active_regs.push_back(reg_idx);
-            }
-        }
-
-        // Store pairs
-        for (size_t i = 0; i < (active_regs.size() - last); i += 2) {
-            h->stp(Xbyak_aarch64::QReg(active_regs[i]),
-                   Xbyak_aarch64::QReg(active_regs[i + 1]),
-                   Xbyak_aarch64::ptr(h->sp, current_offset));
-            current_offset += static_cast<int32_t>(get_vec_length() * 2);
-        }
-
-        // Store the remaining register
-        if (last != 0) {
-            h->str(Xbyak_aarch64::QReg(active_regs[active_regs.size() - 1]), Xbyak_aarch64::ptr(h->sp, current_offset));
-        }
-    }
+    EmitABIRegSpills::store_regs_to_stack(h, collect_spill_regs(gpr_regs, vec_regs, ignore_vec_regs));
 }
 
 void jit_emitter::restore_context(const std::unordered_set<size_t>& ignore_vec_regs) const {
@@ -315,68 +282,7 @@ void jit_emitter::restore_context(const std::unordered_set<size_t>& ignore_vec_r
 void jit_emitter::restore_context(const std::vector<size_t>& gpr_regs,
                                   const std::vector<size_t>& vec_regs,
                                   const std::unordered_set<size_t>& ignore_vec_regs) const {
-    const auto save_gpr_regs_size = gpr_regs.size();
-    const auto save_vec_regs_size = vec_regs.size() - ignore_vec_regs.size();
-
-    // Calculate total stack space (matching store_context)
-    const auto total_gpr_shift =
-        save_gpr_regs_size > 0 ? ov::intel_cpu::rnd_up(get_gpr_length() * save_gpr_regs_size, sp_alignment) : 0;
-    const auto total_vec_shift =
-        save_vec_regs_size > 0 ? ov::intel_cpu::rnd_up(get_vec_length() * save_vec_regs_size, sp_alignment) : 0;
-    const auto total_shift = total_gpr_shift + total_vec_shift;
-
-    // 1. Restore SIMD and Floating-Point registers - load from stack in same order as stored (v0 to v31)
-    if (save_vec_regs_size > 0) {
-        // Collect non-ignored registers
-        std::vector<size_t> active_regs;
-        for (const auto reg_idx : vec_regs) {
-            if (ignore_vec_regs.find(reg_idx) == ignore_vec_regs.end()) {
-                active_regs.push_back(reg_idx);
-            }
-        }
-
-        // Restore vector registers using same order as stored, offset after GPR registers
-        const auto last = active_regs.size() % 2;
-        auto current_offset = static_cast<int32_t>(total_gpr_shift);
-
-        // Restore pairs in same order as stored
-        for (size_t i = 0; i < (active_regs.size() - last); i += 2) {
-            h->ldp(Xbyak_aarch64::QReg(active_regs[i]),
-                   Xbyak_aarch64::QReg(active_regs[i + 1]),
-                   Xbyak_aarch64::ptr(h->sp, current_offset));
-            current_offset += static_cast<int32_t>(get_vec_length() * 2);
-        }
-
-        // Restore the remaining register
-        if (last != 0) {
-            h->ldr(Xbyak_aarch64::QReg(active_regs[active_regs.size() - 1]), Xbyak_aarch64::ptr(h->sp, current_offset));
-        }
-    }
-
-    // 2. Restore General-purpose Registers - load from stack in same order as stored (x0 to x31)
-    if (save_gpr_regs_size > 0) {
-        // Restore GPR registers using same order as stored
-        const auto last = save_gpr_regs_size % 2;
-        int32_t current_offset = 0;
-
-        // Restore pairs in same order as stored
-        for (size_t i = 0; i < (save_gpr_regs_size - last); i += 2) {
-            h->ldp(Xbyak_aarch64::XReg(gpr_regs[i]),
-                   Xbyak_aarch64::XReg(gpr_regs[i + 1]),
-                   Xbyak_aarch64::ptr(h->sp, current_offset));
-            current_offset += static_cast<int32_t>(get_gpr_length() * 2);
-        }
-
-        // Restore the remaining register
-        if (last != 0) {
-            h->ldr(Xbyak_aarch64::XReg(gpr_regs[save_gpr_regs_size - 1]), Xbyak_aarch64::ptr(h->sp, current_offset));
-        }
-    }
-
-    if (total_shift > 0) {
-        // Single stack deallocation for both GPR and vector registers
-        h->add(h->sp, h->sp, total_shift);
-    }
+    EmitABIRegSpills::load_regs_from_stack(h, collect_spill_regs(gpr_regs, vec_regs, ignore_vec_regs));
 }
 
 }  // namespace ov::intel_cpu::aarch64

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -25,6 +25,7 @@
 #include "emitters/snippets/aarch64/jit_kernel_emitter.hpp"
 #include "emitters/snippets/aarch64/jit_loop_emitters.hpp"
 #include "emitters/snippets/aarch64/jit_memory_emitters.hpp"
+#include "emitters/snippets/aarch64/jit_reg_spill_emitters.hpp"
 #include "emitters/snippets/common/emitter_factory.hpp"
 #include "emitters/snippets/cpu_runtime_configurator.hpp"
 #include "jit_snippets_emitters.hpp"
@@ -90,6 +91,7 @@
 #include "snippets/op/powerstatic.hpp"
 #include "snippets/op/rank_normalization.hpp"
 #include "snippets/op/reduce.hpp"
+#include "snippets/op/reg_spill.hpp"
 #include "snippets/op/reorder.hpp"
 #include "snippets/op/reshape.hpp"
 #include "snippets/op/result.hpp"
@@ -349,6 +351,9 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
         emitter_factory.from_expr<jit_kernel_dynamic_emitter>();
     jitters[snippets::op::LoopBegin::get_type_info_static()] = emitter_factory.from_expr<jit_loop_begin_emitter>();
     jitters[snippets::op::LoopEnd::get_type_info_static()] = emitter_factory.from_expr<jit_loop_end_emitter>();
+    jitters[snippets::op::RegSpillBegin::get_type_info_static()] =
+        emitter_factory.from_expr<jit_reg_spill_begin_emitter>();
+    jitters[snippets::op::RegSpillEnd::get_type_info_static()] = emitter_factory.from_expr<jit_reg_spill_end_emitter>();
 
     // others
     jitters[snippets::op::Scalar::get_type_info_static()] = emitter_factory.from_expr<jit_scalar_emitter>();

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
@@ -4,6 +4,7 @@
 
 #include "jit_reg_spill_emitters.hpp"
 
+#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h>
 #include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_reg.h>
 
 #include <cpu/aarch64/cpu_isa_traits.hpp>

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
@@ -106,7 +106,7 @@ private:
     }
 
     void store_vecs() const {
-        int32_t current_offset = static_cast<int32_t>(m_total_gpr_shift);
+        auto current_offset = static_cast<int32_t>(m_total_gpr_shift);
         size_t i = 0;
         for (; i + 1 < m_vec_regs_to_spill.size(); i += 2) {
             h->stp(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]),
@@ -120,7 +120,7 @@ private:
     }
 
     void restore_vecs() const {
-        int32_t current_offset = static_cast<int32_t>(m_total_gpr_shift);
+        auto current_offset = static_cast<int32_t>(m_total_gpr_shift);
         size_t i = 0;
         for (; i + 1 < m_vec_regs_to_spill.size(); i += 2) {
             h->ldp(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]),

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
@@ -4,6 +4,8 @@
 
 #include "jit_reg_spill_emitters.hpp"
 
+#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_reg.h>
+
 #include <algorithm>
 #include <cpu/aarch64/cpu_isa_traits.hpp>
 #include <cpu/aarch64/jit_generator.hpp>

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
@@ -1,0 +1,242 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "jit_reg_spill_emitters.hpp"
+
+#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_reg.h>
+
+#include <cpu/aarch64/cpu_isa_traits.hpp>
+#include <cpu/aarch64/jit_generator.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "emitters/utils.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/type.hpp"
+#include "snippets/emitter.hpp"
+#include "snippets/lowered/expression.hpp"
+#include "snippets/op/reg_spill.hpp"
+
+namespace ov::intel_cpu::aarch64 {
+
+class EmitABIRegSpills {
+public:
+    explicit EmitABIRegSpills(dnnl::impl::cpu::aarch64::jit_generator_t* h_arg) : h(h_arg) {}
+
+    ~EmitABIRegSpills() {
+        OPENVINO_ASSERT(spill_status, "postamble or preamble is missed");
+    }
+
+    [[nodiscard]] size_t get_num_spilled_regs() const {
+        return m_gpr_regs_to_spill.size() + m_vec_regs_to_spill.size();
+    }
+
+    void preamble(const std::set<snippets::Reg>& live_regs) {
+        OPENVINO_ASSERT(spill_status, "Attempt to spill ABI registers twice in a row");
+
+        reset();
+        for (const auto& reg : live_regs) {
+            switch (reg.type) {
+            case snippets::RegType::gpr:
+                m_gpr_regs_to_spill.push_back(reg.idx);
+                break;
+            case snippets::RegType::vec:
+                m_vec_regs_to_spill.push_back(reg.idx);
+                break;
+            default:
+                OPENVINO_THROW("Unsupported register type in Arm64 RegSpill emitter");
+            }
+        }
+
+        m_total_gpr_shift = aligned_size(static_cast<uint32_t>(m_gpr_regs_to_spill.size() * gpr_size));
+        m_total_vec_shift = aligned_size(static_cast<uint32_t>(m_vec_regs_to_spill.size() * vec_size));
+        m_total_shift = m_total_gpr_shift + m_total_vec_shift;
+
+        if (m_total_shift > 0) {
+            h->sub(h->sp, h->sp, m_total_shift);
+        }
+
+        store_gprs();
+        store_vecs();
+        spill_status = false;
+    }
+
+    void postamble() {
+        OPENVINO_ASSERT(!spill_status, "Attempt to restore ABI registers that were not spilled");
+
+        restore_vecs();
+        restore_gprs();
+
+        if (m_total_shift > 0) {
+            h->add(h->sp, h->sp, m_total_shift);
+        }
+
+        reset();
+        spill_status = true;
+    }
+
+private:
+    static constexpr uint32_t stack_alignment = jit_emitter::sp_alignment;
+    static constexpr uint32_t gpr_size = 8;
+    static constexpr uint32_t vec_size = 16;
+
+    [[nodiscard]] static uint32_t aligned_size(uint32_t size) {
+        if (size == 0) {
+            return 0;
+        }
+        return ((size + stack_alignment - 1) / stack_alignment) * stack_alignment;
+    }
+
+    void store_gprs() const {
+        int32_t current_offset = 0;
+        size_t i = 0;
+        for (; i + 1 < m_gpr_regs_to_spill.size(); i += 2) {
+            h->stp(Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i]),
+                   Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i + 1]),
+                   Xbyak_aarch64::ptr(h->sp, current_offset));
+            current_offset += static_cast<int32_t>(2 * gpr_size);
+        }
+        if (i < m_gpr_regs_to_spill.size()) {
+            h->str(Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
+        }
+    }
+
+    void store_vecs() const {
+        int32_t current_offset = static_cast<int32_t>(m_total_gpr_shift);
+        size_t i = 0;
+        for (; i + 1 < m_vec_regs_to_spill.size(); i += 2) {
+            h->stp(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]),
+                   Xbyak_aarch64::QReg(m_vec_regs_to_spill[i + 1]),
+                   Xbyak_aarch64::ptr(h->sp, current_offset));
+            current_offset += static_cast<int32_t>(2 * vec_size);
+        }
+        if (i < m_vec_regs_to_spill.size()) {
+            h->str(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
+        }
+    }
+
+    void restore_vecs() const {
+        int32_t current_offset = static_cast<int32_t>(m_total_gpr_shift);
+        size_t i = 0;
+        for (; i + 1 < m_vec_regs_to_spill.size(); i += 2) {
+            h->ldp(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]),
+                   Xbyak_aarch64::QReg(m_vec_regs_to_spill[i + 1]),
+                   Xbyak_aarch64::ptr(h->sp, current_offset));
+            current_offset += static_cast<int32_t>(2 * vec_size);
+        }
+        if (i < m_vec_regs_to_spill.size()) {
+            h->ldr(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
+        }
+    }
+
+    void restore_gprs() const {
+        int32_t current_offset = 0;
+        size_t i = 0;
+        for (; i + 1 < m_gpr_regs_to_spill.size(); i += 2) {
+            h->ldp(Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i]),
+                   Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i + 1]),
+                   Xbyak_aarch64::ptr(h->sp, current_offset));
+            current_offset += static_cast<int32_t>(2 * gpr_size);
+        }
+        if (i < m_gpr_regs_to_spill.size()) {
+            h->ldr(Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
+        }
+    }
+
+    void reset() {
+        m_gpr_regs_to_spill.clear();
+        m_vec_regs_to_spill.clear();
+        m_total_gpr_shift = 0;
+        m_total_vec_shift = 0;
+        m_total_shift = 0;
+    }
+
+    dnnl::impl::cpu::aarch64::jit_generator_t* h = nullptr;
+    std::vector<size_t> m_gpr_regs_to_spill;
+    std::vector<size_t> m_vec_regs_to_spill;
+    uint32_t m_total_gpr_shift = 0;
+    uint32_t m_total_vec_shift = 0;
+    uint32_t m_total_shift = 0;
+    bool spill_status = true;
+};
+
+/* ================== jit_reg_spill_begin_emitters ====================== */
+
+jit_reg_spill_begin_emitter::jit_reg_spill_begin_emitter(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                                                         dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                                                         const ov::snippets::lowered::ExpressionPtr& expr)
+    : jit_emitter(h, isa) {
+    const auto& reg_spill_node = ov::as_type_ptr<snippets::op::RegSpillBegin>(expr->get_node());
+    OV_CPU_JIT_EMITTER_ASSERT(reg_spill_node, "expects RegSpillBegin expression");
+    const auto& rinfo = expr->get_reg_info();
+    m_regs_to_spill = std::set<snippets::Reg>(rinfo.second.begin(), rinfo.second.end());
+    m_abi_reg_spiller = std::make_shared<EmitABIRegSpills>(h);
+    in_out_type_ = emitter_in_out_map::gpr_to_gpr;
+}
+
+void jit_reg_spill_begin_emitter::validate_arguments(const std::vector<size_t>& in,
+                                                     const std::vector<size_t>& out) const {
+    OV_CPU_JIT_EMITTER_ASSERT(in.empty(), "In regs should be empty for reg_spill_begin emitter");
+    OV_CPU_JIT_EMITTER_ASSERT(out.size() == m_regs_to_spill.size(),
+                              "Invalid number of out regs for reg_spill_begin emitter");
+}
+
+void jit_reg_spill_begin_emitter::emit_code_impl(const std::vector<size_t>& in,
+                                                 const std::vector<size_t>& out,
+                                                 [[maybe_unused]] const std::vector<size_t>& pool_vec_idxs,
+                                                 [[maybe_unused]] const std::vector<size_t>& pool_gpr_idxs) const {
+    validate_arguments(in, out);
+    emit_impl(in, out);
+}
+
+void jit_reg_spill_begin_emitter::emit_impl([[maybe_unused]] const std::vector<size_t>& in,
+                                            [[maybe_unused]] const std::vector<size_t>& out) const {
+    m_abi_reg_spiller->preamble(m_regs_to_spill);
+}
+
+/* ============================================================== */
+
+/* ================== jit_reg_spill_end_emitter ====================== */
+
+jit_reg_spill_end_emitter::jit_reg_spill_end_emitter(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                                                     dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                                                     const ov::snippets::lowered::ExpressionPtr& expr)
+    : jit_emitter(h, isa) {
+    in_out_type_ = emitter_in_out_map::gpr_to_gpr;
+    OV_CPU_JIT_EMITTER_ASSERT(ov::is_type<snippets::op::RegSpillEnd>(expr->get_node()) && expr->get_input_count() > 0,
+                              "Invalid expression in RegSpillEnd emitter");
+
+    const auto& parent_expr = expr->get_input_expr_ptr(0);
+    const auto& reg_spill_begin_emitter =
+        std::dynamic_pointer_cast<jit_reg_spill_begin_emitter>(parent_expr->get_emitter());
+    OV_CPU_JIT_EMITTER_ASSERT(reg_spill_begin_emitter, "Failed to obtain reg_spill_begin emitter");
+    m_abi_reg_spiller = reg_spill_begin_emitter->m_abi_reg_spiller;
+}
+
+void jit_reg_spill_end_emitter::validate_arguments(const std::vector<size_t>& in,
+                                                   const std::vector<size_t>& out) const {
+    OV_CPU_JIT_EMITTER_ASSERT(out.empty(), "Out regs should be empty for reg_spill_end emitter");
+    OV_CPU_JIT_EMITTER_ASSERT(in.size() == m_abi_reg_spiller->get_num_spilled_regs(),
+                              "Invalid number of in regs for reg_spill_end emitter");
+}
+
+void jit_reg_spill_end_emitter::emit_code_impl(const std::vector<size_t>& in,
+                                               const std::vector<size_t>& out,
+                                               [[maybe_unused]] const std::vector<size_t>& pool_vec_idxs,
+                                               [[maybe_unused]] const std::vector<size_t>& pool_gpr_idxs) const {
+    validate_arguments(in, out);
+    emit_impl(in, out);
+}
+
+void jit_reg_spill_end_emitter::emit_impl([[maybe_unused]] const std::vector<size_t>& in,
+                                          [[maybe_unused]] const std::vector<size_t>& out) const {
+    m_abi_reg_spiller->postamble();
+}
+
+/* ============================================================== */
+
+}  // namespace ov::intel_cpu::aarch64

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
@@ -4,19 +4,17 @@
 
 #include "jit_reg_spill_emitters.hpp"
 
-#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h>
-#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_reg.h>
-
+#include <algorithm>
 #include <cpu/aarch64/cpu_isa_traits.hpp>
 #include <cpu/aarch64/jit_generator.hpp>
 #include <cstddef>
-#include <cstdint>
+#include <iterator>
 #include <memory>
 #include <set>
 #include <vector>
 
+#include "emitters/snippets/aarch64/utils.hpp"
 #include "emitters/utils.hpp"
-#include "openvino/core/except.hpp"
 #include "openvino/core/type.hpp"
 #include "snippets/emitter.hpp"
 #include "snippets/lowered/expression.hpp"
@@ -24,146 +22,29 @@
 
 namespace ov::intel_cpu::aarch64 {
 
-class EmitABIRegSpills {
-public:
-    explicit EmitABIRegSpills(dnnl::impl::cpu::aarch64::jit_generator_t* h_arg) : h(h_arg) {}
+namespace {
 
-    ~EmitABIRegSpills() {
-        OPENVINO_ASSERT(spill_status, "postamble or preamble is missed");
+Xbyak_aarch64::Reg to_xbyak_reg(const snippets::Reg& reg) {
+    switch (reg.type) {
+    case snippets::RegType::gpr:
+        return Xbyak_aarch64::XReg(reg.idx);
+    case snippets::RegType::vec:
+        return Xbyak_aarch64::QReg(reg.idx);
+    default:
+        OV_CPU_JIT_EMITTER_THROW("Unsupported register type in Arm64 RegSpill emitter");
     }
+    return Xbyak_aarch64::XReg(0);
+}
 
-    [[nodiscard]] size_t get_num_spilled_regs() const {
-        return m_gpr_regs_to_spill.size() + m_vec_regs_to_spill.size();
-    }
+std::vector<Xbyak_aarch64::Reg> to_xbyak_regs(const std::vector<snippets::Reg>& regs) {
+    const std::set<snippets::Reg> unique_regs(regs.begin(), regs.end());
+    std::vector<Xbyak_aarch64::Reg> xbyak_regs;
+    xbyak_regs.reserve(unique_regs.size());
+    std::transform(unique_regs.begin(), unique_regs.end(), std::back_inserter(xbyak_regs), to_xbyak_reg);
+    return xbyak_regs;
+}
 
-    void preamble(const std::set<snippets::Reg>& live_regs) {
-        OPENVINO_ASSERT(spill_status, "Attempt to spill ABI registers twice in a row");
-
-        reset();
-        for (const auto& reg : live_regs) {
-            switch (reg.type) {
-            case snippets::RegType::gpr:
-                m_gpr_regs_to_spill.push_back(reg.idx);
-                break;
-            case snippets::RegType::vec:
-                m_vec_regs_to_spill.push_back(reg.idx);
-                break;
-            default:
-                OPENVINO_THROW("Unsupported register type in Arm64 RegSpill emitter");
-            }
-        }
-
-        m_total_gpr_shift = aligned_size(static_cast<uint32_t>(m_gpr_regs_to_spill.size() * gpr_size));
-        m_total_vec_shift = aligned_size(static_cast<uint32_t>(m_vec_regs_to_spill.size() * vec_size));
-        m_total_shift = m_total_gpr_shift + m_total_vec_shift;
-
-        if (m_total_shift > 0) {
-            h->sub(h->sp, h->sp, m_total_shift);
-        }
-
-        store_gprs();
-        store_vecs();
-        spill_status = false;
-    }
-
-    void postamble() {
-        OPENVINO_ASSERT(!spill_status, "Attempt to restore ABI registers that were not spilled");
-
-        restore_vecs();
-        restore_gprs();
-
-        if (m_total_shift > 0) {
-            h->add(h->sp, h->sp, m_total_shift);
-        }
-
-        reset();
-        spill_status = true;
-    }
-
-private:
-    static constexpr uint32_t stack_alignment = jit_emitter::sp_alignment;
-    static constexpr uint32_t gpr_size = 8;
-    static constexpr uint32_t vec_size = 16;
-
-    [[nodiscard]] static uint32_t aligned_size(uint32_t size) {
-        if (size == 0) {
-            return 0;
-        }
-        return ((size + stack_alignment - 1) / stack_alignment) * stack_alignment;
-    }
-
-    void store_gprs() const {
-        int32_t current_offset = 0;
-        size_t i = 0;
-        for (; i + 1 < m_gpr_regs_to_spill.size(); i += 2) {
-            h->stp(Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i]),
-                   Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i + 1]),
-                   Xbyak_aarch64::ptr(h->sp, current_offset));
-            current_offset += static_cast<int32_t>(2 * gpr_size);
-        }
-        if (i < m_gpr_regs_to_spill.size()) {
-            h->str(Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
-        }
-    }
-
-    void store_vecs() const {
-        auto current_offset = static_cast<int32_t>(m_total_gpr_shift);
-        size_t i = 0;
-        for (; i + 1 < m_vec_regs_to_spill.size(); i += 2) {
-            h->stp(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]),
-                   Xbyak_aarch64::QReg(m_vec_regs_to_spill[i + 1]),
-                   Xbyak_aarch64::ptr(h->sp, current_offset));
-            current_offset += static_cast<int32_t>(2 * vec_size);
-        }
-        if (i < m_vec_regs_to_spill.size()) {
-            h->str(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
-        }
-    }
-
-    void restore_vecs() const {
-        auto current_offset = static_cast<int32_t>(m_total_gpr_shift);
-        size_t i = 0;
-        for (; i + 1 < m_vec_regs_to_spill.size(); i += 2) {
-            h->ldp(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]),
-                   Xbyak_aarch64::QReg(m_vec_regs_to_spill[i + 1]),
-                   Xbyak_aarch64::ptr(h->sp, current_offset));
-            current_offset += static_cast<int32_t>(2 * vec_size);
-        }
-        if (i < m_vec_regs_to_spill.size()) {
-            h->ldr(Xbyak_aarch64::QReg(m_vec_regs_to_spill[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
-        }
-    }
-
-    void restore_gprs() const {
-        int32_t current_offset = 0;
-        size_t i = 0;
-        for (; i + 1 < m_gpr_regs_to_spill.size(); i += 2) {
-            h->ldp(Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i]),
-                   Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i + 1]),
-                   Xbyak_aarch64::ptr(h->sp, current_offset));
-            current_offset += static_cast<int32_t>(2 * gpr_size);
-        }
-        if (i < m_gpr_regs_to_spill.size()) {
-            h->ldr(Xbyak_aarch64::XReg(m_gpr_regs_to_spill[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
-        }
-    }
-
-    void reset() {
-        m_gpr_regs_to_spill.clear();
-        m_vec_regs_to_spill.clear();
-        m_total_gpr_shift = 0;
-        m_total_vec_shift = 0;
-        m_total_shift = 0;
-    }
-
-    dnnl::impl::cpu::aarch64::jit_generator_t* h = nullptr;
-    std::vector<size_t> m_gpr_regs_to_spill;
-    std::vector<size_t> m_vec_regs_to_spill;
-    uint32_t m_total_gpr_shift = 0;
-    uint32_t m_total_vec_shift = 0;
-    uint32_t m_total_shift = 0;
-    bool spill_status = true;
-};
+}  // namespace
 
 /* ================== jit_reg_spill_begin_emitters ====================== */
 
@@ -174,7 +55,7 @@ jit_reg_spill_begin_emitter::jit_reg_spill_begin_emitter(dnnl::impl::cpu::aarch6
     const auto& reg_spill_node = ov::as_type_ptr<snippets::op::RegSpillBegin>(expr->get_node());
     OV_CPU_JIT_EMITTER_ASSERT(reg_spill_node, "expects RegSpillBegin expression");
     const auto& rinfo = expr->get_reg_info();
-    m_regs_to_spill = std::set<snippets::Reg>(rinfo.second.begin(), rinfo.second.end());
+    m_regs_to_spill = to_xbyak_regs(rinfo.second);
     m_abi_reg_spiller = std::make_shared<EmitABIRegSpills>(h);
     in_out_type_ = emitter_in_out_map::gpr_to_gpr;
 }

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
@@ -4,15 +4,10 @@
 
 #include "jit_reg_spill_emitters.hpp"
 
-#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_reg.h>
-
-#include <algorithm>
 #include <cpu/aarch64/cpu_isa_traits.hpp>
 #include <cpu/aarch64/jit_generator.hpp>
 #include <cstddef>
-#include <iterator>
 #include <memory>
-#include <set>
 #include <vector>
 
 #include "emitters/snippets/aarch64/utils.hpp"
@@ -24,30 +19,6 @@
 
 namespace ov::intel_cpu::aarch64 {
 
-namespace {
-
-Xbyak_aarch64::Reg to_xbyak_reg(const snippets::Reg& reg) {
-    switch (reg.type) {
-    case snippets::RegType::gpr:
-        return Xbyak_aarch64::XReg(reg.idx);
-    case snippets::RegType::vec:
-        return Xbyak_aarch64::QReg(reg.idx);
-    default:
-        OV_CPU_JIT_EMITTER_THROW("Unsupported register type in Arm64 RegSpill emitter");
-    }
-    return Xbyak_aarch64::XReg(0);
-}
-
-std::vector<Xbyak_aarch64::Reg> to_xbyak_regs(const std::vector<snippets::Reg>& regs) {
-    const std::set<snippets::Reg> unique_regs(regs.begin(), regs.end());
-    std::vector<Xbyak_aarch64::Reg> xbyak_regs;
-    xbyak_regs.reserve(unique_regs.size());
-    std::transform(unique_regs.begin(), unique_regs.end(), std::back_inserter(xbyak_regs), to_xbyak_reg);
-    return xbyak_regs;
-}
-
-}  // namespace
-
 /* ================== jit_reg_spill_begin_emitters ====================== */
 
 jit_reg_spill_begin_emitter::jit_reg_spill_begin_emitter(dnnl::impl::cpu::aarch64::jit_generator_t* h,
@@ -57,7 +28,7 @@ jit_reg_spill_begin_emitter::jit_reg_spill_begin_emitter(dnnl::impl::cpu::aarch6
     const auto& reg_spill_node = ov::as_type_ptr<snippets::op::RegSpillBegin>(expr->get_node());
     OV_CPU_JIT_EMITTER_ASSERT(reg_spill_node, "expects RegSpillBegin expression");
     const auto& rinfo = expr->get_reg_info();
-    m_regs_to_spill = to_xbyak_regs(rinfo.second);
+    m_regs_to_spill = utils::to_xbyak_regs(rinfo.second);
     m_abi_reg_spiller = std::make_shared<EmitABIRegSpills>(h);
     in_out_type_ = emitter_in_out_map::gpr_to_gpr;
 }

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.cpp
@@ -13,7 +13,6 @@
 #include "emitters/snippets/aarch64/utils.hpp"
 #include "emitters/utils.hpp"
 #include "openvino/core/type.hpp"
-#include "snippets/emitter.hpp"
 #include "snippets/lowered/expression.hpp"
 #include "snippets/op/reg_spill.hpp"
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.hpp
@@ -4,10 +4,11 @@
 
 #pragma once
 
+#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h>
+
 #include <cpu/aarch64/cpu_isa_traits.hpp>
 #include <cpu/aarch64/jit_generator.hpp>
 #include <memory>
-#include <set>
 #include <vector>
 
 #include "emitters/plugin/aarch64/jit_emitter.hpp"
@@ -40,7 +41,7 @@ protected:
                         const std::vector<size_t>& pool_vec_idxs,
                         const std::vector<size_t>& pool_gpr_idxs) const override;
 
-    std::set<snippets::Reg> m_regs_to_spill;
+    std::vector<Xbyak_aarch64::Reg> m_regs_to_spill;
     std::shared_ptr<EmitABIRegSpills> m_abi_reg_spiller;
 };
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_reg_spill_emitters.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cpu/aarch64/cpu_isa_traits.hpp>
+#include <cpu/aarch64/jit_generator.hpp>
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "emitters/plugin/aarch64/jit_emitter.hpp"
+#include "snippets/emitter.hpp"
+#include "snippets/lowered/expression.hpp"
+
+namespace ov::intel_cpu::aarch64 {
+
+/* ================== jit_reg_spill_begin_emitters ====================== */
+class EmitABIRegSpills;
+class jit_reg_spill_end_emitter;
+
+class jit_reg_spill_begin_emitter : public jit_emitter {
+    friend jit_reg_spill_end_emitter;
+
+public:
+    jit_reg_spill_begin_emitter(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                                dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                                const ov::snippets::lowered::ExpressionPtr& expr);
+
+    size_t get_inputs_count() const override {
+        return 0;
+    }
+
+protected:
+    void validate_arguments(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
+    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
+    void emit_code_impl(const std::vector<size_t>& in_idxs,
+                        const std::vector<size_t>& out_idxs,
+                        const std::vector<size_t>& pool_vec_idxs,
+                        const std::vector<size_t>& pool_gpr_idxs) const override;
+
+    std::set<snippets::Reg> m_regs_to_spill;
+    std::shared_ptr<EmitABIRegSpills> m_abi_reg_spiller;
+};
+
+/* ============================================================== */
+
+/* ================== jit_reg_spill_end_emitter ====================== */
+
+class jit_reg_spill_end_emitter : public jit_emitter {
+public:
+    jit_reg_spill_end_emitter(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                              dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                              const ov::snippets::lowered::ExpressionPtr& expr);
+
+    size_t get_inputs_count() const override {
+        return 0;
+    }
+
+protected:
+    void validate_arguments(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
+    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
+    void emit_code_impl(const std::vector<size_t>& in_idxs,
+                        const std::vector<size_t>& out_idxs,
+                        const std::vector<size_t>& pool_vec_idxs,
+                        const std::vector<size_t>& pool_gpr_idxs) const override;
+
+    std::shared_ptr<EmitABIRegSpills> m_abi_reg_spiller;
+};
+
+/* ============================================================== */
+
+}  // namespace ov::intel_cpu::aarch64

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.cpp
@@ -12,8 +12,10 @@
 #include <cstdint>
 #include <set>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
+#include "emitters/plugin/aarch64/jit_emitter.hpp"
 #include "emitters/snippets/jit_snippets_call_args.hpp"
 #include "emitters/utils.hpp"
 #include "openvino/core/except.hpp"
@@ -23,7 +25,164 @@
 
 using namespace dnnl::impl::cpu::aarch64;
 
-namespace ov::intel_cpu::aarch64::utils {
+namespace ov::intel_cpu::aarch64 {
+
+namespace {
+
+constexpr uint32_t gpr_size = 8;
+constexpr uint32_t vec_size = 16;
+
+[[nodiscard]] uint32_t aligned_size(const uint32_t size) {
+    if (size == 0) {
+        return 0;
+    }
+    return ((size + jit_emitter::sp_alignment - 1) / jit_emitter::sp_alignment) * jit_emitter::sp_alignment;
+}
+
+[[nodiscard]] bool is_gpr(const Xbyak_aarch64::Reg& reg) {
+    return reg.isRReg() && reg.getBit() == gpr_size * 8;
+}
+
+[[nodiscard]] bool is_vec(const Xbyak_aarch64::Reg& reg) {
+    return reg.isVRegSc() && reg.getBit() == vec_size * 8;
+}
+
+[[nodiscard]] uint32_t get_total_gpr_shift(const std::vector<Xbyak_aarch64::Reg>& regs) {
+    return aligned_size(static_cast<uint32_t>(std::count_if(regs.begin(), regs.end(), is_gpr) * gpr_size));
+}
+
+[[nodiscard]] uint32_t get_total_shift(const std::vector<Xbyak_aarch64::Reg>& regs) {
+    return get_total_gpr_shift(regs) +
+           aligned_size(static_cast<uint32_t>(std::count_if(regs.begin(), regs.end(), is_vec) * vec_size));
+}
+
+[[nodiscard]] Xbyak_aarch64::XReg as_gpr(const Xbyak_aarch64::Reg& reg) {
+    OV_CPU_JIT_EMITTER_ASSERT(is_gpr(reg), "Expected a 64-bit GPR register in Arm64 spill helper");
+    return Xbyak_aarch64::XReg(reg.getIdx());
+}
+
+[[nodiscard]] Xbyak_aarch64::QReg as_vec(const Xbyak_aarch64::Reg& reg) {
+    OV_CPU_JIT_EMITTER_ASSERT(is_vec(reg), "Expected a 128-bit vector register in Arm64 spill helper");
+    return Xbyak_aarch64::QReg(reg.getIdx());
+}
+
+template <typename Predicate, typename RegT>
+void store_reg_group(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                     const std::vector<Xbyak_aarch64::Reg>& regs,
+                     int32_t current_offset,
+                     Predicate&& predicate,
+                     RegT&& to_reg,
+                     const uint32_t reg_byte_size) {
+    std::vector<Xbyak_aarch64::Reg> filtered_regs;
+    filtered_regs.reserve(regs.size());
+    std::copy_if(regs.begin(), regs.end(), std::back_inserter(filtered_regs), std::forward<Predicate>(predicate));
+
+    size_t i = 0;
+    for (; i + 1 < filtered_regs.size(); i += 2) {
+        h->stp(to_reg(filtered_regs[i]), to_reg(filtered_regs[i + 1]), Xbyak_aarch64::ptr(h->sp, current_offset));
+        current_offset += static_cast<int32_t>(2 * reg_byte_size);
+    }
+    if (i < filtered_regs.size()) {
+        h->str(to_reg(filtered_regs[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
+    }
+}
+
+template <typename Predicate, typename RegT>
+void load_reg_group(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                    const std::vector<Xbyak_aarch64::Reg>& regs,
+                    int32_t current_offset,
+                    Predicate&& predicate,
+                    RegT&& to_reg,
+                    const uint32_t reg_byte_size) {
+    std::vector<Xbyak_aarch64::Reg> filtered_regs;
+    filtered_regs.reserve(regs.size());
+    std::copy_if(regs.begin(), regs.end(), std::back_inserter(filtered_regs), std::forward<Predicate>(predicate));
+
+    size_t i = 0;
+    for (; i + 1 < filtered_regs.size(); i += 2) {
+        h->ldp(to_reg(filtered_regs[i]), to_reg(filtered_regs[i + 1]), Xbyak_aarch64::ptr(h->sp, current_offset));
+        current_offset += static_cast<int32_t>(2 * reg_byte_size);
+    }
+    if (i < filtered_regs.size()) {
+        h->ldr(to_reg(filtered_regs[i]), Xbyak_aarch64::ptr(h->sp, current_offset));
+    }
+}
+
+}  // namespace
+
+EmitABIRegSpills::EmitABIRegSpills(jit_generator_t* h_arg) : h(h_arg) {}
+
+EmitABIRegSpills::~EmitABIRegSpills() {
+    OPENVINO_ASSERT(spill_status, "postamble or preamble is missed");
+}
+
+std::vector<Xbyak_aarch64::Reg> EmitABIRegSpills::get_regs_to_spill(const std::set<snippets::Reg>& live_regs) {
+    std::vector<Xbyak_aarch64::Reg> regs_to_spill;
+    regs_to_spill.reserve(live_regs.size());
+    for (const auto& reg : live_regs) {
+        switch (reg.type) {
+        case snippets::RegType::gpr:
+            regs_to_spill.emplace_back(Xbyak_aarch64::XReg(reg.idx));
+            break;
+        case snippets::RegType::vec:
+            regs_to_spill.emplace_back(Xbyak_aarch64::QReg(reg.idx));
+            break;
+        default:
+            OPENVINO_THROW("Unsupported register type in Arm64 RegSpill emitter");
+        }
+    }
+    return regs_to_spill;
+}
+
+void EmitABIRegSpills::store_regs_to_stack(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                                           const std::vector<Xbyak_aarch64::Reg>& regs_to_store) {
+    const auto total_shift = get_total_shift(regs_to_store);
+    if (total_shift > 0) {
+        h->sub(h->sp, h->sp, total_shift);
+    }
+
+    store_reg_group(h, regs_to_store, 0, is_gpr, as_gpr, gpr_size);
+    store_reg_group(h,
+                    regs_to_store,
+                    static_cast<int32_t>(get_total_gpr_shift(regs_to_store)),
+                    is_vec,
+                    as_vec,
+                    vec_size);
+}
+
+void EmitABIRegSpills::load_regs_from_stack(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                                            const std::vector<Xbyak_aarch64::Reg>& regs_to_load) {
+    const auto total_gpr_shift = get_total_gpr_shift(regs_to_load);
+    load_reg_group(h, regs_to_load, static_cast<int32_t>(total_gpr_shift), is_vec, as_vec, vec_size);
+    load_reg_group(h, regs_to_load, 0, is_gpr, as_gpr, gpr_size);
+
+    const auto total_shift =
+        total_gpr_shift +
+        aligned_size(static_cast<uint32_t>(std::count_if(regs_to_load.begin(), regs_to_load.end(), is_vec) * vec_size));
+    if (total_shift > 0) {
+        h->add(h->sp, h->sp, total_shift);
+    }
+}
+
+void EmitABIRegSpills::preamble(const std::vector<Xbyak_aarch64::Reg>& live_regs) {
+    OPENVINO_ASSERT(spill_status, "Attempt to spill ABI registers twice in a row");
+    m_regs_to_spill = live_regs;
+    store_regs_to_stack(h, m_regs_to_spill);
+    spill_status = false;
+}
+
+void EmitABIRegSpills::preamble(const std::set<snippets::Reg>& live_regs) {
+    preamble(get_regs_to_spill(live_regs));
+}
+
+void EmitABIRegSpills::postamble() {
+    OPENVINO_ASSERT(!spill_status, "Attempt to restore ABI registers that were not spilled");
+    load_regs_from_stack(h, m_regs_to_spill);
+    m_regs_to_spill.clear();
+    spill_status = true;
+}
+
+namespace utils {
 
 std::vector<Xbyak_aarch64::XReg> get_aux_gprs(const std::vector<size_t>& used_gpr_idxs, size_t count) {
     // X0 and X1 - runtime parameter registers in the kernel
@@ -223,4 +382,5 @@ void push_ptrs_with_offsets_to_stack(dnnl::impl::cpu::aarch64::jit_generator_t* 
     }
 }
 
-}  // namespace ov::intel_cpu::aarch64::utils
+}  // namespace utils
+}  // namespace ov::intel_cpu::aarch64

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.cpp
@@ -7,9 +7,11 @@
 #include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h>
 #include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_reg.h>
 
+#include <algorithm>
 #include <cpu/aarch64/jit_generator.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <set>
 #include <unordered_set>
 #include <utility>

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.cpp
@@ -53,9 +53,12 @@ constexpr uint32_t vec_size = 16;
     return aligned_size(static_cast<uint32_t>(std::count_if(regs.begin(), regs.end(), is_gpr) * gpr_size));
 }
 
+[[nodiscard]] uint32_t get_total_vec_shift(const std::vector<Xbyak_aarch64::Reg>& regs) {
+    return aligned_size(static_cast<uint32_t>(std::count_if(regs.begin(), regs.end(), is_vec) * vec_size));
+}
+
 [[nodiscard]] uint32_t get_total_shift(const std::vector<Xbyak_aarch64::Reg>& regs) {
-    return get_total_gpr_shift(regs) +
-           aligned_size(static_cast<uint32_t>(std::count_if(regs.begin(), regs.end(), is_vec) * vec_size));
+    return get_total_gpr_shift(regs) + get_total_vec_shift(regs);
 }
 
 [[nodiscard]] Xbyak_aarch64::XReg as_gpr(const Xbyak_aarch64::Reg& reg) {
@@ -112,28 +115,37 @@ void load_reg_group(dnnl::impl::cpu::aarch64::jit_generator_t* h,
 
 }  // namespace
 
+namespace utils {
+
+Xbyak_aarch64::Reg to_xbyak_reg(const snippets::Reg& reg) {
+    switch (reg.type) {
+    case snippets::RegType::gpr:
+        return Xbyak_aarch64::XReg(reg.idx);
+    case snippets::RegType::vec:
+        return Xbyak_aarch64::QReg(reg.idx);
+    default:
+        OV_CPU_JIT_EMITTER_THROW("Unsupported register type in Arm64 RegSpill emitter");
+    }
+    return Xbyak_aarch64::XReg(0);
+}
+
+std::vector<Xbyak_aarch64::Reg> to_xbyak_regs(const std::set<snippets::Reg>& regs) {
+    std::vector<Xbyak_aarch64::Reg> xbyak_regs;
+    xbyak_regs.reserve(regs.size());
+    std::transform(regs.begin(), regs.end(), std::back_inserter(xbyak_regs), to_xbyak_reg);
+    return xbyak_regs;
+}
+
+std::vector<Xbyak_aarch64::Reg> to_xbyak_regs(const std::vector<snippets::Reg>& regs) {
+    return to_xbyak_regs(std::set<snippets::Reg>(regs.begin(), regs.end()));
+}
+
+}  // namespace utils
+
 EmitABIRegSpills::EmitABIRegSpills(jit_generator_t* h_arg) : h(h_arg) {}
 
 EmitABIRegSpills::~EmitABIRegSpills() {
     OPENVINO_ASSERT(spill_status, "postamble or preamble is missed");
-}
-
-std::vector<Xbyak_aarch64::Reg> EmitABIRegSpills::get_regs_to_spill(const std::set<snippets::Reg>& live_regs) {
-    std::vector<Xbyak_aarch64::Reg> regs_to_spill;
-    regs_to_spill.reserve(live_regs.size());
-    for (const auto& reg : live_regs) {
-        switch (reg.type) {
-        case snippets::RegType::gpr:
-            regs_to_spill.emplace_back(Xbyak_aarch64::XReg(reg.idx));
-            break;
-        case snippets::RegType::vec:
-            regs_to_spill.emplace_back(Xbyak_aarch64::QReg(reg.idx));
-            break;
-        default:
-            OPENVINO_THROW("Unsupported register type in Arm64 RegSpill emitter");
-        }
-    }
-    return regs_to_spill;
 }
 
 void EmitABIRegSpills::store_regs_to_stack(dnnl::impl::cpu::aarch64::jit_generator_t* h,
@@ -143,6 +155,7 @@ void EmitABIRegSpills::store_regs_to_stack(dnnl::impl::cpu::aarch64::jit_generat
         h->sub(h->sp, h->sp, total_shift);
     }
 
+    // AArch64 pair store/load instructions operate on same kind registers, so GPRs and vectors use separate ranges.
     store_reg_group(h, regs_to_store, 0, is_gpr, as_gpr, gpr_size);
     store_reg_group(h,
                     regs_to_store,
@@ -158,9 +171,7 @@ void EmitABIRegSpills::load_regs_from_stack(dnnl::impl::cpu::aarch64::jit_genera
     load_reg_group(h, regs_to_load, static_cast<int32_t>(total_gpr_shift), is_vec, as_vec, vec_size);
     load_reg_group(h, regs_to_load, 0, is_gpr, as_gpr, gpr_size);
 
-    const auto total_shift =
-        total_gpr_shift +
-        aligned_size(static_cast<uint32_t>(std::count_if(regs_to_load.begin(), regs_to_load.end(), is_vec) * vec_size));
+    const auto total_shift = total_gpr_shift + get_total_vec_shift(regs_to_load);
     if (total_shift > 0) {
         h->add(h->sp, h->sp, total_shift);
     }
@@ -174,7 +185,7 @@ void EmitABIRegSpills::preamble(const std::vector<Xbyak_aarch64::Reg>& live_regs
 }
 
 void EmitABIRegSpills::preamble(const std::set<snippets::Reg>& live_regs) {
-    preamble(get_regs_to_spill(live_regs));
+    preamble(utils::to_xbyak_regs(live_regs));
 }
 
 void EmitABIRegSpills::postamble() {

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.hpp
@@ -15,7 +15,39 @@
 #include "snippets/emitter.hpp"
 #include "snippets/lowered/expression_port.hpp"
 
-namespace ov::intel_cpu::aarch64::utils {
+namespace ov::intel_cpu::aarch64 {
+
+class EmitABIRegSpills {
+public:
+    explicit EmitABIRegSpills(dnnl::impl::cpu::aarch64::jit_generator_t* h_arg);
+    ~EmitABIRegSpills();
+
+    [[nodiscard]] size_t get_num_spilled_regs() const {
+        return m_regs_to_spill.size();
+    }
+
+    [[nodiscard]] const std::vector<Xbyak_aarch64::Reg>& get_spilled_regs() const {
+        return m_regs_to_spill;
+    }
+
+    void preamble(const std::vector<Xbyak_aarch64::Reg>& live_regs);
+    void preamble(const std::set<snippets::Reg>& live_regs);
+    void postamble();
+
+    static void store_regs_to_stack(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                                    const std::vector<Xbyak_aarch64::Reg>& regs_to_store);
+    static void load_regs_from_stack(dnnl::impl::cpu::aarch64::jit_generator_t* h,
+                                     const std::vector<Xbyak_aarch64::Reg>& regs_to_load);
+
+private:
+    static std::vector<Xbyak_aarch64::Reg> get_regs_to_spill(const std::set<snippets::Reg>& live_regs);
+
+    dnnl::impl::cpu::aarch64::jit_generator_t* h = nullptr;
+    std::vector<Xbyak_aarch64::Reg> m_regs_to_spill;
+    bool spill_status = true;
+};
+
+namespace utils {
 
 inline static std::vector<Xbyak_aarch64::XReg> transform_idxs_to_regs(const std::vector<size_t>& idxs) {
     std::vector<Xbyak_aarch64::XReg> regs;
@@ -119,4 +151,5 @@ void push_ptrs_with_offsets_to_stack(dnnl::impl::cpu::aarch64::jit_generator_t* 
                                      const std::vector<Xbyak_aarch64::XReg>& aux_regs,
                                      const std::vector<int32_t>& stack_offsets);
 
-}  // namespace ov::intel_cpu::aarch64::utils
+}  // namespace utils
+}  // namespace ov::intel_cpu::aarch64

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.hpp
@@ -40,14 +40,16 @@ public:
                                      const std::vector<Xbyak_aarch64::Reg>& regs_to_load);
 
 private:
-    static std::vector<Xbyak_aarch64::Reg> get_regs_to_spill(const std::set<snippets::Reg>& live_regs);
-
     dnnl::impl::cpu::aarch64::jit_generator_t* h = nullptr;
     std::vector<Xbyak_aarch64::Reg> m_regs_to_spill;
     bool spill_status = true;
 };
 
 namespace utils {
+
+Xbyak_aarch64::Reg to_xbyak_reg(const snippets::Reg& reg);
+std::vector<Xbyak_aarch64::Reg> to_xbyak_regs(const std::set<snippets::Reg>& regs);
+std::vector<Xbyak_aarch64::Reg> to_xbyak_regs(const std::vector<snippets::Reg>& regs);
 
 inline static std::vector<Xbyak_aarch64::XReg> transform_idxs_to_regs(const std::vector<size_t>& idxs) {
     std::vector<Xbyak_aarch64::XReg> regs;

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -811,10 +811,6 @@ void Subgraph::optimizeIR() {
 
     const auto control_flow_config = std::make_shared<ov::snippets::lowered::pass::PassConfig>();
     const auto control_flow_passes = getControlFlowPasses();
-#if defined(OPENVINO_ARCH_ARM64)
-    // enable it after emitters for RegSpillBegin and RegSpillEnd are implemented on ARM in CVS-162498
-    control_flow_config->disable<ov::snippets::lowered::pass::InsertRegSpills>();
-#endif
 
 #ifdef SNIPPETS_LIBXSMM_TPP
     // Note: temporary disabled. Re-enable after ticket 132833 is resolved

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -58,7 +58,6 @@
 #    include "executors/aarch64/subgraph.hpp"
 #    include "snippets/lowered/pass/init_loops.hpp"
 #    include "snippets/lowered/pass/insert_buffers.hpp"
-#    include "snippets/lowered/pass/insert_reg_spills.hpp"
 #    include "transformations/snippets/aarch64/pass/brgemm_to_gemm_cpu.hpp"
 #    include "transformations/snippets/aarch64/pass/lowered/adjust_gemm_copy_b_loop_ports.hpp"
 #    include "transformations/snippets/aarch64/pass/lowered/gemm_cpu_blocking.hpp"


### PR DESCRIPTION
### Details:
 - Implement JIT emitters for RegSpillBegin and RegSpillNodes in snippets opset
 - Enable register spill insertion pass on ARM

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: yes*
 - The implementation is generated, manually adjusted after that and checked using the tests