### PR TITLE
[GPU] Fix implicit narrowing conversion warnings (C4244) in GPU plugin - Step 2

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -274,30 +274,30 @@ inline std::vector<T> read_vector(cldnn::memory::ptr mem, const cldnn::stream& s
             default: OPENVINO_ASSERT(false, "[GPU] read_vector: unsupported data type");
         }
     } else {
-        auto append_from_lock = [&out_vecs](auto& lock) {
-            out_vecs.reserve(lock.end() - lock.begin());
+        auto append_from_lock = [](auto& lock, std::vector<T>& out) {
+            out.reserve(lock.end() - lock.begin());
             for (auto it = lock.begin(); it != lock.end(); ++it)
-                out_vecs.push_back(static_cast<T>(*it));
+                out.push_back(static_cast<T>(*it));
         };
         switch (mem_dtype) {
             case data_types::i32: {
                 mem_lock<int32_t, mem_lock_type::read> lock{mem, stream};
-                append_from_lock(lock);
+                append_from_lock(lock, out_vecs);
                 break;
             }
             case data_types::i64: {
                 mem_lock<int64_t, mem_lock_type::read> lock{mem, stream};
-                append_from_lock(lock);
+                append_from_lock(lock, out_vecs);
                 break;
             }
             case data_types::f16: {
                 mem_lock<ov::float16, mem_lock_type::read> lock{mem, stream};
-                append_from_lock(lock);
+                append_from_lock(lock, out_vecs);
                 break;
             }
             case data_types::f32: {
                 mem_lock<float, mem_lock_type::read> lock{mem, stream};
-                append_from_lock(lock);
+                append_from_lock(lock, out_vecs);
                 break;
             }
             default: OPENVINO_ASSERT(false, "[GPU] read_vector: unsupported data type");

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -274,33 +274,30 @@ inline std::vector<T> read_vector(cldnn::memory::ptr mem, const cldnn::stream& s
             default: OPENVINO_ASSERT(false, "[GPU] read_vector: unsupported data type");
         }
     } else {
+        auto append_from_lock = [&out_vecs](auto& lock) {
+            out_vecs.reserve(lock.end() - lock.begin());
+            for (auto it = lock.begin(); it != lock.end(); ++it)
+                out_vecs.push_back(static_cast<T>(*it));
+        };
         switch (mem_dtype) {
             case data_types::i32: {
                 mem_lock<int32_t, mem_lock_type::read> lock{mem, stream};
-                out_vecs.reserve(lock.end() - lock.begin());
-                for (auto it = lock.begin(); it != lock.end(); ++it)
-                    out_vecs.push_back(static_cast<T>(*it));
+                append_from_lock(lock);
                 break;
             }
             case data_types::i64: {
                 mem_lock<int64_t, mem_lock_type::read> lock{mem, stream};
-                out_vecs.reserve(lock.end() - lock.begin());
-                for (auto it = lock.begin(); it != lock.end(); ++it)
-                    out_vecs.push_back(static_cast<T>(*it));
+                append_from_lock(lock);
                 break;
             }
             case data_types::f16: {
                 mem_lock<ov::float16, mem_lock_type::read> lock{mem, stream};
-                out_vecs.reserve(lock.end() - lock.begin());
-                for (auto it = lock.begin(); it != lock.end(); ++it)
-                    out_vecs.push_back(static_cast<T>(*it));
+                append_from_lock(lock);
                 break;
             }
             case data_types::f32: {
                 mem_lock<float, mem_lock_type::read> lock{mem, stream};
-                out_vecs.reserve(lock.end() - lock.begin());
-                for (auto it = lock.begin(); it != lock.end(); ++it)
-                    out_vecs.push_back(static_cast<T>(*it));
+                append_from_lock(lock);
                 break;
             }
             default: OPENVINO_ASSERT(false, "[GPU] read_vector: unsupported data type");

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -277,22 +277,30 @@ inline std::vector<T> read_vector(cldnn::memory::ptr mem, const cldnn::stream& s
         switch (mem_dtype) {
             case data_types::i32: {
                 mem_lock<int32_t, mem_lock_type::read> lock{mem, stream};
-                out_vecs = std::move(std::vector<T>(lock.begin(), lock.end()));
+                out_vecs.reserve(lock.end() - lock.begin());
+                for (auto it = lock.begin(); it != lock.end(); ++it)
+                    out_vecs.push_back(static_cast<T>(*it));
                 break;
             }
             case data_types::i64: {
                 mem_lock<int64_t, mem_lock_type::read> lock{mem, stream};
-                out_vecs = std::move(std::vector<T>(lock.begin(), lock.end()));
+                out_vecs.reserve(lock.end() - lock.begin());
+                for (auto it = lock.begin(); it != lock.end(); ++it)
+                    out_vecs.push_back(static_cast<T>(*it));
                 break;
             }
             case data_types::f16: {
                 mem_lock<ov::float16, mem_lock_type::read> lock{mem, stream};
-                out_vecs = std::move(std::vector<T>(lock.begin(), lock.end()));
+                out_vecs.reserve(lock.end() - lock.begin());
+                for (auto it = lock.begin(); it != lock.end(); ++it)
+                    out_vecs.push_back(static_cast<T>(*it));
                 break;
             }
             case data_types::f32: {
                 mem_lock<float, mem_lock_type::read> lock{mem, stream};
-                out_vecs = std::move(std::vector<T>(lock.begin(), lock.end()));
+                out_vecs.reserve(lock.end() - lock.begin());
+                for (auto it = lock.begin(); it != lock.end(); ++it)
+                    out_vecs.push_back(static_cast<T>(*it));
                 break;
             }
             default: OPENVINO_ASSERT(false, "[GPU] read_vector: unsupported data type");

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
@@ -195,12 +195,12 @@ public:
         return _non_padded_pool.size();
     }
 
-    void dump(uint32_t id, uint32_t iter, std::string dump_dir_path = "");
+    void dump(uint32_t id, int64_t iter, std::string dump_dir_path = "");
     size_t get_total_mem_pool_size(allocation_type type);
 
 private:
-    void dump_to_screen(uint32_t id, uint32_t iter);
-    void dump_to_file(uint32_t id, uint32_t iter, std::string dump_dir_path);
+    void dump_to_screen(uint32_t id, int64_t iter);
+    void dump_to_file(uint32_t id, int64_t iter, std::string dump_dir_path);
 
 #ifdef GPU_DEBUG_CONFIG
     std::vector<memory_record> _no_reusable_mems;

--- a/src/plugins/intel_gpu/src/graph/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/batch_to_space.cpp
@@ -71,7 +71,7 @@ layout batch_to_space_inst::calc_output_layout(batch_to_space_node const& node, 
 static std::vector<int32_t> tensor_to_vec(const tensor& t, const format f) {
     std::vector<int32_t> vec(cldnn::format::dimension(f));
     for (size_t i = 0; i < vec.size(); ++i) {
-        vec[i] = t.sizes()[i];
+        vec[i] = static_cast<int32_t>(t.sizes()[i]);
     }
     std::reverse(vec.begin() + 2, vec.end());
     return vec;

--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -722,7 +722,7 @@ NetworkDebugHelper::~NetworkDebugHelper() {
 }
 
 void NetworkDebugHelper::dump_memory_pool(std::string dump_path, int64_t curr_iter) const {
-    m_network.get_memory_pool().dump(m_network.get_id(), curr_iter, dump_path);
+    m_network.get_memory_pool().dump(m_network.get_id(), static_cast<uint32_t>(curr_iter), dump_path);
     auto get_constants_mem_size = [&](allocation_type type) -> size_t {
         size_t mem_size = 0;
         for (auto& prim : m_network._primitives) {

--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -691,7 +691,7 @@ NetworkDebugHelper::~NetworkDebugHelper() {
     }
 
     if (!config.get_dump_graphs_path().empty() && is_target_iteration(m_iter, config.get_dump_iterations())) {
-        auto get_fixed_str = [](size_t value, int length = 2) -> std::string {
+        auto get_fixed_str = [](int64_t value, int length = 2) -> std::string {
             std::ostringstream ss;
             ss << std::setw(length) << std::setfill('0') << std::to_string(value);
             return ss.str();
@@ -722,7 +722,7 @@ NetworkDebugHelper::~NetworkDebugHelper() {
 }
 
 void NetworkDebugHelper::dump_memory_pool(std::string dump_path, int64_t curr_iter) const {
-    m_network.get_memory_pool().dump(m_network.get_id(), static_cast<uint32_t>(curr_iter), dump_path);
+    m_network.get_memory_pool().dump(m_network.get_id(), curr_iter, dump_path);
     auto get_constants_mem_size = [&](allocation_type type) -> size_t {
         size_t mem_size = 0;
         for (auto& prim : m_network._primitives) {

--- a/src/plugins/intel_gpu/src/graph/debug_helper.hpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.hpp
@@ -60,7 +60,7 @@ private:
     stream& m_stream;
     const network& m_network;
     const program* m_program;
-    const size_t m_iter;
+    const int64_t m_iter;
 };
 
 class NetworkDebugHelper {
@@ -71,7 +71,7 @@ public:
 private:
     void dump_memory_pool(std::string dump_path, int64_t curr_iter) const;
     network& m_network;
-    const size_t m_iter;
+    const int64_t m_iter;
 };
 
 #define NETWORK_DEBUG(net) NetworkDebugHelper __network_debug_helper(net)

--- a/src/plugins/intel_gpu/src/graph/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deconvolution.cpp
@@ -37,7 +37,7 @@ layout deconvolution_inst::calc_output_layout(deconvolution_node const& node, ke
     auto pad = desc->pad;
     auto strd = desc->stride;
 
-    int32_t number_of_features = weights_layout.group() * weights_layout.ofm();
+    auto number_of_features = weights_layout.group() * weights_layout.ofm();
 
     format out_fmt = input_layout.format;
     if (node.get_preferred_impl_type() == impl_types::onednn && node.get_preferred_output_fmt() != format::any) {
@@ -127,7 +127,7 @@ std::vector<layout> deconvolution_inst::calc_output_layouts(deconvolution_node c
     auto output_padding = desc->out_padding;
     auto output_partial_shape = desc->output_partial_shape;
 
-    int32_t number_of_features = weights_layout.group() * weights_layout.ofm();
+    auto number_of_features = weights_layout.group() * weights_layout.ofm();
 
     format out_fmt = input_layout.format;
     if (node.get_preferred_impl_type() == impl_types::onednn && node.get_preferred_output_fmt() != format::any) {

--- a/src/plugins/intel_gpu/src/graph/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/detection_output.cpp
@@ -42,7 +42,7 @@ layout detection_output_inst::calc_output_layout(detection_output_node const& no
     }
 
     if (desc->top_k != -1) {
-        int top_k = desc->top_k * num_classes * input_layout.batch();
+        int top_k = desc->top_k * num_classes * static_cast<int>(input_layout.batch());
         if (top_k < output_size) {
             output_size = top_k;
         }
@@ -50,7 +50,7 @@ layout detection_output_inst::calc_output_layout(detection_output_node const& no
 
     output_size *= DETECTION_OUTPUT_ROW_SIZE;
     // Add space for number of output results per image - needed in the next detection output step
-    output_size += ((input_layout.batch() + 15) / 16) * 16;
+    output_size += ((static_cast<int>(input_layout.batch()) + 15) / 16) * 16;
 
     return {input_layout.data_type, cldnn::format::bfyx,
             cldnn::tensor(1, 1, DETECTION_OUTPUT_ROW_SIZE, desc->keep_top_k * input_layout.batch())};

--- a/src/plugins/intel_gpu/src/graph/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/detection_output.cpp
@@ -27,31 +27,6 @@ layout detection_output_inst::calc_output_layout(detection_output_node const& no
 
     auto input_layout = impl_param.get_input_layout();
 
-    // Batch size and feature size are 1.
-    // Number of bounding boxes to be kept is set to keep_top_k*batch size.
-    // If number of detections is lower than top_k, will write dummy results at the end with image_id=-1.
-    // Each row is a 7 dimension vector, which stores:
-    // [image_id, label, confidence, xmin, ymin, xmax, ymax]
-    int output_size = static_cast<int>(input_layout.get_linear_size()) / PRIOR_BOX_SIZE;
-    int num_classes = desc->num_classes;
-
-    if (desc->share_location) {
-        num_classes = (desc->background_label_id == 0) ? desc->num_classes - 1
-                                                       : desc->num_classes;
-        output_size *= num_classes;
-    }
-
-    if (desc->top_k != -1) {
-        int top_k = desc->top_k * num_classes * static_cast<int>(input_layout.batch());
-        if (top_k < output_size) {
-            output_size = top_k;
-        }
-    }
-
-    output_size *= DETECTION_OUTPUT_ROW_SIZE;
-    // Add space for number of output results per image - needed in the next detection output step
-    output_size += ((static_cast<int>(input_layout.batch()) + 15) / 16) * 16;
-
     return {input_layout.data_type, cldnn::format::bfyx,
             cldnn::tensor(1, 1, DETECTION_OUTPUT_ROW_SIZE, desc->keep_top_k * input_layout.batch())};
 }
@@ -198,14 +173,14 @@ detection_output_inst::typed_primitive_inst(network& network, detection_output_n
                           "Location input dimensions",
                           (location_layout.feature() * location_layout.batch()),
                           "detection output layer dimensions",
-                          static_cast<int>(location_layout.count()),
+                          location_layout.count(),
                           "Location input/ detection output dims mismatch");
 
     CLDNN_ERROR_NOT_EQUAL(node.id(),
                           "Confidence input dimensions",
                           (confidence_layout.feature() * confidence_layout.batch()),
                           "detection output layer dimensions",
-                          static_cast<int>(confidence_layout.count()),
+                          confidence_layout.count(),
                           "Confidence input/detection output dims mistmach");
 
     CLDNN_ERROR_NOT_EQUAL(node.id(),

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_roi_feature_extractor.cpp
@@ -55,8 +55,8 @@ layout experimental_detectron_roi_feature_extractor_inst::calc_output_layout(
            "Output data type forcing is not supported for roi_pooling_node!");
     layout rois_layout = impl_param.get_input_layout(0);
     layout data_layout = impl_param.get_input_layout(1);
-    int num_rois = rois_layout.batch();
-    int num_channels = data_layout.feature();
+    int64_t num_rois = rois_layout.batch();
+    int64_t num_channels = data_layout.feature();
     auto desc = impl_param.typed_desc<experimental_detectron_roi_feature_extractor>();
 
     return layout(data_layout.data_type, format::bfyx, {num_rois, num_channels, desc->output_dim, desc->output_dim});

--- a/src/plugins/intel_gpu/src/graph/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather_nd.cpp
@@ -42,7 +42,7 @@ layout gather_nd_inst::calc_output_layout(gather_nd_node const& node, kernel_imp
 
     if (op->batch_merged_output) {
         // calculate batch_size by batch_dims
-        int batch_size = 1;
+        tensor::value_type batch_size = 1;
         for (uint8_t x = 0; x < batch_dims; x++) {
             batch_size *= output_sizes[x];
         }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
@@ -17,7 +17,7 @@ using namespace cldnn;
 
 namespace {
 
-using shuffle_range = std::pair<int32_t, int32_t>;
+using shuffle_range = std::pair<tensor::value_type, tensor::value_type>;
 
 bool can_shuffle_features(program_node& node, program_node& concat_node, stream& stream) {
     if (node.is_type<convolution>()) {
@@ -73,7 +73,7 @@ void shuffle_weights(data_node& node, const std::vector<shuffle_range>& ranges, 
     for (int32_t ofi = 0; ofi < wei_layout.batch(); ++ofi) {
         int32_t new_ifi = 0;
         for (auto& range : ranges) {
-            for (int32_t ifi = range.first; ifi < range.second; ++ifi, ++new_ifi) {
+            for (int32_t ifi = static_cast<int32_t>(range.first); ifi < range.second; ++ifi, ++new_ifi) {
                 for (int32_t wi = 0; wi < wei_layout.spatial(3); ++wi) {
                     for (int32_t zi = 0; zi < wei_layout.spatial(2); ++zi) {
                         for (int32_t yi = 0; yi < wei_layout.spatial(1); ++yi) {
@@ -134,20 +134,20 @@ void concat_input_order::run(program& p) {
 
         auto out_format = concat_node.get_output_layout().format;
         bool correct_format = (out_format == format::b_fs_yx_fsv16) || (out_format == format::b_fs_yx_fsv32);
-        int32_t alignment = 1;
+        tensor::value_type alignment = 1;
         if (out_format == format::b_fs_yx_fsv16)
             alignment = 16;
         else if (out_format == format::b_fs_yx_fsv32)
             alignment = 32;
 
         bool single_format = true;
-        std::vector<int32_t> feature_sizes;
+        std::vector<tensor::value_type> feature_sizes;
         feature_sizes.reserve(inputs_count);
         for (size_t input_idx = 0; input_idx < inputs_count; ++input_idx) {
             const auto dep = concat_node.get_dependency_with_port(input_idx);
             auto dep_layout = dep.first->get_output_layout(false, dep.second);
             single_format &= dep_layout.format == out_format;
-            feature_sizes.push_back(static_cast<int32_t>(dep_layout.feature()));
+            feature_sizes.push_back(dep_layout.feature());
         }
 
         // Alignment is not optimal if aligned input follows unaligned one
@@ -179,7 +179,7 @@ void concat_input_order::run(program& p) {
                 new_order.push_back(i);
         }
         // Calculate new ranges
-        int32_t current_offset = 0;
+        tensor::value_type current_offset = 0;
         std::vector<shuffle_range> original_ranges;
         original_ranges.reserve(inputs_count);
         for (auto& feature_size : feature_sizes) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
@@ -134,20 +134,20 @@ void concat_input_order::run(program& p) {
 
         auto out_format = concat_node.get_output_layout().format;
         bool correct_format = (out_format == format::b_fs_yx_fsv16) || (out_format == format::b_fs_yx_fsv32);
-        tensor::value_type alignment = 1;
+        int32_t alignment = 1;
         if (out_format == format::b_fs_yx_fsv16)
             alignment = 16;
         else if (out_format == format::b_fs_yx_fsv32)
             alignment = 32;
 
         bool single_format = true;
-        std::vector<tensor::value_type> feature_sizes;
+        std::vector<int32_t> feature_sizes;
         feature_sizes.reserve(inputs_count);
         for (size_t input_idx = 0; input_idx < inputs_count; ++input_idx) {
             const auto dep = concat_node.get_dependency_with_port(input_idx);
             auto dep_layout = dep.first->get_output_layout(false, dep.second);
             single_format &= dep_layout.format == out_format;
-            feature_sizes.push_back(dep_layout.feature());
+            feature_sizes.push_back(static_cast<int32_t>(dep_layout.feature()));
         }
 
         // Alignment is not optimal if aligned input follows unaligned one

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
@@ -70,10 +70,13 @@ void shuffle_weights(data_node& node, const std::vector<shuffle_range>& ranges, 
     mem_lock<uint8_t, mem_lock_type::write> new_weights_memory_lock{new_weights_memory, stream};
     auto old_ptr = old_weights_memory_lock.data();
     auto new_ptr = new_weights_memory_lock.data();
+
     for (int32_t ofi = 0; ofi < wei_layout.batch(); ++ofi) {
         int32_t new_ifi = 0;
         for (auto& range : ranges) {
-            for (int32_t ifi = static_cast<int32_t>(range.first); ifi < range.second; ++ifi, ++new_ifi) {
+            const int32_t range_begin = static_cast<int32_t>(range.first);
+            const int32_t range_end = static_cast<int32_t>(range.second);
+            for (int32_t ifi = range_begin; ifi < range_end; ++ifi, ++new_ifi) {
                 for (int32_t wi = 0; wi < wei_layout.spatial(3); ++wi) {
                     for (int32_t zi = 0; zi < wei_layout.spatial(2); ++zi) {
                         for (int32_t yi = 0; yi < wei_layout.spatial(1); ++yi) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -706,7 +706,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
                     // output_pattern[0] == -1 means the batch dim is absorbed (squeezed).
                     reshape_axis = 0;
                 } else {
-                    int64_t mul = 1;
+                    ov::Dimension::value_type mul = 1;
                     auto reshape_ps = user_info.second.get_partial_shape();
                     reshape_axis = reshape_ps.size() - 1;
                     auto crop_dim_val = crop_layout.get_partial_shape()[crop_axis].get_length();

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -454,7 +454,7 @@ static bool can_read_value_be_optimize(const read_value_node& node) {
         return true;
 
     // following pattern should be optimized, otherwise it could lead to corruptted data.
-    // readvalue's users eventually need to pass kvcache before assign, which makes kvcache node the dominator of assign node, 
+    // readvalue's users eventually need to pass kvcache before assign, which makes kvcache node the dominator of assign node,
     // it could be safely treated as if readvalue is directly connecting to kvcache.
     // readvalue --> any
     //       |         |
@@ -706,7 +706,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
                     // output_pattern[0] == -1 means the batch dim is absorbed (squeezed).
                     reshape_axis = 0;
                 } else {
-                    auto mul = 1;
+                    int64_t mul = 1;
                     auto reshape_ps = user_info.second.get_partial_shape();
                     reshape_axis = reshape_ps.size() - 1;
                     auto crop_dim_val = crop_layout.get_partial_shape()[crop_axis].get_length();
@@ -778,7 +778,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
                     reshape_upper_sizes[0] = upper_sizes[0] * batch_stride_factor;
                     reshape_dyn_pad_mask[0] = 1;
                 } else {
-                    auto divider = 1;
+                    int64_t divider = 1;
                     auto reshape_axis = reshape_ps.size();
                     for (size_t i = reshape_ps.size(); i > 1; i--) {
                         const auto& dim_value = reshape_ps[i - 1].get_length();

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -778,7 +778,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
                     reshape_upper_sizes[0] = upper_sizes[0] * batch_stride_factor;
                     reshape_dyn_pad_mask[0] = 1;
                 } else {
-                    int64_t divider = 1;
+                    ov::Dimension::value_type divider = 1;
                     auto reshape_axis = reshape_ps.size();
                     for (size_t i = reshape_ps.size(); i > 1; i--) {
                         const auto& dim_value = reshape_ps[i - 1].get_length();

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -141,7 +141,7 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
         // which would affect a form of its output (unless debug flag is set),
         // we also need to restrict input types to those which support padding on all axis
         if (!pred.first->is_dynamic() || is_runtime) {
-            if (!pred.first->is_padding_supported(static_cast<int>(concat_axis), lower_padd_in_axis))
+            if (!pred.first->is_padding_supported(static_cast<int>(concat_axis), static_cast<int>(lower_padd_in_axis)))
                 return false;
         }
         // TODO: handle optimized reshape

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -87,10 +87,10 @@ void prepare_quantization::prepare_scale_shift_opt(program &p, quantize_node& qu
         auto sizes = l.get_tensor();
         auto pitches = l.get_pitches();
 
-        return (idx.batch[0] % sizes.batch[0])*pitches[0]
+        return static_cast<int>((idx.batch[0] % sizes.batch[0])*pitches[0]
                         + (idx.feature[0] % sizes.feature[0])*pitches[1]
                         + (idx.spatial[1] % sizes.spatial[1])*pitches[2 + 0]   // y
-                        + (idx.spatial[0] % sizes.spatial[0])*pitches[2 + 1];  // x
+                        + (idx.spatial[0] % sizes.spatial[0])*pitches[2 + 1]);  // x
     };
 
     auto lock_memory = [&stream] (memory::ptr memory, std::function<void(std::size_t, float)>& set_data,

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -83,14 +83,14 @@ void prepare_quantization::prepare_scale_shift_opt(program &p, quantize_node& qu
     auto mem_output_scale = p.get_engine().allocate_memory(scales_layout, false);
     auto mem_output_shift = p.get_engine().allocate_memory(scales_layout, false);
 
-    auto get_offset_safe = [](const layout& l, const tensor& idx) -> int {
+    auto get_offset_safe = [](const layout& l, const tensor& idx) -> tensor::value_type {
         auto sizes = l.get_tensor();
         auto pitches = l.get_pitches();
 
-        return static_cast<int>((idx.batch[0] % sizes.batch[0])*pitches[0]
-                        + (idx.feature[0] % sizes.feature[0])*pitches[1]
-                        + (idx.spatial[1] % sizes.spatial[1])*pitches[2 + 0]   // y
-                        + (idx.spatial[0] % sizes.spatial[0])*pitches[2 + 1]);  // x
+        return (idx.batch[0] % sizes.batch[0])*pitches[0]
+                    + (idx.feature[0] % sizes.feature[0])*pitches[1]
+                    + (idx.spatial[1] % sizes.spatial[1])*pitches[2 + 0]   // y
+                    + (idx.spatial[0] % sizes.spatial[0])*pitches[2 + 1];  // x
     };
 
     auto lock_memory = [&stream] (memory::ptr memory, std::function<void(std::size_t, float)>& set_data,

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -573,7 +573,7 @@ void remove_redundant_reorders::run(program& p) {
                     auto sizes_in_format = layout::format_sizes(node->get_input_layout(0).data_padding._lower_size, node_format);
                     for (size_t axis = 0; axis < sizes_in_format.size(); axis++) {
                         if (!user->is_padding_supported(static_cast<int>(axis),
-                            sizes_in_format[axis]))
+                            static_cast<int>(sizes_in_format[axis])))
                             return false;
                     }
                 }

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
@@ -731,8 +731,8 @@ DispatchDataFunc XAttentionEstimateFindBlock::get_dispatch_data_func() const {
         const size_t q_len = out_shape[0];
 
         const size_t sum_per_n_token_in_block = static_cast<size_t>(rtp->xattn_block_size / STRIDE);
-        const uint32_t q_block = static_cast<uint32_t>(ceil_div(rtp->M, sum_per_n_token_in_block));
-        const uint32_t k_block = static_cast<uint32_t>(ceil_div(rtp->N, sum_per_n_token_in_block));
+        const size_t q_block = static_cast<size_t>(ceil_div(rtp->M, sum_per_n_token_in_block));
+        const size_t k_block = static_cast<size_t>(ceil_div(rtp->N, sum_per_n_token_in_block));
 
         const float xattn_thresh = get_xattn_thresh(params);
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
@@ -731,8 +731,8 @@ DispatchDataFunc XAttentionEstimateFindBlock::get_dispatch_data_func() const {
         const size_t q_len = out_shape[0];
 
         const size_t sum_per_n_token_in_block = static_cast<size_t>(rtp->xattn_block_size / STRIDE);
-        const uint32_t q_block = ceil_div(rtp->M, sum_per_n_token_in_block);
-        const uint32_t k_block = ceil_div(rtp->N, sum_per_n_token_in_block);
+        const uint32_t q_block = static_cast<uint32_t>(ceil_div(rtp->M, sum_per_n_token_in_block));
+        const uint32_t k_block = static_cast<uint32_t>(ceil_div(rtp->N, sum_per_n_token_in_block));
 
         const float xattn_thresh = get_xattn_thresh(params);
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/vl_sdpa_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/vl_sdpa_opt.cpp
@@ -55,7 +55,7 @@ protected:
         const size_t head_size = key_shape[query_shape.size() - 1].get_length();
         const size_t num_q_heads = query_shape[query_shape.size() - 3].get_length();
         const size_t num_kv_heads = key_shape[key_shape.size() - 3].get_length();
-        const float scale_factor = 1.0 / std::sqrt(static_cast<double>(head_size));
+        const float scale_factor = 1.0f / std::sqrt(static_cast<float>(head_size));
 
         GPU_DEBUG_TRACE_DETAIL << "VLSDPA query_shape " << query_shape << ", q_transpose_order " << PartialShape(desc->input_q_transpose_order)
                                << ", key_shape " << key_shape << ", k_transpose_order " << PartialShape(desc->input_k_transpose_order)

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
@@ -276,7 +276,7 @@ public:
 
     template <typename dtype>
     void generate_detections(stream& stream, const detection_output_inst& instance,
-                             const int num_of_images,
+                             const int64_t num_of_images,
                              const std::vector<std::vector<std::vector<bounding_box>>>& all_bboxes,
                              std::vector<std::vector<std::vector<std::pair<float, int>>>>& confidences,
                              std::vector<std::vector<std::pair<float, std::pair<int, int>>>>& scoreIndexPairs) {
@@ -288,11 +288,11 @@ public:
         auto confidence_layout = instance.confidence_memory()->get_layout();
         auto priors_layout = instance.prior_box_memory()->get_layout();
 
-        const int num_of_priors = priors_layout.spatial(1) / args->prior_info_size;
-        const int num_classes = (args->num_classes == -1) ? confidence_layout.feature() / num_of_priors : args->num_classes;
+        const int64_t num_of_priors = priors_layout.spatial(1) / args->prior_info_size;
+        const int64_t num_classes = (args->num_classes == -1) ? confidence_layout.feature() / num_of_priors : args->num_classes;
         // Per image -> For each label: Pair (score, prior index)
         std::vector<std::map<int, std::vector<std::pair<float, int>>>> final_detections;
-        for (int image = 0; image < num_of_images; ++image) {
+        for (int64_t image = 0; image < num_of_images; ++image) {
             const std::vector<std::vector<bounding_box>>& bboxes_per_image = all_bboxes[image];
             std::vector<std::vector<std::pair<float, int>>>& conf_per_image = confidences[image];
             std::map<int, std::vector<int>> indices;
@@ -411,18 +411,18 @@ public:
     }
 
     // Compute the linear index taking the padding into account.
-    static inline int get_linear_feature_index(const int batch_id,
-                                               const int feature_id,
-                                               const int input_buffer_size_f,
-                                               const int input_buffer_size_y,
-                                               const int input_buffer_size_x,
-                                               const int input_padding_lower_y,
-                                               const int input_padding_lower_x) {
+    static inline int64_t get_linear_feature_index(const int64_t batch_id,
+                                                  const int64_t feature_id,
+                                                  const int64_t input_buffer_size_f,
+                                                  const int64_t input_buffer_size_y,
+                                                  const int64_t input_buffer_size_x,
+                                                  const int64_t input_padding_lower_y,
+                                                  const int64_t input_padding_lower_x) {
         // This helper function assumes input layout with x_size = 1 and y_size = 1;
         // Location and confidence inputs should be tensors with size {b,f,1,1}.
         // This is validated in detection output primitive instance creation.
 
-        int input_idx = (batch_id * input_buffer_size_f + feature_id) * input_buffer_size_y * input_buffer_size_x;
+        int64_t input_idx = (batch_id * input_buffer_size_f + feature_id) * input_buffer_size_y * input_buffer_size_x;
         input_idx += input_padding_lower_y * input_buffer_size_x + input_padding_lower_x;
 
         return input_idx;
@@ -431,33 +431,33 @@ public:
     template <typename dtype>
     void extract_locations_per_image(stream& stream, const detection_output_inst& instance,
                                      std::vector<std::vector<std::vector<bounding_box>>>& locations,
-                                     const int num_of_priors,
-                                     const int num_loc_classes) {
+                                     const int64_t num_of_priors,
+                                     const int64_t num_loc_classes) {
         const bool share_location = instance.argument->share_location;
         auto input_location = instance.location_memory();
         auto location_layout = input_location->get_layout();
-        const int num_of_images = static_cast<int>(locations.size());
+        const int64_t num_of_images = static_cast<int64_t>(locations.size());
         mem_lock<dtype, mem_lock_type::read> lock{input_location, stream};
         auto location_data = lock.begin();
         assert(num_of_priors * num_loc_classes * PRIOR_BOX_SIZE == input_location->get_layout().feature());
 
         const auto& input_buffer_size = location_layout.get_padded_dims();
-        const int input_buffer_size_x = input_buffer_size[3];
-        const int input_buffer_size_y = input_buffer_size[2];
-        const int input_buffer_size_f = input_buffer_size[1];
+        const int64_t input_buffer_size_x = input_buffer_size[3];
+        const int64_t input_buffer_size_y = input_buffer_size[2];
+        const int64_t input_buffer_size_f = input_buffer_size[1];
         const auto& input_padding = location_layout.data_padding;
-        const int input_padding_lower_x = input_padding._lower_size[2];
-        const int input_padding_lower_y = input_padding._lower_size[3];
+        const int64_t input_padding_lower_x = input_padding._lower_size[2];
+        const int64_t input_padding_lower_y = input_padding._lower_size[3];
 
-        for (int image = 0; image < num_of_images; ++image) {
+        for (int64_t image = 0; image < num_of_images; ++image) {
             std::vector<std::vector<bounding_box>>& label_to_bbox = locations[image];
             label_to_bbox.resize(num_loc_classes);
-            for (int cls = 0; cls < num_loc_classes; ++cls) {
-                int label = share_location ? 0 : cls;
+            for (int64_t cls = 0; cls < num_loc_classes; ++cls) {
+                int64_t label = share_location ? 0 : cls;
                 auto& bboxes = label_to_bbox[label];
                 bboxes.resize(num_of_priors);
-                for (int prior = 0; prior < num_of_priors; ++prior) {
-                    int idx = prior * num_loc_classes * PRIOR_BOX_SIZE;
+                for (int64_t prior = 0; prior < num_of_priors; ++prior) {
+                    int64_t idx = prior * num_loc_classes * PRIOR_BOX_SIZE;
                     bboxes[prior].xmin = static_cast<float>((location_data[get_linear_feature_index(image,
                                                                                         idx + cls * PRIOR_BOX_SIZE,
                                                                                         input_buffer_size_f,
@@ -496,18 +496,18 @@ public:
                                            const bool variance_encoded_in_target,
                                            const int32_t prior_info_size,
                                            const int32_t prior_coordinates_offset,
-                                           const int32_t images_count,
+                                           const int64_t images_count,
                                            std::vector<bounding_box>& prior_bboxes,
                                            std::vector<std::array<float, PRIOR_BOX_SIZE>>& prior_variances) {
         auto input_prior_box = instance.prior_box_memory();
-        const int num_of_priors = static_cast<int>(prior_bboxes.size()) / images_count;
+        const int64_t num_of_priors = static_cast<int64_t>(prior_bboxes.size()) / images_count;
         mem_lock<dtype, mem_lock_type::read> lock{std::move(input_prior_box), stream};
-        for (int i = 0; i < images_count; i++) {
+        for (int64_t i = 0; i < images_count; i++) {
             auto prior_box_data =
                 lock.begin() + i * num_of_priors * prior_info_size * (variance_encoded_in_target ? 1 : 2);
 
-            for (int prior = 0; prior < num_of_priors; ++prior) {
-                int idx = prior * prior_info_size + prior_coordinates_offset;
+            for (int64_t prior = 0; prior < num_of_priors; ++prior) {
+                int64_t idx = prior * prior_info_size + prior_coordinates_offset;
                 prior_bboxes[i * num_of_priors + prior] = bounding_box(static_cast<float>(prior_box_data[idx]),
                                                                        static_cast<float>(prior_box_data[idx + 1]),
                                                                        static_cast<float>(prior_box_data[idx + 2]),
@@ -515,8 +515,8 @@ public:
                 idx += num_of_priors * prior_info_size;
             }
             if (!variance_encoded_in_target) {
-                for (int prior = 0; prior < num_of_priors; ++prior) {
-                    int start_idx = prior * 4;
+                for (int64_t prior = 0; prior < num_of_priors; ++prior) {
+                    int64_t start_idx = prior * 4;
                     std::array<float, PRIOR_BOX_SIZE> var = {0.f, 0.f, 0.f, 0.f};
                     for (int j = 0; j < PRIOR_BOX_SIZE; ++j) {
                         var[j] = (prior_box_data[start_idx + j + num_of_priors * prior_info_size]);
@@ -530,8 +530,8 @@ public:
     template <typename dtype>
     void extract_confidences_per_image_caffe(stream& stream, const detection_output_inst& instance,
                                              std::vector<std::vector<std::vector<std::pair<float, int>>>>& confidences,
-                                             const int num_of_priors, const int num_classes) {
-        const int num_of_images = static_cast<int>(confidences.size());
+                                             const int64_t num_of_priors, const int64_t num_classes) {
+        const int64_t num_of_images = static_cast<int64_t>(confidences.size());
         auto input_confidence = instance.confidence_memory();
         const float confidence_threshold = instance.argument->confidence_threshold;
 
@@ -541,19 +541,19 @@ public:
         assert(num_of_priors * num_classes == input_confidence->get_layout().feature());
 
         const auto& input_buffer_layout = input_confidence->get_layout();
-        const int input_buffer_size_x = input_buffer_layout.spatial(0);
-        const int input_buffer_size_y = input_buffer_layout.spatial(1);
-        const int input_buffer_size_f = input_buffer_layout.feature();
+        const int64_t input_buffer_size_x = input_buffer_layout.spatial(0);
+        const int64_t input_buffer_size_y = input_buffer_layout.spatial(1);
+        const int64_t input_buffer_size_f = input_buffer_layout.feature();
         const auto& input_padding = input_confidence->get_layout().data_padding;
-        const int input_padding_lower_x = input_padding._lower_size[2];
-        const int input_padding_lower_y = input_padding._lower_size[3];
-        const int stride = input_buffer_size_y * input_buffer_size_x;
+        const int64_t input_padding_lower_x = input_padding._lower_size[2];
+        const int64_t input_padding_lower_y = input_padding._lower_size[3];
+        const int64_t stride = input_buffer_size_y * input_buffer_size_x;
 
-        for (int image = 0; image < num_of_images; ++image) {
+        for (int64_t image = 0; image < num_of_images; ++image) {
             std::vector<std::vector<std::pair<float, int>>>& label_to_scores = confidences[image];
             std::vector<std::pair<float, std::pair<int, int>>> score_index_per_prior;
             label_to_scores.resize(num_classes);
-            int idx = get_linear_feature_index(image,
+            int64_t idx = get_linear_feature_index(image,
                                                0,
                                                input_buffer_size_f,
                                                input_buffer_size_y,
@@ -622,10 +622,10 @@ public:
     template <typename dtype>
     void extract_confidences_per_image_mxnet(stream& stream, const detection_output_inst& instance,
                                              std::vector<std::vector<std::vector<std::pair<float, int>>>>& confidences,
-                                             const int num_of_priors, const int num_classes,
+                                             const int64_t num_of_priors, const int64_t num_classes,
                                              std::vector<std::vector<std::pair<float, std::pair<int, int>>>>& scoreIndexPairs) {
         const int background_label_id = instance.argument->background_label_id;
-        const int num_of_images = static_cast<int>(confidences.size());
+        const int64_t num_of_images = static_cast<int64_t>(confidences.size());
         auto input_confidence = instance.confidence_memory();
         const float confidence_threshold = instance.argument->confidence_threshold;
         auto confidence_layout = input_confidence->get_layout();
@@ -635,19 +635,19 @@ public:
 
         assert(num_of_priors * num_classes == confidence_layout.feature());
 
-        const int input_buffer_size_x = confidence_layout.spatial(0);
-        const int input_buffer_size_y = confidence_layout.spatial(1);
-        const int input_buffer_size_f = confidence_layout.feature();
+        const int64_t input_buffer_size_x = confidence_layout.spatial(0);
+        const int64_t input_buffer_size_y = confidence_layout.spatial(1);
+        const int64_t input_buffer_size_f = confidence_layout.feature();
         const auto& input_padding = confidence_layout.data_padding;
-        const int input_padding_lower_x = input_padding._lower_size[2];
-        const int input_padding_lower_y = input_padding._lower_size[3];
-        const int stride = input_buffer_size_y * input_buffer_size_x;
+        const int64_t input_padding_lower_x = input_padding._lower_size[2];
+        const int64_t input_padding_lower_y = input_padding._lower_size[3];
+        const int64_t stride = input_buffer_size_y * input_buffer_size_x;
 
-        for (int image = 0; image < num_of_images; ++image) {
+        for (int64_t image = 0; image < num_of_images; ++image) {
             std::vector<std::vector<std::pair<float, int>>>& label_to_scores = confidences[image];
             std::vector<std::pair<float, std::pair<int, int>>> score_index_per_prior;
             label_to_scores.resize(num_classes);
-            int idx = get_linear_feature_index(image,
+            int64_t idx = get_linear_feature_index(image,
                                                0,
                                                input_buffer_size_f,
                                                input_buffer_size_y,
@@ -757,17 +757,17 @@ public:
         auto confidence_layout = instance.confidence_memory()->get_layout();
         auto priors_layout = instance.prior_box_memory()->get_layout();
 
-        const int num_of_images = static_cast<int>(bboxes.size());
-        const int num_of_priors = priors_layout.spatial(1) / args->prior_info_size;
-        const int num_classes = (args->num_classes == -1) ? confidence_layout.feature() / num_of_priors : args->num_classes;
-        const int num_loc_classes = args->share_location ? 1 : num_classes;
+        const int64_t num_of_images = static_cast<int64_t>(bboxes.size());
+        const int64_t num_of_priors = priors_layout.spatial(1) / args->prior_info_size;
+        const int64_t num_classes = (args->num_classes == -1) ? confidence_layout.feature() / num_of_priors : args->num_classes;
+        const int64_t num_loc_classes = args->share_location ? 1 : num_classes;
 
         // Extract locations per image.
         std::vector<std::vector<std::vector<bounding_box>>> locations(
             num_of_images);  // Per image : label -> bounding boxes.
         extract_locations_per_image<dtype>(stream, instance, locations, num_of_priors, num_loc_classes);
 
-        int32_t batches_in_prior_boxes = priors_layout.batch();
+        int64_t batches_in_prior_boxes = priors_layout.batch();
         std::vector<bounding_box> prior_bboxes(batches_in_prior_boxes *
                                                num_of_priors);  // Prior-Boxes (identical for all images since we assume
                                                                 // all images in a batch are of same dimension).
@@ -800,8 +800,8 @@ public:
 
                 for (int i = 0; i < label_loc_preds_size; ++i) {
                     bounding_box decoded_bbox;
-                    int32_t pb_offset = (batches_in_prior_boxes > 1) ? (image * num_of_priors + i) : i;
-                    int32_t var_offset = (batches_in_prior_boxes > 1) ? (image * num_of_priors + i) : i;
+                    int64_t pb_offset = (batches_in_prior_boxes > 1) ? (image * num_of_priors + i) : i;
+                    int64_t var_offset = (batches_in_prior_boxes > 1) ? (image * num_of_priors + i) : i;
                     decode_bounding_box(prior_bboxes[pb_offset],
                                         prior_variances[var_offset],
                                         args->code_type,
@@ -833,7 +833,7 @@ public:
             stream.wait_for_events(events);
         }
 
-        const int num_of_images = instance.location_memory()->get_layout().batch();  // batch size
+        const int64_t num_of_images = instance.location_memory()->get_layout().batch();  // batch size
         // Per image : label -> decoded bounding boxes.
         std::vector<std::vector<std::vector<bounding_box>>> bboxes(num_of_images);
         // Per image : class -> confidences per bounding box.

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/non_max_suppression.cpp
@@ -121,10 +121,10 @@ vector2D<bounding_box> load_boxes_impl(stream& stream, memory::ptr mem, bool cen
     mem_lock<T, mem_lock_type::read> boxes_lock(mem, stream);
     auto ptr = boxes_lock.data();
 
-    for (int bi = 0; bi < batch_size; ++bi) {
+    for (int64_t bi = 0; bi < batch_size; ++bi) {
         result[bi].reserve(boxes_num);
-        for (int bxi = 0; bxi < boxes_num; ++bxi) {
-            int offset = bi * boxes_num * 4 + bxi * 4;
+        for (int64_t bxi = 0; bxi < boxes_num; ++bxi) {
+            int64_t offset = bi * boxes_num * 4 + bxi * 4;
             if (center_point) {
                 result[bi].emplace_back(static_cast<float>(ptr[offset + 0]),
                                         static_cast<float>(ptr[offset + 1]),

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/proposal.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/proposal.cpp
@@ -74,8 +74,8 @@ void sort_and_keep_n_items(std::vector<proposal_t>& proposals, size_t n) {
 
 roi_t gen_bbox(const proposal_inst::anchor& box,
                const delta_t& delta,
-               int anchor_shift_x,
-               int anchor_shift_y,
+               int64_t anchor_shift_x,
+               int64_t anchor_shift_y,
                int img_w,
                int img_h,
                float coordinates_offset,
@@ -279,25 +279,25 @@ struct proposal_impl : typed_primitive_impl<proposal> {
 
         // feat map sizes
         const auto& score_layout = cls_scores->get_layout();
-        int fm_h = score_layout.spatial(1);
-        int fm_w = score_layout.spatial(0);
+        int64_t fm_h = score_layout.spatial(1);
+        int64_t fm_w = score_layout.spatial(0);
 
-        int fm_sz = fm_w * fm_h;
+        int64_t fm_sz = fm_w * fm_h;
 
         mem_lock<dtype, mem_lock_type::read> cls_scores_ptr{cls_scores, stream};
         mem_lock<dtype, mem_lock_type::read> bbox_pred_ptr{std::move(bbox_pred), stream};
         const dtype* cls_scores_mem = cls_scores_ptr.data();
         const dtype* bbox_pred_mem = bbox_pred_ptr.data();
 
-        for (int n = 0; n < score_layout.batch(); n++) {
+        for (int64_t n = 0; n < score_layout.batch(); n++) {
             std::vector<proposal_t> sorted_proposals_confidence;
             size_t num_proposals = fm_h * fm_w * anchors_num;
             sorted_proposals_confidence.reserve(num_proposals);
-            for (int y = 0; y < fm_h; ++y) {
-                for (int x = 0; x < fm_w; ++x) {
-                    const int anchor_shift_x = (swap_xy ? y : x) * primitive->feature_stride;
-                    const int anchor_shift_y = (swap_xy ? x : y) * primitive->feature_stride;
-                    const int location_index = y * fm_w + x;
+            for (int64_t y = 0; y < fm_h; ++y) {
+                for (int64_t x = 0; x < fm_w; ++x) {
+                    const int64_t anchor_shift_x = (swap_xy ? y : x) * primitive->feature_stride;
+                    const int64_t anchor_shift_y = (swap_xy ? x : y) * primitive->feature_stride;
+                    const int64_t location_index = y * fm_w + x;
 
                     // we assume proposals are grouped by window location
                     for (unsigned int anchor_index = 0; anchor_index < anchors_num; anchor_index++) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -88,7 +88,7 @@ public:
             // However, here we utilize output_layout and axis information to minimize mem_lock.
             auto output_layout = impl_param.get_output_layout(0);
             auto out_dims = output_layout.get_dims();
-            argm_params.topK = out_dims[axis];
+            argm_params.topK = static_cast<uint32_t>(out_dims[axis]);
         } else {
             argm_params.topK = top_k;
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
@@ -31,9 +31,6 @@ struct border_impl : typed_primitive_impl_ocl<border> {
         size_t rank = impl_param.get_input_layout(0).get_rank();
         format pads_format = format::adjust_to_rank(format::bfyx, rank);
 
-        std::vector<int32_t> begin(primitive->pads_begin.begin(), primitive->pads_begin.end());
-        std::vector<int32_t> end(primitive->pads_end.begin(), primitive->pads_end.end());
-
         size_t input_offset = 1;
         if (!(primitive->non_constant_input_mask & border::PAD_NON_CONST_INPUT::BEGIN)) {
             params.begin_type = kernel_selector::base_params::ArgType::Constant;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
@@ -130,9 +130,9 @@ public:
             std::fill(pads_end.begin(), pads_end.end(), 0);
         }
 
-        uint32_t kx = weights_layout.spatial(0);
-        uint32_t ky = weights_layout.spatial(1);
-        uint32_t kz = weights_layout.spatial(2);
+        uint32_t kx = static_cast<uint32_t>(weights_layout.spatial(0));
+        uint32_t ky = static_cast<uint32_t>(weights_layout.spatial(1));
+        uint32_t kz = static_cast<uint32_t>(weights_layout.spatial(2));
         conv_params.filterSize = { kx, ky, kz };
 
         uint32_t pad_begin_x, pad_begin_y, pad_begin_z;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
@@ -43,7 +43,7 @@ public:
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
         params.merge_repeated = primitive->ctc_merge_repeated;
         if (primitive->blank_index == UINT32_MAX) {
-            params.blank_index = impl_param.get_input_layout(0).spatial(1) - 1;
+            params.blank_index = static_cast<uint32_t>(impl_param.get_input_layout(0).spatial(1) - 1);
         } else {
             params.blank_index = primitive->blank_index;
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
@@ -224,7 +224,7 @@ static void add_layout_to_jit(kernel_selector::jit_constants& mem_consts, const 
 
     // Offset (in elements)
     // #define INPUT0_OFFSET 0
-    int32_t offset =
+    auto offset =
         (pitches[0] * l.data_padding._lower_size[0]) + (pitches[1] * l.data_padding._lower_size[1]) +
         (pitches[2] * l.data_padding._lower_size[3]) + (pitches[3] * l.data_padding._lower_size[2]);
     mem_consts.AddConstant(kernel_selector::MakeJitConstant(name + "_OFFSET", std::to_string(offset)));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -49,9 +49,9 @@ public:
 
         const auto weights_idx = 1 + 0;
         const auto& weights_layout = impl_param.input_layouts[weights_idx].convert_to_weights_layout(primitive->grouped_weights_shape);
-        uint32_t kx = weights_layout.spatial(0);
-        uint32_t ky = weights_layout.spatial(1);
-        uint32_t kz = weights_layout.spatial(2);
+        uint32_t kx = static_cast<uint32_t>(weights_layout.spatial(0));
+        uint32_t ky = static_cast<uint32_t>(weights_layout.spatial(1));
+        uint32_t kz = static_cast<uint32_t>(weights_layout.spatial(2));
 
         params.filterSize = { kx, ky, kz };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
@@ -54,10 +54,10 @@ public:
         detectOutParams.decrease_label_id = primitive->decrease_label_id;
         detectOutParams.clip_before_nms = primitive->clip_before_nms;
         detectOutParams.clip_after_nms = primitive->clip_after_nms;
-        detectOutParams.conf_size_x = confidence_layout.get_padded_dims()[2];
-        detectOutParams.conf_size_y = confidence_layout.get_padded_dims()[3];
-        detectOutParams.conf_padding_x = confidence_layout.data_padding._lower_size[2];
-        detectOutParams.conf_padding_y = confidence_layout.data_padding._lower_size[3];
+        detectOutParams.conf_size_x = static_cast<int32_t>(confidence_layout.get_padded_dims()[2]);
+        detectOutParams.conf_size_y = static_cast<int32_t>(confidence_layout.get_padded_dims()[3]);
+        detectOutParams.conf_padding_x = static_cast<int32_t>(confidence_layout.data_padding._lower_size[2]);
+        detectOutParams.conf_padding_y = static_cast<int32_t>(confidence_layout.data_padding._lower_size[3]);
 
         return params;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -1078,8 +1078,8 @@ std::shared_ptr<kernel_selector::fuse_params> convert_fuse_params(std::shared_pt
         auto clamp_max = casted->_desc->clamp_max;
         auto swish_beta = casted->_desc->swish_beta;
         auto up_add_val = casted->_desc->up_add_val;
-        return std::make_shared<kernel_selector::swiglu_fuse_params>(axis,
-                                                                     glu_stride,
+        return std::make_shared<kernel_selector::swiglu_fuse_params>(static_cast<int32_t>(axis),
+                                                                     static_cast<size_t>(glu_stride),
                                                                      gate_idx,
                                                                      clamp_min,
                                                                      clamp_max,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
@@ -27,14 +27,14 @@ struct one_hot_impl : typed_primitive_impl_ocl<one_hot> {
         const auto& primitive = impl_param.typed_desc<one_hot>();
         auto params = get_default_params<kernel_selector::one_hot_params>(impl_param);
 
-        params.one_hot_axis = primitive->one_hot_axis;
+        params.one_hot_axis = static_cast<uint16_t>(primitive->one_hot_axis);
         params.on_value = primitive->on_value;
         params.off_value = primitive->off_value;
         params.indices_normalize_mode = primitive->indices_normalize_mode;
 
         auto output_sizes = impl_param.get_output_layout().get_dims();
 
-        params.one_hot_limit = output_sizes[params.one_hot_axis];
+        params.one_hot_limit = static_cast<int32_t>(output_sizes[params.one_hot_axis]);
         return params;
     }
 };

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
@@ -138,9 +138,9 @@ public:
         uint32_t kernel_x = kernel.size() >= 1 ? static_cast<uint32_t>(kernel[kernel.size() - 1]) : 1;
         pp.poolSize = {kernel_x, kernel_y, kernel_z};
 
-        uint32_t pad_z = std::max<std::ptrdiff_t>(pads_begin.size() >= 3 ? pads_begin[pads_begin.size() - 3] : 0, 0);
-        uint32_t pad_y = std::max<std::ptrdiff_t>(pads_begin.size() >= 2 ? pads_begin[pads_begin.size() - 2] : 0, 0);
-        uint32_t pad_x = std::max<std::ptrdiff_t>(pads_begin.size() >= 1 ? pads_begin[pads_begin.size() - 1] : 0, 0);
+        uint32_t pad_z = static_cast<uint32_t>(std::max<std::ptrdiff_t>(pads_begin.size() >= 3 ? pads_begin[pads_begin.size() - 3] : 0, 0));
+        uint32_t pad_y = static_cast<uint32_t>(std::max<std::ptrdiff_t>(pads_begin.size() >= 2 ? pads_begin[pads_begin.size() - 2] : 0, 0));
+        uint32_t pad_x = static_cast<uint32_t>(std::max<std::ptrdiff_t>(pads_begin.size() >= 1 ? pads_begin[pads_begin.size() - 1] : 0, 0));
         pp.poolPad  = {pad_x, pad_y, pad_z};
 
         uint32_t stride_z = stride.size() >= 3 ? static_cast<uint32_t>(stride[stride.size() - 3]) : 1;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
@@ -65,11 +65,11 @@ struct prior_box_impl : typed_primitive_impl_ocl<prior_box> {
         params.variance = primitive->variance;
         params.reverse_image_width = 1.0f / image_width;
         params.reverse_image_height = 1.0f / image_height;
-        params.width = width;
-        params.height = height;
+        params.width = static_cast<uint32_t>(width);
+        params.height = static_cast<uint32_t>(height);
         if (step == 0) {
-            params.step_x = image_width / width;
-            params.step_y = image_height / height;
+            params.step_x = static_cast<float>(image_width) / static_cast<float>(width);
+            params.step_y = static_cast<float>(image_height) / static_cast<float>(height);
         } else {
             params.step_x = step;
             params.step_y = step;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
@@ -15,7 +15,7 @@ static std::vector<uint16_t> convert_axes(std::vector<int64_t> axes, size_t rank
     std::vector<uint16_t> converted_axes;
     for (auto axis : axes) {
         if (axis == 0 || axis == 1) {
-            converted_axes.push_back(axis);
+            converted_axes.push_back(static_cast<uint16_t>(axis));
             continue;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -106,7 +106,7 @@ public:
         if (output_layout.format == format::winograd_2x3_s1_data) {
             params.winograd_input_offset_x = 0;
             params.winograd_input_offset_y = 0;
-            params.winograd_nr_tiles_x = ceil_div(output_layout.spatial(0), 4);
+            params.winograd_nr_tiles_x = static_cast<uint32_t>(ceil_div(output_layout.spatial(0), 4));
         }
 
         params.winograd = impl_param.input_layouts[0].format.is_winograd() || output_layout.format.is_winograd();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -93,9 +93,15 @@ public:
         auto params = get_default_params<kernel_selector::strided_slice_params>(impl_param, is_shape_agnostic);
         const size_t dims_num = params.inputs[0].Dimentions();
 
-        std::vector<int32_t> begin(prim->begin.begin(), prim->begin.end());
-        std::vector<int32_t> end(prim->end.begin(), prim->end.end());
-        std::vector<int32_t> strides(prim->strides.begin(), prim->strides.end());
+        auto to_i32_vec = [](const auto& src) {
+            std::vector<int32_t> dst;
+            dst.reserve(src.size());
+            for (const auto& v : src) dst.push_back(static_cast<int32_t>(v));
+            return dst;
+        };
+        std::vector<int32_t> begin = to_i32_vec(prim->begin);
+        std::vector<int32_t> end = to_i32_vec(prim->end);
+        std::vector<int32_t> strides = to_i32_vec(prim->strides);
 
         // Getting data from constant inputs. There are 3 args: Begin, End, Stride
         if (!begin.empty() && !params.has_dynamic_tensors()) {
@@ -149,11 +155,17 @@ public:
         auto shrink_axis_mask_ = prim->shrink_axis_mask;
         auto ellipsis_mask_ = prim->ellipsis_mask;
 
-        std::vector<uint8_t> begin_mask(begin_mask_.begin(), begin_mask_.end());
-        std::vector<uint8_t> end_mask(end_mask_.begin(), end_mask_.end());
-        std::vector<uint8_t> new_axis_mask(new_axis_mask_.begin(), new_axis_mask_.end());
-        std::vector<uint8_t> shrink_axis_mask(shrink_axis_mask_.begin(), shrink_axis_mask_.end());
-        std::vector<uint8_t> ellipsis_mask(ellipsis_mask_.begin(), ellipsis_mask_.end());
+        auto to_u8_vec = [](const auto& src) {
+            std::vector<uint8_t> dst;
+            dst.reserve(src.size());
+            for (const auto& v : src) dst.push_back(static_cast<uint8_t>(v));
+            return dst;
+        };
+        std::vector<uint8_t> begin_mask = to_u8_vec(begin_mask_);
+        std::vector<uint8_t> end_mask = to_u8_vec(end_mask_);
+        std::vector<uint8_t> new_axis_mask = to_u8_vec(new_axis_mask_);
+        std::vector<uint8_t> shrink_axis_mask = to_u8_vec(shrink_axis_mask_);
+        std::vector<uint8_t> ellipsis_mask = to_u8_vec(ellipsis_mask_);
         params.end_mask = std::move(end_mask);
         pad_vector_to_size(params.end_mask, dims_num, 0, prim->ellipsis_mask);
         params.begin_mask = std::move(begin_mask);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
@@ -37,8 +37,8 @@ struct swiglu_impl : typed_primitive_impl_ocl<swiglu> {
         auto params = get_default_params<kernel_selector::swiglu_params>(impl_param, is_shape_agnostic);
 
         auto rank = impl_param.get_input_layout(0).get_partial_shape().rank();
-        params.axis = ov::util::normalize(primitive->axis, rank.get_length());
-        params.glu_stride = primitive->glu_stride;
+        params.axis = static_cast<int32_t>(ov::util::normalize(primitive->axis, rank.get_length()));
+        params.glu_stride = static_cast<int32_t>(primitive->glu_stride);
         params.glu_type = primitive->glu_type;
         params.gate_idx = static_cast<int32_t>(primitive->gate_idx);
         params.clamp_min = primitive->clamp_min;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gated_delta_net_ref.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gated_delta_net_ref.cpp
@@ -43,7 +43,7 @@ protected:
         const auto& v_shape = params.get_input_layout(2).get_partial_shape();
         const size_t v_head_nums = v_shape[2].get_length();
         const size_t v_head_dims = v_shape[3].get_length();
-        const float scale_factor = 1.0f / std::sqrt(static_cast<double>(k_head_dims));
+        const float scale_factor = 1.0f / std::sqrt(static_cast<float>(k_head_dims));
         const auto output_state = params.output_layouts.size() > 1 ? 1 : 0;
 
         jit.make("K_HEAD_NUM", q_head_nums);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.cpp
@@ -237,7 +237,7 @@ void MoE3GemmMicroGenerator::init_microkernels(const kernel_impl_params& params,
     if (is_weight_quantized) {
         problem_moe.Ta = micro::Type::f16;
         problem_moe.Ta_ext = convert_type(params.get_input_layout(wei_idx).data_type);
-        problem_moe.A.setAlignment(micro::alignment_for_ld(k * problem_moe.Ta_ext));
+        problem_moe.A.setAlignment(micro::alignment_for_ld(static_cast<int>(k * problem_moe.Ta_ext)));
 
         // scale layout example: f16:bfyx:4x8x3072:nopad
         const auto& scale_layout = params.get_input_layout(scale_idx);
@@ -272,7 +272,7 @@ void MoE3GemmMicroGenerator::init_microkernels(const kernel_impl_params& params,
     problem_moe.A.layout = micro::MatrixLayout::T;
     problem_moe.B.layout = micro::MatrixLayout::N;
     problem_moe.C.layout = micro::MatrixLayout::N;
-    problem_moe.B.setAlignment(micro::alignment_for_ld(k * problem_moe.Tb));
+    problem_moe.B.setAlignment(micro::alignment_for_ld(static_cast<int>(k * problem_moe.Tb)));
     problem_moe.C.setAlignment(static_cast<int32_t>(problem_moe.Tc.size()));
 
     /* Set up problem_moe size information */

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gemm_gen_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gemm_gen_opt.hpp
@@ -53,7 +53,7 @@ public:
             auto k = (weight_shape.size() == 4) ? weight_shape[2] * weight_shape[3] : weight_shape[2];
             auto scale_group_dim = params.input_layouts[moe_cfg.weight_scale_idx].get_shape().size() - 2;
             auto num_scale_groups = (weight_shape.size() == 4) ? params.input_layouts[moe_cfg.weight_scale_idx].get_shape()[scale_group_dim] : 1;
-            moe_cfg.weight_group_size = k / num_scale_groups;
+            moe_cfg.weight_group_size = static_cast<int32_t>(k / num_scale_groups);
             if (static_cast<int32_t>(params.input_layouts.size()) > moe_cfg.weight_zp_idx) {
                 moe_cfg.is_weight_symmetric_quantized = false;
             } else {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1471,18 +1471,18 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
 
     bool is_quantized =
         (K.data_type == ov::element::u8 || K.data_type == ov::element::i8) || (V.data_type == ov::element::u8 || V.data_type == ov::element::i8);
-    int32_t nkeys_v = n_keys.is_dynamic() ? 0 : n_keys.get_length();
+    int32_t nkeys_v = static_cast<int32_t>(n_keys.is_dynamic() ? 0 : n_keys.get_length());
 
     GPU_DEBUG_TRACE_DETAIL << "k_head_size = " << k_head_size << ", nkeys_v = " << nkeys_v << "\n";
     GPU_DEBUG_TRACE_DETAIL << "thin_q = " << thin_q << ", is_quantized = " << is_quantized << "\n";
     switch (device_info.arch) {
     case gpu_arch::xe_hpg: {
-        config = choose_config_xehpg(static_cast<int32_t>(k_head_size), static_cast<int32_t>(nkeys_v), thin_q, is_quantized, is_paged_attention, is_prefill);
+        config = choose_config_xehpg(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_paged_attention, is_prefill);
         break;
     }
     case gpu_arch::xe_hpc:
         config = choose_config_xehpc(static_cast<int32_t>(k_head_size),
-                                     static_cast<int32_t>(nkeys_v),
+                                     nkeys_v,
                                      thin_q,
                                      is_quantized,
                                      is_integrated,
@@ -1491,7 +1491,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
         break;
     default: {
         config = choose_config_xe2(static_cast<int32_t>(k_head_size),
-                                   static_cast<int32_t>(nkeys_v),
+                                   nkeys_v,
                                    thin_q,
                                    is_quantized,
                                    is_integrated,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1576,7 +1576,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
 
     problem_kq.B.layout = micro::MatrixLayout::Pr;
     problem_kq.C.layout = micro::MatrixLayout::T;
-    problem_kq.A.setAlignment(micro::alignment_for_ld(k_head_size * problem.Ta));
+    problem_kq.A.setAlignment(micro::alignment_for_ld(static_cast<int>(k_head_size * problem.Ta)));
     if (is_paged_attention && !is_prefill) {
         auto pa_desc = params.typed_desc<paged_attention>();
         const auto paged_attention_block_size = static_cast<int>(paged_attention::block_size);
@@ -1626,7 +1626,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
         problem_kcq.A.layout = micro::MatrixLayout::T;
         problem_kcq.B.layout = micro::MatrixLayout::Pr;
         problem_kcq.C.layout = micro::MatrixLayout::T;
-        problem_kcq.A.setAlignment(micro::alignment_for_ld(k_head_size * problem.Ta));
+        problem_kcq.A.setAlignment(micro::alignment_for_ld(static_cast<int>(k_head_size * problem.Ta)));
         problem_kcq.B.setAlignment(64);  // Q is packed in VNNI format in SLM
         problem_kcq.B.crosspack = 2;
         problem_kcq.B.tileR = static_cast<uint16_t>(d_max);
@@ -1705,7 +1705,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
 
     problem_vs.B.layout = micro::MatrixLayout::Pr;
     problem_vs.C.layout = micro::MatrixLayout::N;
-    problem_vs.A.setAlignment(micro::alignment_for_ld(v_head_size * problem.Ta));
+    problem_vs.A.setAlignment(micro::alignment_for_ld(static_cast<int>(v_head_size * problem.Ta)));
     problem_vs.B.setAlignment(64);  // S is packed in SLM
     problem_vs.B.crosspack = 16;
     sizes.m = n_values.is_dynamic() ? -1 : n_values.get_length();
@@ -1744,7 +1744,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
 
         problem_vcs.B.layout = micro::MatrixLayout::Pr;
         problem_vcs.C.layout = micro::MatrixLayout::N;
-        problem_vcs.A.setAlignment(micro::alignment_for_ld(v_head_size * problem.Ta));
+        problem_vcs.A.setAlignment(micro::alignment_for_ld(static_cast<int>(v_head_size * problem.Ta)));
         problem_vcs.B.setAlignment(64);  // S is packed in SLM
         problem_vcs.B.crosspack = 16;
         sizes.m = n_values.is_dynamic() ? -1 : n_values.get_length();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1481,22 +1481,10 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
         break;
     }
     case gpu_arch::xe_hpc:
-        config = choose_config_xehpc(static_cast<int32_t>(k_head_size),
-                                     nkeys_v,
-                                     thin_q,
-                                     is_quantized,
-                                     is_integrated,
-                                     is_paged_attention,
-                                     is_prefill);
+        config = choose_config_xehpc(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);
         break;
     default: {
-        config = choose_config_xe2(static_cast<int32_t>(k_head_size),
-                                   nkeys_v,
-                                   thin_q,
-                                   is_quantized,
-                                   is_integrated,
-                                   is_paged_attention,
-                                   is_prefill);
+        config = choose_config_xe2(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);
         break;
     }
     }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
@@ -70,7 +70,7 @@ protected:
         return std::make_shared<dnnl::concat::primitive_desc>(
             engine.get_onednn_engine(),
             output_md,
-            axis,
+            static_cast<int>(axis),
             input_mds,
             attr);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -373,7 +373,7 @@ public:
                 ds_data_type = convert_data_type(scale_layout.data_type);
                 auto ifm = arg.get_dependency(1).get_output_layout().get_dim(weight_rank - 1);
                 auto ngroups = scale_layout.get_dim(weight_rank - 1);
-                group_size = ifm / ngroups;
+                group_size = static_cast<int>(ifm / ngroups);
                 OPENVINO_ASSERT((group_size == 1 || ngroups == 1 || group_size % 16 == 0),
                     "[GPU] group_size should be aligned to 16 if it is not a single scale group or the group_size is not one.");
                 if (scale_layout.count() == 1) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -310,8 +310,8 @@ public:
             auto partial_shape = impl_params->get_input_layout(0).get_partial_shape();
             auto innermost_len = partial_shape[partial_shape.size() - 1].get_length();
             auto& src_scale_shape = impl_params->input_layouts[src_scale_idx].get_partial_shape();
-            int src_scale_ngroups = src_scale_shape[src_scale_shape.size() - 1].get_length();
-            int src_group_size = innermost_len / src_scale_ngroups;
+            int64_t src_scale_ngroups = src_scale_shape[src_scale_shape.size() - 1].get_length();
+            int64_t src_group_size = innermost_len / src_scale_ngroups;
 
             auto act_scale_data_type = convert_data_type(impl_params->get_input_layout(src_scale_idx).data_type);
             _attrs->set_scales(DNNL_ARG_SRC, grouped, dnnl::memory::dims{1, src_group_size}, act_scale_data_type);
@@ -416,8 +416,8 @@ public:
                 auto& partial_shape = impl_params.input_layouts[0].get_partial_shape();
                 auto innermost_len = partial_shape[partial_shape.size() - 1].get_length();
                 auto& src_scale_shape = impl_params.input_layouts[src_scale_idx].get_partial_shape();
-                int src_scale_ngroups = src_scale_shape[src_scale_shape.size() - 1].get_length();
-                int src_group_size = innermost_len / src_scale_ngroups;
+                int64_t src_scale_ngroups = src_scale_shape[src_scale_shape.size() - 1].get_length();
+                int64_t src_group_size = innermost_len / src_scale_ngroups;
 
                 auto act_scale_data_type = convert_data_type(impl_params.input_layouts[src_scale_idx].data_type);
                 attr->set_scales(DNNL_ARG_SRC, grouped, dnnl::memory::dims{1, src_group_size}, act_scale_data_type);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -806,7 +806,8 @@ cldnn::format_traits convert_memory_desc_to_traits(const dnnl::memory::desc& des
 
     std::vector<std::pair<size_t, int>> block_sizes(inner_nblks);
     for (int i = 0; i < inner_nblks; i++) {
-        block_sizes[i] = std::make_pair(inner_idxs[i] + (is_grouped && inner_idxs[i] == 0 ? 9 : 0) + (is_grouped ? -1 : 0), inner_blks[i]);
+        const auto idx = inner_idxs[i] + (is_grouped && inner_idxs[i] == 0 ? 9 : 0) + (is_grouped ? -1 : 0);
+        block_sizes[i] = {static_cast<size_t>(idx), static_cast<int>(inner_blks[i])};
     }
 
     // all fmts has at least batch and feature dim for now

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -544,8 +544,8 @@ layout_optimizer::layout_optimizer(bool output_size_handling_enabled)
 }
 
 bool layout_optimizer::is_depthwise(const convolution_node& node) const {
-        const int32_t output_channels = node.get_output_layout(0).feature();
-        const int32_t input_channels = node.get_input_layout(0).feature();
+        const auto output_channels = node.get_output_layout(0).feature();
+        const auto input_channels = node.get_input_layout(0).feature();
 
         return node.get_groups() == static_cast<uint32_t>(input_channels) && input_channels == output_channels;
 }
@@ -656,8 +656,8 @@ bool layout_optimizer::convolution_b_fs_yx_fsv16_opt(const layout& input_layout,
     int32_t required_feature_num = weak_restrictions ? feature_block_size / 2 : feature_block_size;
     bool correct_in_feature = (input_layout.feature() >= required_feature_num &&
                                   output_layout.feature() >= required_feature_num);
-    int32_t in_features_per_group = input_layout.feature() / conv->groups;
-    int32_t out_features_per_group = output_layout.feature() / conv->groups;
+    auto in_features_per_group = input_layout.feature() / conv->groups;
+    auto out_features_per_group = output_layout.feature() / conv->groups;
     if (!correct_in_feature && input_layout.feature() <= 4 && out_features_per_group >= feature_block_size)
         correct_in_feature = true;
     bool depthwise = conv->groups == static_cast<uint32_t>(input_layout.feature());  // depthwise conv

--- a/src/plugins/intel_gpu/src/graph/multiclass_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/multiclass_nms.cpp
@@ -57,7 +57,7 @@ layout multiclass_nms_inst::calc_output_layout(const multiclass_nms_node& node, 
         num_classes = std::max<ov::Dimension::value_type>(1, num_classes - 1);
     }
 
-    int max_output_boxes_per_class = 0;
+    ov::Dimension::value_type max_output_boxes_per_class = 0;
     if (attrs.nms_top_k >= 0) {
         max_output_boxes_per_class = std::min<ov::Dimension::value_type>(num_boxes, attrs.nms_top_k);
     } else {

--- a/src/plugins/intel_gpu/src/graph/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/one_hot.cpp
@@ -15,7 +15,7 @@
 namespace cldnn {
 GPU_DEFINE_PRIMITIVE_TYPE_ID(one_hot)
 
-static bool is_output_bfzyx(const layout& input, int32_t axis) {
+static bool is_output_bfzyx(const layout& input, int64_t axis) {
     if (input.format == format::bfzyx)
         return true;
     if (axis == 4)

--- a/src/plugins/intel_gpu/src/graph/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/permute.cpp
@@ -80,7 +80,7 @@ std::vector<layout> permute_inst::calc_output_layouts(permute_node const& node, 
     auto permute_order = desc->permute_order;
     if (permute_order.empty()) {
         for (int64_t i = 1; i <= input_static_rank; ++i) {
-            permute_order.emplace_back(input_static_rank - i);
+            permute_order.emplace_back(static_cast<uint16_t>(input_static_rank - i));
         }
     }
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1077,8 +1077,8 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
         if (get_node().is_type<kv_cache>() && i != 1) {
             const auto& desc = get_node().as<kv_cache>().get_primitive();
             const auto shape_rank = updated_layouts[i].get_shape().size();
-            const auto seq_axis = i == 0 ? kv_cache_inst::get_sequence_axis(desc->concat_axis, shape_rank)
-                                         : kv_cache_inst::get_scale_zp_sequence_axis();
+            const int32_t seq_axis = static_cast<int32_t>(i == 0 ? kv_cache_inst::get_sequence_axis(desc->concat_axis, shape_rank)
+                                         : kv_cache_inst::get_scale_zp_sequence_axis());
 
             prealloc_info = sp.predict_preallocation_shape(id(), updated_layouts[i], false, i, tmp_prealloc_count, seq_axis);
         } else {
@@ -1332,10 +1332,10 @@ void primitive_inst::fill_shape_info_data(const layout& runtime_layout, const la
         if (dynamic_pad[j] == 1) {
             GPU_DEBUG_TRACE_DETAIL << " shape_info[" << offset << "] = " << lower_pads[j]
                                    << "(pad_before for " << j << "-th dim)" << std::endl;
-            shape_info_ptr[offset++] = lower_pads[j];  // pad_before
+            shape_info_ptr[offset++] = static_cast<int32_t>(lower_pads[j]);  // pad_before
             GPU_DEBUG_TRACE_DETAIL << " shape_info[" << offset << "] = " << upper_pads[j]
                                    << "(pad_after for " << j << "-th dim)" << std::endl;
-            shape_info_ptr[offset++] = upper_pads[j];  // pad_after
+            shape_info_ptr[offset++] = static_cast<int32_t>(upper_pads[j]);  // pad_after
         }
     }
 }

--- a/src/plugins/intel_gpu/src/graph/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/prior_box.cpp
@@ -26,10 +26,10 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
     // All the inputs for this layer are known at this point,
     // so the output buffer is written here and not in execute().
 
-    const int layer_width = input_layout.spatial(0);
-    const int layer_height = input_layout.spatial(1);
-    const int img_width = argument.img_size.spatial[0];
-    const int img_height = argument.img_size.spatial[1];
+    const int64_t layer_width = input_layout.spatial(0);
+    const int64_t layer_height = input_layout.spatial(1);
+    const int64_t img_width = argument.img_size.spatial[0];
+    const int64_t img_height = argument.img_size.spatial[1];
     float step_w = argument.step_width;
     float step_h = argument.step_height;
     if (!argument.is_clustered() && (step_w == 0 || step_h == 0)) {
@@ -204,7 +204,7 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
     }
 
     // set the variance.
-    int count = output_mem->get_layout().spatial(0) * output_mem->get_layout().spatial(1);
+    int64_t count = output_mem->get_layout().spatial(0) * output_mem->get_layout().spatial(1);
     int var_loop_count = argument.is_clustered() ? var_size : 4;
     for (int h = 0; h < layer_height; ++h) {
         for (int w = 0; w < layer_width; ++w) {

--- a/src/plugins/intel_gpu/src/graph/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/prior_box.cpp
@@ -124,8 +124,8 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
                             continue;
                         }
 
-                        box_width = fixed_size * sqrt(ar);
-                        box_height = fixed_size / sqrt(ar);
+                        box_width = fixed_size * sqrtf(ar);
+                        box_height = fixed_size / sqrtf(ar);
 
                         for (size_t r = 0; r < density; ++r) {
                             for (size_t c = 0; c < density; ++c) {
@@ -161,7 +161,7 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
                 if (argument.max_sizes.size() > 0) {
                     float max_size_ = argument.max_sizes[s];
                     // second prior: aspect_ratio = 1, size = sqrt(min_size * max_size)
-                    box_width = box_height = sqrt(min_size * max_size_);
+                    box_width = box_height = sqrtf(min_size * max_size_);
                     // xmin
                     out_ptr[idx++] = (dtype)((center_x - box_width / 2.f) / img_width);
                     // ymin
@@ -180,8 +180,8 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
                         if (fabs(ar - 1.) < 1e-6) {
                             continue;
                         }
-                        box_width = min_size * sqrt(ar);
-                        box_height = min_size / sqrt(ar);
+                        box_width = min_size * sqrtf(ar);
+                        box_height = min_size / sqrtf(ar);
                         // xmin
                         out_ptr[idx++] = (dtype)((center_x - box_width / 2.f) / img_width);
                         // ymin

--- a/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
@@ -288,7 +288,7 @@ void dump_graph_init(std::ofstream& graph,
             bool doubled = true;
             auto it = user->get_dependencies().begin();
             while (it != user->get_dependencies().end()) {
-                int input_port = it - user->get_dependencies().begin();
+                int input_port = static_cast<int>(it - user->get_dependencies().begin());
                 if (it->first == node && marked_connection.find({node, input_port}) == marked_connection.end()) {
                     marked_connection.emplace(user, input_port);
                     break;

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1224,8 +1224,8 @@ dnnl::post_ops program_node::try_optimize_post_ops(std::vector<fused_primitive_d
         }
     };
 
-    int64_t cur_post_op_idx = 1;
-    int64_t prev_post_op_idx = 0;
+    int cur_post_op_idx = 1;
+    int prev_post_op_idx = 0;
     bool optimization_done = false;
 
     GPU_DEBUG_TRACE << "================================================" << std::endl;
@@ -1251,7 +1251,7 @@ dnnl::post_ops program_node::try_optimize_post_ops(std::vector<fused_primitive_d
     GPU_DEBUG_TRACE << "----------------------------------->>>>>>>>>>>>>" << std::endl;
 
     // Get post-ops size for current node
-    int64_t post_ops_size = cur_post_ops.size();
+    int post_ops_size = static_cast<int>(cur_post_ops.size());
 
     auto get_optimized_eltwise_type = [](onednn_post_op_type type) {
         switch (type) {

--- a/src/plugins/intel_gpu/src/graph/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/reduce.cpp
@@ -27,7 +27,7 @@ static std::vector<uint16_t> convert_axes(std::vector<int64_t> axes, size_t rank
     std::vector<uint16_t> converted_axes;
     for (auto axis : axes) {
         if (axis == 0 || axis == 1) {
-            converted_axes.push_back(axis);
+            converted_axes.push_back(static_cast<uint16_t>(axis));
             continue;
         }
 

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -121,7 +121,7 @@ layout reshape_inst::calc_output_layout(reshape_node const& node, kernel_impl_pa
     auto sizes = desc->output_shape.sizes();
     auto input_sizes = input_layout.get_tensor().sizes();
     size_t need_recalc = 0;
-    uint32_t shape_count = 1;
+    int64_t shape_count = 1;
 
     for (size_t i = 0; i < sizes.size(); i++) {
         if (sizes[i] == -1) {
@@ -137,7 +137,7 @@ layout reshape_inst::calc_output_layout(reshape_node const& node, kernel_impl_pa
         shape_count *= sizes[i];
     }
     if (need_recalc)
-        sizes[need_recalc] = static_cast<int>(input_layout.count()) / shape_count;
+        sizes[need_recalc] = static_cast<int64_t>(input_layout.count()) / shape_count;
 
     return layout{input_layout.data_type, input_layout.format, tensor(sizes)};
 }

--- a/src/plugins/intel_gpu/src/graph/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/roi_pooling.cpp
@@ -19,8 +19,8 @@ layout roi_pooling_inst::calc_output_layout(roi_pooling_node const& node, kernel
     auto desc = impl_param.typed_desc<roi_pooling>();
     layout data_layout = impl_param.get_input_layout(0);
     layout rois_layout = impl_param.get_input_layout(1);
-    int num_rois = rois_layout.batch();
-    int out_fm = desc->position_sensitive ? desc->output_dim : data_layout.feature();
+    int64_t num_rois = rois_layout.batch();
+    int64_t out_fm = desc->position_sensitive ? desc->output_dim : data_layout.feature();
 
     return layout(data_layout.data_type,
                   data_layout.format,

--- a/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
@@ -17,8 +17,8 @@ GPU_DEFINE_PRIMITIVE_TYPE_ID(scatter_elements_update)
 layout scatter_elements_update_inst::calc_output_layout(scatter_elements_update_node const& node, kernel_impl_params const& impl_param) {
     auto desc = impl_param.typed_desc<scatter_elements_update>();
 
-    const int32_t axis = desc->axis;
-    const size_t input_number_of_dims = impl_param.get_input_layout().get_partial_shape().size();
+    const int64_t axis = desc->axis;
+    const int64_t input_number_of_dims = static_cast<int64_t>(impl_param.get_input_layout().get_partial_shape().size());
 
     auto input_layout = impl_param.get_input_layout();
 
@@ -30,7 +30,7 @@ layout scatter_elements_update_inst::calc_output_layout(scatter_elements_update_
         output_type = impl_param.get_output_element_type();
     }
 
-    if (static_cast<size_t>(axis) < 0 || static_cast<size_t>(axis) >= input_number_of_dims)
+    if (axis < 0 || axis >= input_number_of_dims)
         CLDNN_ERROR_MESSAGE(desc->id, "Incorrect axis value for ScatterElementsUpdate: Axis must be positive and less than the input tensor dimension.");
 
     return layout{output_shape, output_type, input_format};

--- a/src/plugins/intel_gpu/src/graph/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/graph/space_to_batch.cpp
@@ -63,7 +63,7 @@ layout space_to_batch_inst::calc_output_layout(space_to_batch_node const& node, 
 static std::vector<int32_t> tensor_to_vec(const tensor& t, const format f) {
     std::vector<int32_t> vec(cldnn::format::dimension(f));
     for (size_t i = 0; i < vec.size(); ++i) {
-        vec[i] = t.sizes()[i];
+        vec[i] = static_cast<int32_t>(t.sizes()[i]);
     }
     std::reverse(vec.begin() + 2, vec.end());
     return vec;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/multiclass_nms/multiclass_nms_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/multiclass_nms/multiclass_nms_kernel_ref.cpp
@@ -89,14 +89,14 @@ JitConstants MulticlassNmsKernelRef::GetJitConstants(const multiclass_nms_params
 
     int64_t max_output_boxes_per_class = 0;
     if (params.nms_top_k >= 0) {
-        max_output_boxes_per_class = std::min<int>(static_cast<int>(num_boxes), params.nms_top_k);
+        max_output_boxes_per_class = std::min<int64_t>(static_cast<int64_t>(num_boxes), params.nms_top_k);
     } else {
         max_output_boxes_per_class = num_boxes;
     }
 
     auto max_output_boxes_per_batch = max_output_boxes_per_class * real_num_classes;
     if (params.keep_top_k >= 0)
-        max_output_boxes_per_batch = std::min<int>(max_output_boxes_per_batch, params.keep_top_k);
+        max_output_boxes_per_batch = std::min<int64_t>(max_output_boxes_per_batch, params.keep_top_k);
 
     jit.AddConstants({
         MakeJitConstant("SORT_RESULT_TYPE", static_cast<int>(params.sort_result_type)),

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_pil_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_pil_ref.cpp
@@ -93,22 +93,22 @@ std::size_t GetKernelsNum(const resample_params& params) {
 }
 
 std::size_t GetFirstRow(const resample_params& params) {
-    float scale = static_cast<float>(getInputVerticalSize(params, true)) / getOutputVerticalSize(params);
+    float scale = static_cast<float>(getInputVerticalSize(params, true)) / static_cast<float>(getOutputVerticalSize(params));
     float filter_scale = std::max(1.f, scale);
     float support = params.resampleType == ResampleType::BILINEAR_PILLOW ? 1.f : 2.f * filter_scale;
-    float center = 0.5 * scale;
-    auto xmin = std::max(0, static_cast<int>(center - support + 0.5));
+    float center = 0.5f * scale;
+    auto xmin = std::max(0, static_cast<int>(center - support + 0.5f));
     return xmin;
 }
 
 std::size_t GetLastRow(const resample_params& params) {
     auto inputVerticalSize = getInputVerticalSize(params, true);
     auto outputVerticalSize = getOutputVerticalSize(params);
-    float scale = static_cast<float>(inputVerticalSize) / outputVerticalSize;
+    float scale = static_cast<float>(inputVerticalSize) / static_cast<float>(outputVerticalSize);
     float filter_scale = std::max(1.f, scale);
     float support = params.resampleType == ResampleType::BILINEAR_PILLOW ? 1.f : 2.f * filter_scale;
-    float center = (outputVerticalSize - 0.5) * scale;
-    auto xmax = std::min(inputVerticalSize, static_cast<std::size_t>(center + support + 0.5));
+    float center = (outputVerticalSize - 0.5f) * scale;
+    auto xmax = std::min(inputVerticalSize, static_cast<std::size_t>(center + support + 0.5f));
     return xmax;
 }
 
@@ -379,7 +379,7 @@ JitConstants ResampleKernelPilRef::GetJitConstantsForKernel(KernelId id, const r
                 MakeJitConstant("ENABLE_VERTICAL_PASS", NeedVerticalPass(params)),
                 MakeJitConstant("ENABLE_HORIZONTAL_PASS", needHorizontalPass),
                 MakeJitConstant("KSIZE", ksize),
-            }); 
+            });
             if (needHorizontalPass) {
                 jit_constants.AddConstant(MakeJitConstant("RESAMPLE_VERTICAL_INPUT_TYPE", "INTERMEDIATE_BUF_TYPE"));
             } else {

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -160,13 +160,13 @@ Graph::~Graph() {
 
             const auto begin = std::begin(host_exec_times) + 1;
             const auto end = std::end(host_exec_times);
-            avg.inputs_processing = std::accumulate(begin, end, 0,
+            avg.inputs_processing = std::accumulate(begin, end, int64_t{0},
                 [](int64_t sum, const HostTimeProfilingEntry& entry) { return sum + entry.inputs_processing; });
-            avg.enqueue = std::accumulate(begin, end, 0,
+            avg.enqueue = std::accumulate(begin, end, int64_t{0},
                 [](int64_t sum, const HostTimeProfilingEntry& entry) { return sum + entry.enqueue; });
-            avg.wait = std::accumulate(begin, end, 0,
+            avg.wait = std::accumulate(begin, end, int64_t{0},
                 [](int64_t sum, const HostTimeProfilingEntry& entry) { return sum + entry.wait; });
-            avg.outputs_processing = std::accumulate(begin, end, 0,
+            avg.outputs_processing = std::accumulate(begin, end, int64_t{0},
                 [](int64_t sum, const HostTimeProfilingEntry& entry) { return sum + entry.outputs_processing; });
 
             const auto iters_num = host_exec_times.size() - 1;

--- a/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
@@ -34,7 +34,7 @@ static void CreateConvolutionOp(ProgramBuilder& p, const std::shared_ptr<ov::int
     auto outDims = op->get_output_partial_shape(0);
 
     cldnn::primitive_id weights = inputs[op::Convolution::Args::WEIGHTS].pid;
-    const uint32_t groups = std::max<int64_t>(op->get_groups(), 1);
+    const uint32_t groups = static_cast<uint32_t>(std::max<int64_t>(op->get_groups(), 1));
     const bool weights_have_group_dim = op->get_groups() > 0;
 
     auto strides = op->get_strides();
@@ -288,8 +288,8 @@ static void DeformableConvolutionImpl(ProgramBuilder& p,
                                        weights,
                                        "",
                                        true,
-                                       groups,
-                                       deformable_groups_num,
+                                       static_cast<uint32_t>(groups),
+                                       static_cast<uint32_t>(deformable_groups_num),
                                        strides,
                                        dilations,
                                        padding,

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_roi_feature_extractor.cpp
@@ -20,9 +20,9 @@ static void CreateExperimentalDetectronROIFeatureExtractorOp(ProgramBuilder& p,
     if (p.use_new_shape_infer()) {
         cldnn::experimental_detectron_roi_feature_extractor prim(layer_type_name_ID(op),
                                                                  inputs,
-                                                                 operation_attributes.output_size,
+                                                                 static_cast<int>(operation_attributes.output_size),
                                                                  operation_attributes.pyramid_scales,
-                                                                 operation_attributes.sampling_ratio,
+                                                                 static_cast<int>(operation_attributes.sampling_ratio),
                                                                  operation_attributes.aligned);
         prim.num_outputs = op->get_output_size();
         prim.output_data_types = get_output_data_types(op, {{ov::element::i64, ov::element::i32}});
@@ -46,9 +46,9 @@ static void CreateExperimentalDetectronROIFeatureExtractorOp(ProgramBuilder& p,
 
         cldnn::experimental_detectron_roi_feature_extractor experimentalDetectronPrim(layerName,
                                                                                     inputs,
-                                                                                    operation_attributes.output_size,
+                                                                                    static_cast<int>(operation_attributes.output_size),
                                                                                     operation_attributes.pyramid_scales,
-                                                                                    operation_attributes.sampling_ratio,
+                                                                                    static_cast<int>(operation_attributes.sampling_ratio),
                                                                                     operation_attributes.aligned);
         p.add_primitive(*op, experimentalDetectronPrim);
 

--- a/src/plugins/intel_gpu/src/plugin/ops/eye.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/eye.cpp
@@ -37,7 +37,7 @@ static void CreateEyeOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v9::Eye
         shift = *constant->get_data_ptr<int32_t>();
         break;
     case ov::element::Type_t::i64:
-        shift = *constant->get_data_ptr<int64_t>();
+        shift = static_cast<int32_t>(*constant->get_data_ptr<int64_t>());
         break;
     default:
         throw std::runtime_error{"Input type can be only either i32 or i64"};

--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -74,6 +74,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
     static const size_t AXES_INDEX = 3;
 
     auto attrs = op->get_attrs();
+    const float cube_coeff = static_cast<float>(attrs.cube_coeff);
 
     auto sizes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(SIZES_INDEX));
     std::vector<int64_t> sizes = sizes_constant ? sizes_constant->cast_vector<int64_t>() : std::vector<int64_t>{};
@@ -101,7 +102,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
                                                              attrs.pads_begin,
                                                              attrs.pads_end,
                                                              attrs.antialias,
-                                                             attrs.cube_coeff,
+                                                             cube_coeff,
                                                              attrs.mode,
                                                              attrs.shape_calculation_mode,
                                                              attrs.coordinate_transformation_mode,
@@ -115,7 +116,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
                                                              attrs.pads_begin,
                                                              attrs.pads_end,
                                                              attrs.antialias,
-                                                             attrs.cube_coeff,
+                                                             cube_coeff,
                                                              attrs.mode,
                                                              attrs.shape_calculation_mode,
                                                              attrs.coordinate_transformation_mode,
@@ -133,7 +134,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
                                                          attrs.pads_begin,
                                                          attrs.pads_end,
                                                          attrs.antialias,
-                                                         attrs.cube_coeff,
+                                                         cube_coeff,
                                                          attrs.mode,
                                                          attrs.shape_calculation_mode,
                                                          attrs.coordinate_transformation_mode,
@@ -154,6 +155,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
     };
 
     auto attrs = op->get_attrs();
+    const float cube_coeff = static_cast<float>(attrs.cube_coeff);
 
     auto scales_or_sizes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(eScalesOrSizesIndex));
     std::vector<float> scales = scales_or_sizes_constant && attrs.shape_calculation_mode == ov::op::v11::Interpolate::ShapeCalcMode::SCALES ?
@@ -181,7 +183,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
                                                              attrs.pads_begin,
                                                              attrs.pads_end,
                                                              attrs.antialias,
-                                                             attrs.cube_coeff,
+                                                             cube_coeff,
                                                              attrs.mode,
                                                              attrs.shape_calculation_mode,
                                                              attrs.coordinate_transformation_mode,
@@ -195,7 +197,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
                                                              attrs.pads_begin,
                                                              attrs.pads_end,
                                                              attrs.antialias,
-                                                             attrs.cube_coeff,
+                                                             cube_coeff,
                                                              attrs.mode,
                                                              attrs.shape_calculation_mode,
                                                              attrs.coordinate_transformation_mode,
@@ -214,7 +216,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
                                                          attrs.pads_begin,
                                                          attrs.pads_end,
                                                          attrs.antialias,
-                                                         attrs.cube_coeff,
+                                                         cube_coeff,
                                                          attrs.mode,
                                                          attrs.shape_calculation_mode,
                                                          attrs.coordinate_transformation_mode,

--- a/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
@@ -110,7 +110,7 @@ static void SetLoopInputOutputMap(ProgramBuilder& p,
     // set output mapping
     if (use_new_shape_infer) {
         for (const auto& loop_output_desc : loop_output_descs) {
-            cldnn::input_info external_input_info(layerName, loop_output_desc->m_output_index);
+            cldnn::input_info external_input_info(layerName, static_cast<int>(loop_output_desc->m_output_index));
             p.primitive_ids[layerName] = layerName;
 
             const auto& body_output = body_outputs.at(loop_output_desc->m_body_value_index);
@@ -137,7 +137,7 @@ static void SetLoopInputOutputMap(ProgramBuilder& p,
         }
     } else {
         for (const auto& loop_output_desc : loop_output_descs) {
-            const uint64_t output_idx = loop_output_desc->m_output_index;
+            const int32_t output_idx = static_cast<int32_t>(loop_output_desc->m_output_index);
 
             // Add additional mutable_data for multiple outputs
             // primitive ID should be <TI primitive ID>.<output_idx> if output_idx > 0

--- a/src/plugins/intel_gpu/src/plugin/ops/mvn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/mvn.cpp
@@ -33,7 +33,7 @@ static void CreateMVNOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::MVN
 
     bool across_channels = op->get_across_channels();
     bool normalize_variance = op->get_normalize_variance();
-    float eps = op->get_eps();
+    float eps = static_cast<float>(op->get_eps());
 
     int64_t axes_count = std::max<int64_t>(static_cast<int64_t>(op->get_input_partial_shape(0).size()) - 2, 0);
     std::vector<int64_t> axes(axes_count);
@@ -56,7 +56,7 @@ static void CreateMVNOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v6::MVN
     ov::util::try_normalize_axes(axes, op->get_output_partial_shape(0).rank(), *op);
 
     bool normalize_variance = op->get_normalize_variance();
-    float eps = op->get_eps();
+    float eps = static_cast<float>(op->get_eps());
     bool eps_inside_sqrt = op->get_eps_mode() == ov::op::MVNEpsMode::INSIDE_SQRT;
 
     CreateCommonMVNOp(p, op, axes, normalize_variance, eps, eps_inside_sqrt);

--- a/src/plugins/intel_gpu/src/plugin/ops/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/paged_attention.cpp
@@ -51,7 +51,7 @@ static void CreatePagedAttentionExtensionOp(ProgramBuilder& p, const std::shared
 
     // WA: in some cases, the query input may have a bounded dimension
     // Use input shape of the input node in such cases
-    auto heads_num = 0;
+    int64_t heads_num = 0;
     auto query_merged_dim = query_ps[1];
     if (query_merged_dim.is_static()) {
         heads_num = query_merged_dim.get_length() / k_head_size;

--- a/src/plugins/intel_gpu/src/plugin/ops/rms.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/rms.cpp
@@ -15,10 +15,11 @@ static void CreateRMSOp(ProgramBuilder& p, const std::shared_ptr<RMS>& op) {
     validate_inputs_count(op, {1, 2});
     auto inputs = p.GetInputInfo(op);
     std::string primitive_name = layer_type_name_ID(op);
+    const float epsilon = static_cast<float>(op->get_epsilon());
 
     auto rms = op->get_elementwise_affine()
-        ? cldnn::rms(primitive_name, inputs[0], inputs[1], op->get_epsilon())
-        : cldnn::rms(primitive_name, inputs[0], op->get_epsilon());
+        ? cldnn::rms(primitive_name, inputs[0], inputs[1], epsilon)
+        : cldnn::rms(primitive_name, inputs[0], epsilon);
     rms.output_data_types = get_output_data_types(op);
     p.add_primitive(*op, rms);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
@@ -31,17 +31,17 @@ static void CreateDeformablePSROIPoolingOp(ProgramBuilder& p, const std::shared_
 
     cldnn::pooling_mode mode = GetPoolingMode(op->get_mode());
     float trans_std = op->get_trans_std();
-    int part_size = op->get_part_size();
+    int part_size = static_cast<int>(op->get_part_size());
     bool no_trans = op->get_input_size() == 2 ? true : false;
 
     // temporary workaround due to incorrect usage of group_size in the nGraph operation for the DeformablePSROIPooling
-    int pooled_width = op->get_group_size();
-    int pooled_height = op->get_group_size();
-    int group_size = op->get_group_size();
-    int output_dim = op->get_output_dim();
+    int pooled_width = static_cast<int>(op->get_group_size());
+    int pooled_height = static_cast<int>(op->get_group_size());
+    int group_size = static_cast<int>(op->get_group_size());
+    int output_dim = static_cast<int>(op->get_output_dim());
     float spatial_scale = op->get_spatial_scale();
-    int spatial_bins_x = op->get_spatial_bins_x();
-    int spatial_bins_y = op->get_spatial_bins_y();
+    int spatial_bins_x = static_cast<int>(op->get_spatial_bins_x());
+    int spatial_bins_y = static_cast<int>(op->get_spatial_bins_y());
     bool position_sensitive = true;
 
     auto psROIPoolingPrim = cldnn::roi_pooling(layerName,

--- a/src/plugins/intel_gpu/src/plugin/ops/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/shuffle_channels.cpp
@@ -15,8 +15,8 @@ static void CreateShuffleChannelsOp(ProgramBuilder& p, const std::shared_ptr<ov:
     auto inputs = p.GetInputInfo(op);
     std::string layerName = layer_type_name_ID(op);
 
-    int32_t group = op->get_group();
-    int64_t axis = ov::util::try_normalize_axis(op->get_axis(), op->get_input_partial_shape(0).rank(), *op);
+    int32_t group = static_cast<int32_t>(op->get_group());
+    int32_t axis = static_cast<int32_t>(ov::util::try_normalize_axis(op->get_axis(), op->get_input_partial_shape(0).rank(), *op));
 
     auto shuffleChannelsPrim = cldnn::shuffle_channels(layerName,
                                                        inputs[0],

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -968,12 +968,12 @@ uint32_t Plugin::get_optimal_batch_size(const ov::AnyMap& options) const {
     ov::MemBandwidthPressure memPressure = ov::mem_bandwidth_pressure_tolerance(cloned_model, L3_cache_size);
     uint32_t batch = 1;
     if (memPressure.max_mem_tolerance != ov::MemBandwidthPressure::UNKNOWN)
-        batch = std::max(1.0, 16 * closest_pow_of_2(memPressure.max_mem_tolerance));
+        batch = static_cast<uint32_t>(std::max(1.0, 16 * closest_pow_of_2(memPressure.max_mem_tolerance)));
     ov::AnyMap options_for_max_batch;
     options_for_max_batch[ov::hint::model.name()] = model;
     options_for_max_batch[ov::num_streams.name()] = ov::streams::AUTO;
     auto max_batch_size = get_metric(ov::max_batch_size.name(), options_for_max_batch).as<uint32_t>();
-    uint32_t closest = closest_pow_of_2(max_batch_size);
+    uint32_t closest = static_cast<uint32_t>(closest_pow_of_2(max_batch_size));
     batch = std::min(closest, batch);
     batch = std::min(256u, batch); //batch 256 is a max
     GPU_DEBUG_INFO << memPressure.max_mem_tolerance << std::endl;

--- a/src/plugins/intel_gpu/src/plugin/transformations/optimize_subsequent_reshapes.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/optimize_subsequent_reshapes.cpp
@@ -77,7 +77,7 @@ OptimizeSubsequentReshapes::OptimizeSubsequentReshapes() {
             if (dim.is_dynamic()) {
                 new_pattern.push_back(-1);
             } else {
-                new_pattern.push_back(dim.get_length());
+                new_pattern.push_back(static_cast<int32_t>(dim.get_length()));
             }
         }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/swiglu_fusion_with_clamp.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/swiglu_fusion_with_clamp.cpp
@@ -61,8 +61,8 @@ namespace intel_gpu {
                 return false;
 
             auto clamp_node = ov::as_type_ptr<ov::op::v0::Clamp>(pattern_map.at(clamp_m).get_node_shared_ptr());
-            auto clamp_min_value = clamp_node->get_min();
-            auto clamp_max_value = clamp_node->get_max();
+            auto clamp_min_value = static_cast<float>(clamp_node->get_min());
+            auto clamp_max_value = static_cast<float>(clamp_node->get_max());
 
             size_t gate_idx = 0;
             if (ov::is_type<ov::op::v4::Swish>(mul_node_ptr->get_input_node_shared_ptr(1)))

--- a/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.cpp
@@ -81,7 +81,10 @@ UnsqueezeBroadcastReshapeSDPAFusion::UnsqueezeBroadcastReshapeSDPAFusion() {
             auto input_node = broadcast->get_input_node_shared_ptr(0);
             if (input_node && input_node->get_output_partial_shape(0).is_static()) {
                 auto pshape = input_node->get_output_shape(0);
-                return std::vector<int32_t>(pshape.begin(), pshape.end());
+                std::vector<int32_t> result(pshape.size());
+                std::transform(pshape.begin(), pshape.end(), result.begin(),
+                               [](size_t v) { return static_cast<int32_t>(v); });
+                return result;
             }
             return {};
         };

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -441,13 +441,13 @@ size_t memory_pool::get_total_mem_pool_size(allocation_type type) {
 #endif
 }
 
-void memory_pool::dump(uint32_t net_id, uint32_t iter, std::string dump_dir_path) {
+void memory_pool::dump(uint32_t net_id, int64_t iter, std::string dump_dir_path) {
     dump_to_screen(net_id, iter);
     if (!dump_dir_path.empty())
         dump_to_file(net_id, iter, dump_dir_path);
 }
 
-void memory_pool::dump_to_file(uint32_t net_id, uint32_t iter, std::string dump_dir_path) {
+void memory_pool::dump_to_file(uint32_t net_id, int64_t iter, std::string dump_dir_path) {
 #ifdef GPU_DEBUG_CONFIG
     const std::string dump_file_name = "dump_runtime_memory_pool_net_" + std::to_string(net_id) + "_iter_" + std::to_string(iter) + ".csv";
     const std::string desc = "pool_type,layout,mem_ptr,mem_type,mem_pool_size,prim_id,unique_id,mem_size";
@@ -482,7 +482,7 @@ void memory_pool::dump_to_file(uint32_t net_id, uint32_t iter, std::string dump_
 #endif
 }
 
-void memory_pool::dump_to_screen(uint32_t net_id, uint32_t iter) {
+void memory_pool::dump_to_screen(uint32_t net_id, int64_t iter) {
 #ifdef GPU_DEBUG_CONFIG
     GPU_DEBUG_COUT << "Dump memory pool of network (net_id : " << net_id << ", iter : " << iter << ")" << std::endl;
     size_t total_requested_mem_non_padded_pool    = 0;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -187,7 +187,7 @@ void set_arguments_impl(ocl_kernel_type& kernel,
             case args_t::LOCAL_MEMORY_SIZE:
                 OPENVINO_ASSERT(args[i].index < data.local_memory_args->size() && data.local_memory_args->at(args[i].index),
                                 "The allocated local memory is necessary to set kernel arguments.");
-                status = set_kernel_arg(kernel, i,  data.local_memory_args->at(args[i].index));
+                status = set_kernel_arg(kernel, i, static_cast<uint32_t>(data.local_memory_args->at(args[i].index)));
                 break;
                 break;
             default:


### PR DESCRIPTION
### Details:

### Details:

- Continue fixing implicit narrowing conversions (C4244) in GPU plugin for `/wd4244` removal (BinSkim BA2007 compliance)
  - Widen local variables to match source types (`int64_t`, `ov::Dimension::value_type`, `tensor::value_type`) instead of narrowing with `static_cast`; use `static_cast` only at API boundaries (kernel_selector `uint32_t`, oneDNN `int`, OpenCL API)
  - Fix `double` → `float` narrowing with `sqrtf()`, float literals (`0.5f`), or `static_cast<float>()` in kernel param calculations
  - Deduplicate conversion patterns: `append_from_lock` lambda in `memory.hpp`, `to_i32_vec`/`to_u8_vec` helpers in `strided_slice.cpp`
  - Fix type mismatches in debug/runtime infra: `m_iter` (`size_t` → `int64_t`), `dump()` signature (`uint32_t` → `uint64_t`)
  - Remove dead code in `border.cpp` and `detection_output.cpp`

### Tickets:

- [CVS-185007](https://jira.devtools.intel.com/browse/CVS-185007)

### AI Assistance:

- AI assistance used: yes
- GitHub Copilot used for code analysis (identifying root causes of each warning, evaluating fix options for type safety), generating fix code, and verifying build results with `CMAKE_COMPILE_WARNING_AS_ERROR=ON` (`/WX`). All changes were human-reviewed for correctness, validated via local `/WX` clean build with `ENABLE_TESTS=ON`, and confirmed to have no performance or accuracy impact.