### PR TITLE
[DO_NOT_MERGE] ScaledShiftedClampExperimental as an example of Experimental OP

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -8,6 +8,8 @@
 
 ov_option (ENABLE_PROXY "Proxy plugin for OpenVINO Runtime" ON)
 
+ov_option (ENABLE_EXPERIMENTAL_OPSET "Include experimental ops into binaries" OFF)
+
 if(WIN32 AND AARCH64 AND NOT CMAKE_CL_64)
     set(ENABLE_INTEL_CPU_DEFAULT OFF)
 else()
@@ -236,6 +238,10 @@ endif()
 
 if (ENABLE_SNIPPETS_DEBUG_CAPS)
     add_definitions(-DSNIPPETS_DEBUG_CAPS)
+endif()
+
+if(ENABLE_EXPERIMENTAL_OPSET)
+    add_definitions(-DENABLE_EXPERIMENTAL_OPSET)
 endif()
 
 ov_print_enabled_features()

--- a/src/common/transformations/CMakeLists.txt
+++ b/src/common/transformations/CMakeLists.txt
@@ -9,6 +9,13 @@ set(PUBLIC_HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE PUBLIC_HEADERS ${PUBLIC_HEADERS_DIR}/*.hpp)
 
+if(NOT ENABLE_EXPERIMENTAL_OPSET)
+    list(REMOVE_ITEM LIBRARY_SRC
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/transformations/scaled_shifted_clamp_experimental_fusion.cpp)
+    list(REMOVE_ITEM PUBLIC_HEADERS
+        ${PUBLIC_HEADERS_DIR}/transformations/scaled_shifted_clamp_experimental_fusion.hpp)
+endif()
+
 # Create named folders for the sources within the .vcproj
 # Empty name lists them directly under the .vcproj
 

--- a/src/common/transformations/include/transformations/scaled_shifted_clamp_experimental_fusion.hpp
+++ b/src/common/transformations/include/transformations/scaled_shifted_clamp_experimental_fusion.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov {
+namespace pass {
+namespace experimental {
+
+class TRANSFORMATIONS_API ScaledShiftedClampFusion;
+
+}  // namespace experimental
+}  // namespace pass
+}  // namespace ov
+
+/**
+ * @ingroup ov_transformation_common_api
+ * @brief Fuses Clamp(Add(Multiply(x, scale_const), bias_const), lo, hi) into a single
+ *        ov::op::experimental::ScaledShiftedClamp op. scale_const and bias_const must
+ *        be scalar (shape_size == 1) Constants.
+ * @note  Experimental. API subject to change. Plugins opt in by registering this pass.
+ */
+class ov::pass::experimental::ScaledShiftedClampFusion : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("ScaledShiftedClampFusion");
+    ScaledShiftedClampFusion();
+};

