### PR TITLE
Remove the shape-inference equality check for PagedCausalConv1D

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-causal-conv1d.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-causal-conv1d.rst
@@ -20,7 +20,7 @@ making it suitable for time-series and autoregressive models.
 
 *PagedCausalConv1D* processes a flat batch of tokens that may belong to multiple independent sequences.
 The token sequences are described by ``subsequence_begins``. Paged memory uses a fixed ``BLOCK_SIZE=1``,
-meaning each block in ``conv_state_table`` stores exactly one convolution state snapshot of shape ``[hidden_size, kernel_size]``.
+meaning each physical block in ``conv_state_table`` stores exactly one convolution state snapshot of shape ``[hidden_size, kernel_size]``.
 For each sequence, the operation:
 
 1. Loads the current convolution state (a window of the last `kernel_size` input vectors) from paged memory using the block table.
@@ -39,13 +39,15 @@ Paged memory management allows states to be shared across sequences (prefix cach
 
 **Paged memory management**
 
-The convolutional state table is organized as non-contiguous pages (blocks). Each block stores one
+The convolutional state table is organized as non-contiguous pages (blocks). Each physical block stores one
 complete state snapshot at a particular token position in the sequence.
 
 For sequence ``s``, the assigned physical block indices are
 ``la_block_indices[la_block_indices_begins[s] : la_block_indices_begins[s+1]]``.
-These indices address rows in ``conv_state_table``. The first block stores the state after
-``cache_interval[s]`` tokens, the second after ``2 * cache_interval[s]`` tokens, and so on.
+These indices address rows in ``conv_state_table``. Multiple logical entries may address the same physical
+row, for example when the read slot and the write slot update a state in-place. The first logical block slot
+is used for reading the current state, and later slots are used for writing states after ``cache_interval[s]``,
+``2 * cache_interval[s]`` tokens, and so on.
 When ``cache_interval[s] <= 0``, no state caching is performed for that sequence.
 
 The ``num_processed_tokens[s]`` value indicates how many tokens have already been processed for sequence
@@ -153,11 +155,12 @@ the constraint ``out_channels == hidden_size``), and ``out_channels`` must equal
   Input token embeddings from all sequences in the batch. **Required.**
 
 * **1**: ``conv_state_table``
-  A 3D tensor of type *T* with shape ``[num_blocks, hidden_size, kernel_size]``.
+  A 3D tensor of type *T* with shape ``[num_physical_blocks, hidden_size, kernel_size]``.
   Paged block table holding the convolution cache states. The paged memory block size is fixed at ``BLOCK_SIZE=1``,
   meaning each physical block stores exactly one convolution state of shape ``[hidden_size, kernel_size]``,
   representing the last ``kernel_size`` input vectors seen by the corresponding sequence.
-  ``num_blocks`` equals the total number of blocks allocated across all sequences (i.e. ``la_block_indices_begins[-1]``).
+  ``num_physical_blocks`` equals the total number of physical state rows allocated in the table. It may be
+  smaller than the number of logical entries in ``la_block_indices`` when several entries refer to the same row.
   The table is updated in-place: during prefill by the plugin, during decoding by GenAI. Initially all states are zero tensors.
   **Required.**
 
@@ -180,9 +183,10 @@ the constraint ``out_channels == hidden_size``), and ``out_channels`` must equal
   The first element is always ``0`` and the last element equals ``batch_size_in_tokens``. **Required.**
 
 * **5**: ``la_block_indices``
-  A 1D tensor of type *T_IND* with shape ``[num_blocks]``.
+  A 1D tensor of type *T_IND* with shape ``[num_logical_blocks]``.
   Physical block indices into ``conv_state_table`` assigned across all sequences,
-  where ``num_blocks = la_block_indices_begins[-1]`` is the total number of blocks allocated.
+  where ``num_logical_blocks = la_block_indices_begins[-1]`` is the total number of logical block slots.
+  Each value must be a valid physical row index in ``conv_state_table``.
   The logical-to-physical mapping for sequence ``s`` is given
   by ``la_block_indices[la_block_indices_begins[s] : la_block_indices_begins[s+1]]``.
   For example, ``la_block_indices = [0, 1, 3, 2, 4]`` with ``la_block_indices_begins = [0, 3, 5]`` means
@@ -237,7 +241,7 @@ token's state to be cached.
                <dim>5</dim>
                <dim>16</dim>
            </port>
