### PR TITLE
[transformations] Extend EliminateConcatStridedSlice to handle v8::Slice

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
@@ -12,6 +12,7 @@ namespace pass {
 
 class TRANSFORMATIONS_API EliminateConcat;
 class TRANSFORMATIONS_API EliminateConcatStridedSlice;
+class TRANSFORMATIONS_API EliminateConcatSlice;
 class TRANSFORMATIONS_API EliminateConvert;
 class TRANSFORMATIONS_API EliminateIdentityConvert;
 class TRANSFORMATIONS_API EliminateConvertNonZero;
@@ -135,6 +136,18 @@ class ov::pass::EliminateConcatStridedSlice : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("EliminateConcatStridedSlice");
     EliminateConcatStridedSlice();
+};
+
+/**
+ * @ingroup ov_transformation_common_api
+ * @brief EliminateConcatSlice eliminates Slice & Concat,
+ * if the Slices split the tensor into the parts and these parts be equal to the original parts before Concat.
+ * Same as EliminateConcatStridedSlice but for v8::Slice operations.
+ */
+class ov::pass::EliminateConcatSlice : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("EliminateConcatSlice");
+    EliminateConcatSlice();
 };
 
 /**

--- a/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
@@ -12,7 +12,6 @@ namespace pass {
 
 class TRANSFORMATIONS_API EliminateConcat;
 class TRANSFORMATIONS_API EliminateConcatStridedSlice;
-class TRANSFORMATIONS_API EliminateConcatSlice;
 class TRANSFORMATIONS_API EliminateConvert;
 class TRANSFORMATIONS_API EliminateIdentityConvert;
 class TRANSFORMATIONS_API EliminateConvertNonZero;
@@ -100,8 +99,9 @@ public:
 
 /**
  * @ingroup ov_transformation_common_api
- * @brief EliminateConcatStridedSlice eliminates StrideSlice & Concat,
- * if the StridedSlices split the tensor into the parts and these parts be equal to the original parts before Concat.
+ * @brief EliminateConcatStridedSlice eliminates StridedSlice/v8::Slice & Concat,
+ * if the slice users split the tensor into parts that match the original inputs of the Concat.
+ * Handles v1::StridedSlice and v8::Slice uniformly (mixed users are also supported).
 // Before:
           ┌─────────┐             ┌─────────┐             ┌─────────┐
           │ Input A │             │ Input B │             │ Input C │
@@ -136,18 +136,6 @@ class ov::pass::EliminateConcatStridedSlice : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("EliminateConcatStridedSlice");
     EliminateConcatStridedSlice();
-};
-
-/**
- * @ingroup ov_transformation_common_api
- * @brief EliminateConcatSlice eliminates Slice & Concat,
- * if the Slices split the tensor into the parts and these parts be equal to the original parts before Concat.
- * Same as EliminateConcatStridedSlice but for v8::Slice operations.
- */
-class ov::pass::EliminateConcatSlice : public ov::pass::MatcherPass {
-public:
-    OPENVINO_MATCHER_PASS_RTTI("EliminateConcatSlice");
-    EliminateConcatSlice();
 };
 
 /**

--- a/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
@@ -99,10 +99,28 @@ public:
 
 /**
  * @ingroup ov_transformation_common_api
- * @brief EliminateConcatStridedSlice eliminates StridedSlice/v8::Slice & Concat,
- * if the slice users split the tensor into parts that match the original inputs of the Concat.
- * Handles v1::StridedSlice and v8::Slice uniformly (mixed users are also supported).
-// Before:
+ * @brief EliminateConcatStridedSlice removes a redundant `Concat -> Slice` ("split-back") subgraph.
+ *
+ * The pass matches a Concat whose users are slice-like ops — v1::StridedSlice and/or v8::Slice,
+ * mixed users included — that cut the concatenated tensor back into pieces along the concat axis.
+ * When a slice reproduces exactly one of the original Concat inputs, the Concat together with that
+ * slice is a no-op for that branch: the slice consumers are rewired straight to the Concat input and
+ * both ops are dropped. A slice that spans several inputs (a partial range) is kept, but rebuilt on
+ * top of a smaller Concat that holds only the inputs it actually needs.
+ *
+ * Two regimes are handled by the same matcher:
+ *  - Static Concat  — the no-op is proven by integer index arithmetic over the fully known concat
+ *                     shape (exact-match rewiring + a residual Concat/slice rebuild for partial users).
+ *  - Dynamic Concat — for the Gated-Delta-Net idiom
+ *                     `Loop -> Reshape(.,[-1]) -> Concat(axis=0) -> Slice -> Reshape`, whose slice
+ *                     bounds are runtime values rather than constants, the no-op is proven
+ *                     structurally instead of arithmetically (see try_eliminate_dynamic_concat_slice).
+ *
+ * Static example below: user (A) is an exact match and is rewired to Input A; user (B + C) is a
+ * partial range, so it is rebuilt over a smaller `Concat(B, C)` — here folded straight into the
+ * downstream Concat that consumed it.
+ * @code
+Before:
           ┌─────────┐             ┌─────────┐             ┌─────────┐
           │ Input A │             │ Input B │             │ Input C │
           └────┬────┘             └────┬────┘             └────┬────┘
@@ -122,7 +140,7 @@ public:
                       ┌─────────────┐                ┌─────────┐
                       │Any OtherNode│                │  Concat │◄────── ...
                       └─────────────┘                └─────────┘
-// After:
+After:
           ┌─────────┐             ┌─────────┐             ┌─────────┐
           │ Input A │             │ Input B │             │ Input C │
           └────┬────┘             └────┬────┘             └────┬────┘
@@ -131,6 +149,7 @@ public:
          ┌─────────────┐               |      ┌─────▼───┐
          │Any OtherNode│               └────► │  Concat │◄────── ...
          └─────────────┘                      └─────────┘
+ * @endcode
  */
 class ov::pass::EliminateConcatStridedSlice : public ov::pass::MatcherPass {
 public:

--- a/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
@@ -115,7 +115,7 @@ public:
                             |                            |
                             ▼                            ▼
                        ┌────────────┐             ┌────────────┐
-                       │StridedSlice│             │StridedSlice│
+                       │StridedSlice│             │ v8::Slice  │
                        └─────┬──────┘             └──────┬─────┘
                              |   (A)                     | (B + C)
                              ▼                           ▼

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -740,6 +740,253 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
     this->register_matcher(m, callback);
 }
 
+EliminateConcatSlice::EliminateConcatSlice() {
+    using node_index_info_map = std::vector<std::tuple<std::shared_ptr<Node>, int64_t, int64_t>>;
+    MATCHER_SCOPE(EliminateConcatSlice);
+    auto pattern_concat = pattern::wrap_type<v0::Concat>(pattern::has_static_rank());
+    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_map();
+        const auto concat = ov::as_type_ptr<v0::Concat>(pattern_map.at(pattern_concat));
+        if (concat->is_dynamic())
+            return false;
+
+        const auto concat_axis =
+            ov::util::normalize(concat->get_axis(), concat->get_output_partial_shape(0).rank().get_length());
+
+        const auto concat_users = concat->get_users();
+        if (concat_users.size() == 1)
+            return false;
+        auto concat_inputs = concat->inputs();
+
+        node_index_info_map slice_out_index_in_concat;
+        for (const auto& user : concat_users) {
+            if (!ov::is_type<v8::Slice>(user))
+                return false;
+
+            auto slice_node = ov::as_type_ptr<v8::Slice>(user);
+            if (!slice_node)
+                return false;
+
+            // get start, stop, step constants
+            const auto& start_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+            if (!start_constant)
+                return false;
+            const auto& stop_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+            if (!stop_constant)
+                return false;
+            const auto& step_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(3));
+            if (!step_constant)
+                return false;
+
+            auto start_values = start_constant->cast_vector<int64_t>();
+            auto stop_values = stop_constant->cast_vector<int64_t>();
+            auto step_values = step_constant->cast_vector<int64_t>();
+
+            // get axes (input 4 is optional for v8::Slice, but in practice always present)
+            std::vector<int64_t> axes_values;
+            if (slice_node->get_input_size() == 5) {
+                const auto& axes_constant =
+                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
+                if (!axes_constant)
+                    return false;
+                axes_values = axes_constant->cast_vector<int64_t>();
+            } else {
+                // default axes: 0, 1, ..., rank-1
+                for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
+                    axes_values.push_back(i);
+            }
+
+            // normalize negative axes
+            const auto rank = concat->get_output_partial_shape(0).rank().get_length();
+            for (auto& ax : axes_values) {
+                if (ax < 0)
+                    ax += rank;
+            }
+
+            // find position of concat_axis in axes
+            int64_t axis_pos = -1;
+            for (size_t i = 0; i < axes_values.size(); ++i) {
+                if (axes_values[i] == concat_axis) {
+                    axis_pos = static_cast<int64_t>(i);
+                    break;
+                }
+            }
+            // if the concat axis is not in the slice axes, the slice doesn't slice along concat axis
+            if (axis_pos == -1)
+                return false;
+
+            // verify all step values are 1
+            for (const auto& s : step_values) {
+                if (s != 1)
+                    return false;
+            }
+
+            // verify that non-concat axes take the full range (start=0, stop>=dim_size)
+            for (size_t i = 0; i < axes_values.size(); ++i) {
+                if (static_cast<int64_t>(i) == axis_pos)
+                    continue;
+                auto ax = axes_values[i];
+                auto dim_size = static_cast<int64_t>(concat->get_shape()[ax]);
+                if (start_values[i] != 0 || stop_values[i] < dim_size)
+                    return false;
+            }
+
+            auto slice_start = start_values[axis_pos];
+            auto slice_stop = stop_values[axis_pos];
+            if (slice_stop > static_cast<int64_t>(concat->get_shape()[concat_axis]))
+                slice_stop = static_cast<int64_t>(concat->get_shape()[concat_axis]);
+
+            slice_out_index_in_concat.push_back(
+                std::make_tuple(slice_node, slice_start, slice_stop - 1));
+        }
+        if (slice_out_index_in_concat.size() == 1)
+            return false;
+
+        uint64_t start_index = 0;
+        node_index_info_map in_index_in_concat;
+        for (auto& concat_in : concat_inputs) {
+            auto tmp_index = start_index + concat_in.get_shape()[concat_axis] - 1;
+            in_index_in_concat.push_back(
+                std::make_tuple(concat_in.get_source_output().get_node_shared_ptr(), start_index, tmp_index));
+            start_index = tmp_index + 1;
+        }
+
+        node_index_info_map mismatch_slices{};
+        bool model_changed = false;
+        for (const auto& [slice_node, slice_begin, slice_end] : slice_out_index_in_concat) {
+            bool matched = false;
+            for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
+                if (slice_begin == concat_input_begin && slice_end == concat_input_end) {
+                    auto slice_outputs = slice_node->outputs();
+                    for (auto& slice_output : slice_outputs) {
+                        replace_output_update_name(slice_output, concat_input_node);
+                        model_changed = true;
+                    }
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched)
+                mismatch_slices.push_back(std::make_tuple(slice_node, slice_begin, slice_end));
+        }
+        if (mismatch_slices.empty())
+            return model_changed;
+
+        if (mismatch_slices.size() == slice_out_index_in_concat.size())
+            return model_changed;
+
+        int64_t new_start_value{std::numeric_limits<int64_t>::max()};
+        int64_t new_end_value{0};
+        for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
+            for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
+                if ((concat_input_begin <= slice_begin) && (concat_input_end >= slice_begin)) {
+                    if (concat_input_begin < new_start_value)
+                        new_start_value = concat_input_begin;
+                    if (concat_input_end > new_end_value)
+                        new_end_value = concat_input_end;
+                }
+                if ((concat_input_begin <= slice_end) && (concat_input_end >= slice_end)) {
+                    if (concat_input_begin < new_start_value)
+                        new_start_value = concat_input_begin;
+                    if (concat_input_end > new_end_value)
+                        new_end_value = concat_input_end;
+                }
+            }
+        }
+
+        std::vector<std::shared_ptr<Node>> new_concat_in_nodes{};
+        bool new_need = false;
+        for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
+            if (concat_input_begin == new_start_value) {
+                new_need = true;
+            }
+            if (concat_input_end == new_end_value) {
+                new_concat_in_nodes.push_back(concat_input_node);
+                new_need = false;
+            }
+            if (new_need) {
+                new_concat_in_nodes.push_back(concat_input_node);
+            }
+        }
+
+        auto new_concat_node = concat->clone_with_new_inputs(ov::as_output_vector(new_concat_in_nodes));
+        replace_output_update_name(concat, new_concat_node);
+
+        for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
+            if (slice_node->get_users().size() == 1 && ov::is_type<v0::Concat>(slice_node->get_users()[0]) &&
+                ov::as_type_ptr<v0::Concat>(slice_node->get_users()[0])->get_axis() == concat_axis) {
+                auto next_concat = ov::as_type_ptr<v0::Concat>(slice_node->get_users()[0]);
+                auto next_concat_inputs = next_concat->input_values();
+                ov::OutputVector new_next_concat_inputs{};
+                for (const auto& t : next_concat_inputs) {
+                    if (t.get_node_shared_ptr() == slice_node) {
+                        for (const auto& need_insert : new_concat_in_nodes) {
+                            new_next_concat_inputs.push_back(need_insert);
+                        }
+                    } else {
+                        new_next_concat_inputs.push_back(t);
+                    }
+                }
+                auto new_next_concat_node = next_concat->clone_with_new_inputs(new_next_concat_inputs);
+                replace_output_update_name(next_concat, new_next_concat_node);
+            } else {
+                // adjust start/stop for the new smaller concat
+                // v8::Slice uses sparse axes indexing, so we need to update the correct position
+                const auto& start_constant =
+                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+                auto start_values = start_constant->cast_vector<int64_t>();
+                const auto& stop_constant =
+                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+                auto stop_values = stop_constant->cast_vector<int64_t>();
+
+                // find position of concat_axis in axes
+                std::vector<int64_t> axes_values;
+                if (slice_node->get_input_size() == 5) {
+                    const auto& axes_constant =
+                        ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
+                    axes_values = axes_constant->cast_vector<int64_t>();
+                } else {
+                    for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
+                        axes_values.push_back(i);
+                }
+                const auto rank = concat->get_output_partial_shape(0).rank().get_length();
+                for (auto& ax : axes_values) {
+                    if (ax < 0)
+                        ax += rank;
+                }
+                int64_t axis_pos = 0;
+                for (size_t i = 0; i < axes_values.size(); ++i) {
+                    if (axes_values[i] == concat_axis) {
+                        axis_pos = static_cast<int64_t>(i);
+                        break;
+                    }
+                }
+
+                start_values[axis_pos] = slice_begin - new_start_value;
+                stop_values[axis_pos] = slice_end - new_start_value + 1;
+
+                ov::OutputVector new_slice_inputs;
+                new_slice_inputs.push_back(new_concat_node);
+                new_slice_inputs.push_back(
+                    v0::Constant::create(ov::element::i64, ov::Shape{start_values.size()}, start_values));
+                new_slice_inputs.push_back(
+                    v0::Constant::create(ov::element::i64, ov::Shape{stop_values.size()}, stop_values));
+                // keep step and axes as-is
+                new_slice_inputs.push_back(slice_node->input_value(3));
+                if (slice_node->get_input_size() == 5)
+                    new_slice_inputs.push_back(slice_node->input_value(4));
+
+                auto new_slice_node = slice_node->clone_with_new_inputs(new_slice_inputs);
+                replace_output_update_name(slice_node, new_slice_node);
+            }
+        }
+        return true;
+    };
+
+    auto m2 = std::make_shared<pattern::Matcher>(pattern_concat, matcher_name);
+    this->register_matcher(m2, callback);
+}
+
 EliminateSplit::EliminateSplit() {
     MATCHER_SCOPE(EliminateSplit);
     auto convert_pattern = pattern::wrap_type<v1::Split>();
@@ -1398,6 +1645,7 @@ ov::pass::NopElimination::NopElimination(bool use_shape_for_elimination) {
     ADD_MATCHER_FOR_THIS(EliminateStridedSlice)
     ADD_MATCHER_FOR_THIS(EliminateSlice)
     ADD_MATCHER_FOR_THIS(EliminateConcatStridedSlice)
+    ADD_MATCHER_FOR_THIS(EliminateConcatSlice)
     ADD_MATCHER_FOR_THIS(EliminateIdentity)
 
     // shape-dependent transformations

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -576,8 +576,7 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
             }
             return true;
         };
