### PR TITLE
[GPU] fix CL_OUT_OF_RESOURCE issue in arg_max_gpu_min_large_output_size.sort_by_indices testcase

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/arg_max_min_axis.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/arg_max_min_axis.cl
@@ -383,7 +383,7 @@ KERNEL(arg_max_min_modified)(
         const uint counter_offset = counter_size * OPERATION_NUM;
         __global uint* merge_counter = OFFSET_GLOBAL_PTR(uint, tmp_buffer1, output_idx * counter_size);
         __global uint* max_merge_counter = OFFSET_GLOBAL_PTR(uint, tmp_buffer1, counter_offset + output_idx * counter_size);
-        __global bool* subgroup_done = OFFSET_GLOBAL_PTR(bool, tmp_buffer2, output_idx);
+        __global bool* subgroup_done = OFFSET_GLOBAL_PTR(bool, tmp_buffer2, output_idx * group_num);
     #else
         uint merge_counter[group_num];
         uint max_merge_counter[group_num];

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
@@ -121,9 +121,15 @@ std::vector<InternalBuffer> get_internal_buffer_sizes(const arg_max_min_params& 
     const size_t sort_size = getSortSize(params);
     const size_t ops_size = getOperationNumber(params);
     const size_t group_size = params.topK >= 8 ? params.topK : 8;
-    const size_t group_num = ((sort_size - 1) / group_size) + 1;
 
     std::vector<InternalBuffer> buffer_sizes;
+    if (sort_size == 0 || ops_size == 0) {
+        buffer_sizes.resize(3);
+        return buffer_sizes;
+    }
+
+    const size_t group_num = (sort_size + group_size - 1) / group_size;
+
     if (params.topK == 1) {
         buffer_sizes.push_back(iav_type_size * sort_size * 2);
     } else {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
@@ -122,23 +122,17 @@ std::vector<InternalBuffer> get_internal_buffer_sizes(const arg_max_min_params& 
     const size_t ops_size = getOperationNumber(params);
     const size_t group_size = params.topK >= 8 ? params.topK : 8;
 
-    std::vector<InternalBuffer> buffer_sizes;
-    if (sort_size == 0 || ops_size == 0) {
-        buffer_sizes.resize(3);
-        return buffer_sizes;
+    if (0 == sort_size || 0 == ops_size) {
+        return {0, 0, 0};
     }
+    const size_t first_buff_size = (params.topK == 1) ? iav_type_size * sort_size * 2 : iav_type_size * sort_size * ops_size * 2;
 
     const size_t group_num = (sort_size + group_size - 1) / group_size;
+    const size_t second_buff_size = 4 * group_num * ops_size * 2;
 
-    if (params.topK == 1) {
-        buffer_sizes.push_back(iav_type_size * sort_size * 2);
-    } else {
-        buffer_sizes.push_back(iav_type_size * sort_size * ops_size * 2);
-    }
-    buffer_sizes.push_back(4 * group_num * ops_size * 2);
-    buffer_sizes.push_back(Align(ops_size * group_num, elem_size));
+    const size_t third_buff_size = Align(ops_size * group_num, elem_size);
 
-    return buffer_sizes;
+    return {first_buff_size, second_buff_size, third_buff_size};
 }
 }  // namespace
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
@@ -114,6 +114,28 @@ ArgMaxMinKernelBase::DispatchData ArgMaxMinKernelAxis::SetDefault(const arg_max_
     return dispatchData;
 }
 
+namespace {
+std::vector<InternalBuffer> get_internal_buffer_sizes(const arg_max_min_params& params) {
+    const size_t elem_size = params.inputs[0].ElementSize();
+    const size_t iav_type_size = Align(elem_size + 4, 4);
+    const size_t sort_size = getSortSize(params);
+    const size_t ops_size = getOperationNumber(params);
+    const size_t group_size = params.topK >= 8 ? params.topK : 8;
+    const size_t group_num = ((sort_size - 1) / group_size) + 1;
+
+    std::vector<InternalBuffer> buffer_sizes;
+    if (params.topK == 1) {
+        buffer_sizes.push_back(iav_type_size * sort_size * 2);
+    } else {
+        buffer_sizes.push_back(iav_type_size * sort_size * ops_size * 2);
+    }
+    buffer_sizes.push_back(4 * group_num * ops_size * 2);
+    buffer_sizes.push_back(ops_size * elem_size);
+
+    return buffer_sizes;
+}
+}  // namespace
+
 void ArgMaxMinKernelAxis::GetUpdateDispatchDataFunc(KernelData& kd) const {
     kd.update_dispatch_data_func = [this](const Params& params, KernelData& kd) {
         const auto& prim_params = static_cast<const arg_max_min_params&>(params);
@@ -123,21 +145,7 @@ void ArgMaxMinKernelAxis::GetUpdateDispatchDataFunc(KernelData& kd) const {
         kd.kernels[0].params.workGroups.local = dispatchData.lws;
         kd.kernels[0].skip_execution = KernelData::SkipKernelExecution(prim_params);
 
-        const size_t elem_size = prim_params.inputs[0].ElementSize();
-        const size_t iav_type_size = Align(elem_size + 4, 4);
-        const size_t sort_size = getSortSize(prim_params);
-        const size_t ops_size = getOperationNumber(prim_params);
-        const size_t group_size = prim_params.topK >= 8 ? prim_params.topK : 8;
-        const size_t group_num = ((sort_size - 1) / group_size) + 1;
-
-        kd.internalBuffers.clear();
-        if (prim_params.topK == 1) {
-            kd.internalBuffers.push_back(iav_type_size * sort_size * 2);
-        } else {
-            kd.internalBuffers.push_back(iav_type_size * sort_size * ops_size * 2);
-        }
-        kd.internalBuffers.push_back(4 * group_num * ops_size * 2);
-        kd.internalBuffers.push_back(ops_size * elem_size);
+        kd.internalBuffers = get_internal_buffer_sizes(prim_params);
         kd.internalBufferDataType = prim_params.inputs[0].GetDType();
     };
 }
@@ -176,9 +184,7 @@ KernelsData ArgMaxMinKernelAxis::GetKernelsData(const Params& params) const {
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 0});
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 1});
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 2});
-        kd.internalBuffers.push_back(orgParams.inputs[0].PhysicalSizeInBytes());
-        kd.internalBuffers.push_back(orgParams.inputs[0].PhysicalSizeInBytes());
-        kd.internalBuffers.push_back(orgParams.inputs[0].PhysicalSizeInBytes());
+        kd.internalBuffers = get_internal_buffer_sizes(orgParams);
         kd.internalBufferDataType = orgParams.inputs[0].GetDType();
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
@@ -136,7 +136,7 @@ std::vector<InternalBuffer> get_internal_buffer_sizes(const arg_max_min_params& 
         buffer_sizes.push_back(iav_type_size * sort_size * ops_size * 2);
     }
     buffer_sizes.push_back(4 * group_num * ops_size * 2);
