### PR TITLE
[GPU] Fix reshape runtime padding propagation when cropped axis is dropped

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -100,13 +100,20 @@ public:
         // Iteratively check the total product of all static innermost dimensions
         // until the crop dimension value matches or the first dynamic dimension is encountered
         int64_t mul = 1;
+        size_t matched_trailing_dims = 0;
         for (size_t i = output_pshape.size(); i > 1 ; i--) {
             if (output_pshape[i - 1].is_dynamic() || mul == input_last_dim_val)
                 break;
 
             mul *= output_pshape[i - 1].get_length();
+            matched_trailing_dims++;
         }
         if (input_last_dim_val != mul)
+            return false;
+        // Reject when reshape drops the cropped axis (e.g. [N,M,1] -> [N,M]): no output axis can
+        // carry the cropped axis padding, so sibling crop outputs would all point to the same
+        // base buffer region (aliased).
+        if (matched_trailing_dims == 0 && output_pshape.size() < input_pshape.size())
             return false;
 
         return true;

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -2095,3 +2095,45 @@ TEST(prepare_buffer_fusing, in_place_crop_self_multiply_spatial_split) {
         }
     }
 }
+
+// A base-mode reshape that drops the cropped (size-1) last axis must not be marked
+// runtime-padding-propagatable; otherwise sibling crop outputs alias the same buffer.
+TEST(prepare_buffer_fusing, in_place_crop_dynamic_last_axis_split_to_collapsing_reshape) {
+    auto& engine = get_test_engine();
+
+    auto in_layout = layout{ ov::PartialShape{-1, -1, 4}, data_types::f32, format::bfyx };
+    auto axis_mem = engine.allocate_memory({ {}, data_types::i64, format::bfyx });
+    auto splits_length_mem = engine.allocate_memory({ {4}, data_types::i64, format::bfyx });
+
+    const int64_t axis = 2;
+    set_values<int64_t>(axis_mem, { axis });
+    set_values<int64_t>(splits_length_mem, { 1, 1, 1, 1 });
+
+    auto op_mode = cldnn::crop_ngraph_op_mode::variadic_split;
+    topology topology(
+        input_layout("input", in_layout),
+        data("axis", axis_mem),
+        data("splits_length", splits_length_mem),
+        crop("crop0", { input_info("input"), input_info("axis"), input_info("splits_length") },
+             cldnn::tensor(1), cldnn::tensor(0), op_mode, 0, axis),
+        crop("crop1", { input_info("input"), input_info("axis"), input_info("splits_length") },
+             cldnn::tensor(1), cldnn::tensor(0), op_mode, 1, axis),
+        // Drops the cropped axis: [-1,-1,1] -> [-1,-1]  => must be rejected.
+        reshape("rs0_collapse", input_info("crop0"), false, std::vector<int64_t>{-1, 3},
+                ov::PartialShape{-1, -1}, cldnn::reshape::reshape_mode::base),
+        // Preserves the cropped axis: [-1,-1,1] -> [-1,-1,1]  => still allowed.
+        reshape("rs1_keep", input_info("crop1"), true, std::vector<int64_t>{-1, -1, 1},
+                ov::PartialShape{-1, -1, 1}, cldnn::reshape::reshape_mode::base),
+        reorder("out0", input_info("rs0_collapse"), format::bfyx, data_types::f32),
+        reorder("out1", input_info("rs1_keep"), format::bfyx, data_types::f32)
+    );
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    auto prog = program::build_program(engine, topology, config, false, true);
+    ASSERT_NE(prog, nullptr);
+
+    ASSERT_FALSE(prog->get_node("rs0_collapse").as<reshape>().is_runtime_propagatable_padding());
+    ASSERT_TRUE(prog->get_node("rs1_keep").as<reshape>().is_runtime_propagatable_padding());
+}


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - **Symptom**: GPU produced wrong box coordinates / accuracy mismatch vs CPU on a detection model with a `VariadicSplit (last axis, lengths [1,1,1,1])` followed by base-mode `Reshape`s that drop the cropped size-1 axis (`[N,M,1] -> [N,M]`).
 - **Root cause**: In `is_runtime_propagatable_padding()` (last-axis crop branch), the trailing-dim matching loop exits immediately when the cropped axis is size 1, returning true even when the reshape removes that axis. With no output dim left to carry the crop's dynamic padding, the four sibling reshape outputs propagated zero padding and ended up aliased to the same base-buffer offset, so downstream consumers read interleaved channel data as if it were contiguous.
 - **Fix**: Track the number of trailing output dims actually matched against the cropped axis (`matched_trailing_dims`) and reject propagation when none were matched and the reshape reduces rank — i.e. the cropped axis is genuinely dropped. Identity reshapes that preserve it (`[N,M,1] -> [N,M,1]`) remain eligible.

#### The code and line that caused this issue (if it is not changed directly)
 - `src/plugins/intel_gpu/src/graph/include/reshape_inst.h`

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - ./ov_gpu_unit_tests --gtest_filter='prepare_buffer_fusing.in_place_crop_dynamic_last_axis_split_to_collapsing_reshape'

#### Problematic graph
<img width="670" height="555" alt="image" src="https://github.com/user-attachments/assets/10790a77-7887-408d-9133-0d883c9d4ee1" />

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - Reviewed existing tests under `prepare_buffer_fusing` in `src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp` (in-place crop / reshape padding tests)
### Tickets:
 - [CVS-185921](https://jira.devtools.intel.com/browse/CVS-185921)