### PR TITLE
[TF FE] fix out-of-bounds read in RestoreV2 output index parsing

### DIFF
--- a/src/frontends/tensorflow/src/parse_output_index.hpp
+++ b/src/frontends/tensorflow/src/parse_output_index.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cctype>
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+#include <string>
+
+namespace ov {
+namespace frontend {
+namespace tensorflow {
+
+// Strict integer parser for the output-index suffix of a TF node reference
+// like "RestoreV2:3". Returns nullopt for empty / non-numeric / trailing
+// garbage / overflow / out-of-int-range tokens; the caller decides how to
+// react (e.g. throw a frontend exception). Uses strtoll + std::int64_t so
+// the int-range check is meaningful on platforms where long aliases int.
+inline std::optional<int> parse_output_index(const std::string& token) {
+    if (token.empty()) {
+        return std::nullopt;
+    }
+    // strtoll otherwise silently skips leading whitespace; well-formed TF node
+    // references never contain it, so reject it as malformed up front.
+    if (std::isspace(static_cast<unsigned char>(token.front()))) {
+        return std::nullopt;
+    }
+    char* end = nullptr;
+    errno = 0;
+    constexpr auto base = 10;
+    const std::int64_t v = std::strtoll(token.c_str(), &end, base);
+    if (end == token.c_str() || *end != '\0' || errno == ERANGE) {
+        return std::nullopt;
+    }
+    if (v < std::numeric_limits<int>::min() || v > std::numeric_limits<int>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<int>(v);
+}
+
+}  // namespace tensorflow
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <cerrno>
-#include <climits>
-#include <cstdlib>
 #include <fstream>
 #include <string>
 
@@ -15,6 +12,7 @@
 #include "openvino/util/mmap_object.hpp"
 #include "ov_tensorflow/tensor_bundle.pb.h"
 #include "ov_tensorflow/trackable_object_graph.pb.h"
+#include "parse_output_index.hpp"
 #include "tf_utils.hpp"
 
 #ifdef ENABLE_SNAPPY_COMPRESSION
@@ -379,26 +377,22 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
         }
     }
 
+    // RestoreV2 data inputs (per the TF Op definition): prefix(0), tensor_names(1),
+    // shape_and_slices(2). Control inputs ('^'-prefixed) live in the same input list
+    // and are filtered out by the data-port check below.
+    constexpr int tensor_names_index = 1;
+
     const auto get_variable_name = [](const PtrNode::SharedPtrNode& rv2_node, int idx) -> const std::string& {
-        // Pick tensor_names by data-port semantics: RestoreV2 data inputs are
-        // prefix(0), tensor_names(1), shape_and_slices(2). TF GraphDef stores
-        // control inputs in the same input list, prefixed with '^'; skip them
-        // so a crafted node like ["prefix", "^bogus"] cannot have its control
-        // dep silently treated as tensor_names.
-        std::string tn_input_name;
-        int data_idx = 0;
-        for (const auto& in : rv2_node->node->input()) {
-            if (!in.empty() && in[0] == '^') {
-                continue;
-            }
-            if (data_idx++ == 1) {
-                tn_input_name = in;
-                break;
+        std::string tensor_name;
+        if (rv2_node->node->input().size() > tensor_names_index) {
+            const std::string& in = rv2_node->node->input(tensor_names_index);
+            if (!in.empty() && in[0] != '^') {
+                tensor_name = in;
             }
         }
-        FRONT_END_GENERAL_CHECK(!tn_input_name.empty(), "RestoreV2 node is missing tensor_names input");
+        FRONT_END_GENERAL_CHECK(!tensor_name.empty(), "RestoreV2 node is missing tensor_names input");
         std::vector<std::string> parsed;
-        PtrNode::parse_node_name(tn_input_name, parsed);
+        PtrNode::parse_node_name(tensor_name, parsed);
         // Match by local node name on the rv2_node's already-linked inputs. Pointer-based:
         // works in both top-level and StatefulPartitionedCall scopes (the global node dictionary
         // uses prefixed keys for SPC-flattened nodes, but each PtrNode's NodeDef carries its
@@ -415,9 +409,10 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                                 "RestoreV2 tensor_names input not found among RestoreV2 inputs: ",
                                 parsed[0]);
         const auto* tn_node = tn_ptr->node;
-        FRONT_END_GENERAL_CHECK(tn_node->op() == "Const" && tn_node->attr().count("value") > 0,
+        const auto value_attr_it = tn_node->attr().find("value");
+        FRONT_END_GENERAL_CHECK(tn_node->op() == "Const" && value_attr_it != tn_node->attr().end(),
                                 "RestoreV2 tensor_names input is not a Const with 'value' attribute");
-        const auto& tensor = tn_node->attr().at("value").tensor();
+        const auto& tensor = value_attr_it->second.tensor();
         FRONT_END_GENERAL_CHECK(idx >= 0 && idx < tensor.string_val_size(),
                                 "RestoreV2 output index out of range: ",
                                 idx,
@@ -427,13 +422,20 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
         return tensor.string_val(idx);
     };
 
-    const auto parse_output_index = [](const std::string& token) -> int {
-        char* end = nullptr;
-        errno = 0;
-        const long v = std::strtol(token.c_str(), &end, 10);
-        return (end == token.c_str() || *end != '\0' || errno == ERANGE || v > INT_MAX || v < INT_MIN)
-                   ? 0
-                   : static_cast<int>(v);
+    // Parse the integer suffix of a "RestoreV2:N" reference. The colon-less form
+    // (size < 2) implicitly refers to output 0 — preserved here as an explicit
+    // call-site default. Anything past the colon must be a strictly valid in-range
+    // integer; non-numeric, trailing garbage and overflow all throw via
+    // FRONT_END_GENERAL_CHECK below.
+    const auto resolve_output_index = [](const std::vector<std::string>& restore_output) -> int {
+        if (restore_output.size() < 2) {
+            return 0;
+        }
+        const auto parsed = parse_output_index(restore_output.back());
+        FRONT_END_GENERAL_CHECK(parsed.has_value(),
+                                "RestoreV2 output index is not a valid integer: ",
+                                restore_output.back());
+        return *parsed;
     };
 
     for (const auto& node : nodes) {
@@ -463,7 +465,7 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                     FRONT_END_THROW("Unexpected topology near AssignVariableOp");
                 }
 
-                const int output_index = parse_output_index(restore_output[restore_output.size() - 1]);
+                const int output_index = resolve_output_index(restore_output);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
                 variables_map[varhandle_nodes[0]->node->name()] = get_variable_name(restorev2_nodes[0], output_index);
@@ -488,7 +490,7 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 // Expected path is: RestoreV2 -(output_index)-(1)-> Assign
                 PtrNode::parse_node_name(node.second->node->input(1), restore_output);
 
-                const int output_index = parse_output_index(restore_output[restore_output.size() - 1]);
+                const int output_index = resolve_output_index(restore_output);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
                 variables_map[variablev2_nodes[0]->node->name()] = get_variable_name(restorev2_nodes[0], output_index);

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -5,7 +5,6 @@
 #include <cerrno>
 #include <climits>
 #include <cstdlib>
-
 #include <fstream>
 #include <string>
 
@@ -420,9 +419,9 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 FRONT_END_GENERAL_CHECK(restorev2_nodes[0]->inputs.size() > 1,
                                         "RestoreV2 node is missing tensor_names input");
                 const auto& tensor_names_node = restorev2_nodes[0]->inputs[1]->node;
-                FRONT_END_GENERAL_CHECK(tensor_names_node->op() == "Const" &&
-                                            tensor_names_node->attr().count("value") > 0,
-                                        "RestoreV2 tensor_names input is not a Const with 'value' attribute");
+                FRONT_END_GENERAL_CHECK(
+                    tensor_names_node->op() == "Const" && tensor_names_node->attr().count("value") > 0,
+                    "RestoreV2 tensor_names input is not a Const with 'value' attribute");
                 const auto& tensor = tensor_names_node->attr().at("value").tensor();
                 FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
                                         "RestoreV2 output index out of range: ",
@@ -464,9 +463,9 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 FRONT_END_GENERAL_CHECK(restorev2_nodes[0]->inputs.size() > 1,
                                         "RestoreV2 node is missing tensor_names input");
                 const auto& tensor_names_node = restorev2_nodes[0]->inputs[1]->node;
-                FRONT_END_GENERAL_CHECK(tensor_names_node->op() == "Const" &&
-                                            tensor_names_node->attr().count("value") > 0,
-                                        "RestoreV2 tensor_names input is not a Const with 'value' attribute");
+                FRONT_END_GENERAL_CHECK(
+                    tensor_names_node->op() == "Const" && tensor_names_node->attr().count("value") > 0,
+                    "RestoreV2 tensor_names input is not a Const with 'value' attribute");
                 const auto& tensor = tensor_names_node->attr().at("value").tensor();
                 FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
                                         "RestoreV2 output index out of range: ",

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <cerrno>
+#include <climits>
 #include <stdlib.h>
 
 #include <fstream>
@@ -405,7 +407,14 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                     FRONT_END_THROW("Unexpected topology near AssignVariableOp");
                 }
 
-                int output_index = std::atoi(restore_output[restore_output.size() - 1].c_str());
+                const auto& index_str_av = restore_output[restore_output.size() - 1];
+                char* end_av = nullptr;
+                errno = 0;
+                const long parsed_av = std::strtol(index_str_av.c_str(), &end_av, 10);
+                const int output_index =
+                    (end_av == index_str_av.c_str() || errno == ERANGE || parsed_av > INT_MAX || parsed_av < INT_MIN)
+                        ? 0
+                        : static_cast<int>(parsed_av);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
                 const auto& tensor = restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();
@@ -436,7 +445,14 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 // Expected path is: RestoreV2 -(output_index)-(1)-> Assign
                 PtrNode::parse_node_name(node.second->node->input(1), restore_output);
 
-                int output_index = std::atoi(restore_output[restore_output.size() - 1].c_str());
+                const auto& index_str_a = restore_output[restore_output.size() - 1];
+                char* end_a = nullptr;
+                errno = 0;
+                const long parsed_a = std::strtol(index_str_a.c_str(), &end_a, 10);
+                const int output_index =
+                    (end_a == index_str_a.c_str() || errno == ERANGE || parsed_a > INT_MAX || parsed_a < INT_MIN)
+                        ? 0
+                        : static_cast<int>(parsed_a);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
                 const auto& tensor = restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -405,15 +405,14 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                     FRONT_END_THROW("Unexpected topology near AssignVariableOp");
                 }
 
-                FRONT_END_GENERAL_CHECK(restore_output.size() >= 2,
-                                        "RestoreV2 input is missing output index");
+                FRONT_END_GENERAL_CHECK(restore_output.size() >= 2, "RestoreV2 input is missing output index");
                 int output_index = std::atoi(restore_output[restore_output.size() - 1].c_str());
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                const auto& tensor =
-                    restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();
+                const auto& tensor = restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();
                 FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
-                                        "RestoreV2 output index out of range: ", output_index);
+                                        "RestoreV2 output index out of range: ",
+                                        output_index);
                 const auto& variable_name = tensor.string_val(output_index);
 
                 variables_map[varhandle_nodes[0]->node->name()] = variable_name;
@@ -438,15 +437,14 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 // Expected path is: RestoreV2 -(output_index)-(1)-> Assign
                 PtrNode::parse_node_name(node.second->node->input(1), restore_output);
 
-                FRONT_END_GENERAL_CHECK(restore_output.size() >= 2,
-                                        "RestoreV2 input is missing output index");
+                FRONT_END_GENERAL_CHECK(restore_output.size() >= 2, "RestoreV2 input is missing output index");
                 int output_index = std::atoi(restore_output[restore_output.size() - 1].c_str());
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                const auto& tensor =
-                    restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();
+                const auto& tensor = restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();
                 FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
-                                        "RestoreV2 output index out of range: ", output_index);
+                                        "RestoreV2 output index out of range: ",
+                                        output_index);
                 const auto& variable_name = tensor.string_val(output_index);
 
                 variables_map[variablev2_nodes[0]->node->name()] = variable_name;

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -380,9 +380,25 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
     }
 
     const auto get_variable_name = [](const PtrNode::SharedPtrNode& rv2_node, int idx) -> const std::string& {
-        FRONT_END_GENERAL_CHECK(rv2_node->node->input_size() > 1, "RestoreV2 node is missing tensor_names input");
+        // Pick tensor_names by data-port semantics: RestoreV2 data inputs are
+        // prefix(0), tensor_names(1), shape_and_slices(2). TF GraphDef stores
+        // control inputs in the same input list, prefixed with '^'; skip them
+        // so a crafted node like ["prefix", "^bogus"] cannot have its control
+        // dep silently treated as tensor_names.
+        std::string tn_input_name;
+        int data_idx = 0;
+        for (const auto& in : rv2_node->node->input()) {
+            if (!in.empty() && in[0] == '^') {
+                continue;
+            }
+            if (data_idx++ == 1) {
+                tn_input_name = in;
+                break;
+            }
+        }
+        FRONT_END_GENERAL_CHECK(!tn_input_name.empty(), "RestoreV2 node is missing tensor_names input");
         std::vector<std::string> parsed;
-        PtrNode::parse_node_name(rv2_node->node->input(1), parsed);
+        PtrNode::parse_node_name(tn_input_name, parsed);
         // Match by local node name on the rv2_node's already-linked inputs. Pointer-based:
         // works in both top-level and StatefulPartitionedCall scopes (the global node dictionary
         // uses prefixed keys for SPC-flattened nodes, but each PtrNode's NodeDef carries its

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -379,10 +379,8 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
         }
     }
 
