### PR TITLE
cache serialization for ReadValueWithSubgraph

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/read_value_with_subgraph.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/read_value_with_subgraph.cpp
@@ -90,8 +90,8 @@ bool ov::intel_cpu::ReadValueWithSubgraph::visit_attributes(AttributeVisitor& vi
     m_variable->update(variable_info);
 
     visitor.on_attribute("body", m_bodies[0]);
-    visitor.on_attribute("inputs", m_input_descriptions[0]);
-    visitor.on_attribute("outputs", m_output_descriptions[0]);
+    visitor.on_attribute("input_descriptions", m_input_descriptions[0]);
+    visitor.on_attribute("output_descriptions", m_output_descriptions[0]);
     return true;
 }
 

--- a/src/plugins/intel_cpu/tests/unit/transformations/readvalue_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/readvalue_subgraph.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.hpp>
 #include <transformations/init_node_info.hpp>
 
@@ -12,6 +13,7 @@
 #include "openvino/op/convert.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/read_value.hpp"
+#include "openvino/pass/serialize.hpp"
 #include "transformations/cpu_opset/common/op/read_value_with_subgraph.hpp"
 
 using namespace testing;
@@ -229,4 +231,50 @@ TEST(TransformationTests, ReadValueWithSubgraph_2) {
         auto res = compare_functions(model, model_ref, 0, 0, 0, 0, 0, 0);
         ASSERT_TRUE(res.first) << res.second;
     }
+}
+
+static std::shared_ptr<ov::intel_cpu::ReadValueWithSubgraph> constructRVWithSubGraph3(
+    std::shared_ptr<ov::op::v0::Parameter> input_lhs,
+    std::shared_ptr<ov::op::v0::Parameter> input_rhs,
+    std::shared_ptr<ov::op::util::Variable> variable) {
+    auto func_input_lhs =
+        std::make_shared<ov::op::v0::Parameter>(input_lhs->get_element_type(), input_lhs->get_output_partial_shape(0));
+    auto func_input_rhs =
+        std::make_shared<ov::op::v0::Parameter>(input_rhs->get_element_type(), input_rhs->get_output_partial_shape(0));
+
+    auto add = std::make_shared<ov::op::v1::Add>(func_input_lhs, func_input_rhs);
+    auto func_output = std::make_shared<ov::op::v0::Result>(add);
+
+    auto func = std::make_shared<ov::Model>(ov::OutputVector({func_output}),
+                                            ov::ParameterVector{func_input_lhs, func_input_rhs},
+                                            "state_init_submodel_no_const");
+
+    auto readvalue = std::make_shared<ov::intel_cpu::ReadValueWithSubgraph>(variable, func);
+    readvalue->set_input(input_lhs->output(0), func_input_lhs);
+    readvalue->set_input(input_rhs->output(0), func_input_rhs);
+    readvalue->set_output(func_output);
+    readvalue->validate_and_infer_types();
+
+    return readvalue;
+}
+
+TEST(TransformationTests, ReadValueWithSubgraph_Serialize) {
+    const ov::PartialShape shape{1, 1, 2};
+    const ov::element::Type type = ov::element::f32;
+    auto variable =
+        std::make_shared<ov::op::util::Variable>(ov::op::util::VariableInfo{ov::PartialShape{1, 1, 2}, type, "var_id"});
+
+    auto input = std::make_shared<ov::op::v0::Parameter>(type, shape);
+    auto input_rhs = std::make_shared<ov::op::v0::Parameter>(type, shape);
+    auto readvalue = constructRVWithSubGraph3(input, input_rhs, variable);
+    auto assign = std::make_shared<ov::op::v6::Assign>(readvalue, variable);
+    auto result = std::make_shared<ov::op::v0::Result>(readvalue);
+
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result},
+                                             ov::SinkVector{assign},
+                                             ov::ParameterVector{input, input_rhs});
+
+    std::stringstream model_ss;
+    std::stringstream weights_ss;
+    ASSERT_NO_THROW(ov::pass::Serialize(model_ss, weights_ss).run_on_model(model));
 }


### PR DESCRIPTION
### Details:
 - *The CPU custom op ReadValueWithSubgraph uses attribute names inputs and outputs which is not expected body target attribute name in XML serialization, caused whisper model compilation fails with cache_dir*. This PR changed the attribute name in ReadValueWithSubgraph

### Tickets:
 - *CVS-183302*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
