### PR TITLE
[NPU][WS] Remove NPU_WEIGHTLESS_BLOB property

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -1393,20 +1393,6 @@ struct ENABLE_WEIGHTLESS final : OptionBase<ENABLE_WEIGHTLESS, bool> {
     }
 };
 
-struct WEIGHTLESS_BLOB final : OptionBase<WEIGHTLESS_BLOB, bool> {
-    static std::string_view key() {
-        return ov::intel_npu::weightless_blob.name();
-    }
-
-    static bool defaultValue() {
-        return false;
-    }
-
-    static OptionMode mode() {
-        return OptionMode::CompileTime;
-    }
-};
-
 struct SEPARATE_WEIGHTS_VERSION final : OptionBase<SEPARATE_WEIGHTS_VERSION, ov::intel_npu::WSVersion> {
     static std::string_view key() {
         return ov::intel_npu::separate_weights_version.name();

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
@@ -340,16 +340,6 @@ static constexpr ov::Property<WSVersion> separate_weights_version{"NPU_SEPARATE_
 
 /**
  * @brief [Only for NPU Plugin]
- * Type: bool. Default is "false".
- *
- * This option enables/disables the "weights separation" feature. If enabled, the result of compilation will be a binary
- * object stripped of a significant amount of weights. Before running the model, these weights need to be provided by
- * external means.
- */
-static constexpr ov::Property<bool> weightless_blob{"NPU_WEIGHTLESS_BLOB"};
-
-/**
- * @brief [Only for NPU Plugin]
  * Type: enum. Default is "AUTO".
  *
  * This config option concerns the algorithm used for serializing the "ov::Model" at compilation time in order to be


### PR DESCRIPTION
### Details:
 - *Removing the NPU specific config option `ov::intel_npu::weightless_blob` which was replaced by `ov::enable_weightless` - https://github.com/openvinotoolkit/openvino/commit/f488845c8b8bc8105767d3318b2d331bfd93cd49.*

### Tickets:
 - *C#181697*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*