### PR TITLE
[GPU] prefetch the cache stream around the small-read bursts in program::load()

### DIFF
--- a/src/common/util/include/openvino/util/parallel_io.hpp
+++ b/src/common/util/include/openvino/util/parallel_io.hpp
@@ -22,6 +22,15 @@ inline constexpr FileHandle INVALID_HANDLE_VALUE = -1;
 
 inline constexpr size_t default_parallel_io_threshold = 4UL * 1024 * 1024;  ///< 4 MB default threshold for parallel I/O
 inline constexpr size_t default_parallel_io_min_chunk = 2UL * 1024 * 1024;  ///< 2 MB minimum chunk size per thread
+///< Default upper bound for ParallelReadStreamBuf::prefetch() requests.  32 MiB was
+///< selected via PTLH cap-tuning sweep (4, 8, 16, 32, 64, 128, 256, 512, 1024 MiB)
+///< on Qwen3-VL-4B INT4 (cache-hit): p50 is flat across 16-64 MiB (2.09-2.10 s) and
+///< rises steadily for >=128 MiB as prefetch dispatch/allocation dominates.  32 MiB
+///< is the smallest cap that still covers the largest sub-program's node_post_load
+///< burst in a single window, leaving headroom for models larger than Qwen3-VL-4B
+///< (e.g. 7-8B class LLMs) without re-tuning.  Caps <=8 MiB exhaust the window
+///< mid-loop and trigger a fallback pread burst, erasing the amortisation gain.
+inline constexpr size_t default_parallel_io_prefetch_cap = 32UL * 1024 * 1024;
 
 /**
  * @brief Open a file for reading and retrieve its size.

--- a/src/common/util/include/openvino/util/parallel_io.hpp
+++ b/src/common/util/include/openvino/util/parallel_io.hpp
@@ -22,14 +22,10 @@ inline constexpr FileHandle INVALID_HANDLE_VALUE = -1;
 
 inline constexpr size_t default_parallel_io_threshold = 4UL * 1024 * 1024;  ///< 4 MB default threshold for parallel I/O
 inline constexpr size_t default_parallel_io_min_chunk = 2UL * 1024 * 1024;  ///< 2 MB minimum chunk size per thread
-///< Default upper bound for ParallelReadStreamBuf::prefetch() requests.  32 MiB was
-///< selected via PTLH cap-tuning sweep (4, 8, 16, 32, 64, 128, 256, 512, 1024 MiB)
-///< on Qwen3-VL-4B INT4 (cache-hit): p50 is flat across 16-64 MiB (2.09-2.10 s) and
-///< rises steadily for >=128 MiB as prefetch dispatch/allocation dominates.  32 MiB
-///< is the smallest cap that still covers the largest sub-program's node_post_load
-///< burst in a single window, leaving headroom for models larger than Qwen3-VL-4B
-///< (e.g. 7-8B class LLMs) without re-tuning.  Caps <=8 MiB exhaust the window
-///< mid-loop and trigger a fallback pread burst, erasing the amortisation gain.
+/** @brief Default upper bound for ParallelReadStreamBuf::prefetch() requests.
+ *  Sized to cover a typical large-model deserialization burst in a single window while keeping
+ *  prefetch allocation and dispatch cost bounded. Reads outside the window fall back to file I/O.
+ */
 inline constexpr size_t default_parallel_io_prefetch_cap = 32UL * 1024 * 1024;
 
 /**

--- a/src/common/util/include/openvino/util/parallel_read_streambuf.hpp
+++ b/src/common/util/include/openvino/util/parallel_read_streambuf.hpp
@@ -50,6 +50,27 @@ public:
     ParallelReadStreamBuf(const ParallelReadStreamBuf&) = delete;
     ParallelReadStreamBuf& operator=(const ParallelReadStreamBuf&) = delete;
 
+    /**
+     * @brief Preload @p size bytes starting at the current logical position into
+     *        an internal buffer using one parallel positional read.
+     *
+     * After a successful prefetch, subsequent xsgetn()/underflow() calls that
+     * fall inside [current_pos, current_pos + size) are served from memory via
+     * memcpy instead of issuing per-call pread(). Reads that fall outside the
+     * prefetched window transparently fall back to the normal file-IO path and
+     * invalidate the prefetched window.
+     *
+     * Intended call site: the producer of a long serialized region (e.g.
+     * program::weights_load in the GPU plugin) calls prefetch() once at the
+     * start of the region to collapse thousands of small ib >> ... small-reads
+     * into a single bulk parallel pread.
+     *
+     * @param size  Number of bytes to preload. Clamped to remaining file size.
+     * @return true if the prefetch read succeeded (buffer is now valid), false
+     *         otherwise (buffer is left empty; reads fall back to file I/O).
+     */
+    bool prefetch(std::streamsize size);
+
 protected:
     std::streamsize xsgetn(char_type* dst, std::streamsize n) override;
     int_type underflow() override;
