### PR TITLE
[EXPERIMENT][WIP] [ONNX FE] Add DynamicQuantizeLSTM operator support

### DIFF
--- a/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
@@ -1,0 +1,435 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/operator_set.hpp"
+#include "exceptions.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/lstm_sequence.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
+#include "openvino/util/common_util.hpp"
+#include "utils/common.hpp"
+#include "utils/reshape.hpp"
+#include "utils/split.hpp"
+
+namespace ov {
+namespace frontend {
+namespace onnx {
+namespace com_microsoft {
+namespace {
+
+enum class DynamicQuantizeLSTMInput {
+    X,
+    W,
+    R,
+    B,
+    SEQUENCE_LENS,
+    INITIAL_H,
+    INITIAL_C,
+};
+
+struct PreparedQuantizedWeights {
+    ov::Output<ov::Node> weights;
+    int64_t original_rank;
+};
+
+ov::Output<ov::Node> normalize_tensor_rank(const ov::Output<ov::Node>& input,
+                                           int64_t target_rank,
+                                           const std::string& input_name) {
+    const auto& input_rank = input.get_partial_shape().rank();
+
+    if (input_rank.is_dynamic()) {
+        return input;
+    }
+
+    if (input_rank.get_length() == target_rank) {
+        return input;
+    }
+
+    if (input_rank.get_length() > target_rank) {
+        const auto dims_to_squeeze = input_rank.get_length() - target_rank;
+        const auto& input_shape = input.get_partial_shape();
+
+        for (int64_t i = 0; i < dims_to_squeeze; ++i) {
+            if (input_shape[i].is_static() && input_shape[i].get_length() != 1) {
+                OPENVINO_THROW("DynamicQuantizeLSTM input '",
+                               input_name,
+                               "' has rank ",
+                               input_rank.get_length(),
+                               " but expected ",
+                               target_rank,
+                               ". Leading dimension [",
+                               i,
+                               "] is ",
+                               input_shape[i].get_length(),
+                               " but must be 1 to squeeze.");
+            }
+        }
+
+        std::vector<int64_t> axes_to_squeeze;
+        axes_to_squeeze.reserve(dims_to_squeeze);
+        for (int64_t i = 0; i < dims_to_squeeze; ++i) {
+            axes_to_squeeze.push_back(i);
+        }
+
+        auto axes_const =
+            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{axes_to_squeeze.size()}, axes_to_squeeze);
+        return std::make_shared<ov::op::v0::Squeeze>(input, axes_const);
+    }
+
+    const auto dims_to_unsqueeze = target_rank - input_rank.get_length();
+    if (dims_to_unsqueeze != 1) {
+        OPENVINO_THROW("DynamicQuantizeLSTM input '",
+                       input_name,
+                       "' has rank ",
+                       input_rank.get_length(),
+                       " but expected ",
+                       target_rank,
+                       ". Rank difference is ",
+                       dims_to_unsqueeze,
+                       " but only 1 is supported.");
+    }
+
+    auto axes_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+    return std::make_shared<ov::op::v0::Unsqueeze>(input, axes_const);
+}
+
+PreparedQuantizedWeights prepare_quantized_weights(const ov::frontend::onnx::Node& node,
+                                                   const ov::Output<ov::Node>& weights,
+                                                   int64_t hidden_size,
+                                                   const std::string& input_name) {
+    const auto& rank = weights.get_partial_shape().rank();
+    CHECK_VALID_NODE(node,
+                     rank.is_static() && (rank.get_length() == 2 || rank.get_length() == 3),
+                     "DynamicQuantizeLSTM input '",
+                     input_name,
+                     "' must have static rank 2 or 3. Got rank: ",
+                     rank);
+
+    const auto gate_axis_size = 4 * hidden_size;
+    auto prepared_weights = weights;
+
+    if (rank.get_length() == 2) {
+        const auto& shape = prepared_weights.get_partial_shape();
+        const auto dim0_matches = shape[0].is_static() && shape[0].get_length() == gate_axis_size;
+        const auto dim1_matches = shape[1].is_static() && shape[1].get_length() == gate_axis_size;
+
+        CHECK_VALID_NODE(node,
+                         dim0_matches || dim1_matches,
+                         "DynamicQuantizeLSTM input '",
+                         input_name,
+                         "' must have one dimension equal to 4*hidden_size (",
+                         gate_axis_size,
+                         "). Got shape: ",
+                         shape);
+
+        if (!dim0_matches && dim1_matches) {
+            prepared_weights = ov::op::util::reorder_axes(prepared_weights, {1, 0});
+        }
+
+        auto axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+        prepared_weights = std::make_shared<ov::op::v0::Unsqueeze>(prepared_weights, axis);
+    } else {
+        const auto& shape = prepared_weights.get_partial_shape();
+        const auto dim1_matches = shape[1].is_static() && shape[1].get_length() == gate_axis_size;
+        const auto dim2_matches = shape[2].is_static() && shape[2].get_length() == gate_axis_size;
+
+        CHECK_VALID_NODE(node,
+                         dim1_matches || dim2_matches,
+                         "DynamicQuantizeLSTM input '",
+                         input_name,
+                         "' must have either axis 1 or axis 2 equal to 4*hidden_size (",
+                         gate_axis_size,
+                         "). Got shape: ",
+                         shape);
+
+        if (!dim1_matches && dim2_matches) {
+            prepared_weights = ov::op::util::reorder_axes(prepared_weights, {0, 2, 1});
+        }
+    }
+
+    return {prepared_weights, rank.get_length()};
+}
+
+ov::Output<ov::Node> align_dequant_param(const ov::frontend::onnx::Node& node,
+                                         const ov::Output<ov::Node>& param,
+                                         int64_t weight_rank,
+                                         const std::string& input_name) {
+    const auto& rank = param.get_partial_shape().rank();
+
+    if (rank.is_dynamic() || rank.get_length() == 0) {
+        return param;
+    }
+
+    CHECK_VALID_NODE(node,
+                     rank.get_length() == 1 || rank.get_length() == 2,
+                     "DynamicQuantizeLSTM input '",
+                     input_name,
+                     "' must be a scalar, rank-1, or rank-2 tensor. Got rank: ",
+                     rank.get_length());
+
+    if (weight_rank == 2) {
+        CHECK_VALID_NODE(node,
+                         rank.get_length() == 1,
+                         "DynamicQuantizeLSTM rank-2 weights require rank-1 scale/zero_point for input '",
+                         input_name,
+                         "'.");
+        auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {0, 2});
+        return std::make_shared<ov::op::v0::Unsqueeze>(param, axes);
+    }
+
+    if (rank.get_length() == 1) {
+        auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 2});
+        return std::make_shared<ov::op::v0::Unsqueeze>(param, axes);
+    }
+
+    auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+    return std::make_shared<ov::op::v0::Unsqueeze>(param, axes);
+}
+
+ov::Output<ov::Node> dequantize_weights(const ov::frontend::onnx::Node& node,
+                                        const PreparedQuantizedWeights& prepared_weights,
+                                        const ov::Output<ov::Node>& scale,
+                                        const ov::Output<ov::Node>& zero_point,
+                                        const std::string& weights_name) {
+    auto dequantized =
+        ov::Output<ov::Node>(std::make_shared<ov::op::v0::Convert>(prepared_weights.weights, scale.get_element_type()));
+    auto aligned_scale = align_dequant_param(node, scale, prepared_weights.original_rank, weights_name + "_scale");
+
+    if (zero_point.get_node_shared_ptr()) {
+        auto aligned_zero_point = align_dequant_param(node,
+                                                      zero_point,
+                                                      prepared_weights.original_rank,
+                                                      weights_name + "_zero_point");
+        aligned_zero_point = std::make_shared<ov::op::v0::Convert>(aligned_zero_point, scale.get_element_type());
+        dequantized = std::make_shared<ov::op::v1::Subtract>(dequantized, aligned_zero_point);
+    }
+
+    return std::make_shared<ov::op::v1::Multiply>(dequantized, aligned_scale);
+}
+
+struct DynamicQuantizeLSTMInputMap {
+    explicit DynamicQuantizeLSTMInputMap(const ov::frontend::onnx::Node& node, int64_t hidden_size) {
+        const auto& ng_inputs = node.get_ov_inputs();
+        constexpr std::size_t gates_count{4};
+
+        auto input_x = normalize_tensor_rank(ng_inputs.at(0), 3, "X");
+        m_input_map[DynamicQuantizeLSTMInput::X] = ov::op::util::reorder_axes(input_x, {1, 0, 2});
+
+        CHECK_VALID_NODE(node,
+                         ng_inputs.at(1).get_element_type() == ov::element::i8 ||
+                             ng_inputs.at(1).get_element_type() == ov::element::u8,
+                         "DynamicQuantizeLSTM input 'W' must have element type int8 or uint8. Got: ",
+                         ng_inputs.at(1).get_element_type());
+        CHECK_VALID_NODE(node,
+                         ng_inputs.at(2).get_element_type() == ov::element::i8 ||
+                             ng_inputs.at(2).get_element_type() == ov::element::u8,
+                         "DynamicQuantizeLSTM input 'R' must have element type int8 or uint8. Got: ",
+                         ng_inputs.at(2).get_element_type());
+        CHECK_VALID_NODE(node,
+                         ng_inputs.at(8).get_element_type() == ov::element::f32,
+                         "DynamicQuantizeLSTM input 'W_scale' must have element type float32. Got: ",
+                         ng_inputs.at(8).get_element_type());
+        CHECK_VALID_NODE(node,
+                         ng_inputs.at(10).get_element_type() == ov::element::f32,
+                         "DynamicQuantizeLSTM input 'R_scale' must have element type float32. Got: ",
+                         ng_inputs.at(10).get_element_type());
+
+        ov::Output<ov::Node> w_zero_point;
+        if (common::is_input_valid(node, 9)) {
+            w_zero_point = ng_inputs.at(9);
+            CHECK_VALID_NODE(node,
+                             w_zero_point.get_element_type() == ov::element::i8 ||
+                                 w_zero_point.get_element_type() == ov::element::u8,
+                             "DynamicQuantizeLSTM input 'W_zero_point' must have element type int8 or uint8. Got: ",
+                             w_zero_point.get_element_type());
+        }
+
+        ov::Output<ov::Node> r_zero_point;
+        if (common::is_input_valid(node, 11)) {
+            r_zero_point = ng_inputs.at(11);
+            CHECK_VALID_NODE(node,
+                             r_zero_point.get_element_type() == ov::element::i8 ||
+                                 r_zero_point.get_element_type() == ov::element::u8,
+                             "DynamicQuantizeLSTM input 'R_zero_point' must have element type int8 or uint8. Got: ",
+                             r_zero_point.get_element_type());
+        }
+
+        auto prepared_w = prepare_quantized_weights(node, ng_inputs.at(1), hidden_size, "W");
+        auto prepared_r = prepare_quantized_weights(node, ng_inputs.at(2), hidden_size, "R");
+
+        m_input_map[DynamicQuantizeLSTMInput::W] =
+            ov::op::util::convert_lstm_node_format(dequantize_weights(node, prepared_w, ng_inputs.at(8), w_zero_point, "W"),
+                                                   ov::op::util::LSTMWeightsFormat::IOFC,
+                                                   ov::op::util::LSTMWeightsFormat::FICO,
+                                                   1);
+        m_input_map[DynamicQuantizeLSTMInput::R] =
+            ov::op::util::convert_lstm_node_format(dequantize_weights(node, prepared_r, ng_inputs.at(10), r_zero_point, "R"),
+                                                   ov::op::util::LSTMWeightsFormat::IOFC,
+                                                   ov::op::util::LSTMWeightsFormat::FICO,
+                                                   1);
+
+        auto shape_of_x = std::make_shared<ov::op::v3::ShapeOf>(m_input_map[DynamicQuantizeLSTMInput::X]);
+        auto axes = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
+        auto batch_size_node = std::make_shared<ov::op::v8::Gather>(shape_of_x,
+                                                                    ov::op::v0::Constant::create(ov::element::i32,
+                                                                                                  ov::Shape{1},
+                                                                                                  {0}),
+                                                                    axes);
+        auto seq_length_node = std::make_shared<ov::op::v8::Gather>(shape_of_x,
+                                                                    ov::op::v0::Constant::create(ov::element::i32,
+                                                                                                  ov::Shape{1},
+                                                                                                  {1}),
+                                                                    axes);
+
+        auto shape_of_r = std::make_shared<ov::op::v3::ShapeOf>(m_input_map[DynamicQuantizeLSTMInput::R]);
+        auto num_directions_node = std::make_shared<ov::op::v8::Gather>(shape_of_r,
+                                                                        ov::op::v0::Constant::create(ov::element::i32,
+                                                                                                      ov::Shape{1},
+                                                                                                      {0}),
+                                                                        axes);
+        auto hidden_size_node = std::make_shared<ov::op::v8::Gather>(shape_of_r,
+                                                                     ov::op::v0::Constant::create(ov::element::i32,
+                                                                                                   ov::Shape{1},
+                                                                                                   {2}),
+                                                                     axes);
+
+        if (common::is_input_valid(node, 3)) {
+            auto bias = normalize_tensor_rank(ng_inputs.at(3), 2, "B");
+            auto split_bias = ov::op::util::make_split(bias, 2, 1);
+            m_input_map[DynamicQuantizeLSTMInput::B] = std::make_shared<ov::op::v1::Add>(split_bias.at(0), split_bias.at(1));
+            m_input_map[DynamicQuantizeLSTMInput::B] =
+                ov::op::util::convert_lstm_node_format(m_input_map[DynamicQuantizeLSTMInput::B],
+                                                       ov::op::util::LSTMWeightsFormat::IOFC,
+                                                       ov::op::util::LSTMWeightsFormat::FICO,
+                                                       1);
+        } else {
+            auto b_shape = std::make_shared<ov::op::v0::Concat>(
+                ov::OutputVector{num_directions_node,
+                                 std::make_shared<ov::op::v1::Multiply>(
+                                     ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {gates_count}),
+                                     hidden_size_node)},
+                0);
+            m_input_map[DynamicQuantizeLSTMInput::B] = std::make_shared<ov::op::v3::Broadcast>(
+                ov::op::v0::Constant::create(m_input_map[DynamicQuantizeLSTMInput::X].get_element_type(), ov::Shape{}, {0}),
+                b_shape);
+        }
+
+        if (common::is_input_valid(node, 4)) {
+            m_input_map[DynamicQuantizeLSTMInput::SEQUENCE_LENS] = ng_inputs.at(4);
+        } else {
+            m_input_map[DynamicQuantizeLSTMInput::SEQUENCE_LENS] =
+                std::make_shared<ov::op::v3::Broadcast>(seq_length_node, batch_size_node);
+        }
+
+        if (common::is_input_valid(node, 5)) {
+            auto init_h = normalize_tensor_rank(ng_inputs.at(5), 3, "initial_h");
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_H] = ov::op::util::reorder_axes(init_h, {1, 0, 2});
+        } else {
+            auto init_h_shape = std::make_shared<ov::op::v0::Concat>(
+                ov::OutputVector{batch_size_node, num_directions_node, hidden_size_node},
+                0);
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_H] = std::make_shared<ov::op::v3::Broadcast>(
+                ov::op::v0::Constant::create(m_input_map[DynamicQuantizeLSTMInput::X].get_element_type(), ov::Shape{}, {0}),
+                init_h_shape);
+        }
+
+        if (common::is_input_valid(node, 6)) {
+            auto init_c = normalize_tensor_rank(ng_inputs.at(6), 3, "initial_c");
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_C] = ov::op::util::reorder_axes(init_c, {1, 0, 2});
+        } else {
+            auto init_c_shape = std::make_shared<ov::op::v0::Concat>(
+                ov::OutputVector{batch_size_node, num_directions_node, hidden_size_node},
+                0);
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_C] = std::make_shared<ov::op::v3::Broadcast>(
+                ov::op::v0::Constant::create(m_input_map[DynamicQuantizeLSTMInput::X].get_element_type(), ov::Shape{}, {0}),
+                init_c_shape);
+        }
+    }
+
+    ov::Output<ov::Node>& at(const DynamicQuantizeLSTMInput& key) {
+        return m_input_map.at(key);
+    }
+
+    std::map<DynamicQuantizeLSTMInput, ov::Output<ov::Node>> m_input_map;
+};
+
+struct LSTMAttributes {
+    explicit LSTMAttributes(const ov::frontend::onnx::Node& node)
+        : m_hidden_size{node.get_attribute_value<std::int64_t>("hidden_size")},
+          m_clip_threshold{node.get_attribute_value<float>("clip", 0.f)},
+          m_activations{node.get_attribute_value<std::vector<std::string>>("activations", {"sigmoid", "tanh", "tanh"})},
+          m_activation_alpha{node.get_attribute_value<std::vector<float>>("activation_alpha", std::vector<float>{})},
+          m_activation_beta{node.get_attribute_value<std::vector<float>>("activation_beta", std::vector<float>{})},
+          m_input_forget{static_cast<bool>(node.get_attribute_value<std::int64_t>("input_forget", 0))} {
+        m_clip_threshold = std::abs(m_clip_threshold);
+        const auto direction = ov::util::to_lower(node.get_attribute_value<std::string>("direction", "forward"));
+        m_direction = ov::as_enum<ov::op::RecurrentSequenceDirection>(direction);
+    }
+
+    ov::op::RecurrentSequenceDirection m_direction;
+    std::int64_t m_hidden_size;
+    float m_clip_threshold;
+    std::vector<std::string> m_activations;
+    std::vector<float> m_activation_alpha;
+    std::vector<float> m_activation_beta;
+    bool m_input_forget;
+};
+
+}  // namespace
+
+namespace opset_1 {
+
+ov::OutputVector dynamic_quantize_lstm(const ov::frontend::onnx::Node& node) {
+    common::default_op_checks(node, 11, 12);
+
+    LSTMAttributes attributes{node};
+    DynamicQuantizeLSTMInputMap input_map{node, attributes.m_hidden_size};
+
+    auto lstm_sequence = std::make_shared<ov::op::v5::LSTMSequence>(input_map.at(DynamicQuantizeLSTMInput::X),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::INITIAL_H),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::INITIAL_C),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::SEQUENCE_LENS),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::W),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::R),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::B),
+                                                                    attributes.m_hidden_size,
+                                                                    attributes.m_direction,
+                                                                    attributes.m_activation_alpha,
+                                                                    attributes.m_activation_beta,
+                                                                    attributes.m_activations,
+                                                                    attributes.m_clip_threshold);
+
+    const auto Y = lstm_sequence->output(0);
+    const auto Y_h = lstm_sequence->output(1);
+    const auto Y_c = lstm_sequence->output(2);
+
+    return {ov::op::util::reorder_axes(Y, {2, 1, 0, 3}),
+            ov::op::util::reorder_axes(Y_h, {1, 0, 2}),
+            ov::op::util::reorder_axes(Y_c, {1, 0, 2})};
+}
+
+ONNX_OP("DynamicQuantizeLSTM", OPSET_SINCE(1), com_microsoft::opset_1::dynamic_quantize_lstm, MICROSOFT_DOMAIN);
+
+}  // namespace opset_1
+}  // namespace com_microsoft
+}  // namespace onnx
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/onnx/tests/models/com.microsoft/dynamic_quantize_lstm.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/dynamic_quantize_lstm.prototxt
@@ -1,0 +1,273 @@
+ir_version: 13
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "X"
+    input: "W"
+    input: "R"
+    input: "B"
+    input: "sequence_lens"
+    input: "initial_h"
+    input: "initial_c"
+    input: ""
+    input: "W_scale"
+    input: "W_zero_point"
+    input: "R_scale"
+    input: "R_zero_point"
+    output: "Y"
+    output: "Y_h"
+    output: "Y_c"
+    op_type: "DynamicQuantizeLSTM"
+    attribute {
+      name: "hidden_size"
+      i: 2
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  name: "dq_lstm_test"
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "R"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 16
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "sequence_lens"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "initial_h"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "initial_c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W_scale"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W_zero_point"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "R_scale"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "R_zero_point"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y_h"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y_c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 17
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -1566,6 +1566,47 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_dynamic_quantize_matmul_null_b
     test_case.run_with_tolerance_as_fp(0.0055f);
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_dynamic_quantize_lstm) {
+    const auto model = convert_model("com.microsoft/dynamic_quantize_lstm.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    const std::vector<float> input_X{0.25f, -0.5f, 1.0f, 1.5f, 0.75f, -1.25f};
+    const std::vector<int8_t> input_W{12, -7, 5, 9, -11, 3, 4, -6, 8, 13, -9, 2, 7, -5, 10, 1, -4, 6, 14, -8, 12,
+                                      -10, 11, -3};
+    const std::vector<int8_t> input_R{5, -3, 4, 7, -6, 2, 1, -4, 9, 8, -5, 3, 6, -7, 10, -2};
+    const std::vector<float> input_B{0.1f,  -0.2f,  0.05f, 0.3f,  -0.4f, 0.2f,  0.15f, -0.25f,
+                                     -0.05f, 0.12f, -0.18f, 0.22f, -0.08f, 0.09f, -0.11f, 0.07f};
+    const std::vector<int32_t> input_sequence_lens{2};
+    const std::vector<float> input_initial_h{0.2f, -0.1f};
+    const std::vector<float> input_initial_c{0.05f, 0.15f};
+    const std::vector<float> input_W_scale{0.05f};
+    const std::vector<int8_t> input_W_zero_point{1};
+    const std::vector<float> input_R_scale{0.04f};
+    const std::vector<int8_t> input_R_zero_point{-2};
+
+    const std::vector<float> expected_Y{0.11440717f, -0.06565752f, -0.00265372f, -0.20275351f};
+    const std::vector<float> expected_Y_h{-0.00265372f, -0.20275351f};
+    const std::vector<float> expected_Y_c{-0.00976340f, -0.24270093f};
+
+    test_case.add_input<float>(Shape{2, 1, 3}, input_X);
+    test_case.add_input<int8_t>(Shape{1, 3, 8}, input_W);
+    test_case.add_input<int8_t>(Shape{1, 2, 8}, input_R);
+    test_case.add_input<float>(Shape{1, 16}, input_B);
+    test_case.add_input<int32_t>(Shape{1}, input_sequence_lens);
+    test_case.add_input<float>(Shape{1, 1, 2}, input_initial_h);
+    test_case.add_input<float>(Shape{1, 1, 2}, input_initial_c);
+    test_case.add_input<float>(Shape{1}, input_W_scale);
+    test_case.add_input<int8_t>(Shape{1}, input_W_zero_point);
+    test_case.add_input<float>(Shape{1}, input_R_scale);
+    test_case.add_input<int8_t>(Shape{1}, input_R_zero_point);
+
+    test_case.add_expected_output<float>(Shape{2, 1, 1, 2}, expected_Y);
+    test_case.add_expected_output<float>(Shape{1, 1, 2}, expected_Y_h);
+    test_case.add_expected_output<float>(Shape{1, 1, 2}, expected_Y_c);
+
+    test_case.run_with_tolerance_as_fp(1e-6f);
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_skip_simplified_layer_normalization) {
     const auto model = convert_model("com.microsoft/skip_simplified_layer_normalization.onnx");
     auto test_case = ov::test::TestCase(model, s_device);


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY MEAT AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

---

## Summary

Adds `com.microsoft::DynamicQuantizeLSTM` support to the OpenVINO ONNX Frontend and adds frontend regression coverage for a minimal valid model.

## Motivation

This operator appears in ORT-exported / ORT-targeted models and blocks out-of-the-box import in OpenVINO when it is encountered. The implementation keeps the lowering inside ONNX FE, alongside existing `com.microsoft` translators already shipped in OpenVINO.

## Operator spec (`com.microsoft::DynamicQuantizeLSTM`, opset 1)

### Attributes
- `hidden_size` (`int`): number of hidden units.
- `direction` (`string`, optional): `forward` / `reverse` / `bidirectional`; default `forward`.
- `clip` (`float`, optional): cell clip threshold.
- `activations` (`list[string]`, optional): 3 activations (or 6 for bidirectional).
- `activation_alpha` (`list[float]`, optional): activation scaling values.
- `activation_beta` (`list[float]`, optional): activation bias/scaling values.
- `input_forget` (`int`, optional): couples input/forget gates if `1`.

### Inputs
1. `X` (`float`): `[seq_length, batch_size, input_size]`
2. `W` (`int8|uint8`): `[num_directions, input_size, 4*hidden_size]`
3. `R` (`int8|uint8`): `[num_directions, hidden_size, 4*hidden_size]`
4. `B` (`float`, optional): `[num_directions, 8*hidden_size]`
5. `sequence_lens` (`int32`, optional): `[batch_size]`
6. `initial_h` (`float`, optional): `[num_directions, batch_size, hidden_size]`
7. `initial_c` (`float`, optional): `[num_directions, batch_size, hidden_size]`
8. `P` (`float`, optional): `[num_directions, 3*hidden_size]`
9. `W_scale` (`float`): `[num_directions]` or `[num_directions, 4*hidden_size]`
10. `W_zero_point` (`int8|uint8`): `[num_directions]` or `[num_directions, 4*hidden_size]`
11. `R_scale` (`float`): `[num_directions]` or `[num_directions, 4*hidden_size]`
12. `R_zero_point` (`int8|uint8`): `[num_directions]` or `[num_directions, 4*hidden_size]`

### Outputs
- `Y` (`float`): `[seq_length, num_directions, batch_size, hidden_size]`
- `Y_h` (`float`): `[num_directions, batch_size, hidden_size]`
- `Y_c` (`float`): `[num_directions, batch_size, hidden_size]`

### Semantics
`W` and `R` are quantized gate weights. The translator dequantizes them using the provided scales / zero-points and lowers the op to OpenVINO `LSTMSequence`, with the usual ONNX↔OV layout and gate-order conversions.

## Test coverage

Added a new ONNX FE regression model and test:
- `src/frontends/onnx/tests/models/com.microsoft/dynamic_quantize_lstm.prototxt`
- `src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp`

Coverage details:
- single-direction forward `DynamicQuantizeLSTM`
- explicit `B`, `sequence_lens`, `initial_h`, `initial_c`
- per-tensor `W_scale` / `W_zero_point` and `R_scale` / `R_zero_point`
- validates all three outputs: `Y`, `Y_h`, `Y_c`
- expected values were generated from ONNX Runtime for the same model and inputs

## OP Extension API consideration

I checked the OpenVINO Frontend Extension API (`ConversionExtension` / `OpExtension`). A custom ONNX conversion extension can implement this lowering outside OpenVINO core, and that is a good option for one-off / application-local custom domains.

I kept the native ONNX FE approach here because:
- OpenVINO already carries native translators for multiple `com.microsoft` contrib ops.
- The goal is out-of-the-box import for models that already use this ORT contrib op.
- This PR only adds frontend translation; it does not introduce a new OpenVINO core op.

If maintainers prefer not to grow built-in support for ORT contrib ops, the same lowering can be moved to an external extension with minimal functional change.