### PR TITLE
Introduce new check for CompressFloatConstantsImpl

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -76,7 +76,8 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
         }
     }
 
-    // if more than 75% of a FP32 constant do not fit into FP16 keep in FP32
+    // if more than 75% of elements are rejected (outside FP16 range or FP16
+    // round-trip relative error exceeds the threshold), keep the Constant in FP32
     const double out_of_range_proportion = static_cast<double>(num_out_of_range) / static_cast<double>(size);
 
     if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold) {
@@ -190,7 +191,8 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
             if (check.has_lossy)
                 return false;
 
-            // if more than 75% of a FP32 constant do not fit into FP16 keep in FP32
+            // if more than 75% of elements are rejected (outside FP16 range or FP16
+    // round-trip relative error exceeds the threshold), keep the Constant in FP32
             const float out_of_range_proportion =
                 static_cast<float>(check.out_of_range_count) / static_cast<float>(size);
             if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold)

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -58,26 +58,19 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
             dst_data[i] = std::numeric_limits<ov::float16>::lowest();
             num_out_of_range++;
         } else {
-            constexpr double max_relative_error = ov::reference::f16_compression_max_rel_error;
-            constexpr double max_abs_error = ov::reference::f16_compression_max_abs_error;
             const ov::float16 f16_val = static_cast<ov::float16>(src_data[i]);
             const double src_val = static_cast<double>(src_data[i]);
             const double roundtripped = static_cast<double>(static_cast<src_type>(f16_val));
             const double abs_diff = std::abs(src_val - roundtripped);
 
-            if (abs_diff > max_abs_error) {
+            if (abs_diff > ov::reference::f16_compression_max_abs_error) {
                 return nullptr;
-            }
-
-            if (src_val != 0.0 && abs_diff / std::abs(src_val) > max_relative_error) {
-                num_out_of_range++;
             }
             dst_data[i] = f16_val;
         }
     }
 
-    // if more than 75% of elements are rejected (outside FP16 range or FP16
-    // round-trip relative error exceeds the threshold), keep the Constant in FP32
+    // if more than 75% of elements fall outside the finite FP16 range, keep the Constant in FP32
     const double out_of_range_proportion = static_cast<double>(num_out_of_range) / static_cast<double>(size);
 
     if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold) {
@@ -91,6 +84,23 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
     } else {
         return new_constant;
     }
+}
+
+// Returns true if a scalar constant of type T loses significant precision when rounded to FP16.
+// Used to protect mathematical scale factors (e.g. log(16) in attention bucketing) from FP16
+// rounding errors that cascade through every computation referencing them. Tensor-wide
+// compression decisions do not use this check — bulk weights tolerate FP16 quantization noise.
+template <typename T>
+bool scalar_has_high_f16_error(const ov::op::v0::Constant& const_node) {
+    static_assert(sizeof(T) >= 4);
+    const T src = *const_node.get_data_ptr<T>();
+    if (std::isfinite(src) && src != T{0}) {
+        const double src_val = static_cast<double>(src);
+        const ov::float16 f16_val = static_cast<ov::float16>(src);
+        const double roundtripped = static_cast<double>(static_cast<T>(f16_val));
+        return std::abs(src_val - roundtripped) / std::abs(src_val) > ov::reference::f16_compression_max_rel_error;
+    }
+    return false;
 }
 
 class DetectFakeQuantizeOrFakeConvert : public MatcherPass {
@@ -169,6 +179,16 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
 
         auto c_type = const_node->get_element_type();
 
+        // Skip FP16 compression for scalar constants with significant rounding error.
+        // Scalar constants often serve as mathematical scale factors (e.g. log(16) in attention
+        // bucketing) where FP16 rounding error cascades through every computation that uses them.
+        if (ov::shape_size(const_node->get_shape()) == 1) {
+            if (c_type == ov::element::f32 && scalar_has_high_f16_error<float>(*const_node))
+                return false;
+            if (c_type == ov::element::f64 && scalar_has_high_f16_error<double>(*const_node))
+                return false;
+        }
+
         std::shared_ptr<ov::Node> new_const;
 
 #if !defined(OPENVINO_ARCH_X86) && !defined(OPENVINO_ARCH_X86_64)
@@ -191,8 +211,7 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
             if (check.has_lossy)
                 return false;
 
-            // if more than 75% of elements are rejected (outside FP16 range or FP16
-            // round-trip relative error exceeds the threshold), keep the Constant in FP32
+            // if more than 75% of elements fall outside the finite FP16 range, keep the Constant in FP32
             const float out_of_range_proportion =
                 static_cast<float>(check.out_of_range_count) / static_cast<float>(size);
             if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold)

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -58,19 +58,26 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
             dst_data[i] = std::numeric_limits<ov::float16>::lowest();
             num_out_of_range++;
         } else {
+            constexpr double max_relative_error = ov::reference::f16_compression_max_rel_error;
+            constexpr double max_abs_error = ov::reference::f16_compression_max_abs_error;
             const ov::float16 f16_val = static_cast<ov::float16>(src_data[i]);
             const double src_val = static_cast<double>(src_data[i]);
             const double roundtripped = static_cast<double>(static_cast<src_type>(f16_val));
             const double abs_diff = std::abs(src_val - roundtripped);
 
-            if (abs_diff > ov::reference::f16_compression_max_abs_error) {
+            if (abs_diff > max_abs_error) {
                 return nullptr;
+            }
+
+            if (src_val != 0.0 && abs_diff / std::abs(src_val) > max_relative_error) {
+                num_out_of_range++;
             }
             dst_data[i] = f16_val;
         }
     }
 
-    // if more than 75% of elements fall outside the finite FP16 range, keep the Constant in FP32
+    // if more than 75% of elements are rejected (outside FP16 range or FP16
+    // round-trip relative error exceeds the threshold), keep the Constant in FP32
     const double out_of_range_proportion = static_cast<double>(num_out_of_range) / static_cast<double>(size);
 
     if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold) {
@@ -84,23 +91,6 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
     } else {
         return new_constant;
     }
-}
-
-// Returns true if a scalar constant of type T loses significant precision when rounded to FP16.
-// Used to protect mathematical scale factors (e.g. log(16) in attention bucketing) from FP16
-// rounding errors that cascade through every computation referencing them. Tensor-wide
-// compression decisions do not use this check — bulk weights tolerate FP16 quantization noise.
-template <typename T>
-bool scalar_has_high_f16_error(const ov::op::v0::Constant& const_node) {
-    static_assert(sizeof(T) >= 4);
-    const T src = *const_node.get_data_ptr<T>();
-    if (std::isfinite(src) && src != T{0}) {
-        const double src_val = static_cast<double>(src);
-        const ov::float16 f16_val = static_cast<ov::float16>(src);
-        const double roundtripped = static_cast<double>(static_cast<T>(f16_val));
-        return std::abs(src_val - roundtripped) / std::abs(src_val) > ov::reference::f16_compression_max_rel_error;
-    }
-    return false;
 }
 
 class DetectFakeQuantizeOrFakeConvert : public MatcherPass {
@@ -179,16 +169,6 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
 
         auto c_type = const_node->get_element_type();
 
-        // Skip FP16 compression for scalar constants with significant rounding error.
-        // Scalar constants often serve as mathematical scale factors (e.g. log(16) in attention
-        // bucketing) where FP16 rounding error cascades through every computation that uses them.
-        if (ov::shape_size(const_node->get_shape()) == 1) {
-            if (c_type == ov::element::f32 && scalar_has_high_f16_error<float>(*const_node))
-                return false;
-            if (c_type == ov::element::f64 && scalar_has_high_f16_error<double>(*const_node))
-                return false;
-        }
-
         std::shared_ptr<ov::Node> new_const;
 
 #if !defined(OPENVINO_ARCH_X86) && !defined(OPENVINO_ARCH_X86_64)
@@ -211,7 +191,8 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
             if (check.has_lossy)
                 return false;
 
-            // if more than 75% of elements fall outside the finite FP16 range, keep the Constant in FP32
+            // if more than 75% of elements are rejected (outside FP16 range or FP16
+    // round-trip relative error exceeds the threshold), keep the Constant in FP32
             const float out_of_range_proportion =
                 static_cast<float>(check.out_of_range_count) / static_cast<float>(size);
             if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold)

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -192,7 +192,7 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
                 return false;
 
             // if more than 75% of elements are rejected (outside FP16 range or FP16
-    // round-trip relative error exceeds the threshold), keep the Constant in FP32
+            // round-trip relative error exceeds the threshold), keep the Constant in FP32
             const float out_of_range_proportion =
                 static_cast<float>(check.out_of_range_count) / static_cast<float>(size);
             if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold)

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -64,18 +64,18 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
     if (!dst_data || !size)
         return nullptr;
 
-    size_t num_out_of_range = 0;
+    size_t num_rejected = 0;
     for (size_t i = 0; i < size; ++i) {
         // if abs value is smaller than the smallest positive fp16, but not zero
         if (std::abs(src_data[i]) < ov::float16::from_bits(0x0001) && src_data[i] != 0.0f) {
             dst_data[i] = static_cast<ov::float16>(src_data[i]);
-            num_out_of_range++;
+            num_rejected++;
         } else if (src_data[i] > std::numeric_limits<ov::float16>::max()) {
             dst_data[i] = std::numeric_limits<ov::float16>::max();
-            num_out_of_range++;
+            num_rejected++;
         } else if (src_data[i] < std::numeric_limits<ov::float16>::lowest()) {
             dst_data[i] = std::numeric_limits<ov::float16>::lowest();
-            num_out_of_range++;
+            num_rejected++;
         } else {
             constexpr double max_relative_error = ov::reference::f16_compression_max_rel_error;
             constexpr double max_abs_error = ov::reference::f16_compression_max_abs_error;
@@ -89,7 +89,7 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
             }
 
             if (src_val != 0.0 && abs_diff / std::abs(src_val) > max_relative_error) {
-                num_out_of_range++;
+                num_rejected++;
             }
             dst_data[i] = f16_val;
         }
@@ -99,9 +99,9 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
     // range PLUS in-range values whose FP16 round-trip relative error exceeds
     // f16_compression_max_rel_error) reaches f16_compression_keep_threshold
     // (inclusive, 75% by default), keep the Constant in its original precision.
-    const double out_of_range_proportion = static_cast<double>(num_out_of_range) / static_cast<double>(size);
+    const double rejected_proportion = static_cast<double>(num_rejected) / static_cast<double>(size);
 
-    if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold) {
+    if (rejected_proportion >= ov::reference::f16_compression_keep_threshold) {
         return nullptr;
     }
 
@@ -216,9 +216,9 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
             // range PLUS in-range values whose FP16 round-trip relative error exceeds
             // f16_compression_max_rel_error) reaches f16_compression_keep_threshold
             // (inclusive, 75% by default), keep the Constant in FP32.
-            const float out_of_range_proportion =
-                static_cast<float>(check.out_of_range_count) / static_cast<float>(size);
-            if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold)
+            const float rejected_proportion =
+                static_cast<float>(check.rejected_count) / static_cast<float>(size);
+            if (rejected_proportion >= ov::reference::f16_compression_keep_threshold)
                 return false;
 
             if (postponed) {

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -216,8 +216,7 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
             // range PLUS in-range values whose FP16 round-trip relative error exceeds
             // f16_compression_max_rel_error) reaches f16_compression_keep_threshold
             // (inclusive, 75% by default), keep the Constant in FP32.
-            const float rejected_proportion =
-                static_cast<float>(check.rejected_count) / static_cast<float>(size);
+            const float rejected_proportion = static_cast<float>(check.rejected_count) / static_cast<float>(size);
             if (rejected_proportion >= ov::reference::f16_compression_keep_threshold)
                 return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -32,6 +32,25 @@ namespace ov::pass {
 
 namespace {
 
+/// Slow (non-JIT) FP32/FP64 -> FP16 compression for a single Constant node.
+///
+/// Returns either:
+///   * the new `v0::Constant` with FP16 data (fully converted and approved), or
+///   * `constant` unchanged when `postponed == true` (the Constant is kept in the
+///     graph and compressed later during serialization), or
+///   * `nullptr` if the tensor must stay in its original precision.
+///
+/// The tensor is rejected (returns `nullptr`) when:
+///   * any in-range element has absolute round-trip error above
+///     `f16_compression_max_abs_error` (RoPE-like high-magnitude values), or
+///   * the combined count of elements outside the finite FP16 range *plus*
+///     elements whose relative round-trip error exceeds
+///     `f16_compression_max_rel_error` reaches
+///     `f16_compression_keep_threshold` (75% by default).
+///
+/// Used by `CompressFloatConstantsImpl` for f64 constants on all platforms and
+/// for both f32/f64 on non-x86 architectures where the JIT fast-path
+/// `ov::reference::check_f16_compression` is unavailable.
 template <ov::element::Type_t PREC_FROM>
 std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::Constant>& constant,
                                                             bool postponed = false) {
@@ -45,7 +64,6 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
     if (!dst_data || !size)
         return nullptr;
 
-    // slow implementation: is used when optimized ones are not available: f64 or for ARM (both for f64 and f32)
     size_t num_out_of_range = 0;
     for (size_t i = 0; i < size; ++i) {
         // if abs value is smaller than the smallest positive fp16, but not zero
@@ -61,7 +79,7 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
         } else {
             constexpr double max_relative_error = ov::reference::f16_compression_max_rel_error;
             constexpr double max_abs_error = ov::reference::f16_compression_max_abs_error;
-            const ov::float16 f16_val = static_cast<ov::float16>(src_data[i]);
+            const auto f16_val = static_cast<ov::float16>(src_data[i]);
             const double src_val = static_cast<double>(src_data[i]);
             const double roundtripped = static_cast<double>(static_cast<src_type>(f16_val));
             const double abs_diff = std::abs(src_val - roundtripped);

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -58,15 +58,28 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
             dst_data[i] = std::numeric_limits<ov::float16>::lowest();
             num_out_of_range++;
         } else {
-            dst_data[i] = static_cast<ov::float16>(src_data[i]);
+            constexpr double max_relative_error = ov::reference::f16_compression_max_rel_error;
+            constexpr double max_abs_error = ov::reference::f16_compression_max_abs_error;
+            const ov::float16 f16_val = static_cast<ov::float16>(src_data[i]);
+            const double src_val = static_cast<double>(src_data[i]);
+            const double roundtripped = static_cast<double>(static_cast<src_type>(f16_val));
+            const double abs_diff = std::abs(src_val - roundtripped);
+
+            if (abs_diff > max_abs_error) {
+                return nullptr;
+            }
+
+            if (src_val != 0.0 && abs_diff / std::abs(src_val) > max_relative_error) {
+                num_out_of_range++;
+            }
+            dst_data[i] = f16_val;
         }
     }
 
     // if more than 75% of a FP32 constant do not fit into FP16 keep in FP32
-    const float keep_threshold = 0.75f;
     const float out_of_range_proportion = static_cast<float>(num_out_of_range) / static_cast<float>(size);
 
-    if (out_of_range_proportion >= keep_threshold) {
+    if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold) {
         return nullptr;
     }
 
@@ -138,27 +151,6 @@ void compress_model_to_f16(const std::shared_ptr<Model>& model, bool postponed) 
     }
 }
 
-namespace {
-
-// Returns true if a scalar constant of type T loses significant precision when rounded to FP16.
-// Used to protect mathematical scale factors (e.g., log(16) in attention bucketing) from FP16
-// rounding errors that cascade through every computation referencing them.
-template <typename T>
-bool scalar_has_high_f16_error(const ov::op::v0::Constant& const_node) {
-    constexpr double max_relative_error = 1e-4;
-    static_assert(sizeof(T) >= 4);
-    const T src = *const_node.get_data_ptr<T>();
-    if (std::isfinite(src) && src != T{0}) {
-        const double src_val = static_cast<double>(src);
-        const ov::float16 f16_val = static_cast<ov::float16>(src);
-        const double roundtripped = static_cast<double>(static_cast<T>(f16_val));
-        return std::abs(src_val - roundtripped) / std::abs(src_val) > max_relative_error;
-    }
-    return false;
-}
-
-}  // namespace
-
 CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
     MATCHER_SCOPE(CompressFloatConstantsImpl);
     auto const_pattern = pattern::wrap_type<v0::Constant>();
@@ -176,16 +168,6 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
 
         auto c_type = const_node->get_element_type();
 
-        // Skip FP16 compression for scalar constants with significant rounding error.
-        // Scalar constants often serve as mathematical scale factors (e.g., log(16) in attention
-        // bucketing) where FP16 rounding error cascades through every computation that uses them.
-        if (ov::shape_size(const_node->get_shape()) == 1) {
-            if (c_type == ov::element::f32 && scalar_has_high_f16_error<float>(*const_node))
-                return false;
-            if (c_type == ov::element::f64 && scalar_has_high_f16_error<double>(*const_node))
-                return false;
-        }
-
         std::shared_ptr<ov::Node> new_const;
 
 #if !defined(OPENVINO_ARCH_X86) && !defined(OPENVINO_ARCH_X86_64)
@@ -201,13 +183,17 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
             auto size = shape_size(const_node->get_output_shape(0));
             if (size == 0)
                 return false;
-            auto num_out_of_range =
-                ov::reference::count_out_of_f16_range(const_node->get_data_ptr<ov::element::f32>(), size);
+            const auto* src_data = const_node->get_data_ptr<float>();
+
+            // Single-pass check: counts out-of-range and bails on any lossy element (JIT accelerated)
+            auto check = ov::reference::check_f16_compression(src_data, size);
+            if (check.has_lossy)
+                return false;
 
             // if more than 75% of a FP32 constant do not fit into FP16 keep in FP32
-            const float keep_threshold = 0.75f;
-            const float out_of_range_proportion = static_cast<float>(num_out_of_range) / static_cast<float>(size);
-            if (out_of_range_proportion >= keep_threshold)
+            const float out_of_range_proportion =
+                static_cast<float>(check.out_of_range_count) / static_cast<float>(size);
+            if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold)
                 return false;
 
             if (postponed) {

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
         return nullptr;
 
     // slow implementation: is used when optimized ones are not available: f64 or for ARM (both for f64 and f32)
-    int num_out_of_range = 0;
+    size_t num_out_of_range = 0;
     for (size_t i = 0; i < size; ++i) {
         // if abs value is smaller than the smallest positive fp16, but not zero
         if (std::abs(src_data[i]) < ov::float16::from_bits(0x0001) && src_data[i] != 0.0f) {
@@ -77,7 +77,7 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
     }
 
     // if more than 75% of a FP32 constant do not fit into FP16 keep in FP32
-    const float out_of_range_proportion = static_cast<float>(num_out_of_range) / static_cast<float>(size);
+    const double out_of_range_proportion = static_cast<double>(num_out_of_range) / static_cast<double>(size);
 
     if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold) {
         return nullptr;

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -95,8 +95,10 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
         }
     }
 
