### PR TITLE
[GPU] Fix for build with ENABLE_ONEDNN_FOR_GPU=OFF ENABLE_LTO=ON

### DIFF
--- a/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
@@ -6,6 +6,7 @@
 #include "registry.hpp"
 #include "intel_gpu/primitives/reorder.hpp"
 #include "primitive_inst.h"
+#include "reorder_inst.h"
 
 #if OV_GPU_WITH_ONEDNN
     #include "impls/onednn/reorder_onednn.hpp"


### PR DESCRIPTION
### Details:
 - *There are two different instantiations of structure `typed_program_node<reorder>` in such configuration. Need to specify implementation source explicitly.*

### Tickets:
 - *155111*

### AI Assistance:
 - *AI assistance used: no*
