### PR TITLE
[Onnx FE] Fix vulnerability issue in sanitize_path() helper 

### DIFF
--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -93,6 +93,8 @@ inline auto path_to_string(const std::filesystem::path& path) -> decltype(path_t
     return path_to_string(path.native());
 }
 
+std::filesystem::path sanitize_path(const std::filesystem::path& dir, const std::filesystem::path& relative_path);
+
 /**
  * @brief Interface function to get absolute path of file
  * @param path - path to file, can be relative to current working directory

--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -93,6 +93,14 @@ inline auto path_to_string(const std::filesystem::path& path) -> decltype(path_t
     return path_to_string(path.native());
 }
 
+/**
+ * @brief Resolves and validates a path relative to a base directory to prevent path traversal.
+ *
+ * @param dir           Base directory. If empty, the current working directory is used.
+ * @param relative_path Path relative to @p dir (may contain '.', '..', symlinks).
+ * @return              Absolute, normalized path within @p dir.
+ * @throw std::runtime_error if the resolved path escapes the base directory.
+ */
 std::filesystem::path sanitize_path(const std::filesystem::path& dir, const std::filesystem::path& relative_path);
 
 /**

--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -93,11 +93,6 @@ inline auto path_to_string(const std::filesystem::path& path) -> decltype(path_t
     return path_to_string(path.native());
 }
 
-/// \brief Remove path components which would allow traversing up a directory tree.
-/// \param path A path to file
-/// \return A sanitized path
-std::string sanitize_path(const std::string& path);
-
 /**
  * @brief Interface function to get absolute path of file
  * @param path - path to file, can be relative to current working directory

--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -96,12 +96,12 @@ inline auto path_to_string(const std::filesystem::path& path) -> decltype(path_t
 /**
  * @brief Resolves and validates a path relative to a base directory to prevent path traversal.
  *
- * @param dir           Base directory. If empty, the current working directory is used.
- * @param relative_path Path relative to @p dir (may contain '.', '..', symlinks).
+ * @param base          Base directory. If empty, the current working directory is used.
+ * @param relative_path Path relative to @p dir .
  * @return              Absolute, normalized path within @p dir.
  * @throw std::runtime_error if the resolved path escapes the base directory.
  */
