### PR TITLE
[TF Lite FE] Migrate GraphIteratorFlatBuffer to use std::filesystem::path

### DIFF
--- a/src/frontends/tensorflow_lite/src/frontend.cpp
+++ b/src/frontends/tensorflow_lite/src/frontend.cpp
@@ -58,8 +58,7 @@ bool FrontEnd::supported_impl(const std::vector<ov::Any>& variants) const {
         return false;
 
     if (const auto path = ov::frontend::get_path_from_any(variants[0])) {
-        const auto model_path = path.value().native();
-        if (GraphIteratorFlatBuffer::is_supported(model_path)) {
+        if (GraphIteratorFlatBuffer::is_supported(path.value())) {
             return true;
         }
     } else if (variants[0].is<GraphIterator::Ptr>()) {
@@ -73,10 +72,9 @@ ov::frontend::InputModel::Ptr FrontEnd::load_impl(const std::vector<ov::Any>& va
     size_t extra_variants_num = variants.size() > 0 && variants[variants.size() - 1].is<bool>() ? 1 : 0;
     if (variants.size() == 1 + extra_variants_num) {
         if (const auto path = ov::frontend::get_path_from_any(variants[0])) {
-            const auto model_path = path.value().native();
-            if (GraphIteratorFlatBuffer::is_supported(model_path)) {
+            if (GraphIteratorFlatBuffer::is_supported(path.value())) {
                 return std::make_shared<tensorflow_lite::InputModel>(
-                    std::make_shared<GraphIteratorFlatBuffer>(model_path),
+                    std::make_shared<GraphIteratorFlatBuffer>(path.value()),
                     m_telemetry);
             }
         } else if (variants[0].is<GraphIterator::Ptr>()) {

--- a/src/frontends/tensorflow_lite/src/frontend.cpp
+++ b/src/frontends/tensorflow_lite/src/frontend.cpp
@@ -58,7 +58,7 @@ bool FrontEnd::supported_impl(const std::vector<ov::Any>& variants) const {
         return false;
 
     if (const auto path = ov::frontend::get_path_from_any(variants[0])) {
-        if (GraphIteratorFlatBuffer::is_supported(path.value())) {
+        if (GraphIteratorFlatBuffer::is_supported(*path)) {
             return true;
         }
     } else if (variants[0].is<GraphIterator::Ptr>()) {
@@ -72,10 +72,9 @@ ov::frontend::InputModel::Ptr FrontEnd::load_impl(const std::vector<ov::Any>& va
     size_t extra_variants_num = variants.size() > 0 && variants[variants.size() - 1].is<bool>() ? 1 : 0;
     if (variants.size() == 1 + extra_variants_num) {
         if (const auto path = ov::frontend::get_path_from_any(variants[0])) {
-            if (GraphIteratorFlatBuffer::is_supported(path.value())) {
-                return std::make_shared<tensorflow_lite::InputModel>(
-                    std::make_shared<GraphIteratorFlatBuffer>(path.value()),
-                    m_telemetry);
+            if (GraphIteratorFlatBuffer::is_supported(*path)) {
+                return std::make_shared<tensorflow_lite::InputModel>(std::make_shared<GraphIteratorFlatBuffer>(*path),
+                                                                     m_telemetry);
             }
         } else if (variants[0].is<GraphIterator::Ptr>()) {
             auto graph_iterator = variants[0].as<GraphIterator::Ptr>();

--- a/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.cpp
+++ b/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.cpp
@@ -10,14 +10,7 @@
 
 using namespace ov::frontend::tensorflow_lite;
 
-#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-
-GraphIteratorFlatBuffer::GraphIteratorFlatBuffer(const std::wstring& path)
-    : GraphIteratorFlatBuffer(ov::util::wstring_to_string(path)) {}
-
-#endif  // OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-
-GraphIteratorFlatBuffer::GraphIteratorFlatBuffer(const std::string& path) {
+GraphIteratorFlatBuffer::GraphIteratorFlatBuffer(const std::filesystem::path& path) {
     std::ifstream model_file(path, std::ios::binary | std::ios::in);
     FRONT_END_GENERAL_CHECK(model_file && model_file.is_open(), "Model file does not exist: ", path);
 
@@ -26,9 +19,9 @@ GraphIteratorFlatBuffer::GraphIteratorFlatBuffer(const std::string& path) {
 
     flatbuffers::Verifier verifier(m_data.data(), m_data.size());
     FRONT_END_GENERAL_CHECK(tflite::VerifyModelBuffer(verifier),
-                            "TensorFlow Lite Frontend: the model file \"",
+                            "TensorFlow Lite Frontend: the model file ",
                             path,
-                            "\" is corrupted or malformed (FlatBuffer verification failed).");
+                            " is corrupted or malformed (FlatBuffer verification failed).");
 
     m_model = tflite::GetModel(m_data.data());
     FRONT_END_GENERAL_CHECK(m_model != nullptr, "Failed to parse TFLite model from file: ", path);
@@ -176,15 +169,3 @@ std::shared_ptr<DecoderBase> GraphIteratorFlatBuffer::get_decoder() const {
         return std::make_shared<DecoderFlatBufferTensors>(info, input_idx, output_idx);
     }
 }
-
-template <>
-std::basic_string<char> ov::frontend::tensorflow_lite::get_model_extension<char>() {
-    return ::tflite::ModelExtension();
-}
-
-#if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
-template <>
-std::basic_string<wchar_t> ov::frontend::tensorflow_lite::get_model_extension<wchar_t>() {
-    return util::string_to_wstring(::tflite::ModelExtension());
-}
-#endif

--- a/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.hpp
+++ b/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.hpp
@@ -4,16 +4,13 @@
 
 #pragma once
 
+#include <filesystem>
 #include <fstream>
-#if defined(__MINGW32__) || defined(__MINGW64__)
-#    include <filesystem>
-#endif
 
 #include "openvino/core/any.hpp"
 #include "openvino/frontend/exception.hpp"
 #include "openvino/frontend/tensorflow_lite/decoder.hpp"
 #include "openvino/frontend/tensorflow_lite/graph_iterator.hpp"
-#include "openvino/util/common_util.hpp"
 #include "openvino/util/file_util.hpp"
 #include "schema_generated.h"
 
@@ -26,16 +23,6 @@ struct TensorInfo {
     const tflite::Buffer* buffer;
 };
 
-template <typename T>
-std::basic_string<T> get_model_extension() {}
-template <>
-std::basic_string<char> get_model_extension<char>();
-
-#if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
-template <>
-std::basic_string<wchar_t> get_model_extension<wchar_t>();
-#endif
-
 class GraphIteratorFlatBuffer : public GraphIterator {
     size_t node_index = 0;
     std::vector<uint8_t> m_data;
@@ -46,25 +33,18 @@ class GraphIteratorFlatBuffer : public GraphIterator {
 
 public:
     GraphIteratorFlatBuffer() = default;
-    explicit GraphIteratorFlatBuffer(const std::string& path);
-
-#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-    explicit GraphIteratorFlatBuffer(const std::wstring& path);
-#endif
+    explicit GraphIteratorFlatBuffer(const std::filesystem::path& path);
 
     using Ptr = std::shared_ptr<GraphIteratorFlatBuffer>;
 
     ~GraphIteratorFlatBuffer() = default;
 
     /// Verifies file is supported
-    template <typename T>
-    static bool is_supported(const std::basic_string<T>& path) {
-        FRONT_END_GENERAL_CHECK(util::file_exists(path),
-                                "Could not open the file: \"",
-                                util::path_to_string(path),
-                                '"');
+    static bool is_supported(const std::filesystem::path& path) {
+        FRONT_END_GENERAL_CHECK(util::file_exists(path), "Could not open the file: ", path);
+
         try {
-            if (!ov::util::ends_with<T>(path, get_model_extension<T>())) {
+            if (path.extension() != std::filesystem::path("." + std::string(::tflite::ModelExtension()))) {
                 return false;
             }
             const std::streamsize offset_size = static_cast<std::streamsize>(sizeof(::flatbuffers::uoffset_t));
@@ -73,11 +53,7 @@ public:
             if (file_size < offset_size) {
                 return false;
             }
-#if defined(__MINGW32__) || defined(__MINGW64__)
-            std::ifstream tflite_stream(std::filesystem::path(path), std::ios::in | std::ifstream::binary);
-#else
             std::ifstream tflite_stream(path, std::ios::in | std::ifstream::binary);
-#endif
             char buf[offset_size * 2 + 1] = {};  // +1 is used to overcome gcc's -Wstringop-overread warning
             tflite_stream.read(buf, offset_size * 2);
             // If we have enough read bytes - try to detect prefixed identifier, else try without size prefix


### PR DESCRIPTION
### Details:
 - _tensorflow_lite/src/frontend.cpp_ methods pass `std::filesystem::path` directly instead of extracting `.native()`
 - Replaces `std::string/std::wstring` path parameters with `std::filesystem::path` in `GraphIteratorFlatBuffer` constructor and `is_supported()` method

### Tickets:
 - part of [CVS-146661](https://jira.devtools.intel.com/browse/CVS-146661)

### AI Assistance:
 - yes, codebase analysis
