### PR TITLE
[GPU] use common shape inference for eltwise validation

### DIFF
--- a/src/plugins/intel_gpu/src/graph/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/eltwise.cpp
@@ -394,35 +394,18 @@ eltwise_inst::typed_primitive_inst(network& network, eltwise_node const& node) :
                                       out_y,
                                       "");
         }
-    } else {
-        bool use_new_shape_infer = network.get_config().get_allow_new_shape_infer();
-        auto input0_pshape = node.get_input_pshape(0);
+    } else if (inputs_count > 1) {
+        ov::op::v1::Add op;
+        op.set_autob(prim->broadcast_spec);
 
+        auto output_shape = node.get_input_pshape(0);
         for (size_t i = 1; i < inputs_count; ++i) {
-            auto input_pshape = node.get_input_pshape(i);
-
-            if (input0_pshape.size() > input_pshape.size()) {
-                if (use_new_shape_infer) {
-                    input_pshape.insert(input_pshape.begin(), input0_pshape.size() - input_pshape.size(), 1);
-                } else {
-                    input_pshape.insert(input_pshape.end(), input0_pshape.size() - input_pshape.size(), 1);
-                }
-            }
-
-            auto base_pshape = input0_pshape;
-            if (prim->broadcast_spec == ov::op::AutoBroadcastType::NUMPY &&
-                base_pshape.size() < input_pshape.size()) {
-                base_pshape.insert(base_pshape.begin(), input_pshape.size() - base_pshape.size(), 1);
-            }
-
-            for (size_t d = 0; d < base_pshape.size(); ++d) {
-                bool sizes_equal = base_pshape[d] == input_pshape[d];
-                bool broadcast =
-                    (base_pshape[d] == 1 || input_pshape[d] == 1) && (base_pshape[d] != 1 || input_pshape[d] != 1);
-                CLDNN_ERROR_BOOL(node.id(),
-                                 "Sizes equal or broadcast is possible",
-                                 !(sizes_equal || broadcast),
-                                 "Invalid input shapes");
+            try {
+                output_shape = ov::op::eltwise_shape_infer(&op,
+                                                           std::vector<ov::PartialShape>{output_shape, node.get_input_pshape(i)})
+                                   .front();
+            } catch (const std::exception& ex) {
+                CLDNN_ERROR_MESSAGE(node.id(), std::string("Invalid input shapes: ") + ex.what());
             }
         }
     }

--- a/src/plugins/intel_gpu/src/graph/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/eltwise.cpp
@@ -397,12 +397,22 @@ eltwise_inst::typed_primitive_inst(network& network, eltwise_node const& node) :
     } else if (inputs_count > 1) {
         ov::op::v1::Add op;
         op.set_autob(prim->broadcast_spec);
+        bool use_new_shape_infer = network.get_config().get_allow_new_shape_infer();
 
         auto output_shape = node.get_input_pshape(0);
         for (size_t i = 1; i < inputs_count; ++i) {
+            auto input_pshape = node.get_input_pshape(i);
+            // cldnn legacy path right-pads the shorter shape with 1s so
+            // per-channel operands (e.g. [1, C, 1, 1]) broadcast against
+            // higher-rank outputs (e.g. [1, C, D, H, W]).
+            if (!use_new_shape_infer && output_shape.size() > input_pshape.size()) {
+                input_pshape.insert(input_pshape.end(),
+                                    output_shape.size() - input_pshape.size(),
+                                    1);
+            }
             try {
                 output_shape = ov::op::eltwise_shape_infer(&op,
-                                                           std::vector<ov::PartialShape>{output_shape, node.get_input_pshape(i)})
+                                                           std::vector<ov::PartialShape>{output_shape, input_pshape})
                                    .front();
             } catch (const std::exception& ex) {
                 CLDNN_ERROR_MESSAGE(node.id(), std::string("Invalid input shapes: ") + ex.what());

--- a/src/plugins/intel_gpu/src/graph/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/eltwise.cpp
@@ -467,7 +467,7 @@ bool eltwise_node::need_align_for_numpy_broadcast(const layout& input) const {
     auto pshape_a_rank = get_input_pshape(0).size();
     auto pshape_b_rank = get_input_pshape(1).size();
     auto small_pshape_rank = (pshape_a_rank > pshape_b_rank) ? pshape_b_rank : pshape_a_rank;
-    if (pshape_a_rank != pshape_b_rank && pshape_a_rank > 1 && pshape_b_rank > 1 &&
+    if (pshape_a_rank != pshape_b_rank && small_pshape_rank > 0 &&
         input.get_partial_shape().rank() == small_pshape_rank)
         return true;
 

--- a/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
@@ -167,7 +167,8 @@ static void CreatePowerOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v1::P
     validate_inputs_count(op, {2});
     auto power_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
     if (power_node) {
-        if (ov::shape_size(power_node->get_output_shape(0)) == 1) {
+        if (ov::shape_size(power_node->get_output_shape(0)) == 1 &&
+            op->get_input_partial_shape(0).same_scheme(op->get_output_partial_shape(0))) {
             float pow;
             if (!ov::op::util::get_single_value(power_node, pow))
                 OPENVINO_THROW("Invalid parameter size in ", op->get_friendly_name(), " (", op->get_type_name(), ")");

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -34,6 +34,10 @@ std::vector<std::vector<ov::Shape>>  inShapes = {
         {{1, 3, 2, 2, 2, 3, 2}, {1, 3, 2, 2, 2, 3, 2}},
 };
 
+std::vector<std::vector<ov::Shape>> numpyBroadcastDivShapes = {
+        {{1, 1, 1, 8}, {1, 4, 1, 8}},
+};
+
 std::vector<ov::test::ElementType> netPrecisions = {
         ov::element::f32,
         ov::element::f16,
@@ -142,5 +146,19 @@ INSTANTIATE_TEST_SUITE_P(smoke_IntModulo_CompareWithRefs,
                                             ::testing::Values(ov::test::utils::DEVICE_GPU),
                                             ::testing::Values(additional_config)),
                          EltwiseLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_NumpyBroadcastDiv,
+    EltwiseLayerTest,
+    ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(numpyBroadcastDivShapes)),
+                       ::testing::Values(EltwiseTypes::DIVIDE),
+                       ::testing::Values(InputLayerType::PARAMETER),
+                       ::testing::Values(OpType::VECTOR),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(ov::element::dynamic),
+                       ::testing::Values(ov::element::dynamic),
+                       ::testing::Values(ov::test::utils::DEVICE_GPU),
+                       ::testing::Values(additional_config)),
+    EltwiseLayerTest::getTestCaseName);
 
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -38,6 +38,10 @@ std::vector<std::vector<ov::Shape>> numpyBroadcastDivShapes = {
         {{1, 1, 1, 8}, {1, 4, 1, 8}},
 };
 
+std::vector<std::vector<ov::Shape>> numpyBroadcastPowerShapes = {
+        {{2}, {1, 1, 1, 1}},
+};
+
 std::vector<ov::test::ElementType> netPrecisions = {
         ov::element::f32,
         ov::element::f16,
@@ -160,5 +164,18 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::test::utils::DEVICE_GPU),
                        ::testing::Values(additional_config)),
     EltwiseLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_NumpyBroadcastPower,
+                         EltwiseLayerTest,
+                         ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(numpyBroadcastPowerShapes)),
+                                            ::testing::Values(EltwiseTypes::POWER),
+                                            ::testing::Values(InputLayerType::CONSTANT),
+                                            ::testing::Values(OpType::VECTOR),
+                                            ::testing::Values(ov::element::f32),
+                                            ::testing::Values(ov::element::dynamic),
+                                            ::testing::Values(ov::element::dynamic),
+                                            ::testing::Values(ov::test::utils::DEVICE_GPU),
+                                            ::testing::Values(additional_config)),
+                         EltwiseLayerTest::getTestCaseName);
 
 }  // namespace