-        if (!check_axis(strided_slice_node->get_begin_mask()) ||
-            !check_axis(strided_slice_node->get_end_mask())) {
+        if (!check_axis(strided_slice_node->get_begin_mask()) || !check_axis(strided_slice_node->get_end_mask())) {
             return false;
         }
 
@@ -679,8 +678,7 @@ std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& 
     if (ov::is_type<v1::StridedSlice>(slice_node)) {
         std::vector<std::shared_ptr<ov::Node>> new_slice_in_nodes{new_concat_node};
 
-        const auto& begin_constant_node =
-            ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+        const auto& begin_constant_node = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
         auto begin_values = begin_constant_node->cast_vector<int64_t>();
         begin_values[concat_axis] = slice_begin - new_start_value;
         new_slice_in_nodes.push_back(
@@ -689,8 +687,7 @@ std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& 
         const auto& end_constant_node = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
         auto end_values = end_constant_node->cast_vector<int64_t>();
         end_values[concat_axis] = slice_end - new_start_value + 1;
-        new_slice_in_nodes.push_back(
-            v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
+        new_slice_in_nodes.push_back(v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
 
         return slice_node->clone_with_new_inputs(ov::as_output_vector(new_slice_in_nodes));
     }
@@ -760,11 +757,7 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
         for (const auto& user : concat_users) {
             int64_t begin_idx = 0;
             int64_t end_idx_inclusive = 0;
-            if (!extract_slice_range_along_axis(user,
-                                                concat_axis,
-                                                concat->get_shape(),
-                                                begin_idx,
-                                                end_idx_inclusive)) {
+            if (!extract_slice_range_along_axis(user, concat_axis, concat->get_shape(), begin_idx, end_idx_inclusive)) {
                 return false;
             }
             slice_out_index_in_concat.push_back(std::make_tuple(user, begin_idx, end_idx_inclusive));

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -836,8 +836,7 @@ EliminateConcatSlice::EliminateConcatSlice() {
             if (slice_stop > static_cast<int64_t>(concat->get_shape()[concat_axis]))
                 slice_stop = static_cast<int64_t>(concat->get_shape()[concat_axis]);
 
-            slice_out_index_in_concat.push_back(
-                std::make_tuple(slice_node, slice_start, slice_stop - 1));
+            slice_out_index_in_concat.push_back(std::make_tuple(slice_node, slice_start, slice_stop - 1));
         }
         if (slice_out_index_in_concat.size() == 1)
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -542,6 +542,202 @@ EliminateConcat::EliminateConcat() {
     this->register_matcher(m, callback);
 }
 
+namespace {
+
+// Extracts [begin, end_inclusive] range along `concat_axis` from a slice-like user of Concat.
+// Returns false if the user is not a supported slice-like op or does not produce a clean
+// axis-aligned slice along concat_axis.
+bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
+                                    int64_t concat_axis,
+                                    const ov::Shape& concat_shape,
+                                    int64_t& out_begin,
+                                    int64_t& out_end_inclusive) {
+    if (auto strided_slice_node = ov::as_type_ptr<v1::StridedSlice>(user)) {
+        auto check_mask = [](const std::vector<int64_t>& mask_to_check) {
+            auto it = std::find_if(mask_to_check.begin(), mask_to_check.end(), [](const int64_t& value) {
+                return value != 0;
+            });
+            return mask_to_check.empty() || it == mask_to_check.end();
+        };
+        if (!check_mask(strided_slice_node->get_shrink_axis_mask()) ||
+            !check_mask(strided_slice_node->get_new_axis_mask()) ||
+            !check_mask(strided_slice_node->get_ellipsis_mask())) {
+            return false;
+        }
+
+        auto check_axis = [concat_axis](const std::vector<int64_t>& masks) {
+            for (size_t axis = 0; axis < masks.size(); ++axis) {
+                if (masks[axis] != 1 && axis != static_cast<size_t>(concat_axis)) {
+                    return false;
+                }
+                if (masks[axis] != 0 && axis == static_cast<size_t>(concat_axis)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        if (!check_axis(strided_slice_node->get_begin_mask()) ||
+            !check_axis(strided_slice_node->get_end_mask())) {
+            return false;
+        }
+
+        const auto& begin_constant_node =
+            ov::util::get_constant_from_source(strided_slice_node->get_input_node_shared_ptr(1));
+        if (!begin_constant_node)
+            return false;
+        auto begin_values = begin_constant_node->cast_vector<int64_t>();
+
+        const auto& end_constant_node =
+            ov::util::get_constant_from_source(strided_slice_node->get_input_node_shared_ptr(2));
+        if (!end_constant_node)
+            return false;
+        auto end_values = end_constant_node->cast_vector<int64_t>();
+        if (end_values[concat_axis] > static_cast<int64_t>(concat_shape[concat_axis]))
+            end_values[concat_axis] = static_cast<int64_t>(concat_shape[concat_axis]);
+
+        out_begin = begin_values[concat_axis];
+        out_end_inclusive = end_values[concat_axis] - 1;
+        return true;
+    }
+
+    if (auto slice_node = ov::as_type_ptr<v8::Slice>(user)) {
+        const auto& start_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+        if (!start_constant)
+            return false;
+        const auto& stop_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+        if (!stop_constant)
+            return false;
+        const auto& step_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(3));
+        if (!step_constant)
+            return false;
+
+        auto start_values = start_constant->cast_vector<int64_t>();
+        auto stop_values = stop_constant->cast_vector<int64_t>();
+        auto step_values = step_constant->cast_vector<int64_t>();
+
+        std::vector<int64_t> axes_values;
+        if (slice_node->get_input_size() == 5) {
+            const auto& axes_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
+            if (!axes_constant)
+                return false;
+            axes_values = axes_constant->cast_vector<int64_t>();
+        } else {
+            for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
+                axes_values.push_back(i);
+        }
+
+        const auto rank = static_cast<int64_t>(concat_shape.size());
+        for (auto& ax : axes_values) {
+            if (ax < 0)
+                ax += rank;
+        }
+
+        int64_t axis_pos = -1;
+        for (size_t i = 0; i < axes_values.size(); ++i) {
+            if (axes_values[i] == concat_axis) {
+                axis_pos = static_cast<int64_t>(i);
+                break;
+            }
+        }
+        if (axis_pos == -1)
+            return false;
+
+        for (const auto& s : step_values) {
+            if (s != 1)
+                return false;
+        }
+
+        for (size_t i = 0; i < axes_values.size(); ++i) {
+            if (static_cast<int64_t>(i) == axis_pos)
+                continue;
+            auto ax = axes_values[i];
+            auto dim_size = static_cast<int64_t>(concat_shape[ax]);
+            if (start_values[i] != 0 || stop_values[i] < dim_size)
+                return false;
+        }
+
+        auto slice_stop = stop_values[axis_pos];
+        if (slice_stop > static_cast<int64_t>(concat_shape[concat_axis]))
+            slice_stop = static_cast<int64_t>(concat_shape[concat_axis]);
+
+        out_begin = start_values[axis_pos];
+        out_end_inclusive = slice_stop - 1;
+        return true;
+    }
+
+    return false;
+}
+
+// Rebuilds a slice-like node that consumes the shrunken concat, with its range shifted
+// by new_start_value. Dispatches by runtime type of slice_node (StridedSlice or v8::Slice).
+std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& slice_node,
+                                               const std::shared_ptr<ov::Node>& new_concat_node,
+                                               int64_t concat_axis,
+                                               int64_t slice_begin,
+                                               int64_t slice_end,
+                                               int64_t new_start_value) {
+    if (ov::is_type<v1::StridedSlice>(slice_node)) {
+        std::vector<std::shared_ptr<ov::Node>> new_slice_in_nodes{new_concat_node};
+
+        const auto& begin_constant_node =
+            ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+        auto begin_values = begin_constant_node->cast_vector<int64_t>();
+        begin_values[concat_axis] = slice_begin - new_start_value;
+        new_slice_in_nodes.push_back(
+            v0::Constant::create(ov::element::i64, ov::Shape{begin_values.size()}, begin_values));
+
+        const auto& end_constant_node = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+        auto end_values = end_constant_node->cast_vector<int64_t>();
+        end_values[concat_axis] = slice_end - new_start_value + 1;
+        new_slice_in_nodes.push_back(
+            v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
+
+        return slice_node->clone_with_new_inputs(ov::as_output_vector(new_slice_in_nodes));
+    }
+
+    // v8::Slice: sparse axes indexing — update only the axis_pos entry, keep step/axes as-is.
+    const auto& start_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+    auto start_values = start_constant->cast_vector<int64_t>();
+    const auto& stop_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+    auto stop_values = stop_constant->cast_vector<int64_t>();
+
+    std::vector<int64_t> axes_values;
+    if (slice_node->get_input_size() == 5) {
+        const auto& axes_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
+        axes_values = axes_constant->cast_vector<int64_t>();
+    } else {
+        for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
+            axes_values.push_back(i);
+    }
+    const auto rank = static_cast<int64_t>(new_concat_node->get_output_partial_shape(0).size());
+    for (auto& ax : axes_values) {
+        if (ax < 0)
+            ax += rank;
+    }
+    int64_t axis_pos = 0;
+    for (size_t i = 0; i < axes_values.size(); ++i) {
+        if (axes_values[i] == concat_axis) {
+            axis_pos = static_cast<int64_t>(i);
+            break;
+        }
+    }
+
+    start_values[axis_pos] = slice_begin - new_start_value;
+    stop_values[axis_pos] = slice_end - new_start_value + 1;
+
+    ov::OutputVector new_slice_inputs;
+    new_slice_inputs.push_back(new_concat_node);
+    new_slice_inputs.push_back(v0::Constant::create(ov::element::i64, ov::Shape{start_values.size()}, start_values));
+    new_slice_inputs.push_back(v0::Constant::create(ov::element::i64, ov::Shape{stop_values.size()}, stop_values));
+    new_slice_inputs.push_back(slice_node->input_value(3));
+    if (slice_node->get_input_size() == 5)
+        new_slice_inputs.push_back(slice_node->input_value(4));
+
+    return slice_node->clone_with_new_inputs(new_slice_inputs);
+}
+
+}  // namespace
+
 EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
     using node_index_info_map = std::vector<std::tuple<std::shared_ptr<Node>, int64_t, int64_t>>;
     MATCHER_SCOPE(EliminateConcatStridedSlice);
@@ -562,65 +758,16 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
 
         node_index_info_map slice_out_index_in_concat;
         for (const auto& user : concat_users) {
-            if (ov::is_type<v1::StridedSlice>(user)) {
-                auto strided_slice_node = ov::as_type_ptr<v1::StridedSlice>(user);
-                if (!strided_slice_node) {
-                    return false;
-                }
-                // check that all values of the mask is equal 0
-                auto check_mask = [](const std::vector<int64_t>& mask_to_check) {
-                    auto it = std::find_if(mask_to_check.begin(), mask_to_check.end(), [](const int64_t& value) {
-                        return value != 0;
-                    });
-                    if (mask_to_check.empty() || it == mask_to_check.end()) {
-                        return true;
-                    }
-                    return false;
-                };
-                // check that we won't do change dimension rank
-                if (!check_mask(strided_slice_node->get_shrink_axis_mask()) ||
-                    !check_mask(strided_slice_node->get_new_axis_mask()) ||
-                    !check_mask(strided_slice_node->get_ellipsis_mask())) {
-                    return false;
-                }
-
-                // check that concatenated and split axis is the same
-                auto check_axis = [concat_axis](const std::vector<int64_t>& masks) {
-                    for (size_t axis = 0; axis < masks.size(); ++axis) {
-                        if (masks[axis] != 1 && axis != static_cast<size_t>(concat_axis)) {
-                            return false;
-                        }
-                        if (masks[axis] != 0 && axis == static_cast<size_t>(concat_axis)) {
-                            return false;
-                        }
-                    }
-                    return true;
-                };
-                auto begin_mask = strided_slice_node->get_begin_mask();
-                auto end_mask = strided_slice_node->get_end_mask();
-                if (!check_axis(begin_mask) || !check_axis(end_mask)) {
-                    return false;
-                }
-
-                auto begin_node = strided_slice_node->get_input_node_shared_ptr(1);
-                const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node);
-                if (begin_constant_node == nullptr)
-                    return false;
-                auto begin_values = begin_constant_node->cast_vector<int64_t>();
-
-                auto end_node = strided_slice_node->get_input_node_shared_ptr(2);
-                const auto& end_constant_node = ov::util::get_constant_from_source(end_node);
-                if (end_constant_node == nullptr)
-                    return false;
-                auto end_values = end_constant_node->cast_vector<int64_t>();
-                if (end_values[concat_axis] > static_cast<int64_t>(concat->get_shape()[concat_axis]))
-                    end_values[concat_axis] = static_cast<int64_t>(concat->get_shape()[concat_axis]);
-
-                slice_out_index_in_concat.push_back(
-                    std::make_tuple(strided_slice_node, begin_values[concat_axis], end_values[concat_axis] - 1));
-            } else {
+            int64_t begin_idx = 0;
+            int64_t end_idx_inclusive = 0;
+            if (!extract_slice_range_along_axis(user,
+                                                concat_axis,
+                                                concat->get_shape(),
+                                                begin_idx,
+                                                end_idx_inclusive)) {
                 return false;
             }
+            slice_out_index_in_concat.push_back(std::make_tuple(user, begin_idx, end_idx_inclusive));
         }
         if (slice_out_index_in_concat.size() == 1)
             return false;
@@ -713,23 +860,12 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                 auto new_next_concat_node = next_concat->clone_with_new_inputs(new_next_concat_inputs);
                 replace_output_update_name(next_concat, new_next_concat_node);
             } else {
-                std::vector<std::shared_ptr<Node>> new_slice_in_nodes{};
-                new_slice_in_nodes.push_back(new_concat_node);
-
-                auto begin_node = slice_node->get_input_node_shared_ptr(1);
-                const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node);
-                auto begin_values = begin_constant_node->cast_vector<int64_t>();
-                begin_values[concat_axis] = slice_begin - new_start_value;
-                new_slice_in_nodes.push_back(
-                    v0::Constant::create(ov::element::i64, ov::Shape{begin_values.size()}, begin_values));
-
-                auto end_node = slice_node->get_input_node_shared_ptr(2);
-                const auto& end_constant_node = ov::util::get_constant_from_source(end_node);
-                auto end_values = end_constant_node->cast_vector<int64_t>();
-                end_values[concat_axis] = slice_end - new_start_value + 1;
-                new_slice_in_nodes.push_back(
-                    v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
-                auto new_slice_node = slice_node->clone_with_new_inputs(ov::as_output_vector(new_slice_in_nodes));
+                auto new_slice_node = build_residual_slice(slice_node,
+                                                           new_concat_node,
+                                                           concat_axis,
+                                                           slice_begin,
+                                                           slice_end,
+                                                           new_start_value);
                 replace_output_update_name(slice_node, new_slice_node);
             }
         }
@@ -738,252 +874,6 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
 
     auto m = std::make_shared<pattern::Matcher>(pattern_concat, matcher_name);
     this->register_matcher(m, callback);
-}
-
-EliminateConcatSlice::EliminateConcatSlice() {
-    using node_index_info_map = std::vector<std::tuple<std::shared_ptr<Node>, int64_t, int64_t>>;
-    MATCHER_SCOPE(EliminateConcatSlice);
-    auto pattern_concat = pattern::wrap_type<v0::Concat>(pattern::has_static_rank());
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        const auto& pattern_map = m.get_pattern_map();
-        const auto concat = ov::as_type_ptr<v0::Concat>(pattern_map.at(pattern_concat));
-        if (concat->is_dynamic())
-            return false;
-
-        const auto concat_axis =
-            ov::util::normalize(concat->get_axis(), concat->get_output_partial_shape(0).rank().get_length());
-
-        const auto concat_users = concat->get_users();
-        if (concat_users.size() == 1)
-            return false;
-        auto concat_inputs = concat->inputs();
-
-        node_index_info_map slice_out_index_in_concat;
-        for (const auto& user : concat_users) {
-            if (!ov::is_type<v8::Slice>(user))
-                return false;
-
-            auto slice_node = ov::as_type_ptr<v8::Slice>(user);
-            if (!slice_node)
-                return false;
-
-            // get start, stop, step constants
-            const auto& start_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
-            if (!start_constant)
-                return false;
-            const auto& stop_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
-            if (!stop_constant)
-                return false;
-            const auto& step_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(3));
-            if (!step_constant)
-                return false;
-
-            auto start_values = start_constant->cast_vector<int64_t>();
-            auto stop_values = stop_constant->cast_vector<int64_t>();
-            auto step_values = step_constant->cast_vector<int64_t>();
-
-            // get axes (input 4 is optional for v8::Slice, but in practice always present)
-            std::vector<int64_t> axes_values;
-            if (slice_node->get_input_size() == 5) {
-                const auto& axes_constant =
-                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
-                if (!axes_constant)
-                    return false;
-                axes_values = axes_constant->cast_vector<int64_t>();
-            } else {
-                // default axes: 0, 1, ..., rank-1
-                for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
-                    axes_values.push_back(i);
-            }
-
-            // normalize negative axes
-            const auto rank = concat->get_output_partial_shape(0).rank().get_length();
-            for (auto& ax : axes_values) {
-                if (ax < 0)
-                    ax += rank;
-            }
-
-            // find position of concat_axis in axes
-            int64_t axis_pos = -1;
-            for (size_t i = 0; i < axes_values.size(); ++i) {
-                if (axes_values[i] == concat_axis) {
-                    axis_pos = static_cast<int64_t>(i);
-                    break;
-                }
-            }
-            // if the concat axis is not in the slice axes, the slice doesn't slice along concat axis
-            if (axis_pos == -1)
-                return false;
-
-            // verify all step values are 1
-            for (const auto& s : step_values) {
-                if (s != 1)
-                    return false;
-            }
-
-            // verify that non-concat axes take the full range (start=0, stop>=dim_size)
-            for (size_t i = 0; i < axes_values.size(); ++i) {
-                if (static_cast<int64_t>(i) == axis_pos)
-                    continue;
-                auto ax = axes_values[i];
-                auto dim_size = static_cast<int64_t>(concat->get_shape()[ax]);
-                if (start_values[i] != 0 || stop_values[i] < dim_size)
-                    return false;
-            }
-
-            auto slice_start = start_values[axis_pos];
-            auto slice_stop = stop_values[axis_pos];
-            if (slice_stop > static_cast<int64_t>(concat->get_shape()[concat_axis]))
-                slice_stop = static_cast<int64_t>(concat->get_shape()[concat_axis]);
-
-            slice_out_index_in_concat.push_back(std::make_tuple(slice_node, slice_start, slice_stop - 1));
-        }
-        if (slice_out_index_in_concat.size() == 1)
-            return false;
-
-        uint64_t start_index = 0;
-        node_index_info_map in_index_in_concat;
-        for (auto& concat_in : concat_inputs) {
-            auto tmp_index = start_index + concat_in.get_shape()[concat_axis] - 1;
-            in_index_in_concat.push_back(
-                std::make_tuple(concat_in.get_source_output().get_node_shared_ptr(), start_index, tmp_index));
-            start_index = tmp_index + 1;
-        }
-
-        node_index_info_map mismatch_slices{};
-        bool model_changed = false;
-        for (const auto& [slice_node, slice_begin, slice_end] : slice_out_index_in_concat) {
-            bool matched = false;
-            for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
-                if (slice_begin == concat_input_begin && slice_end == concat_input_end) {
-                    auto slice_outputs = slice_node->outputs();
-                    for (auto& slice_output : slice_outputs) {
-                        replace_output_update_name(slice_output, concat_input_node);
-                        model_changed = true;
-                    }
-                    matched = true;
-                    break;
-                }
-            }
-            if (!matched)
-                mismatch_slices.push_back(std::make_tuple(slice_node, slice_begin, slice_end));
-        }
-        if (mismatch_slices.empty())
-            return model_changed;
-
-        if (mismatch_slices.size() == slice_out_index_in_concat.size())
-            return model_changed;
-
-        int64_t new_start_value{std::numeric_limits<int64_t>::max()};
-        int64_t new_end_value{0};
-        for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
-            for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
-                if ((concat_input_begin <= slice_begin) && (concat_input_end >= slice_begin)) {
-                    if (concat_input_begin < new_start_value)
-                        new_start_value = concat_input_begin;
-                    if (concat_input_end > new_end_value)
-                        new_end_value = concat_input_end;
-                }
-                if ((concat_input_begin <= slice_end) && (concat_input_end >= slice_end)) {
-                    if (concat_input_begin < new_start_value)
-                        new_start_value = concat_input_begin;
-                    if (concat_input_end > new_end_value)
-                        new_end_value = concat_input_end;
-                }
-            }
-        }
-
-        std::vector<std::shared_ptr<Node>> new_concat_in_nodes{};
-        bool new_need = false;
-        for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
-            if (concat_input_begin == new_start_value) {
-                new_need = true;
-            }
-            if (concat_input_end == new_end_value) {
-                new_concat_in_nodes.push_back(concat_input_node);
-                new_need = false;
-            }
-            if (new_need) {
-                new_concat_in_nodes.push_back(concat_input_node);
-            }
-        }
-
-        auto new_concat_node = concat->clone_with_new_inputs(ov::as_output_vector(new_concat_in_nodes));
-        replace_output_update_name(concat, new_concat_node);
-
-        for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
-            if (slice_node->get_users().size() == 1 && ov::is_type<v0::Concat>(slice_node->get_users()[0]) &&
-                ov::as_type_ptr<v0::Concat>(slice_node->get_users()[0])->get_axis() == concat_axis) {
-                auto next_concat = ov::as_type_ptr<v0::Concat>(slice_node->get_users()[0]);
-                auto next_concat_inputs = next_concat->input_values();
-                ov::OutputVector new_next_concat_inputs{};
-                for (const auto& t : next_concat_inputs) {
-                    if (t.get_node_shared_ptr() == slice_node) {
-                        for (const auto& need_insert : new_concat_in_nodes) {
-                            new_next_concat_inputs.push_back(need_insert);
-                        }
-                    } else {
-                        new_next_concat_inputs.push_back(t);
-                    }
-                }
-                auto new_next_concat_node = next_concat->clone_with_new_inputs(new_next_concat_inputs);
-                replace_output_update_name(next_concat, new_next_concat_node);
-            } else {
-                // adjust start/stop for the new smaller concat
-                // v8::Slice uses sparse axes indexing, so we need to update the correct position
-                const auto& start_constant =
-                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
-                auto start_values = start_constant->cast_vector<int64_t>();
-                const auto& stop_constant =
-                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
-                auto stop_values = stop_constant->cast_vector<int64_t>();
-
-                // find position of concat_axis in axes
-                std::vector<int64_t> axes_values;
-                if (slice_node->get_input_size() == 5) {
-                    const auto& axes_constant =
-                        ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
-                    axes_values = axes_constant->cast_vector<int64_t>();
-                } else {
-                    for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
-                        axes_values.push_back(i);
-                }
-                const auto rank = concat->get_output_partial_shape(0).rank().get_length();
-                for (auto& ax : axes_values) {
-                    if (ax < 0)
-                        ax += rank;
-                }
-                int64_t axis_pos = 0;
-                for (size_t i = 0; i < axes_values.size(); ++i) {
-                    if (axes_values[i] == concat_axis) {
-                        axis_pos = static_cast<int64_t>(i);
-                        break;
-                    }
-                }
-
-                start_values[axis_pos] = slice_begin - new_start_value;
-                stop_values[axis_pos] = slice_end - new_start_value + 1;
-
-                ov::OutputVector new_slice_inputs;
-                new_slice_inputs.push_back(new_concat_node);
-                new_slice_inputs.push_back(
-                    v0::Constant::create(ov::element::i64, ov::Shape{start_values.size()}, start_values));
-                new_slice_inputs.push_back(
-                    v0::Constant::create(ov::element::i64, ov::Shape{stop_values.size()}, stop_values));
-                // keep step and axes as-is
-                new_slice_inputs.push_back(slice_node->input_value(3));
-                if (slice_node->get_input_size() == 5)
-                    new_slice_inputs.push_back(slice_node->input_value(4));
-
-                auto new_slice_node = slice_node->clone_with_new_inputs(new_slice_inputs);
-                replace_output_update_name(slice_node, new_slice_node);
-            }
-        }
-        return true;
-    };
-
-    auto m2 = std::make_shared<pattern::Matcher>(pattern_concat, matcher_name);
-    this->register_matcher(m2, callback);
 }
 
 EliminateSplit::EliminateSplit() {
@@ -1644,7 +1534,6 @@ ov::pass::NopElimination::NopElimination(bool use_shape_for_elimination) {
     ADD_MATCHER_FOR_THIS(EliminateStridedSlice)
     ADD_MATCHER_FOR_THIS(EliminateSlice)
     ADD_MATCHER_FOR_THIS(EliminateConcatStridedSlice)
-    ADD_MATCHER_FOR_THIS(EliminateConcatSlice)
     ADD_MATCHER_FOR_THIS(EliminateIdentity)
 
     // shape-dependent transformations

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -595,11 +595,22 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
         if (!end_constant_node)
             return false;
         auto end_values = end_constant_node->cast_vector<int64_t>();
-        if (end_values[concat_axis] > static_cast<int64_t>(concat_shape[concat_axis]))
-            end_values[concat_axis] = static_cast<int64_t>(concat_shape[concat_axis]);
 
-        out_begin = begin_values[concat_axis];
-        out_end_inclusive = end_values[concat_axis] - 1;
+        const auto axis_idx = static_cast<size_t>(concat_axis);
+        if (begin_values.size() <= axis_idx || end_values.size() <= axis_idx)
+            return false;
+
+        const int64_t concat_dim = static_cast<int64_t>(concat_shape[concat_axis]);
+        if (end_values[concat_axis] > concat_dim)
+            end_values[concat_axis] = concat_dim;
+
+        const int64_t begin = begin_values[concat_axis];
+        const int64_t end_inclusive = end_values[concat_axis] - 1;
+        if (begin < 0 || end_inclusive < begin || end_inclusive >= concat_dim)
+            return false;
+
+        out_begin = begin;
+        out_end_inclusive = end_inclusive;
         return true;
     }
 
@@ -629,10 +640,16 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
                 axes_values.push_back(i);
         }
 
+        if (start_values.size() != axes_values.size() || stop_values.size() != axes_values.size() ||
+            step_values.size() != axes_values.size())
+            return false;
+
         const auto rank = static_cast<int64_t>(concat_shape.size());
         for (auto& ax : axes_values) {
             if (ax < 0)
                 ax += rank;
+            if (ax < 0 || ax >= rank)
+                return false;
         }
 
         int64_t axis_pos = -1;
