### PR TITLE
[Docs] Expand weightless caching documentation with enable_weightless and NPU/CPU support

### DIFF
--- a/docs/articles_en/assets/snippets/ov_caching.cpp
+++ b/docs/articles_en/assets/snippets/ov_caching.cpp
@@ -149,6 +149,50 @@ auto compiled = core.compile_model(modelPath,
     }
 }
 
+void part7() {
+    std::string modelPath = "/tmp/myModel.xml";
+    std::string device = "NPU";
+    ov::Core core;
+    core.set_property(ov::cache_dir("/path/to/cache/dir"));
+//! [ov:caching:part7]
+// Explicitly enable weightless caching using the ov::enable_weightless property.
+// This is supported on NPU, GPU, and CPU devices.
+auto compiled = core.compile_model(modelPath,
+                                   device,
+                                   ov::enable_weightless(true));
+//! [ov:caching:part7]
+    if (!compiled) {
+        throw std::runtime_error("error");
+    }
+}
+
+void part8() {
+    std::string modelPath = "/tmp/myModel.xml";
+    std::string device = "NPU";
+    ov::Core core;
+    core.set_property(ov::cache_dir("/path/to/cache/dir"));
+    auto model = core.read_model(modelPath);
+//! [ov:caching:part8]
+// When loading a weightless cached model, you can provide the weights
+// using ov::weights_path or ov::hint::model.
+
+// Option 1: Provide weights via file path
+auto compiled = core.compile_model(model,
+                                   device,
+                                   ov::enable_weightless(true),
+                                   ov::weights_path("/path/to/model.bin"));
+
+// Option 2: Provide weights via the original model
+auto compiled2 = core.compile_model(model,
+                                    device,
+                                    ov::enable_weightless(true),
+                                    ov::hint::model(model));
+//! [ov:caching:part8]
+    if (!compiled || !compiled2) {
+        throw std::runtime_error("error");
+    }
+}
+
 int main() {
     try {
         part0();
@@ -158,6 +202,8 @@ int main() {
         part4();
         part5();
         part6();
+        part7();
+        part8();
     } catch (...) {
     }
     return 0;

--- a/docs/articles_en/assets/snippets/ov_caching.py
+++ b/docs/articles_en/assets/snippets/ov_caching.py
@@ -87,3 +87,30 @@ if any("GPU" in device for device in core.available_devices):
     config_cache["CACHE_MODE"] = "OPTIMIZE_SIZE"
     compiled_model = core.compile_model(model=model_path, device_name='GPU', config=config_cache)
 # ! [ov:caching:part6]
+
+# ! [ov:caching:part7]
+import openvino.properties as props
+
+core = ov.Core()
+core.set_property({props.cache_dir: path_to_cache_dir})
+# Explicitly enable weightless caching using the ENABLE_WEIGHTLESS property.
+# This is supported on NPU, GPU, and CPU devices.
+config_weightless = {"ENABLE_WEIGHTLESS": True}
+compiled_model = core.compile_model(model=model_path, device_name="NPU", config=config_weightless)
+# ! [ov:caching:part7]
+
+# ! [ov:caching:part8]
+core = ov.Core()
+core.set_property({props.cache_dir: path_to_cache_dir})
+model = core.read_model(model=model_path)
+
+# When loading a weightless cached model, provide the weights
+# using WEIGHTS_PATH or MODEL_PTR.
+
+# Option 1: Provide weights via file path
+config_weights = {
+    "ENABLE_WEIGHTLESS": True,
+    "WEIGHTS_PATH": "/path/to/model.bin",
+}
+compiled_model = core.compile_model(model=model, device_name="NPU", config=config_weights)
+# ! [ov:caching:part8]

--- a/docs/articles_en/openvino-workflow/running-inference/optimize-inference/optimizing-latency/model-caching-overview.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/optimize-inference/optimizing-latency/model-caching-overview.rst
@@ -143,7 +143,9 @@ model caching, use the following code in your application:
 Set ``CacheMode`` property to ``OPTIMIZE_SIZE`` to enable weightless caching
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Weightless caching is a feature that allows you to create a cache file which doesn't contain the weights of the model. Instead, the weights are loaded from the original model file. This helps to reduce the size of the cache file.
+Weightless caching is a feature that allows you to create a cache file which doesn't contain the weights of the model. Instead, the weights are loaded from the original model file. This helps to reduce the size of the cache file and lower peak memory consumption during compilation — which is especially beneficial for edge and client deployments.
+
+You can enable weightless caching implicitly by setting the ``cache_mode`` property to ``OPTIMIZE_SIZE``:
 
 .. tab-set::
 
@@ -161,9 +163,61 @@ Weightless caching is a feature that allows you to create a cache file which doe
          :language: cpp
          :fragment: [ov:caching:part4]
 
+
+Explicitly enable weightless caching using ``enable_weightless``
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+You can also enable weightless caching explicitly using the ``ov::enable_weightless`` property (``ENABLE_WEIGHTLESS``). This property takes priority over ``cache_mode`` when both are specified.
+
+.. tab-set::
+
+   .. tab-item:: Python
+      :sync: py
+
+      .. doxygensnippet:: docs/articles_en/assets/snippets/ov_caching.py
+         :language: py
+         :fragment: [ov:caching:part7]
+
+   .. tab-item:: C++
+      :sync: cpp
+
+      .. doxygensnippet:: docs/articles_en/assets/snippets/ov_caching.cpp
+         :language: cpp
+         :fragment: [ov:caching:part7]
+
+
+Providing weights for weightless cache reload
+++++++++++++++++++++++++++++++++++++++++++++++
+
+When a weightless cached model is loaded, the weights must be provided separately. You can do this using one of the following options:
+
+- ``ov::weights_path`` (``WEIGHTS_PATH``) — path to the ``.bin`` file containing the weights.
+- ``ov::hint::model`` (``MODEL_PTR``) — a shared pointer to the original ``ov::Model`` object.
+- Passing the original model directly to ``compile_model`` — in this case, the model itself serves as the weight source.
+
+If ``ov::hint::model`` and ``ov::weights_path`` are both provided, ``ov::hint::model`` takes priority.
+
+.. tab-set::
+
+   .. tab-item:: Python
+      :sync: py
+
+      .. doxygensnippet:: docs/articles_en/assets/snippets/ov_caching.py
+         :language: py
+         :fragment: [ov:caching:part8]
+
+   .. tab-item:: C++
+      :sync: cpp
+
+      .. doxygensnippet:: docs/articles_en/assets/snippets/ov_caching.cpp
+         :language: cpp
+         :fragment: [ov:caching:part8]
+
 .. important::
 
-   Currently, this property is supported only by the GPU Plugin and IR model format.
+   Weightless caching is supported by the GPU, NPU, and CPU plugins. The behavior may vary slightly
+   across devices — for example, NPU uses an internal weights separation mechanism, while GPU and CPU
+   rely on the shared weightless caching infrastructure.
 
 .. important::
 


### PR DESCRIPTION
### Details:

Fixes #35339

The release notes mention a "release-weights API for `ov::Model`" but no documentation exists explaining how to use it. The existing Model Caching Overview page had a basic weightless caching section that only covered `CacheMode::OPTIMIZE_SIZE` for GPU.

This PR expands the weightless caching documentation to cover:

- **`ov::enable_weightless`** (`ENABLE_WEIGHTLESS`) property for explicit weightless caching control
- **`ov::weights_path`** (`WEIGHTS_PATH`) for providing weights on cache reload
- **`ov::hint::model`** (`MODEL_PTR`) as an alternative weight source
- Updated device support: **GPU, NPU, and CPU** (was GPU-only)
- New C++ and Python code snippets demonstrating usage

### Files changed:

- `docs/articles_en/openvino-workflow/running-inference/optimize-inference/optimizing-latency/model-caching-overview.rst` — expanded weightless caching section with new subsections
- `docs/articles_en/assets/snippets/ov_caching.cpp` — added `part7` (enable_weightless) and `part8` (weights_path) snippets
- `docs/articles_en/assets/snippets/ov_caching.py` — added `part7` and `part8` Python snippets