-    // if more than 75% of elements are rejected (outside FP16 range or FP16
-    // round-trip relative error exceeds the threshold), keep the Constant in FP32
+    // If the combined count of rejected elements (values outside the finite FP16
+    // range PLUS in-range values whose FP16 round-trip relative error exceeds
+    // f16_compression_max_rel_error) reaches f16_compression_keep_threshold
+    // (inclusive, 75% by default), keep the Constant in its original precision.
     const double out_of_range_proportion = static_cast<double>(num_out_of_range) / static_cast<double>(size);
 
     if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold) {
@@ -210,8 +212,10 @@ CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed) {
             if (check.has_lossy)
                 return false;
 
-            // if more than 75% of elements are rejected (outside FP16 range or FP16
-    // round-trip relative error exceeds the threshold), keep the Constant in FP32
+            // If the combined count of rejected elements (values outside the finite FP16
+            // range PLUS in-range values whose FP16 round-trip relative error exceeds
+            // f16_compression_max_rel_error) reaches f16_compression_keep_threshold
+            // (inclusive, 75% by default), keep the Constant in FP32.
             const float out_of_range_proportion =
                 static_cast<float>(check.out_of_range_count) / static_cast<float>(size);
             if (out_of_range_proportion >= ov::reference::f16_compression_keep_threshold)

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -50,6 +50,7 @@ std::shared_ptr<ov::Node> change_constant_precision_to_fp16(std::shared_ptr<v0::
     for (size_t i = 0; i < size; ++i) {
         // if abs value is smaller than the smallest positive fp16, but not zero
         if (std::abs(src_data[i]) < ov::float16::from_bits(0x0001) && src_data[i] != 0.0f) {
+            dst_data[i] = static_cast<ov::float16>(src_data[i]);
             num_out_of_range++;
         } else if (src_data[i] > std::numeric_limits<ov::float16>::max()) {
             dst_data[i] = std::numeric_limits<ov::float16>::max();

--- a/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
@@ -656,11 +656,9 @@ TEST_F(TransformationTestsF, CompressConstants_compress_scalar_exact_f16) {
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
 
-// Non-scalar constants should be compressed even if individual elements have high FP16
-// rounding error. The scalar error check only applies to numel == 1 constants.
-TEST_F(TransformationTestsF, CompressConstants_compress_non_scalar_with_high_error) {
+TEST_F(TransformationTestsF, CompressConstants_skip_non_scalar_with_high_error_more_than_75) {
     // Model: Parameter -> Multiply(input, Const({2.7725887, 2.7725887, 2.7725887, 2.7725887})) -> Result
-    // Non-scalar (numel=4) with high per-element error -> still compressed.
+    // Non-scalar (numel=4) with high per-element error -> compressed.
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
         auto scale =
@@ -671,13 +669,70 @@ TEST_F(TransformationTestsF, CompressConstants_compress_non_scalar_with_high_err
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
     }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
+// Non-scalar constant with high absolute FP16 error (e.g. RoPE frequency table)
+// should NOT be compressed — value 5002.0 has FP16 abs error = 2.0 (ULP=4 in [4096,8192) range).
+TEST_F(TransformationTestsF, CompressConstants_skip_non_scalar_with_high_abs_error) {
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
+        auto freqs = v0::Constant::create(ov::element::f32, ov::Shape{4}, {1.0f, 100.0f, 500.0f, 5002.0f});
+        auto mul = std::make_shared<ov::opset8::Multiply>(input, freqs);
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
+
+        manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
+        manager.register_pass<ov::pass::CompressFloatConstants>();
+    }
 
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
-        // Non-scalar constant compressed to FP16 + Convert (error check is scalar-only)
-        auto scale =
-            v0::Constant::create(ov::element::f16, ov::Shape{4}, {2.7725887f, 2.7725887f, 2.7725887f, 2.7725887f});
-        auto convert = std::make_shared<v0::Convert>(scale, ov::element::f32);
+        // Stays FP32: 5002.0 rounds to 5000.0 in FP16, abs error = 2.0 > threshold 1.0
+        auto freqs = v0::Constant::create(ov::element::f32, ov::Shape{4}, {1.0f, 100.0f, 500.0f, 5002.0f});
+        auto mul = std::make_shared<ov::opset8::Multiply>(input, freqs);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
+// f64 constant with high absolute FP16 error should NOT be compressed (same logic as f32 path).
+TEST_F(TransformationTestsF, CompressConstants_skip_f64_non_scalar_with_high_abs_error) {
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f64, ov::Shape{1, 4});
+        auto freqs = v0::Constant::create(ov::element::f64, ov::Shape{4}, {1.0, 100.0, 500.0, 5002.0});
+        auto mul = std::make_shared<ov::opset8::Multiply>(input, freqs);
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
+
+        manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
+        manager.register_pass<ov::pass::CompressFloatConstants>();
+    }
+
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f64, ov::Shape{1, 4});
+        // Stays FP64: 5002.0 rounds to 5000.0 in FP16, abs error = 2.0 > threshold 1.0
+        auto freqs = v0::Constant::create(ov::element::f64, ov::Shape{4}, {1.0, 100.0, 500.0, 5002.0});
+        auto mul = std::make_shared<ov::opset8::Multiply>(input, freqs);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
+// Non-scalar constant with low absolute FP16 error (normal weights) should be compressed.
+TEST_F(TransformationTestsF, CompressConstants_compress_non_scalar_with_low_abs_error) {
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
+        auto weights = v0::Constant::create(ov::element::f32, ov::Shape{4}, {0.5f, 1.23f, -3.14f, 7.77f});
+        auto mul = std::make_shared<ov::opset8::Multiply>(input, weights);
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
+
+        manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
+        manager.register_pass<ov::pass::CompressFloatConstants>();
+    }
+
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
+        auto weights = v0::Constant::create(ov::element::f16, ov::Shape{4}, {0.5f, 1.23f, -3.14f, 7.77f});
+        auto convert = std::make_shared<v0::Convert>(weights, ov::element::f32);
         auto mul = std::make_shared<ov::opset8::Multiply>(input, convert);
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
     }

--- a/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
@@ -656,12 +656,9 @@ TEST_F(TransformationTestsF, CompressConstants_compress_scalar_exact_f16) {
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
 
-// Non-scalar constants are compressed regardless of per-element relative FP16 error. FP16's
-// natural per-binade relative error is ~2^-11 ≈ 4.88e-4; treating that as rejection would
-// reject almost every dense weight tensor. Scalar scale factors are protected separately.
-TEST_F(TransformationTestsF, CompressConstants_compress_non_scalar_with_high_rel_error) {
+TEST_F(TransformationTestsF, CompressConstants_skip_non_scalar_with_high_error_more_than_75) {
     // Model: Parameter -> Multiply(input, Const({2.7725887, 2.7725887, 2.7725887, 2.7725887})) -> Result
-    // Non-scalar (numel=4) with high per-element rel error, but abs error < 1.0 -> still compressed.
+    // Non-scalar (numel=4) with high per-element error in more than 75% of elements -> skipped (not compressed).
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
         auto scale =
@@ -675,10 +672,10 @@ TEST_F(TransformationTestsF, CompressConstants_compress_non_scalar_with_high_rel
 
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
+        // Stays FP32: relative round-trip error exceeds threshold for all 4 elements (>75%).
         auto scale =
-            v0::Constant::create(ov::element::f16, ov::Shape{4}, {2.7725887f, 2.7725887f, 2.7725887f, 2.7725887f});
-        auto convert = std::make_shared<v0::Convert>(scale, ov::element::f32);
-        auto mul = std::make_shared<ov::opset8::Multiply>(input, convert);
+            v0::Constant::create(ov::element::f32, ov::Shape{4}, {2.7725887f, 2.7725887f, 2.7725887f, 2.7725887f});
+        auto mul = std::make_shared<ov::opset8::Multiply>(input, scale);
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);

--- a/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
@@ -658,7 +658,7 @@ TEST_F(TransformationTestsF, CompressConstants_compress_scalar_exact_f16) {
 
 TEST_F(TransformationTestsF, CompressConstants_skip_non_scalar_with_high_error_more_than_75) {
     // Model: Parameter -> Multiply(input, Const({2.7725887, 2.7725887, 2.7725887, 2.7725887})) -> Result
-    // Non-scalar (numel=4) with high per-element error -> compressed.
+    // Non-scalar (numel=4) with high per-element error in more than 75% of elements -> skipped (not compressed).
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
         auto scale =

--- a/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
@@ -656,9 +656,10 @@ TEST_F(TransformationTestsF, CompressConstants_compress_scalar_exact_f16) {
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
 
-TEST_F(TransformationTestsF, CompressConstants_skip_non_scalar_with_high_error_more_than_75) {
+TEST_F(TransformationTestsF, CompressConstants_skip_non_scalar_with_high_error_at_least_75) {
     // Model: Parameter -> Multiply(input, Const({2.7725887, 2.7725887, 2.7725887, 2.7725887})) -> Result
-    // Non-scalar (numel=4) with high per-element error in more than 75% of elements -> skipped (not compressed).
+    // Non-scalar (numel=4) with high per-element error in at least 75% of elements -> skipped (not compressed).
+    // The keep-threshold comparison is inclusive (>= f16_compression_keep_threshold).
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
         auto scale =

--- a/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
@@ -656,9 +656,12 @@ TEST_F(TransformationTestsF, CompressConstants_compress_scalar_exact_f16) {
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
 
-TEST_F(TransformationTestsF, CompressConstants_skip_non_scalar_with_high_error_more_than_75) {
+// Non-scalar constants are compressed regardless of per-element relative FP16 error. FP16's
+// natural per-binade relative error is ~2^-11 ≈ 4.88e-4; treating that as rejection would
+// reject almost every dense weight tensor. Scalar scale factors are protected separately.
+TEST_F(TransformationTestsF, CompressConstants_compress_non_scalar_with_high_rel_error) {
     // Model: Parameter -> Multiply(input, Const({2.7725887, 2.7725887, 2.7725887, 2.7725887})) -> Result
-    // Non-scalar (numel=4) with high per-element error in more than 75% of elements -> skipped (not compressed).
+    // Non-scalar (numel=4) with high per-element rel error, but abs error < 1.0 -> still compressed.
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
         auto scale =
@@ -672,10 +675,10 @@ TEST_F(TransformationTestsF, CompressConstants_skip_non_scalar_with_high_error_m
 
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
-        // Stays FP32: relative round-trip error exceeds threshold for all 4 elements (>75%).
         auto scale =
-            v0::Constant::create(ov::element::f32, ov::Shape{4}, {2.7725887f, 2.7725887f, 2.7725887f, 2.7725887f});
-        auto mul = std::make_shared<ov::opset8::Multiply>(input, scale);
+            v0::Constant::create(ov::element::f16, ov::Shape{4}, {2.7725887f, 2.7725887f, 2.7725887f, 2.7725887f});
+        auto convert = std::make_shared<v0::Convert>(scale, ov::element::f32);
+        auto mul = std::make_shared<ov::opset8::Multiply>(input, convert);
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);

--- a/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
@@ -669,6 +669,15 @@ TEST_F(TransformationTestsF, CompressConstants_skip_non_scalar_with_high_error_m
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
     }
+
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 4});
+        // Stays FP32: relative round-trip error exceeds threshold for all 4 elements (>75%).
+        auto scale =
+            v0::Constant::create(ov::element::f32, ov::Shape{4}, {2.7725887f, 2.7725887f, 2.7725887f, 2.7725887f});
+        auto mul = std::make_shared<ov::opset8::Multiply>(input, scale);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
+    }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
 

--- a/src/core/reference/include/openvino/reference/convert.hpp
+++ b/src/core/reference/include/openvino/reference/convert.hpp
@@ -83,39 +83,51 @@ template <>
 void convert<int32_t, float16>(const int32_t* arg, float16* out, size_t count);
 
 /// Maximum tolerated |abs(src - round_trip_f16(src))| for an in-range element.
-/// If any element exceeds this threshold, the whole tensor is kept in FP32
-/// (acts as a tensor-wide veto in check_f16_compression()).
+/// If any element exceeds this threshold, the whole tensor is kept in its
+/// original precision (FP32 / FP64 — acts as a tensor-wide veto in
+/// check_f16_compression()).
 inline constexpr double f16_compression_max_abs_error = 1.0;
 /// Maximum tolerated relative round-trip error |abs_diff / src| for an
 /// in-range element. Elements above this threshold are accumulated into the
 /// combined rejection count used together with f16_compression_keep_threshold.
 inline constexpr double f16_compression_max_rel_error = 1e-4;
 /// Proportion of combined rejections (out-of-FP16-range + high relative-error)
-/// at which the Constant is kept in FP32 (no FP16 compression).
+/// at which the Constant is kept in its original precision (FP32 / FP64), i.e.
+/// no FP16 compression is applied.
 inline constexpr float f16_compression_keep_threshold = 0.75f;
 
-// Single-pass combined check for FP16 compression feasibility.
-// Bails immediately if any in-range value has significant precision loss
-// (|round-trip error| > f16_compression_max_abs_error). Otherwise accumulates a
-// combined rejection count used by CompressFloatConstantsImpl to decide whether
-// to keep the Constant in FP32 via the f16_compression_keep_threshold.
-// JIT/AVX2+F16C accelerated on x86.
+/// Result of a single-pass FP16-compression feasibility check produced by
+/// check_f16_compression(). Used by CompressFloatConstantsImpl to decide
+/// whether a floating-point Constant may be safely compressed to FP16.
 struct CompressionCheckResult {
-    // Combined count of rejected elements: values outside finite FP16 range PLUS
-    // in-range values whose FP16 conversion exceeds f16_compression_max_rel_error.
-    // This is NOT a pure out-of-range count — see count_out_of_f16_range() for
-    // that.
+    /// Combined count of rejected elements: values outside the finite FP16
+    /// range PLUS in-range values whose FP16 conversion exceeds
+    /// f16_compression_max_rel_error. Compared against
+    /// f16_compression_keep_threshold to keep the Constant in its original
+    /// precision. NOT a pure out-of-range count — see count_out_of_f16_range()
+    /// for that.
     size_t out_of_range_count;
-    // Early-bail flag: true iff any in-range element has |abs error| greater
-    // than f16_compression_max_abs_error after the FP16 round-trip. When set,
-    // out_of_range_count is not guaranteed to be complete.
+    /// Early-bail flag: true iff any in-range element has |abs error| greater
+    /// than f16_compression_max_abs_error after the FP16 round-trip. When set,
+    /// out_of_range_count is not guaranteed to be complete.
     bool has_lossy;
 };
+
+/// Single-pass combined FP16-compression feasibility check.
+///
+/// Bails immediately if any in-range value has significant precision loss
+/// (|round-trip error| > f16_compression_max_abs_error), setting
+/// CompressionCheckResult::has_lossy. Otherwise accumulates a combined
+/// rejection count (out-of-FP16-range + high relative-error) in
+/// CompressionCheckResult::out_of_range_count, to be compared against
+/// f16_compression_keep_threshold. JIT/AVX-512 (or AVX2+F16C) accelerated on
+/// x86; falls back to a scalar loop elsewhere.
 CompressionCheckResult check_f16_compression(const float* arg, size_t count);
 
-// Counts elements in `arg` that fall outside the finite FP16 range (subnormal
-// when rounded, or larger in magnitude than float16::max()). Distinct from
-// check_f16_compression(), which also accounts for relative-error rejections.
+/// Counts elements in `arg` that fall outside the finite FP16 range (subnormal
+/// when rounded, or larger in magnitude than float16::max()). Distinct from
+/// check_f16_compression(), which also accounts for relative-error rejections.
+/// Kept as a backward-compatible helper for external consumers of this header.
 size_t count_out_of_f16_range(const float* arg, size_t count);
 
 // Convert values from f32 to f16 with clamping to f16 min/max when value is out of normal finite numbers range

--- a/src/core/reference/include/openvino/reference/convert.hpp
+++ b/src/core/reference/include/openvino/reference/convert.hpp
@@ -83,26 +83,20 @@ template <>
 void convert<int32_t, float16>(const int32_t* arg, float16* out, size_t count);
 
 constexpr double f16_compression_max_abs_error = 1.0;
-// FP16 has a 10-bit mantissa, so the natural per-element relative round-trip
-// error is ~2^-11 (≈4.88e-4). This threshold is intentionally tighter than
-// that — it's meaningful only for scalar (numel==1) constants used as
-// mathematical scale factors (e.g. log(16) in attention bucketing), where a
-// rounded value cascades through every dependent computation. Tensor-wide
-// compression decisions rely on the abs-error veto (has_lossy) instead.
 constexpr double f16_compression_max_rel_error = 1e-4;
 constexpr float f16_compression_keep_threshold = 0.75f;
 
-// Single-pass check for FP16 compression feasibility. Bails immediately if any
-// in-range value has significant precision loss (|abs error| >
-// f16_compression_max_abs_error). Otherwise counts values outside the finite
-// FP16 range; CompressFloatConstantsImpl uses that count with
-// f16_compression_keep_threshold to decide whether to keep the Constant in
-// FP32. JIT/AVX2+F16C accelerated on x86.
+// Single-pass combined check for FP16 compression feasibility.
+// Bails immediately if any in-range value has significant precision loss
+// (|round-trip error| > f16_compression_max_abs_error). Otherwise accumulates a
+// combined rejection count used by CompressFloatConstantsImpl to decide whether
+// to keep the Constant in FP32 via the f16_compression_keep_threshold.
+// JIT/AVX2+F16C accelerated on x86.
 struct CompressionCheckResult {
-    // Number of elements whose FP16 representation falls outside the finite
-    // FP16 range: subnormal when rounded (|v| < float16::from_bits(0x0001))
-    // or larger in magnitude than float16::max(). Same semantics as
-    // count_out_of_f16_range().
+    // Combined count of rejected elements: values outside finite FP16 range PLUS
+    // in-range values whose FP16 conversion exceeds f16_compression_max_rel_error.
+    // This is NOT a pure out-of-range count — see count_out_of_f16_range() for
+    // that.
     size_t out_of_range_count;
     // Early-bail flag: true iff any in-range element has |abs error| greater
     // than f16_compression_max_abs_error after the FP16 round-trip. When set,
@@ -112,9 +106,8 @@ struct CompressionCheckResult {
 CompressionCheckResult check_f16_compression(const float* arg, size_t count);
 
 // Counts elements in `arg` that fall outside the finite FP16 range (subnormal
-// when rounded, or larger in magnitude than float16::max()). Back-compat shim
-// for external developer-package consumers that linked against the pre-JIT
-// symbol; the in-tree compression path uses check_f16_compression().
+// when rounded, or larger in magnitude than float16::max()). Distinct from
+// check_f16_compression(), which also accounts for relative-error rejections.
 size_t count_out_of_f16_range(const float* arg, size_t count);
 
 // Convert values from f32 to f16 with clamping to f16 min/max when value is out of normal finite numbers range

--- a/src/core/reference/include/openvino/reference/convert.hpp
+++ b/src/core/reference/include/openvino/reference/convert.hpp
@@ -83,20 +83,26 @@ template <>
 void convert<int32_t, float16>(const int32_t* arg, float16* out, size_t count);
 
 constexpr double f16_compression_max_abs_error = 1.0;
+// FP16 has a 10-bit mantissa, so the natural per-element relative round-trip
+// error is ~2^-11 (≈4.88e-4). This threshold is intentionally tighter than
+// that — it's meaningful only for scalar (numel==1) constants used as
+// mathematical scale factors (e.g. log(16) in attention bucketing), where a
+// rounded value cascades through every dependent computation. Tensor-wide
+// compression decisions rely on the abs-error veto (has_lossy) instead.
 constexpr double f16_compression_max_rel_error = 1e-4;
 constexpr float f16_compression_keep_threshold = 0.75f;
 
-// Single-pass combined check for FP16 compression feasibility.
-// Bails immediately if any in-range value has significant precision loss
-// (|round-trip error| > f16_compression_max_abs_error). Otherwise accumulates a
-// combined rejection count used by CompressFloatConstantsImpl to decide whether
-// to keep the Constant in FP32 via the f16_compression_keep_threshold.
-// JIT/AVX2+F16C accelerated on x86.
+// Single-pass check for FP16 compression feasibility. Bails immediately if any
+// in-range value has significant precision loss (|abs error| >
+// f16_compression_max_abs_error). Otherwise counts values outside the finite
+// FP16 range; CompressFloatConstantsImpl uses that count with
+// f16_compression_keep_threshold to decide whether to keep the Constant in
+// FP32. JIT/AVX2+F16C accelerated on x86.
 struct CompressionCheckResult {
-    // Combined count of rejected elements: values outside finite FP16 range PLUS
-    // in-range values whose FP16 conversion exceeds f16_compression_max_rel_error.
-    // This is NOT a pure out-of-range count — see count_out_of_f16_range() for
-    // that.
+    // Number of elements whose FP16 representation falls outside the finite
+    // FP16 range: subnormal when rounded (|v| < float16::from_bits(0x0001))
+    // or larger in magnitude than float16::max(). Same semantics as
+    // count_out_of_f16_range().
     size_t out_of_range_count;
     // Early-bail flag: true iff any in-range element has |abs error| greater
     // than f16_compression_max_abs_error after the FP16 round-trip. When set,
@@ -106,8 +112,9 @@ struct CompressionCheckResult {
 CompressionCheckResult check_f16_compression(const float* arg, size_t count);
 
 // Counts elements in `arg` that fall outside the finite FP16 range (subnormal
-// when rounded, or larger in magnitude than float16::max()). Distinct from
-// check_f16_compression(), which also accounts for relative-error rejections.
+// when rounded, or larger in magnitude than float16::max()). Back-compat shim
+// for external developer-package consumers that linked against the pre-JIT
+// symbol; the in-tree compression path uses check_f16_compression().
 size_t count_out_of_f16_range(const float* arg, size_t count);
 
 // Convert values from f32 to f16 with clamping to f16 min/max when value is out of normal finite numbers range

--- a/src/core/reference/include/openvino/reference/convert.hpp
+++ b/src/core/reference/include/openvino/reference/convert.hpp
@@ -87,7 +87,7 @@ void convert<int32_t, float16>(const int32_t* arg, float16* out, size_t count);
 /// original precision (FP32 / FP64 — acts as a tensor-wide veto in
 /// check_f16_compression()).
 inline constexpr double f16_compression_max_abs_error = 1.0;
-/// Maximum tolerated relative round-trip error |abs_diff / src| for an
+/// Maximum tolerated relative round-trip error abs_diff / |src| for an
 /// in-range element. Elements above this threshold are accumulated into the
 /// combined rejection count used together with f16_compression_keep_threshold.
 inline constexpr double f16_compression_max_rel_error = 1e-4;
@@ -104,12 +104,11 @@ struct CompressionCheckResult {
     /// range PLUS in-range values whose FP16 conversion exceeds
     /// f16_compression_max_rel_error. Compared against
     /// f16_compression_keep_threshold to keep the Constant in its original
-    /// precision. NOT a pure out-of-range count — see count_out_of_f16_range()
-    /// for that.
-    size_t out_of_range_count;
+    /// precision. For a pure out-of-range count, use count_out_of_f16_range().
+    size_t rejected_count;
     /// Early-bail flag: true iff any in-range element has |abs error| greater
     /// than f16_compression_max_abs_error after the FP16 round-trip. When set,
-    /// out_of_range_count is not guaranteed to be complete.
+    /// rejected_count is not guaranteed to be complete.
     bool has_lossy;
 };
 
@@ -119,7 +118,7 @@ struct CompressionCheckResult {
 /// (|round-trip error| > f16_compression_max_abs_error), setting
 /// CompressionCheckResult::has_lossy. Otherwise accumulates a combined
 /// rejection count (out-of-FP16-range + high relative-error) in
-/// CompressionCheckResult::out_of_range_count, to be compared against
+/// CompressionCheckResult::rejected_count, to be compared against
 /// f16_compression_keep_threshold. JIT/AVX-512 (or AVX2+F16C) accelerated on
 /// x86; falls back to a scalar loop elsewhere.
 CompressionCheckResult check_f16_compression(const float* arg, size_t count);

--- a/src/core/reference/include/openvino/reference/convert.hpp
+++ b/src/core/reference/include/openvino/reference/convert.hpp
@@ -82,9 +82,17 @@ void convert<bfloat16, float>(const bfloat16* arg, float* out, size_t count);
 template <>
 void convert<int32_t, float16>(const int32_t* arg, float16* out, size_t count);
 
-constexpr double f16_compression_max_abs_error = 1.0;
-constexpr double f16_compression_max_rel_error = 1e-4;
-constexpr float f16_compression_keep_threshold = 0.75f;
+/// Maximum tolerated |abs(src - round_trip_f16(src))| for an in-range element.
+/// If any element exceeds this threshold, the whole tensor is kept in FP32
+/// (acts as a tensor-wide veto in check_f16_compression()).
+inline constexpr double f16_compression_max_abs_error = 1.0;
+/// Maximum tolerated relative round-trip error |abs_diff / src| for an
+/// in-range element. Elements above this threshold are accumulated into the
+/// combined rejection count used together with f16_compression_keep_threshold.
+inline constexpr double f16_compression_max_rel_error = 1e-4;
+/// Proportion of combined rejections (out-of-FP16-range + high relative-error)
+/// at which the Constant is kept in FP32 (no FP16 compression).
+inline constexpr float f16_compression_keep_threshold = 0.75f;
 
 // Single-pass combined check for FP16 compression feasibility.
 // Bails immediately if any in-range value has significant precision loss

--- a/src/core/reference/include/openvino/reference/convert.hpp
+++ b/src/core/reference/include/openvino/reference/convert.hpp
@@ -82,8 +82,18 @@ void convert<bfloat16, float>(const bfloat16* arg, float* out, size_t count);
 template <>
 void convert<int32_t, float16>(const int32_t* arg, float16* out, size_t count);
 
-// Count how many f32 values is out of normal finite numbers range when converted to f16
-size_t count_out_of_f16_range(const float* arg, size_t count);
+constexpr double f16_compression_max_abs_error = 1.0;
+constexpr double f16_compression_max_rel_error = 1e-4;
+constexpr float f16_compression_keep_threshold = 0.75f;
+
+// Single-pass combined check for FP16 compression feasibility.
+// Counts out-of-range values and bails immediately if any in-range value has significant precision loss.
+// JIT/AVX2+F16C accelerated on x86.
+struct CompressionCheckResult {
+    size_t out_of_range_count;
+    bool has_lossy;
+};
+CompressionCheckResult check_f16_compression(const float* arg, size_t count);
 
 // Convert values from f32 to f16 with clamping to f16 min/max when value is out of normal finite numbers range
 void convert_from_f32_to_f16_with_clamp(const float* arg, float16* out, size_t count);

--- a/src/core/reference/include/openvino/reference/convert.hpp
+++ b/src/core/reference/include/openvino/reference/convert.hpp
@@ -87,13 +87,28 @@ constexpr double f16_compression_max_rel_error = 1e-4;
 constexpr float f16_compression_keep_threshold = 0.75f;
 
 // Single-pass combined check for FP16 compression feasibility.
-// Counts out-of-range values and bails immediately if any in-range value has significant precision loss.
+// Bails immediately if any in-range value has significant precision loss
+// (|round-trip error| > f16_compression_max_abs_error). Otherwise accumulates a
+// combined rejection count used by CompressFloatConstantsImpl to decide whether
+// to keep the Constant in FP32 via the f16_compression_keep_threshold.
 // JIT/AVX2+F16C accelerated on x86.
 struct CompressionCheckResult {
+    // Combined count of rejected elements: values outside finite FP16 range PLUS
+    // in-range values whose FP16 conversion exceeds f16_compression_max_rel_error.
+    // This is NOT a pure out-of-range count — see count_out_of_f16_range() for
+    // that.
     size_t out_of_range_count;
+    // Early-bail flag: true iff any in-range element has |abs error| greater
+    // than f16_compression_max_abs_error after the FP16 round-trip. When set,
+    // out_of_range_count is not guaranteed to be complete.
     bool has_lossy;
 };
 CompressionCheckResult check_f16_compression(const float* arg, size_t count);
+
+// Counts elements in `arg` that fall outside the finite FP16 range (subnormal
+// when rounded, or larger in magnitude than float16::max()). Distinct from
+// check_f16_compression(), which also accounts for relative-error rejections.
+size_t count_out_of_f16_range(const float* arg, size_t count);
 
 // Convert values from f32 to f16 with clamping to f16 min/max when value is out of normal finite numbers range
 void convert_from_f32_to_f16_with_clamp(const float* arg, float16* out, size_t count);

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -388,14 +388,14 @@ public:
     }
 };
 
-// Single-pass JIT kernel for AVX-512: counts out-of-range AND detects lossy f16 compression.
+// Combined single-pass JIT kernel for AVX-512: counts out-of-range AND detects lossy f16 compression.
 // Processes 16 floats per iteration using zmm + opmask + F16C (vcvtps2ph/vcvtph2ps). Bails immediately
 // if any in-range element has significant precision loss (abs error > 1.0). Tail handled via masked load.
 class jit_check_f16_compression_avx512 : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* oor_dst;    // size_t* — output: strict FP16 out-of-range count
+        void* oor_dst;    // size_t* — output: combined out-of-range + high-relative-error count
         void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
@@ -432,12 +432,15 @@ private:
         const auto& reg_addr = r15;  // callee-saved — used to load constants
 
         // ZMM register allocation
-        const auto& data_vec = zmm0;      // chunk of 16 floats
-        const auto& rt_vec = zmm1;        // f32->f16->f32 roundtripped
-        const auto& rt_ymm = ymm1;        // low 256-bit alias for vcvtps2ph dest
-        const auto& diff_vec = zmm2;      // |data - roundtripped|
-        const auto& abs_mask_vec = zmm5;  // 0x7FFFFFFF broadcast
-        const auto& abs_err_vec = zmm6;   // 1.0f broadcast
+        const auto& data_vec = zmm0;        // chunk of 16 floats
+        const auto& rt_vec = zmm1;          // f32->f16->f32 roundtripped
+        const auto& rt_ymm = ymm1;          // low 256-bit alias for vcvtps2ph dest
+        const auto& diff_vec = zmm2;        // |data - roundtripped|
+        const auto& abs_data_vec = zmm3;    // |data|
+        const auto& rel_thresh_vec = zmm4;  // |data| * 1e-4
+        const auto& abs_mask_vec = zmm5;    // 0x7FFFFFFF broadcast
+        const auto& abs_err_vec = zmm6;     // 1.0f broadcast
+        const auto& rel_err_vec = zmm7;     // 1e-4f broadcast
         const auto& f16_max_pos_vec = zmm8;
         const auto& f16_max_neg_vec = zmm9;
         const auto& f16_min_pos_vec = zmm10;
@@ -445,8 +448,9 @@ private:
         const auto& zero_vec = zmm12;
 
         // Opmasks (k0 reserved by ISA — represents "no mask")
-        const auto& k_oor = k1;    // strict FP16 OOR per chunk (subnormal | overflow)
+        const auto& k_oor = k1;    // OOR per chunk (subnormal | overflow), then |= relative-error
         const auto& k_lossy = k2;  // (abs_diff > 1.0) AND NOT k_oor — early exit
+        const auto& k_rel = k3;    // (abs_diff > |data|*1e-4) AND NOT k_oor
         const auto& k_tail = k4;   // tail mask (built once before tail iteration)
         const auto& k_tmp1 = k5;
         const auto& k_tmp2 = k6;
@@ -462,6 +466,7 @@ private:
         static const float f16_min_pos = ov::float16::from_bits(0x0001);
         static const float f16_min_neg = -ov::float16::from_bits(0x0001);
         static const float abs_err_val = static_cast<float>(ov::reference::f16_compression_max_abs_error);
+        static const float rel_err_val = static_cast<float>(ov::reference::f16_compression_max_rel_error);
         static const uint32_t abs_mask_val = 0x7FFFFFFF;
 
         auto bcast = [&, this](const Xbyak::Zmm& vec, const void* p) {
@@ -474,6 +479,7 @@ private:
         bcast(f16_min_pos_vec, &f16_min_pos);
         bcast(f16_min_neg_vec, &f16_min_neg);
         bcast(abs_err_vec, &abs_err_val);
+        bcast(rel_err_vec, &rel_err_val);
         bcast(abs_mask_vec, &abs_mask_val);
         vpxorq(zero_vec, zero_vec, zero_vec);
 
@@ -523,6 +529,16 @@ private:
             }
             kortestw(k_lossy, k_lossy);
             jnz(lossy_exit, T_NEAR);
+
+            // === Relative-error check: (abs_diff > |data| * 1e-4) AND NOT k_oor ===
+            vpandd(abs_data_vec, data_vec, abs_mask_vec);
+            vmulps(rel_thresh_vec, abs_data_vec, rel_err_vec);
+            vcmpps(k_rel, diff_vec, rel_thresh_vec, _cmp_gt_os);
+            kandnw(k_rel, k_oor, k_rel);
+            korw(k_oor, k_oor, k_rel);
+            if (masked) {
+                kandw(k_oor, k_oor, k_tail);
+            }
 
             // === Accumulate popcount(k_oor) into reg_oor_accum ===
             // Branchless 16-bit SWAR popcount — avoids POPCNT (not gated by mayiuse(avx512_core)).
@@ -596,14 +612,14 @@ private:
     }
 };
 
-// Single-pass JIT kernel: counts out-of-range AND detects lossy f16 compression.
+// Combined single-pass JIT kernel: counts out-of-range AND detects lossy f16 compression.
 // Processes 8 floats per iteration using AVX2+F16C. Bails immediately if any in-range
 // element has significant precision loss (abs error > 1.0).
 class jit_check_f16_compression : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* oor_dst;    // size_t* — output: strict FP16 out-of-range count
+        void* oor_dst;    // size_t* — output: combined out-of-range + high-relative-error count
         void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
@@ -652,6 +668,7 @@ private:
         // Lossy check constants
         const auto& abs_err_vec = ymm11;  // 1.0f broadcast
         const auto& abs_mask_vec = ymm0;  // 0x7FFFFFFF broadcast (for fabs)
+        const auto& rel_err_vec = ymm12;  // 1e-4f broadcast (for relative error threshold)
         // Temps for lossy computation (reused per chunk)
         const auto& diff_vec = ymm14;
         const auto& rt_vec_xmm = xmm15;  // for f32->f16->f32 roundtrip
@@ -668,6 +685,7 @@ private:
         static const float f16_min_neg = -ov::float16::from_bits(0x0001);
         static const int32_t i32_one = 1;
         static const float abs_err_val = static_cast<float>(ov::reference::f16_compression_max_abs_error);
+        static const float rel_err_val = static_cast<float>(ov::reference::f16_compression_max_rel_error);
         static const uint32_t abs_mask_val = 0x7FFFFFFF;
 
         static const float max_pos_bounds[8] =
@@ -681,6 +699,8 @@ private:
         static const int32_t i32_ones[8] = {i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one};
         static const float abs_errs[8] =
             {abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val};
+        static const float rel_errs[8] =
+            {rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val};
         static const uint32_t abs_masks[8] = {abs_mask_val,
                                               abs_mask_val,
                                               abs_mask_val,
@@ -701,6 +721,7 @@ private:
         load_vec(f16_min_neg_vec, (size_t)min_neg_bounds);
         load_vec(i32_ones_vec, (size_t)i32_ones);
         load_vec(abs_err_vec, (size_t)abs_errs);
+        load_vec(rel_err_vec, (size_t)rel_errs);
         load_vec(abs_mask_vec, (size_t)abs_masks);
         vxorps(f16_zero_vec, f16_zero_vec, f16_zero_vec);
         vxorps(oor_accum, oor_accum, oor_accum);
@@ -754,7 +775,15 @@ private:
             vtestps(tmp_vec, tmp_vec);  // ZF=1 if all zeros
             jnz(exit_lossy, T_NEAR);    // bail if any lossy
 
-            // === Accumulate strict OOR count ===
+            // === Relative error check: count elements where |diff| > |value| * 1e-4 ===
+            // (equivalent to abs_diff / |value| > 1e-4, but avoids division)
+            vandps(tmp_vec, data_vec, abs_mask_vec);         // tmp_vec = |data|
+            vmulps(tmp_vec, tmp_vec, rel_err_vec);           // tmp_vec = |data| * 1e-4
+            vcmpps(tmp_vec, diff_vec, tmp_vec, _cmp_gt_os);  // 1 where |diff| > |data|*1e-4
+            vandnps(tmp_vec, mask_vec, tmp_vec);             // exclude OOR (avoid double-count)
+            vorps(mask_vec, mask_vec, tmp_vec);              // combine OOR + relative-error
+
+            // === Accumulate combined OOR + relative-error count ===
             vandps(mask_vec, mask_vec, i32_ones_vec);
             vphaddd(mask_vec, mask_vec, mask_vec);
             vpermq(mask_vec, mask_vec, 0x08);
@@ -924,6 +953,9 @@ CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
             const double abs_diff = std::abs(v - roundtripped);
             if (abs_diff > f16_compression_max_abs_error) {
                 return {0, true};
+            }
+            if (v != 0.0f && abs_diff / std::abs(v) > f16_compression_max_rel_error) {
+                ++out_of_range;
             }
         }
     }

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -409,7 +409,7 @@ class jit_check_f16_compression_avx512 : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* oor_dst;    // size_t* — output: combined out-of-range + high-relative-error count
+        void* rejected_dst;    // size_t* — output: combined out-of-range + high-relative-error count
         void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
@@ -436,10 +436,10 @@ private:
 
         // GP register allocation
         const auto& reg_src = rax;
-        const auto& reg_oor_dst = rbx;    // callee-saved
+        const auto& reg_rejected_dst = rbx;    // callee-saved
         const auto& reg_lossy_dst = r12;  // callee-saved
         const auto& reg_count = rdx;
-        const auto& reg_oor_accum = r14;  // callee-saved — 64-bit OOR + RelErr accumulator
+        const auto& reg_rejected_accum = r14;  // callee-saved — 64-bit combined rejection accumulator (OOR + high-rel-err)
         const auto& reg_main_iters = r8;
         const auto& reg_idx = rsi;
         const auto& reg_tmp = r9;
@@ -471,7 +471,7 @@ private:
         Label main_loop, tail_block, normal_exit, lossy_exit, done;
 
         preamble();
-        xor_(reg_oor_accum, reg_oor_accum);
+        xor_(reg_rejected_accum, reg_rejected_accum);
 
         auto bcast = [&, this](const Xbyak::Zmm& vec, const void* p) {
             mov(reg_addr, reinterpret_cast<size_t>(p));
@@ -489,7 +489,7 @@ private:
 
         // --- Load args ---
         mov(reg_src, ptr[param + offsetof(args_t, src)]);
-        mov(reg_oor_dst, ptr[param + offsetof(args_t, oor_dst)]);
+        mov(reg_rejected_dst, ptr[param + offsetof(args_t, rejected_dst)]);
         mov(reg_lossy_dst, ptr[param + offsetof(args_t, lossy_dst)]);
         mov(reg_count, ptr[param + offsetof(args_t, count)]);
 
@@ -546,7 +546,7 @@ private:
                 kandw(k_oor, k_oor, k_tail);
             }
 
-            // === Accumulate popcount(k_oor) into reg_oor_accum ===
+            // === Accumulate popcount(k_oor) into reg_rejected_accum ===
             // Branchless 16-bit SWAR popcount — avoids POPCNT (not gated by mayiuse(avx512_core)).
             kmovw(reg_tmp.cvt32(), k_oor);           // x = k_oor (16 bits in low word)
             mov(reg_addr.cvt32(), reg_tmp.cvt32());  // tmp2 = x
@@ -566,7 +566,7 @@ private:
             shr(reg_addr.cvt32(), 8);
             add(reg_tmp.cvt32(), reg_addr.cvt32());  // low byte = popcount (max 16)
             and_(reg_tmp, 0xFF);                     // zero upper bits before 64-bit add
-            add(reg_oor_accum, reg_tmp);
+            add(reg_rejected_accum, reg_tmp);
         };
 
         // --- Main loop: 16 elements per iteration ---
@@ -603,7 +603,7 @@ private:
 
         // --- Normal exit: write OOR accumulator and lossy=0 ---
         L(normal_exit);
-        mov(qword[reg_oor_dst], reg_oor_accum);
+        mov(qword[reg_rejected_dst], reg_rejected_accum);
         xor_(reg_tmp, reg_tmp);
         mov(qword[reg_lossy_dst], reg_tmp);
         jmp(done, T_NEAR);
@@ -611,7 +611,7 @@ private:
         // --- Lossy exit: partial OOR count is meaningless, write 0; lossy=1 ---
         L(lossy_exit);
         xor_(reg_tmp, reg_tmp);
-        mov(qword[reg_oor_dst], reg_tmp);
+        mov(qword[reg_rejected_dst], reg_tmp);
         mov(reg_tmp, 1);
         mov(qword[reg_lossy_dst], reg_tmp);
 
@@ -627,7 +627,7 @@ class jit_check_f16_compression : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* oor_dst;    // size_t* — output: combined out-of-range + high-relative-error count
+        void* rejected_dst;    // size_t* — output: combined out-of-range + high-relative-error count
         void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
@@ -654,7 +654,7 @@ private:
 
         // GP register allocation
         const auto& reg_src = rax;
-        const auto& reg_oor_dst = rbx;
+        const auto& reg_rejected_dst = rbx;
         const auto& reg_lossy_dst = r12;  // callee-saved, preserved by preamble
         const auto& reg_sz = rdx;
         const auto& reg_saved_rsp = r13;  // callee-saved, for stack cleanup on lossy exit
@@ -665,8 +665,8 @@ private:
         const auto& mask_vec = ymm2;  // OOR mask per chunk
         const auto& mask_vec_xmm = xmm2;
         const auto& tmp_vec = ymm3;
-        const auto& oor_accum = ymm4;
-        const auto& oor_accum_xmm = xmm4;
+        const auto& rejected_accum = ymm4;
+        const auto& rejected_accum_xmm = xmm4;
         const auto& f16_max_pos_vec = ymm5;
         const auto& f16_max_neg_vec = ymm6;
         const auto& f16_min_pos_vec = ymm7;
@@ -732,11 +732,11 @@ private:
         load_vec(rel_err_vec, reinterpret_cast<size_t>(rel_errs));
         load_vec(abs_mask_vec, reinterpret_cast<size_t>(abs_masks));
         vxorps(f16_zero_vec, f16_zero_vec, f16_zero_vec);
-        vxorps(oor_accum, oor_accum, oor_accum);
+        vxorps(rejected_accum, rejected_accum, rejected_accum);
 
         // Load args
         mov(reg_src, ptr[param + offsetof(args_t, src)]);
-        mov(reg_oor_dst, ptr[param + offsetof(args_t, oor_dst)]);
+        mov(reg_rejected_dst, ptr[param + offsetof(args_t, rejected_dst)]);
         mov(reg_lossy_dst, ptr[param + offsetof(args_t, lossy_dst)]);
         mov(reg_sz, ptr[param + offsetof(args_t, count)]);
 
@@ -796,7 +796,7 @@ private:
             vphaddd(mask_vec, mask_vec, mask_vec);
             vpermq(mask_vec, mask_vec, 0x08);
             vpmovsxdq(mask_vec, mask_vec_xmm);
-            vpaddq(oor_accum, oor_accum, mask_vec);
+            vpaddq(rejected_accum, rejected_accum, mask_vec);
         };
 
         // --- Main loop: 8 elements per iteration ---
@@ -836,15 +836,15 @@ private:
         // --- Normal exit: no lossy elements found ---
         L(exit_normal);
         {
-            // Horizontal sum of oor_accum (4 x i64) -> single i64
+            // Horizontal sum of rejected_accum (4 x i64) -> single i64
             const auto& tmp0 = xmm2;  // reuse mask_vec
             const auto& tmp1 = xmm3;  // reuse tmp_vec
-            vextractf128(tmp0, oor_accum, 0);
-            vextractf128(tmp1, oor_accum, 1);
-            vpaddq(oor_accum_xmm, tmp0, tmp1);
-            vpermilpd(tmp0, oor_accum_xmm, 0x01);
-            vpaddq(oor_accum_xmm, oor_accum_xmm, tmp0);
-            vmovq(qword[reg_oor_dst], oor_accum_xmm);
+            vextractf128(tmp0, rejected_accum, 0);
+            vextractf128(tmp1, rejected_accum, 1);
+            vpaddq(rejected_accum_xmm, tmp0, tmp1);
+            vpermilpd(tmp0, rejected_accum_xmm, 0x01);
+            vpaddq(rejected_accum_xmm, rejected_accum_xmm, tmp0);
+            vmovq(qword[reg_rejected_dst], rejected_accum_xmm);
 
             // lossy = 0
             xor_(rsi, rsi);
@@ -856,7 +856,7 @@ private:
         L(exit_lossy);
         mov(rsp, reg_saved_rsp);  // restore rsp (handles both main loop and tail cases)
         xor_(rsi, rsi);
-        mov(qword[reg_oor_dst], rsi);  // oor_count = 0 (meaningless, caller checks lossy first)
+        mov(qword[reg_rejected_dst], rsi);  // rejected_count = 0 (meaningless, caller checks lossy first)
         mov(rsi, 1);
         mov(qword[reg_lossy_dst], rsi);  // lossy = 1
 
@@ -952,7 +952,7 @@ template <typename Jit>
 CompressionCheckResult run_check_f16_compression_jit(typename Jit::fn_t fn, const float* arg, size_t count) {
     CompressionCheckResult result{0, false};
     size_t lossy_count = 0;
-    typename Jit::args_t args = {arg, &result.out_of_range_count, &lossy_count, count};
+    typename Jit::args_t args = {arg, &result.rejected_count, &lossy_count, count};
     fn(&args);
     result.has_lossy = lossy_count > 0;
     return result;
@@ -975,7 +975,7 @@ CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
     for (size_t i = 0; i < count; ++i) {
         const float v = arg[i];
         if (is_out_of_f16_range(v)) {
-            ++result.out_of_range_count;
+            ++result.rejected_count;
         } else {
             const double roundtripped = static_cast<double>(static_cast<float>(static_cast<float16>(v)));
             const double abs_diff = std::abs(v - roundtripped);
@@ -983,7 +983,7 @@ CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
                 return {0, true};
             }
             if (v != 0.0f && abs_diff / std::abs(v) > f16_compression_max_rel_error) {
-                ++result.out_of_range_count;
+                ++result.rejected_count;
             }
         }
     }

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -20,6 +20,13 @@ namespace reference {
 
 namespace {
 #ifdef OV_CORE_USE_XBYAK_JIT
+// vcvtps2ph immediate: force round-to-nearest-even and suppress all FP
+// exceptions, so the rounding is independent of caller MXCSR state and
+// bit-identical to static_cast<ov::float16>(float). Equivalent to
+// _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC from <immintrin.h>.
+// (Not 0x04 — that is _MM_FROUND_CUR_DIRECTION, i.e. "use MXCSR".)
+static constexpr uint8_t kVcvtps2phRneNoExc = 0x08;
+
 template <typename src_t, typename dst_t, bool clamp = false>
 void jit_convert_vec(jit::Generator&, const Xbyak::RegExp&, const Xbyak::RegExp&) {}
 
@@ -36,7 +43,7 @@ void jit_convert_vec<uint8_t, float16>(jit::Generator& gen, const Xbyak::RegExp&
     gen.movq(u8vec, gen.qword[src]);
     gen.vpmovzxbd(i32vec, u8vec);
     gen.vcvtdq2ps(fvec, i32vec);
-    gen.vcvtps2ph(f16vec, fvec, 0x08);  // RNE + suppress all exceptions (independent of MXCSR)
+    gen.vcvtps2ph(f16vec, fvec, kVcvtps2phRneNoExc);
     gen.vzeroupper();
     gen.vmovdqu(gen.xword[dst], f16vec);
 }
@@ -57,7 +64,7 @@ void jit_convert_vec<float, float16>(jit::Generator& gen, const Xbyak::RegExp& s
     auto f32vec = gen.ymm4;
 
     gen.vmovups(f32vec, gen.yword[src]);
-    gen.vcvtps2ph(f16vec, f32vec, 0x08);  // RNE + suppress all exceptions (independent of MXCSR)
+    gen.vcvtps2ph(f16vec, f32vec, kVcvtps2phRneNoExc);
     gen.vmovdqu(gen.xword[dst], f16vec);
 }
 
@@ -66,9 +73,9 @@ void jit_convert_vec<bfloat16, float16>(jit::Generator& gen, const Xbyak::RegExp
     const auto f32vec = gen.ymm4;
     const auto f16vec = gen.xmm3;
 
-    gen.vpmovzxwd(f32vec, gen.yword[src]);  // load bf16 into tmp
-    gen.vpslld(f32vec, f32vec, 16);         // convert bf16->f32 by bit shift
-    gen.vcvtps2ph(f16vec, f32vec, 0x08);    // convert f32 -> f16 (RNE + suppress exc, independent of MXCSR)
+    gen.vpmovzxwd(f32vec, gen.yword[src]);               // load bf16 into tmp
+    gen.vpslld(f32vec, f32vec, 16);                      // convert bf16->f32 by bit shift
+    gen.vcvtps2ph(f16vec, f32vec, kVcvtps2phRneNoExc);   // convert f32 -> f16
     gen.vmovdqu(gen.xword[dst], f16vec);    // move result to destination
 }
 
@@ -82,9 +89,9 @@ void jit_convert_vec<bfloat16, float16, true>(jit::Generator& gen, const Xbyak::
 
     gen.vpmovzxwd(f32vec, gen.yword[src]);    // load bf16 into tmp
     gen.vpslld(f32vec, f32vec, 16);           // convert bf16->f32 by bit shift
-    gen.vminps(f32vec, f32vec, upper_bound);  // clamp f16 max
-    gen.vmaxps(f32vec, f32vec, lower_bound);  // clamp f16 lowest
-    gen.vcvtps2ph(f16vec, f32vec, 0x08);      // convert f32 -> f16 (RNE + suppress exc, independent of MXCSR)
+    gen.vminps(f32vec, f32vec, upper_bound);              // clamp f16 max
+    gen.vmaxps(f32vec, f32vec, lower_bound);              // clamp f16 lowest
+    gen.vcvtps2ph(f16vec, f32vec, kVcvtps2phRneNoExc);    // convert f32 -> f16
     gen.vmovdqu(gen.xword[dst], f16vec);      // move result to destination
 }
 
@@ -129,7 +136,7 @@ void jit_convert_vec<float, float16, true>(jit::Generator& gen, const Xbyak::Reg
     gen.vmovups(f32vec, gen.yword[src]);
     gen.vminps(f32vec, f32vec, upper_bound);
     gen.vmaxps(f32vec, f32vec, lower_bound);
-    gen.vcvtps2ph(f16vec, f32vec, 0x08);  // RNE + suppress all exceptions (independent of MXCSR)
+    gen.vcvtps2ph(f16vec, f32vec, kVcvtps2phRneNoExc);
     gen.vmovdqu(gen.xword[dst], f16vec);
 }
 
@@ -388,7 +395,7 @@ class jit_check_f16_compression_avx512 : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* oor_dst;    // size_t* — output: out-of-range + relative-error count
+        void* oor_dst;    // size_t* — output: combined out-of-range + high-relative-error count
         void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
@@ -507,8 +514,7 @@ private:
             }
 
             // === Roundtrip f32 -> f16 -> f32 ===
-            // imm=0x08 (RNE + suppress all exceptions, ignore MXCSR) — matches static_cast<float16> in C++ fallback
-            vcvtps2ph(rt_ymm, data_vec, 0x08);
+            vcvtps2ph(rt_ymm, data_vec, kVcvtps2phRneNoExc);
             vcvtph2ps(rt_vec, rt_ymm);
 
             // === abs_diff = |data - roundtripped| ===
@@ -613,7 +619,7 @@ class jit_check_f16_compression : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* oor_dst;    // size_t* — output: out-of-range count
+        void* oor_dst;    // size_t* — output: combined out-of-range + high-relative-error count
         void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
@@ -751,9 +757,8 @@ private:
             // mask_vec now has per-element OOR mask (0xFFFFFFFF for OOR, 0 for in-range)
 
             // === Lossy check for in-range elements ===
-            // Roundtrip: f32 -> f16 -> f32
-            // imm=0x08 (RNE + suppress all exceptions, ignore MXCSR) — matches static_cast<float16> in C++ fallback
-            vcvtps2ph(rt_vec_xmm, data_vec, 0x08);  // f32 -> f16 (8 values)
+            // Roundtrip: f32 -> f16 -> f32 (f16 part written to low xmm of rt_vec_xmm)
+            vcvtps2ph(rt_vec_xmm, data_vec, kVcvtps2phRneNoExc);  // f32 -> f16 (8 values)
             vcvtph2ps(diff_vec, rt_vec_xmm);        // f16 -> f32 (roundtripped)
 
             // abs_diff = |data - roundtripped|
@@ -955,6 +960,18 @@ CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
         }
     }
     return {out_of_range, false};
+}
+
+size_t count_out_of_f16_range(const float* arg, size_t count) {
+    // Backward-compatible helper: strict FP16-range count only (no relative-error accounting).
+    // The in-tree FP16 compression path uses check_f16_compression(); this wrapper exists for
+    // external developer-package consumers that linked against the pre-PR symbol.
+    const auto is_out_of_f16_range = [](const float v) {
+        return (std::abs(v) < float16::from_bits(0x0001) && v != 0.0f) || (v > std::numeric_limits<float16>::max()) ||
+               (v < std::numeric_limits<float16>::lowest());
+    };
+
+    return std::count_if(arg, arg + count, is_out_of_f16_range);
 }
 
 }  // namespace reference

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -411,25 +411,25 @@ private:
 
         // GP register allocation
         const auto& reg_src = rax;
-        const auto& reg_oor_dst = rbx;       // callee-saved
-        const auto& reg_lossy_dst = r12;     // callee-saved
+        const auto& reg_oor_dst = rbx;    // callee-saved
+        const auto& reg_lossy_dst = r12;  // callee-saved
         const auto& reg_count = rdx;
-        const auto& reg_oor_accum = r14;     // callee-saved — 64-bit OOR + RelErr accumulator
+        const auto& reg_oor_accum = r14;  // callee-saved — 64-bit OOR + RelErr accumulator
         const auto& reg_main_iters = r8;
         const auto& reg_idx = rsi;
         const auto& reg_tmp = r9;
-        const auto& reg_addr = r15;          // callee-saved — used to load constants
+        const auto& reg_addr = r15;  // callee-saved — used to load constants
 
         // ZMM register allocation
-        const auto& data_vec = zmm0;         // chunk of 16 floats
-        const auto& rt_vec = zmm1;           // f32->f16->f32 roundtripped
-        const auto& rt_ymm = ymm1;           // low 256-bit alias for vcvtps2ph dest
-        const auto& diff_vec = zmm2;         // |data - roundtripped|
-        const auto& abs_data_vec = zmm3;     // |data|
-        const auto& rel_thresh_vec = zmm4;   // |data| * 1e-4
-        const auto& abs_mask_vec = zmm5;     // 0x7FFFFFFF broadcast
-        const auto& abs_err_vec = zmm6;      // 1.0f broadcast
-        const auto& rel_err_vec = zmm7;      // 1e-4f broadcast
+        const auto& data_vec = zmm0;        // chunk of 16 floats
+        const auto& rt_vec = zmm1;          // f32->f16->f32 roundtripped
+        const auto& rt_ymm = ymm1;          // low 256-bit alias for vcvtps2ph dest
+        const auto& diff_vec = zmm2;        // |data - roundtripped|
+        const auto& abs_data_vec = zmm3;    // |data|
+        const auto& rel_thresh_vec = zmm4;  // |data| * 1e-4
+        const auto& abs_mask_vec = zmm5;    // 0x7FFFFFFF broadcast
+        const auto& abs_err_vec = zmm6;     // 1.0f broadcast
+        const auto& rel_err_vec = zmm7;     // 1e-4f broadcast
         const auto& f16_max_pos_vec = zmm8;
         const auto& f16_max_neg_vec = zmm9;
         const auto& f16_min_pos_vec = zmm10;
@@ -437,10 +437,10 @@ private:
         const auto& zero_vec = zmm12;
 
         // Opmasks (k0 reserved by ISA — represents "no mask")
-        const auto& k_oor = k1;     // OOR per chunk (subnormal | overflow), then |= relative-error
-        const auto& k_lossy = k2;   // (abs_diff > 1.0) AND NOT k_oor — early exit
-        const auto& k_rel = k3;     // (abs_diff > |data|*1e-4) AND NOT k_oor
-        const auto& k_tail = k4;    // tail mask (built once before tail iteration)
+        const auto& k_oor = k1;    // OOR per chunk (subnormal | overflow), then |= relative-error
+        const auto& k_lossy = k2;  // (abs_diff > 1.0) AND NOT k_oor — early exit
+        const auto& k_rel = k3;    // (abs_diff > |data|*1e-4) AND NOT k_oor
+        const auto& k_tail = k4;   // tail mask (built once before tail iteration)
         const auto& k_tmp1 = k5;
         const auto& k_tmp2 = k6;
 
@@ -490,8 +490,8 @@ private:
             // subnormal-when-rounded: |data| < min_pos AND data != 0
             vcmpps(k_tmp1, data_vec, f16_min_pos_vec, _cmp_lt_os);  // data < min_pos
             vcmpps(k_tmp2, data_vec, f16_min_neg_vec, _cmp_gt_os);  // data > min_neg
-            kandw(k_oor, k_tmp1, k_tmp2);                            // in (-min_pos, min_pos)
-            vcmpps(k_tmp1, data_vec, zero_vec, _cmp_neq_uq);         // data != 0
+            kandw(k_oor, k_tmp1, k_tmp2);                           // in (-min_pos, min_pos)
+            vcmpps(k_tmp1, data_vec, zero_vec, _cmp_neq_uq);        // data != 0
             kandw(k_oor, k_oor, k_tmp1);
             // overflow: data > max_pos OR data < max_neg
             vcmpps(k_tmp1, data_vec, f16_max_pos_vec, _cmp_gt_os);

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -536,24 +536,24 @@ private:
 
             // === Accumulate popcount(k_oor) into reg_oor_accum ===
             // Branchless 16-bit SWAR popcount — avoids POPCNT (not gated by mayiuse(avx512_core)).
-            kmovw(reg_tmp.cvt32(), k_oor);                // x = k_oor (16 bits in low word)
-            mov(reg_addr.cvt32(), reg_tmp.cvt32());       // tmp2 = x
+            kmovw(reg_tmp.cvt32(), k_oor);           // x = k_oor (16 bits in low word)
+            mov(reg_addr.cvt32(), reg_tmp.cvt32());  // tmp2 = x
             shr(reg_addr.cvt32(), 1);
             and_(reg_addr.cvt32(), 0x5555);
-            sub(reg_tmp.cvt32(), reg_addr.cvt32());       // x -= (x >> 1) & 0x5555
+            sub(reg_tmp.cvt32(), reg_addr.cvt32());  // x -= (x >> 1) & 0x5555
             mov(reg_addr.cvt32(), reg_tmp.cvt32());
             and_(reg_addr.cvt32(), 0x3333);
             shr(reg_tmp.cvt32(), 2);
             and_(reg_tmp.cvt32(), 0x3333);
-            add(reg_tmp.cvt32(), reg_addr.cvt32());       // x = (x & 0x3333) + ((x >> 2) & 0x3333)
+            add(reg_tmp.cvt32(), reg_addr.cvt32());  // x = (x & 0x3333) + ((x >> 2) & 0x3333)
             mov(reg_addr.cvt32(), reg_tmp.cvt32());
             shr(reg_addr.cvt32(), 4);
             add(reg_tmp.cvt32(), reg_addr.cvt32());
-            and_(reg_tmp.cvt32(), 0x0F0F);                // x = (x + (x >> 4)) & 0x0F0F
+            and_(reg_tmp.cvt32(), 0x0F0F);  // x = (x + (x >> 4)) & 0x0F0F
             mov(reg_addr.cvt32(), reg_tmp.cvt32());
             shr(reg_addr.cvt32(), 8);
-            add(reg_tmp.cvt32(), reg_addr.cvt32());       // low byte = popcount (max 16)
-            and_(reg_tmp, 0xFF);                          // zero upper bits before 64-bit add
+            add(reg_tmp.cvt32(), reg_addr.cvt32());  // low byte = popcount (max 16)
+            and_(reg_tmp, 0xFF);                     // zero upper bits before 64-bit add
             add(reg_oor_accum, reg_tmp);
         };
 

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -36,7 +36,7 @@ void jit_convert_vec<uint8_t, float16>(jit::Generator& gen, const Xbyak::RegExp&
     gen.movq(u8vec, gen.qword[src]);
     gen.vpmovzxbd(i32vec, u8vec);
     gen.vcvtdq2ps(fvec, i32vec);
-    gen.vcvtps2ph(f16vec, fvec, 0x04);  // force RNE, independent of MXCSR
+    gen.vcvtps2ph(f16vec, fvec, 0x08);  // RNE + suppress all exceptions (independent of MXCSR)
     gen.vzeroupper();
     gen.vmovdqu(gen.xword[dst], f16vec);
 }
@@ -57,7 +57,7 @@ void jit_convert_vec<float, float16>(jit::Generator& gen, const Xbyak::RegExp& s
     auto f32vec = gen.ymm4;
 
     gen.vmovups(f32vec, gen.yword[src]);
-    gen.vcvtps2ph(f16vec, f32vec, 0x04);  // force RNE, independent of MXCSR
+    gen.vcvtps2ph(f16vec, f32vec, 0x08);  // RNE + suppress all exceptions (independent of MXCSR)
     gen.vmovdqu(gen.xword[dst], f16vec);
 }
 
@@ -68,7 +68,7 @@ void jit_convert_vec<bfloat16, float16>(jit::Generator& gen, const Xbyak::RegExp
 
     gen.vpmovzxwd(f32vec, gen.yword[src]);  // load bf16 into tmp
     gen.vpslld(f32vec, f32vec, 16);         // convert bf16->f32 by bit shift
-    gen.vcvtps2ph(f16vec, f32vec, 0x04);    // convert f32 -> f16 (force RNE, independent of MXCSR)
+    gen.vcvtps2ph(f16vec, f32vec, 0x08);    // convert f32 -> f16 (RNE + suppress exc, independent of MXCSR)
     gen.vmovdqu(gen.xword[dst], f16vec);    // move result to destination
 }
 
@@ -84,7 +84,7 @@ void jit_convert_vec<bfloat16, float16, true>(jit::Generator& gen, const Xbyak::
     gen.vpslld(f32vec, f32vec, 16);           // convert bf16->f32 by bit shift
     gen.vminps(f32vec, f32vec, upper_bound);  // clamp f16 max
     gen.vmaxps(f32vec, f32vec, lower_bound);  // clamp f16 lowest
-    gen.vcvtps2ph(f16vec, f32vec, 0x04);      // convert f32 -> f16 (force RNE, independent of MXCSR)
+    gen.vcvtps2ph(f16vec, f32vec, 0x08);      // convert f32 -> f16 (RNE + suppress exc, independent of MXCSR)
     gen.vmovdqu(gen.xword[dst], f16vec);      // move result to destination
 }
 
@@ -129,7 +129,7 @@ void jit_convert_vec<float, float16, true>(jit::Generator& gen, const Xbyak::Reg
     gen.vmovups(f32vec, gen.yword[src]);
     gen.vminps(f32vec, f32vec, upper_bound);
     gen.vmaxps(f32vec, f32vec, lower_bound);
-    gen.vcvtps2ph(f16vec, f32vec, 0x04);  // force RNE, independent of MXCSR
+    gen.vcvtps2ph(f16vec, f32vec, 0x08);  // RNE + suppress all exceptions (independent of MXCSR)
     gen.vmovdqu(gen.xword[dst], f16vec);
 }
 
@@ -507,8 +507,8 @@ private:
             }
 
             // === Roundtrip f32 -> f16 -> f32 ===
-            // imm=0x04 (RNE, ignore MXCSR) — matches static_cast<float16> in C++ fallback
-            vcvtps2ph(rt_ymm, data_vec, 0x04);
+            // imm=0x08 (RNE + suppress all exceptions, ignore MXCSR) — matches static_cast<float16> in C++ fallback
+            vcvtps2ph(rt_ymm, data_vec, 0x08);
             vcvtph2ps(rt_vec, rt_ymm);
 
             // === abs_diff = |data - roundtripped| ===
@@ -535,8 +535,25 @@ private:
             }
 
             // === Accumulate popcount(k_oor) into reg_oor_accum ===
-            kmovw(reg_tmp.cvt32(), k_oor);
-            popcnt(reg_tmp, reg_tmp);
+            // Branchless 16-bit SWAR popcount — avoids POPCNT (not gated by mayiuse(avx512_core)).
+            kmovw(reg_tmp.cvt32(), k_oor);                // x = k_oor (16 bits in low word)
+            mov(reg_addr.cvt32(), reg_tmp.cvt32());       // tmp2 = x
+            shr(reg_addr.cvt32(), 1);
+            and_(reg_addr.cvt32(), 0x5555);
+            sub(reg_tmp.cvt32(), reg_addr.cvt32());       // x -= (x >> 1) & 0x5555
+            mov(reg_addr.cvt32(), reg_tmp.cvt32());
+            and_(reg_addr.cvt32(), 0x3333);
+            shr(reg_tmp.cvt32(), 2);
+            and_(reg_tmp.cvt32(), 0x3333);
+            add(reg_tmp.cvt32(), reg_addr.cvt32());       // x = (x & 0x3333) + ((x >> 2) & 0x3333)
+            mov(reg_addr.cvt32(), reg_tmp.cvt32());
+            shr(reg_addr.cvt32(), 4);
+            add(reg_tmp.cvt32(), reg_addr.cvt32());
+            and_(reg_tmp.cvt32(), 0x0F0F);                // x = (x + (x >> 4)) & 0x0F0F
+            mov(reg_addr.cvt32(), reg_tmp.cvt32());
+            shr(reg_addr.cvt32(), 8);
+            add(reg_tmp.cvt32(), reg_addr.cvt32());       // low byte = popcount (max 16)
+            and_(reg_tmp, 0xFF);                          // zero upper bits before 64-bit add
             add(reg_oor_accum, reg_tmp);
         };
 
@@ -560,9 +577,12 @@ private:
         and_(reg_count, 15);
         jz(normal_exit, T_NEAR);
 
-        // k_tail = (1 << reg_count) - 1, via bzhi (BMI2 — always present with avx512_core)
-        mov(reg_tmp, static_cast<int>(-1));
-        bzhi(reg_tmp, reg_tmp, reg_count);
+        // k_tail = (1 << reg_count) - 1, using baseline SHL (BMI2 bzhi not gated by mayiuse(avx512_core)).
+        // rcx is free at this point: args_t pointer was consumed in the preamble.
+        mov(rcx, reg_count);
+        mov(reg_tmp, 1);
+        shl(reg_tmp, cl);
+        dec(reg_tmp);
         kmovw(k_tail, reg_tmp.cvt32());
 
         // Masked zeroing-load: out-of-mask lanes read as +0.0 (benign — pass none of the predicates)
@@ -732,8 +752,8 @@ private:
 
             // === Lossy check for in-range elements ===
             // Roundtrip: f32 -> f16 -> f32
-            // imm=0x04 (RNE, ignore MXCSR) — matches static_cast<float16> in C++ fallback
-            vcvtps2ph(rt_vec_xmm, data_vec, 0x04);  // f32 -> f16 (8 values)
+            // imm=0x08 (RNE + suppress all exceptions, ignore MXCSR) — matches static_cast<float16> in C++ fallback
+            vcvtps2ph(rt_vec_xmm, data_vec, 0x08);  // f32 -> f16 (8 values)
             vcvtph2ps(diff_vec, rt_vec_xmm);        // f16 -> f32 (roundtripped)
 
             // abs_diff = |data - roundtripped|

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -388,14 +388,14 @@ public:
     }
 };
 
-// Combined single-pass JIT kernel for AVX-512: counts out-of-range AND detects lossy f16 compression.
+// Single-pass JIT kernel for AVX-512: counts out-of-range AND detects lossy f16 compression.
 // Processes 16 floats per iteration using zmm + opmask + F16C (vcvtps2ph/vcvtph2ps). Bails immediately
 // if any in-range element has significant precision loss (abs error > 1.0). Tail handled via masked load.
 class jit_check_f16_compression_avx512 : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* oor_dst;    // size_t* — output: combined out-of-range + high-relative-error count
+        void* oor_dst;    // size_t* — output: strict FP16 out-of-range count
         void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
@@ -432,15 +432,12 @@ private:
         const auto& reg_addr = r15;  // callee-saved — used to load constants
 
         // ZMM register allocation
-        const auto& data_vec = zmm0;        // chunk of 16 floats
-        const auto& rt_vec = zmm1;          // f32->f16->f32 roundtripped
-        const auto& rt_ymm = ymm1;          // low 256-bit alias for vcvtps2ph dest
-        const auto& diff_vec = zmm2;        // |data - roundtripped|
-        const auto& abs_data_vec = zmm3;    // |data|
-        const auto& rel_thresh_vec = zmm4;  // |data| * 1e-4
-        const auto& abs_mask_vec = zmm5;    // 0x7FFFFFFF broadcast
-        const auto& abs_err_vec = zmm6;     // 1.0f broadcast
-        const auto& rel_err_vec = zmm7;     // 1e-4f broadcast
+        const auto& data_vec = zmm0;      // chunk of 16 floats
+        const auto& rt_vec = zmm1;        // f32->f16->f32 roundtripped
+        const auto& rt_ymm = ymm1;        // low 256-bit alias for vcvtps2ph dest
+        const auto& diff_vec = zmm2;      // |data - roundtripped|
+        const auto& abs_mask_vec = zmm5;  // 0x7FFFFFFF broadcast
+        const auto& abs_err_vec = zmm6;   // 1.0f broadcast
         const auto& f16_max_pos_vec = zmm8;
         const auto& f16_max_neg_vec = zmm9;
         const auto& f16_min_pos_vec = zmm10;
@@ -448,9 +445,8 @@ private:
         const auto& zero_vec = zmm12;
 
         // Opmasks (k0 reserved by ISA — represents "no mask")
-        const auto& k_oor = k1;    // OOR per chunk (subnormal | overflow), then |= relative-error
+        const auto& k_oor = k1;    // strict FP16 OOR per chunk (subnormal | overflow)
         const auto& k_lossy = k2;  // (abs_diff > 1.0) AND NOT k_oor — early exit
-        const auto& k_rel = k3;    // (abs_diff > |data|*1e-4) AND NOT k_oor
         const auto& k_tail = k4;   // tail mask (built once before tail iteration)
         const auto& k_tmp1 = k5;
         const auto& k_tmp2 = k6;
@@ -466,7 +462,6 @@ private:
         static const float f16_min_pos = ov::float16::from_bits(0x0001);
         static const float f16_min_neg = -ov::float16::from_bits(0x0001);
         static const float abs_err_val = static_cast<float>(ov::reference::f16_compression_max_abs_error);
-        static const float rel_err_val = static_cast<float>(ov::reference::f16_compression_max_rel_error);
         static const uint32_t abs_mask_val = 0x7FFFFFFF;
 
         auto bcast = [&, this](const Xbyak::Zmm& vec, const void* p) {
@@ -479,7 +474,6 @@ private:
         bcast(f16_min_pos_vec, &f16_min_pos);
         bcast(f16_min_neg_vec, &f16_min_neg);
         bcast(abs_err_vec, &abs_err_val);
-        bcast(rel_err_vec, &rel_err_val);
         bcast(abs_mask_vec, &abs_mask_val);
         vpxorq(zero_vec, zero_vec, zero_vec);
 
@@ -529,16 +523,6 @@ private:
             }
             kortestw(k_lossy, k_lossy);
             jnz(lossy_exit, T_NEAR);
-
-            // === Relative-error check: (abs_diff > |data| * 1e-4) AND NOT k_oor ===
-            vpandd(abs_data_vec, data_vec, abs_mask_vec);
-            vmulps(rel_thresh_vec, abs_data_vec, rel_err_vec);
-            vcmpps(k_rel, diff_vec, rel_thresh_vec, _cmp_gt_os);
-            kandnw(k_rel, k_oor, k_rel);
-            korw(k_oor, k_oor, k_rel);
-            if (masked) {
-                kandw(k_oor, k_oor, k_tail);
-            }
 
             // === Accumulate popcount(k_oor) into reg_oor_accum ===
             // Branchless 16-bit SWAR popcount — avoids POPCNT (not gated by mayiuse(avx512_core)).
@@ -612,14 +596,14 @@ private:
     }
 };
 