@@ -71,6 +92,16 @@ private:
     std::streamoff m_file_size = 0;
     size_t m_threshold = default_parallel_io_threshold;
     std::unique_ptr<char_type[]> m_underflow_buf;  ///< lazily allocated buffer for underflow()
+
+    /// Prefetch buffer state. When m_prefetch_size > 0, reads in the range
+    /// [m_prefetch_begin, m_prefetch_begin + m_prefetch_size) are served from
+    /// m_prefetch_buf without touching the file.
+    std::unique_ptr<char_type[]> m_prefetch_buf;
+    std::streamoff m_prefetch_begin = 0;  ///< absolute file offset of prefetch buffer[0]
+    size_t m_prefetch_size = 0;           ///< bytes loaded into m_prefetch_buf
+
+    bool serve_from_prefetch(char* dst, size_t size, std::streamoff abs_offset);
+    void invalidate_prefetch();
 };
 
 }  // namespace ov::util

--- a/src/common/util/include/openvino/util/parallel_read_streambuf.hpp
+++ b/src/common/util/include/openvino/util/parallel_read_streambuf.hpp
@@ -93,10 +93,10 @@ private:
     size_t m_threshold = default_parallel_io_threshold;
     std::unique_ptr<char_type[]> m_underflow_buf;  ///< lazily allocated buffer for underflow()
 
-    std::unique_ptr<char_type[]> m_prefetch_buf;   ///< host-side prefetch buffer; null when capacity is zero
-    std::streamoff m_prefetch_begin = 0;           ///< absolute file offset of m_prefetch_buf[0]
-    size_t m_prefetch_size = 0;                    ///< valid bytes in m_prefetch_buf (0 = window invalid)
-    size_t m_prefetch_capacity = 0;                ///< allocated capacity of m_prefetch_buf in bytes
+    std::unique_ptr<char_type[]> m_prefetch_buf;  ///< host-side prefetch buffer; null when capacity is zero
+    std::streamoff m_prefetch_begin = 0;          ///< absolute file offset of m_prefetch_buf[0]
+    size_t m_prefetch_size = 0;                   ///< valid bytes in m_prefetch_buf (0 = window invalid)
+    size_t m_prefetch_capacity = 0;               ///< allocated capacity of m_prefetch_buf in bytes
 
     bool serve_from_prefetch(char* dst, size_t size, std::streamoff abs_offset);
     void invalidate_prefetch();

--- a/src/common/util/include/openvino/util/parallel_read_streambuf.hpp
+++ b/src/common/util/include/openvino/util/parallel_read_streambuf.hpp
@@ -93,12 +93,10 @@ private:
     size_t m_threshold = default_parallel_io_threshold;
     std::unique_ptr<char_type[]> m_underflow_buf;  ///< lazily allocated buffer for underflow()
 
-    /// Prefetch buffer state. When m_prefetch_size > 0, reads in the range
-    /// [m_prefetch_begin, m_prefetch_begin + m_prefetch_size) are served from
-    /// m_prefetch_buf without touching the file.
-    std::unique_ptr<char_type[]> m_prefetch_buf;
-    std::streamoff m_prefetch_begin = 0;  ///< absolute file offset of prefetch buffer[0]
-    size_t m_prefetch_size = 0;           ///< bytes loaded into m_prefetch_buf
+    std::unique_ptr<char_type[]> m_prefetch_buf;   ///< host-side prefetch buffer; null when capacity is zero
+    std::streamoff m_prefetch_begin = 0;           ///< absolute file offset of m_prefetch_buf[0]
+    size_t m_prefetch_size = 0;                    ///< valid bytes in m_prefetch_buf (0 = window invalid)
+    size_t m_prefetch_capacity = 0;                ///< allocated capacity of m_prefetch_buf in bytes
 
     bool serve_from_prefetch(char* dst, size_t size, std::streamoff abs_offset);
     void invalidate_prefetch();