-    buffer_sizes.push_back(ops_size * elem_size);
+    buffer_sizes.push_back(ops_size * group_num);
 
     return buffer_sizes;
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
@@ -136,7 +136,7 @@ std::vector<InternalBuffer> get_internal_buffer_sizes(const arg_max_min_params& 
         buffer_sizes.push_back(iav_type_size * sort_size * ops_size * 2);
     }
     buffer_sizes.push_back(4 * group_num * ops_size * 2);
-    buffer_sizes.push_back(ops_size * group_num);
+    buffer_sizes.push_back(Align(ops_size * group_num, elem_size));
 
     return buffer_sizes;
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
@@ -737,23 +737,24 @@ TEST(arg_max_gpu_min_large_output_size, sort_by_indices) {
     // No data checking.  The test will fail to compile if kernel not switch to use global memory
 }
 
-TEST(arg_max_gpu_kernel_selector, axis_internal_buffer_sizes_match_update_path) {
+TEST(arg_max_gpu_topk_axis, large_output_size_internal_buffer_sizes_match_update_path) {
     kernel_selector::arg_max_min_params params;
-    params.inputs.push_back(kernel_selector::DataTensor({1, 1, 1, 20000},
-                                                        kernel_selector::Datatype::F32,
-                                                        kernel_selector::DataLayout::bfyx));
-    params.outputs.push_back(kernel_selector::DataTensor({1, 1, 1, 6000},
-                                                         kernel_selector::Datatype::F32,
-                                                         kernel_selector::DataLayout::bfyx));
+    params.inputs[0] = kernel_selector::DataTensor(std::vector<size_t>{20000, 1, 1, 1},
+                                                   kernel_selector::Datatype::F32,
+                                                   kernel_selector::DataLayout::yxfb);
+    params.outputs[0] = kernel_selector::DataTensor(std::vector<size_t>{6000, 1, 1, 1},
+                                                    kernel_selector::Datatype::F32,
+                                                    kernel_selector::DataLayout::yxfb);
     params.argMaxMinAxis = kernel_selector::ArgMaxMinAxis::BATCH;
-    params.argMaxMinOut = kernel_selector::ArgMaxMinOut::MIN;
+    params.argMaxMinOut = kernel_selector::ArgMaxMinOut::MAX;
     params.argMaxMinSortType = kernel_selector::ArgMaxMinSortType::INDEX;
     params.topK = 6000;
     params.outputs_num = 1;
+    // Selector-level tests construct EngineInfo manually. We only need a non-zero
+    // maxWorkGroupSize so GetOptimalLocalWorkGroupSizes() can derive valid LWS;
+    // 256 is the smallest stable bucket in the selector heuristics and avoids
+    // baking in 512/1024-specific behavior that is irrelevant to this test.
     params.engineInfo.maxWorkGroupSize = 256;
-    params.engineInfo.maxLocalMemSize = 64 * 1024;
-    params.engineInfo.computeUnitsCount = 128;
-    params.engineInfo.supports_non_uniform_work_group = true;
 
     kernel_selector::ArgMaxMinKernelAxis kernel;
     auto kernels_data = kernel.GetKernelsData(params);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
@@ -9,6 +9,7 @@
 #include <intel_gpu/primitives/input_layout.hpp>
 #include <intel_gpu/primitives/mutable_data.hpp>
 #include <arg_max_min_inst.h>
+#include "arg_max_min/arg_max_min_kernel_axis.h"
 #include "intel_gpu/runtime/internal_properties.hpp"
 #include "test_utils.h"
 
@@ -734,6 +735,42 @@ TEST(arg_max_gpu_min_large_output_size, sort_by_indices) {
     ASSERT_EQ(outputs.begin()->first, "arg_max");
 
     // No data checking.  The test will fail to compile if kernel not switch to use global memory
+}
+
+TEST(arg_max_gpu_kernel_selector, axis_internal_buffer_sizes_match_update_path) {
+    kernel_selector::arg_max_min_params params;
+    params.inputs.push_back(kernel_selector::DataTensor({1, 1, 1, 20000},
+                                                        kernel_selector::Datatype::F32,
+                                                        kernel_selector::DataLayout::bfyx));
+    params.outputs.push_back(kernel_selector::DataTensor({1, 1, 1, 6000},
+                                                         kernel_selector::Datatype::F32,
+                                                         kernel_selector::DataLayout::bfyx));
+    params.argMaxMinAxis = kernel_selector::ArgMaxMinAxis::BATCH;
+    params.argMaxMinOut = kernel_selector::ArgMaxMinOut::MIN;
+    params.argMaxMinSortType = kernel_selector::ArgMaxMinSortType::INDEX;
+    params.topK = 6000;
+    params.outputs_num = 1;
+    params.engineInfo.maxWorkGroupSize = 256;
+    params.engineInfo.maxLocalMemSize = 64 * 1024;
+    params.engineInfo.computeUnitsCount = 128;
+    params.engineInfo.supports_non_uniform_work_group = true;
+
+    kernel_selector::ArgMaxMinKernelAxis kernel;
+    auto kernels_data = kernel.GetKernelsData(params);
+
+    ASSERT_EQ(kernels_data.size(), size_t(1));
+    auto& kd = kernels_data[0];
+    ASSERT_FALSE(kd.internalBuffers.empty());
+    ASSERT_TRUE(static_cast<bool>(kd.update_dispatch_data_func));
+
+    const auto initial_buffers = kd.internalBuffers;
+    kd.update_dispatch_data_func(params, kd);
+
+    ASSERT_EQ(initial_buffers.size(), kd.internalBuffers.size());
+    for (size_t i = 0; i < initial_buffers.size(); ++i) {
+        ASSERT_EQ(initial_buffers[i].byte_count, kd.internalBuffers[i].byte_count) << "buffer index=" << i;
+        ASSERT_EQ(initial_buffers[i].lockable, kd.internalBuffers[i].lockable) << "buffer index=" << i;
+    }
 }
 
 template <typename T>

--- a/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
@@ -774,6 +774,44 @@ TEST(arg_max_gpu_topk_axis, large_output_size_internal_buffer_sizes_match_update
     }
 }
 
+TEST(arg_max_gpu_topk_axis, zero_sort_size_internal_buffers_are_clamped) {
+    kernel_selector::arg_max_min_params init_params;
+    init_params.inputs[0] = kernel_selector::DataTensor(std::vector<size_t>{20000, 1, 1, 1},
+                                                        kernel_selector::Datatype::F32,
+                                                        kernel_selector::DataLayout::yxfb);
+    init_params.outputs[0] = kernel_selector::DataTensor(std::vector<size_t>{6000, 1, 1, 1},
+                                                         kernel_selector::Datatype::F32,
+                                                         kernel_selector::DataLayout::yxfb);
+    init_params.argMaxMinAxis = kernel_selector::ArgMaxMinAxis::BATCH;
+    init_params.argMaxMinOut = kernel_selector::ArgMaxMinOut::MAX;
+    init_params.argMaxMinSortType = kernel_selector::ArgMaxMinSortType::INDEX;
+    init_params.topK = 6000;
+    init_params.outputs_num = 1;
+    init_params.engineInfo.maxWorkGroupSize = 256;
+
+    kernel_selector::arg_max_min_params zero_params = init_params;
+    zero_params.inputs[0] = kernel_selector::DataTensor(std::vector<size_t>{0, 1, 1, 1},
+                                                        kernel_selector::Datatype::F32,
+                                                        kernel_selector::DataLayout::yxfb);
+    zero_params.outputs[0] = kernel_selector::DataTensor(std::vector<size_t>{0, 1, 1, 1},
+                                                         kernel_selector::Datatype::F32,
+                                                         kernel_selector::DataLayout::yxfb);
+
+    kernel_selector::ArgMaxMinKernelAxis kernel;
+    auto kernels_data = kernel.GetKernelsData(init_params);
+
+    ASSERT_EQ(kernels_data.size(), size_t(1));
+    auto& kd = kernels_data[0];
+    ASSERT_TRUE(static_cast<bool>(kd.update_dispatch_data_func));
+
+    kd.update_dispatch_data_func(zero_params, kd);
+
+    ASSERT_EQ(kd.internalBuffers.size(), size_t(3));
+    for (size_t i = 0; i < kd.internalBuffers.size(); ++i) {
+        ASSERT_EQ(kd.internalBuffers[i].byte_count, size_t(0)) << "buffer index=" << i;
+    }
+}
+
 template <typename T>
 void test_top_k_layer_tests_sort_probabilities_by_indices(bool is_caching_test) {
     static const int32_t x_size = 10, y_size = 1, feature_num = 1, batch_num = 1;


### PR DESCRIPTION
### Details:
Fix CL_OUT_OF_RESOURCE issue in arg_max_gpu_min_large_output_size.sort_by_indices

### Description of the issue
#### Symptom
"[GPU] clFinish, error code: -5 CL_OUT_OF_RESOURCES" will be reported when running this testcase.

#### Root cause
ArgMaxMinKernelAxis used inconsistent internal buffer sizing logic between the initial kernel creation path and the runtime dispatch-update path.

#### How to fix it
Use a single shared internal buffer sizing function in both GetKernelsData() and GetUpdateDispatchDataFunc().

#### The code and line that caused this issue
https://github.com/openvinotoolkit/openvino/blob/51ac1b94f89e99aafebc0a122a5284852678505f/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp#L179-L181

#### Reproduction step and snapshot
`
./ov_gpu_func_tests --device_suffix=1 --gtest_filter='arg_max_gpu_min_large_output_size.sort_by_indices'
`

#### Problematic graph
N/A

#### Checklist 
 - [x] Is it a proper fix? (not a workaround) 
 - [x] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review? 

### Tickets:
- CVS-185089

### AI Assistance:
 - *AI assistance used: yes*
 - *Used to analyze the symptom.*