### PR TITLE
[CI] Remove duplicate steps key in cleanup_caches workflow

### DIFF
--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -46,7 +46,6 @@ jobs:
     env:
       HF_CACHE_PATH: /mount/caches/huggingface
     steps:
-      steps:
       - name: Pre-Collecting Cache Info
         run: |
           echo "Cache info: "


### PR DESCRIPTION
The `Cleanup_hf_cache` job has a duplicated `steps:` key which prevents the workflow from parsing on forks. Removing the inner duplicate.

### AI Assistance
 - no