### PR TITLE
[GPU] Limit register file size to 128 to prevent CL_INVALID_WORK_GROUP_SIZE

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -169,6 +169,39 @@ bool query_microkernels_supported(cldnn::engine& e, const cldnn::ExecutionConfig
     return cache.at(device);
 }
 
+bool query_register_file_size_option_supported(cldnn::engine& e, const cldnn::ExecutionConfig& config) {
+    auto device = e.get_device().get();
+    if (device->get_info().arch < gpu_arch::xe3)
+        return false;
+
+    static std::mutex m;
+    std::lock_guard<std::mutex> lock(m);
+    static std::map<cldnn::device*, bool> cache;
+    if (cache.find(device) != cache.end()) {
+        return cache.at(device);
+    }
+
+    std::shared_ptr<kernel_selector::KernelString> kernel_string = std::make_shared<kernel_selector::KernelString>();
+    const char* kernel_code = "kernel void reg_file_size_check() {}";
+
+    kernel_string->str = kernel_code;
+    kernel_string->options = "-ze-exp-register-file-size 128";
+    kernel_string->entry_point = "reg_file_size_check";
+    kernel_string->batch_compilation = true;
+
+    try {
+        cldnn::kernel_impl_params dummy_params;
+        auto _kernels_cache_device_query = std::unique_ptr<cldnn::kernels_cache>(new cldnn::kernels_cache(e, config, 0));
+        _kernels_cache_device_query->add_kernels_source(dummy_params, {kernel_string}, false);
+        _kernels_cache_device_query->build_all();
+        cache[device] = true;
+    } catch (std::exception&) {
+        cache[device] = false;
+    }
+
+    return cache.at(device);
+}
+
 kernel_selector::data_type to_data_type(data_types dt) {
     switch (dt) {
         case cldnn::data_types::i4:
@@ -1187,6 +1220,7 @@ void set_params(const kernel_impl_params& param_info, kernel_selector::params& p
     params.engineInfo.bOptHintsSupport = false;
 
     params.engineInfo.supports_microkernels = query_microkernels_supported(engine, config);
+    params.engineInfo.supports_register_file_size_option = query_register_file_size_option_supported(engine, config);
     params.engineInfo.deviceType = get_device_type(device_info.dev_type);
     params.engineInfo.maxWorkGroupSize = device_info.max_work_group_size;
     params.engineInfo.maxLocalMemSize = device_info.max_local_mem_size;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
@@ -311,5 +311,6 @@ inline void update_shapes(kernel_selector::Params& p, const kernel_impl_params& 
 
 bool check_cm_jit_support(cldnn::engine& e, const cldnn::ExecutionConfig& config);
 bool query_microkernels_supported(cldnn::engine& e, const cldnn::ExecutionConfig& config);
+bool query_register_file_size_option_supported(cldnn::engine& e, const cldnn::ExecutionConfig& config);
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
@@ -177,6 +177,8 @@ std::shared_ptr<KernelString> KernelBaseOpenCL::GetKernelString(const std::strin
                 kernel_string->options += " -DOPT_HINTS_SUPPORTED=1";
             if (engine_info.enable_large_allocations)
                 kernel_string->options += " -cl-intel-greater-than-4GB-buffer-required";
+            if (engine_info.supports_register_file_size_option)
+                kernel_string->options += " -ze-exp-register-file-size 128";
         }
 
         if (engine_info.supports_work_group_collective_functions)

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -394,6 +394,7 @@ struct EngineInfo {
     bool supports_microkernels = false;
     bool supports_work_group_collective_functions = false;
     bool supports_non_uniform_work_group = false;
+    bool supports_register_file_size_option = false;
     uint32_t vendor_id = 0x0;
     dev_type deviceType = dev_type::integrated_gpu;
     uint32_t computeUnitsCount = 0;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_ref.cpp
@@ -43,14 +43,7 @@ CommonDispatchData ReduceKernelRef::SetDefault(const reduce_params& params) cons
     dispatchData.gws = { params.outputs[0].X().v * params.outputs[0].Y().v,
                          params.outputs[0].Z().v * params.outputs[0].W().v * params.outputs[0].U().v * params.outputs[0].V().v,
                          params.outputs[0].Batch().v * params.outputs[0].Feature().v };
-
-    // [WA] PTL (Panther Lake, xe3p) IGC may allocate more than 128 GRF per thread,
-    // which reduces the per-kernel max work-group size below the device max reported at query time.
-    // Enqueuing with the original max WGS then triggers CL_INVALID_WORK_GROUP_SIZE (-54).
-    // Limit to 512 on PTL to stay within the reduced per-kernel limit.
-    auto engineInfo = params.engineInfo;
-    engineInfo.maxWorkGroupSize = std::min(engineInfo.maxWorkGroupSize, static_cast<uint64_t>(512));
-    dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, engineInfo, in_layout, out_layout, dims_by_gws);
+    dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo, in_layout, out_layout, dims_by_gws);
 
     return dispatchData;
 }


### PR DESCRIPTION
### Description of the issue
  - On Xe3+ (PTL), some kernels fail with `CL_INVALID_WORK_GROUP_SIZE` at dispatch time.
  - IGC allocates >128 GRF per thread on Xe3+, reducing per-kernel max work group size below the device-reported max. LWS is calculated from the device-level `maxWorkGroupSize`, causing mismatch.
  - Add `-ze-exp-register-file-size 128` build option to all OCL kernels to cap GRF at 128, ensuring kernel max WG size matches device max. The option is gated by a trial compilation probe (cached per device, runs once).

#### The code and line that caused this issue
  - `kernel_base_opencl.cpp` — `GetKernelString()` did not limit register file size
  - `kernel_selector_utils.cpp` — `GetOptimalLocalWorkGroupSizes()` uses `maxWorkGroupSize` from device info as `lws_max`

#### Reproduction step and snapshot
  - Run any model on PTL (Xe3) GPU that triggers kernels with high register pressure (e.g., softmax, mvn, rms_norm)
  - `$ benchmark_app -m <model.xml> -d GPU`
  - Fails with `CL_INVALID_WORK_GROUP_SIZE` error

#### Problematic graph
  - Not graph-specific. Any graph containing operations whose kernels exceed 128 GRF under IGC auto-allocation on Xe3+.

#### Checklist
  - [x] Is it a proper fix? (not a workaround)
    - This could be removed if a solution becomes available at the IGC driver level.
  - [ ] Did you include test case for this fix, if necessary?
  - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *183530*
 - *183129*
 - *184030*
 - *184614*