### PR TITLE
[GPU] Fix PagedAttention intermediate buffer memory explosion

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1607,9 +1607,10 @@ public:
         const auto indexes_buf_size = static_cast<int64_t>(ceil_div(target_seq_len, target_seq_len_block_size)) * element_size;
 
         const bool lockable = true;
-        internal_buffers.emplace_back(indexes_buf_size, indexes_dt, lockable);  // 0
-        internal_buffers.emplace_back(indexes_buf_size, indexes_dt, lockable);  // 1
-        internal_buffers.emplace_back(indexes_buf_size, indexes_dt, lockable);  // 2
+        const bool not_shareable = false;
+        internal_buffers.emplace_back(indexes_buf_size, indexes_dt, lockable, not_shareable);  // 0
+        internal_buffers.emplace_back(indexes_buf_size, indexes_dt, lockable, not_shareable);  // 1
+        internal_buffers.emplace_back(indexes_buf_size, indexes_dt, lockable, not_shareable);  // 2
 
         const auto& input = params.input_layouts[0];
         const int64_t total_tokens = input.get_partial_shape()[0].get_length();
@@ -1649,11 +1650,11 @@ public:
             // Softmax intermediate output
             internal_buffers.emplace_back(softmax_buf_elements_count, indexes_dt);  // 3
             // Precalculated accumulated sequence length offsets for each subsequence
-            internal_buffers.emplace_back(subsequences_number * element_size, indexes_dt, lockable);  // 4
+            internal_buffers.emplace_back(subsequences_number * element_size, indexes_dt, lockable, not_shareable);  // 4
 
             if (desc->has_score_aggregation) {
                 // Cumulative window size sum buffer
-                internal_buffers.emplace_back((subsequences_number + 1) * element_size, indexes_dt, lockable);  // 5
+                internal_buffers.emplace_back((subsequences_number + 1) * element_size, indexes_dt, lockable, not_shareable);  // 5
             }
 
             if (stage == PagedAttentionStage::PREFILL) {
@@ -1675,7 +1676,7 @@ public:
 
         const auto multi_tokens_mode = stage == PagedAttentionStage::MIXED;
         if (multi_tokens_mode && !can_use_micro_sdpa) {
-            internal_buffers.emplace_back(total_tokens, softmax_accumulator_type, lockable);  // 9
+            internal_buffers.emplace_back(total_tokens, softmax_accumulator_type, lockable, not_shareable);  // 9
         }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
@@ -1683,7 +1684,7 @@ public:
             const auto wg_tile_q = 8;  // This is set as the minimum size of query block for sharing between sdpa_micro_prefill and mixed.
             const auto target_seq_len = std::max(paged_attention_aligned_seq_len, static_cast<int64_t>(1));
             const auto indexes_buf_size = ceil_div(target_seq_len, wg_tile_q) * 2;
-            internal_buffers.emplace_back(indexes_buf_size * 4, indexes_dt, lockable);
+            internal_buffers.emplace_back(indexes_buf_size * 4, indexes_dt, lockable, not_shareable);
         }
 #endif
 

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -46,12 +46,14 @@ class PrimitiveInstTestHelper;
 struct ImplementationManager;
 
 struct BufferDescriptor {
-    explicit BufferDescriptor(const layout& l, bool lockable = false) : m_lockable(lockable), m_layout(l) {}
-    BufferDescriptor(const ov::PartialShape& shape, ov::element::Type type, bool lockable = false)
-        : BufferDescriptor(layout(shape, type, format::bfyx), lockable) {}
-    BufferDescriptor(size_t elements_count, ov::element::Type type, bool lockable = false)
-        : BufferDescriptor(layout({static_cast<int64_t>(elements_count)}, type, format::bfyx), lockable) {}
+    explicit BufferDescriptor(const layout& l, bool lockable = false, bool shareable = true)
+        : m_lockable(lockable), m_shareable(shareable), m_layout(l) {}
+    BufferDescriptor(const ov::PartialShape& shape, ov::element::Type type, bool lockable = false, bool shareable = true)
+        : BufferDescriptor(layout(shape, type, format::bfyx), lockable, shareable) {}
+    BufferDescriptor(size_t elements_count, ov::element::Type type, bool lockable = false, bool shareable = true)
+        : BufferDescriptor(layout({static_cast<int64_t>(elements_count)}, type, format::bfyx), lockable, shareable) {}
     bool m_lockable = false;
+    bool m_shareable = true;  // Whether this buffer can be shared via memory pool across primitives
     layout m_layout;
 };
 
