### PR TITLE
[TF FE] Add `UnsortedSegmentMax`

### DIFF
--- a/src/frontends/tensorflow/docs/supported_ops.md
+++ b/src/frontends/tensorflow/docs/supported_ops.md
@@ -1368,7 +1368,7 @@ A "supported operation" is one that TensorFlow Frontend can convert to the OpenV
 | Unpack                                                  | YES                           |                               |
 | UnravelIndex                                            | YES                           |                               |
 | UnsortedSegmentJoin                                     | NO                            |                               |
-| UnsortedSegmentMax                                      | NO                            |                               |
+| UnsortedSegmentMax                                      | YES                           |                               |
 | UnsortedSegmentMin                                      | NO                            |                               |
 | UnsortedSegmentProd                                     | NO                            |                               |
 | UnsortedSegmentSum                                      | YES                           |                               |

--- a/src/frontends/tensorflow/src/op_table.cpp
+++ b/src/frontends/tensorflow/src/op_table.cpp
@@ -430,6 +430,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"UniqueWithCounts", CreatorFunction(translate_unique_with_counts_op)},
         {"Unpack", CreatorFunction(translate_unpack_op)},
         {"UnravelIndex", CreatorFunction(translate_unravel_index_op)},
+        {"UnsortedSegmentMax", CreatorFunction(translate_unsorted_segment_max_op)},
         {"UnsortedSegmentSum", CreatorFunction(translate_unsorted_segment_sum_op)},
         {"While", CreatorFunction(translate_while_op)},
         {"Where", CreatorFunction(translate_where_op)},

--- a/src/frontends/tensorflow_common/include/common_op_table.hpp
+++ b/src/frontends/tensorflow_common/include/common_op_table.hpp
@@ -194,6 +194,7 @@ OP_CONVERTER(translate_truncate_mod_op);
 OP_CONVERTER(translate_unique_with_counts_op);
 OP_CONVERTER(translate_unpack_op);
 OP_CONVERTER(translate_unravel_index_op);
+OP_CONVERTER(translate_unsorted_segment_max_op);
 OP_CONVERTER(translate_unsorted_segment_sum_op);
 OP_CONVERTER(translate_where_op);
 OP_CONVERTER(translate_x_div_y_op);

