### PR TITLE
[GPU] Fix moe3_gemm build errors for L0 runtime

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
@@ -13,7 +13,6 @@
 #    include <algorithm>
 #    include <initializer_list>
 #    include <oneapi/dnnl/dnnl.hpp>
-#    include <oneapi/dnnl/dnnl_ocl.hpp>
 #    include <sstream>
 #    include <string_view>
 #    include <tuple>
@@ -2214,8 +2213,6 @@ public:
         auto cur_moe = instance.get_typed_desc<moe_3gemm_fused_compressed>();
         const auto& config = cur_moe->_config;
         auto& dnn_stream = stream.get_onednn_stream();
-        auto& engine = instance.get_network().get_engine();
-        auto& onednn_engine = engine.get_onednn_engine();
 
         auto [hidden_states_mem_ptr, hidden_states_layout] = get_input_info(instance, static_cast<size_t>(MOE3GemmInputIndex::HIDDEN_STATES));
         auto token_num = get_seq_len(hidden_states_layout);
@@ -2321,7 +2318,7 @@ public:
         // Steps 3-5: OneDNN grouped GEMM – gate, up, SiLU, down
         // ----------------------------------------------------------------
         auto& gk = get_grouped_kernel(total_gathered_tokens, instance);
-        auto* offsets_ptr = intermediates_memories[MOE_INTERNAL_BUFFER_GROUPED_OFFSETS]->buffer_ptr();
+        auto row_offsets = intermediates_memories[MOE_INTERNAL_BUFFER_GROUPED_OFFSETS];
 
         // Runtime dispatch hint: actual max tokens assigned to any single expert.
         // Passed as DNNL_ARG_HINT_MAX_GROUP_SIZE to each grouped matmul execute(),
@@ -2330,26 +2327,12 @@ public:
         auto hint_md = dnnl::memory::desc::host_scalar(dnnl::memory::data_type::s32);
         dnnl::memory hint_mem(hint_md, static_cast<int32_t>(max_tokens_per_expert));
 
-        // Helper: wrap a flat USM buffer as an OneDNN grouped memory (data + expert row-offsets)
-        auto make_grouped_mem = [&](const dnnl::memory::desc& md, void* buf_ptr) {
-            return dnnl::ocl_interop::make_memory(md,
-                                                  onednn_engine,
-                                                  dnnl::ocl_interop::memory_kind::usm,
-                                                  {reinterpret_cast<uint8_t*>(buf_ptr), reinterpret_cast<uint8_t*>(offsets_ptr)});
-        };
-
         // gate GEMM: [total, hidden] * W_gate[E,hidden,inter] -> [total, inter]
         {
-            auto src_mem = make_grouped_mem(gk.gate_pd.src_desc(), scratch.x->buffer_ptr());
-            auto dst_mem = make_grouped_mem(gk.gate_pd.dst_desc(), scratch.gate->buffer_ptr());
-            auto w_mem = dnnl::ocl_interop::make_memory(gk.gate_pd.weights_desc(),
-                                                        onednn_engine,
-                                                        dnnl::ocl_interop::memory_kind::usm,
-                                                        scratch.moe_fusion_wei_addr.weight[0]->buffer_ptr());
-            auto scale_mem = dnnl::ocl_interop::make_memory(gk.gate_scale_md,
-                                                            onednn_engine,
-                                                            dnnl::ocl_interop::memory_kind::usm,
-                                                            scratch.moe_fusion_wei_addr.scale[0]->buffer_ptr());
+            auto src_mem = scratch.x->get_onednn_grouped_memory(gk.gate_pd.src_desc(), *row_offsets);
+            auto dst_mem = scratch.gate->get_onednn_grouped_memory(gk.gate_pd.dst_desc(), *row_offsets);
+            auto w_mem = scratch.moe_fusion_wei_addr.weight[0]->get_onednn_memory(gk.gate_pd.weights_desc());
+            auto scale_mem = scratch.moe_fusion_wei_addr.scale[0]->get_onednn_memory(gk.gate_scale_md);
 
             std::unordered_map<int, dnnl::memory> args{{DNNL_ARG_SRC, src_mem},
                                                        {DNNL_ARG_WEIGHTS, w_mem},
@@ -2358,26 +2341,17 @@ public:
                                                        {DNNL_ARG_HINT_MAX_GROUP_SIZE, hint_mem}};
             if (gk.has_zp) {
                 args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
-                             dnnl::ocl_interop::make_memory(gk.gate_zp_md,
-                                                            onednn_engine,
-                                                            dnnl::ocl_interop::memory_kind::usm,
-                                                            scratch.moe_fusion_wei_addr.zp[0]->buffer_ptr())});
+                             scratch.moe_fusion_wei_addr.zp[0]->get_onednn_memory(gk.gate_zp_md)});
             }
             gk.gate_prim.execute(dnn_stream, args);
         }
 
         // up GEMM: [total, hidden] * W_up[E,hidden,inter] -> [total, inter]
         {
-            auto src_mem = make_grouped_mem(gk.up_pd.src_desc(), scratch.x->buffer_ptr());
-            auto dst_mem = make_grouped_mem(gk.up_pd.dst_desc(), scratch.up->buffer_ptr());
-            auto w_mem = dnnl::ocl_interop::make_memory(gk.up_pd.weights_desc(),
-                                                        onednn_engine,
-                                                        dnnl::ocl_interop::memory_kind::usm,
-                                                        scratch.moe_fusion_wei_addr.weight[1]->buffer_ptr());
-            auto scale_mem = dnnl::ocl_interop::make_memory(gk.up_scale_md,
-                                                            onednn_engine,
-                                                            dnnl::ocl_interop::memory_kind::usm,
-                                                            scratch.moe_fusion_wei_addr.scale[1]->buffer_ptr());
+            auto src_mem = scratch.x->get_onednn_grouped_memory(gk.up_pd.src_desc(), *row_offsets);
+            auto dst_mem = scratch.up->get_onednn_grouped_memory(gk.up_pd.dst_desc(), *row_offsets);
+            auto w_mem = scratch.moe_fusion_wei_addr.weight[1]->get_onednn_memory(gk.up_pd.weights_desc());
+            auto scale_mem = scratch.moe_fusion_wei_addr.scale[1]->get_onednn_memory(gk.up_scale_md);
 
             std::unordered_map<int, dnnl::memory> args{{DNNL_ARG_SRC, src_mem},
                                                        {DNNL_ARG_WEIGHTS, w_mem},
@@ -2386,10 +2360,7 @@ public:
                                                        {DNNL_ARG_HINT_MAX_GROUP_SIZE, hint_mem}};
             if (gk.has_zp) {
                 args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
-                             dnnl::ocl_interop::make_memory(gk.up_zp_md,
-                                                            onednn_engine,
-                                                            dnnl::ocl_interop::memory_kind::usm,
-                                                            scratch.moe_fusion_wei_addr.zp[1]->buffer_ptr())});
+                             scratch.moe_fusion_wei_addr.zp[1]->get_onednn_memory(gk.up_zp_md)});
             }
             gk.up_prim.execute(dnn_stream, args);
         }
