### PR TITLE
[GPU] Disable dynamic output tensor substitution for dGPU

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -674,10 +674,17 @@ void SyncInferRequest::allocate_output(const ov::Output<const ov::Node>& port, s
 
     // For dynamic outputs with USM host support, create an OutputMemoryBlock
     // that will be plugged into the graph to enable zero-copy output.
-    if (shape.is_dynamic() && can_use_usm_host(m_graph->get_engine(), total_output_bytes)) {
+    auto&& engine = m_graph->get_engine();
+    const auto& device_info = engine.get_device_info();
+    // In the case of dynamic shapes, the total_output_bytes is useless as the actual output size is determined only at runtime.
+    // For dGPUs, using USM Host memory for outputs may lead to performance degradation in some scenarios (see can_use_usm_host impl).
+    // We have to be conservative and enable USM Host memory for dynamic outputs only on iGPUs. 
+    if (cldnn::device_type::integrated_gpu == device_info.dev_type &&
+        shape.is_dynamic() &&
+        can_use_usm_host(engine, total_output_bytes)) {
         auto device_et = convert_to_supported_device_type(element_type);
         if (!is_convert_required(device_et, element_type)) {
-            m_output_memory_blocks[output_idx] = std::make_unique<OutputMemoryBlock>(m_graph->get_engine());
+            m_output_memory_blocks[output_idx] = std::make_unique<OutputMemoryBlock>(engine);
         }
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/dynamic_execution/zero_copy_output_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/dynamic_execution/zero_copy_output_test.cpp
@@ -39,6 +39,9 @@ protected:
         if (!engine.get_device_info().supports_usm) {
             GTEST_SKIP() << "USM not supported on this device, skipping zero-copy output test";
         }
+        if (engine.get_device_info().dev_type == device_type::discrete_gpu) {
+            GTEST_SKIP() << "Dynamic output tensor substitution is disabled on dGPU";
+        }
 
         weight_data.resize(K * N);
         for (size_t i = 0; i < K * N; ++i)


### PR DESCRIPTION
### Details:
Some dGPU configs have know limitation on the max host tensor size (see `can_use_usm_host` implementation).
In the case of dynamic shapes, it's impossible to estimate the maximum tensor size. This led to the fact that the host output tensor is used for any output tensor size, and if it's large enough, we get visible performance drop on some specific HW.
It was decided to unconditionally disable this reuse for discrete GPUs to keep performance intact.

### Tickets:
 - CVS-184515

### AI Assistance:
 - *AI assistance used: no