### PR TITLE
[TRANSFORMATIONS] Destroy constants after replacement in ConvertPrecision

### DIFF
--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -283,7 +283,13 @@ bool convert_function_precision(ov::pass::PassBase& pass,
     // Register internal constants only after fixing input type that could lead to nodes
     // replacement
     register_constants(ops);
-    for (auto& node : ops) {
+    // Move each shared_ptr out of `ops` as we iterate so that an old constant
+    // is destroyed as soon as fuse_type_to_constant has rewired its consumers
+    // to the freshly allocated replacement. Without the std::move the original
+    // constants stay alive until the loop ends, doubling the peak memory of
+    // the pass on constant-heavy models.
+    for (size_t i = 0; i < ops.size(); ++i) {
+        auto node = std::move(ops[i]);
         // skip precision sensitive nodes
         if (skip_precision_sensitive && fp16_compression_is_disabled(node) && has_fp16_compression)
             continue;
@@ -323,8 +329,12 @@ bool convert_function_precision(ov::pass::PassBase& pass,
                                       is_output_precision_changed;
     }
 
+    // The constant-replacement loop above moved every shared_ptr out of `ops`,
+    // so the vector is now full of nullptrs. Always refresh it before the
+    // downstream Convert-cleanup loop, otherwise that loop would silently skip
+    // every node and miss freshly inserted Convert ops.
+    ops = f->get_ordered_ops();
     if (is_output_precision_changed) {
-        ops = f->get_ordered_ops();
         is_changed = true;
     }
 

--- a/src/common/transformations/tests/utils/convert_precision.cpp
+++ b/src/common/transformations/tests/utils/convert_precision.cpp
@@ -2969,3 +2969,78 @@ TEST(TransformationTests, ConvertPrecision_assign_read_value_preserve_weightless
     auto weightless_caching_attr_it = new_rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
     ASSERT_TRUE(weightless_caching_attr_it != new_rt_info.end());
 }
+
+// ConvertPrecision must release each old constant as soon as its consumers
+// have been rewired to the freshly allocated replacement, instead of keeping
+// all originals alive until the end of the constant-replacement loop.
+//
+// Detection strategy: build a chain
+//     param -> Add(c0) -> Add(c1) -> Add(c2) -> Add(c3) -> Result
+// and register an additional type_to_fuse handler for Add. The pass walks
+// nodes in topological order, which yields
+//     param, c0, Add0, c1, Add1, c2, Add2, c3, Add3, Result
+// so by the time the loop reaches Add#i it has already visited (and tried to
+// replace) c0..ci. With the fix in place every old constant c0..ci has been
+// destroyed already, so only the not-yet-visited constants c_{i+1}..c_{N-1}
+// (i.e. N-1-i of them) are still alive when the Add handler fires. Without
+// the fix the local `ops` vector inside ConvertPrecision still owns every
+// original constant for the entire pass, so the handler would observe all N
+// constants alive at every Add visit.
+TEST(TransformationTests, ConvertPrecision_ReleasesOldConstantsDuringLoop) {
+    constexpr size_t kNumConsts = 4;
+
+    auto param = std::make_shared<opset10::Parameter>(element::f32, Shape{4});
+    std::vector<std::weak_ptr<ov::Node>> weak_consts;
+    weak_consts.reserve(kNumConsts);
+
+    std::shared_ptr<Node> chain = param;
+    for (size_t i = 0; i < kNumConsts; ++i) {
+        auto c = opset10::Constant::create(element::f32,
+                                           Shape{4},
+                                           {1.0f + static_cast<float>(i), 2.0f, 3.0f, 4.0f});
+        weak_consts.push_back(c);
+        chain = std::make_shared<opset10::Add>(chain, c);
+    }
+    auto model = std::make_shared<Model>(OutputVector{chain}, ParameterVector{param});
+
+    // Drop test-side strong refs from `chain` so the only owners of the
+    // original constants are the model itself and, transitively,
+    // ConvertPrecision's local `ops` vector while the pass is running.
+    chain.reset();
+
+    std::vector<size_t> alive_when_add_visited;
+    alive_when_add_visited.reserve(kNumConsts);
+
+    type_to_fuse_map handlers;
+    handlers[opset10::Add::get_type_info_static()] =
+        [&weak_consts, &alive_when_add_visited](const std::shared_ptr<Node>&,
+                                                const precisions_map&) {
+            size_t alive = 0;
+            for (const auto& w : weak_consts) {
+                if (!w.expired()) {
+                    ++alive;
+                }
+            }
+            alive_when_add_visited.push_back(alive);
+            return false;
+        };
+
+    pass::Manager manager;
+    manager.register_pass<pass::ConvertPrecision>(precisions_map{{element::f32, element::f16}},
+                                                  handlers);
+    manager.run_passes(model);
+
+    ASSERT_EQ(alive_when_add_visited.size(), kNumConsts);
+    for (size_t i = 0; i < alive_when_add_visited.size(); ++i) {
+        const size_t expected_alive = kNumConsts - 1 - i;
+        EXPECT_EQ(alive_when_add_visited[i], expected_alive)
+            << "At Add #" << i << " the test expected exactly " << expected_alive
+            << " original f32 constant(s) still alive (the not-yet-visited ones), "
+            << "but observed " << alive_when_add_visited[i] << ". A larger value means "
+            << "ConvertPrecision is keeping already-replaced constants alive and "
+            << "doubling peak memory.";
+    }
+
+    // Sanity: after the pass no f32 outputs remain in the converted model.
+    ASSERT_FALSE(has_type<element::Type_t::f32>(model));
+}

--- a/src/common/transformations/tests/utils/convert_precision.cpp
+++ b/src/common/transformations/tests/utils/convert_precision.cpp
@@ -2995,9 +2995,7 @@ TEST(TransformationTests, ConvertPrecision_ReleasesOldConstantsDuringLoop) {
 
     std::shared_ptr<Node> chain = param;
     for (size_t i = 0; i < kNumConsts; ++i) {
-        auto c = opset10::Constant::create(element::f32,
-                                           Shape{4},
-                                           {1.0f + static_cast<float>(i), 2.0f, 3.0f, 4.0f});
+        auto c = opset10::Constant::create(element::f32, Shape{4}, {1.0f + static_cast<float>(i), 2.0f, 3.0f, 4.0f});
         weak_consts.push_back(c);
         chain = std::make_shared<opset10::Add>(chain, c);
     }
@@ -3013,8 +3011,7 @@ TEST(TransformationTests, ConvertPrecision_ReleasesOldConstantsDuringLoop) {
 
     type_to_fuse_map handlers;
     handlers[opset10::Add::get_type_info_static()] =
-        [&weak_consts, &alive_when_add_visited](const std::shared_ptr<Node>&,
-                                                const precisions_map&) {
+        [&weak_consts, &alive_when_add_visited](const std::shared_ptr<Node>&, const precisions_map&) {
             size_t alive = 0;
             for (const auto& w : weak_consts) {
                 if (!w.expired()) {
@@ -3026,8 +3023,7 @@ TEST(TransformationTests, ConvertPrecision_ReleasesOldConstantsDuringLoop) {
         };
 
     pass::Manager manager;
-    manager.register_pass<pass::ConvertPrecision>(precisions_map{{element::f32, element::f16}},
-                                                  handlers);
+    manager.register_pass<pass::ConvertPrecision>(precisions_map{{element::f32, element::f16}}, handlers);
     manager.run_passes(model);
 
     ASSERT_EQ(alive_when_add_visited.size(), kNumConsts);
@@ -3035,10 +3031,9 @@ TEST(TransformationTests, ConvertPrecision_ReleasesOldConstantsDuringLoop) {
         const size_t expected_alive = kNumConsts - 1 - i;
         EXPECT_EQ(alive_when_add_visited[i], expected_alive)
             << "At Add #" << i << " the test expected exactly " << expected_alive
-            << " original f32 constant(s) still alive (the not-yet-visited ones), "
-            << "but observed " << alive_when_add_visited[i] << ". A larger value means "
-            << "ConvertPrecision is keeping already-replaced constants alive and "
-            << "doubling peak memory.";
+            << " original f32 constant(s) still alive (the not-yet-visited ones), " << "but observed "
+            << alive_when_add_visited[i] << ". A larger value means "
+            << "ConvertPrecision is keeping already-replaced constants alive and " << "doubling peak memory.";
     }
 
     // Sanity: after the pass no f32 outputs remain in the converted model.


### PR DESCRIPTION
### Details:
 - Changed the for-each loop over the local `ops` vector in `convert_function_precision` to an index-based loop that uses
   `std::move` to transfer ownership of each node out of the vector. That lets each old constant be destroyed as soon as
   `fuse_type_to_constant` has rewired its consumers to the freshly allocated replacement, instead of being kept alive until the loop ends. Without this change the original constants and their replacements coexist in memory for the entire pass, doubling the peak memory consumption on constant-heavy models.
 - The same fix was applied to `ConstantFolding` earlier in #33961; this change extends the same approach to `ConvertPrecision`, which was the next pass to allocate the doubled-memory peak on the same
   workloads (e.g. Qwen3-30B-A3B).
 - Made the `ops = f->get_ordered_ops()` refresh that follows the modified loop unconditional. The moving loop leaves `ops` full of nullptrs, and the downstream Convert-cleanup loop must walk a fresh topological order rather than a vector of moved-from entries.
 - Added a regression test that builds a chain `param -> Add(c0) -> Add(c1) -> Add(c2) -> Add(c3)` of f32 constants and registers an additional `type_to_fuse` callback on Add to inspect loop state mid-pass. With the fix in place each already-visited constant is destroyed before the loop reaches the next op; without the fix the test observes all originals still alive at every Add visit.

### Tickets:
 - 182143