@@ -659,11 +676,16 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
                 return false;
         }
 
-        auto slice_stop = stop_values[axis_pos];
-        if (slice_stop > static_cast<int64_t>(concat_shape[concat_axis]))
-            slice_stop = static_cast<int64_t>(concat_shape[concat_axis]);
+        const int64_t concat_dim = static_cast<int64_t>(concat_shape[concat_axis]);
+        int64_t slice_start = start_values[axis_pos];
+        int64_t slice_stop = stop_values[axis_pos];
+        if (slice_stop > concat_dim)
+            slice_stop = concat_dim;
 
-        out_begin = start_values[axis_pos];
+        if (slice_start < 0 || slice_stop <= slice_start || slice_stop > concat_dim)
+            return false;
+
+        out_begin = slice_start;
         out_end_inclusive = slice_stop - 1;
         return true;
     }

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -614,6 +614,28 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
         if (begin_values.size() <= axis_idx || end_values.size() <= axis_idx)
             return false;
 
+        // Empty/short begin_mask|end_mask means explicit begin/end is used on those axes.
+        // On every non-concat axis with active begin/end the slice must cover the full
+        // dimension — analog of the v8::Slice non-concat-axis guard below.
+        const auto& begin_mask = strided_slice_node->get_begin_mask();
+        const auto& end_mask = strided_slice_node->get_end_mask();
+        const auto rank = static_cast<int64_t>(concat_shape.size());
+        for (int64_t ax = 0; ax < rank; ++ax) {
+            if (ax == concat_axis)
+                continue;
+            const bool begin_used = static_cast<size_t>(ax) >= begin_mask.size() || begin_mask[ax] == 0;
+            const bool end_used = static_cast<size_t>(ax) >= end_mask.size() || end_mask[ax] == 0;
+            if (begin_used) {
+                if (static_cast<size_t>(ax) >= begin_values.size() || begin_values[ax] != 0)
+                    return false;
+            }
+            if (end_used) {
+                const auto dim_size = static_cast<int64_t>(concat_shape[ax]);
+                if (static_cast<size_t>(ax) >= end_values.size() || end_values[ax] < dim_size)
+                    return false;
+            }
+        }
+
         const int64_t concat_dim = static_cast<int64_t>(concat_shape[concat_axis]);
         if (end_values[concat_axis] > concat_dim)
             end_values[concat_axis] = concat_dim;

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -744,6 +744,253 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
     this->register_matcher(m, callback);
 }
 
+EliminateConcatSlice::EliminateConcatSlice() {
+    using node_index_info_map = std::vector<std::tuple<std::shared_ptr<Node>, int64_t, int64_t>>;
+    MATCHER_SCOPE(EliminateConcatSlice);
+    auto pattern_concat = pattern::wrap_type<v0::Concat>(pattern::has_static_rank());
+    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_map();
+        const auto concat = ov::as_type_ptr<v0::Concat>(pattern_map.at(pattern_concat));
+        if (concat->is_dynamic())
+            return false;
+
+        const auto concat_axis =
+            ov::util::normalize(concat->get_axis(), concat->get_output_partial_shape(0).rank().get_length());
+
+        const auto concat_users = concat->get_users();
+        if (concat_users.size() == 1)
+            return false;
+        auto concat_inputs = concat->inputs();
+
+        node_index_info_map slice_out_index_in_concat;
+        for (const auto& user : concat_users) {
+            if (!ov::is_type<v8::Slice>(user))
+                return false;
+
+            auto slice_node = ov::as_type_ptr<v8::Slice>(user);
+            if (!slice_node)
+                return false;
+
+            // get start, stop, step constants
+            const auto& start_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+            if (!start_constant)
+                return false;
+            const auto& stop_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+            if (!stop_constant)
+                return false;
+            const auto& step_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(3));
+            if (!step_constant)
+                return false;
+
+            auto start_values = start_constant->cast_vector<int64_t>();
+            auto stop_values = stop_constant->cast_vector<int64_t>();
+            auto step_values = step_constant->cast_vector<int64_t>();
+
+            // get axes (input 4 is optional for v8::Slice, but in practice always present)
+            std::vector<int64_t> axes_values;
+            if (slice_node->get_input_size() == 5) {
+                const auto& axes_constant =
+                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
+                if (!axes_constant)
+                    return false;
+                axes_values = axes_constant->cast_vector<int64_t>();
+            } else {
+                // default axes: 0, 1, ..., rank-1
+                for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
+                    axes_values.push_back(i);
+            }
+
+            // normalize negative axes
+            const auto rank = concat->get_output_partial_shape(0).rank().get_length();
+            for (auto& ax : axes_values) {
+                if (ax < 0)
+                    ax += rank;
+            }
+
+            // find position of concat_axis in axes
+            int64_t axis_pos = -1;
+            for (size_t i = 0; i < axes_values.size(); ++i) {
+                if (axes_values[i] == concat_axis) {
+                    axis_pos = static_cast<int64_t>(i);
+                    break;
+                }
+            }
+            // if the concat axis is not in the slice axes, the slice doesn't slice along concat axis
+            if (axis_pos == -1)
+                return false;
+
+            // verify all step values are 1
+            for (const auto& s : step_values) {
+                if (s != 1)
+                    return false;
+            }
+
+            // verify that non-concat axes take the full range (start=0, stop>=dim_size)
+            for (size_t i = 0; i < axes_values.size(); ++i) {
+                if (static_cast<int64_t>(i) == axis_pos)
+                    continue;
+                auto ax = axes_values[i];
+                auto dim_size = static_cast<int64_t>(concat->get_shape()[ax]);
+                if (start_values[i] != 0 || stop_values[i] < dim_size)
+                    return false;
+            }
+
+            auto slice_start = start_values[axis_pos];
+            auto slice_stop = stop_values[axis_pos];
+            if (slice_stop > static_cast<int64_t>(concat->get_shape()[concat_axis]))
+                slice_stop = static_cast<int64_t>(concat->get_shape()[concat_axis]);
+
+            slice_out_index_in_concat.push_back(
+                std::make_tuple(slice_node, slice_start, slice_stop - 1));
+        }
+        if (slice_out_index_in_concat.size() == 1)
+            return false;
+
+        uint64_t start_index = 0;
+        node_index_info_map in_index_in_concat;
+        for (auto& concat_in : concat_inputs) {
+            auto tmp_index = start_index + concat_in.get_shape()[concat_axis] - 1;
+            in_index_in_concat.push_back(
+                std::make_tuple(concat_in.get_source_output().get_node_shared_ptr(), start_index, tmp_index));
+            start_index = tmp_index + 1;
+        }
+
+        node_index_info_map mismatch_slices{};
+        bool model_changed = false;
+        for (const auto& [slice_node, slice_begin, slice_end] : slice_out_index_in_concat) {
+            bool matched = false;
+            for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
+                if (slice_begin == concat_input_begin && slice_end == concat_input_end) {
+                    auto slice_outputs = slice_node->outputs();
+                    for (auto& slice_output : slice_outputs) {
+                        replace_output_update_name(slice_output, concat_input_node);
+                        model_changed = true;
+                    }
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched)
+                mismatch_slices.push_back(std::make_tuple(slice_node, slice_begin, slice_end));
+        }
+        if (mismatch_slices.empty())
+            return model_changed;
+
+        if (mismatch_slices.size() == slice_out_index_in_concat.size())
+            return model_changed;
+
+        int64_t new_start_value{std::numeric_limits<int64_t>::max()};
+        int64_t new_end_value{0};
+        for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
+            for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
+                if ((concat_input_begin <= slice_begin) && (concat_input_end >= slice_begin)) {
+                    if (concat_input_begin < new_start_value)
+                        new_start_value = concat_input_begin;
+                    if (concat_input_end > new_end_value)
+                        new_end_value = concat_input_end;
+                }
+                if ((concat_input_begin <= slice_end) && (concat_input_end >= slice_end)) {
+                    if (concat_input_begin < new_start_value)
+                        new_start_value = concat_input_begin;
+                    if (concat_input_end > new_end_value)
+                        new_end_value = concat_input_end;
+                }
+            }
+        }
+
+        std::vector<std::shared_ptr<Node>> new_concat_in_nodes{};
+        bool new_need = false;
+        for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
+            if (concat_input_begin == new_start_value) {
+                new_need = true;
+            }
+            if (concat_input_end == new_end_value) {
+                new_concat_in_nodes.push_back(concat_input_node);
+                new_need = false;
+            }
+            if (new_need) {
+                new_concat_in_nodes.push_back(concat_input_node);
+            }
+        }
+
+        auto new_concat_node = concat->clone_with_new_inputs(ov::as_output_vector(new_concat_in_nodes));
+        replace_output_update_name(concat, new_concat_node);
+
+        for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
+            if (slice_node->get_users().size() == 1 && ov::is_type<v0::Concat>(slice_node->get_users()[0]) &&
+                ov::as_type_ptr<v0::Concat>(slice_node->get_users()[0])->get_axis() == concat_axis) {
+                auto next_concat = ov::as_type_ptr<v0::Concat>(slice_node->get_users()[0]);
+                auto next_concat_inputs = next_concat->input_values();
+                ov::OutputVector new_next_concat_inputs{};
+                for (const auto& t : next_concat_inputs) {
+                    if (t.get_node_shared_ptr() == slice_node) {
+                        for (const auto& need_insert : new_concat_in_nodes) {
+                            new_next_concat_inputs.push_back(need_insert);
+                        }
+                    } else {
+                        new_next_concat_inputs.push_back(t);
+                    }
+                }
+                auto new_next_concat_node = next_concat->clone_with_new_inputs(new_next_concat_inputs);
+                replace_output_update_name(next_concat, new_next_concat_node);
+            } else {
+                // adjust start/stop for the new smaller concat
+                // v8::Slice uses sparse axes indexing, so we need to update the correct position
+                const auto& start_constant =
+                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+                auto start_values = start_constant->cast_vector<int64_t>();
+                const auto& stop_constant =
+                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+                auto stop_values = stop_constant->cast_vector<int64_t>();
+
+                // find position of concat_axis in axes
+                std::vector<int64_t> axes_values;
+                if (slice_node->get_input_size() == 5) {
+                    const auto& axes_constant =
+                        ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
+                    axes_values = axes_constant->cast_vector<int64_t>();
+                } else {
+                    for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
+                        axes_values.push_back(i);
+                }
+                const auto rank = concat->get_output_partial_shape(0).rank().get_length();
+                for (auto& ax : axes_values) {
+                    if (ax < 0)
+                        ax += rank;
+                }
+                int64_t axis_pos = 0;
+                for (size_t i = 0; i < axes_values.size(); ++i) {
+                    if (axes_values[i] == concat_axis) {
+                        axis_pos = static_cast<int64_t>(i);
+                        break;
+                    }
+                }
+
+                start_values[axis_pos] = slice_begin - new_start_value;
+                stop_values[axis_pos] = slice_end - new_start_value + 1;
+
+                ov::OutputVector new_slice_inputs;
+                new_slice_inputs.push_back(new_concat_node);
+                new_slice_inputs.push_back(
+                    v0::Constant::create(ov::element::i64, ov::Shape{start_values.size()}, start_values));
+                new_slice_inputs.push_back(
+                    v0::Constant::create(ov::element::i64, ov::Shape{stop_values.size()}, stop_values));
+                // keep step and axes as-is
+                new_slice_inputs.push_back(slice_node->input_value(3));
+                if (slice_node->get_input_size() == 5)
+                    new_slice_inputs.push_back(slice_node->input_value(4));
+
+                auto new_slice_node = slice_node->clone_with_new_inputs(new_slice_inputs);
+                replace_output_update_name(slice_node, new_slice_node);
+            }
+        }
+        return true;
+    };
+
+    auto m2 = std::make_shared<pattern::Matcher>(pattern_concat, matcher_name);
+    this->register_matcher(m2, callback);
+}
+
 EliminateSplit::EliminateSplit() {
     MATCHER_SCOPE(EliminateSplit);
     auto convert_pattern = pattern::wrap_type<v1::Split>();
@@ -1402,6 +1649,7 @@ ov::pass::NopElimination::NopElimination(bool use_shape_for_elimination) {
     ADD_MATCHER_FOR_THIS(EliminateStridedSlice)
     ADD_MATCHER_FOR_THIS(EliminateSlice)
     ADD_MATCHER_FOR_THIS(EliminateConcatStridedSlice)
+    ADD_MATCHER_FOR_THIS(EliminateConcatSlice)
     ADD_MATCHER_FOR_THIS(EliminateIdentity)
 
     // shape-dependent transformations

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -757,7 +757,12 @@ std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& 
         end_values[concat_axis] = slice_end - new_start_value + 1;
         new_slice_in_nodes.push_back(v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
 
-        return slice_node->clone_with_new_inputs(ov::as_output_vector(new_slice_in_nodes));
+        // Preserve strides on the 4-input StridedSlice form; the upstream guard in
+        // extract_slice_range_along_axis() already pins it to a unit-stride constant.
+        ov::OutputVector new_inputs = ov::as_output_vector(new_slice_in_nodes);
+        if (slice_node->get_input_size() == 4)
+            new_inputs.push_back(slice_node->input_value(3));
+        return slice_node->clone_with_new_inputs(new_inputs);
     }
 
     // v8::Slice: sparse axes indexing — update only the axis_pos entry, keep step/axes as-is.

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -4,10 +4,14 @@
 
 #include "transformations/common_optimizations/nop_elimination.hpp"
 
+#include <algorithm>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 #include "compare.hpp"
 #include "itt.hpp"
@@ -804,6 +808,261 @@ std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& 
     return slice_node->clone_with_new_inputs(new_slice_inputs);
 }
 
+// --- Dynamic (structural) elimination of a Concat -> Slice NOPE subgraph ---------------------
+//
+// The static algorithm above proves the no-op by integer index arithmetic over a fully static
+// Concat shape, so it bails the moment the Concat (and its slice bounds) are dynamic. The
+// Gated-Delta-Net export produces exactly such a dynamic case: `Loop -> Reshape(.,[-1]) ->
+// Concat(axis=0) -> Slice -> Reshape`, where the slice boundary is a runtime
+// `ReduceProd(ShapeOf(...))` rather than a foldable constant.
+//
+// For that idiom the no-op is proven STRUCTURALLY, not arithmetically, with the same trust model
+// as ov::pass::RemoveConcatSliceAfterLoop (fuse_gated_delta_net.cpp): the boundary node shared
+// between adjacent slices makes the partition contiguous by construction, and each slice's
+// Reshape-back consumer (which restores the pre-flatten producer's shape) pins the chunk length to
+// that producer's element count under the standard "input model is valid" assumption. The dynamic
+// dimensions themselves are trusted via the idiom; the guards below reject everything that is not
+// exactly this shape, so a non-NOPE Concat is never rewired.
+
+// Matches `out = Reshape(src, [-1])` flattening to rank 1 and reports `src`. special_zero is
+// irrelevant because a [-1] target carries no 0 entry.
+bool match_flatten_to_1d(const ov::Output<ov::Node>& out, ov::Output<ov::Node>& src) {
+    const auto reshape = ov::as_type_ptr<v1::Reshape>(out.get_node_shared_ptr());
+    if (!reshape)
+        return false;
+    const auto& out_shape = reshape->get_output_partial_shape(0);
+    if (out_shape.rank().is_dynamic() || out_shape.size() != 1)
+        return false;
+    const auto& target = ov::util::get_constant_from_source(reshape->input_value(1));
+    if (!target)
+        return false;
+    const auto target_values = target->cast_vector<int64_t>();
+    if (target_values.size() != 1 || target_values[0] != -1)
+        return false;
+    src = reshape->input_value(0);
+    return true;
+}
+
+// Folds a single-element integer Output to its scalar value.
+bool fold_scalar_int(const ov::Output<ov::Node>& out, int64_t& value) {
+    const auto& constant = ov::util::get_constant_from_source(out);
+    if (!constant)
+        return false;
+    const auto values = constant->cast_vector<int64_t>();
+    if (values.size() != 1)
+        return false;
+    value = values[0];
+    return true;
+}
+
+// Begin/end Outputs of a slice along axis 0 of a rank-1 dynamic Concat, plus whether they fold to
+// the "0" and "to-end" sentinels. begin/end stay as Outputs so adjacent slices can be chained by
+// producer identity rather than by their (unknown) runtime values.
+struct DynamicSliceBounds {
+    ov::Output<ov::Node> begin;
+    ov::Output<ov::Node> end;
+    bool begin_is_zero = false;
+    bool end_is_to_end = false;
+    bool has_explicit_begin = false;
+};
+
+// Validates `user` is a unit-step slice covering only axis 0 of a rank-1 Concat. Partial shapes
+// only — never calls get_shape() (which throws on a dynamic Concat).
+bool validate_dynamic_axis_slice(const std::shared_ptr<ov::Node>& user, DynamicSliceBounds& bounds) {
+    constexpr int64_t to_end = std::numeric_limits<int64_t>::max();
+    if (const auto slice = ov::as_type_ptr<v8::Slice>(user)) {
+        const auto& data_shape = slice->get_input_partial_shape(0);
+        if (data_shape.rank().is_dynamic() || data_shape.size() != 1)
+            return false;
+        int64_t step = 0;
+        if (!fold_scalar_int(slice->input_value(3), step) || step != 1)
+            return false;
+        if (slice->get_input_size() == 5) {
+            int64_t axis = 0;
+            if (!fold_scalar_int(slice->input_value(4), axis) || ov::util::normalize(axis, 1) != 0)
+                return false;
+        }
+        bounds.begin = slice->input_value(1);
+        bounds.end = slice->input_value(2);
+        bounds.has_explicit_begin = true;
+        int64_t begin_value = 0;
+        if (fold_scalar_int(bounds.begin, begin_value)) {
+            if (begin_value < 0)
+                return false;
+            bounds.begin_is_zero = (begin_value == 0);
+        }
+        int64_t end_value = 0;
+        if (fold_scalar_int(bounds.end, end_value))
+            bounds.end_is_to_end = (end_value >= to_end);
+        return true;
+    }
+    if (const auto strided = ov::as_type_ptr<v1::StridedSlice>(user)) {
+        const auto& data_shape = strided->get_input_partial_shape(0);
+        if (data_shape.rank().is_dynamic() || data_shape.size() != 1)
+            return false;
+        const auto all_zero = [](const std::vector<int64_t>& mask) {
+            return std::all_of(mask.begin(), mask.end(), [](int64_t v) {
+                return v == 0;
+            });
+        };
+        if (!all_zero(strided->get_shrink_axis_mask()) || !all_zero(strided->get_new_axis_mask()) ||
+            !all_zero(strided->get_ellipsis_mask()))
+            return false;
+        if (strided->get_input_size() == 4) {
+            int64_t stride = 0;
+            if (!fold_scalar_int(strided->input_value(3), stride) || stride != 1)
+                return false;
+        }
+        const auto& begin_mask = strided->get_begin_mask();
+        const auto& end_mask = strided->get_end_mask();
+        const bool begin_explicit = begin_mask.empty() || begin_mask[0] == 0;
+        const bool end_explicit = end_mask.empty() || end_mask[0] == 0;
+        if (begin_explicit) {
+            bounds.begin = strided->input_value(1);
+            bounds.has_explicit_begin = true;
+            int64_t begin_value = 0;
+            if (fold_scalar_int(bounds.begin, begin_value)) {
+                if (begin_value < 0)
+                    return false;
+                bounds.begin_is_zero = (begin_value == 0);
+            }
+        } else {
+            bounds.begin_is_zero = true;  // begin_mask selects the start of the dimension
+        }
+        if (end_explicit) {
+            bounds.end = strided->input_value(2);
+            int64_t end_value = 0;
+            if (fold_scalar_int(bounds.end, end_value))
+                bounds.end_is_to_end = (end_value >= to_end);
+        } else {
+            bounds.end_is_to_end = true;  // end_mask selects the end of the dimension
+        }
+        return true;
+    }
+    return false;
+}
+
+// Structural dynamic-Concat NOPE elimination — see the comment block above. Rewires each
+// Reshape-back directly to its pre-flatten producer and lets dead-node cleanup drop the slices and
+// the Concat. Returns false (no change) for anything that is not exactly the flatten / Concat /
+// contiguous-slice / Reshape-back idiom.
+bool try_eliminate_dynamic_concat_slice(const std::shared_ptr<v0::Concat>& concat, int64_t concat_axis) {
+    // G1: the idiom is a rank-1 Concat along axis 0 (1-D flattened inputs).
+    if (concat_axis != 0)
+        return false;
+    const auto concat_inputs = concat->input_values();
+    const size_t num_inputs = concat_inputs.size();
+    if (num_inputs < 2)
+        return false;
+
+    // G2: every Concat input is `Reshape(Y_i, [-1])`; collect the pre-flatten producers Y_i.
+    std::vector<ov::Output<ov::Node>> pre_flatten(num_inputs);
+    for (size_t i = 0; i < num_inputs; ++i) {
+        const auto& input_shape = concat_inputs[i].get_partial_shape();
+        if (input_shape.rank().is_dynamic() || input_shape.size() != 1)
+            return false;
+        if (!match_flatten_to_1d(concat_inputs[i], pre_flatten[i]))
+            return false;
+    }
+
+    // G6 (Concat side): the Concat's only users are slice-like ops slicing it as their data input,
+    // one per Concat input.
+    const auto concat_users = concat->get_users();
+    if (concat_users.size() != num_inputs)
+        return false;
+    std::vector<DynamicSliceBounds> bounds(num_inputs);
+    for (size_t i = 0; i < num_inputs; ++i) {
+        if (concat_users[i]->input_value(0).get_node_shared_ptr() != concat)
+            return false;
+        if (!validate_dynamic_axis_slice(concat_users[i], bounds[i]))
+            return false;
+    }
+
+    // G5: order the slices into a contiguous partition [0 .. end) via the shared-boundary identity
+    // chain — slice_0 begins at 0, slice_k.begin is the SAME Output as slice_{k-1}.end, and only
+    // the last slice reaches the end.
+    int first = -1;
+    for (size_t i = 0; i < num_inputs; ++i) {
+        if (bounds[i].begin_is_zero) {
+            if (first != -1)
+                return false;  // more than one slice starts at 0
+            first = static_cast<int>(i);
+        }
+    }
+    if (first == -1)
+        return false;
+
+    std::vector<size_t> order{static_cast<size_t>(first)};
+    std::vector<bool> used(num_inputs, false);
+    used[first] = true;
+    for (size_t k = 1; k < num_inputs; ++k) {
+        const auto& prev = bounds[order.back()];
+        if (prev.end_is_to_end)
+            return false;  // a non-last slice already reaches the end
+        int next = -1;
+        for (size_t i = 0; i < num_inputs; ++i) {
+            if (used[i] || !bounds[i].has_explicit_begin)
+                continue;
+            if (bounds[i].begin == prev.end) {  // Output identity == shared boundary node
+                if (next != -1)
+                    return false;  // ambiguous boundary
+                next = static_cast<int>(i);
+            }
+        }
+        if (next == -1)
+            return false;
+        order.push_back(static_cast<size_t>(next));
+        used[next] = true;
+    }
+    if (!bounds[order.back()].end_is_to_end)
+        return false;  // the last slice must cover the dimension end
+
+    // G3 + G6 (slice side): each slice feeds exactly one Reshape-back whose output shape matches the
+    // corresponding pre-flatten producer Y_k. Collect all rewrites first; commit only if every slice
+    // in the partition passes. The k-th tiling region (concat_users[order[k]]) reconstructs the k-th
+    // Concat input: the partition is contiguous from 0 and each boundary is pinned to a Concat-input
+    // numel by the Reshape-back below (under the valid-model assumption), so tiling order and input
+    // order align one-to-one — hence it is paired with pre_flatten[k], not pre_flatten[order[k]].
+    std::vector<std::pair<std::shared_ptr<ov::Node>, ov::Output<ov::Node>>> rewrites;
+    rewrites.reserve(num_inputs);
+    for (size_t k = 0; k < num_inputs; ++k) {
+        const auto& slice = concat_users[order[k]];
+        const auto& producer = pre_flatten[k];
+        const auto slice_users = slice->get_users();
+        if (slice_users.size() != 1)
+            return false;
+        const auto reshape_back = ov::as_type_ptr<v1::Reshape>(slice_users[0]);
+        if (!reshape_back)
+            return false;
+        const auto& back_shape = reshape_back->get_output_partial_shape(0);
+        const auto& producer_shape = producer.get_partial_shape();
+        if (back_shape.rank().is_dynamic() || producer_shape.rank().is_dynamic() ||
+            back_shape.size() != producer_shape.size())
+            return false;
+        // The Reshape-back may be less shape-refined than Y_k at this pipeline stage (its target is a
+        // runtime ShapeOf, not yet fully inferred), so require only that every dim it DOES pin
+        // statically agrees with Y_k; a dim it leaves dynamic is trusted via the idiom (cf.
+        // RemoveConcatSliceAfterLoop). This still rejects a Reshape-back that restores a different,
+        // statically-incompatible shape.
+        for (size_t d = 0; d < back_shape.size(); ++d) {
+            if (back_shape[d].is_static() &&
+                (producer_shape[d].is_dynamic() || back_shape[d] != producer_shape[d]))
+                return false;
+        }
+        rewrites.emplace_back(reshape_back, producer);
+    }
+
+    // Commit: rewire every Reshape-back to its pre-flatten producer (mirrors the rewiring in
+    // ov::pass::RemoveConcatSliceAfterLoop). replace_output_update_name() declines when the output
+    // feeds a Result and the producer already has several users, so fall back to a plain replace —
+    // the producer keeps its own name. The slices and the Concat become dead afterwards.
+    for (const auto& rewrite : rewrites) {
+        if (!ov::replace_output_update_name(rewrite.first->output(0), rewrite.second))
+            rewrite.first->output(0).replace(rewrite.second);
+    }
+    return true;
+}
+
 }  // namespace
 
 EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
