### PR TITLE
[`NPU`] [`Configs`] [`ENV vars`] Fix throwing on NPU plugin load if wrong environment value for an option was provided

### DIFF
--- a/src/plugins/intel_npu/src/al/src/config/config.cpp
+++ b/src/plugins/intel_npu/src/al/src/config/config.cpp
@@ -245,7 +245,15 @@ void Config::parseEnvVars() {
                            envVar,
                            opt.envVar().data());
 
-                _impl[opt.key().data()] = opt.validateAndParseFromString(envVar);
+                try {
+                    _impl[opt.key().data()] = opt.validateAndParseFromString(envVar);
+                } catch (const std::exception& e) {
+                    _log.error("Failed to parse environment variable '%s' with value '%s' for option '%s': %s",
+                               opt.envVar().data(),
+                               envVar,
+                               opt.key().data(),
+                               e.what());
+                }
             }
         }
     });

--- a/src/plugins/intel_npu/src/al/src/config/config.cpp
+++ b/src/plugins/intel_npu/src/al/src/config/config.cpp
@@ -248,11 +248,12 @@ void Config::parseEnvVars() {
                 try {
                     _impl[opt.key().data()] = opt.validateAndParseFromString(envVar);
                 } catch (const std::exception& e) {
-                    _log.error("Failed to parse environment variable '%s' with value '%s' for option '%s': %s",
-                               opt.envVar().data(),
-                               envVar,
-                               opt.key().data(),
-                               e.what());
+                    _log.warning(
+                        "Environment variable '%s' with value '%s' was ignored for option '%s' due to error:\n%s",
+                        opt.envVar().data(),
+                        envVar,
+                        opt.key().data(),
+                        e.what());
                 }
             }
         }

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
@@ -4,8 +4,31 @@
 
 #include "internal_properties_tests.hpp"
 
+#include <cstdlib>
+
 #include "common/utils.hpp"
+#include "intel_npu/config/options.hpp"
 #include "intel_npu/npu_private_properties.hpp"
+
+namespace {
+
+void set_env(const std::string& name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name.c_str(), value.c_str());
+#else
+    ::setenv(name.c_str(), value.c_str(), 1);
+#endif
+}
+
+void unset_env(const std::string& name) {
+#ifdef _WIN32
+    _putenv_s(name.c_str(), "");
+#else
+    ::unsetenv(name.c_str());
+#endif
+}
+
+}  // namespace
 
 namespace ov::test::behavior {
 
@@ -110,6 +133,21 @@ TEST_P(OVPropertiesIncorrectTestsNPU, SetPropertiesWithIncorrectKey) {
     }
 }
 
+TEST_P(OVPropertiesEnvVarTestsNPU, WrongEnvVarsDontAffectPluginLoading) {
+    const std::string wrong_env_var_value = "WRONG_ENV_VAR_VALUE";
+    std::ignore = core->get_available_devices();
+    core->unload_plugin(target_device);
+    for (const auto& property_item : properties) {
+        if (std::getenv(property_item.second.as<std::string>().c_str()) == nullptr) {
+            set_env(property_item.second.as<std::string>(), wrong_env_var_value);
+            auto plugins = core->get_available_devices();
+            unset_env(property_item.second.as<std::string>());
+            ASSERT_TRUE(util::contains(plugins, target_device))
+                << "Plugin was not loaded with wrong environment variable " << property_item.second.as<std::string>();
+        }
+    }
+}
+
 TEST_P(OVCheckSetSupportedRWMetricsPropsTestsNPU, ChangeCorrectProperties) {
     std::vector<ov::PropertyName> supported_properties;
     OV_ASSERT_NO_THROW(supported_properties = core->get_property(target_device, ov::supported_properties));
@@ -156,6 +194,23 @@ const std::vector<ov::AnyMap> IncorrectMutablePropertiesWrongValueTypes = {
     {{ov::intel_npu::stepping.name(), "V1"}},
 };
 
+const std::vector<AnyMap> PropsWithEnvVars{
+    {{ov::log::level.name(), ::intel_npu::LOG_LEVEL::envVar()}},
+#ifdef NPU_PLUGIN_DEVELOPER_BUILD
+    {{ov::intel_npu::platform.name(), ::intel_npu::PLATFORM::envVar()}},
+    {{ov::intel_npu::create_executor.name(), ::intel_npu::CREATE_EXECUTOR::envVar()}},
+    {{ov::intel_npu::defer_weights_load.name(), ::intel_npu::DEFER_WEIGHTS_LOAD::envVar()}},
+    {{ov::intel_npu::compiler_type.name(), ::intel_npu::COMPILER_TYPE::envVar()}},
+    {{ov::intel_npu::compilation_mode.name(), ::intel_npu::COMPILATION_MODE::envVar()}},
+    {{ov::intel_npu::dynamic_shape_to_static.name(), ::intel_npu::DYNAMIC_SHAPE_TO_STATIC::envVar()}},
+    {{ov::intel_npu::tiles.name(), ::intel_npu::TILES::envVar()}},
+    {{ov::intel_npu::dma_engines.name(), ::intel_npu::DMA_ENGINES::envVar()}},
+    {{ov::intel_npu::disable_version_check.name(), ::intel_npu::DISABLE_VERSION_CHECK::envVar()}},
+    {{ov::intel_npu::export_raw_blob.name(), ::intel_npu::EXPORT_RAW_BLOB::envVar()}},
+    {{ov::intel_npu::import_raw_blob.name(), ::intel_npu::IMPORT_RAW_BLOB::envVar()}},
+#endif
+};
+
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                          OVPropertiesTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
@@ -167,6 +222,12 @@ INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(compat_IncorrectMutablePropertiesWrongValueTypes)),
                          (ov::test::utils::appendPlatformTypeTestName<OVPropertiesIncorrectTestsNPU>));
