### PR TITLE
[Transformations] Simplify MoE router to Transpose + Gather

### DIFF
--- a/src/common/transformations/include/ov_ops/moe_compressed.hpp
+++ b/src/common/transformations/include/ov_ops/moe_compressed.hpp
@@ -28,9 +28,6 @@ public:
         // numeric_limits<size_t>::max() means per_channel compression (single group).
         // other non-zero value means group compression with this given group_size.
         size_t group_size = 0;
-        // In CB, intermediate shapes are expanded to {SeqLen, 1, HiddenSize}
-        // In Non-CB, intermediate shapes are expanded to {Batch, SeqLen, HiddenSize}
-        bool has_batch_dim = false;
         bool has_zp = false;
         ov::element::Type out_type = ov::element::dynamic;
         RoutingType routing_type = RoutingType::SOFTMAX;

--- a/src/common/transformations/include/transformations/common_optimizations/canonicalize_moe_router.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/canonicalize_moe_router.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov {
+namespace pass {
+
+/**
+ * @brief Rewrites a MoE routing tail expressed via ScatterElementsUpdate
+ * (densified routing weights) into the canonical Transpose + Gather form.
+ *
+ * Matches:
+ *   ScatterElementsUpdate(zeros[T,E], topk_idx[T,K], topk_val[T,K], axis=1)
+ *     -> Transpose([1,0]) -> Reshape -> (Unsqueeze(-1)) ->
+ *     Multiply(Reshape(down_out, [E,B,*,H]), routing) ->
+ *     ReduceSum(axis=0)
+ *
+ * Replaces with:
+ *   Transpose(down_out, [1,0,2]) ->
+ *   Gather(axis=1, batch_dims=1, topk_idx) ->
+ *   Multiply(Unsqueeze(topk_val, -1)) ->
+ *   ReduceSum(axis=1)
+ *
+ * Handles both fused-MoE output (FuseMOEExperts) and natively exported
+ * GPT-OSS-style IR, which share the same ScatterElementsUpdate shape.
+ */
+class TRANSFORMATIONS_API CanonicalizeMoeRouter : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("CanonicalizeMoeRouter");
+    CanonicalizeMoeRouter();
+};
+
+}  // namespace pass
+}  // namespace ov

--- a/src/common/transformations/include/transformations/common_optimizations/moe_op_fusion.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/moe_op_fusion.hpp
@@ -22,20 +22,20 @@ class TRANSFORMATIONS_API MoeOpFusion;
 class ov::pass::Convert2GatherMatmulMoeBlockToMoeOp : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("Convert2GatherMatmulMoeBlockToMoeOp");
-    Convert2GatherMatmulMoeBlockToMoeOp(bool has_batch_dim = true);
+    Convert2GatherMatmulMoeBlockToMoeOp();
 };
 
 class ov::pass::Convert3GatherMatmulMoeBlockToMoeOp : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("Convert3GatherMatmulMoeBlockToMoeOp");
