### PR TITLE
Support positive axis in VariadicSplit for RoPEFusionGPTOSS pattern

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -1148,10 +1148,10 @@ RoPEFusionGPTOSS::RoPEFusionGPTOSS() {
     auto t_sin = pattern::any_input(pattern::shape_matches("[?, 1, ?, half_ndims]"));
 
     auto vsplit_out0 = pattern::wrap_type<op::v1::VariadicSplit>(
-        {x, -1, {"half_ndims", "?"}},
+        {x, pattern::wrap_type<v0::Constant>(), {"half_ndims", "?"}},
         pattern::output_index_matches(0) && pattern::shape_matches("[?, ?, ?, half_ndims]"));
     auto vsplit_out1 = pattern::wrap_type<op::v1::VariadicSplit>(
-        {x, -1, {"half_ndims", "?"}},
+        {x, pattern::wrap_type<v0::Constant>(), {"half_ndims", "?"}},
         pattern::output_index_matches(1) && pattern::shape_matches("[?, ?, ?, half_ndims]"));
     auto first_half_mul_cos = pattern::wrap_type<v1::Multiply>({vsplit_out0, t_cos}, {{"auto_broadcast", "numpy"}});
     auto second_half_mul_sin = pattern::wrap_type<v1::Multiply>({vsplit_out1, t_sin}, {{"auto_broadcast", "numpy"}});
@@ -1188,6 +1188,20 @@ RoPEFusionGPTOSS::RoPEFusionGPTOSS() {
         if (!half_ndims.is_integer()) {
             return false;
         }
+
+        // Verify VariadicSplit axis is the last dimension (accepts both -1 and positive equivalent)
+        auto vsplit_node = pattern_map.at(vsplit_out0).get_node_shared_ptr();
+        auto axis_const = ov::as_type_ptr<v0::Constant>(vsplit_node->input_value(1).get_node_shared_ptr());
+        if (!axis_const)
+            return false;
+        auto axis_val = axis_const->cast_vector<int64_t>();
+        if (axis_val.size() != 1)
+            return false;
+        auto input_rank = x_val.get_partial_shape().rank();
+        if (input_rank.is_dynamic())
+            return false;
+        if (axis_val[0] != -1 && axis_val[0] != input_rank.get_length() - 1)
+            return false;
 
         op::internal::RoPE::Config config;
         OutputVector new_args;

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -1183,12 +1183,6 @@ RoPEFusionGPTOSS::RoPEFusionGPTOSS() {
         if (concat_axis != -1 && concat_axis != concat_rank.get_length() - 1)
             return false;
 
-        auto symbols = m.get_symbols();
-        const auto& half_ndims = symbols["half_ndims"];
-        if (!half_ndims.is_integer()) {
-            return false;
-        }
-
         // Verify VariadicSplit axis is the last dimension (accepts both -1 and positive equivalent)
         auto vsplit_node = pattern_map.at(vsplit_out0).get_node_shared_ptr();
         auto axis_const = ov::as_type_ptr<v0::Constant>(vsplit_node->input_value(1).get_node_shared_ptr());
@@ -1202,6 +1196,12 @@ RoPEFusionGPTOSS::RoPEFusionGPTOSS() {
             return false;
         if (axis_val[0] != -1 && axis_val[0] != input_rank.get_length() - 1)
             return false;
+
+        auto symbols = m.get_symbols();
+        const auto& half_ndims = symbols["half_ndims"];
+        if (!half_ndims.is_integer()) {
+            return false;
+        }
 
         op::internal::RoPE::Config config;
         OutputVector new_args;

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -2124,7 +2124,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_LtxVideo) {
     }
 }
 
-TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_concat_axis_negative) {
+TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_negative_axis) {
     disable_rt_info_check();
     const int batch = 2;
     const int num_head = 32;
@@ -2185,7 +2185,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_concat_axis_negative) {
     }
 }
 
-TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_concat_axis_positive) {
+TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_positive_axis) {
     disable_rt_info_check();
     const int batch = 2;
     const int num_head = 32;
@@ -2194,13 +2194,13 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_concat_axis_positive) {
     const int half_ndims = ndims / 2;
     using namespace ov;
     {
-        // gpt-oss style RoPE pattern with concat axis = 3 (positive last axis for rank-4 tensor)
+        // gpt-oss style RoPE pattern with positive axis = 3 for both VariadicSplit and Concat
         auto input = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, num_head, seq_len, ndims});
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
 
         auto split_lengths = makeConst(element::i64, {2}, std::vector<int64_t>{half_ndims, half_ndims});
-        auto axis_const = makeConst(element::i64, {}, std::vector<int64_t>{-1});
+        auto axis_const = makeConst(element::i64, {}, std::vector<int64_t>{3});
         auto vsplit = makeOP<opset1::VariadicSplit>({input, axis_const, split_lengths});
 
         // first_ = first_half * cos - second_half * sin

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -2133,7 +2133,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_negative_axis) {
     const int half_ndims = ndims / 2;
     using namespace ov;
     {
-        // gpt-oss style RoPE pattern with concat axis = -1
+        // gpt-oss style RoPE pattern with Concat and VariadicSplit using axis = -1 to represent the last dimension.
         auto input = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, num_head, seq_len, ndims});
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
@@ -2185,7 +2185,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_negative_axis) {
     }
 }
 
-TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_positive_axis) {
+TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_concat_axis_positive) {
     disable_rt_info_check();
     const int batch = 2;
     const int num_head = 32;
@@ -2194,7 +2194,68 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_positive_axis) {
     const int half_ndims = ndims / 2;
     using namespace ov;
     {
-        // gpt-oss style RoPE pattern with positive axis = 3 for both VariadicSplit and Concat
+        // gpt-oss style RoPE pattern with Concat using axis = 3 to represent the last dimension.
+        auto input = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, num_head, seq_len, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
+
+        auto split_lengths = makeConst(element::i64, {2}, std::vector<int64_t>{half_ndims, half_ndims});
+        auto axis_const = makeConst(element::i64, {}, std::vector<int64_t>{-1});
+        auto vsplit = makeOP<opset1::VariadicSplit>({input, axis_const, split_lengths});
+
+        // first_ = first_half * cos - second_half * sin
+        auto first_half_mul_cos = makeOP<opset1::Multiply>({vsplit->output(0), t_cos}, {{"auto_broadcast", "numpy"}});
+        auto second_half_mul_sin = makeOP<opset1::Multiply>({vsplit->output(1), t_sin}, {{"auto_broadcast", "numpy"}});
+        auto neg = makeOP<opset1::Multiply>({second_half_mul_sin, -1.0f}, {{"auto_broadcast", "numpy"}});
+        auto first_ = makeOP<opset1::Add>({first_half_mul_cos, neg}, {{"auto_broadcast", "numpy"}});
+
+        // second_ = second_half * cos + first_half * sin
+        auto second_half_mul_cos = makeOP<opset1::Multiply>({vsplit->output(1), t_cos}, {{"auto_broadcast", "numpy"}});
+        auto first_half_mul_sin = makeOP<opset1::Multiply>({vsplit->output(0), t_sin}, {{"auto_broadcast", "numpy"}});
+        auto second_ = makeOP<opset1::Add>({second_half_mul_cos, first_half_mul_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto result = makeOP<opset1::Concat>({first_, second_}, {{"axis", 3}});
+
+        model = std::make_shared<Model>(OutputVector{result}, ParameterVector{input, t_cos, t_sin});
+    }
+    manager.register_pass<pass::RoPEFusion>();
+    {
+        auto input = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, num_head, seq_len, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
+
+        auto rope = makeOP<op::internal::RoPE>({input, t_cos, t_sin},
+                                               {{"config.slice_start", 0},
+                                                {"config.slice_stop", 0},
+                                                {"config.input_trans0213", false},
+                                                {"config.output_trans0213", false},
+                                                {"config.is_interleaved", false},
+                                                {"config.rotary_ndims", ndims},
+                                                {"config.cos_sin_ndims", half_ndims},
+                                                {"config.is_chatglm", false},
+                                                {"config.support_2d_rope", false},
+                                                {"config.support_3d_rope", false},
+                                                {"config.is_qwen", false},
+                                                {"config.use_rope_cache", false},
+                                                {"config.is_ltx_video", false},
+                                                {"config.head_cnt", 0},
+                                                {"config.head_size", 0},
+                                                {"config.gather_position_arg_id", 0}});
+
+        model_ref = std::make_shared<Model>(OutputVector{rope}, ParameterVector{input, t_cos, t_sin});
+    }
+}
+
+TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_split_axis_positive) {
+    disable_rt_info_check();
+    const int batch = 2;
+    const int num_head = 32;
+    const int seq_len = 16;
+    const int ndims = 128;
+    const int half_ndims = ndims / 2;
+    using namespace ov;
+    {
+        // gpt-oss style RoPE pattern with VariadicSplit using axis = 3 to represent the last dimension.
         auto input = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, num_head, seq_len, ndims});
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{batch, 1, seq_len, half_ndims});
@@ -2214,7 +2275,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_positive_axis) {
         auto first_half_mul_sin = makeOP<opset1::Multiply>({vsplit->output(0), t_sin}, {{"auto_broadcast", "numpy"}});
         auto second_ = makeOP<opset1::Add>({second_half_mul_cos, first_half_mul_sin}, {{"auto_broadcast", "numpy"}});
 
-        auto result = makeOP<opset1::Concat>({first_, second_}, {{"axis", 3}});
+        auto result = makeOP<opset1::Concat>({first_, second_}, {{"axis", -1}});
 
         model = std::make_shared<Model>(OutputVector{result}, ParameterVector{input, t_cos, t_sin});
     }


### PR DESCRIPTION
### Details

The `RoPEFusionGPTOSS` pattern is changed previously to supporte both negative and positive axis values for the final `Concat` node, but the `VariadicSplit` axis was hardcoded to only match `-1`. Some model exports produce `VariadicSplit` with a positive last-axis value, causing the pattern to fail to match.

This PR extends the `VariadicSplit` axis matching to accept both negative and positive last-axis values , consistent with the existing `Concat` axis handling in the same pattern.

### Jira Ticket:
https://jira.devtools.intel.com/browse/CVS-182397
