### PR TITLE
[CPU][Debug Caps] Enable perf counters collection for exec graph

### DIFF
--- a/src/plugins/intel_cpu/docs/debug_capabilities/exec_graph_serialization.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/exec_graph_serialization.md
@@ -2,8 +2,9 @@
 
 Execution graph serialization is disabled by default and controlled by environment variable **OV_CPU_EXEC_GRAPH_PATH**:
 ```sh
-    OV_CPU_EXEC_GRAPH_PATH=<option> binary ...
+OV_CPU_EXEC_GRAPH_PATH=<option> binary ...
 ```
+
 Possible serialization options:
 * cout\
 Serialize to console output.
@@ -11,3 +12,21 @@ Serialize to console output.
 Serialize graph into .xml and .bin files. Can be opened using, for example, *netron* app.
 * \<path\>_index.dot\
 Serialize graph into .dot file. Can be inspected using, for example, *graphviz* tools.
+
+## Output filename
+
+Output files are named `<option>_<index>_<model_name>.<ext>`, where `index` reflects compilation order. Example with `OV_CPU_EXEC_GRAPH_PATH=exec.xml`:
+```
+exec_0_ModelA.xml
+exec_1_ModelB.xml
+```
+
+## Two-phase serialization
+
+Each graph is serialized twice:
+1. **At compile time** — written immediately after graph construction with `not_executed` perf counters. Useful for diagnosing crashes during the first inference.
+2. **After inference** — the same file is overwritten with real per-layer execution times when the compiled model is destroyed.
+
+## Multi-stream
+
+All streams of the same model share one output file. The last stream to be destroyed overwrites it, which is fine since all streams run the same graph.

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -48,8 +48,9 @@ Config::Config() {
  * configuration properties
  */
 void Config::applyDebugCapsProperties() {
-    // always enable perf counters for verbose, performance summary and average counters
-    if (!debugCaps.verbose.empty() || debugCaps.summaryPerf || !debugCaps.averageCountersPath.empty()) {
+    // always enable perf counters for verbose, performance summary, average counters and exec graph serialization
+    if (!debugCaps.verbose.empty() || debugCaps.summaryPerf || !debugCaps.averageCountersPath.empty() ||
+        !debugCaps.execGraphPath.empty()) {
         collectPerfCounters = true;
     }
 }

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -104,7 +104,7 @@ namespace ov::intel_cpu {
 Graph::~Graph() {
     CPU_DEBUG_CAP_ENABLE(summary_perf(*this));
     CPU_DEBUG_CAP_ENABLE(average_counters(*this));
-    CPU_DEBUG_CAP_ENABLE(serialize(*this, true));
+    CPU_DEBUG_CAP_ENABLE(serialize(*this));
 }
 
 template <typename NET>

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -104,6 +104,7 @@ namespace ov::intel_cpu {
 Graph::~Graph() {
     CPU_DEBUG_CAP_ENABLE(summary_perf(*this));
     CPU_DEBUG_CAP_ENABLE(average_counters(*this));
+    CPU_DEBUG_CAP_ENABLE(serialize(*this));
 }
 
 template <typename NET>
@@ -403,8 +404,6 @@ void Graph::Activate() {
         graphNode->cleanup();
     }
 #endif
-
-    CPU_DEBUG_CAP_ENABLE(serialize(*this));
 }
 
 void Graph::Configure([[maybe_unused]] bool optimize) {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -104,7 +104,7 @@ namespace ov::intel_cpu {
 Graph::~Graph() {
     CPU_DEBUG_CAP_ENABLE(summary_perf(*this));
     CPU_DEBUG_CAP_ENABLE(average_counters(*this));
-    CPU_DEBUG_CAP_ENABLE(serialize(*this));
+    CPU_DEBUG_CAP_ENABLE(serialize(*this, true));
 }
 
 template <typename NET>
@@ -404,6 +404,8 @@ void Graph::Activate() {
         graphNode->cleanup();
     }
 #endif
+
+    CPU_DEBUG_CAP_ENABLE(serialize(*this));
 }
 
 void Graph::Configure([[maybe_unused]] bool optimize) {

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -16,6 +16,7 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <unordered_map>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <sstream>
 #include <string>
@@ -277,7 +278,7 @@ void serialize(const Graph& graph, bool isPostInference) {
     static std::unordered_map<std::string, int> numPerModel;
     static std::unordered_map<const Graph*, int> graphToIdx;
 
-    int assignedIdx;
+    int assignedIdx = 0;
     if (!isPostInference) {
         assignedIdx = numPerModel[graph.GetName()]++;
         graphToIdx[&graph] = assignedIdx;

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -232,6 +232,10 @@ std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph& graph) {
 
 #ifdef CPU_DEBUG_CAPS
 void serialize(const Graph& graph) {
+    if (!graph.getGraphContext()) {
+        return;
+    }
+
     const std::string& pathStr = graph.getConfig().debugCaps.execGraphPath;
 
     if (pathStr.empty()) {

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -231,7 +231,7 @@ std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph& graph) {
 }
 
 #ifdef CPU_DEBUG_CAPS
-void serialize(const Graph& graph, bool isPostInference) {
+void serialize(const Graph& graph) {
     const std::string& pathStr = graph.getConfig().debugCaps.execGraphPath;
 
     if (pathStr.empty()) {
@@ -251,54 +251,27 @@ void serialize(const Graph& graph, bool isPostInference) {
     }
 
     // Exec graph serialization happens twice per graph instance:
-    //   1. At compile time (Graph::Activate, isPostInference=false): the graph structure
-    //      is written with "not_executed" perf counters.
-    //   2. At destruction (Graph::~Graph, isPostInference=true): the same file is
-    //      overwritten with real perf counters collected during inference.
+    //   1. At compile time (Graph::Activate): the graph structure is written with
+    //      "not_executed" perf counters. This ensures a file is always present even
+    //      if a crash occurs during inference.
+    //   2. At destruction (Graph::~Graph): the same file is overwritten with real
+    //      perf counters collected during inference.
     //
-    // 'numPerModel'  assigns a unique, monotonically increasing file index per model name,
-    //                so that graphs of different models (or separate compiled-model instances
-    //                of the same model) each get their own file.
-    // 'graphToIdx'   maps each Graph* to its assigned index, so the destructor can locate
-    //                and overwrite the exact file written during Activate(), regardless of
-    //                how many other graphs have been compiled or destroyed in between.
-    //
-    // Example with 2 streams (nstreams=2), 2 models (A and B),
-    // OV_CPU_EXEC_GRAPH_PATH=exec.xml:
-    //
-    //   Compile modelA stream0 -> numPerModel["A"]=0, graphToIdx[s0A]=0, writes exec_A_0.xml (no perf)
-    //   Compile modelA stream1 -> numPerModel["A"]=1, graphToIdx[s1A]=1, writes exec_A_1.xml (no perf)
-    //   Compile modelB stream0 -> numPerModel["B"]=0, graphToIdx[s0B]=0, writes exec_B_0.xml (no perf)
-    //   Compile modelB stream1 -> numPerModel["B"]=1, graphToIdx[s1B]=1, writes exec_B_1.xml (no perf)
-    //   --- all inference runs ---
-    //   Destruct modelA stream0 -> graphToIdx[s0A]=0, erases it, overwrites exec_A_0.xml (with perf)
-    //   Destruct modelA stream1 -> graphToIdx[s1A]=1, erases it, overwrites exec_A_1.xml (with perf)
-    //   Destruct modelB stream0 -> graphToIdx[s0B]=0, erases it, overwrites exec_B_0.xml (with perf)
-    //   Destruct modelB stream1 -> graphToIdx[s1B]=1, erases it, overwrites exec_B_1.xml (with perf)
-    static std::unordered_map<std::string, int> numPerModel;
-    static std::unordered_map<const Graph*, int> graphToIdx;
-
-    int assignedIdx = 0;
-    if (!isPostInference) {
-        assignedIdx = numPerModel[graph.GetName()]++;
-        graphToIdx[&graph] = assignedIdx;
-    } else {
-        auto it = graphToIdx.find(&graph);
-        if (it == graphToIdx.end()) {
-            return;
-        }
-        assignedIdx = it->second;
-        graphToIdx.erase(it);
-    }
-
-    const auto indexedFileName =
-        p.stem().string() + "_" + graph.GetName() + "_" + std::to_string(assignedIdx) + ext.string();
-    const auto indexedPath = p.parent_path() / indexedFileName;
+    // All streams of the same model share a single file. A monotonically increasing
+    // index is assigned once per unique model name so that the order of compilation
+    // is visible in the filename and multiple models don't overwrite each other.
+    // Example with OV_CPU_EXEC_GRAPH_PATH=exec.xml:
+    //   modelA (any stream) -> exec_0_A.xml
+    //   modelB (any stream) -> exec_1_B.xml
+    static std::unordered_map<std::string, size_t> numPerModel;
+    const auto idx = numPerModel.emplace(graph.GetName(), numPerModel.size()).first->second;
+    const auto fileName = p.stem().string() + "_" + std::to_string(idx) + "_" + graph.GetName() + ext.string();
+    const auto filePath = p.parent_path() / fileName;
 
     if (ext == ".xml") {
-        serializeToXML(graph, indexedPath);
+        serializeToXML(graph, filePath);
     } else {
-        serializeToDot(graph, indexedPath);
+        serializeToDot(graph, filePath);
     }
 }
 

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -16,10 +16,10 @@
 #include <iterator>
 #include <map>
 #include <memory>
-#include <unordered_map>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -230,7 +230,7 @@ std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph& graph) {
 }
 
 #ifdef CPU_DEBUG_CAPS
-void serialize(const Graph& graph) {
+void serialize(const Graph& graph, bool isPostInference) {
     const std::string& pathStr = graph.getConfig().debugCaps.execGraphPath;
 
     if (pathStr.empty()) {
@@ -249,8 +249,49 @@ void serialize(const Graph& graph) {
         OPENVINO_THROW("Unknown serialize format. Should be either 'cout', '*.xml' or '*.dot'. Got ", pathStr);
     }
 
-    static int g_idx = 0;
-    const auto indexedFileName = p.stem().string() + "_" + std::to_string(g_idx++) + ext.string();
+    // Exec graph serialization happens twice per graph instance:
+    //   1. At compile time (Graph::Activate, isPostInference=false): the graph structure
+    //      is written with "not_executed" perf counters.
+    //   2. At destruction (Graph::~Graph, isPostInference=true): the same file is
+    //      overwritten with real perf counters collected during inference.
+    //
+    // 'numPerModel'  assigns a unique, monotonically increasing file index per model name,
+    //                so that graphs of different models (or separate compiled-model instances
+    //                of the same model) each get their own file.
+    // 'graphToIdx'   maps each Graph* to its assigned index, so the destructor can locate
+    //                and overwrite the exact file written during Activate(), regardless of
+    //                how many other graphs have been compiled or destroyed in between.
+    //
+    // Example with 2 streams (nstreams=2), 2 models (A and B),
+    // OV_CPU_EXEC_GRAPH_PATH=exec.xml:
+    //
+    //   Compile modelA stream0 -> numPerModel["A"]=0, graphToIdx[s0A]=0, writes exec_A_0.xml (no perf)
+    //   Compile modelA stream1 -> numPerModel["A"]=1, graphToIdx[s1A]=1, writes exec_A_1.xml (no perf)
+    //   Compile modelB stream0 -> numPerModel["B"]=0, graphToIdx[s0B]=0, writes exec_B_0.xml (no perf)
+    //   Compile modelB stream1 -> numPerModel["B"]=1, graphToIdx[s1B]=1, writes exec_B_1.xml (no perf)
+    //   --- all inference runs ---
+    //   Destruct modelA stream0 -> graphToIdx[s0A]=0, erases it, overwrites exec_A_0.xml (with perf)
+    //   Destruct modelA stream1 -> graphToIdx[s1A]=1, erases it, overwrites exec_A_1.xml (with perf)
+    //   Destruct modelB stream0 -> graphToIdx[s0B]=0, erases it, overwrites exec_B_0.xml (with perf)
+    //   Destruct modelB stream1 -> graphToIdx[s1B]=1, erases it, overwrites exec_B_1.xml (with perf)
+    static std::unordered_map<std::string, int> numPerModel;
+    static std::unordered_map<const Graph*, int> graphToIdx;
+
+    int assignedIdx;
+    if (!isPostInference) {
+        assignedIdx = numPerModel[graph.GetName()]++;
+        graphToIdx[&graph] = assignedIdx;
+    } else {
+        auto it = graphToIdx.find(&graph);
+        if (it == graphToIdx.end()) {
+            return;
+        }
+        assignedIdx = it->second;
+        graphToIdx.erase(it);
+    }
+
+    const auto indexedFileName =
+        p.stem().string() + "_" + graph.GetName() + "_" + std::to_string(assignedIdx) + ext.string();
     const auto indexedPath = p.parent_path() / indexedFileName;
 
     if (ext == ".xml") {

--- a/src/plugins/intel_cpu/src/graph_dumper.h
+++ b/src/plugins/intel_cpu/src/graph_dumper.h
@@ -13,7 +13,7 @@ namespace ov::intel_cpu {
 
 std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph& graph);
 #ifdef CPU_DEBUG_CAPS
-void serialize(const Graph& graph);
+void serialize(const Graph& graph, bool isPostInference = false);
 void summary_perf(const Graph& graph);
 void average_counters(const Graph& graph);
 #endif  // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/graph_dumper.h
+++ b/src/plugins/intel_cpu/src/graph_dumper.h
@@ -13,7 +13,7 @@ namespace ov::intel_cpu {
 
 std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph& graph);
 #ifdef CPU_DEBUG_CAPS
-void serialize(const Graph& graph, bool isPostInference = false);
+void serialize(const Graph& graph);
 void summary_perf(const Graph& graph);
 void average_counters(const Graph& graph);
 #endif  // CPU_DEBUG_CAPS


### PR DESCRIPTION
### Details:
Currently, `OV_CPU_EXEC_GRAPH_PATH` debug env variable collects exec graphs without performance numbers. In this PR, the performance statistic collection is enabled for this debug scenario. Also, exec graph serialization is moved to the Graph destructor

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: no*
