### PR TITLE
Align NPU and OV deps resolving scripts

### DIFF
--- a/src/plugins/intel_npu/cmake/download_compiler_libs.cmake
+++ b/src/plugins/intel_npu/cmake/download_compiler_libs.cmake
@@ -4,14 +4,14 @@
 
 # This script resolves the prebuilt NPU Plugin Compiler dependency by downloading and extracting the appropriate
 # archive based on the current platform. The expected location of the archive and naming convention is as follows:
-#     vcl version: 7.6.0
-#     release: releases/unified/2026/12_cip
+#     vcl version: 8.1.0
+#     release: releases/unified/2026/20
 #     storage location: https://storage.openvinotoolkit.org/dependencies/thirdparty
 #     WINDOWS: 
-#         windows2022: npu_compiler_vcl_windows_2022-7_6_0-da3cc32.zip
+#         windows2022: npu_compiler_vcl_windows_2022-8_1_0-727e603.zip
 #     LINUX:
-#         ubuntu22.04: npu_compiler_vcl_ubuntu_22_04-7_6_0-da3cc32.tar.gz
-#         ubuntu24.04: npu_compiler_vcl_ubuntu_24_04-7_6_0-da3cc32.tar.gz
+#         ubuntu22.04: npu_compiler_vcl_ubuntu_22_04-8_1_0-727e603.tar.gz
+#         ubuntu24.04: npu_compiler_vcl_ubuntu_24_04-8_1_0-727e603.tar.gz
 #
 # This script replicates cmake/dependencies.cmake common OV dependency resolution logic including:
 #     THIRDPARTY_SERVER_PATH environment variable or cmake options support that allows
@@ -30,9 +30,10 @@
 # The script expects the archive to contain:
 #     build_manifest.json file with build information about the prebuilt compiler.
 #         If the file is present, its content will be printed in cmake output.
-#     lib/npu_driver_compiler.dll for Windows or lib/libnpu_driver_compiler.so for Linux that will be copied to
-#         the output directory and renamed to openvino_intel_npu_compiler.dll
-#         or libopenvino_intel_npu_compiler.so respectively.
+#     lib folder with the following libraries that will be copied to the output directory
+#     and included in the installation package:
+#         WINDOWS: openvino_intel_npu_compiler.dll, openvino_intel_npu_compiler_loader.dll
+#         LINUX: libopenvino_intel_npu_compiler.so, libopenvino_intel_npu_compiler_loader.so
 
 function(print_build_manifest extracted_file)
     if(NOT EXISTS "${extracted_file}")
@@ -47,13 +48,13 @@ endfunction()
 if(ENABLE_INTEL_NPU_COMPILER)
     message(STATUS "Resolving prebuilt NPU Plugin Compiler dependencies...")
 
-    set(PLUGIN_COMPILER_VERSION_MAJOR 7)
-    set(PLUGIN_COMPILER_VERSION_MINOR 6)
+    set(PLUGIN_COMPILER_VERSION_MAJOR 8)
+    set(PLUGIN_COMPILER_VERSION_MINOR 1)
     set(PLUGIN_COMPILER_VERSION_PATCH 0)
-    set(PLUGIN_COMPILER_COMMIT_SHA da3cc32)
-    set(PLUGIN_COMPILER_WINDOWS_2022_CHECKSUM 265bda74dfe07260e9b30ca02ec011653a57aa2900b40fd1f5291352922c363c)
-    set(PLUGIN_COMPILER_UBUNTU_22_04_CHECKSUM db1a967d14ce47af64fcd8c66ced0ae8de68923bfd82fb02236fffa0fc625c0d)
-    set(PLUGIN_COMPILER_UBUNTU_24_04_CHECKSUM c7b6fd5798cfc256fa28e9a75f1e150b75fb34a8441a4fbc453315805073c5aa)
+    set(PLUGIN_COMPILER_COMMIT_SHA 727e603)
+    set(PLUGIN_COMPILER_WINDOWS_2022_CHECKSUM f7cb6501df6e38fc90e6591470069d3a705749113b39438e92391271bc6835c1)
+    set(PLUGIN_COMPILER_UBUNTU_22_04_CHECKSUM d50bf866a37a2d599709fb6a805de86fd9b052a67b588d2a83558a224aaf7e95)
+    set(PLUGIN_COMPILER_UBUNTU_24_04_CHECKSUM 3c9c5960c4a86577652cd9a96cb4630576ec398f126fd8b37979063b63929448)
 
     set(PLUGIN_COMPILER_VERSION_UNDERSCORE "${PLUGIN_COMPILER_VERSION_MAJOR}_${PLUGIN_COMPILER_VERSION_MINOR}_${PLUGIN_COMPILER_VERSION_PATCH}")
     message(STATUS "The prebuilt compiler version is ${PLUGIN_COMPILER_VERSION_MAJOR}.${PLUGIN_COMPILER_VERSION_MINOR}.${PLUGIN_COMPILER_VERSION_PATCH}.${PLUGIN_COMPILER_COMMIT_SHA}")
