### PR TITLE
NPUW: Move subgraph accuracy checking logic into an individual wrapper class

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
@@ -23,9 +23,6 @@ ov::npuw::IBaseInferRequest::IBaseInferRequest(const std::shared_ptr<ov::npuw::C
       m_num_submodels(m_npuw_model->m_compiled_submodels.size()) {
     m_subrequests.resize(m_num_submodels, {});
     m_completion_cbs.resize(m_num_submodels, {});
-    if (m_npuw_model->m_acc_check) {
-        m_ref_subrequests.resize(m_num_submodels);
-    }
 
     // Initialize profiling
     m_profile.report_on_die = ov::npuw::profiling_enabled();
@@ -65,79 +62,7 @@ ov::npuw::IBaseInferRequest::RqPtrs ov::npuw::IBaseInferRequest::create_infer_re
     }
     NPUW_ASSERT(rqs.size() == nireq);
 
-    // TODO: Support creation and return of multiple infer requests
-    if (m_npuw_model->m_acc_check && m_ref_subrequests.at(id) == nullptr) {
-        if (nireq > 1) {
-            OPENVINO_THROW("NPUW: TEMPORARY LIMITATION: Couldn't create reference infer "
-                           "requests if 'nireq' is set to > 1!");
-        }
-        LOG_INFO("Create reference subrequest for submodel [" << id << "] on " << m_npuw_model->m_ref_device << "...");
-        LOG_BLOCK();
-        if (m_npuw_model->submodel_device(id) != m_npuw_model->m_ref_device) {
-            auto& ref_submodel = m_npuw_model->m_compiled_submodels.at(id).ref_compiled_model;
-            ov::SoPtr<ov::IAsyncInferRequest> ref_infer_request = {ref_submodel->create_infer_request(),
-                                                                   ref_submodel._so};
-            NPUW_ASSERT(ref_infer_request);
-            m_ref_subrequests.at(id) = std::move(ref_infer_request);
-            LOG_INFO("Done");
-        } else {
-            LOG_INFO("Skip creation of reference subrequest for submodule["
-                     << id << "] on reference device: " << m_npuw_model->m_ref_device << ", as actual subrequest ["
-                     << id << "] has been already created on " << "it .");
-        }
-    }
-
     return rqs;
-}
-
-void ov::npuw::IBaseInferRequest::ensure_subrequest_is_accurate(std::size_t idx) {
-    LOG_INFO("Check if subrequest[" << idx << "] is accurate...");
-    LOG_BLOCK();
-    if (m_ref_subrequests.at(idx) != nullptr && m_subrequests.at(idx)._ptr != m_ref_subrequests.at(idx)._ptr) {
-        NPUW_ASSERT(m_npuw_model->m_compiled_submodels.at(idx).switched_to_ref == false);
-        NPUW_ASSERT(m_npuw_model->m_compiled_submodels.at(idx).replaced_by.value_or(idx) == idx);
-
-        const auto& ref_comp_model = m_ref_subrequests.at(idx)->get_compiled_model();
-        const auto& actual_comp_model = m_subrequests.at(idx)->get_compiled_model();
-        NPUW_ASSERT(actual_comp_model->inputs().size() == ref_comp_model->inputs().size());
-        // Setting inputs:
-        for (size_t i = 0; i < actual_comp_model->inputs().size(); i++) {
-            const auto& itensor = m_subrequests.at(idx)->get_tensor(actual_comp_model->inputs()[i]);
-            m_ref_subrequests.at(idx)->set_tensor(ref_comp_model->inputs()[i], itensor);
-        }
-        m_ref_subrequests.at(idx)->infer();
-
-        LOG_INFO("Compare actual outputs against references:");
-        bool tensors_converge = true;
-        for (size_t i = 0; i < actual_comp_model->outputs().size(); i++) {
-            LOG_INFO(" - " << actual_comp_model->outputs()[i]);
-            const auto& actual_tensor = m_subrequests.at(idx)->get_tensor(actual_comp_model->outputs()[i]);
-            const auto& ref_tensor = m_ref_subrequests.at(idx)->get_tensor(ref_comp_model->outputs()[i]);
-            LOG_BLOCK();
-            tensors_converge &= m_npuw_model->m_acc_check(actual_tensor, ref_tensor);
-        }
-        LOG_INFO((tensors_converge ? "PASS" : "FAIL"));
-
-        if (!tensors_converge) {
-            LOG_INFO("Subrequest is inaccurate, failover to reference.");
-            // FIXME: We need to copy reference tensors to actual only in single-model-inference mode
-            //        or if our subgraph is last in the chain.
-            for (size_t i = 0; i < actual_comp_model->outputs().size(); i++) {
-                const auto& actual_tensor = m_subrequests.at(idx)->get_tensor(actual_comp_model->outputs()[i]);
-                const auto& ref_tensor = m_ref_subrequests.at(idx)->get_tensor(ref_comp_model->outputs()[i]);
-                ref_tensor->copy_to(actual_tensor._ptr);
-            }
-            m_npuw_model->m_compiled_submodels.at(idx).compiled_model =
-                m_npuw_model->m_compiled_submodels.at(idx).ref_compiled_model;
-            m_npuw_model->m_compiled_submodels.at(idx).switched_to_ref = true;
-            m_subrequests.at(idx) = m_ref_subrequests.at(idx);
-            update_subrequest_links(idx);
-        }
-
-        LOG_INFO("Done");
-    } else {
-        LOG_INFO("Skipped, subrequest is launched on reference device.");
-    }
 }
 
 ov::SoPtr<ov::ITensor> ov::npuw::IBaseInferRequest::get_tensor(const ov::Output<const ov::Node>& port) const {
@@ -297,9 +222,6 @@ void ov::npuw::IBaseInferRequest::infer() {
             run_subrequest_for_success(idx);
         });
         complete_subrequest(idx);
-        if (m_npuw_model->m_acc_check) {
-            ensure_subrequest_is_accurate(idx);
-        }
     }
 
     // Increment counter regardless if dumps etc are enabled or not.

--- a/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.hpp
@@ -92,7 +92,6 @@ protected:
     // their inference requests anymore - they must be stored
     // only once in the subrequests list
     RqPtrs create_infer_requests(std::size_t id, size_t nireq = 1);
-    void ensure_subrequest_is_accurate(std::size_t idx);
     virtual void update_subrequest_links(std::size_t idx) = 0;
 
     std::shared_ptr<ov::npuw::CompiledModel> m_npuw_model;
@@ -231,8 +230,6 @@ protected:
     bool needs_copy(std::size_t idx, std::size_t cidx) const;
     std::size_t next(std::size_t idx_base) const;
     std::size_t real(std::size_t idx) const;
