### PR TITLE
[NO REVIEW] [transformations] Temp debug dumps for flaky GRUFusionTest

### DIFF
--- a/.github/workflows/job_cxx_unit_tests.yml
+++ b/.github/workflows/job_cxx_unit_tests.yml
@@ -184,6 +184,17 @@ jobs:
           ${{ env.SOURCE_COMMAND }} ${{ env.SETUPVARS }}
           ${{ env.INSTALL_TEST_DIR }}/ov_transformations_tests --gtest_print_time=1 --gtest_output=xml:${{ env.INSTALL_TEST_DIR }}/TEST-Transformations.xml
 
+      - name: GRUFusionTest stress repeat (debug)
+        # tmp debug: repeats the flaky GRUFusionTest.GRUCellPattern/7 many times in a single
+        # process to maximise the chance of catching the random shape-mismatch failure with
+        # the OV_TMP_DEBUG dumps captured.  always() so this runs even if the regular
+        # Transformations func tests step above failed (it does on Debian ARM due to
+        # unrelated SDPA test issues hidden by the previous ARM64 gate).
+        if: ${{ always() && fromJSON(inputs.affected-components).transformations.test }}
+        run: |
+          ${{ env.SOURCE_COMMAND }} ${{ env.SETUPVARS }}
+          ${{ env.INSTALL_TEST_DIR }}/ov_transformations_tests --gtest_filter='GRUFusionTest/GRUFusionTest.GRUCellPattern/7' --gtest_repeat=500 --gtest_break_on_failure=0 --gtest_print_time=1
+
       - name: Common test utils tests
         if: ${{ runner.os != 'macOS' }} # Ticket: 134469
         run: |

--- a/.github/workflows/job_cxx_unit_tests.yml
+++ b/.github/workflows/job_cxx_unit_tests.yml
@@ -178,7 +178,8 @@ jobs:
           ${{ env.INSTALL_TEST_DIR }}/ov_tensorflow_lite_frontend_tests --gtest_print_time=1 --gtest_output=xml:${{ env.INSTALL_TEST_DIR }}/TEST-TensorFlowLiteFrontend.xml
 
       - name: Transformations func tests
-        if: ${{ fromJSON(inputs.affected-components).transformations.test && runner.arch != 'ARM64' }} # Ticket: 126281
+        # tmp debug: ARM64 gate removed so the flaky GRUFusionTest runs with OV_TMP_DEBUG dumps on macOS arm64
+        if: ${{ fromJSON(inputs.affected-components).transformations.test }}
         run: |
           ${{ env.SOURCE_COMMAND }} ${{ env.SETUPVARS }}
           ${{ env.INSTALL_TEST_DIR }}/ov_transformations_tests --gtest_print_time=1 --gtest_output=xml:${{ env.INSTALL_TEST_DIR }}/TEST-Transformations.xml

--- a/.github/workflows/job_cxx_unit_tests.yml
+++ b/.github/workflows/job_cxx_unit_tests.yml
@@ -56,6 +56,9 @@ jobs:
       INSTALL_TEST_DIR: ${{ github.workspace }}/install/tests
       SOURCE_COMMAND: ${{ contains(inputs.runner, 'linux') && 'source' || '.' }}
       SETUPVARS: ${{ github.workspace }}/install/${{ contains(inputs.runner, 'win') && 'setupvars.ps1' || 'setupvars.sh' }}
+      # tmp debug: extra dumps in TransformationTestsF / GRUCellFusion / accuracy_check
+      # for the flaky GRUFusionTest.GRUCellPattern case.  No-op when unset.
+      OV_TMP_DEBUG: '1'
     steps:
       - name: Download OpenVINO artifacts (package)
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0

--- a/.github/workflows/job_cxx_unit_tests.yml
+++ b/.github/workflows/job_cxx_unit_tests.yml
@@ -185,15 +185,20 @@ jobs:
           ${{ env.INSTALL_TEST_DIR }}/ov_transformations_tests --gtest_print_time=1 --gtest_output=xml:${{ env.INSTALL_TEST_DIR }}/TEST-Transformations.xml
 
       - name: GRUFusionTest stress repeat (debug)
