### PR TITLE
[NPU] Check the sanity of the device each time the singleton returns the instance created previously

### DIFF
--- a/src/common/zero_loader/include/openvino/zero_api.hpp
+++ b/src/common/zero_loader/include/openvino/zero_api.hpp
@@ -85,7 +85,8 @@ namespace ov {
     symbol_statement(zeKernelSetArgumentValue)                \
     symbol_statement(zeCommandListCreateImmediate)            \
     symbol_statement(zeKernelSetGroupSize)                    \
-    symbol_statement(zeCommandListAppendLaunchKernel)
+    symbol_statement(zeCommandListAppendLaunchKernel)         \
+    symbol_statement(zeDeviceGetStatus)
 
 /**
  * @def weak_symbols_list

--- a/src/plugins/intel_npu/src/backend/src/zero_dynamic_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_dynamic_pipeline.cpp
@@ -58,13 +58,11 @@ DynamicPipeline::DynamicPipeline(const std::shared_ptr<ZeroInitStructsHolder>& i
     OPENVINO_ASSERT(dynamicGraph != nullptr, "Failed to cast graph to IDynamicGraph");
 
     if (!_sync_output_with_fences) {
-        _event_pool = std::make_shared<EventPool>(_init_structs->getDevice(),
-                                                  _init_structs->getContext(),
-                                                  _batch_size ? static_cast<uint32_t>(_batch_size) : 1);
+        _event_pool = std::make_shared<EventPool>(_init_structs, _batch_size ? static_cast<uint32_t>(_batch_size) : 1);
 
         _events.reserve(_batch_size);
         for (size_t i = 0; i < _batch_size; i++) {
-            _events.emplace_back(std::make_shared<Event>(_event_pool, static_cast<uint32_t>(i)));
+            _events.emplace_back(std::make_shared<Event>(_init_structs, _event_pool, static_cast<uint32_t>(i)));
         }
     }
     _logger.debug("DynamicPipeline - event pool and command queue setup completed");
@@ -79,7 +77,7 @@ DynamicPipeline::DynamicPipeline(const std::shared_ptr<ZeroInitStructsHolder>& i
     if (_sync_output_with_fences) {
         _fences.reserve(_batch_size);
         for (size_t i = 0; i < _batch_size; i++) {
-            _fences.emplace_back(std::make_unique<Fence>(_command_queue));
+            _fences.emplace_back(std::make_unique<Fence>(_init_structs, _command_queue));
         }
     }
 
@@ -188,7 +186,7 @@ void DynamicPipeline::push() {
 
         if (_sync_output_with_fences) {
             for (size_t i = 0; i < _fences.size(); i++) {
-                _fences[i] = std::make_unique<Fence>(_command_queue);
+                _fences[i] = std::make_unique<Fence>(_init_structs, _command_queue);
             }
         }
     }

--- a/src/plugins/intel_npu/src/backend/src/zero_dynamic_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_dynamic_pipeline.cpp
@@ -62,7 +62,7 @@ DynamicPipeline::DynamicPipeline(const std::shared_ptr<ZeroInitStructsHolder>& i
 
         _events.reserve(_batch_size);
         for (size_t i = 0; i < _batch_size; i++) {
-            _events.emplace_back(std::make_shared<Event>(_init_structs, _event_pool, static_cast<uint32_t>(i)));
+            _events.emplace_back(std::make_shared<Event>(_event_pool, static_cast<uint32_t>(i)));
         }
     }
     _logger.debug("DynamicPipeline - event pool and command queue setup completed");
@@ -77,7 +77,7 @@ DynamicPipeline::DynamicPipeline(const std::shared_ptr<ZeroInitStructsHolder>& i
     if (_sync_output_with_fences) {
         _fences.reserve(_batch_size);
         for (size_t i = 0; i < _batch_size; i++) {
-            _fences.emplace_back(std::make_unique<Fence>(_init_structs, _command_queue));
+            _fences.emplace_back(std::make_unique<Fence>(_command_queue));
         }
     }
 
@@ -186,7 +186,7 @@ void DynamicPipeline::push() {
 
         if (_sync_output_with_fences) {
             for (size_t i = 0; i < _fences.size(); i++) {
-                _fences[i] = std::make_unique<Fence>(_init_structs, _command_queue);
+                _fences[i] = std::make_unique<Fence>(_command_queue);
             }
         }
     }

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -152,20 +152,18 @@ Pipeline::Pipeline(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                     "In-order execution doesn't work in case synchronization of the inferences is done using events");
 
     if (!_sync_output_with_fences || _run_inferences_sequentially) {
-        _event_pool = std::make_shared<EventPool>(_init_structs->getDevice(),
-                                                  _init_structs->getContext(),
-                                                  _batch_size ? static_cast<uint32_t>(_batch_size) : 1);
+        _event_pool = std::make_shared<EventPool>(_init_structs, _batch_size ? static_cast<uint32_t>(_batch_size) : 1);
 
         _events.reserve(_batch_size);
         for (size_t i = 0; i < _batch_size; i++) {
-            _events.emplace_back(std::make_shared<Event>(_event_pool, static_cast<uint32_t>(i)));
+            _events.emplace_back(std::make_shared<Event>(_init_structs, _event_pool, static_cast<uint32_t>(i)));
         }
     }
 
     if (_sync_output_with_fences) {
         _fences.reserve(_batch_size);
         for (size_t i = 0; i < _batch_size; i++) {
-            _fences.emplace_back(std::make_unique<Fence>(_command_queue));
+            _fences.emplace_back(std::make_unique<Fence>(_init_structs, _command_queue));
         }
     }
 
@@ -292,7 +290,7 @@ void Pipeline::push() {
 
         if (_sync_output_with_fences) {
             for (size_t i = 0; i < _fences.size(); i++) {
-                _fences[i] = std::make_unique<Fence>(_command_queue);
+                _fences[i] = std::make_unique<Fence>(_init_structs, _command_queue);
             }
         }
     }

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -156,14 +156,14 @@ Pipeline::Pipeline(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
 
         _events.reserve(_batch_size);
         for (size_t i = 0; i < _batch_size; i++) {
-            _events.emplace_back(std::make_shared<Event>(_init_structs, _event_pool, static_cast<uint32_t>(i)));
+            _events.emplace_back(std::make_shared<Event>(_event_pool, static_cast<uint32_t>(i)));
         }
     }
 
     if (_sync_output_with_fences) {
         _fences.reserve(_batch_size);
         for (size_t i = 0; i < _batch_size; i++) {
-            _fences.emplace_back(std::make_unique<Fence>(_init_structs, _command_queue));
+            _fences.emplace_back(std::make_unique<Fence>(_command_queue));
         }
     }
 
@@ -290,7 +290,7 @@ void Pipeline::push() {
 
         if (_sync_output_with_fences) {
             for (size_t i = 0; i < _fences.size(); i++) {
-                _fences[i] = std::make_unique<Fence>(_init_structs, _command_queue);
+                _fences[i] = std::make_unique<Fence>(_command_queue);
             }
         }
     }

--- a/src/plugins/intel_npu/src/backend/src/zero_profiling.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_profiling.cpp
@@ -41,7 +41,7 @@ bool ProfilingPool::create() {
 }
 
 ProfilingPool::~ProfilingPool() {
-    if (_handle) {
+    if (_handle && _init_structs->getContext()) {
         _init_structs->getProfilingDdiTable().pfnProfilingPoolDestroy(_handle);
     }
 }
@@ -61,7 +61,7 @@ LayerStatistics ProfilingQuery::getLayerStatistics() const {
 }
 
 ProfilingQuery::~ProfilingQuery() {
-    if (_handle) {
+    if (_handle && _init_structs->getContext()) {
         _init_structs->getProfilingDdiTable().pfnProfilingQueryDestroy(_handle);
     }
 }
@@ -238,14 +238,18 @@ int64_t NpuInferProfiling::convertCCtoUS(int64_t val_cc) const {
 
 NpuInferProfiling::~NpuInferProfiling() {
     /// deallocate npu_ts_infer_start and npu_ts_infer_end, allocated externally by ze driver
+    auto context = _init_structs->getContext();
+    if (context == nullptr) {
+        return;
+    }
     if (npu_ts_infer_start != nullptr) {
-        auto ze_ret = zeMemFree(_init_structs->getContext(), npu_ts_infer_start);
+        auto ze_ret = zeMemFree(context, npu_ts_infer_start);
         if (ZE_RESULT_SUCCESS != ze_ret) {
             _logger.error("zeMemFree on npu_ts_infer_start failed %#X", uint64_t(ze_ret));
         }
     }
     if (npu_ts_infer_end != nullptr) {
-        auto ze_ret = zeMemFree(_init_structs->getContext(), npu_ts_infer_end);
+        auto ze_ret = zeMemFree(context, npu_ts_infer_end);
         if (ZE_RESULT_SUCCESS != ze_ret) {
             _logger.error("zeMemFree on npu_ts_infer_end failed %#X", uint64_t(ze_ret));
         }

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -524,7 +524,7 @@ void WeightlessGraph::create_pipeline(const size_t initIndex,
     }
 
     _initsCommandLists.at(initIndex) = std::make_unique<CommandList>(_zeroInitStruct);
-    _initsFences.at(initIndex) = std::make_unique<Fence>(_initsCommandQueue);
+    _initsFences.at(initIndex) = std::make_unique<Fence>(_zeroInitStruct, _initsCommandQueue);
 
     size_t io_index = 0;
     for (const auto& desc : _initsMetadata.at(initIndex).inputs) {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -524,7 +524,7 @@ void WeightlessGraph::create_pipeline(const size_t initIndex,
     }
 
     _initsCommandLists.at(initIndex) = std::make_unique<CommandList>(_zeroInitStruct);
-    _initsFences.at(initIndex) = std::make_unique<Fence>(_zeroInitStruct, _initsCommandQueue);
+    _initsFences.at(initIndex) = std::make_unique<Fence>(_initsCommandQueue);
 
     size_t io_index = 0;
     for (const auto& desc : _initsMetadata.at(initIndex).inputs) {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -155,13 +155,15 @@ ZeGraphExtWrappers::~ZeGraphExtWrappers() {
 void ZeGraphExtWrappers::destroyGraph(GraphDescriptor& graphDescriptor) {
     if (_zeroInitStruct == nullptr || _zeroInitStruct->getContext() == nullptr || graphDescriptor._handle == nullptr) {
         _logger.warning("Context or graph is null while trying to destroy graph. Graph might be already destroyed.");
+        graphDescriptor._handle = nullptr;
         return;
     }
 
     _logger.debug("destroyGraph - perform pfnDestroy");
     auto result = _zeroInitStruct->getGraphDdiTable().pfnDestroy(graphDescriptor._handle);
-    graphDescriptor._handle = nullptr;
-    if (ZE_RESULT_SUCCESS != result) {
+    if (ZE_RESULT_SUCCESS == result) {
+        graphDescriptor._handle = nullptr;
+    } else {
         _logger.error("failed to destroy graph handle. L0 pfnDestroy result: %s, code %#X",
                       ze_result_to_string(result).c_str(),
                       uint64_t(result));

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -153,17 +153,18 @@ ZeGraphExtWrappers::~ZeGraphExtWrappers() {
 }
 
 void ZeGraphExtWrappers::destroyGraph(GraphDescriptor& graphDescriptor) {
-    if (graphDescriptor._handle) {
-        _logger.debug("destroyGraph - perform pfnDestroy");
+    if (_zeroInitStruct == nullptr || _zeroInitStruct->getContext() == nullptr || graphDescriptor._handle == nullptr) {
+        _logger.warning("Context or graph is null while trying to destroy graph. Graph might be already destroyed.");
+        return;
+    }
 
-        auto result = _zeroInitStruct->getGraphDdiTable().pfnDestroy(graphDescriptor._handle);
-        if (ZE_RESULT_SUCCESS != result) {
-            _logger.error("failed to destroy graph handle. L0 pfnDestroy result: %s, code %#X",
-                          ze_result_to_string(result).c_str(),
-                          uint64_t(result));
-        } else {
-            graphDescriptor._handle = nullptr;
-        }
+    _logger.debug("destroyGraph - perform pfnDestroy");
+    auto result = _zeroInitStruct->getGraphDdiTable().pfnDestroy(graphDescriptor._handle);
+    graphDescriptor._handle = nullptr;
+    if (ZE_RESULT_SUCCESS != result) {
+        _logger.error("failed to destroy graph handle. L0 pfnDestroy result: %s, code %#X",
+                      ze_result_to_string(result).c_str(),
+                      uint64_t(result));
     }
 }
 
@@ -281,7 +282,7 @@ void ZeGraphExtWrappers::initializeGraphThroughCommandList(ze_graph_handle_t gra
     const auto graphCommandQueue = ZeroCmdQueuePool::getInstance().getCommandQueue(_zeroInitStruct, CommandQueueDesc{});
 
     _logger.debug("initializeGraphThroughCommandList - create fence");
-    Fence fence(graphCommandQueue);
+    Fence fence(_zeroInitStruct, graphCommandQueue);
 
     _logger.debug("initializeGraphThroughCommandList - performing appendGraphInitialize");
     graphCommandList.appendGraphInitialize(graphHandle);

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -284,7 +284,7 @@ void ZeGraphExtWrappers::initializeGraphThroughCommandList(ze_graph_handle_t gra
     const auto graphCommandQueue = ZeroCmdQueuePool::getInstance().getCommandQueue(_zeroInitStruct, CommandQueueDesc{});
 
     _logger.debug("initializeGraphThroughCommandList - create fence");
-    Fence fence(_zeroInitStruct, graphCommandQueue);
+    Fence fence(graphCommandQueue);
 
     _logger.debug("initializeGraphThroughCommandList - performing appendGraphInitialize");
     graphCommandList.appendGraphInitialize(graphHandle);

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -6,6 +6,7 @@
 
 #include <ze_intel_npu_uuid.h>
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -41,7 +42,7 @@ public:
         return _device_handle;
     }
     inline ze_context_handle_t getContext() const {
-        return _context;
+        return _context.load();
     }
     inline ze_graph_dditable_ext_curr_t& getGraphDdiTable() const {
         return *_graph_dditable_ext_decorator;
@@ -109,7 +110,7 @@ private:
 
     Logger _log;
 
-    ze_context_handle_t _context = nullptr;
+    std::atomic<ze_context_handle_t> _context{nullptr};
     ze_driver_handle_t _driver_handle = nullptr;
     ze_device_handle_t _device_handle = nullptr;
 

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -97,6 +97,8 @@ private:
     void initCompilerPropertiesLocked();
     void getExtensionFunctionAddress(const std::string& name, const uint32_t version, void** function_address);
     void setContextProperties();
+    void destroyContextLocked();
+    static void destroyContextForInstance(std::shared_ptr<ZeroInitStructsHolder>& instance);
 
     inline ZeroMemPool& getZeroMemPool() {
         return _zero_mem_pool;

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -118,7 +118,8 @@ private:
 class Fence {
 public:
     Fence() = delete;
-    Fence(const std::shared_ptr<CommandQueue>& command_queue);
+    Fence(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
+          const std::shared_ptr<CommandQueue>& command_queue);
     Fence(const Fence&) = delete;
     Fence(Fence&&) = delete;
     Fence& operator=(const Fence&) = delete;
@@ -132,6 +133,7 @@ public:
     }
 
 private:
+    std::shared_ptr<ZeroInitStructsHolder> _init_structs;
     std::shared_ptr<CommandQueue> _command_queue;
 
     ze_fence_handle_t _handle = nullptr;
@@ -162,16 +164,15 @@ private:
     std::shared_ptr<ZeroInitStructsHolder> _init_structs;
 
     CommandQueueDesc _desc;
+    ze_command_queue_handle_t _handle = nullptr;
 
     Logger _log;
-
-    ze_command_queue_handle_t _handle = nullptr;
 };
 
 class EventPool {
 public:
     EventPool() = delete;
-    EventPool(ze_device_handle_t device_handle, const ze_context_handle_t& context, uint32_t event_count);
+    EventPool(const std::shared_ptr<ZeroInitStructsHolder>& init_structs, uint32_t event_count);
     EventPool(const EventPool&) = delete;
     EventPool(EventPool&&) = delete;
     EventPool& operator=(const EventPool&) = delete;
@@ -182,6 +183,8 @@ public:
     }
 
 private:
+    std::shared_ptr<ZeroInitStructsHolder> _init_structs;
+
     ze_event_pool_handle_t _handle = nullptr;
 
     Logger _log;
@@ -190,7 +193,9 @@ private:
 class Event {
 public:
     Event() = delete;
-    Event(const std::shared_ptr<EventPool>& event_pool, uint32_t event_index);
+    Event(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
+          const std::shared_ptr<EventPool>& event_pool,
+          uint32_t event_index);
     Event(const Event&) = delete;
     Event(Event&&) = delete;
     Event& operator=(const Event&) = delete;
@@ -204,6 +209,8 @@ public:
     ~Event();
 
 private:
+    std::shared_ptr<ZeroInitStructsHolder> _init_structs;
+
     std::shared_ptr<EventPool> _event_pool;
     ze_event_handle_t _handle = nullptr;
 

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -118,8 +118,7 @@ private:
 class Fence {
 public:
     Fence() = delete;
-    Fence(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
-          const std::shared_ptr<CommandQueue>& command_queue);
+    Fence(const std::shared_ptr<CommandQueue>& command_queue);
     Fence(const Fence&) = delete;
     Fence(Fence&&) = delete;
     Fence& operator=(const Fence&) = delete;
@@ -133,7 +132,6 @@ public:
     }
 
 private:
-    std::shared_ptr<ZeroInitStructsHolder> _init_structs;
     std::shared_ptr<CommandQueue> _command_queue;
 
     ze_fence_handle_t _handle = nullptr;
@@ -159,6 +157,9 @@ public:
     inline CommandQueueDesc desc() const {
         return _desc;
     }
+    inline ze_context_handle_t getZeroContext() const {
+        return _init_structs->getContext();
+    }
 
 private:
     std::shared_ptr<ZeroInitStructsHolder> _init_structs;
@@ -181,6 +182,9 @@ public:
     inline ze_event_pool_handle_t handle() const {
         return _handle;
     }
+    inline ze_context_handle_t getZeroContext() const {
+        return _init_structs->getContext();
+    }
 
 private:
     std::shared_ptr<ZeroInitStructsHolder> _init_structs;
@@ -193,9 +197,7 @@ private:
 class Event {
 public:
     Event() = delete;
-    Event(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
-          const std::shared_ptr<EventPool>& event_pool,
-          uint32_t event_index);
+    Event(const std::shared_ptr<EventPool>& event_pool, uint32_t event_index);
     Event(const Event&) = delete;
     Event(Event&&) = delete;
     Event& operator=(const Event&) = delete;
@@ -209,8 +211,6 @@ public:
     ~Event();
 
 private:
-    std::shared_ptr<ZeroInitStructsHolder> _init_structs;
-
     std::shared_ptr<EventPool> _event_pool;
     ze_event_handle_t _handle = nullptr;
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -369,7 +369,9 @@ ZeroInitStructsHolder::ZeroInitStructsHolder()
 
     // Create context - share between the compiler and the backend
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
-    THROW_ON_FAIL_FOR_LEVELZERO("zeContextCreate", zeContextCreate(_driver_handle, &context_desc, &_context));
+    ze_context_handle_t ctx = nullptr;
+    THROW_ON_FAIL_FOR_LEVELZERO("zeContextCreate", zeContextCreate(_driver_handle, &context_desc, &ctx));
+    _context.store(ctx);
     _log.debug("ZeroInitStructsHolder initialize complete");
 
     // Discover if standard allocation is supported
@@ -496,7 +498,7 @@ void ZeroInitStructsHolder::setContextProperties() {
     ze_context_properties_npu_ext_t context_properties_npu_ext = {ZE_STRUCTURE_TYPE_CONTEXT_PROPERTIES_NPU_EXT,
                                                                   nullptr,
                                                                   _context_options};
-    _context_npu_dditable_ext_decorator->pfnSetProperties(_context, &context_properties_npu_ext);
+    _context_npu_dditable_ext_decorator->pfnSetProperties(_context.load(), &context_properties_npu_ext);
 }
 
 void ZeroInitStructsHolder::clearContextOptions(const uint32_t options) {
@@ -512,13 +514,13 @@ void ZeroInitStructsHolder::setContextOptions(const uint32_t options) {
 }
 
 void ZeroInitStructsHolder::destroyContextLocked() {
-    if (!_context) {
+    if (!_context.load()) {
         return;
     }
 
     _log.debug("ZeroInitStructsHolder - performing zeContextDestroy");
-    auto result = zeContextDestroy(_context);
-    _context = nullptr;
+    auto result = zeContextDestroy(_context.load());
+    _context.store(nullptr);
     if (result != ZE_RESULT_SUCCESS) {
         if (result == ZE_RESULT_ERROR_UNINITIALIZED) {
             _log.warning("zeContextDestroy failed to destroy the context; Level zero context was already destroyed");

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -418,10 +418,21 @@ const std::shared_ptr<ZeroInitStructsHolder> ZeroInitStructsHolder::getInstance(
 
     std::lock_guard<std::mutex> lock(mutex);
     auto instance = weak_instance.lock();
+
+    if (instance) {
+        // Check if device is still valid
+        auto res = zeDeviceGetStatus(instance->getDevice());
+        if (res == ZE_RESULT_ERROR_DEVICE_LOST) {
+            weak_instance.reset();
+            instance.reset();
+        }
+    }
+
     if (!instance) {
         instance = std::make_shared<ZeroInitStructsHolder>();
         weak_instance = instance;
     }
+
     return instance;
 }
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -462,8 +462,9 @@ void ZeroInitStructsHolder::initCompilerPropertiesLocked() {
     // Keep optional disengaged unless driver query succeeds.
     ze_device_graph_properties_t compiler_properties = {};
     compiler_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
-    auto result = _graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(_device_handle, &compiler_properties);
-    THROW_ON_FAIL_FOR_LEVELZERO("pfnDeviceGetGraphProperties", result);
+    THROW_ON_FAIL_FOR_LEVELZERO(
+        "pfnDeviceGetGraphProperties",
+        _graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(_device_handle, &compiler_properties));
 
     _compiler_properties = compiler_properties;
 }
@@ -498,7 +499,9 @@ void ZeroInitStructsHolder::setContextProperties() {
     ze_context_properties_npu_ext_t context_properties_npu_ext = {ZE_STRUCTURE_TYPE_CONTEXT_PROPERTIES_NPU_EXT,
                                                                   nullptr,
                                                                   _context_options};
-    _context_npu_dditable_ext_decorator->pfnSetProperties(_context.load(), &context_properties_npu_ext);
+    THROW_ON_FAIL_FOR_LEVELZERO(
+        "pfnSetProperties",
+        _context_npu_dditable_ext_decorator->pfnSetProperties(_context.load(), &context_properties_npu_ext));
 }
 
 void ZeroInitStructsHolder::clearContextOptions(const uint32_t options) {
@@ -520,13 +523,14 @@ void ZeroInitStructsHolder::destroyContextLocked() {
 
     _log.debug("ZeroInitStructsHolder - performing zeContextDestroy");
     auto result = zeContextDestroy(_context.load());
-    _context.store(nullptr);
-    if (result != ZE_RESULT_SUCCESS) {
-        if (result == ZE_RESULT_ERROR_UNINITIALIZED) {
-            _log.warning("zeContextDestroy failed to destroy the context; Level zero context was already destroyed");
-        } else {
-            _log.error("zeContextDestroy failed %#X", uint64_t(result));
-        }
+    if (result == ZE_RESULT_SUCCESS) {
+        _context.store(nullptr);
+        _log.debug("ZeroInitStructsHolder - zeContextDestroy succeeded");
+    } else if (result == ZE_RESULT_ERROR_UNINITIALIZED) {
+        _context.store(nullptr);
+        _log.warning("zeContextDestroy failed to destroy the context; Level zero context was already destroyed");
+    } else {
+        _log.error("zeContextDestroy failed %#X", uint64_t(result));
     }
 }
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -423,6 +423,7 @@ const std::shared_ptr<ZeroInitStructsHolder> ZeroInitStructsHolder::getInstance(
         // Check if device is still valid
         auto res = zeDeviceGetStatus(instance->getDevice());
         if (res == ZE_RESULT_ERROR_DEVICE_LOST) {
+            destroyContextForInstance(instance);
             weak_instance.reset();
             instance.reset();
         }
@@ -434,6 +435,15 @@ const std::shared_ptr<ZeroInitStructsHolder> ZeroInitStructsHolder::getInstance(
     }
 
     return instance;
+}
+
+void ZeroInitStructsHolder::destroyContextForInstance(std::shared_ptr<ZeroInitStructsHolder>& instance) {
+    if (!instance) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(instance->_mutex);
+    instance->destroyContextLocked();
 }
 
 ze_device_graph_properties_t ZeroInitStructsHolder::getCompilerProperties() {
@@ -501,20 +511,26 @@ void ZeroInitStructsHolder::setContextOptions(const uint32_t options) {
     setContextProperties();
 }
 
-ZeroInitStructsHolder::~ZeroInitStructsHolder() {
-    if (_context) {
-        _log.debug("ZeroInitStructsHolder - performing zeContextDestroy");
-        auto result = zeContextDestroy(_context);
-        _context = nullptr;
-        if (result != ZE_RESULT_SUCCESS) {
-            if (result == ZE_RESULT_ERROR_UNINITIALIZED) {
-                _log.warning(
-                    "zeContextDestroy failed to destroy the context; Level zero context was already destroyed");
-            } else {
-                _log.error("zeContextDestroy failed %#X", uint64_t(result));
-            }
+void ZeroInitStructsHolder::destroyContextLocked() {
+    if (!_context) {
+        return;
+    }
+
+    _log.debug("ZeroInitStructsHolder - performing zeContextDestroy");
+    auto result = zeContextDestroy(_context);
+    _context = nullptr;
+    if (result != ZE_RESULT_SUCCESS) {
+        if (result == ZE_RESULT_ERROR_UNINITIALIZED) {
+            _log.warning("zeContextDestroy failed to destroy the context; Level zero context was already destroyed");
+        } else {
+            _log.error("zeContextDestroy failed %#X", uint64_t(result));
         }
     }
+}
+
+ZeroInitStructsHolder::~ZeroInitStructsHolder() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    destroyContextLocked();
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
@@ -111,12 +111,13 @@ uint64_t ZeroMem::id() {
 }
 
 ZeroMem::~ZeroMem() {
-    if (!_init_structs->getContext()) {
+    auto ze_context = _init_structs->getContext();
+    if (ze_context == nullptr) {
         _logger.warning("Context is null while trying to free memory with id %lu. Memory might be already freed.", _id);
         return;
     }
 
-    auto result = zeMemFree(_init_structs->getContext(), _ptr);
+    auto result = zeMemFree(ze_context, _ptr);
     if (ZE_RESULT_SUCCESS != result) {
         _logger.error("L0 zeMemFree result: %s, code %#X - %s",
                       ze_result_to_string(result).c_str(),

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
@@ -111,6 +111,11 @@ uint64_t ZeroMem::id() {
 }
 
 ZeroMem::~ZeroMem() {
+    if (!_init_structs->getContext()) {
+        _logger.warning("Context is null while trying to free memory with id %lu. Memory might be already freed.", _id);
+        return;
+    }
+
     auto result = zeMemFree(_init_structs->getContext(), _ptr);
     if (ZE_RESULT_SUCCESS != result) {
         _logger.error("L0 zeMemFree result: %s, code %#X - %s",

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
@@ -113,7 +113,8 @@ uint64_t ZeroMem::id() {
 ZeroMem::~ZeroMem() {
     auto ze_context = _init_structs->getContext();
     if (ze_context == nullptr) {
-        _logger.warning("Context is null while trying to free memory with id %lu. Memory might be already freed.", _id);
+        _logger.warning("Context is null while trying to free memory with id %llu. Memory might be already freed.",
+                        _id);
         return;
     }
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -91,12 +91,14 @@ EventPool::EventPool(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
 EventPool::~EventPool() {
     if (_init_structs->getContext() == nullptr || _handle == nullptr) {
         _log.warning("Context or EventPool handle is null during destruction. EventPool might be already destroyed.");
+        _handle = nullptr;
         return;
     }
 
     auto result = zeEventPoolDestroy(_handle);
-    _handle = nullptr;
-    if (ZE_RESULT_SUCCESS != result) {
+    if (ZE_RESULT_SUCCESS == result) {
+        _handle = nullptr;
+    } else {
         _log.error("zeEventPoolDestroy failed %#X", uint64_t(result));
     }
 }
@@ -135,8 +137,9 @@ Event::~Event() {
     }
 
     auto result = zeEventDestroy(_handle);
-    _handle = nullptr;
-    if (ZE_RESULT_SUCCESS != result) {
+    if (ZE_RESULT_SUCCESS == result) {
+        _handle = nullptr;
+    } else {
         _log.error("zeEventDestroy failed %#X", uint64_t(result));
     }
 }
@@ -221,12 +224,14 @@ CommandList::~CommandList() {
     if (_init_structs->getContext() == nullptr || _handle == nullptr) {
         _log.warning(
             "Context or CommandList handle is null during destruction. CommandList might be already destroyed.");
+        _handle = nullptr;
         return;
     }
 
     auto result = zeCommandListDestroy(_handle);
-    _handle = nullptr;
-    if (ZE_RESULT_SUCCESS != result) {
+    if (ZE_RESULT_SUCCESS == result) {
+        _handle = nullptr;
+    } else {
         _log.error("zeCommandListDestroy failed %#X", uint64_t(result));
     }
 }
@@ -352,12 +357,14 @@ CommandQueue::~CommandQueue() {
     if (_init_structs->getContext() == nullptr || _handle == nullptr) {
         _log.warning(
             "Context or CommandQueue handle is null during destruction. CommandQueue might be already destroyed.");
+        _handle = nullptr;
         return;
     }
 
     auto result = zeCommandQueueDestroy(_handle);
-    _handle = nullptr;
-    if (ZE_RESULT_SUCCESS != result) {
+    if (ZE_RESULT_SUCCESS == result) {
+        _handle = nullptr;
+    } else {
         _log.error("zeCommandQueueDestroy failed %#X", uint64_t(result));
     }
 }
@@ -379,12 +386,14 @@ void Fence::hostSynchronize() const {
 Fence::~Fence() {
     if (_init_structs->getContext() == nullptr || _handle == nullptr) {
         _log.warning("Context or Fence handle is null during destruction. Fence might be already destroyed.");
+        _handle = nullptr;
         return;
     }
 
     auto result = zeFenceDestroy(_handle);
-    _handle = nullptr;
-    if (ZE_RESULT_SUCCESS != result) {
+    if (ZE_RESULT_SUCCESS == result) {
+        _handle = nullptr;
+    } else {
         _log.error("zeFenceDestroy failed %#X", uint64_t(result));
     }
 }

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -76,26 +76,36 @@ void CommandQueueDesc::update_key() {
     _key = hash;
 }
 
-EventPool::EventPool(ze_device_handle_t device_handle, const ze_context_handle_t& context, uint32_t event_count)
-    : _log("EventPool", Logger::global().level()) {
+EventPool::EventPool(const std::shared_ptr<ZeroInitStructsHolder>& init_structs, uint32_t event_count)
+    : _init_structs(init_structs),
+      _log("EventPool", Logger::global().level()) {
     ze_event_pool_desc_t event_pool_desc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC,
                                             nullptr,
                                             ZE_EVENT_POOL_FLAG_HOST_VISIBLE,
                                             event_count};
-    THROW_ON_FAIL_FOR_LEVELZERO("zeEventPoolCreate",
-                                zeEventPoolCreate(context, &event_pool_desc, 1, &device_handle, &_handle));
+    auto device_handle = _init_structs->getDevice();
+    THROW_ON_FAIL_FOR_LEVELZERO(
+        "zeEventPoolCreate",
+        zeEventPoolCreate(_init_structs->getContext(), &event_pool_desc, 1, &device_handle, &_handle));
 }
 EventPool::~EventPool() {
+    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+        _log.warning("Context or EventPool handle is null during destruction. EventPool might be already destroyed.");
+        return;
+    }
+
     auto result = zeEventPoolDestroy(_handle);
+    _handle = nullptr;
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeEventPoolDestroy failed %#X", uint64_t(result));
     }
-
-    _handle = nullptr;
 }
 
-Event::Event(const std::shared_ptr<EventPool>& event_pool, uint32_t event_index)
-    : _event_pool(event_pool),
+Event::Event(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
+             const std::shared_ptr<EventPool>& event_pool,
+             uint32_t event_index)
+    : _init_structs(init_structs),
+      _event_pool(event_pool),
       _log("Event", Logger::global().level()) {
     ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, event_index, 0, 0};
     THROW_ON_FAIL_FOR_LEVELZERO("zeEventCreate", zeEventCreate(_event_pool->handle(), &event_desc, &_handle));
@@ -119,12 +129,16 @@ void Event::reset() const {
     THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostReset", zeEventHostReset(_handle));
 }
 Event::~Event() {
+    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+        _log.warning("Context or Event handle is null during destruction. Event might be already destroyed.");
+        return;
+    }
+
     auto result = zeEventDestroy(_handle);
+    _handle = nullptr;
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeEventDestroy failed %#X", uint64_t(result));
     }
-
-    _handle = nullptr;
 }
 
 CommandList::CommandList(const std::shared_ptr<ZeroInitStructsHolder>& init_structs)
@@ -204,12 +218,17 @@ void CommandList::close() const {
     THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListClose", zeCommandListClose(_handle));
 }
 CommandList::~CommandList() {
+    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+        _log.warning(
+            "Context or CommandList handle is null during destruction. CommandList might be already destroyed.");
+        return;
+    }
+
     auto result = zeCommandListDestroy(_handle);
+    _handle = nullptr;
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeCommandListDestroy failed %#X", uint64_t(result));
     }
-
-    _handle = nullptr;
 }
 void CommandList::updateMutableCommandList(uint32_t index, const void* data) const {
     ze_mutable_graph_argument_exp_desc_t desc = {};
@@ -330,16 +349,23 @@ void CommandQueue::executeCommandList(CommandList& command_list, Fence& fence) c
                                 zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, fence.handle()));
 }
 CommandQueue::~CommandQueue() {
+    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+        _log.warning(
+            "Context or CommandQueue handle is null during destruction. CommandQueue might be already destroyed.");
+        return;
+    }
+
     auto result = zeCommandQueueDestroy(_handle);
+    _handle = nullptr;
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeCommandQueueDestroy failed %#X", uint64_t(result));
     }
-
-    _handle = nullptr;
 }
 
-Fence::Fence(const std::shared_ptr<CommandQueue>& command_queue)
-    : _command_queue(command_queue),
+Fence::Fence(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
+             const std::shared_ptr<CommandQueue>& command_queue)
+    : _init_structs(init_structs),
+      _command_queue(command_queue),
       _log("Fence", Logger::global().level()) {
     ze_fence_desc_t fence_desc = {ZE_STRUCTURE_TYPE_FENCE_DESC, nullptr, 0};
     THROW_ON_FAIL_FOR_LEVELZERO("zeFenceCreate", zeFenceCreate(_command_queue->handle(), &fence_desc, &_handle));
@@ -351,12 +377,16 @@ void Fence::hostSynchronize() const {
     THROW_ON_FAIL_FOR_LEVELZERO("zeFenceHostSynchronize", zeFenceHostSynchronize(_handle, UINT64_MAX));
 }
 Fence::~Fence() {
+    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+        _log.warning("Context or Fence handle is null during destruction. Fence might be already destroyed.");
+        return;
+    }
+
     auto result = zeFenceDestroy(_handle);
+    _handle = nullptr;
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeFenceDestroy failed %#X", uint64_t(result));
     }
-
-    _handle = nullptr;
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -89,7 +89,7 @@ EventPool::EventPool(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
         zeEventPoolCreate(_init_structs->getContext(), &event_pool_desc, 1, &device_handle, &_handle));
 }
 EventPool::~EventPool() {
-    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+    if (_init_structs->getContext() == nullptr || _handle == nullptr) {
         _log.warning("Context or EventPool handle is null during destruction. EventPool might be already destroyed.");
         return;
     }
@@ -129,7 +129,7 @@ void Event::reset() const {
     THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostReset", zeEventHostReset(_handle));
 }
 Event::~Event() {
-    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+    if (_init_structs->getContext() == nullptr || _handle == nullptr) {
         _log.warning("Context or Event handle is null during destruction. Event might be already destroyed.");
         return;
     }
@@ -218,7 +218,7 @@ void CommandList::close() const {
     THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListClose", zeCommandListClose(_handle));
 }
 CommandList::~CommandList() {
-    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+    if (_init_structs->getContext() == nullptr || _handle == nullptr) {
         _log.warning(
             "Context or CommandList handle is null during destruction. CommandList might be already destroyed.");
         return;
@@ -349,7 +349,7 @@ void CommandQueue::executeCommandList(CommandList& command_list, Fence& fence) c
                                 zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, fence.handle()));
 }
 CommandQueue::~CommandQueue() {
-    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+    if (_init_structs->getContext() == nullptr || _handle == nullptr) {
         _log.warning(
             "Context or CommandQueue handle is null during destruction. CommandQueue might be already destroyed.");
         return;
@@ -377,7 +377,7 @@ void Fence::hostSynchronize() const {
     THROW_ON_FAIL_FOR_LEVELZERO("zeFenceHostSynchronize", zeFenceHostSynchronize(_handle, UINT64_MAX));
 }
 Fence::~Fence() {
-    if (_init_structs == nullptr || _init_structs->getContext() == nullptr || _handle == nullptr) {
+    if (_init_structs->getContext() == nullptr || _handle == nullptr) {
         _log.warning("Context or Fence handle is null during destruction. Fence might be already destroyed.");
         return;
     }

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -103,11 +103,8 @@ EventPool::~EventPool() {
     }
 }
 
-Event::Event(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
-             const std::shared_ptr<EventPool>& event_pool,
-             uint32_t event_index)
-    : _init_structs(init_structs),
-      _event_pool(event_pool),
+Event::Event(const std::shared_ptr<EventPool>& event_pool, uint32_t event_index)
+    : _event_pool(event_pool),
       _log("Event", Logger::global().level()) {
     ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, event_index, 0, 0};
     THROW_ON_FAIL_FOR_LEVELZERO("zeEventCreate", zeEventCreate(_event_pool->handle(), &event_desc, &_handle));
@@ -131,7 +128,7 @@ void Event::reset() const {
     THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostReset", zeEventHostReset(_handle));
 }
 Event::~Event() {
-    if (_init_structs->getContext() == nullptr || _handle == nullptr) {
+    if (_event_pool->getZeroContext() == nullptr || _handle == nullptr) {
         _log.warning("Context or Event handle is null during destruction. Event might be already destroyed.");
         return;
     }
@@ -369,10 +366,8 @@ CommandQueue::~CommandQueue() {
     }
 }
 
-Fence::Fence(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
-             const std::shared_ptr<CommandQueue>& command_queue)
-    : _init_structs(init_structs),
-      _command_queue(command_queue),
+Fence::Fence(const std::shared_ptr<CommandQueue>& command_queue)
+    : _command_queue(command_queue),
       _log("Fence", Logger::global().level()) {
     ze_fence_desc_t fence_desc = {ZE_STRUCTURE_TYPE_FENCE_DESC, nullptr, 0};
     THROW_ON_FAIL_FOR_LEVELZERO("zeFenceCreate", zeFenceCreate(_command_queue->handle(), &fence_desc, &_handle));
@@ -384,7 +379,7 @@ void Fence::hostSynchronize() const {
     THROW_ON_FAIL_FOR_LEVELZERO("zeFenceHostSynchronize", zeFenceHostSynchronize(_handle, UINT64_MAX));
 }
 Fence::~Fence() {
-    if (_init_structs->getContext() == nullptr || _handle == nullptr) {
+    if (_command_queue->getZeroContext() == nullptr || _handle == nullptr) {
         _log.warning("Context or Fence handle is null during destruction. Fence might be already destroyed.");
         _handle = nullptr;
         return;

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.hpp
@@ -10,6 +10,7 @@
 
 #include "behavior/compiled_model/properties.hpp"
 #include "common/npu_test_env_cfg.hpp"
+#include "common/utils.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 #include "openvino/core/log.hpp"
@@ -18,20 +19,6 @@
 using namespace ov::test::behavior;
 
 namespace {
-
-class LogCallbackGuard {
-public:
-    explicit LogCallbackGuard(const std::function<void(std::string_view)>& callback) {
-        ov::util::set_log_callback(callback);
-    }
-
-    ~LogCallbackGuard() {
-        ov::util::reset_log_callback();
-    }
-
-    LogCallbackGuard(const LogCallbackGuard&) = delete;
-    LogCallbackGuard& operator=(const LogCallbackGuard&) = delete;
-};
 
 bool has_non_negative_numeric_suffix(const std::string& value) {
     const auto dot_pos = value.find('.');
@@ -368,7 +355,7 @@ TEST_P(CheckCompilerTypeProperty, CheckLogAfterSettingExtraConfigToGetProperty) 
 
     auto compiler_type = ov::intel_npu::CompilerType::PLUGIN;
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         compiler_type = core.get_property(
             deviceName,
             ov::intel_npu::compiler_type,
@@ -397,7 +384,7 @@ TEST_P(CheckCompilerTypeProperty, CheckLogAfterGettingPropertyWithExtraConfig) {
     };
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(core.get_property(deviceName,
                                              ov::intel_npu::defer_weights_load,
                                              {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}));
@@ -408,7 +395,7 @@ TEST_P(CheckCompilerTypeProperty, CheckLogAfterGettingPropertyWithExtraConfig) {
     logs.clear();
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(core.get_property(deviceName,
                                              ov::intel_npu::defer_weights_load,
                                              {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
@@ -433,7 +420,7 @@ TEST_P(CheckCompilerTypeProperty, SetRuntimeProperty) {
     };
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(
             core.set_property(deviceName, ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)));
         OV_ASSERT_NO_THROW(core.get_property(deviceName, ov::intel_npu::defer_weights_load));
@@ -444,7 +431,7 @@ TEST_P(CheckCompilerTypeProperty, SetRuntimeProperty) {
     logs.clear();
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(core.set_property(deviceName, ov::intel_npu::qdq_optimization(true)));
     }
 
@@ -466,7 +453,7 @@ TEST_P(CheckCompilerTypeProperty, SetCompilerPropertyForDifferentCompiler) {
     };
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(
             core.set_property(deviceName, ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)));
         OV_ASSERT_NO_THROW(core.get_property(deviceName, ov::intel_npu::defer_weights_load));
@@ -476,7 +463,7 @@ TEST_P(CheckCompilerTypeProperty, SetCompilerPropertyForDifferentCompiler) {
     logs.clear();
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(core.set_property(deviceName, ov::intel_npu::qdq_optimization(true)));
     }
     ASSERT_NE(logs.find("initialize DriverCompilerAdapter start"), std::string::npos);
@@ -484,7 +471,7 @@ TEST_P(CheckCompilerTypeProperty, SetCompilerPropertyForDifferentCompiler) {
     logs.clear();
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(
             core.set_property(deviceName, ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN)));
     }
@@ -494,7 +481,7 @@ TEST_P(CheckCompilerTypeProperty, SetCompilerPropertyForDifferentCompiler) {
     logs.clear();
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(core.set_property(deviceName, ov::intel_npu::qdq_optimization(true)));
     }
     ASSERT_NE(logs.find("initialize PluginCompilerAdapter start"), std::string::npos);
@@ -517,7 +504,7 @@ TEST_P(CheckCompilerTypeProperty, GetCompilerVersion) {
     OV_ASSERT_NO_THROW(
         core.set_property(deviceName, ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)));
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(core.get_property(deviceName, ov::intel_npu::compiler_version));
     }
     ASSERT_NE(logs.find("initialize DriverCompilerAdapter start"), std::string::npos);
@@ -528,7 +515,7 @@ TEST_P(CheckCompilerTypeProperty, GetCompilerVersion) {
     OV_ASSERT_NO_THROW(
         core.set_property(deviceName, ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN)));
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(core.get_property(deviceName, ov::intel_npu::compiler_version));
     }
     ASSERT_EQ(logs.find("initialize DriverCompilerAdapter start"), std::string::npos);
@@ -537,7 +524,7 @@ TEST_P(CheckCompilerTypeProperty, GetCompilerVersion) {
     logs.clear();
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(core.get_property(deviceName,
                                              ov::intel_npu::compiler_version,
                                              {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}));
@@ -617,7 +604,7 @@ TEST_P(CheckCompilerPropertyWhenImporting, ExpectedNoThrowFromImportWithCompiler
     };
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         core_import.set_property(deviceName, ov::log::level(ov::log::Level::INFO));
         OV_ASSERT_NO_THROW(
             core_import.import_model(export_stream, deviceName, {{ov::intel_npu::qdq_optimization(true)}}));
@@ -701,7 +688,7 @@ TEST_P(CheckCompilerPropertyWhenImporting, CheckImportWithCompilerProperty) {
     };
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(
             core_for_importing.import_model(export_stream,
                                             deviceName,
@@ -741,7 +728,7 @@ TEST_P(CheckCompilerPropertyWhenImporting, CheckImportWithCompilerPropertyAfterC
     };
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
+        ov::test::utils::LogCallbackGuard log_callback_guard(log_cb);
         OV_ASSERT_NO_THROW(core.import_model(export_stream,
                                              deviceName,
                                              {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
@@ -17,6 +17,7 @@
 #include "behavior/ov_infer_request/inference.hpp"
 #include "common/npu_test_env_cfg.hpp"
 #include "common/utils.hpp"
+#include "common/zero_init_mock.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 #include "intel_npu/utils/zero/zero_init.hpp"
@@ -36,22 +37,6 @@ using CompilationParams = std::tuple<std::string,  // Device name
 
 using ::testing::AllOf;
 using ::testing::HasSubstr;
-
-namespace {
-class LogCallbackGuard {
-public:
-    explicit LogCallbackGuard(const std::function<void(std::string_view)>& callback) {
-        ov::util::set_log_callback(callback);
-    }
-
-    ~LogCallbackGuard() {
-        ov::util::reset_log_callback();
-    }
-
-    LogCallbackGuard(const LogCallbackGuard&) = delete;
-    LogCallbackGuard& operator=(const LogCallbackGuard&) = delete;
-};
-}  // namespace
 
 namespace ov {
 namespace test {
@@ -2323,7 +2308,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRawMemoryIsDestroyedAndReallocatedAft
     internal_core.set_property(target_device, ov::log::level(ov::log::Level::DEBUG));
     {
         // don't flood console with messages from model compilation
-        LogCallbackGuard log_callback_guard(log_cb);
+        utils::LogCallbackGuard log_callback_guard(log_cb);
         ov::CompiledModel compiled_model = internal_core.compile_model(model, target_device, configuration);
         inference_request = compiled_model.create_infer_request();
     }
@@ -2337,7 +2322,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRawMemoryIsDestroyedAndReallocatedAft
         }
 
         {
-            LogCallbackGuard log_callback_guard(log_cb);
+            utils::LogCallbackGuard log_callback_guard(log_cb);
             inference_request.set_input_tensor(ov::Tensor{ov::element::f32, shape, input_data});
             inference_request.set_output_tensor(ov::Tensor{ov::element::f32, shape, output_data});
             inference_request.infer();
@@ -2387,7 +2372,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameRawMemoryMultipleTimes
     internal_core.set_property(target_device, ov::log::level(ov::log::Level::DEBUG));
     {
         // don't flood console with messages from model compilation
-        LogCallbackGuard log_callback_guard(log_cb);
+        utils::LogCallbackGuard log_callback_guard(log_cb);
         ov::CompiledModel compiled_model = internal_core.compile_model(model, target_device, configuration);
         inference_request = compiled_model.create_infer_request();
         inference_request.set_input_tensor(ov::Tensor{ov::element::f32, shape, input_data});
@@ -2401,7 +2386,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameRawMemoryMultipleTimes
         }
 
         {
-            LogCallbackGuard log_callback_guard(log_cb);
+            utils::LogCallbackGuard log_callback_guard(log_cb);
             inference_request.infer();
         }
 
@@ -2453,7 +2438,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameZeroTensorMultipleTime
     internal_core.set_property(target_device, ov::log::level(ov::log::Level::DEBUG));
     {
         // don't flood console with messages from model compilation
-        LogCallbackGuard log_callback_guard(log_cb);
+        utils::LogCallbackGuard log_callback_guard(log_cb);
         ov::CompiledModel compiled_model = internal_core.compile_model(model, target_device, configuration);
         inference_request = compiled_model.create_infer_request();
         input_tensor = inference_request.get_input_tensor();
@@ -2469,7 +2454,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameZeroTensorMultipleTime
         }
 
         {
-            LogCallbackGuard log_callback_guard(log_cb);
+            utils::LogCallbackGuard log_callback_guard(log_cb);
             inference_request.infer();
         }
 
@@ -2518,7 +2503,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameZeroHostTensorMultiple
     internal_core.set_property(target_device, ov::log::level(ov::log::Level::DEBUG));
     {
         // don't flood console with messages from model compilation
-        LogCallbackGuard log_callback_guard(log_cb);
+        utils::LogCallbackGuard log_callback_guard(log_cb);
         ov::CompiledModel compiled_model = internal_core.compile_model(model, target_device, configuration);
         inference_request = compiled_model.create_infer_request();
         inference_request.set_input_tensor(input_tensor);
@@ -2532,7 +2517,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameZeroHostTensorMultiple
         }
 
         {
-            LogCallbackGuard log_callback_guard(log_cb);
+            utils::LogCallbackGuard log_callback_guard(log_cb);
             inference_request.infer();
         }
 

--- a/src/plugins/intel_npu/tests/functional/common/utils.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/utils.hpp
@@ -4,14 +4,16 @@
 
 #pragma once
 
-#include <common_test_utils/subgraph_builders/conv_pool_relu.hpp>
 #include <filesystem>
-#include <openvino/runtime/core.hpp>
-#include <openvino/runtime/intel_npu/properties.hpp>
-#include <shared_test_classes/base/ov_behavior_test_utils.hpp>
 
+#include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 #include "common_test_utils/unicode_utils.hpp"
+#include "intel_npu/utils/logger/logger.hpp"
 #include "npu_test_env_cfg.hpp"
+#include "openvino/core/log.hpp"
+#include "openvino/runtime/core.hpp"
+#include "openvino/runtime/intel_npu/properties.hpp"
+#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
 
 std::string getBackendName(const ov::Core& core);
 
@@ -195,6 +197,37 @@ void set_tensors_and_infer(const std::shared_ptr<T>& infer_request,
     if (withResetInferRequest) {
         reset_cb();
     }
+};
+
+class LogCallbackGuard {
+public:
+    explicit LogCallbackGuard(const std::function<void(std::string_view)>& callback) {
+        ov::util::set_log_callback(callback);
+    }
+
+    ~LogCallbackGuard() {
+        ov::util::reset_log_callback();
+    }
+
+    LogCallbackGuard(const LogCallbackGuard&) = delete;
+    LogCallbackGuard& operator=(const LogCallbackGuard&) = delete;
+};
+
+class LoggerLevelGuard {
+public:
+    explicit LoggerLevelGuard(ov::log::Level level) : _previousLevel(::intel_npu::Logger::global().level()) {
+        ::intel_npu::Logger::global().setLevel(level);
+    }
+
+    ~LoggerLevelGuard() {
+        ::intel_npu::Logger::global().setLevel(_previousLevel);
+    }
+
+    LoggerLevelGuard(const LoggerLevelGuard&) = delete;
+    LoggerLevelGuard& operator=(const LoggerLevelGuard&) = delete;
+
+private:
+    ov::log::Level _previousLevel;
 };
 
 }  // namespace utils

--- a/src/plugins/intel_npu/tests/functional/common/zero_init_mock.cpp
+++ b/src/plugins/intel_npu/tests/functional/common/zero_init_mock.cpp
@@ -322,7 +322,9 @@ ZeroInitStructsMock::ZeroInitStructsMock(uint32_t zeDriverNpuExtVersion,
 
     // Create context - share between the compiler and the backend
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
-    THROW_ON_FAIL_FOR_LEVELZERO("zeContextCreate", zeContextCreate(_driver_handle, &context_desc, &_context));
+    ze_context_handle_t ctx = nullptr;
+    THROW_ON_FAIL_FOR_LEVELZERO("zeContextCreate", zeContextCreate(_driver_handle, &context_desc, &ctx));
+    _context.store(ctx);
     _log.debug("ZeroInitStructsHolder initialize complete");
 
     // Discover if standard allocation is supported
@@ -385,20 +387,36 @@ void ZeroInitStructsMock::getExtensionFunctionAddress(const std::string& name,
     }
 }
 
-ZeroInitStructsMock::~ZeroInitStructsMock() {
-    if (_context) {
-        _log.debug("ZeroInitStructsHolder - performing zeContextDestroy");
-        auto result = zeContextDestroy(_context);
-        _context = nullptr;
-        if (result != ZE_RESULT_SUCCESS) {
-            if (result == ZE_RESULT_ERROR_UNINITIALIZED) {
-                _log.warning(
-                    "zeContextDestroy failed to destroy the context; Level zero context was already destroyed");
-            } else {
-                _log.error("zeContextDestroy failed %#X", uint64_t(result));
-            }
-        }
+void ZeroInitStructsMock::destroyContextForInstance(std::shared_ptr<ZeroInitStructsMock>& instance) {
+    if (!instance) {
+        return;
     }
+
+    std::lock_guard<std::mutex> lock(instance->_mutex);
+    instance->destroyContextLocked();
+}
+
+void ZeroInitStructsMock::destroyContextLocked() {
+    if (!_context.load()) {
+        return;
+    }
+
+    _log.debug("ZeroInitStructsHolder - performing zeContextDestroy");
+    auto result = zeContextDestroy(_context.load());
+    if (result == ZE_RESULT_SUCCESS) {
+        _context.store(nullptr);
+        _log.debug("ZeroInitStructsHolder - zeContextDestroy succeeded");
+    } else if (result == ZE_RESULT_ERROR_UNINITIALIZED) {
+        _context.store(nullptr);
+        _log.warning("zeContextDestroy failed to destroy the context; Level zero context was already destroyed");
+    } else {
+        _log.error("zeContextDestroy failed %#X", uint64_t(result));
+    }
+}
+
+ZeroInitStructsMock::~ZeroInitStructsMock() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    destroyContextLocked();
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/tests/functional/common/zero_init_mock.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/zero_init_mock.hpp
@@ -45,15 +45,18 @@ public:
         return _zero_mem_pool;
     }
 
+    static void destroyContextForInstance(std::shared_ptr<ZeroInitStructsMock>& instance);
+
 private:
     void initNpuDriver();
     void getExtensionFunctionAddress(const std::string& name, const uint32_t version, void** function_address);
+    void destroyContextLocked();
 
     std::shared_ptr<intel_npu::ZeroApi> _zero_api;
 
     Logger _log;
 
-    ze_context_handle_t _context = nullptr;
+    std::atomic<ze_context_handle_t> _context{nullptr};
     ze_driver_handle_t _driver_handle = nullptr;
     ze_device_handle_t _device_handle = nullptr;
 

--- a/src/plugins/intel_npu/tests/functional/internal/backend/zero_infer_request_tests.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/backend/zero_infer_request_tests.hpp
@@ -6,9 +6,9 @@
 
 #include <gtest/gtest.h>
 
-#include "../compiler_adapter/zero_init_mock.hpp"
 #include "common/npu_test_env_cfg.hpp"
 #include "common/utils.hpp"
+#include "common/zero_init_mock.hpp"
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/ov_plugin_cache.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"

--- a/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.hpp
@@ -93,7 +93,9 @@ protected:
     }
 
     void TearDown() override {
-        zeGraphExt->destroyGraph(graphDescriptor);
+        if (zeGraphExt != nullptr) {
+            zeGraphExt->destroyGraph(graphDescriptor);
+        }
         if (blob) {
             ::operator delete(blob, std::align_val_t(::utils::STANDARD_PAGE_SIZE));
         }

--- a/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.hpp
@@ -10,6 +10,7 @@
 #include <common_test_utils/test_assertions.hpp>
 
 #include "common/npu_test_env_cfg.hpp"
+#include "common/zero_init_mock.hpp"
 #include "common_test_utils/subgraph_builders/multi_single_conv.hpp"
 #include "intel_npu/utils/utils.hpp"
 #include "intel_npu/utils/zero/zero_mem.hpp"
@@ -18,7 +19,6 @@
 #include "model_serializer.hpp"
 #include "openvino/runtime/intel_npu/properties.hpp"
 #include "ze_graph_ext_wrappers.hpp"
-#include "zero_init_mock.hpp"
 
 using namespace intel_npu;
 

--- a/src/plugins/intel_npu/tests/functional/internal/plugin/test_properties.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/plugin/test_properties.hpp
@@ -40,39 +40,6 @@ using ::testing::HasSubstr;
 using ConfigParams = std::tuple<std::string,   // Device name
                                 std::string>;  // Config name
 
-namespace {
-class LogCallbackGuard {
-public:
-    explicit LogCallbackGuard(const std::function<void(std::string_view)>& callback) {
-        ov::util::set_log_callback(callback);
-    }
-
-    ~LogCallbackGuard() {
-        ov::util::reset_log_callback();
-    }
-
-    LogCallbackGuard(const LogCallbackGuard&) = delete;
-    LogCallbackGuard& operator=(const LogCallbackGuard&) = delete;
-};
-
-class LoggerLevelGuard {
-public:
-    explicit LoggerLevelGuard(ov::log::Level level) : _previousLevel(::intel_npu::Logger::global().level()) {
-        ::intel_npu::Logger::global().setLevel(level);
-    }
-
-    ~LoggerLevelGuard() {
-        ::intel_npu::Logger::global().setLevel(_previousLevel);
-    }
-
-    LoggerLevelGuard(const LoggerLevelGuard&) = delete;
-    LoggerLevelGuard& operator=(const LoggerLevelGuard&) = delete;
-
-private:
-    ov::log::Level _previousLevel;
-};
-}  // namespace
-
 namespace ov {
 namespace test {
 namespace behavior {
@@ -235,8 +202,8 @@ TEST_P(PropertiesManagerTests, ExpectRunTimeSpecialBothPropertyIsSupported) {
     };
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
-        LoggerLevelGuard logger_level_guard(ov::log::Level::INFO);
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::INFO);
         propertiesManager->setProperty({{ov::log::level(ov::log::Level::INFO)}});
         propertiesManager->setProperty({{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}});
         isSupported = propertiesManager->isPropertySupported(configuration);
@@ -263,8 +230,8 @@ TEST_P(PropertiesManagerTests, ExpectArgumentIsNotSupported) {
                             {"DUMMY_PROPERTY", "DUMMY_VALUE"}};
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
-        LoggerLevelGuard logger_level_guard(ov::log::Level::INFO);
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::INFO);
 
         try {
             propertiesManager->setProperty(arguments);
@@ -294,8 +261,8 @@ TEST_P(ExpectLoadingCompilerPropertySupported, ExpectCompilerPropertyIsSupported
     };
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
-        LoggerLevelGuard logger_level_guard(ov::log::Level::INFO);
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::INFO);
         propertiesManager->setProperty({{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}});
         isSupported = propertiesManager->isPropertySupported(configuration);
     }
@@ -320,8 +287,8 @@ TEST_P(ExpectLoadingCompilerPropertyNotSupported, ExpectCompilerPropertyIsNotSup
     };
 
     {
-        LogCallbackGuard log_callback_guard(log_cb);
-        LoggerLevelGuard logger_level_guard(ov::log::Level::INFO);
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::INFO);
         propertiesManager->setProperty({{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}});
         isSupported = propertiesManager->isPropertySupported(configuration);
     }

--- a/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_mem_pool_tests.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_mem_pool_tests.hpp
@@ -17,6 +17,7 @@
 
 #include "common/npu_test_env_cfg.hpp"
 #include "common/utils.hpp"
+#include "common/zero_init_mock.hpp"
 #include "functional_test_utils/ov_plugin_cache.hpp"
 #include "intel_npu/common/npu.hpp"
 #include "intel_npu/config/config.hpp"
@@ -25,8 +26,8 @@
 #include "intel_npu/utils/zero/zero_mem.hpp"
 #include "intel_npu/utils/zero/zero_mem_pool.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
-#include "internal/compiler_adapter/zero_init_mock.hpp"
 #include "openvino/core/any.hpp"
+#include "openvino/core/log.hpp"
 #include "openvino/runtime/core.hpp"
 #include "shared_test_classes/base/ov_behavior_test_utils.hpp"
 
@@ -365,6 +366,41 @@ TEST_P(ZeroMemPoolTests, MultiThreadingImportMemoryReUseAndDestroyItWithMultiple
             ::operator delete(data[s][i], std::align_val_t(4096));
         }
     }
+}
+
+TEST_P(ZeroMemPoolTests, DontDestroyZeroMemoryWhenZeroContextIsDestroyed) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    std::string logs;
+    std::mutex logs_mutex;
+
+    // Keep this std::function alive while logging is active.
+    std::function<void(std::string_view)> log_cb = [&](std::string_view msg) {
+        std::lock_guard<std::mutex> lock(logs_mutex);
+        logs.append(msg);
+        logs.push_back('\n');
+    };
+
+    auto zero_init_mock = std::make_shared<::intel_npu::ZeroInitStructsMock>();
+
+    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> zero_init_struct =
+        std::reinterpret_pointer_cast<::intel_npu::ZeroInitStructsHolder>(zero_init_mock);
+
+    {
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::WARNING);
+
+        auto zero_memory = ::intel_npu::zero_mem::allocate_memory(zero_init_struct, 4096, 4096);
+        ::intel_npu::ZeroInitStructsMock::destroyContextForInstance(zero_init_mock);
+
+        try {
+            zero_memory = {};
+        } catch (const std::exception& ex) {
+            ASSERT_FALSE(true) << ex.what();
+        }
+    }
+    ASSERT_NE(logs.find("Context is null while trying to free memory with id"), std::string::npos);
+    ASSERT_EQ(logs.find("L0 zeMemFree result:"), std::string::npos);
 }
 
 }  // namespace behavior

--- a/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_wrappers_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_wrappers_tests.cpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "internal/utils/zero/zero_wrappers_tests.hpp"
+
+#include "common/npu_test_env_cfg.hpp"
+#include "common/utils.hpp"
+#include "intel_npu/config/options.hpp"
+#include "intel_npu/npu_private_properties.hpp"
+
+using namespace ov::test::behavior;
+
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
+                         ZeroWrappersTests,
+                         ::testing::Values(ov::test::utils::DEVICE_NPU),
+                         ZeroWrappersTests::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_wrappers_tests.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_wrappers_tests.hpp
@@ -1,0 +1,250 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <random>
+#include <thread>
+
+#include "common/npu_test_env_cfg.hpp"
+#include "common/utils.hpp"
+#include "common/zero_init_mock.hpp"
+#include "functional_test_utils/ov_plugin_cache.hpp"
+#include "intel_npu/utils/zero/zero_init.hpp"
+#include "intel_npu/utils/zero/zero_wrappers.hpp"
+#include "openvino/core/any.hpp"
+#include "openvino/core/log.hpp"
+#include "openvino/runtime/core.hpp"
+#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
+
+namespace ov {
+namespace test {
+namespace behavior {
+using CompilationParams = std::string;
+
+using ::testing::AllOf;
+using ::testing::HasSubstr;
+class ZeroWrappersTests : public ov::test::behavior::OVPluginTestBase,
+                          public testing::WithParamInterface<CompilationParams> {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<CompilationParams>& obj) {
+        std::string target_device;
+        ov::AnyMap configuration;
+        target_device = obj.param;
+        std::replace(target_device.begin(), target_device.end(), ':', '_');
+        target_device = ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU);
+
+        std::ostringstream result;
+        result << "targetDevice=" << target_device << "_";
+        result << "targetPlatform=" << ov::test::utils::getTestsPlatformFromEnvironmentOr(target_device) << "_";
+        if (!configuration.empty()) {
+            for (auto& configItem : configuration) {
+                result << "configItem=" << configItem.first << "_";
+                configItem.second.print(result);
+            }
+        }
+
+        return result.str();
+    }
+
+    void SetUp() override {
+        target_device = this->GetParam();
+
+        SKIP_IF_CURRENT_TEST_IS_DISABLED()
+        OVPluginTestBase::SetUp();
+    }
+
+    void TearDown() override {
+        APIBaseTest::TearDown();
+    }
+};
+
+TEST_P(ZeroWrappersTests, DontDestroyZeroCommandListWhenZeroContextIsDestroyed) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    std::string logs;
+    std::mutex logs_mutex;
+
+    // Keep this std::function alive while logging is active.
+    std::function<void(std::string_view)> log_cb = [&](std::string_view msg) {
+        std::lock_guard<std::mutex> lock(logs_mutex);
+        logs.append(msg);
+        logs.push_back('\n');
+    };
+
+    auto zero_init_mock = std::make_shared<::intel_npu::ZeroInitStructsMock>();
+
+    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> zero_init_struct =
+        std::reinterpret_pointer_cast<::intel_npu::ZeroInitStructsHolder>(zero_init_mock);
+
+    {
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::WARNING);
+
+        auto command_list = std::make_shared<::intel_npu::CommandList>(zero_init_struct);
+        ::intel_npu::ZeroInitStructsMock::destroyContextForInstance(zero_init_mock);
+
+        try {
+            command_list = {};
+        } catch (const std::exception& ex) {
+            ASSERT_FALSE(true) << ex.what();
+        }
+    }
+    ASSERT_NE(logs.find("Context or CommandList handle is null during destruction."), std::string::npos);
+    ASSERT_EQ(logs.find("zeCommandListDestroy failed"), std::string::npos);
+}
+
+TEST_P(ZeroWrappersTests, DontDestroyZeroCommandQueueWhenZeroContextIsDestroyed) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    std::string logs;
+    std::mutex logs_mutex;
+
+    std::function<void(std::string_view)> log_cb = [&](std::string_view msg) {
+        std::lock_guard<std::mutex> lock(logs_mutex);
+        logs.append(msg);
+        logs.push_back('\n');
+    };
+
+    auto zero_init_mock = std::make_shared<::intel_npu::ZeroInitStructsMock>();
+
+    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> zero_init_struct =
+        std::reinterpret_pointer_cast<::intel_npu::ZeroInitStructsHolder>(zero_init_mock);
+
+    {
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::WARNING);
+
+        auto command_queue =
+            std::make_shared<::intel_npu::CommandQueue>(zero_init_struct, ::intel_npu::CommandQueueDesc{});
+        ::intel_npu::ZeroInitStructsMock::destroyContextForInstance(zero_init_mock);
+
+        try {
+            command_queue = {};
+        } catch (const std::exception& ex) {
+            ASSERT_FALSE(true) << ex.what();
+        }
+    }
+    ASSERT_NE(logs.find("Context or CommandQueue handle is null during destruction."), std::string::npos);
+    ASSERT_EQ(logs.find("zeCommandQueueDestroy failed"), std::string::npos);
+}
+
+TEST_P(ZeroWrappersTests, DontDestroyZeroFenceWhenZeroContextIsDestroyed) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    std::string logs;
+    std::mutex logs_mutex;
+
+    std::function<void(std::string_view)> log_cb = [&](std::string_view msg) {
+        std::lock_guard<std::mutex> lock(logs_mutex);
+        logs.append(msg);
+        logs.push_back('\n');
+    };
+
+    auto zero_init_mock = std::make_shared<::intel_npu::ZeroInitStructsMock>();
+
+    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> zero_init_struct =
+        std::reinterpret_pointer_cast<::intel_npu::ZeroInitStructsHolder>(zero_init_mock);
+
+    {
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::WARNING);
+
+        auto command_queue =
+            std::make_shared<::intel_npu::CommandQueue>(zero_init_struct, ::intel_npu::CommandQueueDesc{});
+        auto fence = std::make_shared<::intel_npu::Fence>(command_queue);
+        ::intel_npu::ZeroInitStructsMock::destroyContextForInstance(zero_init_mock);
+
+        try {
+            fence = {};
+            command_queue = {};
+        } catch (const std::exception& ex) {
+            ASSERT_FALSE(true) << ex.what();
+        }
+    }
+    ASSERT_NE(logs.find("Context or Fence handle is null during destruction."), std::string::npos);
+    ASSERT_EQ(logs.find("zeFenceDestroy failed"), std::string::npos);
+}
+
+TEST_P(ZeroWrappersTests, DontDestroyZeroEventPoolWhenZeroContextIsDestroyed) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    std::string logs;
+    std::mutex logs_mutex;
+
+    std::function<void(std::string_view)> log_cb = [&](std::string_view msg) {
+        std::lock_guard<std::mutex> lock(logs_mutex);
+        logs.append(msg);
+        logs.push_back('\n');
+    };
+
+    auto zero_init_mock = std::make_shared<::intel_npu::ZeroInitStructsMock>();
+
+    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> zero_init_struct =
+        std::reinterpret_pointer_cast<::intel_npu::ZeroInitStructsHolder>(zero_init_mock);
+
+    {
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::WARNING);
+
+        auto event_pool = std::make_shared<::intel_npu::EventPool>(zero_init_struct, 1);
+        ::intel_npu::ZeroInitStructsMock::destroyContextForInstance(zero_init_mock);
+
+        try {
+            event_pool = {};
+        } catch (const std::exception& ex) {
+            ASSERT_FALSE(true) << ex.what();
+        }
+    }
+    ASSERT_NE(logs.find("Context or EventPool handle is null during destruction."), std::string::npos);
+    ASSERT_EQ(logs.find("zeEventPoolDestroy failed"), std::string::npos);
+}
+
+TEST_P(ZeroWrappersTests, DontDestroyZeroEventWhenZeroContextIsDestroyed) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    std::string logs;
+    std::mutex logs_mutex;
+
+    std::function<void(std::string_view)> log_cb = [&](std::string_view msg) {
+        std::lock_guard<std::mutex> lock(logs_mutex);
+        logs.append(msg);
+        logs.push_back('\n');
+    };
+
+    auto zero_init_mock = std::make_shared<::intel_npu::ZeroInitStructsMock>();
+
+    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> zero_init_struct =
+        std::reinterpret_pointer_cast<::intel_npu::ZeroInitStructsHolder>(zero_init_mock);
+
+    {
+        utils::LogCallbackGuard log_callback_guard(log_cb);
+        utils::LoggerLevelGuard logger_level_guard(ov::log::Level::WARNING);
+
+        auto event_pool = std::make_shared<::intel_npu::EventPool>(zero_init_struct, 1);
+        auto event = std::make_shared<::intel_npu::Event>(event_pool, 0);
+        ::intel_npu::ZeroInitStructsMock::destroyContextForInstance(zero_init_mock);
+
+        try {
+            event = {};
+            event_pool = {};
+        } catch (const std::exception& ex) {
+            ASSERT_FALSE(true) << ex.what();
+        }
+    }
+    ASSERT_NE(logs.find("Context or Event handle is null during destruction."), std::string::npos);
+    ASSERT_EQ(logs.find("zeEventDestroy failed"), std::string::npos);
+}
+
+}  // namespace behavior
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - *Check the sanity of the device each time the singleton returns the instance created previously*
 - *Destroy previous zero context if the driver/device was reset/reinstalled*
 - *Add tests to make sure that we don't try to destroy elements already destroyed by zeContextDestroy*

### Tickets:
 - *E#202059*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
