### PR TITLE
[GHA] Testing usage of `uv` for Python modules installation in one Windows job

### DIFF
--- a/.github/actions/setup_python/action.yml
+++ b/.github/actions/setup_python/action.yml
@@ -65,3 +65,10 @@ runs:
         $pipVersion = python3 -c "import pip; print(pip.__version__)"
         Write-Host "Using pip version: $pipVersion"
         "PIP_CACHE_DIR=${{ inputs.pip-cache-path }}/$pipVersion" >> $env:GITHUB_ENV
+
+    # See PR #34185 for details, this is just for debug purposes and will be reverted
+    - if: ${{ runner.os == 'Windows' }}
+      name: Set PIP_INSTALL_COMMAND variable for Windows
+      shell: pwsh
+      run: |
+        "PIP_INSTALL_COMMAND=python3 c:/pip_diag.py install" >> $env:GITHUB_ENV

--- a/.github/workflows/job_jax_layer_tests.yml
+++ b/.github/workflows/job_jax_layer_tests.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           echo "HF_HUB_CACHE=${{ runner.os == 'Linux' && env.HF_HUB_CACHE_LIN || env.HF_HUB_CACHE_WIN }}" >> "$GITHUB_ENV"
           echo "HUGGINGFACE_HUB_CACHE=${{ runner.os == 'Linux' && env.HF_HUB_CACHE_LIN || env.HF_HUB_CACHE_WIN }}" >> "$GITHUB_ENV"
+          echo "PIP_INSTALL_COMMAND=python3 -m pip install" >> "$GITHUB_ENV" # Linux and MacOS only, and just for debug purposes, will be reverted, see PR #34185
 
       - name: Install OpenVINO dependencies (mac)
         if: runner.os == 'macOS'
@@ -109,7 +110,7 @@ jobs:
       - name: Install JAX Layer tests dependencies
         run: |
           # jax test requirements
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/requirements_jax
+          ${{ env.PIP_INSTALL_COMMAND }} -r ${{ env.INSTALL_TEST_DIR }}/requirements_jax
 
       - name: JAX Layer Tests
         if: ${{ fromJSON(inputs.affected-components).JAX_FE.test && runner.arch != 'ARM64' }} # Ticket: 126287, 142196

--- a/.github/workflows/job_python_unit_tests.yml
+++ b/.github/workflows/job_python_unit_tests.yml
@@ -88,24 +88,28 @@ jobs:
           wheels-dir-path: ${{ env.INSTALL_DIR }}
           wheels-to-install: 'openvino'
 
+      - name: Setup Variables
+        run: |
+          echo "PIP_INSTALL_COMMAND=python3 -m pip install" >> "$GITHUB_ENV" # Linux and MacOS only, and just for debug purposes, will be reverted, see PR #34185
+
       - name: Install Python API tests dependencies
         run: |
           # To enable pytest parallel features
-          python3 -m pip install pytest-xdist[psutil]
-          python3 -m pip install -r ${INSTALL_TEST_DIR}/bindings/python/requirements_test.txt
+          ${{ env.PIP_INSTALL_COMMAND }} pytest-xdist[psutil]
+          ${{ env.PIP_INSTALL_COMMAND }} -r ${INSTALL_TEST_DIR}/bindings/python/requirements_test.txt
 
       - name: Install Python Layer tests dependencies and for OVC unit tests
         run: |
           # For torchvision to OpenVINO preprocessing converter
-          python3 -m pip install -r ${INSTALL_TEST_DIR}/python/preprocess/torchvision/requirements.txt
+          ${{ env.PIP_INSTALL_COMMAND }} -r ${INSTALL_TEST_DIR}/python/preprocess/torchvision/requirements.txt
 
           # layer test requirements
-          python3 -m pip install -r ${INSTALL_TEST_DIR}/layer_tests/requirements.txt
+          ${{ env.PIP_INSTALL_COMMAND }} -r ${INSTALL_TEST_DIR}/layer_tests/requirements.txt
 
       - name: Install ONNX tests dependencies
         run: |
           #  ONNX tests requirements