@@ -320,7 +322,6 @@ public:
     bool mem_allocated() const { return _mem_allocated; }
     bool is_dynamic() const { return _is_dynamic; }
     bool can_share_buffer() const { return _can_share_buffer; }
-    bool can_share_internal_buffer() const { return _can_share_internal_buffer; }
     bool is_constant() const { return _is_constant; }
     bool needs_completion_event() const { return _needs_completion_event; }
     bool has_unfused_subgraph() const { return (_unfused_subgraph != nullptr); }
@@ -438,7 +439,6 @@ protected:
     size_t _fused_mem_offset = 0;
     bool _can_be_optimized = false;
     bool _can_share_buffer = true;
-    bool _can_share_internal_buffer = true;
     bool _is_constant = false;
     bool _needs_completion_event = false;
 
@@ -448,7 +448,7 @@ protected:
     std::vector<memory::ptr> allocate_outputs(kernel_impl_params* updated_params = nullptr,
                                               bool reset_mem = true,
                                               bool runtime_alloc = false);
-    memory::ptr allocate_internal_buffer(const layout& layout, size_t idx, bool reset = true, bool lockable = false);
+    memory::ptr allocate_internal_buffer(const layout& layout, size_t idx, bool reset = true, bool lockable = false, bool shareable = true);
     void allocate_shape_info_memory();
     static std::vector<primitive_inst*> build_exec_deps(
         std::vector<std::pair<primitive_inst*, int32_t>> const& mem_deps);

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -321,10 +321,6 @@ public:
     bool can_share_buffer() const { return share_buffer; }
     void can_share_buffer(bool share) { share_buffer = share; }
 
-    // check/set if the node's internal buffer can be shared
-    bool can_share_internal_buffer() const { return share_internal_buffer; }
-    void can_share_internal_buffer(bool share) { share_internal_buffer = share; }
-
     // Sets padding support for all axis
     void support_padding_all(bool support);
     // Sets padding support for specified axis

