### PR TITLE
[GPU] Fix Select kernel compilation failure on broadcast inputs with different ranks

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/select_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/select_gpu_ref.cl
@@ -4,15 +4,9 @@
 
 #include "include/batch_headers/fetch_data.cl"
 
-#if OUTPUT_DIMS == 5
-    #define INPUT_0 input0[INPUT0_GET_INDEX_SAFE(b, f, z, y, x)]
-    #define INPUT_1 input1[INPUT1_GET_INDEX_SAFE(b, f, z, y, x)]
-    #define INPUT_2 input2[INPUT2_GET_INDEX_SAFE(b, f, z, y, x)]
-#elif OUTPUT_DIMS == 4
-    #define INPUT_0 input0[INPUT0_GET_INDEX_SAFE(b, f, y, x)]
-    #define INPUT_1 input1[INPUT1_GET_INDEX_SAFE(b, f, y, x)]
-    #define INPUT_2 input2[INPUT2_GET_INDEX_SAFE(b, f, y, x)]
-#endif
+// INPUT_0, INPUT_1, INPUT_2 are JIT-defined in select_kernel_base.cpp with
+// correct per-input dimensionality to support broadcasting (e.g., a 4D mask
+// broadcast to a 5D output).
 
 KERNEL(select)(
     OPTIONAL_SHAPE_INFO_ARG

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/select/select_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/select/select_kernel_base.cpp
@@ -41,6 +41,22 @@ JitConstants SelectKernelBase::GetJitConstantsCommon(const select_params& params
 
     jit.AddConstant(MakeJitConstant("INPUTS_DECLS", inputs_decls));
 
+    // Generate INPUT_N macros with correct dimensionality for each input tensor.
+    // Each input may have a different rank than the output (e.g., a 2D mask broadcast
+    // to a 5D output), so the index arguments must match each input's GET_INDEX_SAFE
+    // macro, which is generated based on that input's actual layout.
+    for (size_t i = 0; i < params.inputs.size(); i++) {
+        std::string indexArgs;
+        switch (params.inputs[i].Dimentions()) {
+        case 6:  indexArgs = "b, f, w, z, y, x"; break;
+        case 5:  indexArgs = "b, f, z, y, x"; break;
+        default: indexArgs = "b, f, y, x"; break;
+        }
+        std::string macro = "input" + toCodeString(i) + "[INPUT" + toCodeString(i) +
+                            "_GET_INDEX_SAFE(" + indexArgs + ")]";
+        jit.AddConstant(MakeJitConstant("INPUT_" + toCodeString(i), macro));
+    }
+
     std::string destType, absType;
 
     // i8, i8, i8

--- a/src/plugins/intel_gpu/tests/unit/test_cases/select_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/select_gpu_test.cpp
@@ -2558,3 +2558,48 @@ TEST(select_cpu_impl_f32, select_basic_bfyx_2x2x2x2_bcast_mask_2x2x1x2) {
         ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
+
+// Regression test: 5D output with 4D broadcast mask.
+// The mask (condition) tensor has fewer dimensions than the output, requiring
+// per-input dimensionality in the generated INPUT_N macros.
+TEST(select_gpu_f32, select_5d_broadcast_mask_4d) {
+    auto& engine = get_test_engine();
+
+    // 5D output: [1, 2, 2, 2, 2] in bfzyx format
+    auto input = engine.allocate_memory({ data_types::f32, format::bfzyx, tensor{ 1, 2, 2, 2, 2 } });
+    auto input2 = engine.allocate_memory({ data_types::f32, format::bfzyx, tensor{ 1, 2, 2, 2, 2 } });
+    // 4D mask broadcast to 5D: [1, 1, 2, 2] in bfyx — broadcasts across z dimension
+    auto mask = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 1, 2, 2 } });
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(input_layout("input2", input2->get_layout()));
+    topology.add(input_layout("mask", mask->get_layout()));
+    topology.add(cldnn::select("select", input_info("mask"), input_info("input"), input_info("input2")));
+
+    // Fill input with 1s, input2 with 0s
+    std::vector<float> ones(16, 1.f);
+    std::vector<float> zeros(16, 0.f);
+    set_values(input, ones);
+    set_values(input2, zeros);
+    // Mask: lower-triangular [2x2] — nonzero selects input (true), zero selects input2 (false)
+    set_values(mask, { 1.f, 0.f, 1.f, 1.f });
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input);
+    network.set_input_data("input2", input2);
+    network.set_input_data("mask", mask);
+    auto outputs = network.execute();
+
+    auto output = outputs.at("select").get_memory();
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+
+    // The mask [1,0; 1,1] is broadcast across batch, feature, and z dimensions.
+    // For each (b,f,z) slice: element (0,0)=1(input), (0,1)=0(input2), (1,0)=1(input), (1,1)=1(input)
+    for (int slice = 0; slice < 4; slice++) {  // 1*2*2 = 4 slices of z*f*b
+        ASSERT_EQ(1.f, output_ptr[slice * 4 + 0]);  // mask=1 -> input=1
+        ASSERT_EQ(0.f, output_ptr[slice * 4 + 1]);  // mask=0 -> input2=0
+        ASSERT_EQ(1.f, output_ptr[slice * 4 + 2]);  // mask=1 -> input=1
+        ASSERT_EQ(1.f, output_ptr[slice * 4 + 3]);  // mask=1 -> input=1
+    }
+}