-    Convert3GatherMatmulMoeBlockToMoeOp(bool has_batch_dim = true);
+    Convert3GatherMatmulMoeBlockToMoeOp();
 };
 
 class ov::pass::MoeOpFusion : public ov::pass::GraphRewrite {
 public:
     OPENVINO_GRAPH_REWRITE_RTTI("MoeOpFusion");
-    MoeOpFusion(bool has_batch_dim = true) {
-        add_matcher<ov::pass::Convert2GatherMatmulMoeBlockToMoeOp>(has_batch_dim);
-        add_matcher<ov::pass::Convert3GatherMatmulMoeBlockToMoeOp>(has_batch_dim);
+    MoeOpFusion() {
+        add_matcher<ov::pass::Convert2GatherMatmulMoeBlockToMoeOp>();
+        add_matcher<ov::pass::Convert3GatherMatmulMoeBlockToMoeOp>();
     }
 };

--- a/src/common/transformations/src/ov_ops/moe_compressed.cpp
+++ b/src/common/transformations/src/ov_ops/moe_compressed.cpp
@@ -161,7 +161,6 @@ bool MOECompressed::visit_attributes(ov::AttributeVisitor& visitor) {
     visitor.on_attribute("num_shared_expert", m_config.num_shared_expert);
     visitor.on_attribute("top_k", m_config.top_k);
     visitor.on_attribute("group_size", m_config.group_size);
-    visitor.on_attribute("has_batch_dim", m_config.has_batch_dim);
     visitor.on_attribute("has_zp", m_config.has_zp);
     visitor.on_attribute("out_type", m_config.out_type);
     visitor.on_attribute("routing_type", m_config.routing_type);

--- a/src/common/transformations/src/transformations/common_optimizations/canonicalize_moe_router.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/canonicalize_moe_router.cpp
@@ -1,0 +1,133 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/canonicalize_moe_router.hpp"
+
+#include <memory>
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/scatter_elements_update.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace ov::pass {
+
+namespace {
+
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+namespace v3 = ov::op::v3;
+namespace v8 = ov::op::v8;
+namespace v12 = ov::op::v12;
+
+// True if the input is a Constant filled with zeros, or a Broadcast of a scalar zero Constant.
+bool is_zero_filled(const Output<Node>& output) {
+    auto node = output.get_node_shared_ptr();
+    if (auto bcast = ov::as_type_ptr<v3::Broadcast>(node)) {
+        node = bcast->get_input_node_shared_ptr(0);
+    }
+    auto c = ov::as_type_ptr<v0::Constant>(node);
+    if (!c) {
+        return false;
+    }
+    return ov::op::util::constantIsEqualTo(c, 0.0F);
+}
+
+}  // namespace
+
+ov::pass::CanonicalizeMoeRouter::CanonicalizeMoeRouter() {
+    MATCHER_SCOPE(CanonicalizeMoeRouter);
+
+    // BMM output of the down projection: [E, T, H], where T = num_tokens.
+    auto down_out = pattern::any_input(pattern::rank_equals(3));
+    // Reshape to [E, B, S, H] (or [E, B, -1, H] dynamically).
+    auto end_reshape = pattern::wrap_type<v1::Reshape>({down_out, pattern::any_input()});
+
+    // Densified routing weights: ScatterElementsUpdate(zeros[T,E], topk_idx, topk_val, axis=1).
+    auto scatter_data = pattern::any_input();
+    auto scatter_idx = pattern::any_input(pattern::rank_equals(2));
+    auto scatter_upd = pattern::any_input(pattern::rank_equals(2));
+    auto scatter_axis = pattern::wrap_type<v0::Constant>(pattern::value_matches("1"));
+    auto scatter = pattern::wrap_type<v3::ScatterElementsUpdate, v12::ScatterElementsUpdate>(
+        {scatter_data, scatter_idx, scatter_upd, scatter_axis});
+
+    // Transpose [T,E] -> [E,T]; Reshape to [E,B,*]; Unsqueeze last dim to broadcast over H.
+    auto transpose_perm = pattern::wrap_type<v0::Constant>(pattern::value_matches("1, 0"));
+    auto routing_transpose = pattern::wrap_type<v1::Transpose>({scatter, transpose_perm});
+    auto routing_reshape = pattern::wrap_type<v1::Reshape>({routing_transpose, pattern::any_input()});
+    auto routing_unsq = pattern::wrap_type<v0::Unsqueeze>({routing_reshape, pattern::any_input()});
+
+    auto multiply = pattern::wrap_type<v1::Multiply>({end_reshape, routing_unsq});
+    auto reduce_axis = pattern::wrap_type<v0::Constant>(pattern::value_matches("0"));
+    auto reduce_sum =
+        pattern::wrap_type<v1::ReduceSum>({multiply, reduce_axis}, pattern::attrs_match({{"keep_dims", false}}));
+
+    matcher_pass_callback callback = [=](pattern::Matcher& m) -> bool {
+        const auto& pm = m.get_pattern_value_map();
+
+        // Guardrail: scatter data must be all zeros — otherwise this is not a routing densification.
+        if (!is_zero_filled(pm.at(scatter_data))) {
+            return false;
+        }
+
+        const auto reduce_sum_node = pm.at(reduce_sum).get_node_shared_ptr();
+
+        const auto down_out_value = pm.at(down_out);
+        const auto topk_idx_value = pm.at(scatter_idx);
+        const auto topk_val_value = pm.at(scatter_upd);
+
+        // [E,T,H] -> [T,E,H]
+        const auto perm_const = v0::Constant::create(element::i64, Shape{3}, {1, 0, 2});
+        const auto transpose = std::make_shared<v1::Transpose>(down_out_value, perm_const);
+
+        // [T,E,H] -> Gather(axis=1, batch_dims=1, topk_idx[T,K]) -> [T,K,H]
+        const auto gather_axis_const = v0::Constant::create(element::i64, Shape{}, {1});
+        const auto gather = std::make_shared<v8::Gather>(transpose,
+                                                         topk_idx_value,
+                                                         gather_axis_const,
+                                                         /*batch_dims=*/1);
+
+        // topk_val[T,K] -> Unsqueeze(-1) -> [T,K,1]
+        const auto unsq_axis_const = v0::Constant::create(element::i64, Shape{1}, {-1});
+        const auto unsq = std::make_shared<v0::Unsqueeze>(topk_val_value, unsq_axis_const);
+
+        // [T,K,H] * [T,K,1] -> [T,K,H]; ReduceSum(axis=1, keep_dims=false) -> [T,H].
+        const auto multiply_node = std::make_shared<v1::Multiply>(gather, unsq);
+        const auto reduce_axis_const = v0::Constant::create(element::i64, Shape{1}, {1});
+        const auto new_reduce = std::make_shared<v1::ReduceSum>(multiply_node, reduce_axis_const, false);
+
+        // Old reduce produced [B,S,H] (or some [..,H]); new produces [T,H]. Both have the same total
+        // element count, so the downstream Reshape to original shape adapts unchanged.
+        ov::copy_runtime_info(reduce_sum_node,
+                              {perm_const,
+                               transpose,
+                               gather_axis_const,
+                               gather,
+                               unsq_axis_const,
+                               unsq,
+                               multiply_node,
+                               reduce_axis_const,
+                               new_reduce});
+        new_reduce->set_friendly_name(reduce_sum_node->get_friendly_name());
+        ov::replace_node(reduce_sum_node, new_reduce);
+        return true;
+    };
+
+    auto matcher = std::make_shared<pattern::Matcher>(reduce_sum, matcher_name);
+    register_matcher(matcher, callback);
+}
+
+}  // namespace ov::pass

--- a/src/common/transformations/src/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.cpp
@@ -12,19 +12,18 @@
 #include "openvino/op/add.hpp"
 #include "openvino/op/clamp.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/gather.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/minimum.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/reshape.hpp"
-#include "openvino/op/scatter_elements_update.hpp"
 #include "openvino/op/slice.hpp"
 #include "openvino/op/swish.hpp"
 #include "openvino/op/tile.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
-#include "openvino/pass/pattern/op/optional.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "ov_ops/gather_matmul.hpp"
 
@@ -33,10 +32,8 @@ using namespace ov::pass;
 
 namespace v0 = ov::op::v0;
 namespace v1 = ov::op::v1;
-namespace v3 = ov::op::v3;
 namespace v4 = ov::op::v4;
 namespace v8 = ov::op::v8;
-namespace v12 = ov::op::v12;
 
 // Note: intermediate nodes remain unchanged,
 // but we need to explicitly call shape inference for them to keep shapes consistency
@@ -60,9 +57,8 @@ struct MOE2GEMMPatternNodes {
     std::shared_ptr<ov::Node> gate_up_matmul, gate_up_add, gate_up_bias;
     std::shared_ptr<ov::Node> slice1, clamp, add1, slice2, minimum1, swish_beta, swish, multiply2;
     std::shared_ptr<ov::Node> down_proj_matmul, down_proj_bias, down_proj_add;
-    std::shared_ptr<ov::Node> end_reshape_target_shape, end_reshape;
-    std::shared_ptr<ov::Node> router_topk_indices, chosen_experts, scatter_elements_update;
-    std::shared_ptr<ov::Node> router_transpose, router_reshape, optional_unsqueeze;
+    std::shared_ptr<ov::Node> router_transpose, router_topk_indices, router_gather;
+    std::shared_ptr<ov::Node> chosen_experts_unsqueeze;
     std::shared_ptr<ov::Node> mul3, reduce_sum;
 };
 
@@ -96,27 +92,28 @@ MOE2GEMMPatternNodes build_2gemm_pattern() {
     // Join: Multiply_2
     p.multiply2 = pattern::wrap_type<v1::Multiply>({p.add1, p.swish}, pattern::consumers_count(1));
 
-    // Down projection
+    // Down projection -> [E, B, H_out]
     p.down_proj_matmul = pattern::wrap_type<v0::MatMul>(
         {p.multiply2, pattern::any_input()},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
     p.down_proj_bias = pattern::wrap_const();
     p.down_proj_add = pattern::wrap_type<v1::Add>({p.down_proj_matmul, p.down_proj_bias}, pattern::consumers_count(1));
-    p.end_reshape_target_shape = pattern::any_input();
-    p.end_reshape =
-        pattern::wrap_type<v1::Reshape>({p.down_proj_add, p.end_reshape_target_shape}, pattern::consumers_count(1));
 
-    // Routing weights/mask
+    // Router (FuseMOEExperts emits): Transpose[1,0,2] -> Gather(axis=1, batch_dims=1, topk)
+    p.router_transpose =
+        pattern::wrap_type<v1::Transpose>({p.down_proj_add, pattern::any_input()}, pattern::consumers_count(1));
     p.router_topk_indices = pattern::any_input();
-    p.chosen_experts = pattern::any_input();
-    p.scatter_elements_update = pattern::wrap_type<v3::ScatterElementsUpdate, v12::ScatterElementsUpdate>(
-        {pattern::any_input(), p.router_topk_indices, p.chosen_experts, pattern::any_input()});
+    p.router_gather =
+        pattern::wrap_type<v8::Gather>({p.router_transpose, p.router_topk_indices, pattern::any_input()},
+                                       pattern::consumers_count(1) && pattern::attrs_match({{"batch_dims", 1}}));
 
-    p.router_transpose = pattern::wrap_type<v1::Transpose>({p.scatter_elements_update, pattern::any_input()});
-    p.router_reshape = pattern::wrap_type<v1::Reshape>({p.router_transpose, pattern::any_input()});
-    p.optional_unsqueeze = pattern::optional<v0::Unsqueeze>({p.router_reshape, pattern::any_input()});
+    // Router weights: normalized-topk tensor -> Unsqueeze(-1) -> [B, K, 1]
+    // NopElimination rewrites Unsqueeze(axis=-1) into Reshape when the output has <2 dynamic dims.
+    p.chosen_experts_unsqueeze =
+        pattern::wrap_type<v0::Unsqueeze, v1::Reshape>({pattern::any_input(), pattern::any_input()});
 
-    p.mul3 = pattern::wrap_type<v1::Multiply>({p.end_reshape, p.optional_unsqueeze}, pattern::consumers_count(1));
+    p.mul3 =
+        pattern::wrap_type<v1::Multiply>({p.router_gather, p.chosen_experts_unsqueeze}, pattern::consumers_count(1));
     p.reduce_sum = pattern::wrap_type<v1::ReduceSum>({p.mul3, pattern::any_input()},
                                                      pattern::consumers_count(1),
                                                      {{"keep_dims", false}});
@@ -128,9 +125,8 @@ struct MOE3GEMMPatternNodes {
     std::shared_ptr<ov::Node> experts_input, tile, after_tile_reshape;
     std::shared_ptr<ov::Node> gate_matmul, swish, up_matmul, swiglu;
     std::shared_ptr<ov::Node> down_matmul;
-    std::shared_ptr<ov::Node> end_reshape_target_shape, end_reshape;
-    std::shared_ptr<ov::Node> router_topk_indices, chosen_experts, scatter_elements_update;
-    std::shared_ptr<ov::Node> router_transpose, router_reshape, optional_unsqueeze;
+    std::shared_ptr<ov::Node> router_transpose, router_topk_indices, router_gather;
+    std::shared_ptr<ov::Node> chosen_experts_unsqueeze;
     std::shared_ptr<ov::Node> mul3, reduce_sum;
 };
 
@@ -153,24 +149,26 @@ MOE3GEMMPatternNodes build_3gemm_pattern() {
     // Join: Multiply (SwiGLU)
     p.swiglu = pattern::wrap_type<v1::Multiply>({p.swish, p.up_matmul}, pattern::consumers_count(1));
 
-    // Third GEMM (down_projection)
+    // Third GEMM (down_projection) -> [E, B, H_out]
     p.down_matmul = pattern::wrap_type<v0::MatMul>(
         {p.swiglu, pattern::any_input()},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
-    p.end_reshape_target_shape = pattern::any_input();
-    p.end_reshape =
-        pattern::wrap_type<v1::Reshape>({p.down_matmul, p.end_reshape_target_shape}, pattern::consumers_count(1));
 
-    // Routing weights/mask
+    // Router (FuseMOEExperts emits): Transpose[1,0,2] -> Gather(axis=1, batch_dims=1, topk)
+    p.router_transpose =
+        pattern::wrap_type<v1::Transpose>({p.down_matmul, pattern::any_input()}, pattern::consumers_count(1));
     p.router_topk_indices = pattern::any_input();
-    p.chosen_experts = pattern::any_input();
-    p.scatter_elements_update = pattern::wrap_type<v3::ScatterElementsUpdate, v12::ScatterElementsUpdate>(
-        {pattern::any_input(), p.router_topk_indices, p.chosen_experts, pattern::any_input()});
-    p.router_transpose = pattern::wrap_type<v1::Transpose>({p.scatter_elements_update, pattern::any_input()});
-    p.router_reshape = pattern::wrap_type<v1::Reshape>({p.router_transpose, pattern::any_input()});
-    p.optional_unsqueeze = pattern::optional<v0::Unsqueeze>({p.router_reshape, pattern::any_input()});
+    p.router_gather =
+        pattern::wrap_type<v8::Gather>({p.router_transpose, p.router_topk_indices, pattern::any_input()},
+                                       pattern::consumers_count(1) && pattern::attrs_match({{"batch_dims", 1}}));
 
-    p.mul3 = pattern::wrap_type<v1::Multiply>({p.end_reshape, p.optional_unsqueeze}, pattern::consumers_count(1));
+    // Router weights: some normalized-topk tensor -> Unsqueeze(-1) -> [B, K, 1]
+    // NopElimination rewrites Unsqueeze(axis=-1) into Reshape when the output has <2 dynamic dims.
+    p.chosen_experts_unsqueeze =
+        pattern::wrap_type<v0::Unsqueeze, v1::Reshape>({pattern::any_input(), pattern::any_input()});
+
+    p.mul3 =
+        pattern::wrap_type<v1::Multiply>({p.router_gather, p.chosen_experts_unsqueeze}, pattern::consumers_count(1));
     p.reduce_sum = pattern::wrap_type<v1::ReduceSum>({p.mul3, pattern::any_input()},
                                                      pattern::consumers_count(1),
                                                      {{"keep_dims", false}});
@@ -221,6 +219,7 @@ ConvertTiledMoeBlockTo2GatherMatmuls::ConvertTiledMoeBlockTo2GatherMatmuls() {
         const auto down_proj_mm_node = pm.at(p.down_proj_matmul).get_node_shared_ptr();
         const auto down_proj_bias_node = pm.at(p.down_proj_bias).get_node_shared_ptr();
 
+        // GatherMatmul output: [K, B, H_out]
         const auto down_gathered_mm = std::make_shared<GatherMatmul>(pm.at(p.multiply2),
                                                                      down_proj_mm_node->input_value(1),
                                                                      active_indices,
@@ -228,50 +227,33 @@ ConvertTiledMoeBlockTo2GatherMatmuls::ConvertTiledMoeBlockTo2GatherMatmuls() {
         ov::copy_runtime_info(down_proj_mm_node, down_gathered_mm);
         down_gathered_mm->set_friendly_name(down_proj_mm_node->get_friendly_name());
 
-        const auto& chosen_experts_input = pm.at(p.chosen_experts);
-        const auto router_transpose_node = pm.at(p.router_transpose).get_node_shared_ptr();
-        const auto new_router_transpose =
-            std::make_shared<v1::Transpose>(chosen_experts_input, router_transpose_node->input_value(1));
-        ov::copy_runtime_info(router_transpose_node, new_router_transpose);
-        new_router_transpose->set_friendly_name(router_transpose_node->get_friendly_name());
+        // Build routing weights in [K, B, 1] layout expected by MoeOpFusion downstream pattern.
+        // Source tensor is the Unsqueeze output [B, K, 1]; reach into it to pull the [B, K] input,
+        // then Transpose([1,0]) and Unsqueeze(-1) -> [K, B, 1].
+        const auto chosen_experts_unsqueeze_node = pm.at(p.chosen_experts_unsqueeze).get_node_shared_ptr();
+        const auto normalized_topk = chosen_experts_unsqueeze_node->input_value(0);
 
-        const auto router_unsqueeze_const = v0::Constant::create(ov::element::i32, ov::Shape{}, {-1});
-        const auto router_unsqueeze = std::make_shared<v0::Unsqueeze>(new_router_transpose, router_unsqueeze_const);
-        ov::copy_runtime_info(router_transpose_node, {router_unsqueeze_const, router_unsqueeze});
+        const auto routing_transpose_perm = v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 0});
+        const auto router_transposed = std::make_shared<v1::Transpose>(normalized_topk, routing_transpose_perm);
+        const auto router_unsqueeze_axis = v0::Constant::create(ov::element::i32, ov::Shape{}, {-1});
+        const auto router_weights_kb1 = std::make_shared<v0::Unsqueeze>(router_transposed, router_unsqueeze_axis);
+        ov::copy_runtime_info(chosen_experts_unsqueeze_node,
+                              {routing_transpose_perm, router_transposed, router_unsqueeze_axis, router_weights_kb1});
 
+        // Multiply [K,B,H_out] * [K,B,1] -> [K,B,H_out]; ReduceSum(axis=0) -> [B,H_out].
         const auto final_mul_node = pm.at(p.mul3).get_node_shared_ptr();
         const auto new_final_mul =
-            final_mul_node->clone_with_new_inputs({down_gathered_mm->output(0), router_unsqueeze->output(0)});
+            final_mul_node->clone_with_new_inputs({down_gathered_mm->output(0), router_weights_kb1->output(0)});
         ov::copy_runtime_info(final_mul_node, new_final_mul);
         new_final_mul->set_friendly_name(final_mul_node->get_friendly_name());
 
+        const auto reduce_sum_k_axis = v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
         const auto reduce_sum_node = pm.at(p.reduce_sum).get_node_shared_ptr();
-        const auto new_reduce_sum =
-            reduce_sum_node->clone_with_new_inputs({new_final_mul->output(0), reduce_sum_node->input_value(1)});
-        ov::copy_runtime_info(reduce_sum_node, new_reduce_sum);
+        const auto new_reduce_sum = std::make_shared<v1::ReduceSum>(new_final_mul, reduce_sum_k_axis, false);
+        ov::copy_runtime_info(reduce_sum_node, {reduce_sum_k_axis, new_reduce_sum});
         new_reduce_sum->set_friendly_name(reduce_sum_node->get_friendly_name());
 
-        const auto& end_reshape_out = pm.at(p.end_reshape);
-        const auto end_reshape_rank = end_reshape_out.get_partial_shape().rank();
-        const auto& end_reshape_shape = pm.at(p.end_reshape_target_shape);
-        // n_all_experts dimension is cut off after ReduceSum
-        const auto shape_slice = std::make_shared<v8::Slice>(
-            end_reshape_shape,
-            v0::Constant::create(ov::element::i32, ov::Shape{1}, {1}),
-            v0::Constant::create(ov::element::i32, ov::Shape{1}, {end_reshape_rank.get_length()}),
-            v0::Constant::create(ov::element::i32, ov::Shape{1}, {1}),
-            v0::Constant::create(ov::element::i32, ov::Shape{1}, {0}));
-        ov::copy_runtime_info(end_reshape_out.get_node_shared_ptr(),
-                              {shape_slice,
-                               shape_slice->get_input_node_shared_ptr(1),
-                               shape_slice->get_input_node_shared_ptr(2),
-                               shape_slice->get_input_node_shared_ptr(3),
-                               shape_slice->get_input_node_shared_ptr(4)});
-
-        const auto reshape = std::make_shared<v1::Reshape>(new_reduce_sum, shape_slice, true);
-        ov::replace_output_update_name(pm.at(p.reduce_sum), reshape->output(0));
-        // To avoid friendly name duplication
-        reshape->set_friendly_name(reshape->get_friendly_name() + "_Reshape");
+        ov::replace_output_update_name(pm.at(p.reduce_sum), new_reduce_sum->output(0));
         return true;
     };
 
@@ -310,53 +292,39 @@ ConvertTiledMoeBlockTo3GatherMatmuls::ConvertTiledMoeBlockTo3GatherMatmuls() {
 
         validate_nodes(pm, {p.swish, p.swiglu});
 
+        // GatherMatmul output: [K, B, H_out]
         const auto down_gathered_mm =
             std::make_shared<GatherMatmul>(pm.at(p.swiglu), down_mm_node->input_value(1), active_indices);
         ov::copy_runtime_info(down_mm_node, down_gathered_mm);
         down_gathered_mm->set_friendly_name(down_mm_node->get_friendly_name());
 
-        const auto& chosen_experts_input = pm.at(p.chosen_experts);
-        const auto router_transpose_node = pm.at(p.router_transpose).get_node_shared_ptr();
-        const auto new_router_transpose =
-            std::make_shared<v1::Transpose>(chosen_experts_input, router_transpose_node->input_value(1));
-        ov::copy_runtime_info(router_transpose_node, new_router_transpose);
-        new_router_transpose->set_friendly_name(router_transpose_node->get_friendly_name());
+        // Build routing weights in [K, B, 1] layout expected by MoeOpFusion downstream pattern.
+        // Source tensor is the Unsqueeze output [B, K, 1]; reach into it to pull the [B, K] input,
+        // then Transpose([1,0]) and Unsqueeze(-1) → [K, B, 1].
+        const auto chosen_experts_unsqueeze_node = pm.at(p.chosen_experts_unsqueeze).get_node_shared_ptr();
+        const auto normalized_topk = chosen_experts_unsqueeze_node->input_value(0);
 
-        const auto router_unsqueeze_const = v0::Constant::create(ov::element::i32, ov::Shape{}, {-1});
-        const auto router_unsqueeze = std::make_shared<v0::Unsqueeze>(new_router_transpose, router_unsqueeze_const);
-        ov::copy_runtime_info(router_transpose_node, {router_unsqueeze_const, router_unsqueeze});
+        const auto routing_transpose_perm = v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 0});
+        const auto router_transposed = std::make_shared<v1::Transpose>(normalized_topk, routing_transpose_perm);
+        const auto router_unsqueeze_axis = v0::Constant::create(ov::element::i32, ov::Shape{}, {-1});
+        const auto router_weights_kb1 = std::make_shared<v0::Unsqueeze>(router_transposed, router_unsqueeze_axis);
+        ov::copy_runtime_info(chosen_experts_unsqueeze_node,
+                              {routing_transpose_perm, router_transposed, router_unsqueeze_axis, router_weights_kb1});
 
+        // Multiply [K,B,H_out] * [K,B,1] → [K,B,H_out]; ReduceSum(axis=0) → [B,H_out].
         const auto final_mul_node = pm.at(p.mul3).get_node_shared_ptr();
         const auto new_final_mul =
-            final_mul_node->clone_with_new_inputs({down_gathered_mm->output(0), router_unsqueeze->output(0)});
+            final_mul_node->clone_with_new_inputs({down_gathered_mm->output(0), router_weights_kb1->output(0)});
         ov::copy_runtime_info(final_mul_node, new_final_mul);
         new_final_mul->set_friendly_name(final_mul_node->get_friendly_name());
+
+        const auto reduce_sum_k_axis = v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
         const auto reduce_sum_node = pm.at(p.reduce_sum).get_node_shared_ptr();
-        const auto new_reduce_sum =
-            reduce_sum_node->clone_with_new_inputs({new_final_mul->output(0), reduce_sum_node->input_value(1)});
-        ov::copy_runtime_info(reduce_sum_node, new_reduce_sum);
+        const auto new_reduce_sum = std::make_shared<v1::ReduceSum>(new_final_mul, reduce_sum_k_axis, false);
+        ov::copy_runtime_info(reduce_sum_node, {reduce_sum_k_axis, new_reduce_sum});
         new_reduce_sum->set_friendly_name(reduce_sum_node->get_friendly_name());
 
-        const auto& end_reshape_out = pm.at(p.end_reshape);
-        const auto end_reshape_rank = end_reshape_out.get_partial_shape().rank();
-        const auto& end_reshape_shape = pm.at(p.end_reshape_target_shape);
-        // n_all_experts dimension is cut off after ReduceSum
-        const auto shape_slice = std::make_shared<v8::Slice>(
-            end_reshape_shape,
-            v0::Constant::create(ov::element::i32, ov::Shape{1}, {1}),
-            v0::Constant::create(ov::element::i32, ov::Shape{1}, {end_reshape_rank.get_length()}),
-            v0::Constant::create(ov::element::i32, ov::Shape{1}, {1}),
-            v0::Constant::create(ov::element::i32, ov::Shape{1}, {0}));
-        ov::copy_runtime_info(end_reshape_out.get_node_shared_ptr(),
-                              {shape_slice,
-                               shape_slice->get_input_node_shared_ptr(1),
-                               shape_slice->get_input_node_shared_ptr(2),
-                               shape_slice->get_input_node_shared_ptr(3),
-                               shape_slice->get_input_node_shared_ptr(4)});
-
-        const auto reshape = std::make_shared<v1::Reshape>(new_reduce_sum, shape_slice, true);
-        ov::replace_output_update_name(pm.at(p.reduce_sum), reshape->output(0));
-        reshape->set_friendly_name(new_reduce_sum->get_friendly_name() + "_Reshape");
+        ov::replace_output_update_name(pm.at(p.reduce_sum), new_reduce_sum->output(0));
         return true;
     };
 

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -35,6 +35,7 @@
 #include "transformations/common_optimizations/fold_subgraph_empty_inputs.hpp"
 #include "transformations/common_optimizations/fq_mul_fusion.hpp"
 #include "transformations/common_optimizations/fq_reshape_fusion.hpp"
+#include "transformations/common_optimizations/canonicalize_moe_router.hpp"
 #include "transformations/common_optimizations/fuse_moe_experts.hpp"
 #include "transformations/common_optimizations/gelu_fusion.hpp"
 #include "transformations/common_optimizations/gru_cell_fusion.hpp"
@@ -298,6 +299,7 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     // tests/model_hub_tests/transformation_tests/test_moe_transformation.py
     REGISTER_PASS(manager, FuseMOE)
     REGISTER_PASS(manager, VectorizedMOE2GEMMTransposeWeights)
+    REGISTER_PASS(manager, CanonicalizeMoeRouter)
     REGISTER_PASS(manager, Validate)
 
     manager.run_passes(f);

--- a/src/common/transformations/src/transformations/common_optimizations/moe_op_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moe_op_fusion.cpp
@@ -48,7 +48,7 @@ static size_t weight_logical_K(const ov::Shape& shape) {
     return shape.size() == 4 ? shape[2] * shape[3] : shape[2];
 }
 
-Convert3GatherMatmulMoeBlockToMoeOp::Convert3GatherMatmulMoeBlockToMoeOp(bool has_batch_dim) {
+Convert3GatherMatmulMoeBlockToMoeOp::Convert3GatherMatmulMoeBlockToMoeOp() {
     MATCHER_SCOPE(Convert3GatherMatmulMoeBlockToMoeOp);
 
     auto experts_reshape_m = pattern::any_input();
@@ -92,9 +92,9 @@ Convert3GatherMatmulMoeBlockToMoeOp::Convert3GatherMatmulMoeBlockToMoeOp(bool ha
     auto routing_unsqueeze_m = pattern::wrap_type<v0::Unsqueeze>({routing_transpose_m, pattern::any_input()});
 
     auto final_mul_m = pattern::wrap_type<v1::Multiply>({bgm_down_m, routing_unsqueeze_m}, pattern::consumers_count(1));
+    // Root at ReduceSum: any trailing Reshape is model-specific (not part of the MoE block) and
+    // continues to operate on the MoE op's 2D output unchanged.
     auto reduce_sum_m = pattern::wrap_type<v1::ReduceSum>({final_mul_m, pattern::any_input()}, {{"keep_dims", false}});
-    auto end_reshape_shape_m = pattern::any_input();
-    auto end_reshape_m = pattern::wrap_type<v1::Reshape>({reduce_sum_m, end_reshape_shape_m});
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto& pm = m.get_pattern_value_map();
@@ -103,8 +103,9 @@ Convert3GatherMatmulMoeBlockToMoeOp::Convert3GatherMatmulMoeBlockToMoeOp(bool ha
             return false;
         }
 
-        auto experts_reshape_node = pm.at(experts_reshape_m).get_node_shared_ptr();
-        auto hidden_states = experts_reshape_node->input_value(0);
+        // Use the flattened 2D output (experts_reshape) so MOECompressed has 2D input(0),
+        // matching the natural 2D output of the matched ReduceSum.
+        auto hidden_states = pm.at(experts_reshape_m);
 
         auto routing = pm.at(routing_unsqueeze_m).get_node_shared_ptr();
         auto topk_indices = pm.at(topk_indices_m);
@@ -182,7 +183,6 @@ Convert3GatherMatmulMoeBlockToMoeOp::Convert3GatherMatmulMoeBlockToMoeOp(bool ha
                 0,  // num_shared_expert
                 static_cast<size_t>(topk_shape[1].get_length()),
                 group_size,
-                has_batch_dim,
                 has_zp,
                 ov::element::f16,
             };
@@ -215,11 +215,11 @@ Convert3GatherMatmulMoeBlockToMoeOp::Convert3GatherMatmulMoeBlockToMoeOp(bool ha
         return true;
     };
 
-    auto matcher = std::make_shared<pattern::Matcher>(end_reshape_m, matcher_name);
+    auto matcher = std::make_shared<pattern::Matcher>(reduce_sum_m, matcher_name);
     this->register_matcher(matcher, callback);
 }
 
-Convert2GatherMatmulMoeBlockToMoeOp::Convert2GatherMatmulMoeBlockToMoeOp(bool has_batch_dim) {
+Convert2GatherMatmulMoeBlockToMoeOp::Convert2GatherMatmulMoeBlockToMoeOp() {
     MATCHER_SCOPE(Convert2GatherMatmulMoeBlockToMoeOp);
 
     auto experts_reshape_m = pattern::any_input();
@@ -271,9 +271,9 @@ Convert2GatherMatmulMoeBlockToMoeOp::Convert2GatherMatmulMoeBlockToMoeOp(bool ha
     auto routing_unsqueeze_m = pattern::wrap_type<v0::Unsqueeze>({routing_reshape_m, pattern::any_input()});
 
     auto final_mul_m = pattern::wrap_type<v1::Multiply>({bgm_down_m, routing_unsqueeze_m});
+    // Root at ReduceSum: any trailing Reshape is model-specific (not part of the MoE block) and
+    // continues to operate on the MoE op's 2D output unchanged.
     auto reduce_sum_m = pattern::wrap_type<v1::ReduceSum>({final_mul_m, pattern::any_input()}, {{"keep_dims", false}});
-    auto end_reshape_shape_m = pattern::any_input();
-    auto end_reshape_m = pattern::wrap_type<v1::Reshape>({reduce_sum_m, end_reshape_shape_m});
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto& pm = m.get_pattern_value_map();
@@ -282,8 +282,9 @@ Convert2GatherMatmulMoeBlockToMoeOp::Convert2GatherMatmulMoeBlockToMoeOp(bool ha
             return false;
         }
 
-        auto experts_reshape_node = pm.at(experts_reshape_m).get_node_shared_ptr();
-        auto hidden_states = experts_reshape_node->input_value(0);
+        // Use the flattened 2D output (experts_reshape) so MOECompressed has 2D input(0),
+        // matching the natural 2D output of the matched ReduceSum.
+        auto hidden_states = pm.at(experts_reshape_m);
 
         // Bypass the [1,0] Transpose: moe_scatter_reduction expects tokens-major routing.
         // Order is enforced by the pattern (value_matches("1, 0")).
@@ -390,7 +391,6 @@ Convert2GatherMatmulMoeBlockToMoeOp::Convert2GatherMatmulMoeBlockToMoeOp(bool ha
                 0,  // num_shared_expert
                 static_cast<size_t>(topk_indices_shape[topk_rank - 1].get_length()),
                 group_size,
-                has_batch_dim,
                 has_zp,
                 ov::element::dynamic,
             };
@@ -416,7 +416,7 @@ Convert2GatherMatmulMoeBlockToMoeOp::Convert2GatherMatmulMoeBlockToMoeOp(bool ha
         return true;
     };
 
-    auto matcher = std::make_shared<pattern::Matcher>(end_reshape_m, matcher_name);
+    auto matcher = std::make_shared<pattern::Matcher>(reduce_sum_m, matcher_name);
     this->register_matcher(matcher, callback);
 }
 

--- a/src/common/transformations/tests/common_optimizations/convert_gather_matmuls_moe_block_to_moe_op.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_gather_matmuls_moe_block_to_moe_op.cpp
@@ -402,13 +402,24 @@ inline std::shared_ptr<ov::Model> build_3gemm_bgm_to_moe_reference_model() {
     auto down_w =
         op::v0::Constant::create(element::f32, Shape{number_of_experts, hidden_size, intermediate_size}, {1.0f});
 
-    // MOE op with compact routing
-    ov::OutputVector moe_inputs = {input, router_unsqueeze, topk_indices, gate_w, up_w, down_w};
+    // MOE op with compact routing.
+    // hidden_states is the flattened 2D experts_reshape so MOE's natural output is 2D [tokens, hidden].
+    ov::OutputVector moe_inputs = {experts_reshape, router_unsqueeze, topk_indices, gate_w, up_w, down_w};
     ov::op::internal::MOE::Config config;
     config.expert_type = ov::op::internal::MOE::Expert_type::GEMM3_SWIGLU;
     auto moe = std::make_shared<ov::op::internal::MOE>(moe_inputs, config);
 
-    return std::make_shared<ov::Model>(ov::OutputVector{moe}, ov::ParameterVector{input});
+    // Trailing Reshape is part of the surrounding model, not the MoE block; it stays in the graph
+    // and reshapes MOE's 2D output back to the original 3D output shape.
+    auto end_reshape = std::make_shared<op::v1::Reshape>(
+        moe,
+        op::v0::Constant::create(
+            element::i64,
+            Shape{3},
+            std::vector<int64_t>{static_cast<int64_t>(batch), -1, static_cast<int64_t>(hidden_size)}),
+        true);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{end_reshape}, ov::ParameterVector{input});
 }
 
 inline std::shared_ptr<ov::Model> build_2gemm_bgm_model() {
@@ -571,7 +582,8 @@ inline std::shared_ptr<ov::Model> build_2gemm_bgm_to_moe_reference_model() {
         op::v0::Constant::create(element::f32, Shape{number_of_experts, hidden_size, intermediate_size}, {1.0f});
     auto down_bias = op::v0::Constant::create(element::f32, Shape{number_of_experts, 1, hidden_size}, {1.0f});
 
-    ov::OutputVector moe_inputs = {input, routing, topk_indices, gate_up_w, gate_up_bias, down_w, down_bias};
+    // hidden_states is the flattened 2D experts_reshape so MOE's natural output is 2D [tokens, hidden].
+    ov::OutputVector moe_inputs = {experts_reshape, routing, topk_indices, gate_up_w, gate_up_bias, down_w, down_bias};
 
     ov::op::internal::MOE::Config config;
     config.expert_type = ov::op::internal::MOE::Expert_type::GEMM2_BIAS_SWIGLU_CLAMP;
@@ -579,7 +591,18 @@ inline std::shared_ptr<ov::Model> build_2gemm_bgm_to_moe_reference_model() {
     config.expert_beta = expert_beta;
 
     auto moe = std::make_shared<ov::op::internal::MOE>(moe_inputs, config);
-    return std::make_shared<ov::Model>(ov::OutputVector{moe}, ov::ParameterVector{input});
+
+    // Trailing Reshape is part of the surrounding model, not the MoE block; it stays in the graph
+    // and reshapes MOE's 2D output back to the original 3D output shape.
+    auto end_reshape = std::make_shared<op::v1::Reshape>(
+        moe,
+        op::v0::Constant::create(
+            element::i64,
+            Shape{3},
+            std::vector<int64_t>{static_cast<int64_t>(batch), -1, static_cast<int64_t>(hidden_size)}),
+        true);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{end_reshape}, ov::ParameterVector{input});
 }
 
 // ============================================================================

--- a/src/common/transformations/tests/common_optimizations/convert_tiled_moe_block_to_gather_matmuls_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_tiled_moe_block_to_gather_matmuls_test.cpp
@@ -19,6 +19,7 @@
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/divide.hpp"
+#include "openvino/op/gather.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/minimum.hpp"
 #include "openvino/op/multiply.hpp"
@@ -75,9 +76,6 @@ inline std::ostream& operator<<(std::ostream& os, const AdditionalConsumersMode&
 }
 
 using ConvertTiledMoeBlockToGatherMatmulsParams = std::tuple<MoEType,                  // moe_type
-                                                             bool,                     // use_scatter_v12
-                                                             bool,                     // use_broadcast_v3
-                                                             bool,                     // skip_unsqueeze
                                                              bool,                     // matmul_transpose_b
                                                              AdditionalConsumersMode,  // additional_consumers_mode
                                                              bool>;  // transformation_should_be_applied
@@ -97,10 +95,7 @@ inline std::shared_ptr<ov::Node> build_matmul_weights(const ov::Shape& weights_s
                                           ov::test::utils::InputGenerateData(0, 10, 1, seed));
 }
 
-inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraph(bool use_scatter_v12,
-                                                       bool use_broadcast_v3,
-                                                       bool skip_unsqueeze,
-                                                       bool matmul_transpose_b,
+inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraph(bool matmul_transpose_b,
                                                        AdditionalConsumersMode additional_consumers_mode) {
     // Fixed values that don't affect pass behavior
     const auto expert_alpha = 1.625f;
@@ -217,81 +212,25 @@ inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraph(bool use_scatter_v12,
     auto router_topk_values = router_topk_values_and_indices->output(0);
     auto router_topk_values_softmax = std::make_shared<ov::op::v1::Softmax>(router_topk_values, 1);
     auto router_topk_indices = router_topk_values_and_indices->output(1);
-    auto slice3 = std::make_shared<ov::op::v8::Slice>(
+
+    // Router (new form): Transpose[1,0,2] -> Gather(axis=1, batch_dims=1, topk)
+    auto eb_to_be_perm = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{1, 0, 2});
+    auto router_transpose = std::make_shared<ov::op::v1::Transpose>(down_proj_add, eb_to_be_perm);
+    auto gather_axis_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
+    auto router_gather = std::make_shared<ov::op::v8::Gather>(router_transpose,
+                                                              router_topk_indices,
+                                                              gather_axis_const,
+                                                              /*batch_dims=*/1);
+
+    auto routing_weights_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(
         router_topk_values_softmax,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 0}),
-        std::make_shared<ov::op::v3::ShapeOf>(router_topk_indices),
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 1}),
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 1}));
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1}));
 
-    auto shape_of = std::make_shared<ov::op::v0::ShapeOf>(router_bias);
-    auto zero_const = ov::op::v0::Constant::create(slice3->get_output_element_type(0), ov::Shape{1}, {0});
-
-    std::shared_ptr<ov::Node> broadcast_zero;
-    if (use_broadcast_v3) {
-        broadcast_zero = std::make_shared<ov::op::v3::Broadcast>(zero_const, shape_of);
-    } else {
-        broadcast_zero = std::make_shared<ov::op::v1::Broadcast>(zero_const, shape_of);
-    }
-
-    std::shared_ptr<ov::Node> scatter_elements_update;
-    if (use_scatter_v12) {
-        scatter_elements_update = std::make_shared<ov::op::v12::ScatterElementsUpdate>(
-            broadcast_zero,
-            router_topk_indices,
-            slice3,
-            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}));
-    } else {
-        scatter_elements_update = std::make_shared<ov::op::v3::ScatterElementsUpdate>(
-            broadcast_zero,
-            router_topk_indices,
-            slice3,
-            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}));
-    }
-
-    auto router_transpose = std::make_shared<ov::op::v1::Transpose>(
-        scatter_elements_update,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0}));
-
-    const auto number_of_experts_const =
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {static_cast<int64_t>(number_of_experts)});
-    auto first_in_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(input, {0});
-    auto last_in_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(input, {2});
-    auto minus_one = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
-
-    std::shared_ptr<ov::op::v0::Concat> router_shape;
-    if (skip_unsqueeze) {
-        auto one_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
-        router_shape = std::make_shared<ov::op::v0::Concat>(
-            ov::OutputVector{number_of_experts_const, first_in_dim, minus_one, one_const},
-            0);
-    } else {
-        router_shape =
-            std::make_shared<ov::op::v0::Concat>(ov::OutputVector{number_of_experts_const, first_in_dim, minus_one}, 0);
-    }
-
-    auto router_reshape = std::make_shared<ov::op::v1::Reshape>(router_transpose, router_shape, true);
-
-    std::shared_ptr<ov::Node> routing_weights_final;
-    if (skip_unsqueeze) {
-        routing_weights_final = router_reshape;
-    } else {
-        auto unsqueeze_routing_weights = std::make_shared<ov::op::v0::Unsqueeze>(
-            router_reshape,
-            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{3}));
-        routing_weights_final = unsqueeze_routing_weights;
-    }
-
-    auto end_shape = std::make_shared<ov::op::v0::Concat>(
-        ov::OutputVector{number_of_experts_const, first_in_dim, minus_one, last_in_dim},
-        0);
-    auto end_reshape = std::make_shared<ov::op::v1::Reshape>(down_proj_add, end_shape, true);
-
-    auto mul3 = std::make_shared<ov::op::v1::Multiply>(end_reshape, routing_weights_final);
+    auto mul3 = std::make_shared<ov::op::v1::Multiply>(router_gather, routing_weights_unsqueeze);
 
     auto reduce_sum = std::make_shared<ov::op::v1::ReduceSum>(
         mul3,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}),
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}),
         false);
 
     ov::ParameterVector params = {input};
