### PR TITLE
[NPUW] Add Mixture of Experts support to model builder

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
@@ -246,12 +246,15 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
     // --- Scale: per-group or per-channel, with optional batch dim ---
     // Magnitude kept small (scale_range ≈ 1/hi) so decompressed values stay moderate
     // (roughly ±1), preventing hidden state overflow.
-    // Scale shape: always 2D [rows, 1] (or [rows, num_groups, 1] for group quant).
-    // For 3D batched weights (MoE), a 2D scale broadcasts across the batch dimension.
-    // This is required because NPUW's MoE executor slices weights per-expert but not scales.
+    // 3D batched weights (MoE) use 3D scale [batch, rows, 1] so DEVICE_ROUTED transform
+    // can identify the expert dimension (shape[0] == num_experts).
     ov::Shape scale_shape;
-    scale_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
-    const size_t scale_count = has_groups ? rows * num_groups : rows;
+    if (is_3d) {
+        scale_shape = has_groups ? ov::Shape{batch, rows, num_groups, 1} : ov::Shape{batch, rows, 1};
+    } else {
+        scale_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
+    }
+    const size_t scale_count = batch * (has_groups ? rows * num_groups : rows);
     const float scale_range = 1.0f / static_cast<float>(hi);
     uint32_t s_state = seed_from_name(name + "_scale");
     std::vector<float> scale_data(scale_count);
@@ -862,83 +865,86 @@ MoEFFN::MoEFFN(size_t hs, size_t is, size_t ne, size_t k,
         weight_fn = CompressedWeight{ov::element::i4, 0, DCOffPattern::SYMM_NO_ZP};
     }
     using C = ov::opset11::Constant;
-    int64_t is_i = static_cast<int64_t>(is);
-    int64_t ne_i = static_cast<int64_t>(ne);
-    int64_t k_i = static_cast<int64_t>(k);
+    int32_t is_i = static_cast<int32_t>(is);
+    int32_t ne_i = static_cast<int32_t>(ne);
+    int32_t k_i = static_cast<int32_t>(k);
 
-    tile_repeats = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{ne_i, 1});
-    slice_step = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
-    slice_axis2 = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{2});
-    slice_start_0 = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0});
-    slice_stop_is = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{is_i});
-    slice_start_is = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{is_i});
-    slice_stop_2is = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{2 * is_i});
+    // Use i32 for shape/axis/step constants matching real GPT-OSS HuggingFace export.
+    tile_repeats = C::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{ne_i, 1});
+    slice_step = C::create(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{1});
+    slice_axis2 = C::create(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{2});
+    slice_start_0 = C::create(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{0});
+    slice_stop_is = C::create(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{is_i});
+    slice_start_is = C::create(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{is_i});
+    slice_stop_2is = C::create(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{static_cast<int32_t>(2 * is_i)});
     min_const = C::create(prec, ov::Shape{1}, std::vector<float>{20.0f});
     swish_beta = C::create(prec, ov::Shape{}, std::vector<float>{1.0f});
     clamp_add_zero = C::create(prec, ov::Shape{1}, std::vector<float>{0.0f});
-    topk_k_const = C::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{k_i});
-    sl_start = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 0});
-    sl_step_r = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 1});
-    sl_axes = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 1});
-    scatter_axis = C::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
-    tp_order = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0});
-    unsq_axis = C::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{3});
-    reduce_axis = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0});
+    topk_k_const = C::create(ov::element::i32, ov::Shape{}, std::vector<int32_t>{k_i});
+    sl_start = C::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{0, 0});
+    sl_step_r = C::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{1, 1});
+    sl_axes = C::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{0, 1});
+    scatter_axis = C::create(ov::element::i32, ov::Shape{}, std::vector<int32_t>{1});
+    tp_order = C::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{1, 0});
+    unsq_axis = C::create(ov::element::i32, ov::Shape{}, std::vector<int32_t>{3});
+    reduce_axis = C::create(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{0});
 }
 
 ov::Output<ov::Node> MoEFFN::operator()(const ov::Output<ov::Node>& input,
                                                       const std::string& name) const {
     using C = ov::opset11::Constant;
     const auto prec = precision;
-    const int64_t ne_i = static_cast<int64_t>(num_experts);
-    const int64_t hs_i = static_cast<int64_t>(hidden_size);
-    auto mk = [](std::vector<int64_t> v) {
+    const int32_t ne_i = static_cast<int32_t>(num_experts);
+    const int32_t hs_i = static_cast<int32_t>(hidden_size);
+    auto mk = [](std::vector<int32_t> v) {
         ov::OutputVector p;
         for (auto x : v)
-            p.push_back(C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{x})->output(0));
+            p.push_back(C::create(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{x})->output(0));
         return std::make_shared<ov::opset11::Concat>(p, 0);
     };
 
-    auto original_shape = std::make_shared<ov::opset11::ShapeOf>(input, ov::element::i64);
+    auto original_shape = std::make_shared<ov::opset11::ShapeOf>(input, ov::element::i32);
     original_shape->set_friendly_name(name + ".original_shape");
 
     auto input_2d = std::make_shared<ov::opset11::Reshape>(input, mk({-1, hs_i}), false);
     input_2d->set_friendly_name(name + ".input_2d");
 
-    // Router + expert weights use the configured weight_fn
-    auto rw = weight_fn(name + ".router.weight", ov::Shape{num_experts, hidden_size}, prec);
+    // Router uses i8 weights matching real GPT-OSS two-pass quantization
+    // (router excluded from 4-bit, gets 8-bit instead).
+    static const CompressedWeight router_wt{ov::element::i8, 0, DCOffPattern::SYMM_NO_ZP};
+    auto rw = router_wt(name + ".expert.router.weight", ov::Shape{num_experts, hidden_size}, prec);
     auto r_mm = std::make_shared<ov::opset11::MatMul>(input_2d, rw, false, true);
-    r_mm->set_friendly_name(name + ".router.matmul");
+    r_mm->set_friendly_name(name + ".expert.router.matmul");
     auto r_bias = C::create(prec, ov::Shape{1, num_experts}, std::vector<float>(num_experts, 0.0f));
-    r_bias->set_friendly_name(name + ".router.bias");
+    r_bias->set_friendly_name(name + ".expert.router.bias");
     auto r_add = std::make_shared<ov::opset11::Add>(r_mm, r_bias);
-    r_add->set_friendly_name(name + ".router.add");
+    r_add->set_friendly_name(name + ".expert.router.add");
 
     auto topk = std::make_shared<ov::opset11::TopK>(r_add, topk_k_const, 1, "max", "value", ov::element::i64);
-    topk->set_friendly_name(name + ".router.topk");
+    topk->set_friendly_name(name + ".expert.router.topk");
     auto softmax = std::make_shared<ov::op::v8::Softmax>(topk->output(0), 1);
-    softmax->set_friendly_name(name + ".router.softmax");
+    softmax->set_friendly_name(name + ".expert.router.softmax");
     auto topk_cvt = std::make_shared<ov::opset11::Convert>(topk->output(1), ov::element::i32);
-    topk_cvt->set_friendly_name(name + ".router.topk_convert");
-    auto topk_shape = std::make_shared<ov::op::v3::ShapeOf>(topk_cvt, ov::element::i64);
-    topk_shape->set_friendly_name(name + ".router.topk_shapeof");
+    topk_cvt->set_friendly_name(name + ".expert.router.topk_convert");
+    auto topk_shape = std::make_shared<ov::op::v3::ShapeOf>(topk_cvt, ov::element::i32);
+    topk_shape->set_friendly_name(name + ".expert.router.topk_shapeof");
 
     auto r_slice = std::make_shared<ov::op::v8::Slice>(softmax, sl_start, topk_shape, sl_step_r, sl_axes);
-    r_slice->set_friendly_name(name + ".router.slice");
-    auto add_shape = std::make_shared<ov::op::v3::ShapeOf>(r_add, ov::element::i64);
-    add_shape->set_friendly_name(name + ".router.add_shapeof");
+    r_slice->set_friendly_name(name + ".expert.router.slice");
+    auto add_shape = std::make_shared<ov::op::v3::ShapeOf>(r_add, ov::element::i32);
+    add_shape->set_friendly_name(name + ".expert.router.add_shapeof");
     auto zeros = std::make_shared<ov::op::v3::Broadcast>(
         C::create(prec, ov::Shape{}, std::vector<float>{0.0f}), add_shape, ov::op::BroadcastType::NUMPY);
-    zeros->set_friendly_name(name + ".router.zeros");
+    zeros->set_friendly_name(name + ".expert.router.zeros");
     auto scatter = std::make_shared<ov::op::v3::ScatterElementsUpdate>(zeros, topk_cvt, r_slice, scatter_axis);
-    scatter->set_friendly_name(name + ".router.scatter");
+    scatter->set_friendly_name(name + ".expert.router.scatter");
 
     auto r_tp = std::make_shared<ov::opset11::Transpose>(scatter, tp_order);
-    r_tp->set_friendly_name(name + ".router.transpose");
+    r_tp->set_friendly_name(name + ".expert.router.transpose");
     auto r_reshape = std::make_shared<ov::opset11::Reshape>(r_tp, mk({ne_i, 1, -1}), false);
-    r_reshape->set_friendly_name(name + ".router.reshape");
+    r_reshape->set_friendly_name(name + ".expert.router.reshape");
     auto router_scores = std::make_shared<ov::opset11::Unsqueeze>(r_reshape, unsq_axis);
-    router_scores->set_friendly_name(name + ".router.unsqueeze");
+    router_scores->set_friendly_name(name + ".expert.router.unsqueeze");
 
     // Expert: Tile → Reshape → MatMul → Add → dual-branch → MatMul → Add → Reshape → Multiply → ReduceSum
     auto tiled = std::make_shared<ov::op::v0::Tile>(input_2d, tile_repeats);

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
@@ -5,6 +5,7 @@
 #include "model_builder.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <unordered_map>
 
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
@@ -90,9 +91,14 @@ ov::Output<ov::Node> FloatWeight::operator()(const std::string& name,
 ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
                                                   const ov::Shape& shape,
                                                   ov::element::Type compute_precision) const {
-    OPENVINO_ASSERT(shape.size() == 2, "CompressedWeight expects 2D shape, got ", shape.size(), "D");
-    const size_t rows = shape[0];
-    const size_t cols = shape[1];
+    OPENVINO_ASSERT(shape.size() == 2 || shape.size() == 3,
+                    "CompressedWeight expects 2D or 3D shape, got ", shape.size(), "D");
+    // 3D [batch, rows, cols]: batched expert weights (MoE).
+    // 2D [rows, cols]: standard linear projection.
+    const bool is_3d = (shape.size() == 3);
+    const size_t batch = is_3d ? shape[0] : 1;
+    const size_t rows = is_3d ? shape[1] : shape[0];
+    const size_t cols = is_3d ? shape[2] : shape[1];
 
     // --- Validate pattern constraints ---
     const bool has_zp =
@@ -114,6 +120,9 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
         hi = 7;
     } else if (storage_type == ov::element::u4) {
         lo = 1;
+        hi = 15;
+    } else if (storage_type == ov::element::nf4) {
+        lo = 0;
         hi = 15;
     } else {
         lo = -100;
@@ -146,12 +155,18 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
                         " requires group_size > 0 (no per-channel DCOFF pass exists)");
     }
 
