### PR TITLE
[GPU] Support 4-D non-grouped weights in ConvertFCToCompressed

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
@@ -76,7 +76,7 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
                                                             : ov::Shape{current_shape[0], current_shape[1] * current_shape[2]};
             } else if (current_shape.size() == 4 && is_weight_3d) {
                 new_shape = (has_transpose || !grouped) ? ov::Shape{current_shape[0], current_shape[1] * current_shape[2], current_shape[3]}
-                                                        : ov::Shape{current_shape[0], current_shape[1], current_shape[3] * current_shape[2]};
+                                                        : ov::Shape{current_shape[0], current_shape[1], current_shape[2] * current_shape[3]};
             } else if (current_shape.size() == 4 && !is_weight_3d) {
                 new_shape = (has_transpose || !grouped) ? ov::Shape{current_shape[0] * current_shape[1] * current_shape[2], current_shape[3]}
                                                         : ov::Shape{current_shape[0] * current_shape[1], current_shape[2] * current_shape[3]};

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
@@ -74,10 +74,15 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
                 else
                     new_shape = (has_transpose || !grouped) ? ov::Shape{current_shape[0] * current_shape[1], current_shape[2]}
                                                             : ov::Shape{current_shape[0], current_shape[1] * current_shape[2]};
+            } else if (current_shape.size() == 4 && is_weight_3d) {
+                new_shape = (has_transpose || !grouped) ? ov::Shape{current_shape[0], current_shape[1] * current_shape[2], current_shape[3]}
+                                                        : ov::Shape{current_shape[0], current_shape[1], current_shape[3] * current_shape[2]};
+            } else if (current_shape.size() == 4 && !is_weight_3d) {
+                new_shape = (has_transpose || !grouped) ? ov::Shape{current_shape[0] * current_shape[1] * current_shape[2], current_shape[3]}
+                                                        : ov::Shape{current_shape[0] * current_shape[1], current_shape[2] * current_shape[3]};
             } else {
-                OPENVINO_ASSERT(current_shape.size() == 4 && is_weight_3d);
-                    new_shape = (has_transpose || !grouped) ? ov::Shape{current_shape[0], current_shape[1] * current_shape[2], current_shape[3]}
-                                                            : ov::Shape{current_shape[0], current_shape[1], current_shape[3] * current_shape[2]};
+                OPENVINO_THROW("Unexpected constant shape rank ", current_shape.size(),
+                                " with is_weight_3d=", is_weight_3d);
             }
             auto new_constant = std::make_shared<ov::op::v0::Constant>(*constant, new_shape);
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_fc_to_compressed_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_fc_to_compressed_test.cpp
@@ -662,6 +662,70 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed16_i8ZpNotConvertedToU8) {
     }
 }
 
+// 4D non-grouped weight constant: leading dims are unit, only last two are
+// real (K, N). is_weight_3d is false, so the reshape branch must collapse
+// dims [d0, d1, d2, d3] -> [d0*d1*d2, d3] for weight/scale/zp.
+TEST_F(TransformationTestsF, ConvertFCToCompressed17_4dNonGrouped) {
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 16 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 1, 1, 32, 16 }, { 1 });
+        auto convert = std::make_shared<ov::op::v0::Convert>(weights_const, ov::element::f16);
+        auto zp_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 1, 1, 32, 1 }, { 1 });
+        auto zp_convert = std::make_shared<ov::op::v0::Convert>(zp_const, ov::element::f16);
+        auto sub = std::make_shared<ov::op::v1::Subtract>(convert, zp_convert);
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1, 1, 32, 1 }, { 1 });
+        auto scale = std::make_shared<ov::op::v1::Multiply>(sub, scale_const);
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, scale, no_bias);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
+        manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
+    }
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 16 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 32, 16 }, { 1 });
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto zp_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 32, 1 }, { 1 });
+        auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, weights_const, no_bias, scale_const, zp_const);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
+    }
+}
+
+// 4D grouped weight/scale/zp constants with is_weight_3d=true: the FC sees
+// a 3D weight (after 4D->3D reshape), so the reshape_const lambda must
+// collapse 4D constants [d0, d1, d2, d3] -> [d0, d1, d2*d3] (grouped path).
+TEST_F(TransformationTestsF, ConvertFCToCompressed18_4dGroupedWith3dWeight) {
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 8 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u4, ov::Shape{ 2, 4, 2, 4 }, { 1 });
+        auto convert = std::make_shared<ov::op::v0::Convert>(weights_const, ov::element::f16);
+        auto zp_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 2, 4, 2, 1 }, { 1 });
+        auto zp_convert = std::make_shared<ov::op::v0::Convert>(zp_const, ov::element::f16);
+        auto sub = std::make_shared<ov::op::v1::Subtract>(convert, zp_convert);
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 2, 4, 2, 1 }, { 1 });
+        auto scale = std::make_shared<ov::op::v1::Multiply>(sub, scale_const);
+        auto reshape_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 2, 4, -1 });
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(scale, reshape_const, false);
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, reshape, no_bias);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
+        manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
+    }
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 8 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u4, ov::Shape{ 2, 4, 8 }, { 1 });
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 2, 4, 2 }, { 1 });
+        auto zp_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 2, 4, 2 }, { 1 });
+        auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, weights_const, no_bias, scale_const, zp_const);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
+    }
+}
+
 }  // namespace intel_gpu
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
A 4-D weight Constant with only the last two dims non-unit (e.g. [1, 1, K, N]) hit an OPENVINO_ASSERT and dropped off the compressed-FC path.

Add a branch that flattens such shapes to the 2-D layout the compressed-FC kernel expects, and a unit test covering it.

### Tickets:
 - [183843](https://jira.devtools.intel.com/browse/CVS-183843)