### PR TITLE
[GHA][Coverage] Add Codecov token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -182,6 +182,7 @@ jobs:
       - name: Upload Codecov (C++ runtime, CPU)
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.OV_WORKSPACE }}/coverage.info
           disable_search: true
           plugins: noop
@@ -325,6 +326,7 @@ jobs:
       - name: Upload Codecov (Python API, CPU)
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.OV_WORKSPACE }}/python-coverage.xml
           disable_search: true
           plugins: noop
@@ -337,6 +339,7 @@ jobs:
       - name: Upload Codecov (C++ runtime, Python suite, CPU)
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.OV_WORKSPACE }}/coverage.info
           disable_search: true
           plugins: noop
@@ -481,6 +484,7 @@ jobs:
       - name: Upload Codecov (JS bindings, CPU)
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.OV_WORKSPACE }}/js-lcov.info
           disable_search: true
           plugins: noop
@@ -493,6 +497,7 @@ jobs:
       - name: Upload Codecov (C++ runtime, JS suite, CPU)
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.OV_WORKSPACE }}/coverage.info
           disable_search: true
           plugins: noop


### PR DESCRIPTION
### Details:
Codecov requires token to allow uploading results from protected branches.
This is required to successfully upload coverage results for nightly workflow runs on master branch.
