### PR TITLE
[GPU] Fix reshape buffer aliasing: propagate memory dependencies to prevent pool recycling

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -953,6 +953,16 @@ void prepare_buffer_fusing::run(program& p) {
                 node.adjust_output_padding();
 
             node.can_be_optimized(can_reshape_be_optimized(node));
+            // When reshape is optimized out, its output aliases the input buffer.
+            // Extend the input's memory dependency to reshape's consumers so the
+            // pool won't recycle the input buffer while those consumers still need it.
+            if (node.can_be_optimized()) {
+                auto& dep0 = node.get_dependency(0);
+                for (auto* user : node.get_users()) {
+                    user->add_memory_dependency(dep0);
+                    dep0.add_memory_dependency(*user);
+                }
+            }
             GPU_DEBUG_TRACE_DETAIL << "[prepare_buffer_fusing] : " << node.id() << " can be optimized" << std::endl;
         });
         program_helpers::do_for_types<kv_cache>(*node, [](kv_cache_node& node) {

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -259,6 +259,7 @@ public:
     }
 
     const memory_restricter<uint32_t>& get_runtime_memory_dependencies() const { return _runtime_memory_dependencies; }
+    void add_runtime_memory_dependency(uint32_t uid) { _runtime_memory_dependencies.insert(uid); }
 
     const kernel_impl_params* get_impl_params() const { return _impl_params.get(); }
     // return pointer to const to prevent arbitrary 'execute' call -> use primitive_inst.execute() instead

--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -219,10 +219,10 @@ public:
     typed_primitive_inst(network& network, reshape_node const& node);
 
     void update_output_memory() override;
-    bool _runtime_deps_patched = false;
 
 private:
     void on_execute() override;
+    bool _runtime_deps_patched = false;
 };
 
 using reshape_inst = typed_primitive_inst<reshape>;

--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -219,11 +219,13 @@ public:
     typed_primitive_inst(network& network, reshape_node const& node);
 
     void update_output_memory() override;
+    bool _runtime_deps_patched = false;
 
 private:
     void on_execute() override;
 };
 
 using reshape_inst = typed_primitive_inst<reshape>;
+
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -346,6 +346,27 @@ void reshape_inst::update_output_memory() {
     }
     _outputs = {_network.get_engine().reinterpret_buffer(input_memory(), _impl_params->get_output_layout())};
     _mem_allocated = false;
+
+    // When reshape is optimized out (aliases input buffer via reinterpret_buffer),
+    // the memory pool doesn't know that downstream consumers still need the input buffer.
+    // Propagate the input dependency's unique_id into consumers' runtime restriction sets
+    // so the pool won't hand out the input buffer to unrelated nodes.
+    // Gated by _runtime_deps_patched: set insertion is idempotent but the traversal
+    // on every on_execute() is unnecessary overhead.
+    if (!_runtime_deps_patched && !get_user_insts().empty()) {
+        auto dep0_uid = static_cast<uint32_t>(get_node().get_dependency(0).get_unique_id());
+        std::function<void(const std::vector<primitive_inst*>&)> propagate;
+        propagate = [&](const std::vector<primitive_inst*>& users) {
+            for (auto* user : users) {
+                user->add_runtime_memory_dependency(dep0_uid);
+                if (user->can_be_optimized())
+                    propagate(user->get_user_insts());
+            }
+        };
+        propagate(get_user_insts());
+        _runtime_deps_patched = true;
+
+    }
 }
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#include <functional>
 #include <iterator>
 #include <string>
 