-    const auto get_variable_name = [](const PtrNode::SharedPtrNode& rv2_node,
-                                       int idx) -> const std::string& {
-        FRONT_END_GENERAL_CHECK(rv2_node->inputs.size() > 1,
-                                "RestoreV2 node is missing tensor_names input");
+    const auto get_variable_name = [](const PtrNode::SharedPtrNode& rv2_node, int idx) -> const std::string& {
+        FRONT_END_GENERAL_CHECK(rv2_node->inputs.size() > 1, "RestoreV2 node is missing tensor_names input");
         const auto* tn_node = rv2_node->inputs[1]->node;
         FRONT_END_GENERAL_CHECK(tn_node->op() == "Const" && tn_node->attr().count("value") > 0,
                                 "RestoreV2 tensor_names input is not a Const with 'value' attribute");
@@ -424,15 +422,13 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 char* end_av = nullptr;
                 errno = 0;
                 const long parsed_av = std::strtol(index_str_av.c_str(), &end_av, 10);
-                const int output_index =
-                    (end_av == index_str_av.c_str() || *end_av != '\0' || errno == ERANGE ||
-                     parsed_av > INT_MAX || parsed_av < INT_MIN)
-                        ? 0
-                        : static_cast<int>(parsed_av);
+                const int output_index = (end_av == index_str_av.c_str() || *end_av != '\0' || errno == ERANGE ||
+                                          parsed_av > INT_MAX || parsed_av < INT_MIN)
+                                             ? 0
+                                             : static_cast<int>(parsed_av);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                variables_map[varhandle_nodes[0]->node->name()] =
-                    get_variable_name(restorev2_nodes[0], output_index);
+                variables_map[varhandle_nodes[0]->node->name()] = get_variable_name(restorev2_nodes[0], output_index);
             }
         } else if (node.second->op() == "Assign") {
             std::vector<PtrNode::SharedPtrNode> restorev2_nodes;
@@ -458,15 +454,13 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 char* end_a = nullptr;
                 errno = 0;
                 const long parsed_a = std::strtol(index_str_a.c_str(), &end_a, 10);
-                const int output_index =
-                    (end_a == index_str_a.c_str() || *end_a != '\0' || errno == ERANGE ||
-                     parsed_a > INT_MAX || parsed_a < INT_MIN)
-                        ? 0
-                        : static_cast<int>(parsed_a);
+                const int output_index = (end_a == index_str_a.c_str() || *end_a != '\0' || errno == ERANGE ||
+                                          parsed_a > INT_MAX || parsed_a < INT_MIN)
+                                             ? 0
+                                             : static_cast<int>(parsed_a);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                variables_map[variablev2_nodes[0]->node->name()] =
-                    get_variable_name(restorev2_nodes[0], output_index);
+                variables_map[variablev2_nodes[0]->node->name()] = get_variable_name(restorev2_nodes[0], output_index);
             }
         } else if (node.second->op() == "LookupTableImportV2") {
             std::vector<PtrNode::SharedPtrNode> hash_tablev2_nodes;

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -380,8 +380,7 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
     }
 
     const auto get_variable_name = [&nodes](const PtrNode::SharedPtrNode& rv2_node, int idx) -> const std::string& {
-        FRONT_END_GENERAL_CHECK(rv2_node->node->input_size() > 1,
-                                "RestoreV2 node is missing tensor_names input");
+        FRONT_END_GENERAL_CHECK(rv2_node->node->input_size() > 1, "RestoreV2 node is missing tensor_names input");
         std::vector<std::string> parsed;
         PtrNode::parse_node_name(rv2_node->node->input(1), parsed);
         const auto it = nodes.find(parsed[0]);

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -23,6 +23,13 @@ namespace ov {
 namespace frontend {
 namespace tensorflow {
 
+namespace {
+// RestoreV2 data inputs (per the TF Op definition): prefix(0), tensor_names(1),
+// shape_and_slices(2). Control inputs ('^'-prefixed) live in the same input list
+// and are filtered out by the data-port check below.
+constexpr int tensor_names_index = 1;
+}  // namespace
+
 void VariablesIndex::read_variables_index_block(std::ifstream& fs,
                                                 const VIBlock& index,
                                                 std::vector<char>& data,
@@ -377,12 +384,7 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
         }
     }
 
-    // RestoreV2 data inputs (per the TF Op definition): prefix(0), tensor_names(1),
-    // shape_and_slices(2). Control inputs ('^'-prefixed) live in the same input list
-    // and are filtered out by the data-port check below.
-    constexpr int tensor_names_index = 1;
-
-    const auto get_variable_name = [](const PtrNode::SharedPtrNode& rv2_node, int idx) -> const std::string& {
+    const auto get_variable_name = [](const PtrNode::SharedPtrNode& rv2_node, int idx) -> std::string {
         std::string tensor_name;
         if (rv2_node->node->input().size() > tensor_names_index) {
             const std::string& in = rv2_node->node->input(tensor_names_index);

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -379,9 +379,16 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
         }
     }
 
-    const auto get_variable_name = [](const PtrNode::SharedPtrNode& rv2_node, int idx) -> const std::string& {
-        FRONT_END_GENERAL_CHECK(rv2_node->inputs.size() > 1, "RestoreV2 node is missing tensor_names input");
-        const auto* tn_node = rv2_node->inputs[1]->node;
+    const auto get_variable_name = [&nodes](const PtrNode::SharedPtrNode& rv2_node, int idx) -> const std::string& {
+        FRONT_END_GENERAL_CHECK(rv2_node->node->input_size() > 1,
+                                "RestoreV2 node is missing tensor_names input");
+        std::vector<std::string> parsed;
+        PtrNode::parse_node_name(rv2_node->node->input(1), parsed);
+        const auto it = nodes.find(parsed[0]);
+        FRONT_END_GENERAL_CHECK(it != nodes.end(),
+                                "RestoreV2 tensor_names input not found in node dictionary: ",
+                                parsed[0]);
+        const auto* tn_node = it->second->node;
         FRONT_END_GENERAL_CHECK(tn_node->op() == "Const" && tn_node->attr().count("value") > 0,
                                 "RestoreV2 tensor_names input is not a Const with 'value' attribute");
         const auto& tensor = tn_node->attr().at("value").tensor();

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -379,15 +379,26 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
         }
     }
 
-    const auto get_variable_name = [&nodes](const PtrNode::SharedPtrNode& rv2_node, int idx) -> const std::string& {
+    const auto get_variable_name = [](const PtrNode::SharedPtrNode& rv2_node, int idx) -> const std::string& {
         FRONT_END_GENERAL_CHECK(rv2_node->node->input_size() > 1, "RestoreV2 node is missing tensor_names input");
         std::vector<std::string> parsed;
         PtrNode::parse_node_name(rv2_node->node->input(1), parsed);
-        const auto it = nodes.find(parsed[0]);
-        FRONT_END_GENERAL_CHECK(it != nodes.end(),
-                                "RestoreV2 tensor_names input not found in node dictionary: ",
+        // Match by local node name on the rv2_node's already-linked inputs. Pointer-based:
+        // works in both top-level and StatefulPartitionedCall scopes (the global node dictionary
+        // uses prefixed keys for SPC-flattened nodes, but each PtrNode's NodeDef carries its
+        // local name in both cases). Also catches the case where associate_node compacted the
+        // inputs vector and inputs[1] silently refers to a non-tensor_names Const.
+        PtrNode::SharedPtrNode tn_ptr = nullptr;
+        for (const auto& input : rv2_node->inputs) {
+            if (input->node->name() == parsed[0]) {
+                tn_ptr = input;
+                break;
+            }
+        }
+        FRONT_END_GENERAL_CHECK(tn_ptr != nullptr,
+                                "RestoreV2 tensor_names input not found among RestoreV2 inputs: ",
                                 parsed[0]);
-        const auto* tn_node = it->second->node;
+        const auto* tn_node = tn_ptr->node;
         FRONT_END_GENERAL_CHECK(tn_node->op() == "Const" && tn_node->attr().count("value") > 0,
                                 "RestoreV2 tensor_names input is not a Const with 'value' attribute");
         const auto& tensor = tn_node->attr().at("value").tensor();

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -4,7 +4,7 @@
 
 #include <cerrno>
 #include <climits>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <fstream>
 #include <string>
@@ -417,7 +417,13 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                         : static_cast<int>(parsed_av);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                const auto& tensor = restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();
+                FRONT_END_GENERAL_CHECK(restorev2_nodes[0]->inputs.size() > 1,
+                                        "RestoreV2 node is missing tensor_names input");
+                const auto& tensor_names_node = restorev2_nodes[0]->inputs[1]->node;
+                FRONT_END_GENERAL_CHECK(tensor_names_node->op() == "Const" &&
+                                            tensor_names_node->attr().count("value") > 0,
+                                        "RestoreV2 tensor_names input is not a Const with 'value' attribute");
+                const auto& tensor = tensor_names_node->attr().at("value").tensor();
                 FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
                                         "RestoreV2 output index out of range: ",
                                         output_index);
@@ -455,7 +461,13 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                         : static_cast<int>(parsed_a);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                const auto& tensor = restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();
+                FRONT_END_GENERAL_CHECK(restorev2_nodes[0]->inputs.size() > 1,
+                                        "RestoreV2 node is missing tensor_names input");
+                const auto& tensor_names_node = restorev2_nodes[0]->inputs[1]->node;
+                FRONT_END_GENERAL_CHECK(tensor_names_node->op() == "Const" &&
+                                            tensor_names_node->attr().count("value") > 0,
+                                        "RestoreV2 tensor_names input is not a Const with 'value' attribute");
+                const auto& tensor = tensor_names_node->attr().at("value").tensor();
                 FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
                                         "RestoreV2 output index out of range: ",
                                         output_index);

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -405,11 +405,16 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                     FRONT_END_THROW("Unexpected topology near AssignVariableOp");
                 }
 
+                FRONT_END_GENERAL_CHECK(restore_output.size() >= 2,
+                                        "RestoreV2 input is missing output index");
                 int output_index = std::atoi(restore_output[restore_output.size() - 1].c_str());
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                const auto& variable_name =
-                    restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor().string_val(output_index);
+                const auto& tensor =
+                    restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();
+                FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
+                                        "RestoreV2 output index out of range: ", output_index);
+                const auto& variable_name = tensor.string_val(output_index);
 
                 variables_map[varhandle_nodes[0]->node->name()] = variable_name;
             }
@@ -433,11 +438,16 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 // Expected path is: RestoreV2 -(output_index)-(1)-> Assign
                 PtrNode::parse_node_name(node.second->node->input(1), restore_output);
 
+                FRONT_END_GENERAL_CHECK(restore_output.size() >= 2,
+                                        "RestoreV2 input is missing output index");
                 int output_index = std::atoi(restore_output[restore_output.size() - 1].c_str());
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                const auto& variable_name =
-                    restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor().string_val(output_index);
+                const auto& tensor =
+                    restorev2_nodes[0]->inputs[1]->node->attr().at("value").tensor();
+                FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
+                                        "RestoreV2 output index out of range: ", output_index);
+                const auto& variable_name = tensor.string_val(output_index);
 
                 variables_map[variablev2_nodes[0]->node->name()] = variable_name;
             }

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -405,7 +405,6 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                     FRONT_END_THROW("Unexpected topology near AssignVariableOp");
                 }
 
-                FRONT_END_GENERAL_CHECK(restore_output.size() >= 2, "RestoreV2 input is missing output index");
                 int output_index = std::atoi(restore_output[restore_output.size() - 1].c_str());
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
@@ -437,7 +436,6 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 // Expected path is: RestoreV2 -(output_index)-(1)-> Assign
                 PtrNode::parse_node_name(node.second->node->input(1), restore_output);
 
-                FRONT_END_GENERAL_CHECK(restore_output.size() >= 2, "RestoreV2 input is missing output index");
                 int output_index = std::atoi(restore_output[restore_output.size() - 1].c_str());
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -387,8 +387,20 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
         const auto& tensor = tn_node->attr().at("value").tensor();
         FRONT_END_GENERAL_CHECK(idx >= 0 && idx < tensor.string_val_size(),
                                 "RestoreV2 output index out of range: ",
-                                idx);
+                                idx,
+                                " (size=",
+                                tensor.string_val_size(),
+                                ")");
         return tensor.string_val(idx);
+    };
+
+    const auto parse_output_index = [](const std::string& token) -> int {
+        char* end = nullptr;
+        errno = 0;
+        const long v = std::strtol(token.c_str(), &end, 10);
+        return (end == token.c_str() || *end != '\0' || errno == ERANGE || v > INT_MAX || v < INT_MIN)
+                   ? 0
+                   : static_cast<int>(v);
     };
 
     for (const auto& node : nodes) {
@@ -418,14 +430,7 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                     FRONT_END_THROW("Unexpected topology near AssignVariableOp");
                 }
 
-                const auto& index_str_av = restore_output[restore_output.size() - 1];
-                char* end_av = nullptr;
-                errno = 0;
-                const long parsed_av = std::strtol(index_str_av.c_str(), &end_av, 10);
-                const int output_index = (end_av == index_str_av.c_str() || *end_av != '\0' || errno == ERANGE ||
-                                          parsed_av > INT_MAX || parsed_av < INT_MIN)
-                                             ? 0
-                                             : static_cast<int>(parsed_av);
+                const int output_index = parse_output_index(restore_output[restore_output.size() - 1]);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
                 variables_map[varhandle_nodes[0]->node->name()] = get_variable_name(restorev2_nodes[0], output_index);
@@ -450,14 +455,7 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 // Expected path is: RestoreV2 -(output_index)-(1)-> Assign
                 PtrNode::parse_node_name(node.second->node->input(1), restore_output);
 
-                const auto& index_str_a = restore_output[restore_output.size() - 1];
-                char* end_a = nullptr;
-                errno = 0;
-                const long parsed_a = std::strtol(index_str_a.c_str(), &end_a, 10);
-                const int output_index = (end_a == index_str_a.c_str() || *end_a != '\0' || errno == ERANGE ||
-                                          parsed_a > INT_MAX || parsed_a < INT_MIN)
-                                             ? 0
-                                             : static_cast<int>(parsed_a);
+                const int output_index = parse_output_index(restore_output[restore_output.size() - 1]);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
                 variables_map[variablev2_nodes[0]->node->name()] = get_variable_name(restorev2_nodes[0], output_index);

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -379,6 +379,20 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
         }
     }
 
