### PR TITLE
[NPUW] Handle prototype outputs with no cross-subgraph consumers in MemAccessSim.

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
@@ -89,7 +89,16 @@ const ov::npuw::MemAccessSim::ReadList& ov::npuw::MemAccessSim::read_list(std::s
 }
 
 std::size_t ov::npuw::MemAccessSim::remaining_reads(const LinkFrom& from) {
-    return m_remaining_reads.at(from);
+    auto it = m_remaining_reads.find(from);
+    if (it == m_remaining_reads.end()) {
+        // No cross-subgraph consumers for this output. This can legitimately happen
+        // when a prototype output is unused by some call instances (e.g. in KV-sharing
+        // models like Gemma4, non-head layers receive shared K/V directly and never
+        // consume the layernorm output that head layers forward to K/V projection).
+        // Return 0 so the tensor slot is immediately available for reuse.
+        return 0u;
+    }
+    return it->second;
 }
 
 void ov::npuw::MemAccessSim::register_read(const LinkFrom& from) {


### PR DESCRIPTION
### Details:
A prototype output is unused by some call instances (e.g. in KV-sharing models like Gemma4, non-head layers receive shared K/V directly and never consume the layernorm output that head layers forward to K/V projection).
There may be no link registered in m_remaining_reads, which would cause invalid map access.

### Tickets:
 - *[EISW-211817](https://jira.devtools.intel.com/browse/EISW-211817)*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
