### PR TITLE
CVS-175243 hf-token utilisation - Optimize HF API rate limit usage

### DIFF
--- a/tests/model_hub_tests/jax/test_hf_transformers.py
+++ b/tests/model_hub_tests/jax/test_hf_transformers.py
@@ -23,7 +23,10 @@ from jax_utils import TestJaxConvertModel
 class TestTransformersModel(TestJaxConvertModel):
     @retry(3, exceptions=(OSError,), delay=1)
     def load_model(self, model_name, _):
-        model_cached = snapshot_download(model_name)  # required to avoid HF rate limits
+        try:
+            model_cached = snapshot_download(model_name, local_files_only=True)
+        except Exception:
+            model_cached = snapshot_download(model_name)  # fallback: download if not cached
         model = FlaxAutoModel.from_pretrained(model_cached)
         if model_name in ['google/vit-base-patch16-224-in21k']:
             url = "http://images.cocodataset.org/val2017/000000039769.jpg"

--- a/tests/model_hub_tests/jax/test_hf_transformers.py
+++ b/tests/model_hub_tests/jax/test_hf_transformers.py
@@ -8,7 +8,7 @@ import requests
 from huggingface_hub import snapshot_download
 from PIL import Image
 from models_hub_common.constants import hf_cache_dir, clean_hf_cache_dir
