### PR TITLE
[GHA][Coverage] Use pinned oneDNN in nightly

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,6 +83,7 @@ jobs:
       build-additional-python-packages: false
       build-debian-packages: false
       upload-coverage-notes: true
+      use_latest_onednn: false
       cmake-options: >-
         -G 'Ninja Multi-Config'
         -DENABLE_NCC_STYLE=OFF


### PR DESCRIPTION
### Details:
Fix nightly coverage build failure: scheduled runs were overriding the pinned onednn_gpu
submodule with oneDNN main, which is incompatible with the current OpenVINO GPU code and
caused the XE3P build error.

**Change**: set use_latest_onednn: false in coverage.yml so nightly coverage builds use the
pinned oneDNN revision, same as regular CI builds.

### AI Assistance:
 - *AI assistance used: yes*
 - *Analyzing multiple build logs to identify root cause.*