+
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
+                         OVPropertiesEnvVarTestsNPU,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(PropsWithEnvVars)),
+                         (ov::test::utils::appendPlatformTypeTestName<OVPropertiesEnvVarTestsNPU>));
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          OVCheckSetSupportedRWMetricsPropsTestsNPU,

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
@@ -140,10 +140,22 @@ TEST_P(OVPropertiesEnvVarTestsNPU, WrongEnvVarsDontAffectPluginLoading) {
     for (const auto& property_item : properties) {
         if (std::getenv(property_item.second.as<std::string>().c_str()) == nullptr) {
             set_env(property_item.second.as<std::string>(), wrong_env_var_value);
-            auto plugins = core->get_available_devices();
+            std::vector<std::string> plugins;
+            try {
+                plugins = core->get_available_devices();
+            } catch (const std::exception& e) {
+                FAIL() << "Failed to get available devices due to error: " << e.what();
+            }
             unset_env(property_item.second.as<std::string>());
-            ASSERT_TRUE(util::contains(plugins, target_device))
-                << "Plugin was not loaded with wrong environment variable " << property_item.second.as<std::string>();
+            if (!plugins.empty()) {
+                auto it = std::find_if(plugins.begin(),
+                                       plugins.end(),
+                                       [&target_device = std::as_const(target_device)](const std::string& plugin) {
+                                           return plugin.find(target_device) != std::string::npos;
+                                       });
+                ASSERT_TRUE(it != plugins.end()) << "Plugin was not loaded with wrong environment value for "
+                                                 << property_item.second.as<std::string>();
+            }
         }
     }
 }

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.hpp
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
 #include "behavior/ov_plugin/properties_tests.hpp"
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/test_assertions.hpp"
 #include "common_test_utils/unicode_utils.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/util/common_util.hpp"
+#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
 
 namespace ov::test::behavior {
 
@@ -26,6 +26,8 @@ public:
 };
 
 using OVPropertiesIncorrectTestsNPU = OVPropertiesTestsNPU;
+
+using OVPropertiesEnvVarTestsNPU = OVPropertiesTestsNPU;
 
 using CompileModelPropertiesParamsNPU = std::tuple<std::string, AnyMap>;
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -27,12 +27,16 @@ constexpr std::vector<T> operator+(const std::vector<T>& vector1, const std::vec
 
 ov::log::Level getTestsLogLevelFromEnvironmentOr(ov::log::Level instead) {
     if (auto var = std::getenv("OV_NPU_LOG_LEVEL")) {
-        std::istringstream stringStream = std::istringstream(var);
-        ov::log::Level level;
+        try {
+            std::istringstream stringStream = std::istringstream(var);
+            ov::log::Level level;
 
-        stringStream >> level;
+            stringStream >> level;
 
-        return level;
+            return level;
+        } catch (...) {
+            // ignore parsing errors and return default log level
+        }
     }
     return instead;
 }


### PR DESCRIPTION
### Details:
 - *Modify `intel_npu::Config::parseEnvVars()` to log a<s>n error</s> warning instead of throwing for failed option value parsing*
 - *Add tests to cover wrong env values scenarios*

### Tickets:
 - *C184112*

### AI Assistance:
 - *AI assistance used: no / <s>yes</s>*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
