### PR TITLE
Use defusedxml for coverage XML parsing

### DIFF
--- a/.github/scripts/coverage/requirements-ci.txt
+++ b/.github/scripts/coverage/requirements-ci.txt
@@ -1,4 +1,5 @@
 coverage==7.13.5
+defusedxml==0.7.1
 pytest==9.0.3
 pytest-cov==7.1.0
 PyYAML==6.0.3

--- a/.github/scripts/coverage/run_tests.py
+++ b/.github/scripts/coverage/run_tests.py
@@ -11,7 +11,8 @@ import shlex
 import shutil
 import subprocess
 import time
-import xml.etree.ElementTree as ET
+
+import defusedxml.ElementTree as ET
 
 from coverage_workflow import (
     CoverageContext,


### PR DESCRIPTION
### Details:
Replace stdlib XML parsing in the coverage test runner with defusedxml.ElementTree and add the missing
coverage workflow dependency so coverage XML rewriting follows Bandit security guidance (B314/B405)

### Tickets:
 - CVS-185682
 - CVS-185681