### PR TITLE
[Skills] Apply code standards skill

### DIFF
--- a/.claude/skills/apply-code-standards/SKILL.md
+++ b/.claude/skills/apply-code-standards/SKILL.md
@@ -11,14 +11,15 @@ Iteratively detect and fix all clang-format, clang-tidy, and copyright violation
 
 ## Step 1: Identify Affected Build Targets
 
-Detect the upstream base branch:
+Ask the user which files to check:
+> "Should I check uncommitted changes only, or all changes on the current branch? If the full branch, what is the upstream branch to diff against (e.g. `origin/master`)?"
 
+For **uncommitted changes** (staged + unstaged):
 ```bash
-git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || git rev-parse --abbrev-ref origin/HEAD 2>/dev/null
+{ git diff --name-only HEAD; git diff --name-only --cached; } | sort -u | grep -v '^thirdparty' | tee /tmp/changed_files.txt
 ```
 
-List changed files (excluding submodules) and write to a temp file for reuse across steps:
-
+For **full branch** (all commits since upstream):
 ```bash
 git diff --name-only <upstream> | grep -v '^thirdparty' | tee /tmp/changed_files.txt
 ```
@@ -28,7 +29,25 @@ Map them to CMake targets. If the mapping is not obvious, ask the user:
 
 ## Step 2: Configure with clang-18 + Style Checks
 
-Configure the project with clang-18 and both style options enabled per [docs/dev/coding_style.md](../../../docs/dev/coding_style.md). If the user already has a configured build directory, re-run cmake in it with just the new flags appended — do not wipe their existing configuration.
+clang-tidy requires the build to use clang-18 as the compiler. Check whether an existing build directory already uses clang-18:
+
+```bash
+grep "CMAKE_CXX_COMPILER" <build_dir>/CMakeCache.txt | grep -i clang
+```
+
+- **If it does**, re-run cmake in it with the style flags appended — do not wipe the existing configuration:
+  ```bash
+  cmake -DENABLE_CLANG_FORMAT=ON -DENABLE_CLANG_TIDY=ON <build_dir>
+  ```
+- **If it doesn't** (or no build directory exists), create a dedicated `build-clang/` directory:
+  ```bash
+  mkdir -p build-clang && cd build-clang
+  cmake -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 \
+        -DENABLE_CLANG_FORMAT=ON -DENABLE_CLANG_TIDY=ON \
+        -DCMAKE_BUILD_TYPE=Release ..
+  ```
+
+See [docs/dev/coding_style.md](../../../docs/dev/coding_style.md) for full flag reference.
 
 ## Step 3: Check, Fix, Repeat
 

--- a/.claude/skills/apply-code-standards/SKILL.md
+++ b/.claude/skills/apply-code-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apply-code-standards
-description: Detect and fix clang-format, clang-tidy, and copyright header violations in an OpenVINO C++ codebase. Trigger on: code style/formatting complaints, "cleanup changes", "fix linting", "copyright header missing/wrong", "style check failing", "linting CI failure". DO NOT trigger for build errors, compilation failures, linker errors, test failures, runtime crashes, accuracy issues, or CMake config problems.
+description: Detect and fix clang-format, clang-tidy, and copyright header violations in an OpenVINO C++ codebase. Use when the user complains about code style or formatting, asks to clean up changes, fix linting, add a copyright header, or when a style check or linting CI job is failing. Do not use for build errors, compilation failures, linker errors, test failures, runtime crashes, accuracy issues, or CMake config problems.
 ---
 
 # Apply Code Standards

--- a/.claude/skills/apply-code-standards/SKILL.md
+++ b/.claude/skills/apply-code-standards/SKILL.md
@@ -28,20 +28,7 @@ Map them to CMake targets. If the mapping is not obvious, ask the user:
 
 ## Step 2: Configure with clang-18 + Style Checks
 
-Locate or create a build directory (typically `build/` or `build-clang/` in the repo root).
-
-Run CMake with clang-18 and both style options enabled:
-
-```bash
-cmake -S <repo_root> -B <build_dir> \
-  -DCMAKE_C_COMPILER=clang-18 \
-  -DCMAKE_CXX_COMPILER=clang++-18 \
-  -DENABLE_CLANG_FORMAT=ON \
-  -DENABLE_CLANG_TIDY=ON \
-  [any other flags already in use by the user's build]
-```
-
-If the user already has a configured build directory, re-run cmake in it with just the new flags appended — do not wipe their existing configuration.
+Configure the project with clang-18 and both style options enabled per [docs/dev/coding_style.md](../../../docs/dev/coding_style.md). If the user already has a configured build directory, re-run cmake in it with just the new flags appended — do not wipe their existing configuration.
 
 ## Step 3: Check, Fix, Repeat
 
@@ -49,27 +36,11 @@ Follow the fix order from `coding_style.md`: copyright → clang-tidy → clang-
 
 ### 3a. Copyright headers
 
-```bash
-python3 .github/scripts/check_copyright.py /tmp/changed_files.txt
-```
-
-If non-zero exit, inspect then apply the generated patch:
-```bash
-cat copyright_fixes.diff
-patch -p1 < copyright_fixes.diff
-python3 .github/scripts/check_copyright.py /tmp/changed_files.txt
-```
-
-If the patch looks wrong, fix the copyright header directly in the file.
+Run the check script and patch workflow per [coding_style.md](../../../docs/dev/coding_style.md). If the patch looks wrong, fix the header directly in the file.
 
 ### 3b. clang-tidy
 
