### PR TITLE
[NO REVIEW] [AUTO] tests: fix "occured" -> "occurred" typo

### DIFF
--- a/src/plugins/auto/tests/functional/behavior/auto_func_test.hpp
+++ b/src/plugins/auto/tests/functional/behavior/auto_func_test.hpp
@@ -22,13 +22,13 @@ namespace tests {
     do {                                                                            \
         try {                                                                       \
             { code; }                                                               \
-            FAIL() << "no exception occured" << std::endl;                          \
+            FAIL() << "no exception occurred" << std::endl;                         \
         } catch (const expected_exception& e) {                                     \
             EXPECT_THAT(e.what(), testing::HasSubstr(expected_message));            \
         } catch (const std::exception& e) {                                         \
-            FAIL() << "an unexpected exception occured: " << e.what() << std::endl; \
+            FAIL() << "an unexpected exception occurred: " << e.what() << std::endl;\
         } catch (...) {                                                             \
-            FAIL() << "an unknown exception occured" << std::endl;                  \
+            FAIL() << "an unknown exception occurred" << std::endl;                 \
         }                                                                           \
     } while (0);
 


### PR DESCRIPTION
## Summary
- Fix a spelling typo in the three `FAIL()` messages of the `ASSERT_THROW_WITH_MESSAGE` helper macro in `src/plugins/auto/tests/functional/behavior/auto_func_test.hpp`.
- Pure spelling change, no behavioural impact.

## Test plan
- [ ] Build `ov_auto_func_tests` (or any consumer of the macro) on Linux — verify it still compiles.
- [ ] Visually grep `\boccured\b` to confirm no remaining instances were missed.