### PR TITLE
[GPU] Fix warning issue binskim final

### DIFF
--- a/src/plugins/intel_gpu/CMakeLists.txt
+++ b/src/plugins/intel_gpu/CMakeLists.txt
@@ -29,11 +29,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # 4267 4244 conversion from 'XXX' to 'YYY', possible loss of data
-    ov_add_compiler_flags(/wd4244)
-    # '<': signed/unsigned mismatch
-    ov_add_compiler_flags(/wd4018)
-
     add_compile_definitions(_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)
     # see https://github.com/oneapi-src/oneDNN/issues/2028
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -134,14 +134,14 @@ static int64_t get_aligned_seq_len(const kernel_impl_params& impl_param, const P
         const auto subsequence_begins_mem = input_mem.at(PagedAttentionInputIdx::SUBSEQUENCE_BEGINS);
         mem_lock<int32_t, mem_lock_type::read> subsequence_begins_mem_lock(subsequence_begins_mem, *impl_param.strm);
 
-        auto aligned_seq_len = 0;
+        int64_t aligned_seq_len = 0;
         if (stage == PagedAttentionStage::MIXED) {
             const auto past_lens_mem = input_mem.at(PagedAttentionInputIdx::PAST_LENS);
             mem_lock<int32_t, mem_lock_type::read> past_lens_mem_lock(past_lens_mem, *impl_param.strm);
 
             for (size_t i = 0; i < subsequence_begins_mem_lock.size() - 1; i++) {
                 auto past_len = past_lens_mem_lock[i];
-                auto seq_length = subsequence_begins_mem_lock[i + 1] - subsequence_begins_mem_lock[i];
+                int64_t seq_length = subsequence_begins_mem_lock[i + 1] - subsequence_begins_mem_lock[i];
 
                 // Since in MIXED execution mode the present KV-cache can be appended to the past KV-cache at any offset inside block,
                 // to ensure proper alignment and update_kv_cache kernel scheduling, we need to account for the number of unaligned tokens

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -833,7 +833,7 @@ cldnn::format_traits convert_memory_desc_to_traits(const dnnl::memory::desc& des
         auto pos = outer_order.find(c);
         OPENVINO_ASSERT(pos != std::string::npos, "[GPU] Unknown coord type: ", c);
 
-        logic_block_sizes[i] = std::make_pair(order[pos], inner_blks[i]);
+        logic_block_sizes[i] = std::make_pair(order[pos], static_cast<int>(inner_blks[i]));
     }
 
     format_traits traits;

--- a/src/plugins/intel_gpu/src/graph/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/prior_box.cpp
@@ -37,18 +37,18 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
         step_h = static_cast<float>(img_height) / layer_height;
     }
     const float offset = argument.offset;
-    int num_priors = argument.is_clustered() ?
-        static_cast<int>(argument.widths.size()) :
+    int64_t num_priors = argument.is_clustered() ?
+        static_cast<int64_t>(argument.widths.size()) :
         output_mem->get_layout().spatial(1) / 4 / layer_width / layer_height;
     int var_size = static_cast<int>(argument.variance.size());
 
     mem_lock<dtype> lock{output_mem, stream};
     auto out_ptr = lock.begin();
-    int dim = layer_height * layer_width * num_priors * 4;
+    int64_t dim = layer_height * layer_width * num_priors * 4;
 
-    int idx = 0;
-    for (int h = 0; h < layer_height; ++h) {
-        for (int w = 0; w < layer_width; ++w) {
+    int64_t idx = 0;
+    for (int64_t h = 0; h < layer_height; ++h) {
+        for (int64_t w = 0; w < layer_width; ++w) {
             float center_x, center_y;
             if (argument.step_width == 0.f || argument.step_height == 0.f) {
                 center_x = (w + 0.5f) * step_w;
@@ -60,7 +60,7 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
             float box_width, box_height;
 
             if (argument.is_clustered()) {
-                for (int s = 0; s < num_priors; ++s) {
+                for (int64_t s = 0; s < num_priors; ++s) {
                     box_width = argument.widths[s];
                     box_height = argument.heights[s];
                     idx = h * layer_width * num_priors * 4 + w * num_priors * 4 + s * 4;
@@ -83,8 +83,8 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
 
                 if (argument.fixed_ratio.size() > 0) {
                     for (auto fr : argument.fixed_ratio) {
-                        box_width = fixed_size * sqrt(fr);
-                        box_height = fixed_size / sqrt(fr);
+                        box_width = fixed_size * sqrtf(fr);
+                        box_height = fixed_size / sqrtf(fr);
 
                         for (size_t r = 0; r < density; ++r) {
                             for (size_t c = 0; c < density; ++c) {
@@ -228,9 +228,9 @@ std::string vector_to_string(const std::vector<float>& vec) {
 std::vector<float> normalized_aspect_ratio(const std::vector<float>& aspect_ratio, bool flip) {
     std::set<float> unique_ratios;
     for (auto ratio : aspect_ratio) {
-        unique_ratios.insert(std::round(ratio * 1e6) / 1e6);
+        unique_ratios.insert(static_cast<float>(std::round(ratio * 1e6) / 1e6));
         if (flip)
-            unique_ratios.insert(std::round(1 / ratio * 1e6) / 1e6);
+            unique_ratios.insert(static_cast<float>(std::round(1 / ratio * 1e6) / 1e6));
     }
     unique_ratios.insert(1);
     return std::vector<float>(unique_ratios.begin(), unique_ratios.end());

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -927,7 +927,7 @@ uint32_t Plugin::get_optimal_batch_size(const ov::AnyMap& options) const {
     auto context = get_default_contexts().at(device_id);
     const auto& device_info = context->get_device().get_info();
 
-    auto closest_pow_of_2 = [] (float x) {
+    auto closest_pow_of_2 = [] (double x) {
         int lower_power = static_cast<int>(floor(std::log(x) / std::log(2)));
         double lower_value = pow(2, lower_power);        // Current power of 2
         double upper_value = pow(2, lower_power + 1);   // Next power of 2
@@ -963,7 +963,7 @@ uint32_t Plugin::get_optimal_batch_size(const ov::AnyMap& options) const {
     // Initialize the context before use
     context->initialize();
 
-    size_t L3_cache_size = device_info.max_global_cache_size;
+    float L3_cache_size = static_cast<float>(device_info.max_global_cache_size);
     auto config = m_configs_map.at(device_id);
     auto cloned_model = clone_and_transform_model(model, config, context);
     ov::MemBandwidthPressure memPressure = ov::mem_bandwidth_pressure_tolerance(cloned_model, L3_cache_size);

--- a/src/plugins/intel_gpu/src/plugin/variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/variable_state.cpp
@@ -98,7 +98,7 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
             upper_pad[pad_dim] = static_cast<ov::Dimension::value_type>(padded_size) - static_cast<ov::Dimension::value_type>(non_padded_size);
         }
     }
-    cldnn::padding src_padd = cldnn::padding(lower_pad, upper_pad, 0.f);
+    cldnn::padding src_padd = cldnn::padding(lower_pad, upper_pad);
     auto src_fmt = cldnn::format::get_default_format(src_rank);
     auto src_layout = cldnn::layout(ov::PartialShape(src_shape), state->get_element_type(), src_fmt, src_padd);
 

--- a/src/plugins/intel_gpu/tests/CMakeLists.txt
+++ b/src/plugins/intel_gpu/tests/CMakeLists.txt
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # Test code is not part of the released plugin DLL (not subject to BinSkim BA2007).
+    # Keep warning suppression here to avoid mass test code changes.
+    ov_add_compiler_flags(/wd4244)
+    ov_add_compiler_flags(/wd4018)
+endif()
+
 add_subdirectory(common)
 add_subdirectory(unit)
 add_subdirectory(functional)

--- a/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
@@ -5,9 +5,8 @@
 set(TARGET_NAME ov_gpu_func_tests)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # C4267, 4244 issues from oneDNN headers conversion from 'XXX' to 'YYY', possible loss of data
+    # C4267 issues from oneDNN headers conversion from 'XXX' to 'YYY', possible loss of data
     ov_add_compiler_flags(/wd4267)
-    ov_add_compiler_flags(/wd4244)
     # 'initializing': truncation from 'XXX' to 'YYY'
     ov_add_compiler_flags(/wd4305)
 endif()


### PR DESCRIPTION
### Details:
- Remove `/wd4244` and `/wd4018` global warning suppression from GPU plugin `CMakeLists.txt` and fix remaining C4244 narrowing conversion warnings for BinSkim BA2007 compliance (final step)
  - **CMake:** Remove `/wd4244` `/wd4018` from plugin `CMakeLists.txt`; relocate to `tests/CMakeLists.txt` (test binaries are not subject to BinSkim). Remove duplicate `/wd4244` from `tests/functional/CMakeLists.txt`.
  - **prior_box.cpp:** Widen `int` → `int64_t` for loop vars/accumulators; `sqrt` → `sqrtf`; `static_cast<float>` for `std::round` results
  - **paged_attention_opt.cpp:** `auto` → `int64_t` for `aligned_seq_len` and `seq_length`
  - **variable_state.cpp:** Remove erroneous `0.f` third arg from `cldnn::padding` ctor (parameter is `DynamicDimsMask`, not `float`)
  - **plugin.cpp:** Lambda param `float` → `double`; cast `max_global_cache_size` to `float` at declaration
  - **utils.cpp:** `static_cast<int>(inner_blks[i])` at oneDNN API boundary

### Tickets:
- [CVS-185007](https://jira.devtools.intel.com/browse/CVS-185007)

### AI Assistance:
- AI assistance used: yes
- GitHub Copilot used for code analysis (identifying root causes of each warning, evaluating fix options for type safety), generating fix code, and verifying build results with `CMAKE_COMPILE_WARNING_AS_ERROR=ON` (`/WX`). All changes were human-reviewed for correctness, validated via local `/WX` clean build with `ENABLE_TESTS=ON`, and confirmed via BinSkim BA2007 scan to have zero GPU plugin violations.
