### PR TITLE
[PyTorch Frontend] Map torch.clamp to native Clamp op for constant bounds

### DIFF
--- a/src/frontends/pytorch/src/op/clamp.cpp
+++ b/src/frontends/pytorch/src/op/clamp.cpp
@@ -6,6 +6,8 @@
 #include "openvino/op/convert_like.hpp"
 #include "openvino/op/maximum.hpp"
 #include "openvino/op/minimum.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/constant.hpp"
 #include "utils.hpp"
 
 namespace ov {
@@ -18,6 +20,40 @@ using namespace ov::op;
 OutputVector translate_clamp(const NodeContext& context) {
     num_inputs_check(context, 1, 3);
     auto x = context.get_input(0);
+
+    bool min_is_const_scalar = context.input_is_none(1);
+    bool max_is_const_scalar = context.input_is_none(2);
+    double min_val = std::numeric_limits<double>::lowest();
+    double max_val = std::numeric_limits<double>::max();
+
+    // Check if 'min' is a constant scalar
+    if (!context.input_is_none(1)) {
+        if (auto min_const = ov::as_type_ptr<v0::Constant>(context.get_input(1).get_node_shared_ptr())) {
+            auto min_vals = min_const->cast_vector<double>();
+            if (min_vals.size() == 1) {
+                min_is_const_scalar = true;
+                min_val = min_vals[0];
+            }
+        }
+    }
+
+    // Check if 'max' is a constant scalar
+    if (!context.input_is_none(2)) {
+        if (auto max_const = ov::as_type_ptr<v0::Constant>(context.get_input(2).get_node_shared_ptr())) {
+            auto max_vals = max_const->cast_vector<double>();
+            if (max_vals.size() == 1) {
+                max_is_const_scalar = true;
+                max_val = max_vals[0];
+            }
+        }
+    }
+
+    // Use native Clamp if bounds are constants
+    if (min_is_const_scalar && max_is_const_scalar && (!context.input_is_none(1) || !context.input_is_none(2))) {
+        return {context.mark_node(std::make_shared<v0::Clamp>(x, min_val, max_val))};
+    }
+
+    // Fallback for dynamic tensor bounds
     if (!context.input_is_none(1)) {
         auto min_clip = context.get_input(1);
         min_clip = context.mark_node(std::make_shared<v1::ConvertLike>(min_clip, x));


### PR DESCRIPTION
Fixes #33033.

Previously, torch.clamp was always decomposed into Maximum and Minimum nodes. While mathematically equivalent, this bypassed the optimized native Clamp paths in the CPU plugin (specifically dnnl::algorithm::eltwise_clip), leading to bounds overflow during C++ inference for certain precisions like 16-bit integers (e.g., 10-bit video processing).

This commit checks if the bounds are constant scalars and maps them directly to ov::op::v0::Clamp, falling back to the decomposed logic only for dynamic tensor bounds.