### PR TITLE
[Transformations][Debug Caps] Matcher logging is moved under ENABLE_DEBUG_CAPS cmake option

### DIFF
--- a/.claude/skills/ov-debug-matcher-pass/SKILL.md
+++ b/.claude/skills/ov-debug-matcher-pass/SKILL.md
@@ -39,20 +39,20 @@ Ask the user only if the transformation name or run command is missing. The buil
 
 ## Step 1: Verify Debug Build
 
-The matcher logging macros are compiled in only when `ENABLE_OPENVINO_DEBUG=ON`. Check whether the current build already has it:
+The matcher logging macros are compiled in only when `ENABLE_DEBUG_CAPS=ON`. Check whether the current build already has it:
 
 ```bash
-grep -i "ENABLE_OPENVINO_DEBUG" build/*/CMakeCache.txt
+grep -i "ENABLE_DEBUG_CAPS" build/*/CMakeCache.txt
 ```
 
 If the flag is absent or set to `OFF`, reconfigure CMake using the existing build directory and build type from Step 0:
 
 ```bash
-cmake -B <build_dir> -DENABLE_OPENVINO_DEBUG=ON
+cmake -B <build_dir> -DENABLE_DEBUG_CAPS=ON
 cmake --build <build_dir> --parallel
 ```
 
-> **Note:** Logging also works in `Release` builds as long as `ENABLE_OPENVINO_DEBUG=ON` is set at configure time.
+> **Note:** Logging also works in `Release` builds as long as `ENABLE_DEBUG_CAPS=ON` is set at configure time.
 
 ---
 
@@ -173,7 +173,7 @@ Work inward through the nested blocks to find the deepest `}` labeled with a fai
 
 If the log file is empty or contains no matcher output even though the flag is set:
 
-- Confirm `ENABLE_OPENVINO_DEBUG=ON` in `CMakeCache.txt` for the binary you are actually running (not a different build directory).
+- Confirm `ENABLE_DEBUG_CAPS=ON` in `CMakeCache.txt` for the binary you are actually running (not a different build directory).
 - Confirm the env var is exported in the same shell context as the run command: `export OV_MATCHER_LOGGING=true` or prefix it inline.
 - If calling through Python or a launcher script, the env var must survive into the child process — use `os.environ` or prefix the full command.
 - Verify you are running the freshly rebuilt binary, not a cached one from a different `bin/` location.

--- a/.claude/skills/ov-debug/SKILL.md
+++ b/.claude/skills/ov-debug/SKILL.md
@@ -7,8 +7,7 @@ description: Troubleshooting all sorts of failures, crashes, exceptions and erro
 
 ## Prerequisites
 Build flags that enable debug capabilities (check CMakeCache.txt in the build dir):
-- `-DENABLE_DEBUG_CAPS=ON` — CPU/GPU plugin debug env vars
-- `-DENABLE_OPENVINO_DEBUG=ON` — transformation matcher logging
+- `-DENABLE_DEBUG_CAPS=ON` — CPU/GPU plugin debug env vars, transformation matcher logging
 
 ## Components
 

--- a/.claude/skills/ov-debug/components/debug-transformations.md
+++ b/.claude/skills/ov-debug/components/debug-transformations.md
@@ -1,8 +1,5 @@
 The debug and troubleshooting of OpenVINO transformations can be performed using various debug capabilities activated via environment variables.
 
-# Prerequisites
-Matcher logging requires `-DENABLE_OPENVINO_DEBUG=ON`. Verify in CMakeCache.txt before suggesting `OV_MATCHER_LOGGING`.
-
 # Reference
 Read `src/common/transformations/docs/debug_capabilities/README.md` — use the "When to use" guidance to match the observed problem to the right capability.
 

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -234,6 +234,10 @@ if(ENABLE_OPENVINO_DEBUG)
     add_definitions(-DENABLE_OPENVINO_DEBUG)
 endif()
 
+if(ENABLE_DEBUG_CAPS)
+    add_definitions(-DENABLE_DEBUG_CAPS)
+endif()
+
 if (ENABLE_SNIPPETS_DEBUG_CAPS)
     add_definitions(-DSNIPPETS_DEBUG_CAPS)
 endif()

