### PR TITLE
Fix APT mirrors for Debian Packages job

### DIFF
--- a/.github/workflows/job_debian_packages.yml
+++ b/.github/workflows/job_debian_packages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Switch Ubuntu APT sources to Azure mirrors
         if: runner.os == 'Linux'
         run: |
-          sed -i -E 's|http://(archive\|security).ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sed -i -E 's|http://(archive\|security).ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
 
       - name: Download OpenVINO debian packages
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0

--- a/.github/workflows/job_debian_packages.yml
+++ b/.github/workflows/job_debian_packages.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Switch Ubuntu APT sources to Azure mirrors
         if: runner.os == 'Linux'
         run: |
+          # compatible with both Ubuntu 22.04 and 24.04, which have different formats of sources.list files
+          touch /etc/apt/sources.list.d/ubuntu.sources
+          sed -i -E 's|http://(archive\|security).ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
           sed -i -E 's|http://(archive\|security).ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
 
       - name: Download OpenVINO debian packages


### PR DESCRIPTION
### Details:
It turns out Ubuntu 24.04 have its repositories in a different file, this PR fixes `sed` command that switches to Ubuntu repository mirror in Azure (faster speeds, less networking errors)