-Build affected targets as a background task:
-```bash
-cmake --build <build_dir> --target <target1> --target <target2> -- -j$(nproc) 2>&1 | tee /tmp/ct_check.txt
-```
-
-After completion, separate the two issue categories for your changed files:
+Build the affected targets (pipe to `/tmp/ct_check.txt`), then separate the two issue categories for your changed files:
 ```bash
 # Compilation errors (no check name in brackets)
 grep "error:" /tmp/ct_check.txt | grep -v "\[" | grep -Ff /tmp/changed_files.txt
@@ -78,30 +49,13 @@ grep "error:" /tmp/ct_check.txt | grep -v "\[" | grep -Ff /tmp/changed_files.txt
 grep -E "warning:|error:" /tmp/ct_check.txt | grep "\[" | grep -Ff /tmp/changed_files.txt
 ```
 
-**Fix compilation errors first (manual):** Read each error and fix by hand. Rebuild to confirm clean before proceeding — `ENABLE_CLANG_TIDY_FIX` cannot help with these.
+**Fix compilation errors first:** `ENABLE_CLANG_TIDY_FIX` cannot help with these.
 
-**Auto-fix clang-tidy diagnostics:** Once the code compiles cleanly:
-```bash
-cmake <build_dir> -DENABLE_CLANG_TIDY_FIX=ON
-cmake --build <build_dir> --target <target1> --target <target2> -- -j$(nproc) 2>&1 | tee /tmp/ct_fix.txt
-cmake <build_dir> -DENABLE_CLANG_TIDY_FIX=OFF
-```
-
-**Manual fix (remaining tidy issues):** For diagnostics auto-fix missed or got wrong, fix by hand. If a check cannot be resolved, **do not add `// NOLINT` on your own** — present the diagnostic to the user and ask whether to suppress, refactor, or handle it another way.
+If a tidy diagnostic cannot be resolved, **do not add `// NOLINT` on your own** — present it to the user and ask whether to suppress, refactor, or handle it another way.
 
 ### 3c. clang-format
 
-```bash
-cmake --build <build_dir> --target clang_format_check_all 2>&1 | tee /tmp/cf_check.txt
-grep "Code style check failed" /tmp/cf_check.txt
-```
-
-If failures found, auto-fix:
-```bash
-cmake --build <build_dir> --target clang_format_fix_all 2>&1 | tee /tmp/cf_fix.txt
-```
-
-Re-run the check to confirm clean. If auto-fix still fails, fix the specific file manually.
+Use `clang_format_check_all` to detect violations, `clang_format_fix_all` to auto-fix (see [coding_style.md](../../../docs/dev/coding_style.md)). Pipe output to `/tmp/cf_check.txt` and grep for `"Code style check failed"`. Re-run the check after fixing to confirm clean.
 
 ### 3d. Stop condition
 

--- a/.claude/skills/apply-code-standards/SKILL.md
+++ b/.claude/skills/apply-code-standards/SKILL.md
@@ -7,18 +7,22 @@ description: Detect and fix clang-format, clang-tidy, and copyright header viola
 
 Iteratively detect and fix all clang-format, clang-tidy, and copyright violations introduced by the current branch's changes.
 
-## Step 1: Identify Affected Build Targets
+## Step 1: Identify Affected Files and Build Targets
 
-Ask the user to confirm the upstream reference:
+**Before running any commands**, check whether the upstream reference is already confirmed in the conversation. If it is not, stop and ask:
+
 > "I'll diff against `upstream/master`. Let me know if you use a different upstream."
 
+Do not proceed until the user replies. Use the confirmed reference <ref_branch> in all subsequent steps. Once the upstream branch is known, you must fetch <ref_branch> and find a merge-base commit <ref_commit>, against which the diff should be collected. Then run:
+
 ```bash
-git diff --name-only <ref> | grep -v '^thirdparty' | tee /tmp/changed_files.txt
+git diff --name-only <ref_commit> | grep -v '^thirdparty' | tee /tmp/changed_files.txt
 ```
 
-Map them to CMake targets. If the mapping is not obvious, ask the user:
+Map the changed files to CMake targets. If the mapping is not obvious, ask the user:
+
 > "Which CMake targets cover the files you changed? (e.g., `openvino_intel_cpu_plugin`)"
 
 ## Step 2: Check, Fix, Repeat
 
-Follow the fix order from [coding_style.md](../../../docs/dev/coding_style.md). Repeat until all checks pass.
+**Follow the fix order and tool instructions from [coding_style.md](../../../docs/dev/coding_style.md) exactly  — do not rearrange or skip steps.** Read that file before proceeding. Repeat the full cycle until all checks pass.

--- a/.claude/skills/apply-code-standards/SKILL.md
+++ b/.claude/skills/apply-code-standards/SKILL.md
@@ -7,6 +7,8 @@ description: Detect and fix clang-format, clang-tidy, and copyright header viola
 
 Iteratively detect and fix all clang-format, clang-tidy, and copyright violations introduced by the current branch's changes.
 
+> Background on each tool (flags, targets, install instructions, recommended fix order): [docs/dev/coding_style.md](../../../docs/dev/coding_style.md).
+
 ## Step 1: Identify Affected Build Targets
 
 Detect the upstream base branch:
