### PR TITLE
[GPU] Fix implicit narrowing conversion warnings (C4244) in GPU plugin

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/op/swiglu_with_clamp.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/swiglu_with_clamp.hpp
@@ -82,10 +82,10 @@ public:
     void set_gate_idx(size_t gate_idx) {
         m_gate_idx = gate_idx;
     }
-    void set_clamp_min(int64_t min) {
+    void set_clamp_min(float min) {
         m_clamp_min = min;
     }
-    void set_clamp_max(int64_t max) {
+    void set_clamp_max(float max) {
         m_clamp_max = max;
     }
     void set_swiglu_beta(float beta) {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
@@ -55,7 +55,7 @@ struct custom_gpu_primitive : public primitive_base<custom_gpu_primitive> {
                                        const std::vector<std::string>& localSizeRules,
                                        std::vector<size_t>& gws,
                                        std::vector<size_t>& lws) {
-#define GetDim(DIM) DIM.is_dynamic() ? -1 : DIM.get_length()
+#define GetDim(DIM) static_cast<int>(DIM.is_dynamic() ? -1 : DIM.get_length())
 
         gws.clear();
         lws.clear();
@@ -63,10 +63,10 @@ struct custom_gpu_primitive : public primitive_base<custom_gpu_primitive> {
         int batchDim = 0, featureDim = 0, yDim = 0, xDim = 0;
         // if calcWgDimInputIdx is greater than -1, take dimension from input
         if (calcWgDimInputIdx >= 0) {
-            xDim = static_cast<int>(GetDim(inputDims[inputDims.size() - 1]));
-            yDim = dims.size() > 1 ? static_cast<int>(GetDim(inputDims[inputDims.size() - 2])) : 0;
-            featureDim = dims.size() > 2 ? static_cast<int>(GetDim(inputDims[inputDims.size() - 3])) : 0;
-            batchDim = dims.size() > 3 ? static_cast<int>(GetDim(inputDims[inputDims.size() - 4])) : 0;
+            xDim = GetDim(inputDims[inputDims.size() - 1]);
+            yDim = dims.size() > 1 ? GetDim(inputDims[inputDims.size() - 2]) : 0;
+            featureDim = dims.size() > 2 ? GetDim(inputDims[inputDims.size() - 3]) : 0;
+            batchDim = dims.size() > 3 ? GetDim(inputDims[inputDims.size() - 4]) : 0;
         } else {
             batchDim = (dims.size() > 0) ? GetDim(dims[0]) : 1;
             featureDim = (dims.size() > 1) ? GetDim(dims[1]) : 1;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
@@ -192,7 +192,7 @@ struct loop : public primitive_base<loop> {
          const std::vector<io_primitive_map>& input_primitive_maps,
          const std::vector<io_primitive_map>& output_primitive_maps,
          const std::vector<backedge_mapping>& back_edges,
-         int64_t max_num_iterations = -1,
+         int32_t max_num_iterations = -1,
          const primitive_id& body_current_iteration_id = primitive_id(),
          const primitive_id& body_execution_condition_id = primitive_id(),
          const size_t num_outputs = 1)

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
@@ -205,12 +205,12 @@ private:
 #ifdef GPU_DEBUG_CONFIG
     std::vector<memory_record> _no_reusable_mems;
 
-    float total_mem_size_non_padded_pool        = 0.f;
-    float total_mem_size_padded_pool            = 0.f;
-    float total_mem_size_no_reusable            = 0.f;
-    float mem_size_non_padded_pool_host         = 0.f;
-    float mem_size_padded_pool_host             = 0.f;
-    float mem_size_no_reusable_host             = 0.f;
+    size_t total_mem_size_non_padded_pool        = 0;
+    size_t total_mem_size_padded_pool            = 0;
+    size_t total_mem_size_no_reusable            = 0;
+    size_t mem_size_non_padded_pool_host         = 0;
+    size_t mem_size_padded_pool_host             = 0;
+    size_t mem_size_no_reusable_host             = 0;
 #endif
 };
 

--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -691,7 +691,7 @@ NetworkDebugHelper::~NetworkDebugHelper() {
     }
 
     if (!config.get_dump_graphs_path().empty() && is_target_iteration(m_iter, config.get_dump_iterations())) {
-        auto get_fixed_str = [](int value, int length = 2) -> std::string {
+        auto get_fixed_str = [](size_t value, int length = 2) -> std::string {
             std::ostringstream ss;
             ss << std::setw(length) << std::setfill('0') << std::to_string(value);
             return ss.str();

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
@@ -297,7 +297,7 @@ Arguments PagedAttentionGeneratorMultiToken::get_arguments_desc(const kernel_imp
 JitConstants PagedAttentionGeneratorMultiToken::get_jit_constants(const kernel_impl_params& params) const {
     auto jit = PagedAttentionGeneratorBase::get_jit_constants(params);
     const auto desc = params.typed_desc<paged_attention>();
-    const float scale_factor = 1.0 / std::sqrt(static_cast<double>(desc->k_head_size));
+    const float scale_factor = 1.0f / std::sqrt(static_cast<float>(desc->k_head_size));
     OPENVINO_ASSERT(_xattn_block_size == 1 || _xattn_block_size == 128 || _xattn_block_size == 256,
                     "Unsupported xattention block size for multi token kernel: ",
                     _xattn_block_size);
@@ -379,7 +379,7 @@ JitConstants PagedAttentionGeneratorSingleToken::get_jit_constants(const kernel_
     auto jit = PagedAttentionGeneratorBase::get_jit_constants(params);
     // jit.add(make_jit_constant("KERNEL_NAME", get_entry_point(params)));
     auto desc = params.typed_desc<paged_attention>();
-    const float scale_factor = 1.0 / std::sqrt(static_cast<double>(desc->k_head_size));
+    const float scale_factor = 1.0f / std::sqrt(static_cast<float>(desc->k_head_size));
     const size_t kv_partition_size = get_partition_size(desc->has_xattention);
     jit.make("KV_PARTITION_SIZE", kv_partition_size);
     if (desc->has_xattention) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_base.h
@@ -34,7 +34,7 @@ struct swiglu_params : public base_params {
 };
 
 struct swiglu_fuse_params : fuse_params {
-    explicit swiglu_fuse_params(int32_t axis, size_t glu_stride, size_t gate_idx, size_t clamp_min, size_t clamp_max, float swish_beta, float up_add_val)
+    explicit swiglu_fuse_params(int32_t axis, size_t glu_stride, size_t gate_idx, float clamp_min, float clamp_max, float swish_beta, float up_add_val)
         : fuse_params(KernelType::SWIGLU),
           axis(axis),
           glu_stride(glu_stride),

--- a/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
@@ -20,6 +20,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <limits>
 
 using Loop = ov::op::v5::Loop;
 using TensorIterator = ov::op::v0::TensorIterator;
@@ -209,7 +210,11 @@ static void CreateCommonLoopOp(ProgramBuilder& p, const std::shared_ptr<ov::op::
     auto inputs = p.GetInputInfo(op);
     bool is_dynamic = p.use_new_shape_infer() || op->is_dynamic();
 
-    int64_t num_iterations = op->get_num_iterations();
+    OPENVINO_ASSERT(op->get_num_iterations() >= std::numeric_limits<int32_t>::min() &&
+                    op->get_num_iterations() <= std::numeric_limits<int32_t>::max(),
+                    "num_iterations (", op->get_num_iterations(), ") exceeds int32_t range");
+
+    int32_t num_iterations = static_cast<int32_t>(op->get_num_iterations());
 
     auto num_outputs = is_dynamic? op->get_output_size() : 1;
     auto ov_model = op->get_function();

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -419,11 +419,11 @@ memory_pool::memory_pool(engine& engine, const ExecutionConfig& config) : _engin
 inline std::string get_mb_size(size_t size) {
     if (size == 0)
         return "0 MB";
-    return std::to_string(static_cast<float>(size) / (1024 * 1024)) + " MB";
+    return std::to_string(static_cast<float>(size) / (1024.f * 1024.f)) + " MB";
 }
 
 inline float get_utilization(size_t size, size_t total_size) {
-    return (static_cast<float>(size) * 100.0f / total_size);
+    return (static_cast<float>(size) * 100.0f / static_cast<float>(total_size));
 }
 #endif
 
@@ -485,8 +485,8 @@ void memory_pool::dump_to_file(uint32_t net_id, uint32_t iter, std::string dump_
 void memory_pool::dump_to_screen(uint32_t net_id, uint32_t iter) {
 #ifdef GPU_DEBUG_CONFIG
     GPU_DEBUG_COUT << "Dump memory pool of network (net_id : " << net_id << ", iter : " << iter << ")" << std::endl;
-    float total_requested_mem_non_padded_pool    = 0.f;
-    float total_requested_mem_padded_pool        = 0.f;
+    size_t total_requested_mem_non_padded_pool    = 0;
+    size_t total_requested_mem_padded_pool        = 0;
 
     {
         GPU_DEBUG_COUT << "========== non-padded pool ( " << _non_padded_pool.size() << " records) ==========" << std::endl;
@@ -499,7 +499,7 @@ void memory_pool::dump_to_screen(uint32_t net_id, uint32_t iter) {
                 float utilization = get_utilization(user._mem_size, mem.first);
                 min_utilization = std::min(utilization, min_utilization);
                 max_utilization = std::max(utilization, max_utilization);
-                total_requested_mem_non_padded_pool += static_cast<float>(user._mem_size);
+                total_requested_mem_non_padded_pool += user._mem_size;
                 GPU_DEBUG_COUT << "    --- " << user._prim_id << " (" << user._unique_id << "), "
                     << get_mb_size(user._mem_size) << ", " << utilization << "%" << std::endl;
             }
@@ -522,7 +522,7 @@ void memory_pool::dump_to_screen(uint32_t net_id, uint32_t iter) {
                     float utilization = get_utilization(user._mem_size, mem_size);
                     min_utilization = std::min(utilization, min_utilization);
                     max_utilization = std::max(utilization, max_utilization);
-                    total_requested_mem_padded_pool += static_cast<float>(user._mem_size);
+                    total_requested_mem_padded_pool += user._mem_size;
                     GPU_DEBUG_COUT << "    --- " << user._prim_id << " (" << user._unique_id << "), "
                         << get_mb_size(user._mem_size) << ", " << utilization << "%" << std::endl;
                 }
@@ -546,9 +546,9 @@ void memory_pool::dump_to_screen(uint32_t net_id, uint32_t iter) {
     GPU_DEBUG_COUT << "************************************************************************" << std::endl;
     GPU_DEBUG_COUT << "Memory pool footprint of the network (net_id : " << net_id << ", iter : " << iter << ")" << std::endl;
     GPU_DEBUG_COUT << "Total memory size of non_padded_pool     : " << get_mb_size(total_mem_size_non_padded_pool) << std::endl;
-    if (total_mem_size_non_padded_pool > 0.f) {
+    if (total_mem_size_non_padded_pool > 0) {
         GPU_DEBUG_COUT << " * Efficiency        : "
-            << std::to_string(static_cast<float>(total_requested_mem_non_padded_pool / total_mem_size_non_padded_pool))
+            << std::to_string(static_cast<float>(total_requested_mem_non_padded_pool) / static_cast<float>(total_mem_size_non_padded_pool))
             << " (total mem requested : " << get_mb_size(total_requested_mem_non_padded_pool)
             << " / total mem pool size : " << get_mb_size(total_mem_size_non_padded_pool) << ")" << std::endl;
         GPU_DEBUG_COUT << " * host mem size     : " << get_mb_size(mem_size_non_padded_pool_host) << std::endl;
@@ -556,16 +556,16 @@ void memory_pool::dump_to_screen(uint32_t net_id, uint32_t iter) {
                             << get_mb_size(total_mem_size_non_padded_pool - mem_size_non_padded_pool_host) << std::endl;
     }
     GPU_DEBUG_COUT << "Total memory size of padded_pool memory  : " << get_mb_size(total_mem_size_padded_pool) << std::endl;
-    if (total_mem_size_padded_pool > 0.f) {
+    if (total_mem_size_padded_pool > 0) {
         GPU_DEBUG_COUT << " * Efficiency        : "
-            << std::to_string(static_cast<float>(total_requested_mem_padded_pool / total_mem_size_padded_pool))
+            << std::to_string(static_cast<float>(total_requested_mem_padded_pool) / static_cast<float>(total_mem_size_padded_pool))
             << " (total mem requested : " << get_mb_size(total_requested_mem_padded_pool)
             << " / total mem pool size : " << get_mb_size(total_mem_size_padded_pool) << ")" << std::endl;
         GPU_DEBUG_COUT << " * host mem size     : " << get_mb_size(mem_size_padded_pool_host) << std::endl;
         GPU_DEBUG_COUT << " * device mem size   : " << get_mb_size((total_mem_size_padded_pool - mem_size_padded_pool_host)) << std::endl;
     }
     GPU_DEBUG_COUT << "Total memory size of no reusable memory  : " << get_mb_size(total_mem_size_no_reusable) << std::endl;
-    if (total_mem_size_no_reusable > 0.f) {
+    if (total_mem_size_no_reusable > 0) {
         GPU_DEBUG_COUT << " * host mem size     : " << get_mb_size(mem_size_no_reusable_host) << std::endl;
         GPU_DEBUG_COUT << " * device mem size   : " << get_mb_size((total_mem_size_no_reusable - mem_size_no_reusable_host)) << std::endl;
     }

--- a/src/plugins/intel_gpu/tests/unit/fusions/loop_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/loop_fusion_test.cpp
@@ -19,7 +19,7 @@ using namespace ::tests;
 
 namespace {
 struct loop_params {
-    size_t loop_trip_count;
+    int32_t loop_trip_count;
     tensor in_shape;
     tensor loop_input_shape;
     tensor loop_eltwise_shape;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/loop_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/loop_gpu_test.cpp
@@ -288,7 +288,7 @@ void test_loop_gpu_basic_concat_nested(bool is_caching_test)
         1.f, -2.f, 3.f, -4.f
     };
 
-    size_t inner_trip_count = input_data.size() / inner_eltwise_operand.size();
+    int32_t inner_trip_count = static_cast<int32_t>(input_data.size() / inner_eltwise_operand.size());
     int inner_initial_condition = 1;
     int outer_trip_count = 8;
     int outer_initial_condition = 1;


### PR DESCRIPTION
### Details:
 - Fix implicit narrowing conversions (C4244) in GPU plugin to prepare for /wd4244 removal (BinSkim BA2007 compliance)
 - loop.hpp: Change constructor param from int64_t to int32_t with OPENVINO_ASSERT range check at caller
 - memory_pool.cpp/hpp: Change debug accumulators from float to size_t (float loses precision above 16MB)
 - swiglu_with_clamp.hpp / swiglu_kernel_base.h: Correct setter and fuse_params types to float to match member types
 - paged_attention_gen.cpp: Use float sqrt path instead of double for scale_factor
 - custom_gpu_primitive.hpp: Add static_cast<int> in GetDim macro to prevent int64_t→int narrowing

### Tickets:
 - CVS-185007

### AI Assistance:
 - AI assistance used: yes
 - GitHub Copilot used for code analysis (identifying root causes of each warning, evaluating fix options for type safety vs. serialization compatibility), generating fix code, and verifying build results. All changes were human-reviewed for correctness, validated via local /WX incremental build, and confirmed to have no performance or accuracy impact.