-// Combined single-pass JIT kernel: counts out-of-range AND detects lossy f16 compression.
+// Single-pass JIT kernel: counts out-of-range AND detects lossy f16 compression.
 // Processes 8 floats per iteration using AVX2+F16C. Bails immediately if any in-range
 // element has significant precision loss (abs error > 1.0).
 class jit_check_f16_compression : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* oor_dst;    // size_t* — output: combined out-of-range + high-relative-error count
+        void* oor_dst;    // size_t* — output: strict FP16 out-of-range count
         void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
@@ -668,7 +652,6 @@ private:
         // Lossy check constants
         const auto& abs_err_vec = ymm11;  // 1.0f broadcast
         const auto& abs_mask_vec = ymm0;  // 0x7FFFFFFF broadcast (for fabs)
-        const auto& rel_err_vec = ymm12;  // 1e-4f broadcast (for relative error threshold)
         // Temps for lossy computation (reused per chunk)
         const auto& diff_vec = ymm14;
         const auto& rt_vec_xmm = xmm15;  // for f32->f16->f32 roundtrip
@@ -685,7 +668,6 @@ private:
         static const float f16_min_neg = -ov::float16::from_bits(0x0001);
         static const int32_t i32_one = 1;
         static const float abs_err_val = static_cast<float>(ov::reference::f16_compression_max_abs_error);