@@ -813,11 +1072,14 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_map();
         const auto concat = ov::as_type_ptr<v0::Concat>(pattern_map.at(pattern_concat));
-        if (concat->is_dynamic())
-            return false;
 
         const auto concat_axis =
             ov::util::normalize(concat->get_axis(), concat->get_output_partial_shape(0).rank().get_length());
+
+        // Dynamic Concat: the static index arithmetic below cannot run; prove the no-op
+        // structurally instead (Gated-Delta-Net flatten/Concat/Slice/Reshape idiom).
+        if (concat->is_dynamic())
+            return try_eliminate_dynamic_concat_slice(concat, concat_axis);
 
         const auto concat_users = concat->get_users();
         if (concat_users.size() == 1)

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -580,8 +580,7 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
             }
             return true;
         };
-        if (!check_axis(strided_slice_node->get_begin_mask()) ||
-            !check_axis(strided_slice_node->get_end_mask())) {
+        if (!check_axis(strided_slice_node->get_begin_mask()) || !check_axis(strided_slice_node->get_end_mask())) {
             return false;
         }
 
@@ -683,8 +682,7 @@ std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& 
     if (ov::is_type<v1::StridedSlice>(slice_node)) {
         std::vector<std::shared_ptr<ov::Node>> new_slice_in_nodes{new_concat_node};
 
-        const auto& begin_constant_node =
-            ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+        const auto& begin_constant_node = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
         auto begin_values = begin_constant_node->cast_vector<int64_t>();
         begin_values[concat_axis] = slice_begin - new_start_value;
         new_slice_in_nodes.push_back(
@@ -693,8 +691,7 @@ std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& 
         const auto& end_constant_node = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
         auto end_values = end_constant_node->cast_vector<int64_t>();
         end_values[concat_axis] = slice_end - new_start_value + 1;
-        new_slice_in_nodes.push_back(
-            v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
+        new_slice_in_nodes.push_back(v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
 
         return slice_node->clone_with_new_inputs(ov::as_output_vector(new_slice_in_nodes));
     }
@@ -764,11 +761,7 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
         for (const auto& user : concat_users) {
             int64_t begin_idx = 0;
             int64_t end_idx_inclusive = 0;
-            if (!extract_slice_range_along_axis(user,
-                                                concat_axis,
-                                                concat->get_shape(),
-                                                begin_idx,
-                                                end_idx_inclusive)) {
+            if (!extract_slice_range_along_axis(user, concat_axis, concat->get_shape(), begin_idx, end_idx_inclusive)) {
                 return false;
             }
             slice_out_index_in_concat.push_back(std::make_tuple(user, begin_idx, end_idx_inclusive));

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -584,6 +584,19 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
             return false;
         }
 
+        // NOPE pattern requires unit strides — non-unit strides skip elements and cannot reconstruct the Concat input.
+        if (strided_slice_node->get_input_size() == 4) {
+            const auto& strides_constant_node =
+                ov::util::get_constant_from_source(strided_slice_node->get_input_node_shared_ptr(3));
+            if (!strides_constant_node)
+                return false;
+            auto strides_values = strides_constant_node->cast_vector<int64_t>();
+            for (const auto& s : strides_values) {
+                if (s != 1)
+                    return false;
+            }
+        }
+
         const auto& begin_constant_node =
             ov::util::get_constant_from_source(strided_slice_node->get_input_node_shared_ptr(1));
         if (!begin_constant_node)

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -546,6 +546,202 @@ EliminateConcat::EliminateConcat() {
     this->register_matcher(m, callback);
 }
 
+namespace {
+
+// Extracts [begin, end_inclusive] range along `concat_axis` from a slice-like user of Concat.
+// Returns false if the user is not a supported slice-like op or does not produce a clean
+// axis-aligned slice along concat_axis.
+bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
+                                    int64_t concat_axis,
+                                    const ov::Shape& concat_shape,
+                                    int64_t& out_begin,
+                                    int64_t& out_end_inclusive) {
+    if (auto strided_slice_node = ov::as_type_ptr<v1::StridedSlice>(user)) {
+        auto check_mask = [](const std::vector<int64_t>& mask_to_check) {
+            auto it = std::find_if(mask_to_check.begin(), mask_to_check.end(), [](const int64_t& value) {
+                return value != 0;
+            });
+            return mask_to_check.empty() || it == mask_to_check.end();
+        };
+        if (!check_mask(strided_slice_node->get_shrink_axis_mask()) ||
+            !check_mask(strided_slice_node->get_new_axis_mask()) ||
+            !check_mask(strided_slice_node->get_ellipsis_mask())) {
+            return false;
+        }
+
+        auto check_axis = [concat_axis](const std::vector<int64_t>& masks) {
+            for (size_t axis = 0; axis < masks.size(); ++axis) {
+                if (masks[axis] != 1 && axis != static_cast<size_t>(concat_axis)) {
+                    return false;
+                }
+                if (masks[axis] != 0 && axis == static_cast<size_t>(concat_axis)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        if (!check_axis(strided_slice_node->get_begin_mask()) ||
+            !check_axis(strided_slice_node->get_end_mask())) {
+            return false;
+        }
+
+        const auto& begin_constant_node =
+            ov::util::get_constant_from_source(strided_slice_node->get_input_node_shared_ptr(1));
+        if (!begin_constant_node)
+            return false;
+        auto begin_values = begin_constant_node->cast_vector<int64_t>();
+
+        const auto& end_constant_node =
+            ov::util::get_constant_from_source(strided_slice_node->get_input_node_shared_ptr(2));
+        if (!end_constant_node)
+            return false;
+        auto end_values = end_constant_node->cast_vector<int64_t>();
+        if (end_values[concat_axis] > static_cast<int64_t>(concat_shape[concat_axis]))
+            end_values[concat_axis] = static_cast<int64_t>(concat_shape[concat_axis]);
+
+        out_begin = begin_values[concat_axis];
+        out_end_inclusive = end_values[concat_axis] - 1;
+        return true;
+    }
+
+    if (auto slice_node = ov::as_type_ptr<v8::Slice>(user)) {
+        const auto& start_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+        if (!start_constant)
+            return false;
+        const auto& stop_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+        if (!stop_constant)
+            return false;
+        const auto& step_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(3));
+        if (!step_constant)
+            return false;
+
+        auto start_values = start_constant->cast_vector<int64_t>();
+        auto stop_values = stop_constant->cast_vector<int64_t>();
+        auto step_values = step_constant->cast_vector<int64_t>();
+
+        std::vector<int64_t> axes_values;
+        if (slice_node->get_input_size() == 5) {
+            const auto& axes_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
+            if (!axes_constant)
+                return false;
+            axes_values = axes_constant->cast_vector<int64_t>();
+        } else {
+            for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
+                axes_values.push_back(i);
+        }
+
+        const auto rank = static_cast<int64_t>(concat_shape.size());
+        for (auto& ax : axes_values) {
+            if (ax < 0)
+                ax += rank;
+        }
+
+        int64_t axis_pos = -1;
+        for (size_t i = 0; i < axes_values.size(); ++i) {
+            if (axes_values[i] == concat_axis) {
+                axis_pos = static_cast<int64_t>(i);
+                break;
+            }
+        }
+        if (axis_pos == -1)
+            return false;
+
+        for (const auto& s : step_values) {
+            if (s != 1)
+                return false;
+        }
+
+        for (size_t i = 0; i < axes_values.size(); ++i) {
+            if (static_cast<int64_t>(i) == axis_pos)
+                continue;
+            auto ax = axes_values[i];
+            auto dim_size = static_cast<int64_t>(concat_shape[ax]);
+            if (start_values[i] != 0 || stop_values[i] < dim_size)
+                return false;
+        }
+
+        auto slice_stop = stop_values[axis_pos];
+        if (slice_stop > static_cast<int64_t>(concat_shape[concat_axis]))
+            slice_stop = static_cast<int64_t>(concat_shape[concat_axis]);
+
+        out_begin = start_values[axis_pos];
+        out_end_inclusive = slice_stop - 1;
+        return true;
+    }
+
+    return false;
+}
+
+// Rebuilds a slice-like node that consumes the shrunken concat, with its range shifted
+// by new_start_value. Dispatches by runtime type of slice_node (StridedSlice or v8::Slice).
+std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& slice_node,
+                                               const std::shared_ptr<ov::Node>& new_concat_node,
+                                               int64_t concat_axis,
+                                               int64_t slice_begin,
+                                               int64_t slice_end,
+                                               int64_t new_start_value) {
+    if (ov::is_type<v1::StridedSlice>(slice_node)) {
+        std::vector<std::shared_ptr<ov::Node>> new_slice_in_nodes{new_concat_node};
+
+        const auto& begin_constant_node =
+            ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+        auto begin_values = begin_constant_node->cast_vector<int64_t>();
+        begin_values[concat_axis] = slice_begin - new_start_value;
+        new_slice_in_nodes.push_back(
+            v0::Constant::create(ov::element::i64, ov::Shape{begin_values.size()}, begin_values));
+
+        const auto& end_constant_node = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+        auto end_values = end_constant_node->cast_vector<int64_t>();
+        end_values[concat_axis] = slice_end - new_start_value + 1;
+        new_slice_in_nodes.push_back(
+            v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
+
+        return slice_node->clone_with_new_inputs(ov::as_output_vector(new_slice_in_nodes));
+    }
+
+    // v8::Slice: sparse axes indexing — update only the axis_pos entry, keep step/axes as-is.
+    const auto& start_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
+    auto start_values = start_constant->cast_vector<int64_t>();
+    const auto& stop_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
+    auto stop_values = stop_constant->cast_vector<int64_t>();
+
+    std::vector<int64_t> axes_values;
+    if (slice_node->get_input_size() == 5) {
+        const auto& axes_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
+        axes_values = axes_constant->cast_vector<int64_t>();
+    } else {
+        for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
+            axes_values.push_back(i);
+    }
+    const auto rank = static_cast<int64_t>(new_concat_node->get_output_partial_shape(0).size());
+    for (auto& ax : axes_values) {
+        if (ax < 0)
+            ax += rank;
+    }
+    int64_t axis_pos = 0;
+    for (size_t i = 0; i < axes_values.size(); ++i) {
+        if (axes_values[i] == concat_axis) {
+            axis_pos = static_cast<int64_t>(i);
+            break;
+        }
+    }
+
+    start_values[axis_pos] = slice_begin - new_start_value;
+    stop_values[axis_pos] = slice_end - new_start_value + 1;
+
+    ov::OutputVector new_slice_inputs;
+    new_slice_inputs.push_back(new_concat_node);
+    new_slice_inputs.push_back(v0::Constant::create(ov::element::i64, ov::Shape{start_values.size()}, start_values));
+    new_slice_inputs.push_back(v0::Constant::create(ov::element::i64, ov::Shape{stop_values.size()}, stop_values));
+    new_slice_inputs.push_back(slice_node->input_value(3));
+    if (slice_node->get_input_size() == 5)
+        new_slice_inputs.push_back(slice_node->input_value(4));
+
+    return slice_node->clone_with_new_inputs(new_slice_inputs);
+}
+
+}  // namespace
+
 EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
     using node_index_info_map = std::vector<std::tuple<std::shared_ptr<Node>, int64_t, int64_t>>;
     MATCHER_SCOPE(EliminateConcatStridedSlice);
@@ -566,65 +762,16 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
 
         node_index_info_map slice_out_index_in_concat;
         for (const auto& user : concat_users) {
-            if (ov::is_type<v1::StridedSlice>(user)) {
-                auto strided_slice_node = ov::as_type_ptr<v1::StridedSlice>(user);
-                if (!strided_slice_node) {
-                    return false;
-                }
-                // check that all values of the mask is equal 0
-                auto check_mask = [](const std::vector<int64_t>& mask_to_check) {
-                    auto it = std::find_if(mask_to_check.begin(), mask_to_check.end(), [](const int64_t& value) {
-                        return value != 0;
-                    });
-                    if (mask_to_check.empty() || it == mask_to_check.end()) {
-                        return true;
-                    }
-                    return false;
-                };
-                // check that we won't do change dimension rank
-                if (!check_mask(strided_slice_node->get_shrink_axis_mask()) ||
-                    !check_mask(strided_slice_node->get_new_axis_mask()) ||
-                    !check_mask(strided_slice_node->get_ellipsis_mask())) {
-                    return false;
-                }
-
-                // check that concatenated and split axis is the same
-                auto check_axis = [concat_axis](const std::vector<int64_t>& masks) {
-                    for (size_t axis = 0; axis < masks.size(); ++axis) {
-                        if (masks[axis] != 1 && axis != static_cast<size_t>(concat_axis)) {
-                            return false;
-                        }
-                        if (masks[axis] != 0 && axis == static_cast<size_t>(concat_axis)) {
-                            return false;
-                        }
-                    }
-                    return true;
-                };
-                auto begin_mask = strided_slice_node->get_begin_mask();
-                auto end_mask = strided_slice_node->get_end_mask();
-                if (!check_axis(begin_mask) || !check_axis(end_mask)) {
-                    return false;
-                }
-
-                auto begin_node = strided_slice_node->get_input_node_shared_ptr(1);
-                const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node);
-                if (begin_constant_node == nullptr)
-                    return false;
-                auto begin_values = begin_constant_node->cast_vector<int64_t>();
-
-                auto end_node = strided_slice_node->get_input_node_shared_ptr(2);
-                const auto& end_constant_node = ov::util::get_constant_from_source(end_node);
-                if (end_constant_node == nullptr)
-                    return false;
-                auto end_values = end_constant_node->cast_vector<int64_t>();
-                if (end_values[concat_axis] > static_cast<int64_t>(concat->get_shape()[concat_axis]))
-                    end_values[concat_axis] = static_cast<int64_t>(concat->get_shape()[concat_axis]);
-
-                slice_out_index_in_concat.push_back(
-                    std::make_tuple(strided_slice_node, begin_values[concat_axis], end_values[concat_axis] - 1));
-            } else {
+            int64_t begin_idx = 0;
+            int64_t end_idx_inclusive = 0;
+            if (!extract_slice_range_along_axis(user,
+                                                concat_axis,
+                                                concat->get_shape(),
+                                                begin_idx,
+                                                end_idx_inclusive)) {
                 return false;
             }
+            slice_out_index_in_concat.push_back(std::make_tuple(user, begin_idx, end_idx_inclusive));
         }
         if (slice_out_index_in_concat.size() == 1)
             return false;
@@ -717,23 +864,12 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                 auto new_next_concat_node = next_concat->clone_with_new_inputs(new_next_concat_inputs);
                 replace_output_update_name(next_concat, new_next_concat_node);
             } else {
-                std::vector<std::shared_ptr<Node>> new_slice_in_nodes{};
-                new_slice_in_nodes.push_back(new_concat_node);
-
-                auto begin_node = slice_node->get_input_node_shared_ptr(1);
-                const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node);
-                auto begin_values = begin_constant_node->cast_vector<int64_t>();
-                begin_values[concat_axis] = slice_begin - new_start_value;
-                new_slice_in_nodes.push_back(
-                    v0::Constant::create(ov::element::i64, ov::Shape{begin_values.size()}, begin_values));
-
-                auto end_node = slice_node->get_input_node_shared_ptr(2);
-                const auto& end_constant_node = ov::util::get_constant_from_source(end_node);
-                auto end_values = end_constant_node->cast_vector<int64_t>();
-                end_values[concat_axis] = slice_end - new_start_value + 1;
-                new_slice_in_nodes.push_back(
-                    v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
-                auto new_slice_node = slice_node->clone_with_new_inputs(ov::as_output_vector(new_slice_in_nodes));
+                auto new_slice_node = build_residual_slice(slice_node,
+                                                           new_concat_node,
+                                                           concat_axis,
+                                                           slice_begin,
+                                                           slice_end,
+                                                           new_start_value);
                 replace_output_update_name(slice_node, new_slice_node);
             }
         }
@@ -742,252 +878,6 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
 
     auto m = std::make_shared<pattern::Matcher>(pattern_concat, matcher_name);
     this->register_matcher(m, callback);
-}
-
-EliminateConcatSlice::EliminateConcatSlice() {
-    using node_index_info_map = std::vector<std::tuple<std::shared_ptr<Node>, int64_t, int64_t>>;
-    MATCHER_SCOPE(EliminateConcatSlice);
-    auto pattern_concat = pattern::wrap_type<v0::Concat>(pattern::has_static_rank());
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        const auto& pattern_map = m.get_pattern_map();
-        const auto concat = ov::as_type_ptr<v0::Concat>(pattern_map.at(pattern_concat));
-        if (concat->is_dynamic())
-            return false;
-
-        const auto concat_axis =
-            ov::util::normalize(concat->get_axis(), concat->get_output_partial_shape(0).rank().get_length());
-
-        const auto concat_users = concat->get_users();
-        if (concat_users.size() == 1)
-            return false;
-        auto concat_inputs = concat->inputs();
-
-        node_index_info_map slice_out_index_in_concat;
-        for (const auto& user : concat_users) {
-            if (!ov::is_type<v8::Slice>(user))
-                return false;
-
-            auto slice_node = ov::as_type_ptr<v8::Slice>(user);
-            if (!slice_node)
-                return false;
-
-            // get start, stop, step constants
-            const auto& start_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
-            if (!start_constant)
-                return false;
-            const auto& stop_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
-            if (!stop_constant)
-                return false;
-            const auto& step_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(3));
-            if (!step_constant)
-                return false;
-
-            auto start_values = start_constant->cast_vector<int64_t>();
-            auto stop_values = stop_constant->cast_vector<int64_t>();
-            auto step_values = step_constant->cast_vector<int64_t>();
-
-            // get axes (input 4 is optional for v8::Slice, but in practice always present)
-            std::vector<int64_t> axes_values;
-            if (slice_node->get_input_size() == 5) {
-                const auto& axes_constant =
-                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
-                if (!axes_constant)
-                    return false;
-                axes_values = axes_constant->cast_vector<int64_t>();
-            } else {
-                // default axes: 0, 1, ..., rank-1
-                for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
-                    axes_values.push_back(i);
-            }
-
-            // normalize negative axes
-            const auto rank = concat->get_output_partial_shape(0).rank().get_length();
-            for (auto& ax : axes_values) {
-                if (ax < 0)
-                    ax += rank;
-            }
-
-            // find position of concat_axis in axes
-            int64_t axis_pos = -1;
-            for (size_t i = 0; i < axes_values.size(); ++i) {
-                if (axes_values[i] == concat_axis) {
-                    axis_pos = static_cast<int64_t>(i);
-                    break;
-                }
-            }
-            // if the concat axis is not in the slice axes, the slice doesn't slice along concat axis
-            if (axis_pos == -1)
-                return false;
-
-            // verify all step values are 1
-            for (const auto& s : step_values) {
-                if (s != 1)
-                    return false;
-            }
-
-            // verify that non-concat axes take the full range (start=0, stop>=dim_size)
-            for (size_t i = 0; i < axes_values.size(); ++i) {
-                if (static_cast<int64_t>(i) == axis_pos)
-                    continue;
-                auto ax = axes_values[i];
-                auto dim_size = static_cast<int64_t>(concat->get_shape()[ax]);
-                if (start_values[i] != 0 || stop_values[i] < dim_size)
-                    return false;
-            }
-
-            auto slice_start = start_values[axis_pos];
-            auto slice_stop = stop_values[axis_pos];
-            if (slice_stop > static_cast<int64_t>(concat->get_shape()[concat_axis]))
-                slice_stop = static_cast<int64_t>(concat->get_shape()[concat_axis]);
-
-            slice_out_index_in_concat.push_back(std::make_tuple(slice_node, slice_start, slice_stop - 1));
-        }
-        if (slice_out_index_in_concat.size() == 1)
-            return false;
-
-        uint64_t start_index = 0;
-        node_index_info_map in_index_in_concat;
-        for (auto& concat_in : concat_inputs) {
-            auto tmp_index = start_index + concat_in.get_shape()[concat_axis] - 1;
-            in_index_in_concat.push_back(
-                std::make_tuple(concat_in.get_source_output().get_node_shared_ptr(), start_index, tmp_index));
-            start_index = tmp_index + 1;
-        }
-
-        node_index_info_map mismatch_slices{};
-        bool model_changed = false;
-        for (const auto& [slice_node, slice_begin, slice_end] : slice_out_index_in_concat) {
-            bool matched = false;
-            for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
-                if (slice_begin == concat_input_begin && slice_end == concat_input_end) {
-                    auto slice_outputs = slice_node->outputs();
-                    for (auto& slice_output : slice_outputs) {
-                        replace_output_update_name(slice_output, concat_input_node);
-                        model_changed = true;
-                    }
-                    matched = true;
-                    break;
-                }
-            }
-            if (!matched)
-                mismatch_slices.push_back(std::make_tuple(slice_node, slice_begin, slice_end));
-        }
-        if (mismatch_slices.empty())
-            return model_changed;
-
-        if (mismatch_slices.size() == slice_out_index_in_concat.size())
-            return model_changed;
-
-        int64_t new_start_value{std::numeric_limits<int64_t>::max()};
-        int64_t new_end_value{0};
-        for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
-            for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
-                if ((concat_input_begin <= slice_begin) && (concat_input_end >= slice_begin)) {
-                    if (concat_input_begin < new_start_value)
-                        new_start_value = concat_input_begin;
-                    if (concat_input_end > new_end_value)
-                        new_end_value = concat_input_end;
-                }
-                if ((concat_input_begin <= slice_end) && (concat_input_end >= slice_end)) {
-                    if (concat_input_begin < new_start_value)
-                        new_start_value = concat_input_begin;
-                    if (concat_input_end > new_end_value)
-                        new_end_value = concat_input_end;
-                }
-            }
-        }
-
-        std::vector<std::shared_ptr<Node>> new_concat_in_nodes{};
-        bool new_need = false;
-        for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
-            if (concat_input_begin == new_start_value) {
-                new_need = true;
-            }
-            if (concat_input_end == new_end_value) {
-                new_concat_in_nodes.push_back(concat_input_node);
-                new_need = false;
-            }
-            if (new_need) {
-                new_concat_in_nodes.push_back(concat_input_node);
-            }
-        }
-
-        auto new_concat_node = concat->clone_with_new_inputs(ov::as_output_vector(new_concat_in_nodes));
-        replace_output_update_name(concat, new_concat_node);
-
-        for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
-            if (slice_node->get_users().size() == 1 && ov::is_type<v0::Concat>(slice_node->get_users()[0]) &&
-                ov::as_type_ptr<v0::Concat>(slice_node->get_users()[0])->get_axis() == concat_axis) {
-                auto next_concat = ov::as_type_ptr<v0::Concat>(slice_node->get_users()[0]);
-                auto next_concat_inputs = next_concat->input_values();
-                ov::OutputVector new_next_concat_inputs{};
-                for (const auto& t : next_concat_inputs) {
-                    if (t.get_node_shared_ptr() == slice_node) {
-                        for (const auto& need_insert : new_concat_in_nodes) {
-                            new_next_concat_inputs.push_back(need_insert);
-                        }
-                    } else {
-                        new_next_concat_inputs.push_back(t);
-                    }
-                }
-                auto new_next_concat_node = next_concat->clone_with_new_inputs(new_next_concat_inputs);
-                replace_output_update_name(next_concat, new_next_concat_node);
-            } else {
-                // adjust start/stop for the new smaller concat
-                // v8::Slice uses sparse axes indexing, so we need to update the correct position
-                const auto& start_constant =
-                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
-                auto start_values = start_constant->cast_vector<int64_t>();
-                const auto& stop_constant =
-                    ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
-                auto stop_values = stop_constant->cast_vector<int64_t>();
-
-                // find position of concat_axis in axes
-                std::vector<int64_t> axes_values;
-                if (slice_node->get_input_size() == 5) {
-                    const auto& axes_constant =
-                        ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
-                    axes_values = axes_constant->cast_vector<int64_t>();
-                } else {
-                    for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
-                        axes_values.push_back(i);
-                }
-                const auto rank = concat->get_output_partial_shape(0).rank().get_length();
-                for (auto& ax : axes_values) {
-                    if (ax < 0)
-                        ax += rank;
-                }
-                int64_t axis_pos = 0;
-                for (size_t i = 0; i < axes_values.size(); ++i) {
-                    if (axes_values[i] == concat_axis) {
-                        axis_pos = static_cast<int64_t>(i);
-                        break;
-                    }
-                }
-
-                start_values[axis_pos] = slice_begin - new_start_value;
-                stop_values[axis_pos] = slice_end - new_start_value + 1;
-
-                ov::OutputVector new_slice_inputs;
-                new_slice_inputs.push_back(new_concat_node);
-                new_slice_inputs.push_back(
-                    v0::Constant::create(ov::element::i64, ov::Shape{start_values.size()}, start_values));
-                new_slice_inputs.push_back(
-                    v0::Constant::create(ov::element::i64, ov::Shape{stop_values.size()}, stop_values));
-                // keep step and axes as-is
-                new_slice_inputs.push_back(slice_node->input_value(3));
-                if (slice_node->get_input_size() == 5)
-                    new_slice_inputs.push_back(slice_node->input_value(4));
-
-                auto new_slice_node = slice_node->clone_with_new_inputs(new_slice_inputs);
-                replace_output_update_name(slice_node, new_slice_node);
-            }
-        }
-        return true;
-    };
-
-    auto m2 = std::make_shared<pattern::Matcher>(pattern_concat, matcher_name);
-    this->register_matcher(m2, callback);
 }
 
 EliminateSplit::EliminateSplit() {
@@ -1648,7 +1538,6 @@ ov::pass::NopElimination::NopElimination(bool use_shape_for_elimination) {
     ADD_MATCHER_FOR_THIS(EliminateStridedSlice)
     ADD_MATCHER_FOR_THIS(EliminateSlice)
     ADD_MATCHER_FOR_THIS(EliminateConcatStridedSlice)
-    ADD_MATCHER_FOR_THIS(EliminateConcatSlice)
     ADD_MATCHER_FOR_THIS(EliminateIdentity)
 
     // shape-dependent transformations

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -597,6 +597,7 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
         auto end_values = end_constant_node->cast_vector<int64_t>();
 
         const auto axis_idx = static_cast<size_t>(concat_axis);
+        // StridedSlice with active masks may carry begin/end shorter than rank — index only after length check.
         if (begin_values.size() <= axis_idx || end_values.size() <= axis_idx)
             return false;
 
@@ -606,7 +607,8 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
 
         const int64_t begin = begin_values[concat_axis];
         const int64_t end_inclusive = end_values[concat_axis] - 1;
-        if (begin < 0 || end_inclusive < begin || end_inclusive >= concat_dim)
+        // Downstream coverage logic requires a valid absolute range; upper bound is enforced by the clamp above.
+        if (begin < 0 || end_inclusive < begin)
             return false;
 
         out_begin = begin;
@@ -640,11 +642,13 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
                 axes_values.push_back(i);
         }
 
+        // v8::Slice spec: start/stop/step are indexed in parallel with axes; otherwise the model is malformed.
         if (start_values.size() != axes_values.size() || stop_values.size() != axes_values.size() ||
             step_values.size() != axes_values.size())
             return false;
 
         const auto rank = static_cast<int64_t>(concat_shape.size());
+        // ov::util::normalize() converts negative indices but does not validate the range.
         for (auto& ax : axes_values) {
             ax = ov::util::normalize(ax, rank);
             if (ax < 0 || ax >= rank)
@@ -658,14 +662,17 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
                 break;
             }
         }