-
-    RqPtrs m_ref_subrequests;
 
     using now_t = std::optional<std::size_t>;
     now_t now_idx() const;

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -1828,24 +1828,19 @@ bool ov::npuw::CompiledModel::compile_for_success(std::size_t id, const std::vec
     auto make_wrapped = [&](const std::shared_ptr<ov::Model>& model,
                             const std::string& profile_suffix,
                             const std::vector<std::string>& devs) -> ov::SoPtr<ov::ICompiledModel> {
-        auto main_cm = ov::npuw::failsafe::CompiledModel::create(model,
-                                                                  get_plugin(),
-                                                                  devs,
-                                                                  make_factory(model, profile_suffix));
+        auto main_cm =
+            ov::npuw::failsafe::CompiledModel::create(model, get_plugin(), devs, make_factory(model, profile_suffix));
         if (m_acc_check) {
-            const auto exec_devs =
-                main_cm->get_property(ov::execution_devices.name()).as<std::vector<std::string>>();
+            const auto exec_devs = main_cm->get_property(ov::execution_devices.name()).as<std::vector<std::string>>();
             const std::string actual_device = exec_devs.empty() ? "" : exec_devs.front();
             if (actual_device != m_ref_device) {
-                LOG_INFO("Wrapping with AccuracyChecked (main: " << actual_device << ", ref: " << m_ref_device
-                                                                 << ").");
+                LOG_INFO("Wrapping with AccuracyChecked (main: " << actual_device << ", ref: " << m_ref_device << ").");
                 auto ref_cm = compile_submodel(model, m_ref_device);
-                return ov::npuw::accuracy_checked::CompiledModel::create(
-                    model,
-                    get_plugin(),
-                    std::move(main_cm),
-                    std::move(ref_cm),
-                    m_acc_check);
+                return ov::npuw::accuracy_checked::CompiledModel::create(model,
+                                                                         get_plugin(),
+                                                                         std::move(main_cm),
+                                                                         std::move(ref_cm),
+                                                                         m_acc_check);
             }
         }
         return main_cm;

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -26,6 +26,7 @@
 #include "plugin.hpp"
 #include "unfold_sync_infer_request.hpp"
 #include "util.hpp"
+#include "v1/elements/accuracy_checked.hpp"
 #include "v1/elements/failsafe.hpp"
 
 // required for get_properties_per_device()
@@ -594,19 +595,7 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
                            "]");
         }
 
-        if (m_acc_check) {
-            if (submodel_device(real_id) != m_ref_device) {
-                LOG_INFO("Compile Subgraph[" << real_id << "] for reference device: " << m_ref_device << ".");
-                LOG_BLOCK();
-                m_compiled_submodels.at(real_id).ref_compiled_model =
-                    compile_submodel(m_compiled_submodels.at(real_id).model, m_ref_device);
-                LOG_INFO("Done (reference)");
-            } else {
-                LOG_INFO("Skip compilation of submodel[" << real_id << "] for reference device: " << m_ref_device
-                                                         << ", as original submodel[" << real_id
-                                                         << "] has been already compiled for it.");
-            }
-        }
+        LOG_INFO("Done (Subgraph[" << id << "]).");
     };  // compile
 
     // Parallel compilation is unstable so is disabled by default.
