### PR TITLE
[GPU] Fix dynamic reorder impl selection in shape-of flow

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -3185,15 +3185,31 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
     // 6. Finally, if no impl found so far, we just enforce static impl compilation
     auto static_impl = find_impl(node, updated_params, shape_types::static_shape);
     if (!static_impl) {
+        auto stringify_layouts = [](const std::vector<layout>& layouts) {
+            if (layouts.empty())
+                return std::string("<none>");
+
+            std::string result;
+            for (size_t i = 0; i < layouts.size(); ++i) {
+                if (i > 0)
+                    result += ", ";
+                result += layouts[i].to_short_string();
+            }
+            return result;
+        };
+
         std::string available_impls_info = "available_impls: " + std::to_string(m_available_impls.size()) + " [";
-        for (auto& m : m_available_impls) {
+        for (size_t i = 0; i < m_available_impls.size(); ++i) {
+            auto& m = m_available_impls[i];
+            if (i > 0)
+                available_impls_info += ",";
             available_impls_info += " {type=" + std::to_string(static_cast<int>(m->get_impl_type())) +
                                    ", shape=" + std::to_string(static_cast<int>(m->get_shape_type())) + "}";
         }
         available_impls_info += " ]";
         OPENVINO_ASSERT(false, "No static impl " + node->id() + ". " + available_impls_info +
-                        ". Input: " + updated_params.input_layouts[0].to_short_string() +
-                        ". Output: " + updated_params.output_layouts[0].to_short_string());
+                        ". Input: " + stringify_layouts(updated_params.input_layouts) +
+                        ". Output: " + stringify_layouts(updated_params.output_layouts));
     }
     static_impl->set_node_params(*node);
     if (!inst.can_be_optimized()) {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -3095,7 +3095,9 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
             if (!impl_manager->support_shapes(params))
                 continue;
 
-            return impl_manager->create(*node, params);
+            auto impl = impl_manager->create(*node, params);
+            if (impl)
+                return impl;
         }
 
         return nullptr;
@@ -3145,11 +3147,12 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
 
             std::unique_ptr<primitive_impl> impl = find_impl(&inst.get_node(), updated_params, shape_types::static_shape);
 
-            if (impl->get_kernels_source().size() > 0) {
+            if (impl && impl->get_kernels_source().size() > 0) {
                 auto kernels = _program.get_kernels_cache().compile(updated_params, impl->get_kernels_source());
                 impl->set_kernels(kernels);
             }
-            cache.add(updated_params, std::move(impl));
+            if (impl)
+                cache.add(updated_params, std::move(impl));
         });
     }
 
@@ -3181,7 +3184,17 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
 
     // 6. Finally, if no impl found so far, we just enforce static impl compilation
     auto static_impl = find_impl(node, updated_params, shape_types::static_shape);