-from models_hub_common.utils import cleanup_dir, get_models_list, retry
+from models_hub_common.utils import cached_snapshot_download, cleanup_dir, get_models_list, retry
 from transformers import (
     AutoProcessor,
     AutoTokenizer,
@@ -23,10 +23,7 @@ from jax_utils import TestJaxConvertModel
 class TestTransformersModel(TestJaxConvertModel):
     @retry(3, exceptions=(OSError,), delay=1)
     def load_model(self, model_name, _):
-        try:
-            model_cached = snapshot_download(model_name, local_files_only=True)
-        except Exception:
-            model_cached = snapshot_download(model_name)  # fallback: download if not cached
+        model_cached = cached_snapshot_download(model_name)
         model = FlaxAutoModel.from_pretrained(model_cached)
         if model_name in ['google/vit-base-patch16-224-in21k']:
             url = "http://images.cocodataset.org/val2017/000000039769.jpg"

--- a/tests/model_hub_tests/models_hub_common/utils.py
+++ b/tests/model_hub_tests/models_hub_common/utils.py
@@ -8,6 +8,7 @@ import shutil
 import time
 
 import numpy as np
+from huggingface_hub import snapshot_download
 from models_hub_common.constants import test_device
 
 
@@ -101,6 +102,24 @@ def get_params(ie_device=None):
     for element in itertools.product(ie_device_params):
         test_args.append(element)
     return test_args
+
+
+def cached_snapshot_download(repo_id: str) -> str:
+    """Return local path to a cached HuggingFace repo snapshot.
+
+    Tries the local cache first (no network call).
+    Falls back to a full download on cache miss.
+
+    Args:
+        repo_id: HuggingFace repo identifier, e.g. "google/bert-base"
+
+    Returns:
+        Local filesystem path to the downloaded snapshot directory.
+    """
+    try:
+        return snapshot_download(repo_id, local_files_only=True)
+    except Exception:
+        return snapshot_download(repo_id)
 
 
 def cleanup_dir(dir: str):

--- a/tests/model_hub_tests/pytorch/test_hf_transformers.py
+++ b/tests/model_hub_tests/pytorch/test_hf_transformers.py
@@ -63,7 +63,10 @@ class TestTransformersModel(TestTorchConvertModel):
 
         name, _, name_suffix = name.partition(':')
 
-        model_cached = snapshot_download(name)  # required to avoid HF rate limits
+        try:
+            model_cached = snapshot_download(name, local_files_only=True)
+        except Exception:
+            model_cached = snapshot_download(name)  # fallback: download if not cached
         mi = model_info(name)
         auto_processor = None
         model = None
@@ -526,7 +529,10 @@ class TestTransformersModel(TestTorchConvertModel):
         from huggingface_hub import model_info, snapshot_download
         from transformers import AutoModel
 
-        model_cached = snapshot_download(name)  # required to avoid HF rate limits
+        try:
+            model_cached = snapshot_download(name, local_files_only=True)
+        except Exception:
+            model_cached = snapshot_download(name)  # fallback: download if not cached
         try:
             mi = model_info(name)
             assert len({"owlv2", "owlvit", "vit_mae"}.intersection(

--- a/tests/model_hub_tests/pytorch/test_hf_transformers.py
+++ b/tests/model_hub_tests/pytorch/test_hf_transformers.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from models_hub_common.constants import hf_cache_dir, clean_hf_cache_dir
-from models_hub_common.utils import cleanup_dir, get_models_list, retry
+from models_hub_common.utils import cached_snapshot_download, cleanup_dir, get_models_list, retry
 from torch_utils import TestTorchConvertModel
 
 
@@ -63,10 +63,7 @@ class TestTransformersModel(TestTorchConvertModel):
 
         name, _, name_suffix = name.partition(':')
 
-        try:
-            model_cached = snapshot_download(name, local_files_only=True)
-        except Exception:
-            model_cached = snapshot_download(name)  # fallback: download if not cached
+        model_cached = cached_snapshot_download(name)
         mi = model_info(name)
         auto_processor = None
         model = None
@@ -529,10 +526,7 @@ class TestTransformersModel(TestTorchConvertModel):
         from huggingface_hub import model_info, snapshot_download
         from transformers import AutoModel
 
-        try:
-            model_cached = snapshot_download(name, local_files_only=True)
-        except Exception:
-            model_cached = snapshot_download(name)  # fallback: download if not cached
+        model_cached = cached_snapshot_download(name)
         try:
             mi = model_info(name)
             assert len({"owlv2", "owlvit", "vit_mae"}.intersection(

--- a/tests/model_hub_tests/pytorch/test_llm.py
+++ b/tests/model_hub_tests/pytorch/test_llm.py
@@ -9,7 +9,7 @@ import platform
 import pytest
 import torch
 
-from models_hub_common.utils import retry
+from models_hub_common.utils import cached_snapshot_download, retry
 from openvino.frontend.pytorch.patch_model import __make_16bit_traceable as patch
 from openvino.frontend.pytorch.patch_model import unpatch_model as unpatch
 from torch_utils import TestTorchConvertModel
@@ -152,10 +152,7 @@ class TestLLMModel(TestTorchConvertModel):
 
         model = None
         example = None
-        try:
-            model_cached = snapshot_download(name, local_files_only=True)
-        except Exception:
-            model_cached = snapshot_download(name)  # fallback: download if not cached
+        model_cached = cached_snapshot_download(name)
         try:
             config = AutoConfig.from_pretrained(model_cached, trust_remote_code=True)
         except Exception:
@@ -173,10 +170,7 @@ class TestLLMModel(TestTorchConvertModel):
             model_kwargs["torch_dtype"] = torch.float16
         else:
             model_kwargs["torch_dtype"] = "auto"
-        try:
-            model_cached = snapshot_download(name, local_files_only=True)
-        except Exception:
-            model_cached = snapshot_download(name)  # fallback: download if not cached
+        model_cached = cached_snapshot_download(name)
         t = AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True)
         self.model = AutoModelForCausalLM.from_pretrained(model_cached, **model_kwargs)
         if is_quant:

--- a/tests/model_hub_tests/pytorch/test_llm.py
+++ b/tests/model_hub_tests/pytorch/test_llm.py
@@ -152,7 +152,10 @@ class TestLLMModel(TestTorchConvertModel):
 
         model = None
         example = None
-        model_cached = snapshot_download(name)  # required to avoid HF rate limits
+        try:
+            model_cached = snapshot_download(name, local_files_only=True)
+        except Exception:
+            model_cached = snapshot_download(name)  # fallback: download if not cached
         try:
             config = AutoConfig.from_pretrained(model_cached, trust_remote_code=True)
         except Exception:
@@ -170,7 +173,10 @@ class TestLLMModel(TestTorchConvertModel):
             model_kwargs["torch_dtype"] = torch.float16
         else:
             model_kwargs["torch_dtype"] = "auto"
-        model_cached = snapshot_download(name)  # required to avoid HF rate limits
+        try:
+            model_cached = snapshot_download(name, local_files_only=True)
+        except Exception:
+            model_cached = snapshot_download(name)  # fallback: download if not cached
         t = AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True)
         self.model = AutoModelForCausalLM.from_pretrained(model_cached, **model_kwargs)
         if is_quant:

--- a/tests/model_hub_tests/tensorflow/test_tf_convert_model.py
+++ b/tests/model_hub_tests/tensorflow/test_tf_convert_model.py
@@ -15,7 +15,7 @@ import tensorflow_hub as hub
 #import tensorflow_text  # do not delete, needed for text models. Commended due to ticket 179327
 from huggingface_hub import snapshot_download
 from models_hub_common.test_convert_model import TestConvertModel
-from models_hub_common.utils import get_models_list
+from models_hub_common.utils import cached_snapshot_download, get_models_list
 from openvino import Core
 
 from utils import load_graph, get_input_signature, get_output_signature, unpack_tf_result, \
@@ -45,10 +45,7 @@ class TestTFHubConvertModel(TestConvertModel):
 
     def load_model(self, model_name, model_link: str):
         if is_hf_link(model_link):
-            try:
-                model_cached = snapshot_download(model_name, local_files_only=True)
-            except Exception:
-                model_cached = snapshot_download(model_name)  # fallback: download if not cached
+            model_cached = cached_snapshot_download(model_name)
             library_type = model_link[3:]
             if library_type == "transformers":
                 from transformers import TFAutoModel

--- a/tests/model_hub_tests/tensorflow/test_tf_convert_model.py
+++ b/tests/model_hub_tests/tensorflow/test_tf_convert_model.py
@@ -45,7 +45,10 @@ class TestTFHubConvertModel(TestConvertModel):
 
     def load_model(self, model_name, model_link: str):
         if is_hf_link(model_link):
-            model_cached = snapshot_download(model_name)  # required to avoid HF rate limits
+            try:
+                model_cached = snapshot_download(model_name, local_files_only=True)
+            except Exception:
+                model_cached = snapshot_download(model_name)  # fallback: download if not cached
             library_type = model_link[3:]
             if library_type == "transformers":
                 from transformers import TFAutoModel

--- a/tests/model_hub_tests/transformation_tests/generate_ref_diffs.py
+++ b/tests/model_hub_tests/transformation_tests/generate_ref_diffs.py
@@ -94,7 +94,10 @@ def main():
         for model_id, _, _, _, cls in model_list:
             # wrapping in try/catch block to continue printing models even if one has failed
             try:
-                model_cached = snapshot_download(model_id)  # required to avoid HF rate limits
+                try:
+                    model_cached = snapshot_download(model_id, local_files_only=True)
+                except Exception:
+                    model_cached = snapshot_download(model_id)  # fallback: download if not cached
                 model = cls.from_pretrained(model_cached, export=True, trust_remote_code=True)
             except:
                 print(f"Couldn't read {model_id}.")

--- a/tests/model_hub_tests/transformation_tests/generate_ref_diffs.py
+++ b/tests/model_hub_tests/transformation_tests/generate_ref_diffs.py
@@ -41,6 +41,7 @@ import sys
 from huggingface_hub import snapshot_download
 from pathlib import Path
 import models_hub_common.utils as utils
+from models_hub_common.utils import cached_snapshot_download
 from openvino._offline_transformations import paged_attention_transformation
 from openvino._pyopenvino.op import _PagedAttentionExtension, Parameter, Result
 from optimum.intel import OVModelForCausalLM, OVModelForSeq2SeqLM
@@ -94,10 +95,7 @@ def main():
         for model_id, _, _, _, cls in model_list:
             # wrapping in try/catch block to continue printing models even if one has failed
             try:
-                try:
-                    model_cached = snapshot_download(model_id, local_files_only=True)
-                except Exception:
-                    model_cached = snapshot_download(model_id)  # fallback: download if not cached
+                model_cached = cached_snapshot_download(model_id)
                 model = cls.from_pretrained(model_cached, export=True, trust_remote_code=True)
             except:
                 print(f"Couldn't read {model_id}.")

--- a/tests/model_hub_tests/transformation_tests/test_gptq_torchfx_transformations.py
+++ b/tests/model_hub_tests/transformation_tests/test_gptq_torchfx_transformations.py
@@ -42,7 +42,10 @@ def patch_gptq(config):
     return orig_cuda_check, orig_post_init_model
 
 def run_gptq_torchfx(tmp_path, model_id, model_link, prompt_result_pair):
-    model_cached = snapshot_download(model_id)  # required to avoid HF rate limits
+    try:
+        model_cached = snapshot_download(model_id, local_files_only=True)
+    except Exception:
+        model_cached = snapshot_download(model_id)  # fallback: download if not cached
     config = AutoConfig.from_pretrained(model_cached, trust_remote_code=True, torch_dtype=torch.float32)
     cuda, post_init = patch_gptq(config)
     tokenizer = AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True, torch_dtype=torch.float32)

--- a/tests/model_hub_tests/transformation_tests/test_gptq_torchfx_transformations.py
+++ b/tests/model_hub_tests/transformation_tests/test_gptq_torchfx_transformations.py
@@ -7,6 +7,7 @@ import torch
 import hashlib
 from openvino.frontend.pytorch.torchdynamo.execute import compiled_cache
 import models_hub_common.utils as utils
+from models_hub_common.utils import cached_snapshot_download
 import pytest
 import os
 import platform
@@ -42,10 +43,7 @@ def patch_gptq(config):
     return orig_cuda_check, orig_post_init_model
 
 def run_gptq_torchfx(tmp_path, model_id, model_link, prompt_result_pair):
-    try:
-        model_cached = snapshot_download(model_id, local_files_only=True)
-    except Exception:
-        model_cached = snapshot_download(model_id)  # fallback: download if not cached
+    model_cached = cached_snapshot_download(model_id)
     config = AutoConfig.from_pretrained(model_cached, trust_remote_code=True, torch_dtype=torch.float32)
     cuda, post_init = patch_gptq(config)
     tokenizer = AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True, torch_dtype=torch.float32)

--- a/tests/model_hub_tests/transformation_tests/test_moe_transformation.py
+++ b/tests/model_hub_tests/transformation_tests/test_moe_transformation.py
@@ -4,7 +4,7 @@
 from huggingface_hub import snapshot_download
 from optimum.intel import OVModelForCausalLM
 import openvino as ov
-from models_hub_common.utils import retry
+from models_hub_common.utils import cached_snapshot_download, retry
 import models_hub_common.utils as utils
 import pytest
 import os
@@ -103,10 +103,7 @@ def create_synthetic_moe_model(tmp_path, num_layers, num_experts, dtype="float32
         str: Path to the saved model
     """
     # Load config from cache to avoid HuggingFace rate limits
-    try:
-        config_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe", local_files_only=True)
-    except Exception:
-        config_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe")  # fallback: download if not cached
+    config_cache = cached_snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe")
     config = AutoConfig.from_pretrained(config_cache)
     config.num_hidden_layers = num_layers
     config.decoder_sparse_step = 1
@@ -140,10 +137,7 @@ def run_moe(tmp_path,
     Args:
         batch_size: Number of sequences to process in parallel (default: 1)
     """
-    try:
-        model_cached = snapshot_download(model_id, local_files_only=True)
-    except Exception:
-        model_cached = snapshot_download(model_id)  # fallback: download if not cached
+    model_cached = cached_snapshot_download(model_id)
 
     # Load original PyTorch model and tokenizer for comparison (from cache to avoid rate limits)
     pt_model = AutoModelForCausalLM.from_pretrained(model_cached, trust_remote_code=True)
@@ -216,10 +210,7 @@ def run_moe_synthetic(tmp_path,
     # Load original PyTorch model for comparison (from local path)
     pt_model = AutoModelForCausalLM.from_pretrained(model_path, trust_remote_code=True)
     # Load tokenizer from cache to avoid HuggingFace rate limits
-    try:
-        tokenizer_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe", local_files_only=True)
-    except Exception:
-        tokenizer_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe")  # fallback: download if not cached
+    tokenizer_cache = cached_snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe")
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_cache, trust_remote_code=True)
 
     # Prepare test input with specified batch size

--- a/tests/model_hub_tests/transformation_tests/test_moe_transformation.py
+++ b/tests/model_hub_tests/transformation_tests/test_moe_transformation.py
@@ -103,7 +103,10 @@ def create_synthetic_moe_model(tmp_path, num_layers, num_experts, dtype="float32
         str: Path to the saved model
     """
     # Load config from cache to avoid HuggingFace rate limits
-    config_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe")
+    try:
+        config_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe", local_files_only=True)
+    except Exception:
+        config_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe")  # fallback: download if not cached
     config = AutoConfig.from_pretrained(config_cache)
     config.num_hidden_layers = num_layers
     config.decoder_sparse_step = 1
@@ -137,7 +140,10 @@ def run_moe(tmp_path,
     Args:
         batch_size: Number of sequences to process in parallel (default: 1)
     """
-    model_cached = snapshot_download(model_id)  # required to avoid HF rate limits
+    try:
+        model_cached = snapshot_download(model_id, local_files_only=True)
+    except Exception:
+        model_cached = snapshot_download(model_id)  # fallback: download if not cached
 
     # Load original PyTorch model and tokenizer for comparison (from cache to avoid rate limits)
     pt_model = AutoModelForCausalLM.from_pretrained(model_cached, trust_remote_code=True)
@@ -210,7 +216,10 @@ def run_moe_synthetic(tmp_path,
     # Load original PyTorch model for comparison (from local path)
     pt_model = AutoModelForCausalLM.from_pretrained(model_path, trust_remote_code=True)
     # Load tokenizer from cache to avoid HuggingFace rate limits
-    tokenizer_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe")
+    try:
+        tokenizer_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe", local_files_only=True)
+    except Exception:
+        tokenizer_cache = snapshot_download("optimum-internal-testing/tiny-random-qwen3_moe")  # fallback: download if not cached
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_cache, trust_remote_code=True)
 
     # Prepare test input with specified batch size

--- a/tests/model_hub_tests/transformation_tests/test_pa_transformation.py
+++ b/tests/model_hub_tests/transformation_tests/test_pa_transformation.py
@@ -157,7 +157,10 @@ def run_pa(tmp_path,
            allow_adaptive_rkv,
            allow_qq_bias,
            ie_device):
-    model_cached = snapshot_download(model_id)  # required to avoid HF rate limits
+    try:
+        model_cached = snapshot_download(model_id, local_files_only=True)
+    except Exception:
+        model_cached = snapshot_download(model_id)  # fallback: download if not cached
     model = cls.from_pretrained(model_cached, export=True, trust_remote_code=True)
 
     if cls is OVModelForCausalLM:

--- a/tests/model_hub_tests/transformation_tests/test_pa_transformation.py
+++ b/tests/model_hub_tests/transformation_tests/test_pa_transformation.py
@@ -9,7 +9,7 @@ from optimum.intel import OVModelForCausalLM, OVModelForSeq2SeqLM
 from optimum.intel.openvino import OVModelForVisualCausalLM
 from typing import Union
 import openvino as ov
-from models_hub_common.utils import retry
+from models_hub_common.utils import cached_snapshot_download, retry
 import models_hub_common.utils as utils
 from sdpa2pa_ref_diff import ref_diff_map, ref_diff_map_optimizations, nodes_to_compare
 import pytest
@@ -157,10 +157,7 @@ def run_pa(tmp_path,
            allow_adaptive_rkv,
            allow_qq_bias,
            ie_device):
-    try:
-        model_cached = snapshot_download(model_id, local_files_only=True)
-    except Exception:
-        model_cached = snapshot_download(model_id)  # fallback: download if not cached
+    model_cached = cached_snapshot_download(model_id)
     model = cls.from_pretrained(model_cached, export=True, trust_remote_code=True)
 
     if cls is OVModelForCausalLM:

--- a/tests/model_hub_tests/transformation_tests/test_stateful_to_stateless_transformation.py
+++ b/tests/model_hub_tests/transformation_tests/test_stateful_to_stateless_transformation.py
@@ -5,7 +5,7 @@ import openvino as ov
 from huggingface_hub import snapshot_download
 from openvino._offline_transformations import stateful_to_stateless_transformation
 from optimum.intel import OVModelForCausalLM
-from models_hub_common.utils import retry
+from models_hub_common.utils import cached_snapshot_download, retry
 import models_hub_common.utils as utils
 import pytest
 import os
@@ -53,10 +53,7 @@ def check_result_desc_tensors(expected_tensors, tensors):
 
 @retry(3, exceptions=(OSError,), delay=1)
 def run_stateful_to_stateless_in_runtime(tmp_path, model_id, model_link):
-    try:
-        model_cached = snapshot_download(model_id, local_files_only=True)
-    except Exception:
-        model_cached = snapshot_download(model_id)  # fallback: download if not cached
+    model_cached = cached_snapshot_download(model_id)
     model = OVModelForCausalLM.from_pretrained(model_cached, export=True, stateful=True, compile=False)
     assert len(model.model.get_sinks()), f"Input model is not in the expected stateful form because it doesn't have any sinks."
     assert len(get_read_value_ops(model.model)), f"Input model is not in the expected stateful form because it doesn't have any ReadValue operations."

--- a/tests/model_hub_tests/transformation_tests/test_stateful_to_stateless_transformation.py
+++ b/tests/model_hub_tests/transformation_tests/test_stateful_to_stateless_transformation.py
@@ -53,7 +53,10 @@ def check_result_desc_tensors(expected_tensors, tensors):
 
 @retry(3, exceptions=(OSError,), delay=1)
 def run_stateful_to_stateless_in_runtime(tmp_path, model_id, model_link):
-    model_cached = snapshot_download(model_id)  # required to avoid HF rate limits
+    try:
+        model_cached = snapshot_download(model_id, local_files_only=True)
+    except Exception:
+        model_cached = snapshot_download(model_id)  # fallback: download if not cached
     model = OVModelForCausalLM.from_pretrained(model_cached, export=True, stateful=True, compile=False)
     assert len(model.model.get_sinks()), f"Input model is not in the expected stateful form because it doesn't have any sinks."
     assert len(get_read_value_ops(model.model)), f"Input model is not in the expected stateful form because it doesn't have any ReadValue operations."

--- a/tests/model_hub_tests/transformation_tests/test_transformations.py
+++ b/tests/model_hub_tests/transformation_tests/test_transformations.py
@@ -92,7 +92,10 @@ def run_test(model_id, ie_device, ts_names, expected_layer_types):
         except (ImportError, AttributeError):
             pytest.skip("OVModelForCausalLM unavailable with installed package versions")
 
-    model_cached = snapshot_download(model_id)  # required to avoid HF rate limits
+    try:
+        model_cached = snapshot_download(model_id, local_files_only=True)
+    except Exception:
+        model_cached = snapshot_download(model_id)  # fallback: download if not cached
     try:
         model = OVModelForCausalLM.from_pretrained(model_cached, export=True, trust_remote_code=True)
     except (ValueError, ImportError) as e:
@@ -104,7 +107,10 @@ def run_test(model_id, ie_device, ts_names, expected_layer_types):
 def run_flux_test(model_id, ie_device, ts_names, expected_layer_types):
     from diffusers import FluxTransformer2DModel
 
-    model_cached = snapshot_download(model_id)
+    try:
+        model_cached = snapshot_download(model_id, local_files_only=True)
+    except Exception:
+        model_cached = snapshot_download(model_id)  # fallback: download if not cached
     try:
         transformer = FluxTransformer2DModel.from_pretrained(
             model_cached, subfolder="transformer")

--- a/tests/model_hub_tests/transformation_tests/test_transformations.py
+++ b/tests/model_hub_tests/transformation_tests/test_transformations.py
@@ -3,6 +3,7 @@
 
 from huggingface_hub import snapshot_download
 import models_hub_common.utils as utils
+from models_hub_common.utils import cached_snapshot_download
 import pytest
 import os
 import platform
@@ -92,10 +93,7 @@ def run_test(model_id, ie_device, ts_names, expected_layer_types):
         except (ImportError, AttributeError):
             pytest.skip("OVModelForCausalLM unavailable with installed package versions")
 
-    try:
-        model_cached = snapshot_download(model_id, local_files_only=True)
-    except Exception:
-        model_cached = snapshot_download(model_id)  # fallback: download if not cached
+    model_cached = cached_snapshot_download(model_id)
     try:
         model = OVModelForCausalLM.from_pretrained(model_cached, export=True, trust_remote_code=True)
     except (ValueError, ImportError) as e:
@@ -107,10 +105,7 @@ def run_test(model_id, ie_device, ts_names, expected_layer_types):
 def run_flux_test(model_id, ie_device, ts_names, expected_layer_types):
     from diffusers import FluxTransformer2DModel
 
-    try:
-        model_cached = snapshot_download(model_id, local_files_only=True)
-    except Exception:
-        model_cached = snapshot_download(model_id)  # fallback: download if not cached
+    model_cached = cached_snapshot_download(model_id)
     try:
         transformer = FluxTransformer2DModel.from_pretrained(
             model_cached, subfolder="transformer")


### PR DESCRIPTION
### Details:
 - Optimize HF API rate limit usage

Problem: Every snapshot_download(model_id) call — even when the model is already cached — fires one HTTP request to https://huggingface.co/api/models/<id> to check if anything changed remotely. With many models × many workers, this drains the rate limit quota even though nothing gets downloaded.

Fix: local_files_only=True skips that HTTP check entirely and reads straight from the local cache. If the cache has the model → returns the path instantly, zero network calls. If not cached → raises an exception, so the except falls back to a normal download.


CVS-175243

AI assistance used: yes

GitHub Copilot was used to help implement the cached_snapshot_download() wrapper in models_hub_common/utils.py. The approach was tested on staging before applying — was allegedly confirmed 2-3x reduction in HuggingFace API requests.