--- a/src/common/transformations/src/transformations/scaled_shifted_clamp_experimental_fusion.cpp
+++ b/src/common/transformations/src/transformations/scaled_shifted_clamp_experimental_fusion.cpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/scaled_shifted_clamp_experimental_fusion.hpp"
+
+#include <memory>
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/scaled_shifted_clamp_experimental.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+
+namespace ov::pass::experimental {
+
+ScaledShiftedClampFusion::ScaledShiftedClampFusion() {
+    MATCHER_SCOPE(ScaledShiftedClampFusion);
+
+    auto data_p = pattern::any_input();
+    auto scale_p = pattern::wrap_type<v0::Constant>();
+    auto bias_p = pattern::wrap_type<v0::Constant>();
+    auto mul_p = pattern::wrap_type<v1::Multiply>({data_p, scale_p}, pattern::consumers_count(1));
+    auto add_p = pattern::wrap_type<v1::Add>({mul_p, bias_p}, pattern::consumers_count(1));
+    auto clamp_p = pattern::wrap_type<v0::Clamp>({add_p});
+
+    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+        const auto& pm = m.get_pattern_value_map();
+
+        auto scale_c = ov::as_type_ptr<v0::Constant>(pm.at(scale_p).get_node_shared_ptr());
+        auto bias_c = ov::as_type_ptr<v0::Constant>(pm.at(bias_p).get_node_shared_ptr());
+        if (!scale_c || !bias_c)
+            return false;
+        if (shape_size(scale_c->get_shape()) != 1 || shape_size(bias_c->get_shape()) != 1)
+            return false;
+
+        auto clamp = ov::as_type_ptr<v0::Clamp>(pm.at(clamp_p).get_node_shared_ptr());
+        if (!clamp)
+            return false;
+
+        const double scale = scale_c->cast_vector<double>()[0];
+        const double bias = bias_c->cast_vector<double>()[0];
+        const double lo = clamp->get_min();
+        const double hi = clamp->get_max();
+
+        auto fused = register_new_node<ov::op::experimental::ScaledShiftedClamp>(pm.at(data_p), scale, bias, lo, hi);
+        fused->set_friendly_name(clamp->get_friendly_name());
+
+        copy_runtime_info({pm.at(mul_p).get_node_shared_ptr(),
+                           pm.at(add_p).get_node_shared_ptr(),
+                           pm.at(clamp_p).get_node_shared_ptr()},
+                          fused);
+        replace_node(clamp, fused);
+
+        return true;
+    };
+
+    auto matcher = std::make_shared<pattern::Matcher>(clamp_p, matcher_name);
+    register_matcher(matcher, callback);
+}
+
+}  // namespace ov::pass::experimental

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,6 +15,14 @@ file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
 file(GLOB_RECURSE PUBLIC_HEADERS ${OV_CORE_INCLUDE_PATH}/*.hpp)
 file(GLOB_RECURSE DEV_HEADERS ${OV_CORE_DEV_API_PATH}/*.hpp)
 
+if(NOT ENABLE_EXPERIMENTAL_OPSET)
+    list(REMOVE_ITEM LIBRARY_SRC
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/op/scaled_shifted_clamp_experimental.cpp)
+    list(REMOVE_ITEM DEV_HEADERS
+        ${OV_CORE_DEV_API_PATH}/openvino/op/scaled_shifted_clamp_experimental.hpp
+        ${OV_CORE_DEV_API_PATH}/openvino/op/experimental_ops.hpp)
+endif()
+
 add_subdirectory(reference)
 add_subdirectory(shape_inference)
 add_subdirectory(xml_util)

--- a/src/core/dev_api/openvino/op/experimental_ops.hpp
+++ b/src/core/dev_api/openvino/op/experimental_ops.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+// Shared registry of experimental ops. Each new experimental op appends its header here.
+// Entire body is gated by ENABLE_EXPERIMENTAL_OPSET so downstream TUs that do not set
+// the define see no experimental symbols.
+
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+
+#    include "openvino/op/scaled_shifted_clamp_experimental.hpp"
+
+#endif  // ENABLE_EXPERIMENTAL_OPSET

--- a/src/core/dev_api/openvino/op/scaled_shifted_clamp_experimental.hpp
+++ b/src/core/dev_api/openvino/op/scaled_shifted_clamp_experimental.hpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <limits>
+
+#include "openvino/op/op.hpp"
+
+namespace ov {
+namespace op {
+namespace experimental {
+
+/// \note Experimental op. API is subject to change or removal.
+///
+/// \brief Computes y = clamp(x * scale + bias, lo, hi) elementwise.
+/// \ingroup ov_ops_cpp_api
+class OPENVINO_API ScaledShiftedClamp : public ov::op::Op {
+public:
+    OPENVINO_OP("ScaledShiftedClampExperimental");
+
+    ScaledShiftedClamp() = default;
+    ScaledShiftedClamp(const Output<Node>& data, double scale, double bias, double lo, double hi);
+
+    bool visit_attributes(ov::AttributeVisitor& visitor) override;
+    void validate_and_infer_types() override;
+    std::shared_ptr<Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
+
+    double get_scale() const {
+        return m_scale;
+    }
+    double get_bias() const {
+        return m_bias;
+    }
+    double get_lo() const {
+        return m_lo;
+    }
+    double get_hi() const {
+        return m_hi;
+    }
+
+private:
+    double m_scale{1.0};
+    double m_bias{0.0};
+    double m_lo{std::numeric_limits<double>::lowest()};
+    double m_hi{std::numeric_limits<double>::max()};
+};
+
+}  // namespace experimental
+}  // namespace op
+}  // namespace ov

--- a/src/core/src/op/scaled_shifted_clamp_experimental.cpp
+++ b/src/core/src/op/scaled_shifted_clamp_experimental.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/scaled_shifted_clamp_experimental.hpp"
+
+#include "itt.hpp"
+
+namespace ov {
+namespace op {
+namespace experimental {
+
+ScaledShiftedClamp::ScaledShiftedClamp(const Output<Node>& data, double scale, double bias, double lo, double hi)
+    : Op({data}),
+      m_scale(scale),
+      m_bias(bias),
+      m_lo(lo),
+      m_hi(hi) {
+    constructor_validate_and_infer_types();
+}
+
+bool ScaledShiftedClamp::visit_attributes(ov::AttributeVisitor& visitor) {
+    OV_OP_SCOPE(experimental_ScaledShiftedClamp_visit_attributes);
+    visitor.on_attribute("scale", m_scale);
+    visitor.on_attribute("bias", m_bias);
+    visitor.on_attribute("lo", m_lo);
+    visitor.on_attribute("hi", m_hi);
+    return true;
+}
+
+void ScaledShiftedClamp::validate_and_infer_types() {
+    OV_OP_SCOPE(experimental_ScaledShiftedClamp_validate_and_infer_types);
+
+    const auto& data_et = get_input_element_type(0);
+    NODE_VALIDATION_CHECK(this,
+                          data_et.is_dynamic() || data_et.is_real(),
+                          "Input element type must be a floating point type. Got: ",
+                          data_et);
+    NODE_VALIDATION_CHECK(this, m_lo <= m_hi, "Attribute `lo` must be <= `hi`. Got lo=", m_lo, ", hi=", m_hi);
+
+    set_output_type(0, data_et, get_input_partial_shape(0));
+}
+
+std::shared_ptr<Node> ScaledShiftedClamp::clone_with_new_inputs(const ov::OutputVector& new_args) const {
+    OV_OP_SCOPE(experimental_ScaledShiftedClamp_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    return std::make_shared<ScaledShiftedClamp>(new_args.at(0), m_scale, m_bias, m_lo, m_hi);
+}
+
+}  // namespace experimental
+}  // namespace op
+}  // namespace ov

--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -215,6 +215,12 @@ if (NOT ENABLE_SNIPPETS_LIBXSMM_TPP)
                               ${CMAKE_CURRENT_SOURCE_DIR}/src/transformations/tpp/*)
 endif ()
 
+if(NOT ENABLE_EXPERIMENTAL_OPSET)
+    list(APPEND EXCLUDE_PATHS
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/nodes/scaled_shifted_clamp_experimental.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/nodes/scaled_shifted_clamp_experimental.h)
+endif()
+
 file(GLOB_RECURSE FILES_TO_REMOVE ${EXCLUDE_PATHS})
 list(REMOVE_ITEM SOURCES ${FILES_TO_REMOVE})
 list(REMOVE_ITEM HEADERS ${FILES_TO_REMOVE})

--- a/src/plugins/intel_cpu/src/cpu_types.cpp
+++ b/src/plugins/intel_cpu/src/cpu_types.cpp
@@ -264,7 +264,11 @@ static const TypeToNameMap& get_type_to_name_tbl() {
         {"LoraSubgraph", Type::LoRA},
         {"GatherMatmul", Type::GatherMatmul},
         {"GatherMatmulCompressed", Type::GatherMatmul},
-        {"GatedDeltaNet", Type::GatedDeltaNet}};
+        {"GatedDeltaNet", Type::GatedDeltaNet},
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+        {"ScaledShiftedClampExperimental", Type::ScaledShiftedClampExperimental},
+#endif
+    };
     return type_to_name_tbl;
 }
 
@@ -401,6 +405,9 @@ std::string NameFromType(const Type type) {
         CASE(LoRA);
         CASE(GatherMatmul);
         CASE(GatedDeltaNet);
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+        CASE(ScaledShiftedClampExperimental);
+#endif
         CASE(Unknown);
     }
 #undef CASE

--- a/src/plugins/intel_cpu/src/cpu_types.h
+++ b/src/plugins/intel_cpu/src/cpu_types.h
@@ -139,7 +139,10 @@ enum class Type : uint8_t {
     SegmentMax,
     LoRA,
     GatherMatmul,
-    GatedDeltaNet
+    GatedDeltaNet,
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+    ScaledShiftedClampExperimental,
+#endif
 };
 
 enum class Algorithm : uint8_t {

--- a/src/plugins/intel_cpu/src/nodes/scaled_shifted_clamp_experimental.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_shifted_clamp_experimental.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "scaled_shifted_clamp_experimental.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <oneapi/dnnl/dnnl_common.hpp>
+#include <shape_inference/shape_inference_pass_through.hpp>
+#include <string>
+
+#include "cpu_types.h"
+#include "graph_context.h"
+#include "memory_desc/cpu_memory_desc.h"
+#include "node.h"
+#include "onednn/iml_type_mapper.h"
+#include "openvino/core/except.hpp"
+#include "openvino/core/type.hpp"
+#include "openvino/op/scaled_shifted_clamp_experimental.hpp"
+
+namespace ov::intel_cpu::node {
+
+bool ScaledShiftedClamp::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
+                                              std::string& errorMessage) noexcept {
+    if (!ov::as_type_ptr<const ov::op::experimental::ScaledShiftedClamp>(op)) {
+        errorMessage = "Only experimental::ScaledShiftedClamp op is supported";
+        return false;
+    }
+    return true;
+}
+
+ScaledShiftedClamp::ScaledShiftedClamp(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
+    : Node(op, context, PassThroughShapeInferFactory()) {
+    std::string errorMessage;
+    if (!isSupportedOperation(op, errorMessage)) {
+        OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
+    }
+    const auto typed = ov::as_type_ptr<const ov::op::experimental::ScaledShiftedClamp>(op);
+    m_scale = static_cast<float>(typed->get_scale());
+    m_bias = static_cast<float>(typed->get_bias());
+    m_lo = static_cast<float>(typed->get_lo());
+    m_hi = static_cast<float>(typed->get_hi());
+}
+
+void ScaledShiftedClamp::initSupportedPrimitiveDescriptors() {
+    if (!supportedPrimitiveDescriptors.empty()) {
+        return;
+    }
+    addSupportedPrimDesc({{LayoutType::ncsp, ov::element::f32}},
+                         {{LayoutType::ncsp, ov::element::f32}},
+                         impl_desc_type::ref_any);
+}
+
+void ScaledShiftedClamp::execute([[maybe_unused]] const dnnl::stream& strm) {
+    const auto* src = getSrcDataAtPortAs<const float>(0);
+    auto* dst = getDstDataAtPortAs<float>(0);
+    const auto n = getDstMemoryAtPort(0)->getShape().getElementsCount();
+    for (size_t i = 0; i < n; ++i) {
+        dst[i] = std::clamp(src[i] * m_scale + m_bias, m_lo, m_hi);
+    }
+}
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/scaled_shifted_clamp_experimental.h
+++ b/src/plugins/intel_cpu/src/nodes/scaled_shifted_clamp_experimental.h
@@ -1,0 +1,41 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <oneapi/dnnl/dnnl_common.hpp>
+#include <string>
+
+#include "graph_context.h"
+#include "node.h"
+#include "openvino/core/node.hpp"
+
+namespace ov::intel_cpu::node {
+
+class ScaledShiftedClamp : public Node {
+public:
+    ScaledShiftedClamp(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
+
+    void getSupportedDescriptors() override {}
+    void initSupportedPrimitiveDescriptors() override;
+    void prepareParams() override {}
+    void execute(const dnnl::stream& strm) override;
+    void executeDynamicImpl(const dnnl::stream& strm) override {
+        execute(strm);
+    }
+    [[nodiscard]] bool created() const override {
+        return getType() == Type::ScaledShiftedClampExperimental;
+    }
+    static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
+
+private:
+    float m_scale{1.0F};
+    float m_bias{0.0F};
+    float m_lo{std::numeric_limits<float>::lowest()};
+    float m_hi{std::numeric_limits<float>::max()};
+};
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes_factory.cpp
+++ b/src/plugins/intel_cpu/src/nodes_factory.cpp
@@ -88,6 +88,9 @@
 #include "nodes/roll.h"
 #include "nodes/rope.h"
 #include "nodes/scaled_attn.h"
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+#    include "nodes/scaled_shifted_clamp_experimental.h"
+#endif
 #include "nodes/scatter_update.h"
 #include "nodes/search_sorted.h"
 #include "nodes/segment_max.h"
@@ -244,6 +247,9 @@ Node::NodesFactory::NodesFactory() : Factory("NodesFactory") {
     INTEL_CPU_NODE(LoRA, Type::LoRA);
     INTEL_CPU_NODE(GatherMatmul, Type::GatherMatmul);
     INTEL_CPU_NODE(GatedDeltaNet, Type::GatedDeltaNet);
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+    INTEL_CPU_NODE(ScaledShiftedClamp, Type::ScaledShiftedClampExperimental);
+#endif
 #if defined(OPENVINO_ARCH_X86_64)
     INTEL_CPU_NODE(FakeQuantize, Type::FakeQuantize);
     INTEL_CPU_NODE(GridSample, Type::GridSample);

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -127,6 +127,9 @@
 #include "transformations/op_conversions/unique_decomposition.hpp"
 #include "transformations/opset_conversions/convert_opset2_to_opset1.hpp"
 #include "transformations/rt_info/keep_const_precision.hpp"
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+#    include "transformations/scaled_shifted_clamp_experimental_fusion.hpp"
+#endif
 #include "transformations/smart_reshape/matmul_sr.hpp"
 #include "transformations/symbolic_transformations/symbolic_optimizations.hpp"
 #include "utils/general_utils.h"
@@ -584,6 +587,9 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::AUGRUCellFusion);
     CPU_REGISTER_PASS_COMMON(manager, SDPASubgraphFusion);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::GatedDeltaNetFusion);
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+    CPU_REGISTER_PASS_COMMON(manager, ov::pass::experimental::ScaledShiftedClampFusion);
+#endif
     ov::pass::ConvertPagedAttnInputs::KVCacheConfig cacheConfig;
     cacheConfig.keyCachePrecision = config.keyCachePrecision;
     cacheConfig.valueCachePrecision = config.valueCachePrecision;

--- a/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
@@ -96,6 +96,11 @@ if(NOT X86_64)
          ${CMAKE_CURRENT_SOURCE_DIR}/shared_tests_instances/low_precision_transformations/x64)
 endif()
 
+if(NOT ENABLE_EXPERIMENTAL_OPSET)
+    list(APPEND EXCLUDED_SOURCE_PATHS
+         ${CMAKE_CURRENT_SOURCE_DIR}/custom/single_layer_tests/scaled_shifted_clamp_experimental.cpp)
+endif()
+
 ov_add_test_target(
         NAME ${TARGET_NAME}
         ROOT ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/scaled_shifted_clamp_experimental.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/scaled_shifted_clamp_experimental.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/runtime/exec_model_info.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+
+class ScaledShiftedClampFusionCPUTest : public virtual SubgraphBaseStaticTest {
+protected:
+    void SetUp() override {
+        targetDevice     = utils::DEVICE_CPU;
+        const auto t     = element::f32;
+        const Shape s{1, 4, 8, 8};
+        auto       param = std::make_shared<op::v0::Parameter>(t, s);
+        auto       scale = op::v0::Constant::create(t, Shape{1}, {2.0F});
+        auto       bias  = op::v0::Constant::create(t, Shape{1}, {0.5F});
+        auto       mul   = std::make_shared<op::v1::Multiply>(param, scale);
+        auto       add   = std::make_shared<op::v1::Add>(mul, bias);
+        auto       clamp = std::make_shared<op::v0::Clamp>(add, -1.0, 1.0);
+        function         = std::make_shared<Model>(clamp, ParameterVector{param});
+    }
+
+    void check_fused() {
+        const auto exec = compiledModel.get_runtime_model();
+        bool       found = false;
+        for (const auto& n : exec->get_ordered_ops()) {
+            const auto layer = n->get_rt_info().at(exec_model_info::LAYER_TYPE).as<std::string>();
+            if (layer == "ScaledShiftedClampExperimental") {
+                found = true;
+                break;
+            }
+        }
+        ASSERT_TRUE(found) << "ScaledShiftedClampExperimental node not found in exec graph";
+    }
+};
+
+TEST_F(ScaledShiftedClampFusionCPUTest, smoke_Fuses) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    run();
+    check_fused();
+}
+
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_gpu/CMakeLists.txt
+++ b/src/plugins/intel_gpu/CMakeLists.txt
@@ -69,6 +69,11 @@ add_subdirectory(src/graph)
 
 file(GLOB_RECURSE PLUGIN_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/plugin/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/include/intel_gpu/plugin/*.hpp)
 
+if(NOT ENABLE_EXPERIMENTAL_OPSET)
+    list(REMOVE_ITEM PLUGIN_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/plugin/ops/scaled_shifted_clamp_experimental.cpp)
+endif()
+
 ov_add_plugin(NAME ${TARGET_NAME}
               DEVICE_NAME "GPU"
               SOURCES ${PLUGIN_SOURCES}

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/primitives_list.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/primitives_list.hpp
@@ -318,3 +318,8 @@ REGISTER_FACTORY(internal, VLSDPA);
 REGISTER_FACTORY(internal, MOE3GemmFusedCompressed);
 REGISTER_FACTORY(internal, MOECompressed);
 REGISTER_FACTORY(internal, GatedDeltaNet);
+
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+// --------------------------- Supported experimental ops --------------------------- //
+REGISTER_FACTORY(experimental, ScaledShiftedClamp);
+#endif

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_shifted_clamp_experimental.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_shifted_clamp_experimental.hpp
@@ -1,0 +1,70 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <limits>
+
+#include "primitive.hpp"
+
+namespace cldnn {
+
+/// @brief Elementwise y = clamp(x * scale + bias, lo, hi). Experimental.
+struct scaled_shifted_clamp_experimental : public primitive_base<scaled_shifted_clamp_experimental> {
+    CLDNN_DECLARE_PRIMITIVE(scaled_shifted_clamp_experimental);
+
+    scaled_shifted_clamp_experimental() : primitive_base("", {}) {}
+
+    scaled_shifted_clamp_experimental(const primitive_id& id,
+                                      const input_info& input,
+                                      const float scale,
+                                      const float bias,
+                                      const float lo,
+                                      const float hi)
+        : primitive_base(id, {input}),
+          scale(scale),
+          bias(bias),
+          lo(lo),
+          hi(hi) {}
+
+    float scale{1.0f};
+    float bias{0.0f};
+    float lo{std::numeric_limits<float>::lowest()};
+    float hi{std::numeric_limits<float>::max()};
+
+    size_t hash() const override {
+        size_t seed = primitive::hash();
+        seed = hash_combine(seed, scale);
+        seed = hash_combine(seed, bias);
+        seed = hash_combine(seed, lo);
+        seed = hash_combine(seed, hi);
+        return seed;
+    }
+
+    bool operator==(const primitive& rhs) const override {
+        if (!compare_common_params(rhs)) {
+            return false;
+        }
+        auto rhs_casted = downcast<const scaled_shifted_clamp_experimental>(rhs);
+        return scale == rhs_casted.scale && bias == rhs_casted.bias && lo == rhs_casted.lo && hi == rhs_casted.hi;
+    }
+
+    void save(BinaryOutputBuffer& ob) const override {
+        primitive_base<scaled_shifted_clamp_experimental>::save(ob);
+        ob << scale;
+        ob << bias;
+        ob << lo;
+        ob << hi;
+    }
+
+    void load(BinaryInputBuffer& ib) override {
+        primitive_base<scaled_shifted_clamp_experimental>::load(ib);
+        ib >> scale;
+        ib >> bias;
+        ib >> lo;
+        ib >> hi;
+    }
+};
+
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/CMakeLists.txt
@@ -16,6 +16,13 @@ foreach(SUBDIR IN LISTS SUBDIRS)
     endif()
 endforeach()
 
+if(NOT ENABLE_EXPERIMENTAL_OPSET)
+    list(APPEND EXCLUDE_PATHS
+        ${CMAKE_CURRENT_SOURCE_DIR}/scaled_shifted_clamp_experimental.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/scaled_shifted_clamp_experimental_inst.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/registry/scaled_shifted_clamp_experimental_impls.cpp)
+endif()
+
 if(SUGGEST_OVERRIDE_SUPPORTED)
     set(COMMON_COMPILE_OPTIONS $<$<CONFIG:Release>:$<IF:$<CXX_COMPILER_ID:MSVC>,/Os,-Os -Wno-suggest-override>>)
 else()

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/CMakeLists.txt
@@ -4,8 +4,14 @@
 
 set(TARGET_NAME "openvino_intel_gpu_ocl_obj")
 
+set(OCL_EXCLUDE "")
+if(NOT ENABLE_EXPERIMENTAL_OPSET)
+    list(APPEND OCL_EXCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/scaled_shifted_clamp_experimental.cpp)
+endif()
+
 ov_gpu_add_backend_target(
     NAME ${TARGET_NAME}
+    BYPASS EXCLUDED_SOURCE_PATHS ${OCL_EXCLUDE}
 )
 
 ov_build_target_faster(${TARGET_NAME} PCH)

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/register.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/register.cpp
@@ -48,6 +48,9 @@ void register_implementations() {
     REGISTER_OCL(prior_box);
     REGISTER_OCL(quantize);
     REGISTER_OCL(random_uniform);
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+    REGISTER_OCL(scaled_shifted_clamp_experimental);
+#endif
     REGISTER_OCL(range);
     REGISTER_OCL(reduce);
     REGISTER_OCL(region_yolo);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/register.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/register.hpp
@@ -49,6 +49,9 @@
 #include "intel_gpu/primitives/reshape.hpp"
 #include "intel_gpu/primitives/reverse_sequence.hpp"
 #include "intel_gpu/primitives/rms.hpp"
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+#    include "intel_gpu/primitives/scaled_shifted_clamp_experimental.hpp"
+#endif
 #include "intel_gpu/primitives/roi_align.hpp"
 #include "intel_gpu/primitives/roi_pooling.hpp"
 #include "intel_gpu/primitives/roll.hpp"
@@ -126,6 +129,9 @@ REGISTER_OCL(reshape);
 REGISTER_OCL(reverse);
 REGISTER_OCL(reverse_sequence);
 REGISTER_OCL(rms);
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+REGISTER_OCL(scaled_shifted_clamp_experimental);
+#endif
 REGISTER_OCL(roi_align);
 REGISTER_OCL(roi_pooling);
 REGISTER_OCL(roll);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_shifted_clamp_experimental.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_shifted_clamp_experimental.cpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "primitive_base.hpp"
+#include "scaled_shifted_clamp_experimental_inst.h"
+#include "scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_ref.h"
+#include "scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_selector.h"
+
+namespace cldnn {
+namespace ocl {
+
+struct scaled_shifted_clamp_experimental_impl : typed_primitive_impl_ocl<scaled_shifted_clamp_experimental> {
+    using parent = typed_primitive_impl_ocl<scaled_shifted_clamp_experimental>;
+    using parent::parent;
+    using kernel_selector_t = kernel_selector::scaled_shifted_clamp_experimental_kernel_selector;
+    using kernel_params_t   = kernel_selector::scaled_shifted_clamp_experimental_params;
+
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::scaled_shifted_clamp_experimental_impl)
+
+    std::unique_ptr<primitive_impl> clone() const override {
+        return make_deep_copy<scaled_shifted_clamp_experimental_impl, kernel_params_t>(*this);
+    }
+
+    void load(BinaryInputBuffer& ib) override {
+        parent::load(ib);
+        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+            auto& ks   = kernel_selector_t::Instance();
+            auto  impl = ks.GetImplementation(_kernel_data.kernelName);
+            impl->GetUpdateDispatchDataFunc(_kernel_data);
+        }
+    }
+
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param, bool is_shape_agnostic = false) {
+        auto        params = get_default_params<kernel_params_t>(impl_param, is_shape_agnostic);
+        const auto  desc   = impl_param.typed_desc<scaled_shifted_clamp_experimental>();
+        params.scale = desc->scale;
+        params.bias  = desc->bias;
+        params.lo    = desc->lo;
+        params.hi    = desc->hi;
+        return params;
+    }
+
+    void update_dispatch_data(const kernel_impl_params& impl_param) override {
+        if (_kernel_data.params == nullptr) {
+            _kernel_data.params = std::make_shared<kernel_params_t>(get_kernel_params(impl_param, true));
+        }
+        update_shapes(*_kernel_data.params, impl_param);
+        (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
+    }
+};
+
+namespace detail {
+
+attach_scaled_shifted_clamp_experimental_impl::attach_scaled_shifted_clamp_experimental_impl() {
+    auto types   = {data_types::f16, data_types::f32};
+    auto formats = {format::bfyx};
+    implementation_map<scaled_shifted_clamp_experimental>::add(
+        impl_types::ocl,
+        shape_types::any,
+        typed_primitive_impl_ocl<scaled_shifted_clamp_experimental>::create<scaled_shifted_clamp_experimental_impl>,
+        types,
+        formats);
+}
+
+}  // namespace detail
+}  // namespace ocl
+}  // namespace cldnn
+
+BIND_BINARY_BUFFER_WITH_TYPE(cldnn::ocl::scaled_shifted_clamp_experimental_impl)
+BIND_BINARY_BUFFER_WITH_TYPE(cldnn::scaled_shifted_clamp_experimental)

--- a/src/plugins/intel_gpu/src/graph/include/scaled_shifted_clamp_experimental_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/scaled_shifted_clamp_experimental_inst.h
@@ -1,0 +1,47 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <string>
+
+#include "intel_gpu/primitives/scaled_shifted_clamp_experimental.hpp"
+#include "primitive_inst.h"
+
+namespace cldnn {
+
+template <>
+struct typed_program_node<scaled_shifted_clamp_experimental>
+    : public typed_program_node_base<scaled_shifted_clamp_experimental> {
+    using parent = typed_program_node_base<scaled_shifted_clamp_experimental>;
+
+public:
+    using parent::parent;
+
+    program_node& input(size_t index = 0) const { return get_dependency(index); }
+    std::vector<size_t> get_shape_infer_dependencies() const override { return {}; }
+};
+
+using scaled_shifted_clamp_experimental_node = typed_program_node<scaled_shifted_clamp_experimental>;
+
+template <>
+class typed_primitive_inst<scaled_shifted_clamp_experimental>
+    : public typed_primitive_inst_base<scaled_shifted_clamp_experimental> {
+    using parent = typed_primitive_inst_base<scaled_shifted_clamp_experimental>;
+    using parent::parent;
+
+public:
+    template <typename ShapeType>
+    static std::vector<layout> calc_output_layouts(scaled_shifted_clamp_experimental_node const& node,
+                                                   const kernel_impl_params& impl_params);
+    static layout calc_output_layout(scaled_shifted_clamp_experimental_node const& node,
+                                     kernel_impl_params const& impl_params);
+    static std::string to_string(scaled_shifted_clamp_experimental_node const& node);
+
+    typed_primitive_inst(network& network, scaled_shifted_clamp_experimental_node const& node);
+};
+
+using scaled_shifted_clamp_experimental_inst = typed_primitive_inst<scaled_shifted_clamp_experimental>;
+
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/registry/registry.hpp
+++ b/src/plugins/intel_gpu/src/graph/registry/registry.hpp
@@ -177,6 +177,9 @@ REGISTER_IMPLS(moe_mask_gen_reshape);
 REGISTER_IMPLS(moe_gemm);
 REGISTER_IMPLS(moe_scatter_reduction);
 REGISTER_IMPLS(moe_gather);
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+REGISTER_IMPLS(scaled_shifted_clamp_experimental);
+#endif
 
 REGISTER_DEFAULT_IMPLS(assign, CPU_S, CPU_D);
 REGISTER_DEFAULT_IMPLS(read_value, CPU_S, CPU_D);

--- a/src/plugins/intel_gpu/src/graph/registry/scaled_shifted_clamp_experimental_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/scaled_shifted_clamp_experimental_impls.cpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "predicates.hpp"
+#include "registry.hpp"
+#include "intel_gpu/primitives/scaled_shifted_clamp_experimental.hpp"
+#include "primitive_inst.h"
+
+namespace ov::intel_gpu {
+
+using namespace cldnn;
+
+const std::vector<std::shared_ptr<cldnn::ImplementationManager>>&
+Registry<scaled_shifted_clamp_experimental>::get_implementations() {
+    static const std::vector<std::shared_ptr<ImplementationManager>> impls = {
+        OV_GPU_GET_INSTANCE_OCL(scaled_shifted_clamp_experimental, shape_types::static_shape)
+        OV_GPU_GET_INSTANCE_OCL(scaled_shifted_clamp_experimental, shape_types::dynamic_shape)
+    };
+    return impls;
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/graph/scaled_shifted_clamp_experimental.cpp
+++ b/src/plugins/intel_gpu/src/graph/scaled_shifted_clamp_experimental.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "scaled_shifted_clamp_experimental_inst.h"
+
+#include <sstream>
+#include <string>
+
+#include "json_object.h"
+#include "primitive_type_base.h"
+
+namespace cldnn {
+GPU_DEFINE_PRIMITIVE_TYPE_ID(scaled_shifted_clamp_experimental);
+
+layout scaled_shifted_clamp_experimental_inst::calc_output_layout(
+    scaled_shifted_clamp_experimental_node const& /*node*/,
+    kernel_impl_params const& impl_param) {
+    const auto input_layout = impl_param.get_input_layout();
+    const auto output_type  = impl_param.desc->output_data_types[0].value_or(input_layout.data_type);
+    return layout(output_type, input_layout.format, input_layout.get_tensor());
+}
+
+template <typename ShapeType>
+std::vector<layout> scaled_shifted_clamp_experimental_inst::calc_output_layouts(
+    scaled_shifted_clamp_experimental_node const& /*node*/,
+    const kernel_impl_params& impl_param) {
+    const auto input_layout = impl_param.get_input_layout();
+    const auto output_type  = impl_param.desc->output_data_types[0].value_or(input_layout.data_type);
+    return {layout(input_layout.get<ShapeType>(), output_type, input_layout.format)};
+}
+
+template std::vector<layout> scaled_shifted_clamp_experimental_inst::calc_output_layouts<ov::PartialShape>(
+    scaled_shifted_clamp_experimental_node const& node,
+    const kernel_impl_params& impl_param);
+
+std::string scaled_shifted_clamp_experimental_inst::to_string(scaled_shifted_clamp_experimental_node const& node) {
+    const auto  desc      = node.get_primitive();
+    auto        node_info = node.desc_to_json();
+    const auto& input     = node.input();
+
+    std::stringstream primitive_description;
+
+    json_composite info;
+    info.add("input_id", input.id());
+    info.add("scale", desc->scale);
+    info.add("bias", desc->bias);
+    info.add("lo", desc->lo);
+    info.add("hi", desc->hi);
+
+    node_info->add("scaled_shifted_clamp_experimental_info", info);
+    node_info->dump(primitive_description);
+    return primitive_description.str();
+}
+
+scaled_shifted_clamp_experimental_inst::typed_primitive_inst(network& network,
+                                                             scaled_shifted_clamp_experimental_node const& node)
+    : parent(network, node) {}
+
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/kernel_selector/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/kernel_selector/CMakeLists.txt
@@ -16,6 +16,16 @@ file(GLOB_RECURSE KERNELS
     "${CMAKE_CURRENT_SOURCE_DIR}/cl_kernels/*.cl"
   )
 