@@ -309,10 +248,7 @@ inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraph(bool use_scatter_v12,
     return std::make_shared<ov::Model>(results, params);
 }
 
-inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraphRef(bool use_scatter_v12,
-                                                          bool use_broadcast_v3,
-                                                          bool skip_unsqueeze,
-                                                          bool matmul_transpose_b) {
+inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraphRef(bool matmul_transpose_b) {
     // Fixed values that don't affect pass behavior
     const auto expert_alpha = 1.625f;
     const auto expert_beta = 7.0f;
@@ -360,12 +296,6 @@ inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraphRef(bool use_scatter_v12,
     auto router_topk_values = router_topk_values_and_indices->output(0);
     auto router_topk_values_softmax = std::make_shared<ov::op::v1::Softmax>(router_topk_values, 1);
     auto router_topk_indices = router_topk_values_and_indices->output(1);
-    auto slice3 = std::make_shared<ov::op::v8::Slice>(
-        router_topk_values_softmax,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 0}),
-        std::make_shared<ov::op::v3::ShapeOf>(router_topk_indices),
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 1}),
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 1}));
 
     // Note: we need to use different seed to avoid the exact weights generation for the MatMuls with the same shape
     int seed = 1;
@@ -419,48 +349,28 @@ inline std::shared_ptr<ov::Model> initMoE2GeMMSubgraphRef(bool use_scatter_v12,
     auto down_gathered_mm =
         std::make_shared<GatherMatmul>(multiply2, down_proj_weights, router_topk_indices, down_proj_bias);
 
-    auto router_transpose = std::make_shared<ov::op::v1::Transpose>(
-        slice3,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0}));
+    // Routing weights: [B,K] -> Transpose([1,0]) -> [K,B] -> Unsqueeze(-1) -> [K,B,1]
+    auto routing_transpose_perm =
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0});
+    auto routing_transposed =
+        std::make_shared<ov::op::v1::Transpose>(router_topk_values_softmax, routing_transpose_perm);
+    auto routing_weights_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(
+        routing_transposed,
+        ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, std::vector<int32_t>{-1}));
 