-        # tmp debug: repeats the flaky GRUFusionTest.GRUCellPattern/7 many times in a single
-        # process to maximise the chance of catching the random shape-mismatch failure with
-        # the OV_TMP_DEBUG dumps captured.  always() so this runs even if the regular
-        # Transformations func tests step above failed (it does on Debian ARM due to
-        # unrelated SDPA test issues hidden by the previous ARM64 gate).
+        # tmp debug: repeats the flaky GRUFusionTest.GRUCellPattern/7 10000 times in a single
+        # process to maximise the chance of catching the random shape-mismatch failure.
+        # OV_TMP_DEBUG is locally disabled for this step to keep the log size manageable —
+        # if a failure occurs the gtest assertion message itself prints the offending
+        # shapes, which is enough to confirm reproduction (full dumps are still captured
+        # by the regular Transformations func tests step above).
+        # always() so this runs even when the previous step fails (it does on Debian ARM
+        # due to unrelated SDPA test issues hidden by the previous ARM64 gate).
         if: ${{ always() && fromJSON(inputs.affected-components).transformations.test }}
+        env:
+          OV_TMP_DEBUG: '0'
         run: |
           ${{ env.SOURCE_COMMAND }} ${{ env.SETUPVARS }}
-          ${{ env.INSTALL_TEST_DIR }}/ov_transformations_tests --gtest_filter='GRUFusionTest/GRUFusionTest.GRUCellPattern/7' --gtest_repeat=500 --gtest_break_on_failure=0 --gtest_print_time=1
+          ${{ env.INSTALL_TEST_DIR }}/ov_transformations_tests --gtest_filter='GRUFusionTest/GRUFusionTest.GRUCellPattern/7' --gtest_repeat=10000 --gtest_break_on_failure=0 --gtest_print_time=1
 
       - name: Common test utils tests
         if: ${{ runner.os != 'macOS' }} # Ticket: 134469

--- a/.github/workflows/job_cxx_unit_tests.yml
+++ b/.github/workflows/job_cxx_unit_tests.yml
@@ -184,21 +184,24 @@ jobs:
           ${{ env.SOURCE_COMMAND }} ${{ env.SETUPVARS }}
           ${{ env.INSTALL_TEST_DIR }}/ov_transformations_tests --gtest_print_time=1 --gtest_output=xml:${{ env.INSTALL_TEST_DIR }}/TEST-Transformations.xml
 
-      - name: GRUFusionTest stress repeat (debug)
-        # tmp debug: repeats the flaky GRUFusionTest.GRUCellPattern/7 10000 times in a single
-        # process to maximise the chance of catching the random shape-mismatch failure.
-        # OV_TMP_DEBUG is locally disabled for this step to keep the log size manageable —
-        # if a failure occurs the gtest assertion message itself prints the offending
-        # shapes, which is enough to confirm reproduction (full dumps are still captured
-        # by the regular Transformations func tests step above).
-        # always() so this runs even when the previous step fails (it does on Debian ARM
-        # due to unrelated SDPA test issues hidden by the previous ARM64 gate).
+      - name: Transformations stress shuffle (debug)
+        # tmp debug: re-runs the entire ov_transformations_tests binary multiple times
+        # with --gtest_shuffle so that each iteration uses a different test order. The
+        # flaky GRUFusionTest.GRUCellPattern/7 is reported to fail only when *other*
+        # tests have run before it (interaction with cross-test pointer/allocator
+        # state). The previous filtered 10000-iter stress could not reproduce —
+        # running the whole binary, in different orders, exercises that cross-test
+        # state directly. --gtest_also_run_disabled_tests broadens coverage in case a
+        # disabled test is part of the trigger sequence. OV_TMP_DEBUG is kept off
+        # here to keep log size manageable; the gtest assertion already prints the
+        # offending shapes on failure.
+        # always() so this runs even when the previous step fails.
         if: ${{ always() && fromJSON(inputs.affected-components).transformations.test }}
         env:
           OV_TMP_DEBUG: '0'
         run: |
           ${{ env.SOURCE_COMMAND }} ${{ env.SETUPVARS }}
-          ${{ env.INSTALL_TEST_DIR }}/ov_transformations_tests --gtest_filter='GRUFusionTest/GRUFusionTest.GRUCellPattern/7' --gtest_repeat=10000 --gtest_break_on_failure=0 --gtest_print_time=1
+          ${{ env.INSTALL_TEST_DIR }}/ov_transformations_tests --gtest_repeat=50 --gtest_shuffle --gtest_also_run_disabled_tests --gtest_break_on_failure=0 --gtest_print_time=1
 
       - name: Common test utils tests
         if: ${{ runner.os != 'macOS' }} # Ticket: 134469

