### PR TITLE
Updated dependencies script for Rocky/RHEL 10

### DIFF
--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -96,10 +96,12 @@ elif [ -f /etc/redhat-release ] || grep -q "rhel\|tencentos\|opencloudos" /etc/o
         source /etc/os-release
         if [[ "$ID" == "fedora" ]]; then
             yum install -y fedora-repos
-        else
+        elif [[ "$ID" == "centos" ]]; then
             yum install -y centos-release-scl
             # CentOS 7 is EOL and throws an error for centos-sclo-sclo
             yum-config-manager --save --setopt=centos-sclo-sclo.skip_if_unavailable=true
+            yum install -y epel-release
+        else
             yum install -y epel-release
         fi
         yum install -y \
@@ -110,13 +112,18 @@ elif [ -f /etc/redhat-release ] || grep -q "rhel\|tencentos\|opencloudos" /etc/o
     else
         yum install -y epol-release
     fi
+    MAJOR_VERSION=${VERSION_ID%%.*}
+    if [[ ( "$ID" == "rhel" || "$ID" == "rocky" ) && "$MAJOR_VERSION" -ge 10 ]]; then
+        yum config-manager --set-enabled crb
+        yum install -y cmake python3-scons python3-rpm
+    else
+        yum install -y cmake3 scons rpm-python
+    fi
     yum install -y \
         file \
         `# build tools` \
-        cmake3 \
         ccache \
         ninja-build \
-        scons \
         gcc \
         gcc-c++ \
         make \
@@ -138,9 +145,7 @@ elif [ -f /etc/redhat-release ] || grep -q "rhel\|tencentos\|opencloudos" /etc/o
         opencl-headers \
         `# python API` \
         python3-pip \
-        python3-devel \
-        `# rpmlint dependency` \
-        rpm-python
+        python3-devel
 elif [ -f /etc/os-release ] && grep -q "SUSE" /etc/os-release ; then
     zypper refresh
     zypper install -y \

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -110,7 +110,7 @@ elif [ -f /etc/redhat-release ] || grep -q "rhel\|tencentos\|opencloudos" /etc/o
             `# check bash scripts for correctness` \
             ShellCheck
     else
-        yum install -y epol-release
+        yum install -y epel-release
     fi
     MAJOR_VERSION=${VERSION_ID%%.*}
     if [[ ( "$ID" == "rhel" || "$ID" == "rocky" ) && "$MAJOR_VERSION" -ge 10 ]]; then


### PR DESCRIPTION
### Details:
 - *RHEL and Rocky 10 have slightly different package names from older Redhat style distros*
 - *This updates the dependency script to detect RHEL/Rocky with major vers >= 10*
 - *Isolated some CentOS code within an elif that triggers if $ID = centos so it won't cause error on RHEL/Rocky 10*
 - *Tested on my local Rocky 10.1 box*

### Tickets: 
 - *35172*

### AI Assistance:
 - *no*
 
### Note
- *There is a line of code (111/113) in the Redhat section that doesn't execute for RHEL, CentOS, Rocky, or Fedora (maybe it's dead code?) but I think it has a typo. On all the Redhat type distros I'm familiar with this should epel-release, not epol-release. But since it doesn't execute on Rocky, I left it as-is.*

```
else
    yum install -y epol-release
```

### Test Results on Rocky 10