+if(NOT ENABLE_EXPERIMENTAL_OPSET)
+    list(REMOVE_ITEM LIBRARY_SRC
+        ${CMAKE_CURRENT_SOURCE_DIR}/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_ref.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_ref.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_selector.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_selector.h)
+    list(REMOVE_ITEM KERNELS
+        ${CMAKE_CURRENT_SOURCE_DIR}/cl_kernels/scaled_shifted_clamp_experimental_ref.cl)
+endif()
+
 # Path which points to root directory where code generated elements are created
 # (specific to build configuration).
 set(CODEGEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/codegen")

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scaled_shifted_clamp_experimental_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scaled_shifted_clamp_experimental_ref.cl
@@ -1,0 +1,14 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+KERNEL(scaled_shifted_clamp_experimental_ref)(OPTIONAL_SHAPE_INFO_ARG
+                                              const __global INPUT0_TYPE* input,
+                                              __global OUTPUT_TYPE* output)
+{
+    const uint i = get_global_id(2);
+    OUTPUT_TYPE y = TO_OUTPUT_TYPE(input[i]) * TO_OUTPUT_TYPE(SCALE) + TO_OUTPUT_TYPE(BIAS);
+    y = max(y, TO_OUTPUT_TYPE(LO));
+    y = min(y, TO_OUTPUT_TYPE(HI));
+    output[i] = y;
+}

--- a/src/plugins/intel_gpu/src/kernel_selector/common_types.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/common_types.h
@@ -111,7 +111,10 @@ enum class KernelType {
     STFT,
     ISTFT,
     COL2IM,
-    LORA
+    LORA,
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+    SCALED_SHIFTED_CLAMP_EXPERIMENTAL,
+#endif
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_ref.cpp
@@ -1,0 +1,83 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "scaled_shifted_clamp_experimental_kernel_ref.h"
+
+#include <kernel_selector_utils.h>
+
+namespace kernel_selector {
+
+namespace {
+
+CommonDispatchData SetDefault(const scaled_shifted_clamp_experimental_params& params) {
+    CommonDispatchData dd;
+    const auto& out = params.outputs[0];
+    dd.gws = {1, 1, out.Batch().v * out.Feature().v * out.X().v * out.Y().v * out.Z().v * out.W().v};
+    dd.lws = GetOptimalLocalWorkGroupSizes(dd.gws, params.engineInfo);
+    return dd;
+}
+
+}  // namespace
+
+void ScaledShiftedClampExperimentalKernelRef::GetUpdateDispatchDataFunc(KernelData& kd) const {
+    kd.update_dispatch_data_func = [](const Params& params, KernelData& kd) {
+        const auto& p = static_cast<const scaled_shifted_clamp_experimental_params&>(params);
+        auto dd = SetDefault(p);
+        OPENVINO_ASSERT(kd.kernels.size() == 1, "[GPU] Invalid kernels size for update dispatch data func");
+        kd.kernels[0].params.workGroups.global = dd.gws;
+        kd.kernels[0].params.workGroups.local  = dd.lws;
+        kd.kernels[0].skip_execution           = KernelData::SkipKernelExecution(p);
+    };
+}
+
+KernelsData ScaledShiftedClampExperimentalKernelRef::GetKernelsData(const Params& params) const {
+    if (!Validate(params))
+        return {};
+
+    KernelData   kd     = KernelData::Default<scaled_shifted_clamp_experimental_params>(params);
+    const auto&  p      = static_cast<const scaled_shifted_clamp_experimental_params&>(params);
+    auto         dd     = SetDefault(p);
+    auto         entry  = GetEntryPoint(kernelName, p.layerID, params);
+    auto         jit_cs = MakeBaseParamsJitConstants(p);
+    jit_cs.AddConstant(MakeJitConstant("SCALE", p.scale));
+    jit_cs.AddConstant(MakeJitConstant("BIAS", p.bias));
+    jit_cs.AddConstant(MakeJitConstant("LO", p.lo));
+    jit_cs.AddConstant(MakeJitConstant("HI", p.hi));
+    auto jit = CreateJit(kernelName, jit_cs, entry);
+
+    GetUpdateDispatchDataFunc(kd);
+
+    auto&      kernel     = kd.kernels[0];
+    const bool is_dynamic = p.has_dynamic_tensors();
+    FillCLKernelData(kernel, dd, params.engineInfo, kernelName, jit, entry,
+                     EXE_MODE_DEFAULT, false, false, 1, 0, 1, is_dynamic);
+    return {kd};
+}
+
+KernelsPriority ScaledShiftedClampExperimentalKernelRef::GetKernelsPriority(const Params& /*params*/) const {
+    return DONT_USE_IF_HAVE_SOMETHING_ELSE;
+}
+
+ParamsKey ScaledShiftedClampExperimentalKernelRef::GetSupportedKey() const {
+    ParamsKey k;
+    k.EnableInputDataType(Datatype::F32);
+    k.EnableInputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::F32);
+    k.EnableOutputDataType(Datatype::F16);
+    k.EnableInputLayout(DataLayout::bfyx);
+    k.EnableOutputLayout(DataLayout::bfyx);
+    k.EnableTensorOffset();
+    k.EnableTensorPitches();
+    k.EnableBatching();
+    k.EnableDynamicShapesSupport();
+    return k;
+}
+
+bool ScaledShiftedClampExperimentalKernelRef::Validate(const Params& p) const {
+    if (p.GetType() != KernelType::SCALED_SHIFTED_CLAMP_EXPERIMENTAL)
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    return true;
+}
+
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_ref.h
@@ -1,0 +1,31 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "kernel_base_opencl.h"
+
+namespace kernel_selector {
+
+struct scaled_shifted_clamp_experimental_params : public base_params {
+    scaled_shifted_clamp_experimental_params()
+        : base_params(KernelType::SCALED_SHIFTED_CLAMP_EXPERIMENTAL) {}
+    float scale{1.0f};
+    float bias{0.0f};
+    float lo{0.0f};
+    float hi{0.0f};
+};
+
+class ScaledShiftedClampExperimentalKernelRef : public KernelBaseOpenCL {
+public:
+    ScaledShiftedClampExperimentalKernelRef() : KernelBaseOpenCL("scaled_shifted_clamp_experimental_ref") {}
+
+    KernelsData    GetKernelsData(const Params& params) const override;
+    KernelsPriority GetKernelsPriority(const Params& params) const override;
+    ParamsKey      GetSupportedKey() const override;
+    bool           Validate(const Params& p) const override;
+    void           GetUpdateDispatchDataFunc(KernelData& kd) const override;
+};
+
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_selector.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "scaled_shifted_clamp_experimental_kernel_selector.h"
+
+#include "scaled_shifted_clamp_experimental_kernel_ref.h"
+
+namespace kernel_selector {
+
+scaled_shifted_clamp_experimental_kernel_selector::scaled_shifted_clamp_experimental_kernel_selector() {
+    Attach<ScaledShiftedClampExperimentalKernelRef>();
+}
+
+KernelsData scaled_shifted_clamp_experimental_kernel_selector::GetBestKernels(const Params& params) const {
+    return GetNaiveBestKernel(params, KernelType::SCALED_SHIFTED_CLAMP_EXPERIMENTAL);
+}
+
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scaled_shifted_clamp_experimental/scaled_shifted_clamp_experimental_kernel_selector.h
@@ -1,0 +1,24 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "kernel_selector.h"
+
+namespace kernel_selector {
+
+class scaled_shifted_clamp_experimental_kernel_selector : public kernel_selector_base {
+public:
+    static scaled_shifted_clamp_experimental_kernel_selector& Instance() {
+        static scaled_shifted_clamp_experimental_kernel_selector instance_;
+        return instance_;
+    }
+
+    scaled_shifted_clamp_experimental_kernel_selector();
+    ~scaled_shifted_clamp_experimental_kernel_selector() override = default;
+
+    KernelsData GetBestKernels(const Params& params) const override;
+};
+
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/plugin/ops/scaled_shifted_clamp_experimental.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scaled_shifted_clamp_experimental.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "intel_gpu/plugin/common_utils.hpp"
+#include "intel_gpu/plugin/program_builder.hpp"
+#include "intel_gpu/primitives/scaled_shifted_clamp_experimental.hpp"
+#include "openvino/op/scaled_shifted_clamp_experimental.hpp"
+
+using Op = ov::op::experimental::ScaledShiftedClamp;
+
+namespace ov::intel_gpu {
+
+static void CreateScaledShiftedClampOp(ProgramBuilder& p, const std::shared_ptr<Op>& op) {
+    validate_inputs_count(op, {1});
+    const auto  inputs        = p.GetInputInfo(op);
+    const auto  primitive_name = layer_type_name_ID(op);
+
+    cldnn::scaled_shifted_clamp_experimental prim(primitive_name,
+                                                  inputs[0],
+                                                  static_cast<float>(op->get_scale()),
+                                                  static_cast<float>(op->get_bias()),
+                                                  static_cast<float>(op->get_lo()),
+                                                  static_cast<float>(op->get_hi()));
+    prim.output_data_types = get_output_data_types(op);
+    p.add_primitive(*op, prim);
+}
+
+REGISTER_FACTORY_IMPL(experimental, ScaledShiftedClamp);
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -199,6 +199,9 @@
 #include "transformations/rt_info/dequantization_node.hpp"
 #include "transformations/rt_info/fused_names_attribute.hpp"
 #include "transformations/rt_info/keep_const_precision.hpp"
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+#    include "transformations/scaled_shifted_clamp_experimental_fusion.hpp"
+#endif
 #include "transformations/smart_reshape/matmul_sr.hpp"
 #include "openvino/op/abs.hpp"
 #include "openvino/op/broadcast.hpp"
@@ -507,6 +510,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             manager.register_pass<ov::intel_gpu::FuseMOE3GemmCompressed>();
         }
         manager.register_pass<ov::pass::GatedDeltaNetFusion>();
+#ifdef ENABLE_EXPERIMENTAL_OPSET
+        manager.register_pass<ov::pass::experimental::ScaledShiftedClampFusion>();
+#endif
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<EinsumDecomposition>();
 

--- a/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
@@ -14,6 +14,11 @@ endif()
 
 list(APPEND DEFINES TEST_CUSTOM_OP_CONFIG_PATH="${CMAKE_CURRENT_SOURCE_DIR}/custom_op/custom_op.xml")
 
+set(GPU_TEST_EXCLUDE "")
+if(NOT ENABLE_EXPERIMENTAL_OPSET)
+    list(APPEND GPU_TEST_EXCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/single_layer_tests/scaled_shifted_clamp_experimental.cpp)
+endif()
+
 ov_add_test_target(
         NAME
             ${TARGET_NAME}
@@ -25,6 +30,8 @@ ov_add_test_target(
             ${CMAKE_CURRENT_SOURCE_DIR}
             $<TARGET_PROPERTY:openvino_intel_gpu_plugin,SOURCE_DIR>/include/
             ${TEST_COMMON_INCLUDE_DIR}
+        EXCLUDED_SOURCE_PATHS
+            ${GPU_TEST_EXCLUDE}
         DEFINES
             ${DEFINES}
         DEPENDENCIES

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/scaled_shifted_clamp_experimental.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/scaled_shifted_clamp_experimental.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/runtime/exec_model_info.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+
+class ScaledShiftedClampFusionGPUTest : public virtual SubgraphBaseStaticTest {
+protected:
+    void SetUp() override {
+        targetDevice     = utils::DEVICE_GPU;
+        const auto t     = element::f32;
+        const Shape s{1, 4, 8, 8};
+        auto       param = std::make_shared<op::v0::Parameter>(t, s);
+        auto       scale = op::v0::Constant::create(t, Shape{1}, {2.0F});
+        auto       bias  = op::v0::Constant::create(t, Shape{1}, {0.5F});
+        auto       mul   = std::make_shared<op::v1::Multiply>(param, scale);
+        auto       add   = std::make_shared<op::v1::Add>(mul, bias);
+        auto       clamp = std::make_shared<op::v0::Clamp>(add, -1.0, 1.0);
+        function         = std::make_shared<Model>(clamp, ParameterVector{param});
+    }
+
+    void check_fused() {
+        const auto exec = compiledModel.get_runtime_model();
+        bool       found = false;
+        for (const auto& n : exec->get_ordered_ops()) {
+            if (n->get_friendly_name().find("scaled_shifted_clamp_experimental") != std::string::npos ||
+                n->get_type_name() == std::string("scaled_shifted_clamp_experimental")) {
+                found = true;
+                break;
+            }
+        }
+        ASSERT_TRUE(found) << "scaled_shifted_clamp_experimental primitive not found in exec graph";
+    }
+};
+
+TEST_F(ScaledShiftedClampFusionGPUTest, smoke_Fuses) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    run();
+    check_fused();
+}
+
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - This is just an example of how an Experimental Op can be introduced into the project
 - Everything is isolated under "ENABLE_EXPERIMENTAL_OPSET' cmake option
 - Some changes, i.e. fusing pass, are optional. Current PR just demonstrates where to put a new code and the changes.


<!-- Message of single commit: -->