### PR TITLE
[Bug]: OpenVINO Backend is not support bfloat16 fully in Python Binding

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/common.cpp
+++ b/src/bindings/python/src/pyopenvino/core/common.cpp
@@ -43,6 +43,7 @@ py::dtype get_dtype(const ov::element::Type& ov_type) {
 
 std::map<int, ov::element::Type> init_num_to_ov_type() {
     static const std::map<std::string, ov::element::Type> str_to_type_mapping = {
+        {"bfloat16", ov::element::bf16},
         {"float16", ov::element::f16},
         {"float32", ov::element::f32},
         {"float64", ov::element::f64},


### PR DESCRIPTION
### Details:
 - Support `bf16` type in Python binding.

### Tickets:
 - Fixes: #35284

### AI Assistance:
 - *AI assistance used: no
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
