### PR TITLE
[GHA] Use pip-proxy for one more Windows job

### DIFF
--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -328,27 +328,33 @@ jobs:
           wheels-to-install: 'openvino'
 
       - name: Install Python API tests dependencies
+        env:
+          PIP_INDEX_URL: "http://pip-proxy.pip-proxy.svc.cluster.local/simple/"
+          PIP_TRUSTED_HOST: "pip-proxy.pip-proxy.svc.cluster.local"
         run: |
           # To enable pytest parallel features
-          python3 -m pip install pytest-xdist[psutil]
+          python3 -m pip install --no-cache-dir pytest-xdist[psutil]
 
           # For torchvision to OpenVINO preprocessing converter
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/python/preprocess/torchvision/requirements.txt
+          python3 -m pip install --no-cache-dir -r ${{ env.INSTALL_TEST_DIR }}/python/preprocess/torchvision/requirements.txt
 
           # For validation of Python API
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
+          python3 -m pip install --no-cache-dir -r ${{ env.INSTALL_TEST_DIR }}/bindings/python/requirements_test.txt
 
           #  ONNX tests requirements
-          python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}/requirements_onnx
+          python3 -m pip install --no-cache-dir -r ${{ env.INSTALL_TEST_DIR }}/requirements_onnx
 
           # For getting rid of SSL issues during model downloading for unit tests
-          python3 -m pip install certifi
+          python3 -m pip install --no-cache-dir certifi
 
       - name: Set SSL_CERT_FILE for model downloading for unit tests
         run: echo SSL_CERT_FILE=$(python3 -m certifi) >> $env:GITHUB_ENV
 
       - name: Install Python Layer tests dependencies
-        run: python3 -m pip install -r ${{ env.LAYER_TESTS_INSTALL_DIR }}/requirements.txt
+        env:
+          PIP_INDEX_URL: "http://pip-proxy.pip-proxy.svc.cluster.local/simple/"
+          PIP_TRUSTED_HOST: "pip-proxy.pip-proxy.svc.cluster.local"
+        run: python3 -m pip install --no-cache-dir -r ${{ env.LAYER_TESTS_INSTALL_DIR }}/requirements.txt
 
       - name: Python API Tests
         #if: fromJSON(needs.smart_ci.outputs.affected_components).Python_API.test # Ticket: 127101


### PR DESCRIPTION
### Details:
Using `pip-proxy` for Python Unit Tests job on Windows in addition to Python Layer tests https://github.com/openvinotoolkit/openvino/pull/34376 

This job's modules installation step is the longest and also affected by `Content-Type: Unknown` error. Let's see if `pip-proxy` helps. There's one caveat though: currently modules downloaded from download.pytorch.org registry are not cached.