--- a/.github/workflows/mac_arm64.yml
+++ b/.github/workflows/mac_arm64.yml
@@ -20,14 +20,14 @@ on:
    branches:
      - 'master'
      - 'releases/**'
-  # pull_request:
-  #  paths-ignore:
-  #    - '**/docs/**'
-  #    - 'docs/**'
-  #    - '**/**.md'
-  #    - '**.md'
-  #    - '**/layer_tests_summary/**'
-  #    - '**/conformance/**'
+  pull_request:
+    paths-ignore:
+      - '**/docs/**'
+      - 'docs/**'
+      - '**/**.md'
+      - '**.md'
+      - '**/layer_tests_summary/**'
+      - '**/conformance/**'
 
 concurrency:
   # github.ref is not unique in post-commit
@@ -42,6 +42,9 @@ env:
   MANIFEST_FILE: manifest.yml
   PRODUCT_TYPE: public_macos_arm64_release
   TARGET_BRANCH: ${{ inputs.target-branch || github.base_ref || github.event.merge_group.base_ref || github.ref }}
+  # tmp debug: enable extra dumps in TransformationTestsF / GRUCellFusion / accuracy_check
+  # for the flaky GRUFusionTest.GRUCellPattern case.  No-op when unset.
+  OV_TMP_DEBUG: '1'
 
 jobs:
   Smart_CI:

--- a/src/common/transformations/src/transformations/common_optimizations/gru_cell_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/gru_cell_fusion.cpp
@@ -8,9 +8,9 @@
 #include <memory>
 
 #include "itt.hpp"
-#include "openvino/core/tmp_debug.hpp"  // tmp debug
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/core/tmp_debug.hpp"  // tmp debug
 #include "openvino/op/add.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
@@ -132,10 +132,8 @@ GRUCellFusion::GRUCellFusion() {
                 }
                 std::ostringstream ss;
                 ss << it->second->get_output_partial_shape(0);
-                std::cerr << "[OV_TMP_DEBUG]   " << tag
-                          << "  ptr=" << static_cast<const void*>(it->second.get())
-                          << "  type=" << it->second->get_type_name()
-                          << "  shape=" << ss.str()
+                std::cerr << "[OV_TMP_DEBUG]   " << tag << "  ptr=" << static_cast<const void*>(it->second.get())
+                          << "  type=" << it->second->get_type_name() << "  shape=" << ss.str()
                           << "  name=" << it->second->get_friendly_name() << "\n";
             };
             dump_bind("concat_1  ", concat_1);
@@ -147,11 +145,10 @@ GRUCellFusion::GRUCellFusion() {
             dump_bind("activ_1   ", activation_1);
             dump_bind("activ_2   ", activation_2);
             std::ostringstream xs, hs;
-            xs << x_pshape; hs << h_pshape;
-            std::cerr << "[OV_TMP_DEBUG]   X.shape=" << xs.str()
-                      << "  H.shape=" << hs.str()
-                      << "  input_size=" << input_size
-                      << "  hidden_size=" << hidden_size << "\n";
+            xs << x_pshape;
+            hs << h_pshape;
+            std::cerr << "[OV_TMP_DEBUG]   X.shape=" << xs.str() << "  H.shape=" << hs.str()
+                      << "  input_size=" << input_size << "  hidden_size=" << hidden_size << "\n";
         }
 
         auto axis_0 = rg.make<v0::Constant>(element::i64, Shape{}, 0);