--- a/src/frontends/tensorflow_common/src/op/unsorted_segment_max.cpp
+++ b/src/frontends/tensorflow_common/src/op/unsorted_segment_max.cpp
@@ -1,0 +1,70 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_op_table.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/segment_max.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/topk.hpp"
+#include "utils.hpp"
+
+using namespace std;
+using namespace ov;
+using namespace ov::op;
+
+namespace ov {
+namespace frontend {
+namespace tensorflow {
+namespace op {
+OutputVector translate_unsorted_segment_max_op(const NodeContext& node) {
+    default_op_checks(node, 3, {"UnsortedSegmentMax"});
+    auto data = node.get_input(0);
+    auto segment_ids = node.get_input(1);
+    auto num_segments = node.get_input(2);
+
+    // Flatten segment_ids to 1D for TopK
+    auto const_minus_one = make_shared<v0::Constant>(element::i64, Shape{1}, vector<int64_t>{-1});
+    auto flat_ids = make_shared<v1::Reshape>(segment_ids, const_minus_one, false);
+
+    // Determine K = number of elements
+    auto squeeze_axis = make_shared<v0::Constant>(element::i32, Shape{1}, vector<int32_t>{0});
+    auto ids_shape = make_shared<v3::ShapeOf>(flat_ids, element::i64);
+    auto num_indices = make_shared<v0::Squeeze>(ids_shape, squeeze_axis);
+
+    // Sort segment_ids ascending via TopK(MIN, SORT_VALUES)
+    auto topk = make_shared<v11::TopK>(flat_ids,
+                                       num_indices,
+                                       /*axis=*/0,
+                                       v11::TopK::Mode::MIN,
+                                       v11::TopK::SortType::SORT_VALUES,
+                                       element::i32);
+    auto sorted_segment_ids = topk->output(0);
+    auto sort_permutation = topk->output(1);
+
+    // Gather data in sorted order along axis 0
+    auto gather_axis = make_shared<v0::Constant>(element::i32, Shape{1}, vector<int32_t>{0});
+    auto sorted_data = make_shared<v8::Gather>(data, sort_permutation, gather_axis);
+
+    // Make num_segments a scalar i64 for SegmentMax
+    auto scalar_shape = make_shared<v0::Constant>(element::i32, Shape{0}, vector<int32_t>{});
+    auto num_segments_scalar =
+        make_shared<v1::Reshape>(make_shared<v0::Convert>(num_segments, element::i64), scalar_shape, false);
+
+    // Cast sorted segment ids to i32
+    auto sorted_ids_i32 = make_shared<v0::Convert>(sorted_segment_ids, element::i32);
+
+    // SegmentMax with FillMode::LOWEST: empty segments get the type's minimum value, matching TF
+    auto seg_max =
+        make_shared<v16::SegmentMax>(sorted_data, sorted_ids_i32, num_segments_scalar, FillMode::LOWEST);
+    set_node_name(node.get_name(), seg_max);
+    return {seg_max};
+}
+}  // namespace op
+}  // namespace tensorflow
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/tensorflow_common/src/op/unsorted_segment_max.cpp
+++ b/src/frontends/tensorflow_common/src/op/unsorted_segment_max.cpp
@@ -13,10 +13,6 @@
 #include "openvino/op/topk.hpp"
 #include "utils.hpp"
 
-using namespace std;
-using namespace ov;
-using namespace ov::op;
-
 namespace ov {
 namespace frontend {
 namespace tensorflow {
@@ -27,40 +23,38 @@ OutputVector translate_unsorted_segment_max_op(const NodeContext& node) {
     auto segment_ids = node.get_input(1);
     auto num_segments = node.get_input(2);
 
-    // Flatten segment_ids to 1D for TopK
-    auto const_minus_one = make_shared<v0::Constant>(element::i64, Shape{1}, vector<int64_t>{-1});
-    auto flat_ids = make_shared<v1::Reshape>(segment_ids, const_minus_one, false);
+    auto const_minus_one =
+        std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
+    auto flat_ids = std::make_shared<ov::op::v1::Reshape>(segment_ids, const_minus_one, false);
 
-    // Determine K = number of elements
-    auto squeeze_axis = make_shared<v0::Constant>(element::i32, Shape{1}, vector<int32_t>{0});
-    auto ids_shape = make_shared<v3::ShapeOf>(flat_ids, element::i64);
-    auto num_indices = make_shared<v0::Squeeze>(ids_shape, squeeze_axis);
+    auto squeeze_axis = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{0});
+    auto ids_shape = std::make_shared<ov::op::v3::ShapeOf>(flat_ids, ov::element::i64);
+    auto num_indices = std::make_shared<ov::op::v0::Squeeze>(ids_shape, squeeze_axis);
 
-    // Sort segment_ids ascending via TopK(MIN, SORT_VALUES)
-    auto topk = make_shared<v11::TopK>(flat_ids,
-                                       num_indices,
-                                       /*axis=*/0,
-                                       v11::TopK::Mode::MIN,
-                                       v11::TopK::SortType::SORT_VALUES,
-                                       element::i32);
+    auto topk = std::make_shared<ov::op::v11::TopK>(flat_ids,
+                                                    num_indices,
+                                                    0,
+                                                    ov::op::v11::TopK::Mode::MIN,
+                                                    ov::op::v11::TopK::SortType::SORT_VALUES,
+                                                    ov::element::i32);
     auto sorted_segment_ids = topk->output(0);
     auto sort_permutation = topk->output(1);
 
-    // Gather data in sorted order along axis 0
-    auto gather_axis = make_shared<v0::Constant>(element::i32, Shape{1}, vector<int32_t>{0});
-    auto sorted_data = make_shared<v8::Gather>(data, sort_permutation, gather_axis);
+    auto gather_axis = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int32_t>{0});
+    auto sorted_data = std::make_shared<ov::op::v8::Gather>(data, sort_permutation, gather_axis);
 
-    // Make num_segments a scalar i64 for SegmentMax
-    auto scalar_shape = make_shared<v0::Constant>(element::i32, Shape{0}, vector<int32_t>{});
+    auto scalar_shape = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
     auto num_segments_scalar =
-        make_shared<v1::Reshape>(make_shared<v0::Convert>(num_segments, element::i64), scalar_shape, false);
+        std::make_shared<ov::op::v1::Reshape>(std::make_shared<ov::op::v0::Convert>(num_segments, ov::element::i64),
+                                              scalar_shape,
+                                              false);
 
-    // Cast sorted segment ids to i32
-    auto sorted_ids_i32 = make_shared<v0::Convert>(sorted_segment_ids, element::i32);
+    auto sorted_ids_i32 = std::make_shared<ov::op::v0::Convert>(sorted_segment_ids, ov::element::i32);
 
-    // SegmentMax with FillMode::LOWEST: empty segments get the type's minimum value, matching TF
-    auto seg_max =
-        make_shared<v16::SegmentMax>(sorted_data, sorted_ids_i32, num_segments_scalar, FillMode::LOWEST);
+    auto seg_max = std::make_shared<ov::op::v16::SegmentMax>(sorted_data,
+                                                             sorted_ids_i32,
+                                                             num_segments_scalar,
+                                                             ov::op::FillMode::LOWEST);
     set_node_name(node.get_name(), seg_max);
     return {seg_max};
 }

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
@@ -17,7 +17,6 @@ class TestUnsortedSegmentMax(CommonTFLayerTest):
         segment_ids_shape = inputs_info['segment_ids:0']
         inputs_data = {}
         inputs_data['data:0'] = rng.integers(-50, 50, data_shape).astype(self.data_type)
-        # segment_ids are non-negative for UnsortedSegmentMax (TF requires >= 0)
         inputs_data['segment_ids:0'] = rng.integers(0, self.num_segments_val,
                                                     segment_ids_shape).astype(self.segment_ids_type)
         return inputs_data
@@ -60,7 +59,6 @@ class TestUnsortedSegmentMax(CommonTFLayerTest):
                                                          num_segments_type=num_segments_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
 
-    # Test with empty segments (num_segments > max segment_id) to verify FillMode::LOWEST
     test_data_empty_segments = [
         dict(data_shape=[4], segment_ids_shape=[4], num_segments_val=10),
         dict(data_shape=[3, 5], segment_ids_shape=[3], num_segments_val=8),

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
@@ -52,8 +52,6 @@ class TestUnsortedSegmentMax(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_unsorted_segment_max_basic(self, params, data_type, segment_ids_type, num_segments_type, ie_device,
                                         precision, ir_version, temp_dir):
-        if ie_device == 'GPU':
-            pytest.skip("Operation SegmentMax is not supported on GPU")
         self._test(*self.create_unsorted_segment_max_net(**params,
                                                          data_type=data_type, segment_ids_type=segment_ids_type,
                                                          num_segments_type=num_segments_type),
@@ -68,8 +66,6 @@ class TestUnsortedSegmentMax(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_unsorted_segment_max_empty_segments(self, params, ie_device, precision, ir_version, temp_dir):
-        if ie_device == 'GPU':
-            pytest.skip("Operation SegmentMax is not supported on GPU")
         self._test(*self.create_unsorted_segment_max_net(**params,
                                                          data_type=np.float32, segment_ids_type=np.int32,
                                                          num_segments_type=np.int32),

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
@@ -72,7 +72,7 @@ class TestUnsortedSegmentMax(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_unsorted_segment_max_empty_segments(self, params, ie_device, precision, ir_version, temp_dir):
-        if ie_device == 'GPU':
+        if precision == 'FP16':
             pytest.skip("FP16 lowest fill value differs from FP32 for empty segments")
         self._test(*self.create_unsorted_segment_max_net(**params,
                                                          data_type=np.float32, segment_ids_type=np.int32,

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
@@ -18,9 +18,12 @@ class TestUnsortedSegmentMax(CommonTFLayerTest):
         inputs_data = {}
         inputs_data['data:0'] = rng.integers(-50, 50, data_shape).astype(self.data_type)
         num_ids = segment_ids_shape[0]
-        ids = list(range(self.num_segments_val))
-        ids += rng.integers(0, self.num_segments_val, num_ids - self.num_segments_val).tolist()
-        rng.shuffle(ids)
+        if num_ids >= self.num_segments_val:
+            ids = list(range(self.num_segments_val))
+            ids += rng.integers(0, self.num_segments_val, num_ids - self.num_segments_val).tolist()
+            rng.shuffle(ids)
+        else:
+            ids = rng.integers(0, self.num_segments_val, num_ids).tolist()
         inputs_data['segment_ids:0'] = np.array(ids, dtype=self.segment_ids_type)
         return inputs_data
 

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
@@ -17,8 +17,11 @@ class TestUnsortedSegmentMax(CommonTFLayerTest):
         segment_ids_shape = inputs_info['segment_ids:0']
         inputs_data = {}
         inputs_data['data:0'] = rng.integers(-50, 50, data_shape).astype(self.data_type)
-        inputs_data['segment_ids:0'] = rng.integers(0, self.num_segments_val,
-                                                    segment_ids_shape).astype(self.segment_ids_type)
+        num_ids = segment_ids_shape[0]
+        ids = list(range(self.num_segments_val))
+        ids += rng.integers(0, self.num_segments_val, num_ids - self.num_segments_val).tolist()
+        rng.shuffle(ids)
+        inputs_data['segment_ids:0'] = np.array(ids, dtype=self.segment_ids_type)
         return inputs_data
 
     def create_unsorted_segment_max_net(self, data_shape, segment_ids_shape, num_segments_val, data_type,
@@ -41,7 +44,7 @@ class TestUnsortedSegmentMax(CommonTFLayerTest):
     test_data_basic = [
         dict(data_shape=[8], segment_ids_shape=[8], num_segments_val=5),
         dict(data_shape=[10, 4], segment_ids_shape=[10], num_segments_val=5),
-        dict(data_shape=[5, 6, 7], segment_ids_shape=[5], num_segments_val=8),
+        dict(data_shape=[8, 6, 7], segment_ids_shape=[8], num_segments_val=8),
     ]
 
     @pytest.mark.parametrize("params", test_data_basic)
@@ -66,6 +69,8 @@ class TestUnsortedSegmentMax(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_unsorted_segment_max_empty_segments(self, params, ie_device, precision, ir_version, temp_dir):
+        if ie_device == 'GPU':
+            pytest.skip("FP16 lowest fill value differs from FP32 for empty segments")
         self._test(*self.create_unsorted_segment_max_net(**params,
                                                          data_type=np.float32, segment_ids_type=np.int32,
                                                          num_segments_type=np.int32),

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentMax.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from common.tf_layer_test_class import CommonTFLayerTest
+
+rng = np.random.default_rng(56234)
+
+
+class TestUnsortedSegmentMax(CommonTFLayerTest):
+    def _prepare_input(self, inputs_info):
+        assert 'data:0' in inputs_info, "Test error: inputs_info must contain `data`"
+        assert 'segment_ids:0' in inputs_info, "Test error: inputs_info must contain `segment_ids`"
+        data_shape = inputs_info['data:0']
+        segment_ids_shape = inputs_info['segment_ids:0']
+        inputs_data = {}
+        inputs_data['data:0'] = rng.integers(-50, 50, data_shape).astype(self.data_type)
+        # segment_ids are non-negative for UnsortedSegmentMax (TF requires >= 0)
+        inputs_data['segment_ids:0'] = rng.integers(0, self.num_segments_val,
+                                                    segment_ids_shape).astype(self.segment_ids_type)
+        return inputs_data
+
+    def create_unsorted_segment_max_net(self, data_shape, segment_ids_shape, num_segments_val, data_type,
+                                        segment_ids_type, num_segments_type):
+        self.data_type = data_type
+        self.segment_ids_type = segment_ids_type
+        self.num_segments_val = num_segments_val
+        tf.compat.v1.reset_default_graph()
+        with tf.compat.v1.Session() as sess:
+            data = tf.compat.v1.placeholder(data_type, data_shape, 'data')
+            segment_ids = tf.compat.v1.placeholder(segment_ids_type, segment_ids_shape, 'segment_ids')
+            num_segments = tf.constant(num_segments_val, dtype=num_segments_type, shape=[])
+            tf.raw_ops.UnsortedSegmentMax(data=data, segment_ids=segment_ids, num_segments=num_segments)
+            tf.compat.v1.global_variables_initializer()
+
+            tf_net = sess.graph_def
+
+        return tf_net, None
+
+    test_data_basic = [
+        dict(data_shape=[8], segment_ids_shape=[8], num_segments_val=5),
+        dict(data_shape=[10, 4], segment_ids_shape=[10], num_segments_val=5),
+        dict(data_shape=[5, 6, 7], segment_ids_shape=[5], num_segments_val=8),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_basic)
+    @pytest.mark.parametrize("data_type", [np.float32, np.int32])
+    @pytest.mark.parametrize("segment_ids_type", [np.int32, np.int64])
+    @pytest.mark.parametrize("num_segments_type", [np.int32, np.int64])
+    @pytest.mark.precommit
+    @pytest.mark.nightly
+    def test_unsorted_segment_max_basic(self, params, data_type, segment_ids_type, num_segments_type, ie_device,
+                                        precision, ir_version, temp_dir):
+        if ie_device == 'GPU':
+            pytest.skip("Operation SegmentMax is not supported on GPU")
+        self._test(*self.create_unsorted_segment_max_net(**params,
+                                                         data_type=data_type, segment_ids_type=segment_ids_type,
+                                                         num_segments_type=num_segments_type),
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
+
+    # Test with empty segments (num_segments > max segment_id) to verify FillMode::LOWEST
+    test_data_empty_segments = [
+        dict(data_shape=[4], segment_ids_shape=[4], num_segments_val=10),
+        dict(data_shape=[3, 5], segment_ids_shape=[3], num_segments_val=8),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_empty_segments)
+    @pytest.mark.precommit
+    @pytest.mark.nightly
+    def test_unsorted_segment_max_empty_segments(self, params, ie_device, precision, ir_version, temp_dir):
+        if ie_device == 'GPU':
+            pytest.skip("Operation SegmentMax is not supported on GPU")
+        self._test(*self.create_unsorted_segment_max_net(**params,
+                                                         data_type=np.float32, segment_ids_type=np.int32,
+                                                         num_segments_type=np.int32),
+                   ie_device, precision, ir_version, temp_dir=temp_dir)


### PR DESCRIPTION
### Details:
 - Use existing op `SegmentMax`
 - Needed for model in CVS-173001

### Tickets:
 - CVS-173001

### AI Assistance:
 - *AI assistance used:* yes
 - Subgraph generation for reusing existing op `SegmentMax`