@@ -329,7 +330,7 @@ void reshape_inst::update_output_memory() {
     if (!can_be_optimized())
         return;
 
-    if (_outputs[0] && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()) &&
+    if (_runtime_deps_patched && _outputs[0] && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()) &&
         output_memory().get_layout() == _impl_params->get_output_layout())
         return;
 

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/reshape_buffer_aliasing.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/reshape_buffer_aliasing.cpp
@@ -1,0 +1,112 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/relu.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/softmax.hpp"
+
+namespace {
+
+// Test 1: Single consumer after noop reshape
+// Param -> Softmax -> Reshape(noop) -> MatMul -> Result
+// Verifies that the reshape buffer aliasing doesn't corrupt data
+// when the reshape is optimized away and buffers are shared.
+class OVReshapeBufferAliasingSingleConsumerTest : public ov::test::SubgraphBaseStaticTest {
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+        auto type = ov::element::f32;
+        ov::Shape input_shape{2, 4, 8};
+
+        auto input = std::make_shared<ov::op::v0::Parameter>(type, input_shape);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(input, -1);
+
+        // Noop reshape: {2, 4, 8} -> {2, 4, 8}
+        auto target_shape = ov::op::v0::Constant::create(ov::element::i64, {3}, {2, 4, 8});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(softmax, target_shape, false);
+
+        auto weights = ov::op::v0::Constant::create(type, {8, 8}, {0.1f});
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, weights, false, true);
+
+        function = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
+    }
+};
+
+TEST_F(OVReshapeBufferAliasingSingleConsumerTest, Inference) {
+    run();
+}
+
+// Test 2: Multiple consumers sharing reshape output
+// Param_A -> Relu -> Reshape(noop) -> Add -> Result
+// Param_B -> Relu ------------------>
+// Verifies memory deps are correct when reshape output feeds into an op
+// alongside another branch.
+class OVReshapeBufferAliasingMultiConsumerTest : public ov::test::SubgraphBaseStaticTest {
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+        auto type = ov::element::f32;
+        ov::Shape shape{2, 4};
+
+        auto param_a = std::make_shared<ov::op::v0::Parameter>(type, shape);
+        auto relu_a = std::make_shared<ov::op::v0::Relu>(param_a);
+
+        // Noop reshape: {2, 4} -> {2, 4}
+        auto target_shape = ov::op::v0::Constant::create(ov::element::i64, {2}, {2, 4});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(relu_a, target_shape, false);
+
+        auto param_b = std::make_shared<ov::op::v0::Parameter>(type, shape);
+        auto relu_b = std::make_shared<ov::op::v0::Relu>(param_b);
+
+        auto add = std::make_shared<ov::op::v1::Add>(reshape, relu_b);
+
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{param_a, param_b});
+    }
+};
+
+TEST_F(OVReshapeBufferAliasingMultiConsumerTest, Inference) {
+    run();
+}
+
+// Test 3: Chained reshapes
+// Param -> Softmax -> Reshape -> Reshape -> Add -> Result
+// Param_B ------------------------------>
+// Verifies correct buffer aliasing through a chain of optimized reshapes.
+class OVReshapeBufferAliasingChainedReshapesTest : public ov::test::SubgraphBaseStaticTest {
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+        auto type = ov::element::f32;
+        ov::Shape shape{2, 8};
+
+        auto param_a = std::make_shared<ov::op::v0::Parameter>(type, shape);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(param_a, -1);
+
+        // Reshape 1: {2, 8} -> {2, 8} (noop)
+        auto target1 = ov::op::v0::Constant::create(ov::element::i64, {2}, {2, 8});
+        auto reshape1 = std::make_shared<ov::op::v1::Reshape>(softmax, target1, false);
+
+        // Reshape 2: {2, 8} -> {2, 8} (noop)
+        auto target2 = ov::op::v0::Constant::create(ov::element::i64, {2}, {2, 8});
+        auto reshape2 = std::make_shared<ov::op::v1::Reshape>(reshape1, target2, false);
+
+        auto param_b = std::make_shared<ov::op::v0::Parameter>(type, shape);
+        auto add = std::make_shared<ov::op::v1::Add>(reshape2, param_b);
+
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{param_a, param_b});
+    }
+};
+
+TEST_F(OVReshapeBufferAliasingChainedReshapesTest, Inference) {
+    run();
+}
+
+}  // namespace

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -1995,3 +1995,103 @@ TEST(prepare_buffer_fusing, in_place_crop_dynamic_batch_axis_split_with_reshape_
     for (size_t i = 0; i < slice_elems; i++)
         ASSERT_FLOAT_EQ(v_out[i], input_data[2 * slice_elems + i]) << "V mismatch at " << i;
 }
