### PR TITLE
[Protopipe] Fix const reference binding in config parser

### DIFF
--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -145,7 +145,7 @@ struct convert<std::vector<T>> {
             return false;
         }
 
-        for (auto& child : node) {
+        for (const auto& child : node) {
             vec.push_back(child.as<T>());
         }
         return true;


### PR DESCRIPTION
### Details:
 - *This fixes the following compile error, introduced by commit 64a330242e291e372e37f4344316deb63f6474fe:*
```
src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp:148:9: error: cannot bind non-const lvalue reference of type ‘ConfigNode::KeyValueProxy&’ to an rvalue of type ‘ConfigNode::KeyValueProxy’
  148 |         for (auto& child : node) {
      |         ^~~
```

### Tickets:
 - *none*

### AI Assistance:
 - *AI assistance used: no*
