### PR TITLE
[GPU] update fc_bf_tiled_opt not to check batch dim

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -183,7 +183,7 @@ bool should_dynamic_quantize(const fully_connected_params& params) {
     auto input_f = threads.second;
 
     if ((scale_group_size % simd == 0) && (input_f % dynamic_quantization_group_size == 0) &&
-        (params.is_shape_agnostic || (params.inputs[0].Batch().v > 1 && input_b > min_slm_size)) &&
+        (params.is_shape_agnostic || input_b > min_slm_size) &&
         params.inputs[0].GetDType() == Datatype::F16 && is_weight_dyn_quantizable(params)) {
         GPU_DEBUG_TRACE_DETAIL << " Dynamic quantizing for FC : scale_group_size: " << scale_group_size
                                << ", Dyn-quan group size: " << dynamic_quantization_group_size


### PR DESCRIPTION
### Details:
 - This PR updated `fc_bf_tiled_opt` not to check batch dim, and it allows dynamic quantization when fake alignment is disabled.

### Tickets:
 - 184234

### AI Assistance:
 - *AI assistance used: no