+
+// When reshape is optimized out, its output aliases the input buffer (dep0).
+// Memory dependencies must be propagated bidirectionally between dep0 and
+// reshape's consumers so the memory pool won't recycle the aliased buffer.
+// This test verifies the dynamic-pattern reshape variant (2 dependencies).
+TEST(prepare_buffer_fusing, optimized_reshape_propagates_memory_deps_dynamic) {
+    auto& engine = get_test_engine();
+    auto in_layout = layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx};
+    auto pattern_layout = layout{ov::PartialShape::dynamic(4), data_types::i64, format::bfyx};
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(input_layout("pattern", pattern_layout));
+    topology.add(permute("permute1", input_info("input"), {0, 2, 3, 1}));
+    topology.add(reshape("reshape", input_info("permute1"), input_info("pattern"),
+                         false, ov::PartialShape::dynamic(4)));
+    topology.add(permute("permute2", input_info("reshape"), {0, 3, 2, 1}));
+    topology.add(reorder("reorder", input_info("permute2"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    auto prog = program::build_program(engine, topology, config, false, true);
+    ASSERT_NE(prog, nullptr);
+
+    program_wrapper::apply_opt_pass<prepare_buffer_fusing>(*prog);
+
+    auto& reshape_node = prog->get_node("reshape").as<reshape>();
+    ASSERT_TRUE(reshape_node.can_be_optimized());
+
+    // dep0 is the data input whose buffer is aliased by the optimized reshape.
+    auto& dep0 = reshape_node.get_dependency(0);
+    auto dep0_uid = static_cast<uint32_t>(dep0.get_unique_id());
+
+    // The reshape's consumer (permute2) must have dep0 in its memory deps.
+    auto* user = reshape_node.get_users().front();
+    auto user_uid = static_cast<uint32_t>(user->get_unique_id());
+
+    const auto& user_mem_deps = user->get_memory_dependencies();
+    ASSERT_TRUE(user_mem_deps.count(dep0_uid))
+        << "Reshape consumer must have dep0's unique_id in memory dependencies "
+           "to prevent pool from recycling the aliased buffer";
+
+    // dep0 must have the consumer in its memory deps (bidirectional).
+    const auto& dep0_mem_deps = dep0.get_memory_dependencies();
+    ASSERT_TRUE(dep0_mem_deps.count(user_uid))
+        << "dep0 must have reshape consumer's unique_id in memory dependencies "
+           "to prevent pool from recycling the aliased buffer";
+
+    // Verify the reshape has 2 deps (data + shape pattern).
+    ASSERT_EQ(reshape_node.get_dependencies().size(), 2u);
+}
+
+// Same verification for a static-pattern reshape (single dependency).
+// Validates that memory dependencies are propagated bidirectionally between
+// the data input (dep0) and the reshape consumer (fc).
+TEST(prepare_buffer_fusing, optimized_reshape_propagates_memory_deps_static) {
+    auto& engine = get_test_engine();
+    auto in_layout = layout{ov::PartialShape{1, 2, -1}, data_types::f32, format::bfyx};
+    auto weights_layout = layout{ov::PartialShape{2, 4}, data_types::f32, format::bfyx};
+    auto weights_memory = engine.allocate_memory(weights_layout);
+    set_values<float>(weights_memory, {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weights", weights_memory));
+    topology.add(permute("permute1", input_info("input"), {0, 2, 1}));
+    topology.add(reshape("reshape", input_info("permute1"), false,
+                         {2, 4}, ov::PartialShape{2, 4}));
+    topology.add(fully_connected("fc", input_info("reshape"), "weights", "", 2));
+    topology.add(reorder("reorder", input_info("fc"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    auto prog = program::build_program(engine, topology, config, false, true);
+    ASSERT_NE(prog, nullptr);
+
+    prog->get_node("reorder").get_output_layout(true);
+    program_wrapper::apply_opt_pass<prepare_buffer_fusing>(*prog);
+
+    auto& reshape_node = prog->get_node("reshape").as<reshape>();
+    ASSERT_TRUE(reshape_node.can_be_optimized());
+
+    // dep0 is the data input (permute1).
+    auto& dep0 = reshape_node.get_dependency(0);
+    auto dep0_uid = static_cast<uint32_t>(dep0.get_unique_id());
+
+    // Consumer is fc.
+    auto* user = reshape_node.get_users().front();
+    auto user_uid = static_cast<uint32_t>(user->get_unique_id());
+
+    // Verify: consumer has dep0 in its memory dependencies.
+    const auto& user_mem_deps = user->get_memory_dependencies();
+    ASSERT_TRUE(user_mem_deps.count(dep0_uid))
+        << "Reshape consumer (fc) must have dep0's unique_id in memory dependencies";
+
+    // Verify: dep0 has consumer in its memory dependencies (bidirectional).
+    const auto& dep0_mem_deps = dep0.get_memory_dependencies();
+    ASSERT_TRUE(dep0_mem_deps.count(user_uid))
+        << "dep0 must have reshape consumer's unique_id in memory dependencies";
+}


### PR DESCRIPTION
**Details:**

When reshape is optimized out via can_be_optimized() (i.e., it aliases its input buffer through reinterpret_buffer), the memory pool is unaware that downstream consumers of the reshape still require the original input buffer. This can cause the pool to recycle/reassign the input buffer to unrelated nodes while reshape consumers are still reading from it, leading to data corruption.


**Root cause:**

prepare_buffer_fusing marks reshape as optimized and sets up the buffer alias, but does not propagate the input node's memory dependency to reshape's consumers. At runtime, update_output_memory() creates a reinterpret_buffer alias but the pool's restriction mechanism has no record of the dependency between the input provider and the reshape consumers.

**Fix (two-pronged):**

Build-time (prepare_buffer_fusing.cpp): When reshape is marked optimized, explicitly call add_memory_dependency between dep0 and each reshape consumer (bidirectional), so the memory pool's static analysis knows these nodes share a buffer.

Runtime (reshape.cpp): In update_output_memory(), propagate dep0's unique_id into each consumer's _runtime_memory_dependencies set. This covers dynamic/runtime allocation paths the static dependency graph may miss. Propagation walks through chains of optimized-out nodes. Gated by a _runtime_deps_patched flag to avoid redundant traversals on repeated executions.


### Tickets:
 -[CVS-181352](https://jira.devtools.intel.com/browse/CVS-181352)

### AI Assistance:
 - AI assistance used: Yes
 - For RCA