-        static const float rel_err_val = static_cast<float>(ov::reference::f16_compression_max_rel_error);
         static const uint32_t abs_mask_val = 0x7FFFFFFF;
 
         static const float max_pos_bounds[8] =
@@ -699,8 +681,6 @@ private:
         static const int32_t i32_ones[8] = {i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one};
         static const float abs_errs[8] =
             {abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val};
-        static const float rel_errs[8] =
-            {rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val};
         static const uint32_t abs_masks[8] = {abs_mask_val,
                                               abs_mask_val,
                                               abs_mask_val,
@@ -721,7 +701,6 @@ private:
         load_vec(f16_min_neg_vec, (size_t)min_neg_bounds);
         load_vec(i32_ones_vec, (size_t)i32_ones);
         load_vec(abs_err_vec, (size_t)abs_errs);
-        load_vec(rel_err_vec, (size_t)rel_errs);
         load_vec(abs_mask_vec, (size_t)abs_masks);
         vxorps(f16_zero_vec, f16_zero_vec, f16_zero_vec);
         vxorps(oor_accum, oor_accum, oor_accum);
@@ -775,15 +754,7 @@ private:
             vtestps(tmp_vec, tmp_vec);  // ZF=1 if all zeros
             jnz(exit_lossy, T_NEAR);    // bail if any lossy
 
-            // === Relative error check: count elements where |diff| > |value| * 1e-4 ===
-            // (equivalent to abs_diff / |value| > 1e-4, but avoids division)
-            vandps(tmp_vec, data_vec, abs_mask_vec);         // tmp_vec = |data|
-            vmulps(tmp_vec, tmp_vec, rel_err_vec);           // tmp_vec = |data| * 1e-4
-            vcmpps(tmp_vec, diff_vec, tmp_vec, _cmp_gt_os);  // 1 where |diff| > |data|*1e-4
-            vandnps(tmp_vec, mask_vec, tmp_vec);             // exclude OOR (avoid double-count)
-            vorps(mask_vec, mask_vec, tmp_vec);              // combine OOR + relative-error
-
-            // === Accumulate combined OOR + relative-error count ===
+            // === Accumulate strict OOR count ===
             vandps(mask_vec, mask_vec, i32_ones_vec);
             vphaddd(mask_vec, mask_vec, mask_vec);
             vpermq(mask_vec, mask_vec, 0x08);
@@ -953,9 +924,6 @@ CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
             const double abs_diff = std::abs(v - roundtripped);
             if (abs_diff > f16_compression_max_abs_error) {
                 return {0, true};
-            }
-            if (v != 0.0f && abs_diff / std::abs(v) > f16_compression_max_rel_error) {
-                ++out_of_range;
             }
         }
     }

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -409,8 +409,8 @@ class jit_check_f16_compression_avx512 : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* rejected_dst;    // size_t* — output: combined out-of-range + high-relative-error count
-        void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
+        void* rejected_dst;  // size_t* — output: combined out-of-range + high-relative-error count
+        void* lossy_dst;     // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
 