-    auto router_unsqueeze =
-        std::make_shared<ov::op::v0::Unsqueeze>(router_transpose,
-                                                ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {-1}));
-
-    auto mul3 = std::make_shared<ov::op::v1::Multiply>(down_gathered_mm, router_unsqueeze);
+    // Multiply [K,B,H_out] * [K,B,1] -> ReduceSum axis=0 -> [B,H_out]
+    auto mul3 = std::make_shared<ov::op::v1::Multiply>(down_gathered_mm, routing_weights_unsqueeze);
 
     auto reduce_sum = std::make_shared<ov::op::v1::ReduceSum>(
         mul3,
         ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}),
         false);
 
-    const auto number_of_experts_const =
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {static_cast<int64_t>(number_of_experts)});
-    auto first_in_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(input, {0});
-    auto last_in_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(input, {2});
-    auto minus_one = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
-
-    auto end_shape = std::make_shared<ov::op::v0::Concat>(
-        ov::OutputVector{number_of_experts_const, first_in_dim, minus_one, last_in_dim},
-        0);
-
-    auto slice_shape =
-        std::make_shared<ov::op::v8::Slice>(end_shape,
-                                            ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1}),
-                                            ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {4}),
-                                            ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1}),
-                                            ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0}));
-
-    auto final_reshape = std::make_shared<ov::op::v1::Reshape>(reduce_sum, slice_shape, true);
-
     ov::ParameterVector params = {input};
-    return std::make_shared<ov::Model>(ov::OutputVector{final_reshape}, params);
+    return std::make_shared<ov::Model>(ov::OutputVector{reduce_sum}, params);
 }
 
-inline std::shared_ptr<ov::Model> initMoE3GeMMSubgraph(bool use_scatter_v12,
-                                                       bool use_broadcast_v3,
-                                                       bool skip_unsqueeze,
-                                                       bool matmul_transpose_b,
+inline std::shared_ptr<ov::Model> initMoE3GeMMSubgraph(bool matmul_transpose_b,
                                                        AdditionalConsumersMode additional_consumers_mode) {
     // Fixed values that don't affect pass behavior
     const ov::PartialShape input_shape = {-1, -1, 256};
@@ -552,86 +462,28 @@ inline std::shared_ptr<ov::Model> initMoE3GeMMSubgraph(bool use_scatter_v12,
         std::make_shared<ov::op::v1::Divide>(router_topk_values_and_indices->output(0), router_topk_values_reduce);
     auto router_topk_indices = router_topk_values_and_indices->output(1);
 
-    const auto number_of_experts_const =
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {static_cast<int64_t>(number_of_experts)});
+    // Router (new form): Transpose[1,0,2] -> Gather(axis=1, batch_dims=1, topk)
+    auto eb_to_be_perm = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{1, 0, 2});
+    auto router_transpose = std::make_shared<ov::op::v1::Transpose>(down_matmul, eb_to_be_perm);
+    auto gather_axis_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
+    auto router_gather = std::make_shared<ov::op::v8::Gather>(router_transpose,
+                                                              router_topk_indices,
+                                                              gather_axis_const,
+                                                              /*batch_dims=*/1);
 
-    auto zero_const =
-        ov::op::v0::Constant::create(router_topk_values_normalization->get_output_element_type(0), ov::Shape{1}, {0});
-    auto first_topk_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(router_topk_indices, {0});
-    auto bcast_target_shape =
-        std::make_shared<ov::op::v0::Concat>(ov::OutputVector{first_topk_dim, number_of_experts_const}, 0);
+    auto routing_weights_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(
+        router_topk_values_normalization,
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1}));
 
-    std::shared_ptr<ov::Node> broadcast_zero;
-    if (use_broadcast_v3) {
-        broadcast_zero = std::make_shared<ov::op::v3::Broadcast>(zero_const, bcast_target_shape);
-    } else {
-        broadcast_zero = std::make_shared<ov::op::v1::Broadcast>(zero_const, bcast_target_shape);
-    }
-
-    std::shared_ptr<ov::Node> scatter_elements_update;
-    if (use_scatter_v12) {
-        scatter_elements_update = std::make_shared<ov::op::v12::ScatterElementsUpdate>(
-            broadcast_zero,
-            router_topk_indices,
-            router_topk_values_normalization,
-            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}));
-    } else {
-        scatter_elements_update = std::make_shared<ov::op::v3::ScatterElementsUpdate>(
-            broadcast_zero,
-            router_topk_indices,
-            router_topk_values_normalization,
-            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}));
-    }
-
-    auto router_transpose = std::make_shared<ov::op::v1::Transpose>(
-        scatter_elements_update,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0}));
-
-    auto minus_one = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
-    std::shared_ptr<ov::op::v0::Concat> router_shape;
-    if (skip_unsqueeze) {
-        auto one_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
-        router_shape = std::make_shared<ov::op::v0::Concat>(
-            ov::OutputVector{number_of_experts_const, first_topk_dim, minus_one, one_const},
-            0);
-    } else {
-        router_shape =
-            std::make_shared<ov::op::v0::Concat>(ov::OutputVector{number_of_experts_const, first_topk_dim, minus_one},
-                                                 0);
-    }
-
-    auto router_reshape = std::make_shared<ov::op::v1::Reshape>(router_transpose, router_shape, true);
-
-    std::shared_ptr<ov::Node> routing_weights_final;
-    if (skip_unsqueeze) {
-        routing_weights_final = router_reshape;
-    } else {
-        auto unsqueeze_routing_weights = std::make_shared<ov::op::v0::Unsqueeze>(
-            router_reshape,
-            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{3}));
-        routing_weights_final = unsqueeze_routing_weights;
-    }
-
-    auto last_in_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(input, {2});
-    auto end_shape = std::make_shared<ov::op::v0::Concat>(
-        ov::OutputVector{number_of_experts_const, first_topk_dim, minus_one, last_in_dim},
-        0);
-    auto end_reshape = std::make_shared<ov::op::v1::Reshape>(down_matmul, end_shape, true);
-
-    auto mul3 = std::make_shared<ov::op::v1::Multiply>(end_reshape, routing_weights_final);
+    auto mul3 = std::make_shared<ov::op::v1::Multiply>(router_gather, routing_weights_unsqueeze);
 
     auto reduce_sum = std::make_shared<ov::op::v1::ReduceSum>(
         mul3,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}),
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}),
         false);
 
-    auto final_reshape_const = ov::op::v0::Constant::create(ov::element::i64,
-                                                            ov::Shape{2},
-                                                            std::vector<int64_t>{0, static_cast<int64_t>(hidden_size)});
-    auto final_reshape = std::make_shared<ov::op::v1::Reshape>(reduce_sum, final_reshape_const, true);
-
     ov::ParameterVector params = {input};
-    ov::ResultVector results = {std::make_shared<ov::op::v0::Result>(final_reshape)};
+    ov::ResultVector results = {std::make_shared<ov::op::v0::Result>(reduce_sum)};
 
     if (additional_consumers_mode == AdditionalConsumersMode::MATMULS) {
         results.push_back(std::make_shared<ov::op::v0::Result>(gate_matmul));
@@ -647,10 +499,7 @@ inline std::shared_ptr<ov::Model> initMoE3GeMMSubgraph(bool use_scatter_v12,
     return std::make_shared<ov::Model>(results, params);
 }
 
-inline std::shared_ptr<ov::Model> initMoE3GeMMSubgraphRef(bool use_scatter_v12,
-                                                          bool use_broadcast_v3,
-                                                          bool skip_unsqueeze,
-                                                          bool matmul_transpose_b) {
+inline std::shared_ptr<ov::Model> initMoE3GeMMSubgraphRef(bool matmul_transpose_b) {
     // Fixed values that don't affect pass behavior
     const ov::PartialShape input_shape = {-1, -1, 256};
     const size_t topk = 4;
@@ -725,93 +574,50 @@ inline std::shared_ptr<ov::Model> initMoE3GeMMSubgraphRef(bool use_scatter_v12,
 
     auto down_gathered_mm = std::make_shared<GatherMatmul>(swiglu, down_weights, router_topk_indices);
 
-    auto router_transpose = std::make_shared<ov::op::v1::Transpose>(
-        router_topk_values_normalization,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0}));
+    // Routing weights: [B,K] -> Transpose([1,0]) -> [K,B] -> Unsqueeze(-1) -> [K,B,1]
+    auto routing_transpose_perm =
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0});
+    auto routing_transposed =
+        std::make_shared<ov::op::v1::Transpose>(router_topk_values_normalization, routing_transpose_perm);
+    auto routing_weights_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(
+        routing_transposed,
+        ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, std::vector<int32_t>{-1}));
 
-    auto router_unsqueeze =
-        std::make_shared<ov::op::v0::Unsqueeze>(router_transpose,
-                                                ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {-1}));
-
-    auto mul3 = std::make_shared<ov::op::v1::Multiply>(down_gathered_mm, router_unsqueeze);
+    // Multiply [K,B,H_out] * [K,B,1] -> ReduceSum axis=0 -> [B,H_out]
+    auto mul3 = std::make_shared<ov::op::v1::Multiply>(down_gathered_mm, routing_weights_unsqueeze);
 
     auto reduce_sum = std::make_shared<ov::op::v1::ReduceSum>(
         mul3,
         ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}),
         false);
 
-    const auto number_of_experts_const =
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {static_cast<int64_t>(number_of_experts)});
-    auto first_topk_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(router_topk_indices, {0});
-    auto last_in_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(input, {2});
-    auto minus_one = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
-
-    auto end_shape = std::make_shared<ov::op::v0::Concat>(
-        ov::OutputVector{number_of_experts_const, first_topk_dim, minus_one, last_in_dim},
-        0);
-
-    auto slice_shape =
-        std::make_shared<ov::op::v8::Slice>(end_shape,
-                                            ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1}),
-                                            ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {4}),
-                                            ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1}),
-                                            ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0}));
-
-    auto final_reshape = std::make_shared<ov::op::v1::Reshape>(reduce_sum, slice_shape, true);
-
-    auto final_reshape_const = ov::op::v0::Constant::create(ov::element::i64,
-                                                            ov::Shape{2},
-                                                            std::vector<int64_t>{0, static_cast<int64_t>(hidden_size)});
-    auto original_final_reshape = std::make_shared<ov::op::v1::Reshape>(final_reshape, final_reshape_const, true);
-
     ov::ParameterVector params = {input};
