### PR TITLE
[ONNX] Remove warning supression from ONNX wrapper

### DIFF
--- a/thirdparty/onnx/CMakeLists.txt
+++ b/thirdparty/onnx/CMakeLists.txt
@@ -18,11 +18,6 @@ else()
     set(ONNX_USE_LITE_PROTO_DEFAULT ON)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # 4244 conversion from 'XXX' to 'YYY', possible loss of data
-    ov_add_compiler_flags(/wd4244)
-endif()
-
 set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
 set(ONNX_USE_PROTOBUF_SHARED_LIBS OFF CACHE BOOL "Use dynamic protobuf by ONNX library" FORCE)
 set(ONNX_NAMESPACE ${OV_ONNX_NAMESPACE})


### PR DESCRIPTION
### Details:
 - *Remove unnecessary /wd4244 (C4244: possible loss of data) warning suppression from CMakeLists.txt.*
- *The upstream ONNX build (CMakeLists.txt) already suppresses /wd4244 on its own targets via target_compile_options, so ONNX compilation is unaffected.*

### Tickets:
 - *CVS-185008*

### AI Assistance:
 - *AI assistance used: yes*