+        // Slice does not touch concat_axis — not a Concat-input splitter.
         if (axis_pos == -1)
             return false;
 
+        // NOPE pattern requires each Slice to reconstruct its Concat input verbatim; step != 1 skips elements.
         for (const auto& s : step_values) {
             if (s != 1)
                 return false;
         }
 
+        // Analog of StridedSlice's begin_mask/end_mask: on non-concat axes the slice must cover the full dimension.
         for (size_t i = 0; i < axes_values.size(); ++i) {
             if (static_cast<int64_t>(i) == axis_pos)
                 continue;
@@ -681,7 +688,8 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
         if (slice_stop > concat_dim)
             slice_stop = concat_dim;
 
-        if (slice_start < 0 || slice_stop <= slice_start || slice_stop > concat_dim)
+        // Reject negative start and empty/inverted range; upper bound is enforced by the clamp above.
+        if (slice_start < 0 || slice_stop <= slice_start)
             return false;
 
         out_begin = slice_start;

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -646,8 +646,7 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
 
         const auto rank = static_cast<int64_t>(concat_shape.size());
         for (auto& ax : axes_values) {
-            if (ax < 0)
-                ax += rank;
+            ax = ov::util::normalize(ax, rank);
             if (ax < 0 || ax >= rank)
                 return false;
         }
@@ -733,10 +732,8 @@ std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& 
             axes_values.push_back(i);
     }
     const auto rank = static_cast<int64_t>(new_concat_node->get_output_partial_shape(0).size());
