### PR TITLE
[GPU] Fix std::sort comparator violating strict weak ordering

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -794,9 +794,9 @@ const std::vector<primitive_id>& program::get_allocating_order(bool forced_updat
                         return po.get_processing_number(lhs.get()) < po.get_processing_number(rhs.get());
                     }
 
-                    if (rhs_layout.is_dynamic())
+                    if (rhs_layout.is_dynamic() && !lhs_layout.is_dynamic())
                         return true;
-                    if (lhs_layout.is_dynamic())
+                    if (lhs_layout.is_dynamic() && !rhs_layout.is_dynamic())
                         return false;
 
                     if (lhs_layout.bytes_count() == rhs_layout.bytes_count()) {


### PR DESCRIPTION

### Details:
- Fixes an invalid std::sort comparator in the Intel GPU plugin by restoring strict weak ordering and preventing unstable sorting behavior.

Fixes https://github.com/openvinotoolkit/openvino/issues/30788

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes
 - *AI wa used to extract changes from openvinotoolkit/openvino/pull/33842 and create clean PR