-    // Weight shape: 3D [rows, num_groups, group_size] for group quant, 2D [rows, cols]
-    // for per-channel.  DCOFF patterns expect the weight Parameter to already be in the
-    // correct shape — no leading Reshape is recognized.
-    const ov::Shape weight_shape = has_groups ? ov::Shape{rows, num_groups, group_size} : ov::Shape{rows, cols};
+    // Weight shape includes batch dim for 3D (MoE batched experts).
+    // Group quant adds an extra group dim inside each [rows, cols] slice.
+    ov::Shape weight_shape;
+    if (is_3d) {
+        weight_shape = has_groups ? ov::Shape{batch, rows, num_groups, group_size}
+                                 : ov::Shape{batch, rows, cols};
+    } else {
+        weight_shape = has_groups ? ov::Shape{rows, num_groups, group_size}
+                                 : ov::Shape{rows, cols};
+    }
     uint32_t w_state = seed_from_name(name);
-    std::vector<int8_t> w_data(rows * cols);
+    std::vector<int8_t> w_data(batch * rows * cols);
     for (size_t i = 0; i < w_data.size(); ++i) {
         uint32_t r = xorshift32(w_state);
         int val = static_cast<int>(lo) + static_cast<int>(r % static_cast<uint32_t>(hi - lo + 1));
@@ -162,15 +177,21 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
 
     ov::Output<ov::Node> decomp_input = weight->output(0);
 
-    // --- Convert weight to decomp element type ---
-    auto convert = std::make_shared<ov::opset11::Convert>(decomp_input, decomp_et);
-    convert->set_friendly_name(name + "_convert");
-
-    ov::Output<ov::Node> multiply_input = convert->output(0);
+    // --- Convert weight to decomp element type (skip if already matching) ---
+    ov::Output<ov::Node> multiply_input;
+    if (storage_type != decomp_et) {
+        auto convert = std::make_shared<ov::opset11::Convert>(decomp_input, decomp_et);
+        convert->set_friendly_name(name + "_convert");
+        multiply_input = convert->output(0);
+    } else {
+        multiply_input = decomp_input;
+    }
 
     // --- Zero-point subtraction (SYMM_ZP, GPTQ, ASYMM_ZP) ---
     if (has_zp) {
-        const ov::Shape zp_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
+        // ZP shape: always 2D (same reasoning as scale — MoE executor doesn't slice ZP)
+        ov::Shape zp_shape;
+        zp_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
         const size_t zp_count = has_groups ? rows * num_groups : rows;
         const int mid = (static_cast<int>(lo) + static_cast<int>(hi)) / 2;
 
@@ -181,7 +202,7 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
             auto zp_const = ov::opset11::Constant::create(ov::element::f32, zp_shape, zp_f32);
             zp_const->set_friendly_name(name + "_zp");
 
-            auto subtract = std::make_shared<ov::opset11::Subtract>(convert, zp_const);
+            auto subtract = std::make_shared<ov::opset11::Subtract>(multiply_input, zp_const);
             subtract->set_friendly_name(name + "_subtract");
             multiply_input = subtract->output(0);
 
@@ -195,7 +216,7 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
             auto zp_convert = std::make_shared<ov::opset11::Convert>(zp_const, ov::element::f16);
             zp_convert->set_friendly_name(name + "_zp_convert");
 
-            auto subtract = std::make_shared<ov::opset11::Subtract>(convert, zp_convert);
+            auto subtract = std::make_shared<ov::opset11::Subtract>(multiply_input, zp_convert);
             subtract->set_friendly_name(name + "_subtract");
             multiply_input = subtract->output(0);
 
@@ -216,16 +237,20 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
             auto zp_convert = std::make_shared<ov::opset11::Convert>(zp_const, ov::element::f16);
             zp_convert->set_friendly_name(name + "_zp_convert");
 
-            auto subtract = std::make_shared<ov::opset11::Subtract>(convert, zp_convert);
+            auto subtract = std::make_shared<ov::opset11::Subtract>(multiply_input, zp_convert);
             subtract->set_friendly_name(name + "_subtract");
             multiply_input = subtract->output(0);
         }
     }
 
-    // --- Scale: per-group [rows, num_groups, 1] or per-channel [rows, 1] ---
+    // --- Scale: per-group or per-channel, with optional batch dim ---
     // Magnitude kept small (scale_range ≈ 1/hi) so decompressed values stay moderate
     // (roughly ±1), preventing hidden state overflow.
