### PR TITLE
- Allow quantize fusion for non per-tensor cases if no shape change

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -936,14 +936,6 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             auto out_dt_is_i8_u8 = data_type_traits::is_i8_u8(out_dt);
             auto in_dt_is_i8_u8 = data_type_traits::is_i8_u8(in_dt);
 
-            bool per_tensor_values = quantize_node.get_scale_shift_opt() &&
-                                     quantize_node.get_per_tensor_input_scale() &&
-                                     quantize_node.get_per_tensor_input_shift() &&
-                                     quantize_node.get_per_tensor_input_range() &&
-                                     quantize_node.get_per_tensor_output_scale() &&
-                                     quantize_node.get_per_tensor_output_shift() &&
-                                     quantize_node.get_per_tensor_output_range();
-
             bool should_fuse = input_data.is_type<convolution>() && conv_supports_fusings(input_data.as<convolution>()) &&
                            quantize_node.get_scale_shift_opt() &&
                            ((out_dt == data_types::f32 || out_dt == data_types::f16)  ||
@@ -1008,7 +1000,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
 
             should_fuse |= input_data.is_type<softmax>() &&
                            input_data.as<softmax>().get_primitive()->dimension == 1 &&
-                           per_tensor_values;
+                           quantize_node.has_per_tensor_values();
 
             should_fuse |= input_data.is_type<broadcast>() && broadcast_supports_fusings(input_data.as<broadcast>());
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -74,6 +74,7 @@ void prepare_primitive_fusing_through::run(program& p) {
     while (node_itr != p.get_processing_order().end()) {
         auto node = (*node_itr++);
         cldnn::program_node* input_node;
+        bool per_tensor_values;
 
         if (node->is_output() || node->is_constant())
             continue;
@@ -85,7 +86,7 @@ void prepare_primitive_fusing_through::run(program& p) {
             input_node = &node->get_dependency(0);
         } else if (node->is_type<quantize>()) {
             auto& quantize_node = node->as<quantize>();
-            bool per_tensor_values = quantize_node.get_scale_shift_opt() &&
+            per_tensor_values = quantize_node.get_scale_shift_opt() &&
                                      quantize_node.get_per_tensor_input_scale() &&
                                      (quantize_node.get_per_tensor_input_shift() || !quantize_node.get_need_pre_shift()) &&
                                      quantize_node.get_per_tensor_input_range() &&
@@ -93,8 +94,15 @@ void prepare_primitive_fusing_through::run(program& p) {
                                      (quantize_node.get_per_tensor_output_shift() || !quantize_node.get_need_post_shift()) &&
                                      quantize_node.get_per_tensor_output_range();
 
-            if (!per_tensor_values)
-                continue;
+            /*if (!per_tensor_values)
+                continue;*/
+
+            if (!per_tensor_values) {
+                // Shape compatibility with the target node is verified later
+                // by comparing new_prev output shape with quantize input shape.
+                if (!quantize_node.get_scale_shift_opt())
+                    continue;
+            }
 
             input_node = &node->get_dependency(0);
         } else if (node->is_type<eltwise>()) {
@@ -133,6 +141,16 @@ void prepare_primitive_fusing_through::run(program& p) {
 
         auto new_prev = fuse_through_order[fuse_through_order.size() - 1];
         auto new_next = fuse_through_order[fuse_through_order.size() - 2];
+
+        // For per-channel quantize, allow only when the fused target's output shape
+        // matches the quantize's current input shape. This ensures per-channel
+        // parameters remain correctly broadcast-aligned at the new position.
+        if (node->is_type<quantize>() && !per_tensor_values) {
+            auto target_shape = new_prev->get_output_layout().get_partial_shape();
+            auto current_input_shape = node->get_input_layout(0).get_partial_shape();
+            if (target_shape != current_input_shape)
+                continue;  // shapes differ: per-channel params would be misaligned
+        }
 
         // Check broadcastable for fused eltwise's output
         if (node->is_type<eltwise>()) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -74,7 +74,6 @@ void prepare_primitive_fusing_through::run(program& p) {
     while (node_itr != p.get_processing_order().end()) {
         auto node = (*node_itr++);
         cldnn::program_node* input_node;
-        bool per_tensor_values = false;
 
         if (node->is_output() || node->is_constant())
             continue;
@@ -87,11 +86,8 @@ void prepare_primitive_fusing_through::run(program& p) {
         } else if (node->is_type<quantize>()) {
             auto& quantize_node = node->as<quantize>();
 
-            if (!quantize_node.has_per_tensor_values()) {
-                // Shape compatibility with the target node is verified later
-                // by comparing new_prev output shape with quantize input shape.
-                if (!quantize_node.get_scale_shift_opt())
-                    continue;
+            if (!quantize_node.has_per_tensor_values() && !quantize_node.get_scale_shift_opt()) {
+                continue;
             }
 
             input_node = &node->get_dependency(0);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -74,7 +74,7 @@ void prepare_primitive_fusing_through::run(program& p) {
     while (node_itr != p.get_processing_order().end()) {
         auto node = (*node_itr++);
         cldnn::program_node* input_node;
-        bool per_tensor_values;
+        bool per_tensor_values = false;
 
         if (node->is_output() || node->is_constant())
             continue;
@@ -93,9 +93,6 @@ void prepare_primitive_fusing_through::run(program& p) {
                                      quantize_node.get_per_tensor_output_scale() &&
                                      (quantize_node.get_per_tensor_output_shift() || !quantize_node.get_need_post_shift()) &&
                                      quantize_node.get_per_tensor_output_range();
-
-            /*if (!per_tensor_values)
-                continue;*/
 
             if (!per_tensor_values) {
                 // Shape compatibility with the target node is verified later

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -86,15 +86,8 @@ void prepare_primitive_fusing_through::run(program& p) {
             input_node = &node->get_dependency(0);
         } else if (node->is_type<quantize>()) {
             auto& quantize_node = node->as<quantize>();
-            per_tensor_values = quantize_node.get_scale_shift_opt() &&
-                                     quantize_node.get_per_tensor_input_scale() &&
-                                     (quantize_node.get_per_tensor_input_shift() || !quantize_node.get_need_pre_shift()) &&
-                                     quantize_node.get_per_tensor_input_range() &&
-                                     quantize_node.get_per_tensor_output_scale() &&
-                                     (quantize_node.get_per_tensor_output_shift() || !quantize_node.get_need_post_shift()) &&
-                                     quantize_node.get_per_tensor_output_range();
 
-            if (!per_tensor_values) {
+            if (!quantize_node.has_per_tensor_values()) {
                 // Shape compatibility with the target node is verified later
                 // by comparing new_prev output shape with quantize input shape.
                 if (!quantize_node.get_scale_shift_opt())
@@ -142,11 +135,11 @@ void prepare_primitive_fusing_through::run(program& p) {
         // For per-channel quantize, allow only when the fused target's output shape
         // matches the quantize's current input shape. This ensures per-channel
         // parameters remain correctly broadcast-aligned at the new position.
-        if (node->is_type<quantize>() && !per_tensor_values) {
+        if (node->is_type<quantize>() && !node->as<quantize>().has_per_tensor_values()) {
             auto target_shape = new_prev->get_output_layout().get_partial_shape();
             auto current_input_shape = node->get_input_layout(0).get_partial_shape();
-            if (target_shape != current_input_shape)
-                continue;  // shapes differ: per-channel params would be misaligned
+            if ((target_shape != current_input_shape) || target_shape.is_dynamic() || current_input_shape.is_dynamic())
+                continue;
         }
 
         // Check broadcastable for fused eltwise's output

--- a/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
@@ -192,6 +192,16 @@ public:
     float get_output_lo_val() const { return get_primitive()->out_lo; }
     float get_output_hi_val() const { return get_primitive()->out_hi; }
 
+    bool has_per_tensor_values() const {
+        return get_scale_shift_opt() &&
+               get_per_tensor_input_scale() &&
+               (get_per_tensor_input_shift() || !get_need_pre_shift()) &&
+               get_per_tensor_input_range() &&
+               get_per_tensor_output_scale() &&
+               (get_per_tensor_output_shift() || !get_need_post_shift()) &&
+               get_per_tensor_output_range();
+    }
+
     std::shared_ptr<NodeFuseParams> get_fuse_params() const override {
         return std::make_shared<QuantizeFuseParams>(get_output_layout(),
                                                     get_primitive()->scale_shift_opt,

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_primitive_fusing_through_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_primitive_fusing_through_test.cpp
@@ -111,13 +111,14 @@ TEST(prepare_primitive_fusing_through, dont_fuse_quantize_per_channel_shape_mism
     ASSERT_EQ(quant_node.get_dependency(0).id(), "reshape1");
 }
 
-// Negative test: per-channel quantize should NOT fuse when scale_shift_opt is not set
-// (i.e., prepare_quantization has not run).
-// Topology same as positive test but we skip prepare_quantization pass.
-TEST(prepare_primitive_fusing_through, dont_fuse_quantize_per_channel_without_scale_shift_opt) {
+// Negative test: per-channel quantize should NOT fuse through when shapes are dynamic.
+// Topology: Input[-1,3,1,1] -> FC[-1,3,1,1] -> Reshape[-1,3,1,1] -> Quantize(per-ch) -> Reorder
+// FC output and quantize input have the same dynamic shape,
+// but fusing is conservatively blocked since shape equality cannot be guaranteed at graph compilation time.
+TEST(prepare_primitive_fusing_through, dont_fuse_quantize_per_channel_dynamic_shapes) {
     auto& engine = get_test_engine();
-    auto in_layout = layout{ov::PartialShape{4, 3, 1, 1}, data_types::f32, format::bfyx};
-    auto weights_mem = engine.allocate_memory({ov::PartialShape{3, 3}, data_types::f32, format::bfyx});
+    auto in_layout = layout{ov::PartialShape{-1, 3, 1, 1}, data_types::f32, format::bfyx};
+    auto weights_mem = engine.allocate_memory({ov::PartialShape{1, 1}, data_types::f32, format::bfyx});
     auto in_lo_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
     auto in_hi_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
     auto out_lo_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
@@ -132,26 +133,31 @@ TEST(prepare_primitive_fusing_through, dont_fuse_quantize_per_channel_without_sc
     topology.add(input_layout("input", in_layout));
     topology.add(data("weights", weights_mem));
     topology.add(fully_connected("fc", input_info("input"), "weights"));
-    topology.add(reshape("reshape1", input_info("fc"), tensor(1, 3, 2, 2)));
-    topology.add(reshape("reshape2", input_info("reshape1"), tensor(4, 3, 1, 1)));
+    topology.add(reshape("reshape1", input_info("fc"), true, std::vector<int64_t>{0, 0, 0, 0}, ov::PartialShape{-1, 3, 1, 1}));
     topology.add(data("in_lo", in_lo_mem));
     topology.add(data("in_hi", in_hi_mem));
     topology.add(data("out_lo", out_lo_mem));
     topology.add(data("out_hi", out_hi_mem));
-    topology.add(quantize("quantize", input_info("reshape2"),
-                          input_info("in_lo"), input_info("in_hi"),
-                          input_info("out_lo"), input_info("out_hi"), 256, data_types::u8));
+    topology.add(quantize("quantize",
+                          input_info("reshape1"),
+                          input_info("in_lo"),
+                          input_info("in_hi"),
+                          input_info("out_lo"),
+                          input_info("out_hi"),
+                          256,
+                          data_types::u8));
     topology.add(reorder("output", input_info("quantize"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
 
-    // Intentionally skip prepare_quantization — scale_shift_opt remains false
+    program_wrapper::apply_opt_pass<prepare_quantization>(*prog);
     program_wrapper::apply_opt_pass<prepare_primitive_fusing_through>(*prog);
 
     ASSERT_NE(prog, nullptr);
     auto& quant_node = prog->get_node("quantize");
-    // Without scale_shift_opt, quantize should NOT have moved
-    ASSERT_EQ(quant_node.get_dependency(0).id(), "reshape2");
+    // With dynamic shapes, quantize should NOT have moved — stays after reshape
+    ASSERT_EQ(quant_node.get_dependency(0).id(), "reshape1");
 }

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_primitive_fusing_through_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_primitive_fusing_through_test.cpp
@@ -1,0 +1,157 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils.h"
+
+#include "intel_gpu/runtime/engine.hpp"
+
+#include "intel_gpu/graph/network.hpp"
+#include "intel_gpu/graph/program.hpp"
+#include "data_inst.h"
+#include "quantize_inst.h"
+#include "reshape_inst.h"
+#include "fully_connected_inst.h"
+#include "pass_manager.h"
+#include "to_string_utils.h"
+
+#include "program_wrapper.h"
+
+#include <memory>
+
+using namespace cldnn;
+using namespace ::tests;
+
+// Positive test: per-channel quantize should fuse through reshape chain when shapes match (round-trip).
+// Topology: Input[4,3,1,1] -> FC[4,3,1,1] -> Reshape1[1,3,2,2] -> Reshape2[4,3,1,1] -> Quantize(per-ch) -> Reorder
+// After pass: Quantize should be moved next to FC (quantize's dep 0 == "fc").
+TEST(prepare_primitive_fusing_through, fuse_quantize_per_channel_through_reshape_chain) {
+    auto& engine = get_test_engine();
+    auto in_layout = layout{ov::PartialShape{4, 3, 1, 1}, data_types::f32, format::bfyx};
+    auto weights_mem = engine.allocate_memory({ov::PartialShape{3, 3}, data_types::f32, format::bfyx});
+    auto in_lo_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+    auto in_hi_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+    auto out_lo_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+    auto out_hi_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+
+    set_values<float>(in_lo_mem, {0.f, 0.f, 0.f});
+    set_values<float>(in_hi_mem, {1.f, 2.f, 3.f});
+    set_values<float>(out_lo_mem, {0.f, 0.f, 0.f});
+    set_values<float>(out_hi_mem, {255.f, 255.f, 255.f});
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weights", weights_mem));
+    topology.add(fully_connected("fc", input_info("input"), "weights"));
+    topology.add(reshape("reshape1", input_info("fc"), tensor(1, 3, 2, 2)));
+    topology.add(reshape("reshape2", input_info("reshape1"), tensor(4, 3, 1, 1)));
+    topology.add(data("in_lo", in_lo_mem));
+    topology.add(data("in_hi", in_hi_mem));
+    topology.add(data("out_lo", out_lo_mem));
+    topology.add(data("out_hi", out_hi_mem));
+    topology.add(quantize("quantize", input_info("reshape2"),
+                          input_info("in_lo"), input_info("in_hi"),
+                          input_info("out_lo"), input_info("out_hi"), 256, data_types::u8));
+    topology.add(reorder("output", input_info("quantize"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config;
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    auto prog = program::build_program(engine, topology, config, false, true);
+
+    program_wrapper::apply_opt_pass<prepare_quantization>(*prog);
+    program_wrapper::apply_opt_pass<prepare_primitive_fusing_through>(*prog);
+
+    ASSERT_NE(prog, nullptr);
+    auto& quant_node = prog->get_node("quantize");
+    // After the pass, quantize should have been moved next to FC
+    ASSERT_EQ(quant_node.get_dependency(0).id(), "fc");
+}
+
+// Negative test: per-channel quantize should NOT fuse through reshape when shapes don't match.
+// Topology: Input[4,3,1,1] -> FC[4,3,1,1] -> Reshape1[1,3,2,2] -> Quantize(per-ch) -> Reorder
+// FC output is {4,3,1,1} but quantize input is {1,3,2,2} — mismatch blocks fusing.
+TEST(prepare_primitive_fusing_through, dont_fuse_quantize_per_channel_shape_mismatch) {
+    auto& engine = get_test_engine();
+    auto in_layout = layout{ov::PartialShape{4, 3, 1, 1}, data_types::f32, format::bfyx};
+    auto weights_mem = engine.allocate_memory({ov::PartialShape{3, 3}, data_types::f32, format::bfyx});
+    auto in_lo_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+    auto in_hi_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+    auto out_lo_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+    auto out_hi_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+
+    set_values<float>(in_lo_mem, {0.f, 0.f, 0.f});
+    set_values<float>(in_hi_mem, {1.f, 2.f, 3.f});
+    set_values<float>(out_lo_mem, {0.f, 0.f, 0.f});
+    set_values<float>(out_hi_mem, {255.f, 255.f, 255.f});
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weights", weights_mem));
+    topology.add(fully_connected("fc", input_info("input"), "weights"));
+    topology.add(reshape("reshape1", input_info("fc"), tensor(1, 3, 2, 2)));
+    topology.add(data("in_lo", in_lo_mem));
+    topology.add(data("in_hi", in_hi_mem));
+    topology.add(data("out_lo", out_lo_mem));
+    topology.add(data("out_hi", out_hi_mem));
+    topology.add(quantize("quantize", input_info("reshape1"),
+                          input_info("in_lo"), input_info("in_hi"),
+                          input_info("out_lo"), input_info("out_hi"), 256, data_types::u8));
+    topology.add(reorder("output", input_info("quantize"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config;
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    auto prog = program::build_program(engine, topology, config, false, true);
+
+    program_wrapper::apply_opt_pass<prepare_quantization>(*prog);
+    program_wrapper::apply_opt_pass<prepare_primitive_fusing_through>(*prog);
+
+    ASSERT_NE(prog, nullptr);
+    auto& quant_node = prog->get_node("quantize");
+    // Quantize should NOT have moved — its input should still be reshape1
+    ASSERT_EQ(quant_node.get_dependency(0).id(), "reshape1");
+}
+
+// Negative test: per-channel quantize should NOT fuse when scale_shift_opt is not set
+// (i.e., prepare_quantization has not run).
+// Topology same as positive test but we skip prepare_quantization pass.
+TEST(prepare_primitive_fusing_through, dont_fuse_quantize_per_channel_without_scale_shift_opt) {
+    auto& engine = get_test_engine();
+    auto in_layout = layout{ov::PartialShape{4, 3, 1, 1}, data_types::f32, format::bfyx};
+    auto weights_mem = engine.allocate_memory({ov::PartialShape{3, 3}, data_types::f32, format::bfyx});
+    auto in_lo_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+    auto in_hi_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+    auto out_lo_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+    auto out_hi_mem = engine.allocate_memory({ov::PartialShape{1, 3, 1, 1}, data_types::f32, format::bfyx});
+
+    set_values<float>(in_lo_mem, {0.f, 0.f, 0.f});
+    set_values<float>(in_hi_mem, {1.f, 2.f, 3.f});
+    set_values<float>(out_lo_mem, {0.f, 0.f, 0.f});
+    set_values<float>(out_hi_mem, {255.f, 255.f, 255.f});
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weights", weights_mem));
+    topology.add(fully_connected("fc", input_info("input"), "weights"));
+    topology.add(reshape("reshape1", input_info("fc"), tensor(1, 3, 2, 2)));
+    topology.add(reshape("reshape2", input_info("reshape1"), tensor(4, 3, 1, 1)));
+    topology.add(data("in_lo", in_lo_mem));
+    topology.add(data("in_hi", in_hi_mem));
+    topology.add(data("out_lo", out_lo_mem));
+    topology.add(data("out_hi", out_hi_mem));
+    topology.add(quantize("quantize", input_info("reshape2"),
+                          input_info("in_lo"), input_info("in_hi"),
+                          input_info("out_lo"), input_info("out_hi"), 256, data_types::u8));
+    topology.add(reorder("output", input_info("quantize"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config;
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    auto prog = program::build_program(engine, topology, config, false, true);
+
+    // Intentionally skip prepare_quantization — scale_shift_opt remains false
+    program_wrapper::apply_opt_pass<prepare_primitive_fusing_through>(*prog);
+
+    ASSERT_NE(prog, nullptr);
+    auto& quant_node = prog->get_node("quantize");
+    // Without scale_shift_opt, quantize should NOT have moved
+    ASSERT_EQ(quant_node.get_dependency(0).id(), "reshape2");
+}


### PR DESCRIPTION
### Details:
**Problem:**
 - *Quantize node is not fused to preceding FullyConnected due to presence of Reshape/Reorder operations even though there is no shape change.*
     - Quantize -> FullyConnected ->Reorder -> Reshape -> Reorder -> Reshape -> Quantize -> FullyConnected
 - *The execution time for the Quantize node is notably high, which directly impacts overall performance.*

**Implementation Details:**
 - *Current _prepare_primitive_fusing_through_ only supports per-tensor quantization.*
 - *Additionally, while the reshape -> reorder -> reshape pattern is getting detected and removed by the [remove_redundant_reorders] https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp#L687) pass, that pass currently runs after the prepare_primitive_fusing pass. And due this sequence we miss the opportunity to fuse the quantize nodes*
 - *However, it can be safely extended to non per-tensor scenarios if there is no change in shape through chain of reshapes/reorders.*

**Graph:** 
<img width="631" height="334" alt="image" src="https://github.com/user-attachments/assets/1e3e307f-ca33-4d3f-a862-ef1e670569ed" />

**Performance improvement:**
- Observed about 5-7% performance gain with SAM2 encoder model.

**Tests performed:**
1. Performance results: 
    - LLM Models: [LLM CMP link](https://benchmarks.sclab.intel.com/cmp.py?predef=llm-lat.json&order=gain/1&extend=1/all&extend=2/all&ref=devel_2/REF_LLM_SA/DEV_LS_GPU_long_windows11_ultra5-338H_ovptl11/5&target=devel_2/PR_LLM_SA/DEV_LS_GPU_long_windows11_ultra5-338H_ovptl11/11)
    
    - Non-LLM Models: [Non-LLM CMP Link](https://benchmarks.sclab.intel.com/cmp.py?predef=ba-tput.json&order=gain/1&ref=devel_2/REF_STATIC_SA/DEV_W_GPU_parallel-8_windows11_ultra5-338H_ovptl11/2&target=devel_2/PR_STATIC_SA/DEV_W_GPU_parallel-8_windows11_ultra5-338H_ovptl11/6)

2. Accuracy result:
    - Results with PR changes: https://ci-dlbenchmark-icv.iotg.sclab.intel.com/job/DL-Benchmark/job/dev/job/PR_LLM_SA/job/DEV_LO_GPU_acc_wwb_cli_ref_nat_vs_genai_windows11_ultra7-368H_ovptl32/1/
    
    - Reference: https://ci-dlbenchmark-icv.iotg.sclab.intel.com/job/DL-Benchmark/job/dev/job/REF_LLM_SA/job/DEV_LO_GPU_acc_wwb_cli_ref_nat_vs_genai_windows11_ultra7-368H_ovptl32/1/

### Tickets:
 - *CVS-182948*

### AI Assistance:
 - *AI assistance used: yes*
 - *Copilot was used for fixing the error. Manually reviewed the code and ran performance /accuracy tests.*