-    return std::make_shared<ov::Model>(ov::OutputVector{original_final_reshape}, params);
+    return std::make_shared<ov::Model>(ov::OutputVector{reduce_sum}, params);
 }
 
 class ConvertTiledMoeBlockToGatherMatmulsTest : public TransformationTestsF,
                                                 public WithParamInterface<ConvertTiledMoeBlockToGatherMatmulsParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ConvertTiledMoeBlockToGatherMatmulsParams>& obj) {
-        const auto& [moe_type,
-                     use_scatter_v12,
-                     use_broadcast_v3,
-                     skip_unsqueeze,
-                     matmul_transpose_b,
-                     additional_consumers_mode,
-                     should_be_applied] = obj.param;
+        const auto& [moe_type, matmul_transpose_b, additional_consumers_mode, should_be_applied] = obj.param;
         std::ostringstream result;
-        result << "MoEType_" << moe_type << "_ScatterV" << (use_scatter_v12 ? "12" : "3") << "_BroadcastV"
-               << (use_broadcast_v3 ? "3" : "1") << "_SkipUnsqueeze_" << (skip_unsqueeze ? "true" : "false")
-               << "_MatMulTransposeB_" << (matmul_transpose_b ? "true" : "false") << "_AdditionalConsumers_"
-               << additional_consumers_mode << "_shouldBeApplied_" << (should_be_applied ? "true" : "false");
+        result << "MoEType_" << moe_type << "_MatMulTransposeB_" << (matmul_transpose_b ? "true" : "false")
+               << "_AdditionalConsumers_" << additional_consumers_mode << "_shouldBeApplied_"
+               << (should_be_applied ? "true" : "false");
         return result.str();
     }
 
 protected:
     void SetUp() override {
         TransformationTestsF::SetUp();
-        const auto& [moe_type,
-                     use_scatter_v12,
-                     use_broadcast_v3,
-                     skip_unsqueeze,
-                     matmul_transpose_b,
-                     additional_consumers_mode,
-                     should_be_applied] = this->GetParam();
+        const auto& [moe_type, matmul_transpose_b, additional_consumers_mode, should_be_applied] = this->GetParam();
 
         switch (moe_type) {
         case MoEType::MoE2GeMM:
-            model = initMoE2GeMMSubgraph(use_scatter_v12,
-                                         use_broadcast_v3,
-                                         skip_unsqueeze,
-                                         matmul_transpose_b,
-                                         additional_consumers_mode);
+            model = initMoE2GeMMSubgraph(matmul_transpose_b, additional_consumers_mode);
             break;
         case MoEType::MoE3GeMM:
-            model = initMoE3GeMMSubgraph(use_scatter_v12,
-                                         use_broadcast_v3,
-                                         skip_unsqueeze,
-                                         matmul_transpose_b,
-                                         additional_consumers_mode);
+            model = initMoE3GeMMSubgraph(matmul_transpose_b, additional_consumers_mode);
             break;
         default:
             OPENVINO_THROW("Unexpected MoEType value");
@@ -822,12 +628,10 @@ protected:
         if (should_be_applied) {
             switch (moe_type) {
             case MoEType::MoE2GeMM:
-                model_ref =
-                    initMoE2GeMMSubgraphRef(use_scatter_v12, use_broadcast_v3, skip_unsqueeze, matmul_transpose_b);
+                model_ref = initMoE2GeMMSubgraphRef(matmul_transpose_b);
                 break;
             case MoEType::MoE3GeMM:
-                model_ref =
-                    initMoE3GeMMSubgraphRef(use_scatter_v12, use_broadcast_v3, skip_unsqueeze, matmul_transpose_b);
+                model_ref = initMoE3GeMMSubgraphRef(matmul_transpose_b);
                 break;
             default:
                 OPENVINO_THROW("Unexpected MoEType value");
@@ -839,16 +643,10 @@ protected:
 TEST_P(ConvertTiledMoeBlockToGatherMatmulsTest, CompareFunctions) {}
 
 const std::vector<MoEType> moe_types = {MoEType::MoE2GeMM, MoEType::MoE3GeMM};
-const std::vector<bool> scatter_versions = {false, true};    // false = v3, true = v12
-const std::vector<bool> broadcast_versions = {false, true};  // false = v1, true = v3
-const std::vector<bool> skip_unsqueeze_versions = {false, true};
 
 INSTANTIATE_TEST_SUITE_P(ConvertTiledMoeBlockToGatherMatmulsTest_positive_cases,
                          ConvertTiledMoeBlockToGatherMatmulsTest,
                          ::testing::Combine(::testing::ValuesIn(moe_types),
-                                            ::testing::ValuesIn(scatter_versions),
-                                            ::testing::ValuesIn(broadcast_versions),
-                                            ::testing::ValuesIn(skip_unsqueeze_versions),
                                             ::testing::Values(true),
                                             ::testing::Values(AdditionalConsumersMode::NO),
                                             ::testing::Values(true)),
@@ -857,9 +655,6 @@ INSTANTIATE_TEST_SUITE_P(ConvertTiledMoeBlockToGatherMatmulsTest_positive_cases,
 INSTANTIATE_TEST_SUITE_P(ConvertTiledMoeBlockToGatherMatmulsTest_negative_cases_no_transpose,
                          ConvertTiledMoeBlockToGatherMatmulsTest,
                          ::testing::Combine(::testing::ValuesIn(moe_types),
-                                            ::testing::ValuesIn(scatter_versions),
-                                            ::testing::ValuesIn(broadcast_versions),
-                                            ::testing::ValuesIn(skip_unsqueeze_versions),
                                             ::testing::Values(false),
                                             ::testing::Values(AdditionalConsumersMode::NO),
                                             ::testing::Values(false)),
@@ -868,9 +663,6 @@ INSTANTIATE_TEST_SUITE_P(ConvertTiledMoeBlockToGatherMatmulsTest_negative_cases_
 INSTANTIATE_TEST_SUITE_P(ConvertTiledMoeBlockToGatherMatmulsTest_negative_cases_additional_consumers,
                          ConvertTiledMoeBlockToGatherMatmulsTest,
                          ::testing::Combine(::testing::ValuesIn(moe_types),
-                                            ::testing::Values(false),
-                                            ::testing::Values(false),
-                                            ::testing::Values(false),
                                             ::testing::Values(true),
                                             ::testing::Values(AdditionalConsumersMode::MATMULS,
                                                               AdditionalConsumersMode::AFTER_MATMULS,

--- a/src/common/transformations/tests/common_optimizations/fuse_moe_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_moe_test.cpp
@@ -15,6 +15,7 @@
 #include "openvino/opsets/opset4.hpp"
 #include "openvino/opsets/opset6.hpp"
 #include "openvino/opsets/opset8.hpp"
+#include "transformations/common_optimizations/canonicalize_moe_router.hpp"
 #include "transformations/common_optimizations/fuse_moe_experts.hpp"
 #include "transformations/rt_info/decompression.hpp"
 #include "transformations/utils/gen_pattern.hpp"
@@ -25,8 +26,7 @@ using namespace ov;
 
 namespace v0 = ov::op::v0;
 namespace v1 = ov::op::v1;
-namespace v3 = ov::op::v3;
-namespace v12 = ov::op::v12;
+namespace v8 = ov::op::v8;
 std::shared_ptr<ov::Model> BuildMOE(int expert_num, int topk) {
     ov::element::Type inType = ov::element::f32;
     // param1: [batch*seq, 2048]
@@ -234,8 +234,6 @@ static std::shared_ptr<ov::Model> BuildFusedMOE(const int expert_num, const int 
     auto axis0_vector = makeConst(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0});
     auto axis1_vector = makeConst(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
     auto axis_minus_one_vector = makeConst(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
-    auto transpose_axes = makeConst(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0});
-    auto minus_one = makeConst(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
     auto axes0_i64 = makeConst(ov::element::i64, ov::Shape{}, std::vector<int64_t>{0});
     auto gate_weight_shape = makeOP<opset3::ShapeOf>({single_gate_weight_convert}, {{"output_type", "i64"}});
     auto gather_index_one = makeConst(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
@@ -267,28 +265,21 @@ static std::shared_ptr<ov::Model> BuildFusedMOE(const int expert_num, const int 
     auto down_bmm = makeOP<opset1::MatMul>({swiglu_mul, fused_down_weights->output(0)},
                                            {{"transpose_a", false}, {"transpose_b", true}});
 
-    auto expert_output_shape =
-        makeOP<opset1::Concat>({num_experts_unsqueeze, batch_dim_unsqueeze, minus_one, hidden_dim_unsqueeze},
-                               {{"axis", 0}});
-    auto expert_outputs = makeOP<opset1::Reshape>({down_bmm, expert_output_shape}, {{"special_zero", false}});
+    // Router: [E,B,H_out] -Transpose-> [B,E,H_out] -Gather(axis=1, batch_dims=1, topk)-> [B,K,H_out]
+    auto eb_to_be_perm = makeConst(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{1, 0, 2});
+    auto outputs_bEH = std::make_shared<v1::Transpose>(down_bmm, eb_to_be_perm);
+    auto gather_axis = makeConst(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
+    auto gathered_outputs =
+        std::make_shared<v8::Gather>(outputs_bEH, topk_TopK->output(1), gather_axis, /*batch_dims=*/1);
 
     auto topk_values = topk_TopK->output(0);
     auto sum_reduce = makeOP<opset1::ReduceSum>({topk_values, axis_minus_one}, {{"keep_dims", true}});
     auto normalized_topk =
         makeOP<opset1::Divide>({topk_values, sum_reduce}, {{"auto_broadcast", "numpy"}, {"m_pythondiv", true}});
-    auto zeros_scalar = makeConst(ov::element::f32, ov::Shape{}, std::vector<float>{0.0f});
-    auto scatter_shape = std::make_shared<v0::Concat>(ov::OutputVector{batch_dim_unsqueeze, num_experts_unsqueeze}, 0);
-    auto zeros_tensor = std::make_shared<v3::Broadcast>(zeros_scalar, scatter_shape);
-    auto scatter =
-        std::make_shared<v12::ScatterElementsUpdate>(zeros_tensor, topk_TopK->output(1), normalized_topk, axis1_vector);
-    auto router_transpose = std::make_shared<v1::Transpose>(scatter, transpose_axes);
-    auto router_shape =
-        std::make_shared<v0::Concat>(ov::OutputVector{num_experts_unsqueeze, batch_dim_unsqueeze, minus_one}, 0);
-    auto router_reshape = std::make_shared<v1::Reshape>(router_transpose, router_shape, true);
-    auto routing_unsqueeze = std::make_shared<v0::Unsqueeze>(router_reshape, axis_minus_one_vector);
+    auto routing_unsqueeze = std::make_shared<v0::Unsqueeze>(normalized_topk, axis_minus_one_vector);
 
-    auto weighted_outputs = std::make_shared<v1::Multiply>(expert_outputs, routing_unsqueeze);
-    auto final_output = std::make_shared<v1::ReduceSum>(weighted_outputs, axis0_vector, false);
+    auto weighted_outputs = std::make_shared<v1::Multiply>(gathered_outputs, routing_unsqueeze);
+    auto final_output = std::make_shared<v1::ReduceSum>(weighted_outputs, axis1_vector, false);
 
     auto final_reshape = std::make_shared<v1::Reshape>(final_output, target_shape, false);
     auto final_add = std::make_shared<v1::Add>(residual_input, final_reshape);
@@ -306,6 +297,89 @@ TEST_F(TransformationTestsF, ConvertMOEToFuseMOE_FP16) {
     int topk = 8;
 
     model = BuildMOE(expert_num, topk);
-    ov::pass::FuseMOE().run_on_model(model);
+    manager.register_pass<ov::pass::FuseMOE>();
+    manager.register_pass<ov::pass::CanonicalizeMoeRouter>();
     model_ref = BuildFusedMOE(expert_num, topk);
+}
+
+namespace {
+
+// Reproduces the routing tail emitted by FuseMOEExperts and produced natively by GPT-OSS export:
+// rank-3 down output -> Reshape to [E,B,*,H], multiplied by densified routing weights from a
+// ScatterElementsUpdate over a zero tensor, then ReduceSum over the expert axis.
+std::shared_ptr<ov::Model> BuildScatterRoutingTail(int expert_num, int topk_k) {
+    constexpr int64_t hidden_size = 64;
+    auto down_out =
+        std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{expert_num, -1, hidden_size});
+    auto topk_idx = std::make_shared<ov::opset1::Parameter>(ov::element::i64, ov::PartialShape{-1, topk_k});
+    auto topk_val = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, topk_k});
+
+    // Reshape rank-3 [E, T, H] -> rank-4 [E, B, -1, H]. Builder uses static shape for simplicity.
+    auto end_shape = makeConst(ov::element::i64, ov::Shape{4}, std::vector<int64_t>{expert_num, 1, -1, hidden_size});
+    auto end_reshape = makeOP<opset1::Reshape>({down_out, end_shape}, {{"special_zero", false}});
+
+    // Densified routing: scatter normalized topk values into a zeros[T,E] grid along axis=1.
+    auto topk_idx_shape = makeOP<opset3::ShapeOf>({topk_idx}, {{"output_type", "i64"}});
+    auto t_dim_scalar = makeOP<opset8::Gather>({topk_idx_shape,
+                                                makeConst(ov::element::i64, ov::Shape{}, std::vector<int64_t>{0}),
+                                                makeConst(ov::element::i64, ov::Shape{}, std::vector<int64_t>{0})},
+                                               {{"batch_dims", 0}});
+    auto t_dim = makeOP<opset1::Unsqueeze>({t_dim_scalar, {0}});
+    auto e_dim = makeConst(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{expert_num});
+    auto zeros_shape = makeOP<opset1::Concat>({t_dim, e_dim}, {{"axis", 0}});
+    auto zero_scalar = makeConst(ov::element::f32, ov::Shape{}, std::vector<float>{0.0f});
+    auto zeros = makeOP<opset3::Broadcast>({zero_scalar, zeros_shape}, {{"mode", "numpy"}});
+
+    auto scatter_axis = makeConst(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
+    auto scatter = makeOP<opset12::ScatterElementsUpdate>({zeros, topk_idx, topk_val, scatter_axis},
+                                                          {{"reduction", "none"}, {"use_init_val", true}});
+    auto t_perm = makeConst(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0});
+    auto t = makeOP<opset1::Transpose>({scatter, t_perm});
+    auto rshape = makeConst(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{expert_num, 1, -1});
+    auto rs = makeOP<opset1::Reshape>({t, rshape}, {{"special_zero", false}});
+    auto unsq_axis = makeConst(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
+    auto unsq = makeOP<opset1::Unsqueeze>({rs, unsq_axis});
+
+    auto mul = makeOP<opset1::Multiply>({end_reshape, unsq}, {{"auto_broadcast", "numpy"}});
+    auto reduce_axis = makeConst(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0});
+    auto reduce = makeOP<opset1::ReduceSum>({mul, reduce_axis}, {{"keep_dims", false}});
+
+    return std::make_shared<ov::Model>(ov::OutputVector{reduce}, ov::ParameterVector{down_out, topk_idx, topk_val});
+}
+
+// Expected canonical form: Transpose([1,0,2]) -> Gather(axis=1, batch_dims=1, topk_idx)
+// -> Multiply(Unsqueeze(topk_val, -1)) -> ReduceSum(axis=1).
+std::shared_ptr<ov::Model> BuildCanonicalRoutingTail(int expert_num, int topk_k) {
+    constexpr int64_t hidden_size = 64;
+    auto down_out =
+        std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{expert_num, -1, hidden_size});
+    auto topk_idx = std::make_shared<ov::opset1::Parameter>(ov::element::i64, ov::PartialShape{-1, topk_k});
+    auto topk_val = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, topk_k});
+
+    auto perm = makeConst(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{1, 0, 2});
+    auto trans = std::make_shared<v1::Transpose>(down_out, perm);
+    auto gather_axis = makeConst(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
+    auto gather = std::make_shared<v8::Gather>(trans, topk_idx, gather_axis, /*batch_dims=*/1);
+
+    auto unsq_axis = makeConst(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
+    auto unsq = std::make_shared<v0::Unsqueeze>(topk_val, unsq_axis);
+    auto mul = std::make_shared<v1::Multiply>(gather, unsq);
+    auto reduce_axis = makeConst(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
+    auto reduce = std::make_shared<v1::ReduceSum>(mul, reduce_axis, false);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{reduce}, ov::ParameterVector{down_out, topk_idx, topk_val});
+}
+
+}  // namespace
+
+TEST_F(TransformationTestsF, CanonicalizeMoeRouter_RewritesScatterRoutingTail) {
+    disable_rt_info_check();
+    disable_result_friendly_names_check();
+
+    constexpr int expert_num = 4;
+    constexpr int topk_k = 2;
+
+    model = BuildScatterRoutingTail(expert_num, topk_k);
+    manager.register_pass<ov::pass::CanonicalizeMoeRouter>();
+    model_ref = BuildCanonicalRoutingTail(expert_num, topk_k);
 }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_gather.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_gather.hpp
@@ -25,15 +25,13 @@ struct moe_gather : public primitive_base<moe_gather> {
               const input_info& data,
               const input_info& tokens_per_expert,
               const ov::op::internal::MOECompressed::Config& moe_config)
-        : primitive_base(id, {data, tokens_per_expert}), num_experts_per_token(static_cast<int32_t>(moe_config.top_k)), has_batch_dim(moe_config.has_batch_dim) {}
+        : primitive_base(id, {data, tokens_per_expert}), num_experts_per_token(static_cast<int32_t>(moe_config.top_k)) {}
 
     int32_t num_experts_per_token = 0;
-    bool has_batch_dim = true;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, num_experts_per_token);
-        seed = hash_combine(seed, has_batch_dim);
         return seed;
     }
 
@@ -42,19 +40,17 @@ struct moe_gather : public primitive_base<moe_gather> {
             return false;
 
         auto rhs_casted = downcast<const moe_gather>(rhs);
-        return num_experts_per_token == rhs_casted.num_experts_per_token && has_batch_dim == rhs_casted.has_batch_dim;
+        return num_experts_per_token == rhs_casted.num_experts_per_token;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
         primitive_base<moe_gather>::save(ob);
         ob << num_experts_per_token;
-        ob << has_batch_dim;
     }
 
     void load(BinaryInputBuffer& ib) override {
         primitive_base<moe_gather>::load(ib);
         ib >> num_experts_per_token;
-        ib >> has_batch_dim;
     }
 };
 }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_gemm.hpp
@@ -42,18 +42,15 @@ struct moe_gemm : public primitive_base<moe_gemm> {
              const std::vector<input_info>& inputs,
              const ov::op::internal::MOECompressed::Config& moe_config)
           : primitive_base(id, inputs),
-            num_experts_per_token(static_cast<int32_t>(moe_config.top_k)),
-            has_batch_dim(moe_config.has_batch_dim) {}
+            num_experts_per_token(static_cast<int32_t>(moe_config.top_k)) {}
 
     bool has_bias = false;
     int32_t num_experts_per_token = 0;
-    bool has_batch_dim = true;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, has_bias);
         seed = hash_combine(seed, num_experts_per_token);
-        seed = hash_combine(seed, has_batch_dim);
         return seed;
     }
 
@@ -62,22 +59,19 @@ struct moe_gemm : public primitive_base<moe_gemm> {
             return false;
         auto rhs_casted = downcast<const moe_gemm>(rhs);
         return has_bias == rhs_casted.has_bias &&
-               num_experts_per_token == rhs_casted.num_experts_per_token &&
-               has_batch_dim == rhs_casted.has_batch_dim;
+               num_experts_per_token == rhs_casted.num_experts_per_token;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
         primitive_base<moe_gemm>::save(ob);
         ob << has_bias;
         ob << num_experts_per_token;
-        ob << has_batch_dim;
     }
 
     void load(BinaryInputBuffer& ib) override {
         primitive_base<moe_gemm>::load(ib);
         ib >> has_bias;
         ib >> num_experts_per_token;
-        ib >> has_batch_dim;
     }
 };
 }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_scatter_reduction.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_scatter_reduction.hpp
@@ -37,17 +37,14 @@ struct moe_scatter_reduction : public primitive_base<moe_scatter_reduction> {
                           const bool onednn_grouped_gemm_used = false)
         : primitive_base(id, {data, experts_per_token, expert_weights_per_token, tokens_per_expert, experts_info_offsets, tokens_len_per_expert, experts_ids}),
           num_active_experts_per_token(static_cast<int32_t>(moe_config.top_k)),
-          has_batch_dim(moe_config.has_batch_dim),
           onednn_grouped_gemm_used(onednn_grouped_gemm_used) {}
 
     int32_t num_active_experts_per_token = 0;
-    bool has_batch_dim = true;
     bool onednn_grouped_gemm_used = false;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, num_active_experts_per_token);
-        seed = hash_combine(seed, has_batch_dim);
         seed = hash_combine(seed, onednn_grouped_gemm_used);
         return seed;
     }
@@ -59,21 +56,18 @@ struct moe_scatter_reduction : public primitive_base<moe_scatter_reduction> {
         auto rhs_casted = downcast<const moe_scatter_reduction>(rhs);
 
         return num_active_experts_per_token == rhs_casted.num_active_experts_per_token &&
-               has_batch_dim == rhs_casted.has_batch_dim &&
                onednn_grouped_gemm_used == rhs_casted.onednn_grouped_gemm_used;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
         primitive_base<moe_scatter_reduction>::save(ob);
         ob << num_active_experts_per_token;
-        ob << has_batch_dim;
         ob << onednn_grouped_gemm_used;
     }
 
     void load(BinaryInputBuffer& ib) override {
         primitive_base<moe_scatter_reduction>::load(ib);
         ib >> num_active_experts_per_token;
-        ib >> has_batch_dim;
         ib >> onednn_grouped_gemm_used;
     }
 };

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_base.hpp
@@ -64,7 +64,6 @@ enum class MOE3GemmInputIndex : uint8_t {
 
 struct moe_3gemm_config {
     int32_t weight_group_size = -1;
-    bool has_batch_dim = false;  // 0 - pa, 1 - non-pa
 };
 
 struct MoE3GemmRuntimeParams : public MoEGemmRuntimeParams {};

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.cpp
@@ -339,7 +339,7 @@ DispatchDataFunc MoE3GemmMicroGenerator::get_dispatch_data_func() const {
         GPU_DEBUG_TRACE_DETAIL << "\t wei_idx = " << wei_idx << std::endl;
         GPU_DEBUG_TRACE_DETAIL << "\t experts_weight_layout: " << experts_weight_layout.to_short_string() << std::endl;
 
-        // has_batch_dim indicates whether the input tensor has batch dimension
+        // Total tokens = product of leading dims (kernel addresses linearly via HIDDEN_SIZE).
         size_t n = input_layout.get_shape()[0];
         switch (input_layout.get_shape().size()) {
         case 2:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.hpp
@@ -67,7 +67,6 @@ public:
         moe_3gemm_config cfg;
         auto desc = params.typed_desc<moe_3gemm_fused_compressed>();
         cfg.weight_group_size = static_cast<int32_t>(desc->_config.group_size);
-        cfg.has_batch_dim = desc->_config.has_batch_dim;
         return cfg;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gather.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gather.hpp
@@ -36,7 +36,8 @@ struct MoeGatherRef : public ImplementationManager {
         const auto& out_layout = node.get_output_layout(0);
         const auto& input_pshapes = in0_layout.get_partial_shape();
 
-        if (input_pshapes.rank() != 3 || input_pshapes[2].is_dynamic()) {
+        // MoE primitives operate on rank-2 [N_tokens, hidden]; hidden must be static.
+        if (input_pshapes.rank().get_length() != 2 || input_pshapes[1].is_dynamic()) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gemm_gen_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gemm_gen_opt.hpp
@@ -25,7 +25,6 @@ struct moe_config {
     int32_t weight_group_size = -1;
     int32_t weight_scale_idx = -1;
     int32_t weight_zp_idx = -1;
-    bool has_batch_dim = false;
 };
 
 class MoEGemmOptGeneratorBase : public MoEGemmBase {
@@ -60,7 +59,6 @@ public:
                 moe_cfg.is_weight_symmetric_quantized = true;
             }
         }
-        moe_cfg.has_batch_dim = desc->has_batch_dim;
         return moe_cfg;
     }
 };

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_opt.cpp
@@ -41,7 +41,9 @@ protected:
     [[nodiscard]] JitConstants get_jit_constants(const RuntimeParams& params) const override {
         auto jit = KernelGenerator::get_jit_constants(params);
         auto in_l = params.input_layouts[0];
-        auto hidden_size = extract_channel(ChannelName::Y, in_l);
+        // Hidden = last dim regardless of rank (validate_impl gates last-dim staticness).
+        const auto& in_pshape = in_l.get_partial_shape();
+        auto hidden_size = in_pshape[in_pshape.size() - 1].get_length();
         auto [local_threads_count, batches_per_thread] = calc_thread_count(const_cast<RuntimeParams&>(params), MoeScatterReductionOpt::block_size, hidden_size);
 
         const auto& desc = params.typed_desc<moe_scatter_reduction>();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_opt.hpp
@@ -31,11 +31,12 @@ struct MoeScatterReductionOpt : public MoeScatterReductionBase {
         const auto& out_layout = node.get_output_layout(0);
         const auto& input_pshapes = in0_layout.get_partial_shape();
 
-        if (input_pshapes.rank().get_length() != 3 || input_pshapes[2].is_dynamic()) {
+        // MoE primitives operate on rank-2 [N*K, hidden]; hidden must be static.
+        if (input_pshapes.rank().get_length() != 2 || input_pshapes[1].is_dynamic()) {
             return false;
         }
 
-        if (input_pshapes[2].get_length() % block_size != 0) {
+        if (input_pshapes[1].get_length() % block_size != 0) {
             return false;
         }
         if (!one_of(in0_layout.format, supported_fmts) || !one_of(out_layout.format, supported_fmts)) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_ref.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_ref.cpp
@@ -21,7 +21,9 @@ protected:
     [[nodiscard]] JitConstants get_jit_constants(const RuntimeParams& params) const override {
         auto jit = KernelGenerator::get_jit_constants(params);
         auto in_l = params.input_layouts[0];
-        auto hidden_size = extract_channel(ChannelName::Y, in_l);
+        // Hidden = last dim regardless of rank (validate_impl gates last-dim staticness).
+        const auto& in_pshape = in_l.get_partial_shape();
+        auto hidden_size = in_pshape[in_pshape.size() - 1].get_length();
 
         const auto& desc = params.typed_desc<moe_scatter_reduction>();
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_ref.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_ref.hpp
@@ -35,7 +35,8 @@ struct MoeScatterReductionRef : public MoeScatterReductionBase {
         const auto& out_layout = node.get_output_layout(0);
         const auto& input_pshapes = in0_layout.get_partial_shape();
 
-        if (input_pshapes.rank().get_length() != 3 || input_pshapes[2].is_dynamic()) {
+        // MoE primitives operate on rank-2 [N*K, hidden]; hidden must be static.
+        if (input_pshapes.rank().get_length() != 2 || input_pshapes[1].is_dynamic()) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.cpp
@@ -104,14 +104,16 @@ protected:
         get_moe_gemm_primitive_descriptor(const kernel_impl_params& impl_params,
                                           const dnnl::primitive_attr& attr = dnnl::primitive_attr()) {
         auto& engine = impl_params.prog->get_engine();
-        auto prim = impl_params.typed_desc<moe_gemm>();
         auto moe_cfg = MoEGemmImplementationManager::get_moe_cfg(impl_params);
 
         auto input_layout = impl_params.get_input_layout(moe_gemm::MoEGemmInputIdx::INPUT);
         auto weights_layout = impl_params.get_input_layout(moe_gemm::MoEGemmInputIdx::WEIGHT);
         auto output_layout = impl_params.get_output_layout();
 
-        dnnl::memory::dim total_tokens = prim->has_batch_dim ? input_layout.get_shape()[1] : input_layout.get_shape()[0];
+        const auto& in_shape = input_layout.get_shape();
+        OPENVINO_ASSERT(in_shape.size() == 2,
+                        "moe_gemm (onednn) expects rank-2 [N_tokens, K_in] input, got rank ", in_shape.size());
+        const dnnl::memory::dim total_tokens = in_shape[0];
         const auto& experts_weight_shape = weights_layout.get_shape();
         dnnl::memory::dim N = experts_weight_shape[1];
         dnnl::memory::dim K = experts_weight_shape.size() == 4 ? experts_weight_shape[2] * experts_weight_shape[3] : experts_weight_shape[2];

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.hpp
@@ -22,7 +22,6 @@ struct moe_config {
     int32_t weight_group_size = -1;
     int32_t weight_scale_idx = -1;
     int32_t weight_zp_idx = -1;
-    bool has_batch_dim = false;
 };
 
 struct MoEGemmImplementationManager : public ImplementationManager {
@@ -169,7 +168,6 @@ struct MoEGemmImplementationManager : public ImplementationManager {
                 moe_cfg.is_weight_symmetric_quantized = true;
             }
         }
-        moe_cfg.has_batch_dim = desc->has_batch_dim;
         return moe_cfg;
     }
 };

--- a/src/plugins/intel_gpu/src/graph/moe_gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/moe_gather.cpp
@@ -23,21 +23,17 @@ std::vector<layout> moe_gather_inst::calc_output_layouts(const moe_gather_node& 
     const auto num_experts_per_token = desc->num_experts_per_token;
     const auto& in_layout = impl_param.input_layouts[0];
     const auto& input_shape = in_layout.get<ShapeType>();
-    const auto& hidden_size = input_shape[input_shape.size() - 1];
-    OPENVINO_ASSERT(hidden_size.is_static(), impl_param.desc->id, " hidden size dimension (shape[1]) must be static");
+    OPENVINO_ASSERT(input_shape.size() == 2,
+                    impl_param.desc->id, " expects rank-2 [N_tokens, hidden] input, got rank ", input_shape.size());
+    OPENVINO_ASSERT(input_shape[1].is_static(),
+                    impl_param.desc->id, " hidden size dimension must be static");
 
-    if (in_layout.is_dynamic()) {
-        return {layout{ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension::dynamic(), ov::Dimension(hidden_size)},
-                in_layout.data_type, in_layout.format}};
+    // [N, H] -> [N*K, H].
+    auto out_shape = input_shape;
+    if (input_shape[0].is_static()) {
+        out_shape[0] = ov::Dimension(input_shape[0].get_length() * num_experts_per_token);
     }
-    const auto num_tokens = input_shape.size() == 2 ? input_shape[0] : desc->has_batch_dim ? input_shape[1] : input_shape[0];
-    if (desc->has_batch_dim) {
-        const auto& out_shape = ov::PartialShape{ov::Dimension(1), ov::Dimension(num_tokens * num_experts_per_token), ov::Dimension(hidden_size)};
-        return {layout{out_shape, in_layout.data_type, in_layout.format}};
-    } else {
-        const auto& out_shape = ov::PartialShape{ov::Dimension(num_tokens * num_experts_per_token), ov::Dimension(1), ov::Dimension(hidden_size)};
-        return {layout{out_shape, in_layout.data_type, in_layout.format}};
-    }
+    return {layout{out_shape, in_layout.data_type, in_layout.format}};
 }
 
 template std::vector<layout> moe_gather_inst::calc_output_layouts<ov::PartialShape>(moe_gather_node const& node, const kernel_impl_params& impl_param);

--- a/src/plugins/intel_gpu/src/graph/moe_gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/moe_gemm.cpp
@@ -19,40 +19,24 @@ layout moe_gemm_inst::calc_output_layout(moe_gemm_node const& node, kernel_impl_
 template<typename ShapeType>
 std::vector<layout> moe_gemm_inst::calc_output_layouts(moe_gemm_node const& /*node*/, const kernel_impl_params& impl_param) {
     const auto& desc = impl_param.typed_desc<moe_gemm>();
-    size_t num_experts_per_token = desc->num_experts_per_token;
-    auto input_layout = impl_param.get_input_layout(0);
-    size_t input_rank = input_layout.get_partial_shape().size();
-    if (input_rank != 3)
-        OPENVINO_THROW("moe_gemm's input rank should be 3");
-    auto experts_layout = impl_param.get_input_layout(1);
-    auto out_n_dim = input_rank - 1;
-    auto output_shape = input_layout.get_partial_shape();
-    for (auto& o : output_shape) {
-        o = ov::Dimension::dynamic();
-    }
-    size_t n = experts_layout.get_shape()[1];
-    output_shape[out_n_dim] = ov::Dimension(n);
+    const size_t num_experts_per_token = desc->num_experts_per_token;
+    const auto input_layout = impl_param.get_input_layout(0);
+    const auto input_shape = input_layout.get_partial_shape();
+    OPENVINO_ASSERT(input_shape.size() == 2,
+                    "moe_gemm expects rank-2 [N_tokens, K_in] input, got rank ", input_shape.size());
 
-    if (!input_layout.is_dynamic()) {
-        size_t seq_len_dim = (desc->has_batch_dim) ? 1 : 0;
-        auto m = input_layout.get_shape()[seq_len_dim];
-        if (m == 1) {
-            // first gemm (up/gate) in the generate phase
-            if (!desc->has_batch_dim) {
-                output_shape = ov::PartialShape{ov::Dimension(num_experts_per_token), ov::Dimension(1), ov::Dimension(n)};
-            } else {
-                output_shape = ov::PartialShape{ov::Dimension(1), ov::Dimension(num_experts_per_token), ov::Dimension(n)};
-            }
-        } else {
-            if (!desc->has_batch_dim) {
-                output_shape = ov::PartialShape{ov::Dimension(m), ov::Dimension(1), ov::Dimension(n)};
-            } else {
-                output_shape = ov::PartialShape{ov::Dimension(1), ov::Dimension(m), ov::Dimension(n)};
-            }
-        }
+    const auto experts_layout = impl_param.get_input_layout(1);
+    const size_t n = experts_layout.get_shape()[1];
+
+    // [N, K_in] -> [N, n_out]. Generate-phase: m==1 input expands tokens by K.
+    auto output_shape = input_shape;
+    output_shape[1] = ov::Dimension(n);
+
+    if (!input_layout.is_dynamic() && input_shape[0].get_length() == 1) {
+        output_shape[0] = ov::Dimension(num_experts_per_token);
     }
-    auto output_layout = layout{output_shape, input_layout.data_type, input_layout.format};
-    return {output_layout};
+
+    return {layout{output_shape, input_layout.data_type, input_layout.format}};
 }
 
 template std::vector<layout> moe_gemm_inst::calc_output_layouts<ov::PartialShape>(moe_gemm_node const& node, const kernel_impl_params& impl_param);

--- a/src/plugins/intel_gpu/src/graph/moe_scatter_reduction.cpp
+++ b/src/plugins/intel_gpu/src/graph/moe_scatter_reduction.cpp
@@ -21,22 +21,19 @@ template<typename ShapeType>
 std::vector<layout> moe_scatter_reduction_inst::calc_output_layouts(moe_scatter_reduction_node const& /*node*/, const kernel_impl_params& impl_param) {
     const auto& desc = impl_param.typed_desc<moe_scatter_reduction>();
     const auto num_active_experts_per_token = desc->num_active_experts_per_token;
+    const auto& in_layout = impl_param.input_layouts[0];
+    const auto& input_shape = in_layout.get<ShapeType>();
+    OPENVINO_ASSERT(input_shape.size() == 2,
+                    impl_param.desc->id, " expects rank-2 [N*K, hidden] input, got rank ", input_shape.size());
+    OPENVINO_ASSERT(input_shape[1].is_static(),
+                    impl_param.desc->id, " hidden size dimension must be static");
 
-    const auto& input_shape = impl_param.input_layouts[0].get<ShapeType>();
-    const auto& hidden_size = input_shape[input_shape.size() - 1];
-    OPENVINO_ASSERT(hidden_size.is_static(), impl_param.desc->id, " hidden size dimension (shape[1]) must be static");
-    if (impl_param.input_layouts[0].is_dynamic())
-        return {layout{ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension::dynamic(), ov::Dimension(hidden_size)},
-                impl_param.input_layouts[0].data_type, impl_param.input_layouts[0].format}};
-    if (desc->has_batch_dim) {
-        const auto num_tokens = impl_param.input_layouts[0].get_shape()[1] / num_active_experts_per_token;
-        const auto& out_shape = ov::PartialShape{1, ov::Dimension(num_tokens), ov::Dimension(hidden_size)};
-        return {layout{out_shape, impl_param.input_layouts[0].data_type, impl_param.input_layouts[0].format}};
-    } else {
-        const auto num_tokens = impl_param.input_layouts[0].get_shape()[0] / num_active_experts_per_token;
-        const auto& out_shape = ov::PartialShape{ov::Dimension(num_tokens), 1, ov::Dimension(hidden_size)};
-        return {layout{out_shape, impl_param.input_layouts[0].data_type, impl_param.input_layouts[0].format}};
+    // [N*K, H] -> [N, H] (inverse of moe_gather).
+    auto out_shape = input_shape;
+    if (input_shape[0].is_static()) {
+        out_shape[0] = ov::Dimension(input_shape[0].get_length() / num_active_experts_per_token);
     }
+    return {layout{out_shape, in_layout.data_type, in_layout.format}};
 }
 
 template std::vector<layout> moe_scatter_reduction_inst::calc_output_layouts<ov::PartialShape>(moe_scatter_reduction_node const& node,

--- a/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
@@ -190,9 +190,12 @@ static void CreateMOECompressedOp(ProgramBuilder& p, const std::shared_ptr<ov::o
         p.add_primitive(*op, moe_gemm_up);
 
         // GPT-OSS swiglu: stride-2 interleave (gate=swish, up=clamp+add).
+        // Axis = last dim (= rank-1): hidden axis of moe_gemm_up's output, regardless of rank.
+        const auto swiglu_axis = static_cast<int64_t>(
+            op->get_input_partial_shape(0).rank().get_length() - 1);
         auto moe_swiglu_prim = cldnn::swiglu(moe_swiglu_name,
                                              input_info(moe_gemm_up_name),
-                                             2,  // axis
+                                             swiglu_axis,
                                              2,  // glu_stride
                                              ov::op::internal::GLU::GluType::Swish,
                                              config.gate_idx,

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -534,16 +534,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             std::vector<ov::element::Type>{ ov::element::i8, ov::element::u8, ov::element::i4, ov::element::u4 },
             !device_info.supports_immad);
 
-        const bool is_pa = [&func]() {
-            for (const auto& op : func->get_ops()) {
-                if (ov::is_type<ov::op::PagedAttentionExtension>(op)) {
-                    return true;
-                }
-            }
-
-            return false;
-        }();
-
         const bool disable_moe_opt = GPU_DEBUG_VALUE_OR(config.get_disable_moe_opt(), false);
 
         // MOE: TiledMoeBlock -> GatherMatmuls(compressed) -> MoeOp(compressed) -> MoeOpWithRouting(compressed).
@@ -559,9 +549,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                                                ov::element::i8, ov::element::u8});
 
             if (!disable_moe_opt) {
-                // PA models flatten batch into seq.
-                const bool has_batch_dim = !is_pa;
-                manager.register_pass<ov::pass::MoeOpFusion>(has_batch_dim);
+                manager.register_pass<ov::pass::MoeOpFusion>();
                 manager.register_pass<ov::intel_gpu::FuseMOESharedExpert>();
                 manager.register_pass<ov::intel_gpu::FuseMOE3GemmCompressed>();
             }

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/moe.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/moe.cpp
@@ -152,7 +152,7 @@ const std::vector<MoERoutingType> routing_types = {MoERoutingType::SOFTMAX, MoER
 
 const std::vector<MoeTestShapeParams> moe_params_smoke = {
     {
-        // TODO: batch>1 trips a pre-existing master bug (moe_mask_gen vs moe_gather/scatter has_batch_dim mismatch → OOB).
+        // TODO: batch>1 still untested end-to-end — only batch=1 shapes here.
         {{-1, -1, 256}, {{1, 30, 256}, {1, 2, 256}, {1, 24, 256}}},  // data_shape,
                                                                      // seq_len=dynamic, hidden_size=256
         4,                                                           // topk

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
@@ -786,7 +786,6 @@ TEST_P(moe_3gemm_compressed_gpu_shared_random, moe_accuracy_test_shared_expert_r
     moe_config.out_type = data_types::f16;
     moe_config.num_shared_expert = 1;
     moe_config.has_zp = true;
-    // has_batch_dim default is 0.
 
     // Create Primitive with extended inputs
     auto moe_prim = moe_3gemm_fused_compressed("moe_3gemm_fused_compressed",

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_gather_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_gather_gpu_test.cpp
@@ -39,7 +39,6 @@ void test_moe_gather(bool is_caching_test, int k) {
     moe_config.top_k = 2;
     moe_config.hidden_size = k;
     moe_config.num_expert = num_total_experts;
-    moe_config.has_batch_dim = false;
 
     auto input_activation_shape = ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension(hidden_size)};
     auto input_activation_layout = layout{input_activation_shape, data_types::f16, format::bfyx};

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_gemm_gpu_test.cpp
@@ -32,7 +32,6 @@ struct moe_gemm_test_params {
     cldnn::data_types scale_dt = cldnn::data_types::f16;
     int32_t scale_group_size;
     bool weight_symmetric_quant;
-    bool is_pa;
     bool is_caching_test;
 };
 
@@ -277,11 +276,12 @@ struct MoEGemmTest : public ::testing::TestWithParam<T> {
         ov::op::internal::MOECompressed::Config moe_config;
         moe_config.top_k = p.num_experts_per_token;
         moe_config.num_expert = p.num_total_experts;
-        moe_config.has_batch_dim = !p.is_pa;
         moe_config.hidden_size = p.hidden_size;
         moe_config.inter_size = p.out_N;
         auto num_scale_groups = p.hidden_size / p.scale_group_size;
-        auto input_shape = ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension::dynamic(), ov::Dimension(p.hidden_size)};
+        // moe_gemm now operates on rank-2 [N_tokens, hidden]; the kernel addresses linearly so the old
+        // [1,M,H] vs [M,1,H] disambiguation (has_batch_dim) is gone.
+        auto input_shape = ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension(p.hidden_size)};
         auto input_act_layout = layout{input_shape, p.input_dt, format::bfyx};
 
         auto experts_shape = num_scale_groups > 1
@@ -433,8 +433,7 @@ struct MoEGemmTest : public ::testing::TestWithParam<T> {
 
         const auto M = p.phase == PHASE::UP ? p.num_tokens : p.num_tokens * p.num_experts_per_token;
         auto input_data = get_input_data(M, p.hidden_size, rg);
-        auto input_data_shape = p.is_pa ? ov::PartialShape{ov::Dimension(M), ov::Dimension(1), ov::Dimension(p.hidden_size)}
-                                        : ov::PartialShape{ov::Dimension(1), ov::Dimension(M), ov::Dimension(p.hidden_size)};
+        auto input_data_shape = ov::PartialShape{ov::Dimension(M), ov::Dimension(p.hidden_size)};
         auto input_data_layout = layout{input_data_shape, data_types::f16, format::bfyx};
         auto input_mem = engine.allocate_memory(input_data_layout);
         set_values(input_mem, input_data);
@@ -553,7 +552,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f16,   /*scale_dt*/
                                                                                    -1,                       /*scale_group_size*/
                                                                                    false,                    /*weight_symmetric_quant*/
-                                                                                   false,                    /*is_pa*/
                                                                                    true                      /*is_caching_test*/
                                                                                },
                                                                                // f16 / up
@@ -571,7 +569,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f16,   /*scale_dt*/
                                                                                    -1,                       /*scale_group_size*/
                                                                                    false,                    /*weight_symmetric_quant*/
-                                                                                   false,                    /*is_pa*/
                                                                                    false                     /*is_caching_test*/
                                                                                },
                                                                                // f16 / down
@@ -589,7 +586,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f16,   /*scale_dt*/
                                                                                    -1,                       /*scale_group_size*/
                                                                                    false,                    /*weight_symmetric_quant*/
-                                                                                   false,                    /*is_pa*/
                                                                                    true                      /*is_caching_test*/
                                                                                },
                                                                                // i4 / symmetric/ group size 32 / prefill
@@ -607,7 +603,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f16,   /*scale_dt*/
                                                                                    32,                       /*scale_group_size*/
                                                                                    true,                     /*weight_symmetric_quant*/
-                                                                                   false,                    /*is_pa*/
                                                                                    false,                    /*is_caching_test*/
                                                                                },
                                                                                // i4 / symmetric/ group size 32 / up
@@ -625,7 +620,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f16,   /*scale_dt*/
                                                                                    32,                       /*scale_group_size*/
                                                                                    true,                     /*weight_symmetric_quant*/
-                                                                                   false,                    /*is_pa*/
                                                                                    true                      /*is_caching_test*/
                                                                                },
                                                                                // i4 / symmetric/ group size 32 / down
@@ -643,7 +637,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f16,    /*scale_dt*/
                                                                                    32,                        /*scale_group_size*/
                                                                                    true,                      /*weight_symmetric_quant*/
-                                                                                   false,                     /*is_pa*/
                                                                                    false                      /*is_caching_test*/
                                                                                },
                                                                                // u4 / asymmetric/ per_token / prefill
@@ -661,7 +654,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f16,    /*scale_dt*/
                                                                                    2880,                      /*scale_group_size*/
                                                                                    false,                     /*weight_symmetric_quant*/
-                                                                                   false,                     /*is_pa*/
                                                                                    true                       /*is_caching_test*/
                                                                                },
                                                                                // u4 / asymmetric/ group size 32 / prefill
@@ -679,7 +671,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f32,   /*scale_dt*/
                                                                                    32,                       /*scale_group_size*/
                                                                                    false,                    /*weight_symmetric_quant*/
-                                                                                   false,                    /*is_pa*/
                                                                                    false                     /*is_caching_test*/
                                                                                },
                                                                                // u4 / asymmetric/ group size 32 / up
@@ -697,7 +688,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f32,   /*scale_dt*/
                                                                                    32,                       /*scale_group_size*/
                                                                                    false,                    /*weight_symmetric_quant*/
-                                                                                   false,                    /*is_pa*/
                                                                                    true                      /*is_caching_test*/
                                                                                },
                                                                                // u4 / asymmetric/ group size 32 / down
@@ -715,6 +705,5 @@ INSTANTIATE_TEST_SUITE_P(smoke_moe_gemm,
                                                                                    cldnn::data_types::f32,   /*scale_dt*/
                                                                                    32,                       /*scale_group_size*/
                                                                                    false,                    /*weight_symmetric_quant*/
-                                                                                   false,                    /*is_pa*/
                                                                                    false                     /*is_caching_test*/
                                                                                }}));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_scatter_reduction_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_scatter_reduction_gpu_test.cpp
@@ -54,9 +54,9 @@ void test_moe_scatter_reduction(bool is_caching_test, size_t k) {
 
     ov::op::internal::MOECompressed::Config moe_config;
     moe_config.top_k = num_active_experts_per_token;
-    moe_config.has_batch_dim = false;
 
-    auto input_activation_shape = ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension::dynamic(), ov::Dimension(hidden_size)};
+    // moe_scatter_reduction now operates on rank-2 [N*K, hidden] (no has_batch_dim disambiguation).
+    auto input_activation_shape = ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension(hidden_size)};
     auto input_activation_layout = create_layout<T>(input_activation_shape);
 
     auto experts_per_token_shape = ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension(num_active_experts_per_token)};
@@ -94,7 +94,7 @@ void test_moe_scatter_reduction(bool is_caching_test, size_t k) {
                                             input_info("experts_ids"),
                                             moe_config,
                                             true));
-    auto input_data_shape = ov::PartialShape{ov::Dimension(num_tokens * num_active_experts_per_token), 1, ov::Dimension(hidden_size)};
+    auto input_data_shape = ov::PartialShape{ov::Dimension(num_tokens * num_active_experts_per_token), ov::Dimension(hidden_size)};
     auto input_data_layout = create_layout<T>(input_data_shape);
 
     std::vector<T> input_data;

--- a/src/tests/test_utils/common_test_utils/src/node_builders/moe_builders.cpp
+++ b/src/tests/test_utils/common_test_utils/src/node_builders/moe_builders.cpp
@@ -46,6 +46,7 @@ namespace test {
 std::pair<ov::Output<ov::Node>, ov::Output<ov::Node>>
 build_softmax_routing_subgraph(const ov::Output<ov::Node>& routing_weights, size_t number_of_experts, size_t topk) {
     using namespace ov::op;
+    (void)number_of_experts;
 
     auto router_softmax = std::make_shared<v8::Softmax>(routing_weights, 1);
 
@@ -55,45 +56,15 @@ build_softmax_routing_subgraph(const ov::Output<ov::Node>& routing_weights, size
 
     auto reduce_sm =
         std::make_shared<v1::ReduceSum>(router_topk->output(0),
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}),
+                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1}),
                                         true);
-    auto scatter_w = ov::Output<ov::Node>{std::make_shared<v1::Divide>(router_topk->output(0), reduce_sm)};
+    auto normalized = std::make_shared<v1::Divide>(router_topk->output(0), reduce_sm);
     auto topk_idx = router_topk->output(1);
 
-    auto shapeof = std::make_shared<v3::ShapeOf>(topk_idx);
-    auto gather = std::make_shared<v8::Gather>(shapeof,
-                                               v0::Constant::create(ov::element::i64, ov::Shape{}, {0}),
-                                               v0::Constant::create(ov::element::i64, ov::Shape{}, {0}));
-    auto unsq_seq =
-        std::make_shared<v0::Unsqueeze>(gather,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}));
-
-    auto ne_scalar = v0::Constant::create(ov::element::i64, ov::Shape{}, {static_cast<int64_t>(number_of_experts)});
-    auto unsq_ne =
-        std::make_shared<v0::Unsqueeze>(ne_scalar,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}));
-
-    ov::OutputVector bcast_vec{unsq_seq, unsq_ne};
-    auto bcast_shape = std::make_shared<v0::Concat>(bcast_vec, 0);
-
-    auto one = v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
-    ov::OutputVector reshape_vec{unsq_ne, unsq_seq, one};
-    auto reshape_shape = std::make_shared<v0::Concat>(reshape_vec, 0);
-
-    auto zero = v0::Constant::create(scatter_w.get_element_type(), ov::Shape{1}, {0});
-    auto bcast = std::make_shared<v3::Broadcast>(zero, bcast_shape);
-    auto scatter = std::make_shared<v12::ScatterElementsUpdate>(
-        bcast,
-        topk_idx,
-        scatter_w,
-        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}));
-    auto transp = std::make_shared<v1::Transpose>(
-        scatter,
-        v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0}));
-    auto reshape = std::make_shared<v1::Reshape>(transp, reshape_shape, false);
-    auto unsqueeze_moe = ov::Output<ov::Node>{
-        std::make_shared<v0::Unsqueeze>(reshape,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{3}))};
+    // [B, K] -> Unsqueeze(-1) -> [B, K, 1] (matches FuseMOEExperts new router tail).
+    auto unsqueeze_moe = ov::Output<ov::Node>{std::make_shared<v0::Unsqueeze>(
+        normalized,
+        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1}))};
 
     return {unsqueeze_moe, topk_idx};
 }