+    const auto get_variable_name = [](const PtrNode::SharedPtrNode& rv2_node,
+                                       int idx) -> const std::string& {
+        FRONT_END_GENERAL_CHECK(rv2_node->inputs.size() > 1,
+                                "RestoreV2 node is missing tensor_names input");
+        const auto* tn_node = rv2_node->inputs[1]->node;
+        FRONT_END_GENERAL_CHECK(tn_node->op() == "Const" && tn_node->attr().count("value") > 0,
+                                "RestoreV2 tensor_names input is not a Const with 'value' attribute");
+        const auto& tensor = tn_node->attr().at("value").tensor();
+        FRONT_END_GENERAL_CHECK(idx >= 0 && idx < tensor.string_val_size(),
+                                "RestoreV2 output index out of range: ",
+                                idx);
+        return tensor.string_val(idx);
+    };
+
     for (const auto& node : nodes) {
         if (node.second->op() == "AssignVariableOp") {
             // TODO: assets reading
@@ -411,24 +425,14 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 errno = 0;
                 const long parsed_av = std::strtol(index_str_av.c_str(), &end_av, 10);
                 const int output_index =
-                    (end_av == index_str_av.c_str() || errno == ERANGE || parsed_av > INT_MAX || parsed_av < INT_MIN)
+                    (end_av == index_str_av.c_str() || *end_av != '\0' || errno == ERANGE ||
+                     parsed_av > INT_MAX || parsed_av < INT_MIN)
                         ? 0
                         : static_cast<int>(parsed_av);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                FRONT_END_GENERAL_CHECK(restorev2_nodes[0]->inputs.size() > 1,
-                                        "RestoreV2 node is missing tensor_names input");
-                const auto& tensor_names_node = restorev2_nodes[0]->inputs[1]->node;
-                FRONT_END_GENERAL_CHECK(
-                    tensor_names_node->op() == "Const" && tensor_names_node->attr().count("value") > 0,
-                    "RestoreV2 tensor_names input is not a Const with 'value' attribute");
-                const auto& tensor = tensor_names_node->attr().at("value").tensor();
-                FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
-                                        "RestoreV2 output index out of range: ",
-                                        output_index);
-                const auto& variable_name = tensor.string_val(output_index);
-
-                variables_map[varhandle_nodes[0]->node->name()] = variable_name;
+                variables_map[varhandle_nodes[0]->node->name()] =
+                    get_variable_name(restorev2_nodes[0], output_index);
             }
         } else if (node.second->op() == "Assign") {
             std::vector<PtrNode::SharedPtrNode> restorev2_nodes;
@@ -455,24 +459,14 @@ void VariablesIndex::map_assignvariable(const std::shared_ptr<::tensorflow::Grap
                 errno = 0;
                 const long parsed_a = std::strtol(index_str_a.c_str(), &end_a, 10);
                 const int output_index =
-                    (end_a == index_str_a.c_str() || errno == ERANGE || parsed_a > INT_MAX || parsed_a < INT_MIN)
+                    (end_a == index_str_a.c_str() || *end_a != '\0' || errno == ERANGE ||
+                     parsed_a > INT_MAX || parsed_a < INT_MIN)
                         ? 0
                         : static_cast<int>(parsed_a);
 
                 // Expected path is: Const(tensor_names) -(0)-(1)-> RestoreV2
-                FRONT_END_GENERAL_CHECK(restorev2_nodes[0]->inputs.size() > 1,
-                                        "RestoreV2 node is missing tensor_names input");
-                const auto& tensor_names_node = restorev2_nodes[0]->inputs[1]->node;
-                FRONT_END_GENERAL_CHECK(
-                    tensor_names_node->op() == "Const" && tensor_names_node->attr().count("value") > 0,
-                    "RestoreV2 tensor_names input is not a Const with 'value' attribute");
-                const auto& tensor = tensor_names_node->attr().at("value").tensor();
-                FRONT_END_GENERAL_CHECK(output_index >= 0 && output_index < tensor.string_val_size(),
-                                        "RestoreV2 output index out of range: ",
-                                        output_index);
-                const auto& variable_name = tensor.string_val(output_index);
-
-                variables_map[variablev2_nodes[0]->node->name()] = variable_name;
+                variables_map[variablev2_nodes[0]->node->name()] =
+                    get_variable_name(restorev2_nodes[0], output_index);
             }
         } else if (node.second->op() == "LookupTableImportV2") {
             std::vector<PtrNode::SharedPtrNode> hash_tablev2_nodes;

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -296,14 +296,14 @@ TEST(FrontEndConvertModelTest, SavedModelOobRestoreV2ShortInputs) {
 // node exists in the GraphDef.  shape_and_slices is a Const that occupies the
 // inputs[1] slot in the compacted PtrNode::inputs vector — a buggy
 // implementation that resolves tensor_names via inputs[1] would silently use
-// shape_and_slices.  Resolving by name through the nodes dictionary makes the
-// missing input explicit.
+// shape_and_slices.  Resolving by matching node->name() across rv2_node->inputs
+// makes the missing input explicit.
 TEST(FrontEndConvertModelTest, SavedModelOobRestoreV2WrongInputAtPort1) {
     try {
         convert_model("saved_model_oob_wrong_input_at_port1");
         FAIL() << "Expected exception when RestoreV2 tensor_names input node is absent";
     } catch (const ov::Exception& e) {
-        EXPECT_TRUE(string(e.what()).find("not found in node dictionary") != string::npos)
+        EXPECT_TRUE(string(e.what()).find("not found among RestoreV2 inputs") != string::npos)
             << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -224,8 +224,7 @@ TEST(FrontEndConvertModelTest, SavedModelOobPositiveIndex) {
         convert_model("saved_model_oob_pos_index");
         FAIL() << "Expected exception for OOB positive RestoreV2 output index";
     } catch (const ov::Exception& e) {
-        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos)
-            << "Unexpected error message: " << e.what();
+        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos) << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();
     } catch (...) {
@@ -239,8 +238,7 @@ TEST(FrontEndConvertModelTest, SavedModelOobNegativeIndex) {
         convert_model("saved_model_oob_neg_index");
         FAIL() << "Expected exception for negative RestoreV2 output index";
     } catch (const ov::Exception& e) {
-        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos)
-            << "Unexpected error message: " << e.what();
+        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos) << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();
     } catch (...) {
@@ -256,8 +254,7 @@ TEST(FrontEndConvertModelTest, SavedModelOobEmptyTensorNames) {
         convert_model("saved_model_oob_empty_names");
         FAIL() << "Expected exception for OOB index into empty tensor_names";
     } catch (const ov::Exception& e) {
-        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos)
-            << "Unexpected error message: " << e.what();
+        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos) << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();
     } catch (...) {
@@ -273,8 +270,7 @@ TEST(FrontEndConvertModelTest, SavedModelOobAssignPath) {
         convert_model("saved_model_oob_assign_path");
         FAIL() << "Expected exception for OOB RestoreV2 output index in Assign path";
     } catch (const ov::Exception& e) {
-        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos)
-            << "Unexpected error message: " << e.what();
+        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos) << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();
     } catch (...) {

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -217,6 +217,62 @@ TEST(FrontEndConvertModelTest, SavedModelMaliciousOverflowOffset) {
     }
 }
 
+// Crafted SavedModel where AssignVariableOp input references "save/RestoreV2:999"
+// but the Const(tensor_names) has only 1 string_val entry → OOB positive index.
+TEST(FrontEndConvertModelTest, SavedModelOobPositiveIndex) {
+    shared_ptr<Model> model = nullptr;
+    try {
+        model = convert_model("saved_model_oob_pos_index");
+        FAIL() << "Expected exception for OOB positive RestoreV2 output index";
+    } catch (const ov::Exception& e) {
+        string msg = e.what();
+        EXPECT_TRUE(msg.find("out of range") != string::npos || msg.find("missing") != string::npos)
+            << "Unexpected error message: " << msg;
+        EXPECT_EQ(model, nullptr);
+    } catch (const std::exception& e) {
+        FAIL() << "Unexpected std::exception: " << e.what();
+    } catch (...) {
+        FAIL() << "Unexpected non-std exception";
+    }
+}
+
+// Crafted SavedModel where AssignVariableOp input references "save/RestoreV2:-1" → negative OOB.
+TEST(FrontEndConvertModelTest, SavedModelOobNegativeIndex) {
+    shared_ptr<Model> model = nullptr;
+    try {
+        model = convert_model("saved_model_oob_neg_index");
+        FAIL() << "Expected exception for negative RestoreV2 output index";
+    } catch (const ov::Exception& e) {
+        string msg = e.what();
+        EXPECT_TRUE(msg.find("out of range") != string::npos || msg.find("missing") != string::npos)
+            << "Unexpected error message: " << msg;
+        EXPECT_EQ(model, nullptr);
+    } catch (const std::exception& e) {
+        FAIL() << "Unexpected std::exception: " << e.what();
+    } catch (...) {
+        FAIL() << "Unexpected non-std exception";
+    }
+}
+
+// Crafted SavedModel where AssignVariableOp input references "save/RestoreV2" (no colon)
+// → parse_node_name produces only 1 token → size<2 guard fires.
+TEST(FrontEndConvertModelTest, SavedModelOobMissingColon) {
+    shared_ptr<Model> model = nullptr;
+    try {
+        model = convert_model("saved_model_oob_no_colon");
+        FAIL() << "Expected exception for RestoreV2 input without output index";
+    } catch (const ov::Exception& e) {
+        string msg = e.what();
+        EXPECT_TRUE(msg.find("out of range") != string::npos || msg.find("missing") != string::npos)
+            << "Unexpected error message: " << msg;
+        EXPECT_EQ(model, nullptr);
+    } catch (const std::exception& e) {
+        FAIL() << "Unexpected std::exception: " << e.what();
+    } catch (...) {
+        FAIL() << "Unexpected non-std exception";
+    }
+}
+
 // Same test with mmap disabled to verify the stream code path is also protected
 TEST(FrontEndConvertModelTest, SavedModelMaliciousOverflowOffsetNoMmap) {
     shared_ptr<Model> model = nullptr;

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -254,16 +254,17 @@ TEST(FrontEndConvertModelTest, SavedModelOobNegativeIndex) {
     }
 }
 