-    const ov::Shape scale_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
+    // Scale shape: always 2D [rows, 1] (or [rows, num_groups, 1] for group quant).
+    // For 3D batched weights (MoE), a 2D scale broadcasts across the batch dimension.
+    // This is required because NPUW's MoE executor slices weights per-expert but not scales.
+    ov::Shape scale_shape;
+    scale_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
     const size_t scale_count = has_groups ? rows * num_groups : rows;
     const float scale_range = 1.0f / static_cast<float>(hi);
     uint32_t s_state = seed_from_name(name + "_scale");
@@ -242,12 +267,15 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
 
     ov::Output<ov::Node> decompressed = scaled->output(0);
 
-    // --- Group quant: Reshape 3D → 2D [rows, cols] ---
+    // --- Group quant: collapse group dims back to original shape ---
     if (has_groups) {
-        auto out_shape =
-            ov::opset11::Constant::create(ov::element::i64,
-                                          ov::Shape{2},
-                                          std::vector<int64_t>{static_cast<int64_t>(rows), static_cast<int64_t>(cols)});
+        std::vector<int64_t> out_dims;
+        if (is_3d)
+            out_dims = {static_cast<int64_t>(batch), static_cast<int64_t>(rows), static_cast<int64_t>(cols)};
+        else
+            out_dims = {static_cast<int64_t>(rows), static_cast<int64_t>(cols)};
+        auto out_shape = ov::opset11::Constant::create(
+            ov::element::i64, ov::Shape{out_dims.size()}, out_dims);
         auto reshaped = std::make_shared<ov::opset11::Reshape>(decompressed, out_shape, false);
         reshaped->set_friendly_name(name + "_reshape");
         decompressed = reshaped->output(0);
@@ -823,6 +851,151 @@ ov::Output<ov::Node> GELU::operator()(const ov::Output<ov::Node>& input, const s
 
     return down;
 }
+
+MoEFFN::MoEFFN(size_t hs, size_t is, size_t ne, size_t k,
+                                         ov::element::Type prec, WeightFn wf)
+    : hidden_size(hs), intermediate_size(is), num_experts(ne), num_experts_per_tok(k),
+      precision(prec), weight_fn(std::move(wf)) {
+    // Default to i4 CompressedWeight if no weight function provided.
+    // i4 (not nf4) because NPUW's nf4 unpack doesn't handle 3D batched scales.
+    if (!weight_fn) {
+        weight_fn = CompressedWeight{ov::element::i4, 0, DCOffPattern::SYMM_NO_ZP};
+    }
+    using C = ov::opset11::Constant;
+    int64_t is_i = static_cast<int64_t>(is);
+    int64_t ne_i = static_cast<int64_t>(ne);
+    int64_t k_i = static_cast<int64_t>(k);
+
+    tile_repeats = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{ne_i, 1});
+    slice_step = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
+    slice_axis2 = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{2});
+    slice_start_0 = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0});
+    slice_stop_is = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{is_i});
+    slice_start_is = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{is_i});
+    slice_stop_2is = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{2 * is_i});
+    min_const = C::create(prec, ov::Shape{1}, std::vector<float>{20.0f});
+    swish_beta = C::create(prec, ov::Shape{}, std::vector<float>{1.0f});
+    clamp_add_zero = C::create(prec, ov::Shape{1}, std::vector<float>{0.0f});
+    topk_k_const = C::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{k_i});
+    sl_start = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 0});
+    sl_step_r = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 1});
+    sl_axes = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 1});
+    scatter_axis = C::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
+    tp_order = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0});
+    unsq_axis = C::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{3});
+    reduce_axis = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0});
+}
+
+ov::Output<ov::Node> MoEFFN::operator()(const ov::Output<ov::Node>& input,
+                                                      const std::string& name) const {
+    using C = ov::opset11::Constant;
+    const auto prec = precision;
+    const int64_t ne_i = static_cast<int64_t>(num_experts);
+    const int64_t hs_i = static_cast<int64_t>(hidden_size);
+    auto mk = [](std::vector<int64_t> v) {
+        ov::OutputVector p;
+        for (auto x : v)
+            p.push_back(C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{x})->output(0));
+        return std::make_shared<ov::opset11::Concat>(p, 0);
+    };
+
+    auto original_shape = std::make_shared<ov::opset11::ShapeOf>(input, ov::element::i64);
+    original_shape->set_friendly_name(name + ".original_shape");
+
+    auto input_2d = std::make_shared<ov::opset11::Reshape>(input, mk({-1, hs_i}), false);
+    input_2d->set_friendly_name(name + ".input_2d");
+
+    // Router + expert weights use the configured weight_fn
+    auto rw = weight_fn(name + ".router.weight", ov::Shape{num_experts, hidden_size}, prec);
+    auto r_mm = std::make_shared<ov::opset11::MatMul>(input_2d, rw, false, true);
+    r_mm->set_friendly_name(name + ".router.matmul");
+    auto r_bias = C::create(prec, ov::Shape{1, num_experts}, std::vector<float>(num_experts, 0.0f));
+    r_bias->set_friendly_name(name + ".router.bias");
+    auto r_add = std::make_shared<ov::opset11::Add>(r_mm, r_bias);
+    r_add->set_friendly_name(name + ".router.add");
+
+    auto topk = std::make_shared<ov::opset11::TopK>(r_add, topk_k_const, 1, "max", "value", ov::element::i64);
+    topk->set_friendly_name(name + ".router.topk");
+    auto softmax = std::make_shared<ov::op::v8::Softmax>(topk->output(0), 1);
+    softmax->set_friendly_name(name + ".router.softmax");
+    auto topk_cvt = std::make_shared<ov::opset11::Convert>(topk->output(1), ov::element::i32);
+    topk_cvt->set_friendly_name(name + ".router.topk_convert");
+    auto topk_shape = std::make_shared<ov::op::v3::ShapeOf>(topk_cvt, ov::element::i64);
+    topk_shape->set_friendly_name(name + ".router.topk_shapeof");
+
+    auto r_slice = std::make_shared<ov::op::v8::Slice>(softmax, sl_start, topk_shape, sl_step_r, sl_axes);
+    r_slice->set_friendly_name(name + ".router.slice");
+    auto add_shape = std::make_shared<ov::op::v3::ShapeOf>(r_add, ov::element::i64);
+    add_shape->set_friendly_name(name + ".router.add_shapeof");
+    auto zeros = std::make_shared<ov::op::v3::Broadcast>(
+        C::create(prec, ov::Shape{}, std::vector<float>{0.0f}), add_shape, ov::op::BroadcastType::NUMPY);
+    zeros->set_friendly_name(name + ".router.zeros");
+    auto scatter = std::make_shared<ov::op::v3::ScatterElementsUpdate>(zeros, topk_cvt, r_slice, scatter_axis);
+    scatter->set_friendly_name(name + ".router.scatter");
+
+    auto r_tp = std::make_shared<ov::opset11::Transpose>(scatter, tp_order);
+    r_tp->set_friendly_name(name + ".router.transpose");
+    auto r_reshape = std::make_shared<ov::opset11::Reshape>(r_tp, mk({ne_i, 1, -1}), false);
+    r_reshape->set_friendly_name(name + ".router.reshape");
+    auto router_scores = std::make_shared<ov::opset11::Unsqueeze>(r_reshape, unsq_axis);
+    router_scores->set_friendly_name(name + ".router.unsqueeze");
+
+    // Expert: Tile → Reshape → MatMul → Add → dual-branch → MatMul → Add → Reshape → Multiply → ReduceSum
+    auto tiled = std::make_shared<ov::op::v0::Tile>(input_2d, tile_repeats);
+    tiled->set_friendly_name(name + ".expert.tile");
+    auto expert_3d = std::make_shared<ov::opset11::Reshape>(tiled, mk({ne_i, -1, hs_i}), false);
+    expert_3d->set_friendly_name(name + ".expert.reshape_in");
+
+    auto gu_w = weight_fn(name + ".expert.gate_up_proj.weight",
+                        ov::Shape{num_experts, 2 * intermediate_size, hidden_size}, prec);
+    auto gu_mm = std::make_shared<ov::opset11::MatMul>(expert_3d, gu_w, false, true);
+    gu_mm->set_friendly_name(name + ".expert.gate_up_matmul");
+    auto gu_bias = C::create(prec, ov::Shape{num_experts, 1, 2 * intermediate_size},
+                             std::vector<float>(num_experts * 2 * intermediate_size, 0.0f));
+    gu_bias->set_friendly_name(name + ".expert.gate_up_bias");
+    auto gu_add = std::make_shared<ov::opset11::Add>(gu_mm, gu_bias);
+    gu_add->set_friendly_name(name + ".expert.gate_up_add");
+
+    auto act_slice = std::make_shared<ov::op::v8::Slice>(gu_add, slice_start_0, slice_stop_is, slice_step, slice_axis2);
+    act_slice->set_friendly_name(name + ".expert.slice_act");
+    auto act_min = std::make_shared<ov::opset11::Minimum>(act_slice, min_const);
+    act_min->set_friendly_name(name + ".expert.minimum");
+    auto act_swish = std::make_shared<ov::op::v4::Swish>(act_min, swish_beta);
+    act_swish->set_friendly_name(name + ".expert.swish");
+
+    auto gate_slice =
+        std::make_shared<ov::op::v8::Slice>(gu_add, slice_start_is, slice_stop_2is, slice_step, slice_axis2);
+    gate_slice->set_friendly_name(name + ".expert.slice_gate");
+    auto gate_clamp = std::make_shared<ov::op::v0::Clamp>(gate_slice, -20.0f, 20.0f);
+    gate_clamp->set_friendly_name(name + ".expert.clamp");
+    auto gate_add = std::make_shared<ov::opset11::Add>(gate_clamp, clamp_add_zero);
+    gate_add->set_friendly_name(name + ".expert.gate_add");
+
+    auto merged = std::make_shared<ov::opset11::Multiply>(act_swish, gate_add);
+    merged->set_friendly_name(name + ".expert.merge");
+
+    auto dn_w = weight_fn(name + ".expert.down_proj.weight",
+                        ov::Shape{num_experts, hidden_size, intermediate_size}, prec);
+    auto dn_mm = std::make_shared<ov::opset11::MatMul>(merged, dn_w, false, true);
+    dn_mm->set_friendly_name(name + ".expert.down_matmul");
+    auto dn_bias = C::create(prec, ov::Shape{num_experts, 1, hidden_size},
+                             std::vector<float>(num_experts * hidden_size, 0.0f));
+    dn_bias->set_friendly_name(name + ".expert.down_bias");
+    auto dn_add = std::make_shared<ov::opset11::Add>(dn_mm, dn_bias);
+    dn_add->set_friendly_name(name + ".expert.down_add");
+
+    auto expert_out = std::make_shared<ov::opset11::Reshape>(dn_add, mk({ne_i, 1, -1, hs_i}), false);
+    expert_out->set_friendly_name(name + ".expert.reshape_out");
+    auto weighted = std::make_shared<ov::opset11::Multiply>(expert_out, router_scores);
+    weighted->set_friendly_name(name + ".expert.weighted");
+    auto reduced = std::make_shared<ov::opset11::ReduceSum>(weighted, reduce_axis, false);
+    reduced->set_friendly_name(name + ".expert.reduced");
+
+    auto output = std::make_shared<ov::opset11::Reshape>(reduced, original_shape, false);
+    output->set_friendly_name(name + ".output");
+    return output->output(0);
+}
+
 
 ov::Output<ov::Node> make_transformer_layers(const ov::Output<ov::Node>& initial,
                                              size_t num_layers,
@@ -1544,8 +1717,23 @@ std::shared_ptr<ov::Model> ModelBuilder::build_llm(const LLMConfig& config_in) {
     LLMConfig config = config_in;
     if (!config.norm)
         config.norm = LayerNorm(config.hidden_size, config.precision);
-    if (!config.ffn)
-        config.ffn = SwiGLU(config.hidden_size, config.intermediate_size, config.precision, config.weight);
+    if (!config.ffn) {
+        if (config.num_experts > 0) {
+            size_t moe_inter = config.moe_intermediate_size > 0
+                                   ? config.moe_intermediate_size
+                                   : config.intermediate_size;
+            size_t moe_k = config.num_experts_per_tok > 0
+                               ? config.num_experts_per_tok
+                               : std::min<size_t>(2, config.num_experts);
+            OPENVINO_ASSERT(moe_k >= 1 && moe_k <= config.num_experts,
+                            "Invalid MoE config: num_experts_per_tok (",
+                            moe_k, ") must be in [1, num_experts (", config.num_experts, ")]");
+            config.ffn = MoEFFN(config.hidden_size, moe_inter, config.num_experts,
+                                moe_k, config.precision);
+        } else {
+            config.ffn = SwiGLU(config.hidden_size, config.intermediate_size, config.precision, config.weight);
+        }
+    }
     const auto prec = config.precision;
 
     auto attention_mask = parameter(ov::element::i64, ov::PartialShape{-1, -1}, "attention_mask");
@@ -1882,7 +2070,7 @@ static ov::Output<ov::Node> make_whisper_causal_mask(const CachePositionResult& 
     auto slice_step = ov::opset11::Constant::create(ov::element::i64, ov::Shape{1}, {1});
     auto slice_axes = ov::opset11::Constant::create(ov::element::i64, ov::Shape{1}, {3});
     auto causal_sliced =
-        std::make_shared<ov::op::v8::Slice>(causal_float, slice_start, slice_stop, slice_step, slice_axes);
+        std::make_shared<ov::opset11::Slice>(causal_float, slice_start, slice_stop, slice_step, slice_axes);
     causal_sliced->set_friendly_name(prefix + "causal_mask_sliced");
 
     return causal_sliced->output(0);

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
@@ -5,6 +5,7 @@
 #include "model_builder.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <unordered_map>
 
 #include "openvino/op/assign.hpp"
@@ -90,9 +91,14 @@ ov::Output<ov::Node> FloatWeight::operator()(const std::string& name,
 ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
                                                   const ov::Shape& shape,
                                                   ov::element::Type compute_precision) const {
-    OPENVINO_ASSERT(shape.size() == 2, "CompressedWeight expects 2D shape, got ", shape.size(), "D");
-    const size_t rows = shape[0];
-    const size_t cols = shape[1];
+    OPENVINO_ASSERT(shape.size() == 2 || shape.size() == 3,
+                    "CompressedWeight expects 2D or 3D shape, got ", shape.size(), "D");
+    // 3D [batch, rows, cols]: batched expert weights (MoE).
+    // 2D [rows, cols]: standard linear projection.
+    const bool is_3d = (shape.size() == 3);
+    const size_t batch = is_3d ? shape[0] : 1;
+    const size_t rows = is_3d ? shape[1] : shape[0];
+    const size_t cols = is_3d ? shape[2] : shape[1];
 
     // --- Validate pattern constraints ---
     const bool has_zp =
@@ -114,6 +120,9 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
         hi = 7;
     } else if (storage_type == ov::element::u4) {
         lo = 1;
+        hi = 15;
+    } else if (storage_type == ov::element::nf4) {
+        lo = 0;
         hi = 15;
     } else {
         lo = -100;
@@ -146,12 +155,18 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
                         " requires group_size > 0 (no per-channel DCOFF pass exists)");
     }
 
-    // Weight shape: 3D [rows, num_groups, group_size] for group quant, 2D [rows, cols]
-    // for per-channel.  DCOFF patterns expect the weight Parameter to already be in the
-    // correct shape — no leading Reshape is recognized.
-    const ov::Shape weight_shape = has_groups ? ov::Shape{rows, num_groups, group_size} : ov::Shape{rows, cols};
+    // Weight shape includes batch dim for 3D (MoE batched experts).
+    // Group quant adds an extra group dim inside each [rows, cols] slice.
+    ov::Shape weight_shape;
+    if (is_3d) {
+        weight_shape = has_groups ? ov::Shape{batch, rows, num_groups, group_size}
+                                 : ov::Shape{batch, rows, cols};
+    } else {
+        weight_shape = has_groups ? ov::Shape{rows, num_groups, group_size}
+                                 : ov::Shape{rows, cols};
+    }
     uint32_t w_state = seed_from_name(name);
-    std::vector<int8_t> w_data(rows * cols);
+    std::vector<int8_t> w_data(batch * rows * cols);
     for (size_t i = 0; i < w_data.size(); ++i) {
         uint32_t r = xorshift32(w_state);
         int val = static_cast<int>(lo) + static_cast<int>(r % static_cast<uint32_t>(hi - lo + 1));
@@ -162,15 +177,21 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
 
     ov::Output<ov::Node> decomp_input = weight->output(0);
 
-    // --- Convert weight to decomp element type ---
-    auto convert = std::make_shared<ov::opset11::Convert>(decomp_input, decomp_et);
-    convert->set_friendly_name(name + "_convert");
-
-    ov::Output<ov::Node> multiply_input = convert->output(0);
+    // --- Convert weight to decomp element type (skip if already matching) ---
+    ov::Output<ov::Node> multiply_input;
+    if (storage_type != decomp_et) {
+        auto convert = std::make_shared<ov::opset11::Convert>(decomp_input, decomp_et);
+        convert->set_friendly_name(name + "_convert");
+        multiply_input = convert->output(0);
+    } else {
+        multiply_input = decomp_input;
+    }
 
     // --- Zero-point subtraction (SYMM_ZP, GPTQ, ASYMM_ZP) ---
     if (has_zp) {
-        const ov::Shape zp_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
+        // ZP shape: always 2D (same reasoning as scale — MoE executor doesn't slice ZP)
+        ov::Shape zp_shape;
+        zp_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
         const size_t zp_count = has_groups ? rows * num_groups : rows;
         const int mid = (static_cast<int>(lo) + static_cast<int>(hi)) / 2;
 
@@ -181,7 +202,7 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
             auto zp_const = ov::opset11::Constant::create(ov::element::f32, zp_shape, zp_f32);
             zp_const->set_friendly_name(name + "_zp");
 
-            auto subtract = std::make_shared<ov::opset11::Subtract>(convert, zp_const);
+            auto subtract = std::make_shared<ov::opset11::Subtract>(multiply_input, zp_const);
             subtract->set_friendly_name(name + "_subtract");
             multiply_input = subtract->output(0);
 
@@ -195,7 +216,7 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
             auto zp_convert = std::make_shared<ov::opset11::Convert>(zp_const, ov::element::f16);
             zp_convert->set_friendly_name(name + "_zp_convert");
 
-            auto subtract = std::make_shared<ov::opset11::Subtract>(convert, zp_convert);
+            auto subtract = std::make_shared<ov::opset11::Subtract>(multiply_input, zp_convert);
             subtract->set_friendly_name(name + "_subtract");
             multiply_input = subtract->output(0);
 
@@ -216,16 +237,20 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
             auto zp_convert = std::make_shared<ov::opset11::Convert>(zp_const, ov::element::f16);
             zp_convert->set_friendly_name(name + "_zp_convert");
 
-            auto subtract = std::make_shared<ov::opset11::Subtract>(convert, zp_convert);
+            auto subtract = std::make_shared<ov::opset11::Subtract>(multiply_input, zp_convert);
             subtract->set_friendly_name(name + "_subtract");
             multiply_input = subtract->output(0);
         }
     }
 
-    // --- Scale: per-group [rows, num_groups, 1] or per-channel [rows, 1] ---
+    // --- Scale: per-group or per-channel, with optional batch dim ---
     // Magnitude kept small (scale_range ≈ 1/hi) so decompressed values stay moderate
     // (roughly ±1), preventing hidden state overflow.
-    const ov::Shape scale_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
+    // Scale shape: always 2D [rows, 1] (or [rows, num_groups, 1] for group quant).
+    // For 3D batched weights (MoE), a 2D scale broadcasts across the batch dimension.
+    // This is required because NPUW's MoE executor slices weights per-expert but not scales.
+    ov::Shape scale_shape;
+    scale_shape = has_groups ? ov::Shape{rows, num_groups, 1} : ov::Shape{rows, 1};
     const size_t scale_count = has_groups ? rows * num_groups : rows;
     const float scale_range = 1.0f / static_cast<float>(hi);
     uint32_t s_state = seed_from_name(name + "_scale");
@@ -242,12 +267,15 @@ ov::Output<ov::Node> CompressedWeight::operator()(const std::string& name,
 
     ov::Output<ov::Node> decompressed = scaled->output(0);
 
-    // --- Group quant: Reshape 3D → 2D [rows, cols] ---
+    // --- Group quant: collapse group dims back to original shape ---
     if (has_groups) {
-        auto out_shape =
-            ov::opset11::Constant::create(ov::element::i64,
-                                          ov::Shape{2},
-                                          std::vector<int64_t>{static_cast<int64_t>(rows), static_cast<int64_t>(cols)});
+        std::vector<int64_t> out_dims;
+        if (is_3d)
+            out_dims = {static_cast<int64_t>(batch), static_cast<int64_t>(rows), static_cast<int64_t>(cols)};
+        else
+            out_dims = {static_cast<int64_t>(rows), static_cast<int64_t>(cols)};
+        auto out_shape = ov::opset11::Constant::create(
+            ov::element::i64, ov::Shape{out_dims.size()}, out_dims);
         auto reshaped = std::make_shared<ov::opset11::Reshape>(decompressed, out_shape, false);
         reshaped->set_friendly_name(name + "_reshape");
         decompressed = reshaped->output(0);
@@ -823,6 +851,151 @@ ov::Output<ov::Node> GELU::operator()(const ov::Output<ov::Node>& input, const s
 
     return down;
 }
+
+MoEFFN::MoEFFN(size_t hs, size_t is, size_t ne, size_t k,
+                                         ov::element::Type prec, WeightFn wf)
+    : hidden_size(hs), intermediate_size(is), num_experts(ne), num_experts_per_tok(k),
+      precision(prec), weight_fn(std::move(wf)) {
+    // Default to i4 CompressedWeight if no weight function provided.
+    // i4 (not nf4) because NPUW's nf4 unpack doesn't handle 3D batched scales.
+    if (!weight_fn) {
+        weight_fn = CompressedWeight{ov::element::i4, 0, DCOffPattern::SYMM_NO_ZP};
+    }
+    using C = ov::opset11::Constant;
+    int64_t is_i = static_cast<int64_t>(is);
+    int64_t ne_i = static_cast<int64_t>(ne);
+    int64_t k_i = static_cast<int64_t>(k);
+
+    tile_repeats = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{ne_i, 1});
+    slice_step = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
+    slice_axis2 = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{2});
+    slice_start_0 = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0});
+    slice_stop_is = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{is_i});
+    slice_start_is = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{is_i});
+    slice_stop_2is = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{2 * is_i});
+    min_const = C::create(prec, ov::Shape{1}, std::vector<float>{20.0f});
+    swish_beta = C::create(prec, ov::Shape{}, std::vector<float>{1.0f});
+    clamp_add_zero = C::create(prec, ov::Shape{1}, std::vector<float>{0.0f});
+    topk_k_const = C::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{k_i});
+    sl_start = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 0});
+    sl_step_r = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 1});
+    sl_axes = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 1});
+    scatter_axis = C::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
+    tp_order = C::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0});
+    unsq_axis = C::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{3});
+    reduce_axis = C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0});
+}
+
+ov::Output<ov::Node> MoEFFN::operator()(const ov::Output<ov::Node>& input,
+                                                      const std::string& name) const {
+    using C = ov::opset11::Constant;
+    const auto prec = precision;
+    const int64_t ne_i = static_cast<int64_t>(num_experts);
+    const int64_t hs_i = static_cast<int64_t>(hidden_size);
+    auto mk = [](std::vector<int64_t> v) {
+        ov::OutputVector p;
+        for (auto x : v)
+            p.push_back(C::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{x})->output(0));
+        return std::make_shared<ov::opset11::Concat>(p, 0);
+    };
+
+    auto original_shape = std::make_shared<ov::opset11::ShapeOf>(input, ov::element::i64);
+    original_shape->set_friendly_name(name + ".original_shape");
+
+    auto input_2d = std::make_shared<ov::opset11::Reshape>(input, mk({-1, hs_i}), false);
+    input_2d->set_friendly_name(name + ".input_2d");
+
+    // Router + expert weights use the configured weight_fn
+    auto rw = weight_fn(name + ".router.weight", ov::Shape{num_experts, hidden_size}, prec);
+    auto r_mm = std::make_shared<ov::opset11::MatMul>(input_2d, rw, false, true);
+    r_mm->set_friendly_name(name + ".router.matmul");
+    auto r_bias = C::create(prec, ov::Shape{1, num_experts}, std::vector<float>(num_experts, 0.0f));
+    r_bias->set_friendly_name(name + ".router.bias");
+    auto r_add = std::make_shared<ov::opset11::Add>(r_mm, r_bias);
+    r_add->set_friendly_name(name + ".router.add");
+
+    auto topk = std::make_shared<ov::opset11::TopK>(r_add, topk_k_const, 1, "max", "value", ov::element::i64);
+    topk->set_friendly_name(name + ".router.topk");
+    auto softmax = std::make_shared<ov::op::v8::Softmax>(topk->output(0), 1);
+    softmax->set_friendly_name(name + ".router.softmax");
+    auto topk_cvt = std::make_shared<ov::opset11::Convert>(topk->output(1), ov::element::i32);
+    topk_cvt->set_friendly_name(name + ".router.topk_convert");
+    auto topk_shape = std::make_shared<ov::op::v3::ShapeOf>(topk_cvt, ov::element::i64);
+    topk_shape->set_friendly_name(name + ".router.topk_shapeof");
+
+    auto r_slice = std::make_shared<ov::op::v8::Slice>(softmax, sl_start, topk_shape, sl_step_r, sl_axes);
+    r_slice->set_friendly_name(name + ".router.slice");
+    auto add_shape = std::make_shared<ov::op::v3::ShapeOf>(r_add, ov::element::i64);
+    add_shape->set_friendly_name(name + ".router.add_shapeof");
+    auto zeros = std::make_shared<ov::op::v3::Broadcast>(
+        C::create(prec, ov::Shape{}, std::vector<float>{0.0f}), add_shape, ov::op::BroadcastType::NUMPY);
+    zeros->set_friendly_name(name + ".router.zeros");
+    auto scatter = std::make_shared<ov::op::v3::ScatterElementsUpdate>(zeros, topk_cvt, r_slice, scatter_axis);
+    scatter->set_friendly_name(name + ".router.scatter");
+
+    auto r_tp = std::make_shared<ov::opset11::Transpose>(scatter, tp_order);
+    r_tp->set_friendly_name(name + ".router.transpose");
+    auto r_reshape = std::make_shared<ov::opset11::Reshape>(r_tp, mk({ne_i, 1, -1}), false);
+    r_reshape->set_friendly_name(name + ".router.reshape");
+    auto router_scores = std::make_shared<ov::opset11::Unsqueeze>(r_reshape, unsq_axis);
+    router_scores->set_friendly_name(name + ".router.unsqueeze");
+
+    // Expert: Tile → Reshape → MatMul → Add → dual-branch → MatMul → Add → Reshape → Multiply → ReduceSum
+    auto tiled = std::make_shared<ov::op::v0::Tile>(input_2d, tile_repeats);
+    tiled->set_friendly_name(name + ".expert.tile");
+    auto expert_3d = std::make_shared<ov::opset11::Reshape>(tiled, mk({ne_i, -1, hs_i}), false);
+    expert_3d->set_friendly_name(name + ".expert.reshape_in");
+
+    auto gu_w = weight_fn(name + ".expert.gate_up_proj.weight",
+                        ov::Shape{num_experts, 2 * intermediate_size, hidden_size}, prec);
+    auto gu_mm = std::make_shared<ov::opset11::MatMul>(expert_3d, gu_w, false, true);
+    gu_mm->set_friendly_name(name + ".expert.gate_up_matmul");
+    auto gu_bias = C::create(prec, ov::Shape{num_experts, 1, 2 * intermediate_size},
+                             std::vector<float>(num_experts * 2 * intermediate_size, 0.0f));
+    gu_bias->set_friendly_name(name + ".expert.gate_up_bias");
+    auto gu_add = std::make_shared<ov::opset11::Add>(gu_mm, gu_bias);
+    gu_add->set_friendly_name(name + ".expert.gate_up_add");
+
+    auto act_slice = std::make_shared<ov::op::v8::Slice>(gu_add, slice_start_0, slice_stop_is, slice_step, slice_axis2);
+    act_slice->set_friendly_name(name + ".expert.slice_act");
+    auto act_min = std::make_shared<ov::opset11::Minimum>(act_slice, min_const);
+    act_min->set_friendly_name(name + ".expert.minimum");
+    auto act_swish = std::make_shared<ov::op::v4::Swish>(act_min, swish_beta);
+    act_swish->set_friendly_name(name + ".expert.swish");
+
+    auto gate_slice =
+        std::make_shared<ov::op::v8::Slice>(gu_add, slice_start_is, slice_stop_2is, slice_step, slice_axis2);
+    gate_slice->set_friendly_name(name + ".expert.slice_gate");
+    auto gate_clamp = std::make_shared<ov::op::v0::Clamp>(gate_slice, -20.0f, 20.0f);
+    gate_clamp->set_friendly_name(name + ".expert.clamp");
+    auto gate_add = std::make_shared<ov::opset11::Add>(gate_clamp, clamp_add_zero);
+    gate_add->set_friendly_name(name + ".expert.gate_add");
+
+    auto merged = std::make_shared<ov::opset11::Multiply>(act_swish, gate_add);
+    merged->set_friendly_name(name + ".expert.merge");
+
+    auto dn_w = weight_fn(name + ".expert.down_proj.weight",
+                        ov::Shape{num_experts, hidden_size, intermediate_size}, prec);
+    auto dn_mm = std::make_shared<ov::opset11::MatMul>(merged, dn_w, false, true);
+    dn_mm->set_friendly_name(name + ".expert.down_matmul");
+    auto dn_bias = C::create(prec, ov::Shape{num_experts, 1, hidden_size},
+                             std::vector<float>(num_experts * hidden_size, 0.0f));
+    dn_bias->set_friendly_name(name + ".expert.down_bias");
+    auto dn_add = std::make_shared<ov::opset11::Add>(dn_mm, dn_bias);
+    dn_add->set_friendly_name(name + ".expert.down_add");
+
+    auto expert_out = std::make_shared<ov::opset11::Reshape>(dn_add, mk({ne_i, 1, -1, hs_i}), false);
+    expert_out->set_friendly_name(name + ".expert.reshape_out");
+    auto weighted = std::make_shared<ov::opset11::Multiply>(expert_out, router_scores);
+    weighted->set_friendly_name(name + ".expert.weighted");
+    auto reduced = std::make_shared<ov::opset11::ReduceSum>(weighted, reduce_axis, false);
+    reduced->set_friendly_name(name + ".expert.reduced");
+
+    auto output = std::make_shared<ov::opset11::Reshape>(reduced, original_shape, false);
+    output->set_friendly_name(name + ".output");
+    return output->output(0);
+}
+
 
 ov::Output<ov::Node> make_transformer_layers(const ov::Output<ov::Node>& initial,
                                              size_t num_layers,
@@ -1424,8 +1597,23 @@ std::shared_ptr<ov::Model> ModelBuilder::build_llm(const LLMConfig& config_in) {
     LLMConfig config = config_in;
     if (!config.norm)
         config.norm = LayerNorm(config.hidden_size, config.precision);
-    if (!config.ffn)
-        config.ffn = SwiGLU(config.hidden_size, config.intermediate_size, config.precision, config.weight);
+    if (!config.ffn) {
+        if (config.num_experts > 0) {
+            size_t moe_inter = config.moe_intermediate_size > 0
+                                   ? config.moe_intermediate_size
+                                   : config.intermediate_size;
+            size_t moe_k = config.num_experts_per_tok > 0
+                               ? config.num_experts_per_tok
+                               : std::min<size_t>(2, config.num_experts);
+            OPENVINO_ASSERT(moe_k >= 1 && moe_k <= config.num_experts,
+                            "Invalid MoE config: num_experts_per_tok (",
+                            moe_k, ") must be in [1, num_experts (", config.num_experts, ")]");
+            config.ffn = MoEFFN(config.hidden_size, moe_inter, config.num_experts,
+                                moe_k, config.precision);
+        } else {
+            config.ffn = SwiGLU(config.hidden_size, config.intermediate_size, config.precision, config.weight);
+        }
+    }
     const auto prec = config.precision;
 
     auto attention_mask = parameter(ov::element::i64, ov::PartialShape{-1, -1}, "attention_mask");
@@ -1762,7 +1950,7 @@ static ov::Output<ov::Node> make_whisper_causal_mask(const CachePositionResult& 
     auto slice_step = ov::opset11::Constant::create(ov::element::i64, ov::Shape{1}, {1});
     auto slice_axes = ov::opset11::Constant::create(ov::element::i64, ov::Shape{1}, {3});
     auto causal_sliced =
-        std::make_shared<ov::op::v8::Slice>(causal_float, slice_start, slice_stop, slice_step, slice_axes);
+        std::make_shared<ov::opset11::Slice>(causal_float, slice_start, slice_stop, slice_step, slice_axes);
     causal_sliced->set_friendly_name(prefix + "causal_mask_sliced");
 
     return causal_sliced->output(0);

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
@@ -187,6 +187,30 @@ struct GELU {
     ov::Output<ov::Node> operator()(const ov::Output<ov::Node>& input, const std::string& name) const;
 };
 
+/// GPT-OSS style batched MoE FFN matching NPUW's GPTOSSExpert + GPTOSSRouter patterns.
+/// All experts compute on all tokens via Tile + 3D batched MatMul (no NonZero).
+/// Weight function must produce a Multiply→Convert→MatMul chain (default: i4 CompressedWeight)
+/// for the isolation patterns to match.  Shared constants across layers enable repeating
+/// block detection.  Conforms to FFNFn for drop-in use in transformer layer templates.
+struct MoEFFN {
+    size_t hidden_size, intermediate_size, num_experts, num_experts_per_tok;
+    ov::element::Type precision;
+    WeightFn weight_fn;
+
+    /// Default weight_fn: CompressedWeight{i4, 0, SYMM_NO_ZP}.
+    MoEFFN(size_t hs, size_t is, size_t ne, size_t k, ov::element::Type prec, WeightFn wf = {});
+
+    ov::Output<ov::Node> operator()(const ov::Output<ov::Node>& input, const std::string& name) const;
+
+private:
+    // Shared across layers for matchRepeatedSubgraphs (created once in ctor)
+    std::shared_ptr<ov::Node> tile_repeats, topk_k_const;
+    std::shared_ptr<ov::Node> slice_step, slice_axis2, slice_start_0, slice_stop_is, slice_start_is, slice_stop_2is;
+    std::shared_ptr<ov::Node> min_const, swish_beta, clamp_add_zero;
+    std::shared_ptr<ov::Node> sl_start, sl_step_r, sl_axes, scatter_axis;
+    std::shared_ptr<ov::Node> tp_order, unsq_axis, reduce_axis;
+};
+
 ov::Output<ov::Node> make_linear(const ov::Output<ov::Node>& input,
                                  size_t in_features,
                                  size_t out_features,
@@ -403,6 +427,11 @@ struct LLMConfig : public BaseModelConfig {
     bool use_inputs_embeds = false;
     bool internal_position_ids = false;  ///< embedding model
     bool pre_norm = true;
+
+    // MoE configuration (num_experts=0 means dense, no MoE)
+    size_t num_experts = 0;           ///< Total experts. 0 = dense model.
+    size_t num_experts_per_tok = 0;   ///< Top-K. 0 = default to 2.
+    size_t moe_intermediate_size = 0; ///< Expert FFN intermediate size. 0 = use intermediate_size.
 };
 
 struct WhisperConfig : public BaseModelConfig {

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
@@ -187,6 +187,30 @@ struct GELU {
     ov::Output<ov::Node> operator()(const ov::Output<ov::Node>& input, const std::string& name) const;
 };
 
+/// GPT-OSS style batched MoE FFN matching NPUW's GPTOSSExpert + GPTOSSRouter patterns.
+/// All experts compute on all tokens via Tile + 3D batched MatMul (no NonZero).
+/// Weight function must produce a Multiply→Convert→MatMul chain (default: i4 CompressedWeight)
+/// for the isolation patterns to match.  Shared constants across layers enable repeating
+/// block detection.  Conforms to FFNFn for drop-in use in transformer layer templates.
+struct MoEFFN {
+    size_t hidden_size, intermediate_size, num_experts, num_experts_per_tok;
+    ov::element::Type precision;
+    WeightFn weight_fn;
+
+    /// Default weight_fn: CompressedWeight{i4, 0, SYMM_NO_ZP}.
+    MoEFFN(size_t hs, size_t is, size_t ne, size_t k, ov::element::Type prec, WeightFn wf = {});
+
+    ov::Output<ov::Node> operator()(const ov::Output<ov::Node>& input, const std::string& name) const;
+
+private:
+    // Shared across layers for matchRepeatedSubgraphs (created once in ctor)
+    std::shared_ptr<ov::Node> tile_repeats, topk_k_const;
+    std::shared_ptr<ov::Node> slice_step, slice_axis2, slice_start_0, slice_stop_is, slice_start_is, slice_stop_2is;
+    std::shared_ptr<ov::Node> min_const, swish_beta, clamp_add_zero;
+    std::shared_ptr<ov::Node> sl_start, sl_step_r, sl_axes, scatter_axis;
+    std::shared_ptr<ov::Node> tp_order, unsq_axis, reduce_axis;
+};
+
 ov::Output<ov::Node> make_linear(const ov::Output<ov::Node>& input,
                                  size_t in_features,
                                  size_t out_features,
@@ -403,6 +427,11 @@ struct LLMConfig : public BaseModelConfig {
     bool use_inputs_embeds = false;
     bool internal_position_ids = false; ///< embedding model
     bool pre_norm = true;
+
+    // MoE configuration (num_experts=0 means dense, no MoE)
+    size_t num_experts = 0;           ///< Total experts. 0 = dense model.
+    size_t num_experts_per_tok = 0;   ///< Top-K. 0 = default to 2.
+    size_t moe_intermediate_size = 0; ///< Expert FFN intermediate size. 0 = use intermediate_size.
 };
 
 struct WhisperConfig : public BaseModelConfig {

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
@@ -85,6 +85,14 @@ inline std::shared_ptr<ov::Model> build_embedding_decoder_test_model() {
     return mb.build_llm(cfg);
 }
 
+inline std::shared_ptr<ov::Model> build_moe_llm_test_model() {
+    ModelBuilder mb;
+    auto cfg = make_test_model_config();
+    cfg.num_experts = 8;
+    cfg.num_experts_per_tok = 2;
+    return mb.build_llm(cfg);
+}
+
 class NullPlugin : public ov::IPlugin {
 public:
     std::shared_ptr<ov::ICompiledModel> compile_model(const std::shared_ptr<const ov::Model>&,

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
@@ -46,6 +46,14 @@ inline std::shared_ptr<ov::Model> build_embedding_test_model() {
     return mb.build_embedding_encoder(make_test_model_config<BertConfig>());
 }
 
+inline std::shared_ptr<ov::Model> build_moe_llm_test_model() {
+    ModelBuilder mb;
+    auto cfg = make_test_model_config();
+    cfg.num_experts = 8;
+    cfg.num_experts_per_tok = 2;
+    return mb.build_llm(cfg);
+}
+
 class NullPlugin : public ov::IPlugin {
 public:
     std::shared_ptr<ov::ICompiledModel> compile_model(const std::shared_ptr<const ov::Model>&,

--- a/src/plugins/intel_npu/tests/unit/npuw/moe_transformation_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/moe_transformation_test.cpp
@@ -8,6 +8,8 @@
 
 #include <common_test_utils/test_common.hpp>
 
+#include "llm_test_helpers.hpp"
+#include "model_builder.hpp"
 #include "openvino/op/ops.hpp"
 #include "openvino/pass/serialize.hpp"
 
@@ -556,5 +558,40 @@ TEST_F(MoETransformationTest, AWQvsNonAWQComparison) {
     EXPECT_EQ(result_awq->get_input_partial_shape(0), result_non_awq->get_input_partial_shape(0))
         << "AWQ and non-AWQ models should have identical output shapes";
 }
+
+// ============================================================================
+// MoEFFN + build_llm E2E Tests (uses build_moe_llm_test_model from llm_test_helpers.hpp)
+// ============================================================================
+
+TEST_F(MoETransformationTest, BuildMoELLM_HasExpertAndRouterNodes) {
+    auto model = ov::test::npuw::build_moe_llm_test_model();
+    ASSERT_NE(model, nullptr);
+
+    bool has_tile = false, has_topk = false, has_reduce_sum = false;
+    size_t topk_router_count = 0, scatter_count = 0;
+
+    for (const auto& op : model->get_ordered_ops()) {
+        if (std::dynamic_pointer_cast<ov::op::v0::Tile>(op))
+            has_tile = true;
+        if (std::dynamic_pointer_cast<ov::op::v1::ReduceSum>(op))
+            has_reduce_sum = true;
+        if (auto topk = std::dynamic_pointer_cast<ov::op::v11::TopK>(op)) {
+            has_topk = true;
+            if (topk->get_friendly_name().find(".mlp.router") != std::string::npos) {
+                EXPECT_EQ(topk->get_mode(), ov::op::v11::TopK::Mode::MAX);
+                topk_router_count++;
+            }
+        }
+        if (std::dynamic_pointer_cast<ov::op::v3::ScatterElementsUpdate>(op))
+            scatter_count++;
+    }
+
+    EXPECT_TRUE(has_tile) << "Missing Tile (expert)";
+    EXPECT_TRUE(has_topk) << "Missing TopK (router)";
+    EXPECT_TRUE(has_reduce_sum) << "Missing ReduceSum (aggregation)";
+    EXPECT_EQ(topk_router_count, 2u) << "One router TopK per layer";
+    EXPECT_EQ(scatter_count, 2u) << "One ScatterElementsUpdate per layer";
+}
+
 
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/moe_transformation_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/moe_transformation_test.cpp
@@ -577,7 +577,7 @@ TEST_F(MoETransformationTest, BuildMoELLM_HasExpertAndRouterNodes) {
             has_reduce_sum = true;
         if (auto topk = std::dynamic_pointer_cast<ov::op::v11::TopK>(op)) {
             has_topk = true;
-            if (topk->get_friendly_name().find(".mlp.router") != std::string::npos) {
+            if (topk->get_friendly_name().find("router") != std::string::npos) {
                 EXPECT_EQ(topk->get_mode(), ov::op::v11::TopK::Mode::MAX);
                 topk_router_count++;
             }

--- a/src/plugins/intel_npu/tests/unit/npuw/moe_transformation_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/moe_transformation_test.cpp
@@ -567,8 +567,8 @@ TEST_F(MoETransformationTest, BuildMoELLM_HasExpertAndRouterNodes) {
     auto model = ov::test::npuw::build_moe_llm_test_model();
     ASSERT_NE(model, nullptr);
 
-    bool has_tile = false, has_topk = false, has_reduce_sum = false;
-    size_t topk_router_count = 0, scatter_count = 0;
+    bool has_tile = false, has_topk = false, has_reduce_sum = false, has_softmax = false;
+    size_t topk_router_count = 0, scatter_count = 0, softmax_router_count = 0;
 
     for (const auto& op : model->get_ordered_ops()) {
         if (std::dynamic_pointer_cast<ov::op::v0::Tile>(op))
@@ -582,6 +582,12 @@ TEST_F(MoETransformationTest, BuildMoELLM_HasExpertAndRouterNodes) {
                 topk_router_count++;
             }
         }
+        if (auto softmax = std::dynamic_pointer_cast<ov::op::v8::Softmax>(op)) {
+            has_softmax = true;
+            if (softmax->get_friendly_name().find("router") != std::string::npos) {
+                softmax_router_count++;
+            }
+        }
         if (std::dynamic_pointer_cast<ov::op::v3::ScatterElementsUpdate>(op))
             scatter_count++;
     }
@@ -589,7 +595,9 @@ TEST_F(MoETransformationTest, BuildMoELLM_HasExpertAndRouterNodes) {
     EXPECT_TRUE(has_tile) << "Missing Tile (expert)";
     EXPECT_TRUE(has_topk) << "Missing TopK (router)";
     EXPECT_TRUE(has_reduce_sum) << "Missing ReduceSum (aggregation)";
+    EXPECT_TRUE(has_softmax) << "Missing Softmax (router)";
     EXPECT_EQ(topk_router_count, 2u) << "One router TopK per layer";
+    EXPECT_EQ(softmax_router_count, 2u) << "One router Softmax per layer";
     EXPECT_EQ(scatter_count, 2u) << "One ScatterElementsUpdate per layer";
 }
 


### PR DESCRIPTION
### Details:
 - Add Mixture of Experts support to model builder

### Tickets:
 - *EISW-209517*

### AI Assistance:
 - *AI assistance used: yes*
 - *Claude Code used for coding assistance and to analyze GPT OSS model to recreate patterns, manually tested and verified*

Correct subgraphs produced

Generate:
```
{
  "pipeline_name": "npuw_synthetic_decoder_kv1152",
  "repeated_numbers": {
    "total_subgraphs": 1,
    "synthetic_decoder_kv1152_0_FCEW000": 1
  },
  "subgraphs": [
    "synthetic_decoder_kv1152_0_FCEW000.xml"
  ]
}
```
Prefill:
```
{
  "pipeline_name": "npuw_synthetic_decoder_prefill",
  "repeated_numbers": {
    "total_subgraphs": 5,
    "synthetic_decoder_prefill_00_FCEW000": 1,
    "synthetic_decoder_prefill_01_REP009C": 12,
    "synthetic_decoder_prefill_02_REP00B7": 12,
    "synthetic_decoder_prefill_03_REP00B9": 11,
    "synthetic_decoder_prefill_36_FCEW001": 1
  },
  "subgraphs": [
    "synthetic_decoder_prefill_00_FCEW000.xml",
    "synthetic_decoder_prefill_01_REP009C.xml",
    "synthetic_decoder_prefill_03_REP00B9.xml",
    "synthetic_decoder_prefill_36_FCEW001.xml"
  ],
  "moe_subgraphs": [
    "synthetic_decoder_prefill_02_REP00B7_moe_chunk_16.xml",
    "synthetic_decoder_prefill_02_REP00B7_moe_chunk_32.xml",
    "synthetic_decoder_prefill_02_REP00B7_moe_chunk_64.xml",
    "synthetic_decoder_prefill_02_REP00B7_moe_chunk_128.xml",
    "synthetic_decoder_prefill_02_REP00B7_moe_chunk_256.xml"
  ]

```