-    OPENVINO_ASSERT(static_impl != nullptr, "No static impl " + node->id());
+    if (!static_impl) {
+        std::string available_impls_info = "available_impls: " + std::to_string(m_available_impls.size()) + " [";
+        for (auto& m : m_available_impls) {
+            available_impls_info += " {type=" + std::to_string(static_cast<int>(m->get_impl_type())) +
+                                   ", shape=" + std::to_string(static_cast<int>(m->get_shape_type())) + "}";
+        }
+        available_impls_info += " ]";
+        OPENVINO_ASSERT(false, "No static impl " + node->id() + ". " + available_impls_info +
+                        ". Input: " + updated_params.input_layouts[0].to_short_string() +
+                        ". Output: " + updated_params.output_layouts[0].to_short_string());
+    }
     static_impl->set_node_params(*node);
     if (!inst.can_be_optimized()) {
         auto& kernels_cache = prog.get_kernels_cache();

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <sstream>
+
 #include "intel_gpu/graph/kernel_impl_params.hpp"
 #include "intel_gpu/primitives/implementation_desc.hpp"
 #include "intel_gpu/runtime/stream.hpp"
@@ -3189,25 +3191,26 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
             if (layouts.empty())
                 return std::string("<none>");
 
-            std::string result;
-            for (size_t i = 0; i < layouts.size(); ++i) {
-                if (i > 0)
-                    result += ", ";
-                result += layouts[i].to_short_string();
+            std::ostringstream oss;
+            oss << layouts[0].to_short_string();
+            for (size_t i = 1; i < layouts.size(); ++i) {
+                oss << ", " << layouts[i].to_short_string();
             }
-            return result;
+            return oss.str();
         };
 
-        std::string available_impls_info = "available_impls: " + std::to_string(m_available_impls.size()) + " [";
+        std::ostringstream available_impls_oss;
+        available_impls_oss << "available_impls: " << m_available_impls.size() << " [";
         for (size_t i = 0; i < m_available_impls.size(); ++i) {
-            auto& m = m_available_impls[i];
             if (i > 0)
-                available_impls_info += ",";
-            available_impls_info += " {type=" + std::to_string(static_cast<int>(m->get_impl_type())) +
-                                   ", shape=" + std::to_string(static_cast<int>(m->get_shape_type())) + "}";
+                available_impls_oss << ",";
+            const auto& m = m_available_impls[i];
+            available_impls_oss << " {type=" << static_cast<int>(m->get_impl_type())
+                                << ", shape=" << static_cast<int>(m->get_shape_type()) << "}";
         }
-        available_impls_info += " ]";
-        OPENVINO_ASSERT(false, "No static impl " + node->id() + ". " + available_impls_info +
+        available_impls_oss << " ]";
+
+        OPENVINO_ASSERT(false, "No static impl " + node->id() + ". " + available_impls_oss.str() +
                         ". Input: " + stringify_layouts(updated_params.input_layouts) +
                         ". Output: " + stringify_layouts(updated_params.output_layouts));
     }

--- a/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
@@ -48,7 +48,7 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<reord
                 const auto& out_layout = node.get_output_layout(0);
                 if (!one_of(in_layout.format, supported_dyn_formats) || !one_of(out_layout.format, supported_dyn_formats))
                     return false;
-                // WA: CPU impl does not support b_fs_yx_fsv16 format, so prefer CPU impl only
+                // CPU impl does not support b_fs_yx_fsv16 format, so prefer CPU impl only
                 // when both input and output formats are simple (CPU-compatible)
                 if (node.is_in_shape_of_subgraph() && format::is_simple_data_format(out_layout.format)
                     && format::is_simple_data_format(in_layout.format))

--- a/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
@@ -48,8 +48,10 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<reord
                 const auto& out_layout = node.get_output_layout(0);
                 if (!one_of(in_layout.format, supported_dyn_formats) || !one_of(out_layout.format, supported_dyn_formats))
                     return false;
-                // WA: CPU impl does not support b_fs_yx_fsv16 format
-                if (node.is_in_shape_of_subgraph() && format::is_simple_data_format(out_layout.format))
+                // WA: CPU impl does not support b_fs_yx_fsv16 format, so prefer CPU impl only
+                // when both input and output formats are simple (CPU-compatible)
+                if (node.is_in_shape_of_subgraph() && format::is_simple_data_format(out_layout.format)
+                    && format::is_simple_data_format(in_layout.format))
                     return false;
                 return true;
             })

