### PR TITLE
[NPUW] Detect asymmetric cross-group connections to disable F16IC.

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
@@ -213,6 +213,74 @@ bool isRegularParameterCase(const std::unordered_map<std::shared_ptr<Repeated>, 
     return true;
 }
 
+bool isRegularCrossGroupConsumerCase(const std::unordered_map<std::shared_ptr<Repeated>, GPtrSet>& reptag_to_gset,
+                                     const std::unordered_map<std::string, NodeSPtr>& node_id_cache,
+                                     const std::map<std::string, std::vector<std::set<std::string>>>& m_layer_matches) {
+    // Build a map: node name -> group, covering all nodes that belong to a repeated block group.
+    std::unordered_map<std::string, std::shared_ptr<ov::npuw::online::Group>> node_name_to_group;
+    for (const auto& reptag_and_gset : reptag_to_gset) {
+        for (const auto& gptr : reptag_and_gset.second) {
+            for (const auto& node : gptr->getContent()) {
+                node_name_to_group[node->get_friendly_name()] = gptr;
+            }
+            for (const auto& node : gptr->getOutputs()) {
+                node_name_to_group[node->get_friendly_name()] = gptr;
+            }
+            for (const auto& node : gptr->getInputs()) {
+                node_name_to_group[node->get_friendly_name()] = gptr;
+            }
+        }
+    }
+
+    // For each repeated block, check that the "has external non-Result reader" flag
+    // is consistent across all instances within each operation bank.
+    for (const auto& reptag_and_gset : reptag_to_gset) {
+        const auto& reptag = reptag_and_gset.first;
+
+        if (reptag_and_gset.second.size() <= 1) {
+            continue;
+        }
+
+        for (const auto& bank : m_layer_matches.at(reptag->id())) {
+            // Compute the mask per bank entry: vector<bool> per output port indicating
+            // whether that port has at least one reader outside the node's own group.
+            std::optional<std::vector<bool>> expected_mask;
+            for (const auto& layer_name : bank) {
+                auto layer_ptr = node_id_cache.at(layer_name);
+                auto group_it = node_name_to_group.find(layer_name);
+                auto this_group = (group_it != node_name_to_group.end()) ? group_it->second : nullptr;
+
+                std::vector<bool> mask;
+                for (auto&& output_desc : layer_ptr->outputs()) {
+                    bool has_external = false;
+                    for (auto&& r : output_desc.get_target_inputs()) {
+                        auto reader_ptr = r.get_node()->shared_from_this();
+                        if (ov::op::util::is_output(reader_ptr)) {
+                            continue;  // ov::Result readers are handled by isRegularResultCase
+                        }
+                        auto reader_group_it = node_name_to_group.find(reader_ptr->get_friendly_name());
+                        if (reader_group_it == node_name_to_group.end() || reader_group_it->second != this_group) {
+                            has_external = true;
+                            break;
+                        }
+                    }
+                    mask.push_back(has_external);
+                }
+
+                if (!expected_mask.has_value()) {
+                    expected_mask = mask;
+                } else if (*expected_mask != mask) {
+                    LOG_INFO("This is NOT a regular cross-group consumer case. "
+                             << "Cross-group consumer pattern mismatch for layer " << layer_name << " in bank.");
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
 }  // namespace
 
 using ov::npuw::online::detail::getConstsPrecision;
@@ -1490,6 +1558,16 @@ bool Snapshot::isRegularIOCase() const {
     if (!isRegularParameterCase(reptag_to_gset, node_id_cache, m_layer_matches)) {
         LOG_INFO("This is not a regular parameter case");
         LOG_INFO("DONE");
+        return false;
+    }
+
+    // Checks that cross-group (non-Result) consumer patterns are symmetric across all
+    // instances of each repeated block. F16IC inserts Convert nodes only on cross-group
+    // connections, so asymmetric connectivity (e.g. KV-sharing in Gemma4 where non-head
+    // layers have no external consumer for an output that head layers forward to K/V
+    // projection) would produce different Convert counts per instance and break folding.
+    if (!isRegularCrossGroupConsumerCase(reptag_to_gset, node_id_cache, m_layer_matches)) {
+        LOG_INFO("This is not a regular cross-group consumer case");
         return false;
     }
 

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <unordered_map>
 
+#include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/assign.hpp"
 #include "openvino/op/ops.hpp"
 #include "openvino/op/read_value.hpp"
@@ -14,7 +15,6 @@
 #include "openvino/op/util/variable.hpp"
 #include "openvino/openvino.hpp"
 #include "openvino/opsets/opset11.hpp"
-#include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 
 namespace ov {
 namespace test {
@@ -1199,6 +1199,126 @@ std::shared_ptr<ov::Model> ModelBuilder::get_model_with_repeated_blocks_and_para
     m_nodes.push_back(result);
 
     return std::make_shared<ov::Model>(ov::OutputVector{result->output(0)});
+}
+
+// Builds a model with N identical repeated blocks (using get_block(), same structure as
+// get_model_with_repeated_blocks_and_results) where "head" blocks additionally expose
+// their output via a MatMul to a separate Parameter-weighted projection group, mimicking
+// Gemma4's KV-sharing pattern:
+//   - Non-head blocks: block_output → next_block (only internal consumer)
+//   - Head blocks:     block_output → next_block  (internal)
+// Builds a model with N identical repeated blocks where "head" blocks additionally
+// expose their interior Relu via a cross-group MatMul, reproducing the Gemma4
+// KV-sharing asymmetry pattern.
+//
+// Block structure: Add(bias) → Relu(interior/TAP) → Multiply(scale) → Relu(boundary)
+//
+// Both Relu nodes have identical metadescs (same op type, same f32{1,1,8} I/O shape).
+// When a "head" block's interior Relu gains an external MatMul consumer, it becomes
+// an additional output_layer — but its metadesc ("Relu…") is already present in
+// output_ometa via the boundary Relu.  Therefore ALL blocks retain the same
+// MetaInterconnectIO and remain in one repeated-block family, allowing
+// isRegularCrossGroupConsumerCase to observe the per-bank inconsistency:
+//   - non-head: interior Relu bank → has_external=false (only internal Multiply consumer)
+//   - head:     interior Relu bank → has_external=true  (Multiply + external MatMul)
+// The mask mismatch causes isRegularCrossGroupConsumerCase to return false →
+// irregular_io=true, disabling F16IC for this model.
+std::shared_ptr<ov::Model> ModelBuilder::get_model_with_kv_sharing_repeated_blocks(
+    std::size_t repetitions,
+    const std::vector<std::size_t>& head_block_indices) {
+    clear();
+    if (repetitions == 0)
+        repetitions = 1;
+
+    const std::unordered_set<std::size_t> head_set(head_block_indices.begin(), head_block_indices.end());
+
+    auto input = std::make_shared<ov::opset11::Parameter>(ov::element::f32, ov::Shape{1, 1, 8});
+    auto kv_weight = std::make_shared<ov::opset11::Parameter>(ov::element::f32, ov::Shape{8, 4});
+    m_nodes.push_back(input);
+    m_nodes.push_back(kv_weight);
+    set_name(input);
+    set_name(kv_weight);
+
+    // Shared constants — same pointer → same Constant node used by all blocks,
+    // ensuring identical metadescs for the Add and Multiply ops in every block.
+    auto bias_const = ov::opset11::Constant::create(ov::element::f32, ov::Shape{1, 1, 8}, std::vector<float>(8, 0.1f));
+    auto scale_const = ov::opset11::Constant::create(ov::element::f32, ov::Shape{1}, std::vector<float>{0.5f});
+    m_nodes.push_back(bias_const);
+    m_nodes.push_back(scale_const);
+    set_name(bias_const);
+    set_name(scale_const);
+
+    // Non-repeated prefix — distinct structure prevents it from joining the repetitions.
+    auto head_const = ov::opset11::Constant::create(ov::element::f32, ov::Shape{1, 1, 8}, std::vector<float>(8, 1.f));
+    auto head_add = std::make_shared<ov::opset11::Add>(input, head_const);
+    auto head_relu = std::make_shared<ov::opset11::Relu>(head_add);
+    m_nodes.push_back(head_const);
+    m_nodes.push_back(head_add);
+    m_nodes.push_back(head_relu);
+    set_name(head_const);
+    set_name(head_add);
+    set_name(head_relu);
+
+    ov::Output<ov::Node> current = head_relu;
+    ov::OutputVector kv_outputs;
+
+    for (std::size_t i = 0; i < repetitions; ++i) {
+        auto add_i = std::make_shared<ov::opset11::Add>(current, bias_const);
+        auto relu_interior_i = std::make_shared<ov::opset11::Relu>(add_i);  // TAP POINT
+        auto mul_i = std::make_shared<ov::opset11::Multiply>(relu_interior_i, scale_const);
+        auto relu_boundary_i = std::make_shared<ov::opset11::Relu>(mul_i);  // boundary output
+        m_nodes.push_back(add_i);
+        m_nodes.push_back(relu_interior_i);
+        m_nodes.push_back(mul_i);
+        m_nodes.push_back(relu_boundary_i);
+        set_name(add_i);
+        set_name(relu_interior_i);
+        set_name(mul_i);
+        set_name(relu_boundary_i);
+
+        if (head_set.count(i)) {
+            // Cross-group edge from the interior Relu, mirroring Gemma4's
+            // Multiply_1 → k/v_proj pattern.  Because relu_interior_i and
+            // relu_boundary_i share the same metadesc, adding relu_interior_i
+            // as a second output_layer leaves output_ometa = {"Relu…"} unchanged.
+            auto kv_mm_i = std::make_shared<ov::opset11::MatMul>(relu_interior_i, kv_weight, false, false);
+            m_nodes.push_back(kv_mm_i);
+            set_name(kv_mm_i);
+            kv_outputs.push_back(kv_mm_i->output(0));
+        }
+
+        current = relu_boundary_i;
+    }
+
+    // Non-repeated tail suffix.
+    auto tail_const = ov::opset11::Constant::create(ov::element::f32, ov::Shape{1, 1, 8}, std::vector<float>(8, 2.f));
+    auto tail_mul = std::make_shared<ov::opset11::Multiply>(current, tail_const);
+    auto tail_add = std::make_shared<ov::opset11::Add>(tail_mul, tail_const);
+    m_nodes.push_back(tail_const);
+    m_nodes.push_back(tail_mul);
+    m_nodes.push_back(tail_add);
+    set_name(tail_const);
+    set_name(tail_mul);
+    set_name(tail_add);
+
+    auto main_result = std::make_shared<ov::opset11::Result>(tail_add);
+    m_nodes.push_back(main_result);
+    set_name(main_result);
+    ov::OutputVector outputs{main_result->output(0)};
+
+    // Each head block's KV MatMul connects to an independent Result to avoid
+    // creating asymmetric ov::Result consumer patterns across the repeated family.
+    // If we accumulated kv_outputs into a single Result, only the last block would
+    // indirectly connect to that Result via the accumulation chain, causing
+    // isRegularResultCase to fail.
+    for (auto&& kv_out : kv_outputs) {
+        auto kv_result = std::make_shared<ov::opset11::Result>(kv_out);
+        m_nodes.push_back(kv_result);
+        set_name(kv_result);
+        outputs.push_back(kv_result->output(0));
+    }
+
+    return std::make_shared<ov::Model>(outputs, ov::ParameterVector{input, kv_weight});
 }
 
 std::shared_ptr<ov::Model> ModelBuilder::get_model_with_multi_output_repeating_blocks(

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
@@ -401,7 +401,7 @@ struct BaseModelConfig {
 struct LLMConfig : public BaseModelConfig {
     bool use_kv_cache = true;
     bool use_inputs_embeds = false;
-    bool internal_position_ids = false; ///< embedding model
+    bool internal_position_ids = false;  ///< embedding model
     bool pre_norm = true;
 };
 
@@ -446,6 +446,15 @@ public:
     std::shared_ptr<ov::Model> get_model_with_repeated_blocks_and_parameters(
         std::size_t repetitions,
         const std::vector<std::size_t>& block_indices);
+    // Builds a model with N repeated blocks using a 4-op structure
+    // (Add→Relu→Multiply→Relu) where both Relu nodes share the same metadesc.
+    // "Head" blocks additionally expose their interior Relu via a cross-group MatMul.
+    // Because the interior and boundary Relu share the same metadesc, ALL blocks stay
+    // in one repeated-block family regardless of head/non-head status, allowing
+    // isRegularCrossGroupConsumerCase to detect the per-bank connectivity asymmetry.
+    std::shared_ptr<ov::Model> get_model_with_kv_sharing_repeated_blocks(
+        std::size_t repetitions,
+        const std::vector<std::size_t>& head_block_indices);
     std::shared_ptr<ov::Model> get_model_with_multi_output_repeating_blocks(std::size_t repetitions,
                                                                             bool last_block_has_direct_result);
 

--- a/src/plugins/intel_npu/tests/unit/npuw/online_partitioning.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/online_partitioning.cpp
@@ -17,8 +17,8 @@
 #include "partitioning/online/group.hpp"
 #include "partitioning/online/snapshot.hpp"
 
-using ov::test::npuw::ModelBuilder;
 using ov::test::npuw::LLMConfig;
+using ov::test::npuw::ModelBuilder;
 
 namespace {
 
@@ -107,6 +107,8 @@ bool isEqualEns(ov::npuw::Ensemble& ens1, ov::npuw::Ensemble& ens2) {
 class IsRegularResultCaseParametrized : public ::testing::TestWithParam<std::tuple<std::vector<std::size_t>, bool>> {};
 class IsRegularParameterCaseParametrized : public ::testing::TestWithParam<std::tuple<std::vector<std::size_t>, bool>> {
 };
+class IsRegularCrossGroupConsumerCaseParametrized
+    : public ::testing::TestWithParam<std::tuple<std::vector<std::size_t>, bool>> {};
 
 };  // namespace
 
@@ -731,5 +733,84 @@ TEST(OnlinePartitioningTest, IsRegularParameterCase_PrefillModel_InputsEmbeds) {
     EXPECT_GE(ens.repeated.size(), 1u);  // sanity: transformer layers must form a repeated block
     // Layer 0 reads inputs_embeds (ov::Parameter); layers 1+ read from prior computation.
     // isRegularParameterCase must detect this structural asymmetry and set irregular_io=true.
+    EXPECT_TRUE(ens.irregular_io);
+}
+
+TEST_P(IsRegularCrossGroupConsumerCaseParametrized, CheckForDifferentCrossGroupConsumerConfigs) {
+    auto [head_block_indices, expected_result] = GetParam();
+
+    ModelBuilder mb;
+    // Uses the KV-sharing block structure (Add→Relu→Multiply→Relu) where both Relu
+    // nodes share an identical metadesc.  When a head block's interior Relu gains an
+    // external consumer, output_ometa remains {"Relu"} because the boundary Relu
+    // already contributes that metadesc.  All 10 blocks stay in one repeated family,
+    // so isRegularCrossGroupConsumerCase is the first check that can detect the
+    // per-bank connectivity asymmetry.
+    auto model = mb.get_model_with_kv_sharing_repeated_blocks(10, head_block_indices);
+
+    // keepBlockSize=4 matches the 4-op block structure (Add→Relu→Multiply→Relu)
+    auto cfg = createConfigWithKeepBlockSize(4);
+    auto ens = ov::npuw::online::buildPartitioning(model, cfg);
+
+    EXPECT_GE(ens.repeated.size(), 1u);  // sanity check that we have repeated blocks
+    EXPECT_EQ(ens.irregular_io, expected_result);
+}
+
+// isRegularCrossGroupConsumerCase checks that within each operation bank of a repeated
+// block family, the cross-group (non-Result) consumer pattern is symmetric across all
+// instances.  F16IC inserts a Convert on every cross-group edge; if some instances
+// have an external consumer for a given output port and others do not, the Convert
+// count differs, breaking the operation-bank invariant.
+//
+// The key model property required to trigger this check:
+//   - All blocks must remain in ONE repeated-block family (same MetaInterconnectIO).
+//   - Some blocks' interior node must have an extra external consumer.
+// get_model_with_kv_sharing_repeated_blocks() satisfies both conditions because the
+// interior Relu and the boundary Relu share the same metadesc ("Relu f32{1,1,8}").
+// Adding the interior Relu as an extra output_layer leaves output_ometa unchanged.
+INSTANTIATE_TEST_SUITE_P(OnlinePartitioningTest,
+                         IsRegularCrossGroupConsumerCaseParametrized,
+                         ::testing::Values(
+                             // All blocks have a cross-group consumer: symmetric, F16IC safe
+                             std::make_tuple(std::vector<std::size_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+                                             /*irregular_io=*/false),
+                             // Some blocks have a cross-group consumer: interior Relu bank is asymmetric
+                             // (some mask=[true], others mask=[false]) → isRegularCrossGroupConsumerCase
+                             // returns false → irregular_io=true
+                             std::make_tuple(std::vector<std::size_t>{2, 5, 8}, /*irregular_io=*/true),
+                             // Only one block has a cross-group consumer: same asymmetry detected
+                             std::make_tuple(std::vector<std::size_t>{9}, /*irregular_io=*/true),
+                             // No blocks have a cross-group consumer: symmetric, F16IC safe
+                             std::make_tuple(std::vector<std::size_t>{}, /*irregular_io=*/false)));
+
+// Regression test for isRegularCrossGroupConsumerCase, introduced to handle the
+// Gemma4 KV-sharing pattern.
+//
+// In Gemma4, ALL transformer layers belong to one repeated-block family.  However,
+// only the "head" layers additionally forward their interior Multiply_1 output to
+// k/v_proj (a different partition group), while non-head layers keep Multiply_1
+// purely internal.  Because Multiply_1's metadesc is already present in output_ometa
+// (via another boundary node of the same op type), gaining an extra output_layer for
+// Multiply_1 leaves output_ometa unchanged, so the family is NOT split by the scanner.
+// isRegularCrossGroupConsumerCase then detects the per-bank inconsistency:
+//   - non-head interior node bank → mask=[false] (no external consumer)
+//   - head interior node bank     → mask=[true]  (external MatMul consumer)
+// → returns false → irregular_io=true, disabling F16IC for this model.
+//
+// get_model_with_kv_sharing_repeated_blocks() reproduces this same condition by using
+// a block structure (Add→Relu(interior)→Multiply→Relu(boundary)) where both Relu
+// nodes share an identical metadesc.  Block 5's interior Relu gains an external
+// MatMul consumer but output_ometa stays {"Relu"}, so all 10 blocks remain in one
+// family and the function's return-false path is exercised.
+TEST(OnlinePartitioningTest, IsRegularCrossGroupConsumerCase_Gemma4KVSharingPattern) {
+    ModelBuilder mb;
+    auto model = mb.get_model_with_kv_sharing_repeated_blocks(10, {5});
+
+    auto cfg = createConfigWithKeepBlockSize(4);
+    auto ens = ov::npuw::online::buildPartitioning(model, cfg);
+
+    EXPECT_GE(ens.repeated.size(), 1u);
+    // isRegularCrossGroupConsumerCase detects the interior-Relu bank asymmetry
+    // (block 5 has external consumer, others do not) → irregular_io=true.
     EXPECT_TRUE(ens.irregular_io);
 }


### PR DESCRIPTION
### Details:
Added a validation prevents F16IC from inserting asymmetric Convert operations when:

A repeated-block has both "head" and "non-head" instances:
Head blocks expose interior nodes to different partition groups (e.g., k/v_proj in Gemma4)
Non-head blocks keep the same nodes purely internal
When detected, irregular_io=true is set, disabling F16IC to maintain correctness.

### Tickets:
 - *[EISW-211489](https://jira.devtools.intel.com/browse/EISW-211489)*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