@@ -118,61 +89,21 @@ std::pair<ov::Output<ov::Node>, ov::Output<ov::Node>> build_sigmoid_bias_routing
                                     v11::TopK::SortType::SORT_VALUES,
                                     ov::element::i64);
 
-    auto convert_topk = std::make_shared<v0::Convert>(router_topk->output(1), ov::element::i32);
-    auto topk_idx = ov::Output<ov::Node>{convert_topk};
+    auto topk_idx = router_topk->output(1);
 
-    auto gather_el = std::make_shared<v6::GatherElements>(sigmoid, convert_topk, 1);
+    auto gather_el = std::make_shared<v6::GatherElements>(sigmoid, topk_idx, 1);
     auto reduce =
         std::make_shared<v1::ReduceSum>(gather_el,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}),
+                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1}),
                                         true);
     auto eps = v0::Constant::create(data_precision, ov::Shape{1, 1}, {1e-6f});
     auto add_eps = std::make_shared<v1::Add>(reduce, eps);
-    auto norm = std::make_shared<v1::Divide>(gather_el, add_eps);
+    auto normalized = std::make_shared<v1::Divide>(gather_el, add_eps);
 
-    auto sl_stop = std::make_shared<v3::ShapeOf>(convert_topk, ov::element::i32);
-    auto scatter_w = ov::Output<ov::Node>{
-        std::make_shared<v8::Slice>(norm,
-                                    v0::Constant::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{0, 0}),
-                                    sl_stop,
-                                    v0::Constant::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{1, 1}),
-                                    v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 1}))};
-
-    auto shapeof = std::make_shared<v3::ShapeOf>(convert_topk, ov::element::i64);
-    auto gather = std::make_shared<v8::Gather>(shapeof,
-                                               v0::Constant::create(ov::element::i64, ov::Shape{}, {0}),
-                                               v0::Constant::create(ov::element::i64, ov::Shape{}, {0}));
-    auto unsq_seq =
-        std::make_shared<v0::Unsqueeze>(gather,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}));
-
-    auto ne_scalar = v0::Constant::create(ov::element::i64, ov::Shape{}, {static_cast<int64_t>(number_of_experts)});
-    auto unsq_ne =
-        std::make_shared<v0::Unsqueeze>(ne_scalar,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}));
-
-    ov::OutputVector bcast_vec{unsq_seq, unsq_ne};
-    auto bcast_shape = std::make_shared<v0::Concat>(bcast_vec, 0);
-
-    auto zero = v0::Constant::create(scatter_w.get_element_type(), ov::Shape{1}, {0});
-    auto bcast = std::make_shared<v3::Broadcast>(zero, bcast_shape);
-    auto scatter = std::make_shared<v12::ScatterElementsUpdate>(
-        bcast,
-        topk_idx,
-        scatter_w,
-        v0::Constant::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1}));
-    auto transp = std::make_shared<v1::Transpose>(
-        scatter,
-        v0::Constant::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{1, 0}));
-
-    auto one = v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
-    ov::OutputVector reshape_vec{unsq_ne, one, unsq_seq};
-    auto reshape_shape = std::make_shared<v0::Concat>(reshape_vec, 0);
-    auto reshape = std::make_shared<v1::Reshape>(transp, reshape_shape, false);
-
-    auto unsqueeze_moe = ov::Output<ov::Node>{
-        std::make_shared<v0::Unsqueeze>(reshape,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{3}))};
+    // [B, K] -> Unsqueeze(-1) -> [B, K, 1].
+    auto unsqueeze_moe = ov::Output<ov::Node>{std::make_shared<v0::Unsqueeze>(
+        normalized,
+        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1}))};
 
     return {unsqueeze_moe, topk_idx};
 }