--- a/src/plugins/intel_gpu/src/graph/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/paged_attention.cpp
@@ -13,7 +13,6 @@ GPU_DEFINE_PRIMITIVE_TYPE_ID(paged_attention)
 
 paged_attention_node::typed_program_node(const std::shared_ptr<paged_attention> prim, program& prog)
     : parent(prim, prog) {
-    can_share_internal_buffer(false);
 }
 
 layout paged_attention_inst::calc_output_layout(const paged_attention_node& /*node*/, kernel_impl_params const& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -691,11 +691,11 @@ void primitive_inst::realloc_intermediates() {
             // we'll need additional handle for that purpose like need_reset_output_memory
             const bool need_reset = false;
             if (i < _intermediates_memory.size()) {
-                _intermediates_memory[i] = allocate_internal_buffer(buffer_descs[i].m_layout, i, need_reset, need_lockable);
+                _intermediates_memory[i] = allocate_internal_buffer(buffer_descs[i].m_layout, i, need_reset, need_lockable, buffer_descs[i].m_shareable);
                 _max_intermediates_memory_sizes[i] = _intermediates_memory[i]->size();
             } else {
                 // i-th layout has not been allocated yet
-                _intermediates_memory.push_back(allocate_internal_buffer(buffer_descs[i].m_layout, i, need_reset, need_lockable));
+                _intermediates_memory.push_back(allocate_internal_buffer(buffer_descs[i].m_layout, i, need_reset, need_lockable, buffer_descs[i].m_shareable));
                 _max_intermediates_memory_sizes.push_back(_intermediates_memory[i]->size());
             }
             GPU_DEBUG_CODE(memalloc_info +=
@@ -2298,7 +2298,6 @@ primitive_inst::primitive_inst(network & network, program_node const& node, bool
     , _fused_mem_offset((_fused_mem_count > 0 && node.get_first_fused_dep_idx() > 0) ? static_cast<uint64_t>(node.get_first_fused_dep_idx()) : 0)
     , _can_be_optimized(node.can_be_optimized())
     , _can_share_buffer(node.can_share_buffer())
-    , _can_share_internal_buffer(node.can_share_internal_buffer())
     , _is_constant(node.is_constant())
     , _needs_completion_event(is_any_user_cpu(node.get_users()) || node.is_output()) {
     // When dynamic shape node has huge upper boundary which causes bigger mem size than system max allocable mem size, do not allocate in build time.
@@ -2370,7 +2369,7 @@ primitive_inst::primitive_inst(network & network, program_node const& node, bool
     OPENVINO_ASSERT(_max_output_layout_count.size() == get_node().get_output_layouts().size());
 }
 
-memory::ptr primitive_inst::allocate_internal_buffer(const layout& layout, size_t idx, bool reset, bool lockable) {
+memory::ptr primitive_inst::allocate_internal_buffer(const layout& layout, size_t idx, bool reset, bool lockable, bool shareable) {
     if (_impl == nullptr || _outputs.empty() || _outputs[0] == nullptr)
         return nullptr;
 
@@ -2434,7 +2433,7 @@ memory::ptr primitive_inst::allocate_internal_buffer(const layout& layout, size_
                              *_node,
                              layout,
                              alloc_type,
-                             can_share_internal_buffer(),
+                             shareable,
                              _runtime_memory_dependencies,
                              reset,
                              _intermediates_memory.size() > idx ? _intermediates_memory[idx].get() : nullptr);
@@ -2455,7 +2454,7 @@ void primitive_inst::allocate_internal_buffers(bool reset) {
     for (size_t i = 0; i < buffer_descs.size(); ++i) {
         if (buffer_descs[i].m_layout.get_linear_size() == 0)
             continue;
-        intermediates_memory.push_back(allocate_internal_buffer(buffer_descs[i].m_layout, i, reset));
+        intermediates_memory.push_back(allocate_internal_buffer(buffer_descs[i].m_layout, i, reset, buffer_descs[i].m_lockable, buffer_descs[i].m_shareable));
         _max_intermediates_memory_sizes.push_back(intermediates_memory[i]->size());
     }
     _intermediates_memory = intermediates_memory;


### PR DESCRIPTION
### Description of the issue (symptom, root-cause, how it was resolved)
- **Symptom**: On ARL-HX (iGPU) Windows, PagedAttention models consume 3–8 GB extra device memory for intermediate buffers (`exp_sums`, `max_logits`, `tmp_output`), each ~90–235 MB × 36 layers × 3 buffers, all individually allocated without pool reuse.
- **Root cause**: The `paged_attention_node` constructor sets `can_share_internal_buffer(false)` as a blanket disable to prevent sharing of lockable buffers that use CPU `mem_lock<write>` in `prepare_internal_buffers()`. However, this also blocks pool sharing for GPU-only (non-lockable) intermediate buffers that are safe to share. (Introduced in PR #33204)
- **Resolution**: Removed the blanket `can_share_internal_buffer(false)` and instead made the pool-sharing decision per-buffer in `allocate_internal_buffer()`: lockable buffers (`m_lockable=true`) bypass the pool (preserving the original safety intent), while non-lockable buffers participate in `_non_padded_pool` sharing as designed.
- DG2 is unaffected because it uses `sdpa_micro_generate` kernel which does not allocate buf5/6/7.

#### The code and line that caused this issue (if it is not changed directly)
- `intel_gpu/src/graph/paged_attention.cpp` L16: `can_share_internal_buffer(false);`
- `intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp` `get_internal_buffer_descs()` — defines `m_lockable` per buffer descriptor

#### Problematic graph
- Any transformer model with 36+ PagedAttention layers where `pa_multi_tokens` kernel is selected (iGPU path, not `sdpa_micro_generate`)
- Each PA layer allocates ~10 internal buffers; buf5 (`exp_sums`), buf6 (`max_logits`), buf7 (`tmp_output`) are non-lockable GPU-only buffers that should be shared across layers

#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [ ] Did you include test case for this fix, if necessary?
- Unit test is not feasible: requires real GPU hardware, full PA topology compilation, and access to private `_intermediates_memory` / pool internals. No mock engine infrastructure exists. Verified correctness through static code analysis of the `_non_padded_pool` sharing path, `has_conflict()` / `basic_memory_dependencies` restriction sets, and `realloc_intermediates()` lifecycle.
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
- Reviewed `memory_pool` tests in `memory_test.cpp` — tests output buffer pool sharing but not internal buffer lockable/non-lockable distinction.
- Reviewed `paged_attention_gpu_test.cpp` (~5300 lines) — tests PA correctness/accuracy but not memory pool behavior. Existing PA tests serve as regression coverage for this change.

#### Master branch
- https://github.com/openvinotoolkit/openvino/pull/35479

### Tickets:
 - *185192*