-// Crafted SavedModel where AssignVariableOp input references "save/RestoreV2" (no colon)
-// → parse_node_name produces only 1 token → size<2 guard fires.
-TEST(FrontEndConvertModelTest, SavedModelOobMissingColon) {
+// Crafted SavedModel where AssignVariableOp input references "save/RestoreV2:0" but
+// Const(tensor_names) has zero string_val entries → upper-bound guard fires at index 0.
+// This exercises the security check on the implicit-0 code path.
+TEST(FrontEndConvertModelTest, SavedModelOobEmptyTensorNames) {
     shared_ptr<Model> model = nullptr;
     try {
-        model = convert_model("saved_model_oob_no_colon");
-        FAIL() << "Expected exception for RestoreV2 input without output index";
+        model = convert_model("saved_model_oob_empty_names");
+        FAIL() << "Expected exception for OOB index into empty tensor_names";
     } catch (const ov::Exception& e) {
         string msg = e.what();
-        EXPECT_TRUE(msg.find("out of range") != string::npos || msg.find("missing") != string::npos)
+        EXPECT_TRUE(msg.find("out of range") != string::npos)
             << "Unexpected error message: " << msg;
         EXPECT_EQ(model, nullptr);
     } catch (const std::exception& e) {

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -312,6 +312,27 @@ TEST(FrontEndConvertModelTest, SavedModelOobRestoreV2WrongInputAtPort1) {
     }
 }
 
+// Crafted SavedModel where RestoreV2.input(1) is a control dep (`^bogus`) and
+// `bogus` is a Const with non-empty `string_val`.  parse_node_name strips the
+// `^`, and associate_node has already linked `bogus` into rv2_node->inputs, so
+// a buggy implementation that pulls the candidate from node->input(1) without
+// checking for the `^` prefix would silently bind the variable to bogus's
+// first string_val.  The fix iterates node->input() and skips control inputs,
+// finds only one data input ('prefix'), and throws.
+TEST(FrontEndConvertModelTest, SavedModelOobRestoreV2ControlDepAtPort1) {
+    try {
+        convert_model("saved_model_oob_control_dep_at_port1");
+        FAIL() << "Expected exception when RestoreV2.input(1) is a control dep";
+    } catch (const ov::Exception& e) {
+        EXPECT_TRUE(string(e.what()).find("missing tensor_names input") != string::npos)
+            << "Unexpected error message: " << e.what();
+    } catch (const std::exception& e) {
+        FAIL() << "Unexpected std::exception: " << e.what();
+    } catch (...) {
+        FAIL() << "Unexpected non-std exception";
+    }
+}
+
 // Same test with mmap disabled to verify the stream code path is also protected
 TEST(FrontEndConvertModelTest, SavedModelMaliciousOverflowOffsetNoMmap) {
     shared_ptr<Model> model = nullptr;

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -273,6 +273,25 @@ TEST(FrontEndConvertModelTest, SavedModelOobEmptyTensorNames) {
     }
 }
 
+// Crafted TF1-style SavedModel where Assign.input(1) = "save/RestoreV2:999" but
+// Const(tensor_names) has only 1 string_val entry → exercises the Assign code path
+// in map_assignvariable() (distinct from the AssignVariableOp path in other OOB tests).
+TEST(FrontEndConvertModelTest, SavedModelOobAssignPath) {
+    shared_ptr<Model> model = nullptr;
+    try {
+        model = convert_model("saved_model_oob_assign_path");
+        FAIL() << "Expected exception for OOB RestoreV2 output index in Assign path";
+    } catch (const ov::Exception& e) {
+        string msg = e.what();
+        EXPECT_TRUE(msg.find("out of range") != string::npos) << "Unexpected error message: " << msg;
+        EXPECT_EQ(model, nullptr);
+    } catch (const std::exception& e) {
+        FAIL() << "Unexpected std::exception: " << e.what();
+    } catch (...) {
+        FAIL() << "Unexpected non-std exception";
+    }
+}
+
 // Same test with mmap disabled to verify the stream code path is also protected
 TEST(FrontEndConvertModelTest, SavedModelMaliciousOverflowOffsetNoMmap) {
     shared_ptr<Model> model = nullptr;

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -292,6 +292,26 @@ TEST(FrontEndConvertModelTest, SavedModelOobRestoreV2ShortInputs) {
     }
 }
 
+// Crafted SavedModel where RestoreV2.input(1) names "tensor_names" but no such
+// node exists in the GraphDef.  shape_and_slices is a Const that occupies the
+// inputs[1] slot in the compacted PtrNode::inputs vector — a buggy
+// implementation that resolves tensor_names via inputs[1] would silently use
+// shape_and_slices.  Resolving by name through the nodes dictionary makes the
+// missing input explicit.
+TEST(FrontEndConvertModelTest, SavedModelOobRestoreV2WrongInputAtPort1) {
+    try {
+        convert_model("saved_model_oob_wrong_input_at_port1");
+        FAIL() << "Expected exception when RestoreV2 tensor_names input node is absent";
+    } catch (const ov::Exception& e) {
+        EXPECT_TRUE(string(e.what()).find("not found in node dictionary") != string::npos)
+            << "Unexpected error message: " << e.what();
+    } catch (const std::exception& e) {
+        FAIL() << "Unexpected std::exception: " << e.what();
+    } catch (...) {
+        FAIL() << "Unexpected non-std exception";
+    }
+}
+
 // Same test with mmap disabled to verify the stream code path is also protected
 TEST(FrontEndConvertModelTest, SavedModelMaliciousOverflowOffsetNoMmap) {
     shared_ptr<Model> model = nullptr;

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -292,6 +292,24 @@ TEST(FrontEndConvertModelTest, SavedModelOobAssignPath) {
     }
 }
 
+TEST(FrontEndConvertModelTest, SavedModelOobRestoreV2ShortInputs) {
+    shared_ptr<Model> model = nullptr;
+    try {
+        model = convert_model("saved_model_oob_restorev2_short_inputs");
+        FAIL() << "Expected exception when RestoreV2 tensor_names input is missing";
+    } catch (const ov::Exception& e) {
+        string msg = e.what();
+        EXPECT_TRUE(msg.find("missing") != string::npos || msg.find("Const") != string::npos ||
+                    msg.find("attribute") != string::npos)
+            << "Unexpected error message: " << msg;
+        EXPECT_EQ(model, nullptr);
+    } catch (const std::exception& e) {
+        FAIL() << "Unexpected std::exception: " << e.what();
+    } catch (...) {
+        FAIL() << "Unexpected non-std exception";
+    }
+}
+
 // Same test with mmap disabled to verify the stream code path is also protected
 TEST(FrontEndConvertModelTest, SavedModelMaliciousOverflowOffsetNoMmap) {
     shared_ptr<Model> model = nullptr;

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -220,15 +220,12 @@ TEST(FrontEndConvertModelTest, SavedModelMaliciousOverflowOffset) {
 // Crafted SavedModel where AssignVariableOp input references "save/RestoreV2:999"
 // but the Const(tensor_names) has only 1 string_val entry → OOB positive index.
 TEST(FrontEndConvertModelTest, SavedModelOobPositiveIndex) {
-    shared_ptr<Model> model = nullptr;
     try {
-        model = convert_model("saved_model_oob_pos_index");
+        convert_model("saved_model_oob_pos_index");
         FAIL() << "Expected exception for OOB positive RestoreV2 output index";
     } catch (const ov::Exception& e) {
-        string msg = e.what();
-        EXPECT_TRUE(msg.find("out of range") != string::npos || msg.find("missing") != string::npos)
-            << "Unexpected error message: " << msg;
-        EXPECT_EQ(model, nullptr);
+        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos)
+            << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();
     } catch (...) {
@@ -238,15 +235,12 @@ TEST(FrontEndConvertModelTest, SavedModelOobPositiveIndex) {
 
 // Crafted SavedModel where AssignVariableOp input references "save/RestoreV2:-1" → negative OOB.
 TEST(FrontEndConvertModelTest, SavedModelOobNegativeIndex) {
-    shared_ptr<Model> model = nullptr;
     try {
-        model = convert_model("saved_model_oob_neg_index");
+        convert_model("saved_model_oob_neg_index");
         FAIL() << "Expected exception for negative RestoreV2 output index";
     } catch (const ov::Exception& e) {
-        string msg = e.what();
-        EXPECT_TRUE(msg.find("out of range") != string::npos || msg.find("missing") != string::npos)
-            << "Unexpected error message: " << msg;
-        EXPECT_EQ(model, nullptr);
+        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos)
+            << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();
     } catch (...) {
@@ -258,14 +252,12 @@ TEST(FrontEndConvertModelTest, SavedModelOobNegativeIndex) {
 // Const(tensor_names) has zero string_val entries → upper-bound guard fires at index 0.
 // This exercises the security check on the implicit-0 code path.
 TEST(FrontEndConvertModelTest, SavedModelOobEmptyTensorNames) {
-    shared_ptr<Model> model = nullptr;
     try {
-        model = convert_model("saved_model_oob_empty_names");
+        convert_model("saved_model_oob_empty_names");
         FAIL() << "Expected exception for OOB index into empty tensor_names";
     } catch (const ov::Exception& e) {
-        string msg = e.what();
-        EXPECT_TRUE(msg.find("out of range") != string::npos) << "Unexpected error message: " << msg;
-        EXPECT_EQ(model, nullptr);
+        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos)
+            << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();
     } catch (...) {
@@ -277,14 +269,12 @@ TEST(FrontEndConvertModelTest, SavedModelOobEmptyTensorNames) {
 // Const(tensor_names) has only 1 string_val entry → exercises the Assign code path
 // in map_assignvariable() (distinct from the AssignVariableOp path in other OOB tests).
 TEST(FrontEndConvertModelTest, SavedModelOobAssignPath) {
-    shared_ptr<Model> model = nullptr;
     try {
-        model = convert_model("saved_model_oob_assign_path");
+        convert_model("saved_model_oob_assign_path");
         FAIL() << "Expected exception for OOB RestoreV2 output index in Assign path";
     } catch (const ov::Exception& e) {
-        string msg = e.what();
-        EXPECT_TRUE(msg.find("out of range") != string::npos) << "Unexpected error message: " << msg;
-        EXPECT_EQ(model, nullptr);
+        EXPECT_TRUE(string(e.what()).find("out of range") != string::npos)
+            << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();
     } catch (...) {
@@ -293,16 +283,12 @@ TEST(FrontEndConvertModelTest, SavedModelOobAssignPath) {
 }
 
 TEST(FrontEndConvertModelTest, SavedModelOobRestoreV2ShortInputs) {
-    shared_ptr<Model> model = nullptr;
     try {
-        model = convert_model("saved_model_oob_restorev2_short_inputs");
+        convert_model("saved_model_oob_restorev2_short_inputs");
         FAIL() << "Expected exception when RestoreV2 tensor_names input is missing";
     } catch (const ov::Exception& e) {
-        string msg = e.what();
-        EXPECT_TRUE(msg.find("missing") != string::npos || msg.find("Const") != string::npos ||
-                    msg.find("attribute") != string::npos)
-            << "Unexpected error message: " << msg;
-        EXPECT_EQ(model, nullptr);
+        EXPECT_TRUE(string(e.what()).find("missing tensor_names input") != string::npos)
+            << "Unexpected error message: " << e.what();
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();
     } catch (...) {

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -264,8 +264,7 @@ TEST(FrontEndConvertModelTest, SavedModelOobEmptyTensorNames) {
         FAIL() << "Expected exception for OOB index into empty tensor_names";
     } catch (const ov::Exception& e) {
         string msg = e.what();
-        EXPECT_TRUE(msg.find("out of range") != string::npos)
-            << "Unexpected error message: " << msg;
+        EXPECT_TRUE(msg.find("out of range") != string::npos) << "Unexpected error message: " << msg;
         EXPECT_EQ(model, nullptr);
     } catch (const std::exception& e) {
         FAIL() << "Unexpected std::exception: " << e.what();

--- a/src/frontends/tensorflow/tests/parse_output_index_tests.cpp
+++ b/src/frontends/tensorflow/tests/parse_output_index_tests.cpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "../src/parse_output_index.hpp"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <optional>
+#include <string>
+
+using ov::frontend::tensorflow::parse_output_index;
+
+struct ParseOutputIndexCase {
+    std::string input;
+    std::optional<int> expected;
+};
+
+class ParseOutputIndexTest : public ::testing::TestWithParam<ParseOutputIndexCase> {};
+
+TEST_P(ParseOutputIndexTest, ParsesValidAndRejectsInvalid) {
+    const auto& c = GetParam();
+    EXPECT_EQ(parse_output_index(c.input), c.expected) << "input=\"" << c.input << "\"";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Valid,
+    ParseOutputIndexTest,
+    ::testing::Values(
+        ParseOutputIndexCase{"0", 0},
+        ParseOutputIndexCase{"42", 42},
+        ParseOutputIndexCase{"-7", -7},
+        ParseOutputIndexCase{"2147483647", std::numeric_limits<int>::max()},
+        ParseOutputIndexCase{"-2147483648", std::numeric_limits<int>::min()}));
+
+INSTANTIATE_TEST_SUITE_P(
+    Invalid,
+    ParseOutputIndexTest,
+    ::testing::Values(
+        ParseOutputIndexCase{"", std::nullopt},
+        ParseOutputIndexCase{"abc", std::nullopt},
+        ParseOutputIndexCase{"1junk", std::nullopt},
+        ParseOutputIndexCase{" 42", std::nullopt},
+        ParseOutputIndexCase{"99999999999999999999", std::nullopt},
+        ParseOutputIndexCase{"2147483648", std::nullopt},
+        ParseOutputIndexCase{"-2147483649", std::nullopt}));

--- a/src/frontends/tensorflow/tests/parse_output_index_tests.cpp
+++ b/src/frontends/tensorflow/tests/parse_output_index_tests.cpp
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "../src/parse_output_index.hpp"
-
 #include <gtest/gtest.h>
 
 #include <limits>
 #include <optional>
 #include <string>
+
+#include "../src/parse_output_index.hpp"
 
 using ov::frontend::tensorflow::parse_output_index;
 
@@ -24,24 +24,20 @@ TEST_P(ParseOutputIndexTest, ParsesValidAndRejectsInvalid) {
     EXPECT_EQ(parse_output_index(c.input), c.expected) << "input=\"" << c.input << "\"";
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    Valid,
-    ParseOutputIndexTest,
-    ::testing::Values(
-        ParseOutputIndexCase{"0", 0},
-        ParseOutputIndexCase{"42", 42},
-        ParseOutputIndexCase{"-7", -7},
-        ParseOutputIndexCase{"2147483647", std::numeric_limits<int>::max()},
-        ParseOutputIndexCase{"-2147483648", std::numeric_limits<int>::min()}));
+INSTANTIATE_TEST_SUITE_P(Valid,
+                         ParseOutputIndexTest,
+                         ::testing::Values(ParseOutputIndexCase{"0", 0},
+                                           ParseOutputIndexCase{"42", 42},
+                                           ParseOutputIndexCase{"-7", -7},
+                                           ParseOutputIndexCase{"2147483647", std::numeric_limits<int>::max()},
+                                           ParseOutputIndexCase{"-2147483648", std::numeric_limits<int>::min()}));
 
-INSTANTIATE_TEST_SUITE_P(
-    Invalid,
-    ParseOutputIndexTest,
-    ::testing::Values(
-        ParseOutputIndexCase{"", std::nullopt},
-        ParseOutputIndexCase{"abc", std::nullopt},
-        ParseOutputIndexCase{"1junk", std::nullopt},
-        ParseOutputIndexCase{" 42", std::nullopt},
-        ParseOutputIndexCase{"99999999999999999999", std::nullopt},
-        ParseOutputIndexCase{"2147483648", std::nullopt},
-        ParseOutputIndexCase{"-2147483649", std::nullopt}));
+INSTANTIATE_TEST_SUITE_P(Invalid,
+                         ParseOutputIndexTest,
+                         ::testing::Values(ParseOutputIndexCase{"", std::nullopt},
+                                           ParseOutputIndexCase{"abc", std::nullopt},
+                                           ParseOutputIndexCase{"1junk", std::nullopt},
+                                           ParseOutputIndexCase{" 42", std::nullopt},
+                                           ParseOutputIndexCase{"99999999999999999999", std::nullopt},
+                                           ParseOutputIndexCase{"2147483648", std::nullopt},
+                                           ParseOutputIndexCase{"-2147483649", std::nullopt}));

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# What: Generates 6 malicious TF SavedModel directories that trigger security guards in
+# What: Generates 7 malicious TF SavedModel directories that trigger security guards in
 #       VariablesIndex::map_assignvariable() (variables_index.cpp).
 #       No TF runtime needed — all protobuf and SSTable structures are built by hand.
 #
@@ -10,7 +10,7 @@
 #         variables/variables.index   — Minimal SSTable (bundle header only, num_shards=1).
 #         variables/variables.data-*  — 64 zero bytes (needed to pass open-file checks).
 #
-#       Six variants:
+#       Seven variants:
 #         saved_model_oob_pos_index/              — TF2 (AssignVariableOp path):
 #                                                   Identity.input = "save/RestoreV2:999",
 #                                                   tensor_names has 1 entry → positive OOB index
@@ -33,6 +33,12 @@
 #                                                   no such node exists; shape_and_slices is a
 #                                                   Const present in the dict and would shift to
 #                                                   inputs[1] in a buggy implementation
+#         saved_model_oob_control_dep_at_port1/   — TF2 (AssignVariableOp path):
+#                                                   RestoreV2.input(1) is a control dep (^bogus),
+#                                                   bogus is a Const with non-empty string_val
+#                                                   already in the node dict; data-port scan must
+#                                                   skip control inputs and refuse the silent
+#                                                   variable mis-binding
 #
 # Why:  SSTable builder is copied verbatim from generate_saved_model_malicious_overflow.py.
 #       Generator is run by the CMake build system.
@@ -614,6 +620,116 @@ def write_savedmodel_wrong_input_at_port1(output_dir):
         f.write(b'\x00' * 64)
 
 
+def build_saved_model_pb_control_dep_at_port1():
+    """
+    Build saved_model.pb where RestoreV2 is declared with inputs
+    ["prefix", "^bogus"]: only one data input plus a control dependency on
+    'bogus'.  'bogus' is a Const with a non-empty string_val and is declared
+    before RestoreV2 so associate_node() links it into rv2_node->inputs.
+
+    A buggy implementation that resolves tensor_names through node->input(1)
+    blindly would parse the control-dep token (parse_node_name strips '^'),
+    find 'bogus' among the linked inputs, observe it is a Const with 'value',
+    and silently bind the variable to bogus's first string_val — a security
+    regression (silent variable mis-mapping).  The correct implementation
+    iterates node->input() and skips control inputs (those starting with '^'),
+    finds only one data input ('prefix'), and throws "missing tensor_names
+    input".
+    """
+    DT_FLOAT = 1
+    DT_STRING = 7
+
+    dtype_attr = encode_varint_field(6, DT_FLOAT)
+    dim2 = encode_signed_varint_field(1, 2)
+    shape_proto = encode_bytes_field(2, dim2) + encode_bytes_field(2, dim2)
+    shape_attr = encode_bytes_field(7, shape_proto)
+
+    varhandle_node = build_node_def(
+        "my_var", "VarHandleOp",
+        attrs={"dtype": dtype_attr, "shape": shape_attr,
+               "container": encode_string_field(2, ""),
+               "shared_name": encode_string_field(2, "my_var")})
+
+    dtype_str_attr = encode_varint_field(6, DT_STRING)
+    scalar_shape = encode_bytes_field(4, b"")
+    prefix_tensor = (encode_varint_field(1, DT_STRING) +
+                     scalar_shape +
+                     encode_bytes_field(8, b"checkpoint"))
+    prefix_attr = encode_bytes_field(8, prefix_tensor)
+    prefix_node = build_node_def(
+        "prefix", "Const",
+        attrs={"value": prefix_attr, "dtype": dtype_str_attr})
+
+    # 'bogus' is a Const with a non-empty string_val; it would satisfy every
+    # current guard (Const + 'value' attr + idx 0 in range) if a buggy
+    # implementation accepted it as tensor_names.
+    bogus_tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, 1))
+    bogus_tensor = (encode_varint_field(1, DT_STRING) +
+                    encode_bytes_field(4, bogus_tensor_shape) +
+                    encode_bytes_field(8, b"fake_var"))
+    bogus_attr = encode_bytes_field(8, bogus_tensor)
+    bogus_node = build_node_def(
+        "bogus", "Const",
+        attrs={"value": bogus_attr, "dtype": dtype_str_attr})
+
+    list_attr = encode_bytes_field(5, encode_varint_field(6, DT_FLOAT))
+    restorev2_node = build_node_def(
+        "save/RestoreV2", "RestoreV2",
+        inputs=["prefix", "^bogus"],
+        attrs={"dtypes": list_attr})
+
+    t_attr = encode_varint_field(6, DT_FLOAT)
+    identity_node = build_node_def(
+        "save/identity", "Identity",
+        inputs=["save/RestoreV2:0"],
+        attrs={"T": t_attr})
+    assign_node = build_node_def(
+        "save/Assign", "AssignVariableOp",
+        inputs=["my_var", "save/identity"],
+        attrs={"dtype": dtype_attr})
+    read_node = build_node_def(
+        "read_var", "ReadVariableOp",
+        inputs=["my_var"],
+        attrs={"dtype": dtype_attr})
+    output_identity = build_node_def(
+        "Identity", "Identity",
+        inputs=["read_var"],
+        attrs={"T": t_attr})
+
+    # 'prefix' and 'bogus' declared BEFORE RestoreV2 so associate_node() links
+    # them into rv2_node->inputs (associate_node strips '^' before lookup, so
+    # the control dep is reachable via rv2_node->inputs in a buggy lookup).
+    graph_def = (encode_bytes_field(1, varhandle_node) +
+                 encode_bytes_field(1, prefix_node) +
+                 encode_bytes_field(1, bogus_node) +
+                 encode_bytes_field(1, restorev2_node) +
+                 encode_bytes_field(1, identity_node) +
+                 encode_bytes_field(1, assign_node) +
+                 encode_bytes_field(1, read_node) +
+                 encode_bytes_field(1, output_identity))
+
+    meta_info_def = encode_string_field(1, "serve")
+    tensor_info = encode_string_field(1, "Identity:0") + encode_varint_field(2, DT_FLOAT)
+    sig_output_entry = encode_string_field(1, "output_0") + encode_bytes_field(2, tensor_info)
+    signature_def = encode_bytes_field(2, sig_output_entry)
+    sig_map_entry = encode_string_field(1, "serving_default") + encode_bytes_field(2, signature_def)
+    meta_graph_def = (encode_bytes_field(1, meta_info_def) +
+                      encode_bytes_field(2, graph_def) +
+                      encode_bytes_field(5, sig_map_entry))
+
+    return encode_signed_varint_field(1, 1) + encode_bytes_field(2, meta_graph_def)
+
+
+def write_savedmodel_control_dep_at_port1(output_dir):
+    os.makedirs(os.path.join(output_dir, "variables"), exist_ok=True)
+    with open(os.path.join(output_dir, "saved_model.pb"), 'wb') as f:
+        f.write(build_saved_model_pb_control_dep_at_port1())
+    with open(os.path.join(output_dir, "variables", "variables.index"), 'wb') as f:
+        f.write(build_minimal_variables_index())
+    with open(os.path.join(output_dir, "variables", "variables.data-00000-of-00001"), 'wb') as f:
+        f.write(b'\x00' * 64)
+
+
 def main():
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} <output_dir>")
@@ -652,6 +768,14 @@ def main():
     write_savedmodel_wrong_input_at_port1(
         os.path.join(base, "saved_model_oob_wrong_input_at_port1"))
     print(f"Generated: {os.path.join(base, 'saved_model_oob_wrong_input_at_port1')}")
+
+    # RestoreV2 declared with inputs ["prefix", "^bogus"]: control dep at
+    # node->input(1).  A buggy implementation would parse the control token,
+    # match 'bogus' (a Const with non-empty string_val) and silently bind the
+    # variable to the wrong name.  Data-port iteration must skip control deps.
+    write_savedmodel_control_dep_at_port1(
+        os.path.join(base, "saved_model_oob_control_dep_at_port1"))
+    print(f"Generated: {os.path.join(base, 'saved_model_oob_control_dep_at_port1')}")
 
 
 if __name__ == '__main__':

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -739,35 +739,29 @@ def main():
 
     # Positive OOB: index 999 into a tensor with 1 string_val
     write_savedmodel(os.path.join(base, "saved_model_oob_pos_index"), "save/RestoreV2:999")
-    print(f"Generated: {os.path.join(base, 'saved_model_oob_pos_index')}")
 
     # Negative OOB: index -1 into a tensor with 1 string_val
     write_savedmodel(os.path.join(base, "saved_model_oob_neg_index"), "save/RestoreV2:-1")
-    print(f"Generated: {os.path.join(base, 'saved_model_oob_neg_index')}")
 
     # Empty tensor_names: index 0 into a tensor with 0 string_val entries;
     # exercises the upper-bound guard on the implicit-0 code path
     write_savedmodel(os.path.join(base, "saved_model_oob_empty_names"), "save/RestoreV2:0",
                      num_string_vals=0)
-    print(f"Generated: {os.path.join(base, 'saved_model_oob_empty_names')}")
 
     # TF1-style Assign path: OOB positive index in the Assign branch of map_assignvariable()
     write_savedmodel_tf1_assign(os.path.join(base, "saved_model_oob_assign_path"),
                                 "save/RestoreV2:999")
-    print(f"Generated: {os.path.join(base, 'saved_model_oob_assign_path')}")
 
     # RestoreV2 declared with only 1 input ('prefix') in the GraphDef itself —
     # node->input_size()==1, exercises the "missing tensor_names input" guard.
     write_savedmodel_restorev2_short_inputs(
         os.path.join(base, "saved_model_oob_restorev2_short_inputs"))
-    print(f"Generated: {os.path.join(base, 'saved_model_oob_restorev2_short_inputs')}")
 
     # RestoreV2 references tensor_names by name at port 1 but no node named
     # tensor_names exists; shape_and_slices is present and would shift into
     # the compacted inputs[1] slot in a buggy implementation.
     write_savedmodel_wrong_input_at_port1(
         os.path.join(base, "saved_model_oob_wrong_input_at_port1"))
-    print(f"Generated: {os.path.join(base, 'saved_model_oob_wrong_input_at_port1')}")
 
     # RestoreV2 declared with inputs ["prefix", "^bogus"]: control dep at
     # node->input(1).  A buggy implementation would parse the control token,
@@ -775,7 +769,6 @@ def main():
     # variable to the wrong name.  Data-port iteration must skip control deps.
     write_savedmodel_control_dep_at_port1(
         os.path.join(base, "saved_model_oob_control_dep_at_port1"))
-    print(f"Generated: {os.path.join(base, 'saved_model_oob_control_dep_at_port1')}")
 
 
 if __name__ == '__main__':

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# What: Generates 4 malicious TF SavedModel directories that trigger the OOB read in
+# What: Generates 5 malicious TF SavedModel directories that trigger security guards in
 #       VariablesIndex::map_assignvariable() (variables_index.cpp).
 #       No TF runtime needed — all protobuf and SSTable structures are built by hand.
 #
@@ -10,20 +10,24 @@
 #         variables/variables.index   — Minimal SSTable (bundle header only, num_shards=1).
 #         variables/variables.data-*  — 64 zero bytes (needed to pass open-file checks).
 #
-#       Four variants:
-#         saved_model_oob_pos_index/    — TF2 (AssignVariableOp path):
-#                                         Identity.input = "save/RestoreV2:999",
-#                                         tensor_names has 1 entry → positive OOB index
-#         saved_model_oob_neg_index/    — TF2 (AssignVariableOp path):
-#                                         Identity.input = "save/RestoreV2:-1",
-#                                         tensor_names has 1 entry → negative OOB index
-#         saved_model_oob_empty_names/  — TF2 (AssignVariableOp path):
-#                                         Identity.input = "save/RestoreV2:0",
-#                                         tensor_names has 0 entries → OOB via implicit-0
-#                                         path when string_val_size()==0
-#         saved_model_oob_assign_path/  — TF1 (Assign path):
-#                                         Assign.input(1) = "save/RestoreV2:999",
-#                                         tensor_names has 1 entry → positive OOB index
+#       Five variants:
+#         saved_model_oob_pos_index/              — TF2 (AssignVariableOp path):
+#                                                   Identity.input = "save/RestoreV2:999",
+#                                                   tensor_names has 1 entry → positive OOB index
+#         saved_model_oob_neg_index/              — TF2 (AssignVariableOp path):
+#                                                   Identity.input = "save/RestoreV2:-1",
+#                                                   tensor_names has 1 entry → negative OOB index
+#         saved_model_oob_empty_names/            — TF2 (AssignVariableOp path):
+#                                                   Identity.input = "save/RestoreV2:0",
+#                                                   tensor_names has 0 entries → OOB via implicit-0
+#                                                   path when string_val_size()==0
+#         saved_model_oob_assign_path/            — TF1 (Assign path):
+#                                                   Assign.input(1) = "save/RestoreV2:999",
+#                                                   tensor_names has 1 entry → positive OOB index
+#         saved_model_oob_restorev2_short_inputs/ — TF2 (AssignVariableOp path):
+#                                                   tensor_names Const declared after RestoreV2
+#                                                   in GraphDef → associate_node skips it →
+#                                                   restorev2->inputs.size()==1 → inputs guard
 #
 # Why:  SSTable builder is copied verbatim from generate_saved_model_malicious_overflow.py.
 #       Generator is run by the CMake build system.
@@ -413,6 +417,113 @@ def write_savedmodel_tf1_assign(output_dir, index_str, num_string_vals=1):
         f.write(b'\x00' * 64)
 
 
+def build_saved_model_pb_restorev2_short_inputs():
+    """
+    Build saved_model.pb where tensor_names and shape_and_slices Const nodes appear
+    AFTER RestoreV2 in the GraphDef node list.  associate_node() only links inputs
+    that are already in the node dictionary, so RestoreV2->inputs will have only
+    'prefix' (inputs.size()==1), triggering the new inputs.size() > 1 guard.
+    """
+    DT_FLOAT = 1
+    DT_STRING = 7
+
+    dtype_attr = encode_varint_field(6, DT_FLOAT)
+    dim2 = encode_signed_varint_field(1, 2)
+    shape_proto = encode_bytes_field(2, dim2) + encode_bytes_field(2, dim2)
+    shape_attr = encode_bytes_field(7, shape_proto)
+
+    varhandle_node = build_node_def(
+        "my_var", "VarHandleOp",
+        attrs={"dtype": dtype_attr, "shape": shape_attr,
+               "container": encode_string_field(2, ""),
+               "shared_name": encode_string_field(2, "my_var")})
+
+    # prefix first (will be in dict before RestoreV2)
+    scalar_shape = encode_bytes_field(4, b"")
+    prefix_tensor = (encode_varint_field(1, DT_STRING) +
+                     scalar_shape +
+                     encode_bytes_field(8, b"checkpoint"))
+    dtype_str_attr = encode_varint_field(6, DT_STRING)
+    prefix_attr = encode_bytes_field(8, prefix_tensor)
+    prefix_node = build_node_def(
+        "prefix", "Const",
+        attrs={"value": prefix_attr, "dtype": dtype_str_attr})
+
+    # RestoreV2 declared before tensor_names / shape_and_slices
+    list_attr = encode_bytes_field(5, encode_varint_field(6, DT_FLOAT))
+    restorev2_node = build_node_def(
+        "save/RestoreV2", "RestoreV2",
+        inputs=["prefix", "tensor_names", "shape_and_slices"],
+        attrs={"dtypes": list_attr})
+
+    # tensor_names and shape_and_slices declared AFTER RestoreV2 — will not be linked
+    tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, 1))
+    tensor_proto = encode_varint_field(1, DT_STRING) + encode_bytes_field(4, tensor_shape)
+    tensor_proto += encode_bytes_field(8, b"Variable")
+    tensor_attr = encode_bytes_field(8, tensor_proto)
+    const_node = build_node_def(
+        "tensor_names", "Const",
+        attrs={"value": tensor_attr, "dtype": dtype_str_attr})
+
+    shape_tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, 1))
+    empty_shape_tensor = encode_varint_field(1, DT_STRING) + encode_bytes_field(4, shape_tensor_shape)
+    empty_shape_tensor += encode_bytes_field(8, b"")
+    empty_shape_attr = encode_bytes_field(8, empty_shape_tensor)
+    shape_slices_node = build_node_def(
+        "shape_and_slices", "Const",
+        attrs={"value": empty_shape_attr, "dtype": dtype_str_attr})
+
+    t_attr = encode_varint_field(6, DT_FLOAT)
+    identity_node = build_node_def(
+        "save/identity", "Identity",
+        inputs=["save/RestoreV2:0"],
+        attrs={"T": t_attr})
+    assign_node = build_node_def(
+        "save/Assign", "AssignVariableOp",
+        inputs=["my_var", "save/identity"],
+        attrs={"dtype": dtype_attr})
+    read_node = build_node_def(
+        "read_var", "ReadVariableOp",
+        inputs=["my_var"],
+        attrs={"dtype": dtype_attr})
+    output_identity = build_node_def(
+        "Identity", "Identity",
+        inputs=["read_var"],
+        attrs={"T": t_attr})
+
+    # Intentional ordering: RestoreV2 before its Const inputs
+    graph_def = (encode_bytes_field(1, varhandle_node) +
+                 encode_bytes_field(1, prefix_node) +
+                 encode_bytes_field(1, restorev2_node) +
+                 encode_bytes_field(1, const_node) +
+                 encode_bytes_field(1, shape_slices_node) +
+                 encode_bytes_field(1, identity_node) +
+                 encode_bytes_field(1, assign_node) +
+                 encode_bytes_field(1, read_node) +
+                 encode_bytes_field(1, output_identity))
+
+    meta_info_def = encode_string_field(1, "serve")
+    tensor_info = encode_string_field(1, "Identity:0") + encode_varint_field(2, DT_FLOAT)
+    sig_output_entry = encode_string_field(1, "output_0") + encode_bytes_field(2, tensor_info)
+    signature_def = encode_bytes_field(2, sig_output_entry)
+    sig_map_entry = encode_string_field(1, "serving_default") + encode_bytes_field(2, signature_def)
+    meta_graph_def = (encode_bytes_field(1, meta_info_def) +
+                      encode_bytes_field(2, graph_def) +
+                      encode_bytes_field(5, sig_map_entry))
+
+    return encode_signed_varint_field(1, 1) + encode_bytes_field(2, meta_graph_def)
+
+
+def write_savedmodel_restorev2_short_inputs(output_dir):
+    os.makedirs(os.path.join(output_dir, "variables"), exist_ok=True)
+    with open(os.path.join(output_dir, "saved_model.pb"), 'wb') as f:
+        f.write(build_saved_model_pb_restorev2_short_inputs())
+    with open(os.path.join(output_dir, "variables", "variables.index"), 'wb') as f:
+        f.write(build_minimal_variables_index())
+    with open(os.path.join(output_dir, "variables", "variables.data-00000-of-00001"), 'wb') as f:
+        f.write(b'\x00' * 64)
+
+
 def main():
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} <output_dir>")
@@ -438,6 +549,12 @@ def main():
     write_savedmodel_tf1_assign(os.path.join(base, "saved_model_oob_assign_path"),
                                 "save/RestoreV2:999")
     print(f"Generated: {os.path.join(base, 'saved_model_oob_assign_path')}")
+
+    # RestoreV2 with missing tensor_names input: tensor_names declared after RestoreV2 in
+    # GraphDef so associate_node leaves restorev2->inputs.size()==1 (only prefix linked)
+    write_savedmodel_restorev2_short_inputs(
+        os.path.join(base, "saved_model_oob_restorev2_short_inputs"))
+    print(f"Generated: {os.path.join(base, 'saved_model_oob_restorev2_short_inputs')}")
 
 
 if __name__ == '__main__':

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# What: Generates 5 malicious TF SavedModel directories that trigger security guards in
+# What: Generates 6 malicious TF SavedModel directories that trigger security guards in
 #       VariablesIndex::map_assignvariable() (variables_index.cpp).
 #       No TF runtime needed — all protobuf and SSTable structures are built by hand.
 #
@@ -10,7 +10,7 @@
 #         variables/variables.index   — Minimal SSTable (bundle header only, num_shards=1).
 #         variables/variables.data-*  — 64 zero bytes (needed to pass open-file checks).
 #
-#       Five variants:
+#       Six variants:
 #         saved_model_oob_pos_index/              — TF2 (AssignVariableOp path):
 #                                                   Identity.input = "save/RestoreV2:999",
 #                                                   tensor_names has 1 entry → positive OOB index
@@ -25,9 +25,14 @@
 #                                                   Assign.input(1) = "save/RestoreV2:999",
 #                                                   tensor_names has 1 entry → positive OOB index
 #         saved_model_oob_restorev2_short_inputs/ — TF2 (AssignVariableOp path):
-#                                                   tensor_names Const declared after RestoreV2
-#                                                   in GraphDef → associate_node skips it →
-#                                                   restorev2->inputs.size()==1 → inputs guard
+#                                                   RestoreV2 declared with only 1 input in
+#                                                   GraphDef → node->input_size()==1 →
+#                                                   "missing tensor_names input" guard
+#         saved_model_oob_wrong_input_at_port1/   — TF2 (AssignVariableOp path):
+#                                                   RestoreV2.input(1) names "tensor_names" but
+#                                                   no such node exists; shape_and_slices is a
+#                                                   Const present in the dict and would shift to
+#                                                   inputs[1] in a buggy implementation
 #
 # Why:  SSTable builder is copied verbatim from generate_saved_model_malicious_overflow.py.
 #       Generator is run by the CMake build system.
@@ -419,10 +424,9 @@ def write_savedmodel_tf1_assign(output_dir, index_str, num_string_vals=1):
 
 def build_saved_model_pb_restorev2_short_inputs():
     """
-    Build saved_model.pb where tensor_names and shape_and_slices Const nodes appear
-    AFTER RestoreV2 in the GraphDef node list.  associate_node() only links inputs
-    that are already in the node dictionary, so RestoreV2->inputs will have only
-    'prefix' (inputs.size()==1), triggering the new inputs.size() > 1 guard.
+    Build saved_model.pb where RestoreV2 declares only 1 input ('prefix') in the
+    GraphDef itself, so node->input_size()==1.  Triggers the
+    'RestoreV2 node is missing tensor_names input' guard in get_variable_name().
     """
     DT_FLOAT = 1
     DT_STRING = 7
@@ -438,7 +442,6 @@ def build_saved_model_pb_restorev2_short_inputs():
                "container": encode_string_field(2, ""),
                "shared_name": encode_string_field(2, "my_var")})
 
-    # prefix first (will be in dict before RestoreV2)
     scalar_shape = encode_bytes_field(4, b"")
     prefix_tensor = (encode_varint_field(1, DT_STRING) +
                      scalar_shape +
@@ -449,29 +452,13 @@ def build_saved_model_pb_restorev2_short_inputs():
         "prefix", "Const",
         attrs={"value": prefix_attr, "dtype": dtype_str_attr})
 
-    # RestoreV2 declared before tensor_names / shape_and_slices
+    # RestoreV2 with only 1 declared input — no tensor_names, no shape_and_slices.
+    # node->input_size() == 1 in the GraphDef itself.
     list_attr = encode_bytes_field(5, encode_varint_field(6, DT_FLOAT))
     restorev2_node = build_node_def(
         "save/RestoreV2", "RestoreV2",
-        inputs=["prefix", "tensor_names", "shape_and_slices"],
+        inputs=["prefix"],
         attrs={"dtypes": list_attr})
-
-    # tensor_names and shape_and_slices declared AFTER RestoreV2 — will not be linked
-    tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, 1))
-    tensor_proto = encode_varint_field(1, DT_STRING) + encode_bytes_field(4, tensor_shape)
-    tensor_proto += encode_bytes_field(8, b"Variable")
-    tensor_attr = encode_bytes_field(8, tensor_proto)
-    const_node = build_node_def(
-        "tensor_names", "Const",
-        attrs={"value": tensor_attr, "dtype": dtype_str_attr})
-
-    shape_tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, 1))
-    empty_shape_tensor = encode_varint_field(1, DT_STRING) + encode_bytes_field(4, shape_tensor_shape)
-    empty_shape_tensor += encode_bytes_field(8, b"")
-    empty_shape_attr = encode_bytes_field(8, empty_shape_tensor)
-    shape_slices_node = build_node_def(
-        "shape_and_slices", "Const",
-        attrs={"value": empty_shape_attr, "dtype": dtype_str_attr})
 
     t_attr = encode_varint_field(6, DT_FLOAT)
     identity_node = build_node_def(
@@ -491,12 +478,9 @@ def build_saved_model_pb_restorev2_short_inputs():
         inputs=["read_var"],
         attrs={"T": t_attr})
 
-    # Intentional ordering: RestoreV2 before its Const inputs
     graph_def = (encode_bytes_field(1, varhandle_node) +
                  encode_bytes_field(1, prefix_node) +
                  encode_bytes_field(1, restorev2_node) +
-                 encode_bytes_field(1, const_node) +
-                 encode_bytes_field(1, shape_slices_node) +
                  encode_bytes_field(1, identity_node) +
                  encode_bytes_field(1, assign_node) +
                  encode_bytes_field(1, read_node) +
@@ -518,6 +502,112 @@ def write_savedmodel_restorev2_short_inputs(output_dir):
     os.makedirs(os.path.join(output_dir, "variables"), exist_ok=True)
     with open(os.path.join(output_dir, "saved_model.pb"), 'wb') as f:
         f.write(build_saved_model_pb_restorev2_short_inputs())
+    with open(os.path.join(output_dir, "variables", "variables.index"), 'wb') as f:
+        f.write(build_minimal_variables_index())
+    with open(os.path.join(output_dir, "variables", "variables.data-00000-of-00001"), 'wb') as f:
+        f.write(b'\x00' * 64)
+
+
+def build_saved_model_pb_wrong_input_at_port1():
+    """
+    Build saved_model.pb where RestoreV2.input(1) refers to 'tensor_names' but no
+    node named 'tensor_names' exists in the GraphDef.  shape_and_slices IS present
+    and is a Const with a 'value' attribute, so a buggy implementation that
+    consults the compacted PtrNode::inputs vector would pick up shape_and_slices
+    at index 1 and silently use the wrong Const.  The correct implementation
+    resolves tensor_names by name through the nodes dictionary and throws.
+    """
+    DT_FLOAT = 1
+    DT_STRING = 7
+
+    dtype_attr = encode_varint_field(6, DT_FLOAT)
+    dim2 = encode_signed_varint_field(1, 2)
+    shape_proto = encode_bytes_field(2, dim2) + encode_bytes_field(2, dim2)
+    shape_attr = encode_bytes_field(7, shape_proto)
+
+    varhandle_node = build_node_def(
+        "my_var", "VarHandleOp",
+        attrs={"dtype": dtype_attr, "shape": shape_attr,
+               "container": encode_string_field(2, ""),
+               "shared_name": encode_string_field(2, "my_var")})
+
+    dtype_str_attr = encode_varint_field(6, DT_STRING)
+    scalar_shape = encode_bytes_field(4, b"")
+    prefix_tensor = (encode_varint_field(1, DT_STRING) +
+                     scalar_shape +
+                     encode_bytes_field(8, b"checkpoint"))
+    prefix_attr = encode_bytes_field(8, prefix_tensor)
+    prefix_node = build_node_def(
+        "prefix", "Const",
+        attrs={"value": prefix_attr, "dtype": dtype_str_attr})
+
+    # shape_and_slices declared with a non-empty string_val so a buggy
+    # implementation using inputs[1] would silently succeed.
+    shape_tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, 1))
+    shape_tensor = (encode_varint_field(1, DT_STRING) +
+                    encode_bytes_field(4, shape_tensor_shape) +
+                    encode_bytes_field(8, b"fake_var"))
+    shape_attr_const = encode_bytes_field(8, shape_tensor)
+    shape_slices_node = build_node_def(
+        "shape_and_slices", "Const",
+        attrs={"value": shape_attr_const, "dtype": dtype_str_attr})
+
+    # RestoreV2 references "tensor_names" at port 1, but the node is missing
+    # from the GraphDef entirely.  prefix and shape_and_slices ARE in the dict
+    # at the time associate_node runs, so RestoreV2->inputs ends up as
+    # [prefix, shape_and_slices] (size==2) — buggy implementation indexes [1].
+    list_attr = encode_bytes_field(5, encode_varint_field(6, DT_FLOAT))
+    restorev2_node = build_node_def(
+        "save/RestoreV2", "RestoreV2",
+        inputs=["prefix", "tensor_names", "shape_and_slices"],
+        attrs={"dtypes": list_attr})
+
+    t_attr = encode_varint_field(6, DT_FLOAT)
+    identity_node = build_node_def(
+        "save/identity", "Identity",
+        inputs=["save/RestoreV2:0"],
+        attrs={"T": t_attr})
+    assign_node = build_node_def(
+        "save/Assign", "AssignVariableOp",
+        inputs=["my_var", "save/identity"],
+        attrs={"dtype": dtype_attr})
+    read_node = build_node_def(
+        "read_var", "ReadVariableOp",
+        inputs=["my_var"],
+        attrs={"dtype": dtype_attr})
+    output_identity = build_node_def(
+        "Identity", "Identity",
+        inputs=["read_var"],
+        attrs={"T": t_attr})
+
+    # prefix and shape_and_slices declared BEFORE RestoreV2 so they get linked
+    # into RestoreV2->inputs by associate_node (which only links nodes already
+    # in the dictionary).
+    graph_def = (encode_bytes_field(1, varhandle_node) +
+                 encode_bytes_field(1, prefix_node) +
+                 encode_bytes_field(1, shape_slices_node) +
+                 encode_bytes_field(1, restorev2_node) +
+                 encode_bytes_field(1, identity_node) +
+                 encode_bytes_field(1, assign_node) +
+                 encode_bytes_field(1, read_node) +
+                 encode_bytes_field(1, output_identity))
+
+    meta_info_def = encode_string_field(1, "serve")
+    tensor_info = encode_string_field(1, "Identity:0") + encode_varint_field(2, DT_FLOAT)
+    sig_output_entry = encode_string_field(1, "output_0") + encode_bytes_field(2, tensor_info)
+    signature_def = encode_bytes_field(2, sig_output_entry)
+    sig_map_entry = encode_string_field(1, "serving_default") + encode_bytes_field(2, signature_def)
+    meta_graph_def = (encode_bytes_field(1, meta_info_def) +
+                      encode_bytes_field(2, graph_def) +
+                      encode_bytes_field(5, sig_map_entry))
+
+    return encode_signed_varint_field(1, 1) + encode_bytes_field(2, meta_graph_def)
+
+
+def write_savedmodel_wrong_input_at_port1(output_dir):
+    os.makedirs(os.path.join(output_dir, "variables"), exist_ok=True)
+    with open(os.path.join(output_dir, "saved_model.pb"), 'wb') as f:
+        f.write(build_saved_model_pb_wrong_input_at_port1())
     with open(os.path.join(output_dir, "variables", "variables.index"), 'wb') as f:
         f.write(build_minimal_variables_index())
     with open(os.path.join(output_dir, "variables", "variables.data-00000-of-00001"), 'wb') as f:
