### PR TITLE
[TFL FE] Validate Tensor.name presence to prevent null-ptr deref on malformed flatbuffer

### DIFF
--- a/src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp
+++ b/src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp
@@ -17,6 +17,14 @@ namespace frontend {
 namespace tensorflow_lite {
 
 namespace {
+std::string safe_tensor_name(const tflite::Tensor* tensor) {
+    FRONT_END_GENERAL_CHECK(tensor != nullptr, "TensorFlow Lite Frontend: tensor pointer is null.");
+    FRONT_END_GENERAL_CHECK(tensor->name() != nullptr,
+                            "TensorFlow Lite Frontend: tensor has no 'name' field "
+                            "(malformed flatbuffer: optional 'name' string is absent).");
+    return tensor->name()->str();
+}
+
 TensorMetaInfo extract_tensor_meta_info(const TensorInfo& tensor_info) {
     TensorMetaInfo tensor_meta_info;
     const auto tensor = tensor_info.tensor;
@@ -36,7 +44,7 @@ TensorMetaInfo extract_tensor_meta_info(const TensorInfo& tensor_info) {
                                                                                    tensor_data_size);
     tensor_meta_info.m_tensor_data = tensor_data;
     tensor_meta_info.m_tensor_data_size = tensor_data_size;
-    tensor_meta_info.m_tensor_name = tensor->name()->str();
+    tensor_meta_info.m_tensor_name = safe_tensor_name(tensor);
 
     return tensor_meta_info;
 }
@@ -60,8 +68,7 @@ void DecoderFlatBuffer::get_input_node(size_t input_port_idx,
                             inputs->size());
     auto input_tensor_idx = (*inputs)[static_cast<flatbuffers::uoffset_t>(input_port_idx)];
     auto tensor = m_input_info.at(input_port_idx).tensor;
-    std::string name = (*tensor).name()->str();
-    producer_name = name;
+    producer_name = safe_tensor_name(tensor);
     producer_output_port_index = input_tensor_idx;
 }
 
@@ -79,7 +86,7 @@ size_t DecoderFlatBuffer::get_output_size() const {
 
 std::string DecoderFlatBuffer::get_input_tensor_name(size_t idx) const {
     FRONT_END_GENERAL_CHECK(idx < get_input_size(), "Requested input is out-of-range");
-    return m_input_info.at(idx).tensor->name()->str();
+    return safe_tensor_name(m_input_info.at(idx).tensor);
 }
 
 ov::element::Type DecoderFlatBuffer::get_input_tensor_type(size_t idx) const {
@@ -89,7 +96,7 @@ ov::element::Type DecoderFlatBuffer::get_input_tensor_type(size_t idx) const {
 
 std::string DecoderFlatBuffer::get_output_tensor_name(size_t idx) const {
     FRONT_END_GENERAL_CHECK(idx < get_output_size(), "Requested output is out-of-range");
-    return m_output_info.at(idx).tensor->name()->str();
+    return safe_tensor_name(m_output_info.at(idx).tensor);
 }
 
 ov::element::Type DecoderFlatBuffer::get_output_tensor_type(size_t idx) const {
@@ -115,7 +122,7 @@ std::shared_ptr<ov::frontend::tensorflow_lite::TensorLitePlace> DecoderFlatBuffe
     const ov::frontend::tensorflow_lite::TensorInfo& tensor_info,
     const ov::frontend::InputModel& model) const {
     const auto tensor = tensor_info.tensor;
-    std::vector<std::string> names = {tensor->name()->str()};
+    std::vector<std::string> names = {safe_tensor_name(tensor)};
     const uint8_t* tensor_data =
         (tensor_info.buffer && tensor_info.buffer->data() ? tensor_info.buffer->data()->data() : nullptr);
     const size_t tensor_data_size =

--- a/src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp
+++ b/src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp
@@ -17,11 +17,15 @@ namespace frontend {
 namespace tensorflow_lite {
 
 namespace {
-std::string safe_tensor_name(const tflite::Tensor* tensor) {
+void validate_tensor_name(const tflite::Tensor* tensor) {
     FRONT_END_GENERAL_CHECK(tensor != nullptr, "TensorFlow Lite Frontend: tensor pointer is null.");
     FRONT_END_GENERAL_CHECK(tensor->name() != nullptr,
                             "TensorFlow Lite Frontend: tensor has no 'name' field "
                             "(malformed flatbuffer: optional 'name' string is absent).");
+}
+
+std::string safe_tensor_name(const tflite::Tensor* tensor) {
+    validate_tensor_name(tensor);
     return tensor->name()->str();
 }
 

--- a/src/frontends/tensorflow_lite/tests/convert_unsupported.cpp
+++ b/src/frontends/tensorflow_lite/tests/convert_unsupported.cpp
@@ -85,3 +85,8 @@ INSTANTIATE_TEST_SUITE_P(BadBufferSize,
                          MalformedModelLoadTest,
                          ::testing::Values("bad_buffer_size/undersized_buffer.tflite",
                                            "bad_buffer_size/empty_buffer_nonempty_shape.tflite"));
+
+// Tensor with no `name` field set in its vtable: load() throws in safe_tensor_name() instead of segfault
+INSTANTIATE_TEST_SUITE_P(MissingTensorName,
+                         MalformedModelLoadTest,
+                         ::testing::Values("malformed_tensor_name/missing_tensor_name.tflite"));

--- a/src/frontends/tensorflow_lite/tests/test_models/gen_scripts/generate_malformed_tensor_name.py
+++ b/src/frontends/tensorflow_lite/tests/test_models/gen_scripts/generate_malformed_tensor_name.py
@@ -1,0 +1,177 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Generate a crafted .tflite model whose Tensor.name field is absent.
+#
+# In the FlatBuffer schema for TensorFlow Lite, every table field is implicitly
+# optional - the field is absent when its vtable slot offset is 0. The schema-
+# generated `Tensor::name()` accessor returns nullptr for an absent name, and
+# any caller that dereferences that pointer (e.g. `tensor->name()->str()`)
+# crashes with a null-pointer dereference.
+#
+# This generator produces a structurally valid TFLite buffer
+# (`tflite::VerifyModelBuffer` returns true) where one tensor has no `name`
+# slot in its vtable. It is the regression input for the load-time null-name
+# check in src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp.
+#
+# Models generated:
+#   malformed_tensor_name/missing_tensor_name.tflite
+#       - 2 tensors, both legal indices, but tensor 0 has no `name` field set.
+#         The frontend must throw a clear ov::Exception during load(), not
+#         segfault.
+
+import os
+import sys
+
+import flatbuffers
+
+
+def build_tflite_with_unnamed_tensor(unnamed_tensor_indices=()):
+    """Build a minimal valid TFLite FlatBuffer with selected tensors lacking a `name`.
+
+    Default valid model structure:
+      - 2 tensors (index 0 = input, index 1 = output)
+      - 3 buffers (0 = empty sentinel, 1 for tensor0, 2 for tensor1)
+      - 1 operator code (ADD)
+      - 1 operator: inputs=[0], outputs=[1], opcode_index=0
+      - SubGraph inputs=[0], outputs=[1]
+
+    For each tensor index in `unnamed_tensor_indices`, the `name` slot is omitted
+    from the tensor's vtable so that `Tensor::name()` returns nullptr at load time.
+    """
+    builder = flatbuffers.Builder(1024)
+
+    num_tensors = 2
+    num_buffers = 3
+    num_opcodes = 1
+
+    # -- Buffers --
+    buffer_offsets = []
+    for _ in range(num_buffers):
+        builder.StartObject(3)  # Buffer: data, offset, size
+        buf_offset = builder.EndObject()
+        buffer_offsets.append(buf_offset)
+
+    builder.StartVector(4, len(buffer_offsets), 4)
+    for off in reversed(buffer_offsets):
+        builder.PrependUOffsetTRelative(off)
+    buffers_vec = builder.EndVector()
+
+    # -- Operator Codes --
+    opcode_offsets = []
+    for _ in range(num_opcodes):
+        builder.StartObject(4)  # OperatorCode: deprecated_builtin_code, custom_code, version, builtin_code
+        builder.PrependInt8Slot(0, 0, 0)    # deprecated_builtin_code = ADD(0)
+        builder.PrependInt32Slot(3, 0, 0)   # builtin_code = ADD(0)
+        builder.PrependInt32Slot(2, 1, 1)   # version = 1
+        oc_offset = builder.EndObject()
+        opcode_offsets.append(oc_offset)
+
+    builder.StartVector(4, len(opcode_offsets), 4)
+    for off in reversed(opcode_offsets):
+        builder.PrependUOffsetTRelative(off)
+    opcodes_vec = builder.EndVector()
+
+    # -- Tensors --
+    # Pre-create name strings for the tensors that should be named. Strings are
+    # built up-front because builder offsets are LIFO; we cannot create strings
+    # while a table object is open.
+    tensor_names = {}
+    for i in range(num_tensors):
+        if i not in unnamed_tensor_indices:
+            tensor_names[i] = builder.CreateString(f"tensor_{i}")
+
+    shape_vecs = []
+    for _ in range(num_tensors):
+        builder.StartVector(4, 1, 4)
+        builder.PrependInt32(1)
+        shape_vecs.append(builder.EndVector())
+
+    tensor_offsets = []
+    for i in range(num_tensors):
+        buf_idx = i + 1 if i + 1 < num_buffers else 0
+        builder.StartObject(11)  # Tensor: shape, type, buffer, name, ...
+        builder.PrependUOffsetTRelativeSlot(0, shape_vecs[i], 0)  # shape
+        builder.PrependInt8Slot(1, 0, 0)    # type = FLOAT32
+        builder.PrependUint32Slot(2, buf_idx, 0)  # buffer index
+        if i in tensor_names:
+            builder.PrependUOffsetTRelativeSlot(3, tensor_names[i], 0)  # name
+        # else: deliberately omit slot 3 - this is the regression-under-test condition.
+        t_offset = builder.EndObject()
+        tensor_offsets.append(t_offset)
+
+    builder.StartVector(4, len(tensor_offsets), 4)
+    for off in reversed(tensor_offsets):
+        builder.PrependUOffsetTRelative(off)
+    tensors_vec = builder.EndVector()
+
+    # -- Operator --
+    builder.StartVector(4, 1, 4)
+    builder.PrependInt32(0)
+    op_inputs_vec = builder.EndVector()
+
+    builder.StartVector(4, 1, 4)
+    builder.PrependInt32(1)
+    op_outputs_vec = builder.EndVector()
+
+    builder.StartObject(11)  # Operator: opcode_index, inputs, outputs, ...
+    builder.PrependUint32Slot(0, 0, 0)
+    builder.PrependUOffsetTRelativeSlot(1, op_inputs_vec, 0)
+    builder.PrependUOffsetTRelativeSlot(2, op_outputs_vec, 0)
+    op_offset = builder.EndObject()
+
+    builder.StartVector(4, 1, 4)
+    builder.PrependUOffsetTRelative(op_offset)
+    operators_vec = builder.EndVector()
+
+    # -- SubGraph --
+    builder.StartVector(4, 1, 4)
+    builder.PrependInt32(0)
+    sg_inputs_vec = builder.EndVector()
+
+    builder.StartVector(4, 1, 4)
+    builder.PrependInt32(1)
+    sg_outputs_vec = builder.EndVector()
+
+    sg_name = builder.CreateString("main")
+
+    builder.StartObject(7)  # SubGraph: tensors, inputs, outputs, operators, name, ...
+    builder.PrependUOffsetTRelativeSlot(0, tensors_vec, 0)
+    builder.PrependUOffsetTRelativeSlot(1, sg_inputs_vec, 0)
+    builder.PrependUOffsetTRelativeSlot(2, sg_outputs_vec, 0)
+    builder.PrependUOffsetTRelativeSlot(3, operators_vec, 0)
+    builder.PrependUOffsetTRelativeSlot(4, sg_name, 0)
+    sg_offset = builder.EndObject()
+
+    builder.StartVector(4, 1, 4)
+    builder.PrependUOffsetTRelative(sg_offset)
+    subgraphs_vec = builder.EndVector()
+
+    desc = builder.CreateString("missing_tensor_name_test_model")
+
+    # -- Model --
+    builder.StartObject(8)  # Model: version, operator_codes, subgraphs, description, buffers, ...
+    builder.PrependUint32Slot(0, 3, 0)  # version = 3
+    builder.PrependUOffsetTRelativeSlot(1, opcodes_vec, 0)
+    builder.PrependUOffsetTRelativeSlot(2, subgraphs_vec, 0)
+    builder.PrependUOffsetTRelativeSlot(3, desc, 0)
+    builder.PrependUOffsetTRelativeSlot(4, buffers_vec, 0)
+    model_offset = builder.EndObject()
+
+    builder.Finish(model_offset, b"TFL3")
+    return bytes(builder.Output())
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <output_directory>")
+        sys.exit(1)
+
+    path_to_model_dir = os.path.join(sys.argv[1], "malformed_tensor_name")
+    os.makedirs(path_to_model_dir, exist_ok=True)
+
+    # Tensor 0 (the graph input) has no `name` field in its vtable. The frontend
+    # must reject this with an ov::Exception during load(), not crash.
+    model = build_tflite_with_unnamed_tensor(unnamed_tensor_indices=(0,))
+    with open(os.path.join(path_to_model_dir, "missing_tensor_name.tflite"), "wb") as f:
+        f.write(model)

--- a/src/frontends/tensorflow_lite/tests/test_models/gen_scripts/generate_malformed_tensor_name.py
+++ b/src/frontends/tensorflow_lite/tests/test_models/gen_scripts/generate_malformed_tensor_name.py
@@ -164,7 +164,7 @@ def build_tflite_with_unnamed_tensor(unnamed_tensor_indices=()):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <output_directory>")
+        print(f"Usage: {sys.argv[0]} <output_directory>", file=sys.stderr)
         sys.exit(1)
 
     path_to_model_dir = os.path.join(sys.argv[1], "malformed_tensor_name")


### PR DESCRIPTION
### Details:

In the TFLite FlatBuffer schema every table field is implicitly optional, so
the schema-generated `Tensor::name()` accessor returns nullptr when the
`name` slot is absent in the tensor's vtable. The frontend dereferenced the
result without a guard at five sites in `decoder_flatbuffer.cpp`, crashing
with SIGSEGV on structurally valid but malformed `.tflite` inputs (e.g.
those produced by fuzzers).

The buffer verifier (`tflite::VerifyModelBuffer`) accepts such inputs,
since absent optional fields are legal flatbuffer semantics, so the check
has to happen at the call sites that consume the field.

This change centralises the dereference in a `safe_tensor_name()` helper
that fails fast via `FRONT_END_GENERAL_CHECK` when the tensor pointer or
the `name` field is null, and routes all five existing call sites through
it.

## Changes

- New `safe_tensor_name()` helper in the anonymous namespace of
  `src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp`.
- Five call sites updated to use the helper:
  `extract_tensor_meta_info`, `DecoderFlatBuffer::get_input_node`,
  `get_input_tensor_name`, `get_output_tensor_name`, `decode_tensor`.
- New flatbuffers-based generator
  `tests/test_models/gen_scripts/generate_malformed_tensor_name.py` that
  emits a minimal, schema-valid `.tflite` whose first tensor has no `name`
  slot in its vtable.
- New parametrised regression case `MissingTensorName` under
  `MalformedModelLoadTest` in
  `tests/convert_unsupported.cpp`. The CMake `GLOB_RECURSE` over
  `generate_*.py` picks up the new generator with no CMake edit.

## Test plan

- [x] `ov_tensorflow_lite_frontend_tests --gtest_filter='*Malformed*'` —
  all 17 cases pass, including the new `MissingTensorName/MalformedModelLoadTest.load_throws/0`.
- [x] `ov_tensorflow_lite_frontend_tests` (with the suites that depend on
  fixtures from tensorflow-importing generators filtered out, due to a
  pre-existing Python 3.12 / wrapt issue in the build venv) — green.
- [x] Crash reproducer (calling `ov::Core::read_model()` on the original
  fuzzer corpus input) now returns a clean `ov::Exception` with the
  diagnostic message instead of segfaulting.

### Tickets:
 - 183013

