### PR TITLE
[ Jax FE]  Todo Fix memory leak 

### DIFF
--- a/src/bindings/python/src/openvino/frontend/jax/jaxpr_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/jax/jaxpr_decoder.py
@@ -83,7 +83,7 @@ class JaxprPythonDecoder(Decoder):
                     self.params.update(converted)
 
         
-        self.m_decoders =weakref.WeakSet()
+        self.m_decoders = weakref.WeakSet()
 
     def inputs(self) -> list[int]:
         if isinstance(self.jaxpr, jex.core.JaxprEqn):

--- a/src/bindings/python/src/openvino/frontend/jax/jaxpr_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/jax/jaxpr_decoder.py
@@ -14,6 +14,7 @@ if version.parse(jax.__version__) < version.parse("0.6.0"):
 else:
     import jax.extend as jex
 
+import weakref
 from openvino.frontend.jax.py_jax_frontend import _FrontEndJaxDecoder as Decoder
 from openvino import PartialShape, Type as OVType, OVAny
 from openvino.frontend.jax.utils import jax_array_to_ov_const, get_ov_type_for_value, \
@@ -81,8 +82,8 @@ class JaxprPythonDecoder(Decoder):
                 if converted is not None:
                     self.params.update(converted)
 
-        # TODO: this implementation may lead to memory increasing. Any better solution?
-        self.m_decoders = []
+        
+        self.m_decoders =weakref.WeakSet()
 
     def inputs(self) -> list[int]:
         if isinstance(self.jaxpr, jex.core.JaxprEqn):
@@ -147,7 +148,7 @@ class JaxprPythonDecoder(Decoder):
         if isinstance(self.jaxpr, jex.core.JaxprEqn):
             return
         for _, decoder in self.params.items():
-            self.m_decoders.append(decoder)
+            self.m_decoders.add(decoder)
             node_visitor(decoder)
         for idx, node in enumerate(self.jaxpr.constvars):
             decoder = self.convert_literal_to_constant_node(
@@ -155,7 +156,7 @@ class JaxprPythonDecoder(Decoder):
                 name=self.name + "/" + f"const({id(node)})",
                 output_id=id(node)
             )
-            self.m_decoders.append(decoder)
+            self.m_decoders.add(decoder)
             node_visitor(decoder)
         # Visit every `JaxEqn` in the jaxpr, see https://github.com/google/jax/blob/jaxlib-v0.4.29/jax/_src/core.py#L285
         for node in self.jaxpr.eqns:
@@ -166,7 +167,7 @@ class JaxprPythonDecoder(Decoder):
                     literal_decoders.append(literal_decoder)
                     node_visitor(literal_decoder)
             decoder = JaxprPythonDecoder(node, name=self.name + "/" + node.primitive.name, literals=literal_decoders)
-            self.m_decoders.append(decoder)
+            self.m_decoders.add(decoder)
             node_visitor(decoder)
 
     def get_op_type(self) -> str:

--- a/src/bindings/python/src/pyopenvino/frontend/jax/decoder.cpp
+++ b/src/bindings/python/src/pyopenvino/frontend/jax/decoder.cpp
@@ -17,6 +17,6 @@ using namespace ov::frontend;
 
 
 void regclass_frontend_jax_decoder(py::module m) {
-    py::class_<jax::JaxDecoder, IDecoder, PyDecoder, std::shared_ptr<jax::JaxDecoder>>(m, "_FrontEndJaxDecoder")
+    py::class_<jax::JaxDecoder, IDecoder, PyDecoder, std::shared_ptr<jax::JaxDecoder>>(m, "_FrontEndJaxDecoder", py::dynamic_attr())
         .def(py::init<>());
 }


### PR DESCRIPTION
### Details:
The JAX frontend `JaxprPythonDecoder` was storing all decoders created during `visit_subgraph` in a standard Python list (`self.m_decoders`). This created strong references, causing memory usage to increase linearly with model size, as noted by an existing `TODO`.

### Changes:
- Replaced the `self.m_decoders = []` list with `weakref.WeakSet()` to prevent unbound memory growth 

- Updated all instances of `m_decoders.append()` to `m_decoders.add()`.

**Closes** : https://github.com/jax-ml/jax/issues/37352



### AI Assistance:
 - *AI assistance used: no 
 
