### PR TITLE
[GPU] fix dGPU func testcases in smoke_MatMulCompressedWeights_extra_multiply

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -54,6 +54,45 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         auto fc_input_a = pattern_map.at(activations_m);
         auto fc_input_b = pattern_map.at(weights_m);
 
+        auto introduces_non_trivial_batch_broadcast = [](const ov::PartialShape& original_shape,
+                                                         const ov::PartialShape& broadcasted_shape) {
+            if (!original_shape.rank().is_static() || !broadcasted_shape.rank().is_static()) {
+                return false;
+            }
+
+            const auto original_rank = static_cast<size_t>(original_shape.rank().get_length());
+            const auto broadcasted_rank = static_cast<size_t>(broadcasted_shape.rank().get_length());
+            if (broadcasted_rank < 2 || original_rank > broadcasted_rank) {
+                return false;
+            }
+
+            ov::PartialShape aligned_original_shape = original_shape;
+            for (size_t i = 0, cnt = broadcasted_rank - original_rank; i < cnt; ++i) {
+                aligned_original_shape.insert(aligned_original_shape.begin(), 1);
+            }
+
+            for (size_t i = 0; i < broadcasted_rank - 2; ++i) {
+                const auto& original_dim = aligned_original_shape[i];
+                const auto& broadcasted_dim = broadcasted_shape[i];
+                if (original_dim == 1 && broadcasted_dim.is_static() && broadcasted_dim.get_length() != 1) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        auto mul2_it = pattern_map.find(mul2_m);
+        if (mul2_it != pattern_map.end() && mul2_it->second.get_node_shared_ptr() == fc_input_b.get_node_shared_ptr()) {
+            const auto reshape_output = pattern_map.at(reshape_m);
+            // Keep valid 3D compressed FC cases enabled. Only reject the extra post-reshape multiply when broadcasting changes the weights
+            // from a shared matrix into data with real batch dimensions. For example, reshape may first squeeze the weights to [16, 32],
+            // then an extra multiply with scale [8, 1, 32] broadcasts them to [8, 16, 32], which makes the weights effectively batched again.
+            if (introduces_non_trivial_batch_broadcast(reshape_output.get_partial_shape(), fc_input_b.get_partial_shape())) {
+                return false;
+            }
+        }
+
         // If 'fc_input_b' is shared with another matmul, transposing 'fc_input_b' is restricted.
         // If it is connected to the 'input_a' of another matmul, do not transpose
         // If it is connected to the 'input_b' of another matmul and the transpose option differs between the two matmuls, do not transpose.

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -405,6 +405,7 @@ const std::vector<bool> transpose_weights = {true, false};
 const std::vector<bool> param_weights = {true, false};
 const std::vector<ShapeParams> input_shapes_basic = {
     {{{-1, -1, -1}, {{1, 4, 16}, {10, 16, 16}}}, {16, 32}},
+    {{{}, {{1, 4, 16}}}, {16, 32}, 2ul},
     {{{}, {{1, 4, 16}}}, {1, 16, 32}},
     {{{}, {{1, 4, 48}}}, {48, 256}},
     {{{}, {{11, 339, 377}}}, {377, 335}}
@@ -412,6 +413,7 @@ const std::vector<ShapeParams> input_shapes_basic = {
 
 const std::vector<ShapeParams> input_shapes_extra_multiply = {
     {{{}, {{1, 4, 2}}}, {2, 32}, 2ul},
+    {{{}, {{1, 4, 16}}}, {1, 16, 32}},
 };
 
 const std::vector<ShapeParams> input_shapes_extra_multiply_non_trivial_batch_broadcast = {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -405,10 +405,17 @@ const std::vector<bool> transpose_weights = {true, false};
 const std::vector<bool> param_weights = {true, false};
 const std::vector<ShapeParams> input_shapes_basic = {
     {{{-1, -1, -1}, {{1, 4, 16}, {10, 16, 16}}}, {16, 32}},
-    {{{}, {{1, 4, 16}}}, {16, 32}, 2ul},
     {{{}, {{1, 4, 16}}}, {1, 16, 32}},
     {{{}, {{1, 4, 48}}}, {48, 256}},
     {{{}, {{11, 339, 377}}}, {377, 335}}
+};
+
+const std::vector<ShapeParams> input_shapes_extra_multiply = {
+    {{{}, {{1, 4, 2}}}, {2, 32}, 2ul},
+};
+
+const std::vector<ShapeParams> input_shapes_extra_multiply_non_trivial_batch_broadcast = {
+    {{{}, {{1, 4, 16}}}, {16, 32}, 2ul},
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_basic,
@@ -428,7 +435,22 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_basic,
 
 INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_extra_multiply,
                          MatmulWeightsDecompression,
-                         ::testing::Combine(::testing::ValuesIn(input_shapes_basic),
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_extra_multiply),
+                                            ::testing::ValuesIn(weights_precisions),
+                                            ::testing::ValuesIn(activations_precisions),
+                                            ::testing::Values(false),
+                                            ::testing::Values(false),
+                                            ::testing::Values(false),
+                                            ::testing::Values(true),
+                                            ::testing::Values(false),
+                                            ::testing::ValuesIn(param_weights),
+                                            ::testing::Values(0),
+                                            ::testing::Values(1.0f)),
+                         MatmulWeightsDecompression::get_test_case_name);
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_extra_multiply_non_trivial_batch_broadcast_no_convert,
+                         MatmulWeightsDecompression,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_extra_multiply_non_trivial_batch_broadcast),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(activations_precisions),
                                             ::testing::Values(false),

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -474,6 +474,72 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_compressed_u8_par
     }
 }
 
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_compressed_u8_weights_extra_multiply) {
+    {
+        auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{1, 4, 2});
+        auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{1, 2, 32}, {1});
+        auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f16);
+        auto mul_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 1, 32}, {1});
+        auto mul = std::make_shared<ov::opset1::Multiply>(convert, mul_const);
+        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {2, 32});
+        auto reshape = std::make_shared<ov::opset1::Reshape>(mul, reshape_const, false);
+        auto extra_mul = std::make_shared<ov::opset1::Multiply>(reshape, mul_const);
+        auto matmul = std::make_shared<ov::opset1::MatMul>(data, extra_mul);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data});
+        bool support_immad = true;
+        manager.register_pass<ConvertMatMulToFullyConnected>(support_immad);
+    }
+    {
+        auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{1, 4, 2});
+        auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{1, 2, 32}, {1});
+        auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f16);
+        auto mul_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 1, 32}, {1});
+        auto mul = std::make_shared<ov::opset1::Multiply>(convert, mul_const);
+        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {2, 32});
+        auto reshape = std::make_shared<ov::opset1::Reshape>(mul, reshape_const, false);
+        auto extra_mul = std::make_shared<ov::opset1::Multiply>(reshape, mul_const);
+
+        auto transpose_const = ov::opset1::Constant::create(ov::element::i32, {3}, {0, 2, 1});
+        auto transpose = std::make_shared<ov::opset1::Transpose>(extra_mul, transpose_const);
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto matmul = std::make_shared<op::FullyConnected>(data, transpose, no_bias);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data});
+    }
+}
+
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_compressed_u8_weights_extra_multiply_non_trivial_batch_broadcast) {
+    {
+        auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{1, 4, 16});
+        auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{8, 2, 32}, {1});
+        auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f16);
+        auto mul_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{8, 1, 32}, {1});
+        auto mul = std::make_shared<ov::opset1::Multiply>(convert, mul_const);
+        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {16, 32});
+        auto reshape = std::make_shared<ov::opset1::Reshape>(mul, reshape_const, false);
+        auto extra_mul = std::make_shared<ov::opset1::Multiply>(reshape, mul_const);
+        auto matmul = std::make_shared<ov::opset1::MatMul>(data, extra_mul);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data});
+        bool support_immad = true;
+        manager.register_pass<ConvertMatMulToFullyConnected>(support_immad);
+    }
+    {
+        auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{1, 4, 16});
+        auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{8, 2, 32}, {1});
+        auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f16);
+        auto mul_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{8, 1, 32}, {1});
+        auto mul = std::make_shared<ov::opset1::Multiply>(convert, mul_const);
+        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {16, 32});
+        auto reshape = std::make_shared<ov::opset1::Reshape>(mul, reshape_const, false);
+        auto extra_mul = std::make_shared<ov::opset1::Multiply>(reshape, mul_const);
+        auto matmul = std::make_shared<ov::opset1::MatMul>(data, extra_mul);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data});
+    }
+}
+
 TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_compressed_u4_weights_3D) {
     {
         auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{3, 2, 2});


### PR DESCRIPTION
### Details
fixed dGPU functional testcase of `smoke_MatMulCompressedWeights_extra_multiply_non_trivial_batch_broadcast_no_convert/MatmulWeightsDecompression.Inference`, which is splitted from the original failed testcase of `smoke_MatMulCompressedWeights_extra_multiply/MatmulWeightsDecompression.Inference`.


### Description of the issue
#### Symptom
The testcase failed on dGPU for compressed-weight MatMul patterns with group_size=2 and extra_multiply=1, especially for cases where the post-reshape multiply made the weights effectively batched again. The failure surfaced during GPU program build (implementation selection) after MatMul had been rewritten to FullyConnected.

#### Root cause
ConvertMatMulToFullyConnected allowed MatMul -> FullyConnected conversion for an extra_multiply compressed-weights pattern even when the extra-multiply broadcasted the weights back into non-trivial batch dimensions.
For example, the weights may first be reshaped into a shared 2D form such as [16, 32], but the extra multiply can broadcast them to a batched shape such as [8, 16, 32]. That makes the weights effectively per-batch again, so forcing the FullyConnected path is unsafe.

#### How to fix it
Detect whether the extra-multiply introduces non-trivial batch broadcast in the weights path. If yes, block MatMul -> FullyConnected conversion and keep the original MatMul; otherwise, keep valid compressed FullyConnected handling enabled for supported extra-multiply patterns.

Split the functional coverage by behavior:
  - `smoke_MatMulCompressedWeights_extra_multiply` for supported convert cases
  - `smoke_MatMulCompressedWeights_extra_multiply_non_trivial_batch_broadcast_no_convert` for blocked no-convert cases


#### The code and line that caused this issue
smoke_MatMulCompressedWeights_extra_multiply
https://github.com/openvinotoolkit/openvino/blob/6c7a684978b986767661b4b7ee6c236a29199a5c/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp#L122-L124

#### Reproduction step and snapshot
- before this PR
```
./ov_gpu_func_tests --device_suffix=1 --gtest_filter=
'smoke_MatMulCompressedWeights_extra_multiply/
MatmulWeightsDecompression.Inference/data_shape=[]_[1.4.16]__weights_shape=[16,32]_group_size=2_
weights_precision=u8_activations_precision=f32_transpose_weights=0_decompression_subtract=0_
reshape_on_decompression=0_extra_multiply=1_per_tensor_zp=0_param_weights=1_dyn_quan_group_size=0'
```

- after this PR
```
./ov_gpu_func_tests --device_suffix=1 --gtest_filter=
'smoke_MatMulCompressedWeights_extra_multiply_non_trivial_batch_broadcast_no_convert/
MatmulWeightsDecompression.Inference/data_shape=[]_[1.4.16]__weights_shape=[16,32]_group_size=2_
weights_precision=u8_activations_precision=f32_transpose_weights=0_decompression_subtract=0_
reshape_on_decompression=0_extra_multiply=1_per_tensor_zp=0_param_weights=1_dyn_quan_group_size=0'
```

#### Problematic graph
N/A

#### Checklist 
 - [x] Is it a proper fix? (not a workaround) 
 - [x] Did you include test case for this fix, if necessary? 
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
- CVS-182520

### AI Assistance:
 - *AI assistance used: yes*
 - *Used it to reproduce the failing dGPU function tests, inspect the dumped GPU graphs, find the root cause, and also add testcases.*