### PR TITLE
[CORE] Fix PagedCausalConv1D type validation to allow independent float types for state table

### DIFF
--- a/src/core/src/op/paged_causal_conv1d.cpp
+++ b/src/core/src/op/paged_causal_conv1d.cpp
@@ -41,18 +41,26 @@ void PagedCausalConv1D::validate_and_infer_types() {
 
     NODE_VALIDATION_CHECK(this, get_input_size() == 9);
 
+    // input_embeds (0), conv_weight (2), conv_bias (3) participate in the convolution MAC and
+    // therefore must share a common float element type; it also determines the output precision.
+    // conv_state_table (1) is an in-place state cache and is allowed to use an independent float
+    // element type so plugins can maintain a lower-precision state without breaking in-place semantics.
     ov::element::Type common_float_type = get_input_element_type(0);
     const bool float_types_merge =
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(1)) &&
         ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(2)) &&
         ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(3));
     NODE_VALIDATION_CHECK(this,
                           float_types_merge,
-                          "PagedCausalConv1D expects input_embeds, conv_state_table, conv_weight, and conv_bias to "
-                          "have the same element type.");
+                          "PagedCausalConv1D expects input_embeds, conv_weight, and conv_bias to have the same "
+                          "element type.");
     NODE_VALIDATION_CHECK(this,
                           common_float_type.is_dynamic() || common_float_type == ov::element::f32 ||
                               common_float_type == ov::element::f16 || common_float_type == ov::element::bf16,
+                          "Float inputs must have f32, f16, or bf16 element type.");
+    const auto& state_et = get_input_element_type(1);
+    NODE_VALIDATION_CHECK(this,
+                          state_et.is_dynamic() || state_et == ov::element::f32 || state_et == ov::element::f16 ||
+                              state_et == ov::element::bf16,
                           "Float inputs must have f32, f16, or bf16 element type.");
     for (size_t i = 4; i < 9; ++i) {
         const auto& et = get_input_element_type(i);

--- a/src/core/tests/type_prop/paged_causal_conv1d.cpp
+++ b/src/core/tests/type_prop/paged_causal_conv1d.cpp
@@ -162,10 +162,36 @@ TEST_F(TypePropPagedCausalConv1DTest, invalid_float_type) {
                     testing::HasSubstr("Float inputs must have f32, f16, or bf16 element type."));
 }
 
-TEST_F(TypePropPagedCausalConv1DTest, float_type_mismatch) {
+TEST_F(TypePropPagedCausalConv1DTest, state_float_type_independent_from_embeds) {
     const auto input_embeds = std::make_shared<op::v0::Parameter>(element::f32, Shape{10, 256});
     const auto conv_state_table = std::make_shared<op::v0::Parameter>(element::f16, Shape{5, 256, 4});
     const auto conv_weight = std::make_shared<op::v0::Parameter>(element::f32, Shape{256, 256, 4});
+    const auto conv_bias = std::make_shared<op::v0::Parameter>(element::f32, Shape{256});
+    const auto subsequence_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    const auto la_block_indices = std::make_shared<op::v0::Parameter>(element::i32, Shape{5});
+    const auto la_block_indices_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    const auto processed_tokens = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    const auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+
+    const auto op = make_op(OutputVector{input_embeds,
+                                         conv_state_table,
+                                         conv_weight,
+                                         conv_bias,
+                                         subsequence_begins,
+                                         la_block_indices,
+                                         la_block_indices_begins,
+                                         processed_tokens,
+                                         cache_interval});
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{10, 256}));
+}
+
+TEST_F(TypePropPagedCausalConv1DTest, float_type_mismatch_among_embeds_weight_bias) {
+    const auto input_embeds = std::make_shared<op::v0::Parameter>(element::f32, Shape{10, 256});
+    const auto conv_state_table = std::make_shared<op::v0::Parameter>(element::f32, Shape{5, 256, 4});
+    const auto conv_weight = std::make_shared<op::v0::Parameter>(element::f16, Shape{256, 256, 4});
     const auto conv_bias = std::make_shared<op::v0::Parameter>(element::f32, Shape{256});
     const auto subsequence_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
     const auto la_block_indices = std::make_shared<op::v0::Parameter>(element::i32, Shape{5});
@@ -183,8 +209,8 @@ TEST_F(TypePropPagedCausalConv1DTest, float_type_mismatch) {
                                                        processed_tokens,
                                                        cache_interval}),
                     NodeValidationFailure,
-                    testing::HasSubstr("PagedCausalConv1D expects input_embeds, conv_state_table, conv_weight, and "
-                                       "conv_bias to have the same element type."));
+                    testing::HasSubstr("PagedCausalConv1D expects input_embeds, conv_weight, and conv_bias to have "
+                                       "the same element type."));
 }
 
 TEST_F(TypePropPagedCausalConv1DTest, hidden_size_mismatch) {


### PR DESCRIPTION
### Details:
 - *Allow independent float types for state table*
 - *Based on https://github.com/openvinotoolkit/openvino/pull/35200/changes/043c0c917250eb575b9083a78c0796fcb7caa023 by @liubo-intel*

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
