### PR TITLE
[NPU] Fix Caching Test samePlatformProduceTheSameBlobCacheEnabled

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/work_with_devices.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/work_with_devices.hpp
@@ -85,6 +85,9 @@ TEST_P(TestCompiledModelNPU, samePlatformProduceTheSameBlobCacheEnabled) {
         const auto& ov_model2 = buildSingleLayerSoftMaxNetwork();
         // call compile_model() twice to make sure compiled model is cached
         auto compiled_model2 = core->compile_model(ov_model2, target_device, configuration2);
+        // Workaround: destroy graph to force driver to close file descriptor to cache file
+        compiled_model2 = {};
+
         auto compiled_model3 = core->compile_model(ov_model2, target_device, configuration2);
         std::stringstream blobStream3;
         compiled_model3.export_model(blobStream3);


### PR DESCRIPTION
### Details:
Test creates an unchached blob and a cached blob, then compares the two. Expecting them to be bit accurate.
Driver caching mechanism doesn't guarantee immediate closing of file descriptor after writing to cache, but the tests expects this.

Workaround to force file descriptor closing is to delete the graph object after the first compilation, this way the second compilation will correctly retrieve blob from cache.

### Tickets:
 - E210236
 - E178258
 - E188354

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