-           <port id="1">   <!-- conv_state_table: [num_blocks, hidden_size, kernel_size] -->
+           <port id="1">   <!-- conv_state_table: [num_physical_blocks, hidden_size, kernel_size] -->
                <dim>5</dim>
                <dim>16</dim>
                <dim>4</dim>
@@ -253,7 +257,7 @@ token's state to be cached.
            <port id="4">   <!-- subsequence_begins: [batch_size_in_sequences+1] -->
                <dim>3</dim>
            </port>
-           <port id="5">   <!-- la_block_indices: [num_blocks] -->
+           <port id="5">   <!-- la_block_indices: [num_logical_blocks] -->
                <dim>5</dim>
            </port>
            <port id="6">   <!-- la_block_indices_begins: [batch_size_in_sequences+1] -->

--- a/src/common/transformations/include/transformations/paged_attention/paged_causal_conv1d_fusion.hpp
+++ b/src/common/transformations/include/transformations/paged_attention/paged_causal_conv1d_fusion.hpp
@@ -83,7 +83,7 @@ public:
                             std::unordered_set<std::string>& var_ids_to_remove);
 
 private:
-    size_t m_layer_index;
+    size_t m_layer_index = 0;
 };
 
 }  // namespace pass

--- a/src/core/dev_api/openvino/op/paged_causal_conv1d.hpp
+++ b/src/core/dev_api/openvino/op/paged_causal_conv1d.hpp
@@ -21,13 +21,14 @@ public:
     /// \brief Constructs a PagedCausalConv1D operation.
     ///
     /// \param input_embeds Input embeddings [batch_size_in_tokens, hidden_size].
-    /// \param conv_state_table Block table containing conv_cache states [num_blocks, hidden_size, kernel_size].
+    /// \param conv_state_table Physical block table containing conv_cache states
+    ///        [num_physical_blocks, hidden_size, kernel_size].
     /// \param conv_weight Convolution weight [out_channels, hidden_size/group_size, conv_kernel_size].
     /// \param conv_bias Convolution bias [out_channels] or [0] (empty = no bias).
     /// \param subsequence_begins Start indices of tokens from current sequences [batch_size_in_sequences+1],
     ///        element type i32 or i64.
-    /// \param la_block_indices Block index along 0-th dim in conv_state table [num_blocks],
-    ///        element type i32 or i64.
+    /// \param la_block_indices Logical block slots containing physical indices along 0-th dim in conv_state table
+    ///        [num_logical_blocks], element type i32 or i64.
     /// \param la_block_indices_begins Defines how block indices are split among sequences [batch_size_in_sequences+1],
     ///        element type i32 or i64.
     /// \param processed_tokens Number of tokens already handled per sequence [batch_size_in_sequences],