@@ -394,53 +325,28 @@ std::shared_ptr<ov::Model> initMoE2GeMMSubgraph(
     auto router_topk_values = router_topk_values_and_indices->output(0);
     auto router_topk_values_softmax = std::make_shared<ov::op::v1::Softmax>(router_topk_values, 1);
     auto router_topk_indices = router_topk_values_and_indices->output(1);
-    auto slice3 = std::make_shared<ov::op::v8::Slice>(
-        router_topk_values_softmax,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 0}),
-        std::make_shared<ov::op::v3::ShapeOf>(router_topk_indices),
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 1}),
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 1}));
 
-    auto shape_of = std::make_shared<ov::op::v0::ShapeOf>(router_bias);
-    auto zero_const = ov::op::v0::Constant::create(slice3->get_output_element_type(0), ov::Shape{1}, {0});
-    auto broadcast_zero = std::make_shared<ov::op::v3::Broadcast>(zero_const, shape_of);
+    // Router (new form): down_proj_add [E,B,H] -> Transpose[1,0,2] -> [B,E,H]
+    //                    -> Gather(axis=1, batch_dims=1, topk) -> [B,K,H]
+    auto eb_to_be_perm = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{1, 0, 2});
+    auto router_transpose = std::make_shared<ov::op::v1::Transpose>(down_proj_add, eb_to_be_perm);
+    auto gather_axis_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
+    auto router_gather = std::make_shared<ov::op::v8::Gather>(router_transpose,
+                                                              router_topk_indices,
+                                                              gather_axis_const,
+                                                              /*batch_dims=*/1);
 