```

openvino# cat /etc/redhat-release
Rocky Linux release 10.1 (Red Quartz)

openvino# ./install_build_dependencies.sh
Last metadata expiration check: 0:36:57 ago on Fri 10 Apr 2026 03:06:48 PM CDT.
Dependencies resolved.
Nothing to do.
Complete!
Last metadata expiration check: 0:36:57 ago on Fri 10 Apr 2026 03:06:48 PM CDT.
Package epel-release-10-7.el10_1.noarch is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Last metadata expiration check: 0:36:58 ago on Fri 10 Apr 2026 03:06:48 PM CDT.
Package ShellCheck-0.10.0-3.el10_0.x86_64 is already installed.
Dependencies resolved.
================================================================================================================================
 Package                       Architecture                Version                              Repository                 Size
================================================================================================================================
Installing:
 patchelf                      x86_64                      0.18.0-6.el10_0                      epel                      128 k

Transaction Summary
================================================================================================================================
Install  1 Package

Total download size: 128 k
Installed size: 296 k
Downloading Packages:
patchelf-0.18.0-6.el10_0.x86_64.rpm                                                             402 kB/s | 128 kB     00:00    
--------------------------------------------------------------------------------------------------------------------------------
Total                                                                                           236 kB/s | 128 kB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                        1/1 
  Installing       : patchelf-0.18.0-6.el10_0.x86_64                                                                        1/1 
  Running scriptlet: patchelf-0.18.0-6.el10_0.x86_64                                                                        1/1 

Installed:
  patchelf-0.18.0-6.el10_0.x86_64                                                                                               

Complete!
Last metadata expiration check: 0:37:00 ago on Fri 10 Apr 2026 03:06:48 PM CDT.
Rocky Linux 10 - BaseOS                                                                          27 kB/s | 4.3 kB     00:00    
Rocky Linux 10 - AppStream                                                                       29 kB/s | 4.3 kB     00:00    
Rocky Linux 10 - CRB                                                                             32 kB/s | 4.3 kB     00:00    
Package cmake-3.30.5-3.el10_0.x86_64 is already installed.
Package python3-scons-4.8.1-1.el10_0.noarch is already installed.
Package python3-rpm-4.19.1.1-20.el10.x86_64 is already installed.
Dependencies resolved.
Last metadata expiration check: 0:37:01 ago on Fri 10 Apr 2026 03:06:48 PM CDT.
Package file-5.45-8.el10.x86_64 is already installed.
Package gcc-14.3.1-2.1.el10.x86_64 is already installed.
Package gcc-c++-14.3.1-2.1.el10.x86_64 is already installed.
Package make-1:4.4.1-9.el10.x86_64 is already installed.
Package git-2.47.3-1.el10.x86_64 is already installed.
Package rpm-build-4.19.1.1-20.el10.x86_64 is already installed.
Package tbb-devel-2021.11.0-7.el10.x86_64 is already installed.
Dependencies resolved.
================================================================================================================================
 Package                                Architecture      Version                                    Repository            Size
================================================================================================================================
Installing:
 ccache                                 x86_64            4.11.3-1.el10_1                            epel                 691 k
 fdupes                                 x86_64            1:2.4.0-1.el10_1                           epel                  59 k
 libva-devel                            x86_64            2.22.0-2.el10                              appstream            136 k
 ninja-build                            x86_64            1.11.1-9.el10                              crb                  178 k
 ocl-icd-devel                          x86_64            2.3.2-8.el10                               crb                   64 k
 opencl-headers                         noarch            3.0-23.20231212git2368105.el10             appstream             93 k
 pugixml-devel                          x86_64            1.13-6.el10_0                              epel                  23 k
 python3-devel                          x86_64            3.12.12-4.el10_1.2                         appstream            277 k
 python3-pip                            noarch            23.3.2-7.el10                              appstream            3.2 M
 rpmlint                                noarch            2.7.0-6.el10_1                             epel                 312 k
 snappy-devel                           x86_64            1.1.10-7.el10                              appstream             22 k
Installing dependencies:
 devscripts-checkbashisms               noarch            2.25.5-1.el10_1                            epel                  28 k
 fmt                                    x86_64            11.0.2-1.el10_0                            epel                 101 k
 hiredis                                x86_64            1.2.0-5.el10_0                             epel                  50 k
 libappstream-glib                      x86_64            0.8.3-3.el10                               appstream            411 k
 libffi-devel                           x86_64            3.4.4-10.el10                              appstream             28 k
 pugixml                                x86_64            1.13-6.el10_0                              epel                 102 k
 python-rpm-macros                      noarch            3.12-10.el10                               appstream             16 k
 python3-enchant                        noarch            3.2.2-14.el10                              appstream            102 k
 python3-pyxdg                          noarch            0.27-13.el10                               appstream            132 k
 python3-rpm-generators                 noarch            14-12.el10                                 appstream             29 k
 python3-rpm-macros                     noarch            3.12-10.el10                               appstream             11 k
 python3-tomli-w                        noarch            1.0.0-6.el10_0                             epel                  21 k
 python3-zstandard                      x86_64            0.23.0-1.el10_0                            epel                 475 k
 rpmlint-fedora-license-data            noarch            1.74-1.el10_1                              epel                  30 k
 wayland-devel                          x86_64            1.23.1-1.el10                              appstream            156 k
 xxhash-libs                            x86_64            0.8.3-1.el10_0                             epel                  38 k

Transaction Summary
================================================================================================================================
Install  27 Packages

Total download size: 6.7 M
Installed size: 26 M
Downloading Packages:
(1/27): devscripts-checkbashisms-2.25.5-1.el10_1.noarch.rpm                                     178 kB/s |  28 kB     00:00    
(2/27): fdupes-2.4.0-1.el10_1.x86_64.rpm                                                        278 kB/s |  59 kB     00:00    
(3/27): fmt-11.0.2-1.el10_0.x86_64.rpm                                                          997 kB/s | 101 kB     00:00    
(4/27): hiredis-1.2.0-5.el10_0.x86_64.rpm                                                       898 kB/s |  50 kB     00:00    
(5/27): ccache-4.11.3-1.el10_1.x86_64.rpm                                                       2.0 MB/s | 691 kB     00:00    
(6/27): python3-tomli-w-1.0.0-6.el10_0.noarch.rpm                                               313 kB/s |  21 kB     00:00    
(7/27): python3-zstandard-0.23.0-1.el10_0.x86_64.rpm                                            3.0 MB/s | 475 kB     00:00    
(8/27): rpmlint-2.7.0-6.el10_1.noarch.rpm                                                       1.9 MB/s | 312 kB     00:00    
(9/27): rpmlint-fedora-license-data-1.74-1.el10_1.noarch.rpm                                    507 kB/s |  30 kB     00:00    
(10/27): xxhash-libs-0.8.3-1.el10_0.x86_64.rpm                                                  753 kB/s |  38 kB     00:00    
(11/27): libappstream-glib-0.8.3-3.el10.x86_64.rpm                                              1.7 MB/s | 411 kB     00:00    
(12/27): libffi-devel-3.4.4-10.el10.x86_64.rpm                                                  676 kB/s |  28 kB     00:00    
(13/27): libva-devel-2.22.0-2.el10.x86_64.rpm                                                   2.3 MB/s | 136 kB     00:00    
(14/27): opencl-headers-3.0-23.20231212git2368105.el10.noarch.rpm                               1.9 MB/s |  93 kB     00:00    
(15/27): python-rpm-macros-3.12-10.el10.noarch.rpm                                              397 kB/s |  16 kB     00:00    
(16/27): python3-devel-3.12.12-4.el10_1.2.x86_64.rpm                                            740 kB/s | 277 kB     00:00    
(17/27): python3-enchant-3.2.2-14.el10.noarch.rpm                                               443 kB/s | 102 kB     00:00    
(18/27): python3-pip-23.3.2-7.el10.noarch.rpm                                                   6.4 MB/s | 3.2 MB     00:00    
(19/27): python3-pyxdg-0.27-13.el10.noarch.rpm                                                  3.0 MB/s | 132 kB     00:00    
(20/27): python3-rpm-generators-14-12.el10.noarch.rpm                                           698 kB/s |  29 kB     00:00    
(21/27): python3-rpm-macros-3.12-10.el10.noarch.rpm                                             268 kB/s |  11 kB     00:00    
(22/27): snappy-devel-1.1.10-7.el10.x86_64.rpm                                                  418 kB/s |  22 kB     00:00    
(23/27): wayland-devel-1.23.1-1.el10.x86_64.rpm                                                 3.3 MB/s | 156 kB     00:00    
(24/27): ninja-build-1.11.1-9.el10.x86_64.rpm                                                   472 kB/s | 178 kB     00:00    
(25/27): ocl-icd-devel-2.3.2-8.el10.x86_64.rpm                                                  844 kB/s |  64 kB     00:00    
(26/27): pugixml-devel-1.13-6.el10_0.x86_64.rpm                                                 8.1 kB/s |  23 kB     00:02    
(27/27): pugixml-1.13-6.el10_0.x86_64.rpm                                                        34 kB/s | 102 kB     00:02    
--------------------------------------------------------------------------------------------------------------------------------
Total                                                                                           1.9 MB/s | 6.7 MB     00:03     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                        1/1 
  Installing       : python-rpm-macros-3.12-10.el10.noarch                                                                 1/27 
  Installing       : python3-rpm-macros-3.12-10.el10.noarch                                                                2/27 
  Installing       : python3-rpm-generators-14-12.el10.noarch                                                              3/27 
  Installing       : python3-pyxdg-0.27-13.el10.noarch                                                                     4/27 
  Installing       : python3-pip-23.3.2-7.el10.noarch                                                                      5/27 
  Installing       : python3-enchant-3.2.2-14.el10.noarch                                                                  6/27 
  Installing       : opencl-headers-3.0-23.20231212git2368105.el10.noarch                                                  7/27 
  Installing       : libffi-devel-3.4.4-10.el10.x86_64                                                                     8/27 
  Installing       : wayland-devel-1.23.1-1.el10.x86_64                                                                    9/27 
  Installing       : libappstream-glib-0.8.3-3.el10.x86_64                                                                10/27 
  Installing       : xxhash-libs-0.8.3-1.el10_0.x86_64                                                                    11/27 
  Installing       : python3-zstandard-0.23.0-1.el10_0.x86_64                                                             12/27 
  Installing       : python3-tomli-w-1.0.0-6.el10_0.noarch                                                                13/27 
  Installing       : pugixml-1.13-6.el10_0.x86_64                                                                         14/27 
  Installing       : hiredis-1.2.0-5.el10_0.x86_64                                                                        15/27 
  Installing       : fmt-11.0.2-1.el10_0.x86_64                                                                           16/27 
  Installing       : devscripts-checkbashisms-2.25.5-1.el10_1.noarch                                                      17/27 
  Installing       : rpmlint-fedora-license-data-1.74-1.el10_1.noarch                                                     18/27 
  Installing       : rpmlint-2.7.0-6.el10_1.noarch                                                                        19/27 
  Installing       : ccache-4.11.3-1.el10_1.x86_64                                                                        20/27 
warning: group ccache does not exist - using root

  Running scriptlet: ccache-4.11.3-1.el10_1.x86_64                                                                        20/27 
  Installing       : pugixml-devel-1.13-6.el10_0.x86_64                                                                   21/27 
  Installing       : libva-devel-2.22.0-2.el10.x86_64                                                                     22/27 
  Installing       : ocl-icd-devel-2.3.2-8.el10.x86_64                                                                    23/27 
  Installing       : python3-devel-3.12.12-4.el10_1.2.x86_64                                                              24/27 
  Installing       : ninja-build-1.11.1-9.el10.x86_64                                                                     25/27 
  Installing       : snappy-devel-1.1.10-7.el10.x86_64                                                                    26/27 
  Installing       : fdupes-1:2.4.0-1.el10_1.x86_64                                                                       27/27 
  Running scriptlet: fdupes-1:2.4.0-1.el10_1.x86_64                                                                       27/27 
Creating group 'ccache' with GID 979.


Installed:
  ccache-4.11.3-1.el10_1.x86_64                                    devscripts-checkbashisms-2.25.5-1.el10_1.noarch             
  fdupes-1:2.4.0-1.el10_1.x86_64                                   fmt-11.0.2-1.el10_0.x86_64                                  
  hiredis-1.2.0-5.el10_0.x86_64                                    libappstream-glib-0.8.3-3.el10.x86_64                       
  libffi-devel-3.4.4-10.el10.x86_64                                libva-devel-2.22.0-2.el10.x86_64                            
  ninja-build-1.11.1-9.el10.x86_64                                 ocl-icd-devel-2.3.2-8.el10.x86_64                           
  opencl-headers-3.0-23.20231212git2368105.el10.noarch             pugixml-1.13-6.el10_0.x86_64                                
  pugixml-devel-1.13-6.el10_0.x86_64                               python-rpm-macros-3.12-10.el10.noarch                       
  python3-devel-3.12.12-4.el10_1.2.x86_64                          python3-enchant-3.2.2-14.el10.noarch                        
  python3-pip-23.3.2-7.el10.noarch                                 python3-pyxdg-0.27-13.el10.noarch                           
  python3-rpm-generators-14-12.el10.noarch                         python3-rpm-macros-3.12-10.el10.noarch                      
  python3-tomli-w-1.0.0-6.el10_0.noarch                            python3-zstandard-0.23.0-1.el10_0.x86_64                    
  rpmlint-2.7.0-6.el10_1.noarch                                    rpmlint-fedora-license-data-1.74-1.el10_1.noarch            
  snappy-devel-1.1.10-7.el10.x86_64                                wayland-devel-1.23.1-1.el10.x86_64                          
  xxhash-libs-0.8.3-1.el10_0.x86_64                               

Complete!

```