### PR TITLE
[NPUW] Kokoro updates

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
@@ -93,23 +93,21 @@ ov::npuw::KokoroCompiledModel::KokoroCompiledModel(const std::shared_ptr<ov::Mod
     ov::npuw::kokoro::guard_angle_divide(split_result.model_b);
 
     LOG_DEBUG("Compiling kokoro model A...");
-    // Model A doesn't require decomposition, so it should be handled by CPU or NPU plugin
-    if (is_cpu_only(common_props)) {
-        auto core = plugin->get_core();
-        m_model_a_compiled = core->compile_model(split_result.model_a, "CPU", ov::AnyMap{});
-    } else {
-        // Plugin don't have to know about NPUW parameters
-        ov::AnyMap model_a_properties = without_npuw_params(common_props);
-        m_model_a_compiled = plugin->compile_model(split_result.model_a, model_a_properties);
-    }
+    // Model A (BERT + LSTMs + duration predictor) — compile through NPUW
+    // so that NPUW_CACHE_DIR caching works for both models.
+    // NONE pipeline keeps it as a single subgraph (no partitioning overhead).
+    ov::AnyMap properties_model_a = common_props;
+    properties_model_a["NPUW_ONLINE_PIPELINE"] = "NONE";
+    m_model_a_compiled = std::dynamic_pointer_cast<ov::npuw::ICompiledModel>(
+        ov::npuw::ICompiledModel::create(split_result.model_a, plugin, properties_model_a));
 
     LOG_DEBUG("Compiling kokoro model B...");
     ov::AnyMap properties_model_b = common_props;
 
     // Enforce offloading to CPU for non-accurate subgraphs
     if (!properties_model_b.count("NPUW_ONLINE_PIPELINE")) {
-        // REP mode is giving best compile time / stability results
-        properties_model_b["NPUW_ONLINE_PIPELINE"] = "REP";
+        // Long compilation time, but best performance
+        properties_model_b["NPUW_ONLINE_PIPELINE"] = "NONE";
     }
     if (!properties_model_b.count("NPUW_ONLINE_AVOID")) {
         properties_model_b["NPUW_ONLINE_AVOID"] = "P:DownsampleInterpolate/NPU,P:FloorModFP32/NPU,P:CumSumSinGen/"

--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
@@ -78,6 +78,7 @@ ov::npuw::KokoroCompiledModel::KokoroCompiledModel(const std::shared_ptr<ov::Mod
     ov::AnyMap common_props;
 
     split_kokoro_properties(properties, common_props, npuw_kokoro_props);
+    common_props["NPUW_FALLBACK_EXEC"] = "NO";
 
     m_cfg.parseEnvVars();
     m_cfg.update(any_copy(npuw_kokoro_props));

--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
@@ -13,26 +13,6 @@
 #include "plugin.hpp"
 
 namespace {
-// Remove all options "NPUW_.*"
-ov::AnyMap without_npuw_params(const ov::AnyMap& properties) {
-    ov::AnyMap result;
-    for (const auto& item : properties) {
-        if (item.first.find("NPUW") == std::string::npos) {
-            result.insert(item);
-        }
-    }
-    return result;
-}
-
-// Check properties for NPUW_DEVICES options and return true if only CPU is present
-bool is_cpu_only(const ov::AnyMap& properties) {
-    auto it = properties.find("NPUW_DEVICES");
-    if (it != properties.end()) {
-        return it->second.as<std::string>() == "CPU";
-    }
-    return false;
-}
-
 void split_kokoro_properties(const ov::AnyMap& properties,
                              ov::AnyMap& other_properties,
                              ov::AnyMap& kokoro_properties) {

--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_infer_request.cpp
@@ -135,6 +135,12 @@ ov::npuw::KokoroInferRequest::KokoroInferRequest(const std::shared_ptr<ov::npuw:
             continue;
         }
 
+        // input_lengths is generated internally — not exposed to the user
+        if (names.count("input_lengths")) {
+            m_a_input_lengths = a_in;
+            continue;
+        }
+
         auto original_port = ov::npuw::util::find_port_by_names(original_inputs, names);
         if (original_port.has_value()) {
             m_model_a_in_map.push_back({a_in, original_port.value()});
@@ -472,6 +478,17 @@ void ov::npuw::KokoroInferRequest::fill_text_mask() {
     }
 
     ov::npuw::kokoro::fill_text_mask_from_lengths(mask_tensor->data<bool>(), seq_len, real_len);
+
+    // Also set input_lengths to the real sequence length so that LSTMSequence ops
+    // (from pack_padded_sequence) only process valid tokens, not padding.
+    if (m_a_input_lengths.get_node()) {
+        auto lengths_tensor = m_model_a_request->get_tensor(m_a_input_lengths);
+        if (!lengths_tensor || lengths_tensor->get_shape() != ov::Shape{1}) {
+            lengths_tensor = ov::make_tensor(ov::element::i64, ov::Shape{1});
+            m_model_a_request->set_tensor(m_a_input_lengths, lengths_tensor);
+        }
+        lengths_tensor->data<int64_t>()[0] = static_cast<int64_t>(real_len);
+    }
 
     m_real_seq_len = real_len;
 

--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_infer_request.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_infer_request.hpp
@@ -49,7 +49,9 @@ protected:
 
     // Model A attention mask input (auto-filled from input_ids)
     ov::Output<const ov::Node> m_a_text_mask;
-    // Original input_ids port (used to compute text_mask at runtime)
+    // Model A input_lengths input (auto-filled from input_ids)
+    ov::Output<const ov::Node> m_a_input_lengths;
+    // Original input_ids port (used to compute text_mask and input_lengths at runtime)
     ov::Output<const ov::Node> m_orig_input_ids;
     // Real (unpadded) sequence length — set by fill_text_mask(), used to
     // truncate pred_dur so Model B only processes valid tokens.

--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
@@ -62,6 +62,70 @@ void replace_text_mask_with_parameter(std::shared_ptr<ov::Model>& model) {
     model->add_parameters({text_mask_param});
     model->validate_nodes_and_infer_types();
 }
+
+// TODO Should be replaced with proper LSTMSequence implementation which can accept such inputs.
+//
+// Replace the input_lengths value (derived from ShapeOf(input_ids)) with a Parameter input.
+// In the static model, ShapeOf(input_ids) always returns the padded size (e.g. 512), which
+// feeds as sequence_lengths into all LSTMSequence ops (from pack_padded_sequence in PyTorch).
+// This makes the LSTMs process all 512 positions including padding, corrupting hidden states
+// (especially in bidirectional LSTMs where the backward pass starts from padding).
+// By exposing input_lengths as a Parameter, the host can provide the real sequence length.
+//
+// NOTE: The NPU compiler frontend (IE.cpp) only accepts sequence_lengths that is either
+// a Constant or a Parameter node — any intermediate op (like TopK) causes a rejection.
+// Therefore we must connect ALL LSTMSequence port 3 inputs directly to the Parameter.
+void replace_input_lengths_with_parameter(std::shared_ptr<ov::Model>& model) {
+    // Find the Broadcast node whose output tensor has the name "input_lengths".
+    // This is the node that broadcasts ShapeOf(input_ids)[1] → [batch_size].
+    std::shared_ptr<ov::Node> input_lengths_node;
+    for (const auto& op : model->get_ops()) {
+        for (size_t i = 0; i < op->get_output_size(); ++i) {
+            if (op->output(i).get_names().count("input_lengths")) {
+                input_lengths_node = op;
+                break;
+            }
+        }
+        if (input_lengths_node)
+            break;
+    }
+
+    if (!input_lengths_node) {
+        LOG_WARN("input_lengths node not found — skipping replacement");
+        return;
+    }
+
+    LOG_DEBUG("replacing input_lengths (ShapeOf-derived) with Parameter input");
+
+    // input_lengths shape is [1] (batch_size) with element type I64
+    auto input_lengths_param = std::make_shared<ov::op::v0::Parameter>(
+        input_lengths_node->get_output_element_type(0),
+        input_lengths_node->get_output_partial_shape(0));
+    input_lengths_param->set_friendly_name("input_lengths");
+    input_lengths_param->output(0).get_tensor().set_names({"input_lengths"});
+
+    // Replace the main Broadcast output with the Parameter
+    input_lengths_node->output(0).replace(input_lengths_param->output(0));
+
+    // Connect ALL LSTMSequence sequence_lengths (port 3) directly to the Parameter.
+    // Some LSTMs receive it through TopK (sort for pack_padded_sequence), others
+    // through a separate ShapeOf chain — but the NPU compiler requires the source
+    // to be exactly a Parameter or Constant, not an intermediate op.
+    for (const auto& op : model->get_ops()) {
+        if (std::string(op->get_type_info().name) != "LSTMSequence")
+            continue;
+
+        auto source = op->input_value(3).get_node_shared_ptr();
+        if (source.get() != input_lengths_param.get()) {
+            LOG_DEBUG("Redirecting LSTM '" << op->get_friendly_name()
+                                          << "' sequence_lengths directly to input_lengths parameter");
+            op->input(3).replace_source_output(input_lengths_param->output(0));
+        }
+    }
+
+    model->add_parameters({input_lengths_param});
+    model->validate_nodes_and_infer_types();
+}
 }  // namespace
 
 //  Main logic for kokoro model is splitting it into two parts,
@@ -158,6 +222,10 @@ std::shared_ptr<ov::Model> KokoroSplit::create_model_a(const std::shared_ptr<ov:
     // Replace text_mask generation with an explicit Parameter input so that
     // the host can provide the correct padding mask for static-shape models.
     replace_text_mask_with_parameter(model_a);
+
+    // Replace input_lengths (derived from ShapeOf(input_ids) = 512) with an explicit
+    // Parameter so LSTMs process only real tokens, not padding.
+    replace_input_lengths_with_parameter(model_a);
 
     return model_a;
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
@@ -62,6 +62,70 @@ void replace_text_mask_with_parameter(std::shared_ptr<ov::Model>& model) {
     model->add_parameters({text_mask_param});
     model->validate_nodes_and_infer_types();
 }
+
+// TODO Should be replaced with proper LSTMSequence implementation which can accept such inputs.
+//
+// Replace the input_lengths value (derived from ShapeOf(input_ids)) with a Parameter input.
+// In the static model, ShapeOf(input_ids) always returns the padded size (e.g. 512), which
+// feeds as sequence_lengths into all LSTMSequence ops (from pack_padded_sequence in PyTorch).
+// This makes the LSTMs process all 512 positions including padding, corrupting hidden states
+// (especially in bidirectional LSTMs where the backward pass starts from padding).
+// By exposing input_lengths as a Parameter, the host can provide the real sequence length.
+//
+// NOTE: The NPU compiler frontend (IE.cpp) only accepts sequence_lengths that is either
+// a Constant or a Parameter node for a static model — any intermediate op (like TopK) causes
+// a rejection. Therefore we must connect ALL LSTMSequence port 3 inputs directly to the Parameter.
+void replace_input_lengths_with_parameter(std::shared_ptr<ov::Model>& model) {
+    // Find the Broadcast node whose output tensor has the name "input_lengths".
+    // This is the node that broadcasts ShapeOf(input_ids)[1] → [batch_size].
+    std::shared_ptr<ov::Node> input_lengths_node;
+    for (const auto& op : model->get_ops()) {
+        for (size_t i = 0; i < op->get_output_size(); ++i) {
+            if (op->output(i).get_names().count("input_lengths")) {
+                input_lengths_node = op;
+                break;
+            }
+        }
+        if (input_lengths_node)
+            break;
+    }
+
+    if (!input_lengths_node) {
+        LOG_WARN("input_lengths node not found — skipping replacement");
+        return;
+    }
+
+    LOG_DEBUG("replacing input_lengths (ShapeOf-derived) with Parameter input");
+
+    // input_lengths shape is [1] (batch_size) with element type I64
+    auto input_lengths_param = std::make_shared<ov::op::v0::Parameter>(
+        input_lengths_node->get_output_element_type(0),
+        input_lengths_node->get_output_partial_shape(0));
+    input_lengths_param->set_friendly_name("input_lengths");
+    input_lengths_param->output(0).get_tensor().set_names({"input_lengths"});
+
+    // Replace the main Broadcast output with the Parameter
+    input_lengths_node->output(0).replace(input_lengths_param->output(0));
+
+    // Connect ALL LSTMSequence sequence_lengths (port 3) directly to the Parameter.
+    // Some LSTMs receive it through TopK (sort for pack_padded_sequence), others
+    // through a separate ShapeOf chain — but the NPU compiler requires the source
+    // to be exactly a Parameter or Constant, not an intermediate op.
+    for (const auto& op : model->get_ops()) {
+        if (std::string(op->get_type_info().name) != "LSTMSequence")
+            continue;
+
+        auto source = op->input_value(3).get_node_shared_ptr();
+        if (source.get() != input_lengths_param.get()) {
+            LOG_DEBUG("Redirecting LSTM '" << op->get_friendly_name()
+                                          << "' sequence_lengths directly to input_lengths parameter");
+            op->input(3).replace_source_output(input_lengths_param->output(0));
+        }
+    }
+
+    model->add_parameters({input_lengths_param});
+    model->validate_nodes_and_infer_types();
+}
 }  // namespace
 
 //  Main logic for kokoro model is splitting it into two parts,
@@ -158,6 +222,10 @@ std::shared_ptr<ov::Model> KokoroSplit::create_model_a(const std::shared_ptr<ov:
     // Replace text_mask generation with an explicit Parameter input so that
     // the host can provide the correct padding mask for static-shape models.
     replace_text_mask_with_parameter(model_a);
+
+    // Replace input_lengths (derived from ShapeOf(input_ids) = 512) with an explicit
+    // Parameter so LSTMs process only real tokens, not padding.
+    replace_input_lengths_with_parameter(model_a);
 
     return model_a;
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
@@ -98,9 +98,8 @@ void replace_input_lengths_with_parameter(std::shared_ptr<ov::Model>& model) {
     LOG_DEBUG("replacing input_lengths (ShapeOf-derived) with Parameter input");
 
     // input_lengths shape is [1] (batch_size) with element type I64
-    auto input_lengths_param = std::make_shared<ov::op::v0::Parameter>(
-        input_lengths_node->get_output_element_type(0),
-        input_lengths_node->get_output_partial_shape(0));
+    auto input_lengths_param = std::make_shared<ov::op::v0::Parameter>(input_lengths_node->get_output_element_type(0),
+                                                                       input_lengths_node->get_output_partial_shape(0));
     input_lengths_param->set_friendly_name("input_lengths");
     input_lengths_param->output(0).get_tensor().set_names({"input_lengths"});
 
@@ -118,7 +117,7 @@ void replace_input_lengths_with_parameter(std::shared_ptr<ov::Model>& model) {
         auto source = op->input_value(3).get_node_shared_ptr();
         if (source.get() != input_lengths_param.get()) {
             LOG_DEBUG("Redirecting LSTM '" << op->get_friendly_name()
-                                          << "' sequence_lengths directly to input_lengths parameter");
+                                           << "' sequence_lengths directly to input_lengths parameter");
             op->input(3).replace_source_output(input_lengths_param->output(0));
         }
     }


### PR DESCRIPTION
### Details:
 - [Switch to NPUW NONE partitioning for both kokoro parts](https://github.com/openvinotoolkit/openvino/pull/35390/commits/3f8ba6e93b22f6d07ddf7981dcfa3c0e79553877) to improve inference performance (though increasing compilation time)
   - also fix NPUW model caching for model A
 - [Fix issue of LSTMSquences using wrong (full 512) input_length value](https://github.com/openvinotoolkit/openvino/pull/35390/commits/a0a90d7e687987698863668f0929228044810dfb) 
    - replace input_lengths value with Parameter
    - set input_lengths to the real sequence length
    - add m_a_input_lengths parameter for KokoroInferRequest to manage the parameter
 - [set NPUW_FALLBACK_EXEC=false for Kokoro model to avoid caching problem](https://github.com/openvinotoolkit/openvino/pull/35390/commits/fd9c4240593e253ee49b90ac1e679c06e5419209) discussed in https://github.com/openvinotoolkit/openvino/pull/35635

Metrics:
- NPU4000:
  - Compilation for NPU:
    - w/o PR:
      - cold: 60s
    - PR:
      - cold: 52s
      - warm: 0.6s
  - Performance:
    - baseline
      - CPU Pytorch
        - Real-time Speedup Factor: 4.8x
      - CPU OpenVINO
        - Real-time Speedup Factor: 3.7x
    - w/o PR:
      - NPU
        - Real-time Speedup Factor: 8x
    - PR:
      - NPU
        - Real-time Speedup Factor: 8.1x
        
(Real-time Speedup Factor = Generated Audio Length / Inference Time)

### Tickets:
E210201
E211208
E213246

### AI Assistance:
 - *AI assistance used: yes*
   - replace_input_lengths_with_parameter()
   - comments
