### PR TITLE
[GHA] Fix copyright check workflow in case all changes are deletions

### DIFF
--- a/.github/workflows/copyright_check.yml
+++ b/.github/workflows/copyright_check.yml
@@ -24,7 +24,8 @@ jobs:
           
           # Extract changed file names from the diff
           # Lines starting with +++ indicate new/modified files (skip /dev/null for deleted files)
-          grep '^+++' pr.diff | sed 's|^+++ b/||' | grep -v '/dev/null' > changed_files.txt
+          # || true prevents grep from failing with exit code 1 when all changes are deletions
+          grep '^+++' pr.diff | sed 's|^+++ b/||' | grep -v '/dev/null' > changed_files.txt || true
 
       - name: Check copyright headers
         id: check


### PR DESCRIPTION
### Details:
- Failure example, the latest grep returns exit code 1 when nothing else except /dev/null is found: https://github.com/openvinotoolkit/openvino/actions/runs/24531278015/job/71714803074?pr=35394
