### PR TITLE
[GPU] Fix L0 USM allocations alignment

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ze/ze_memory.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_memory.hpp
@@ -70,7 +70,7 @@ public:
         host_desc.pNext = nullptr;
 
         void* memory = nullptr;
-        OV_ZE_EXPECT(ze::zeMemAllocHost(_context, &host_desc, size, 1, &memory));
+        OV_ZE_EXPECT(ze::zeMemAllocHost(_context, &host_desc, size, 0, &memory));
         _usm_pointer = std::make_shared<UsmHolder>(_context, memory);
     }
 
@@ -87,7 +87,7 @@ public:
         host_desc.pNext = nullptr;
 
         void* memory = nullptr;
-        OV_ZE_EXPECT(ze::zeMemAllocShared(_context, &device_desc, &host_desc, size, 1, _device, &memory));
+        OV_ZE_EXPECT(ze::zeMemAllocShared(_context, &device_desc, &host_desc, size, 0, _device, &memory));
         _usm_pointer = std::make_shared<UsmHolder>(_context, memory);
     }
 
@@ -99,7 +99,7 @@ public:
         device_desc.pNext = nullptr;
 
         void* memory = nullptr;
-        OV_ZE_EXPECT(ze::zeMemAllocDevice(_context, &device_desc, size, 4096, _device, &memory));
+        OV_ZE_EXPECT(ze::zeMemAllocDevice(_context, &device_desc, size, 0, _device, &memory));
         _usm_pointer = std::make_shared<UsmHolder>(_context, memory);
     }
 


### PR DESCRIPTION
### Details:
 - Pass alignment=0 when allocating USM memory on L0 path (same as OCL path).