-    for (auto& ax : axes_values) {
-        if (ax < 0)
-            ax += rank;
-    }
+    for (auto& ax : axes_values)
+        ax = ov::util::normalize(ax, rank);
     int64_t axis_pos = 0;
     for (size_t i = 0; i < axes_values.size(); ++i) {
         if (axes_values[i] == concat_axis) {

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -840,8 +840,7 @@ EliminateConcatSlice::EliminateConcatSlice() {
             if (slice_stop > static_cast<int64_t>(concat->get_shape()[concat_axis]))
                 slice_stop = static_cast<int64_t>(concat->get_shape()[concat_axis]);
 
-            slice_out_index_in_concat.push_back(
-                std::make_tuple(slice_node, slice_start, slice_stop - 1));
+            slice_out_index_in_concat.push_back(std::make_tuple(slice_node, slice_start, slice_stop - 1));
         }
         if (slice_out_index_in_concat.size() == 1)
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -552,6 +552,47 @@ EliminateConcat::EliminateConcat() {
 
 namespace {
 
+// =================================================================================================
+// EliminateConcatStridedSlice — `Concat -> Slice` ("split-back") no-op elimination.
+//
+// The matcher itself is defined further below (EliminateConcatStridedSlice::EliminateConcatStridedSlice).
+// It fires on a Concat and looks at the slice-like users (v1::StridedSlice / v8::Slice) that cut the
+// concatenated tensor back apart along the concat axis. If a slice reproduces one of the Concat
+// inputs verbatim, that `Concat -> Slice` round-trip is a no-op and the slice's consumers can read
+// the original input directly. The work is split into small free helpers so the matcher body reads
+// as a short sequence of phases rather than one long lambda:
+//
+//   Static path — Concat shape fully known, proven by integer index arithmetic:
+//     extract_slice_range_along_axis() — turn each slice user into a [begin, end_inclusive] index
+//                                        range along the concat axis, rejecting anything that is not
+//                                        a clean, unit-stride, axis-aligned cut of that one axis.
+//     build_residual_slice()           — rebuild a partial-range slice on top of the shrunken Concat
+//                                        once the exact-match users have been peeled off.
+//     fold_const_i64() / is_mask_empty_or_all_zero() — shared const-folding and mask helpers.
+//
+//   Dynamic path — Concat shape dynamic (the Gated-Delta-Net export idiom), proven structurally
+//   because the slice bounds are runtime values, not foldable constants:
+//     try_eliminate_dynamic_concat_slice() — entry point; matches the exact
+//                                        Reshape([-1]) / Concat(axis=0) / contiguous-Slice /
+//                                        Reshape-back idiom and rewires past it.
+//     match_flatten_to_1d() / fold_scalar_int() / validate_dynamic_axis_slice() / DynamicSliceBounds
+//                                        — building blocks of that structural proof.
+// =================================================================================================
+
+// A StridedSlice mask is inactive when it is empty or all-zero.
+bool is_mask_empty_or_all_zero(const std::vector<int64_t>& mask) {
+    return std::all_of(mask.begin(), mask.end(), [](int64_t v) {
+        return v == 0;
+    });
+}
+
+// Folds input `idx` of an already-validated slice node to an int64 vector.
+// Precondition: extract_slice_range_along_axis() proved this input is constant-foldable, so
+// get_constant_from_source() never returns null here (matches the original residual rebuild).
+std::vector<int64_t> fold_const_i64(const std::shared_ptr<ov::Node>& node, size_t idx) {
+    return ov::util::get_constant_from_source(node->get_input_node_shared_ptr(idx))->cast_vector<int64_t>();
+}
+
 // Extracts [begin, end_inclusive] range along `concat_axis` from a slice-like user of Concat.
 // Returns false if the user is not a supported slice-like op or does not produce a clean
 // axis-aligned slice along concat_axis.
@@ -561,15 +602,9 @@ bool extract_slice_range_along_axis(const std::shared_ptr<ov::Node>& user,
                                     int64_t& out_begin,
                                     int64_t& out_end_inclusive) {
     if (auto strided_slice_node = ov::as_type_ptr<v1::StridedSlice>(user)) {
-        auto check_mask = [](const std::vector<int64_t>& mask_to_check) {
-            auto it = std::find_if(mask_to_check.begin(), mask_to_check.end(), [](const int64_t& value) {
-                return value != 0;
-            });
-            return mask_to_check.empty() || it == mask_to_check.end();
-        };
-        if (!check_mask(strided_slice_node->get_shrink_axis_mask()) ||
-            !check_mask(strided_slice_node->get_new_axis_mask()) ||
-            !check_mask(strided_slice_node->get_ellipsis_mask())) {
+        if (!is_mask_empty_or_all_zero(strided_slice_node->get_shrink_axis_mask()) ||
+            !is_mask_empty_or_all_zero(strided_slice_node->get_new_axis_mask()) ||
+            !is_mask_empty_or_all_zero(strided_slice_node->get_ellipsis_mask())) {
             return false;
         }
 
@@ -750,14 +785,12 @@ std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& 
     if (ov::is_type<v1::StridedSlice>(slice_node)) {
         std::vector<std::shared_ptr<ov::Node>> new_slice_in_nodes{new_concat_node};
 
-        const auto& begin_constant_node = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
-        auto begin_values = begin_constant_node->cast_vector<int64_t>();
+        auto begin_values = fold_const_i64(slice_node, 1);
         begin_values[concat_axis] = slice_begin - new_start_value;
         new_slice_in_nodes.push_back(
             v0::Constant::create(ov::element::i64, ov::Shape{begin_values.size()}, begin_values));
 
-        const auto& end_constant_node = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
-        auto end_values = end_constant_node->cast_vector<int64_t>();
+        auto end_values = fold_const_i64(slice_node, 2);
         end_values[concat_axis] = slice_end - new_start_value + 1;
         new_slice_in_nodes.push_back(v0::Constant::create(ov::element::i64, ov::Shape{end_values.size()}, end_values));
 
@@ -770,15 +803,12 @@ std::shared_ptr<ov::Node> build_residual_slice(const std::shared_ptr<ov::Node>& 
     }
 
     // v8::Slice: sparse axes indexing — update only the axis_pos entry, keep step/axes as-is.
-    const auto& start_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(1));
-    auto start_values = start_constant->cast_vector<int64_t>();
-    const auto& stop_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(2));
-    auto stop_values = stop_constant->cast_vector<int64_t>();
+    auto start_values = fold_const_i64(slice_node, 1);
+    auto stop_values = fold_const_i64(slice_node, 2);
 
     std::vector<int64_t> axes_values;
     if (slice_node->get_input_size() == 5) {
-        const auto& axes_constant = ov::util::get_constant_from_source(slice_node->get_input_node_shared_ptr(4));
-        axes_values = axes_constant->cast_vector<int64_t>();
+        axes_values = fold_const_i64(slice_node, 4);
     } else {
         for (int64_t i = 0; i < static_cast<int64_t>(start_values.size()); ++i)
             axes_values.push_back(i);
@@ -900,13 +930,9 @@ bool validate_dynamic_axis_slice(const std::shared_ptr<ov::Node>& user, DynamicS
         const auto& data_shape = strided->get_input_partial_shape(0);
         if (data_shape.rank().is_dynamic() || data_shape.size() != 1)
             return false;
-        const auto all_zero = [](const std::vector<int64_t>& mask) {
-            return std::all_of(mask.begin(), mask.end(), [](int64_t v) {
-                return v == 0;
-            });
-        };
-        if (!all_zero(strided->get_shrink_axis_mask()) || !all_zero(strided->get_new_axis_mask()) ||
-            !all_zero(strided->get_ellipsis_mask()))
+        if (!is_mask_empty_or_all_zero(strided->get_shrink_axis_mask()) ||
+            !is_mask_empty_or_all_zero(strided->get_new_axis_mask()) ||
+            !is_mask_empty_or_all_zero(strided->get_ellipsis_mask()))
             return false;
         if (strided->get_input_size() == 4) {
             int64_t stride = 0;
@@ -1065,7 +1091,15 @@ bool try_eliminate_dynamic_concat_slice(const std::shared_ptr<v0::Concat>& conca
 
 }  // namespace
 
+// Matches a Concat and tries to remove the `Concat -> Slice` split-back round-trip described in the
+// helper overview above and in the class doxygen. For a dynamic Concat it delegates to the structural
+// path; for a static Concat it runs the index-arithmetic algorithm inline, in five phases marked
+// below. The pass is conservative: it bails out (returns false, no change) the moment any user is not
+// a clean axis-aligned slice, so a Concat that is not a genuine split-back is never touched.
 EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
+    // Each entry is (node, begin, end_inclusive): a half-open [begin, end] index range along the
+    // concat axis. Reused for two roles — the range a slice user reads, and the span a Concat input
+    // occupies — so the two can be compared with plain integer equality.
     using node_index_info_map = std::vector<std::tuple<std::shared_ptr<Node>, int64_t, int64_t>>;
     MATCHER_SCOPE(EliminateConcatStridedSlice);
     auto pattern_concat = pattern::wrap_type<v0::Concat>(pattern::has_static_rank());
@@ -1081,11 +1115,16 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
         if (concat->is_dynamic())
             return try_eliminate_dynamic_concat_slice(concat, concat_axis);
 
+        // A single user cannot re-split the Concat back into its inputs — there is nothing to peel off.
         const auto concat_users = concat->get_users();
         if (concat_users.size() == 1)
             return false;
         auto concat_inputs = concat->inputs();
 
+        // Phase 1 — describe every Concat user as a [begin, end_inclusive] index range along the
+        // concat axis. extract_slice_range_along_axis() returns false for any user that is not a
+        // clean, unit-stride, axis-aligned slice; one such user means this is not a pure split-back,
+        // so abandon the whole match.
         node_index_info_map slice_out_index_in_concat;
         for (const auto& user : concat_users) {
             int64_t begin_idx = 0;
@@ -1098,6 +1137,9 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
         if (slice_out_index_in_concat.size() == 1)
             return false;
 
+        // Phase 2 — lay out the Concat inputs end to end and record the [begin, end_inclusive] span
+        // each one occupies along the concat axis. These spans are the "ground truth" partition that
+        // the slice ranges from phase 1 are matched against.
         uint64_t start_index = 0;
         node_index_info_map in_index_in_concat;
         for (auto& concat_in : concat_inputs) {
@@ -1107,6 +1149,10 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
             start_index = tmp_index + 1;
         }
 
+        // Phase 3 — exact matches. A slice whose range equals one input's span reproduces that input
+        // verbatim, so the `Concat -> Slice` pair is a pure no-op: rewire the slice consumers straight
+        // to the input and let dead-node cleanup drop the slice. Anything that does not line up with a
+        // single input is set aside as a "mismatch" (a partial range) for phase 4.
         node_index_info_map mismatch_slices{};
         bool model_changed = false;
         for (const auto& [slice_node, slice_begin, slice_end] : slice_out_index_in_concat) {
@@ -1125,12 +1171,19 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
             if (!matched)
                 mismatch_slices.push_back(std::make_tuple(slice_node, slice_begin, slice_end));
         }
+        // Every user was an exact match — done, the Concat itself dies once its slices are gone.
         if (mismatch_slices.empty())
             return model_changed;
 
+        // No exact match anchored the Concat — shrinking it would not save anything, so leave it
+        // (and any rewiring already done by an unrelated earlier match) as is.
         if (mismatch_slices.size() == slice_out_index_in_concat.size())
             return model_changed;
 
+        // Phase 4 — the remaining (partial) slices still need a Concat, but only over the inputs they
+        // actually overlap. Widen [new_start_value, new_end_value] to the union of the spans of every
+        // Concat input touched by a mismatch slice's begin or end — i.e. the smallest contiguous block
+        // of inputs that still covers all partial users.
         int64_t new_start_value{std::numeric_limits<int64_t>::max()};
         int64_t new_end_value{0};
         for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
@@ -1150,6 +1203,10 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
             }
         }
 
+        // Gather that contiguous block of inputs (from the one starting at new_start_value up to the
+        // one ending at new_end_value) and clone a smaller Concat over just them. The original Concat
+        // is replaced by this shrunken one; the exact-match inputs peeled off in phase 3 are no longer
+        // part of it.
         std::vector<std::shared_ptr<Node>> new_concat_in_nodes{};
         bool new_need = false;
         for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
@@ -1168,6 +1225,12 @@ EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
         auto new_concat_node = concat->clone_with_new_inputs(ov::as_output_vector(new_concat_in_nodes));
         replace_output_update_name(concat, new_concat_node);
 
+        // Phase 5 — re-attach each partial slice to the shrunken Concat. Two cases:
+        //   (a) the slice feeds a single downstream Concat on the same axis — then the slice is pure
+        //       plumbing: splice the shrunken Concat's inputs directly into that downstream Concat and
+        //       drop the slice (this is the "After" picture in the class doxygen).
+        //   (b) otherwise — rebuild the slice over the shrunken Concat with its range shifted by
+        //       new_start_value (build_residual_slice handles StridedSlice vs v8::Slice).
         for (const auto& [slice_node, slice_begin, slice_end] : mismatch_slices) {
             if (slice_node->get_users().size() == 1 && ov::is_type<v0::Concat>(slice_node->get_users()[0]) &&
                 ov::as_type_ptr<v0::Concat>(slice_node->get_users()[0])->get_axis() == concat_axis) {

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -1071,8 +1071,7 @@ bool try_eliminate_dynamic_concat_slice(const std::shared_ptr<v0::Concat>& conca
         // RemoveConcatSliceAfterLoop). This still rejects a Reshape-back that restores a different,
         // statically-incompatible shape.
         for (size_t d = 0; d < back_shape.size(); ++d) {
-            if (back_shape[d].is_static() &&
-                (producer_shape[d].is_dynamic() || back_shape[d] != producer_shape[d]))
+            if (back_shape[d].is_static() && (producer_shape[d].is_dynamic() || back_shape[d] != producer_shape[d]))
                 return false;
         }
         rewrites.emplace_back(reshape_back, producer);

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2183,7 +2183,7 @@ TEST_F(TransformationTestsF, EliminateConcatSlice) {
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2},
                                             ParameterVector{param1, param2, param3, param4, add_param});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2233,7 +2233,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceAll) {
         auto result2 = std::make_shared<op::v0::Result>(relu2);
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
@@ -2273,7 +2273,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceConcat) {
 
         auto result = std::make_shared<op::v0::Result>(concat1);
         model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2313,7 +2313,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceMismatch) {
 
         auto result = std::make_shared<op::v0::Result>(concat1);
         model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2358,7 +2358,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceDiffAxis) {
 
         auto result = std::make_shared<op::v0::Result>(relu);
         model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2403,7 +2403,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceNonUnitStep) {
         auto result2 = std::make_shared<op::v0::Result>(relu2);
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2465,7 +2465,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceWithAxes) {
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2, result3},
                                             ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 3, 10});

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2153,3 +2153,335 @@ TEST_F(TransformationTestsF, ScatterNDUpdates15Elimination) {
         model_ref = std::make_shared<ov::Model>(OutputVector{result}, ParameterVector{data, indices, updates});
     }
 }
+
+TEST_F(TransformationTestsF, EliminateConcatSlice) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto param4 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 6});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3, param4}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+
+        auto add_param = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto add = std::make_shared<op::v1::Add>(slice1, add_param);
+        auto result1 = std::make_shared<op::v0::Result>(add);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {18});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2},
+                                            ParameterVector{param1, param2, param3, param4, add_param});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto param4 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 6});
+        auto add_param = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto add = std::make_shared<op::v1::Add>(param1, add_param);
+        auto result1 = std::make_shared<op::v0::Result>(add);
+
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param2, param3, param4}), axis);
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {15});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2},
+                                                ParameterVector{param1, param2, param3, param4, add_param});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceAll) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {4});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
+
+        auto relu1 = std::make_shared<op::v0::Relu>(param1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto relu2 = std::make_shared<op::v0::Relu>(param2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceConcat) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {12});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
+
+        auto result = std::make_shared<op::v0::Result>(concat1);
+        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+
+        auto relu = std::make_shared<op::v0::Relu>(param1);
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({relu, param2, param3}), axis);
+        auto result = std::make_shared<op::v0::Result>(concat);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceMismatch) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {4});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {10});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
+
+        auto result = std::make_shared<op::v0::Result>(concat1);
+        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {4});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {10});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
+
+        auto result = std::make_shared<op::v0::Result>(concat1);
+        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceDiffAxis) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {1});  // different axis than concat
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto result = std::make_shared<op::v0::Result>(relu);
+        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto result = std::make_shared<op::v0::Result>(relu);
+        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceNonUnitStep) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {2});  // non-unit step
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {6});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {2});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {6});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceWithAxes) {
+    {
+        int64_t axis = 1;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 3, 10});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 4, 10});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 5, 10});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {7});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        auto start3 = v0::Constant::create(element::i64, Shape{1}, {7});
+        auto stop3 = v0::Constant::create(element::i64, Shape{1}, {12});
+        auto step3 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes3 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice3 = std::make_shared<op::v8::Slice>(concat, start3, stop3, step3, axes3);
+        auto relu3 = std::make_shared<op::v0::Relu>(slice3);
+        auto result3 = std::make_shared<op::v0::Result>(relu3);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2, result3},
+                                            ParameterVector{param1, param2, param3});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 3, 10});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 4, 10});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 5, 10});
+
+        auto relu1 = std::make_shared<op::v0::Relu>(param1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto relu2 = std::make_shared<op::v0::Relu>(param2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        auto relu3 = std::make_shared<op::v0::Relu>(param3);
+        auto result3 = std::make_shared<op::v0::Result>(relu3);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2, result3},
+                                                ParameterVector{param1, param2, param3});
+    }
+}

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2359,6 +2359,57 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceNonUnitStrides) {
     }
 }
 
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceEmptyMaskNonAxisAligned) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        // Empty begin_mask/end_mask — slice1 has begin[1]=1 so it is NOT axis-aligned along concat_axis=2.
+        std::vector<int64_t> empty_mask{};
+        auto begin1 = v0::Constant::create(element::i64, Shape{3}, {0, 1, 0});
+        auto end1 = v0::Constant::create(element::i64, Shape{3}, {2, 10, 3});
+        auto strides1 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+        auto slice1 = std::make_shared<v1::StridedSlice>(concat, begin1, end1, strides1, empty_mask, empty_mask);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto begin2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 3});
+        auto end2 = v0::Constant::create(element::i64, Shape{3}, {2, 10, 6});
+        auto strides2 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+        auto slice2 = std::make_shared<v1::StridedSlice>(concat, begin2, end2, strides2, empty_mask, empty_mask);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        std::vector<int64_t> empty_mask{};
+        auto begin1 = v0::Constant::create(element::i64, Shape{3}, {0, 1, 0});
+        auto end1 = v0::Constant::create(element::i64, Shape{3}, {2, 10, 3});
+        auto strides1 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+        auto slice1 = std::make_shared<v1::StridedSlice>(concat, begin1, end1, strides1, empty_mask, empty_mask);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto begin2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 3});
+        auto end2 = v0::Constant::create(element::i64, Shape{3}, {2, 10, 6});
+        auto strides2 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+        auto slice2 = std::make_shared<v1::StridedSlice>(concat, begin2, end2, strides2, empty_mask, empty_mask);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+    }
+}
+
 TEST_F(TransformationTestsF, EliminateConcatStridedSliceWithAxesV8Slice) {
     {
         int64_t axis = 1;

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory>
 #include <queue>
 #include <sstream>
@@ -2661,5 +2662,311 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceMixedUsersPartial) {
 
         model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2},
                                                 ParameterVector{param1, param2, param3, param4, add_param});
+    }
+}
+
+// --- Dynamic (structural) EliminateConcatStridedSlice — Gated-Delta-Net idiom -----------------
+//
+// These exercise the dynamic branch: a rank-1 Concat (axis 0) of `Reshape(Y_i, [-1])` flattens,
+// re-split by contiguous unit-step slices that share their boundary nodes and end at INT64_MAX,
+// each consumed by a Reshape that restores the pre-flatten producer shape. The pass must rewire
+// each Reshape-back straight to Y_i. Negative cases must leave the graph unchanged.
+
+// Flattens `src` to rank 1 via Reshape(src, [-1]).
+static std::shared_ptr<ov::Node> flatten_to_1d(const ov::Output<ov::Node>& src) {
+    auto minus_one = v0::Constant::create(element::i64, Shape{1}, {-1});
+    return std::make_shared<v1::Reshape>(src, minus_one, false);
+}
+
+// Reshapes `data` back to `like`'s (dynamic) shape via Reshape(data, ShapeOf(like)).
+static std::shared_ptr<ov::Node> reshape_to_like(const ov::Output<ov::Node>& data, const ov::Output<ov::Node>& like) {
+    auto shape = std::make_shared<ov::op::v3::ShapeOf>(like, element::i64);
+    return std::make_shared<v1::Reshape>(data, shape, false);
+}
+
+// Non-foldable element count of `src` along all dims: ReduceProd(ShapeOf(src)) -> shape [1].
+static std::shared_ptr<ov::Node> numel_of(const ov::Output<ov::Node>& src) {
+    auto shape = std::make_shared<ov::op::v3::ShapeOf>(src, element::i64);
+    auto axis = v0::Constant::create(element::i64, Shape{1}, {0});
+    return std::make_shared<v1::ReduceProd>(shape, axis, true);
+}
+
+static std::shared_ptr<ov::Node> make_unit_v8_slice(const ov::Output<ov::Node>& data,
+                                                    const ov::Output<ov::Node>& begin,
+                                                    const ov::Output<ov::Node>& end) {
+    auto step = v0::Constant::create(element::i64, Shape{1}, {1});
+    auto axes = v0::Constant::create(element::i64, Shape{1}, {0});
+    return std::make_shared<op::v8::Slice>(data, begin, end, step, axes);
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnTwoInputs) {
+    disable_rt_info_check();
+    disable_result_friendly_names_check();
+    {
+        auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+        auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+        auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+
+        auto boundary = numel_of(y0);
+        auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+
+        auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+        auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
+
+        model = make_shared<ov::Model>(
+            ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                         make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+            ParameterVector{y0, y1});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+        auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+        model_ref = make_shared<ov::Model>(
+            ResultVector{make_shared<v0::Result>(y0), make_shared<v0::Result>(y1)}, ParameterVector{y0, y1});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnThreeInputs) {
+    disable_rt_info_check();
+    disable_result_friendly_names_check();
+    {
+        auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+        auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+        auto y2 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 4, 8});
+        auto concat =
+            make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1), flatten_to_1d(y2)}, 0);
+
+        auto numel0 = numel_of(y0);
+        auto boundary1 = std::make_shared<v1::Add>(numel0, numel_of(y1));  // numel0 + numel1
+        auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+
+        auto slice0 = make_unit_v8_slice(concat, zero, numel0);
+        auto slice1 = make_unit_v8_slice(concat, numel0, boundary1);
+        auto slice2 = make_unit_v8_slice(concat, boundary1, to_end);
+
+        model = make_shared<ov::Model>(
+            ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                         make_shared<v0::Result>(reshape_to_like(slice1, y1)),
+                         make_shared<v0::Result>(reshape_to_like(slice2, y2))},
+            ParameterVector{y0, y1, y2});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+        auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+        auto y2 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 4, 8});
+        model_ref = make_shared<ov::Model>(
+            ResultVector{make_shared<v0::Result>(y0), make_shared<v0::Result>(y1), make_shared<v0::Result>(y2)},
+            ParameterVector{y0, y1, y2});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnStridedSlice) {
+    disable_rt_info_check();
+    disable_result_friendly_names_check();
+    {
+        auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+        auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+        auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+
+        auto boundary = numel_of(y0);
+        auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto ignored_end = v0::Constant::create(element::i64, Shape{1}, {0});
+
+        auto slice0 = std::make_shared<v1::StridedSlice>(concat,
+                                                         zero,
+                                                         boundary,
+                                                         std::vector<int64_t>{0},
+                                                         std::vector<int64_t>{0});
+        auto slice1 = std::make_shared<v1::StridedSlice>(concat,
+                                                         boundary,
+                                                         ignored_end,
+                                                         std::vector<int64_t>{0},
+                                                         std::vector<int64_t>{1});  // end_mask: to the end
+
+        model = make_shared<ov::Model>(
+            ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                         make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+            ParameterVector{y0, y1});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+        auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+        model_ref = make_shared<ov::Model>(
+            ResultVector{make_shared<v0::Result>(y0), make_shared<v0::Result>(y1)}, ParameterVector{y0, y1});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicNonSharedBoundary) {
+    // slice1.begin is a DIFFERENT (though structurally identical) node than slice0.end — the
+    // shared-boundary identity chain must reject it.
+    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+
+    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+    auto slice0 = make_unit_v8_slice(concat, zero, numel_of(y0));
+    auto slice1 = make_unit_v8_slice(concat, numel_of(y0), to_end);  // separate ReduceProd instance
+
+    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                   ParameterVector{y0, y1});
+    model_ref = model->clone();
+    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicStepNot1) {
+    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+
+    auto boundary = numel_of(y0);
+    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+    auto step2 = v0::Constant::create(element::i64, Shape{1}, {2});
+    auto one = v0::Constant::create(element::i64, Shape{1}, {1});
+    auto axes = v0::Constant::create(element::i64, Shape{1}, {0});
+    auto slice0 = std::make_shared<op::v8::Slice>(concat, zero, boundary, step2, axes);  // non-unit step
+    auto slice1 = std::make_shared<op::v8::Slice>(concat, boundary, to_end, one, axes);
+
+    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                   ParameterVector{y0, y1});
+    model_ref = model->clone();
+    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicReshapeBackShapeMismatch) {
+    // slice0's Reshape-back restores y1's shape, not y0's — the static-dim guard must reject.
+    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+
+    auto boundary = numel_of(y0);
+    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+    auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
+
+    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y1)),
+                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                   ParameterVector{y0, y1});
+    model_ref = model->clone();
+    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicInputNotFlatten) {
+    // One Concat input is not a Reshape(.,[-1]) — G2 must reject.
+    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+    auto raw1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1});  // already rank-1, not a flatten
+    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), raw1}, 0);
+
+    auto boundary = numel_of(y0);
+    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+    auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
+
+    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                make_shared<v0::Result>(slice1)},
+                                   ParameterVector{y0, raw1});
+    model_ref = model->clone();
+    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicLastNotToEnd) {
+    // The last slice does not reach the end (a non-foldable, non-sentinel stop) — must reject.
+    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+
+    auto boundary = numel_of(y0);
+    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+    auto slice1 = make_unit_v8_slice(concat, boundary, numel_of(y1));  // finite, not to-end
+
+    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                   ParameterVector{y0, y1});
+    model_ref = model->clone();
+    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicSliceHasExtraConsumer) {
+    // slice0 feeds both a Reshape-back and an extra Relu — the single-consumer guard must reject.
+    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+
+    auto boundary = numel_of(y0);
+    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+    auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
+    auto extra = std::make_shared<op::v0::Relu>(slice0);
+
+    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                make_shared<v0::Result>(extra),
+                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                   ParameterVector{y0, y1});
+    model_ref = model->clone();
+    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicConcatHasExtraUser) {
+    // The Concat feeds a non-slice user (Relu) besides the slices — must reject.
+    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+
+    auto boundary = numel_of(y0);
+    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+    auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
+    auto extra = std::make_shared<op::v0::Relu>(concat);
+
+    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                make_shared<v0::Result>(reshape_to_like(slice1, y1)),
+                                                make_shared<v0::Result>(extra)},
+                                   ParameterVector{y0, y1});
+    model_ref = model->clone();
+    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnReversedSliceOrder) {
+    // The last-region slice is built (and wired) BEFORE the first-region slice, so the Concat's user
+    // order does not match its input order. The pass must still pair each slice with the correct
+    // pre-flatten producer via the tiling chain (proves the pre_flatten[k] pairing is order-robust).
+    disable_rt_info_check();
+    disable_result_friendly_names_check();
+    {
+        auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+        auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+        auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+
+        auto boundary = numel_of(y0);
+        auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+
+        auto slice1 = make_unit_v8_slice(concat, boundary, to_end);  // built first: covers y1's region
+        auto slice0 = make_unit_v8_slice(concat, zero, boundary);    // built second: covers y0's region
+
+        model = make_shared<ov::Model>(
+            ResultVector{make_shared<v0::Result>(reshape_to_like(slice1, y1)),
+                         make_shared<v0::Result>(reshape_to_like(slice0, y0))},
+            ParameterVector{y0, y1});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+        auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+        model_ref = make_shared<ov::Model>(
+            ResultVector{make_shared<v0::Result>(y1), make_shared<v0::Result>(y0)}, ParameterVector{y0, y1});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2276,3 +2276,334 @@ TEST_F(TransformationTestsF, EliminateIdentityConvert_identity_multiple_consumer
 
     model_ref = model->clone();
 }
+TEST_F(TransformationTestsF, EliminateConcatSlice) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto param4 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 6});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3, param4}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+
+        auto add_param = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto add = std::make_shared<op::v1::Add>(slice1, add_param);
+        auto result1 = std::make_shared<op::v0::Result>(add);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {18});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2},
+                                            ParameterVector{param1, param2, param3, param4, add_param});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto param4 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 6});
+        auto add_param = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto add = std::make_shared<op::v1::Add>(param1, add_param);
+        auto result1 = std::make_shared<op::v0::Result>(add);
+
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param2, param3, param4}), axis);
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {15});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2},
+                                                ParameterVector{param1, param2, param3, param4, add_param});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceAll) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {4});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
+
+        auto relu1 = std::make_shared<op::v0::Relu>(param1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto relu2 = std::make_shared<op::v0::Relu>(param2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceConcat) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {12});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
+
+        auto result = std::make_shared<op::v0::Result>(concat1);
+        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+
+        auto relu = std::make_shared<op::v0::Relu>(param1);
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({relu, param2, param3}), axis);
+        auto result = std::make_shared<op::v0::Result>(concat);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceMismatch) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {4});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {10});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
+
+        auto result = std::make_shared<op::v0::Result>(concat1);
+        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {4});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {10});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
+
+        auto result = std::make_shared<op::v0::Result>(concat1);
+        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceDiffAxis) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {1});  // different axis than concat
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto result = std::make_shared<op::v0::Result>(relu);
+        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
+
+        auto result = std::make_shared<op::v0::Result>(relu);
+        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceNonUnitStep) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {2});  // non-unit step
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {6});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {2});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {6});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatSliceWithAxes) {
+    {
+        int64_t axis = 1;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 3, 10});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 4, 10});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 5, 10});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {7});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        auto start3 = v0::Constant::create(element::i64, Shape{1}, {7});
+        auto stop3 = v0::Constant::create(element::i64, Shape{1}, {12});
+        auto step3 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes3 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice3 = std::make_shared<op::v8::Slice>(concat, start3, stop3, step3, axes3);
+        auto relu3 = std::make_shared<op::v0::Relu>(slice3);
+        auto result3 = std::make_shared<op::v0::Result>(relu3);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2, result3},
+                                            ParameterVector{param1, param2, param3});
+        manager.register_pass<ov::pass::EliminateConcatSlice>();
+    }
+    {
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 3, 10});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 4, 10});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 5, 10});
+
+        auto relu1 = std::make_shared<op::v0::Relu>(param1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto relu2 = std::make_shared<op::v0::Relu>(param2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        auto relu3 = std::make_shared<op::v0::Relu>(param3);
+        auto result3 = std::make_shared<op::v0::Result>(relu3);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2, result3},
+                                                ParameterVector{param1, param2, param3});
+    }
+}

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <limits>
 #include <memory>
 #include <queue>