### PR DESCRIPTION
### Details

The Select GPU kernel (`select_gpu_ref.cl`) fails to compile when input tensors have different dimensionalities — specifically when a lower-rank condition tensor (e.g., 4D mask) is broadcast to a higher-rank output (e.g., 5D). This commonly occurs with PyTorch-traced `.masked_fill()` or `.tril()` operations where a 2D boolean mask is broadcast across batch/head/spatial dimensions.

**Root cause:** `select_gpu_ref.cl` defines `INPUT_0`, `INPUT_1`, `INPUT_2` macros using `OUTPUT_DIMS` to determine how many index arguments to pass to each input's `GET_INDEX_SAFE` macro. But `GET_INDEX_SAFE` is generated per-tensor based on that tensor's actual layout (in `jitter.cpp`), so a 4D input's `GET_INDEX_SAFE` accepts 4 arguments while the 5D output's `#if OUTPUT_DIMS == 5` block passes 5. This causes `"too many arguments provided to function-like macro invocation"`.

**Fix:** Move `INPUT_N` macro generation from the `.cl` template into `select_kernel_base.cpp`, where each input's actual dimensionality (`Dimentions()`) is used to select the correct index arguments.

**Changes:**
- `select_kernel_base.cpp`: Generate `INPUT_0`, `INPUT_1`, `INPUT_2` JIT constants with per-input dimensionality (4D → `b,f,y,x`, 5D → `b,f,z,y,x`, 6D → `b,f,w,z,y,x`)
- `select_gpu_ref.cl`: Remove hardcoded `#if OUTPUT_DIMS` blocks for `INPUT_N` definitions (now JIT-defined)
- `select_gpu_test.cpp`: Add regression test for 5D output with 4D broadcast mask

**Reproducer:**

```python
import torch, torch.nn as nn, openvino as ov

class M(nn.Module):
    def __init__(self):
        super().__init__()
        self.register_buffer('mask', torch.triu(torch.ones(16, 16, dtype=torch.bool), diagonal=1))
    def forward(self, x):
        return x.masked_fill(self.mask, 0.0)

model = M().eval()
x = torch.randn(1, 4, 2, 16, 16)  # 5D — FAILS before fix
traced = torch.jit.trace(model, (x,))
ov_model = ov.convert_model(traced, example_input=(x,))
compiled = ov.Core().compile_model(ov_model, "GPU")  # ProgramBuilder crash
```

Ranks 2D–4D work; 5D fails with MASK macro expansion error. After this fix, all ranks compile correctly.

### Tickets

- #35271

### AI Assistance
- AI assistance used: yes
- AI was used to draft the fix and reproducer script. Human validation: build verified on Linux (48-core server), all 37 existing non-f16 select GPU tests pass with zero regressions, new regression test passes, fix verified end-to-end on Intel Core Ultra X7 358H iGPU (Panther Lake) via WSL2 — 5D Select ops that previously crashed now compile and execute correctly.