@@ -1839,10 +1828,27 @@ bool ov::npuw::CompiledModel::compile_for_success(std::size_t id, const std::vec
     auto make_wrapped = [&](const std::shared_ptr<ov::Model>& model,
                             const std::string& profile_suffix,
                             const std::vector<std::string>& devs) -> ov::SoPtr<ov::ICompiledModel> {
-        return ov::npuw::failsafe::CompiledModel::create(model,
-                                                         get_plugin(),
-                                                         devs,
-                                                         make_factory(model, profile_suffix));
+        auto main_cm = ov::npuw::failsafe::CompiledModel::create(model,
+                                                                  get_plugin(),
+                                                                  devs,
+                                                                  make_factory(model, profile_suffix));
+        if (m_acc_check) {
+            const auto exec_devs =
+                main_cm->get_property(ov::execution_devices.name()).as<std::vector<std::string>>();
+            const std::string actual_device = exec_devs.empty() ? "" : exec_devs.front();
+            if (actual_device != m_ref_device) {
+                LOG_INFO("Wrapping with AccuracyChecked (main: " << actual_device << ", ref: " << m_ref_device
+                                                                 << ").");
+                auto ref_cm = compile_submodel(model, m_ref_device);
+                return ov::npuw::accuracy_checked::CompiledModel::create(
+                    model,
+                    get_plugin(),
+                    std::move(main_cm),
+                    std::move(ref_cm),
+                    m_acc_check);
+            }
+        }
+        return main_cm;
     };
 
     if (auto& moe_experts_opt = desc.moe_experts; moe_experts_opt.has_value()) {
@@ -2293,10 +2299,6 @@ std::string ov::npuw::CompiledModel::submodel_device(const std::size_t idx) cons
 
     if (!comp_subm_desc.compiled_model) {
         return "";
-    }
-
-    if (comp_subm_desc.switched_to_ref) {
-        return m_ref_device;
     }
 
     const auto exec_devs =

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
@@ -279,10 +279,6 @@ private:
 
         bool forced_to_fcall = false;
 
-        // FIXME: Take it out of structure
-        ov::SoPtr<ov::ICompiledModel> ref_compiled_model;
-        bool switched_to_ref = false;
-
         // Metrics
         execution_stats stat;
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.cpp
@@ -1,0 +1,244 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "accuracy_checked.hpp"
+
+#include <utility>
+
+#include "openvino/core/except.hpp"
+#include "openvino/runtime/make_tensor.hpp"
+
+namespace ov::npuw::accuracy_checked {
+
+// ============================================================================
+// CompiledModel
+// ============================================================================
+
+ov::SoPtr<ov::ICompiledModel> CompiledModel::create(const std::shared_ptr<ov::Model>& model,
+                                                     const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                     ov::SoPtr<ov::ICompiledModel> main_compiled,
+                                                     ov::SoPtr<ov::ICompiledModel> ref_compiled,
+                                                     Checker checker) {
+    OPENVINO_ASSERT(main_compiled._ptr != nullptr, "AccuracyChecked: main compiled model must not be null");
+    OPENVINO_ASSERT(static_cast<bool>(checker), "AccuracyChecked: checker function must not be null");
+
+    if (ref_compiled._ptr == nullptr) {
+        return main_compiled;
+    }
+
+    auto cm = std::make_shared<CompiledModel>(model, plugin, std::move(main_compiled), std::move(ref_compiled), std::move(checker));
+    return {cm, {}};
+}
+
+CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
+                             const std::shared_ptr<const ov::IPlugin>& plugin,
+                             ov::SoPtr<ov::ICompiledModel> main_compiled,
+                             ov::SoPtr<ov::ICompiledModel> ref_compiled,
+                             Checker checker)
+    : ov::ICompiledModel(model, plugin),
+      m_main_compiled(std::move(main_compiled)),
+      m_ref_compiled(std::move(ref_compiled)),
+      m_checker(std::move(checker)) {}
+
+ov::SoPtr<ov::ICompiledModel> CompiledModel::active_compiled_model_locked() const {
+    return m_switched_to_reference ? m_ref_compiled : m_main_compiled;
+}
+
+bool CompiledModel::has_switched_to_reference() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_switched_to_reference;
+}
+
+void CompiledModel::export_model(std::ostream& stream) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    active_compiled_model_locked()->export_model(stream);
+}
+
+std::shared_ptr<const ov::Model> CompiledModel::get_runtime_model() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return active_compiled_model_locked()->get_runtime_model();
+}
+
+void CompiledModel::set_property(const ov::AnyMap& properties) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    active_compiled_model_locked()->set_property(properties);
+}
+
+ov::Any CompiledModel::get_property(const std::string& name) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return active_compiled_model_locked()->get_property(name);
+}
+
+std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request() const {
+    auto self = std::static_pointer_cast<const CompiledModel>(shared_from_this());
+    return std::make_shared<InferRequest>(std::move(self));
+}
+
+std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() const {
+    return std::make_shared<ov::IAsyncInferRequest>(create_sync_infer_request(),
+                                                    get_task_executor(),
+                                                    get_callback_executor());
+}
+
+// ============================================================================
+// InferRequest
+// ============================================================================
+
+InferRequest::InferRequest(std::shared_ptr<const CompiledModel> compiled_model)
+    : ov::ISyncInferRequest(compiled_model),
+      m_acc_compiled_model(std::move(compiled_model)),
+      m_using_reference(m_acc_compiled_model->has_switched_to_reference()) {}
+
+void InferRequest::ensure_main_request_locked() const {
+    if (m_main_request) {
+        return;
+    }
+    m_main_request = m_acc_compiled_model->m_main_compiled->create_infer_request();
+    OPENVINO_ASSERT(m_main_request, "AccuracyChecked: failed to create main infer request");
+}
+
+void InferRequest::ensure_ref_request_locked() const {
+    if (m_ref_request) {
+        return;
+    }
+    m_ref_request = m_acc_compiled_model->m_ref_compiled->create_infer_request();
+    OPENVINO_ASSERT(m_ref_request, "AccuracyChecked: failed to create reference infer request");
+}
+
+void InferRequest::infer() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (m_using_reference) {
+        ensure_ref_request_locked();
+        m_ref_request->infer();
+        return;
+    }
+
+    ensure_main_request_locked();
+
+    const auto& main_cm = m_acc_compiled_model->m_main_compiled;
+    const auto& ref_cm = m_acc_compiled_model->m_ref_compiled;
+
+    // Snapshot current input/output tensors from the main request.
+    // These are the tensors the user has bound (or the request's defaults).
+    // We use them to (a) feed the reference request and (b) rebind after a
+    // permanent switch so that downstream requests keep reading from the
+    // same memory.
+    std::vector<ov::SoPtr<ov::ITensor>> main_input_tensors;
+    std::vector<ov::SoPtr<ov::ITensor>> main_output_tensors;
+    main_input_tensors.reserve(main_cm->inputs().size());
+    main_output_tensors.reserve(main_cm->outputs().size());
+
+    for (const auto& port : main_cm->inputs()) {
+        main_input_tensors.push_back(m_main_request->get_tensor(port));
+    }
+    for (const auto& port : main_cm->outputs()) {
+        main_output_tensors.push_back(m_main_request->get_tensor(port));
+    }
+
+    m_main_request->infer();
+
+    // Accuracy check: feed reference request with the same inputs and run it.
+    ensure_ref_request_locked();
+    for (size_t i = 0; i < ref_cm->inputs().size(); i++) {
+        m_ref_request->set_tensor(ref_cm->inputs()[i], main_input_tensors[i]);
+    }
+    m_ref_request->infer();
+
+    // Compare outputs using the provided checker.
+    bool accurate = true;
+    for (size_t i = 0; i < main_cm->outputs().size(); i++) {
+        const auto& ref_tensor = m_ref_request->get_tensor(ref_cm->outputs()[i]);
+        if (!m_acc_compiled_model->m_checker(main_output_tensors[i], ref_tensor)) {
+            accurate = false;
+        }
+    }
+
+    if (!accurate) {
+        // Copy reference outputs into the main output buffers so that any
+        // downstream request already bound to those buffers sees the corrected
+        // values immediately.
+        for (size_t i = 0; i < main_cm->outputs().size(); i++) {
+            const auto& ref_tensor = m_ref_request->get_tensor(ref_cm->outputs()[i]);
+            ref_tensor->copy_to(main_output_tensors[i]._ptr);
+        }
+
+        // Rebind the reference request to use the same tensor objects that the
+        // main request was using.  From this point on, the reference request
+        // writes results directly into those buffers, keeping downstream
+        // tensor bindings valid without requiring update_subrequest_links().
+        for (size_t i = 0; i < ref_cm->inputs().size(); i++) {
+            m_ref_request->set_tensor(ref_cm->inputs()[i], main_input_tensors[i]);
+        }
+        for (size_t i = 0; i < ref_cm->outputs().size(); i++) {
+            m_ref_request->set_tensor(ref_cm->outputs()[i], main_output_tensors[i]);
+        }
+
+        m_using_reference = true;
+        {
+            std::lock_guard<std::mutex> model_lock(m_acc_compiled_model->m_mutex);
+            m_acc_compiled_model->m_switched_to_reference = true;
+        }
+    }
+}
+
+ov::SoPtr<ov::ITensor> InferRequest::get_tensor(const ov::Output<const ov::Node>& port) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (m_using_reference) {
+        ensure_ref_request_locked();
+        auto found = find_port(port);
+        OPENVINO_ASSERT(found.found(), "AccuracyChecked: unknown port");
+        const auto& ref_cm = m_acc_compiled_model->m_ref_compiled;
+        return found.is_output() ? m_ref_request->get_tensor(ref_cm->outputs()[found.idx])
+                                 : m_ref_request->get_tensor(ref_cm->inputs()[found.idx]);
+    }
+
+    ensure_main_request_locked();
+    return m_main_request->get_tensor(port);
+}
+
+void InferRequest::set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (m_using_reference) {
+        ensure_ref_request_locked();
+        auto found = find_port(port);
+        OPENVINO_ASSERT(found.found(), "AccuracyChecked: unknown port");
+        const auto& ref_cm = m_acc_compiled_model->m_ref_compiled;
+        if (found.is_output()) {
+            m_ref_request->set_tensor(ref_cm->outputs()[found.idx], tensor);
+        } else {
+            m_ref_request->set_tensor(ref_cm->inputs()[found.idx], tensor);
+        }
+        return;
+    }
+
+    ensure_main_request_locked();
+    m_main_request->set_tensor(port, tensor);
+}
+
+void InferRequest::check_tensors() const {}
+
+std::vector<ov::SoPtr<ov::IVariableState>> InferRequest::query_state() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_using_reference) {
+        ensure_ref_request_locked();
+        return m_ref_request->query_state();
+    }
+    ensure_main_request_locked();
+    return m_main_request->query_state();
+}
+
+std::vector<ov::ProfilingInfo> InferRequest::get_profiling_info() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_using_reference) {
+        ensure_ref_request_locked();
+        return m_ref_request->get_profiling_info();
+    }
+    ensure_main_request_locked();
+    return m_main_request->get_profiling_info();
+}
+
+}  // namespace ov::npuw::accuracy_checked

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.cpp
@@ -16,10 +16,10 @@ namespace ov::npuw::accuracy_checked {
 // ============================================================================
 
 ov::SoPtr<ov::ICompiledModel> CompiledModel::create(const std::shared_ptr<ov::Model>& model,
-                                                     const std::shared_ptr<const ov::IPlugin>& plugin,
-                                                     ov::SoPtr<ov::ICompiledModel> main_compiled,
-                                                     ov::SoPtr<ov::ICompiledModel> ref_compiled,
-                                                     Checker checker) {
+                                                    const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                    ov::SoPtr<ov::ICompiledModel> main_compiled,
+                                                    ov::SoPtr<ov::ICompiledModel> ref_compiled,
+                                                    Checker checker) {
     OPENVINO_ASSERT(main_compiled._ptr != nullptr, "AccuracyChecked: main compiled model must not be null");
     OPENVINO_ASSERT(static_cast<bool>(checker), "AccuracyChecked: checker function must not be null");
 
@@ -27,7 +27,11 @@ ov::SoPtr<ov::ICompiledModel> CompiledModel::create(const std::shared_ptr<ov::Mo
         return main_compiled;
     }
 
-    auto cm = std::make_shared<CompiledModel>(model, plugin, std::move(main_compiled), std::move(ref_compiled), std::move(checker));
+    auto cm = std::make_shared<CompiledModel>(model,
+                                              plugin,
+                                              std::move(main_compiled),
+                                              std::move(ref_compiled),
+                                              std::move(checker));
     return {cm, {}};
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.hpp
@@ -37,10 +37,10 @@ public:
     // Factory method.  Returns main_compiled unwrapped when ref_compiled is
     // null (no-op wrapper) to keep the zero-overhead path trivial.
     static ov::SoPtr<ov::ICompiledModel> create(const std::shared_ptr<ov::Model>& model,
-                                                 const std::shared_ptr<const ov::IPlugin>& plugin,
-                                                 ov::SoPtr<ov::ICompiledModel> main_compiled,
-                                                 ov::SoPtr<ov::ICompiledModel> ref_compiled,
-                                                 Checker checker);
+                                                const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                ov::SoPtr<ov::ICompiledModel> main_compiled,
+                                                ov::SoPtr<ov::ICompiledModel> ref_compiled,
+                                                Checker checker);
 
     CompiledModel(const std::shared_ptr<ov::Model>& model,
                   const std::shared_ptr<const ov::IPlugin>& plugin,

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.hpp
@@ -1,0 +1,108 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+
+#include "openvino/runtime/iasync_infer_request.hpp"
+#include "openvino/runtime/icompiled_model.hpp"
+#include "openvino/runtime/isync_infer_request.hpp"
+#include "openvino/runtime/so_ptr.hpp"
+
+namespace ov::npuw::accuracy_checked {
+
+class InferRequest;
+
+// A compiled-model wrapper that validates inference accuracy against a
+// reference device and permanently switches to that reference if the
+// normalised RMSE threshold is exceeded.
+//
+// The wrapper is transparent: it exposes the same I/O as the wrapped
+// model and forwards all property queries to the currently active model
+// (main until a switch happens, reference afterwards).
+//
+// Intended to be composed on top of a failsafe::CompiledModel so that
+// the full chain becomes:
+//
+//   AccuracyChecked( main = Failsafe(NPU -> CPU), ref = CPU )
+class CompiledModel final : public ov::ICompiledModel {
+public:
+    // Checker: returns true when the output pair is considered accurate.
+    using Checker = std::function<bool(const ov::SoPtr<ov::ITensor>&, const ov::SoPtr<ov::ITensor>&)>;
+
+    // Factory method.  Returns main_compiled unwrapped when ref_compiled is
+    // null (no-op wrapper) to keep the zero-overhead path trivial.
+    static ov::SoPtr<ov::ICompiledModel> create(const std::shared_ptr<ov::Model>& model,
+                                                 const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                 ov::SoPtr<ov::ICompiledModel> main_compiled,
+                                                 ov::SoPtr<ov::ICompiledModel> ref_compiled,
+                                                 Checker checker);
+
+    CompiledModel(const std::shared_ptr<ov::Model>& model,
+                  const std::shared_ptr<const ov::IPlugin>& plugin,
+                  ov::SoPtr<ov::ICompiledModel> main_compiled,
+                  ov::SoPtr<ov::ICompiledModel> ref_compiled,
+                  Checker checker);
+
+    void export_model(std::ostream& model) const override;
+    std::shared_ptr<const ov::Model> get_runtime_model() const override;
+
+    void set_property(const ov::AnyMap& properties) override;
+    ov::Any get_property(const std::string& name) const override;
+
+    std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
+    std::shared_ptr<ov::IAsyncInferRequest> create_infer_request() const override;
+
+    // Returns true if any InferRequest has triggered a permanent switch
+    // to the reference compiled model.
+    bool has_switched_to_reference() const;
+
+private:
+    friend class InferRequest;
+
+    ov::SoPtr<ov::ICompiledModel> active_compiled_model_locked() const;
+
+    ov::SoPtr<ov::ICompiledModel> m_main_compiled;
+    ov::SoPtr<ov::ICompiledModel> m_ref_compiled;
+    Checker m_checker;
+    mutable std::mutex m_mutex;
+    mutable bool m_switched_to_reference = false;
+};
+
+// Sync infer request wrapper produced by AccuracyChecked::CompiledModel.
+//
+// On each infer() call it runs the main request, then copies its inputs
+// to the reference request and runs that too.  Outputs from both are
+// compared using the Checker provided at construction.  If any output
+// fails the check the reference results are copied into the main output
+// buffers and this request (and all subsequent requests from the same
+// CompiledModel) permanently switch to reference-only inference.
+class InferRequest final : public ov::ISyncInferRequest {
+public:
+    explicit InferRequest(std::shared_ptr<const CompiledModel> compiled_model);
+
+    void infer() override;
+
+    ov::SoPtr<ov::ITensor> get_tensor(const ov::Output<const ov::Node>& port) const override;
+    void set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) override;
+    void check_tensors() const override;
+
+    std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override;
+    std::vector<ov::ProfilingInfo> get_profiling_info() const override;
+
+private:
+    void ensure_main_request_locked() const;
+    void ensure_ref_request_locked() const;
+
+    std::shared_ptr<const CompiledModel> m_acc_compiled_model;
+    mutable std::mutex m_mutex;
+    mutable std::shared_ptr<ov::IAsyncInferRequest> m_main_request;
+    mutable std::shared_ptr<ov::IAsyncInferRequest> m_ref_request;
+    mutable bool m_using_reference = false;
+};
+
+}  // namespace ov::npuw::accuracy_checked

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -63,6 +63,7 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/util.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/util_xarch.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/v1/elements/failsafe.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/attention.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/accuracy_checked.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/accuracy_checked.cpp
@@ -1,0 +1,426 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "v1/elements/accuracy_checked.hpp"
+#include "v1/elements/failsafe.hpp"
+#include "openvino/opsets/opset10.hpp"
+#include "openvino/runtime/make_tensor.hpp"
+#include "openvino/runtime/properties.hpp"
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Shared test infrastructure (mirrored from failsafe.cpp)
+// ---------------------------------------------------------------------------
+
+std::shared_ptr<ov::Model> make_test_model() {
+    auto input = std::make_shared<ov::opset10::Parameter>(ov::element::f32, ov::Shape{1});
+    input->set_friendly_name("input");
+    auto zero = ov::opset10::Constant::create(ov::element::f32, ov::Shape{1}, {0.f});
+    auto add = std::make_shared<ov::opset10::Add>(input, zero);
+    add->set_friendly_name("output_add");
+    auto result = std::make_shared<ov::opset10::Result>(add);
+    result->set_friendly_name("output");
+    return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input}, "AccTestModel");
+}
+
+class NullPlugin final : public ov::IPlugin {
+public:
+    std::shared_ptr<ov::ICompiledModel> compile_model(const std::shared_ptr<const ov::Model>&,
+                                                      const ov::AnyMap&) const override { return {}; }
+    std::shared_ptr<ov::ICompiledModel> compile_model(const std::shared_ptr<const ov::Model>&,
+                                                      const ov::AnyMap&,
+                                                      const ov::SoPtr<ov::IRemoteContext>&) const override { return {}; }
+    std::shared_ptr<ov::ICompiledModel> import_model(std::istream&, const ov::AnyMap&) const override { return {}; }
+    std::shared_ptr<ov::ICompiledModel> import_model(std::istream&,
+                                                     const ov::SoPtr<ov::IRemoteContext>&,
+                                                     const ov::AnyMap&) const override { return {}; }
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor&, const ov::AnyMap&) const override { return {}; }
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor&,
+                                                     const ov::SoPtr<ov::IRemoteContext>&,
+                                                     const ov::AnyMap&) const override { return {}; }
+    ov::SupportedOpsMap query_model(const std::shared_ptr<const ov::Model>&, const ov::AnyMap&) const override { return {}; }
+    void set_property(const ov::AnyMap&) override {}
+    ov::Any get_property(const std::string&, const ov::AnyMap&) const override { return {}; }
+    ov::SoPtr<ov::IRemoteContext> create_context(const ov::AnyMap&) const override { return {}; }
+    ov::SoPtr<ov::IRemoteContext> get_default_context(const ov::AnyMap&) const override { return {}; }
+};
+
+// Compiled model that adds a fixed bias to its single input and writes the
+// result to its single output.  Optionally tracks which events occurred.
+struct ModelState {
+    std::string name;
+    std::vector<std::string>* events = nullptr;
+    float output_bias = 0.f;
+    float last_input_value = 0.f;
+    float last_output_value = 0.f;
+};
+
+class TestCompiledModel;
+
+class TestInferRequest final : public ov::ISyncInferRequest {
+public:
+    TestInferRequest(std::shared_ptr<const TestCompiledModel> cm, std::shared_ptr<ModelState> state);
+
+    void infer() override;
+    ov::SoPtr<ov::ITensor> get_tensor(const ov::Output<const ov::Node>& port) const override {
+        return ov::ISyncInferRequest::get_tensor(port);
+    }
+    void set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) override {
+        ov::ISyncInferRequest::set_tensor(port, tensor);
+    }
+    void check_tensors() const override {}
+    std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override { return {}; }
+    std::vector<ov::ProfilingInfo> get_profiling_info() const override { return {}; }
+
+private:
+    std::shared_ptr<ModelState> m_state;
+};
+
+class TestCompiledModel final : public ov::ICompiledModel {
+public:
+    TestCompiledModel(const std::shared_ptr<ov::Model>& model,
+                      const std::shared_ptr<const ov::IPlugin>& plugin,
+                      std::shared_ptr<ModelState> state)
+        : ov::ICompiledModel(model, plugin), m_model(model), m_state(std::move(state)) {}
+
+    void export_model(std::ostream&) const override {}
+    std::shared_ptr<const ov::Model> get_runtime_model() const override { return m_model; }
+    void set_property(const ov::AnyMap&) override {}
+    ov::Any get_property(const std::string& name) const override {
+        if (name == ov::execution_devices.name()) {
+            return std::vector<std::string>{m_state->name};
+        }
+        OPENVINO_THROW("Unsupported property: ", name);
+    }
+    std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override {
+        if (m_state->events) {
+            m_state->events->push_back("create-request:" + m_state->name);
+        }
+        auto self = std::static_pointer_cast<const TestCompiledModel>(shared_from_this());
+        return std::make_shared<TestInferRequest>(std::move(self), m_state);
+    }
+    std::shared_ptr<ov::IAsyncInferRequest> create_infer_request() const override {
+        return std::make_shared<ov::IAsyncInferRequest>(create_sync_infer_request(),
+                                                        get_task_executor(),
+                                                        get_callback_executor());
+    }
+
+private:
+    std::shared_ptr<ov::Model> m_model;
+    std::shared_ptr<ModelState> m_state;
+};
+
+TestInferRequest::TestInferRequest(std::shared_ptr<const TestCompiledModel> cm, std::shared_ptr<ModelState> state)
+    : ov::ISyncInferRequest(cm), m_state(std::move(state)) {
+    for (const auto& input : get_compiled_model()->inputs()) {
+        ov::ISyncInferRequest::set_tensor(
+            input, ov::get_tensor_impl(ov::Tensor(input.get_element_type(), input.get_shape())));
+    }
+    for (const auto& output : get_compiled_model()->outputs()) {
+        ov::ISyncInferRequest::set_tensor(
+            output, ov::get_tensor_impl(ov::Tensor(output.get_element_type(), output.get_shape())));
+    }
+}
+
+void TestInferRequest::infer() {
+    if (m_state->events) {
+        m_state->events->push_back("infer:" + m_state->name);
+    }
+    const auto& input_port = get_compiled_model()->inputs().front();
+    const auto& output_port = get_compiled_model()->outputs().front();
+    const auto& in_tensor = ov::ISyncInferRequest::get_tensor(input_port);
+    const auto& out_tensor = ov::ISyncInferRequest::get_tensor(output_port);
+    m_state->last_input_value = in_tensor->data<const float>()[0];
+    m_state->last_output_value = m_state->last_input_value + m_state->output_bias;
+    out_tensor->data<float>()[0] = m_state->last_output_value;
+}
+
+// Helper to build an ov::SoPtr<ov::ICompiledModel> backed by a TestCompiledModel.
+ov::SoPtr<ov::ICompiledModel> make_test_compiled_model(const std::shared_ptr<ov::Model>& model,
+                                                        const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                        std::shared_ptr<ModelState> state) {
+    return {std::make_shared<TestCompiledModel>(model, plugin, std::move(state)), {}};
+}
+
+// A checker that passes when |actual - reference| <= threshold for a scalar f32 tensor.
+ov::npuw::accuracy_checked::CompiledModel::Checker make_threshold_checker(float threshold) {
+    return [threshold](const ov::SoPtr<ov::ITensor>& actual,
+                       const ov::SoPtr<ov::ITensor>& reference) -> bool {
+        const float a = actual->data<const float>()[0];
+        const float r = reference->data<const float>()[0];
+        return std::abs(a - r) <= threshold;
+    };
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+TEST(AccuracyCheckedCompiledModelTest, NullRefReturnsMainUnwrapped) {
+    auto model = make_test_model();
+    auto plugin = std::make_shared<NullPlugin>();
+    auto main_state = std::make_shared<ModelState>(ModelState{"main", nullptr, 0.f});
+    auto main_cm = make_test_compiled_model(model, plugin, main_state);
+
+    auto so = ov::npuw::accuracy_checked::CompiledModel::create(model, plugin, main_cm, {}, make_threshold_checker(0.f));
+
+    // When ref is null create() must return the unwrapped main model.
+    EXPECT_EQ(std::dynamic_pointer_cast<ov::npuw::accuracy_checked::CompiledModel>(so._ptr), nullptr);
+    ASSERT_NE(so._ptr, nullptr);
+}
+
+TEST(AccuracyCheckedCompiledModelTest, AccurateInferencePassesThrough) {
+    auto model = make_test_model();
+    auto plugin = std::make_shared<NullPlugin>();
+    std::vector<std::string> events;
+
+    auto main_state = std::make_shared<ModelState>(ModelState{"main", &events, 10.f});
+    auto ref_state  = std::make_shared<ModelState>(ModelState{"ref",  &events, 10.f});  // same bias → same output
+
+    auto main_cm = make_test_compiled_model(model, plugin, main_state);
+    auto ref_cm  = make_test_compiled_model(model, plugin, ref_state);
+
+    auto so = ov::npuw::accuracy_checked::CompiledModel::create(
+        model, plugin, main_cm, ref_cm, make_threshold_checker(0.1f));
+    auto compiled = std::dynamic_pointer_cast<ov::npuw::accuracy_checked::CompiledModel>(so._ptr);
+    ASSERT_NE(compiled, nullptr);
+
+    auto request = compiled->create_sync_infer_request();
+    auto input = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+    input->data<float>()[0] = 5.f;
+    request->set_tensor(model->inputs().front(), input);
+
+    ASSERT_NO_THROW(request->infer());
+
+    // Both main and ref should have been inferred.
+    EXPECT_EQ(main_state->last_input_value, 5.f);
+    EXPECT_EQ(ref_state->last_input_value, 5.f);
+    // Output = input + bias = 5 + 10 = 15.
+    EXPECT_FLOAT_EQ(request->get_tensor(model->outputs().front())->data<const float>()[0], 15.f);
+
+    // Model should NOT have switched.
+    EXPECT_FALSE(compiled->has_switched_to_reference());
+}
+
+TEST(AccuracyCheckedCompiledModelTest, InaccurateInferenceSwitchesToReference) {
+    auto model = make_test_model();
+    auto plugin = std::make_shared<NullPlugin>();
+    std::vector<std::string> events;
+
+    // main bias=10, ref bias=11 → difference=1 > threshold=0.5 → fail
+    auto main_state = std::make_shared<ModelState>(ModelState{"main", &events, 10.f});
+    auto ref_state  = std::make_shared<ModelState>(ModelState{"ref",  &events, 11.f});
+
+    auto main_cm = make_test_compiled_model(model, plugin, main_state);
+    auto ref_cm  = make_test_compiled_model(model, plugin, ref_state);
+
+    auto so = ov::npuw::accuracy_checked::CompiledModel::create(
+        model, plugin, main_cm, ref_cm, make_threshold_checker(0.5f));
+    auto compiled = std::dynamic_pointer_cast<ov::npuw::accuracy_checked::CompiledModel>(so._ptr);
+    ASSERT_NE(compiled, nullptr);
+
+    auto request = compiled->create_sync_infer_request();
+    auto input = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+    input->data<float>()[0] = 3.f;
+    request->set_tensor(model->inputs().front(), input);
+
+    ASSERT_NO_THROW(request->infer());
+
+    // Output should be the reference value (3 + 11 = 14), copied into the main output buffer.
+    EXPECT_FLOAT_EQ(request->get_tensor(model->outputs().front())->data<const float>()[0], 14.f);
+    EXPECT_TRUE(compiled->has_switched_to_reference());
+}
+
+TEST(AccuracyCheckedCompiledModelTest, PermanentSwitchSkipsMainOnSubsequentInfers) {
+    auto model = make_test_model();
+    auto plugin = std::make_shared<NullPlugin>();
+    std::vector<std::string> events;
+
+    auto main_state = std::make_shared<ModelState>(ModelState{"main", &events, 10.f});
+    auto ref_state  = std::make_shared<ModelState>(ModelState{"ref",  &events, 11.f});
+
+    auto main_cm = make_test_compiled_model(model, plugin, main_state);
+    auto ref_cm  = make_test_compiled_model(model, plugin, ref_state);
+
+    auto so = ov::npuw::accuracy_checked::CompiledModel::create(
+        model, plugin, main_cm, ref_cm, make_threshold_checker(0.5f));
+    auto compiled = std::dynamic_pointer_cast<ov::npuw::accuracy_checked::CompiledModel>(so._ptr);
+    auto request = compiled->create_sync_infer_request();
+
+    auto input = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+    input->data<float>()[0] = 1.f;
+    request->set_tensor(model->inputs().front(), input);
+
+    // First infer triggers the switch.
+    ASSERT_NO_THROW(request->infer());
+    ASSERT_TRUE(compiled->has_switched_to_reference());
+
+    events.clear();  // Reset event log.
+
+    input->data<float>()[0] = 2.f;
+    ASSERT_NO_THROW(request->infer());
+
+    // After permanent switch the main model must NOT be invoked.
+    for (const auto& ev : events) {
+        EXPECT_NE(ev, "infer:main") << "main should not be inferred after switch";
+    }
+    // Reference should have been inferred with the new input.
+    EXPECT_FLOAT_EQ(ref_state->last_input_value, 2.f);
+    EXPECT_FLOAT_EQ(request->get_tensor(model->outputs().front())->data<const float>()[0], 2.f + 11.f);
+}
+
+TEST(AccuracyCheckedCompiledModelTest, UserOutputBufferReceivesReferenceValueOnSwitch) {
+    auto model = make_test_model();
+    auto plugin = std::make_shared<NullPlugin>();
+
+    auto main_state = std::make_shared<ModelState>(ModelState{"main", nullptr, 10.f});
+    auto ref_state  = std::make_shared<ModelState>(ModelState{"ref",  nullptr, 20.f});
+
+    auto main_cm = make_test_compiled_model(model, plugin, main_state);
+    auto ref_cm  = make_test_compiled_model(model, plugin, ref_state);
+
+    auto so = ov::npuw::accuracy_checked::CompiledModel::create(
+        model, plugin, main_cm, ref_cm, make_threshold_checker(0.5f));
+    auto compiled = std::dynamic_pointer_cast<ov::npuw::accuracy_checked::CompiledModel>(so._ptr);
+    auto request = compiled->create_sync_infer_request();
+
+    auto input  = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+    auto output = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+    input->data<float>()[0]  = 4.f;
+    output->data<float>()[0] = -1.f;  // sentinel
+    request->set_tensor(model->inputs().front(), input);
+    request->set_tensor(model->outputs().front(), output);
+
+    ASSERT_NO_THROW(request->infer());
+
+    // The user-provided output tensor must hold the reference result (4 + 20 = 24).
+    EXPECT_FLOAT_EQ(output->data<const float>()[0], 24.f);
+    // And get_tensor() must return the same object.
+    EXPECT_EQ(request->get_tensor(model->outputs().front())._ptr, output._ptr);
+}
+
+TEST(AccuracyCheckedCompiledModelTest, NewRequestFromSwitchedModelStartsOnReference) {
+    auto model = make_test_model();
+    auto plugin = std::make_shared<NullPlugin>();
+    std::vector<std::string> events;
+
+    auto main_state = std::make_shared<ModelState>(ModelState{"main", &events, 10.f});
+    auto ref_state  = std::make_shared<ModelState>(ModelState{"ref",  &events, 20.f});
+
+    auto main_cm = make_test_compiled_model(model, plugin, main_state);
+    auto ref_cm  = make_test_compiled_model(model, plugin, ref_state);
+
+    auto so = ov::npuw::accuracy_checked::CompiledModel::create(
+        model, plugin, main_cm, ref_cm, make_threshold_checker(0.5f));
+    auto compiled = std::dynamic_pointer_cast<ov::npuw::accuracy_checked::CompiledModel>(so._ptr);
+
+    // Trigger switch via first request.
+    {
+        auto req1 = compiled->create_sync_infer_request();
+        auto in1 = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+        in1->data<float>()[0] = 1.f;
+        req1->set_tensor(model->inputs().front(), in1);
+        req1->infer();
+        ASSERT_TRUE(compiled->has_switched_to_reference());
+    }
+
+    events.clear();
+
+    // A second request created after the switch should use reference directly.
+    auto req2 = compiled->create_sync_infer_request();
+    auto in2 = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+    in2->data<float>()[0] = 5.f;
+    req2->set_tensor(model->inputs().front(), in2);
+    ASSERT_NO_THROW(req2->infer());
+
+    for (const auto& ev : events) {
+        EXPECT_NE(ev, "infer:main") << "new request after switch must not use main";
+    }
+    EXPECT_FLOAT_EQ(ref_state->last_input_value, 5.f);
+    EXPECT_FLOAT_EQ(req2->get_tensor(model->outputs().front())->data<const float>()[0], 5.f + 20.f);
+}
+
+TEST(AccuracyCheckedCompiledModelTest, ChainedWithFailsafeModel) {
+    auto model = make_test_model();
+    auto plugin = std::make_shared<NullPlugin>();
+    std::vector<std::string> events;
+
+    // Failsafe inner layer: NPU fails, falls back to CPU.
+    auto npu_state = std::make_shared<ModelState>(ModelState{"NPU", &events, 10.f});
+    auto cpu_state = std::make_shared<ModelState>(ModelState{"CPU", &events, 10.f});
+
+    auto failsafe_factory = [&](const std::string& device) -> ov::SoPtr<ov::ICompiledModel> {
+        if (device == "NPU") {
+            OPENVINO_THROW("NPU not available");
+        }
+        if (device == "CPU") {
+            return make_test_compiled_model(model, plugin, cpu_state);
+        }
+        OPENVINO_THROW("Unknown device: ", device);
+    };
+
+    auto failsafe_cm = ov::npuw::failsafe::CompiledModel::create(model, plugin, {"NPU", "CPU"}, failsafe_factory);
+
+    // Reference is a separate CPU model with a different bias (simulate inaccuracy).
+    auto ref_state = std::make_shared<ModelState>(ModelState{"ref_cpu", &events, 20.f});
+    auto ref_cm = make_test_compiled_model(model, plugin, ref_state);
+
+    auto so = ov::npuw::accuracy_checked::CompiledModel::create(
+        model, plugin, failsafe_cm, ref_cm, make_threshold_checker(0.5f));
+    auto acc_compiled = std::dynamic_pointer_cast<ov::npuw::accuracy_checked::CompiledModel>(so._ptr);
+    ASSERT_NE(acc_compiled, nullptr);
+
+    auto request = acc_compiled->create_sync_infer_request();
+    auto input = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+    input->data<float>()[0] = 2.f;
+    request->set_tensor(model->inputs().front(), input);
+
+    // Failsafe uses CPU (bias=10), ref uses ref_cpu (bias=20). diff=10 > 0.5 → switch.
+    ASSERT_NO_THROW(request->infer());
+
+    EXPECT_TRUE(acc_compiled->has_switched_to_reference());
+    // Output should be ref result: 2 + 20 = 22.
+    EXPECT_FLOAT_EQ(request->get_tensor(model->outputs().front())->data<const float>()[0], 22.f);
+}
+
+TEST(AccuracyCheckedCompiledModelTest, ExecutionDevicesReflectsActiveModel) {
+    auto model = make_test_model();
+    auto plugin = std::make_shared<NullPlugin>();
+
+    auto main_state = std::make_shared<ModelState>(ModelState{"NPU", nullptr, 10.f});
+    auto ref_state  = std::make_shared<ModelState>(ModelState{"CPU", nullptr, 11.f});
+
+    auto main_cm = make_test_compiled_model(model, plugin, main_state);
+    auto ref_cm  = make_test_compiled_model(model, plugin, ref_state);
+
+    auto so = ov::npuw::accuracy_checked::CompiledModel::create(
+        model, plugin, main_cm, ref_cm, make_threshold_checker(0.5f));
+    auto compiled = std::dynamic_pointer_cast<ov::npuw::accuracy_checked::CompiledModel>(so._ptr);
+    ASSERT_NE(compiled, nullptr);
+
+    // Before switch: reports main device.
+    auto devs_before = compiled->get_property(ov::execution_devices.name()).as<std::vector<std::string>>();
+    EXPECT_EQ(devs_before, (std::vector<std::string>{"NPU"}));
+
+    // Trigger switch.
+    auto request = compiled->create_sync_infer_request();
+    auto input = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+    input->data<float>()[0] = 1.f;
+    request->set_tensor(model->inputs().front(), input);
+    request->infer();
+    ASSERT_TRUE(compiled->has_switched_to_reference());
+
+    // After switch: reports reference device.
+    auto devs_after = compiled->get_property(ov::execution_devices.name()).as<std::vector<std::string>>();
+    EXPECT_EQ(devs_after, (std::vector<std::string>{"CPU"}));
+}

--- a/src/plugins/intel_npu/tests/unit/npuw/accuracy_checked.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/accuracy_checked.cpp
@@ -61,6 +61,11 @@ struct ModelState {
     float output_bias = 0.f;
     float last_input_value = 0.f;
     float last_output_value = 0.f;
+    // Optional glitch: from call number glitch_at_call onwards, output_bias is
+    // replaced with glitch_bias.  Set glitch_at_call <= 0 to disable.
+    int infer_count = 0;
+    int glitch_at_call = 0;
+    float glitch_bias = 0.f;
 };
 
 class TestCompiledModel;
@@ -134,12 +139,16 @@ void TestInferRequest::infer() {
     if (m_state->events) {
         m_state->events->push_back("infer:" + m_state->name);
     }
+    ++m_state->infer_count;
+    const float bias = (m_state->glitch_at_call > 0 && m_state->infer_count >= m_state->glitch_at_call)
+                           ? m_state->glitch_bias
+                           : m_state->output_bias;
     const auto& input_port = get_compiled_model()->inputs().front();
     const auto& output_port = get_compiled_model()->outputs().front();
     const auto& in_tensor = ov::ISyncInferRequest::get_tensor(input_port);
     const auto& out_tensor = ov::ISyncInferRequest::get_tensor(output_port);
     m_state->last_input_value = in_tensor->data<const float>()[0];
-    m_state->last_output_value = m_state->last_input_value + m_state->output_bias;
+    m_state->last_output_value = m_state->last_input_value + bias;
     out_tensor->data<float>()[0] = m_state->last_output_value;
 }
 
@@ -423,4 +432,74 @@ TEST(AccuracyCheckedCompiledModelTest, ExecutionDevicesReflectsActiveModel) {
     // After switch: reports reference device.
     auto devs_after = compiled->get_property(ov::execution_devices.name()).as<std::vector<std::string>>();
     EXPECT_EQ(devs_after, (std::vector<std::string>{"CPU"}));
+}
+
+TEST(AccuracyCheckedCompiledModelTest, RepeatingBlockAccuracyFailsAtThirdCall) {
+    // In NPUW a function body (repeating block) is compiled once and its infer
+    // request pair (main + ref) is *reused* for every call-site invocation
+    // within a single forward pass.  The AccuracyChecked::InferRequest wraps
+    // that pair and is called once per instance.  The shared
+    // m_switched_to_reference flag ensures that once any instance detects an
+    // accuracy failure, all subsequent invocations automatically use reference.
+    //
+    // Scenario: main is accurate on calls 1 and 2, but "glitches" from call 3
+    // onwards (output bias shifts by 1).  Reference is always stable.
+    // Threshold = 0.5, so |glitch| = 1 triggers the permanent switch on call 3.
+    auto model = make_test_model();
+    auto plugin = std::make_shared<NullPlugin>();
+    std::vector<std::string> events;
+
+    auto main_state = std::make_shared<ModelState>(ModelState{"main", &events, 10.f});
+    main_state->glitch_at_call = 3;
+    main_state->glitch_bias    = 11.f;  // diverges from ref by 1 on call 3+
+
+    auto ref_state = std::make_shared<ModelState>(ModelState{"ref", &events, 10.f});
+
+    auto main_cm = make_test_compiled_model(model, plugin, main_state);
+    auto ref_cm  = make_test_compiled_model(model, plugin, ref_state);
+
+    auto so = ov::npuw::accuracy_checked::CompiledModel::create(
+        model, plugin, main_cm, ref_cm, make_threshold_checker(0.5f));
+    auto compiled = std::dynamic_pointer_cast<ov::npuw::accuracy_checked::CompiledModel>(so._ptr);
+    ASSERT_NE(compiled, nullptr);
+
+    // One AccuracyChecked::InferRequest reused for all N instances of the block.
+    auto request = compiled->create_sync_infer_request();
+    auto input   = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1}));
+    request->set_tensor(model->inputs().front(), input);
+
+    // -- Forward pass 1, instance 1: main call #1, bias=10. Accurate. ---------
+    input->data<float>()[0] = 1.f;
+    ASSERT_NO_THROW(request->infer());
+    EXPECT_FALSE(compiled->has_switched_to_reference());
+    EXPECT_FLOAT_EQ(request->get_tensor(model->outputs().front())->data<const float>()[0], 11.f);  // 1+10
+
+    // -- Forward pass 1, instance 2: main call #2, bias=10. Accurate. ---------
+    input->data<float>()[0] = 2.f;
+    ASSERT_NO_THROW(request->infer());
+    EXPECT_FALSE(compiled->has_switched_to_reference());
+    EXPECT_FLOAT_EQ(request->get_tensor(model->outputs().front())->data<const float>()[0], 12.f);  // 2+10
+
+    // -- Forward pass 1, instance 3: main call #3, bias glitches to 11.
+    //    main=3+11=14, ref=3+10=13, |14-13|=1 > 0.5 → permanent switch. ------
+    input->data<float>()[0] = 3.f;
+    ASSERT_NO_THROW(request->infer());
+    EXPECT_TRUE(compiled->has_switched_to_reference());
+    // Output must be the reference result (3+10=13), not the glitched main (14).
+    EXPECT_FLOAT_EQ(request->get_tensor(model->outputs().front())->data<const float>()[0], 13.f);
+
+    // -- Forward pass 2: all instances use reference directly. -----------------
+    events.clear();
+    input->data<float>()[0] = 10.f;
+    ASSERT_NO_THROW(request->infer());  // instance 1
+    input->data<float>()[0] = 20.f;
+    ASSERT_NO_THROW(request->infer());  // instance 2
+    input->data<float>()[0] = 30.f;
+    ASSERT_NO_THROW(request->infer());  // instance 3
+
+    for (const auto& ev : events) {
+        EXPECT_NE(ev, "infer:main") << "main must not be invoked after permanent reference switch";
+    }
+    // Last output via reference: 30+10=40.
+    EXPECT_FLOAT_EQ(request->get_tensor(model->outputs().front())->data<const float>()[0], 40.f);
 }


### PR DESCRIPTION
### Details:
 - Subgraph-level accuracy checking is now moved into a separate component

### Tickets:
- EISW-213302

### AI Assistance:
 - *AI assistance used: yes*
 - *Implemented according to spec*