--- a/src/plugins/intel_gpu/tests/unit/module_tests/impls_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/impls_test.cpp
@@ -30,6 +30,7 @@ struct some_primitive : public primitive_base<some_primitive> {
         SUPPORTED_VALUE_ONEDNN_1,
         SUPPORTED_VALUE_ONEDNN_2,
         SUPPORTED_VALUE_OCL_STATIC,
+        SUPPORTED_VALUE_OCL_DYNAMIC_NULL_FALLBACK,
         SUPPORTED_VALUE_OCL_DYNAMIC_1,
         SUPPORTED_VALUE_OCL_DYNAMIC,
         UNSUPPORTED_VALUE_ALL
@@ -119,7 +120,7 @@ struct SomeImplementationManager : public ImplementationManager {
     }
 
     in_out_fmts_t query_formats(const program_node& node) const override {
-        OPENVINO_NOT_IMPLEMENTED;
+        return {{format::bfyx}, {format::bfyx}};
     }
 
     bool support_shapes(const kernel_impl_params& params) const override {
@@ -205,7 +206,8 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<some_
         OV_GPU_GET_INSTANCE_OCL(some_primitive, shape_types::static_shape,
             [](const program_node& node) {
                 auto p = node.as<some_primitive>().get_primitive()->param;
-                if (!one_of(p, { some_primitive::SomeParameter::SUPPORTED_VALUE_ALL, some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_STATIC }))
+                if (!one_of(p, { some_primitive::SomeParameter::SUPPORTED_VALUE_ALL,
+                                 some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_STATIC }))
                     return false;
                 return true;
         })
@@ -216,11 +218,18 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<some_
                     return true;
                 return false;
         })
+        OV_GPU_CREATE_INSTANCE_OCL(NullReturningImplementationManager, shape_types::dynamic_shape,
+            [](const program_node& node) {
+                auto p = node.as<some_primitive>().get_primitive()->param;
+                return p == some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_DYNAMIC_NULL_FALLBACK;
+        })
         OV_GPU_CREATE_INSTANCE_OCL(SomeDynamicImplementationManager, shape_types::dynamic_shape)
         OV_GPU_GET_INSTANCE_OCL(some_primitive, shape_types::dynamic_shape,
             [](const program_node& node) {
                 auto p = node.as<some_primitive>().get_primitive()->param;
-                if (!one_of(p, { some_primitive::SomeParameter::SUPPORTED_VALUE_ALL, some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_DYNAMIC }))
+                if (!one_of(p, { some_primitive::SomeParameter::SUPPORTED_VALUE_ALL,
+                                 some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_DYNAMIC,
+                                 some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_DYNAMIC_NULL_FALLBACK }))
                     return false;
                 return true;
         })
