### PR TITLE
[NPU] Add FP16-representable input generation for conformance tests

### DIFF
--- a/src/tests/functional/base_func_tests/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/base_func_tests/src/base/utils/generate_inputs.cpp
@@ -4,7 +4,9 @@
 
 #include <math.h>
 #include <algorithm>
+#include <cstdlib>
 #include <functional>
+#include <string>
 
 #include "shared_test_classes/base/utils/generate_inputs.hpp"
 
@@ -46,6 +48,17 @@ namespace {
 
 using ov::test::utils::InputGenerateData;
 
+// Check if FP16 input generation is enabled via environment variable
+static inline bool use_fp16_inputs() {
+    static bool checked = false;
+    static bool use_fp16 = false;
+    if (!checked) {
+        const char* env = std::getenv("OV_CONFORMANCE_FP16_INPUTS");
+        use_fp16 = env != nullptr && std::string(env) == "1";
+        checked = true;
+    }
+    return use_fp16;
+}
 
 static inline void set_real_number_generation_data(InputGenerateData& inGenData) {
     inGenData.range = 8;
@@ -71,6 +84,10 @@ ov::Tensor generate(const std::shared_ptr<ov::Node>& node,
             auto ranges = it->second;
             inGenData = ranges.get_data(port, elemType);
         }
+    }
+    // Use FP16-representable inputs when enabled via OV_CONFORMANCE_FP16_INPUTS=1
+    if (use_fp16_inputs() && elemType.is_real()) {
+        return ov::test::utils::create_and_fill_tensor_fp16_representable(elemType, targetShape, inGenData);
     }
     return ov::test::utils::create_and_fill_tensor(elemType, targetShape, inGenData);
 }

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
@@ -13,6 +13,7 @@
 #include "common_test_utils/data_utils.hpp"
 #include "gtest/gtest.h"
 #include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/core/type/float16.hpp"
 #include "openvino/runtime/tensor.hpp"
 
 namespace ov {
@@ -238,6 +239,49 @@ void inline fill_data_random(T* pointer,
     }
     for (std::size_t i = 0; i < size; i++) {
         pointer[i] = static_cast<T>(start_from + static_cast<double>(random.Generate(k_range)) / k);
+    }
+}
+
+/**
+ * Generates random data that is exactly representable in FP16.
+ * This is useful for NPU tests where FP32 inputs are converted to FP16 internally.
+ * The function generates values, casts them to FP16 and back to ensure exact representation.
+ *
+ * @param pointer Pointer to the output data buffer
+ * @param size Number of elements to generate
+ * @param range Range of values to generate
+ * @param start_from Starting value for generation
+ * @param k Resolution factor
+ * @param seed Random seed
+ */
+template <class T>
+void inline fill_data_random_fp16_representable(T* pointer,
+                                                std::size_t size,
+                                                const uint32_t range = 10,
+                                                double_t start_from = 0,
+                                                const int32_t k = 1,
+                                                const int seed = 1) {
+    if (range == 0) {
+        for (std::size_t i = 0; i < size; i++) {
+            // Cast through FP16 to ensure exact representation
+            ov::float16 fp16_val(static_cast<float>(start_from));
+            pointer[i] = static_cast<T>(static_cast<float>(fp16_val));
+        }
+        return;
+    }
+
+    testing::internal::Random random(seed);
+    const uint32_t k_range = k * range;
+    random.Generate(k_range);
+
+    if (start_from < 0 && !std::numeric_limits<T>::is_signed) {
+        start_from = 0;
+    }
+    for (std::size_t i = 0; i < size; i++) {
+        double val = start_from + static_cast<double>(random.Generate(k_range)) / k;
+        // Cast through FP16 to quantize to FP16-representable values
+        ov::float16 fp16_val(static_cast<float>(val));
+        pointer[i] = static_cast<T>(static_cast<float>(fp16_val));
     }
 }
 

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/ov_tensor_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/ov_tensor_utils.hpp
@@ -184,6 +184,16 @@ ov::Tensor create_and_fill_tensor_real_distribution(const ov::element::Type elem
                                                     const float min,
                                                     const float max,
                                                     const int seed);
+
+/**
+ * Creates and fills a tensor with values that are exactly representable in FP16.
+ * Useful for NPU tests where FP32 inputs are internally converted to FP16.
+ * This ensures no precision loss during FP32->FP16->FP32 round-trip.
+ */
+ov::Tensor create_and_fill_tensor_fp16_representable(const ov::element::Type element_type,
+                                                     const ov::Shape& shape,
+                                                     const InputGenerateData& inGenData = InputGenerateData(0, 10, 1, 1));
+
 namespace tensor_comparation {
 double calculate_threshold(const double abs_threshold, const double rel_threshold, const double ref_value);
 

--- a/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
@@ -331,6 +331,35 @@ ov::Tensor create_and_fill_tensor_consistently(const ov::element::Type element_t
     return tensor;
 }
 
+ov::Tensor create_and_fill_tensor_fp16_representable(const ov::element::Type element_type,
+                                                     const ov::Shape& shape,
+                                                     const InputGenerateData& inGenData) {
+    auto tensor = ov::Tensor{element_type, shape};
+    auto size = shape_size(shape);
+
+#define CASE_FP16_REPR(X)                                                      \
+    case X:                                                                    \
+        fill_data_random_fp16_representable(tensor.data<fundamental_type_for<X>>(), \
+                         size,                                                 \
+                         inGenData.range,                                      \
+                         inGenData.start_from,                                 \
+                         inGenData.resolution,                                 \
+                         inGenData.seed);                                      \
+        break;
+
+    switch (element_type) {
+        CASE_FP16_REPR(ov::element::f32)
+        CASE_FP16_REPR(ov::element::f64)
+        CASE_FP16_REPR(ov::element::f16)
+        CASE_FP16_REPR(ov::element::bf16)
+    default:
+        // For non-floating point types, use regular fill
+        return create_and_fill_tensor(element_type, shape, inGenData);
+    }
+#undef CASE_FP16_REPR
+    return tensor;
+}
+
 namespace tensor_comparation {
 constexpr double eps = std::numeric_limits<double>::epsilon();
 


### PR DESCRIPTION
Add env var OV_CONFORMANCE_FP16_INPUTS=1 to generate inputs that are exactly representable in FP16 format. This helps NPU conformance tests avoid precision loss during FP32->FP16 conversion for operators like Concat, Split, Tile.

Changes:
- generate_inputs.cpp: Check env var and use FP16 tensor generation
- data_utils.hpp: Add fill_data_random_fp16_representable()
- ov_tensor_utils.hpp/cpp: Add create_and_fill_tensor_fp16_representable()

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id* https://jira.devtools.intel.com/browse/EISW-206213 

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