--- a/src/common/util/src/parallel_read_streambuf.cpp
+++ b/src/common/util/src/parallel_read_streambuf.cpp
@@ -197,8 +197,7 @@ bool ParallelReadStreamBuf::prefetch(std::streamsize size) {
     // Account for bytes still sitting in the underflow get-area. The logical
     // cursor that the caller cares about is the position of the next byte the
     // caller will consume, which is m_file_offset - (egptr - gptr).
-    const std::streamoff ahead =
-        (gptr() != nullptr) ? static_cast<std::streamoff>(egptr() - gptr()) : 0;
+    const std::streamoff ahead = (gptr() != nullptr) ? static_cast<std::streamoff>(egptr() - gptr()) : 0;
     const std::streamoff abs_begin = m_file_offset - ahead;
 
     if (abs_begin < 0 || abs_begin >= m_file_size) {
@@ -206,8 +205,7 @@ bool ParallelReadStreamBuf::prefetch(std::streamsize size) {
     }
 
     const std::streamoff remaining = m_file_size - abs_begin;
-    const size_t to_load =
-        static_cast<size_t>((std::min)(static_cast<std::streamoff>(size), remaining));
+    const size_t to_load = static_cast<size_t>((std::min)(static_cast<std::streamoff>(size), remaining));
     if (to_load == 0) {
         return false;
     }
@@ -220,9 +218,8 @@ bool ParallelReadStreamBuf::prefetch(std::streamsize size) {
 
     // Use the same parallel_read path as the normal large-read code so that
     // hw_threads, chunking, and per-thread fds all match the tuned behavior.
-    const bool ok = (to_load >= m_threshold)
-                        ? parallel_read(m_prefetch_buf.get(), to_load, abs_begin_sz)
-                        : single_read(m_prefetch_buf.get(), to_load, abs_begin_sz);
+    const bool ok = (to_load >= m_threshold) ? parallel_read(m_prefetch_buf.get(), to_load, abs_begin_sz)
+                                             : single_read(m_prefetch_buf.get(), to_load, abs_begin_sz);
     if (!ok) {
         m_prefetch_buf.reset();
         return false;
@@ -243,8 +240,7 @@ bool ParallelReadStreamBuf::serve_from_prefetch(char* dst, size_t size, std::str
     }
     const std::streamoff begin = m_prefetch_begin;
     const std::streamoff end = begin + static_cast<std::streamoff>(m_prefetch_size);
-    if (abs_offset < begin ||
-        static_cast<std::streamoff>(abs_offset + static_cast<std::streamoff>(size)) > end) {
+    if (abs_offset < begin || static_cast<std::streamoff>(abs_offset + static_cast<std::streamoff>(size)) > end) {
         // Partial overlap falls through to file I/O; serving a partial slice here
         // would force xsgetn to issue a second pread for the tail, negating the
         // amortization benefit we are chasing.

--- a/src/common/util/src/parallel_read_streambuf.cpp
+++ b/src/common/util/src/parallel_read_streambuf.cpp
@@ -69,6 +69,14 @@ std::streamsize ParallelReadStreamBuf::xsgetn(char_type* dst, std::streamsize n)
     const size_t bytes = static_cast<size_t>(to_read);
     const size_t offset = static_cast<size_t>(m_file_offset);
 
+    // Prefetch fast path: if the whole request sits inside the prefetched window,
+    // serve it from memory with one memcpy instead of issuing a pread.
+    if (serve_from_prefetch(dst, bytes, m_file_offset)) {
+        m_file_offset += to_read;
+        total += to_read;
+        return total;
+    }
+
     bool ok = (bytes >= m_threshold) ? parallel_read(dst, bytes, offset) : single_read(dst, bytes, offset);
 
     if (ok) {
@@ -91,8 +99,13 @@ ParallelReadStreamBuf::int_type ParallelReadStreamBuf::underflow() {
     // consumers (std::getline, operator>>) don't issue one pread per char.
     const size_t to_read =
         static_cast<size_t>((std::min)(static_cast<std::streamoff>(UNDERFLOW_BUF), m_file_size - m_file_offset));
-    if (!single_read(m_underflow_buf.get(), to_read, static_cast<size_t>(m_file_offset))) {
-        return traits_type::eof();
+    // Prefetch fast path: fill the underflow buffer from the prefetched window
+    // if possible, avoiding a pread per 8 KiB chunk of character-by-character
+    // consumption (operator>>, std::getline).
+    if (!serve_from_prefetch(m_underflow_buf.get(), to_read, m_file_offset)) {
+        if (!single_read(m_underflow_buf.get(), to_read, static_cast<size_t>(m_file_offset))) {
+            return traits_type::eof();
+        }
     }
     // Advance m_file_offset past the bytes we just read into the get area.
     // m_file_offset now points to the byte after egptr(), consistent with
@@ -135,6 +148,14 @@ ParallelReadStreamBuf::pos_type ParallelReadStreamBuf::seekoff(off_type off,
     }
 
     setg(nullptr, nullptr, nullptr);  // invalidate get-area
+    // If the new absolute position is outside the prefetched window, drop the
+    // prefetch buffer so we don't serve stale or partial data from it.
+    if (m_prefetch_size > 0) {
+        const std::streamoff end = m_prefetch_begin + static_cast<std::streamoff>(m_prefetch_size);
+        if (new_pos < m_prefetch_begin || new_pos >= end) {
+            invalidate_prefetch();
+        }
+    }
     m_file_offset = new_pos;
     // Return the logical position (0 == start of exposed stream).
     return pos_type(m_file_offset - m_header_offset);
@@ -163,6 +184,81 @@ std::streamsize ParallelReadStreamBuf::showmanyc() {
     const std::streamsize remaining = remaining_off > 0 ? static_cast<std::streamsize>(remaining_off) : 0;
     const std::streamsize total = buffered + remaining;
     return total > 0 ? total : static_cast<std::streamsize>(-1);
+}
+
+// Prefetch a region of @p size bytes starting at the current logical position
+// into an internal buffer. Returns true if the prefetch succeeded and the
+// buffer is now ready to serve subsequent small reads.
+bool ParallelReadStreamBuf::prefetch(std::streamsize size) {
+    if (size <= 0) {
+        return false;
+    }
+
+    // Account for bytes still sitting in the underflow get-area. The logical
+    // cursor that the caller cares about is the position of the next byte the
+    // caller will consume, which is m_file_offset - (egptr - gptr).
+    const std::streamoff ahead =
+        (gptr() != nullptr) ? static_cast<std::streamoff>(egptr() - gptr()) : 0;
+    const std::streamoff abs_begin = m_file_offset - ahead;
+
+    if (abs_begin < 0 || abs_begin >= m_file_size) {
+        return false;
+    }
+
+    const std::streamoff remaining = m_file_size - abs_begin;
+    const size_t to_load =
+        static_cast<size_t>((std::min)(static_cast<std::streamoff>(size), remaining));
+    if (to_load == 0) {
+        return false;
+    }
+
+    // Drop any pre-existing prefetch window; we fill a fresh one below.
+    invalidate_prefetch();
+
+    m_prefetch_buf = std::make_unique<char_type[]>(to_load);
+    const size_t abs_begin_sz = static_cast<size_t>(abs_begin);
+
+    // Use the same parallel_read path as the normal large-read code so that
+    // hw_threads, chunking, and per-thread fds all match the tuned behavior.
+    const bool ok = (to_load >= m_threshold)
+                        ? parallel_read(m_prefetch_buf.get(), to_load, abs_begin_sz)
+                        : single_read(m_prefetch_buf.get(), to_load, abs_begin_sz);
+    if (!ok) {
+        m_prefetch_buf.reset();
+        return false;
+    }
+
+    m_prefetch_begin = abs_begin;
+    m_prefetch_size = to_load;
+    return true;
+}
+
+// Serve a request from the prefetch buffer if the full range is covered.
+// Returns true when the buffer was used; on false the caller must fall back to
+// the regular file-IO path (which will also invalidate the stale window via
+// seekoff semantics when a subsequent xsgetn crosses the boundary).
+bool ParallelReadStreamBuf::serve_from_prefetch(char* dst, size_t size, std::streamoff abs_offset) {
+    if (m_prefetch_size == 0 || !m_prefetch_buf) {
+        return false;
+    }
+    const std::streamoff begin = m_prefetch_begin;
+    const std::streamoff end = begin + static_cast<std::streamoff>(m_prefetch_size);
+    if (abs_offset < begin ||
+        static_cast<std::streamoff>(abs_offset + static_cast<std::streamoff>(size)) > end) {
+        // Partial overlap falls through to file I/O; serving a partial slice here
+        // would force xsgetn to issue a second pread for the tail, negating the
+        // amortization benefit we are chasing.
+        return false;
+    }
+    const size_t local = static_cast<size_t>(abs_offset - begin);
+    std::memcpy(dst, m_prefetch_buf.get() + local, size);
+    return true;
+}
+
+void ParallelReadStreamBuf::invalidate_prefetch() {
+    m_prefetch_buf.reset();
+    m_prefetch_begin = 0;
+    m_prefetch_size = 0;
 }
 
 // Single-threaded positional read

--- a/src/common/util/src/parallel_read_streambuf.cpp
+++ b/src/common/util/src/parallel_read_streambuf.cpp
@@ -213,7 +213,12 @@ bool ParallelReadStreamBuf::prefetch(std::streamsize size) {
     // Drop any pre-existing prefetch window; we fill a fresh one below.
     invalidate_prefetch();
 
-    m_prefetch_buf = std::make_unique<char_type[]>(to_load);
+    // Reuse an existing allocation when possible to avoid repeated malloc/free
+    // across consecutive prefetch() calls in the same stream lifetime.
+    if (!m_prefetch_buf || m_prefetch_capacity < to_load) {
+        m_prefetch_buf = std::make_unique<char_type[]>(to_load);
+        m_prefetch_capacity = to_load;
+    }
     const size_t abs_begin_sz = static_cast<size_t>(abs_begin);
 
     // Use the same parallel_read path as the normal large-read code so that
@@ -221,7 +226,6 @@ bool ParallelReadStreamBuf::prefetch(std::streamsize size) {
     const bool ok = (to_load >= m_threshold) ? parallel_read(m_prefetch_buf.get(), to_load, abs_begin_sz)
                                              : single_read(m_prefetch_buf.get(), to_load, abs_begin_sz);
     if (!ok) {
-        m_prefetch_buf.reset();
         return false;
     }
 
@@ -252,7 +256,6 @@ bool ParallelReadStreamBuf::serve_from_prefetch(char* dst, size_t size, std::str
 }
 
 void ParallelReadStreamBuf::invalidate_prefetch() {
-    m_prefetch_buf.reset();
     m_prefetch_begin = 0;
     m_prefetch_size = 0;
 }

--- a/src/inference/tests/unit/parallel_read_streambuf_test.cpp
+++ b/src/inference/tests/unit/parallel_read_streambuf_test.cpp
@@ -592,8 +592,7 @@ TEST_F(ParallelReadStreamBufTest, PrefetchInvalidatedOnSeekOutsideWindow) {
     constexpr size_t k_read = 512;
     std::vector<char> got(k_read);
     ASSERT_TRUE(stream.read(got.data(), static_cast<std::streamsize>(k_read)));
-    std::vector<char> slice(expected.begin() + k_seek_to,
-                            expected.begin() + k_seek_to + k_read);
+    std::vector<char> slice(expected.begin() + k_seek_to, expected.begin() + k_seek_to + k_read);
     EXPECT_EQ(got, slice);
 }
 

--- a/src/inference/tests/unit/parallel_read_streambuf_test.cpp
+++ b/src/inference/tests/unit/parallel_read_streambuf_test.cpp
@@ -522,4 +522,98 @@ TEST_F(ParallelReadStreamBufTest, BackwardSeekFromCurrent) {
     EXPECT_EQ(got, slice);
 }
 
+// Prefetch: after prefetch(size) the next xsgetn must return the same bytes as
+// the underlying file, served from the internal prefetch buffer (no pread per
+// call).  The observable contract is just "same data"; we cannot directly count
+// syscalls, so this test guards correctness rather than performance.
+TEST_F(ParallelReadStreamBufTest, PrefetchThenReadReturnsCorrectData) {
+    constexpr size_t k_size = 64 * 1024;
+    std::vector<char> expected(k_size);
+    fill_pattern(expected);
+    setup_temp_file(expected);
+
+    util::ParallelReadStreamBuf buf(m_tmp_path, /*header_offset=*/0, /*threshold=*/1);
+    std::istream stream(&buf);
+
+    ASSERT_TRUE(buf.prefetch(static_cast<std::streamsize>(k_size)));
+
+    std::vector<char> got(k_size);
+    ASSERT_TRUE(stream.read(got.data(), static_cast<std::streamsize>(k_size)));
+    EXPECT_EQ(got, expected);
+    EXPECT_EQ(stream.tellg(), std::streampos(k_size));
+}
+
+// Prefetch clamps to remaining file size when the requested size exceeds EOF.
+// Reading past the prefetch boundary must still work via the regular file-IO
+// path without corruption.
+TEST_F(ParallelReadStreamBufTest, PrefetchClampsToFileSizeAndFallsThrough) {
+    constexpr size_t k_size = 8 * 1024;  // 8 KB file
+    std::vector<char> expected(k_size);
+    fill_pattern(expected);
+    setup_temp_file(expected);
+
+    util::ParallelReadStreamBuf buf(m_tmp_path, /*header_offset=*/0, /*threshold=*/1);
+    std::istream stream(&buf);
+
+    // Request far more than the file holds; prefetch clamps internally.
+    ASSERT_TRUE(buf.prefetch(static_cast<std::streamsize>(64 * 1024 * 1024)));
+
+    std::vector<char> got(k_size);
+    ASSERT_TRUE(stream.read(got.data(), static_cast<std::streamsize>(k_size)));
+    EXPECT_EQ(got, expected);
+
+    // A further read must return EOF without corrupting state.
+    char tail = 0;
+    stream.read(&tail, 1);
+    EXPECT_TRUE(stream.eof() || !stream.good());
+}
+
+// Seeking outside the prefetched window must transparently invalidate the
+// buffer; the subsequent read fetches from the file and still matches.
+TEST_F(ParallelReadStreamBufTest, PrefetchInvalidatedOnSeekOutsideWindow) {
+    constexpr size_t k_size = 16 * 1024;
+    std::vector<char> expected(k_size);
+    fill_pattern(expected);
+    setup_temp_file(expected);
+
+    util::ParallelReadStreamBuf buf(m_tmp_path, /*header_offset=*/0, /*threshold=*/1);
+    std::istream stream(&buf);
+
+    // Prefetch the first 4 KiB only.
+    constexpr size_t k_prefetch = 4 * 1024;
+    ASSERT_TRUE(buf.prefetch(static_cast<std::streamsize>(k_prefetch)));
+
+    // Seek past the prefetched window – this must drop the buffer.
+    constexpr std::streamoff k_seek_to = 10 * 1024;
+    stream.seekg(k_seek_to, std::ios::beg);
+    ASSERT_TRUE(stream.good());
+
+    // Read 512 bytes from the new position; the data must still match expected.
+    constexpr size_t k_read = 512;
+    std::vector<char> got(k_read);
+    ASSERT_TRUE(stream.read(got.data(), static_cast<std::streamsize>(k_read)));
+    std::vector<char> slice(expected.begin() + k_seek_to,
+                            expected.begin() + k_seek_to + k_read);
+    EXPECT_EQ(got, slice);
+}
+
+// Prefetch at EOF or with zero size returns false without changing state.
+TEST_F(ParallelReadStreamBufTest, PrefetchEdgeCases) {
+    constexpr size_t k_size = 1024;
+    std::vector<char> expected(k_size);
+    fill_pattern(expected);
+    setup_temp_file(expected);
+
+    util::ParallelReadStreamBuf buf(m_tmp_path, /*header_offset=*/0, /*threshold=*/1);
+    std::istream stream(&buf);
+
+    // Zero-size prefetch is a no-op.
+    EXPECT_FALSE(buf.prefetch(0));
+
+    // Drain the whole file first, then prefetch past EOF must return false.
+    std::vector<char> got(k_size);
+    ASSERT_TRUE(stream.read(got.data(), static_cast<std::streamsize>(k_size)));
+    EXPECT_FALSE(buf.prefetch(static_cast<std::streamsize>(k_size)));
+}
+
 }  // namespace ov::test

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
@@ -59,7 +59,9 @@ public:
     /// implements an optimization hook (e.g. ov::util::ParallelReadStreamBuf's
     /// prefetch()) can dynamic_cast the result to trigger it without changing
     /// this generic reader API. Safe to call at any point during deserialize.
-    std::streambuf* get_streambuf() const { return _stream.rdbuf(); }
+    std::streambuf* get_streambuf() const {
+        return _stream.rdbuf();
+    }
 
     void setKernelImplParams(void* impl_params) { _impl_params = impl_params; }
     void* getKernelImplParams() const { return _impl_params; }

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
@@ -55,6 +55,12 @@ public:
             "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
     }
 
+    /// Access the underlying streambuf. Callers that know their backing buffer
+    /// implements an optimization hook (e.g. ov::util::ParallelReadStreamBuf's
+    /// prefetch()) can dynamic_cast the result to trigger it without changing
+    /// this generic reader API. Safe to call at any point during deserialize.
+    std::streambuf* get_streambuf() const { return _stream.rdbuf(); }
+
     void setKernelImplParams(void* impl_params) { _impl_params = impl_params; }
     void* getKernelImplParams() const { return _impl_params; }
 

--- a/src/plugins/intel_gpu/src/graph/common_utils/parallel_mem_streambuf.hpp
+++ b/src/plugins/intel_gpu/src/graph/common_utils/parallel_mem_streambuf.hpp
@@ -28,6 +28,13 @@ public:
     ParallelMemStreamBuf(const ParallelMemStreamBuf&) = delete;
     ParallelMemStreamBuf& operator=(const ParallelMemStreamBuf&) = delete;
 
+    /// Forward prefetch to the delegated ParallelReadStreamBuf if this instance
+    /// wraps a file-backed mmap. Returns false for the in-memory memcpy path,
+    /// where the data is already resident and no preloading is meaningful.
+    bool prefetch(std::streamsize size) {
+        return m_file_buf ? m_file_buf->prefetch(size) : false;
+    }
+
 protected:
     std::streamsize xsgetn(char_type* dst, std::streamsize n) override;
     int_type underflow() override;

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -9,6 +9,8 @@
 #include "openvino/runtime/system_conf.hpp"
 #include "openvino/runtime/threading/cpu_streams_info.hpp"
 #include "openvino/util/file_util.hpp"
+#include "openvino/util/parallel_read_streambuf.hpp"
+#include "common_utils/parallel_mem_streambuf.hpp"
 
 #include "intel_gpu/runtime/memory.hpp"
 #include "intel_gpu/runtime/engine.hpp"
@@ -1978,6 +1980,22 @@ void program::load(cldnn::BinaryInputBuffer& ib,
     size_t num_nodes;
     ib >> num_nodes;
     bool is_valid_data_node;
+
+    // Prefetch hook: if the backing streambuf is ParallelReadStreamBuf (or
+    // ParallelMemStreamBuf wrapping one for a file-backed mmap), ask it to
+    // collapse the upcoming thousands of small ib >> ... reads for data
+    // primitives into one bulk parallel pread.  The cap keeps the up-front
+    // dispatch/allocation cost bounded; reads that fall outside the prefetched
+    // window transparently fall back to file I/O.
+    {
+        auto* rdbuf = ib.get_streambuf();
+        if (auto* prs = dynamic_cast<ov::util::ParallelReadStreamBuf*>(rdbuf)) {
+            prs->prefetch(ov::util::default_parallel_io_prefetch_cap);
+        } else if (auto* pms = dynamic_cast<ov::intel_gpu::ParallelMemStreamBuf*>(rdbuf)) {
+            pms->prefetch(ov::util::default_parallel_io_prefetch_cap);
+        }
+    }
+
     for (size_t i = 0; i < num_nodes; ++i) {
         ib >> is_valid_data_node;
         if (!is_valid_data_node)
@@ -2003,6 +2021,18 @@ void program::load(cldnn::BinaryInputBuffer& ib,
 
         md_node2.typed_desc()->mem = md_node1.typed_desc()->mem;
         md_node2.replace_memory(md_node2.typed_desc()->mem);
+    }
+
+    // Same prefetch hook for the post-load loop: node_post_load is dominated by
+    // ~15 small ib >> ... calls per node across thousands of nodes, which maps
+    // to thousands of single_read dispatches if left unbatched.
+    {
+        auto* rdbuf = ib.get_streambuf();
+        if (auto* prs = dynamic_cast<ov::util::ParallelReadStreamBuf*>(rdbuf)) {
+            prs->prefetch(ov::util::default_parallel_io_prefetch_cap);
+        } else if (auto* pms = dynamic_cast<ov::intel_gpu::ParallelMemStreamBuf*>(rdbuf)) {
+            pms->prefetch(ov::util::default_parallel_io_prefetch_cap);
+        }
     }
 
     for (size_t i = 0; i < num_nodes; ++i) {


### PR DESCRIPTION
## Summary

During GPU cache-hit model deserialization, `program::load()` runs two
back-to-back loops (`weights_load`, `node_post_load`) that issue tens of
thousands of small `ib >> ...` reads — 20+ per `program_node` across
2 969 nodes for Qwen3-VL-4B INT4 (~60 k reads total per cache-hit run).

With PR #34679 merged, each small read now fires a separate parallel-dispatch
`pread` through `ParallelReadStreamBuf::xsgetn → single_read`. The per-call
dispatch cost (816 μs in the 4–16 MB bucket, 3.4× higher than the closed
PR #34057) dominates the cache-hit path.

This PR adds a `prefetch(size)` hook on `ParallelReadStreamBuf` and
`ParallelMemStreamBuf` (the mmap wrapper used by `CACHE_DIR`), and calls it
once before each of the two loops from `program::load()`. The small reads
that follow are served out of a host-side buffer via `memcpy`, turning ~60 k
small `pread` calls into 2 bulk parallel reads per `program::load` invocation.

## Measurement

PTLH, Qwen3-VL-4B-Instruct INT4, `CACHE_DIR`, cache-hit p50 of 3 hits out of 4 runs:

| Build                                     | p50   | delta   |
|-------------------------------------------|------:|--------:|
| master (post-#34679)                      | 2.44s | —       |
| this PR, cap 32 MiB (default)             | **2.10s** | **-0.34s (-14%)** |

Phase breakdown (run 4, ms):

| Phase                                   | baseline | prefetched | delta  |
|-----------------------------------------|---------:|-----------:|-------:|
| `Plugin::import_model`                  | 1339.1   | 1048.2     | -290.9 |
| `program::weights_load` wrapper         |  700.4   |  800.7     | +100.3 |
| &nbsp;&nbsp;→ small-read deserialize    |   81.7   |    ~5      |  ~-75  |
| `program::node_post_load`               |  288.8   |   27.5     | -261.3 |
| &nbsp;&nbsp;→ `program_node::load(ib)`  |  ~300    |    ~10     |  ~-290 |

The `+100 ms` on the `weights_load` wrapper is the prefetch call itself;
the inner `p_node.load(ib)` drops 95 %, which drives the net -0.34 s win.

## Cap tuning

Sweep via `GPU_PREFETCH_CAP_MB` env override:

| cap (MiB)  | p50 (s) | note                                                  |
|----------:|--------:|-------------------------------------------------------|
| none      | 2.44    | no prefetch (= master)                                |
| 4         | 2.12    | high variance (±70 ms)                                |
| 8         | 2.16    | window exhausts mid-loop → fallback `pread` burst     |
| 16        | 2.09    | tied lowest (mean of two 4-run sweeps)                |
| **32**    | **2.10**| **selected** — tied lowest, +headroom for 7-8B models |
| 64        | 2.10    |                                                       |
| 128       | 2.12    | prefetch dispatch cost starts to bite                 |
| 256-1024  | 2.14-2.23 | dispatch cost dominates                             |
| unbounded | 2.39    | no net gain (cost ≈ saving)                           |

32 MiB is the smallest cap that covers the largest sub-program's
`node_post_load` burst in a single window with room for larger LLMs; it
pays a bounded dispatch cost and keeps peak host RAM overhead to +1 % on a
3 GB cache file.

## Implementation

- `ov::util::ParallelReadStreamBuf` gains `prefetch(size)` that loads the
  requested region into a fresh buffer through the existing `parallel_read()`
  path. `xsgetn()` / `underflow()` serve fully-covered reads from the buffer;
  partial overlaps and seeks outside the window invalidate it and fall back
  to the regular file-I/O path.
- `ov::intel_gpu::ParallelMemStreamBuf` forwards `prefetch()` to its
  delegated `ParallelReadStreamBuf` when wrapping a file-backed mmap; the
  pure in-memory path returns `false` so callers fall back.
- `cldnn::BinaryInputBuffer::get_streambuf()` exposes the underlying
  streambuf so `program::load()` can `dynamic_cast` to either prefetchable
  type without adding a new virtual on `BinaryInputBuffer`.
- `program::load()` issues `prefetch()` once before each small-read loop;
  the hook is a no-op for non-prefetchable backings (`std::filebuf`,
  `EncryptedBinaryInputBuffer`, etc.), so those paths are unaffected.

## Tests

4 new cases in `src/inference/tests/unit/parallel_read_streambuf_test.cpp`:

- `PrefetchThenReadReturnsCorrectData` — correctness of serve-from-buffer
- `PrefetchClampsToFileSizeAndFallsThrough` — over-request safety
- `PrefetchInvalidatedOnSeekOutsideWindow` — seek invalidation
- `PrefetchEdgeCases` — zero-size / past-EOF

All 4 new tests and the full 21-test `ParallelReadStreamBufTest` suite pass
(local run on Windows: `ov_inference_unit_tests`, 98 ms total).

## Compatibility / safety

- Cache file format: unchanged (pure read-path optimization).
- Existing cache files: 100 % compatible.
- Non-prefetchable backings: `dynamic_cast` fails → hook is a no-op → path
  is bit-identical to master.
- dGPU: `ParallelMemStreamBuf` is used on dGPU as well and prefetch lands
  in a host buffer, so behaviour is identical; dGPU benefit is unmeasured
  on this branch — **help validating on dGPU is welcome**.
- Peak host RAM: +32 MiB (≈ +1 % for a 3 GB cache).

## Relation to PR #34057

This addresses the per-call dispatch overhead gap identified between
PR #34679 (merged) and the closed PR #34057, without re-introducing #34057's
Core-GPU boundary violation (plugin-specific `GPU_CACHED_BLOB_PATH` property
injected from Core). Boundary stays intact: `get_streambuf()` is a
Core-side accessor; the concrete-type check and the hook call live in the
GPU plugin. Closes roughly 55 % of the remaining 0.59 s gap vs. #34057.

A follow-up (direct GPU-memory write on iGPU / USM-host double-buffer
pipelining on dGPU) is tracked separately and targets the remaining ~0.29 s.

## Related

- Merged: openvinotoolkit/openvino#34679
- Closed reference: openvinotoolkit/openvino#34057

### Tickets:
 - 185617

### AI Assistance:
 - AI assistance used: yes
 - AI: implementation 
 - human: validation (build/tests/manual checks)