@@ -550,11 +640,18 @@ def main():
                                 "save/RestoreV2:999")
     print(f"Generated: {os.path.join(base, 'saved_model_oob_assign_path')}")
 
-    # RestoreV2 with missing tensor_names input: tensor_names declared after RestoreV2 in
-    # GraphDef so associate_node leaves restorev2->inputs.size()==1 (only prefix linked)
+    # RestoreV2 declared with only 1 input ('prefix') in the GraphDef itself —
+    # node->input_size()==1, exercises the "missing tensor_names input" guard.
     write_savedmodel_restorev2_short_inputs(
         os.path.join(base, "saved_model_oob_restorev2_short_inputs"))
     print(f"Generated: {os.path.join(base, 'saved_model_oob_restorev2_short_inputs')}")
+
+    # RestoreV2 references tensor_names by name at port 1 but no node named
+    # tensor_names exists; shape_and_slices is present and would shift into
+    # the compacted inputs[1] slot in a buggy implementation.
+    write_savedmodel_wrong_input_at_port1(
+        os.path.join(base, "saved_model_oob_wrong_input_at_port1"))
+    print(f"Generated: {os.path.join(base, 'saved_model_oob_wrong_input_at_port1')}")
 
 
 if __name__ == '__main__':

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -16,9 +16,8 @@
 #         saved_model_oob_no_colon/   — Identity.input = "save/RestoreV2"     (no colon,
 #                                       triggers restore_output.size()<2 check)
 #
