### PR TITLE
[Transformations] Restore consumers_count predicates in MoE matmuls related transformations

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.cpp
@@ -70,8 +70,8 @@ MOE2GEMMPatternNodes build_2gemm_pattern() {
     MOE2GEMMPatternNodes p;
 
     p.experts_input = pattern::wrap_type<v1::Reshape>({pattern::any_input(), pattern::any_input()});
-    p.tile = pattern::wrap_type<v0::Tile>({p.experts_input, pattern::any_input()});
-    p.after_tile_reshape = pattern::wrap_type<v1::Reshape>({p.tile, pattern::any_input()});
+    p.tile = pattern::wrap_type<v0::Tile>({p.experts_input, pattern::any_input()}, pattern::consumers_count(1));
+    p.after_tile_reshape = pattern::wrap_type<v1::Reshape>({p.tile, pattern::any_input()}, pattern::consumers_count(1));
     p.gate_up_matmul = pattern::wrap_type<v0::MatMul>(
         {p.after_tile_reshape, pattern::any_input()},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
@@ -80,28 +80,31 @@ MOE2GEMMPatternNodes build_2gemm_pattern() {
 
     // Branch 1: Slice_1 -> Clamp -> Add_1
     p.slice1 = pattern::wrap_type<v8::Slice>(
-        {p.gate_up_add, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    p.clamp = pattern::wrap_type<v0::Clamp>({p.slice1});
-    p.add1 = pattern::wrap_type<v1::Add>({p.clamp, pattern::wrap_const()});
+        {p.gate_up_add, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()},
+        pattern::consumers_count(1));
+    p.clamp = pattern::wrap_type<v0::Clamp>({p.slice1}, pattern::consumers_count(1));
+    p.add1 = pattern::wrap_type<v1::Add>({p.clamp, pattern::wrap_const()}, pattern::consumers_count(1));
 
     // Branch 2: Slice_2 -> Minimum_1 -> Swish
     p.slice2 = pattern::wrap_type<v8::Slice>(
-        {p.gate_up_add, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    p.minimum1 = pattern::wrap_type<v1::Minimum>({p.slice2, pattern::wrap_const()});
+        {p.gate_up_add, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()},
+        pattern::consumers_count(1));
+    p.minimum1 = pattern::wrap_type<v1::Minimum>({p.slice2, pattern::wrap_const()}, pattern::consumers_count(1));
     p.swish_beta = pattern::wrap_const();
-    p.swish = pattern::wrap_type<v4::Swish>({p.minimum1, p.swish_beta});
+    p.swish = pattern::wrap_type<v4::Swish>({p.minimum1, p.swish_beta}, pattern::consumers_count(1));
 
     // Join: Multiply_2
-    p.multiply2 = pattern::wrap_type<v1::Multiply>({p.add1, p.swish});
+    p.multiply2 = pattern::wrap_type<v1::Multiply>({p.add1, p.swish}, pattern::consumers_count(1));
 
     // Down projection
     p.down_proj_matmul = pattern::wrap_type<v0::MatMul>(
         {p.multiply2, pattern::any_input()},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
     p.down_proj_bias = pattern::wrap_const();
-    p.down_proj_add = pattern::wrap_type<v1::Add>({p.down_proj_matmul, p.down_proj_bias});
+    p.down_proj_add = pattern::wrap_type<v1::Add>({p.down_proj_matmul, p.down_proj_bias}, pattern::consumers_count(1));
     p.end_reshape_target_shape = pattern::any_input();
-    p.end_reshape = pattern::wrap_type<v1::Reshape>({p.down_proj_add, p.end_reshape_target_shape});
+    p.end_reshape =
+        pattern::wrap_type<v1::Reshape>({p.down_proj_add, p.end_reshape_target_shape}, pattern::consumers_count(1));
 
     // Routing weights/mask
     p.router_topk_indices = pattern::any_input();
@@ -113,8 +116,10 @@ MOE2GEMMPatternNodes build_2gemm_pattern() {
     p.router_reshape = pattern::wrap_type<v1::Reshape>({p.router_transpose, pattern::any_input()});
     p.optional_unsqueeze = pattern::optional<v0::Unsqueeze>({p.router_reshape, pattern::any_input()});
 
-    p.mul3 = pattern::wrap_type<v1::Multiply>({p.end_reshape, p.optional_unsqueeze});
-    p.reduce_sum = pattern::wrap_type<v1::ReduceSum>({p.mul3, pattern::any_input()}, {{"keep_dims", false}});
+    p.mul3 = pattern::wrap_type<v1::Multiply>({p.end_reshape, p.optional_unsqueeze}, pattern::consumers_count(1));
+    p.reduce_sum = pattern::wrap_type<v1::ReduceSum>({p.mul3, pattern::any_input()},
+                                                     pattern::consumers_count(1),
+                                                     {{"keep_dims", false}});
 
     return p;
 }
@@ -133,27 +138,28 @@ MOE3GEMMPatternNodes build_3gemm_pattern() {
     MOE3GEMMPatternNodes p;
 
     p.experts_input = pattern::wrap_type<v1::Reshape>({pattern::any_input(), pattern::any_input()});
-    p.tile = pattern::wrap_type<v0::Tile>({p.experts_input, pattern::any_input()});
-    p.after_tile_reshape = pattern::wrap_type<v1::Reshape>({p.tile, pattern::any_input()});
+    p.tile = pattern::wrap_type<v0::Tile>({p.experts_input, pattern::any_input()}, pattern::consumers_count(1));
+    p.after_tile_reshape = pattern::wrap_type<v1::Reshape>({p.tile, pattern::any_input()}, pattern::consumers_count(2));
 
     // First GEMM (activation gate)
     p.gate_matmul = pattern::wrap_type<v0::MatMul>(
         {p.after_tile_reshape, pattern::any_input()},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
-    p.swish = pattern::wrap_type<v4::Swish>({p.gate_matmul});
+    p.swish = pattern::wrap_type<v4::Swish>({p.gate_matmul}, pattern::consumers_count(1));
     // Second GEMM (up_projection)
     p.up_matmul = pattern::wrap_type<v0::MatMul>(
         {p.after_tile_reshape, pattern::any_input()},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
     // Join: Multiply (SwiGLU)
-    p.swiglu = pattern::wrap_type<v1::Multiply>({p.swish, p.up_matmul});
+    p.swiglu = pattern::wrap_type<v1::Multiply>({p.swish, p.up_matmul}, pattern::consumers_count(1));
 
     // Third GEMM (down_projection)
     p.down_matmul = pattern::wrap_type<v0::MatMul>(
         {p.swiglu, pattern::any_input()},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
     p.end_reshape_target_shape = pattern::any_input();
-    p.end_reshape = pattern::wrap_type<v1::Reshape>({p.down_matmul, p.end_reshape_target_shape});
+    p.end_reshape =
+        pattern::wrap_type<v1::Reshape>({p.down_matmul, p.end_reshape_target_shape}, pattern::consumers_count(1));
 
     // Routing weights/mask
     p.router_topk_indices = pattern::any_input();
@@ -164,8 +170,10 @@ MOE3GEMMPatternNodes build_3gemm_pattern() {
     p.router_reshape = pattern::wrap_type<v1::Reshape>({p.router_transpose, pattern::any_input()});
     p.optional_unsqueeze = pattern::optional<v0::Unsqueeze>({p.router_reshape, pattern::any_input()});
 
-    p.mul3 = pattern::wrap_type<v1::Multiply>({p.end_reshape, p.optional_unsqueeze});
-    p.reduce_sum = pattern::wrap_type<v1::ReduceSum>({p.mul3, pattern::any_input()}, {{"keep_dims", false}});
+    p.mul3 = pattern::wrap_type<v1::Multiply>({p.end_reshape, p.optional_unsqueeze}, pattern::consumers_count(1));
+    p.reduce_sum = pattern::wrap_type<v1::ReduceSum>({p.mul3, pattern::any_input()},
+                                                     pattern::consumers_count(1),
+                                                     {{"keep_dims", false}});
 
     return p;
 }

--- a/src/common/transformations/tests/common_optimizations/convert_tiled_moe_block_to_gather_matmuls_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_tiled_moe_block_to_gather_matmuls_test.cpp
@@ -57,13 +57,30 @@ inline std::ostream& operator<<(std::ostream& os, const MoEType& type) {
     }
 }
 
-using ConvertTiledMoeBlockToGatherMatmulsParams = std::tuple<MoEType,  // moe_type
-                                                             bool,     // use_scatter_v12
-                                                             bool,     // use_broadcast_v3
-                                                             bool,     // skip_unsqueeze
-                                                             bool,     // matmul_transpose_b
-                                                             bool,     // additional_node_consumers
-                                                             bool>;    // transformation_should_be_applied
+enum class AdditionalConsumersMode { NO, MATMULS, AFTER_MATMULS, REDUCE };
+
+inline std::ostream& operator<<(std::ostream& os, const AdditionalConsumersMode& mode) {
+    switch (mode) {
+    case AdditionalConsumersMode::NO:
+        return os << "NO";
+    case AdditionalConsumersMode::MATMULS:
+        return os << "MATMULS";
+    case AdditionalConsumersMode::AFTER_MATMULS:
+        return os << "AFTER_MATMULS";
+    case AdditionalConsumersMode::REDUCE:
+        return os << "REDUCE";
+    default:
+        OPENVINO_THROW("Unsupported AdditionalConsumersMode");
+    }
+}
+
+using ConvertTiledMoeBlockToGatherMatmulsParams = std::tuple<MoEType,                  // moe_type
+                                                             bool,                     // use_scatter_v12
+                                                             bool,                     // use_broadcast_v3
+                                                             bool,                     // skip_unsqueeze
+                                                             bool,                     // matmul_transpose_b
+                                                             AdditionalConsumersMode,  // additional_consumers_mode
+                                                             bool>;  // transformation_should_be_applied
 
 inline std::shared_ptr<ov::Node> build_matmul_weights(const ov::Shape& weights_shape,
                                                       const ov::element::Type& weights_precision,
@@ -84,7 +101,7 @@ inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraph(bool use_scatter_v12,
                                                        bool use_broadcast_v3,
                                                        bool skip_unsqueeze,
                                                        bool matmul_transpose_b,
-                                                       bool additional_node_consumers) {
+                                                       AdditionalConsumersMode additional_consumers_mode) {
     // Fixed values that don't affect pass behavior
     const auto expert_alpha = 1.625f;
     const auto expert_beta = 7.0f;
@@ -280,11 +297,13 @@ inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraph(bool use_scatter_v12,
     ov::ParameterVector params = {input};
     ov::ResultVector results = {std::make_shared<ov::op::v0::Result>(reduce_sum)};
 
-    if (additional_node_consumers) {
-        results.push_back(std::make_shared<ov::op::v0::Result>(after_tile_reshape));
-        results.push_back(std::make_shared<ov::op::v0::Result>(gate_up_add));
-        results.push_back(std::make_shared<ov::op::v0::Result>(multiply2));
-        results.push_back(std::make_shared<ov::op::v0::Result>(down_proj_add));
+    if (additional_consumers_mode == AdditionalConsumersMode::MATMULS) {
+        results.push_back(std::make_shared<ov::op::v0::Result>(gate_up_matmul));
+        results.push_back(std::make_shared<ov::op::v0::Result>(down_proj_matmul));
+    } else if (additional_consumers_mode == AdditionalConsumersMode::AFTER_MATMULS) {
+        results.push_back(std::make_shared<ov::op::v0::Result>(add1));
+    } else if (additional_consumers_mode == AdditionalConsumersMode::REDUCE) {
+        results.push_back(std::make_shared<ov::op::v0::Result>(reduce_sum));
     }
 
     return std::make_shared<ov::Model>(results, params);
@@ -442,7 +461,7 @@ inline std::shared_ptr<ov::Model> initMoE3GeMMSubgraph(bool use_scatter_v12,
                                                        bool use_broadcast_v3,
                                                        bool skip_unsqueeze,
                                                        bool matmul_transpose_b,
-                                                       bool additional_node_consumers) {
+                                                       AdditionalConsumersMode additional_consumers_mode) {
     // Fixed values that don't affect pass behavior
     const ov::PartialShape input_shape = {-1, -1, 256};
     const size_t topk = 4;
@@ -614,13 +633,15 @@ inline std::shared_ptr<ov::Model> initMoE3GeMMSubgraph(bool use_scatter_v12,
     ov::ParameterVector params = {input};
     ov::ResultVector results = {std::make_shared<ov::op::v0::Result>(final_reshape)};
 
-    if (additional_node_consumers) {
-        results.push_back(std::make_shared<ov::op::v0::Result>(after_tile_reshape));
+    if (additional_consumers_mode == AdditionalConsumersMode::MATMULS) {
         results.push_back(std::make_shared<ov::op::v0::Result>(gate_matmul));
-        results.push_back(std::make_shared<ov::op::v0::Result>(swish));
         results.push_back(std::make_shared<ov::op::v0::Result>(up_matmul));
-        results.push_back(std::make_shared<ov::op::v0::Result>(swiglu));
         results.push_back(std::make_shared<ov::op::v0::Result>(down_matmul));
+    } else if (additional_consumers_mode == AdditionalConsumersMode::AFTER_MATMULS) {
+        results.push_back(std::make_shared<ov::op::v0::Result>(swish));
+        results.push_back(std::make_shared<ov::op::v0::Result>(swiglu));
+    } else if (additional_consumers_mode == AdditionalConsumersMode::REDUCE) {
+        results.push_back(std::make_shared<ov::op::v0::Result>(reduce_sum));
     }
 
     return std::make_shared<ov::Model>(results, params);
@@ -756,14 +777,13 @@ public:
                      use_broadcast_v3,
                      skip_unsqueeze,
                      matmul_transpose_b,
-                     additional_node_consumers,
+                     additional_consumers_mode,
                      should_be_applied] = obj.param;
         std::ostringstream result;
         result << "MoEType_" << moe_type << "_ScatterV" << (use_scatter_v12 ? "12" : "3") << "_BroadcastV"
                << (use_broadcast_v3 ? "3" : "1") << "_SkipUnsqueeze_" << (skip_unsqueeze ? "true" : "false")
                << "_MatMulTransposeB_" << (matmul_transpose_b ? "true" : "false") << "_AdditionalConsumers_"
-               << (additional_node_consumers ? "true" : "false") << "_shouldBeApplied_"
-               << (should_be_applied ? "true" : "false");
+               << additional_consumers_mode << "_shouldBeApplied_" << (should_be_applied ? "true" : "false");
         return result.str();
     }
 
@@ -775,7 +795,7 @@ protected:
                      use_broadcast_v3,
                      skip_unsqueeze,
                      matmul_transpose_b,
-                     additional_node_consumers,
+                     additional_consumers_mode,
                      should_be_applied] = this->GetParam();
 
         switch (moe_type) {
@@ -784,14 +804,14 @@ protected:
                                          use_broadcast_v3,
                                          skip_unsqueeze,
                                          matmul_transpose_b,
-                                         additional_node_consumers);
+                                         additional_consumers_mode);
             break;
         case MoEType::MoE3GeMM:
             model = initMoE3GeMMSubgraph(use_scatter_v12,
                                          use_broadcast_v3,
                                          skip_unsqueeze,
                                          matmul_transpose_b,
-                                         additional_node_consumers);
+                                         additional_consumers_mode);
             break;
         default:
             OPENVINO_THROW("Unexpected MoEType value");
@@ -830,7 +850,7 @@ INSTANTIATE_TEST_SUITE_P(ConvertTiledMoeBlockToGatherMatmulsTest_positive_cases,
                                             ::testing::ValuesIn(broadcast_versions),
                                             ::testing::ValuesIn(skip_unsqueeze_versions),
                                             ::testing::Values(true),
-                                            ::testing::Values(false),
+                                            ::testing::Values(AdditionalConsumersMode::NO),
                                             ::testing::Values(true)),
                          ConvertTiledMoeBlockToGatherMatmulsTest::getTestCaseName);
 
@@ -841,7 +861,7 @@ INSTANTIATE_TEST_SUITE_P(ConvertTiledMoeBlockToGatherMatmulsTest_negative_cases_
                                             ::testing::ValuesIn(broadcast_versions),
                                             ::testing::ValuesIn(skip_unsqueeze_versions),
                                             ::testing::Values(false),
-                                            ::testing::Values(false),
+                                            ::testing::Values(AdditionalConsumersMode::NO),
                                             ::testing::Values(false)),
                          ConvertTiledMoeBlockToGatherMatmulsTest::getTestCaseName);
 
@@ -852,7 +872,9 @@ INSTANTIATE_TEST_SUITE_P(ConvertTiledMoeBlockToGatherMatmulsTest_negative_cases_
                                             ::testing::Values(false),
                                             ::testing::Values(false),
                                             ::testing::Values(true),
-                                            ::testing::Values(true),
+                                            ::testing::Values(AdditionalConsumersMode::MATMULS,
+                                                              AdditionalConsumersMode::AFTER_MATMULS,
+                                                              AdditionalConsumersMode::REDUCE),
                                             ::testing::Values(false)),
                          ConvertTiledMoeBlockToGatherMatmulsTest::getTestCaseName);
 }  // namespace


### PR DESCRIPTION
### Details:
 - *Restore consumers count checks introduced in #32805 that were lost during MOE passes refactoring (#34963)*
 - *Extended tests to catch such type of degradations (WIP)*

### Tickets:
 - *CVS-185748*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used to transfer the changes from initial PR with the fix.*