-    auto scatter_elements_update = std::make_shared<ov::op::v12::ScatterElementsUpdate>(
-        broadcast_zero,
-        router_topk_indices,
-        slice3,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}));
-
-    auto router_transpose = std::make_shared<ov::op::v1::Transpose>(
-        scatter_elements_update,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0}));
-
-    const auto number_of_experts_const =
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {static_cast<int64_t>(number_of_experts)});
-    auto first_in_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(input, {0});
-    auto last_in_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(input, {2});
-    auto minus_one = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
-
-    const auto router_shape =
-        std::make_shared<ov::op::v0::Concat>(ov::OutputVector{number_of_experts_const, first_in_dim, minus_one}, 0);
-
-    auto router_reshape = std::make_shared<ov::op::v1::Reshape>(router_transpose, router_shape, true);
-
+    // Routing weights: [B,K] -> Unsqueeze(-1) -> [B,K,1]
     auto unsqueeze_routing_weights = std::make_shared<ov::op::v0::Unsqueeze>(
-        router_reshape,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{3}));
+        router_topk_values_softmax,
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1}));
 
-    auto end_shape = std::make_shared<ov::op::v0::Concat>(
-        ov::OutputVector{number_of_experts_const, first_in_dim, minus_one, last_in_dim},
-        0);
-    auto end_reshape = std::make_shared<ov::op::v1::Reshape>(down_proj_add, end_shape, true);
+    auto mul3 = std::make_shared<ov::op::v1::Multiply>(router_gather, unsqueeze_routing_weights);
 
-    auto mul3 = std::make_shared<ov::op::v1::Multiply>(end_reshape, unsqueeze_routing_weights);
-
-    // ReduceSum - final node of the MOE pattern
+    // Weighted sum over topk (K axis) -> [B, H]
     auto reduce_sum = std::make_shared<ov::op::v1::ReduceSum>(
         mul3,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}),
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}),
         false);
 
     ov::ParameterVector params = {input};
@@ -585,33 +491,22 @@ std::shared_ptr<ov::Model> initMoE3GeMMSubgraph(
     }
     auto [unsqueeze_routing_weights, router_topk_indices] = routing_outputs;
 
-    const auto number_of_experts_const =
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {static_cast<int64_t>(number_of_experts)});
-    auto minus_one = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
-    auto one_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
+    // Router (new form): down_matmul [E,B,H] -> Transpose[1,0,2] -> [B,E,H]
+    //                    -> Gather(axis=1, batch_dims=1, topk) -> [B,K,H]
+    auto eb_to_be_perm = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{1, 0, 2});
+    auto router_transpose = std::make_shared<ov::op::v1::Transpose>(down_matmul, eb_to_be_perm);
+    auto gather_axis_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1});
+    auto router_gather = std::make_shared<ov::op::v8::Gather>(router_transpose,
+                                                              router_topk_indices,
+                                                              gather_axis_const,
+                                                              /*batch_dims=*/1);
 
-    auto first_topk_dim_for_reshape =
-        ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(router_topk_indices, {0});
+    auto mul3 = std::make_shared<ov::op::v1::Multiply>(router_gather, unsqueeze_routing_weights);
 
-    auto last_in_dim = ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(input, {input_rank - 1});
-
-    // Softmax: end_reshape [ne, seq, 1, hidden]  matched by mul with [ne, seq, 1, 1]
-    // Sigmoid: end_reshape [ne, 1, seq, hidden]  matched by mul with [ne, 1, seq, 1]
-    std::shared_ptr<ov::op::v0::Concat> end_shape;
-    if (routing_type == MoERoutingType::SOFTMAX) {
-        ov::OutputVector end_dims{number_of_experts_const, first_topk_dim_for_reshape, minus_one, last_in_dim};
-        end_shape = std::make_shared<ov::op::v0::Concat>(end_dims, 0);
-    } else {
-        ov::OutputVector end_dims{number_of_experts_const, one_const, first_topk_dim_for_reshape, last_in_dim};
-        end_shape = std::make_shared<ov::op::v0::Concat>(end_dims, 0);
-    }
-    auto end_reshape = std::make_shared<ov::op::v1::Reshape>(down_matmul, end_shape, true);
-
-    auto mul3 = std::make_shared<ov::op::v1::Multiply>(end_reshape, unsqueeze_routing_weights);
-
+    // Weighted sum over topk (K axis) -> [B, H]
     auto reduce_sum = std::make_shared<ov::op::v1::ReduceSum>(
         mul3,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}),
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}),
         false);
 
     // Flatten any leading dimensions to [batch*seq, hidden] regardless of routing type


### PR DESCRIPTION
Convert Scatter-based routing in FuseMOE with Transpose + Gather
(batch_dims=1) using CanonicalizeMoeRouter pass.
Anchor ConvertTiledMoeBlockToGatherMatmuls on the new form; accept Reshape as routing-unsqueeze equivalent since NopElimination rewrites Unsqueeze(-1) into Reshape. Update shared
moe_builders helpers and tests accordingly.

### TODO
- Remove unnecessary code comments

The next step will be to pull MatMul experts part through Transpose + Gather one by one producing GatherMatmuls as a result