-# Why:  Reproduces CVS-182685 (CWE-125) without a TF install. SSTable builder is copied
-#       verbatim from generate_saved_model_malicious_overflow.py. Generator is run by
-#       WORK/run_oob_repro.sh and (after validation) by the CMake build system.
+# Why:  SSTable builder is copied verbatim from generate_saved_model_malicious_overflow.py.
+#       Generator is run by the CMake build system.
 #
 # Usage: python3 generate_saved_model_oob_index.py <output_dir>
 #        Output dirs are created under <output_dir>/.

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -1,24 +1,29 @@
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# What: Generates 3 malicious TF SavedModel directories that trigger the OOB read in
+# What: Generates 4 malicious TF SavedModel directories that trigger the OOB read in
 #       VariablesIndex::map_assignvariable() (variables_index.cpp).
 #       No TF runtime needed — all protobuf and SSTable structures are built by hand.
 #
 # How:  Each SavedModel has:
-#         saved_model.pb              — GraphDef with VarHandleOp, Const(tensor_names),
-#                                       RestoreV2, Identity, AssignVariableOp.
+#         saved_model.pb              — GraphDef with nodes described per variant below.
 #         variables/variables.index   — Minimal SSTable (bundle header only, num_shards=1).
 #         variables/variables.data-*  — 64 zero bytes (needed to pass open-file checks).
 #
-#       Three variants:
-#         saved_model_oob_pos_index/    — Identity.input = "save/RestoreV2:999",
+#       Four variants:
+#         saved_model_oob_pos_index/    — TF2 (AssignVariableOp path):
+#                                         Identity.input = "save/RestoreV2:999",
 #                                         tensor_names has 1 entry → positive OOB index
-#         saved_model_oob_neg_index/    — Identity.input = "save/RestoreV2:-1",
+#         saved_model_oob_neg_index/    — TF2 (AssignVariableOp path):
+#                                         Identity.input = "save/RestoreV2:-1",
 #                                         tensor_names has 1 entry → negative OOB index
-#         saved_model_oob_empty_names/  — Identity.input = "save/RestoreV2:0",
+#         saved_model_oob_empty_names/  — TF2 (AssignVariableOp path):
+#                                         Identity.input = "save/RestoreV2:0",
 #                                         tensor_names has 0 entries → OOB via implicit-0
 #                                         path when string_val_size()==0
+#         saved_model_oob_assign_path/  — TF1 (Assign path):
+#                                         Assign.input(1) = "save/RestoreV2:999",
+#                                         tensor_names has 1 entry → positive OOB index
 #
 # Why:  SSTable builder is copied verbatim from generate_saved_model_malicious_overflow.py.
 #       Generator is run by the CMake build system.
@@ -287,10 +292,121 @@ def build_saved_model_pb(identity_input, num_string_vals=1):
     return encode_signed_varint_field(1, 1) + encode_bytes_field(2, meta_graph_def)
 
 