-          python3 -m pip install -r ${INSTALL_TEST_DIR}/requirements_onnx
+          ${{ env.PIP_INSTALL_COMMAND }} -r ${INSTALL_TEST_DIR}/requirements_onnx
 
       #
       # Tests

--- a/.github/workflows/job_pytorch_fx_layer_tests.yml
+++ b/.github/workflows/job_pytorch_fx_layer_tests.yml
@@ -77,6 +77,10 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "HF_HUB_CACHE=C:\\mount\\caches\\huggingface"
           Add-Content -Path $env:GITHUB_ENV -Value "HUGGINGFACE_HUB_CACHE=C:\\mount\\caches\\huggingface"
 
+      - name: Setup Variables
+        run: |
+          echo "PIP_INSTALL_COMMAND=python3 -m pip install" >> "$GITHUB_ENV" # Linux and MacOS only, and just for debug purposes, will be reverted, see PR #34185
+
       - name: Install OpenVINO dependencies (mac)
         if: runner.os == 'macOS'
         run: brew install pigz
@@ -108,7 +112,7 @@ jobs:
       - name: Install Pytorch FX Layer tests dependencies
         run: |
           # pytorch test requirements
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/requirements_pytorch
+          ${{ env.PIP_INSTALL_COMMAND }} -r ${{ env.INSTALL_TEST_DIR }}/requirements_pytorch
 
       - name: PyTorch torch.compile TORCHFX Layer Tests
         if: ${{ fromJSON(inputs.affected-components).PyTorch_FE.test && runner.os != 'macOS' && runner.arch != 'ARM64' && runner.os != 'Windows' }} # Ticket: 126287

--- a/.github/workflows/job_pytorch_layer_tests.yml
+++ b/.github/workflows/job_pytorch_layer_tests.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           echo "HF_HUB_CACHE=${{ runner.os == 'Linux' && env.HF_HUB_CACHE_LIN || env.HF_HUB_CACHE_WIN }}" >> "$GITHUB_ENV"
           echo "HUGGINGFACE_HUB_CACHE=${{ runner.os == 'Linux' && env.HF_HUB_CACHE_LIN || env.HF_HUB_CACHE_WIN }}" >> "$GITHUB_ENV"
+          echo "PIP_INSTALL_COMMAND=python3 -m pip install" >> "$GITHUB_ENV" # Linux and MacOS only, and just for debug purposes, will be reverted, see PR #34185
 
       - name: Install OpenVINO dependencies (mac)
         if: runner.os == 'macOS'
@@ -117,7 +118,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           # pytorch test requirements
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/requirements_pytorch
+          ${{ env.PIP_INSTALL_COMMAND }} -r ${{ env.INSTALL_TEST_DIR }}/requirements_pytorch
 
       - name: PyTorch Layer Tests
         if: ${{ fromJSON(inputs.affected-components).PyTorch_FE.test && runner.arch != 'ARM64' }} # Ticket: 126287, 142196

--- a/.github/workflows/job_tensorflow_layer_tests.yml
+++ b/.github/workflows/job_tensorflow_layer_tests.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           echo "HF_HUB_CACHE=${{ runner.os == 'Linux' && env.HF_HUB_CACHE_LIN || env.HF_HUB_CACHE_WIN }}" >> "$GITHUB_ENV"
           echo "HUGGINGFACE_HUB_CACHE=${{ runner.os == 'Linux' && env.HF_HUB_CACHE_LIN || env.HF_HUB_CACHE_WIN }}" >> "$GITHUB_ENV"
+          echo "PIP_INSTALL_COMMAND=python3 -m pip install" >> "$GITHUB_ENV" # Linux and MacOS only, and just for debug purposes, will be reverted, see PR #34185
 
       - name: Install OpenVINO dependencies (mac)
         if: ${{ runner.os == 'macOS' }}
