### PR TITLE
[GPU] Account for NULL terminator when building kernel from src with L0

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ze/ze_kernel_builder.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_kernel_builder.cpp
@@ -65,6 +65,8 @@ std::shared_ptr<ze_module_holder> ze_kernel_builder::build_module_l0(const void 
         };
     switch (src_format) {
         case KernelFormat::SOURCE: {
+            // Account for NULL terminator in source format
+            module_desc.inputSize += 1;
             module_desc.format = ze_module_format_oclc;
             break;
         }


### PR DESCRIPTION
### Details:
 - Driver expects that number of source bytes passed when building kernels with Level Zero will include terminating NULL character and the number we are passing in runtime-agnostic code doesn't include it

### Tickets:
 - 183129

### AI Assistance:
 - AI assistance used: no