+def build_saved_model_pb_tf1_assign(index_str, num_string_vals=1):
+    """
+    Build saved_model.pb with TF1-style topology:
+      VariableV2("my_variable")
+      Const("tensor_names")  — num_string_vals string_val entries
+      RestoreV2("save/RestoreV2")
+      Assign("save/Assign")  — input(1) = index_str (e.g. "save/RestoreV2:999")
+      Identity("Identity")   — output node
+
+    This exercises the Assign code path in VariablesIndex::map_assignvariable()
+    rather than the AssignVariableOp path exercised by build_saved_model_pb().
+    """
+    DT_FLOAT = 1
+    DT_STRING = 7
+
+    # VariableV2 attrs
+    dtype_attr = encode_varint_field(6, DT_FLOAT)
+    dim_attr = encode_bytes_field(2, encode_signed_varint_field(1, 4))
+    shape_attr = encode_bytes_field(7, dim_attr)
+
+    variablev2_node = build_node_def(
+        "my_variable", "VariableV2",
+        attrs={"dtype": dtype_attr, "shape": shape_attr,
+               "container": encode_string_field(2, ""),
+               "shared_name": encode_string_field(2, "")})
+
+    # Const("tensor_names")
+    actual_size = max(num_string_vals, 0)
+    tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, actual_size))
+    tensor_proto = encode_varint_field(1, DT_STRING) + encode_bytes_field(4, tensor_shape)
+    for _ in range(actual_size):
+        tensor_proto += encode_bytes_field(8, b"Variable")
+    tensor_attr = encode_bytes_field(8, tensor_proto)
+    dtype_str_attr = encode_varint_field(6, DT_STRING)
+
+    const_node = build_node_def(
+        "tensor_names", "Const",
+        attrs={"value": tensor_attr, "dtype": dtype_str_attr})
+
+    # Const("shape_and_slices")
+    shape_tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, actual_size))
+    empty_shape_tensor = encode_varint_field(1, DT_STRING) + encode_bytes_field(4, shape_tensor_shape)
+    for _ in range(actual_size):
+        empty_shape_tensor += encode_bytes_field(8, b"")
+    empty_shape_attr = encode_bytes_field(8, empty_shape_tensor)
+
+    shape_slices_node = build_node_def(
+        "shape_and_slices", "Const",
+        attrs={"value": empty_shape_attr, "dtype": dtype_str_attr})
+
+    # Const("prefix")
+    scalar_shape = encode_bytes_field(4, b"")
+    prefix_tensor = (encode_varint_field(1, DT_STRING) +
+                     scalar_shape +
+                     encode_bytes_field(8, b"checkpoint"))
+    prefix_attr = encode_bytes_field(8, prefix_tensor)
+
+    prefix_node = build_node_def(
+        "prefix", "Const",
+        attrs={"value": prefix_attr, "dtype": dtype_str_attr})
+
+    # RestoreV2
+    list_attr = encode_bytes_field(5, encode_varint_field(6, DT_FLOAT))
+    restorev2_node = build_node_def(
+        "save/RestoreV2", "RestoreV2",
+        inputs=["prefix", "tensor_names", "shape_and_slices"],
+        attrs={"dtypes": list_attr})
+
+    # Assign: input(0) = variable ref, input(1) = RestoreV2 output with OOB index
+    t_attr = encode_varint_field(6, DT_FLOAT)
+    assign_node = build_node_def(
+        "save/Assign", "Assign",
+        inputs=["my_variable", index_str],
+        attrs={"T": t_attr})
+
+    # Identity for signature output
+    output_identity = build_node_def(
+        "Identity", "Identity",
+        inputs=["my_variable"],
+        attrs={"T": t_attr})
+
+    graph_def = (encode_bytes_field(1, variablev2_node) +
+                 encode_bytes_field(1, const_node) +
+                 encode_bytes_field(1, shape_slices_node) +
+                 encode_bytes_field(1, prefix_node) +
+                 encode_bytes_field(1, restorev2_node) +
+                 encode_bytes_field(1, assign_node) +
+                 encode_bytes_field(1, output_identity))
+
+    meta_info_def = encode_string_field(1, "serve")
+    tensor_info = encode_string_field(1, "Identity:0") + encode_varint_field(2, DT_FLOAT)
+    sig_output_entry = encode_string_field(1, "output_0") + encode_bytes_field(2, tensor_info)
+    signature_def = encode_bytes_field(2, sig_output_entry)
+    sig_map_entry = encode_string_field(1, "serving_default") + encode_bytes_field(2, signature_def)
+    meta_graph_def = (encode_bytes_field(1, meta_info_def) +
+                      encode_bytes_field(2, graph_def) +
+                      encode_bytes_field(5, sig_map_entry))
+
+    return encode_signed_varint_field(1, 1) + encode_bytes_field(2, meta_graph_def)
+
+
 def write_savedmodel(output_dir, identity_input, num_string_vals=1):
     os.makedirs(os.path.join(output_dir, "variables"), exist_ok=True)
     with open(os.path.join(output_dir, "saved_model.pb"), 'wb') as f:
         f.write(build_saved_model_pb(identity_input, num_string_vals))
+    with open(os.path.join(output_dir, "variables", "variables.index"), 'wb') as f:
+        f.write(build_minimal_variables_index())
+    with open(os.path.join(output_dir, "variables", "variables.data-00000-of-00001"), 'wb') as f:
+        f.write(b'\x00' * 64)
+
+
+def write_savedmodel_tf1_assign(output_dir, index_str, num_string_vals=1):
+    os.makedirs(os.path.join(output_dir, "variables"), exist_ok=True)
+    with open(os.path.join(output_dir, "saved_model.pb"), 'wb') as f:
+        f.write(build_saved_model_pb_tf1_assign(index_str, num_string_vals))
     with open(os.path.join(output_dir, "variables", "variables.index"), 'wb') as f:
         f.write(build_minimal_variables_index())
     with open(os.path.join(output_dir, "variables", "variables.data-00000-of-00001"), 'wb') as f:
@@ -317,6 +433,11 @@ def main():
     write_savedmodel(os.path.join(base, "saved_model_oob_empty_names"), "save/RestoreV2:0",
                      num_string_vals=0)
     print(f"Generated: {os.path.join(base, 'saved_model_oob_empty_names')}")
+
+    # TF1-style Assign path: OOB positive index in the Assign branch of map_assignvariable()
+    write_savedmodel_tf1_assign(os.path.join(base, "saved_model_oob_assign_path"),
+                                "save/RestoreV2:999")
+    print(f"Generated: {os.path.join(base, 'saved_model_oob_assign_path')}")
 
 
 if __name__ == '__main__':

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -1,0 +1,318 @@
+# What: Generates 3 malicious TF SavedModel directories that trigger the OOB read in
+#       VariablesIndex::map_assignvariable() (variables_index.cpp lines 408/412 and 436/440).
+#       No TF runtime needed — all protobuf and SSTable structures are built by hand.
+#
+# How:  Each SavedModel has:
+#         saved_model.pb              — GraphDef with VarHandleOp, Const(tensor_names),
+#                                       RestoreV2, Identity, AssignVariableOp.
+#                                       Identity.input[0] is set to a malicious string so
+#                                       parse_node_name() extracts an OOB index.
+#         variables/variables.index   — Minimal SSTable (bundle header only, num_shards=1).
+#         variables/variables.data-*  — 64 zero bytes (needed to pass open-file checks).
+#
+#       Three variants:
+#         saved_model_oob_pos_index/  — Identity.input = "save/RestoreV2:999" (positive OOB)
+#         saved_model_oob_neg_index/  — Identity.input = "save/RestoreV2:-1"  (negative OOB)
+#         saved_model_oob_no_colon/   — Identity.input = "save/RestoreV2"     (no colon,
+#                                       triggers restore_output.size()<2 check)
+#
+# Why:  Reproduces CVS-182685 (CWE-125) without a TF install. SSTable builder is copied
+#       verbatim from generate_saved_model_malicious_overflow.py. Generator is run by
+#       WORK/run_oob_repro.sh and (after validation) by the CMake build system.
+#
+# Usage: python3 generate_saved_model_oob_index.py <output_dir>
+#        Output dirs are created under <output_dir>/.
+
+import os
+import struct
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Protobuf varint / field encoding (copied from generate_saved_model_malicious_overflow.py)
+# ---------------------------------------------------------------------------
+
+def encode_varint(value):
+    result = bytearray()
+    while value > 0x7F:
+        result.append((value & 0x7F) | 0x80)
+        value >>= 7
+    result.append(value & 0x7F)
+    return bytes(result)
+
+
+def encode_signed_varint(value):
+    if value < 0:
+        value = (1 << 64) + value
+    return encode_varint(value)
+
+
+def encode_field(field_number, wire_type, data):
+    tag = (field_number << 3) | wire_type
+    return encode_varint(tag) + data
+
+
+def encode_varint_field(field_number, value):
+    return encode_field(field_number, 0, encode_varint(value))
+
+
+def encode_signed_varint_field(field_number, value):
+    return encode_field(field_number, 0, encode_signed_varint(value))
+
+
+def encode_bytes_field(field_number, data):
+    return encode_field(field_number, 2, encode_varint(len(data)) + data)
+
+
+def encode_string_field(field_number, s):
+    return encode_bytes_field(field_number, s.encode('utf-8'))
+
+
+def encode_fixed32_field(field_number, value):
+    return encode_field(field_number, 5, struct.pack('<I', value))
+
+
+# ---------------------------------------------------------------------------
+# SSTable builder (copied from generate_saved_model_malicious_overflow.py)
+# ---------------------------------------------------------------------------
+
+def build_sstable_block(entries):
+    block = bytearray()
+    restart_offsets = []
+    prev_key = b''
+    for i, (key, value) in enumerate(entries):
+        key_bytes = key.encode('utf-8') if isinstance(key, str) else key
+        shared = 0
+        for j in range(min(len(prev_key), len(key_bytes))):
+            if prev_key[j] == key_bytes[j]:
+                shared += 1
+            else:
+                break
+        non_shared = len(key_bytes) - shared
+        if i % 16 == 0:
+            restart_offsets.append(len(block))
+            shared = 0
+            non_shared = len(key_bytes)
+        block.extend(encode_varint(shared))
+        block.extend(encode_varint(non_shared))
+        block.extend(encode_varint(len(value)))
+        block.extend(key_bytes[shared:])
+        block.extend(value)
+        prev_key = key_bytes
+    if not restart_offsets:
+        restart_offsets = [0]
+    for off in restart_offsets:
+        block.extend(struct.pack('<I', off))
+    block.extend(struct.pack('<I', len(restart_offsets)))
+    return bytes(block)
+
+
+def build_sstable_footer(index_block_offset, index_block_size,
+                         metaindex_block_offset=0, metaindex_block_size=0):
+    metaindex_handle = encode_varint(metaindex_block_offset) + encode_varint(metaindex_block_size)
+    index_handle = encode_varint(index_block_offset) + encode_varint(index_block_size)
+    footer = bytearray()
+    footer.extend(metaindex_handle)
+    footer.extend(index_handle)
+    while len(footer) < 40:
+        footer.append(0)
+    footer.extend(struct.pack('<Q', 0xdb4775248b80fb57))
+    return bytes(footer)
+
+
+def build_bundle_header_proto():
+    """BundleHeaderProto: num_shards=1, endianness=LITTLE, version={producer=1,min_consumer=0}"""
+    version = encode_varint_field(1, 1) + encode_varint_field(2, 0)
+    return encode_varint_field(1, 1) + encode_varint_field(2, 0) + encode_bytes_field(3, version)
+
+
+def build_minimal_variables_index():
+    """Minimal SSTable with only the bundle header key. num_shards=1."""
+    header_proto = build_bundle_header_proto()
+    data_entries = [("", header_proto)]
+    data_block = build_sstable_block(data_entries)
+    data_block_full = data_block + b'\x00' + struct.pack('<I', 0)
+
+    metaindex_block = build_sstable_block([])
+    metaindex_full = metaindex_block + b'\x00' + struct.pack('<I', 0)
+
+    last_key = ""
+    data_block_handle = encode_varint(0) + encode_varint(len(data_block))
+    index_block = build_sstable_block([(last_key, data_block_handle)])
+    index_full = index_block + b'\x00' + struct.pack('<I', 0)
+
+    metaindex_offset = len(data_block_full)
+    index_offset = metaindex_offset + len(metaindex_full)
+
+    footer = build_sstable_footer(
+        index_block_offset=index_offset,
+        index_block_size=len(index_block),
+        metaindex_block_offset=metaindex_offset,
+        metaindex_block_size=len(metaindex_block))
+
+    return data_block_full + metaindex_full + index_full + footer
+
+
+# ---------------------------------------------------------------------------
+# GraphDef / SavedModel builder
+# ---------------------------------------------------------------------------
+
+def build_node_def(name, op, inputs=None, attrs=None):
+    msg = encode_string_field(1, name) + encode_string_field(2, op)
+    if inputs:
+        for inp in inputs:
+            msg += encode_string_field(3, inp)
+    if attrs:
+        for key, val in attrs.items():
+            map_entry = encode_string_field(1, key) + encode_bytes_field(2, val)
+            msg += encode_bytes_field(5, map_entry)
+    return msg
+
+
+def build_saved_model_pb(identity_input):
+    """
+    Build saved_model.pb with:
+      VarHandleOp("my_var")
+      Const("tensor_names")  — 1 string_val entry ("Variable")
+      RestoreV2("save/RestoreV2")  — inputs: [prefix, tensor_names, shape_and_slices]
+      Identity("save/identity")  — input[0] = identity_input  (attacker-controlled)
+      AssignVariableOp("save/Assign")  — input[0]=my_var, input[1]=save/identity
+
+    parse_node_name(identity_input) extracts the RestoreV2 output index.
+    """
+    DT_FLOAT = 1
+    DT_STRING = 7
+
+    # VarHandleOp attrs
+    dtype_attr = encode_varint_field(6, DT_FLOAT)
+    dim2 = encode_signed_varint_field(1, 2)
+    shape_proto = encode_bytes_field(2, dim2) + encode_bytes_field(2, dim2)
+    shape_attr = encode_bytes_field(7, shape_proto)
+
+    varhandle_node = build_node_def(
+        "my_var", "VarHandleOp",
+        attrs={"dtype": dtype_attr, "shape": shape_attr,
+               "container": encode_string_field(2, ""),
+               "shared_name": encode_string_field(2, "my_var")})
+
+    # Const("tensor_names") — TensorProto with exactly 1 string_val
+    # TensorProto: field 1=dtype, field 4=tensor_shape (empty dims = scalar... but
+    # for string_val we use a 1-D shape), field 8=string_val (repeated bytes)
+    tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, 1))  # dim[0].size=1
+    tensor_proto = (encode_varint_field(1, DT_STRING) +      # dtype = DT_STRING
+                    encode_bytes_field(4, tensor_shape) +     # tensor_shape
+                    encode_bytes_field(8, b"Variable"))       # string_val[0] = "Variable"
+    tensor_attr = encode_bytes_field(8, tensor_proto)         # AttrValue.tensor
+    dtype_str_attr = encode_varint_field(6, DT_STRING)        # AttrValue.type = DT_STRING
+
+    const_node = build_node_def(
+        "tensor_names", "Const",
+        attrs={"value": tensor_attr, "dtype": dtype_str_attr})
+
+    # Const("shape_and_slices") — 1 string_val ""
+    empty_shape_tensor = (encode_varint_field(1, DT_STRING) +
+                          encode_bytes_field(4, tensor_shape) +
+                          encode_bytes_field(8, b""))
+    empty_shape_attr = encode_bytes_field(8, empty_shape_tensor)
+
+    shape_slices_node = build_node_def(
+        "shape_and_slices", "Const",
+        attrs={"value": empty_shape_attr, "dtype": dtype_str_attr})
+
+    # Const("prefix") — scalar string "checkpoint"
+    scalar_shape = encode_bytes_field(4, b"")  # empty TensorShapeProto = scalar
+    prefix_tensor = (encode_varint_field(1, DT_STRING) +
+                     scalar_shape +
+                     encode_bytes_field(8, b"checkpoint"))
+    prefix_attr = encode_bytes_field(8, prefix_tensor)
+
+    prefix_node = build_node_def(
+        "prefix", "Const",
+        attrs={"value": prefix_attr, "dtype": dtype_str_attr})
+
+    # RestoreV2 — inputs: prefix, tensor_names, shape_and_slices
+    # output_types attr = [DT_FLOAT]
+    list_attr = encode_bytes_field(5, encode_varint_field(6, DT_FLOAT))  # AttrValue.list.type
+    restorev2_node = build_node_def(
+        "save/RestoreV2", "RestoreV2",
+        inputs=["prefix", "tensor_names", "shape_and_slices"],
+        attrs={"dtypes": list_attr})
+
+    # Identity — input[0] = identity_input (attacker-controlled, e.g. "save/RestoreV2:999")
+    t_attr = encode_varint_field(6, DT_FLOAT)
+    identity_node = build_node_def(
+        "save/identity", "Identity",
+        inputs=[identity_input],
+        attrs={"T": t_attr})
+
+    # AssignVariableOp — input[0]=my_var, input[1]=save/identity
+    assign_node = build_node_def(
+        "save/Assign", "AssignVariableOp",
+        inputs=["my_var", "save/identity"],
+        attrs={"dtype": dtype_attr})
+
+    # ReadVariableOp + Identity for model output (so the model has a signature)
+    read_node = build_node_def(
+        "read_var", "ReadVariableOp",
+        inputs=["my_var"],
+        attrs={"dtype": dtype_attr})
+
+    output_identity = build_node_def(
+        "Identity", "Identity",
+        inputs=["read_var"],
+        attrs={"T": t_attr})
+
+    graph_def = (encode_bytes_field(1, varhandle_node) +
+                 encode_bytes_field(1, const_node) +
+                 encode_bytes_field(1, shape_slices_node) +
+                 encode_bytes_field(1, prefix_node) +
+                 encode_bytes_field(1, restorev2_node) +
+                 encode_bytes_field(1, identity_node) +
+                 encode_bytes_field(1, assign_node) +
+                 encode_bytes_field(1, read_node) +
+                 encode_bytes_field(1, output_identity))
+
+    meta_info_def = encode_string_field(1, "serve")
+    tensor_info = encode_string_field(1, "Identity:0") + encode_varint_field(2, DT_FLOAT)
+    sig_output_entry = encode_string_field(1, "output_0") + encode_bytes_field(2, tensor_info)
+    signature_def = encode_bytes_field(2, sig_output_entry)
+    sig_map_entry = encode_string_field(1, "serving_default") + encode_bytes_field(2, signature_def)
+    meta_graph_def = (encode_bytes_field(1, meta_info_def) +
+                      encode_bytes_field(2, graph_def) +
+                      encode_bytes_field(5, sig_map_entry))
+
+    return encode_signed_varint_field(1, 1) + encode_bytes_field(2, meta_graph_def)
+
+
+def write_savedmodel(output_dir, identity_input):
+    os.makedirs(os.path.join(output_dir, "variables"), exist_ok=True)
+    with open(os.path.join(output_dir, "saved_model.pb"), 'wb') as f:
+        f.write(build_saved_model_pb(identity_input))
+    with open(os.path.join(output_dir, "variables", "variables.index"), 'wb') as f:
+        f.write(build_minimal_variables_index())
+    with open(os.path.join(output_dir, "variables", "variables.data-00000-of-00001"), 'wb') as f:
+        f.write(b'\x00' * 64)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <output_dir>")
+        sys.exit(1)
+
+    base = sys.argv[1]
+
+    # Positive OOB: index 999 into a tensor with 1 string_val
+    write_savedmodel(os.path.join(base, "saved_model_oob_pos_index"), "save/RestoreV2:999")
+    print(f"Generated: {os.path.join(base, 'saved_model_oob_pos_index')}")
+
+    # Negative OOB: index -1
+    write_savedmodel(os.path.join(base, "saved_model_oob_neg_index"), "save/RestoreV2:-1")
+    print(f"Generated: {os.path.join(base, 'saved_model_oob_neg_index')}")
+
+    # No colon: parse_node_name produces only 1 token → size<2 guard fires
+    write_savedmodel(os.path.join(base, "saved_model_oob_no_colon"), "save/RestoreV2")
+    print(f"Generated: {os.path.join(base, 'saved_model_oob_no_colon')}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_oob_index.py
@@ -1,20 +1,24 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # What: Generates 3 malicious TF SavedModel directories that trigger the OOB read in
-#       VariablesIndex::map_assignvariable() (variables_index.cpp lines 408/412 and 436/440).
+#       VariablesIndex::map_assignvariable() (variables_index.cpp).
 #       No TF runtime needed — all protobuf and SSTable structures are built by hand.
 #
 # How:  Each SavedModel has:
 #         saved_model.pb              — GraphDef with VarHandleOp, Const(tensor_names),
 #                                       RestoreV2, Identity, AssignVariableOp.
-#                                       Identity.input[0] is set to a malicious string so
-#                                       parse_node_name() extracts an OOB index.
 #         variables/variables.index   — Minimal SSTable (bundle header only, num_shards=1).
 #         variables/variables.data-*  — 64 zero bytes (needed to pass open-file checks).
 #
 #       Three variants:
-#         saved_model_oob_pos_index/  — Identity.input = "save/RestoreV2:999" (positive OOB)
-#         saved_model_oob_neg_index/  — Identity.input = "save/RestoreV2:-1"  (negative OOB)
-#         saved_model_oob_no_colon/   — Identity.input = "save/RestoreV2"     (no colon,
-#                                       triggers restore_output.size()<2 check)
+#         saved_model_oob_pos_index/    — Identity.input = "save/RestoreV2:999",
+#                                         tensor_names has 1 entry → positive OOB index
+#         saved_model_oob_neg_index/    — Identity.input = "save/RestoreV2:-1",
+#                                         tensor_names has 1 entry → negative OOB index
+#         saved_model_oob_empty_names/  — Identity.input = "save/RestoreV2:0",
+#                                         tensor_names has 0 entries → OOB via implicit-0
+#                                         path when string_val_size()==0
 #
 # Why:  SSTable builder is copied verbatim from generate_saved_model_malicious_overflow.py.
 #       Generator is run by the CMake build system.
@@ -168,16 +172,17 @@ def build_node_def(name, op, inputs=None, attrs=None):
     return msg
 
 
-def build_saved_model_pb(identity_input):
+def build_saved_model_pb(identity_input, num_string_vals=1):
     """
     Build saved_model.pb with:
       VarHandleOp("my_var")
-      Const("tensor_names")  — 1 string_val entry ("Variable")
-      RestoreV2("save/RestoreV2")  — inputs: [prefix, tensor_names, shape_and_slices]
-      Identity("save/identity")  — input[0] = identity_input  (attacker-controlled)
-      AssignVariableOp("save/Assign")  — input[0]=my_var, input[1]=save/identity
+      Const("tensor_names")  — num_string_vals string_val entries
+      RestoreV2("save/RestoreV2")
+      Identity("save/identity")  — input[0] = identity_input
+      AssignVariableOp("save/Assign")
 
-    parse_node_name(identity_input) extracts the RestoreV2 output index.
+    identity_input controls the RestoreV2 output index extracted by parse_node_name().
+    num_string_vals controls how many entries tensor_names has (0 = empty → OOB at index 0).
     """
     DT_FLOAT = 1
     DT_STRING = 7
@@ -194,32 +199,32 @@ def build_saved_model_pb(identity_input):
                "container": encode_string_field(2, ""),
                "shared_name": encode_string_field(2, "my_var")})
 