--- a/src/core/shape_inference/include/paged_causal_conv1d_shape_inference.hpp
+++ b/src/core/shape_inference/include/paged_causal_conv1d_shape_inference.hpp
@@ -27,7 +27,6 @@ std::vector<TRShape> shape_infer(const PagedCausalConv1D* op, const std::vector<
     const auto conv_weight_rank_is_static = input_shapes[2].rank().is_static();
     const auto conv_bias_rank_is_static = input_shapes[3].rank().is_static();
     const auto subsequence_begins_rank_is_static = input_shapes[4].rank().is_static();
-    const auto la_block_indices_rank_is_static = input_shapes[5].rank().is_static();
     const auto la_block_indices_begins_rank_is_static = input_shapes[6].rank().is_static();
     const auto processed_tokens_rank_is_static = input_shapes[7].rank().is_static();
     const auto cache_interval_rank_is_static = input_shapes[8].rank().is_static();
@@ -63,14 +62,6 @@ std::vector<TRShape> shape_infer(const PagedCausalConv1D* op, const std::vector<
             input_shapes[3][0].compatible(input_shapes[2][0]) || input_shapes[3][0].compatible(ov::Dimension(0)),
             "The size of conv_bias must be compatible with the out_channels dimension of "
             "conv_weight or equal to 0 (no bias).");
-    }
-
-    if (conv_state_table_rank_is_static && la_block_indices_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               input_shapes[1][0].compatible(input_shapes[5][0]),
-                               "The num_blocks dimension of la_block_indices must be compatible with the num_blocks "
-                               "dimension of conv_state_table.");
     }
 
     if (subsequence_begins_rank_is_static && la_block_indices_begins_rank_is_static) {

--- a/src/core/tests/type_prop/paged_causal_conv1d.cpp
+++ b/src/core/tests/type_prop/paged_causal_conv1d.cpp
@@ -470,28 +470,29 @@ TEST_F(TypePropPagedCausalConv1DTest, dynamic_type_accepted) {
     EXPECT_EQ(op->get_output_element_type(0), element::dynamic);
 }
 
-TEST_F(TypePropPagedCausalConv1DTest, la_block_indices_num_blocks_mismatch) {
-    const auto input_embeds = std::make_shared<op::v0::Parameter>(element::f32, Shape{10, 256});
-    const auto conv_state_table = std::make_shared<op::v0::Parameter>(element::f32, Shape{5, 256, 4});
+TEST_F(TypePropPagedCausalConv1DTest, logical_block_indices_may_exceed_physical_state_blocks) {
+    const auto input_embeds = std::make_shared<op::v0::Parameter>(element::f32, Shape{5, 256});
+    const auto conv_state_table = std::make_shared<op::v0::Parameter>(element::f32, Shape{1, 256, 4});
     const auto conv_weight = std::make_shared<op::v0::Parameter>(element::f32, Shape{256, 256, 4});
     const auto conv_bias = std::make_shared<op::v0::Parameter>(element::f32, Shape{256});
-    const auto subsequence_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
-    const auto la_block_indices = std::make_shared<op::v0::Parameter>(element::i32, Shape{10});
-    const auto la_block_indices_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
-    const auto processed_tokens = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
-    const auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    const auto subsequence_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    const auto la_block_indices = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    const auto la_block_indices_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    const auto processed_tokens = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
+    const auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
 
-    OV_EXPECT_THROW(std::ignore = make_op(OutputVector{input_embeds,
-                                                       conv_state_table,
-                                                       conv_weight,
-                                                       conv_bias,
-                                                       subsequence_begins,
-                                                       la_block_indices,
-                                                       la_block_indices_begins,
-                                                       processed_tokens,
-                                                       cache_interval}),
-                    NodeValidationFailure,
-                    testing::HasSubstr("num_blocks dimension of la_block_indices must be compatible"));
+    const auto op = make_op(OutputVector{input_embeds,
+                                         conv_state_table,
+                                         conv_weight,
+                                         conv_bias,
+                                         subsequence_begins,
+                                         la_block_indices,
+                                         la_block_indices_begins,
+                                         processed_tokens,
+                                         cache_interval});
+
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{5, 256}));
 }
 
 TEST_F(TypePropPagedCausalConv1DTest, subsequence_begins_block_begins_mismatch) {


### PR DESCRIPTION
### Details:

During Qwen3.5 enablement in OpenVINO GenAI benchmark returned an error.
```bash
python samples/python/text_generation/benchmark_genai.py \
  -m tiny_random_qwen3_5_moe \
  -mt 100 \
  -d CPU
```
Observed error:

```text
[CPU] PagedCausalConv1D node with name '__module.model.model.language_model.layers.0.linear_attn/aten::_convolution/GroupConvolution/PagedCausalConv1D'
Check 'input_shapes[1][0].compatible(input_shapes[5][0])' failed at src/core/shape_inference/include/paged_causal_conv1d_shape_inference.hpp:69
Shape inference input shapes {[5,96],[1,96,4],[96,1,4],[96],[2],[2],[2],[1],[1]}
The num_blocks dimension of la_block_indices must be compatible with the num_blocks dimension of conv_state_table.
```

### The Issue

`PagedCausalConv1D` input 5, `la_block_indices`, is a flattened list of logical per-sequence read/write slots. The kernel expects at least two logical slots per sequence. Those logical slots do not have to correspond one-to-one to distinct physical state-table rows. Examples:

- Static/non-prefix-caching path can use the same physical block for both read and write slots: `block_indices = [0, 0]`, `conv_state_table.shape[0] = 1`.
- More generally, several logical block-index entries can reference the same physical block, or multiple sequences can share physical blocks.

Because of that, this shape inference check appears too strict:

```cpp
input_shapes[1][0].compatible(input_shapes[5][0])
```

It compares physical block count (`conv_state_table.shape[0]`) with logical index-list length (`la_block_indices.shape[0]`). These dimensions are different concepts and should not be required to match.

### Other Issues

- Init `m_layer_index` to avoid layer indices like `conv_state_table.878332661264156340` after PageCausalConv1D fusion transformation.

### AI Assistance:
 - *AI assistance used: yes*
 AI created the fix that was manually validated by a human
