### PR TITLE
[GPU] Ignore "Intel_Symbol_Table_Void_Program" kernel

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
@@ -79,6 +79,9 @@ class ocl_kernel_builder : public kernel_builder{
             }
             for (auto& k : kernels) {
                 const auto &entry_point = k.getInfo<CL_KERNEL_FUNCTION_NAME>();
+                if (entry_point == "Intel_Symbol_Table_Void_Program") {
+                    continue;
+                }
                 out.push_back(std::make_shared<ocl::ocl_kernel>(ocl::ocl_kernel_type(k, m_device.get_usm_helper()), entry_point));
             }
     }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
@@ -79,7 +79,8 @@ class ocl_kernel_builder : public kernel_builder{
             }
             for (auto& k : kernels) {
                 const auto &entry_point = k.getInfo<CL_KERNEL_FUNCTION_NAME>();
-                // Workaround for GSD-12674
+                // Intel_Symbol_Table_Void_Program does not correspond to any real kernel
+                // Ignore this entry point as workaround for GSD-12674
                 if (entry_point == "Intel_Symbol_Table_Void_Program") {
                     continue;
                 }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
@@ -79,6 +79,7 @@ class ocl_kernel_builder : public kernel_builder{
             }
             for (auto& k : kernels) {
                 const auto &entry_point = k.getInfo<CL_KERNEL_FUNCTION_NAME>();
+                // Workaround for GSD-12674
                 if (entry_point == "Intel_Symbol_Table_Void_Program") {
                     continue;
                 }


### PR DESCRIPTION
### Details:
 - With OCL/L0 interoperability enabled in some cases OCL might report additional kernel named "Intel_Symbol_Table_Void_Program". It does not correspond to any actual kernel, and we can ignore it to prevent issues in `kernels_cache` where we expect number of compiled kernels to match number of kernels in the batch.

### Tickets:
 - Related to [CVS-184583](https://jira.devtools.intel.com/browse/CVS-184583)
 - 12674

### AI Assistance:
 - AI assistance used: no