-    # Const("tensor_names") — TensorProto with exactly 1 string_val
-    # TensorProto: field 1=dtype, field 4=tensor_shape (empty dims = scalar... but
-    # for string_val we use a 1-D shape), field 8=string_val (repeated bytes)
-    tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, 1))  # dim[0].size=1
-    tensor_proto = (encode_varint_field(1, DT_STRING) +      # dtype = DT_STRING
-                    encode_bytes_field(4, tensor_shape) +     # tensor_shape
-                    encode_bytes_field(8, b"Variable"))       # string_val[0] = "Variable"
-    tensor_attr = encode_bytes_field(8, tensor_proto)         # AttrValue.tensor
-    dtype_str_attr = encode_varint_field(6, DT_STRING)        # AttrValue.type = DT_STRING
+    # Const("tensor_names") — TensorProto with num_string_vals string_val entries
+    actual_size = max(num_string_vals, 0)
+    tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, actual_size))
+    tensor_proto = encode_varint_field(1, DT_STRING) + encode_bytes_field(4, tensor_shape)
+    for _ in range(actual_size):
+        tensor_proto += encode_bytes_field(8, b"Variable")
+    tensor_attr = encode_bytes_field(8, tensor_proto)
+    dtype_str_attr = encode_varint_field(6, DT_STRING)
 
     const_node = build_node_def(
         "tensor_names", "Const",
         attrs={"value": tensor_attr, "dtype": dtype_str_attr})
 
-    # Const("shape_and_slices") — 1 string_val ""
-    empty_shape_tensor = (encode_varint_field(1, DT_STRING) +
-                          encode_bytes_field(4, tensor_shape) +
-                          encode_bytes_field(8, b""))
+    # Const("shape_and_slices")
+    shape_tensor_shape = encode_bytes_field(2, encode_signed_varint_field(1, actual_size))
+    empty_shape_tensor = encode_varint_field(1, DT_STRING) + encode_bytes_field(4, shape_tensor_shape)
+    for _ in range(actual_size):
+        empty_shape_tensor += encode_bytes_field(8, b"")
     empty_shape_attr = encode_bytes_field(8, empty_shape_tensor)
 
     shape_slices_node = build_node_def(
         "shape_and_slices", "Const",
         attrs={"value": empty_shape_attr, "dtype": dtype_str_attr})
 
-    # Const("prefix") — scalar string "checkpoint"
-    scalar_shape = encode_bytes_field(4, b"")  # empty TensorShapeProto = scalar
+    # Const("prefix")
+    scalar_shape = encode_bytes_field(4, b"")
     prefix_tensor = (encode_varint_field(1, DT_STRING) +
                      scalar_shape +
                      encode_bytes_field(8, b"checkpoint"))
@@ -229,28 +234,27 @@ def build_saved_model_pb(identity_input):
         "prefix", "Const",
         attrs={"value": prefix_attr, "dtype": dtype_str_attr})
 
-    # RestoreV2 — inputs: prefix, tensor_names, shape_and_slices
-    # output_types attr = [DT_FLOAT]
-    list_attr = encode_bytes_field(5, encode_varint_field(6, DT_FLOAT))  # AttrValue.list.type
+    # RestoreV2
+    list_attr = encode_bytes_field(5, encode_varint_field(6, DT_FLOAT))
     restorev2_node = build_node_def(
         "save/RestoreV2", "RestoreV2",
         inputs=["prefix", "tensor_names", "shape_and_slices"],
         attrs={"dtypes": list_attr})
 
-    # Identity — input[0] = identity_input (attacker-controlled, e.g. "save/RestoreV2:999")
+    # Identity
     t_attr = encode_varint_field(6, DT_FLOAT)
     identity_node = build_node_def(
         "save/identity", "Identity",
         inputs=[identity_input],
         attrs={"T": t_attr})
 
-    # AssignVariableOp — input[0]=my_var, input[1]=save/identity
+    # AssignVariableOp
     assign_node = build_node_def(
         "save/Assign", "AssignVariableOp",
         inputs=["my_var", "save/identity"],
         attrs={"dtype": dtype_attr})
 
-    # ReadVariableOp + Identity for model output (so the model has a signature)
+    # ReadVariableOp + Identity for model output
     read_node = build_node_def(
         "read_var", "ReadVariableOp",
         inputs=["my_var"],
@@ -283,10 +287,10 @@ def build_saved_model_pb(identity_input):
     return encode_signed_varint_field(1, 1) + encode_bytes_field(2, meta_graph_def)
 
 
-def write_savedmodel(output_dir, identity_input):
+def write_savedmodel(output_dir, identity_input, num_string_vals=1):
     os.makedirs(os.path.join(output_dir, "variables"), exist_ok=True)
     with open(os.path.join(output_dir, "saved_model.pb"), 'wb') as f:
-        f.write(build_saved_model_pb(identity_input))
+        f.write(build_saved_model_pb(identity_input, num_string_vals))
     with open(os.path.join(output_dir, "variables", "variables.index"), 'wb') as f:
         f.write(build_minimal_variables_index())
     with open(os.path.join(output_dir, "variables", "variables.data-00000-of-00001"), 'wb') as f:
@@ -304,13 +308,15 @@ def main():
     write_savedmodel(os.path.join(base, "saved_model_oob_pos_index"), "save/RestoreV2:999")
     print(f"Generated: {os.path.join(base, 'saved_model_oob_pos_index')}")
 
-    # Negative OOB: index -1
+    # Negative OOB: index -1 into a tensor with 1 string_val
     write_savedmodel(os.path.join(base, "saved_model_oob_neg_index"), "save/RestoreV2:-1")
     print(f"Generated: {os.path.join(base, 'saved_model_oob_neg_index')}")
 
-    # No colon: parse_node_name produces only 1 token → size<2 guard fires
-    write_savedmodel(os.path.join(base, "saved_model_oob_no_colon"), "save/RestoreV2")
-    print(f"Generated: {os.path.join(base, 'saved_model_oob_no_colon')}")
+    # Empty tensor_names: index 0 into a tensor with 0 string_val entries;
+    # exercises the upper-bound guard on the implicit-0 code path
+    write_savedmodel(os.path.join(base, "saved_model_oob_empty_names"), "save/RestoreV2:0",
+                     num_string_vals=0)
+    print(f"Generated: {os.path.join(base, 'saved_model_oob_empty_names')}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Details:
- `map_assignvariable()` in `variables_index.cpp` converted the colon-suffix
  of a node input string (e.g. `RestoreV2:999`) to an integer via `std::atoi()`
  and passed it directly to protobuf's `string_val()`, which has no bounds
  checking in release builds.
- A crafted SavedModel with a large or negative index caused a heap OOB read
  (SIGSEGV on the machines tested).
- Two `FRONT_END_GENERAL_CHECK` guards added before each `string_val()` call
  in both the `AssignVariableOp` and `Assign` paths:
  - `restorev2_nodes[0]->inputs.size() > 1` — RestoreV2 must have its
    `tensor_names` Const input linked (guards against malformed/unordered GraphDef)
  - `tensor_names_node->op() == "Const" && attr().count("value") > 0` — input
    must be a Const with the expected attribute
  - `0 <= output_index < tensor.string_val_size()` — range check
- `std::atoi` replaced with `std::strtol` + overflow detection to eliminate UB
  on out-of-range inputs. A non-numeric or missing colon suffix produces `output_index=0`,
  matching TF semantics for the colon-less form (e.g. `save/RestoreV2` implicitly
  refers to output 0). This is intentional: a strict `restore_output.size() >= 2`
  guard would break valid SavedModels that use the colon-less node reference form
  (regression observed in MetaGraph* tests in CI).
- `<stdlib.h>` replaced with `<cstdlib>` so `std::strtol` is correctly declared.

### Tickets:
 - 182685