@@ -2411,16 +2382,10 @@ public:
 
         // down GEMM: [total, inter] * W_down[E,inter,hidden] -> [total, hidden]
         {
-            auto src_mem = make_grouped_mem(gk.down_pd.src_desc(), scratch.gate->buffer_ptr());
-            auto dst_mem = make_grouped_mem(gk.down_pd.dst_desc(), scratch.y->buffer_ptr());
-            auto w_mem = dnnl::ocl_interop::make_memory(gk.down_pd.weights_desc(),
-                                                        onednn_engine,
-                                                        dnnl::ocl_interop::memory_kind::usm,
-                                                        scratch.moe_fusion_wei_addr.weight[2]->buffer_ptr());
-            auto scale_mem = dnnl::ocl_interop::make_memory(gk.down_scale_md,
-                                                            onednn_engine,
-                                                            dnnl::ocl_interop::memory_kind::usm,
-                                                            scratch.moe_fusion_wei_addr.scale[2]->buffer_ptr());
+            auto src_mem = scratch.gate->get_onednn_grouped_memory(gk.down_pd.src_desc(), *row_offsets);
+            auto dst_mem = scratch.y->get_onednn_grouped_memory(gk.down_pd.dst_desc(), *row_offsets);
+            auto w_mem = scratch.moe_fusion_wei_addr.weight[2]->get_onednn_memory(gk.down_pd.weights_desc());
+            auto scale_mem = scratch.moe_fusion_wei_addr.scale[2]->get_onednn_memory(gk.down_scale_md);
 
             std::unordered_map<int, dnnl::memory> args{{DNNL_ARG_SRC, src_mem},
                                                        {DNNL_ARG_WEIGHTS, w_mem},
@@ -2429,10 +2394,7 @@ public:
                                                        {DNNL_ARG_HINT_MAX_GROUP_SIZE, hint_mem}};
             if (gk.has_zp) {
                 args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
-                             dnnl::ocl_interop::make_memory(gk.down_zp_md,
-                                                            onednn_engine,
-                                                            dnnl::ocl_interop::memory_kind::usm,
-                                                            scratch.moe_fusion_wei_addr.zp[2]->buffer_ptr())});
+                             scratch.moe_fusion_wei_addr.zp[2]->get_onednn_memory(gk.down_zp_md)});
             }
             gk.down_prim.execute(dnn_stream, args);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
@@ -2340,8 +2340,7 @@ public:
                                                        {DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, scale_mem},
                                                        {DNNL_ARG_HINT_MAX_GROUP_SIZE, hint_mem}};
             if (gk.has_zp) {
-                args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
-                             scratch.moe_fusion_wei_addr.zp[0]->get_onednn_memory(gk.gate_zp_md)});
+                args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, scratch.moe_fusion_wei_addr.zp[0]->get_onednn_memory(gk.gate_zp_md)});
             }
             gk.gate_prim.execute(dnn_stream, args);
         }
@@ -2359,8 +2358,7 @@ public:
                                                        {DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, scale_mem},
                                                        {DNNL_ARG_HINT_MAX_GROUP_SIZE, hint_mem}};
             if (gk.has_zp) {
-                args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
-                             scratch.moe_fusion_wei_addr.zp[1]->get_onednn_memory(gk.up_zp_md)});
+                args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, scratch.moe_fusion_wei_addr.zp[1]->get_onednn_memory(gk.up_zp_md)});
             }
             gk.up_prim.execute(dnn_stream, args);
         }
@@ -2393,8 +2391,7 @@ public:
                                                        {DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, scale_mem},
                                                        {DNNL_ARG_HINT_MAX_GROUP_SIZE, hint_mem}};
             if (gk.has_zp) {
-                args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
-                             scratch.moe_fusion_wei_addr.zp[2]->get_onednn_memory(gk.down_zp_md)});
+                args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, scratch.moe_fusion_wei_addr.zp[2]->get_onednn_memory(gk.down_zp_md)});
             }
             gk.down_prim.execute(dnn_stream, args);
         }


### PR DESCRIPTION
### Details:
 - Fix L0 build issues introduced by https://github.com/openvinotoolkit/openvino/pull/34974
 - Replace direct calls to `dnnl::ocl_interop` with `get_onednn_grouped_memory` and `get_onednn_memory` from OpenVINO memory API.
### AI Assistance:
 - *AI assistance used: no 
