### PR TITLE
[PyTorch FE] Fix torch_tensor_to_ov_const crash on 0-dim bfloat16/float8 tensors

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/utils.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/utils.py
@@ -72,12 +72,16 @@ def torch_tensor_to_ov_const(torch_t: torch.Tensor, shared_memory=True):
     torch_t = torch_t.contiguous()
     if dtype == torch.bfloat16:
         # reinterpret bfloat16 data as float16 to allow conversion to numpy
+        if torch_t.dim() == 0:
+            torch_t = torch_t.reshape(1)
         torch_t = torch_t.view(torch.float16)
         narr = torch_t.numpy(force=True)
         tensor = Tensor(narr, torch_t.shape, OVType.bf16)
         ov_const = op.Constant(tensor, shared_memory=shared_memory)
     elif dtype in F8_DTYPE_MAP:
         # reinterpret f8 data as u8 to allow conversion to numpy
+        if torch_t.dim() == 0:
+            torch_t = torch_t.reshape(1)
         torch_t = torch_t.view(torch.uint8)
         narr = torch_t.numpy(force=True)
         tensor = Tensor(narr, torch_t.shape, F8_DTYPE_MAP[dtype])

--- a/tests/layer_tests/pytorch_tests/test_scalar_tensor.py
+++ b/tests/layer_tests/pytorch_tests/test_scalar_tensor.py
@@ -31,3 +31,32 @@ class TestScalarTensor(PytorchLayerTest):
         self._test(*self.create_model(), ie_device, precision, ir_version, use_convert_model=True)
 
 
+class TestZeroDimBF16Buffer:
+    """Regression test: 0-dim bfloat16/float8 buffers must not crash
+    torch_tensor_to_ov_const during model conversion."""
+
+    @staticmethod
+    def _build_params():
+        params = [torch.bfloat16]
+        f8_e4m3 = getattr(torch, "float8_e4m3fn", None)
+        if f8_e4m3 is not None:
+            params.append(f8_e4m3)
+        f8_e5m2 = getattr(torch, "float8_e5m2", None)
+        if f8_e5m2 is not None:
+            params.append(f8_e5m2)
+        return params
+
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("buf_dtype", _build_params.__func__())
+    def test_zero_dim_buffer_conversion(self, buf_dtype):
+        from openvino.frontend.pytorch.utils import torch_tensor_to_ov_const
+
+        if buf_dtype == torch.bfloat16:
+            t = torch.tensor(8.0, dtype=torch.bfloat16)
+        else:
+            t = torch.zeros(1, dtype=buf_dtype).reshape(())
+
+        const = torch_tensor_to_ov_const(t, shared_memory=False)
+        assert const.get_output_shape(0) == [1]
+
+


### PR DESCRIPTION
### Changes

The bfloat16 and float8 code paths in `torch_tensor_to_ov_const` use `Tensor(narr, torch_t.shape, ov_type)` which fails with `IndexError` when the tensor is 0-dimensional (scalar) because `shape` is an empty tuple. Standard dtypes (float32, int64, etc.) are unaffected as they use `op.Constant(narr)` which handles 0-dim ndarrays.

Fix: reshape 0-dim tensors to `[1]` before dtype-specific processing (one line added after `torch_t.contiguous()`).

Test: added `TestZeroDimBF16Buffer` to `test_scalar_tensor.py` covering bfloat16, float8_e4m3fn, and float8_e5m2 0-dim tensors.

### Reason for changes

Models with scalar bfloat16 buffers (e.g., Gemma 4's `embed_scale`) cannot be converted via `ov.convert_model()`. The crash occurs during `prim::GetAttr` resolution in the PyTorch frontend.

### Related tickets

- #35273

### Tests

- `tests/layer_tests/pytorch_tests/test_scalar_tensor.py::TestZeroDimBF16Buffer` -- verifies `torch_tensor_to_ov_const` succeeds for bfloat16 and float8 0-dim tensors
- Manually verified on OV 2026.0.0 (Windows 11, Intel Core Ultra X7 358H): patched `utils.py` in-place, all 7 dtypes pass, full model conversion with bfloat16 scalar buffer succeeds

### AI Assistance
- AI assistance used: yes
- AI was used to draft the fix and test. Human validation: fix patched directly into installed OV package on test machine (Windows 11, Panther Lake), reproducer confirmed all 7 dtype variants pass and full model conversion succeeds.