@@ -436,10 +436,11 @@ private:
 
         // GP register allocation
         const auto& reg_src = rax;
-        const auto& reg_rejected_dst = rbx;    // callee-saved
-        const auto& reg_lossy_dst = r12;  // callee-saved
+        const auto& reg_rejected_dst = rbx;  // callee-saved
+        const auto& reg_lossy_dst = r12;     // callee-saved
         const auto& reg_count = rdx;
-        const auto& reg_rejected_accum = r14;  // callee-saved — 64-bit combined rejection accumulator (OOR + high-rel-err)
+        const auto& reg_rejected_accum =
+            r14;  // callee-saved — 64-bit combined rejection accumulator (OOR + high-rel-err)
         const auto& reg_main_iters = r8;
         const auto& reg_idx = rsi;
         const auto& reg_tmp = r9;
@@ -627,8 +628,8 @@ class jit_check_f16_compression : public jit::Generator {
 public:
     typedef struct {
         const void* src;
-        void* rejected_dst;    // size_t* — output: combined out-of-range + high-relative-error count
-        void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
+        void* rejected_dst;  // size_t* — output: combined out-of-range + high-relative-error count
+        void* lossy_dst;     // size_t* — output: lossy count (0 or non-zero)
         const size_t count;
     } args_t;
 

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -73,10 +73,10 @@ void jit_convert_vec<bfloat16, float16>(jit::Generator& gen, const Xbyak::RegExp
     const auto f32vec = gen.ymm4;
     const auto f16vec = gen.xmm3;
 
-    gen.vpmovzxwd(f32vec, gen.yword[src]);               // load bf16 into tmp
-    gen.vpslld(f32vec, f32vec, 16);                      // convert bf16->f32 by bit shift
-    gen.vcvtps2ph(f16vec, f32vec, kVcvtps2phRneNoExc);   // convert f32 -> f16
-    gen.vmovdqu(gen.xword[dst], f16vec);    // move result to destination
+    gen.vpmovzxwd(f32vec, gen.yword[src]);              // load bf16 into tmp
+    gen.vpslld(f32vec, f32vec, 16);                     // convert bf16->f32 by bit shift
+    gen.vcvtps2ph(f16vec, f32vec, kVcvtps2phRneNoExc);  // convert f32 -> f16
+    gen.vmovdqu(gen.xword[dst], f16vec);                // move result to destination
 }
 
 template <>
@@ -87,12 +87,12 @@ void jit_convert_vec<bfloat16, float16, true>(jit::Generator& gen, const Xbyak::
     auto upper_bound = gen.ymm5;
     auto lower_bound = gen.ymm6;
 
-    gen.vpmovzxwd(f32vec, gen.yword[src]);    // load bf16 into tmp
-    gen.vpslld(f32vec, f32vec, 16);           // convert bf16->f32 by bit shift
-    gen.vminps(f32vec, f32vec, upper_bound);              // clamp f16 max
-    gen.vmaxps(f32vec, f32vec, lower_bound);              // clamp f16 lowest
-    gen.vcvtps2ph(f16vec, f32vec, kVcvtps2phRneNoExc);    // convert f32 -> f16
-    gen.vmovdqu(gen.xword[dst], f16vec);      // move result to destination
+    gen.vpmovzxwd(f32vec, gen.yword[src]);              // load bf16 into tmp
+    gen.vpslld(f32vec, f32vec, 16);                     // convert bf16->f32 by bit shift
+    gen.vminps(f32vec, f32vec, upper_bound);            // clamp f16 max
+    gen.vmaxps(f32vec, f32vec, lower_bound);            // clamp f16 lowest
+    gen.vcvtps2ph(f16vec, f32vec, kVcvtps2phRneNoExc);  // convert f32 -> f16
+    gen.vmovdqu(gen.xword[dst], f16vec);                // move result to destination
 }
 
 template <>
@@ -759,7 +759,7 @@ private:
             // === Lossy check for in-range elements ===
             // Roundtrip: f32 -> f16 -> f32 (f16 part written to low xmm of rt_vec_xmm)
             vcvtps2ph(rt_vec_xmm, data_vec, kVcvtps2phRneNoExc);  // f32 -> f16 (8 values)
-            vcvtph2ps(diff_vec, rt_vec_xmm);        // f16 -> f32 (roundtripped)
+            vcvtph2ps(diff_vec, rt_vec_xmm);                      // f16 -> f32 (roundtripped)
 
             // abs_diff = |data - roundtripped|
             vsubps(diff_vec, data_vec, diff_vec);

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -289,7 +289,7 @@ public:
             // Since the JIT code always resides in memory, and ASAN's memory management may remove executable
             // permissions, we need to restore executable permissions for the generated code.
             generator.setProtectModeRE(false);
-            return (fn_t)generator.getCode();
+            return generator.getCode<fn_t>();
         }
         return nullptr;
     }
@@ -396,7 +396,7 @@ public:
             // Since the JIT code always resides in memory, and ASAN's memory management may remove executable
             // permissions, we need to restore executable permissions for the generated code.
             generator.setProtectModeRE(false);
-            return (fn_t)generator.getCode();
+            return generator.getCode<fn_t>();
         }
         return nullptr;
     }
@@ -423,7 +423,7 @@ public:
             // Since the JIT code always resides in memory, and ASAN's memory management may remove executable
             // permissions, we need to restore executable permissions for the generated code.
             generator.setProtectModeRE(false);
-            return (fn_t)generator.getCode();
+            return generator.getCode<fn_t>();
         }
         return nullptr;
     }
@@ -467,9 +467,8 @@ private:
         const auto& k_rel = k3;    // (abs_diff > |data|*1e-4) AND NOT k_oor
         const auto& k_tail = k4;   // tail mask (built once before tail iteration)
         const auto& k_tmp1 = k5;
-        const auto& k_tmp2 = k6;
 
-        Label main_loop, tail_block, normal_exit, lossy_exit;
+        Label main_loop, tail_block, normal_exit, lossy_exit, done;
 
         preamble();
         xor_(reg_oor_accum, reg_oor_accum);
@@ -494,9 +493,9 @@ private:
         mov(reg_lossy_dst, ptr[param + offsetof(args_t, lossy_dst)]);
         mov(reg_count, ptr[param + offsetof(args_t, count)]);
 
-        const unsigned char _cmp_lt_os = 1;
-        const unsigned char _cmp_neq_uq = 4;
-        const unsigned char _cmp_gt_os = 6;
+        constexpr uint8_t cmp_lt_os = 1;
+        constexpr uint8_t cmp_neq_uq = 4;
+        constexpr uint8_t cmp_gt_os = 6;
 
         // Per-chunk emission. If `masked` is true, all opmasks are AND-ed with k_tail
         // to defensively clear out-of-tail lanes (masked load already zeroed them, but
@@ -504,15 +503,14 @@ private:
         auto emit_chunk = [&, this](bool masked) {
             // === Build OOR mask in k_oor ===
             // subnormal-when-rounded: |data| < min_pos AND data != 0
-            vcmpps(k_tmp1, data_vec, f16_min_pos_vec, _cmp_lt_os);  // data < min_pos
-            vcmpps(k_tmp2, data_vec, f16_min_neg_vec, _cmp_gt_os);  // data > min_neg
-            kandw(k_oor, k_tmp1, k_tmp2);                           // in (-min_pos, min_pos)
-            vcmpps(k_tmp1, data_vec, zero_vec, _cmp_neq_uq);        // data != 0
+            vcmpps(k_tmp1, data_vec, f16_min_pos_vec, cmp_lt_os);             // data < min_pos
+            vcmpps(k_oor | k_tmp1, data_vec, f16_min_neg_vec, cmp_gt_os);     // merge-masked: k_oor = k_tmp1 & (data > min_neg)
+            vcmpps(k_tmp1, data_vec, zero_vec, cmp_neq_uq);                   // data != 0
             kandw(k_oor, k_oor, k_tmp1);
             // overflow: data > max_pos OR data < max_neg
-            vcmpps(k_tmp1, data_vec, f16_max_pos_vec, _cmp_gt_os);
+            vcmpps(k_tmp1, data_vec, f16_max_pos_vec, cmp_gt_os);
             korw(k_oor, k_oor, k_tmp1);
-            vcmpps(k_tmp1, data_vec, f16_max_neg_vec, _cmp_lt_os);
+            vcmpps(k_tmp1, data_vec, f16_max_neg_vec, cmp_lt_os);
             korw(k_oor, k_oor, k_tmp1);
             if (masked) {
                 kandw(k_oor, k_oor, k_tail);
@@ -527,7 +525,7 @@ private:
             vpandd(diff_vec, diff_vec, abs_mask_vec);  // mask off sign bit
 
             // === Lossy check: (abs_diff > 1.0) AND NOT k_oor -> early exit ===
-            vcmpps(k_lossy, diff_vec, abs_err_vec, _cmp_gt_os);
+            vcmpps(k_lossy, diff_vec, abs_err_vec, cmp_gt_os);
             kandnw(k_lossy, k_oor, k_lossy);  // k_lossy = ~k_oor & k_lossy
             if (masked) {
                 kandw(k_lossy, k_lossy, k_tail);
@@ -538,7 +536,7 @@ private:
             // === Relative-error check: (abs_diff > |data| * 1e-4) AND NOT k_oor ===
             vpandd(abs_data_vec, data_vec, abs_mask_vec);
             vmulps(rel_thresh_vec, abs_data_vec, rel_err_vec);
-            vcmpps(k_rel, diff_vec, rel_thresh_vec, _cmp_gt_os);
+            vcmpps(k_rel, diff_vec, rel_thresh_vec, cmp_gt_os);
             kandnw(k_rel, k_oor, k_rel);
             korw(k_oor, k_oor, k_rel);
             if (masked) {
@@ -605,7 +603,7 @@ private:
         mov(qword[reg_oor_dst], reg_oor_accum);
         xor_(reg_tmp, reg_tmp);
         mov(qword[reg_lossy_dst], reg_tmp);
-        postamble();
+        jmp(done, T_NEAR);
 
         // --- Lossy exit: partial OOR count is meaningless, write 0; lossy=1 ---
         L(lossy_exit);
@@ -613,6 +611,8 @@ private:
         mov(qword[reg_oor_dst], reg_tmp);
         mov(reg_tmp, 1);
         mov(qword[reg_lossy_dst], reg_tmp);
+
+        L(done);
         postamble();
     }
 };
@@ -638,7 +638,7 @@ public:
             // Since the JIT code always resides in memory, and ASAN's memory management may remove executable
             // permissions, we need to restore executable permissions for the generated code.
             generator.setProtectModeRE(false);
-            return (fn_t)generator.getCode();
+            return generator.getCode<fn_t>();
         }
         return nullptr;
     }
@@ -678,7 +678,7 @@ private:
         const auto& diff_vec = ymm14;
         const auto& rt_vec_xmm = xmm15;  // for f32->f16->f32 roundtrip
 
-        Label exit_lossy, exit_normal;
+        Label exit_lossy, exit_normal, done;
 
         preamble();
         mov(reg_saved_rsp, rsp);  // save rsp for lossy exit stack cleanup
