### PR TITLE
[GPU] Add Power(-0.5) pattern to RMSFusion

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
@@ -66,7 +66,13 @@ RMSFusion::RMSFusion(bool force_tail_convert, bool enable_div_x, bool enable_wit
     auto const_div = pattern::wrap_type<v0::Constant>(pattern::value_matches("1"));
     auto const_div_convert = pattern::optional<v0::Convert>(const_div);
     auto div = pattern::wrap_type<v1::Divide>({const_div_convert, sqrt});
-    auto div_or_pow = std::make_shared<pattern::op::Or>(OutputVector{div, pow});
+
+    // Power(ReduceMean(x^2,axes)+eps, -0.5) — direct rsqrt without Sqrt node
+    auto const_neg_half = pattern::wrap_type<v0::Constant>(pattern::value_matches("-0.5"));
+    auto const_neg_half_convert = pattern::optional<v0::Convert>(const_neg_half);
+    auto pow_direct = pattern::wrap_type<v1::Power>({add_eps, const_neg_half_convert});
+
+    std::shared_ptr<pattern::op::Or> div_or_pow = std::make_shared<pattern::op::Or>(OutputVector{div, pow, pow_direct});
 
     // x * 1/Sqrt(ReduceMean(x^2,axes)+eps)
     auto mul1 = pattern::wrap_type<v1::Multiply>({x, div_or_pow});

--- a/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
@@ -424,3 +424,148 @@ TEST_F(TransformationTestsF, RMSNormFusionTest12) {
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
+
+// --- Power(-0.5) direct rsqrt path tests ---
+
+// Power(-0.5) direct path with gamma and tail convert
+TEST_F(TransformationTestsF, RMSNormFusionTest13_PowerNegHalf_GammaConvert) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 6});
+        auto power_const = ov::op::v0::Constant::create(ov::element::f32, {}, {2.f});
+        auto power = std::make_shared<ov::op::v1::Power>(input, power_const);
+        auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+        auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
+        auto eps = ov::op::v0::Constant::create(ov::element::f32, {}, {1e-6f});
+        auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps);
+        auto neg_half = ov::op::v0::Constant::create(ov::element::f32, {}, {-0.5f});
+        auto rsqrt = std::make_shared<ov::op::v1::Power>(add_eps, neg_half);
+        auto mul1 = std::make_shared<ov::op::v1::Multiply>(input, rsqrt);
+        auto gamma = ov::op::v0::Constant::create(ov::element::f32,
+                                                  ov::Shape{6},
+                                                  {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
+        auto mul2 = std::make_shared<ov::op::v1::Multiply>(gamma, mul1);
+        auto comp = std::make_shared<ov::op::v0::Convert>(mul2, ov::element::f16);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{comp}, ov::ParameterVector{input});
+        manager.register_pass<RMSFusion>();
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 6});
+        auto rms_const = ov::op::v0::Constant::create(ov::element::f32,
+                                                      ov::Shape{6},
+                                                      {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
+        auto rms = std::make_shared<ov::op::internal::RMS>(input, rms_const, 1e-6f, ov::element::f16);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+// Power(-0.5) direct path with gamma, no tail convert
+TEST_F(TransformationTestsF, RMSNormFusionTest14_PowerNegHalf_GammaNoConvert) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
+        auto power_const = ov::op::v0::Constant::create(ov::element::f32, {}, {2.f});
+        auto power = std::make_shared<ov::op::v1::Power>(input, power_const);
+        auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+        auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
+        auto eps = ov::op::v0::Constant::create(ov::element::f32, {}, {1e-6f});
+        auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps);
+        auto neg_half = ov::op::v0::Constant::create(ov::element::f32, {}, {-0.5f});
+        auto rsqrt = std::make_shared<ov::op::v1::Power>(add_eps, neg_half);
+        auto mul1 = std::make_shared<ov::op::v1::Multiply>(input, rsqrt);
+        auto gamma = ov::op::v0::Constant::create(ov::element::f32,
+                                                  ov::Shape{6},
+                                                  {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
+        auto mul2 = std::make_shared<ov::op::v1::Multiply>(gamma, mul1);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input});
+        manager.register_pass<RMSFusion>(false);
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
+        auto rms_const = ov::op::v0::Constant::create(ov::element::f32,
+                                                      ov::Shape{6},
+                                                      {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
+        auto rms = std::make_shared<ov::op::internal::RMS>(input, rms_const, 1e-6f, ov::element::f32);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+// Power(-0.5) direct path without gamma, with dynamic scale
+TEST_F(TransformationTestsF, RMSNormFusionTest15_PowerNegHalf_NoGammaScale) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
+        auto scale = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
+
+        auto power_const = ov::op::v0::Constant::create(ov::element::f32, {}, {2.f});
+        auto power = std::make_shared<ov::op::v1::Power>(input, power_const);
+        auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+        auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
+        auto eps = ov::op::v0::Constant::create(ov::element::f32, {}, {1e-6f});
+        auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps);
+        auto neg_half = ov::op::v0::Constant::create(ov::element::f32, {}, {-0.5f});
+        auto rsqrt = std::make_shared<ov::op::v1::Power>(add_eps, neg_half);
+        auto mul1 = std::make_shared<ov::op::v1::Multiply>(input, rsqrt);
+        auto mul2 = std::make_shared<ov::op::v1::Multiply>(mul1, scale);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input, scale});
+        manager.register_pass<RMSFusion>(false, false, true);
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
+        auto scale = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
+
+        auto rms = std::make_shared<ov::op::internal::RMS>(input, 1e-6f, ov::element::f32);
+        auto mul = std::make_shared<ov::op::v1::Multiply>(rms, scale);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input, scale});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
+}
+
+// Power(-0.5) direct path with f16 constants and Convert
+TEST_F(TransformationTestsF, RMSNormFusionTest16_PowerNegHalf_F16Convert) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
+        auto power_const = ov::op::v0::Constant::create(ov::element::f16, {}, {2.f});
+        auto power_const_convert = std::make_shared<ov::op::v0::Convert>(power_const, ov::element::f32);
+        auto power = std::make_shared<ov::op::v1::Power>(input, power_const_convert);
+        auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+        auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
+        auto eps = ov::op::v0::Constant::create(ov::element::f16, {}, {1e-5f});
+        auto eps_convert = std::make_shared<ov::op::v0::Convert>(eps, ov::element::f32);
+        auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps_convert);
+        auto neg_half = ov::op::v0::Constant::create(ov::element::f16, {}, {-0.5f});
+        auto neg_half_convert = std::make_shared<ov::op::v0::Convert>(neg_half, ov::element::f32);
+        auto rsqrt = std::make_shared<ov::op::v1::Power>(add_eps, neg_half_convert);
+        auto mul1 = std::make_shared<ov::op::v1::Multiply>(input, rsqrt);
+        auto gamma = ov::op::v0::Constant::create(ov::element::f16,
+                                                  ov::Shape{6},
+                                                  {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
+        auto gamma_convert = std::make_shared<ov::op::v0::Convert>(gamma, ov::element::f32);
+        auto mul2 = std::make_shared<ov::op::v1::Multiply>(gamma_convert, mul1);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input});
+        manager.register_pass<RMSFusion>(false);
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
+        auto gamma = ov::op::v0::Constant::create(ov::element::f16,
+                                                  ov::Shape{6},
+                                                  {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
+        auto gamma_convert = std::make_shared<ov::op::v0::Convert>(gamma, ov::element::f32);
+        auto rms = std::make_shared<ov::op::internal::RMS>(input, gamma_convert, 1e-5f, ov::element::f32);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - RMSNorm fusion (`ov::pass::RMSFusion`) fails to match on models (e.g., Gemma 4 E2B/E4B) that express the reciprocal square root as a single `Power(-0.5)` node instead of the two-node `Sqrt → Power(-1)` sequence.
 - Root cause: the pattern in `rms_fusion.cpp` only matches `Sqrt` → `Power(-1)` or `1/Sqrt` paths; there is no branch for `Power(add_eps, -0.5)`.
 - Resolved by adding a `Power(-0.5)` direct path as a third alternative in the `Or` node, with an optional `Convert` to handle mixed-precision constants.

#### The code and line that caused this issue (if it is not changed directly)
 - `src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp:59-69` — pattern only defines `Sqrt`-based paths

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - Any model converted from PyTorch that lowers `rsqrt(x)` to `Power(x, -0.5)` instead of `Sqrt(x) → Power(x, -1)` will miss RMSNorm fusion.

#### Problematic graph
 - Existing (matched): `x → Power(2) → ReduceMean → Add(eps) → Sqrt → Power(-1) → Multiply(x) → Multiply(gamma)`
 - Missing (unmatched): `x → Power(2) → ReduceMean → Add(eps) → Power(-0.5) → Multiply(x) → Multiply(gamma)`

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
   - Added 4 new tests (Test13–Test16) covering `Power(-0.5)` with gamma+Convert, gamma without Convert, without gamma with dynamic scale, and f16 constants with Convert.
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - Reviewed `rms_norm_decomposition_test.cpp` (Test1–Test12). Existing tests only cover `Sqrt`-based paths; new tests mirror their structure for the `Power(-0.5)` variant.