### PR TITLE
[GHA] Add explicit labeler checkout to Smart CI action

### DIFF
--- a/.github/actions/smart-ci/action.yml
+++ b/.github/actions/smart-ci/action.yml
@@ -81,10 +81,12 @@ runs:
         wait-interval: 10
         timeout: 300
 
-    - name: checkout components file
+    - name: checkout components and labeler files
       uses: ababushk/checkout@9bec46a94a83db82acd4303e7627d88db71402a5 # cherry_pick_retries
       with:
-        sparse-checkout: .github/components.yml
+        sparse-checkout: |
+          .github/components.yml
+          .github/labeler.yml
         sparse-checkout-cone-mode: false
 
     - name: Install Python dependencies


### PR DESCRIPTION
### Details:
 - Attempt to fix Smart CI version update in other openvinotoolkit repos, testing: https://github.com/openvinotoolkit/openvino.genai/pull/3724

### Tickets:
 - CVS-184608

### AI Assistance:
 - *AI assistance used: no