@@ -2801,143 +2802,164 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnStridedSlice) 
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicNonSharedBoundary) {
-    // slice1.begin is a DIFFERENT (though structurally identical) node than slice0.end — the
-    // shared-boundary identity chain must reject it.
-    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
-    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
-    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+// Negative dynamic cases: each builds the GDN flatten/Concat/Slice/Reshape idiom with a single
+// structural violation, so the pass must leave the graph unchanged. They share an identical
+// skeleton (build graph -> model_ref = model->clone() -> register pass), so they are
+// parametrized over a model-builder lambda. (The positive dynamic tests stay TEST_F: they need
+// disable_rt_info_check()/disable_result_friendly_names_check() and distinct model_ref graphs.)
+struct DynamicNegativeParams {
+    std::function<std::shared_ptr<ov::Model>()> build;
+    const char* name;
+};
 
-    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
-    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
-    auto slice0 = make_unit_v8_slice(concat, zero, numel_of(y0));
-    auto slice1 = make_unit_v8_slice(concat, numel_of(y0), to_end);  // separate ReduceProd instance
+class EliminateConcatStridedSliceDynamicNegative : public TransformationTestsF,
+                                                   public ::testing::WithParamInterface<DynamicNegativeParams> {};
 
-    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                                   ParameterVector{y0, y1});
+TEST_P(EliminateConcatStridedSliceDynamicNegative, NoChange) {
+    model = GetParam().build();
     model_ref = model->clone();
     manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
 }
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicStepNot1) {
-    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
-    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
-    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+INSTANTIATE_TEST_SUITE_P(
+    EliminateConcatStridedSliceDynamic,
+    EliminateConcatStridedSliceDynamicNegative,
+    ::testing::ValuesIn(std::vector<DynamicNegativeParams>{
+        {[] {
+             // slice1.begin is a DIFFERENT (though structurally identical) node than slice0.end —
+             // the shared-boundary identity chain must reject it.
+             auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+             auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+             auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
 
-    auto boundary = numel_of(y0);
-    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
-    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
-    auto step2 = v0::Constant::create(element::i64, Shape{1}, {2});
-    auto one = v0::Constant::create(element::i64, Shape{1}, {1});
-    auto axes = v0::Constant::create(element::i64, Shape{1}, {0});
-    auto slice0 = std::make_shared<op::v8::Slice>(concat, zero, boundary, step2, axes);  // non-unit step
-    auto slice1 = std::make_shared<op::v8::Slice>(concat, boundary, to_end, one, axes);
+             auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+             auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+             auto slice0 = make_unit_v8_slice(concat, zero, numel_of(y0));
+             auto slice1 = make_unit_v8_slice(concat, numel_of(y0), to_end);  // separate ReduceProd instance
 
-    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                                   ParameterVector{y0, y1});
-    model_ref = model->clone();
-    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-}
+             return make_shared<ov::Model>(
+                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                 ParameterVector{y0, y1});
+         },
+         "NonSharedBoundary"},
+        {[] {
+             auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+             auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+             auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicReshapeBackShapeMismatch) {
-    // slice0's Reshape-back restores y1's shape, not y0's — the static-dim guard must reject.
-    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
-    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
-    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+             auto boundary = numel_of(y0);
+             auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+             auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+             auto step2 = v0::Constant::create(element::i64, Shape{1}, {2});
+             auto one = v0::Constant::create(element::i64, Shape{1}, {1});
+             auto axes = v0::Constant::create(element::i64, Shape{1}, {0});
+             auto slice0 = std::make_shared<op::v8::Slice>(concat, zero, boundary, step2, axes);  // non-unit step
+             auto slice1 = std::make_shared<op::v8::Slice>(concat, boundary, to_end, one, axes);
 
-    auto boundary = numel_of(y0);
-    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
-    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
-    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
-    auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
+             return make_shared<ov::Model>(
+                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                 ParameterVector{y0, y1});
+         },
+         "StepNot1"},
+        {[] {
+             // slice0's Reshape-back restores y1's shape, not y0's — the static-dim guard must reject.
+             auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+             auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+             auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
 
-    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y1)),
-                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                                   ParameterVector{y0, y1});
-    model_ref = model->clone();
-    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-}
+             auto boundary = numel_of(y0);
+             auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+             auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+             auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+             auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicInputNotFlatten) {
-    // One Concat input is not a Reshape(.,[-1]) — G2 must reject.
-    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
-    auto raw1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1});  // already rank-1, not a flatten
-    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), raw1}, 0);
+             return make_shared<ov::Model>(
+                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y1)),
+                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                 ParameterVector{y0, y1});
+         },
+         "ReshapeBackShapeMismatch"},
+        {[] {
+             // One Concat input is not a Reshape(.,[-1]) — G2 must reject.
+             auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+             auto raw1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1});  // already rank-1, not a flatten
+             auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), raw1}, 0);
 
-    auto boundary = numel_of(y0);
-    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
-    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
-    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
-    auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
+             auto boundary = numel_of(y0);
+             auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+             auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+             auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+             auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
 
-    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                                                make_shared<v0::Result>(slice1)},
-                                   ParameterVector{y0, raw1});
-    model_ref = model->clone();
-    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-}
+             return make_shared<ov::Model>(
+                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                              make_shared<v0::Result>(slice1)},
+                 ParameterVector{y0, raw1});
+         },
+         "InputNotFlatten"},
+        {[] {
+             // The last slice does not reach the end (a non-foldable, non-sentinel stop) — must reject.
+             auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+             auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+             auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicLastNotToEnd) {
-    // The last slice does not reach the end (a non-foldable, non-sentinel stop) — must reject.
-    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
-    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
-    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+             auto boundary = numel_of(y0);
+             auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+             auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+             auto slice1 = make_unit_v8_slice(concat, boundary, numel_of(y1));  // finite, not to-end
 
-    auto boundary = numel_of(y0);
-    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
-    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
-    auto slice1 = make_unit_v8_slice(concat, boundary, numel_of(y1));  // finite, not to-end
+             return make_shared<ov::Model>(
+                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                 ParameterVector{y0, y1});
+         },
+         "LastNotToEnd"},
+        {[] {
+             // slice0 feeds both a Reshape-back and an extra Relu — the single-consumer guard must reject.
+             auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+             auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+             auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
 
-    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                                   ParameterVector{y0, y1});
-    model_ref = model->clone();
-    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-}
+             auto boundary = numel_of(y0);
+             auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+             auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+             auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+             auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
+             auto extra = std::make_shared<op::v0::Relu>(slice0);
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicSliceHasExtraConsumer) {
-    // slice0 feeds both a Reshape-back and an extra Relu — the single-consumer guard must reject.
-    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
-    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
-    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
+             return make_shared<ov::Model>(
+                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                              make_shared<v0::Result>(extra),
+                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                 ParameterVector{y0, y1});
+         },
+         "SliceHasExtraConsumer"},
+        {[] {
+             // The Concat feeds a non-slice user (Relu) besides the slices — must reject.
+             auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
+             auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
+             auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
 
-    auto boundary = numel_of(y0);
-    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
-    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
-    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
-    auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
-    auto extra = std::make_shared<op::v0::Relu>(slice0);
+             auto boundary = numel_of(y0);
+             auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
+             auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
+             auto slice0 = make_unit_v8_slice(concat, zero, boundary);
+             auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
+             auto extra = std::make_shared<op::v0::Relu>(concat);
 
-    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                                                make_shared<v0::Result>(extra),
-                                                make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                                   ParameterVector{y0, y1});
-    model_ref = model->clone();
-    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-}
-
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicConcatHasExtraUser) {
-    // The Concat feeds a non-slice user (Relu) besides the slices — must reject.
-    auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
-    auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
-    auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1)}, 0);
-
-    auto boundary = numel_of(y0);
-    auto zero = v0::Constant::create(element::i64, Shape{1}, {0});
-    auto to_end = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>::max()});
-    auto slice0 = make_unit_v8_slice(concat, zero, boundary);
-    auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
-    auto extra = std::make_shared<op::v0::Relu>(concat);
-
-    model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                                                make_shared<v0::Result>(reshape_to_like(slice1, y1)),
-                                                make_shared<v0::Result>(extra)},
-                                   ParameterVector{y0, y1});
-    model_ref = model->clone();
-    manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-}
+             return make_shared<ov::Model>(
+                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                              make_shared<v0::Result>(reshape_to_like(slice1, y1)),
+                              make_shared<v0::Result>(extra)},
+                 ParameterVector{y0, y1});
+         },
+         "ConcatHasExtraUser"},
+    }),
+    [](const ::testing::TestParamInfo<DynamicNegativeParams>& info) {
+        return std::string(info.param.name);
+    });
 
 TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnReversedSliceOrder) {
     // The last-region slice is built (and wired) BEFORE the first-region slice, so the Concat's user

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2276,7 +2276,8 @@ TEST_F(TransformationTestsF, EliminateIdentityConvert_identity_multiple_consumer
 
     model_ref = model->clone();
 }
-TEST_F(TransformationTestsF, EliminateConcatSlice) {
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceV8Slice) {
     {
         int64_t axis = 2;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
@@ -2331,7 +2332,7 @@ TEST_F(TransformationTestsF, EliminateConcatSlice) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatSliceAll) {
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceAllV8Slice) {
     {
         int64_t axis = 2;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
@@ -2371,7 +2372,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceAll) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatSliceConcat) {
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatV8Slice) {
     {
         int64_t axis = 2;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
@@ -2411,7 +2412,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceConcat) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatSliceMismatch) {
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatMismatchV8Slice) {
     {
         int64_t axis = 2;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
@@ -2463,7 +2464,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceMismatch) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatSliceDiffAxis) {
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatDiffAxisV8Slice) {
     {
         int64_t axis = 2;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
@@ -2501,7 +2502,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceDiffAxis) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatSliceNonUnitStep) {
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceNonUnitStepV8Slice) {
     {
         int64_t axis = 2;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
@@ -2553,7 +2554,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceNonUnitStep) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatSliceWithAxes) {
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceWithAxesV8Slice) {
     {
         int64_t axis = 1;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 3, 10});
@@ -2605,5 +2606,106 @@ TEST_F(TransformationTestsF, EliminateConcatSliceWithAxes) {
 
         model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2, result3},
                                                 ParameterVector{param1, param2, param3});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceMixedUsers) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto begin_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
+        auto end_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
+        auto strided_slice1 = std::make_shared<v1::StridedSlice>(concat,
+                                                                 begin_const1,
+                                                                 end_const1,
+                                                                 std::vector<int64_t>{1, 1, 0},
+                                                                 std::vector<int64_t>{1, 1, 0});
+        auto relu1 = std::make_shared<op::v0::Relu>(strided_slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {7});
+        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+
+        auto relu1 = std::make_shared<op::v0::Relu>(param1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto relu2 = std::make_shared<op::v0::Relu>(param2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceMixedUsersPartial) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto param4 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 6});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3, param4}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
+        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
+
+        auto add_param = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto add = std::make_shared<op::v1::Add>(slice1, add_param);
+        auto result1 = std::make_shared<op::v0::Result>(add);
+
+        auto begin_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
+        auto end_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 18});
+        auto strided_slice2 = std::make_shared<v1::StridedSlice>(concat,
+                                                                 begin_const2,
+                                                                 end_const2,
+                                                                 std::vector<int64_t>{1, 1, 0},
+                                                                 std::vector<int64_t>{1, 1, 0});
+        auto relu = std::make_shared<op::v0::Relu>(strided_slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2},
+                                            ParameterVector{param1, param2, param3, param4, add_param});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto param4 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 6});
+        auto add_param = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto add = std::make_shared<op::v1::Add>(param1, add_param);
+        auto result1 = std::make_shared<op::v0::Result>(add);
+
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param2, param3, param4}), axis);
+        auto begin_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
+        auto end_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 15});
+        auto strided_slice2 = std::make_shared<v1::StridedSlice>(concat,
+                                                                 begin_const2,
+                                                                 end_const2,
+                                                                 std::vector<int64_t>{1, 1, 0},
+                                                                 std::vector<int64_t>{1, 1, 0});
+        auto relu = std::make_shared<op::v0::Relu>(strided_slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2},
+                                                ParameterVector{param1, param2, param3, param4, add_param});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -1559,35 +1559,60 @@ TEST_F(TransformationTestsF, EliminateSliceBeforeGatherElements) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSlice) {
+enum class SliceUserKind { StridedSlice, V8Slice };
+
+// Constructs either a v1::StridedSlice or a v8::Slice consuming `input`,
+// slicing only along `slice_axis` from [begin, end) with step 1. Other axes
+// are kept full-range (StridedSlice via begin_mask/end_mask = 1; v8::Slice
+// via explicit single-element axes/start/stop/step vectors).
+static std::shared_ptr<ov::Node> make_axis_slice(SliceUserKind kind,
+                                                 const ov::Output<ov::Node>& input,
+                                                 int64_t rank,
+                                                 int64_t slice_axis,
+                                                 int64_t begin,
+                                                 int64_t end) {
+    if (kind == SliceUserKind::StridedSlice) {
+        const auto rank_sz = static_cast<size_t>(rank);
+        std::vector<int64_t> begin_vec(rank_sz, 0);
+        std::vector<int64_t> end_vec(rank_sz, 0);
+        std::vector<int64_t> begin_mask(rank_sz, 1);
+        std::vector<int64_t> end_mask(rank_sz, 1);
+        begin_vec[slice_axis] = begin;
+        end_vec[slice_axis] = end;
+        begin_mask[slice_axis] = 0;
+        end_mask[slice_axis] = 0;
+        auto begin_const = v0::Constant::create(element::i64, Shape{rank_sz}, begin_vec);
+        auto end_const = v0::Constant::create(element::i64, Shape{rank_sz}, end_vec);
+        return std::make_shared<v1::StridedSlice>(input, begin_const, end_const, begin_mask, end_mask);
+    }
+    auto start = v0::Constant::create(element::i64, Shape{1}, {begin});
+    auto stop = v0::Constant::create(element::i64, Shape{1}, {end});
+    auto step = v0::Constant::create(element::i64, Shape{1}, {1});
+    auto axes = v0::Constant::create(element::i64, Shape{1}, {slice_axis});
+    return std::make_shared<op::v8::Slice>(input, start, stop, step, axes);
+}
+
+class EliminateConcatStridedSliceVariants : public TransformationTestsF,
+                                            public ::testing::WithParamInterface<SliceUserKind> {};
+
+TEST_P(EliminateConcatStridedSliceVariants, Eliminate) {
+    const auto kind = GetParam();
     {
         int64_t axis = 2;
+        const int64_t rank = 3;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
         auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
         auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
         auto param4 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 6});
         auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3, param4}), axis);
 
-        auto begin_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
-        auto end_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
-        auto strided_slice1 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const1,
-                                                                 end_const1,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-
+        auto slice1 = make_axis_slice(kind, concat, rank, axis, 0, 3);
         auto add_param = make_shared<op::v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto add = std::make_shared<op::v1::Add>(strided_slice1, add_param);
+        auto add = std::make_shared<op::v1::Add>(slice1, add_param);
         auto result1 = std::make_shared<op::v0::Result>(add);
 
-        auto begin_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
-        auto end_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 18});
-        auto strided_slice2 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const2,
-                                                                 end_const2,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-        auto relu = std::make_shared<op::v0::Relu>(strided_slice2);
+        auto slice2 = make_axis_slice(kind, concat, rank, axis, 3, 18);
+        auto relu = std::make_shared<op::v0::Relu>(slice2);
         auto result2 = std::make_shared<op::v0::Result>(relu);
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2},
@@ -1596,6 +1621,7 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSlice) {
     }
     {
         int64_t axis = 2;
+        const int64_t rank = 3;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
         auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
         auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
@@ -1605,14 +1631,8 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSlice) {
         auto result1 = std::make_shared<op::v0::Result>(add);
 
         auto concat = make_shared<v0::Concat>(ov::as_output_vector({param2, param3, param4}), axis);
-        auto begin_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
-        auto end_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 15});
-        auto strided_slice2 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const2,
-                                                                 end_const2,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-        auto relu = std::make_shared<op::v0::Relu>(strided_slice2);
+        auto slice2 = make_axis_slice(kind, concat, rank, axis, 0, 15);
+        auto relu = std::make_shared<op::v0::Relu>(slice2);
         auto result2 = std::make_shared<op::v0::Result>(relu);
 
         model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2},
@@ -1620,32 +1640,21 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSlice) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceAll) {
+TEST_P(EliminateConcatStridedSliceVariants, EliminateAll) {
+    const auto kind = GetParam();
     {
         int64_t axis = 2;
+        const int64_t rank = 3;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
         auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
         auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
 
-        auto begin_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
-        auto end_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 1});
-        auto strided_slice1 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const1,
-                                                                 end_const1,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-
-        auto relu1 = std::make_shared<op::v0::Relu>(strided_slice1);
+        auto slice1 = make_axis_slice(kind, concat, rank, axis, 0, 1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
         auto result1 = std::make_shared<op::v0::Result>(relu1);
 
-        auto begin_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 1});
-        auto end_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 4});
-        auto strided_slice2 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const2,
-                                                                 end_const2,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-        auto relu2 = std::make_shared<op::v0::Relu>(strided_slice2);
+        auto slice2 = make_axis_slice(kind, concat, rank, axis, 1, 4);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
         auto result2 = std::make_shared<op::v0::Result>(relu2);
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
@@ -1665,31 +1674,21 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceAll) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcat) {
+TEST_P(EliminateConcatStridedSliceVariants, EliminateConcat) {
+    const auto kind = GetParam();
     {
         int64_t axis = 2;
+        const int64_t rank = 3;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
         auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
         auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
         auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
 
-        auto begin_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
-        auto end_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
-        auto strided_slice1 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const1,
-                                                                 end_const1,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-        auto relu = std::make_shared<op::v0::Relu>(strided_slice1);
+        auto slice1 = make_axis_slice(kind, concat, rank, axis, 0, 3);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
 
-        auto begin_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
-        auto end_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 12});
-        auto strided_slice2 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const2,
-                                                                 end_const2,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, strided_slice2}), axis);
+        auto slice2 = make_axis_slice(kind, concat, rank, axis, 3, 12);
+        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
 
         auto result = std::make_shared<op::v0::Result>(concat1);
         model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
@@ -1709,31 +1708,21 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcat) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatMismatch) {
+TEST_P(EliminateConcatStridedSliceVariants, EliminateConcatMismatch) {
+    const auto kind = GetParam();
     {
         int64_t axis = 2;
+        const int64_t rank = 3;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
         auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
         auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
         auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
 
-        auto begin_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
-        auto end_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 4});
-        auto strided_slice1 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const1,
-                                                                 end_const1,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-        auto relu = std::make_shared<op::v0::Relu>(strided_slice1);
+        auto slice1 = make_axis_slice(kind, concat, rank, axis, 0, 4);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
 
-        auto begin_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
-        auto end_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 10});
-        auto strided_slice2 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const2,
-                                                                 end_const2,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, strided_slice2}), axis);
+        auto slice2 = make_axis_slice(kind, concat, rank, axis, 3, 10);
+        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
 
         auto result = std::make_shared<op::v0::Result>(concat1);
         model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
@@ -1741,28 +1730,17 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatMismatch) {
     }
     {
         int64_t axis = 2;
+        const int64_t rank = 3;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
         auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
         auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
         auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
 
-        auto begin_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
-        auto end_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 4});
-        auto strided_slice1 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const1,
-                                                                 end_const1,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-        auto relu = std::make_shared<op::v0::Relu>(strided_slice1);
+        auto slice1 = make_axis_slice(kind, concat, rank, axis, 0, 4);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
 
-        auto begin_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
-        auto end_const2 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 10});
-        auto strided_slice2 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const2,
-                                                                 end_const2,
-                                                                 std::vector<int64_t>{1, 1, 0},
-                                                                 std::vector<int64_t>{1, 1, 0});
-        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, strided_slice2}), axis);
+        auto slice2 = make_axis_slice(kind, concat, rank, axis, 3, 10);
+        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
 
         auto result = std::make_shared<op::v0::Result>(concat1);
         model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
@@ -1820,48 +1798,48 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceTopKConcat) {
     }
 }
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatDiffAxis) {
+TEST_P(EliminateConcatStridedSliceVariants, EliminateConcatDiffAxis) {
+    const auto kind = GetParam();
     {
-        int64_t axis = 2;
+        int64_t concat_axis = 2;
+        int64_t slice_axis = 1;
+        const int64_t rank = 3;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
         auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
         auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), concat_axis);
 
-        auto begin_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
-        auto end_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 3, 0});
-        auto strided_slice1 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const1,
-                                                                 end_const1,
-                                                                 std::vector<int64_t>{1, 0, 1},
-                                                                 std::vector<int64_t>{1, 0, 1});
-        auto relu = std::make_shared<op::v0::Relu>(strided_slice1);
+        auto slice1 = make_axis_slice(kind, concat, rank, slice_axis, 0, 3);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
 
         auto result = std::make_shared<op::v0::Result>(relu);
         model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
         manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