@@ -114,7 +115,7 @@ jobs:
       - name: Install Python Layer tests dependencies
         run: |
           # tensorflow test requirements
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/requirements_tensorflow
+          ${{ env.PIP_INSTALL_COMMAND }} -r ${{ env.INSTALL_TEST_DIR }}/requirements_tensorflow
 
       - name: TensorFlow 1 Layer Tests - TF FE
         if: ${{ fromJSON(inputs.affected-components).TF_FE.test }}

--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -360,6 +360,13 @@ jobs:
           should-setup-pip-paths: 'false'
           self-hosted-runner: 'false'
 
+      - name: Install Python's certifi for newer ca-certificates bundle for wget
+        run: |
+          python3 c:/pip_diag.py install certifi
+
+      - name: Set SSL_CERT_FILE for model downloading for unit tests
+        run: echo SSL_CERT_FILE=$(python3 -m certifi) >> $env:GITHUB_ENV
+
       - name: CMake configure - CC ON
         run: |
           cmake `

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Install `uv` to install Python dependencies
         run: |
           python3 -m pip install uv==0.11.7
-          echo "UV_CACHE_DIR=C:\\mount\\caches\\uv\\win\\0.11.7" >> $env:GITHUB_ENV
+          echo "UV_CACHE_DIR=${{ env.PIP_CACHE_PATH }}\\uv\\0.11.7" >> $env:GITHUB_ENV
           echo "UV_SYSTEM_PYTHON=1" >> $env:GITHUB_ENV
 
       - name: Install OpenVINO Python wheels

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -321,6 +321,11 @@ jobs:
           should-setup-pip-paths: 'true'
           self-hosted-runner: 'true'
 
+      - name: Install `uv` to install Python dependencies
+        run: |
+          python3 -m pip install uv==0.11.7
+          echo "UV_CACHE_DIR=C:\\mount\\caches\\uv\\win\\0.11.7" >> $env:GITHUB_ENV
+
       - name: Install OpenVINO Python wheels
         uses: ./openvino/.github/actions/install_ov_wheels
         with:
@@ -330,25 +335,25 @@ jobs:
       - name: Install Python API tests dependencies
         run: |
           # To enable pytest parallel features
-          python3 -m pip install pytest-xdist[psutil]
+          uv pip install pytest-xdist[psutil]
 
           # For torchvision to OpenVINO preprocessing converter
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/python/preprocess/torchvision/requirements.txt
+          uv pip install -r ${{ env.INSTALL_TEST_DIR }}/python/preprocess/torchvision/requirements.txt
 
           # For validation of Python API
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
+          uv pip install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
 
           #  ONNX tests requirements
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/requirements_onnx
+          uv pip install -r ${{ env.INSTALL_TEST_DIR }}/requirements_onnx
 
           # For getting rid of SSL issues during model downloading for unit tests
-          python3 -m pip install certifi
+          uv pip install certifi
 
       - name: Set SSL_CERT_FILE for model downloading for unit tests
         run: echo SSL_CERT_FILE=$(python3 -m certifi) >> $env:GITHUB_ENV
 
       - name: Install Python Layer tests dependencies
-        run: python3 -m pip install -r ${{ env.LAYER_TESTS_INSTALL_DIR }}/requirements.txt
+        run: uv pip install -r ${{ env.LAYER_TESTS_INSTALL_DIR }}/requirements.txt
 
       - name: Python API Tests
         #if: fromJSON(needs.smart_ci.outputs.affected_components).Python_API.test # Ticket: 127101

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -325,6 +325,7 @@ jobs:
         run: |
           python3 -m pip install uv==0.11.7
           echo "UV_CACHE_DIR=C:\\mount\\caches\\uv\\win\\0.11.7" >> $env:GITHUB_ENV
+          echo "UV_SYSTEM_PYTHON=1" >> $env:GITHUB_ENV
 
       - name: Install OpenVINO Python wheels
         uses: ./openvino/.github/actions/install_ov_wheels

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Samples tests
         run: |
-          python3 -m pip install --ignore-installed PyYAML -r ./tests/smoke_tests/requirements.txt
+          python3 c:/pip_diag.py install --ignore-installed PyYAML -r ./tests/smoke_tests/requirements.txt
           . "./setupvars.ps1"
           $Env:PYTHONCOERCECLOCALE="warn"
           python3 -bb -W error -X dev -X warn_default_encoding -m pytest ./tests/smoke_tests --numprocesses auto
@@ -478,7 +478,7 @@ jobs:
           free-threaded-python: ${{ contains(matrix.python-version, 't') }}
 
       - name: Install Python API tests dependencies
-        run: python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
+        run: python3 c:/pip_diag.py install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
 
       - name: Python API Tests
         shell: cmd
@@ -490,8 +490,8 @@ jobs:
         shell: cmd
         run: |
           python3 -m pip uninstall -y numpy
-          python3 -m pip install "numpy>=2.0.0,<2.1.0"
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
+          python3 c:/pip_diag.py install "numpy>=2.0.0,<2.1.0"
+          python3 c:/pip_diag.py install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
           # for 'template' extension
           set PYTHONPATH=${{ env.INSTALL_TEST_DIR }};%PYTHONPATH%
           set PATH=${{ env.INSTALL_TEST_DIR }};%PATH%
@@ -611,7 +611,7 @@ jobs:
           self-hosted-runner: 'true'
 
       - name: Install python dependencies
-        run: python3 -m pip install -r ${{ github.workspace }}\install\tests\functional_test_utils\layer_tests_summary\requirements.txt
+        run: python3 c:/pip_diag.py install -r ${{ github.workspace }}\install\tests\functional_test_utils\layer_tests_summary\requirements.txt
 
       - name: Restore tests execution time
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -326,6 +326,7 @@ jobs:
           python3 -m pip install uv==0.11.7
           echo "UV_CACHE_DIR=${{ env.PIP_CACHE_PATH }}\\uv\\0.11.7" >> $env:GITHUB_ENV
           echo "UV_SYSTEM_PYTHON=1" >> $env:GITHUB_ENV
+          echo "UV_LINK_MODE=copy" >> $env:GITHUB_ENV
 
       - name: Install OpenVINO Python wheels
         uses: ./openvino/.github/actions/install_ov_wheels

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -321,12 +321,13 @@ jobs:
           should-setup-pip-paths: 'true'
           self-hosted-runner: 'true'
 
-      - name: Install `uv` to install Python dependencies
+      - name: Install and configure `uv` to install Python dependencies
         run: |
           python3 -m pip install uv==0.11.7
-          echo "UV_CACHE_DIR=${{ env.PIP_CACHE_PATH }}\\uv\\0.11.7" >> $env:GITHUB_ENV
           echo "UV_SYSTEM_PYTHON=1" >> $env:GITHUB_ENV
-          echo "UV_LINK_MODE=copy" >> $env:GITHUB_ENV
+          echo "UV_DEFAULT_INDEX=http://pip-proxy.pip-proxy.svc.cluster.local/simple/" >> $env:GITHUB_ENV
+          echo "UV_INSECURE_HOST=pip-proxy.pip-proxy.svc.cluster.local" >> $env:GITHUB_ENV
+          echo "UV_NO_CACHE=true" >> $env:GITHUB_ENV
 
       - name: Install OpenVINO Python wheels
         uses: ./openvino/.github/actions/install_ov_wheels


### PR DESCRIPTION
### Details:
Replacing `pip install` with `uv pip install` command in one Windows job - it might help with `Content-Type: Unknown` error without the need to manage HTTP proxy (https://github.com/openvinotoolkit/openvino/pull/34376)
