### PR TITLE
[PyTorch FE] Fix aten.index_add conversion for torch.export by handling missing alpha argument

### DIFF
--- a/src/frontends/pytorch/src/op/index_add.cpp
+++ b/src/frontends/pytorch/src/op/index_add.cpp
@@ -27,12 +27,17 @@ OutputVector translate_index_add(const NodeContext& context) {
     // aten::index_add(Tensor self, int dim, Tensor index, Tensor source, *, Scalar alpha=1) -> Tensor
     // aten::index_add.out(Tensor self, int dim, Tensor index, Tensor source, *, Scalar alpha=1, Tensor(a!) out) ->
     // Tensor(a!)
-    num_inputs_check(context, 5, 6);
+    num_inputs_check(context, 4, 6);
     auto input = context.get_input(0);
     auto dim = context.get_input(1);
     auto index = context.mark_node(std::make_shared<v0::Convert>(context.get_input(2), element::i32));
     auto src = context.get_input(3);
-    auto alpha = context.get_input(4);
+    Output<Node> alpha;
+    if (context.get_input_size() < 5 || context.input_is_none(4)) {
+        alpha = context.mark_node(v0::Constant::create(element::f32, Shape{}, {1.0}));
+    } else {
+        alpha = context.get_input(4);
+    }
     auto converted_alpha = context.mark_node(std::make_shared<v1::ConvertLike>(alpha, src));
     auto alpha_src = context.mark_node(std::make_shared<v1::Multiply>(converted_alpha, src));
     auto input_shape_rank = get_shape_rank(context, input);

--- a/tests/layer_tests/pytorch_tests/test_index_add.py
+++ b/tests/layer_tests/pytorch_tests/test_index_add.py
@@ -27,13 +27,21 @@ class TestIndexAdd(PytorchLayerTest):
 
             def forward(self, x: torch.Tensor):
                 index = self.index
-                if self.inplace:
-                    return x.index_add_(self.dim, index, self.src, alpha=self.alpha), x
+                if self.alpha is None:
+                    if self.inplace:
+                        return x.index_add_(self.dim, index, self.src), x
+                    else:
+                        return torch.index_add(x, self.dim, index, self.src), x
                 else:
-                    return torch.index_add(x, self.dim, index, self.src, alpha=self.alpha), x
+                    if self.inplace:
+                        return x.index_add_(self.dim, index, self.src, alpha=self.alpha), x
+                    else:
+                        return torch.index_add(x, self.dim, index, self.src, alpha=self.alpha), x
 
             def forward_out(self, x: torch.Tensor, out):
                 index = self.index
+                if self.alpha is None:
+                    return torch.index_add(x, self.dim, index, self.src, out=out), out
                 return torch.index_add(x, self.dim, index, self.src, out=out, alpha=self.alpha), out
 
         op_name = "aten::index_add_" if mode == "inplace" else "aten::index_add"
@@ -53,7 +61,7 @@ class TestIndexAdd(PytorchLayerTest):
     @pytest.mark.parametrize("src", [torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])])
     @pytest.mark.parametrize("dtype", ["int32", "int64", "float32", "float64"])
     @pytest.mark.parametrize("mode", ["inplace", "out", "default"])
-    @pytest.mark.parametrize("alpha", [1, -1, 0.5, 0.25])
+    @pytest.mark.parametrize("alpha", [None, 1, -1, 0.5, 0.25])
     def test_scatter_reduce(self, dim, index, src, dtype, mode, alpha, ie_device, precision, ir_version):
         if isinstance(src, torch.Tensor):
             src = src.to(getattr(torch, dtype))


### PR DESCRIPTION
### Details:
When exporting PyTorch models containing `aten.index_add` using `torch.export.export`, the resulting FX graph elides the default keyword-only argument `alpha=1`. As a result, the node arrives at the OpenVINO PyTorch frontend with only 4 positional inputs instead of the expected 5. This causes the conversion to fail with an `OpConversionFailure`.
closes: #35628
### Changes
* **Relaxed input constraints:** Updated `num_inputs_check` in `src/frontends/pytorch/src/op/index_add.cpp` to require a minimum of 4 inputs instead of 5.
* **Handled missing alpha:** Added fallback logic to check if the `alpha` argument (at index 4) is missing or `None`. If so, it dynamically creates a default `f32` scalar constant of `1.0`.


### AI Assistance:
 - *AI assistance used: no 
