### PR TITLE
Remove unsused path_join_w util function

### DIFF
--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -171,7 +171,6 @@ inline bool file_exists(const Path& path) noexcept {
 std::filesystem::path get_directory(const std::filesystem::path& path);
 
 std::filesystem::path path_join(std::initializer_list<std::filesystem::path>&& paths);
-std::wstring path_join_w(std::initializer_list<std::wstring>&& paths);
 
 /**
  * @brief Iterates over files in given directory and applies provided function to each file found.

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -52,10 +52,6 @@ std::filesystem::path ov::util::path_join(std::initializer_list<std::filesystem:
     return ::path_join<>(std::move(paths));
 }
 
-std::wstring ov::util::path_join_w(std::initializer_list<std::wstring>&& paths) {
-    return ::path_join<>(std::move(paths)).wstring();
-}
-
 namespace {
 void process_dir_entry(const std::filesystem::directory_entry& dir_entry,
                        const std::function<void(const std::filesystem::path& file)>& func) {

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -47,7 +47,6 @@ std::filesystem::path path_join(Container&& paths) {
     return joined_path;
 }
 
-// TODO: Remove string() / wstring() casts on function call site
 std::filesystem::path ov::util::path_join(std::initializer_list<std::filesystem::path>&& paths) {
     return ::path_join<>(std::move(paths));
 }

--- a/src/core/tests/pass/serialization/deterministicity.cpp
+++ b/src/core/tests/pass/serialization/deterministicity.cpp
@@ -149,8 +149,8 @@ TEST_F(SerializationDeterministicityTest, ModelWithConstants) {
 }
 
 TEST_F(SerializationDeterministicityTest, ModelWithVariable) {
-    const auto model = ov::test::utils::getModelFromTestModelZoo(
-        ov::util::path_join({SERIALIZED_ZOO, "ir", "dynamic_variable.xml"}));
+    const auto model =
+        ov::test::utils::getModelFromTestModelZoo(ov::util::path_join({SERIALIZED_ZOO, "ir", "dynamic_variable.xml"}));
 
     auto expected = ov::test::readModel(model, "");
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(expected);

--- a/src/core/tests/pass/serialization/deterministicity.cpp
+++ b/src/core/tests/pass/serialization/deterministicity.cpp
@@ -76,7 +76,7 @@ protected:
 
 TEST_F(SerializationDeterministicityTest, BasicModel) {
     const std::string model =
-        ov::test::utils::getModelFromTestModelZoo(ov::util::path_join({SERIALIZED_ZOO, "ir/add_abc.onnx"}).string());
+        ov::test::utils::getModelFromTestModelZoo(ov::util::path_join({SERIALIZED_ZOO, "ir", "add_abc.onnx"}));
 
     auto expected = ov::test::readModel(model, "");
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(expected);
@@ -93,7 +93,7 @@ TEST_F(SerializationDeterministicityTest, BasicModel) {
 
 TEST_F(SerializationDeterministicityTest, ModelWithMultipleLayers) {
     const std::string model =
-        ov::test::utils::getModelFromTestModelZoo(ov::util::path_join({SERIALIZED_ZOO, "ir/addmul_abc.onnx"}).string());
+        ov::test::utils::getModelFromTestModelZoo(ov::util::path_join({SERIALIZED_ZOO, "ir", "addmul_abc.onnx"}));
 
     auto expected = ov::test::readModel(model, "");
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(expected);
@@ -112,9 +112,9 @@ TEST_F(SerializationDeterministicityTest, ModelWithMultipleLayers) {
 
 TEST_F(SerializationDeterministicityTest, ModelWithMultipleOutputs) {
     const std::string model = ov::test::utils::getModelFromTestModelZoo(
-        ov::util::path_join({SERIALIZED_ZOO, "ir/split_equal_parts_2d.xml"}).string());
+        ov::util::path_join({SERIALIZED_ZOO, "ir", "split_equal_parts_2d.xml"}));
     const std::string weights = ov::test::utils::getModelFromTestModelZoo(
-        ov::util::path_join({SERIALIZED_ZOO, "ir/split_equal_parts_2d.bin"}).string());
+        ov::util::path_join({SERIALIZED_ZOO, "ir", "split_equal_parts_2d.bin"}));
 
     auto expected = ov::test::readModel(model, weights);
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(expected);
@@ -131,9 +131,9 @@ TEST_F(SerializationDeterministicityTest, ModelWithMultipleOutputs) {
 
 TEST_F(SerializationDeterministicityTest, ModelWithConstants) {
     const std::string model = ov::test::utils::getModelFromTestModelZoo(
-        ov::util::path_join({SERIALIZED_ZOO, "ir/add_abc_initializers.xml"}).string());
+        ov::util::path_join({SERIALIZED_ZOO, "ir", "add_abc_initializers.xml"}));
     const std::string weights = ov::test::utils::getModelFromTestModelZoo(
-        ov::util::path_join({SERIALIZED_ZOO, "ir/add_abc_initializers.bin"}).string());
+        ov::util::path_join({SERIALIZED_ZOO, "ir", "add_abc_initializers.bin"}));
 
     auto expected = ov::test::readModel(model, weights);
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(expected);
@@ -150,7 +150,7 @@ TEST_F(SerializationDeterministicityTest, ModelWithConstants) {
 
 TEST_F(SerializationDeterministicityTest, ModelWithVariable) {
     const auto model = ov::test::utils::getModelFromTestModelZoo(
-        ov::util::path_join({SERIALIZED_ZOO, "ir/dynamic_variable.xml"}).string());
+        ov::util::path_join({SERIALIZED_ZOO, "ir", "dynamic_variable.xml"}));
 
     auto expected = ov::test::readModel(model, "");
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(expected);

--- a/src/core/tests/pass/serialization/serialize.cpp
+++ b/src/core/tests/pass/serialization/serialize.cpp
@@ -120,10 +120,10 @@ public:
 
     void SetUp() override {
         m_model_path = ov::test::utils::getModelFromTestModelZoo(
-            ov::util::path_join({SERIALIZED_ZOO, "ir/", std::get<0>(GetParam())}).string());
+            ov::util::path_join({SERIALIZED_ZOO, "ir", std::get<0>(GetParam())}));
         if (!std::get<1>(GetParam()).empty()) {
             m_binary_path = ov::test::utils::getModelFromTestModelZoo(
-                ov::util::path_join({SERIALIZED_ZOO, "ir/", std::get<1>(GetParam())}).string());
+                ov::util::path_join({SERIALIZED_ZOO, "ir", std::get<1>(GetParam())}));
         }
 
         std::string filePrefix = ov::test::utils::generateTestFilePrefix();

--- a/src/frontends/onnx/tests/load_from.cpp
+++ b/src/frontends/onnx/tests/load_from.cpp
@@ -31,10 +31,8 @@ static LoadFromFEParam getTestData() {
 }
 
 TEST_P(FrontEndLoadFromTest, testLoadFromStreamAndPassPath) {
-    const auto path =
-        ov::util::path_join(
-            {ov::test::utils::getExecutableDirectory(), TEST_ONNX_MODELS_DIRNAME, "external_data/external_data.onnx"})
-            .string();
+    const auto path = ov::util::path_join(
+        {ov::test::utils::getExecutableDirectory(), TEST_ONNX_MODELS_DIRNAME, "external_data/external_data.onnx"});
     std::ifstream ifs(path, std::ios::in | std::ios::binary);
     ASSERT_TRUE(ifs.is_open()) << "Could not open an ifstream for the model path: " << path;
     std::istream* is = &ifs;
@@ -67,8 +65,7 @@ TEST_P(FrontEndLoadFromTest, load_model_not_exists_at_path) {
 
 TEST_P(FrontEndLoadFromTest, load_model_and_apply_ppp) {
     auto model_file_path =
-        ov::util::path_join({ov::test::utils::getExecutableDirectory(), TEST_ONNX_MODELS_DIRNAME, m_param.m_stream})
-            .string();
+        ov::util::path_join({ov::test::utils::getExecutableDirectory(), TEST_ONNX_MODELS_DIRNAME, m_param.m_stream});
 
     m_frontEnd = m_fem.load_by_model(model_file_path);
     const auto fe_model = m_frontEnd->load(model_file_path);
@@ -102,7 +99,7 @@ using ::ONNX_NAMESPACE::Version;
 
 TEST_P(FrontEndLoadFromTest, testLoadFromModelProtoUint64) {
     const auto path =
-        ov::util::path_join({ov::test::utils::getExecutableDirectory(), TEST_ONNX_MODELS_DIRNAME, "abs.onnx"}).string();
+        ov::util::path_join({ov::test::utils::getExecutableDirectory(), TEST_ONNX_MODELS_DIRNAME, "abs.onnx"});
     std::ifstream ifs(path, std::ios::in | std::ios::binary);
     ASSERT_TRUE(ifs.is_open()) << "Could not open an ifstream for the model path: " << path;
     std::vector<std::string> frontends;
@@ -130,7 +127,7 @@ TEST_P(FrontEndLoadFromTest, testLoadFromModelProtoUint64) {
 
 TEST_P(FrontEndLoadFromTest, testLoadFromModelProtoUint64_Negative) {
     const auto path =
-        ov::util::path_join({ov::test::utils::getExecutableDirectory(), TEST_ONNX_MODELS_DIRNAME, "abs.onnx"}).string();
+        ov::util::path_join({ov::test::utils::getExecutableDirectory(), TEST_ONNX_MODELS_DIRNAME, "abs.onnx"});
     std::ifstream ifs(path, std::ios::in | std::ios::binary);
     ASSERT_TRUE(ifs.is_open()) << "Could not open an ifstream for the model path: " << path;
     std::vector<std::string> frontends;

--- a/src/frontends/onnx/tests/onnx_importer_test.cpp
+++ b/src/frontends/onnx/tests/onnx_importer_test.cpp
@@ -114,7 +114,7 @@ TEST(ONNX_Importer_Tests, ImportModelWhenFileDoesNotExist) {
 
 TEST(ONNX_Importer_Tests, ImportModelFromStream) {
     auto model_file_path =
-        test::utils::getModelFromTestModelZoo(util::path_join({TEST_ONNX_MODELS_DIRNAME, "addmul_abc.onnx"}).string());
+        test::utils::getModelFromTestModelZoo(util::path_join({TEST_ONNX_MODELS_DIRNAME, "addmul_abc.onnx"}));
     std::ifstream model_file_stream(model_file_path, std::ifstream::binary);
     ASSERT_TRUE(model_file_stream.is_open());
     int count_adds = 0;
@@ -135,15 +135,15 @@ TEST(ONNX_Importer_Tests, ImportModelFromStream) {
 
 TEST(ONNX_Importer_Tests, ImportModelWithoutMetadata) {
     Core core;
-    auto model = core.read_model(test::utils::getModelFromTestModelZoo(
-        util::path_join({TEST_ONNX_MODELS_DIRNAME, "priorbox_clustered.onnx"}).string()));
+    auto model = core.read_model(
+        test::utils::getModelFromTestModelZoo(util::path_join({TEST_ONNX_MODELS_DIRNAME, "priorbox_clustered.onnx"})));
     ASSERT_FALSE(model->has_rt_info("framework"));
 }
 
 TEST(ONNX_Importer_Tests, ImportModelWithMetadata) {
     Core core;
-    auto model = core.read_model(test::utils::getModelFromTestModelZoo(
-        util::path_join({TEST_ONNX_MODELS_DIRNAME, "model_with_metadata.onnx"}).string()));
+    auto model = core.read_model(
+        test::utils::getModelFromTestModelZoo(util::path_join({TEST_ONNX_MODELS_DIRNAME, "model_with_metadata.onnx"})));
     ASSERT_TRUE(model->has_rt_info("framework"));
 
     const auto rtinfo = model->get_rt_info();

--- a/src/frontends/onnx/tests/op_extension.cpp
+++ b/src/frontends/onnx/tests/op_extension.cpp
@@ -155,7 +155,7 @@ TEST(ONNXOpExtensionViaCommonConstructor, onnx_op_extension_via_template_arg_wit
     fe->add_extension(ext);
 
     const auto input_model = fe->load(ov::test::utils::getModelFromTestModelZoo(
-        ov::util::path_join({TEST_ONNX_MODELS_DIRNAME, "relu_custom_domain.onnx"}).string()));
+        ov::util::path_join({TEST_ONNX_MODELS_DIRNAME, "relu_custom_domain.onnx"})));
 
     std::shared_ptr<ov::Model> model;
     EXPECT_NO_THROW(fe->convert(input_model));
@@ -169,7 +169,7 @@ TEST(ONNXOpExtensionViaCommonConstructor, onnx_op_extension_via_ov_type_name_wit
     fe->add_extension(ext);
 
     const auto input_model = fe->load(ov::test::utils::getModelFromTestModelZoo(
-        ov::util::path_join({TEST_ONNX_MODELS_DIRNAME, "relu_custom_domain.onnx"}).string()));
+        ov::util::path_join({TEST_ONNX_MODELS_DIRNAME, "relu_custom_domain.onnx"})));
 
     std::shared_ptr<ov::Model> model;
     EXPECT_NO_THROW(fe->convert(input_model));

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/file_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/file_utils.hpp
@@ -253,6 +253,7 @@ inline std::vector<std::string> splitStringByDelimiter(std::string paths, const 
 }
 
 std::string getModelFromTestModelZoo(const std::string& relModelPath);
+std::string getModelFromTestModelZoo(const std::filesystem::path& relModelPath);
 
 std::string getOpenvinoLibDirectory();
 std::string getExecutableDirectory();

--- a/src/tests/test_utils/common_test_utils/src/file_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/file_utils.cpp
@@ -174,6 +174,10 @@ std::string getModelFromTestModelZoo(const std::string& relModelPath) {
     return ov::util::path_join({getExecutableDirectory(), relModelPath}).string();
 }
 
+std::string getModelFromTestModelZoo(const std::filesystem::path& relModelPath) {
+    return ov::util::path_to_string(std::filesystem::path(getExecutableDirectory()) /  relModelPath);
+}
+
 std::string getRelativePath(const std::string& from, const std::string& to) {
     auto split_path = [](const std::string& path) -> std::vector<std::string> {
         std::string sep{FileTraits<char>::file_separator};

--- a/src/tests/test_utils/common_test_utils/src/file_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/file_utils.cpp
@@ -175,7 +175,7 @@ std::string getModelFromTestModelZoo(const std::string& relModelPath) {
 }
 
 std::string getModelFromTestModelZoo(const std::filesystem::path& relModelPath) {
-    return ov::util::path_to_string(std::filesystem::path(getExecutableDirectory()) /  relModelPath);
+    return ov::util::path_to_string(ov::util::make_path(getExecutableDirectory()) / relModelPath);
 }
 
 std::string getRelativePath(const std::string& from, const std::string& to) {


### PR DESCRIPTION
### Details:
 - Removes unused `std::wstring path_join_w(std::initializer_list<std::wstring>&& paths);`
 - Removes `// TODO: Remove string() / wstring() casts on function call site`  and a few `.string()` calls

### Tickets:
 - [CVS-146662](https://jira.devtools.intel.com/browse/CVS-146662)

### AI Assistance:
 - *AI assistance used: no*