-std::filesystem::path sanitize_path(const std::filesystem::path& dir, const std::filesystem::path& relative_path);
+std::filesystem::path sanitize_path(const std::filesystem::path& base, const std::filesystem::path& relative_path);
 
 /**
  * @brief Interface function to get absolute path of file

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -107,19 +107,17 @@ void ov::util::recursive_iterate_files(const std::filesystem::path& path,
 std::filesystem::path ov::util::sanitize_path(const std::filesystem::path& dir,
                                               const std::filesystem::path& relative_path) {
     const auto base = dir.empty() ? std::filesystem::current_path() : dir;
-    const auto dir_canon_absolute = ov::util::get_absolute_file_path(std::filesystem::weakly_canonical(base));
-    const auto merged_path = std::filesystem::weakly_canonical(base / relative_path);
-    auto absolute_path = ov::util::get_absolute_file_path(merged_path);
+    const auto base_canon = std::filesystem::weakly_canonical(base);
+    auto merged_canon = std::filesystem::weakly_canonical(base / relative_path);
 
-    const auto rel = absolute_path.lexically_relative(dir_canon_absolute);
-    if (rel.empty() || *rel.begin() == "..") {
+    if (const auto rel = merged_canon.lexically_relative(base_canon); rel.empty() || *rel.begin() == "..") {
         std::stringstream ss;
-        ss << "Path '" << path_to_string(relative_path) << "' resolves to '" << path_to_string(absolute_path)
-           << "' which is outside the base directory '" << path_to_string(dir_canon_absolute) << "'";
+        ss << "Path '" << path_to_string(relative_path) << "' resolves to '" << path_to_string(merged_canon)
+           << "' which is outside the base directory '" << path_to_string(base_canon) << "'";
         throw std::runtime_error(ss.str());
     }
 
-    return absolute_path;
+    return ov::util::get_absolute_file_path(merged_canon);
 }
 
 std::filesystem::path ov::util::get_absolute_file_path(const std::filesystem::path& path) {

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -104,6 +104,21 @@ void ov::util::recursive_iterate_files(const std::filesystem::path& path,
     }
 }
 
+std::filesystem::path ov::util::sanitize_path(const std::filesystem::path& dir,
+                                              const std::filesystem::path& relative_path) {
+    const auto dir_canon_absolute = ov::util::get_absolute_file_path(std::filesystem::weakly_canonical(dir));
+    const auto merged_path = std::filesystem::weakly_canonical(dir / relative_path);
+    auto absolute_path = ov::util::get_absolute_file_path(merged_path);
+
+    if (absolute_path.string().find(dir_canon_absolute.string()) != 0) {
+        std::stringstream ss;
+        ss << "Path traversal detected in external_data location: " << relative_path;
+        throw std::runtime_error(ss.str());
+    }
+
+    return absolute_path;
+}
+
 std::filesystem::path ov::util::get_absolute_file_path(const std::filesystem::path& path) {
     std::error_code ec;
     if (path.empty() || path.is_absolute()) {

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -104,14 +104,6 @@ void ov::util::recursive_iterate_files(const std::filesystem::path& path,
     }
 }
 
-std::string ov::util::sanitize_path(const std::string& path) {
-    const auto colon_pos = path.find(':');
-    const auto sanitized_path = path.substr(colon_pos == std::string::npos ? 0 : colon_pos + 1);
-    const std::string to_erase = "/.\\";
-    const auto start = sanitized_path.find_first_not_of(to_erase);
-    return (start == std::string::npos) ? "" : sanitized_path.substr(start);
-}
-
 std::filesystem::path ov::util::get_absolute_file_path(const std::filesystem::path& path) {
     std::error_code ec;
     if (path.empty() || path.is_absolute()) {

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -110,9 +110,11 @@ std::filesystem::path ov::util::sanitize_path(const std::filesystem::path& dir,
     const auto merged_path = std::filesystem::weakly_canonical(dir / relative_path);
     auto absolute_path = ov::util::get_absolute_file_path(merged_path);
 
-    if (absolute_path.string().find(dir_canon_absolute.string()) != 0) {
+    const auto rel = absolute_path.lexically_relative(dir_canon_absolute);
+    if (rel.empty() || *rel.begin() == "..") {
         std::stringstream ss;
-        ss << "Path traversal detected in external_data location: " << relative_path;
+        ss << "Path '" << path_to_string(relative_path) << "' resolves to '" << path_to_string(absolute_path)
+           << "' which is outside the base directory '" << path_to_string(dir_canon_absolute) << "'";
         throw std::runtime_error(ss.str());
     }
 

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -106,8 +106,9 @@ void ov::util::recursive_iterate_files(const std::filesystem::path& path,
 
 std::filesystem::path ov::util::sanitize_path(const std::filesystem::path& dir,
                                               const std::filesystem::path& relative_path) {
-    const auto dir_canon_absolute = ov::util::get_absolute_file_path(std::filesystem::weakly_canonical(dir));
-    const auto merged_path = std::filesystem::weakly_canonical(dir / relative_path);
+    const auto base = dir.empty() ? std::filesystem::current_path() : dir;
+    const auto dir_canon_absolute = ov::util::get_absolute_file_path(std::filesystem::weakly_canonical(base));
+    const auto merged_path = std::filesystem::weakly_canonical(base / relative_path);
     auto absolute_path = ov::util::get_absolute_file_path(merged_path);
 
     const auto rel = absolute_path.lexically_relative(dir_canon_absolute);

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -104,11 +104,11 @@ void ov::util::recursive_iterate_files(const std::filesystem::path& path,
     }
 }
 
-std::filesystem::path ov::util::sanitize_path(const std::filesystem::path& dir,
+std::filesystem::path ov::util::sanitize_path(const std::filesystem::path& base,
                                               const std::filesystem::path& relative_path) {
-    const auto base = dir.empty() ? std::filesystem::current_path() : dir;
-    const auto base_canon = std::filesystem::weakly_canonical(base);
-    auto merged_canon = std::filesystem::weakly_canonical(base / relative_path);
+    const auto base_dir = base.empty() ? std::filesystem::current_path() : base;
+    const auto base_canon = std::filesystem::weakly_canonical(base_dir);
+    auto merged_canon = std::filesystem::weakly_canonical(base_dir / relative_path);
 
     if (const auto rel = merged_canon.lexically_relative(base_canon); rel.empty() || *rel.begin() == "..") {
         std::stringstream ss;

--- a/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
+++ b/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
@@ -255,7 +255,7 @@ bool extract_tensor_external_data(ov::frontend::onnx::TensorMetaInfo& tensor_met
     std::string m_sha1_digest{};  // for future use
     for (const auto& entry : tensor_info->external_data()) {
         if (entry.key() == "location") {
-            ext_location = detail::sanitize_external_data_location(entry.value());
+            ext_location = entry.value();
         } else if (entry.key() == "offset") {
             ext_data_offset = std::stoull(entry.value());
         } else if (entry.key() == "length") {
@@ -264,8 +264,15 @@ bool extract_tensor_external_data(ov::frontend::onnx::TensorMetaInfo& tensor_met
             m_sha1_digest = entry.value();
         }
     }
-    const auto full_path = ov::util::get_absolute_file_path(
-        ov::util::path_join({graph_iterator->get_model_dir(), ov::util::make_path(ext_location)}));
+    if (ext_location == "*/_ORT_MEM_ADDR_/*") {
+        // Specific ONNX Runtime Case when it passes a model with self-managed data
+        tensor_meta_info.m_is_raw = true;
+        tensor_meta_info.m_tensor_data = reinterpret_cast<uint8_t*>(ext_data_offset);
+        tensor_meta_info.m_tensor_data_size = ext_data_length;
+        tensor_meta_info.m_external_location = std::make_shared<std::string>(ext_location);
+        return true;
+    }
+    const auto full_path = ov::util::sanitize_path(graph_iterator->get_model_dir(), ov::util::make_path(ext_location));
     const int64_t file_size = ov::util::file_size(full_path);
     if ((file_size <= 0 && ext_data_length > 0) || ext_data_length > static_cast<uint64_t>(file_size) ||
         ext_data_offset > static_cast<uint64_t>(file_size) - ext_data_length) {
@@ -279,14 +286,7 @@ bool extract_tensor_external_data(ov::frontend::onnx::TensorMetaInfo& tensor_met
                                             ? static_cast<size_t>(ext_data_length)
                                             : static_cast<size_t>(file_size) - static_cast<size_t>(ext_data_offset);
     auto memory_mode = graph_iterator->get_memory_management_mode();
-    if (ext_location == "*/_ORT_MEM_ADDR_/*") {
-        // Specific ONNX Runtime Case when it passes a model with self-managed data
-        tensor_meta_info.m_is_raw = true;
-        tensor_meta_info.m_tensor_data = reinterpret_cast<uint8_t*>(ext_data_offset);
-        tensor_meta_info.m_tensor_data_size = ext_data_length;
-        tensor_meta_info.m_external_location = std::make_shared<std::string>(ext_location);
-        return true;
-    } else if (memory_mode == External_MMAP) {
+    if (memory_mode == External_MMAP) {
         auto cache = graph_iterator->get_mmap_cache();
         auto cached_mapped_memory = cache->find(full_path);
         std::shared_ptr<ov::MappedMemory> mapped_memory;

--- a/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
+++ b/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
@@ -23,6 +23,7 @@
 #include "openvino/util/file_util.hpp"
 #include "openvino/util/wstring_convert_util.hpp"
 #include "transform.hpp"
+#include "utils/tensor_external_data.hpp"
 
 namespace {
 // THis is copied from utils/common.hpp
@@ -255,7 +256,7 @@ bool extract_tensor_external_data(ov::frontend::onnx::TensorMetaInfo& tensor_met
     std::string m_sha1_digest{};  // for future use
     for (const auto& entry : tensor_info->external_data()) {
         if (entry.key() == "location") {
-            ext_location = ov::util::sanitize_path(entry.value());
+            ext_location = detail::sanitize_external_data_location(entry.value());
         } else if (entry.key() == "offset") {
             ext_data_offset = std::stoull(entry.value());
         } else if (entry.key() == "length") {

--- a/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
+++ b/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
@@ -264,7 +264,7 @@ bool extract_tensor_external_data(ov::frontend::onnx::TensorMetaInfo& tensor_met
             m_sha1_digest = entry.value();
         }
     }
-    if (ext_location == "*/_ORT_MEM_ADDR_/*") {
+    if (ext_location == detail::ORT_MEM_ADDR) {
         // Specific ONNX Runtime Case when it passes a model with self-managed data
         tensor_meta_info.m_is_raw = true;
         tensor_meta_info.m_tensor_data = reinterpret_cast<uint8_t*>(ext_data_offset);

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
@@ -18,7 +18,7 @@ namespace detail {
 TensorExternalData::TensorExternalData(const TensorProto& tensor) {
     for (const auto& entry : tensor.external_data()) {
         if (entry.key() == "location") {
-            m_data_location = sanitize_external_data_location(entry.value());
+            m_data_location = entry.value();
         } else if (entry.key() == "offset") {
             m_offset = std::stoull(entry.value());
         } else if (entry.key() == "length") {
@@ -41,10 +41,8 @@ TensorExternalData::TensorExternalData(const std::string& location, size_t offse
 
 Buffer<ov::MappedMemory> TensorExternalData::load_external_mmap_data(const std::filesystem::path& model_dir,
                                                                      MappedMemoryHandles cache) const {
-    const auto full_path =
-        model_dir.empty()
-            ? ov::util::make_path(m_data_location)
-            : ov::util::get_absolute_file_path(ov::util::path_join({model_dir, ov::util::make_path(m_data_location)}));
+    const auto full_path = ov::util::sanitize_path(model_dir, ov::util::make_path(m_data_location));
+
     const int64_t file_size = ov::util::file_size(full_path);
     if (file_size <= 0 || m_data_length > static_cast<uint64_t>(file_size) ||
         m_offset > static_cast<uint64_t>(file_size) - m_data_length) {
@@ -68,10 +66,7 @@ Buffer<ov::MappedMemory> TensorExternalData::load_external_mmap_data(const std::
 }
 
 Buffer<ov::AlignedBuffer> TensorExternalData::load_external_data(const std::filesystem::path& model_dir) const {
-    const auto full_path =
-        model_dir.empty()
-            ? ov::util::make_path(m_data_location)
-            : ov::util::get_absolute_file_path(ov::util::path_join({model_dir, ov::util::make_path(m_data_location)}));
+    const auto full_path = ov::util::sanitize_path(model_dir, ov::util::make_path(m_data_location));
     std::ifstream external_data_stream(full_path, std::ios::binary | std::ios::in | std::ios::ate);
 
     if (external_data_stream.fail()) {

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
@@ -18,7 +18,7 @@ namespace detail {
 TensorExternalData::TensorExternalData(const TensorProto& tensor) {
     for (const auto& entry : tensor.external_data()) {
         if (entry.key() == "location") {
-            m_data_location = ov::util::sanitize_path(entry.value());
+            m_data_location = sanitize_external_data_location(entry.value());
         } else if (entry.key() == "offset") {
             m_offset = std::stoull(entry.value());
         } else if (entry.key() == "length") {

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
@@ -41,7 +41,12 @@ TensorExternalData::TensorExternalData(const std::string& location, size_t offse
 
 Buffer<ov::MappedMemory> TensorExternalData::load_external_mmap_data(const std::filesystem::path& model_dir,
                                                                      MappedMemoryHandles cache) const {
-    const auto full_path = ov::util::sanitize_path(model_dir, ov::util::make_path(m_data_location));
+    std::filesystem::path full_path;
+    try {
+        full_path = ov::util::sanitize_path(model_dir, ov::util::make_path(m_data_location));
+    } catch (const std::runtime_error& e) {
+        throw error::invalid_external_data{e.what()};
+    }
 
     const int64_t file_size = ov::util::file_size(full_path);
     if (file_size <= 0 || m_data_length > static_cast<uint64_t>(file_size) ||
@@ -66,7 +71,12 @@ Buffer<ov::MappedMemory> TensorExternalData::load_external_mmap_data(const std::
 }
 
 Buffer<ov::AlignedBuffer> TensorExternalData::load_external_data(const std::filesystem::path& model_dir) const {
-    const auto full_path = ov::util::sanitize_path(model_dir, ov::util::make_path(m_data_location));
+    std::filesystem::path full_path;
+    try {
+        full_path = ov::util::sanitize_path(model_dir, ov::util::make_path(m_data_location));
+    } catch (const std::runtime_error& e) {
+        throw error::invalid_external_data{e.what()};
+    }
     std::ifstream external_data_stream(full_path, std::ios::binary | std::ios::in | std::ios::ate);
 
     if (external_data_stream.fail()) {

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
@@ -6,6 +6,8 @@
 
 #include <onnx/onnx_pb.h>
 
+#include <vector>
+
 #include "openvino/runtime/aligned_buffer.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
 #include "openvino/util/mmap_object.hpp"
@@ -20,14 +22,54 @@ using Buffer = std::shared_ptr<ov::SharedBuffer<std::shared_ptr<T>>>;
 using MappedMemoryHandles = std::shared_ptr<std::map<std::string, std::shared_ptr<ov::MappedMemory>>>;
 using LocalStreamHandles = std::shared_ptr<std::map<std::string, std::shared_ptr<std::ifstream>>>;
 
-/// \brief Remove leading path components that would allow traversing up a directory tree.
+/// \brief Remove path components that would allow traversing up a directory tree.
 /// \note The ONNX Runtime shared-memory marker "*/_ORT_MEM_ADDR_/*" is also accepted here.
 inline std::string sanitize_external_data_location(const std::string& location) {
+    if (location == "*/_ORT_MEM_ADDR_/*") {
+        return location;
+    }
+
+    // Strip an optional drive/scheme prefix (everything up to and including the first ':').
     const auto colon_pos = location.find(':');
-    const auto sanitized_location = location.substr(colon_pos == std::string::npos ? 0 : colon_pos + 1);
-    const std::string leading_components = "/.\\";
-    const auto start = sanitized_location.find_first_not_of(leading_components);
-    return (start == std::string::npos) ? "" : sanitized_location.substr(start);
+    const auto stripped = colon_pos == std::string::npos ? location : location.substr(colon_pos + 1);
+
+    // Pick the separator style based on which slash appears first in the input.
+    const auto fwd = stripped.find('/');
+    const auto bwd = stripped.find('\\');
+    const char separator =
+        (bwd != std::string::npos && (fwd == std::string::npos || bwd < fwd)) ? '\\' : '/';
+
+    std::vector<std::string> components;
+    size_t start = 0;
+    for (size_t pos = 0; pos <= stripped.size(); ++pos) {
+        if (pos != stripped.size() && stripped[pos] != '/' && stripped[pos] != '\\') {
+            continue;
+        }
+        const auto token = stripped.substr(start, pos - start);
+        start = pos + 1;
+
+        if (token.empty() || token == ".") {
+            continue;
+        }
+        if (token == "..") {
+            if (!components.empty()) {
+                components.pop_back();
+            }
+            continue;
+        }
+        components.push_back(token);
+    }
+
+    if (components.empty()) {
+        return "";
+    }
+
+    std::string normalized = components.front();
+    for (size_t i = 1; i < components.size(); ++i) {
+        normalized += separator;
+        normalized += components[i];
+    }
+    return normalized;
 }
 
 /// \brief  Helper class used to load tensor data from external files

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
@@ -19,6 +19,17 @@ template <class T>
 using Buffer = std::shared_ptr<ov::SharedBuffer<std::shared_ptr<T>>>;
 using MappedMemoryHandles = std::shared_ptr<std::map<std::string, std::shared_ptr<ov::MappedMemory>>>;
 using LocalStreamHandles = std::shared_ptr<std::map<std::string, std::shared_ptr<std::ifstream>>>;
+
+/// \brief Remove leading path components that would allow traversing up a directory tree.
+/// \note The ONNX Runtime shared-memory marker "*/_ORT_MEM_ADDR_/*" is also accepted here.
+inline std::string sanitize_external_data_location(const std::string& location) {
+    const auto colon_pos = location.find(':');
+    const auto sanitized_location = location.substr(colon_pos == std::string::npos ? 0 : colon_pos + 1);
+    const std::string leading_components = "/.\\";
+    const auto start = sanitized_location.find_first_not_of(leading_components);
+    return (start == std::string::npos) ? "" : sanitized_location.substr(start);
+}
+
 /// \brief  Helper class used to load tensor data from external files
 class TensorExternalData {
 public:

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
@@ -7,7 +7,6 @@
 #include <onnx/onnx_pb.h>
 
 #include <filesystem>
-#include <vector>
 
 #include "openvino/runtime/aligned_buffer.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
@@ -22,56 +21,6 @@ template <class T>
 using Buffer = std::shared_ptr<ov::SharedBuffer<std::shared_ptr<T>>>;
 using MappedMemoryHandles = std::shared_ptr<std::map<std::filesystem::path, std::shared_ptr<ov::MappedMemory>>>;
 using LocalStreamHandles = std::shared_ptr<std::map<std::filesystem::path, std::shared_ptr<std::ifstream>>>;
-
-/// \brief Remove path components that would allow traversing up a directory tree.
-/// \note The ONNX Runtime shared-memory marker "*/_ORT_MEM_ADDR_/*" is also accepted here.
-inline std::string sanitize_external_data_location(const std::string& location) {
-    if (location == "*/_ORT_MEM_ADDR_/*") {
-        return location;
-    }
-
-    // Strip an optional drive/scheme prefix (everything up to and including the first ':').
-    const auto colon_pos = location.find(':');
-    const auto stripped = colon_pos == std::string::npos ? location : location.substr(colon_pos + 1);
-
-    // Pick the separator style based on which slash appears first in the input.
-    const auto fwd = stripped.find('/');
-    const auto bwd = stripped.find('\\');
-    const char separator = (bwd != std::string::npos && (fwd == std::string::npos || bwd < fwd)) ? '\\' : '/';
-
-    std::vector<std::string> components;
-    size_t start = 0;
-    for (size_t pos = 0; pos <= stripped.size(); ++pos) {
-        if (pos != stripped.size() && stripped[pos] != '/' && stripped[pos] != '\\') {
-            continue;
-        }
-        const auto token = stripped.substr(start, pos - start);
-        start = pos + 1;
-
-        if (token.empty() || token == ".") {
-            continue;
-        }
-        if (token == "..") {
-            if (!components.empty()) {
-                components.pop_back();
-            }
-            continue;
-        }
-        components.push_back(token);
-    }
-
-    if (components.empty()) {
-        return "";
-    }
-
-    std::string normalized = components.front();
-    for (size_t i = 1; i < components.size(); ++i) {
-        normalized += separator;
-        normalized += components[i];
-    }
-    return normalized;
-}
-
 /// \brief  Helper class used to load tensor data from external files
 class TensorExternalData {
 public:

--- a/src/frontends/onnx/tests/models/external_data/inner_scope/external_data_file_in_up_dir.prototxt
+++ b/src/frontends/onnx/tests/models/external_data/inner_scope/external_data_file_in_up_dir.prototxt
@@ -18,14 +18,6 @@ graph {
         key: "location",
         value: "../tensors_data/tensor.data"
     }
-    external_data {
-        key: "offset",
-        value: "4096"
-    }
-    external_data {
-        key: "length",
-        value: "16"
-    }
     data_location: 1
   }
   input {

--- a/src/frontends/onnx/tests/onnx_reader_external_data.cpp
+++ b/src/frontends/onnx/tests/onnx_reader_external_data.cpp
@@ -269,8 +269,7 @@ TEST_P(OnnxFeMmapFixture, onnx_external_invalid_up_dir_path) {
         FAIL() << "Incorrect path to external data not detected";
     } catch (const Exception& ex) {
         EXPECT_PRED_FORMAT2(testing::IsSubstring,
-                            string("tensor.data, offset: 4096, "
-                                   "data_length: 16)"),
+                            string("Path traversal detected in external_data location"),
                             ex.what());
     } catch (...) {
         FAIL() << "Importing onnx model failed for unexpected reason";

--- a/src/frontends/onnx/tests/onnx_reader_external_data.cpp
+++ b/src/frontends/onnx/tests/onnx_reader_external_data.cpp
@@ -26,18 +26,6 @@ using namespace frontend;
 using namespace frontend::onnx::tests;
 using testing::AnyOf, testing::HasSubstr;
 
-TEST(onnx_external_data, sanitize_external_data_location) {
-    using ov::frontend::onnx::detail::sanitize_external_data_location;
-
-    EXPECT_STREQ("tensor.data", sanitize_external_data_location("../../tensor.data").c_str());
-    EXPECT_STREQ("tensor.data", sanitize_external_data_location("/../tensor.data").c_str());
-    EXPECT_STREQ("", sanitize_external_data_location("..").c_str());
-    EXPECT_STREQ("workspace/data/tensor.data", sanitize_external_data_location("workspace/data/tensor.data").c_str());
-    EXPECT_STREQ("tensor.data", sanitize_external_data_location("..\\..\\tensor.data").c_str());
-    EXPECT_STREQ("workspace\\tensor.data", sanitize_external_data_location("C:\\workspace\\tensor.data").c_str());
-    EXPECT_STREQ("etc/passwd", sanitize_external_data_location("directory/../../../../../etc/passwd").c_str());
-    EXPECT_STREQ("*/_ORT_MEM_ADDR_/*", sanitize_external_data_location("*/_ORT_MEM_ADDR_/*").c_str());
-}
 
 // API 2.0 tests
 class OnnxFeMmapFixture : public ::testing::TestWithParam<bool> {};

--- a/src/frontends/onnx/tests/onnx_reader_external_data.cpp
+++ b/src/frontends/onnx/tests/onnx_reader_external_data.cpp
@@ -26,7 +26,6 @@ using namespace frontend;
 using namespace frontend::onnx::tests;
 using testing::AnyOf, testing::HasSubstr;
 
-
 // API 2.0 tests
 class OnnxFeMmapFixture : public ::testing::TestWithParam<bool> {};
 

--- a/src/frontends/onnx/tests/onnx_reader_external_data.cpp
+++ b/src/frontends/onnx/tests/onnx_reader_external_data.cpp
@@ -35,6 +35,8 @@ TEST(onnx_external_data, sanitize_external_data_location) {
     EXPECT_STREQ("workspace/data/tensor.data", sanitize_external_data_location("workspace/data/tensor.data").c_str());
     EXPECT_STREQ("tensor.data", sanitize_external_data_location("..\\..\\tensor.data").c_str());
     EXPECT_STREQ("workspace\\tensor.data", sanitize_external_data_location("C:\\workspace\\tensor.data").c_str());
+    EXPECT_STREQ("etc/passwd",
+                 sanitize_external_data_location("directory/../../../../../etc/passwd").c_str());
     EXPECT_STREQ("*/_ORT_MEM_ADDR_/*", sanitize_external_data_location("*/_ORT_MEM_ADDR_/*").c_str());
 }
 

--- a/src/frontends/onnx/tests/onnx_reader_external_data.cpp
+++ b/src/frontends/onnx/tests/onnx_reader_external_data.cpp
@@ -18,12 +18,25 @@
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/frontend/manager.hpp"
 #include "openvino/op/constant.hpp"
+#include "utils/tensor_external_data.hpp"
 
 using namespace std;
 using namespace ov;
 using namespace frontend;
 using namespace frontend::onnx::tests;
 using testing::AnyOf, testing::HasSubstr;
+
+TEST(onnx_external_data, sanitize_external_data_location) {
+    using ov::frontend::onnx::detail::sanitize_external_data_location;
+
+    EXPECT_STREQ("tensor.data", sanitize_external_data_location("../../tensor.data").c_str());
+    EXPECT_STREQ("tensor.data", sanitize_external_data_location("/../tensor.data").c_str());
+    EXPECT_STREQ("", sanitize_external_data_location("..").c_str());
+    EXPECT_STREQ("workspace/data/tensor.data", sanitize_external_data_location("workspace/data/tensor.data").c_str());
+    EXPECT_STREQ("tensor.data", sanitize_external_data_location("..\\..\\tensor.data").c_str());
+    EXPECT_STREQ("workspace\\tensor.data", sanitize_external_data_location("C:\\workspace\\tensor.data").c_str());
+    EXPECT_STREQ("*/_ORT_MEM_ADDR_/*", sanitize_external_data_location("*/_ORT_MEM_ADDR_/*").c_str());
+}
 
 // API 2.0 tests
 class OnnxFeMmapFixture : public ::testing::TestWithParam<bool> {};

--- a/src/frontends/onnx/tests/onnx_reader_external_data.cpp
+++ b/src/frontends/onnx/tests/onnx_reader_external_data.cpp
@@ -35,8 +35,7 @@ TEST(onnx_external_data, sanitize_external_data_location) {
     EXPECT_STREQ("workspace/data/tensor.data", sanitize_external_data_location("workspace/data/tensor.data").c_str());
     EXPECT_STREQ("tensor.data", sanitize_external_data_location("..\\..\\tensor.data").c_str());
     EXPECT_STREQ("workspace\\tensor.data", sanitize_external_data_location("C:\\workspace\\tensor.data").c_str());
-    EXPECT_STREQ("etc/passwd",
-                 sanitize_external_data_location("directory/../../../../../etc/passwd").c_str());
+    EXPECT_STREQ("etc/passwd", sanitize_external_data_location("directory/../../../../../etc/passwd").c_str());
     EXPECT_STREQ("*/_ORT_MEM_ADDR_/*", sanitize_external_data_location("*/_ORT_MEM_ADDR_/*").c_str());
 }
 
@@ -268,9 +267,7 @@ TEST_P(OnnxFeMmapFixture, onnx_external_invalid_up_dir_path) {
         core.read_model(path);
         FAIL() << "Incorrect path to external data not detected";
     } catch (const Exception& ex) {
-        EXPECT_PRED_FORMAT2(testing::IsSubstring,
-                            string("Path traversal detected in external_data location"),
-                            ex.what());
+        EXPECT_PRED_FORMAT2(testing::IsSubstring, string("which is outside the base directory"), ex.what());
     } catch (...) {
         FAIL() << "Importing onnx model failed for unexpected reason";
     }

--- a/src/tests/test_utils/common_test_utils/tests/file_util_test.cpp
+++ b/src/tests/test_utils/common_test_utils/tests/file_util_test.cpp
@@ -649,4 +649,50 @@ TEST_P(FileUtilTestP, create_directories) {
 
     std::filesystem::remove_all(test_dir);
 }
+
+class SanitizePathTest : public ::testing::Test {
+protected:
+    std::filesystem::path base{std::filesystem::temp_directory_path() / "ov_sanitize_test_base"};
+};
+
+TEST_F(SanitizePathTest, valid_nested_relative_path) {
+    EXPECT_NO_THROW(ov::util::sanitize_path(base, "workspace/data/tensor.data"));
+}
+
+TEST_F(SanitizePathTest, invalid_single_dotdot) {
+    EXPECT_THROW(ov::util::sanitize_path(base, ".."), std::runtime_error);
+}
+
+TEST_F(SanitizePathTest, invalid_dotdot_prefix) {
+    EXPECT_THROW(ov::util::sanitize_path(base, "../tensors_data/tensor.data"), std::runtime_error);
+}
+
+TEST_F(SanitizePathTest, invalid_absolute_path_outside_base) {
+    EXPECT_THROW(ov::util::sanitize_path(base, "/../tensor.data"), std::runtime_error);
+}
+
+#ifdef _WIN32
+TEST_F(SanitizePathTest, invalid_windows_absolute_path_different_drive) {
+    EXPECT_THROW(ov::util::sanitize_path(base, "C:\\workspace\\tensor.data"), std::runtime_error);
+}
+
+TEST_F(SanitizePathTest, invalid_windows_dotdot_backslash) {
+    EXPECT_THROW(ov::util::sanitize_path(base, "..\\..\\tensor.data"), std::runtime_error);
+}
+#endif
+
+TEST_F(SanitizePathTest, empty_dir_uses_cwd) {
+    // When dir is empty, sanitize_path falls back to current_path() as the base.
+    // A simple relative path must resolve without throwing and land under cwd.
+    const auto result = ov::util::sanitize_path("", "tensors/data.bin");
+    const auto expected = ov::util::get_absolute_file_path(
+        std::filesystem::weakly_canonical(std::filesystem::current_path() / "tensors/data.bin"));
+    EXPECT_EQ(result, expected);
+}
+
+TEST_F(SanitizePathTest, empty_dir_dotdot_still_rejected) {
+    // Even with an empty dir (cwd as base), ".." must still be rejected.
+    EXPECT_THROW(ov::util::sanitize_path("", ".."), std::runtime_error);
+}
+
 }  // namespace ov::test

--- a/src/tests/test_utils/common_test_utils/tests/file_util_test.cpp
+++ b/src/tests/test_utils/common_test_utils/tests/file_util_test.cpp
@@ -88,33 +88,6 @@ TEST(file_util, path_join) {
     }
 }
 
-TEST(file_util, sanitize_path) {
-    {
-        string path = "../../tensor.data";
-        EXPECT_STREQ("tensor.data", ov::util::sanitize_path(path).c_str());
-    }
-    {
-        string path = "/../tensor.data";
-        EXPECT_STREQ("tensor.data", ov::util::sanitize_path(path).c_str());
-    }
-    {
-        string path = "..";
-        EXPECT_STREQ("", ov::util::sanitize_path(path).c_str());
-    }
-    {
-        string path = "workspace/data/tensor.data";
-        EXPECT_STREQ("workspace/data/tensor.data", ov::util::sanitize_path(path).c_str());
-    }
-    {
-        string path = "..\\..\\tensor.data";
-        EXPECT_STREQ("tensor.data", ov::util::sanitize_path(path).c_str());
-    }
-    {
-        string path = "C:\\workspace\\tensor.data";
-        EXPECT_STREQ("workspace\\tensor.data", ov::util::sanitize_path(path).c_str());
-    }
-}
-
 using namespace testing;
 
 class TrimFileTest : public Test {

--- a/src/tests/test_utils/common_test_utils/tests/file_util_test.cpp
+++ b/src/tests/test_utils/common_test_utils/tests/file_util_test.cpp
@@ -682,8 +682,6 @@ TEST_F(SanitizePathTest, invalid_windows_dotdot_backslash) {
 #endif
 
 TEST_F(SanitizePathTest, empty_dir_uses_cwd) {
-    // When dir is empty, sanitize_path falls back to current_path() as the base.
-    // A simple relative path must resolve without throwing and land under cwd.
     const auto result = ov::util::sanitize_path("", "tensors/data.bin");
     const auto expected = ov::util::get_absolute_file_path(
         std::filesystem::weakly_canonical(std::filesystem::current_path() / "tensors/data.bin"));
@@ -691,7 +689,6 @@ TEST_F(SanitizePathTest, empty_dir_uses_cwd) {
 }
 
 TEST_F(SanitizePathTest, empty_dir_dotdot_still_rejected) {
-    // Even with an empty dir (cwd as base), ".." must still be rejected.
     EXPECT_THROW(ov::util::sanitize_path("", ".."), std::runtime_error);
 }
 

--- a/src/tests/test_utils/common_test_utils/tests/file_util_test.cpp
+++ b/src/tests/test_utils/common_test_utils/tests/file_util_test.cpp
@@ -656,7 +656,8 @@ protected:
 };
 
 TEST_F(SanitizePathTest, valid_nested_relative_path) {
-    EXPECT_NO_THROW(ov::util::sanitize_path(base, "workspace/data/tensor.data"));
+    const auto result = ov::util::sanitize_path(base, "workspace/data/tensor.data");
+    EXPECT_EQ(result, base / "workspace/data/tensor.data");
 }
 
 TEST_F(SanitizePathTest, invalid_single_dotdot) {


### PR DESCRIPTION
### Details:
 - Fix vulnerability issue in `sanitize_path()` helper [CVS-184059](https://jira.devtools.intel.com/browse/CVS-184059)
 - Update `TensorExternalData::m_data_location` usage and `extract_tensor_external_data()`
 - Update `onnx_external_invalid_up_dir_path`  because it failed due to invalid offset https://github.com/openvinotoolkit/openvino/blob/6e1cbaccbdabd5eab7a4c00c5343fb6024680eb4/src/frontends/onnx/tests/onnx_reader_external_data.cpp#L261-L262

### Tickets:
 - [CVS-179601](https://jira.devtools.intel.com/browse/CVS-179601), [CVS-184059](https://jira.devtools.intel.com/browse/CVS-184059)

### AI Assistance:
 - AI assistance used: yes, codebase analysis, test scenarios suggestions.