@@ -39,89 +41,68 @@ cmake -S <repo_root> -B <build_dir> \
   [any other flags already in use by the user's build]
 ```
 
-If the user already has a configured build directory, re-run cmake in it with just the three new flags appended — do not wipe their existing configuration.
+If the user already has a configured build directory, re-run cmake in it with just the new flags appended — do not wipe their existing configuration.
 
 ## Step 3: Check, Fix, Repeat
 
-Repeat steps 3a–3d until all checks pass.
+Follow the fix order from `coding_style.md`: copyright → clang-tidy → clang-format. Repeat until all checks pass.
 
 ### 3a. Copyright headers
 
-**Check:**
 ```bash
 python3 .github/scripts/check_copyright.py /tmp/changed_files.txt
 ```
 
-**Auto-fix:** If non-zero exit, inspect the generated patch before applying — it is usually correct but can occasionally be malformed:
+If non-zero exit, inspect then apply the generated patch:
 ```bash
 cat copyright_fixes.diff
 patch -p1 < copyright_fixes.diff
 python3 .github/scripts/check_copyright.py /tmp/changed_files.txt
 ```
 
-**Manual fix:** If the patch looks wrong, fix the copyright header directly in the file instead.
+If the patch looks wrong, fix the copyright header directly in the file.
 
 ### 3b. clang-tidy
 
-**Check:** Build affected targets as a background task. For multiple targets, repeat `--target`:
-
+Build affected targets as a background task:
 ```bash
 cmake --build <build_dir> --target <target1> --target <target2> -- -j$(nproc) 2>&1 | tee /tmp/ct_check.txt
 ```
 
-After completion, separate the two categories of issues in your changed files:
-
+After completion, separate the two issue categories for your changed files:
 ```bash
-# Compilation errors (no clang-tidy check name in brackets)
+# Compilation errors (no check name in brackets)
 grep "error:" /tmp/ct_check.txt | grep -v "\[" | grep -Ff /tmp/changed_files.txt
 
 # clang-tidy diagnostics (have check name in brackets, e.g. [modernize-use-auto])
 grep -E "warning:|error:" /tmp/ct_check.txt | grep "\[" | grep -Ff /tmp/changed_files.txt
 ```
 
-**Fix compilation errors first (manual):** If non-tidy compilation errors are present, read each error and fix the source file by hand. Rebuild to confirm they are resolved before moving on — `ENABLE_CLANG_TIDY_FIX` cannot help with these.
+**Fix compilation errors first (manual):** Read each error and fix by hand. Rebuild to confirm clean before proceeding — `ENABLE_CLANG_TIDY_FIX` cannot help with these.
 
-**Auto-fix clang-tidy diagnostics:** Once the code compiles cleanly, re-configure with `ENABLE_CLANG_TIDY_FIX=ON` and rebuild as a background task:
-
+**Auto-fix clang-tidy diagnostics:** Once the code compiles cleanly:
 ```bash
 cmake <build_dir> -DENABLE_CLANG_TIDY_FIX=ON
 cmake --build <build_dir> --target <target1> --target <target2> -- -j$(nproc) 2>&1 | tee /tmp/ct_fix.txt
-```
-
-Re-check diagnostics after the build. Then reset the flag:
-```bash
 cmake <build_dir> -DENABLE_CLANG_TIDY_FIX=OFF
 ```
 
-**Manual fix (remaining tidy issues):** For any tidy diagnostics that auto-fix missed or produced incorrect changes, read the message carefully and fix the source file by hand. If a check fires repeatedly and cannot be fixed, **do not add `// NOLINT` suppressions on your own** — present the diagnostic to the user and ask whether to suppress, refactor, or handle it another way.
+**Manual fix (remaining tidy issues):** For diagnostics auto-fix missed or got wrong, fix by hand. If a check cannot be resolved, **do not add `// NOLINT` on your own** — present the diagnostic to the user and ask whether to suppress, refactor, or handle it another way.
 
 ### 3c. clang-format
 
-**Check:** Run as a background task:
 ```bash
 cmake --build <build_dir> --target clang_format_check_all 2>&1 | tee /tmp/cf_check.txt
-```
-
-After completion, check for failures:
-```bash
 grep "Code style check failed" /tmp/cf_check.txt
 ```
 
-**Auto-fix:** If failures found, run the fix target as a background task:
+If failures found, auto-fix:
 ```bash
 cmake --build <build_dir> --target clang_format_fix_all 2>&1 | tee /tmp/cf_fix.txt
 ```
 
-Re-run the check to confirm clean.
-
-**Manual fix:** If auto-fix still fails (very rare), fix the specific file manually and re-check.
+Re-run the check to confirm clean. If auto-fix still fails, fix the specific file manually.
 
 ### 3d. Stop condition
 
-When the copyright check passes, `clang_format_check_all` produces no "Code style check failed" lines, **and** the changed-file grep in 3b produces zero output, stop and report success to the user.
-
-## Notes
-
-- Always prefer `clang-format-18` / `clang-tidy-18` (versioned binaries) over unversioned ones — the project enforces version 18.
-- If clang-18 is not installed, inform the user: `sudo apt install clang-18 clang-format-18 clang-tidy-18`.
-- Do not modify files outside the set touched by the current branch unless a clang-tidy fix requires it (e.g., a header change). In that case, inform the user.
+When the copyright check passes, `clang_format_check_all` produces no "Code style check failed" lines, and the changed-file grep in 3b produces zero output — report success to the user.

--- a/.claude/skills/apply-code-standards/SKILL.md
+++ b/.claude/skills/apply-code-standards/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: apply-code-standards
+description: Detect and fix clang-format, clang-tidy, and copyright header violations in an OpenVINO C++ codebase. Trigger on: code style/formatting complaints, "cleanup changes", "fix linting", "copyright header missing/wrong", "style check failing", "linting CI failure". DO NOT trigger for build errors, compilation failures, linker errors, test failures, runtime crashes, accuracy issues, or CMake config problems.
+---
+
+# Apply Code Standards
+
+Iteratively detect and fix all clang-format, clang-tidy, and copyright violations introduced by the current branch's changes.
+
+## Step 1: Identify Affected Build Targets
+
+Detect the upstream base branch:
+
+```bash
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || git rev-parse --abbrev-ref origin/HEAD 2>/dev/null
+```
+
+List changed files (excluding submodules) and write to a temp file for reuse across steps:
+
+```bash
+git diff --name-only <upstream> | grep -v '^thirdparty' | tee /tmp/changed_files.txt
+```
+
+Map them to CMake targets. If the mapping is not obvious, ask the user:
+> "Which CMake targets cover the files you changed? (e.g., `openvino_intel_cpu_plugin`)"
+
+## Step 2: Configure with clang-18 + Style Checks
+
+Locate or create a build directory (typically `build/` or `build-clang/` in the repo root).
+
+Run CMake with clang-18 and both style options enabled:
+
+```bash
+cmake -S <repo_root> -B <build_dir> \
+  -DCMAKE_C_COMPILER=clang-18 \
+  -DCMAKE_CXX_COMPILER=clang++-18 \
+  -DENABLE_CLANG_FORMAT=ON \
+  -DENABLE_CLANG_TIDY=ON \
+  [any other flags already in use by the user's build]
+```
+
+If the user already has a configured build directory, re-run cmake in it with just the three new flags appended — do not wipe their existing configuration.
+
+## Step 3: Check, Fix, Repeat
+
+Repeat steps 3a–3d until all checks pass.
+
+### 3a. Copyright headers
+
+**Check:**
+```bash
+python3 .github/scripts/check_copyright.py /tmp/changed_files.txt
+```
+
+**Auto-fix:** If non-zero exit, inspect the generated patch before applying — it is usually correct but can occasionally be malformed:
+```bash
+cat copyright_fixes.diff
+patch -p1 < copyright_fixes.diff
+python3 .github/scripts/check_copyright.py /tmp/changed_files.txt
+```
+
+**Manual fix:** If the patch looks wrong, fix the copyright header directly in the file instead.
+
+### 3b. clang-tidy
+
+**Check:** Build affected targets as a background task. For multiple targets, repeat `--target`:
+
+```bash
+cmake --build <build_dir> --target <target1> --target <target2> -- -j$(nproc) 2>&1 | tee /tmp/ct_check.txt
+```
+
+After completion, separate the two categories of issues in your changed files:
+
+```bash
+# Compilation errors (no clang-tidy check name in brackets)
+grep "error:" /tmp/ct_check.txt | grep -v "\[" | grep -Ff /tmp/changed_files.txt
+
+# clang-tidy diagnostics (have check name in brackets, e.g. [modernize-use-auto])
+grep -E "warning:|error:" /tmp/ct_check.txt | grep "\[" | grep -Ff /tmp/changed_files.txt
+```
+
+**Fix compilation errors first (manual):** If non-tidy compilation errors are present, read each error and fix the source file by hand. Rebuild to confirm they are resolved before moving on — `ENABLE_CLANG_TIDY_FIX` cannot help with these.
+
+**Auto-fix clang-tidy diagnostics:** Once the code compiles cleanly, re-configure with `ENABLE_CLANG_TIDY_FIX=ON` and rebuild as a background task:
+
+```bash
+cmake <build_dir> -DENABLE_CLANG_TIDY_FIX=ON
+cmake --build <build_dir> --target <target1> --target <target2> -- -j$(nproc) 2>&1 | tee /tmp/ct_fix.txt
+```
+
+Re-check diagnostics after the build. Then reset the flag:
+```bash
+cmake <build_dir> -DENABLE_CLANG_TIDY_FIX=OFF
+```
+
+**Manual fix (remaining tidy issues):** For any tidy diagnostics that auto-fix missed or produced incorrect changes, read the message carefully and fix the source file by hand. If a check fires repeatedly and cannot be fixed, **do not add `// NOLINT` suppressions on your own** — present the diagnostic to the user and ask whether to suppress, refactor, or handle it another way.
+
+### 3c. clang-format
+
+**Check:** Run as a background task:
+```bash
+cmake --build <build_dir> --target clang_format_check_all 2>&1 | tee /tmp/cf_check.txt
+```
+
+After completion, check for failures:
+```bash
+grep "Code style check failed" /tmp/cf_check.txt
+```
+
+**Auto-fix:** If failures found, run the fix target as a background task:
+```bash
+cmake --build <build_dir> --target clang_format_fix_all 2>&1 | tee /tmp/cf_fix.txt
+```
+
+Re-run the check to confirm clean.
+
+**Manual fix:** If auto-fix still fails (very rare), fix the specific file manually and re-check.
+
+### 3d. Stop condition
+
+When the copyright check passes, `clang_format_check_all` produces no "Code style check failed" lines, **and** the changed-file grep in 3b produces zero output, stop and report success to the user.
+
+## Notes
+
+- Always prefer `clang-format-18` / `clang-tidy-18` (versioned binaries) over unversioned ones — the project enforces version 18.
+- If clang-18 is not installed, inform the user: `sudo apt install clang-18 clang-format-18 clang-tidy-18`.
+- Do not modify files outside the set touched by the current branch unless a clang-tidy fix requires it (e.g., a header change). In that case, inform the user.

--- a/.claude/skills/apply-code-standards/SKILL.md
+++ b/.claude/skills/apply-code-standards/SKILL.md
@@ -7,75 +7,18 @@ description: Detect and fix clang-format, clang-tidy, and copyright header viola
 
 Iteratively detect and fix all clang-format, clang-tidy, and copyright violations introduced by the current branch's changes.
 
-> Background on each tool (flags, targets, install instructions, recommended fix order): [docs/dev/coding_style.md](../../../docs/dev/coding_style.md).
-
 ## Step 1: Identify Affected Build Targets
 
-Ask the user which files to check:
-> "Should I check uncommitted changes only, or all changes on the current branch? If the full branch, what is the upstream branch to diff against (e.g. `origin/master`)?"
+Ask the user to confirm the upstream reference:
+> "I'll diff against `upstream/master`. Let me know if you use a different upstream."
 
-For **uncommitted changes** (staged + unstaged):
 ```bash
-{ git diff --name-only HEAD; git diff --name-only --cached; } | sort -u | grep -v '^thirdparty' | tee /tmp/changed_files.txt
-```
-
-For **full branch** (all commits since upstream):
-```bash
-git diff --name-only <upstream> | grep -v '^thirdparty' | tee /tmp/changed_files.txt
+git diff --name-only <ref> | grep -v '^thirdparty' | tee /tmp/changed_files.txt
 ```
 
 Map them to CMake targets. If the mapping is not obvious, ask the user:
 > "Which CMake targets cover the files you changed? (e.g., `openvino_intel_cpu_plugin`)"
 
-## Step 2: Configure with clang-18 + Style Checks
+## Step 2: Check, Fix, Repeat
 
-clang-tidy requires the build to use clang-18 as the compiler. Check whether an existing build directory already uses clang-18:
-
-```bash
-grep "CMAKE_CXX_COMPILER" <build_dir>/CMakeCache.txt | grep -i clang
-```
-
-- **If it does**, re-run cmake in it with the style flags appended — do not wipe the existing configuration:
-  ```bash
-  cmake -DENABLE_CLANG_FORMAT=ON -DENABLE_CLANG_TIDY=ON <build_dir>
-  ```
-- **If it doesn't** (or no build directory exists), create a dedicated `build-clang/` directory:
-  ```bash
-  mkdir -p build-clang && cd build-clang
-  cmake -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 \
-        -DENABLE_CLANG_FORMAT=ON -DENABLE_CLANG_TIDY=ON \
-        -DCMAKE_BUILD_TYPE=Release ..
-  ```
-
-See [docs/dev/coding_style.md](../../../docs/dev/coding_style.md) for full flag reference.
-
-## Step 3: Check, Fix, Repeat
-
-Follow the fix order from `coding_style.md`: copyright → clang-tidy → clang-format. Repeat until all checks pass.
-
-### 3a. Copyright headers
-
-Run the check script and patch workflow per [coding_style.md](../../../docs/dev/coding_style.md). If the patch looks wrong, fix the header directly in the file.
-
-### 3b. clang-tidy
-
-Build the affected targets (pipe to `/tmp/ct_check.txt`), then separate the two issue categories for your changed files:
-```bash
-# Compilation errors (no check name in brackets)
-grep "error:" /tmp/ct_check.txt | grep -v "\[" | grep -Ff /tmp/changed_files.txt
-
-# clang-tidy diagnostics (have check name in brackets, e.g. [modernize-use-auto])
-grep -E "warning:|error:" /tmp/ct_check.txt | grep "\[" | grep -Ff /tmp/changed_files.txt
-```
-
-**Fix compilation errors first:** `ENABLE_CLANG_TIDY_FIX` cannot help with these.
-
-If a tidy diagnostic cannot be resolved, **do not add `// NOLINT` on your own** — present it to the user and ask whether to suppress, refactor, or handle it another way.
-
-### 3c. clang-format
-
-Use `clang_format_check_all` to detect violations, `clang_format_fix_all` to auto-fix (see [coding_style.md](../../../docs/dev/coding_style.md)). Pipe output to `/tmp/cf_check.txt` and grep for `"Code style check failed"`. Re-run the check after fixing to confirm clean.
-
-### 3d. Stop condition
-
-When the copyright check passes, `clang_format_check_all` produces no "Code style check failed" lines, and the changed-file grep in 3b produces zero output — report success to the user.
+Follow the fix order from [coding_style.md](../../../docs/dev/coding_style.md). Repeat until all checks pass.

--- a/.claude/skills/ensure-coding-style/SKILL.md
+++ b/.claude/skills/ensure-coding-style/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: apply-code-standards
+name: ensure-coding-style
 description: Detect and fix clang-format, clang-tidy, and copyright header violations in an OpenVINO C++ codebase. Use when the user complains about code style or formatting, asks to clean up changes, fix linting, add a copyright header, or when a style check or linting CI job is failing. Do not use for build errors, compilation failures, linker errors, test failures, runtime crashes, accuracy issues, or CMake config problems.
 ---
 

--- a/docs/dev/coding_style.md
+++ b/docs/dev/coding_style.md
@@ -44,23 +44,22 @@ grep "CMAKE_CXX_COMPILER" <build_dir>/CMakeCache.txt | grep -i clang
 cmake -DENABLE_CLANG_FORMAT=ON -DENABLE_CLANG_TIDY=ON <build_dir>
 ```
 
-**If it doesn't** (or no build directory exists), create a dedicated `build-clang/` directory:
+**If it doesn't** (or no build directory exists), set `<build_dir>=build-clang` and configure it:
 ```bash
-mkdir -p build-clang && cd build-clang
-cmake -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 \
+cmake -B <build_dir> -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 \
       -DENABLE_CLANG_FORMAT=ON -DENABLE_CLANG_TIDY=ON \
-      -DCMAKE_BUILD_TYPE=Release ..
+      -DCMAKE_BUILD_TYPE=Release
 ```
 
 Build a target to run checks (warnings appear inline during compilation):
 ```bash
-cmake --build . --target <your_target> -- -j$(nproc)
+cmake --build  <build_dir> --target <your_target> -- -j$(nproc)
 ```
 
 To auto-fix diagnostics, enable the fix mode and rebuild:
 ```bash
-cmake -DENABLE_CLANG_TIDY_FIX=ON .
-cmake --build . --target <your_target> -- -j$(nproc)
+cmake -DENABLE_CLANG_TIDY_FIX=ON <build_dir>
+cmake --build  <build_dir> --target <your_target> -- -j$(nproc)
 ```
 
 Notes:
@@ -92,8 +91,8 @@ cmake -DENABLE_CLANG_FORMAT=ON <other flags> ..
 
 Check and fix targets:
 ```bash
-cmake --build . --target clang_format_check_all   # report violations
-cmake --build . --target clang_format_fix_all     # auto-fix violations
+cmake --build  <build_dir> --target clang_format_check_all   # report violations
+cmake --build  <build_dir> --target clang_format_fix_all     # auto-fix violations
 ```
 
 ## See also

--- a/docs/dev/coding_style.md
+++ b/docs/dev/coding_style.md
@@ -1,21 +1,80 @@
 # OpenVINO Coding Guidelines
 
-## Coding style
+## Coding style (clang-format)
 
-The majority of OpenVINO components use `clang-format-18` for code style check.
+The majority of OpenVINO components use `clang-format-18` for code style checks.
 
 The code style is based on the Google Code style with some differences. All the differences are described in the configuration file:
 https://github.com/openvinotoolkit/openvino/blob/69f709028a5f8da596d1d0df9a0101e517c35708/src/.clang-format#L1-L28
 
-To fix the code style on your local machine, you need to install the `clang-format-18` tool and make sure that the CMake option `ENABLE_CLANG_FORMAT` is enabled.
-If all dependencies are resolved, you can use the `clang_format_fix_all` target to fix all code style issues.
+To use clang-format locally, install it and enable the CMake option:
+```bash
+sudo apt install clang-format-18
+cmake -DENABLE_CLANG_FORMAT=ON <other flags> ..
+```
 
-## Naming style
+Check and fix targets:
+```bash
+cmake --build . --target clang_format_check_all   # report violations
+cmake --build . --target clang_format_fix_all     # auto-fix violations
+```
+
+## Naming style (ncc)
 
 OpenVINO has strict rules for naming style in public API. All classes must start with a capital letter, and methods and functions should be named in `snake_case` style.
 To check the naming style, `ncc` tool is integrated in the OpenVINO. Read the detailed information about the naming style can be found in the [configuration file](../../cmake/developer_package/ncc_naming_style/openvino.style).
 To activate this tool, you need to have `clang` on the local machine and enable the CMake option `ENABLE_NCC_STYLE`.
 After that, you can use the `ncc_all` target to check the naming style.
+
+## Static analysis (clang-tidy)
+
+`clang-tidy-18` is used for static analysis and enforcing modern C++ patterns.
+
+To enable it:
+```bash
+sudo apt install clang-tidy-18
+cmake -DENABLE_CLANG_TIDY=ON <other flags> ..
+```
+
+Build a target to run checks (warnings appear inline during compilation):
+```bash
+cmake --build . --target <your_target> -- -j$(nproc)
+```
+
+To auto-fix diagnostics, enable the fix mode and rebuild:
+```bash
+cmake -DENABLE_CLANG_TIDY_FIX=ON .
+cmake --build . --target <your_target> -- -j$(nproc)
+```
+
+Note: compilation errors must be resolved before clang-tidy diagnostics can be applied.
+
+## Copyright headers
+
+All source files must carry the standard OpenVINO copyright header.
+
+C++ (`.cpp`, `.hpp`, `.h`):
+```cpp
+// Copyright (C) 2018-<current_year> Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+```
+
+Python (`.py`):
+```python
+# Copyright (C) 2018-<current_year> Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+```
+
+To check and fix headers automatically, the script at `.github/scripts/check_copyright.py` can be used. If it exits non-zero it writes `copyright_fixes.diff`, which can be applied with `patch -p1 < copyright_fixes.diff`.
+
+## Recommended fix order
+
+When bringing a set of changes into compliance, it is recommended to address the three checks in the following order:
+
+1. **Copyright headers** — fast, no build required
+2. **clang-tidy** — requires a clean build; fix compilation errors first, then apply tidy auto-fixes
+3. **clang-format** — purely cosmetic; run last so tidy auto-fixes don't reintroduce formatting issues
 
 ## See also
  * [OpenVINO™ README](../../README.md)

--- a/docs/dev/coding_style.md
+++ b/docs/dev/coding_style.md
@@ -1,52 +1,11 @@
 # OpenVINO Coding Guidelines
 
-## Coding style (clang-format)
-
-The majority of OpenVINO components use `clang-format-18` for code style checks.
-
-The code style is based on the Google Code style with some differences. All the differences are described in the configuration file:
-https://github.com/openvinotoolkit/openvino/blob/69f709028a5f8da596d1d0df9a0101e517c35708/src/.clang-format#L1-L28
-
-To use clang-format locally, `clang-format-18` should be installed, and the corresponding CMake should be enabled:
-```bash
-cmake -DENABLE_CLANG_FORMAT=ON <other flags> ..
-```
-
-Check and fix targets:
-```bash
-cmake --build . --target clang_format_check_all   # report violations
-cmake --build . --target clang_format_fix_all     # auto-fix violations
-```
-
 ## Naming style (ncc)
 
 OpenVINO has strict rules for naming style in public API. All classes must start with a capital letter, and methods and functions should be named in `snake_case` style.
 To check the naming style, `ncc` tool is integrated in the OpenVINO. Read the detailed information about the naming style can be found in the [configuration file](../../cmake/developer_package/ncc_naming_style/openvino.style).
 To activate this tool, you need to have `clang` on the local machine and enable the CMake option `ENABLE_NCC_STYLE`.
 After that, you can use the `ncc_all` target to check the naming style.
-
-## Static analysis (clang-tidy)
-
-`clang-tidy-18` is used for static analysis and enforcing modern C++ patterns. To use it locally, `clang-tidy-18` should be installed, and the corresponding CMake should be enabled:
-```bash
-cmake -DENABLE_CLANG_TIDY=ON <other flags> ..
-```
-
-Build a target to run checks (warnings appear inline during compilation):
-```bash
-cmake --build . --target <your_target> -- -j$(nproc)
-```
-
-To auto-fix diagnostics, enable the fix mode and rebuild:
-```bash
-cmake -DENABLE_CLANG_TIDY_FIX=ON .
-cmake --build . --target <your_target> -- -j$(nproc)
-```
-
-Notes:
-- Compilation errors must be resolved before clang-tidy diagnostics can be applied.
-- Auto-fix can occasionally produce incorrect changes — in some cases, the manual fix is required.
-- Use a dedicated build directory for clang-tidy (e.g. `build-clang/`) — clang-tidy rewrites compilation databases and can interfere with incremental builds in a shared directory.
 
 ## Copyright headers
 
@@ -67,13 +26,75 @@ Python (`.py`):
 
 To check and fix headers automatically, the script at `.github/scripts/check_copyright.py` can be used. If it exits non-zero it writes `copyright_fixes.diff`, which can be applied with `patch -p1 < copyright_fixes.diff`.
 
+Note: automatically generated patch can occasionally produce incorrect changes — in some cases, the manual fix is required.
+
+## Static analysis (clang-tidy)
+
+`clang-tidy-18` is used for static analysis and enforcing modern C++ patterns.
+
+**Prerequisites:** `clang-tidy-18` must be installed, and the project must be compiled with clang as the compiler. Before enabling it, verify that an existing build directory already uses clang:
+```bash
+grep "CMAKE_CXX_COMPILER" <build_dir>/CMakeCache.txt | grep -i clang
+```
+
+**If it does**, re-run cmake in it to append the style flags (preserves the existing configuration):
+```bash
+cmake -DENABLE_CLANG_FORMAT=ON -DENABLE_CLANG_TIDY=ON <build_dir>
+```
+
+**If it doesn't** (or no build directory exists), create a dedicated `build-clang/` directory:
+```bash
+mkdir -p build-clang && cd build-clang
+cmake -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 \
+      -DENABLE_CLANG_FORMAT=ON -DENABLE_CLANG_TIDY=ON \
+      -DCMAKE_BUILD_TYPE=Release ..
+```
+
+Build a target to run checks (warnings appear inline during compilation):
+```bash
+cmake --build . --target <your_target> -- -j$(nproc)
+```
+
+To auto-fix diagnostics, enable the fix mode and rebuild:
+```bash
+cmake -DENABLE_CLANG_TIDY_FIX=ON .
+cmake --build . --target <your_target> -- -j$(nproc)
+```
+
+Notes:
+- Compilation errors must be resolved before clang-tidy diagnostics can be applied.
+- Auto-fix can occasionally produce incorrect changes — in some cases, the manual fix is required.
+- It is better to use a dedicated build directory for clang-tidy (e.g. `build-clang/`) — clang-tidy rewrites compilation databases and can interfere with incremental builds in a shared directory.
+- Do not use `// NOLINT` suppressions to silence diagnostics. A suppression hides the issue without fixing it and can mask real problems in future code. It is strongly recommended to  suppress if if the check is a confirmed false positive with no correct alternative, and document the reason inline.
+
+## Coding style (clang-format)
+
+The majority of OpenVINO components use `clang-format-18` for code style checks.
+
+**Prerequisites:** `clang-format-18` must be installed. No specific compiler is required — clang-format runs as a standalone tool independent of how the project was compiled.
+
+The code style is based on the Google Code style with some differences. All the differences are described in the configuration file:
+https://github.com/openvinotoolkit/openvino/blob/69f709028a5f8da596d1d0df9a0101e517c35708/src/.clang-format#L1-L28
+
+To enable clang-format checks in the build, set the corresponding CMake flag:
+```bash
+cmake -DENABLE_CLANG_FORMAT=ON <other flags> ..
+```
+
+Check and fix targets:
+```bash
+cmake --build . --target clang_format_check_all   # report violations
+cmake --build . --target clang_format_fix_all     # auto-fix violations
+```
+
 ## Recommended fix order
 
 When bringing a set of changes into compliance, it is recommended to address the three checks in the following order:
 
 1. **Copyright headers** — fast, no build required
-2. **clang-tidy** — requires a clean build; fix compilation errors first, then apply tidy auto-fixes
-3. **clang-format** — purely cosmetic; run last so tidy auto-fixes don't reintroduce formatting issues
+2. **Naming style (ncc)** — requires clang, but no full rebuild; fix before tidy to avoid redundant churn
+3. **clang-tidy** — requires a clean build; fix compilation errors first, then apply tidy auto-fixes
+4. **clang-format** — purely cosmetic; run last so tidy auto-fixes don't reintroduce formatting issues
 
 ## See also
  * [OpenVINO™ README](../../README.md)

--- a/docs/dev/coding_style.md
+++ b/docs/dev/coding_style.md
@@ -1,11 +1,13 @@
 # OpenVINO Coding Guidelines
 
-## Naming style (ncc)
+## Fix order
 
-OpenVINO has strict rules for naming style in public API. All classes must start with a capital letter, and methods and functions should be named in `snake_case` style.
-To check the naming style, `ncc` tool is integrated in the OpenVINO. Read the detailed information about the naming style can be found in the [configuration file](../../cmake/developer_package/ncc_naming_style/openvino.style).
-To activate this tool, you need to have `clang` on the local machine and enable the CMake option `ENABLE_NCC_STYLE`.
-After that, you can use the `ncc_all` target to check the naming style.
+When bringing a set of changes into compliance, address the checks in the following order:
+
+1. **Copyright headers** — fast, no build required
+2. **clang-tidy** — requires a clean build; fix compilation errors first, then apply tidy auto-fixes
+3. **Naming style (ncc)** — requires clang, but no full rebuild; fix after tidy to avoid redundant churn
+4. **clang-format** — purely cosmetic; run last so tidy auto-fixes don't reintroduce formatting issues
 
 ## Copyright headers
 
@@ -67,6 +69,13 @@ Notes:
 - It is better to use a dedicated build directory for clang-tidy (e.g. `build-clang/`) — clang-tidy rewrites compilation databases and can interfere with incremental builds in a shared directory.
 - Do not use `// NOLINT` suppressions to silence diagnostics. A suppression hides the issue without fixing it and can mask real problems in future code. It is strongly recommended to  suppress if if the check is a confirmed false positive with no correct alternative, and document the reason inline.
 
+## Naming style (ncc)
+
+OpenVINO has strict rules for naming style in public API. All classes must start with a capital letter, and methods and functions should be named in `snake_case` style.
+To check the naming style, `ncc` tool is integrated in the OpenVINO. Read the detailed information about the naming style can be found in the [configuration file](../../cmake/developer_package/ncc_naming_style/openvino.style).
+To activate this tool, you need to have `clang` on the local machine and enable the CMake option `ENABLE_NCC_STYLE`.
+After that, you can use the `ncc_all` target to check the naming style.
+
 ## Coding style (clang-format)
 
 The majority of OpenVINO components use `clang-format-18` for code style checks.
@@ -86,15 +95,6 @@ Check and fix targets:
 cmake --build . --target clang_format_check_all   # report violations
 cmake --build . --target clang_format_fix_all     # auto-fix violations
 ```
-
-## Recommended fix order
-
-When bringing a set of changes into compliance, it is recommended to address the three checks in the following order:
-
-1. **Copyright headers** — fast, no build required
-2. **Naming style (ncc)** — requires clang, but no full rebuild; fix before tidy to avoid redundant churn
-3. **clang-tidy** — requires a clean build; fix compilation errors first, then apply tidy auto-fixes
-4. **clang-format** — purely cosmetic; run last so tidy auto-fixes don't reintroduce formatting issues
 
 ## See also
  * [OpenVINO™ README](../../README.md)

--- a/docs/dev/coding_style.md
+++ b/docs/dev/coding_style.md
@@ -7,9 +7,8 @@ The majority of OpenVINO components use `clang-format-18` for code style checks.
 The code style is based on the Google Code style with some differences. All the differences are described in the configuration file:
 https://github.com/openvinotoolkit/openvino/blob/69f709028a5f8da596d1d0df9a0101e517c35708/src/.clang-format#L1-L28
 
-To use clang-format locally, install it and enable the CMake option:
+To use clang-format locally, `clang-format-18` should be installed, and the corresponding CMake should be enabled:
 ```bash
-sudo apt install clang-format-18
 cmake -DENABLE_CLANG_FORMAT=ON <other flags> ..
 ```
 
@@ -28,11 +27,8 @@ After that, you can use the `ncc_all` target to check the naming style.
 
 ## Static analysis (clang-tidy)
 
-`clang-tidy-18` is used for static analysis and enforcing modern C++ patterns.
-
-To enable it:
+`clang-tidy-18` is used for static analysis and enforcing modern C++ patterns. To use it locally, `clang-tidy-18` should be installed, and the corresponding CMake should be enabled:
 ```bash
-sudo apt install clang-tidy-18
 cmake -DENABLE_CLANG_TIDY=ON <other flags> ..
 ```
 
@@ -47,7 +43,10 @@ cmake -DENABLE_CLANG_TIDY_FIX=ON .
 cmake --build . --target <your_target> -- -j$(nproc)
 ```
 
-Note: compilation errors must be resolved before clang-tidy diagnostics can be applied.
+Notes:
+- Compilation errors must be resolved before clang-tidy diagnostics can be applied.
+- Auto-fix can occasionally produce incorrect changes — in some cases, the manual fix is required.
+- Use a dedicated build directory for clang-tidy (e.g. `build-clang/`) — clang-tidy rewrites compilation databases and can interfere with incremental builds in a shared directory.
 
 ## Copyright headers
 


### PR DESCRIPTION
### Details:

This PR adds a skill that automates detection and remediation of all code standard violations introduced by a branch's changes in the C++ codebase.

The skill covers three categories in order:

1. Copyright headers — checks via check_copyright.py, auto-fixes by inspecting and applying the generated patch, falls back to manual edit if the patch looks wrong.
2. clang-tidy / compilation — builds affected CMake targets with `ENABLE_CLANG_TIDY=ON`. Separates plain compilation errors (fixed manually) from clang-tidy diagnostics (auto-fixed via `ENABLE_CLANG_TIDY_FIX=ON`, then manual fallback). Compilation errors are resolved first since tidy cannot auto-fix a file that doesn't compile.
3. clang-format — runs `clang_format_check_all`, auto-fixes with `clang_format_fix_all`, re-verifies.

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used for skill testing and improvement: generating test cases, running the skill, adjust the instructions based on user's feedback and test results*