@@ -697,21 +697,21 @@ private:
             {kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg};
         static constexpr int32_t i32_ones[8] = {1, 1, 1, 1, 1, 1, 1, 1};
         static constexpr float abs_errs[8] = {kF16CompressionAbsErrVal,
-                                               kF16CompressionAbsErrVal,
-                                               kF16CompressionAbsErrVal,
-                                               kF16CompressionAbsErrVal,
-                                               kF16CompressionAbsErrVal,
-                                               kF16CompressionAbsErrVal,
-                                               kF16CompressionAbsErrVal,
-                                               kF16CompressionAbsErrVal};
+                                              kF16CompressionAbsErrVal,
+                                              kF16CompressionAbsErrVal,
+                                              kF16CompressionAbsErrVal,
+                                              kF16CompressionAbsErrVal,
+                                              kF16CompressionAbsErrVal,
+                                              kF16CompressionAbsErrVal,
+                                              kF16CompressionAbsErrVal};
         static constexpr float rel_errs[8] = {kF16CompressionRelErrVal,
-                                               kF16CompressionRelErrVal,
-                                               kF16CompressionRelErrVal,
-                                               kF16CompressionRelErrVal,
-                                               kF16CompressionRelErrVal,
-                                               kF16CompressionRelErrVal,
-                                               kF16CompressionRelErrVal,
-                                               kF16CompressionRelErrVal};
+                                              kF16CompressionRelErrVal,
+                                              kF16CompressionRelErrVal,
+                                              kF16CompressionRelErrVal,
+                                              kF16CompressionRelErrVal,
+                                              kF16CompressionRelErrVal,
+                                              kF16CompressionRelErrVal,
+                                              kF16CompressionRelErrVal};
         static constexpr uint32_t abs_masks[8] =
             {kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal};
 
@@ -737,9 +737,9 @@ private:
         mov(reg_lossy_dst, ptr[param + offsetof(args_t, lossy_dst)]);
         mov(reg_sz, ptr[param + offsetof(args_t, count)]);
 
-        const unsigned char _cmp_lt_os = 1;
-        const unsigned char _cmp_neq_uq = 4;
-        const unsigned char _cmp_gt_os = 6;
+        constexpr uint8_t cmp_lt_os = 1;
+        constexpr uint8_t cmp_neq_uq = 4;
+        constexpr uint8_t cmp_gt_os = 6;
 
         // Kernel lambda: emits the combined check code for 8 elements at src_ptr.
         // Called twice (main loop + tail) — each call emits a copy of the instructions.
@@ -749,15 +749,15 @@ private:
 
             // === Out-of-range check (same algorithm as jit_count_out_of_range_vec) ===
             // subnormal: data in (-f16_min_pos, f16_min_pos) and != 0
-            vcmpps(tmp_vec, data_vec, f16_min_pos_vec, _cmp_lt_os);
-            vcmpps(mask_vec, data_vec, f16_min_neg_vec, _cmp_gt_os);
+            vcmpps(tmp_vec, data_vec, f16_min_pos_vec, cmp_lt_os);
+            vcmpps(mask_vec, data_vec, f16_min_neg_vec, cmp_gt_os);
             vandps(mask_vec, mask_vec, tmp_vec);
-            vcmpps(tmp_vec, data_vec, f16_zero_vec, _cmp_neq_uq);
+            vcmpps(tmp_vec, data_vec, f16_zero_vec, cmp_neq_uq);
             vandps(mask_vec, mask_vec, tmp_vec);
             // overflow: data > f16_max or data < f16_lowest
-            vcmpps(tmp_vec, data_vec, f16_max_pos_vec, _cmp_gt_os);
+            vcmpps(tmp_vec, data_vec, f16_max_pos_vec, cmp_gt_os);
             vorps(mask_vec, mask_vec, tmp_vec);
-            vcmpps(tmp_vec, data_vec, f16_max_neg_vec, _cmp_lt_os);
+            vcmpps(tmp_vec, data_vec, f16_max_neg_vec, cmp_lt_os);
             vorps(mask_vec, mask_vec, tmp_vec);
             // mask_vec now has per-element OOR mask (0xFFFFFFFF for OOR, 0 for in-range)
 
@@ -771,7 +771,7 @@ private:
             vandps(diff_vec, diff_vec, abs_mask_vec);  // diff_vec = |diff|
 
             // lossy = |diff| > abs_error (1.0)
-            vcmpps(tmp_vec, diff_vec, abs_err_vec, _cmp_gt_os);  // |diff| > 1.0
+            vcmpps(tmp_vec, diff_vec, abs_err_vec, cmp_gt_os);  // |diff| > 1.0
 
             // Exclude out-of-range elements: keep only in-range lossy
             vandnps(tmp_vec, mask_vec, tmp_vec);  // tmp_vec = NOT(oor) AND lossy
@@ -784,7 +784,7 @@ private:
             // (equivalent to abs_diff / |value| > 1e-4, but avoids division)
             vandps(tmp_vec, data_vec, abs_mask_vec);         // tmp_vec = |data|
             vmulps(tmp_vec, tmp_vec, rel_err_vec);           // tmp_vec = |data| * 1e-4
-            vcmpps(tmp_vec, diff_vec, tmp_vec, _cmp_gt_os);  // 1 where |diff| > |data|*1e-4
+            vcmpps(tmp_vec, diff_vec, tmp_vec, cmp_gt_os);  // 1 where |diff| > |data|*1e-4
             vandnps(tmp_vec, mask_vec, tmp_vec);             // exclude OOR (avoid double-count)
             vorps(mask_vec, mask_vec, tmp_vec);              // combine OOR + relative-error
 
@@ -847,7 +847,7 @@ private:
             xor_(rsi, rsi);
             mov(qword[reg_lossy_dst], rsi);
         }
-        postamble();
+        jmp(done, T_NEAR);
 
         // --- Lossy exit: bail immediately (jumped from kernel via jnz) ---
         L(exit_lossy);
@@ -856,6 +856,8 @@ private:
         mov(qword[reg_oor_dst], rsi);  // oor_count = 0 (meaningless, caller checks lossy first)
         mov(rsi, 1);
         mov(qword[reg_lossy_dst], rsi);  // lossy = 1
+
+        L(done);
         postamble();
     }
 };
@@ -938,30 +940,39 @@ inline bool is_out_of_f16_range(float v) {
 }
 }  // namespace
 
+#ifdef OV_CORE_USE_XBYAK_JIT
+namespace {
+// Invoke a compiled FP16-compression JIT kernel (AVX-512 or AVX2+F16C) and
+// marshal its two size_t outputs into a CompressionCheckResult. Shared by
+// both JIT dispatches in check_f16_compression().
+template <typename Jit>
+CompressionCheckResult run_check_f16_compression_jit(typename Jit::fn_t fn, const float* arg, size_t count) {
+    CompressionCheckResult result{0, false};
+    size_t lossy_count = 0;
+    typename Jit::args_t args = {arg, &result.out_of_range_count, &lossy_count, count};
+    fn(&args);
+    result.has_lossy = lossy_count > 0;
+    return result;
+}
+}  // namespace
+#endif  // OV_CORE_USE_XBYAK_JIT
+
 CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
 #ifdef OV_CORE_USE_XBYAK_JIT
     if (util::may_i_use_dynamic_code()) {
         if (auto fn = jit_check_f16_compression_avx512::get()) {
-            size_t oor_count = 0;
-            size_t lossy_count = 0;
-            jit_check_f16_compression_avx512::args_t args = {arg, &oor_count, &lossy_count, count};
-            fn(&args);
-            return {oor_count, lossy_count > 0};
+            return run_check_f16_compression_jit<jit_check_f16_compression_avx512>(fn, arg, count);
         }
         if (auto fn = jit_check_f16_compression::get()) {
-            size_t oor_count = 0;
-            size_t lossy_count = 0;
-            jit_check_f16_compression::args_t args = {arg, &oor_count, &lossy_count, count};
-            fn(&args);
-            return {oor_count, lossy_count > 0};
+            return run_check_f16_compression_jit<jit_check_f16_compression>(fn, arg, count);
         }
     }
 #endif  // OV_CORE_USE_XBYAK_JIT
-    size_t out_of_range = 0;
+    CompressionCheckResult result{0, false};
     for (size_t i = 0; i < count; ++i) {
         const float v = arg[i];
         if (is_out_of_f16_range(v)) {
-            ++out_of_range;
+            ++result.out_of_range_count;
         } else {
             const double roundtripped = static_cast<double>(static_cast<float>(static_cast<float16>(v)));
             const double abs_diff = std::abs(v - roundtripped);
@@ -969,11 +980,11 @@ CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
                 return {0, true};
             }
             if (v != 0.0f && abs_diff / std::abs(v) > f16_compression_max_rel_error) {
-                ++out_of_range;
+                ++result.out_of_range_count;
             }
         }
     }
