### PR TITLE
[GPU] Avoid OpenCL build failures in broadcast and integer eltwise kernels

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/broadcast_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/broadcast_gpu_ref.cl
@@ -58,7 +58,7 @@ inline uint FUNC(get_idx_pos)(OPTIONAL_SHAPE_INFO_ARG uint out_b, uint out_f, ui
                          (pad_before_y + idx_y) * y_pitch +
                          (pad_before_x + idx_x) * x_pitch;
 #else  // defined(INPUT0_LAYOUT_BFWZYX) && defined(OUTPUT_LAYOUT_BFWZYX)
-    uint8 input_indices;
+    uint input_indices[6];
 
     input_indices[0] = INPUT0_BATCH_NUM;
     input_indices[1] = INPUT0_FEATURE_NUM;
@@ -139,7 +139,7 @@ inline uint FUNC(get_idx_pos)(OPTIONAL_SHAPE_INFO_ARG uint out_b, uint out_f, ui
                          (pad_before_x + idx_x) * x_pitch;
 
 #else  // defined(INPUT0_LAYOUT_BFZYX) && defined(OUTPUT_LAYOUT_BFZYX)
-    uint8 input_indices;
+    uint input_indices[5];
 
     input_indices[0] = INPUT0_BATCH_NUM;
     input_indices[1] = INPUT0_FEATURE_NUM;
@@ -211,7 +211,7 @@ inline uint FUNC(get_idx_pos)(OPTIONAL_SHAPE_INFO_ARG uint out_b, uint out_f, ui
 
 #else  // defined(INPUT0_LAYOUT_BFYX) && defined(OUTPUT_LAYOUT_BFYX)
 
-    uint4 input_indices;
+    uint input_indices[4];
 
     input_indices[0] = INPUT0_BATCH_NUM;
     input_indices[1] = INPUT0_FEATURE_NUM;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
@@ -241,14 +241,17 @@ JitConstants EltwiseKernelBase::GetOperationsJitConstants(const eltwise_params& 
                 auto input_0_type = params.inputs[0].GetDType();
                 auto input_1_type = params.inputs[1].GetDType();
 
+                auto is_integer_type = [](kernel_selector::Datatype type) {
+                    return type == kernel_selector::Datatype::INT8 || type == kernel_selector::Datatype::UINT8 ||
+                           type == kernel_selector::Datatype::INT16 || type == kernel_selector::Datatype::UINT16 ||
+                           type == kernel_selector::Datatype::INT32 || type == kernel_selector::Datatype::UINT32 ||
+                           type == kernel_selector::Datatype::INT64;
+                };
+
                 // input_0 == int
-                if (input_0_type == kernel_selector::Datatype::INT8 ||
-                    input_0_type == kernel_selector::Datatype::INT32 ||
-                    input_0_type == kernel_selector::Datatype::INT64) {
+                if (is_integer_type(input_0_type)) {
                     // input_0 == int && input_1 == int
-                    if (input_1_type == kernel_selector::Datatype::INT8 ||
-                        input_1_type == kernel_selector::Datatype::INT32 ||
-                        input_1_type == kernel_selector::Datatype::INT64) {
+                    if (is_integer_type(input_1_type)) {
                         if (ew.mode == EltwiseMode::MODULU)
                             op += input0_str + " % " + input1_str;
                         else
@@ -257,9 +260,7 @@ JitConstants EltwiseKernelBase::GetOperationsJitConstants(const eltwise_params& 
                         // input_0 == int && input_1 != int
                         op += cast_type + "f" + mode + "(convert_float(" + input0_str + "), " + input1_str + ")";
                     }
-                } else if (input_1_type == kernel_selector::Datatype::INT8 ||
-                           input_1_type == kernel_selector::Datatype::INT32 ||
-                           input_1_type == kernel_selector::Datatype::INT64) {
+                } else if (is_integer_type(input_1_type)) {
                     // input_0 != int && input_1 == int
                     op += cast_type + "f" + mode + "(" + input0_str + ", convert_float(" + input1_str + "))";
                 } else {

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/broadcast.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/broadcast.cpp
@@ -6,6 +6,11 @@
 
 #include "single_op_tests/broadcast.hpp"
 #include "common_test_utils/test_constants.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/runtime/core.hpp"
 
 namespace {
 using ov::test::BroadcastLayerTest;
@@ -252,5 +257,18 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestExplicitBroadcast3D,
                                            ::testing::ValuesIn(inputPrecisions),
                                            ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         BroadcastLayerTest::getTestCaseName);
+
 // END EXPLICIT MODE ///////////////////////////////////
+
+TEST(smoke_BroadcastExplicit6DReorderedAxes, CompileModel) {
+    const auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::u8, ov::Shape{2, 4, 6, 7});
+    const auto target_shape = ov::op::v0::Constant::create(ov::element::i64, {6}, {2, 3, 4, 5, 6, 7});
+    const auto axes_mapping = ov::op::v0::Constant::create(ov::element::i64, {4}, {0, 2, 4, 5});
+    const auto broadcast = std::make_shared<ov::op::v3::Broadcast>(input, target_shape, axes_mapping, ov::op::BroadcastType::EXPLICIT);
+    const auto result = std::make_shared<ov::op::v0::Result>(broadcast);
+    const auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
+
+    ov::Core core;
+    OV_ASSERT_NO_THROW(core.compile_model(model, ov::test::utils::DEVICE_GPU));
+}
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -77,6 +77,15 @@ std::vector<ov::test::ElementType> intOnly_netPrecisions = {
         ov::element::u16
 };
 
+const std::vector<std::vector<ov::Shape>> intModuloShapes = {
+        {{4, 4}, {4, 4}},
+};
+
+const std::vector<ov::test::ElementType> intModuloPrecisions = {
+        ov::element::u8,
+        ov::element::u16,
+};
+
 ov::AnyMap additional_config = {};
 
 INSTANTIATE_TEST_SUITE_P(
@@ -108,17 +117,30 @@ INSTANTIATE_TEST_SUITE_P(
     EltwiseLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
-    CompareWithRefs,
-    EltwiseLayerTest,
-    ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inShapes)),
-                       ::testing::ValuesIn(eltwiseOpTypes),
-                       ::testing::ValuesIn(secondaryInputTypes),
-                       ::testing::ValuesIn(opTypes),
-                       ::testing::ValuesIn(netPrecisions),
-                       ::testing::Values(ov::element::dynamic),
-                       ::testing::Values(ov::element::dynamic),
-                       ::testing::Values(ov::test::utils::DEVICE_GPU),
-                       ::testing::Values(additional_config)),
-    EltwiseLayerTest::getTestCaseName);
+        CompareWithRefs,
+        EltwiseLayerTest,
+        ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inShapes)),
+                                           ::testing::ValuesIn(eltwiseOpTypes),
+                                           ::testing::ValuesIn(secondaryInputTypes),
+                                           ::testing::ValuesIn(opTypes),
+                                           ::testing::ValuesIn(netPrecisions),
+                                           ::testing::Values(ov::element::dynamic),
+                                           ::testing::Values(ov::element::dynamic),
+                                           ::testing::Values(ov::test::utils::DEVICE_GPU),
+                                           ::testing::Values(additional_config)),
+        EltwiseLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_IntModulo_CompareWithRefs,
+                         EltwiseLayerTest,
+                         ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(intModuloShapes)),
+                                            ::testing::Values(EltwiseTypes::MOD),
+                                            ::testing::Values(InputLayerType::CONSTANT),
+                                            ::testing::Values(OpType::VECTOR),
+                                            ::testing::ValuesIn(intModuloPrecisions),
+                                            ::testing::Values(ov::element::dynamic),
+                                            ::testing::Values(ov::element::dynamic),
+                                            ::testing::Values(ov::test::utils::DEVICE_GPU),
+                                            ::testing::Values(additional_config)),
+                         EltwiseLayerTest::getTestCaseName);
 
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
@@ -4,6 +4,11 @@
 
 #include "single_op_tests/minimum_maximum.hpp"
 #include "common_test_utils/test_constants.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/minimum.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/runtime/core.hpp"
 
 namespace {
 using ov::test::MaxMinLayerTest;
@@ -41,5 +46,27 @@ INSTANTIATE_TEST_SUITE_P(smoke_maximum, MaxMinLayerTest,
                                 ::testing::ValuesIn(second_inputType),
                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         MaxMinLayerTest::getTestCaseName);
+
+template <typename OpType>
+void compile_int_extremum(ov::element::Type precision) {
+    const auto input0 = std::make_shared<ov::op::v0::Parameter>(precision, ov::Shape{4, 4});
+    const auto input1 = std::make_shared<ov::op::v0::Parameter>(precision, ov::Shape{4, 4});
+    const auto extremum = std::make_shared<OpType>(input0, input1);
+    const auto result = std::make_shared<ov::op::v0::Result>(extremum);
+    const auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input0, input1});
+
+    ov::Core core;
+    OV_ASSERT_NO_THROW(core.compile_model(model, ov::test::utils::DEVICE_GPU));
+}
+
+TEST(smoke_IntMinimum, CompileModel) {
+    compile_int_extremum<ov::op::v1::Minimum>(ov::element::u8);
+    compile_int_extremum<ov::op::v1::Minimum>(ov::element::u16);
+}
+
+TEST(smoke_IntMaximum, CompileModel) {
+    compile_int_extremum<ov::op::v1::Maximum>(ov::element::u8);
+    compile_int_extremum<ov::op::v1::Maximum>(ov::element::u16);
+}
 
 }  // namespace


### PR DESCRIPTION
### Details
Fixes #33439.

This PR fixes GPU OpenCL kernel build failures in two generated kernel paths:

* Replaces OpenCL vector dynamic indexing in the broadcast reference kernel with fixed-size index arrays for 4D/5D/6D cases.
* Updates generic eltwise JIT integer detection so `MIN`, `MAX`, and `MODULU` generate integer-safe code for unsigned and 16-bit integer precisions.

### Tests
Added GPU functional regression coverage for:
* 6D explicit broadcast with reordered axes
* `Minimum` / `Maximum` compile checks for `u8` and `u16`
* `Modulo` reference comparison for `u8` and `u16`

### Tickets:
 - 185246

### AI Assistance:
 - AI assistance used: yes
 - AI: implement/build/tests
 - Human: review