@@ -235,7 +244,7 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<some_
 
 TEST(impls_test, has_2_not_null_impls) {
     auto list = some_primitive::type_id()->get_all_implementations();
-    ASSERT_EQ(list.size(), 5);
+    ASSERT_EQ(list.size(), 6);
     for (size_t i = 0; i < list.size(); i++) {
         ASSERT_NE(list[i], nullptr) << " i = " << i;
     }
@@ -245,19 +254,21 @@ TEST(impls_test, has_2_not_null_impls) {
     ASSERT_EQ(list[2]->get_impl_type(), impl_types::onednn);
     ASSERT_EQ(list[3]->get_impl_type(), impl_types::ocl);
     ASSERT_EQ(list[4]->get_impl_type(), impl_types::ocl);
+    ASSERT_EQ(list[5]->get_impl_type(), impl_types::ocl);
 
     ASSERT_EQ(list[0]->get_shape_type(), shape_types::static_shape);
     ASSERT_EQ(list[1]->get_shape_type(), shape_types::static_shape);
     ASSERT_EQ(list[2]->get_shape_type(), shape_types::static_shape);
     ASSERT_EQ(list[3]->get_shape_type(), shape_types::dynamic_shape);
     ASSERT_EQ(list[4]->get_shape_type(), shape_types::dynamic_shape);
+    ASSERT_EQ(list[5]->get_shape_type(), shape_types::dynamic_shape);
 }
 
 TEST(impls_test, same_result_on_each_call) {
     auto list_1 = some_primitive::type_id()->get_all_implementations();
     auto list_2 = some_primitive::type_id()->get_all_implementations();
-    ASSERT_EQ(list_1.size(), 5);
-    ASSERT_EQ(list_2.size(), 5);
+    ASSERT_EQ(list_1.size(), 6);
+    ASSERT_EQ(list_2.size(), 6);
     for (size_t i = 0; i < list_1.size(); i++) {
         ASSERT_EQ(list_1[i], list_2[i]) << " i = " << i;
     }
@@ -377,6 +388,7 @@ INSTANTIATE_TEST_SUITE_P(smoke, PrimitiveTypeTest,
      std::vector<PrimitiveTypeTestParams>{
          { some_primitive::SomeParameter::SUPPORTED_VALUE_ALL, impl_types::ocl, shape_types::static_shape, true, 3, 1},
          { some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_STATIC, impl_types::ocl, shape_types::static_shape, true, 1, 1},
+         { some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_DYNAMIC_NULL_FALLBACK, impl_types::ocl, shape_types::dynamic_shape, true, 2, 1},
          { some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_DYNAMIC, impl_types::ocl, shape_types::static_shape, false, 1, 1},
          { some_primitive::SomeParameter::SUPPORTED_VALUE_ONEDNN_1, impl_types::ocl, shape_types::static_shape, false, 1, 1},
          { some_primitive::SomeParameter::SUPPORTED_VALUE_ONEDNN_1, impl_types::onednn, shape_types::static_shape, true, 1, 1},
@@ -392,39 +404,23 @@ INSTANTIATE_TEST_SUITE_P(smoke, PrimitiveTypeTest,
 TEST(impls_test, impl_create_null_fallback) {
     auto& engine = get_test_engine();
 
-    // Create a list of impl managers where the first one returns nullptr,
-    // and the second one returns a valid impl
-    std::vector<std::shared_ptr<ImplementationManager>> test_impls = {
-        std::make_shared<NullReturningImplementationManager>(shape_types::static_shape),
-        std::make_shared<SomeImplementationManager>(shape_types::static_shape, nullptr),
-    };
+    topology topology;
+    topology.add(input_layout("input", layout{{-1}, data_types::f32, format::bfyx}));
+    topology.add(some_primitive("test_fallback",
+                                std::vector<input_info>{input_info{"input"}},
+                                some_primitive::SomeParameter::SUPPORTED_VALUE_OCL_DYNAMIC_NULL_FALLBACK));
 
-    // Simulate find_impl behavior: iterate through impls, skip nullptr results
-    kernel_impl_params params;
-    params.output_layouts = { layout{{1}, data_types::f32, format::bfyx} };
-    params.input_layouts = { layout{{1}, data_types::f32, format::bfyx} };
+    network net(engine, topology, get_test_default_config(engine));
+    auto input_mem = engine.allocate_memory(layout{{2}, data_types::f32, format::bfyx});
+    net.set_input_data("input", input_mem);
+    ASSERT_NO_THROW(net.execute());
 
-    program p(engine, get_test_default_config(engine));
-    auto prim = std::make_shared<some_primitive>("test_fallback", std::vector<input_info>{}, some_primitive::SomeParameter::SUPPORTED_VALUE_ALL);
-    auto& node = p.get_or_create(prim);
-    node.recalc_output_layout();
+    auto inst = net.get_primitive("test_fallback");
 
-    std::unique_ptr<primitive_impl> result = nullptr;
-    for (auto& impl_manager : test_impls) {
-        if ((impl_manager->get_shape_type() & shape_types::static_shape) != shape_types::static_shape)
-            continue;
-        if (!impl_manager->support_shapes(params))
-            continue;
-
-        auto impl = impl_manager->create(node, params);
-        if (impl) {
-            result = std::move(impl);
-            break;
-        }
-    }
-
-    // The first impl returns nullptr, but fallback to the second should succeed
-    ASSERT_NE(result, nullptr);
+    ASSERT_NE(inst, nullptr);
+    ASSERT_NE(inst->get_impl(), nullptr);
+    ASSERT_NE(inst->get_impl()->m_manager, nullptr);
+    ASSERT_EQ(inst->get_impl()->m_manager->get_type_info(), ImplementationManagerLegacy<some_primitive>::get_type_info_static());
 }
 
 // Test: verify that OCL dynamic reorder impl is available for reorder nodes

--- a/src/plugins/intel_gpu/tests/unit/module_tests/impls_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/impls_test.cpp
@@ -6,6 +6,7 @@
 #include "registry/implementation_manager.hpp"
 #include "intel_gpu/graph/program.hpp"
 #include "intel_gpu/primitives/input_layout.hpp"
+#include "intel_gpu/primitives/reorder.hpp"
 #include "intel_gpu/runtime/layout.hpp"
 #include "intel_gpu/runtime/utils.hpp"
 #include "openvino/core/except.hpp"
@@ -148,6 +149,30 @@ struct SomeDynamicImplementationManager : public ImplementationManager {
 
     bool support_shapes(const kernel_impl_params& params) const override {
         return params.output_layouts[0].get_partial_shape()[0] == 1;
+    }
+};
+
+// An impl manager whose create_impl returns nullptr to simulate impl creation failure
+struct NullReturningImplementationManager : public ImplementationManager {
+    OV_GPU_PRIMITIVE_IMPL("test::null_returning_impl")
+    NullReturningImplementationManager(shape_types shape_type, ValidateFunc vf = nullptr)
+        : ImplementationManager(impl_types::ocl, shape_type, vf) {}
+
+    std::unique_ptr<primitive_impl> create_impl(const program_node& node, const kernel_impl_params& params) const override {
+        // Intentionally return nullptr to test fallback behavior
+        return nullptr;
+    }
+
+    bool validate_impl(const program_node& node) const override {
+        return true;
+    }
+
+    in_out_fmts_t query_formats(const program_node& node) const override {
+        OPENVINO_NOT_IMPLEMENTED;
+    }
+
+    bool support_shapes(const kernel_impl_params& params) const override {
+        return true;
     }
 };
 
@@ -361,3 +386,82 @@ INSTANTIATE_TEST_SUITE_P(smoke, PrimitiveTypeTest,
          { some_primitive::SomeParameter::UNSUPPORTED_VALUE_ALL, impl_types::ocl, shape_types::dynamic_shape, false, 0, 0},
     }),
     PrimitiveTypeTest::get_test_case_name);
+
+// Test: verify that find_impl skips impl managers whose create() returns nullptr
+// and continues to the next available impl (fallback behavior)
+TEST(impls_test, impl_create_null_fallback) {
+    auto& engine = get_test_engine();
+
+    // Create a list of impl managers where the first one returns nullptr,
+    // and the second one returns a valid impl
+    std::vector<std::shared_ptr<ImplementationManager>> test_impls = {
+        std::make_shared<NullReturningImplementationManager>(shape_types::static_shape),
+        std::make_shared<SomeImplementationManager>(shape_types::static_shape, nullptr),
+    };
+
+    // Simulate find_impl behavior: iterate through impls, skip nullptr results
+    kernel_impl_params params;
+    params.output_layouts = { layout{{1}, data_types::f32, format::bfyx} };
+    params.input_layouts = { layout{{1}, data_types::f32, format::bfyx} };
+
+    program p(engine, get_test_default_config(engine));
+    auto prim = std::make_shared<some_primitive>("test_fallback", std::vector<input_info>{}, some_primitive::SomeParameter::SUPPORTED_VALUE_ALL);
+    auto& node = p.get_or_create(prim);
+    node.recalc_output_layout();
+
+    std::unique_ptr<primitive_impl> result = nullptr;
+    for (auto& impl_manager : test_impls) {
+        if ((impl_manager->get_shape_type() & shape_types::static_shape) != shape_types::static_shape)
+            continue;
+        if (!impl_manager->support_shapes(params))
+            continue;
+
+        auto impl = impl_manager->create(node, params);
+        if (impl) {
+            result = std::move(impl);
+            break;
+        }
+    }
+
+    // The first impl returns nullptr, but fallback to the second should succeed
+    ASSERT_NE(result, nullptr);
+}
+
+// Test: verify that OCL dynamic reorder impl is available for reorder nodes
+// in shape-of subgraph when input is non-simple (b_fs_yx_fsv16) and output is simple (bfyx).
+// Without the fix, the predicate incorrectly blocks OCL dynamic impl in this case,
+// leaving only CPU impl which doesn't support fsv16 format.
+TEST(impls_test, reorder_ocl_dynamic_available_in_shape_flow_with_nonsimple_input) {
+    auto& engine = get_test_engine();
+    program p(engine, get_test_default_config(engine));
+
+    // Create input_layout node (prerequisite for reorder)
+    auto in_layout = layout{ov::PartialShape{1, 16, {1, 64}, {1, 64}}, data_types::f32, format::b_fs_yx_fsv16};
+    auto input_prim = std::make_shared<input_layout>("input", in_layout);
+    auto& input_node = p.get_or_create(input_prim);
+
+    // Create reorder node: fsv16 -> bfyx
+    auto reorder_prim = std::make_shared<reorder>("reorder_test", input_info("input"), format::bfyx, data_types::f32);
+    auto& reorder_node = p.get_or_create(reorder_prim);
+    p.add_connection(input_node, reorder_node);
+    reorder_node.recalc_output_layout();
+
+    // Mark node as in shape-of subgraph (simulates what mark_shape_of_subgraphs pass does)
+    reorder_node.set_in_shape_of_subgraph(true);
+
+    // Get supported implementations - should include OCL dynamic impl
+    auto supported_impls = reorder::type_id()->get_supported_implementations(reorder_node);
+
+    // Check that at least one OCL dynamic impl is available
+    bool has_ocl_dynamic = false;
+    for (auto& impl : supported_impls) {
+        if (impl->get_impl_type() == impl_types::ocl &&
+            (impl->get_shape_type() & shape_types::dynamic_shape) == shape_types::dynamic_shape) {
+            has_ocl_dynamic = true;
+            break;
+        }
+    }
+
+    ASSERT_TRUE(has_ocl_dynamic) << "OCL dynamic reorder impl should be available for "
+                                    "non-simple(fsv16) -> simple(bfyx) reorder in shape-of subgraph";
+}

--- a/src/plugins/intel_gpu/tests/unit/module_tests/impls_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/impls_test.cpp
@@ -169,7 +169,9 @@ struct NullReturningImplementationManager : public ImplementationManager {
     }
 
     in_out_fmts_t query_formats(const program_node& node) const override {
-        OPENVINO_NOT_IMPLEMENTED;
+        // Return empty formats as this impl is never used in production path
+        // Any future code that calls query_formats will get a valid empty response
+        return {{}, {}};
     }
 
     bool support_shapes(const kernel_impl_params& params) const override {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -1762,12 +1762,16 @@ TEST(reorder_gpu_f32, dynamic_fsv16_to_bfyx_executes_without_error) {
     auto& engine = get_test_engine();
 
     ov::Shape in_shape{ 1, 16, 4, 4 };
+    size_t element_count = 1;
+    for (const auto dim : in_shape)
+        element_count *= dim;
+
     // Dynamic input in b_fs_yx_fsv16 format
     layout in_layout{ov::PartialShape::dynamic(in_shape.size()), data_types::f32, format::b_fs_yx_fsv16};
 
     // Prepare properly formatted fsv16 memory via helper network
     auto input_bfyx = engine.allocate_memory({ov::PartialShape(in_shape), data_types::f32, format::bfyx});
-    std::vector<float> input_data(256);
+    std::vector<float> input_data(element_count);
     std::iota(input_data.begin(), input_data.end(), 1.f);
     set_values(input_bfyx, input_data);
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -19,6 +19,7 @@
 
 #include <cmath>
 #include <limits>
+#include <numeric>
 
 using namespace cldnn;
 using namespace ::tests;
@@ -1751,6 +1752,53 @@ TEST(reorder_gpu_f32, dynamic_bfyx_to_fsv16) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++) {
         ASSERT_NEAR(answers[i], output_ptr[i], 1e-2f);
+    }
+}
+
+// Test: dynamic reorder from b_fs_yx_fsv16 (non-simple) to bfyx (simple)
+// should select OCL dynamic impl even when allow_new_shape_infer is enabled
+// This verifies the fix where OCL dynamic reorder is not incorrectly blocked
+TEST(reorder_gpu_f32, dynamic_fsv16_to_bfyx_executes_without_error) {
+    auto& engine = get_test_engine();
+
+    ov::Shape in_shape{ 1, 16, 4, 4 };
+    // Dynamic input in b_fs_yx_fsv16 format
+    layout in_layout{ov::PartialShape::dynamic(in_shape.size()), data_types::f32, format::b_fs_yx_fsv16};
+
+    // Prepare properly formatted fsv16 memory via helper network
+    auto input_bfyx = engine.allocate_memory({ov::PartialShape(in_shape), data_types::f32, format::bfyx});
+    std::vector<float> input_data(256);
+    std::iota(input_data.begin(), input_data.end(), 1.f);
+    set_values(input_bfyx, input_data);
+
+    topology prep_topology(
+        input_layout("prep_in", layout{ov::PartialShape(in_shape), data_types::f32, format::bfyx}),
+        reorder("prep_out", input_info("prep_in"), format::b_fs_yx_fsv16, data_types::f32));
+    network prep_net(engine, prep_topology, get_test_default_config(engine));
+    prep_net.set_input_data("prep_in", input_bfyx);
+    auto prep_outputs = prep_net.execute();
+    auto input_fsv16 = prep_outputs.at("prep_out").get_memory();
+
+    // Main topology: dynamic fsv16 -> reorder to bfyx
+    topology topology(
+        input_layout("input", in_layout),
+        reorder("output", input_info("input"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, config);
+    network.set_input_data("input", input_fsv16);
+
+    // Must not throw
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+
+    auto output = outputs.at("output").get_memory();
+    ASSERT_EQ(output->get_layout().format, format::bfyx);
+
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    for (size_t i = 0; i < input_data.size(); i++) {
+        ASSERT_NEAR(input_data[i], output_ptr[i], 1e-5f);
     }
 }
 


### PR DESCRIPTION
### Details:
- The reorder node convolutionbackpropdata:/istft/ConvTranspose_1_0_reorder_761 was marked as being in the "shape-of subgraph" and had b_fs_yx_fsv16 input format (a non-simple blocked format). At build time, all reorder implementation validators rejected this node:

  - oneDNN/OCL static — rejected by not_in_shape_flow() predicate (node IS in shape flow)
  - OCL dynamic — rejected by the lambda: node.is_in_shape_of_subgraph() && format::is_simple_data_format(out_layout.format) returned true → blocked
  - CPU static/dynamic — rejected by is_supported() because b_fs_yx_fsv16 is not in the CPU reorder's supported format list
- Fix dynamic reorder implementation selection in shape-of flow by relaxing the OCL dynamic predicate in reorder_impls.cpp to block only when both input/output formats are simple.
- Improve implementation fallback robustness in primitive_inst.cpp:
  - Continue scanning impl managers when create() returns nullptr.
  - Add null guards in async static-compile cache path before kernel compilation/cache insert.
- Improve failure diagnostics for static impl miss with detailed assertion context (available impl types/shape types and input/output layouts).
- Add regression coverage:
  - impls_test.impl_create_null_fallback
  - impls_test.reorder_ocl_dynamic_available_in_shape_flow_with_nonsimple_input
  - reorder_gpu_f32.dynamic_fsv16_to_bfyx_executes_without_error

### Tickets:
 - 185208

### AI Assistance:
 - *AI assistance used: yes*
 - AI was used to draft and implement the code/test changes, iterate on test design, and prepare PR text.