@@ -66,8 +67,8 @@ if(ENABLE_INTEL_NPU_COMPILER)
         set(PLUGIN_COMPILER_PACKAGE_PREFIX "npu_compiler_vcl_windows_${OS_VERSION_UNDERSCORE}")
         set(PLUGIN_COMPILER_PACKAGE_EXT "zip")
         set(PLUGIN_COMPILER_ARCHIVE_TYPE "ARCHIVE_WIN")
-        set(PLUGIN_COMPILER_LIB_OLD_NAME "npu_driver_compiler.dll")
-        set(PLUGIN_COMPILER_LIB_NEW_NAME "openvino_intel_npu_compiler.dll")
+        set(PLUGIN_COMPILER_LIB_NAME "openvino_intel_npu_compiler.dll")
+        set(PLUGIN_COMPILER_LOADER_LIB_NAME "openvino_intel_npu_compiler_loader.dll")
     elseif(UNIX AND NOT APPLE)
         # Get the OS name and OS version
         execute_process(COMMAND lsb_release -is OUTPUT_VARIABLE OS_NAME OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -81,8 +82,8 @@ if(ENABLE_INTEL_NPU_COMPILER)
             set(PLUGIN_COMPILER_PACKAGE_PREFIX "npu_compiler_vcl_ubuntu_${OS_VERSION_UNDERSCORE}")
             set(PLUGIN_COMPILER_PACKAGE_EXT "tar.gz")
             set(PLUGIN_COMPILER_ARCHIVE_TYPE "ARCHIVE_LIN")
-            set(PLUGIN_COMPILER_LIB_OLD_NAME "libnpu_driver_compiler.so")
-            set(PLUGIN_COMPILER_LIB_NEW_NAME "libopenvino_intel_npu_compiler.so")
+            set(PLUGIN_COMPILER_LIB_NAME "libopenvino_intel_npu_compiler.so")
+            set(PLUGIN_COMPILER_LOADER_LIB_NAME "libopenvino_intel_npu_compiler_loader.so")
         else()
             message(STATUS "${OS_NAME} ${OS_VERSION} Linux distribution is not supported, skip downloading prebuilt Plugin Compiler libraries. Can not use plugin compiler libraries!")
             return()
@@ -116,23 +117,21 @@ if(ENABLE_INTEL_NPU_COMPILER)
 
         set(PLUGIN_COMPILER_LIB_PATH "${NPU_PLUGIN_COMPILER}/lib")
 
-        configure_file(
-            "${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_OLD_NAME}"
-            "${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_NEW_NAME}"
-            COPYONLY
-        )
-
         if(USE_BUILD_TYPE_SUBFOLDER)
             set(PLUGIN_COMPILER_LIB_DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
         else()
             set(PLUGIN_COMPILER_LIB_DESTINATION "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}")
         endif()
 
-        set(PLUGIN_COMPILER_LIB "${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_NEW_NAME}")
+        set(PLUGIN_COMPILER_LIB "${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_NAME}")
+        set(PLUGIN_COMPILER_LOADER_LIB "${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LOADER_LIB_NAME}")
         file(COPY "${PLUGIN_COMPILER_LIB}" DESTINATION "${PLUGIN_COMPILER_LIB_DESTINATION}")
-        message(STATUS "Copying prebuilt Plugin compiler library ${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_NEW_NAME} to ${PLUGIN_COMPILER_LIB_DESTINATION}")
+        file(COPY "${PLUGIN_COMPILER_LOADER_LIB}" DESTINATION "${PLUGIN_COMPILER_LIB_DESTINATION}")
+        message(STATUS "Copying prebuilt Plugin compiler library ${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_NAME} to ${PLUGIN_COMPILER_LIB_DESTINATION}")
+        message(STATUS "Copying prebuilt Plugin compiler loader library ${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LOADER_LIB_NAME} to ${PLUGIN_COMPILER_LIB_DESTINATION}")
 
         install(FILES ${PLUGIN_COMPILER_LIB} DESTINATION ${OV_CPACK_PLUGINSDIR} COMPONENT ${NPU_PLUGIN_COMPONENT})
+        install(FILES ${PLUGIN_COMPILER_LOADER_LIB} DESTINATION ${OV_CPACK_PLUGINSDIR} COMPONENT ${NPU_PLUGIN_COMPONENT})
     else()
         message(FATAL_ERROR "Failed to download prebuilt NPU Plugin Compiler libraries. Can not use plugin compiler libraries!")
     endif()

--- a/src/plugins/intel_npu/cmake/download_compiler_libs.cmake
+++ b/src/plugins/intel_npu/cmake/download_compiler_libs.cmake
@@ -2,191 +2,138 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Function to download and extract files
-# download vcl prebuilt package info:
+# This script resolves the prebuilt NPU Plugin Compiler dependency by downloading and extracting the appropriate
+# archive based on the current platform. The expected location of the archive and naming convention is as follows:
 #     vcl version: 7.6.0
 #     release: releases/unified/2026/12_cip
-#     storage localtion: https://storage.openvinotoolkit.org/dependencies/thirdparty
-#     WINDOWS: npu_compiler_vcl_windows_2022-7_6_0-da3cc32.zip
+#     storage location: https://storage.openvinotoolkit.org/dependencies/thirdparty
+#     WINDOWS: 
+#         windows2022: npu_compiler_vcl_windows_2022-7_6_0-da3cc32.zip
 #     LINUX:
 #         ubuntu22.04: npu_compiler_vcl_ubuntu_22_04-7_6_0-da3cc32.tar.gz
 #         ubuntu24.04: npu_compiler_vcl_ubuntu_24_04-7_6_0-da3cc32.tar.gz
-function(download_and_extract url zip_file extracted_dir)
-    # Check if the prebuilt Plugin compiler libraries not exist
-    if(NOT EXISTS "${extracted_dir}")
-        # Download the prebuilt Plugin compiler libraries, if failure, show error message and exit
-        if(NOT "${url}" STREQUAL "")
-            message(STATUS "${url} is not empty")
-            message(STATUS "Downloading prebuilt Plugin compiler libraries from ${url}")
-            file(DOWNLOAD "${url}" "${zip_file}"
-                TIMEOUT 3600
-                LOG log_output
-                STATUS download_status
-                SHOW_PROGRESS)
-
-            list(GET download_status 0 download_result)
-            if(NOT download_result EQUAL 0)
-                message(FATAL_ERROR "Download failed!\nStatus: ${download_status}\nLog: ${log_output}")
-            else()
-                message(STATUS "Download completed: ${zip_file}")
-            endif()
-        endif()
-
-        message(STATUS "Unzipping prebuilt Plugin compiler libraries to ${extracted_dir}")
-        # Determine extraction method based on file extension
-        if("${zip_file}" MATCHES "\\.zip$")
-            file(ARCHIVE_EXTRACT INPUT "${zip_file}" DESTINATION "${extracted_dir}")
-        elseif("${zip_file}" MATCHES "\\.tar.gz$")
-            if(NOT EXISTS "${extracted_dir}")
-                file(MAKE_DIRECTORY "${extracted_dir}")
-                message(STATUS "Directory ${extracted_dir} created to unzip.")
-            endif()
-            execute_process(COMMAND tar -xzf "${zip_file}" -C "${extracted_dir}")
-        elseif("${zip_file}" MATCHES "\\.deb$")
-            execute_process(COMMAND dpkg-deb -x "${zip_file}" "${extracted_dir}")
-        elseif("${zip_file}" MATCHES "\\.exe$")
-            set(WINRAR_PATHS
-                "C:/Program Files/WinRAR"
-                "C:/Program Files (x86)/WinRAR"
-            )
-
-            set(WINRAR_FOUND FALSE)
-            set(WINRAR_EXECUTABLE "")
-
-            foreach(PATH ${WINRAR_PATHS})
-                if(EXISTS "${PATH}/WinRAR.exe")
-                    set(WINRAR_FOUND TRUE)
-                    set(WINRAR_EXECUTABLE "${PATH}/WinRAR.exe")
-                    break()
-                endif()
-            endforeach()
-
-            if(WINRAR_FOUND)
-                message(STATUS "WinRAR found at: ${WINRAR_EXECUTABLE} and extract ${zip_file} to ${extracted_dir}")
-                file(MAKE_DIRECTORY "${extracted_dir}")
-                execute_process(
-                    COMMAND "${WINRAR_EXECUTABLE}" x -y -o+ "${zip_file}" "${extracted_dir}"
-                    RESULT_VARIABLE result
-                    OUTPUT_VARIABLE output 
-                    ERROR_VARIABLE error
-                )
-
-                if(result EQUAL 0)
-                    message(STATUS "Extraction successful: ${output}")
-                else()
-                    #file(REMOVE_RECURSE "${extracted_dir}")
-                    message(STATUS "Extraction failed: ${error}")
-                endif()
-            else()
-                message(FATAL_ERROR "WinRAR not found. Please install WinRAR to proceed.")
-            endif()
-        else()
-            message(FATAL_ERROR "Unsupported file extension for extraction: ${zip_file}")
-        endif()
-        file(REMOVE "${zip_file}")
-    else()
-        message(STATUS "Prebuilt Plugin compiler libraries already exist, skip download")
-    endif()
-endfunction()
+#
+# This script replicates cmake/dependencies.cmake common OV dependency resolution logic including:
+#     THIRDPARTY_SERVER_PATH environment variable or cmake options support that allows
+#         to override default download location.
+#     NPU_PLUGIN_COMPILER_ROOT environment variable support that allows to override default download and extraction
+#         logic and point to already existing extracted archive location.
+#     SHA256 checksum verification of the downloaded archive.
+#     Checking the presence of the archive before downloading to avoid unnecessary downloads.
+#
+# To update the prebuilt compiler version, please update the following variables in this script:
+#     PLUGIN_COMPILER_VERSION_MAJOR, PLUGIN_COMPILER_VERSION_MINOR,
+#     PLUGIN_COMPILER_VERSION_PATCH, PLUGIN_COMPILER_COMMIT_SHA
+#     PLUGIN_COMPILER_WINDOWS_2022_CHECKSUM, PLUGIN_COMPILER_UBUNTU_22_04_CHECKSUM,
+#     PLUGIN_COMPILER_UBUNTU_24_04_CHECKSUM
+# 
+# The script expects the archive to contain:
+#     build_manifest.json file with build information about the prebuilt compiler.
+#         If the file is present, its content will be printed in cmake output.
+#     lib/npu_driver_compiler.dll for Windows or lib/libnpu_driver_compiler.so for Linux that will be copied to
+#         the output directory and renamed to openvino_intel_npu_compiler.dll
+#         or libopenvino_intel_npu_compiler.so respectively.
 
 function(print_build_manifest extracted_file)
     if(NOT EXISTS "${extracted_file}")
         message(WARNING "Build manifest file '${extracted_file}' not found. Skipping build_manifest information printing for plugin compiler.")
         return()
     endif()
-    # read the build_manifest.json file
     file(READ "${extracted_file}" FILE_CONTENT)
     string(REGEX REPLACE "[{}\"']" "" FILE_CONTENT "${FILE_CONTENT}")
     message(STATUS "build_manifest.json for npu plugin compiler:\n${FILE_CONTENT}")
 endfunction()
 
 if(ENABLE_INTEL_NPU_COMPILER)
-    message(STATUS "Downloading prebuilt NPU Plugin compiler libraries")
+    message(STATUS "Resolving prebuilt NPU Plugin Compiler dependencies...")
+
     set(PLUGIN_COMPILER_VERSION_MAJOR 7)
     set(PLUGIN_COMPILER_VERSION_MINOR 6)
     set(PLUGIN_COMPILER_VERSION_PATCH 0)
     set(PLUGIN_COMPILER_COMMIT_SHA da3cc32)
-    set(PLUGIN_COMPILER_VERSION "${PLUGIN_COMPILER_VERSION_MAJOR}_${PLUGIN_COMPILER_VERSION_MINOR}_${PLUGIN_COMPILER_VERSION_PATCH}")
-    message(STATUS "The prebuilt compiler version is ${PLUGIN_COMPILER_VERSION_MAJOR}.${PLUGIN_COMPILER_VERSION_MINOR}.${PLUGIN_COMPILER_VERSION_PATCH}")
-    # The destinations are the same. CMAKE_BUILD_TYPE is added based on the option USE_BUILD_TYPE_SUBFOLDER
-    if(USE_BUILD_TYPE_SUBFOLDER)
-        set(NPU_COMPILER_LIB_DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-    else()
-        set(NPU_COMPILER_LIB_DESTINATION "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}")
-    endif()
+    set(PLUGIN_COMPILER_WINDOWS_2022_CHECKSUM 265bda74dfe07260e9b30ca02ec011653a57aa2900b40fd1f5291352922c363c)
+    set(PLUGIN_COMPILER_UBUNTU_22_04_CHECKSUM db1a967d14ce47af64fcd8c66ced0ae8de68923bfd82fb02236fffa0fc625c0d)
+    set(PLUGIN_COMPILER_UBUNTU_24_04_CHECKSUM c7b6fd5798cfc256fa28e9a75f1e150b75fb34a8441a4fbc453315805073c5aa)
+
+    set(PLUGIN_COMPILER_VERSION_UNDERSCORE "${PLUGIN_COMPILER_VERSION_MAJOR}_${PLUGIN_COMPILER_VERSION_MINOR}_${PLUGIN_COMPILER_VERSION_PATCH}")
+    message(STATUS "The prebuilt compiler version is ${PLUGIN_COMPILER_VERSION_MAJOR}.${PLUGIN_COMPILER_VERSION_MINOR}.${PLUGIN_COMPILER_VERSION_PATCH}.${PLUGIN_COMPILER_COMMIT_SHA}")
+
     if(WIN32)
-        set(PLUGIN_COMPILER_LIBS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/temp/plugin_compiler_lib/win")
-        set(PLUGIN_COMPILER_LIBS_URL "https://storage.openvinotoolkit.org/dependencies/thirdparty/windows/npu_compiler_vcl_windows_2022-${PLUGIN_COMPILER_VERSION}-${PLUGIN_COMPILER_COMMIT_SHA}.zip")
-        set(PLUGIN_COMPILER_LIBS_ZIP "${PLUGIN_COMPILER_LIBS_DIR}/npu_compiler_vcl_windows_2022-${PLUGIN_COMPILER_VERSION}-${PLUGIN_COMPILER_COMMIT_SHA}.zip")
-        set(PLUGIN_COMPILER_LIBS_DIR_UNZIPPED "${PLUGIN_COMPILER_LIBS_DIR}/npu_compiler_vcl_windows_2022-${PLUGIN_COMPILER_VERSION}-${PLUGIN_COMPILER_COMMIT_SHA}")
+        set(OS_FAMILY "windows")
+        set(OS_VERSION_UNDERSCORE "2022")
+        set(OS_UPPERCASE "WINDOWS_${OS_VERSION_UNDERSCORE}")
 
-        download_and_extract("${PLUGIN_COMPILER_LIBS_URL}" "${PLUGIN_COMPILER_LIBS_ZIP}" "${PLUGIN_COMPILER_LIBS_DIR_UNZIPPED}")
-        print_build_manifest("${PLUGIN_COMPILER_LIBS_DIR_UNZIPPED}/build_manifest.json")
+        set(PLUGIN_COMPILER_PACKAGE_PREFIX "npu_compiler_vcl_windows_${OS_VERSION_UNDERSCORE}")
+        set(PLUGIN_COMPILER_PACKAGE_EXT "zip")
+        set(PLUGIN_COMPILER_ARCHIVE_TYPE "ARCHIVE_WIN")
+        set(PLUGIN_COMPILER_LIB_OLD_NAME "npu_driver_compiler.dll")
+        set(PLUGIN_COMPILER_LIB_NEW_NAME "openvino_intel_npu_compiler.dll")
+    elseif(UNIX AND NOT APPLE)
+        # Get the OS name and OS version
+        execute_process(COMMAND lsb_release -is OUTPUT_VARIABLE OS_NAME OUTPUT_STRIP_TRAILING_WHITESPACE)
+        execute_process(COMMAND lsb_release -rs OUTPUT_VARIABLE OS_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-        set(PLUGIN_COMPILER_LIB_PATH "${PLUGIN_COMPILER_LIBS_DIR_UNZIPPED}/lib")
+        if(OS_NAME STREQUAL "Ubuntu" AND (OS_VERSION STREQUAL "22.04" OR OS_VERSION STREQUAL "24.04"))
+            set(OS_FAMILY "linux")
+            string(REPLACE "." "_" OS_VERSION_UNDERSCORE ${OS_VERSION})
+            set(OS_UPPERCASE "UBUNTU_${OS_VERSION_UNDERSCORE}")
+
+            set(PLUGIN_COMPILER_PACKAGE_PREFIX "npu_compiler_vcl_ubuntu_${OS_VERSION_UNDERSCORE}")
+            set(PLUGIN_COMPILER_PACKAGE_EXT "tar.gz")
+            set(PLUGIN_COMPILER_ARCHIVE_TYPE "ARCHIVE_LIN")
+            set(PLUGIN_COMPILER_LIB_OLD_NAME "libnpu_driver_compiler.so")
+            set(PLUGIN_COMPILER_LIB_NEW_NAME "libopenvino_intel_npu_compiler.so")
+        else()
+            message(STATUS "${OS_NAME} ${OS_VERSION} Linux distribution is not supported, skip downloading prebuilt Plugin Compiler libraries. Can not use plugin compiler libraries!")
+            return()
+        endif()
+    else()
+        message(STATUS "Current OS is not supported, skip downloading prebuilt Plugin Compiler libraries. Can not use plugin compiler libraries!")
+        return()
+    endif()
+
+    set(PLUGIN_COMPILER_PACKAGE_SUBDIR "")
+    set(PLUGIN_COMPILER_PACKAGE_NAME "${PLUGIN_COMPILER_PACKAGE_PREFIX}-${PLUGIN_COMPILER_VERSION_UNDERSCORE}-${PLUGIN_COMPILER_COMMIT_SHA}.${PLUGIN_COMPILER_PACKAGE_EXT}")
+    if(DEFINED ENV{THIRDPARTY_SERVER_PATH})
+        set(IE_PATH_TO_DEPS "$ENV{THIRDPARTY_SERVER_PATH}")
+        set(PLUGIN_COMPILER_PACKAGE_SUBDIR "npu_compiler/")
+    elseif(DEFINED THIRDPARTY_SERVER_PATH)
+        set(IE_PATH_TO_DEPS "${THIRDPARTY_SERVER_PATH}")
+        set(PLUGIN_COMPILER_PACKAGE_SUBDIR "npu_compiler/")
+    endif()
+
+    RESOLVE_DEPENDENCY(NPU_PLUGIN_COMPILER
+            ${PLUGIN_COMPILER_ARCHIVE_TYPE} "${PLUGIN_COMPILER_PACKAGE_SUBDIR}${PLUGIN_COMPILER_PACKAGE_NAME}"
+            TARGET_PATH "${TEMP}/${PLATFORM_SUBDIR}/npu_compiler_${PLUGIN_COMPILER_VERSION_UNDERSCORE}_${PLUGIN_COMPILER_COMMIT_SHA}"
+            ENVIRONMENT "NPU_PLUGIN_COMPILER_ROOT"
+            FOLDER
+            SHA256 "${PLUGIN_COMPILER_${OS_UPPERCASE}_CHECKSUM}"
+            USE_NEW_LOCATION TRUE)
+
+    if(NPU_PLUGIN_COMPILER)
+        message(STATUS "Using prebuilt NPU Plugin Compiler libraries from ${NPU_PLUGIN_COMPILER}")
+        print_build_manifest("${NPU_PLUGIN_COMPILER}/build_manifest.json")
+
+        set(PLUGIN_COMPILER_LIB_PATH "${NPU_PLUGIN_COMPILER}/lib")
+
         configure_file(
-            ${PLUGIN_COMPILER_LIB_PATH}/npu_driver_compiler.dll
-            ${PLUGIN_COMPILER_LIB_PATH}/openvino_intel_npu_compiler.dll
+            "${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_OLD_NAME}"
+            "${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_NEW_NAME}"
             COPYONLY
         )
-        set(PLUGIN_COMPILER_LIB "${PLUGIN_COMPILER_LIB_PATH}/openvino_intel_npu_compiler.dll")
-        file(COPY "${PLUGIN_COMPILER_LIB}"
-            DESTINATION "${NPU_COMPILER_LIB_DESTINATION}")
-        message(STATUS "Copying prebuilt Plugin compiler libraries openvino_intel_npu_compiler.dll to ${NPU_COMPILER_LIB_DESTINATION} for windows")
-    else()
-        # Check if the operating system is Linux and not macOS
-        if(UNIX AND NOT APPLE)
-            # Get the OS name and version
-            execute_process(COMMAND lsb_release -is OUTPUT_VARIABLE OS_NAME OUTPUT_STRIP_TRAILING_WHITESPACE)
-            execute_process(COMMAND lsb_release -rs OUTPUT_VARIABLE OS_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-            if(OS_NAME STREQUAL "Ubuntu")
-                if(OS_VERSION STREQUAL "22.04")
-                    # Ubuntu 22.04-specific settings or actions
-                    set(PLUGIN_COMPILER_LIBS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/temp/compiler_libs/ubuntu22.04")
-                    set(PLUGIN_COMPILER_LIBS_URL "https://storage.openvinotoolkit.org/dependencies/thirdparty/linux/npu_compiler_vcl_ubuntu_22_04-${PLUGIN_COMPILER_VERSION}-${PLUGIN_COMPILER_COMMIT_SHA}.tar.gz")
-                    set(PLUGIN_COMPILER_LIBS_TAR "${PLUGIN_COMPILER_LIBS_DIR}/npu_compiler_vcl_ubuntu_22_04-${PLUGIN_COMPILER_VERSION}-${PLUGIN_COMPILER_COMMIT_SHA}.tar.gz")
-                    set(PLUGIN_COMPILER_LIBS_DIR_EXTRACTED "${PLUGIN_COMPILER_LIBS_DIR}/npu_compiler_vcl_ubuntu_22_04-${PLUGIN_COMPILER_VERSION}-${PLUGIN_COMPILER_COMMIT_SHA}")
-
-                    download_and_extract("${PLUGIN_COMPILER_LIBS_URL}" "${PLUGIN_COMPILER_LIBS_TAR}" "${PLUGIN_COMPILER_LIBS_DIR_EXTRACTED}")
-                    print_build_manifest("${PLUGIN_COMPILER_LIBS_DIR_EXTRACTED}/build_manifest.json")
-                    
-                    set(PLUGIN_COMPILER_LIB_PATH "${PLUGIN_COMPILER_LIBS_DIR_EXTRACTED}/lib/")
-                    configure_file(
-                        ${PLUGIN_COMPILER_LIB_PATH}/libnpu_driver_compiler.so
-                        ${PLUGIN_COMPILER_LIB_PATH}/libopenvino_intel_npu_compiler.so
-                        COPYONLY
-                    )
-                    set(PLUGIN_COMPILER_LIB "${PLUGIN_COMPILER_LIB_PATH}/libopenvino_intel_npu_compiler.so")
-                    file(COPY "${PLUGIN_COMPILER_LIB}" DESTINATION "${NPU_COMPILER_LIB_DESTINATION}")
-                    message(STATUS "Copying prebuilt Plugin compiler libraries libopenvino_intel_npu_compiler.so to ${NPU_COMPILER_LIB_DESTINATION} for Ubuntu 22.04")
-                elseif(OS_VERSION STREQUAL "24.04")
-                    message(STATUS "This is Ubuntu 24.04")
-                    set(PLUGIN_COMPILER_LIBS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/temp/compiler_libs/ubuntu24.04")
-                    set(PLUGIN_COMPILER_LIBS_URL "https://storage.openvinotoolkit.org/dependencies/thirdparty/linux/npu_compiler_vcl_ubuntu_24_04-${PLUGIN_COMPILER_VERSION}-${PLUGIN_COMPILER_COMMIT_SHA}.tar.gz")
-                    set(PLUGIN_COMPILER_LIBS_TAR "${PLUGIN_COMPILER_LIBS_DIR}/npu_compiler_vcl_ubuntu_24_04-${PLUGIN_COMPILER_VERSION}-${PLUGIN_COMPILER_COMMIT_SHA}.tar.gz")
-                    set(PLUGIN_COMPILER_LIBS_DIR_EXTRACTED "${PLUGIN_COMPILER_LIBS_DIR}/npu_compiler_vcl_ubuntu_24_04-${PLUGIN_COMPILER_VERSION}-${PLUGIN_COMPILER_COMMIT_SHA}")
-
-                    download_and_extract("${PLUGIN_COMPILER_LIBS_URL}" "${PLUGIN_COMPILER_LIBS_TAR}" "${PLUGIN_COMPILER_LIBS_DIR_EXTRACTED}")
-                    print_build_manifest("${PLUGIN_COMPILER_LIBS_DIR_EXTRACTED}/build_manifest.json")
-                    
-                    set(PLUGIN_COMPILER_LIB_PATH "${PLUGIN_COMPILER_LIBS_DIR_EXTRACTED}/lib/")
-                    configure_file(
-                        ${PLUGIN_COMPILER_LIB_PATH}/libnpu_driver_compiler.so
-                        ${PLUGIN_COMPILER_LIB_PATH}/libopenvino_intel_npu_compiler.so
-                        COPYONLY
-                    )
-                    set(PLUGIN_COMPILER_LIB "${PLUGIN_COMPILER_LIB_PATH}/libopenvino_intel_npu_compiler.so")
-                    file(COPY "${PLUGIN_COMPILER_LIB}" DESTINATION "${NPU_COMPILER_LIB_DESTINATION}")
-                    message(STATUS "Copying prebuilt Plugin compiler libraries libopenvino_intel_npu_compiler.so to ${NPU_COMPILER_LIB_DESTINATION} for Ubuntu 24.04")
-                endif()
-            else()
-            message(STATUS "This is a different Linux distribution: ${OS_NAME}, skip downloading prebuilt Plugin compiler libraries. Can not use plugin compiler libraries!")
-                # Other Linux-specific settings or actions
-            endif()
+        if(USE_BUILD_TYPE_SUBFOLDER)
+            set(PLUGIN_COMPILER_LIB_DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+        else()
+            set(PLUGIN_COMPILER_LIB_DESTINATION "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}")
         endif()
-    endif()
 
-    install(FILES ${PLUGIN_COMPILER_LIB}
-        DESTINATION ${OV_CPACK_PLUGINSDIR} COMPONENT ${NPU_PLUGIN_COMPONENT})
+        set(PLUGIN_COMPILER_LIB "${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_NEW_NAME}")
+        file(COPY "${PLUGIN_COMPILER_LIB}" DESTINATION "${PLUGIN_COMPILER_LIB_DESTINATION}")
+        message(STATUS "Copying prebuilt Plugin compiler library ${PLUGIN_COMPILER_LIB_PATH}/${PLUGIN_COMPILER_LIB_NEW_NAME} to ${PLUGIN_COMPILER_LIB_DESTINATION}")
+
+        install(FILES ${PLUGIN_COMPILER_LIB} DESTINATION ${OV_CPACK_PLUGINSDIR} COMPONENT ${NPU_PLUGIN_COMPONENT})
+    else()
+        message(FATAL_ERROR "Failed to download prebuilt NPU Plugin Compiler libraries. Can not use plugin compiler libraries!")
+    endif()
 endif()


### PR DESCRIPTION
### Details:
 - NPU Plugin compiler cmake script is aligned with other OV dependencies 
 - NPU Plugin compiler update 
   - https://storage.openvinotoolkit.org/dependencies/thirdparty/windows/npu_compiler_vcl_windows_2022-8_1_0-727e603.zip
   - https://storage.openvinotoolkit.org/dependencies/thirdparty/linux/npu_compiler_vcl_ubuntu_22_04-8_1_0-727e603.tar.gz
   - https://storage.openvinotoolkit.org/dependencies/thirdparty/linux/npu_compiler_vcl_ubuntu_24_04-8_1_0-727e603.tar.gz

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