--- a/src/common/transformations/docs/debug_capabilities/README.md
+++ b/src/common/transformations/docs/debug_capabilities/README.md
@@ -5,7 +5,7 @@ They can be activated at runtime and are useful for analyzing transformation beh
 
 * [Matcher logging](matcher_logging.md)
   When to use: a MatcherPass transformation is not firing or matching unexpectedly — logs the pattern matching process to show why matches succeed or fail.
-  Requires: `-DENABLE_OPENVINO_DEBUG=ON`
+  Requires: `-DENABLE_DEBUG_CAPS=ON`
   Example: `OV_MATCHER_LOGGING=true OV_MATCHERS_TO_LOG=EliminateSplitConcat ./your_program`
 
 * [Transformation profiling](transformation_profiling.md)

--- a/src/common/transformations/docs/debug_capabilities/matcher_logging.md
+++ b/src/common/transformations/docs/debug_capabilities/matcher_logging.md
@@ -3,7 +3,7 @@
 The logging functionality allows to observe/debug the pattern matching process.
 
 ## Usage
-In order to utilzie the logging, first, you need to set the CMake flag ```-DENABLE_OPENVINO_DEBUG=ON```
+In order to utilzie the logging, first, you need to set the CMake flag ```-DENABLE_DEBUG_CAPS=ON```
 
 _NOTE: the logging would also work if your build is configured as Release_
 

--- a/src/common/util/include/openvino/util/log.hpp
+++ b/src/common/util/include/openvino/util/log.hpp
@@ -40,7 +40,7 @@ private:
     std::stringstream m_stream;
 };
 