### PR DESCRIPTION
### Details
This PR updates GPU eltwise static shape validation to use the common OpenVINO
eltwise shape inference logic instead of a local manual broadcast check, and
fixes a related Power-op miscompile where a scalar exponent combined with a
broadcast-producing input shape was incorrectly lowered to a unary activation.

The previous GPU validation path rejected a valid NumPy broadcast case for
`Divide` with input shapes:
- `[1, 1, 1, 8]`
- `[1, 4, 1, 8]`

This caused GPU `compile_model()` to fail even though the shape combination is
valid and accepted by common shape inference.

Separately, `CreatePowerOp` lowered `Power` to unary `activation_func::pow`
whenever the exponent was a Constant of `shape_size == 1`, without checking
whether the first input itself is broadcast against the exponent. For shapes
like `input0 = [2]`, `input1 = [1, 1, 1, 1]`, the output must be `[1, 1, 1, 2]`,
but the unary path keeps the input0 layout and produces an incorrect shape.

### Changes
- `src/graph/eltwise.cpp`
  - Replace manual GPU eltwise broadcast validation with `ov::op::eltwise_shape_infer`, folding over all inputs and preserving the primitive `broadcast_spec` via a dummy `ov::op::v1::Add`.
  - Relax `need_align_for_numpy_broadcast` rank guard from `pshape_a_rank > 1 && pshape_b_rank > 1` to `small_pshape_rank > 0`, so rank-1 inputs (e.g. `[2]`) that participate in NumPy broadcast are aligned
    consistently with the common shape inference result.
- `src/plugin/ops/eltwise.cpp`
  - In `CreatePowerOp`, additionally require `input0.partial_shape.same_scheme(output.partial_shape)` before lowering to
    unary `pow`. When the exponent is a scalar Constant but broadcast changes the output shape, fall back to the generic elementwise `pow` path.
- `tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp`
  - Add `smoke_NumpyBroadcastDiv` (`[1,1,1,8]` vs `[1,4,1,8]`) regression for the Divide broadcast case.
  - Add `smoke_NumpyBroadcastPower` (`[2]` vs `[1,1,1,1]` Constant) regression for the Power lowering fix.

### Validation
- Ran targeted regression tests:
  - `ov_gpu_func_tests --gtest_filter='smoke_NumpyBroadcastDiv/*'`
  - `ov_gpu_func_tests --gtest_filter='smoke_NumpyBroadcastPower/*'`

### Tickets:
 - 185355

### AI Assistance:
 - AI assistance used: yes
 - AI: implement/build/tests
 - Human: review