--- a/src/common/transformations/src/transformations/common_optimizations/gru_cell_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/gru_cell_fusion.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "itt.hpp"
+#include "openvino/core/tmp_debug.hpp"  // tmp debug
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/add.hpp"
@@ -118,6 +119,41 @@ GRUCellFusion::GRUCellFusion() {
         auto hidden_size = h_pshape[1].get_length();
         auto input_size = x_pshape[1].get_length();
 
+        // tmp debug: dump pattern-map bindings and derived sizes
+        if (ov::tmp_debug::enabled()) {
+            ov::tmp_debug::log() << "GRUCellFusion callback: match root="
+                                 << static_cast<const void*>(m.get_match_root().get())
+                                 << " name=" << m.get_match_root()->get_friendly_name() << "\n";
+            auto dump_bind = [&](const char* tag, const std::shared_ptr<ov::Node>& pat) {
+                auto it = pattern_map.find(pat);
+                if (it == pattern_map.end()) {
+                    std::cerr << "[OV_TMP_DEBUG]   " << tag << " => (not bound)\n";
+                    return;
+                }
+                std::ostringstream ss;
+                ss << it->second->get_output_partial_shape(0);
+                std::cerr << "[OV_TMP_DEBUG]   " << tag
+                          << "  ptr=" << static_cast<const void*>(it->second.get())
+                          << "  type=" << it->second->get_type_name()
+                          << "  shape=" << ss.str()
+                          << "  name=" << it->second->get_friendly_name() << "\n";
+            };
+            dump_bind("concat_1  ", concat_1);
+            dump_bind("matmul_1  ", matmul_1);
+            dump_bind("add_1     ", add_1);
+            dump_bind("split     ", split);
+            dump_bind("matmul_2  ", matmul_2);
+            dump_bind("add_2     ", add_2);
+            dump_bind("activ_1   ", activation_1);
+            dump_bind("activ_2   ", activation_2);
+            std::ostringstream xs, hs;
+            xs << x_pshape; hs << h_pshape;
+            std::cerr << "[OV_TMP_DEBUG]   X.shape=" << xs.str()
+                      << "  H.shape=" << hs.str()
+                      << "  input_size=" << input_size
+                      << "  hidden_size=" << hidden_size << "\n";
+        }
+
         auto axis_0 = rg.make<v0::Constant>(element::i64, Shape{}, 0);
         auto axis_1 = rg.make<v0::Constant>(element::i64, Shape{}, 1);
 
@@ -132,6 +168,12 @@ GRUCellFusion::GRUCellFusion() {
 
         auto cnt_of_consumers_of_zero_out = pattern_split->get_output_target_inputs(0).size();
         auto cnt_of_consumers_of_first_out = pattern_split->get_output_target_inputs(1).size();
+
+        // tmp debug: which branch do we pick?
+        if (ov::tmp_debug::enabled()) {
+            std::cerr << "[OV_TMP_DEBUG]   split output consumers: out0=" << cnt_of_consumers_of_zero_out
+                      << " out1=" << cnt_of_consumers_of_first_out << "\n";
+        }
 
         Output<Node> B;
         if (pattern_map.find(add_1) != pattern_map.end()) {

--- a/src/core/include/openvino/core/tmp_debug.hpp
+++ b/src/core/include/openvino/core/tmp_debug.hpp
@@ -1,0 +1,56 @@
+// TEMPORARY DEBUG INSTRUMENTATION — for investigating the flaky
+// GRUFusionTest.GRUCellPattern case on macOS arm64.
+//
+// WHAT:  small helpers that print parameter lists / pattern-map bindings / port
+//        shape maps to stderr when env var OV_TMP_DEBUG=1 is set.
+// HOW:   static inline functions; each caller site wraps its dump in
+//        `if (ov::tmp_debug::enabled())`.  No runtime cost when env var is
+//        unset (single getenv read per process, cached in a static bool).
+// WHY:   the flake is reproducible only on macOS arm64.  We need
+//        instrumentation that can be enabled without rebuild in CI (env var),
+//        writes to stderr so the existing gtest logging picks it up, and is
+//        cheap enough to leave on for many iterations while collecting data.
+//
+// To be reverted once the root cause is understood.
+#pragma once
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace ov {
+namespace tmp_debug {
+
+inline bool enabled() {
+    static const bool on = []() {
+        const char* e = std::getenv("OV_TMP_DEBUG");
+        return e && e[0] && std::string(e) != "0";
+    }();
+    return on;
+}
+
+inline std::ostream& log() {
+    return std::cerr << "[OV_TMP_DEBUG] ";
+}
+
+template <typename ParamVector>
+inline void dump_params(const char* tag, const ParamVector& params) {
+    if (!enabled()) return;
+    log() << "-- params dump: " << tag << " (count=" << params.size() << ") --\n";
+    for (size_t i = 0; i < params.size(); ++i) {
+        const auto& p = params[i];
+        std::ostringstream shape_s;
+        shape_s << p->get_partial_shape();
+        std::cerr << "[OV_TMP_DEBUG]   i=" << i
+                  << "  ptr=" << static_cast<const void*>(p.get())
+                  << "  shape=" << shape_s.str()
+                  << "  name=" << p->get_friendly_name()
+                  << "\n";
+    }
+}
+
+}  // namespace tmp_debug
+}  // namespace ov

--- a/src/core/include/openvino/core/tmp_debug.hpp
+++ b/src/core/include/openvino/core/tmp_debug.hpp
@@ -1,3 +1,7 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // TEMPORARY DEBUG INSTRUMENTATION — for investigating the flaky
 // GRUFusionTest.GRUCellPattern case on macOS arm64.
 //
@@ -38,17 +42,15 @@ inline std::ostream& log() {
 
 template <typename ParamVector>
 inline void dump_params(const char* tag, const ParamVector& params) {
-    if (!enabled()) return;
+    if (!enabled())
+        return;
     log() << "-- params dump: " << tag << " (count=" << params.size() << ") --\n";
     for (size_t i = 0; i < params.size(); ++i) {
         const auto& p = params[i];
         std::ostringstream shape_s;
         shape_s << p->get_partial_shape();
-        std::cerr << "[OV_TMP_DEBUG]   i=" << i
-                  << "  ptr=" << static_cast<const void*>(p.get())
-                  << "  shape=" << shape_s.str()
-                  << "  name=" << p->get_friendly_name()
-                  << "\n";
+        std::cerr << "[OV_TMP_DEBUG]   i=" << i << "  ptr=" << static_cast<const void*>(p.get())
+                  << "  shape=" << shape_s.str() << "  name=" << p->get_friendly_name() << "\n";
     }
 }
 

--- a/src/inference/src/dev/isync_infer_request.cpp
+++ b/src/inference/src/dev/isync_infer_request.cpp
@@ -8,10 +8,10 @@
 #include <memory>
 #include <unordered_map>
 
-#include "openvino/core/tmp_debug.hpp"  // tmp debug
 #include "openvino/core/except.hpp"
 #include "openvino/core/layout.hpp"
 #include "openvino/core/parallel.hpp"
+#include "openvino/core/tmp_debug.hpp"  // tmp debug
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/runtime/icompiled_model.hpp"
 #include "openvino/runtime/iinfer_request.hpp"
@@ -281,15 +281,15 @@ void ov::ISyncInferRequest::check_tensor(const ov::Output<const ov::Node>& port,
         std::ostringstream ps, ts;
         ps << port.get_shape();
         ts << tensor->get_shape();
-        ov::tmp_debug::log() << "check_tensor SHAPE MISMATCH (" << tensor_type << ")"
-                             << "  port_shape=" << ps.str()
+        ov::tmp_debug::log() << "check_tensor SHAPE MISMATCH (" << tensor_type << ")" << "  port_shape=" << ps.str()
                              << "  tensor_shape=" << ts.str()
                              << "  port_node_ptr=" << static_cast<const void*>(port.get_node())
                              << "  port_name=" << port.get_node()->get_friendly_name() << "\n";
         std::cerr << "[OV_TMP_DEBUG]   port tensor_names={";
         bool first = true;
         for (const auto& n : port.get_tensor().get_names()) {
-            if (!first) std::cerr << ",";
+            if (!first)
+                std::cerr << ",";
             std::cerr << n;
             first = false;
         }

--- a/src/inference/src/dev/isync_infer_request.cpp
+++ b/src/inference/src/dev/isync_infer_request.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include "openvino/core/tmp_debug.hpp"  // tmp debug
 #include "openvino/core/except.hpp"
 #include "openvino/core/layout.hpp"
 #include "openvino/core/parallel.hpp"
@@ -275,6 +276,25 @@ void ov::ISyncInferRequest::check_tensor(const ov::Output<const ov::Node>& port,
                     " != ",
                     port.get_element_type());
     bool is_dynamic = port.get_partial_shape().is_dynamic();
+    // tmp debug: forensic dump on shape mismatch
+    if (ov::tmp_debug::enabled() && !is_dynamic && port.get_shape() != tensor->get_shape()) {
+        std::ostringstream ps, ts;
+        ps << port.get_shape();
+        ts << tensor->get_shape();
+        ov::tmp_debug::log() << "check_tensor SHAPE MISMATCH (" << tensor_type << ")"
+                             << "  port_shape=" << ps.str()
+                             << "  tensor_shape=" << ts.str()
+                             << "  port_node_ptr=" << static_cast<const void*>(port.get_node())
+                             << "  port_name=" << port.get_node()->get_friendly_name() << "\n";
+        std::cerr << "[OV_TMP_DEBUG]   port tensor_names={";
+        bool first = true;
+        for (const auto& n : port.get_tensor().get_names()) {
+            if (!first) std::cerr << ",";
+            std::cerr << n;
+            first = false;
+        }
+        std::cerr << "}\n";
+    }
     OPENVINO_ASSERT(is_dynamic || port.get_shape() == tensor->get_shape(),
                     "The ",
                     tensor_type,

--- a/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
+++ b/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
@@ -7,6 +7,7 @@
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "common_test_utils/ov_test_utils.hpp"
 #include "gtest/gtest.h"
+#include "openvino/core/tmp_debug.hpp"  // tmp debug
 #include "openvino/op/constant.hpp"
 #include "openvino/op/loop.hpp"
 #include "openvino/op/result.hpp"
@@ -1101,6 +1102,28 @@ AccuracyCheckResult accuracy_check(const std::shared_ptr<ov::Model>& ref_functio
     }
     try {
         OPENVINO_ASSERT(ref_function->get_parameters().size() == cur_function->get_parameters().size());
+
+        // tmp debug: dump side-by-side params
+        if (ov::tmp_debug::enabled()) {
+            ov::tmp_debug::log() << "accuracy_check: side-by-side ref/cur params\n";
+            const auto& rp = ref_function->get_parameters();
+            const auto& cp = cur_function->get_parameters();
+            for (size_t i = 0; i < rp.size(); ++i) {
+                std::ostringstream rs, cs;
+                rs << rp[i]->get_partial_shape();
+                cs << cp[i]->get_partial_shape();
+                const bool mismatch = rp[i]->get_partial_shape() != cp[i]->get_partial_shape();
+                std::cerr << "[OV_TMP_DEBUG]   i=" << i
+                          << "  ref_shape=" << rs.str()
+                          << "  cur_shape=" << cs.str()
+                          << "  ref_ptr=" << static_cast<const void*>(rp[i].get())
+                          << "  cur_ptr=" << static_cast<const void*>(cp[i].get())
+                          << "  ref_name=" << rp[i]->get_friendly_name()
+                          << "  cur_name=" << cp[i]->get_friendly_name()
+                          << (mismatch ? "  <<<<< MISMATCH" : "")
+                          << "\n";
+            }
+        }
 
         std::map<std::shared_ptr<ov::Node>, ov::Tensor> ref_input_data;
         std::map<std::shared_ptr<ov::Node>, ov::Tensor> cur_input_data;

--- a/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
+++ b/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
@@ -1113,15 +1113,11 @@ AccuracyCheckResult accuracy_check(const std::shared_ptr<ov::Model>& ref_functio
                 rs << rp[i]->get_partial_shape();
                 cs << cp[i]->get_partial_shape();
                 const bool mismatch = rp[i]->get_partial_shape() != cp[i]->get_partial_shape();
-                std::cerr << "[OV_TMP_DEBUG]   i=" << i
-                          << "  ref_shape=" << rs.str()
-                          << "  cur_shape=" << cs.str()
+                std::cerr << "[OV_TMP_DEBUG]   i=" << i << "  ref_shape=" << rs.str() << "  cur_shape=" << cs.str()
                           << "  ref_ptr=" << static_cast<const void*>(rp[i].get())
                           << "  cur_ptr=" << static_cast<const void*>(cp[i].get())
-                          << "  ref_name=" << rp[i]->get_friendly_name()
-                          << "  cur_name=" << cp[i]->get_friendly_name()
-                          << (mismatch ? "  <<<<< MISMATCH" : "")
-                          << "\n";
+                          << "  ref_name=" << rp[i]->get_friendly_name() << "  cur_name=" << cp[i]->get_friendly_name()
+                          << (mismatch ? "  <<<<< MISMATCH" : "") << "\n";
             }
         }
 

--- a/src/tests/test_utils/common_test_utils/src/ov_test_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_test_utils.cpp
@@ -161,16 +161,16 @@ ov::TensorVector infer_on_template(const std::shared_ptr<ov::Model>& model,
 
     // tmp debug: dump compiled_model input ports to detect any plugin-side reshuffle
     if (ov::tmp_debug::enabled()) {
-        ov::tmp_debug::log() << "infer_on_template: compiled_model inputs (count="
-                             << compiled_model.inputs().size() << ")\n";
+        ov::tmp_debug::log() << "infer_on_template: compiled_model inputs (count=" << compiled_model.inputs().size()
+                             << ")\n";
         const auto& src_params = model->get_parameters();
         for (size_t i = 0; i < compiled_model.inputs().size(); ++i) {
             const auto& port = compiled_model.inputs()[i];
             std::ostringstream ps, ss;
             ps << port.get_partial_shape();
-            if (i < src_params.size()) ss << src_params[i]->get_partial_shape();
-            std::cerr << "[OV_TMP_DEBUG]   i=" << i
-                      << "  compiled_port_shape=" << ps.str()
+            if (i < src_params.size())
+                ss << src_params[i]->get_partial_shape();
+            std::cerr << "[OV_TMP_DEBUG]   i=" << i << "  compiled_port_shape=" << ps.str()
                       << "  src_param_shape=" << (i < src_params.size() ? ss.str() : std::string("(n/a)"))
                       << "  compiled_port_name=" << port.get_node()->get_friendly_name()
                       << (i < src_params.size() && port.get_partial_shape() != src_params[i]->get_partial_shape()
@@ -178,16 +178,14 @@ ov::TensorVector infer_on_template(const std::shared_ptr<ov::Model>& model,
                               : "")
                       << "\n";
         }
-        ov::tmp_debug::log() << "infer_on_template: inputs map (keyed by src Param ptr) size="
-                             << inputs.size() << "\n";
+        ov::tmp_debug::log() << "infer_on_template: inputs map (keyed by src Param ptr) size=" << inputs.size() << "\n";
         size_t mi = 0;
         for (const auto& kv : inputs) {
             std::ostringstream ts;
             ts << kv.second.get_shape();
             std::cerr << "[OV_TMP_DEBUG]   map_iter=" << mi++
                       << "  src_param_ptr=" << static_cast<const void*>(kv.first.get())
-                      << "  src_param_name=" << kv.first->get_friendly_name()
-                      << "  tensor_shape=" << ts.str() << "\n";
+                      << "  src_param_name=" << kv.first->get_friendly_name() << "  tensor_shape=" << ts.str() << "\n";
         }
     }
 

--- a/src/tests/test_utils/common_test_utils/src/ov_test_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_test_utils.cpp
@@ -7,6 +7,7 @@
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/ov_plugin_cache.hpp"
 #include "common_test_utils/test_constants.hpp"
+#include "openvino/core/tmp_debug.hpp"  // tmp debug
 #include "openvino/op/tensor_iterator.hpp"
 #include "openvino/runtime/core.hpp"
 #include "openvino/util/file_util.hpp"
@@ -74,7 +75,25 @@ void TransformationTestsF::TearDown() {
         cloned_function = model->clone();
     }
     manager.register_pass<ov::pass::CheckUniqueNames>(m_unh, m_soft_names_comparison, m_result_friendly_names_check);
+
+    // tmp debug: dump params before/after passes
+    if (ov::tmp_debug::enabled()) {
+        ov::tmp_debug::log() << "TearDown: dumping params BEFORE run_passes\n";
+        ov::tmp_debug::dump_params("model (before passes)", model->get_parameters());
+        if (cloned_function) {
+            ov::tmp_debug::dump_params("cloned_function (pre-pass clone)", cloned_function->get_parameters());
+        }
+        if (model_ref) {
+            ov::tmp_debug::dump_params("model_ref (hand-written)", model_ref->get_parameters());
+        }
+    }
+
     manager.run_passes(model);
+
+    if (ov::tmp_debug::enabled()) {
+        ov::tmp_debug::log() << "TearDown: dumping params AFTER run_passes\n";
+        ov::tmp_debug::dump_params("model (AFTER passes)", model->get_parameters());
+    }
 
     if (!m_disable_rt_info_check) {
         OV_ASSERT_NO_THROW(check_rt_info(model));
@@ -139,6 +158,39 @@ ov::TensorVector infer_on_template(const std::shared_ptr<ov::Model>& model,
     auto compiled_model = core->compile_model(model,
                                               ov::test::utils::DEVICE_TEMPLATE,
                                               {{ov::template_plugin::disable_transformations(true)}});
+
+    // tmp debug: dump compiled_model input ports to detect any plugin-side reshuffle
+    if (ov::tmp_debug::enabled()) {
+        ov::tmp_debug::log() << "infer_on_template: compiled_model inputs (count="
+                             << compiled_model.inputs().size() << ")\n";
+        const auto& src_params = model->get_parameters();
+        for (size_t i = 0; i < compiled_model.inputs().size(); ++i) {
+            const auto& port = compiled_model.inputs()[i];
+            std::ostringstream ps, ss;
+            ps << port.get_partial_shape();
+            if (i < src_params.size()) ss << src_params[i]->get_partial_shape();
+            std::cerr << "[OV_TMP_DEBUG]   i=" << i
+                      << "  compiled_port_shape=" << ps.str()
+                      << "  src_param_shape=" << (i < src_params.size() ? ss.str() : std::string("(n/a)"))
+                      << "  compiled_port_name=" << port.get_node()->get_friendly_name()
+                      << (i < src_params.size() && port.get_partial_shape() != src_params[i]->get_partial_shape()
+                              ? "  <<<<< SHAPE DIVERGED FROM SRC"
+                              : "")
+                      << "\n";
+        }
+        ov::tmp_debug::log() << "infer_on_template: inputs map (keyed by src Param ptr) size="
+                             << inputs.size() << "\n";
+        size_t mi = 0;
+        for (const auto& kv : inputs) {
+            std::ostringstream ts;
+            ts << kv.second.get_shape();
+            std::cerr << "[OV_TMP_DEBUG]   map_iter=" << mi++
+                      << "  src_param_ptr=" << static_cast<const void*>(kv.first.get())
+                      << "  src_param_name=" << kv.first->get_friendly_name()
+                      << "  tensor_shape=" << ts.str() << "\n";
+        }
+    }
+
     auto infer_request = compiled_model.create_infer_request();
 
     for (auto& input : inputs) {


### PR DESCRIPTION
### Details:
## Summary

Adds env-var-gated (`OV_TMP_DEBUG=1`) stderr dumps at key points to
help diagnose a random shape-mismatch failure of
`GRUFusionTest.GRUCellPattern/7` that reproduces only on macOS arm64.

Observed signature:
The input tensor size is not equal to the model input type:
got [1,256] expecting [128,160].

On Linux the test is deterministic (200+30 repeats over 20 processes
all pass, parameter order stable across processes). The dumps below
are intended to capture the macOS arm64 failure path in CI.

Dump points (all no-op when `OV_TMP_DEBUG` is unset; single cached
`getenv` check, no per-call overhead):

- `TransformationTestsF::TearDown` — parameter lists of `model`
  before/after `run_passes`, plus `cloned_function` and `model_ref`
- `infer_on_template` — compiled-model input ports vs source params,
  and the `inputs` map iteration order (by pointer)
- `accuracy_check` (graph_comparator) — side-by-side `ref` vs `cur`
  parameter pairs with `MISMATCH` markers on shape divergence
- `GRUCellFusion` matcher callback — pattern-map bindings (concat/
  matmul/split/add/activation), derived `input_size`/`hidden_size`,
  split output consumer counts, chosen rz/zr branch
- `ISyncInferRequest::check_tensor` — forensic port vs tensor shape
  dump just before the assert fires

New file: `src/core/include/openvino/core/tmp_debug.hpp`
(shared helpers; to be removed together with the dump call sites
once the root cause is identified).

## Test plan

- [ ] CI macOS arm64 lane triggers `GRUFusionTest` with
      `OV_TMP_DEBUG=1` and captures stderr
- [ ] Failure dumps show where `model` / `cloned_function` / the
      compiled model's parameter ordering diverges (hypothesis:
      parameter-order non-determinism after clone/pass, caused by
      libc++'s per-process `unordered_map<Node*>` hash randomization
      on Darwin)
- [ ] Once root cause is confirmed, this PR is reverted and a
      targeted fix opened

### Tickets:
 - 183517

