### PR TITLE
[Core] Test core.read_model(wchar path with unicode)

### DIFF
--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -193,7 +193,7 @@ TEST_F(CoreBaseTest, read_model_with_const_wchar_path) {
 
     ov::Core core;
     ASSERT_FALSE(model_files_name_w.empty());
-const auto model = core.read_model(model_files_name_w.front().c_str());
+    const auto model = core.read_model(model_files_name_w.front().c_str());
     EXPECT_NE(model, nullptr);
 }
 #endif

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -192,7 +192,7 @@ TEST_F(CoreBaseTest, read_model_with_const_wchar_path) {
     generate_test_model_files("test-model");
 
     ov::Core core;
-    const std::wstring model_path_w = ov::util::string_to_wstring(model_file_name);
+    const std::wstring model_path_w = model_files_name_w[0];
     const wchar_t* model_path = model_path_w.c_str();
     const auto model = core.read_model(model_path);
     EXPECT_NE(model, nullptr);

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -192,7 +192,8 @@ TEST_F(CoreBaseTest, read_model_with_const_wchar_path) {
     generate_test_model_files("test-model");
 
     ov::Core core;
-    const std::wstring model_path_w = model_files_name_w[0];
+    ASSERT_FALSE(model_files_name_w.empty());
+    const std::wstring model_path_w = model_files_name_w.front();
     const wchar_t* model_path = model_path_w.c_str();
     const auto model = core.read_model(model_path);
     EXPECT_NE(model, nullptr);

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -193,9 +193,7 @@ TEST_F(CoreBaseTest, read_model_with_const_wchar_path) {
 
     ov::Core core;
     ASSERT_FALSE(model_files_name_w.empty());
-    const std::wstring model_path_w = model_files_name_w.front();
-    const wchar_t* model_path = model_path_w.c_str();
-    const auto model = core.read_model(model_path);
+const auto model = core.read_model(model_files_name_w.front().c_str());
     EXPECT_NE(model, nullptr);
 }
 #endif


### PR DESCRIPTION
### Details:
Updated `read_model_with_const_wchar_path` in `ov_core_test.cpp` to use the first entry from `model_files_name_w` for the model path 
Follow up to https://github.com/openvinotoolkit/openvino/pull/35040

### AI Assistance:
 - AI assistance used: no