-        int64_t axis = 2;
+        int64_t concat_axis = 2;
+        int64_t slice_axis = 1;
+        const int64_t rank = 3;
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
         auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
         auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), concat_axis);
 
-        auto begin_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
-        auto end_const1 = v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 3, 0});
-        auto strided_slice1 = std::make_shared<v1::StridedSlice>(concat,
-                                                                 begin_const1,
-                                                                 end_const1,
-                                                                 std::vector<int64_t>{1, 0, 1},
-                                                                 std::vector<int64_t>{1, 0, 1});
-        auto relu = std::make_shared<op::v0::Relu>(strided_slice1);
+        auto slice1 = make_axis_slice(kind, concat, rank, slice_axis, 0, 3);
+        auto relu = std::make_shared<op::v0::Relu>(slice1);
 
         auto result = std::make_shared<op::v0::Result>(relu);
 
         model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
     }
 }
+
+INSTANTIATE_TEST_SUITE_P(EliminateConcatStridedSlice,
+                         EliminateConcatStridedSliceVariants,
+                         ::testing::Values(SliceUserKind::StridedSlice, SliceUserKind::V8Slice),
+                         [](const ::testing::TestParamInfo<SliceUserKind>& info) {
+                             return info.param == SliceUserKind::StridedSlice ? "StridedSlice" : "V8Slice";
+                         });
 
 TEST_F(TransformationTestsF, EliminateStridedSlice) {
     {
@@ -2277,231 +2255,6 @@ TEST_F(TransformationTestsF, EliminateIdentityConvert_identity_multiple_consumer
     model_ref = model->clone();
 }
 
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceV8Slice) {
-    {
-        int64_t axis = 2;
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
-        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-        auto param4 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 6});
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3, param4}), axis);
-
-        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
-        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
-        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
-
-        auto add_param = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto add = std::make_shared<op::v1::Add>(slice1, add_param);
-        auto result1 = std::make_shared<op::v0::Result>(add);
-
-        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
-        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {18});
-        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
-        auto relu = std::make_shared<op::v0::Relu>(slice2);
-        auto result2 = std::make_shared<op::v0::Result>(relu);
-
-        model = std::make_shared<ov::Model>(ResultVector{result1, result2},
-                                            ParameterVector{param1, param2, param3, param4, add_param});
-        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-    }
-    {
-        int64_t axis = 2;
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
-        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-        auto param4 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 6});
-        auto add_param = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto add = std::make_shared<op::v1::Add>(param1, add_param);
-        auto result1 = std::make_shared<op::v0::Result>(add);
-
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param2, param3, param4}), axis);
-        auto start2 = v0::Constant::create(element::i64, Shape{1}, {0});
-        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {15});
-        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
-        auto relu = std::make_shared<op::v0::Relu>(slice2);
-        auto result2 = std::make_shared<op::v0::Result>(relu);
-
-        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2},
-                                                ParameterVector{param1, param2, param3, param4, add_param});
-    }
-}
-
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceAllV8Slice) {
-    {
-        int64_t axis = 2;
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
-
-        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
-        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
-        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
-        auto result1 = std::make_shared<op::v0::Result>(relu1);
-
-        auto start2 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {4});
-        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
-        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
-        auto result2 = std::make_shared<op::v0::Result>(relu2);
-
-        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
-        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-    }
-    {
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
-
-        auto relu1 = std::make_shared<op::v0::Relu>(param1);
-        auto result1 = std::make_shared<op::v0::Result>(relu1);
-
-        auto relu2 = std::make_shared<op::v0::Relu>(param2);
-        auto result2 = std::make_shared<op::v0::Result>(relu2);
-
-        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
-    }
-}
-
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatV8Slice) {
-    {
-        int64_t axis = 2;
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
-        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
-
-        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
-        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
-        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
-        auto relu = std::make_shared<op::v0::Relu>(slice1);
-
-        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
-        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {12});
-        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
-        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
-
-        auto result = std::make_shared<op::v0::Result>(concat1);
-        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-    }
-    {
-        int64_t axis = 2;
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
-        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-
-        auto relu = std::make_shared<op::v0::Relu>(param1);
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({relu, param2, param3}), axis);
-        auto result = std::make_shared<op::v0::Result>(concat);
-
-        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-    }
-}
-
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatMismatchV8Slice) {
-    {
-        int64_t axis = 2;
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
-        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
-
-        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
-        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {4});
-        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
-        auto relu = std::make_shared<op::v0::Relu>(slice1);
-
-        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
-        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {10});
-        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
-        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
-
-        auto result = std::make_shared<op::v0::Result>(concat1);
-        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-    }
-    {
-        int64_t axis = 2;
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
-        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
-
-        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
-        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {4});
-        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
-        auto relu = std::make_shared<op::v0::Relu>(slice1);
-
-        auto start2 = v0::Constant::create(element::i64, Shape{1}, {3});
-        auto stop2 = v0::Constant::create(element::i64, Shape{1}, {10});
-        auto step2 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes2 = v0::Constant::create(element::i64, Shape{1}, {axis});
-        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2, axes2);
-        auto concat1 = make_shared<v0::Concat>(ov::as_output_vector({relu, slice2}), axis);
-
-        auto result = std::make_shared<op::v0::Result>(concat1);
-        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-    }
-}
-
-TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatDiffAxisV8Slice) {
-    {
-        int64_t axis = 2;
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
-        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
-
-        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
-        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
-        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {1});  // different axis than concat
-        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
-        auto relu = std::make_shared<op::v0::Relu>(slice1);
-
-        auto result = std::make_shared<op::v0::Result>(relu);
-        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
-    }
-    {
-        int64_t axis = 2;
-        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
-        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
-        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
-        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
-
-        auto start1 = v0::Constant::create(element::i64, Shape{1}, {0});
-        auto stop1 = v0::Constant::create(element::i64, Shape{1}, {3});
-        auto step1 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto axes1 = v0::Constant::create(element::i64, Shape{1}, {1});
-        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1, axes1);
-        auto relu = std::make_shared<op::v0::Relu>(slice1);
-
-        auto result = std::make_shared<op::v0::Result>(relu);
-        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-    }
-}
-
 TEST_F(TransformationTestsF, EliminateConcatStridedSliceNonUnitStepV8Slice) {
     {
         int64_t axis = 2;
@@ -2606,6 +2359,46 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceWithAxesV8Slice) {
 
         model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2, result3},
                                                 ParameterVector{param1, param2, param3});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceNoAxesV8Slice) {
+    // v8::Slice constructed without explicit `axes` input (4-input form):
+    // start/stop/step are sized to rank, axes are inferred as [0, 1, ..., rank-1].
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto start1 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 0});
+        auto stop1 = v0::Constant::create(element::i64, Shape{3}, {2, 10, 3});
+        auto step1 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+        auto slice1 = std::make_shared<op::v8::Slice>(concat, start1, stop1, step1);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto start2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 3});
+        auto stop2 = v0::Constant::create(element::i64, Shape{3}, {2, 10, 7});
+        auto step2 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+        auto slice2 = std::make_shared<op::v8::Slice>(concat, start2, stop2, step2);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+
+        auto relu1 = std::make_shared<op::v0::Relu>(param1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto relu2 = std::make_shared<op::v0::Relu>(param2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
     }
 }
 

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2305,7 +2305,7 @@ TEST_F(TransformationTestsF, EliminateConcatSlice) {
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2},
                                             ParameterVector{param1, param2, param3, param4, add_param});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2355,7 +2355,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceAll) {
         auto result2 = std::make_shared<op::v0::Result>(relu2);
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 1});
@@ -2395,7 +2395,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceConcat) {
 
         auto result = std::make_shared<op::v0::Result>(concat1);
         model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2435,7 +2435,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceMismatch) {
 
         auto result = std::make_shared<op::v0::Result>(concat1);
         model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2480,7 +2480,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceDiffAxis) {
 
         auto result = std::make_shared<op::v0::Result>(relu);
         model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2525,7 +2525,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceNonUnitStep) {
         auto result2 = std::make_shared<op::v0::Result>(relu2);
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         int64_t axis = 2;
@@ -2587,7 +2587,7 @@ TEST_F(TransformationTestsF, EliminateConcatSliceWithAxes) {
 
         model = std::make_shared<ov::Model>(ResultVector{result1, result2, result3},
                                             ParameterVector{param1, param2, param3});
-        manager.register_pass<ov::pass::EliminateConcatSlice>();
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 3, 10});

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2307,6 +2307,58 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceNonUnitStepV8Slice) {
     }
 }
 
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceNonUnitStrides) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto begin1 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 0});
+        auto end1 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 3});
+        auto strides1 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 2});  // non-unit on concat axis
+        std::vector<int64_t> begin_mask{1, 1, 0};
+        std::vector<int64_t> end_mask{1, 1, 0};
+        auto slice1 = std::make_shared<v1::StridedSlice>(concat, begin1, end1, strides1, begin_mask, end_mask);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto begin2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 3});
+        auto end2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 6});
+        auto strides2 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+        auto slice2 = std::make_shared<v1::StridedSlice>(concat, begin2, end2, strides2, begin_mask, end_mask);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto begin1 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 0});
+        auto end1 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 3});
+        auto strides1 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 2});
+        std::vector<int64_t> begin_mask{1, 1, 0};
+        std::vector<int64_t> end_mask{1, 1, 0};
+        auto slice1 = std::make_shared<v1::StridedSlice>(concat, begin1, end1, strides1, begin_mask, end_mask);
+        auto relu1 = std::make_shared<op::v0::Relu>(slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto begin2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 3});
+        auto end2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 6});
+        auto strides2 = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+        auto slice2 = std::make_shared<v1::StridedSlice>(concat, begin2, end2, strides2, begin_mask, end_mask);
+        auto relu2 = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+    }
+}
+
 TEST_F(TransformationTestsF, EliminateConcatStridedSliceWithAxesV8Slice) {
     {
         int64_t axis = 1;

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2410,6 +2410,65 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceEmptyMaskNonAxisAligned)
     }
 }
 
+// Exercises build_residual_slice() with a 4-input v1::StridedSlice (explicit unit strides):
+// one exact-match user is eliminated, the other forces a residual rebuild whose clone must
+// preserve the strides input.
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceUnitStridesResidual) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        std::vector<int64_t> begin_mask{1, 1, 0};
+        std::vector<int64_t> end_mask{1, 1, 0};
+        auto strides_unit = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+
+        // Exact match against param1.
+        auto begin1 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 0});
+        auto end1 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 3});
+        auto slice1 = std::make_shared<v1::StridedSlice>(concat, begin1, end1, strides_unit, begin_mask, end_mask);
+        auto add_param = make_shared<op::v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto add = std::make_shared<op::v1::Add>(slice1, add_param);
+        auto result1 = std::make_shared<op::v0::Result>(add);
+
+        // Mismatch — spans param2+param3 ([3,11]); forces residual rebuild.
+        auto begin2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 3});
+        auto end2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 12});
+        auto slice2 = std::make_shared<v1::StridedSlice>(concat, begin2, end2, strides_unit, begin_mask, end_mask);
+        auto relu = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2},
+                                            ParameterVector{param1, param2, param3, add_param});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto add_param = make_shared<op::v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto add = std::make_shared<op::v1::Add>(param1, add_param);
+        auto result1 = std::make_shared<op::v0::Result>(add);
+
+        auto new_concat = make_shared<v0::Concat>(ov::as_output_vector({param2, param3}), axis);
+        std::vector<int64_t> begin_mask{1, 1, 0};
+        std::vector<int64_t> end_mask{1, 1, 0};
+        auto strides_unit = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
+        auto begin2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 0});
+        auto end2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 9});
+        auto slice2 =
+            std::make_shared<v1::StridedSlice>(new_concat, begin2, end2, strides_unit, begin_mask, end_mask);
+        auto relu = std::make_shared<op::v0::Relu>(slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2},
+                                                ParameterVector{param1, param2, param3, add_param});
+    }
+}
+
 TEST_F(TransformationTestsF, EliminateConcatStridedSliceWithAxesV8Slice) {
     {
         int64_t axis = 1;

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2459,8 +2459,7 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceUnitStridesResidual) {
         auto strides_unit = v0::Constant::create(element::i64, Shape{3}, {1, 1, 1});
         auto begin2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 0});
         auto end2 = v0::Constant::create(element::i64, Shape{3}, {0, 0, 9});
-        auto slice2 =
-            std::make_shared<v1::StridedSlice>(new_concat, begin2, end2, strides_unit, begin_mask, end_mask);
+        auto slice2 = std::make_shared<v1::StridedSlice>(new_concat, begin2, end2, strides_unit, begin_mask, end_mask);
         auto relu = std::make_shared<op::v0::Relu>(slice2);
         auto result2 = std::make_shared<op::v0::Result>(relu);
 

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2715,17 +2715,16 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnTwoInputs) {
         auto slice0 = make_unit_v8_slice(concat, zero, boundary);
         auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
 
-        model = make_shared<ov::Model>(
-            ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                         make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-            ParameterVector{y0, y1});
+        model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                    make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                       ParameterVector{y0, y1});
         manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
         auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
-        model_ref = make_shared<ov::Model>(
-            ResultVector{make_shared<v0::Result>(y0), make_shared<v0::Result>(y1)}, ParameterVector{y0, y1});
+        model_ref = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(y0), make_shared<v0::Result>(y1)},
+                                           ParameterVector{y0, y1});
     }
 }
 
@@ -2736,8 +2735,7 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnThreeInputs) {
         auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
         auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
         auto y2 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 4, 8});
-        auto concat =
-            make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1), flatten_to_1d(y2)}, 0);
+        auto concat = make_shared<v0::Concat>(OutputVector{flatten_to_1d(y0), flatten_to_1d(y1), flatten_to_1d(y2)}, 0);
 
         auto numel0 = numel_of(y0);
         auto boundary1 = std::make_shared<v1::Add>(numel0, numel_of(y1));  // numel0 + numel1
@@ -2748,11 +2746,10 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnThreeInputs) {
         auto slice1 = make_unit_v8_slice(concat, numel0, boundary1);
         auto slice2 = make_unit_v8_slice(concat, boundary1, to_end);
 
-        model = make_shared<ov::Model>(
-            ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                         make_shared<v0::Result>(reshape_to_like(slice1, y1)),
-                         make_shared<v0::Result>(reshape_to_like(slice2, y2))},
-            ParameterVector{y0, y1, y2});
+        model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                    make_shared<v0::Result>(reshape_to_like(slice1, y1)),
+                                                    make_shared<v0::Result>(reshape_to_like(slice2, y2))},
+                                       ParameterVector{y0, y1, y2});
         manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
@@ -2788,17 +2785,16 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnStridedSlice) 
                                                          std::vector<int64_t>{0},
                                                          std::vector<int64_t>{1});  // end_mask: to the end
 
-        model = make_shared<ov::Model>(
-            ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                         make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-            ParameterVector{y0, y1});
+        model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                    make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                       ParameterVector{y0, y1});
         manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
         auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
-        model_ref = make_shared<ov::Model>(
-            ResultVector{make_shared<v0::Result>(y0), make_shared<v0::Result>(y1)}, ParameterVector{y0, y1});
+        model_ref = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(y0), make_shared<v0::Result>(y1)},
+                                           ParameterVector{y0, y1});
     }
 }
 
@@ -2837,10 +2833,9 @@ INSTANTIATE_TEST_SUITE_P(
              auto slice0 = make_unit_v8_slice(concat, zero, numel_of(y0));
              auto slice1 = make_unit_v8_slice(concat, numel_of(y0), to_end);  // separate ReduceProd instance
 
-             return make_shared<ov::Model>(
-                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                 ParameterVector{y0, y1});
+             return make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                        make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                           ParameterVector{y0, y1});
          },
          "NonSharedBoundary"},
         {[] {
@@ -2857,10 +2852,9 @@ INSTANTIATE_TEST_SUITE_P(
              auto slice0 = std::make_shared<op::v8::Slice>(concat, zero, boundary, step2, axes);  // non-unit step
              auto slice1 = std::make_shared<op::v8::Slice>(concat, boundary, to_end, one, axes);
 
-             return make_shared<ov::Model>(
-                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                 ParameterVector{y0, y1});
+             return make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                        make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                           ParameterVector{y0, y1});
          },
          "StepNot1"},
         {[] {
@@ -2875,10 +2869,9 @@ INSTANTIATE_TEST_SUITE_P(
              auto slice0 = make_unit_v8_slice(concat, zero, boundary);
              auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
 
-             return make_shared<ov::Model>(
-                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y1)),
-                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                 ParameterVector{y0, y1});
+             return make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y1)),
+                                                        make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                           ParameterVector{y0, y1});
          },
          "ReshapeBackShapeMismatch"},
         {[] {
@@ -2894,8 +2887,7 @@ INSTANTIATE_TEST_SUITE_P(
              auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
 
              return make_shared<ov::Model>(
-                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                              make_shared<v0::Result>(slice1)},
+                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)), make_shared<v0::Result>(slice1)},
                  ParameterVector{y0, raw1});
          },
          "InputNotFlatten"},
@@ -2910,10 +2902,9 @@ INSTANTIATE_TEST_SUITE_P(
              auto slice0 = make_unit_v8_slice(concat, zero, boundary);
              auto slice1 = make_unit_v8_slice(concat, boundary, numel_of(y1));  // finite, not to-end
 
-             return make_shared<ov::Model>(
-                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                 ParameterVector{y0, y1});
+             return make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                        make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                           ParameterVector{y0, y1});
          },
          "LastNotToEnd"},
         {[] {
@@ -2929,11 +2920,10 @@ INSTANTIATE_TEST_SUITE_P(
              auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
              auto extra = std::make_shared<op::v0::Relu>(slice0);
 
-             return make_shared<ov::Model>(
-                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                              make_shared<v0::Result>(extra),
-                              make_shared<v0::Result>(reshape_to_like(slice1, y1))},
-                 ParameterVector{y0, y1});
+             return make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                        make_shared<v0::Result>(extra),
+                                                        make_shared<v0::Result>(reshape_to_like(slice1, y1))},
+                                           ParameterVector{y0, y1});
          },
          "SliceHasExtraConsumer"},
         {[] {
@@ -2949,11 +2939,10 @@ INSTANTIATE_TEST_SUITE_P(
              auto slice1 = make_unit_v8_slice(concat, boundary, to_end);
              auto extra = std::make_shared<op::v0::Relu>(concat);
 
-             return make_shared<ov::Model>(
-                 ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
-                              make_shared<v0::Result>(reshape_to_like(slice1, y1)),
-                              make_shared<v0::Result>(extra)},
-                 ParameterVector{y0, y1});
+             return make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice0, y0)),
+                                                        make_shared<v0::Result>(reshape_to_like(slice1, y1)),
+                                                        make_shared<v0::Result>(extra)},
+                                           ParameterVector{y0, y1});
          },
          "ConcatHasExtraUser"},
     }),
@@ -2979,16 +2968,15 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceDynamicGdnReversedSliceO
         auto slice1 = make_unit_v8_slice(concat, boundary, to_end);  // built first: covers y1's region
         auto slice0 = make_unit_v8_slice(concat, zero, boundary);    // built second: covers y0's region
 
-        model = make_shared<ov::Model>(
-            ResultVector{make_shared<v0::Result>(reshape_to_like(slice1, y1)),
-                         make_shared<v0::Result>(reshape_to_like(slice0, y0))},
-            ParameterVector{y0, y1});
+        model = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(reshape_to_like(slice1, y1)),
+                                                    make_shared<v0::Result>(reshape_to_like(slice0, y0))},
+                                       ParameterVector{y0, y1});
         manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
         auto y0 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, -1, 8});
         auto y1 = make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 8, 8});
-        model_ref = make_shared<ov::Model>(
-            ResultVector{make_shared<v0::Result>(y1), make_shared<v0::Result>(y0)}, ParameterVector{y0, y1});
+        model_ref = make_shared<ov::Model>(ResultVector{make_shared<v0::Result>(y1), make_shared<v0::Result>(y0)},
+                                           ParameterVector{y0, y1});
     }
 }


### PR DESCRIPTION
### Details:
`EliminateConcatStridedSlice` removes redundant `Concat → Slice` ("split-back")
subgraphs, where the slice users cut the concatenated tensor back into the pieces
it was built from. This PR extends the pass without adding a parallel one (the
earlier standalone `EliminateConcatSlice` was folded in):

- **`v8::Slice` and mixed users.** Previously only `v1::StridedSlice` users were
  matched; now `v8::Slice` is recognized too, and a `Concat` with a mix of both is
  handled in one pass application. This is needed because CPU disables
  `SliceToStridedSlice`, so `v8::Slice` reaches MOC in its native form. The two ops
  use different APIs, so the divergent logic lives in two helpers —
  `extract_slice_range_along_axis()` (read the `[begin, end]` range along the concat
  axis from either op) and `build_residual_slice()` (rebuild the partial-match slice
  over the shrunken `Concat`). The main callback body is unchanged.

- **Hardened guards.** Reject cases that could rewire incorrectly: non-unit
  strides/steps, non-axis-aligned empty/short `StridedSlice` masks, uncovered
  non-concat axes, and dropping an explicit `strides` input in the residual rebuild.

- **Dynamic structural path.** The static algorithm needs a fully static `Concat`.
  For the Gated-Delta-Net / Qwen3-Next idiom
  `Loop → Reshape(·,[-1]) → Concat(axis=0) → Slice → Reshape` (dynamic `[-1]` concat,
  runtime slice bounds) a new branch proves the no-op structurally — same trust model
  as `RemoveConcatSliceAfterLoop`, which it does not replace.

### Tickets:
 - 183090