### PR TITLE
[GPU] Fix Correct return type in DECLARE_LOWER/UPPER_BOUND macros

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/algorithm.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/algorithm.cl
@@ -3,7 +3,7 @@
 //
 
 #define DECLARE_LOWER_BOUND(Name, Type, ValType, GetIndex)                                        \
-    inline Type* FUNC(Name)(const Type* data, uint first_index, uint last_index, ValType value) { \
+    inline uint FUNC(Name)(const Type* data, uint first_index, uint last_index, ValType value) { \
         uint count = last_index - first_index;                                                    \
         while (count > 0) {                                                                       \
             const uint step = count / 2;                                                          \
@@ -19,7 +19,7 @@
     }
 
 #define DECLARE_UPPER_BOUND(Name, Type, ValType, GetIndex)                                        \
-    inline Type* FUNC(Name)(const Type* data, uint first_index, uint last_index, ValType value) { \
+    inline uint FUNC(Name)(const Type* data, uint first_index, uint last_index, ValType value) { \
         uint count = last_index - first_index;                                                    \
         while (count > 0) {                                                                       \
             const uint step = count / 2;                                                          \


### PR DESCRIPTION
Fix GPU kernel compilation: correct return type in binary search macros.

DECLARE_LOWER/UPPER_BOUND macros declared `Type*` return type but returned `uint` indices. This caused kernel compilation failure on certain GPU targets when bucketize uses float input + float16 buckets.

Changed: `inline Type*`-> `inline uint`

Compiler behavior may vary across hardware architectures, which is why this fix ensures consistent compilation across all targets.

### Tickets:
 - *185056*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
