### PR TITLE
[Transformations] Transformations utils: added extract_subgraph helper

### DIFF
--- a/src/common/transformations/CMakeLists.txt
+++ b/src/common/transformations/CMakeLists.txt
@@ -15,6 +15,12 @@ file(GLOB_RECURSE PUBLIC_HEADERS ${PUBLIC_HEADERS_DIR}/*.hpp)
 source_group("src" FILES ${LIBRARY_SRC})
 source_group("include" FILES ${PUBLIC_HEADERS})
 
+# Debug capabilities sources - only compiled when ENABLE_DEBUG_CAPS is ON
+if(NOT ENABLE_DEBUG_CAPS)
+    list(REMOVE_ITEM LIBRARY_SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/transformations/utils/extract_subgraph.cpp")
+    list(REMOVE_ITEM PUBLIC_HEADERS "${PUBLIC_HEADERS_DIR}/transformations/utils/extract_subgraph.hpp")
+endif()
+
 # Create library
 add_library(${TARGET_NAME}_obj OBJECT ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 target_compile_definitions(${TARGET_NAME}_obj PRIVATE IMPLEMENT_OPENVINO_API)

--- a/src/common/transformations/docs/debug_capabilities/README.md
+++ b/src/common/transformations/docs/debug_capabilities/README.md
@@ -20,6 +20,10 @@ They can be activated at runtime and are useful for analyzing transformation beh
   When to use: need to inspect model IR (.xml/.bin) after specific passes — useful for diffing model state before and after a transformation.
   Example: `OV_ENABLE_SERIALIZE_TRACING=true` or `OV_ENABLE_SERIALIZE_TRACING="Pass1,Pass2"`
 
+* [Subgraph extraction](extract_subgraph.md)
+  When to use: working with a large model where full compilation or inference is slow, or where the serialized IR is too large to read or render in graph visualization tools — extract only the relevant subgraph as a standalone `ov::Model`, serialize to IR, and continue investigation on the smaller model independently.
+  Example: `ov::op::util::extract_subgraph(model, {{"MatMul_0", 0}}, {{"Softmax_0", 0}})`
+
 ## See also
 
 * [debug-matcher-pass skill](../../../../.claude/skills/debug-matcher-pass/SKILL.md) — automated diagnosis workflow for MatcherPass transformations that are not firing. Collects matcher logs, identifies root cause, and generates a reproducer test.

--- a/src/common/transformations/docs/debug_capabilities/README.md
+++ b/src/common/transformations/docs/debug_capabilities/README.md
@@ -22,7 +22,7 @@ They can be activated at runtime and are useful for analyzing transformation beh
 
 * [Subgraph extraction](extract_subgraph.md)
   When to use: working with a large model where full compilation or inference is slow, or where the serialized IR is too large to read or render in graph visualization tools — extract only the relevant subgraph as a standalone `ov::Model`, serialize to IR, and continue investigation on the smaller model independently.
-  Example: `ov::op::util::extract_subgraph(model, {{"MatMul_0", 0}}, {{"Softmax_0", 0}})`
+  Example: `extract_subgraph(model, {{"MatMul_0", 0}}, {{"Softmax_0", 0}})`
 
 ## See also
 

--- a/src/common/transformations/docs/debug_capabilities/extract_subgraph.md
+++ b/src/common/transformations/docs/debug_capabilities/extract_subgraph.md
@@ -1,0 +1,61 @@
+# Subgraph extraction
+
+Extracts a subgraph from an `ov::Model` as a standalone `ov::Model`, without modifying the original model.
+
+Useful for inspecting, serializing, or testing a specific portion of a larger model during development or debugging. This is especially valuable when working with large models where full compilation or inference takes a significant amount of time, or where the serialized IR is too large to read or render in graph visualization tools — extracting only the relevant subgraph lets you iterate on it in isolation instead of processing the entire model on each run.
+
+Once extracted, the subgraph can be serialized to IR via `ov::pass::Serialize` and reloaded independently, so subsequent investigation or reproduction work can be done on the smaller model without access to the original.
+
+## API
+
+```cpp
+#include "transformations/utils/extract_subgraph.hpp"
+```
+
+### Core overload — explicit port boundaries
+
+```cpp
+std::shared_ptr<ov::Model> ov::op::util::extract_subgraph(
+    const std::shared_ptr<ov::Model>& model,
+    const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
+    const std::vector<ov::Output<ov::Node>>& subgraph_outputs);
+```
+
+Each `subgraph_inputs` entry becomes a fresh `Parameter` node in the extracted model. The extracted graph spans from those inputs to `subgraph_outputs`.
+
+### Name-based overload — look up ports by friendly name
+
+```cpp
+std::shared_ptr<ov::Model> ov::op::util::extract_subgraph(
+    const std::shared_ptr<ov::Model>& model,
+    const std::multimap<std::string, size_t>& subgraph_inputs,
+    const std::multimap<std::string, size_t>& subgraph_outputs);
+```
+
+Each multimap entry maps a node's friendly name to a port index. Multiple entries with the same name select different ports of the same node.
+
+Throws `ov::Exception` if any name is not found in the model.
+
+## Example
+
+```cpp
+#include "transformations/utils/extract_subgraph.hpp"
+
+// Extract the subgraph between two named nodes
+const std::multimap<std::string, size_t> inputs  = {{"MatMul_0", 0}};
+const std::multimap<std::string, size_t> outputs = {{"Softmax_0", 0}};
+
+auto subgraph = ov::op::util::extract_subgraph(model, inputs, outputs);
+
+// The original model is unchanged; subgraph is an independent ov::Model.
+// Serialize it to IR so further investigation can be done on the isolated subgraph
+// without rerunning the full model pipeline.
+ov::pass::Serialize("subgraph.xml", "subgraph.bin").run_on_model(subgraph);
+```
+
+## Behavior
+
+- The original model is **not modified**.
+- The extracted model is a deep clone — changes to it do not affect the source model.
+- Subgraph `Parameter` nodes inherit the element type and partial shape of their corresponding input ports.
+- Node order within the extracted model follows topological order.

--- a/src/common/transformations/docs/debug_capabilities/extract_subgraph.md
+++ b/src/common/transformations/docs/debug_capabilities/extract_subgraph.md
@@ -6,36 +6,6 @@ Useful for inspecting, serializing, or testing a specific portion of a larger mo
 
 Once extracted, the subgraph can be serialized to IR via `ov::pass::Serialize` and reloaded independently, so subsequent investigation or reproduction work can be done on the smaller model without access to the original.
 
-## API
-
-```cpp
-#include "transformations/utils/extract_subgraph.hpp"
-```
-
-### Core overload — explicit port boundaries
-
-```cpp
-std::shared_ptr<ov::Model> ov::op::util::extract_subgraph(
-    const std::shared_ptr<ov::Model>& model,
-    const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
-    const std::vector<ov::Output<ov::Node>>& subgraph_outputs);
-```
-
-Each `subgraph_inputs` entry becomes a fresh `Parameter` node in the extracted model. The extracted graph spans from those inputs to `subgraph_outputs`.
-
-### Name-based overload — look up ports by friendly name
-
-```cpp
-std::shared_ptr<ov::Model> ov::op::util::extract_subgraph(
-    const std::shared_ptr<ov::Model>& model,
-    const std::multimap<std::string, size_t>& subgraph_inputs,
-    const std::multimap<std::string, size_t>& subgraph_outputs);
-```
-
-Each multimap entry maps a node's friendly name to a port index. Multiple entries with the same name select different ports of the same node.
-
-Throws `ov::Exception` if any name is not found in the model.
-
 ## Example
 
 ```cpp

--- a/src/common/transformations/include/transformations/utils/extract_subgraph.hpp
+++ b/src/common/transformations/include/transformations/utils/extract_subgraph.hpp
@@ -17,11 +17,33 @@ namespace ov {
 namespace op {
 namespace util {
 
+/**
+ * @brief Extracts a subgraph bounded by the given input and output ports as a standalone model.
+ * The original model is not modified; the extracted model is a deep clone.
+ *
+ * @param model            Source model.
+ * @param subgraph_inputs  Input ports that form the subgraph boundary. Each port is replaced
+ *                         by a new Parameter whose element type and partial shape match the port.
+ * @param subgraph_outputs Output ports that define the subgraph results.
+ * @return A new ov::Model representing the extracted subgraph.
+ */
 TRANSFORMATIONS_API std::shared_ptr<ov::Model> extract_subgraph(
     const std::shared_ptr<ov::Model>& model,
     const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
     const std::vector<ov::Output<ov::Node>>& subgraph_outputs);
 
+/**
+ * @brief Extracts a subgraph by resolving boundary ports from node friendly names.
+ *
+ * Convenience wrapper over the port-based overload. Each multimap entry maps a node
+ * friendly name to a port index; multiple entries with the same name select different
+ * ports of the same node. Throws ov::Exception if any name is not found in the model.
+ *
+ * @param model             Source model.
+ * @param subgraph_inputs   Map of { friendly_name -> input_port_index } for boundary inputs.
+ * @param subgraph_outputs  Map of { friendly_name -> output_port_index } for boundary outputs.
+ * @return A new ov::Model representing the extracted subgraph.
+ */
 TRANSFORMATIONS_API std::shared_ptr<ov::Model> extract_subgraph(
     const std::shared_ptr<ov::Model>& model,
     const std::multimap<std::string, size_t>& subgraph_inputs,

--- a/src/common/transformations/include/transformations/utils/extract_subgraph.hpp
+++ b/src/common/transformations/include/transformations/utils/extract_subgraph.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "openvino/core/model.hpp"
+#include "openvino/core/node.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov {
+namespace op {
+namespace util {
+
+TRANSFORMATIONS_API std::shared_ptr<ov::Model> extract_subgraph(
+    const std::shared_ptr<ov::Model>& model,
+    const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
+    const std::vector<ov::Output<ov::Node>>& subgraph_outputs);
+
+TRANSFORMATIONS_API std::shared_ptr<ov::Model> extract_subgraph(
+    const std::shared_ptr<ov::Model>& model,
+    const std::multimap<std::string, size_t>& subgraph_inputs,
+    const std::multimap<std::string, size_t>& subgraph_outputs);
+
+}  // namespace util
+}  // namespace op
+}  // namespace ov

--- a/src/common/transformations/include/transformations/utils/extract_subgraph.hpp
+++ b/src/common/transformations/include/transformations/utils/extract_subgraph.hpp
@@ -13,24 +13,19 @@
 #include "openvino/core/node.hpp"
 #include "transformations_visibility.hpp"
 
-namespace ov {
-namespace op {
-namespace util {
+namespace ov::util {
 
 /**
  * @brief Extracts a subgraph bounded by the given input and output ports as a standalone model.
  * The original model is not modified; the extracted model is a deep clone.
  *
- * @param model            Source model.
  * @param subgraph_inputs  Input ports that form the subgraph boundary. Each port is replaced
  *                         by a new Parameter whose element type and partial shape match the port.
  * @param subgraph_outputs Output ports that define the subgraph results.
  * @return A new ov::Model representing the extracted subgraph.
  */
-TRANSFORMATIONS_API std::shared_ptr<ov::Model> extract_subgraph(
-    const std::shared_ptr<ov::Model>& model,
-    const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
-    const std::vector<ov::Output<ov::Node>>& subgraph_outputs);
+TRANSFORMATIONS_API std::shared_ptr<ov::Model> extract_subgraph(const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
+                                                                const ov::OutputVector& subgraph_outputs);
 
 /**
  * @brief Extracts a subgraph by resolving boundary ports from node friendly names.
@@ -49,6 +44,4 @@ TRANSFORMATIONS_API std::shared_ptr<ov::Model> extract_subgraph(
     const std::multimap<std::string, size_t>& subgraph_inputs,
     const std::multimap<std::string, size_t>& subgraph_outputs);
 
-}  // namespace util
-}  // namespace op
-}  // namespace ov
+}  // namespace ov::util

--- a/src/common/transformations/src/transformations/utils/extract_subgraph.cpp
+++ b/src/common/transformations/src/transformations/utils/extract_subgraph.cpp
@@ -1,0 +1,99 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/utils/extract_subgraph.hpp"
+
+#include <map>
+#include <set>
+#include <utility>
+
+#include "openvino/core/graph_util.hpp"
+#include "openvino/op/parameter.hpp"
+
+namespace ov {
+namespace op {
+namespace util {
+
+std::shared_ptr<ov::Model> extract_subgraph(const std::shared_ptr<ov::Model>& model,
+                                            const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
+                                            const std::vector<ov::Output<ov::Node>>& subgraph_outputs) {
+    ov::OutputVector replaced_outputs;
+    ov::ParameterVector subgraph_parameters;
+    subgraph_parameters.reserve(subgraph_inputs.size());
+    replaced_outputs.reserve(subgraph_inputs.size());
+
+    for (const auto& input : subgraph_inputs) {
+        const auto new_parameter =
+            std::make_shared<ov::op::v0::Parameter>(input.get_element_type(), input.get_partial_shape());
+        subgraph_parameters.push_back(new_parameter);
+
+        const auto& source_output = input.get_source_output();
+        replaced_outputs.push_back(source_output);
+        ov::replace_output_update_name(source_output, new_parameter->output(0));
+    }
+    OPENVINO_ASSERT(subgraph_parameters.size() == replaced_outputs.size(),
+                    "extract_subgraph: number of subgraph_parameters is not equal to the number of replaced_outputs");
+
+    auto subgraph = std::make_shared<ov::Model>(subgraph_outputs, subgraph_parameters)->clone();
+
+    for (size_t i = 0; i < subgraph_parameters.size(); ++i) {
+        subgraph_parameters[i]->output(0).replace(replaced_outputs[i]);
+    }
+    return subgraph;
+}
+
+namespace {
+std::pair<std::vector<ov::Input<ov::Node>>, std::vector<ov::Output<ov::Node>>> resolve_subgraph_boundaries(
+    const std::shared_ptr<ov::Model>& model,
+    const std::multimap<std::string, size_t>& input_map,
+    const std::multimap<std::string, size_t>& output_map) {
+    std::vector<ov::Input<ov::Node>> inputs;
+    std::vector<ov::Output<ov::Node>> outputs;
+
+    std::set<std::string> resolved_input_names;
+    std::set<std::string> resolved_output_names;
+
+    for (const auto& node : model->get_ordered_ops()) {
+        const auto& name = node->get_friendly_name();
+
+        const auto input_range = input_map.equal_range(name);
+        for (auto it = input_range.first; it != input_range.second; ++it) {
+            inputs.push_back(node->input(it->second));
+            resolved_input_names.insert(name);
+        }
+
+        const auto output_range = output_map.equal_range(name);
+        for (auto it = output_range.first; it != output_range.second; ++it) {
+            outputs.push_back(node->output(it->second));
+            resolved_output_names.insert(name);
+        }
+    }
+
+    for (const auto& kv : input_map) {
+        OPENVINO_ASSERT(resolved_input_names.count(kv.first),
+                        "extract_subgraph: node '",
+                        kv.first,
+                        "' specified in subgraph_inputs was not found in the model");
+    }
+    for (const auto& kv : output_map) {
+        OPENVINO_ASSERT(resolved_output_names.count(kv.first),
+                        "extract_subgraph: node '",
+                        kv.first,
+                        "' specified in subgraph_outputs was not found in the model");
+    }
+
+    return {inputs, outputs};
+}
+}  // namespace
+
+std::shared_ptr<ov::Model> extract_subgraph(const std::shared_ptr<ov::Model>& model,
+                                            const std::multimap<std::string, size_t>& subgraph_inputs,
+                                            const std::multimap<std::string, size_t>& subgraph_outputs) {
+    auto [inputs, outputs] = resolve_subgraph_boundaries(model, subgraph_inputs, subgraph_outputs);
+    return extract_subgraph(model, inputs, outputs);
+}
+
+}  // namespace util
+}  // namespace op
+}  // namespace ov

--- a/src/common/transformations/src/transformations/utils/extract_subgraph.cpp
+++ b/src/common/transformations/src/transformations/utils/extract_subgraph.cpp
@@ -6,12 +6,55 @@
 
 #include <map>
 #include <set>
+#include <stack>
+#include <unordered_set>
 #include <utility>
 
 #include "openvino/core/graph_util.hpp"
 #include "openvino/op/parameter.hpp"
+#include "openvino/op/sink.hpp"
 
 namespace ov::util {
+
+namespace {
+ov::SinkVector collect_sinks(const ov::OutputVector& subgraph_outputs,
+                             const ov::ParameterVector& subgraph_parameters) {
+    std::unordered_set<ov::Node*> param_set;
+    for (const auto& p : subgraph_parameters) {
+        param_set.insert(p.get());
+    }
+
+    // First pass: collect all nodes in the subgraph by walking backward from outputs
+    std::unordered_set<ov::Node*> subgraph_nodes;
+    std::stack<ov::Node*> stack;
+    for (const auto& output : subgraph_outputs) {
+        stack.push(output.get_node());
+    }
+    while (!stack.empty()) {
+        auto* node = stack.top();
+        stack.pop();
+        if (!subgraph_nodes.insert(node).second || param_set.count(node)) {
+            continue;
+        }
+        for (size_t i = 0; i < node->get_input_size(); ++i) {
+            stack.push(node->get_input_node_ptr(i));
+        }
+    }
+
+    // Second pass: find Sink nodes that consume outputs of subgraph nodes
+    ov::SinkVector sinks;
+    for (auto* node : subgraph_nodes) {
+        for (const auto& output : node->shared_from_this()->outputs()) {
+            for (const auto& target_input : output.get_target_inputs()) {
+                if (auto sink = std::dynamic_pointer_cast<ov::op::Sink>(target_input.get_node()->shared_from_this())) {
+                    sinks.push_back(sink);
+                }
+            }
+        }
+    }
+    return sinks;
+}
+}  // namespace
 
 std::shared_ptr<ov::Model> extract_subgraph(const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
                                             const ov::OutputVector& subgraph_outputs) {
@@ -37,7 +80,9 @@ std::shared_ptr<ov::Model> extract_subgraph(const std::vector<ov::Input<ov::Node
     OPENVINO_ASSERT(subgraph_parameters.size() == replaced_outputs.size(),
                     "extract_subgraph: number of subgraph_parameters is not equal to the number of replaced_outputs");
 
-    auto subgraph = std::make_shared<ov::Model>(subgraph_outputs, subgraph_parameters)->clone();
+    auto sinks = collect_sinks(subgraph_outputs, subgraph_parameters);
+    auto subgraph =
+        std::make_shared<ov::Model>(subgraph_outputs, sinks, subgraph_parameters)->clone();
 
     for (size_t i = 0; i < subgraph_parameters.size(); ++i) {
         subgraph_parameters[i]->output(0).replace(replaced_outputs[i]);

--- a/src/common/transformations/src/transformations/utils/extract_subgraph.cpp
+++ b/src/common/transformations/src/transformations/utils/extract_subgraph.cpp
@@ -30,7 +30,12 @@ std::shared_ptr<ov::Model> extract_subgraph(const std::shared_ptr<ov::Model>& mo
 
         const auto& source_output = input.get_source_output();
         replaced_outputs.push_back(source_output);
-        ov::replace_output_update_name(source_output, new_parameter->output(0));
+        OPENVINO_ASSERT(ov::replace_output_update_name(source_output, new_parameter->output(0)),
+                        "extract_subgraph: failed to replace boundary source output '",
+                        source_output.get_node()->get_friendly_name(),
+                        "' at port ",
+                        source_output.get_index(),
+                        ". The requested subgraph input cannot be replaced safely.");
     }
     OPENVINO_ASSERT(subgraph_parameters.size() == replaced_outputs.size(),
                     "extract_subgraph: number of subgraph_parameters is not equal to the number of replaced_outputs");

--- a/src/common/transformations/src/transformations/utils/extract_subgraph.cpp
+++ b/src/common/transformations/src/transformations/utils/extract_subgraph.cpp
@@ -11,13 +11,10 @@
 #include "openvino/core/graph_util.hpp"
 #include "openvino/op/parameter.hpp"
 
-namespace ov {
-namespace op {
-namespace util {
+namespace ov::util {
 
-std::shared_ptr<ov::Model> extract_subgraph(const std::shared_ptr<ov::Model>& model,
-                                            const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
-                                            const std::vector<ov::Output<ov::Node>>& subgraph_outputs) {
+std::shared_ptr<ov::Model> extract_subgraph(const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
+                                            const ov::OutputVector& subgraph_outputs) {
     ov::OutputVector replaced_outputs;
     ov::ParameterVector subgraph_parameters;
     subgraph_parameters.reserve(subgraph_inputs.size());
@@ -96,9 +93,7 @@ std::shared_ptr<ov::Model> extract_subgraph(const std::shared_ptr<ov::Model>& mo
                                             const std::multimap<std::string, size_t>& subgraph_inputs,
                                             const std::multimap<std::string, size_t>& subgraph_outputs) {
     auto [inputs, outputs] = resolve_subgraph_boundaries(model, subgraph_inputs, subgraph_outputs);
-    return extract_subgraph(model, inputs, outputs);
+    return extract_subgraph(inputs, outputs);
 }
 
-}  // namespace util
-}  // namespace op
-}  // namespace ov
+}  // namespace ov::util

--- a/src/common/transformations/tests/CMakeLists.txt
+++ b/src/common/transformations/tests/CMakeLists.txt
@@ -8,9 +8,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)
     ov_add_compiler_flags(-Wno-missing-declarations)
 endif()
 
+set(EXCLUDED_PATHS "")
+if(NOT ENABLE_DEBUG_CAPS)
+    list(APPEND EXCLUDED_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/utils/extract_subgraph_test")
+endif()
+
 ov_add_test_target(
     NAME ${TARGET_NAME}
     ROOT ${CMAKE_CURRENT_SOURCE_DIR}
+    EXCLUDED_SOURCE_PATHS
+        ${EXCLUDED_PATHS}
     DEPENDENCIES
     LINK_LIBRARIES
         gmock

--- a/src/common/transformations/tests/utils/extract_subgraph_test.cpp
+++ b/src/common/transformations/tests/utils/extract_subgraph_test.cpp
@@ -22,7 +22,6 @@ namespace op_util = ov::op::util;
 
 // Builds:  param_a -> relu -> add -> result
 //                    param_b -^
-// Node friendly names: "A", "Relu", "B", "Add", "Result"
 static std::shared_ptr<ov::Model> build_linear_model() {
     auto param_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4});
     param_a->set_friendly_name("A");
@@ -45,7 +44,6 @@ static std::shared_ptr<ov::Model> build_linear_model() {
 // Builds a branching model:
 //   param_a -> relu ---------> mul -> result
 //   param_b -> sigmoid -------^
-// Node friendly names: "A", "Relu", "B", "Sigmoid", "Mul", "Result"
 static std::shared_ptr<ov::Model> build_branch_model() {
     auto param_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 3});
     param_a->set_friendly_name("A");
@@ -68,8 +66,6 @@ static std::shared_ptr<ov::Model> build_branch_model() {
     return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param_a, param_b});
 }
 
-// ── Core overload ──────────────────────────────────────────────────────────────
-
 TEST(ExtractSubgraphTest, CoreOverload_SingleOp) {
     auto model = build_linear_model();
 
@@ -80,17 +76,16 @@ TEST(ExtractSubgraphTest, CoreOverload_SingleOp) {
     }
     ASSERT_NE(relu_ptr, nullptr);
 
-    auto subgraph =
-        op_util::extract_subgraph(model, {relu_ptr->input(0)}, {relu_ptr->output(0)});
+    auto subgraph = op_util::extract_subgraph(model, {relu_ptr->input(0)}, {relu_ptr->output(0)});
 
     // Build the expected model: param -> relu -> result
     auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
     auto expected_relu = std::make_shared<ov::op::v0::Relu>(expected_param);
+    expected_relu->set_friendly_name("Relu");
     auto expected_result = std::make_shared<ov::op::v0::Result>(expected_relu);
-    auto expected =
-        std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{expected_param});
+    auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{expected_param});
 
-    const auto cmp = FunctionsComparator::with_default();
+    const auto cmp = FunctionsComparator::all_flags_enabled();
     const auto res = cmp.compare(subgraph, expected);
     EXPECT_TRUE(res.valid) << res.message;
 }
@@ -107,14 +102,14 @@ TEST(ExtractSubgraphTest, CoreOverload_TwoInputsOneOutput) {
 
     auto subgraph = op_util::extract_subgraph(model, {add_ptr->input(0), add_ptr->input(1)}, {add_ptr->output(0)});
 
-    // Expected: two params -> add -> result
     auto p0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
     auto p1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
     auto expected_add = std::make_shared<ov::op::v1::Add>(p0, p1);
+    expected_add->set_friendly_name("Add");
     auto expected_result = std::make_shared<ov::op::v0::Result>(expected_add);
     auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{p0, p1});
 
-    const auto cmp = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto cmp = FunctionsComparator::all_flags_enabled().enable(FunctionsComparator::ATTRIBUTES);
     const auto res = cmp.compare(subgraph, expected);
     EXPECT_TRUE(res.valid) << res.message;
 }
@@ -135,11 +130,8 @@ TEST(ExtractSubgraphTest, CoreOverload_OriginalModelUnchanged) {
     EXPECT_EQ(model->get_ordered_ops().size(), original_op_count);
     EXPECT_EQ(model->get_parameters().size(), 2u);
     EXPECT_EQ(model->get_results().size(), 1u);
-    // Relu must still be fed by the original Parameter in the model
     EXPECT_TRUE(ov::is_type<ov::op::v0::Parameter>(relu_ptr->get_input_node_shared_ptr(0)));
 }
-
-// ── Multimap overload ──────────────────────────────────────────────────────────
 
 TEST(ExtractSubgraphTest, MultimapOverload_SingleOp) {
     auto model = build_linear_model();
@@ -151,11 +143,11 @@ TEST(ExtractSubgraphTest, MultimapOverload_SingleOp) {
 
     auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
     auto expected_relu = std::make_shared<ov::op::v0::Relu>(expected_param);
+    expected_relu->set_friendly_name("Relu");
     auto expected_result = std::make_shared<ov::op::v0::Result>(expected_relu);
-    auto expected =
-        std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{expected_param});
+    auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{expected_param});
 
-    const auto cmp = FunctionsComparator::with_default();
+    const auto cmp = FunctionsComparator::all_flags_enabled();
     const auto res = cmp.compare(subgraph, expected);
     EXPECT_TRUE(res.valid) << res.message;
 }
@@ -173,11 +165,13 @@ TEST(ExtractSubgraphTest, MultimapOverload_MultiInputChain) {
     auto p0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
     auto p1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
     auto expected_relu = std::make_shared<ov::op::v0::Relu>(p0);
+    expected_relu->set_friendly_name("Relu");
     auto expected_add = std::make_shared<ov::op::v1::Add>(expected_relu, p1);
+    expected_add->set_friendly_name("Add");
     auto expected_result = std::make_shared<ov::op::v0::Result>(expected_add);
     auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{p0, p1});
 
-    const auto cmp = FunctionsComparator::with_default();
+    const auto cmp = FunctionsComparator::all_flags_enabled();
     const auto res = cmp.compare(subgraph, expected);
     EXPECT_TRUE(res.valid) << res.message;
 }
@@ -194,10 +188,11 @@ TEST(ExtractSubgraphTest, MultimapOverload_BranchingModel_BothBranches) {
     auto p0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 3});
     auto p1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 3});
     auto expected_mul = std::make_shared<ov::op::v1::Multiply>(p0, p1);
+    expected_mul->set_friendly_name("Mul");
     auto expected_result = std::make_shared<ov::op::v0::Result>(expected_mul);
     auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{p0, p1});
 
-    const auto cmp = FunctionsComparator::with_default();
+    const auto cmp = FunctionsComparator::all_flags_enabled();
     const auto res = cmp.compare(subgraph, expected);
     EXPECT_TRUE(res.valid) << res.message;
 }
@@ -213,16 +208,14 @@ TEST(ExtractSubgraphTest, MultimapOverload_BranchingModel_SingleBranch) {
 
     auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 3});
     auto expected_relu = std::make_shared<ov::op::v0::Relu>(expected_param);
+    expected_relu->set_friendly_name("Relu");
     auto expected_result = std::make_shared<ov::op::v0::Result>(expected_relu);
-    auto expected =
-        std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{expected_param});
+    auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{expected_param});
 
-    const auto cmp = FunctionsComparator::with_default();
+    const auto cmp = FunctionsComparator::all_flags_enabled();
     const auto res = cmp.compare(subgraph, expected);
     EXPECT_TRUE(res.valid) << res.message;
 }
-
-// ── Error cases ────────────────────────────────────────────────────────────────
 
 TEST(ExtractSubgraphTest, MultimapOverload_UnknownInputNameThrows) {
     auto model = build_linear_model();

--- a/src/common/transformations/tests/utils/extract_subgraph_test.cpp
+++ b/src/common/transformations/tests/utils/extract_subgraph_test.cpp
@@ -1,0 +1,243 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/utils/extract_subgraph.hpp"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+
+#include "common_test_utils/graph_comparator.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/relu.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/sigmoid.hpp"
+
+namespace op_util = ov::op::util;
+
+// Builds:  param_a -> relu -> add -> result
+//                    param_b -^
+// Node friendly names: "A", "Relu", "B", "Add", "Result"
+static std::shared_ptr<ov::Model> build_linear_model() {
+    auto param_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4});
+    param_a->set_friendly_name("A");
+
+    auto relu = std::make_shared<ov::op::v0::Relu>(param_a);
+    relu->set_friendly_name("Relu");
+
+    auto param_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4});
+    param_b->set_friendly_name("B");
+
+    auto add = std::make_shared<ov::op::v1::Add>(relu, param_b);
+    add->set_friendly_name("Add");
+
+    auto result = std::make_shared<ov::op::v0::Result>(add);
+    result->set_friendly_name("Result");
+
+    return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param_a, param_b});
+}
+
+// Builds a branching model:
+//   param_a -> relu ---------> mul -> result
+//   param_b -> sigmoid -------^
+// Node friendly names: "A", "Relu", "B", "Sigmoid", "Mul", "Result"
+static std::shared_ptr<ov::Model> build_branch_model() {
+    auto param_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 3});
+    param_a->set_friendly_name("A");
+
+    auto relu = std::make_shared<ov::op::v0::Relu>(param_a);
+    relu->set_friendly_name("Relu");
+
+    auto param_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 3});
+    param_b->set_friendly_name("B");
+
+    auto sigmoid = std::make_shared<ov::op::v0::Sigmoid>(param_b);
+    sigmoid->set_friendly_name("Sigmoid");
+
+    auto mul = std::make_shared<ov::op::v1::Multiply>(relu, sigmoid);
+    mul->set_friendly_name("Mul");
+
+    auto result = std::make_shared<ov::op::v0::Result>(mul);
+    result->set_friendly_name("Result");
+
+    return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param_a, param_b});
+}
+
+// ── Core overload ──────────────────────────────────────────────────────────────
+
+TEST(ExtractSubgraphTest, CoreOverload_SingleOp) {
+    auto model = build_linear_model();
+
+    ov::op::v0::Relu* relu_ptr = nullptr;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (op->get_friendly_name() == "Relu")
+            relu_ptr = ov::as_type<ov::op::v0::Relu>(op.get());
+    }
+    ASSERT_NE(relu_ptr, nullptr);
+
+    auto subgraph =
+        op_util::extract_subgraph(model, {relu_ptr->input(0)}, {relu_ptr->output(0)});
+
+    // Build the expected model: param -> relu -> result
+    auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
+    auto expected_relu = std::make_shared<ov::op::v0::Relu>(expected_param);
+    auto expected_result = std::make_shared<ov::op::v0::Result>(expected_relu);
+    auto expected =
+        std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{expected_param});
+
+    const auto cmp = FunctionsComparator::with_default();
+    const auto res = cmp.compare(subgraph, expected);
+    EXPECT_TRUE(res.valid) << res.message;
+}
+
+TEST(ExtractSubgraphTest, CoreOverload_TwoInputsOneOutput) {
+    auto model = build_linear_model();
+
+    ov::op::v1::Add* add_ptr = nullptr;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (op->get_friendly_name() == "Add")
+            add_ptr = ov::as_type<ov::op::v1::Add>(op.get());
+    }
+    ASSERT_NE(add_ptr, nullptr);
+
+    auto subgraph = op_util::extract_subgraph(model, {add_ptr->input(0), add_ptr->input(1)}, {add_ptr->output(0)});
+
+    // Expected: two params -> add -> result
+    auto p0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
+    auto p1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
+    auto expected_add = std::make_shared<ov::op::v1::Add>(p0, p1);
+    auto expected_result = std::make_shared<ov::op::v0::Result>(expected_add);
+    auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{p0, p1});
+
+    const auto cmp = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto res = cmp.compare(subgraph, expected);
+    EXPECT_TRUE(res.valid) << res.message;
+}
+
+TEST(ExtractSubgraphTest, CoreOverload_OriginalModelUnchanged) {
+    auto model = build_linear_model();
+    const size_t original_op_count = model->get_ordered_ops().size();
+
+    ov::op::v0::Relu* relu_ptr = nullptr;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (op->get_friendly_name() == "Relu")
+            relu_ptr = ov::as_type<ov::op::v0::Relu>(op.get());
+    }
+    ASSERT_NE(relu_ptr, nullptr);
+
+    op_util::extract_subgraph(model, {relu_ptr->input(0)}, {relu_ptr->output(0)});
+
+    EXPECT_EQ(model->get_ordered_ops().size(), original_op_count);
+    EXPECT_EQ(model->get_parameters().size(), 2u);
+    EXPECT_EQ(model->get_results().size(), 1u);
+    // Relu must still be fed by the original Parameter in the model
+    EXPECT_TRUE(ov::is_type<ov::op::v0::Parameter>(relu_ptr->get_input_node_shared_ptr(0)));
+}
+
+// ── Multimap overload ──────────────────────────────────────────────────────────
+
+TEST(ExtractSubgraphTest, MultimapOverload_SingleOp) {
+    auto model = build_linear_model();
+
+    const std::multimap<std::string, size_t> inputs_map = {{"Relu", 0}};
+    const std::multimap<std::string, size_t> outputs_map = {{"Relu", 0}};
+
+    auto subgraph = op_util::extract_subgraph(model, inputs_map, outputs_map);
+
+    auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
+    auto expected_relu = std::make_shared<ov::op::v0::Relu>(expected_param);
+    auto expected_result = std::make_shared<ov::op::v0::Result>(expected_relu);
+    auto expected =
+        std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{expected_param});
+
+    const auto cmp = FunctionsComparator::with_default();
+    const auto res = cmp.compare(subgraph, expected);
+    EXPECT_TRUE(res.valid) << res.message;
+}
+
+TEST(ExtractSubgraphTest, MultimapOverload_MultiInputChain) {
+    auto model = build_linear_model();
+
+    // Extract the whole Relu->Add chain: cut before Relu and before Add.input(1), output at Add
+    const std::multimap<std::string, size_t> inputs_map = {{"Relu", 0}, {"Add", 1}};
+    const std::multimap<std::string, size_t> outputs_map = {{"Add", 0}};
+
+    auto subgraph = op_util::extract_subgraph(model, inputs_map, outputs_map);
+
+    // Expected: p0 -> relu -> add(p1) -> result
+    auto p0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
+    auto p1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
+    auto expected_relu = std::make_shared<ov::op::v0::Relu>(p0);
+    auto expected_add = std::make_shared<ov::op::v1::Add>(expected_relu, p1);
+    auto expected_result = std::make_shared<ov::op::v0::Result>(expected_add);
+    auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{p0, p1});
+
+    const auto cmp = FunctionsComparator::with_default();
+    const auto res = cmp.compare(subgraph, expected);
+    EXPECT_TRUE(res.valid) << res.message;
+}
+
+TEST(ExtractSubgraphTest, MultimapOverload_BranchingModel_BothBranches) {
+    auto model = build_branch_model();
+
+    // Extract both activation branches but not Mul: inputs at Relu.0 and Sigmoid.0, outputs at Relu.0 and Sigmoid.0
+    const std::multimap<std::string, size_t> inputs_map = {{"Mul", 0}, {"Mul", 1}};
+    const std::multimap<std::string, size_t> outputs_map = {{"Mul", 0}};
+
+    auto subgraph = op_util::extract_subgraph(model, inputs_map, outputs_map);
+
+    auto p0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 3});
+    auto p1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 3});
+    auto expected_mul = std::make_shared<ov::op::v1::Multiply>(p0, p1);
+    auto expected_result = std::make_shared<ov::op::v0::Result>(expected_mul);
+    auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{p0, p1});
+
+    const auto cmp = FunctionsComparator::with_default();
+    const auto res = cmp.compare(subgraph, expected);
+    EXPECT_TRUE(res.valid) << res.message;
+}
+
+TEST(ExtractSubgraphTest, MultimapOverload_BranchingModel_SingleBranch) {
+    auto model = build_branch_model();
+
+    // Extract only the Relu branch up to Mul input
+    const std::multimap<std::string, size_t> inputs_map = {{"Relu", 0}};
+    const std::multimap<std::string, size_t> outputs_map = {{"Relu", 0}};
+
+    auto subgraph = op_util::extract_subgraph(model, inputs_map, outputs_map);
+
+    auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 3});
+    auto expected_relu = std::make_shared<ov::op::v0::Relu>(expected_param);
+    auto expected_result = std::make_shared<ov::op::v0::Result>(expected_relu);
+    auto expected =
+        std::make_shared<ov::Model>(ov::ResultVector{expected_result}, ov::ParameterVector{expected_param});
+
+    const auto cmp = FunctionsComparator::with_default();
+    const auto res = cmp.compare(subgraph, expected);
+    EXPECT_TRUE(res.valid) << res.message;
+}
+
+// ── Error cases ────────────────────────────────────────────────────────────────
+
+TEST(ExtractSubgraphTest, MultimapOverload_UnknownInputNameThrows) {
+    auto model = build_linear_model();
+
+    const std::multimap<std::string, size_t> inputs_map = {{"NonExistentNode", 0}};
+    const std::multimap<std::string, size_t> outputs_map = {{"Add", 0}};
+
+    EXPECT_THROW(op_util::extract_subgraph(model, inputs_map, outputs_map), ov::Exception);
+}
+
+TEST(ExtractSubgraphTest, MultimapOverload_UnknownOutputNameThrows) {
+    auto model = build_linear_model();
+
+    const std::multimap<std::string, size_t> inputs_map = {{"Add", 0}};
+    const std::multimap<std::string, size_t> outputs_map = {{"NonExistentNode", 0}};
+
+    EXPECT_THROW(op_util::extract_subgraph(model, inputs_map, outputs_map), ov::Exception);
+}

--- a/src/common/transformations/tests/utils/extract_subgraph_test.cpp
+++ b/src/common/transformations/tests/utils/extract_subgraph_test.cpp
@@ -12,11 +12,16 @@
 #include "common_test_utils/graph_comparator.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/op/assign.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/parameter.hpp"
+#include "openvino/op/read_value.hpp"
 #include "openvino/op/relu.hpp"
 #include "openvino/op/result.hpp"
 #include "openvino/op/sigmoid.hpp"
+#include "openvino/op/util/variable.hpp"
+
+namespace ov::test {
 
 // Builds:  param_a -> relu -> add -> result
 //                    param_b -^
@@ -232,3 +237,111 @@ TEST(ExtractSubgraphTest, MultimapOverload_UnknownOutputNameThrows) {
 
     EXPECT_THROW(ov::util::extract_subgraph(model, inputs_map, outputs_map), ov::Exception);
 }
+
+// Builds a stateful model with a sink:
+//   param -> relu -> result
+//                \-> assign (sink, writes to variable)
+//   read_value (reads from same variable) feeds into relu
+//
+// Simplified topology:
+//   read_value(variable) -> relu -> result
+//                               \-> assign(variable)
+static std::shared_ptr<ov::Model> build_stateful_model() {
+    auto variable = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{ov::Shape{1, 4}, ov::element::f32, "var_0"});
+
+    auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4});
+    param->set_friendly_name("Param");
+
+    auto read_value = std::make_shared<ov::op::v6::ReadValue>(param, variable);
+    read_value->set_friendly_name("ReadValue");
+
+    auto relu = std::make_shared<ov::op::v0::Relu>(read_value);
+    relu->set_friendly_name("Relu");
+
+    auto assign = std::make_shared<ov::op::v6::Assign>(relu, variable);
+    assign->set_friendly_name("Assign");
+
+    auto result = std::make_shared<ov::op::v0::Result>(relu);
+    result->set_friendly_name("Result");
+
+    return std::make_shared<ov::Model>(ov::ResultVector{result},
+                                       ov::SinkVector{assign},
+                                       ov::ParameterVector{param},
+                                       ov::op::util::VariableVector{variable});
+}
+
+TEST(ExtractSubgraphTest, CoreOverload_StatefulModel_SinkIncluded) {
+    auto model = build_stateful_model();
+
+    // Extract subgraph: cut at Relu input, output at Relu output
+    // The Assign sink consumes Relu's output, so it should be included in the extracted model
+    ov::op::v0::Relu* relu_ptr = nullptr;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (op->get_friendly_name() == "Relu")
+            relu_ptr = ov::as_type<ov::op::v0::Relu>(op.get());
+    }
+    ASSERT_NE(relu_ptr, nullptr);
+
+    auto subgraph = ov::util::extract_subgraph({relu_ptr->input(0)}, {relu_ptr->output(0)});
+
+    EXPECT_EQ(subgraph->get_sinks().size(), 1u);
+    EXPECT_EQ(subgraph->get_results().size(), 1u);
+    EXPECT_EQ(subgraph->get_parameters().size(), 1u);
+
+    bool has_assign = false;
+    for (const auto& op : subgraph->get_ordered_ops()) {
+        if (ov::is_type<ov::op::v6::Assign>(op)) {
+            has_assign = true;
+        }
+    }
+    EXPECT_TRUE(has_assign);
+}
+
+TEST(ExtractSubgraphTest, MultimapOverload_StatefulModel_SinkIncluded) {
+    auto model = build_stateful_model();
+
+    // Extract Relu with its sink (Assign consumes Relu output)
+    const std::multimap<std::string, size_t> inputs_map = {{"Relu", 0}};
+    const std::multimap<std::string, size_t> outputs_map = {{"Relu", 0}};
+
+    auto subgraph = ov::util::extract_subgraph(model, inputs_map, outputs_map);
+
+    EXPECT_EQ(subgraph->get_sinks().size(), 1u);
+    EXPECT_EQ(subgraph->get_results().size(), 1u);
+    EXPECT_EQ(subgraph->get_parameters().size(), 1u);
+
+    auto expected_var = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{ov::Shape{1, 4}, ov::element::f32, "var_0"});
+    auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
+    auto expected_relu = std::make_shared<ov::op::v0::Relu>(expected_param);
+    expected_relu->set_friendly_name("Relu");
+    auto expected_assign = std::make_shared<ov::op::v6::Assign>(expected_relu, expected_var);
+    expected_assign->set_friendly_name("Assign");
+    auto expected_result = std::make_shared<ov::op::v0::Result>(expected_relu);
+    auto expected = std::make_shared<ov::Model>(ov::ResultVector{expected_result},
+                                                ov::SinkVector{expected_assign},
+                                                ov::ParameterVector{expected_param},
+                                                ov::op::util::VariableVector{expected_var});
+
+    const auto cmp = FunctionsComparator::all_flags_enabled();
+    const auto res = cmp.compare(subgraph, expected);
+    EXPECT_TRUE(res.valid) << res.message;
+}
+
+TEST(ExtractSubgraphTest, MultimapOverload_StatefulModel_SinkExcluded) {
+    auto model = build_stateful_model();
+
+    // Extract only ReadValue (before Relu). The Assign doesn't consume ReadValue's output
+    // directly, so it should NOT be in the extracted subgraph.
+    const std::multimap<std::string, size_t> inputs_map = {{"ReadValue", 0}};
+    const std::multimap<std::string, size_t> outputs_map = {{"ReadValue", 0}};
+
+    auto subgraph = ov::util::extract_subgraph(model, inputs_map, outputs_map);
+
+    EXPECT_EQ(subgraph->get_sinks().size(), 0u);
+    EXPECT_EQ(subgraph->get_results().size(), 1u);
+    EXPECT_EQ(subgraph->get_parameters().size(), 1u);
+}
+
+}  // namespace ov::test

--- a/src/common/transformations/tests/utils/extract_subgraph_test.cpp
+++ b/src/common/transformations/tests/utils/extract_subgraph_test.cpp
@@ -18,8 +18,6 @@
 #include "openvino/op/result.hpp"
 #include "openvino/op/sigmoid.hpp"
 
-namespace op_util = ov::op::util;
-
 // Builds:  param_a -> relu -> add -> result
 //                    param_b -^
 static std::shared_ptr<ov::Model> build_linear_model() {
@@ -76,7 +74,7 @@ TEST(ExtractSubgraphTest, CoreOverload_SingleOp) {
     }
     ASSERT_NE(relu_ptr, nullptr);
 
-    auto subgraph = op_util::extract_subgraph(model, {relu_ptr->input(0)}, {relu_ptr->output(0)});
+    auto subgraph = ov::util::extract_subgraph({relu_ptr->input(0)}, {relu_ptr->output(0)});
 
     // Build the expected model: param -> relu -> result
     auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
@@ -100,7 +98,7 @@ TEST(ExtractSubgraphTest, CoreOverload_TwoInputsOneOutput) {
     }
     ASSERT_NE(add_ptr, nullptr);
 
-    auto subgraph = op_util::extract_subgraph(model, {add_ptr->input(0), add_ptr->input(1)}, {add_ptr->output(0)});
+    auto subgraph = ov::util::extract_subgraph({add_ptr->input(0), add_ptr->input(1)}, {add_ptr->output(0)});
 
     auto p0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
     auto p1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
@@ -125,7 +123,7 @@ TEST(ExtractSubgraphTest, CoreOverload_OriginalModelUnchanged) {
     }
     ASSERT_NE(relu_ptr, nullptr);
 
-    op_util::extract_subgraph(model, {relu_ptr->input(0)}, {relu_ptr->output(0)});
+    ov::util::extract_subgraph({relu_ptr->input(0)}, {relu_ptr->output(0)});
 
     EXPECT_EQ(model->get_ordered_ops().size(), original_op_count);
     EXPECT_EQ(model->get_parameters().size(), 2u);
@@ -139,7 +137,7 @@ TEST(ExtractSubgraphTest, MultimapOverload_SingleOp) {
     const std::multimap<std::string, size_t> inputs_map = {{"Relu", 0}};
     const std::multimap<std::string, size_t> outputs_map = {{"Relu", 0}};
 
-    auto subgraph = op_util::extract_subgraph(model, inputs_map, outputs_map);
+    auto subgraph = ov::util::extract_subgraph(model, inputs_map, outputs_map);
 
     auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
     auto expected_relu = std::make_shared<ov::op::v0::Relu>(expected_param);
@@ -159,7 +157,7 @@ TEST(ExtractSubgraphTest, MultimapOverload_MultiInputChain) {
     const std::multimap<std::string, size_t> inputs_map = {{"Relu", 0}, {"Add", 1}};
     const std::multimap<std::string, size_t> outputs_map = {{"Add", 0}};
 
-    auto subgraph = op_util::extract_subgraph(model, inputs_map, outputs_map);
+    auto subgraph = ov::util::extract_subgraph(model, inputs_map, outputs_map);
 
     // Expected: p0 -> relu -> add(p1) -> result
     auto p0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 4});
@@ -183,7 +181,7 @@ TEST(ExtractSubgraphTest, MultimapOverload_BranchingModel_BothBranches) {
     const std::multimap<std::string, size_t> inputs_map = {{"Mul", 0}, {"Mul", 1}};
     const std::multimap<std::string, size_t> outputs_map = {{"Mul", 0}};
 
-    auto subgraph = op_util::extract_subgraph(model, inputs_map, outputs_map);
+    auto subgraph = ov::util::extract_subgraph(model, inputs_map, outputs_map);
 
     auto p0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 3});
     auto p1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 3});
@@ -204,7 +202,7 @@ TEST(ExtractSubgraphTest, MultimapOverload_BranchingModel_SingleBranch) {
     const std::multimap<std::string, size_t> inputs_map = {{"Relu", 0}};
     const std::multimap<std::string, size_t> outputs_map = {{"Relu", 0}};
 
-    auto subgraph = op_util::extract_subgraph(model, inputs_map, outputs_map);
+    auto subgraph = ov::util::extract_subgraph(model, inputs_map, outputs_map);
 
     auto expected_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 3});
     auto expected_relu = std::make_shared<ov::op::v0::Relu>(expected_param);
@@ -223,7 +221,7 @@ TEST(ExtractSubgraphTest, MultimapOverload_UnknownInputNameThrows) {
     const std::multimap<std::string, size_t> inputs_map = {{"NonExistentNode", 0}};
     const std::multimap<std::string, size_t> outputs_map = {{"Add", 0}};
 
-    EXPECT_THROW(op_util::extract_subgraph(model, inputs_map, outputs_map), ov::Exception);
+    EXPECT_THROW(ov::util::extract_subgraph(model, inputs_map, outputs_map), ov::Exception);
 }
 
 TEST(ExtractSubgraphTest, MultimapOverload_UnknownOutputNameThrows) {
@@ -232,5 +230,5 @@ TEST(ExtractSubgraphTest, MultimapOverload_UnknownOutputNameThrows) {
     const std::multimap<std::string, size_t> inputs_map = {{"Add", 0}};
     const std::multimap<std::string, size_t> outputs_map = {{"NonExistentNode", 0}};
 
-    EXPECT_THROW(op_util::extract_subgraph(model, inputs_map, outputs_map), ov::Exception);
+    EXPECT_THROW(ov::util::extract_subgraph(model, inputs_map, outputs_map), ov::Exception);
 }

--- a/src/common/transformations/tests/utils/extract_subgraph_test.cpp
+++ b/src/common/transformations/tests/utils/extract_subgraph_test.cpp
@@ -179,7 +179,7 @@ TEST(ExtractSubgraphTest, MultimapOverload_MultiInputChain) {
 TEST(ExtractSubgraphTest, MultimapOverload_BranchingModel_BothBranches) {
     auto model = build_branch_model();
 
-    // Extract both activation branches but not Mul: inputs at Relu.0 and Sigmoid.0, outputs at Relu.0 and Sigmoid.0
+    // Extract only Mul: cut both Mul inputs to Parameters and use Mul output as the subgraph output
     const std::multimap<std::string, size_t> inputs_map = {{"Mul", 0}, {"Mul", 1}};
     const std::multimap<std::string, size_t> outputs_map = {{"Mul", 0}};
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -281,38 +281,6 @@
 
 namespace ov::intel_cpu {
 
-namespace{
-std::shared_ptr<ov::Model> extract_subgraph(const std::shared_ptr<ov::Model>& model,
-                                            const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
-                                            const std::vector<ov::Output<ov::Node>>& subgraph_outputs) {
-    ov::OutputVector replaced_outputs;
-    ov::ParameterVector subgraph_parameters;
-    subgraph_parameters.reserve(subgraph_inputs.size());
-    replaced_outputs.reserve(subgraph_inputs.size());
-
-    // Temporarily replace inputs with subgraph parameters
-    for (const auto& input : subgraph_inputs) {
-        const auto new_parameter = std::make_shared<ov::opset1::Parameter>(input.get_element_type(), input.get_partial_shape());
-        subgraph_parameters.push_back(new_parameter);
-
-        const auto& source_output = input.get_source_output();
-        replaced_outputs.push_back(source_output);
-        ov::replace_output_update_name(source_output, new_parameter->output(0));
-    }
-    OPENVINO_ASSERT(subgraph_parameters.size() == replaced_outputs.size(),
-                    "extract_subgraph: number of subgraph_parameters is not equal to the number of replaced_outputs");
-
-    // The subgraph have to be cloned to avoid original model disruption
-    auto subgraph = std::make_shared<ov::Model>(subgraph_outputs, subgraph_parameters)->clone();
-
-    // Restore original model after subgraph extraction
-    for (size_t i = 0; i < subgraph_parameters.size(); ++i) {
-        subgraph_parameters[i]->output(0).replace(replaced_outputs[i]);
-    }
-    return subgraph;
-}
-} // namespace
-
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
 
 bool Transformations::is_decompression_multiply(const_node_ptr& node) {
@@ -485,32 +453,6 @@ void Transformations::CpuSpecificOpSet() {
 
 void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecisions) {
     CPU_DEBUG_CAP_TRANSFORMATION_SCOPE(this, PreLpt);
-
-    // extract_subgraph demonstrarion: extract inputs/outputs with given names
-    {
-        // <name, in_index>
-        static const std::multimap<std::string, size_t> inputs_to_extract {
-            {"name_1", 0}
-        };
-        // <name, out_index>
-        static const std::multimap<std::string, size_t> outputs_to_extract {
-            {"name_1", 0}
-        };
-        std::vector<ov::Input<ov::Node>> subgraph_inputs;
-        std::vector<ov::Output<ov::Node>> subgraph_outputs;
-        for (const auto& n : model->get_ordered_ops()) {
-            const auto& name = n->get_friendly_name();
-            const auto input_range = inputs_to_extract.equal_range(name);
-            for (auto it = input_range.first; it != input_range.second; ++it)
-                subgraph_inputs.push_back(n->input(it->second));
-
-            const auto output_range = outputs_to_extract.equal_range(name);
-            for (auto it = output_range.first; it != output_range.second; ++it)
-                subgraph_outputs.push_back(n->output(it->second));
-        }
-        const auto subgraph = extract_subgraph(model, subgraph_inputs, subgraph_outputs);
-        ov::pass::Serialize(std::string("subgraph.xml"), std::string("subgraph.bin")).run_on_model(subgraph);
-    }
 
     // Decompression handling related transformations must be run separately from common preLPT pipeline
     // since there is used the same transformations as in LPT related transformations, but with the specific settings.

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -281,6 +281,38 @@
 
 namespace ov::intel_cpu {
 
+namespace{
+std::shared_ptr<ov::Model> extract_subgraph(const std::shared_ptr<ov::Model>& model,
+                                            const std::vector<ov::Input<ov::Node>>& subgraph_inputs,
+                                            const std::vector<ov::Output<ov::Node>>& subgraph_outputs) {
+    ov::OutputVector replaced_outputs;
+    ov::ParameterVector subgraph_parameters;
+    subgraph_parameters.reserve(subgraph_inputs.size());
+    replaced_outputs.reserve(subgraph_inputs.size());
+
+    // Temporarily replace inputs with subgraph parameters
+    for (const auto& input : subgraph_inputs) {
+        const auto new_parameter = std::make_shared<ov::opset1::Parameter>(input.get_element_type(), input.get_partial_shape());
+        subgraph_parameters.push_back(new_parameter);
+
+        const auto& source_output = input.get_source_output();
+        replaced_outputs.push_back(source_output);
+        ov::replace_output_update_name(source_output, new_parameter->output(0));
+    }
+    OPENVINO_ASSERT(subgraph_parameters.size() == replaced_outputs.size(),
+                    "extract_subgraph: number of subgraph_parameters is not equal to the number of replaced_outputs");
+
+    // The subgraph have to be cloned to avoid original model disruption
+    auto subgraph = std::make_shared<ov::Model>(subgraph_outputs, subgraph_parameters)->clone();
+
+    // Restore original model after subgraph extraction
+    for (size_t i = 0; i < subgraph_parameters.size(); ++i) {
+        subgraph_parameters[i]->output(0).replace(replaced_outputs[i]);
+    }
+    return subgraph;
+}
+} // namespace
+
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
 
 bool Transformations::is_decompression_multiply(const_node_ptr& node) {
@@ -453,6 +485,32 @@ void Transformations::CpuSpecificOpSet() {
 
 void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecisions) {
     CPU_DEBUG_CAP_TRANSFORMATION_SCOPE(this, PreLpt);
+
+    // extract_subgraph demonstrarion: extract inputs/outputs with given names
+    {
+        // <name, in_index>
+        static const std::multimap<std::string, size_t> inputs_to_extract {
+            {"name_1", 0}
+        };
+        // <name, out_index>
+        static const std::multimap<std::string, size_t> outputs_to_extract {
+            {"name_1", 0}
+        };
+        std::vector<ov::Input<ov::Node>> subgraph_inputs;
+        std::vector<ov::Output<ov::Node>> subgraph_outputs;
+        for (const auto& n : model->get_ordered_ops()) {
+            const auto& name = n->get_friendly_name();
+            const auto input_range = inputs_to_extract.equal_range(name);
+            for (auto it = input_range.first; it != input_range.second; ++it)
+                subgraph_inputs.push_back(n->input(it->second));
+
+            const auto output_range = outputs_to_extract.equal_range(name);
+            for (auto it = output_range.first; it != output_range.second; ++it)
+                subgraph_outputs.push_back(n->output(it->second));
+        }
+        const auto subgraph = extract_subgraph(model, subgraph_inputs, subgraph_outputs);
+        ov::pass::Serialize(std::string("subgraph.xml"), std::string("subgraph.bin")).run_on_model(subgraph);
+    }
 
     // Decompression handling related transformations must be run separately from common preLPT pipeline
     // since there is used the same transformations as in LPT related transformations, but with the specific settings.

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/graph_comparator.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/graph_comparator.hpp
@@ -58,6 +58,10 @@ public:
         return fc;
     }
 
+    static FunctionsComparator all_flags_enabled() noexcept {
+        return FunctionsComparator{static_cast<CmpValues>(~0)};
+    }
+
     FunctionsComparator& enable(CmpValues f) noexcept {
         m_comparison_flags = static_cast<CmpValues>(m_comparison_flags | f);
         return *this;


### PR DESCRIPTION
### Details:
Adds a new transformations utility helper to extract a bounded subgraph from an existing `ov::Model` into an independent `ov::Model`, primarily to support debugging/isolated repro workflows.

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used to create a feature based on the PoC branch. The tests are also written by the LLM*

### Prerequisites:
 - #35363