-#ifdef ENABLE_OPENVINO_DEBUG
+#if defined(ENABLE_DEBUG_CAPS) || defined(ENABLE_OPENVINO_DEBUG)
 /* Template function _write_all_to_stream has duplicates
  * It's defined in:
  * intel_cpu/src/utils/debug_capabilities and src/core/include/openvino/core/except.hpp
@@ -58,6 +58,29 @@ static inline std::ostream& _write_all_to_stream(std::ostream& os, const T& arg,
 
 #    define OPENVINO_LOG_STREAM(OPENVINO_HELPER_LOG_TYPE) \
         ::ov::util::LogHelper(::ov::util::LOG_TYPE::OPENVINO_HELPER_LOG_TYPE, __FILE__, __LINE__).stream()
+
+static inline bool is_terminal_output() {
+#    ifdef _WIN32
+    // No Windows support for colored logs for now.
+    return false;
+#    else
+    static const bool stdout_to_terminal = isatty(fileno(stdout));
+    return stdout_to_terminal;
+#    endif
+}
+
+#    define OPENVINO_RESET            (ov::util::is_terminal_output() ? "\033[0m" : "")
+#    define OPENVINO_RED              (ov::util::is_terminal_output() ? "\033[31m" : "")
+#    define OPENVINO_GREEN            (ov::util::is_terminal_output() ? "\033[1;32m" : "")
+#    define OPENVINO_YELLOW           (ov::util::is_terminal_output() ? "\033[33m" : "")
+#    define OPENVINO_BLOCK_BEG        "{"
+#    define OPENVINO_BLOCK_END        "}"
+#    define OPENVINO_BLOCK_BODY       "│"
+#    define OPENVINO_BLOCK_BODY_RIGHT "├─"
+
+#endif
+
+#ifdef ENABLE_OPENVINO_DEBUG
 
 #    define OPENVINO_ERR(...)                                                                  \
         do {                                                                                   \
@@ -79,28 +102,26 @@ static inline std::ostream& _write_all_to_stream(std::ostream& os, const T& arg,
             ov::util::_write_all_to_stream(OPENVINO_LOG_STREAM(_LOG_TYPE_DEBUG), __VA_ARGS__); \
         } while (0)
 
+#else
+#    define OPENVINO_ERR(...) \
+        do {                  \
+        } while (0)
+#    define OPENVINO_WARN(...) \
+        do {                   \
+        } while (0)
+#    define OPENVINO_INFO(...) \
+        do {                   \
+        } while (0)
+#    define OPENVINO_DEBUG(...) \
+        do {                    \
+        } while (0)
+#endif
+
+#ifdef ENABLE_DEBUG_CAPS
+
 static const bool logging_enabled = ov::util::getenv_bool("OV_MATCHER_LOGGING");
 static const std::unordered_set<std::string> matchers_to_log =
     ov::util::split_by_delimiter(ov::util::getenv_string("OV_MATCHERS_TO_LOG"), ',');
-
-static inline bool is_terminal_output() {
-#    ifdef _WIN32
-    // No Windows support for colored logs for now.
-    return false;
-#    else
-    static const bool stdout_to_terminal = isatty(fileno(stdout));
-    return stdout_to_terminal;
-#    endif
-}
-
-#    define OPENVINO_RESET            (ov::util::is_terminal_output() ? "\033[0m" : "")
-#    define OPENVINO_RED              (ov::util::is_terminal_output() ? "\033[31m" : "")
-#    define OPENVINO_GREEN            (ov::util::is_terminal_output() ? "\033[1;32m" : "")
-#    define OPENVINO_YELLOW           (ov::util::is_terminal_output() ? "\033[33m" : "")
-#    define OPENVINO_BLOCK_BEG        "{"
-#    define OPENVINO_BLOCK_END        "}"
-#    define OPENVINO_BLOCK_BODY       "│"
-#    define OPENVINO_BLOCK_BODY_RIGHT "├─"
 
 #    define OPENVINO_LOG_MATCHING(matcher_ptr, ...)                                                               \
         do {                                                                                                      \
@@ -122,18 +143,6 @@ static inline bool is_terminal_output() {
         } while (0)
 
 #else
-#    define OPENVINO_ERR(...) \
-        do {                  \
-        } while (0)
-#    define OPENVINO_WARN(...) \
-        do {                   \
-        } while (0)
-#    define OPENVINO_INFO(...) \
-        do {                   \
-        } while (0)
-#    define OPENVINO_DEBUG(...) \
-        do {                    \
-        } while (0)
 #    define OPENVINO_LOG_MATCHING(matcher_ptr, ...) \
         do {                                        \
         } while (0)

--- a/src/core/dev_api/openvino/core/log_util.hpp
+++ b/src/core/dev_api/openvino/core/log_util.hpp
@@ -23,7 +23,7 @@ using LogCallback = std::function<void(std::string_view)>;
 OPENVINO_API
 void log_message(std::string_view message);
 
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef ENABLE_DEBUG_CAPS
 
 class OPENVINO_API LevelString {
 private:
@@ -679,7 +679,7 @@ bool is_verbose_logging();
             }                                                                  \
         } while (0);
 
-#else  // ENABLE_OPENVINO_DEBUG
+#else  // ENABLE_DEBUG_CAPS
 
 #    define OPENVINO_LOG_NODE1(...) \
         do {                        \
@@ -827,5 +827,5 @@ bool is_verbose_logging();
         do {                           \
         } while (0)
 
-#endif  // ENABLE_OPENVINO_DEBUG
+#endif  // ENABLE_DEBUG_CAPS
 }  // namespace ov::util

--- a/src/core/src/log_util.cpp
+++ b/src/core/src/log_util.cpp
@@ -12,7 +12,7 @@
 namespace ov {
 namespace util {
 
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef ENABLE_DEBUG_CAPS
 // Switch on verbose matching logging using OV_VERBOSE_LOGGING=true
 static const bool verbose = ov::util::getenv_bool("OV_VERBOSE_LOGGING");
 


### PR DESCRIPTION
### Details:
Currently, matcher logging is activated via the legacy `ENABLE_OPENVINO_DEBUG` CMake option. Enabling this option also turns on non‑matcher‑related debug output, which clutters the logs with extra lines.
In this PR, the matcher debug feature is moved under the `ENABLE_DEBUG_CAPS` CMake option. This change has two benefits:
- *This option is widely used in plugin development and is often enabled in local builds, which can reduce the number of rebuilds required to use this feature.*
 - *When `ENABLE_DEBUG_CAPS` is set to `ON`, no additional unrelated output is printed by default: all the debug features (including matcher logging) are activated via dedicated environment variables.*

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used for the whole changes generation. The results have been checked manually on some tests*