-    return {out_of_range, false};
+    return result;
 }
 
 size_t count_out_of_f16_range(const float* arg, size_t count) {

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -36,7 +36,7 @@ void jit_convert_vec<uint8_t, float16>(jit::Generator& gen, const Xbyak::RegExp&
     gen.movq(u8vec, gen.qword[src]);
     gen.vpmovzxbd(i32vec, u8vec);
     gen.vcvtdq2ps(fvec, i32vec);
-    gen.vcvtps2ph(f16vec, fvec, 0);
+    gen.vcvtps2ph(f16vec, fvec, 0x04);  // force RNE, independent of MXCSR
     gen.vzeroupper();
     gen.vmovdqu(gen.xword[dst], f16vec);
 }
@@ -57,7 +57,7 @@ void jit_convert_vec<float, float16>(jit::Generator& gen, const Xbyak::RegExp& s
     auto f32vec = gen.ymm4;
 
     gen.vmovups(f32vec, gen.yword[src]);
-    gen.vcvtps2ph(f16vec, f32vec, 0);
+    gen.vcvtps2ph(f16vec, f32vec, 0x04);  // force RNE, independent of MXCSR
     gen.vmovdqu(gen.xword[dst], f16vec);
 }
 
@@ -68,7 +68,7 @@ void jit_convert_vec<bfloat16, float16>(jit::Generator& gen, const Xbyak::RegExp
 
     gen.vpmovzxwd(f32vec, gen.yword[src]);  // load bf16 into tmp
     gen.vpslld(f32vec, f32vec, 16);         // convert bf16->f32 by bit shift
-    gen.vcvtps2ph(f16vec, f32vec, 0);       // convert f32 -> f16
+    gen.vcvtps2ph(f16vec, f32vec, 0x04);    // convert f32 -> f16 (force RNE, independent of MXCSR)
     gen.vmovdqu(gen.xword[dst], f16vec);    // move result to destination
 }
 
@@ -84,7 +84,7 @@ void jit_convert_vec<bfloat16, float16, true>(jit::Generator& gen, const Xbyak::
     gen.vpslld(f32vec, f32vec, 16);           // convert bf16->f32 by bit shift
     gen.vminps(f32vec, f32vec, upper_bound);  // clamp f16 max
     gen.vmaxps(f32vec, f32vec, lower_bound);  // clamp f16 lowest
-    gen.vcvtps2ph(f16vec, f32vec, 0);         // convert f32 -> f16
+    gen.vcvtps2ph(f16vec, f32vec, 0x04);      // convert f32 -> f16 (force RNE, independent of MXCSR)
     gen.vmovdqu(gen.xword[dst], f16vec);      // move result to destination
 }
 
@@ -129,7 +129,7 @@ void jit_convert_vec<float, float16, true>(jit::Generator& gen, const Xbyak::Reg
     gen.vmovups(f32vec, gen.yword[src]);
     gen.vminps(f32vec, f32vec, upper_bound);
     gen.vmaxps(f32vec, f32vec, lower_bound);
-    gen.vcvtps2ph(f16vec, f32vec, 0);
+    gen.vcvtps2ph(f16vec, f32vec, 0x04);  // force RNE, independent of MXCSR
     gen.vmovdqu(gen.xword[dst], f16vec);
 }
 
@@ -398,6 +398,10 @@ public:
     static fn_t get() {
         if (is_x64() && mayiuse(jit::avx512_core) && mayiuse(jit::fp16)) {
             static jit_check_f16_compression_avx512 generator;
+
+            // Since the JIT code always resides in memory, and ASAN's memory management may remove executable
+            // permissions, we need to restore executable permissions for the generated code.
+            generator.setProtectModeRE(false);
             return (fn_t)generator.getCode();
         }
         return nullptr;
@@ -599,6 +603,10 @@ public:
     static fn_t get() {
         if (is_x64() && mayiuse(jit::avx2) && mayiuse(jit::fp16)) {
             static jit_check_f16_compression generator;
+
+            // Since the JIT code always resides in memory, and ASAN's memory management may remove executable
+            // permissions, we need to restore executable permissions for the generated code.
+            generator.setProtectModeRE(false);
             return (fn_t)generator.getCode();
         }
         return nullptr;

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -283,107 +283,6 @@ void jit_count_out_of_range_vec(jit::Generator&, const Xbyak::RegExp&);
 template <typename data_t, typename range_t>
 void jit_count_out_of_range_vec_finalize(jit::Generator&, const Xbyak::RegExp&) {}
 
-template <>
-void jit_count_out_of_range_vec_prepare<float, float16>(jit::Generator& gen) {
-    auto accum_vec = gen.ymm4;
-    auto f16_max_pos_vec = gen.ymm5;
-    auto f16_max_neg_vec = gen.ymm6;
-    auto f16_min_pos_vec = gen.ymm7;
-    auto f16_min_neg_vec = gen.ymm8;
-    auto f16_zero_vec = gen.ymm9;
-    auto i32_ones_vec = gen.ymm10;
-    auto addr = gen.r15;
-
-    static const float f16_max_pos = std::numeric_limits<ov::float16>::max();
-    static const float f16_max_neg = std::numeric_limits<ov::float16>::lowest();
-    static const float f16_min_pos = ov::float16::from_bits(0x0001);
-    static const float f16_min_neg = -ov::float16::from_bits(0x0001);
-    static const int32_t i32_one = 1;
-
-    static const float max_pos_bounds[8] =
-        {f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos};
-    static const float max_neg_bounds[8] =
-        {f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg};
-    static const float min_pos_bounds[8] =
-        {f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos};
-    static const float min_neg_bounds[8] =
-        {f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg};
-    static const int32_t i32_ones[8] = {i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one};
-
-    auto load_vec = [&gen, &addr](Xbyak::Ymm vec, size_t ptr) {
-        gen.mov(addr, ptr);
-        gen.vmovdqu(vec, gen.yword[addr]);
-    };
-
-    load_vec(f16_max_pos_vec, (size_t)max_pos_bounds);
-    load_vec(f16_max_neg_vec, (size_t)max_neg_bounds);
-    load_vec(f16_min_pos_vec, (size_t)min_pos_bounds);
-    load_vec(f16_min_neg_vec, (size_t)min_neg_bounds);
-    load_vec(i32_ones_vec, (size_t)i32_ones);
-    gen.vxorps(f16_zero_vec, f16_zero_vec, f16_zero_vec);
-    gen.vxorps(accum_vec, accum_vec, accum_vec);
-}
-
-template <>
-void jit_count_out_of_range_vec<float, float16>(jit::Generator& gen, const Xbyak::RegExp& data) {
-    auto data_vec = gen.ymm1;
-    auto mask_vec = gen.ymm2;
-    auto mask_vec_xmm = gen.xmm2;
-    auto tmp_vec = gen.ymm3;
-    auto accum_vec = gen.ymm4;
-    auto f16_max_pos_vec = gen.ymm5;
-    auto f16_max_neg_vec = gen.ymm6;
-    auto f16_min_pos_vec = gen.ymm7;
-    auto f16_min_neg_vec = gen.ymm8;
-    auto f16_zero_vec = gen.ymm9;
-    auto i32_ones_vec = gen.ymm10;
-
-    const unsigned char _cmp_lt_os = 1;
-    const unsigned char _cmp_neq_uq = 4;
-    const unsigned char _cmp_gt_os = 6;
-
-    // std::abs(data) < ov::float16::from_bits(0x0001)
-    gen.vmovups(data_vec, gen.yword[data]);
-    gen.vcmpps(tmp_vec, data_vec, f16_min_pos_vec, _cmp_lt_os);
-    gen.vcmpps(mask_vec, data_vec, f16_min_neg_vec, _cmp_gt_os);
-    gen.vandps(mask_vec, mask_vec, tmp_vec);
-
-    // data != 0.0f
-    gen.vcmpps(tmp_vec, data_vec, f16_zero_vec, _cmp_neq_uq);
-    gen.vandps(mask_vec, mask_vec, tmp_vec);
-
-    // data > std::numeric_limits<ov::float16>::max()
-    gen.vcmpps(tmp_vec, data_vec, f16_max_pos_vec, _cmp_gt_os);
-    gen.vorps(mask_vec, mask_vec, tmp_vec);
-
-    // data < std::numeric_limits<ov::float16>::lowest()
-    gen.vcmpps(tmp_vec, data_vec, f16_max_neg_vec, _cmp_lt_os);
-    gen.vorps(mask_vec, mask_vec, tmp_vec);
-
-    // addition to i64 accumulator
-    gen.vandps(mask_vec, mask_vec, i32_ones_vec);
-    gen.vphaddd(mask_vec, mask_vec, mask_vec);
-    gen.vpermq(mask_vec, mask_vec, 0x08);
-    gen.vpmovsxdq(mask_vec, mask_vec_xmm);
-    gen.vpaddq(accum_vec, accum_vec, mask_vec);
-}
-
-template <>
-void jit_count_out_of_range_vec_finalize<float, float16>(jit::Generator& gen, const Xbyak::RegExp& dst) {
-    auto tmp_vec_xmm0 = gen.xmm2;  // reuse mask_vec
-    auto tmp_vec_xmm1 = gen.xmm3;  // reuse tmp_vec
-    auto accum_vec_ymm = gen.ymm4;
-    auto accum_vec_xmm = gen.xmm4;
-
-    // horizontal sum of four i64 values
-    gen.vextractf128(tmp_vec_xmm0, accum_vec_ymm, 0);
-    gen.vextractf128(tmp_vec_xmm1, accum_vec_ymm, 1);
-    gen.vpaddq(accum_vec_xmm, tmp_vec_xmm0, tmp_vec_xmm1);
-    gen.vpermilpd(tmp_vec_xmm0, accum_vec_xmm, 0x01);
-    gen.vpaddq(accum_vec_xmm, accum_vec_xmm, tmp_vec_xmm0);
-    gen.vmovq(gen.qword[dst], accum_vec_xmm);
-}
-
 class jit_count_out_of_range : public jit::Generator {
     typedef struct context {
         struct {
@@ -482,6 +381,447 @@ public:
     }
 };
 
+// Combined single-pass JIT kernel for AVX-512: counts out-of-range AND detects lossy f16 compression.
+// Processes 16 floats per iteration using zmm + opmask + F16C (vcvtps2ph/vcvtph2ps). Bails immediately
+// if any in-range element has significant precision loss (abs error > 1.0). Tail handled via masked load.
+class jit_check_f16_compression_avx512 : public jit::Generator {
+public:
+    typedef struct {
+        const void* src;
+        void* oor_dst;    // size_t* — output: out-of-range + relative-error count
+        void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
+        const size_t count;
+    } args_t;
+
+    typedef void (*fn_t)(const args_t*);
+
+    static fn_t get() {
+        if (is_x64() && mayiuse(jit::avx512_core) && mayiuse(jit::fp16)) {
+            static jit_check_f16_compression_avx512 generator;
+            return (fn_t)generator.getCode();
+        }
+        return nullptr;
+    }
+
+private:
+    jit_check_f16_compression_avx512() : jit::Generator(jit::avx512_core) {
+        using namespace Xbyak;
+
+        const uint32_t vlen = 16u;  // 16 floats per zmm
+
+        // GP register allocation
+        const auto& reg_src = rax;
+        const auto& reg_oor_dst = rbx;       // callee-saved
+        const auto& reg_lossy_dst = r12;     // callee-saved
+        const auto& reg_count = rdx;
+        const auto& reg_oor_accum = r14;     // callee-saved — 64-bit OOR + RelErr accumulator
+        const auto& reg_main_iters = r8;
+        const auto& reg_idx = rsi;
+        const auto& reg_tmp = r9;
+        const auto& reg_addr = r15;          // callee-saved — used to load constants
+
+        // ZMM register allocation
+        const auto& data_vec = zmm0;         // chunk of 16 floats
+        const auto& rt_vec = zmm1;           // f32->f16->f32 roundtripped
+        const auto& rt_ymm = ymm1;           // low 256-bit alias for vcvtps2ph dest
+        const auto& diff_vec = zmm2;         // |data - roundtripped|
+        const auto& abs_data_vec = zmm3;     // |data|
+        const auto& rel_thresh_vec = zmm4;   // |data| * 1e-4
+        const auto& abs_mask_vec = zmm5;     // 0x7FFFFFFF broadcast
+        const auto& abs_err_vec = zmm6;      // 1.0f broadcast
+        const auto& rel_err_vec = zmm7;      // 1e-4f broadcast
+        const auto& f16_max_pos_vec = zmm8;
+        const auto& f16_max_neg_vec = zmm9;
+        const auto& f16_min_pos_vec = zmm10;
+        const auto& f16_min_neg_vec = zmm11;
+        const auto& zero_vec = zmm12;
+
+        // Opmasks (k0 reserved by ISA — represents "no mask")
+        const auto& k_oor = k1;     // OOR per chunk (subnormal | overflow), then |= relative-error
+        const auto& k_lossy = k2;   // (abs_diff > 1.0) AND NOT k_oor — early exit
+        const auto& k_rel = k3;     // (abs_diff > |data|*1e-4) AND NOT k_oor
+        const auto& k_tail = k4;    // tail mask (built once before tail iteration)
+        const auto& k_tmp1 = k5;
+        const auto& k_tmp2 = k6;
+
+        Label main_loop, tail_block, normal_exit, lossy_exit;
+
+        preamble();
+        xor_(reg_oor_accum, reg_oor_accum);
+
+        // --- Broadcast constants ---
+        static const float f16_max_pos = std::numeric_limits<ov::float16>::max();
+        static const float f16_max_neg = std::numeric_limits<ov::float16>::lowest();
+        static const float f16_min_pos = ov::float16::from_bits(0x0001);
+        static const float f16_min_neg = -ov::float16::from_bits(0x0001);
+        static const float abs_err_val = static_cast<float>(ov::reference::f16_compression_max_abs_error);
+        static const float rel_err_val = static_cast<float>(ov::reference::f16_compression_max_rel_error);
+        static const uint32_t abs_mask_val = 0x7FFFFFFF;
+
+        auto bcast = [&, this](const Xbyak::Zmm& vec, const void* p) {
+            mov(reg_addr, reinterpret_cast<size_t>(p));
+            vbroadcastss(vec, dword[reg_addr]);
+        };
+
+        bcast(f16_max_pos_vec, &f16_max_pos);
+        bcast(f16_max_neg_vec, &f16_max_neg);
+        bcast(f16_min_pos_vec, &f16_min_pos);
+        bcast(f16_min_neg_vec, &f16_min_neg);
+        bcast(abs_err_vec, &abs_err_val);
+        bcast(rel_err_vec, &rel_err_val);
+        bcast(abs_mask_vec, &abs_mask_val);
+        vpxorq(zero_vec, zero_vec, zero_vec);
+
+        // --- Load args ---
+        mov(reg_src, ptr[param + offsetof(args_t, src)]);
+        mov(reg_oor_dst, ptr[param + offsetof(args_t, oor_dst)]);
+        mov(reg_lossy_dst, ptr[param + offsetof(args_t, lossy_dst)]);
+        mov(reg_count, ptr[param + offsetof(args_t, count)]);
+
+        const unsigned char _cmp_lt_os = 1;
+        const unsigned char _cmp_neq_uq = 4;
+        const unsigned char _cmp_gt_os = 6;
+
+        // Per-chunk emission. If `masked` is true, all opmasks are AND-ed with k_tail
+        // to defensively clear out-of-tail lanes (masked load already zeroed them, but
+        // this guards against any non-zero residual from sign-bit operations on -0.0).
+        auto emit_chunk = [&, this](bool masked) {
+            // === Build OOR mask in k_oor ===
+            // subnormal-when-rounded: |data| < min_pos AND data != 0
+            vcmpps(k_tmp1, data_vec, f16_min_pos_vec, _cmp_lt_os);  // data < min_pos
+            vcmpps(k_tmp2, data_vec, f16_min_neg_vec, _cmp_gt_os);  // data > min_neg
+            kandw(k_oor, k_tmp1, k_tmp2);                            // in (-min_pos, min_pos)
+            vcmpps(k_tmp1, data_vec, zero_vec, _cmp_neq_uq);         // data != 0
+            kandw(k_oor, k_oor, k_tmp1);
+            // overflow: data > max_pos OR data < max_neg
+            vcmpps(k_tmp1, data_vec, f16_max_pos_vec, _cmp_gt_os);
+            korw(k_oor, k_oor, k_tmp1);
+            vcmpps(k_tmp1, data_vec, f16_max_neg_vec, _cmp_lt_os);
+            korw(k_oor, k_oor, k_tmp1);
+            if (masked) {
+                kandw(k_oor, k_oor, k_tail);
+            }
+
+            // === Roundtrip f32 -> f16 -> f32 ===
+            // imm=0x04 (RNE, ignore MXCSR) — matches static_cast<float16> in C++ fallback
+            vcvtps2ph(rt_ymm, data_vec, 0x04);
+            vcvtph2ps(rt_vec, rt_ymm);
+
+            // === abs_diff = |data - roundtripped| ===
+            vsubps(diff_vec, data_vec, rt_vec);
+            vpandd(diff_vec, diff_vec, abs_mask_vec);  // mask off sign bit
+
+            // === Lossy check: (abs_diff > 1.0) AND NOT k_oor -> early exit ===
+            vcmpps(k_lossy, diff_vec, abs_err_vec, _cmp_gt_os);
+            kandnw(k_lossy, k_oor, k_lossy);  // k_lossy = ~k_oor & k_lossy
+            if (masked) {
+                kandw(k_lossy, k_lossy, k_tail);
+            }
+            kortestw(k_lossy, k_lossy);
+            jnz(lossy_exit, T_NEAR);
+
+            // === Relative-error check: (abs_diff > |data| * 1e-4) AND NOT k_oor ===
+            vpandd(abs_data_vec, data_vec, abs_mask_vec);
+            vmulps(rel_thresh_vec, abs_data_vec, rel_err_vec);
+            vcmpps(k_rel, diff_vec, rel_thresh_vec, _cmp_gt_os);
+            kandnw(k_rel, k_oor, k_rel);
+            korw(k_oor, k_oor, k_rel);
+            if (masked) {
+                kandw(k_oor, k_oor, k_tail);
+            }
+
+            // === Accumulate popcount(k_oor) into reg_oor_accum ===
+            kmovw(reg_tmp.cvt32(), k_oor);
+            popcnt(reg_tmp, reg_tmp);
+            add(reg_oor_accum, reg_tmp);
+        };
+
+        // --- Main loop: 16 elements per iteration ---
+        mov(reg_main_iters, reg_count);
+        shr(reg_main_iters, 4);
+        xor_(reg_idx, reg_idx);
+
+        L(main_loop);
+        cmp(reg_idx, reg_main_iters);
+        jge(tail_block, T_NEAR);
+
+        vmovups(data_vec, zword[reg_src]);
+        emit_chunk(/*masked=*/false);
+        add(reg_src, vlen * sizeof(float));
+        inc(reg_idx);
+        jmp(main_loop, T_NEAR);
+
+        // --- Tail: count & 15 elements via opmask ---
+        L(tail_block);
+        and_(reg_count, 15);
+        jz(normal_exit, T_NEAR);
+
+        // k_tail = (1 << reg_count) - 1, via bzhi (BMI2 — always present with avx512_core)
+        mov(reg_tmp, static_cast<int>(-1));
+        bzhi(reg_tmp, reg_tmp, reg_count);
+        kmovw(k_tail, reg_tmp.cvt32());
+
+        // Masked zeroing-load: out-of-mask lanes read as +0.0 (benign — pass none of the predicates)
+        vmovups(data_vec | k_tail | T_z, zword[reg_src]);
+        emit_chunk(/*masked=*/true);
+
+        // --- Normal exit: write OOR accumulator and lossy=0 ---
+        L(normal_exit);
+        mov(qword[reg_oor_dst], reg_oor_accum);
+        xor_(reg_tmp, reg_tmp);
+        mov(qword[reg_lossy_dst], reg_tmp);
+        postamble();
+
+        // --- Lossy exit: partial OOR count is meaningless, write 0; lossy=1 ---
+        L(lossy_exit);
+        xor_(reg_tmp, reg_tmp);
+        mov(qword[reg_oor_dst], reg_tmp);
+        mov(reg_tmp, 1);
+        mov(qword[reg_lossy_dst], reg_tmp);
+        postamble();
+    }
+};
+
+// Combined single-pass JIT kernel: counts out-of-range AND detects lossy f16 compression.
+// Processes 8 floats per iteration using AVX2+F16C. Bails immediately if any in-range
+// element has significant precision loss (abs error > 1.0).
+class jit_check_f16_compression : public jit::Generator {
+public:
+    typedef struct {
+        const void* src;
+        void* oor_dst;    // size_t* — output: out-of-range count
+        void* lossy_dst;  // size_t* — output: lossy count (0 or non-zero)
+        const size_t count;
+    } args_t;
+
+    typedef void (*fn_t)(const args_t*);
+
+    static fn_t get() {
+        if (is_x64() && mayiuse(jit::avx2) && mayiuse(jit::fp16)) {
+            static jit_check_f16_compression generator;
+            return (fn_t)generator.getCode();
+        }
+        return nullptr;
+    }
+
+private:
+    jit_check_f16_compression() {
+        using namespace Xbyak;
+
+        const uint32_t vlen = 8u;
+
+        // GP register allocation
+        const auto& reg_src = rax;
+        const auto& reg_oor_dst = rbx;
+        const auto& reg_lossy_dst = r12;  // callee-saved, preserved by preamble
+        const auto& reg_sz = rdx;
+        const auto& reg_saved_rsp = r13;  // callee-saved, for stack cleanup on lossy exit
+
+        // YMM register allocation
+        // Range check constants (same as jit_count_out_of_range)
+        const auto& data_vec = ymm1;
+        const auto& mask_vec = ymm2;  // OOR mask per chunk
+        const auto& mask_vec_xmm = xmm2;
+        const auto& tmp_vec = ymm3;
+        const auto& oor_accum = ymm4;
+        const auto& oor_accum_xmm = xmm4;
+        const auto& f16_max_pos_vec = ymm5;
+        const auto& f16_max_neg_vec = ymm6;
+        const auto& f16_min_pos_vec = ymm7;
+        const auto& f16_min_neg_vec = ymm8;
+        const auto& f16_zero_vec = ymm9;
+        const auto& i32_ones_vec = ymm10;
+        // Lossy check constants
+        const auto& abs_err_vec = ymm11;  // 1.0f broadcast
+        const auto& abs_mask_vec = ymm0;  // 0x7FFFFFFF broadcast (for fabs)
+        const auto& rel_err_vec = ymm12;  // 1e-4f broadcast (for relative error threshold)
+        // Temps for lossy computation (reused per chunk)
+        const auto& diff_vec = ymm14;
+        const auto& rt_vec_xmm = xmm15;  // for f32->f16->f32 roundtrip
+
+        Label exit_lossy, exit_normal;
+
+        preamble();
+        mov(reg_saved_rsp, rsp);  // save rsp for lossy exit stack cleanup
+
+        // --- Load constants ---
+        static const float f16_max_pos = std::numeric_limits<ov::float16>::max();
+        static const float f16_max_neg = std::numeric_limits<ov::float16>::lowest();
+        static const float f16_min_pos = ov::float16::from_bits(0x0001);
+        static const float f16_min_neg = -ov::float16::from_bits(0x0001);
+        static const int32_t i32_one = 1;
+        static const float abs_err_val = static_cast<float>(ov::reference::f16_compression_max_abs_error);
+        static const float rel_err_val = static_cast<float>(ov::reference::f16_compression_max_rel_error);
+        static const uint32_t abs_mask_val = 0x7FFFFFFF;
+
+        static const float max_pos_bounds[8] =
+            {f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos};
+        static const float max_neg_bounds[8] =
+            {f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg};
+        static const float min_pos_bounds[8] =
+            {f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos};
+        static const float min_neg_bounds[8] =
+            {f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg};
+        static const int32_t i32_ones[8] = {i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one};
+        static const float abs_errs[8] =
+            {abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val};
+        static const float rel_errs[8] =
+            {rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val};
+        static const uint32_t abs_masks[8] = {abs_mask_val,
+                                              abs_mask_val,
+                                              abs_mask_val,
+                                              abs_mask_val,
+                                              abs_mask_val,
+                                              abs_mask_val,
+                                              abs_mask_val,
+                                              abs_mask_val};
+
+        auto load_vec = [this](Ymm vec, size_t ptr) {
+            mov(r15, ptr);
+            vmovdqu(vec, yword[r15]);
+        };
+
+        load_vec(f16_max_pos_vec, (size_t)max_pos_bounds);
+        load_vec(f16_max_neg_vec, (size_t)max_neg_bounds);
+        load_vec(f16_min_pos_vec, (size_t)min_pos_bounds);
+        load_vec(f16_min_neg_vec, (size_t)min_neg_bounds);
+        load_vec(i32_ones_vec, (size_t)i32_ones);
+        load_vec(abs_err_vec, (size_t)abs_errs);
+        load_vec(rel_err_vec, (size_t)rel_errs);
+        load_vec(abs_mask_vec, (size_t)abs_masks);
+        vxorps(f16_zero_vec, f16_zero_vec, f16_zero_vec);
+        vxorps(oor_accum, oor_accum, oor_accum);
+
+        // Load args
+        mov(reg_src, ptr[param + offsetof(args_t, src)]);
+        mov(reg_oor_dst, ptr[param + offsetof(args_t, oor_dst)]);
+        mov(reg_lossy_dst, ptr[param + offsetof(args_t, lossy_dst)]);
+        mov(reg_sz, ptr[param + offsetof(args_t, count)]);
+
+        const unsigned char _cmp_lt_os = 1;
+        const unsigned char _cmp_neq_uq = 4;
+        const unsigned char _cmp_gt_os = 6;
+
+        // Kernel lambda: emits the combined check code for 8 elements at src_ptr.
+        // Called twice (main loop + tail) — each call emits a copy of the instructions.
+        auto emit_kernel = [&](const RegExp& src_ptr) {
+            // Load 8 floats
+            vmovups(data_vec, yword[src_ptr]);
+
+            // === Out-of-range check (same algorithm as jit_count_out_of_range_vec) ===
+            // subnormal: data in (-f16_min_pos, f16_min_pos) and != 0
+            vcmpps(tmp_vec, data_vec, f16_min_pos_vec, _cmp_lt_os);
+            vcmpps(mask_vec, data_vec, f16_min_neg_vec, _cmp_gt_os);
+            vandps(mask_vec, mask_vec, tmp_vec);
+            vcmpps(tmp_vec, data_vec, f16_zero_vec, _cmp_neq_uq);
+            vandps(mask_vec, mask_vec, tmp_vec);
+            // overflow: data > f16_max or data < f16_lowest
+            vcmpps(tmp_vec, data_vec, f16_max_pos_vec, _cmp_gt_os);
+            vorps(mask_vec, mask_vec, tmp_vec);
+            vcmpps(tmp_vec, data_vec, f16_max_neg_vec, _cmp_lt_os);
+            vorps(mask_vec, mask_vec, tmp_vec);
+            // mask_vec now has per-element OOR mask (0xFFFFFFFF for OOR, 0 for in-range)
+
+            // === Lossy check for in-range elements ===
+            // Roundtrip: f32 -> f16 -> f32
+            // imm=0x04 (RNE, ignore MXCSR) — matches static_cast<float16> in C++ fallback
+            vcvtps2ph(rt_vec_xmm, data_vec, 0x04);  // f32 -> f16 (8 values)
+            vcvtph2ps(diff_vec, rt_vec_xmm);        // f16 -> f32 (roundtripped)
+
+            // abs_diff = |data - roundtripped|
+            vsubps(diff_vec, data_vec, diff_vec);
+            vandps(diff_vec, diff_vec, abs_mask_vec);  // diff_vec = |diff|
+
+            // lossy = |diff| > abs_error (1.0)
+            vcmpps(tmp_vec, diff_vec, abs_err_vec, _cmp_gt_os);  // |diff| > 1.0
+
+            // Exclude out-of-range elements: keep only in-range lossy
+            vandnps(tmp_vec, mask_vec, tmp_vec);  // tmp_vec = NOT(oor) AND lossy
+
+            // Early exit if ANY element is lossy
+            vtestps(tmp_vec, tmp_vec);  // ZF=1 if all zeros
+            jnz(exit_lossy, T_NEAR);    // bail if any lossy
+
+            // === Relative error check: count elements where |diff| > |value| * 1e-4 ===
+            // (equivalent to abs_diff / |value| > 1e-4, but avoids division)
+            vandps(tmp_vec, data_vec, abs_mask_vec);         // tmp_vec = |data|
+            vmulps(tmp_vec, tmp_vec, rel_err_vec);           // tmp_vec = |data| * 1e-4
+            vcmpps(tmp_vec, diff_vec, tmp_vec, _cmp_gt_os);  // 1 where |diff| > |data|*1e-4
+            vandnps(tmp_vec, mask_vec, tmp_vec);             // exclude OOR (avoid double-count)
+            vorps(mask_vec, mask_vec, tmp_vec);              // combine OOR + relative-error
+
+            // === Accumulate combined OOR + relative-error count ===
+            vandps(mask_vec, mask_vec, i32_ones_vec);
+            vphaddd(mask_vec, mask_vec, mask_vec);
+            vpermq(mask_vec, mask_vec, 0x08);
+            vpmovsxdq(mask_vec, mask_vec_xmm);
+            vpaddq(oor_accum, oor_accum, mask_vec);
+        };
+
+        // --- Main loop: 8 elements per iteration ---
+        Label main_loop, main_loop_exit;
+        xor_(rsi, rsi);
+        mov(r8, reg_sz);
+        shr(r8, 3);
+
+        L(main_loop);
+        cmp(rsi, r8);
+        jge(main_loop_exit, T_NEAR);
+
+        emit_kernel(reg_src);
+        add(reg_src, static_cast<uint32_t>(sizeof(float) * vlen));
+
+        add(rsi, 1);
+        jmp(main_loop, T_NEAR);
+        L(main_loop_exit);
+
+        // --- Tail: remaining elements (< 8), zero-padded ---
+        shl(rsi, 3);
+        sub(reg_sz, rsi);
+        test(reg_sz, reg_sz);
+        jz(exit_normal, T_NEAR);
+
+        sub(rsp, vlen * sizeof(float));
+        mov(r8, rsp);
+
+        vpxor(mask_vec, mask_vec, mask_vec);  // zero
+        vmovups(yword[r8], mask_vec);         // zero-pad buffer
+
+        copy<float>(r8, reg_src, reg_sz);  // copy remaining elements
+        emit_kernel(r8);                   // process (zeros won't trigger OOR or lossy)
+
+        add(rsp, vlen * sizeof(float));  // free stack (only reached if no lossy)
+
+        // --- Normal exit: no lossy elements found ---
+        L(exit_normal);
+        {
+            // Horizontal sum of oor_accum (4 x i64) -> single i64
+            const auto& tmp0 = xmm2;  // reuse mask_vec
+            const auto& tmp1 = xmm3;  // reuse tmp_vec
+            vextractf128(tmp0, oor_accum, 0);
+            vextractf128(tmp1, oor_accum, 1);
+            vpaddq(oor_accum_xmm, tmp0, tmp1);
+            vpermilpd(tmp0, oor_accum_xmm, 0x01);
+            vpaddq(oor_accum_xmm, oor_accum_xmm, tmp0);
+            vmovq(qword[reg_oor_dst], oor_accum_xmm);
+
+            // lossy = 0
+            xor_(rsi, rsi);
+            mov(qword[reg_lossy_dst], rsi);
+        }
+        postamble();
+
+        // --- Lossy exit: bail immediately (jumped from kernel via jnz) ---
+        L(exit_lossy);
+        mov(rsp, reg_saved_rsp);  // restore rsp (handles both main loop and tail cases)
+        xor_(rsi, rsi);
+        mov(qword[reg_oor_dst], rsi);  // oor_count = 0 (meaningless, caller checks lossy first)
+        mov(rsi, 1);
+        mov(qword[reg_lossy_dst], rsi);  // lossy = 1
+        postamble();
+    }
+};
+
 #endif  // OV_CORE_USE_XBYAK_JIT
 
 template <class Clamp, typename TI, typename TO>
@@ -550,23 +890,43 @@ void convert_from_bf16_to_f16_with_clamp(const bfloat16* arg, float16* out, size
     // CVS-125496: duplicate and stub for ARM, provide optimized solution
 }
 
-size_t count_out_of_f16_range(const float* arg, size_t count) {
+CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
 #ifdef OV_CORE_USE_XBYAK_JIT
     if (util::may_i_use_dynamic_code()) {
-        if (auto converter = jit_count_out_of_range::get<float, float16>()) {
-            size_t num_out_of_range = 0;
-            jit_count_out_of_range::args_t args = {arg, &num_out_of_range, count};
-            converter(&args);
-            return num_out_of_range;
+        if (auto fn = jit_check_f16_compression_avx512::get()) {
+            size_t oor_count = 0;
+            size_t lossy_count = 0;
+            jit_check_f16_compression_avx512::args_t args = {arg, &oor_count, &lossy_count, count};
+            fn(&args);
+            return {oor_count, lossy_count > 0};
+        }
+        if (auto fn = jit_check_f16_compression::get()) {
+            size_t oor_count = 0;
+            size_t lossy_count = 0;
+            jit_check_f16_compression::args_t args = {arg, &oor_count, &lossy_count, count};
+            fn(&args);
+            return {oor_count, lossy_count > 0};
         }
     }
 #endif  // OV_CORE_USE_XBYAK_JIT
-    const auto is_out_of_f16_range = [](const float v) {
-        return (std::abs(v) < float16::from_bits(0x0001) && v != 0.0f) || (v > std::numeric_limits<float16>::max()) ||
-               (v < std::numeric_limits<float16>::lowest());
-    };
-
-    return std::count_if(arg, arg + count, is_out_of_f16_range);
+    size_t out_of_range = 0;
+    for (size_t i = 0; i < count; ++i) {
+        const float v = arg[i];
+        if ((std::abs(v) < float16::from_bits(0x0001) && v != 0.0f) || v > std::numeric_limits<float16>::max() ||
+            v < std::numeric_limits<float16>::lowest()) {
+            ++out_of_range;
+        } else {
+            const double roundtripped = static_cast<double>(static_cast<float>(static_cast<float16>(v)));
+            const double abs_diff = std::abs(v - roundtripped);
+            if (abs_diff > f16_compression_max_abs_error) {
+                return {0, true};
+            }
+            if (v != 0.0f && abs_diff / std::abs(v) > f16_compression_max_rel_error) {
+                ++out_of_range;
+            }
+        }
+    }
+    return {out_of_range, false};
 }
 
 }  // namespace reference

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -25,7 +25,21 @@ namespace {
 // bit-identical to static_cast<ov::float16>(float). Equivalent to
 // _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC from <immintrin.h>.
 // (Not 0x04 — that is _MM_FROUND_CUR_DIRECTION, i.e. "use MXCSR".)
-static constexpr uint8_t kVcvtps2phRneNoExc = 0x08;
+inline constexpr uint8_t kVcvtps2phRneNoExc = 0x08;
+
+// Shared FP16 range constants used by multiple JIT kernels (fp32<->fp16 conversion,
+// fp16 compression check). ov::float16::operator float() is not constexpr so the
+// ov::float16-derived values must be initialised at runtime; the scalar-error /
+// mask thresholds are plain literals and stay constexpr. We keep them as named
+// file-scope constants to avoid duplicating std::numeric_limits<> lookups and
+// literal values across every JIT body.
+inline const float kF16MaxPos = std::numeric_limits<ov::float16>::max();
+inline const float kF16MaxNeg = std::numeric_limits<ov::float16>::lowest();
+inline const float kF16MinPos = ov::float16::from_bits(0x0001);
+inline const float kF16MinNeg = -ov::float16::from_bits(0x0001);
+inline constexpr float kF16CompressionAbsErrVal = static_cast<float>(ov::reference::f16_compression_max_abs_error);
+inline constexpr float kF16CompressionRelErrVal = static_cast<float>(ov::reference::f16_compression_max_rel_error);
+inline constexpr uint32_t kAbsMaskVal = 0x7FFFFFFFu;
 
 template <typename src_t, typename dst_t, bool clamp = false>
 void jit_convert_vec(jit::Generator&, const Xbyak::RegExp&, const Xbyak::RegExp&) {}
@@ -110,14 +124,14 @@ void jit_convert_vec_prepare<float, float16, true>(jit::Generator& gen) {
     auto lower_bound = gen.ymm6;
     auto addr = gen.r15;
 
-    static const float f16_max = std::numeric_limits<ov::float16>::max();
-    static const float f16_min = std::numeric_limits<ov::float16>::lowest();
-    static const float upper_bounds[8] = {f16_max, f16_max, f16_max, f16_max, f16_max, f16_max, f16_max, f16_max};
-    static const float lower_bounds[8] = {f16_min, f16_min, f16_min, f16_min, f16_min, f16_min, f16_min, f16_min};
+    static const float upper_bounds[8] =
+        {kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos};
+    static const float lower_bounds[8] =
+        {kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg};
 
-    gen.mov(addr, (size_t)upper_bounds);
+    gen.mov(addr, reinterpret_cast<size_t>(upper_bounds));
     gen.vmovdqu(upper_bound, gen.yword[addr]);
-    gen.mov(addr, (size_t)lower_bounds);
+    gen.mov(addr, reinterpret_cast<size_t>(lower_bounds));
     gen.vmovdqu(lower_bound, gen.yword[addr]);
 }
 
@@ -145,11 +159,11 @@ void jit_convert_vec_prepare<float, int8_t>(jit::Generator& gen) {
     auto order = gen.ymm1;
     auto addr = gen.r15;
 
-    static const int8_t offsets[32] = {0,  4,  8,  12, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                                       -1, -1, -1, -1, 0,  4,  8,  12, -1, -1, -1, -1, -1, -1, -1, -1};
+    static constexpr int8_t offsets[32] = {0,  4,  8,  12, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                                           -1, -1, -1, -1, 0,  4,  8,  12, -1, -1, -1, -1, -1, -1, -1, -1};
 
-    gen.mov(addr, (size_t)offsets);       // get offsets[] address
-    gen.vmovdqu(order, gen.yword[addr]);  // save offsets[] to ymm register
+    gen.mov(addr, reinterpret_cast<size_t>(offsets));  // get offsets[] address
+    gen.vmovdqu(order, gen.yword[addr]);               // save offsets[] to ymm register
 }
 
 template <>
@@ -460,27 +474,18 @@ private:
         preamble();
         xor_(reg_oor_accum, reg_oor_accum);
 
-        // --- Broadcast constants ---
-        static const float f16_max_pos = std::numeric_limits<ov::float16>::max();
-        static const float f16_max_neg = std::numeric_limits<ov::float16>::lowest();
-        static const float f16_min_pos = ov::float16::from_bits(0x0001);
-        static const float f16_min_neg = -ov::float16::from_bits(0x0001);
-        static const float abs_err_val = static_cast<float>(ov::reference::f16_compression_max_abs_error);
-        static const float rel_err_val = static_cast<float>(ov::reference::f16_compression_max_rel_error);
-        static const uint32_t abs_mask_val = 0x7FFFFFFF;
-
         auto bcast = [&, this](const Xbyak::Zmm& vec, const void* p) {
             mov(reg_addr, reinterpret_cast<size_t>(p));
             vbroadcastss(vec, dword[reg_addr]);
         };
 
-        bcast(f16_max_pos_vec, &f16_max_pos);
-        bcast(f16_max_neg_vec, &f16_max_neg);
-        bcast(f16_min_pos_vec, &f16_min_pos);
-        bcast(f16_min_neg_vec, &f16_min_neg);
-        bcast(abs_err_vec, &abs_err_val);
-        bcast(rel_err_vec, &rel_err_val);
-        bcast(abs_mask_vec, &abs_mask_val);
+        bcast(f16_max_pos_vec, &kF16MaxPos);
+        bcast(f16_max_neg_vec, &kF16MaxNeg);
+        bcast(f16_min_pos_vec, &kF16MinPos);
+        bcast(f16_min_neg_vec, &kF16MinNeg);
+        bcast(abs_err_vec, &kF16CompressionAbsErrVal);
+        bcast(rel_err_vec, &kF16CompressionRelErrVal);
+        bcast(abs_mask_vec, &kAbsMaskVal);
         vpxorq(zero_vec, zero_vec, zero_vec);
 
         // --- Load args ---
@@ -679,50 +684,50 @@ private:
         mov(reg_saved_rsp, rsp);  // save rsp for lossy exit stack cleanup
 
         // --- Load constants ---
-        static const float f16_max_pos = std::numeric_limits<ov::float16>::max();
-        static const float f16_max_neg = std::numeric_limits<ov::float16>::lowest();
-        static const float f16_min_pos = ov::float16::from_bits(0x0001);
-        static const float f16_min_neg = -ov::float16::from_bits(0x0001);
-        static const int32_t i32_one = 1;
-        static const float abs_err_val = static_cast<float>(ov::reference::f16_compression_max_abs_error);
-        static const float rel_err_val = static_cast<float>(ov::reference::f16_compression_max_rel_error);
-        static const uint32_t abs_mask_val = 0x7FFFFFFF;
-
+        // 256-bit (8-lane) broadcast arrays for AVX2 (no vbroadcastss on ymm here; we use vmovdqu).
+        // Arrays filled from FP16-derived constants (non-constexpr — see kF16* above) are static const;
+        // arrays filled from literal/constexpr thresholds are static constexpr.
         static const float max_pos_bounds[8] =
-            {f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos, f16_max_pos};
+            {kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos, kF16MaxPos};
         static const float max_neg_bounds[8] =
-            {f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg, f16_max_neg};
+            {kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg, kF16MaxNeg};
         static const float min_pos_bounds[8] =
-            {f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos, f16_min_pos};
+            {kF16MinPos, kF16MinPos, kF16MinPos, kF16MinPos, kF16MinPos, kF16MinPos, kF16MinPos, kF16MinPos};
         static const float min_neg_bounds[8] =
-            {f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg, f16_min_neg};
-        static const int32_t i32_ones[8] = {i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one, i32_one};
-        static const float abs_errs[8] =
-            {abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val, abs_err_val};
-        static const float rel_errs[8] =
-            {rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val, rel_err_val};
-        static const uint32_t abs_masks[8] = {abs_mask_val,
-                                              abs_mask_val,
-                                              abs_mask_val,
-                                              abs_mask_val,
-                                              abs_mask_val,
-                                              abs_mask_val,
-                                              abs_mask_val,
-                                              abs_mask_val};
+            {kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg, kF16MinNeg};
+        static constexpr int32_t i32_ones[8] = {1, 1, 1, 1, 1, 1, 1, 1};
+        static constexpr float abs_errs[8] = {kF16CompressionAbsErrVal,
+                                               kF16CompressionAbsErrVal,
+                                               kF16CompressionAbsErrVal,
+                                               kF16CompressionAbsErrVal,
+                                               kF16CompressionAbsErrVal,
+                                               kF16CompressionAbsErrVal,
+                                               kF16CompressionAbsErrVal,
+                                               kF16CompressionAbsErrVal};
+        static constexpr float rel_errs[8] = {kF16CompressionRelErrVal,
+                                               kF16CompressionRelErrVal,
+                                               kF16CompressionRelErrVal,
+                                               kF16CompressionRelErrVal,
+                                               kF16CompressionRelErrVal,
+                                               kF16CompressionRelErrVal,
+                                               kF16CompressionRelErrVal,
+                                               kF16CompressionRelErrVal};
+        static constexpr uint32_t abs_masks[8] =
+            {kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal, kAbsMaskVal};
 
         auto load_vec = [this](Ymm vec, size_t ptr) {
             mov(r15, ptr);
             vmovdqu(vec, yword[r15]);
         };
 
-        load_vec(f16_max_pos_vec, (size_t)max_pos_bounds);
-        load_vec(f16_max_neg_vec, (size_t)max_neg_bounds);
-        load_vec(f16_min_pos_vec, (size_t)min_pos_bounds);
-        load_vec(f16_min_neg_vec, (size_t)min_neg_bounds);
-        load_vec(i32_ones_vec, (size_t)i32_ones);
-        load_vec(abs_err_vec, (size_t)abs_errs);
-        load_vec(rel_err_vec, (size_t)rel_errs);
-        load_vec(abs_mask_vec, (size_t)abs_masks);
+        load_vec(f16_max_pos_vec, reinterpret_cast<size_t>(max_pos_bounds));
+        load_vec(f16_max_neg_vec, reinterpret_cast<size_t>(max_neg_bounds));
+        load_vec(f16_min_pos_vec, reinterpret_cast<size_t>(min_pos_bounds));
+        load_vec(f16_min_neg_vec, reinterpret_cast<size_t>(min_neg_bounds));
+        load_vec(i32_ones_vec, reinterpret_cast<size_t>(i32_ones));
+        load_vec(abs_err_vec, reinterpret_cast<size_t>(abs_errs));
+        load_vec(rel_err_vec, reinterpret_cast<size_t>(rel_errs));
+        load_vec(abs_mask_vec, reinterpret_cast<size_t>(abs_masks));
         vxorps(f16_zero_vec, f16_zero_vec, f16_zero_vec);
         vxorps(oor_accum, oor_accum, oor_accum);
 
@@ -923,6 +928,16 @@ void convert_from_bf16_to_f16_with_clamp(const bfloat16* arg, float16* out, size
     // CVS-125496: duplicate and stub for ARM, provide optimized solution
 }
 
+namespace {
+// Predicate: true iff the FP16 representation of `v` falls outside the finite FP16
+// normal range (subnormal when rounded, or magnitude larger than float16::max()).
+// Shared between check_f16_compression() slow-path and count_out_of_f16_range().
+inline bool is_out_of_f16_range(float v) {
+    return (std::abs(v) < float16::from_bits(0x0001) && v != 0.0f) || v > std::numeric_limits<float16>::max() ||
+           v < std::numeric_limits<float16>::lowest();
+}
+}  // namespace
+
 CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
 #ifdef OV_CORE_USE_XBYAK_JIT
     if (util::may_i_use_dynamic_code()) {
@@ -945,8 +960,7 @@ CompressionCheckResult check_f16_compression(const float* arg, size_t count) {
     size_t out_of_range = 0;
     for (size_t i = 0; i < count; ++i) {
         const float v = arg[i];
-        if ((std::abs(v) < float16::from_bits(0x0001) && v != 0.0f) || v > std::numeric_limits<float16>::max() ||
-            v < std::numeric_limits<float16>::lowest()) {
+        if (is_out_of_f16_range(v)) {
             ++out_of_range;
         } else {
             const double roundtripped = static_cast<double>(static_cast<float>(static_cast<float16>(v)));
@@ -966,11 +980,6 @@ size_t count_out_of_f16_range(const float* arg, size_t count) {
     // Backward-compatible helper: strict FP16-range count only (no relative-error accounting).
     // The in-tree FP16 compression path uses check_f16_compression(); this wrapper exists for
     // external developer-package consumers that linked against the pre-PR symbol.
-    const auto is_out_of_f16_range = [](const float v) {
-        return (std::abs(v) < float16::from_bits(0x0001) && v != 0.0f) || (v > std::numeric_limits<float16>::max()) ||
-               (v < std::numeric_limits<float16>::lowest());
-    };
-
     return std::count_if(arg, arg + count, is_out_of_f16_range);
 }
 

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -503,9 +503,12 @@ private:
         auto emit_chunk = [&, this](bool masked) {
             // === Build OOR mask in k_oor ===
             // subnormal-when-rounded: |data| < min_pos AND data != 0
-            vcmpps(k_tmp1, data_vec, f16_min_pos_vec, cmp_lt_os);             // data < min_pos
-            vcmpps(k_oor | k_tmp1, data_vec, f16_min_neg_vec, cmp_gt_os);     // merge-masked: k_oor = k_tmp1 & (data > min_neg)
-            vcmpps(k_tmp1, data_vec, zero_vec, cmp_neq_uq);                   // data != 0
+            vcmpps(k_tmp1, data_vec, f16_min_pos_vec, cmp_lt_os);  // data < min_pos
+            vcmpps(k_oor | k_tmp1,
+                   data_vec,
+                   f16_min_neg_vec,
+                   cmp_gt_os);                               // merge-masked: k_oor = k_tmp1 & (data > min_neg)
+            vcmpps(k_tmp1, data_vec, zero_vec, cmp_neq_uq);  // data != 0
             kandw(k_oor, k_oor, k_tmp1);
             // overflow: data > max_pos OR data < max_neg
             vcmpps(k_tmp1, data_vec, f16_max_pos_vec, cmp_gt_os);
@@ -782,11 +785,11 @@ private:
 
             // === Relative error check: count elements where |diff| > |value| * 1e-4 ===
             // (equivalent to abs_diff / |value| > 1e-4, but avoids division)
-            vandps(tmp_vec, data_vec, abs_mask_vec);         // tmp_vec = |data|
-            vmulps(tmp_vec, tmp_vec, rel_err_vec);           // tmp_vec = |data| * 1e-4
+            vandps(tmp_vec, data_vec, abs_mask_vec);        // tmp_vec = |data|
+            vmulps(tmp_vec, tmp_vec, rel_err_vec);          // tmp_vec = |data| * 1e-4
             vcmpps(tmp_vec, diff_vec, tmp_vec, cmp_gt_os);  // 1 where |diff| > |data|*1e-4
-            vandnps(tmp_vec, mask_vec, tmp_vec);             // exclude OOR (avoid double-count)
-            vorps(mask_vec, mask_vec, tmp_vec);              // combine OOR + relative-error
+            vandnps(tmp_vec, mask_vec, tmp_vec);            // exclude OOR (avoid double-count)
+            vorps(mask_vec, mask_vec, tmp_vec);             // combine OOR + relative-error
 
             // === Accumulate combined OOR + relative-error count ===
             vandps(mask_vec, mask_vec, i32_ones_vec);

--- a/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
@@ -585,7 +585,12 @@ def create_pytorch_module_convert_pytorch_frontend_oob(tmp_dir):
     class ConvModel(torch.nn.Module):
         def __init__(self):
             super(ConvModel, self).__init__()
-            self.weights = torch.rand([1, 3, 3, 3])
+            # Deterministic weights with zero FP16 round-trip error so the
+            # CompressFloatConstants decision doesn't depend on a random state.
+            # 0.5 is exactly representable in FP16 (abs/rel round-trip error = 0),
+            # so compression always happens and the reference model below matches.
+            torch.manual_seed(0)
+            self.weights = torch.full([1, 3, 3, 3], 0.5)
 
         def forward(self, x):
             return F.conv2d(x, self.weights)

--- a/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
@@ -589,7 +589,6 @@ def create_pytorch_module_convert_pytorch_frontend_oob(tmp_dir):
             # CompressFloatConstants decision doesn't depend on a random state.
             # 0.5 is exactly representable in FP16 (abs/rel round-trip error = 0),
             # so compression always happens and the reference model below matches.
-            torch.manual_seed(0)
             self.weights = torch.full([1, 3, 3, 3], 0.5)
 
         def forward(self, x):


### PR DESCRIPTION
### Details:

This PR builds on top of #35106 and addresses the open review comments from @nshchego that were left unanswered there.

### Carried from #35106

Previously, `CompressFloatConstantsImpl` relied on checking whether f64/f32 Constant values fit into the finite f16 range. If 75% of the values did not fit, the Constant's conversion was skipped. However, even when f64/f32 values are inside the f16 range, they might not always be converted with high precision, as f16 has a narrower mantissa. The larger the values grow, the bigger the round-trip error becomes. For values > 1024 the absolute round-trip error can reach 1.0 or more and may cause significant accuracy degradation — this was observed for the LTX-Video model where the RoPE frequency values were compressed to f16 with substantial degradation.

To prevent this, both absolute and relative error are now accounted for:

1. If a large absolute error (`> f16_compression_max_abs_error`, currently `1.0`) is observed for any in-range value of the Constant, the Constant is kept in its original precision (abs-error veto, `has_lossy=true`).
2. Values with a large relative round-trip error (`> f16_compression_max_rel_error`, currently `1e-4`) are accumulated into the same rejection count as true out-of-range values, and fed into the existing `f16_compression_keep_threshold` (75%) rule.

The logic works uniformly for scalar and non-scalar Constants. This preserves precision-sensitive Constants (RoPE tables, attention scale factors like `log(16)`, …) while keeping typical dense weights compressed, and does not visibly affect compilation time or IR `.bin` size. On wwb the similarity on the generated IR reaches 0.98.

### Additional changes on top of #35106

1. In the slow (non-JIT) `change_constant_precision_to_fp16`, the `src_data[i]` value is cast to `double` before subtracting the f16 round-trip, so the absolute and relative error are measured in `double` precision (the original code lost f32 precision on the f32 source path). The subnormal branch now also writes `static_cast<float16>(src_data[i])` into `dst_data[i]` instead of relying on the Constant's zero-initialisation — this matches the x86 fast path, which produces an FP16 subnormal there.
2. A new `jit_check_f16_compression_avx512` JIT kernel is added. It processes 16 floats per iteration using `zmm` registers and opmasks, with an F16C `vcvtps2ph`/`vcvtph2ps` round-trip and a masked load for the tail. The selection cascade in `check_f16_compression()` becomes `avx512_core + fp16` → `avx2 + fp16` → C++ fallback.
3. The `vcvtps2ph` immediate is changed from `0` (use MXCSR) to `0x08` (force RNE and suppress all FP exceptions — equivalent to `_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC`) in both the AVX2 and AVX512 paths, and applied consistently across every `vcvtps2ph` call site in this file. This makes the JIT result independent of the caller's MXCSR state and bit-identical to `static_cast<float16>` used in the C++ fallback. Note: `0x04` is `_MM_FROUND_CUR_DIRECTION` (use MXCSR), not RNE — a common point of confusion flagged during review.
4. The AVX-512 kernel is written without `POPCNT` or `BMI2` (`bzhi`) instructions — neither is guaranteed by `mayiuse(avx512_core)` / `mayiuse(fp16)`. Lane counts use a branchless 16-bit SWAR popcount; the tail mask uses a baseline `SHL cl` / `dec`.
5. The back-compat symbol `count_out_of_f16_range()` is kept in `openvino/reference/convert.hpp` as a thin C++ wrapper — external developer-package consumers that linked against the pre-PR symbol stay source- and link-compatible. The in-tree compression path uses `check_f16_compression()`.
6. JIT register and vector aliases are declared as `const auto&` instead of `auto`, so the global Xbyak `Reg64`/`Ymm`/`Zmm` instances are taken by reference instead of copied.
7. Shared FP16 range / threshold constants (`kF16MaxPos`, `kF16MaxNeg`, `kF16MinPos`, `kF16MinNeg`, `kF16CompressionAbsErrVal`, `kF16CompressionRelErrVal`, `kAbsMaskVal`, `kVcvtps2phRneNoExc`) are lifted to the translation-unit anonymous namespace as `inline const` / `inline constexpr`, deduplicating the per-kernel copies. The shared `is_out_of_f16_range` predicate is used from both the `check_f16_compression` slow path and the `count_out_of_f16_range` back-compat shim.
8. `layer_tests/ovc_python_api_tests/test_pytorch.py::create_pytorch_module_convert_pytorch_frontend_oob` no longer uses unseeded `torch.rand` for the weight tensor. Random draws ~half the time produce uniformly-distributed values whose relative round-trip error exceeds the threshold for ≥75% of elements, which — correctly, under the new combined check — rejects compression and diverges from the reference model. Weights are now `torch.full([1, 3, 3, 3], 0.5)` (0.5 is exactly representable in FP16), so the outcome is deterministic regardless of RNG state.

### Tickets:
 - 180611