### PR TITLE
[GPU] Enable fused MoE for trinity-mini AFMoE (sub-128 group _size + routed_scaling_factor)

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
@@ -5,8 +5,31 @@
 
 #define unroll_for __attribute__((opencl_unroll_hint)) for
 
-// Fake group size for compatibility and computation performance balance
-#define FAKE_GROUP_SIZE 128
+// Fake group size for compatibility and computation performance balance.
+// Each gk-iteration of the inner GEMV loop processes FAKE_GROUP_SIZE K-elements
+// using a single (scale, zp) entry, so FAKE_GROUP_SIZE must divide both
+// GATE_UP_GROUP_SIZE and DOWN_GROUP_SIZE. The traditional value is 128 which
+// matches the sub_group_block_read tile widths below; for models whose weight
+// quantization uses a smaller group (e.g. 64) we shrink FAKE_GROUP_SIZE so the
+// per-iteration accumulation stays within one quant group.
+#if defined(GATE_UP_GROUP_SIZE) && defined(DOWN_GROUP_SIZE)
+#    if GATE_UP_GROUP_SIZE < DOWN_GROUP_SIZE
+#        define MOE_MIN_GROUP_SIZE GATE_UP_GROUP_SIZE
+#    else
+#        define MOE_MIN_GROUP_SIZE DOWN_GROUP_SIZE
+#    endif
+#    if MOE_MIN_GROUP_SIZE < 128
+#        define FAKE_GROUP_SIZE MOE_MIN_GROUP_SIZE
+#    else
+#        define FAKE_GROUP_SIZE 128
+#    endif
+#else
+#    define FAKE_GROUP_SIZE 128
+#endif
+
+// Number of K-elements each work-item handles per gk-iteration via the
+// intel_sub_group_block_read tile. Drives the inner-loop variant selection.
+#define ELEMS_PER_LANE (FAKE_GROUP_SIZE / SUBGROUP_SIZE)
 
 // HAS_ZP: 1 = asymmetric quantization (subtract zero point), 0 = symmetric (no zero point)
 #if HAS_ZP
@@ -64,7 +87,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
             half z_hf1 = convert_half(z >> 4);
 #endif
 
-#    if SUBGROUP_SIZE == 32
+#    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
             half4 a = as_half4(intel_sub_group_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
@@ -171,7 +194,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
             half z1 = convert_half(Z[zp_offset + 1]);
 #endif
 
-#    if SUBGROUP_SIZE == 32
+#    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
             half4 a = as_half4(intel_sub_group_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
@@ -257,7 +280,7 @@ inline void gate_up_gemv_n2x_f16(const __global half* weight, __global half* y, 
         float sum_all0 = 0;
         float sum_all1 = 0;
         unroll_for(int gk = 0; gk < K / FAKE_GROUP_SIZE; gk++) {
-#    if SUBGROUP_SIZE == 32
+#    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
             half4 a = as_half4(intel_sub_group_block_read_us4((const __global ushort*)x2 + gk * FAKE_GROUP_SIZE));
@@ -554,7 +577,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
             half z_hf1 = convert_half(z >> 4);
 #endif
 
-#    if SUBGROUP_SIZE == 32
+#    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
             half4 a = as_half4(intel_sub_group_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
@@ -655,7 +678,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
             half z1 = convert_half(Z[zp_offset + 1]);
 #endif
 
-#    if SUBGROUP_SIZE == 32
+#    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
             half4 a = as_half4(intel_sub_group_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
@@ -736,7 +759,7 @@ inline void down_gemv_n2x_f16(const __global half* weight, __global MOE_DTYPE* r
         float sum_all1 = 0;
         unroll_for(int gk = 0; gk < K / FAKE_GROUP_SIZE; gk++) {
 
-#    if SUBGROUP_SIZE == 32
+#    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
             half4 a = as_half4(intel_sub_group_block_read_us4((const __global ushort*)x2 + gk * FAKE_GROUP_SIZE));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
@@ -29,6 +29,8 @@
 
 // Number of K-elements each work-item handles per gk-iteration via the
 // intel_sub_group_block_read tile. Drives the inner-loop variant selection.
+// Supported values: 2 (FAKE_GROUP_SIZE = 1 * SUBGROUP_SIZE * 2, e.g. SG=16 + 32),
+// 4 (e.g. SG=32 + FAKE=128 or SG=16 + FAKE=64), and 8 (SG=16 + FAKE=128).
 #define ELEMS_PER_LANE (FAKE_GROUP_SIZE / SUBGROUP_SIZE)
 
 // HAS_ZP: 1 = asymmetric quantization (subtract zero point), 0 = symmetric (no zero point)
@@ -110,6 +112,27 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
 #else
             sum_all0 += (sum0[0] + sum0[1]) * s0;
             sum_all1 += (sum1[0] + sum1[1]) * s1;
+#endif
+#    elif ELEMS_PER_LANE == 2
+            // Each lane reads 2 K-elements (1 byte = 2 nibbles).
+            half sum0;
+            half sum1;
+            half2 a = as_half2(intel_sub_group_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            uchar b = intel_sub_group_block_read_uc((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
+            uchar b2 = intel_sub_group_block_read_uc((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
+
+            sum0 = fma(a.s0, (DEQUANT_4BIT_LO(b)), (half)0);
+            sum0 = fma(a.s1, (DEQUANT_4BIT_HI(b)), sum0);
+
+            sum1 = fma(a.s0, (DEQUANT_4BIT_LO(b2)), (half)0);
+            sum1 = fma(a.s1, (DEQUANT_4BIT_HI(b2)), sum1);
+
+#if HAS_ZP
+            sum_all0 += (sum0 - xg_sum[gk] * z_hf0) * s0;
+            sum_all1 += (sum1 - xg_sum[gk] * z_hf1) * s1;
+#else
+            sum_all0 += sum0 * s0;
+            sum_all1 += sum1 * s1;
 #endif
 #    else
             half4 sum0;
@@ -218,6 +241,27 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
             sum_all0 += (sum0[0] + sum0[1]) * s0;
             sum_all1 += (sum1[0] + sum1[1]) * s1;
 #endif
+#    elif ELEMS_PER_LANE == 2
+            // Each lane reads 2 K-elements (8-bit weights, 1 byte each).
+            float sum0;
+            float sum1;
+            half2 a = as_half2(intel_sub_group_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
+            uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
+
+            sum0 = fma((float)a.s0, (float)(DEQUANT_8BIT(b.s0)), 0.0f);
+            sum0 = fma((float)a.s1, (float)(DEQUANT_8BIT(b.s1)), sum0);
+
+            sum1 = fma((float)a.s0, (float)(DEQUANT_8BIT(b2.s0)), 0.0f);
+            sum1 = fma((float)a.s1, (float)(DEQUANT_8BIT(b2.s1)), sum1);
+
+#if HAS_ZP
+            sum_all0 += (sum0 - xg_sum[gk] * z0) * s0;
+            sum_all1 += (sum1 - xg_sum[gk] * z1) * s1;
+#else
+            sum_all0 += sum0 * s0;
+            sum_all1 += sum1 * s1;
+#endif
 #    else
             float4 sum0;
             float4 sum1;
@@ -299,6 +343,22 @@ inline void gate_up_gemv_n2x_f16(const __global half* weight, __global half* y, 
 
             sum_all0 += sum0[0] + sum0[1];
             sum_all1 += sum1[0] + sum1[1];
+#    elif ELEMS_PER_LANE == 2
+            // Each lane reads 2 fp16 elements.
+            half sum0;
+            half sum1;
+            half2 a = as_half2(intel_sub_group_block_read_us2((const __global ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 b = as_half2(intel_sub_group_block_read_us2((const __global ushort*)B + gk * FAKE_GROUP_SIZE));
+            half2 b2 = as_half2(intel_sub_group_block_read_us2((const __global ushort*)B + K + gk * FAKE_GROUP_SIZE));
+
+            sum0 = fma(a.s0, b.s0, (half)0);
+            sum0 = fma(a.s1, b.s1, sum0);
+
+            sum1 = fma(a.s0, b2.s0, (half)0);
+            sum1 = fma(a.s1, b2.s1, sum1);
+
+            sum_all0 += sum0;
+            sum_all1 += sum1;
 #    else
             half4 sum0;
             half4 sum1;
@@ -601,6 +661,27 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
             sum_all0 += (sum0[0] + sum0[1]) * s0;
             sum_all1 += (sum1[0] + sum1[1]) * s1;
 #endif
+#    elif ELEMS_PER_LANE == 2
+            // Each lane reads 2 K-elements (1 byte = 2 nibbles).
+            half sum0;
+            half sum1;
+            half2 a = as_half2(intel_sub_group_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            uchar b = intel_sub_group_block_read_uc((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
+            uchar b2 = intel_sub_group_block_read_uc((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
+
+            sum0 = fma(a.s0, (DEQUANT_4BIT_LO(b)), (half)0);
+            sum0 = fma(a.s1, (DEQUANT_4BIT_HI(b)), sum0);
+
+            sum1 = fma(a.s0, (DEQUANT_4BIT_LO(b2)), (half)0);
+            sum1 = fma(a.s1, (DEQUANT_4BIT_HI(b2)), sum1);
+
+#if HAS_ZP
+            sum_all0 += (sum0 - xg_sum[gk] * z_hf0) * s0;
+            sum_all1 += (sum1 - xg_sum[gk] * z_hf1) * s1;
+#else
+            sum_all0 += sum0 * s0;
+            sum_all1 += sum1 * s1;
+#endif
 #    else
             half4 sum0;
             half4 sum1;
@@ -702,6 +783,27 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
             sum_all0 += (sum0[0] + sum0[1]) * s0;
             sum_all1 += (sum1[0] + sum1[1]) * s1;
 #endif
+#    elif ELEMS_PER_LANE == 2
+            // Each lane reads 2 K-elements (8-bit weights, 1 byte each).
+            float sum0;
+            float sum1;
+            half2 a = as_half2(intel_sub_group_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
+            uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)B + K + gk * FAKE_GROUP_SIZE);
+
+            sum0 = fma((float)a.s0, (float)(DEQUANT_8BIT(b.s0)), 0.0f);
+            sum0 = fma((float)a.s1, (float)(DEQUANT_8BIT(b.s1)), sum0);
+
+            sum1 = fma((float)a.s0, (float)(DEQUANT_8BIT(b2.s0)), 0.0f);
+            sum1 = fma((float)a.s1, (float)(DEQUANT_8BIT(b2.s1)), sum1);
+
+#if HAS_ZP
+            sum_all0 += (sum0 - xg_sum[gk] * z0) * s0;
+            sum_all1 += (sum1 - xg_sum[gk] * z1) * s1;
+#else
+            sum_all0 += sum0 * s0;
+            sum_all1 += sum1 * s1;
+#endif
 #    else
             float4 sum0;
             float4 sum1;
@@ -778,6 +880,22 @@ inline void down_gemv_n2x_f16(const __global half* weight, __global MOE_DTYPE* r
 
             sum_all0 += sum0[0] + sum0[1];
             sum_all1 += sum1[0] + sum1[1];
+#    elif ELEMS_PER_LANE == 2
+            // Each lane reads 2 fp16 elements.
+            half sum0;
+            half sum1;
+            half2 a = as_half2(intel_sub_group_block_read_us2((const __global ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 b = as_half2(intel_sub_group_block_read_us2((const __global ushort*)B + gk * FAKE_GROUP_SIZE));
+            half2 b2 = as_half2(intel_sub_group_block_read_us2((const __global ushort*)B + K + gk * FAKE_GROUP_SIZE));
+
+            sum0 = fma(a.s0, b.s0, (half)0);
+            sum0 = fma(a.s1, b.s1, sum0);
+
+            sum1 = fma(a.s0, b2.s0, (half)0);
+            sum1 = fma(a.s1, b2.s1, sum1);
+
+            sum_all0 += sum0;
+            sum_all1 += sum1;
 #    else
             half4 sum0;
             half4 sum1;

--- a/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
@@ -120,8 +120,16 @@ static void CreateMOECompressedOp(ProgramBuilder& p, const std::shared_ptr<ov::o
         //   shape [num_experts, hidden_size, group_num, 1]
         //   11: w2_zp - expert zp for final projection for compressed experts,
         //   shape [num_experts, hidden_size, group_num, 1]
-
         // Use moe_3gemm_fused_compressed to replace it.
+
+        // Reaching here means MOECompressed (GEMM3_SWIGLU) survived all transformation passes.
+        // It must be replaced by moe_3gemm_fused_compressed via FuseMOE3GemmCompressed; if the
+        // routing subgraph did not match the expected pattern, the model would otherwise fail later
+        // with the cryptic "Input ... hasn't been found in primitive_ids map" from the program builder.
+        // Surface the real cause explicitly here.
+        OPENVINO_THROW("[GPU] MOECompressed (GEMM3_SWIGLU) reached the GPU backend without being fused: "
+                       "FuseMOE3GemmCompressed transformation did not match the routing subgraph for op '",
+                       op->get_friendly_name(), "'. Please check the routing pattern.");
     } else {
         // Create GEMM2_BIAS_SWIGLU_CLAMP specific primitives
         // input0 : input {#tokens, hidden_size}

--- a/src/plugins/intel_gpu/src/plugin/transformations/fuse_moe_3gemm_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fuse_moe_3gemm_compressed.cpp
@@ -76,7 +76,10 @@ FuseMOE3GemmCompressed::FuseMOE3GemmCompressed() {
     auto sig_norm = wrap_type<ov::op::v1::Divide>({sig_gather_el, sig_add_eps}, consumers_count(1));
     // Some models (e.g. trinity-mini afmoe) apply an additional `routed_scaling_factor`
     // multiplication on the normalized routing weights before the final Slice.
-    auto sig_norm_scaled = optional<ov::op::v1::Multiply>({sig_norm, ANY}, consumers_count(1));
+    // The named `sig_norm_scale` lets the callback fetch the scale directly from pattern_map
+    // without manually inspecting Multiply inputs.
+    auto sig_norm_scale = ANY;
+    auto sig_norm_scaled = optional<ov::op::v1::Multiply>({sig_norm, sig_norm_scale}, consumers_count(1));
     auto sig_slice = optional<ov::op::v8::Slice>({sig_norm_scaled, ANY, ANY, ANY, ANY});
     auto sig_transpose = wrap_type<ov::op::v1::Transpose>({sig_slice, ANY}, consumers_count(1));
     auto sig_unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({sig_transpose, ANY}, consumers_count(1));
@@ -210,27 +213,16 @@ FuseMOE3GemmCompressed::FuseMOE3GemmCompressed() {
         // sum by `s` (Σ (w·s)·y_e = s · Σ w·y_e). Insert a post-multiplication so the
         // kernel does not need to know about this scale.
         if (pattern_map.count(sig_norm_scaled)) {
-            auto scaled_node = pattern_map.at(sig_norm_scaled).get_node_shared_ptr();
-            // Multiply has two inputs; the one that's not `sig_norm` is the scale.
-            ov::Output<ov::Node> scale;
-            auto sig_norm_out = pattern_map.at(sig_norm);
-            for (size_t i = 0; i < scaled_node->get_input_size(); ++i) {
-                if (scaled_node->input_value(i) != sig_norm_out) {
-                    scale = scaled_node->input_value(i);
-                    break;
-                }
+            auto scale = pattern_map.at(sig_norm_scale);
+            // Match the dtype of the fused-op output (typically f16) to avoid
+            // an element-type mismatch in Multiply.
+            if (scale.get_element_type() != moe_router_fused->get_output_element_type(0)) {
+                scale = std::make_shared<ov::op::v0::Convert>(scale, moe_router_fused->get_output_element_type(0));
+                ov::copy_runtime_info(moe_compressed, scale.get_node_shared_ptr());
             }
-            if (scale.get_node_shared_ptr()) {
-                // Match the dtype of the fused-op output (typically f16) to avoid
-                // an element-type mismatch in Multiply.
-                if (scale.get_element_type() != moe_router_fused->get_output_element_type(0)) {
-                    scale = std::make_shared<ov::op::v0::Convert>(scale, moe_router_fused->get_output_element_type(0));
-                    ov::copy_runtime_info(moe_compressed, scale.get_node_shared_ptr());
-                }
-                auto post_mul = std::make_shared<ov::op::v1::Multiply>(moe_router_fused, scale);
-                ov::copy_runtime_info(moe_compressed, post_mul);
-                moe_router_fused = post_mul;
-            }
+            auto post_mul = std::make_shared<ov::op::v1::Multiply>(moe_router_fused, scale);
+            ov::copy_runtime_info(moe_compressed, post_mul);
+            moe_router_fused = post_mul;
         }
 
         moe_router_fused->set_friendly_name(moe_compressed->get_friendly_name());

--- a/src/plugins/intel_gpu/src/plugin/transformations/fuse_moe_3gemm_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fuse_moe_3gemm_compressed.cpp
@@ -17,6 +17,7 @@
 #include "openvino/op/divide.hpp"
 #include "openvino/op/gather_elements.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/shape_of.hpp"
@@ -73,7 +74,10 @@ FuseMOE3GemmCompressed::FuseMOE3GemmCompressed() {
     });
     auto sig_add_eps = wrap_type<ov::op::v1::Add>({sig_reduce, sig_eps_value}, consumers_count(1));
     auto sig_norm = wrap_type<ov::op::v1::Divide>({sig_gather_el, sig_add_eps}, consumers_count(1));
-    auto sig_slice = optional<ov::op::v8::Slice>({sig_norm, ANY, ANY, ANY, ANY});
+    // Some models (e.g. trinity-mini afmoe) apply an additional `routed_scaling_factor`
+    // multiplication on the normalized routing weights before the final Slice.
+    auto sig_norm_scaled = optional<ov::op::v1::Multiply>({sig_norm, ANY}, consumers_count(1));
+    auto sig_slice = optional<ov::op::v8::Slice>({sig_norm_scaled, ANY, ANY, ANY, ANY});
     auto sig_transpose = wrap_type<ov::op::v1::Transpose>({sig_slice, ANY}, consumers_count(1));
     auto sig_unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({sig_transpose, ANY}, consumers_count(1));
 
@@ -197,6 +201,36 @@ FuseMOE3GemmCompressed::FuseMOE3GemmCompressed() {
             auto hidden_state_shape = std::make_shared<ov::op::v3::ShapeOf>(pattern_map.at(hidden_state_m));
             moe_router_fused = std::make_shared<ov::op::v1::Reshape>(moe_router_fused, hidden_state_shape, false);
             ov::copy_runtime_info(moe_compressed, {hidden_state_shape, moe_router_fused});
+        }
+
+        // If the routing branch contained an additional `routed_scaling_factor` Multiply
+        // (e.g. trinity-mini afmoe), it was consumed by the pattern but is NOT applied
+        // inside the fused op. Re-apply it on the output: since the routing weights
+        // are used as Σ w·y_e, scaling each w by `s` is equivalent to scaling the final
+        // sum by `s` (Σ (w·s)·y_e = s · Σ w·y_e). Insert a post-multiplication so the
+        // kernel does not need to know about this scale.
+        if (pattern_map.count(sig_norm_scaled)) {
+            auto scaled_node = pattern_map.at(sig_norm_scaled).get_node_shared_ptr();
+            // Multiply has two inputs; the one that's not `sig_norm` is the scale.
+            ov::Output<ov::Node> scale;
+            auto sig_norm_out = pattern_map.at(sig_norm);
+            for (size_t i = 0; i < scaled_node->get_input_size(); ++i) {
+                if (scaled_node->input_value(i) != sig_norm_out) {
+                    scale = scaled_node->input_value(i);
+                    break;
+                }
+            }
+            if (scale.get_node_shared_ptr()) {
+                // Match the dtype of the fused-op output (typically f16) to avoid
+                // an element-type mismatch in Multiply.
+                if (scale.get_element_type() != moe_router_fused->get_output_element_type(0)) {
+                    scale = std::make_shared<ov::op::v0::Convert>(scale, moe_router_fused->get_output_element_type(0));
+                    ov::copy_runtime_info(moe_compressed, scale.get_node_shared_ptr());
+                }
+                auto post_mul = std::make_shared<ov::op::v1::Multiply>(moe_router_fused, scale);
+                ov::copy_runtime_info(moe_compressed, post_mul);
+                moe_router_fused = post_mul;
+            }
         }
 
         moe_router_fused->set_friendly_name(moe_compressed->get_friendly_name());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
@@ -564,11 +564,7 @@ TEST_P(moe_3gemm_compressed_gpu_random, moe_accuracy_test_random) {
                           : ref.run_reference_softmax(hidden_states, routing_weights, w0_data, w1_data, w2_data);
     // SigmoidBias routing performs all routing math (sigmoid, bias, normalization) in f16 on the kernel side,
     // while the reference uses f32, leading to slightly larger numerical divergence than Softmax.
-    // Sub-128 weight quantization group sizes also accumulate more drift (more group transitions per K).
-    float base_tolerance = routing_type == cldnn::MOE3GemmFusedCompressed::RoutingType::SIGMOID_BIAS ? 0.2f : 0.1f;
-    if (config.group_size < 128) {
-        base_tolerance *= 3.0f;
-    }
+    const float base_tolerance = routing_type == cldnn::MOE3GemmFusedCompressed::RoutingType::SIGMOID_BIAS ? 0.2f : 0.1f;
     const float tolerance = base_tolerance * (config.hidden_size / 128);
     for (size_t i = 0; i < ref_output.size(); ++i) {
         ASSERT_NEAR(static_cast<float>(output_ptr[i]), static_cast<float>(ref_output[i]), tolerance);
@@ -1192,10 +1188,7 @@ TEST_P(moe_3gemm_compressed_gpu_symmetric_random, moe_accuracy_test_symmetric) {
                           ? ref.run_reference_sigmoid(hidden_states, routing_weights, routing_bias_data, routing_eps_val, w0_data, w1_data, w2_data)
                           : ref.run_reference_softmax(hidden_states, routing_weights, w0_data, w1_data, w2_data);
 
-    float base_tolerance = routing_type == cldnn::MOE3GemmFusedCompressed::RoutingType::SIGMOID_BIAS ? 0.2f : 0.1f;
-    if (config.group_size < 128) {
-        base_tolerance *= 3.0f;
-    }
+    const float base_tolerance = routing_type == cldnn::MOE3GemmFusedCompressed::RoutingType::SIGMOID_BIAS ? 0.2f : 0.1f;
     const float tolerance = base_tolerance * (config.hidden_size / 128);
     for (size_t i = 0; i < ref_output.size(); ++i) {
         ASSERT_NEAR(static_cast<float>(output_ptr[i]), static_cast<float>(ref_output[i]), tolerance);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
@@ -564,7 +564,11 @@ TEST_P(moe_3gemm_compressed_gpu_random, moe_accuracy_test_random) {
                           : ref.run_reference_softmax(hidden_states, routing_weights, w0_data, w1_data, w2_data);
     // SigmoidBias routing performs all routing math (sigmoid, bias, normalization) in f16 on the kernel side,
     // while the reference uses f32, leading to slightly larger numerical divergence than Softmax.
-    const float base_tolerance = routing_type == cldnn::MOE3GemmFusedCompressed::RoutingType::SIGMOID_BIAS ? 0.2f : 0.1f;
+    // Sub-128 weight quantization group sizes also accumulate more drift (more group transitions per K).
+    float base_tolerance = routing_type == cldnn::MOE3GemmFusedCompressed::RoutingType::SIGMOID_BIAS ? 0.2f : 0.1f;
+    if (config.group_size < 128) {
+        base_tolerance *= 3.0f;
+    }
     const float tolerance = base_tolerance * (config.hidden_size / 128);
     for (size_t i = 0; i < ref_output.size(); ++i) {
         ASSERT_NEAR(static_cast<float>(output_ptr[i]), static_cast<float>(ref_output[i]), tolerance);
@@ -582,7 +586,14 @@ INSTANTIATE_TEST_SUITE_P(smoke,
                                                               Moe3GemmTestParams{1, true, 256, 512, 4, 2, 256},
                                                               Moe3GemmTestParams{1, false, 256, 512, 4, 2, 256},
                                                               Moe3GemmTestParams{1, true, 512, 512, 4, 2, 512},
-                                                              Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512})));
+                                                              Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512},
+                                                              // Sub-128 weight quantization group size
+                                                              // (e.g. trinity-mini afmoe uses group_size=64).
+                                                              Moe3GemmTestParams{1, true, 128, 256, 4, 2, 64},
+                                                              Moe3GemmTestParams{16, true, 128, 256, 4, 2, 64},
+                                                              Moe3GemmTestParams{1, false, 128, 256, 4, 2, 64},
+                                                              Moe3GemmTestParams{1, true, 256, 512, 4, 2, 64},
+                                                              Moe3GemmTestParams{1, false, 256, 512, 4, 2, 64})));
 
 class moe_3gemm_compressed_gpu_u4 : public ::testing::TestWithParam<cldnn::MOE3GemmFusedCompressed::RoutingType> {};
 
@@ -847,7 +858,11 @@ INSTANTIATE_TEST_SUITE_P(smoke,
                                            Moe3GemmTestParams{1, true, 256, 512, 4, 2, 256},
                                            Moe3GemmTestParams{1, false, 256, 512, 4, 2, 256},
                                            Moe3GemmTestParams{1, true, 512, 512, 4, 2, 512},
-                                           Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512}));
+                                           Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512},
+                                           // Sub-128 group_size (trinity-mini afmoe shape).
+                                           Moe3GemmTestParams{1, true, 128, 256, 4, 2, 64},
+                                           Moe3GemmTestParams{1, false, 128, 256, 4, 2, 64},
+                                           Moe3GemmTestParams{1, true, 256, 512, 4, 2, 64}));
 
 TEST_P(moe_3gemm_compressed_gpu_u4, moe_accuracy_test_u4) {
     auto routing_type = GetParam();
@@ -1172,7 +1187,10 @@ TEST_P(moe_3gemm_compressed_gpu_symmetric_random, moe_accuracy_test_symmetric) {
                           ? ref.run_reference_sigmoid(hidden_states, routing_weights, routing_bias_data, routing_eps_val, w0_data, w1_data, w2_data)
                           : ref.run_reference_softmax(hidden_states, routing_weights, w0_data, w1_data, w2_data);
 
-    const float base_tolerance = routing_type == cldnn::MOE3GemmFusedCompressed::RoutingType::SIGMOID_BIAS ? 0.2f : 0.1f;
+    float base_tolerance = routing_type == cldnn::MOE3GemmFusedCompressed::RoutingType::SIGMOID_BIAS ? 0.2f : 0.1f;
+    if (config.group_size < 128) {
+        base_tolerance *= 3.0f;
+    }
     const float tolerance = base_tolerance * (config.hidden_size / 128);
     for (size_t i = 0; i < ref_output.size(); ++i) {
         ASSERT_NEAR(static_cast<float>(output_ptr[i]), static_cast<float>(ref_output[i]), tolerance);
@@ -1190,7 +1208,10 @@ INSTANTIATE_TEST_SUITE_P(smoke,
                                                               Moe3GemmTestParams{1, true, 256, 512, 4, 2, 256, true},
                                                               Moe3GemmTestParams{1, false, 256, 512, 4, 2, 256, true},
                                                               Moe3GemmTestParams{1, true, 512, 512, 4, 2, 512, true},
-                                                              Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512, true})));
+                                                              Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512, true},
+                                                              // Sub-128 group_size for symmetric quantization.
+                                                              Moe3GemmTestParams{1, true, 128, 256, 4, 2, 64, true},
+                                                              Moe3GemmTestParams{1, false, 128, 256, 4, 2, 64, true})));
 
 // Symmetric quantization test with shared expert
 class moe_3gemm_compressed_gpu_shared_symmetric_random : public ::testing::TestWithParam<Moe3GemmTestParams> {};
@@ -1423,4 +1444,8 @@ INSTANTIATE_TEST_SUITE_P(smoke,
                                            Moe3GemmTestParams{1, true, 256, 512, 4, 2, 256, true},
                                            Moe3GemmTestParams{1, false, 256, 512, 4, 2, 256, true},
                                            Moe3GemmTestParams{1, true, 512, 512, 4, 2, 512, true},
-                                           Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512, true}));
+                                           Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512, true},
+                                           // Sub-128 group_size for symmetric shared expert.
+                                           Moe3GemmTestParams{1, true, 128, 256, 4, 2, 64, true},
+                                           Moe3GemmTestParams{1, false, 128, 256, 4, 2, 64, true},
+                                           Moe3GemmTestParams{1, true, 256, 512, 4, 2, 64, true}));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
@@ -586,10 +586,15 @@ INSTANTIATE_TEST_SUITE_P(smoke,
                                                               Moe3GemmTestParams{1, true, 256, 512, 4, 2, 256},
                                                               Moe3GemmTestParams{1, false, 256, 512, 4, 2, 256},
                                                               Moe3GemmTestParams{1, true, 512, 512, 4, 2, 512},
-                                                              Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512},
-                                                              // Sub-128 weight quantization group size
-                                                              // (e.g. trinity-mini afmoe uses group_size=64).
-                                                              Moe3GemmTestParams{1, true, 128, 256, 4, 2, 64},
+                                                              Moe3GemmTestParams{1, false, 512, 512, 4, 2, 512})));
+
+// Sub-128 weight quantization group size (e.g. trinity-mini afmoe uses group_size=64
+// with SIGMOID_BIAS routing). Limited to SIGMOID_BIAS to mirror real model usage and
+// to avoid known accuracy noise of the SOFTMAX path on some platforms.
+INSTANTIATE_TEST_SUITE_P(smoke_sub128_group_size,
+                         moe_3gemm_compressed_gpu_random,
+                         ::testing::Combine(::testing::Values(cldnn::MOE3GemmFusedCompressed::RoutingType::SIGMOID_BIAS),
+                                            ::testing::Values(Moe3GemmTestParams{1, true, 128, 256, 4, 2, 64},
                                                               Moe3GemmTestParams{16, true, 128, 256, 4, 2, 64},
                                                               Moe3GemmTestParams{1, false, 128, 256, 4, 2, 64},
                                                               Moe3GemmTestParams{1, true, 256, 512, 4, 2, 64},

--- a/src/plugins/intel_gpu/tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp
@@ -138,11 +138,14 @@ TEST_P(FuseMOE3GemmCompressedTest, CompareFunctions) {
         auto routing_weights = std::make_shared<ov::op::v0::MatMul>(hidden_states_reshape, routers);
 
         // Build post-GatherMatmul routing (no ScatterElementsUpdate)
+        std::optional<float> scale_opt;
+        if (with_routed_scale) {
+            scale_opt = routed_scale_value;
+        }
         auto [unsqueeze_moe, topk_indices] =
             routing_type == MoERoutingType::SOFTMAX
                 ? build_softmax_routing_for_fuse_test(routing_weights, 8)
-                : build_sigmoid_routing_for_fuse_test(routing_weights, element::f16, 128, 8,
-                                                      with_routed_scale ? std::optional<float>(routed_scale_value) : std::nullopt);
+                : build_sigmoid_routing_for_fuse_test(routing_weights, element::f16, 128, 8, scale_opt);
 
         // weight
         auto wei_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});

--- a/src/plugins/intel_gpu/tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp
@@ -39,7 +39,7 @@ namespace intel_gpu {
 
 using namespace ov::test;
 
-using FuseMOE3GemmCompressedTestParams = std::tuple<MoERoutingType, bool /* reshape_on_moe_input */>;
+using FuseMOE3GemmCompressedTestParams = std::tuple<MoERoutingType, bool /* reshape_on_moe_input */, bool /* with_routed_scale */>;
 
 class FuseMOE3GemmCompressedTest : public TransformationTestsF,
                                    public ::testing::WithParamInterface<FuseMOE3GemmCompressedTestParams> {
@@ -58,6 +58,8 @@ public:
         }
         if (std::get<1>(info.param))
             name += "_ReshapeOnMoeInput";
+        if (std::get<2>(info.param))
+            name += "_RoutedScalingFactor";
         return name;
     }
 };
@@ -81,12 +83,15 @@ build_softmax_routing_for_fuse_test(const ov::Output<ov::Node>& routing_weights,
     return {unsqueeze_moe, topk_node->output(1)};
 }
 
-// Sigmoid+bias routing: Sigmoid → Add → TopK → Convert → GatherElements → ReduceSum → Add(eps) → Divide → Transpose → Unsqueeze.
+// Sigmoid+bias routing: Sigmoid → Add → TopK → Convert → GatherElements → ReduceSum → Add(eps) → Divide
+//                       [→ Multiply(routed_scaling_factor) when scale_value is set]
+//                       → Transpose → Unsqueeze.
 static std::pair<ov::Output<ov::Node>, ov::Output<ov::Node>>
 build_sigmoid_routing_for_fuse_test(const ov::Output<ov::Node>& routing_weights,
                                     ov::element::Type data_precision,
                                     size_t number_of_experts,
-                                    size_t topk) {
+                                    size_t topk,
+                                    std::optional<float> scale_value = std::nullopt) {
     auto sigmoid = std::make_shared<ov::op::v0::Sigmoid>(routing_weights);
     auto bias = op::v0::Constant::create(data_precision, Shape{1, number_of_experts}, {0.1f});
     auto sig_add = std::make_shared<ov::op::v1::Add>(sigmoid, bias);
@@ -101,7 +106,15 @@ build_sigmoid_routing_for_fuse_test(const ov::Output<ov::Node>& routing_weights,
     auto reduce_sum = std::make_shared<ov::op::v1::ReduceSum>(gather_el, reduce_axis, true);
     auto eps = op::v0::Constant::create(data_precision, Shape{1, 1}, {1e-6f});
     auto add_eps = std::make_shared<ov::op::v1::Add>(reduce_sum, eps);
-    auto norm = std::make_shared<ov::op::v1::Divide>(gather_el, add_eps);
+    std::shared_ptr<ov::Node> norm = std::make_shared<ov::op::v1::Divide>(gather_el, add_eps);
+
+    // Mirror trinity-mini afmoe `routed_scaling_factor`: an extra Multiply between
+    // the normalized routing weights and the final Transpose. The matcher's optional<Multiply>
+    // absorbs it; the callback re-applies it as a post-op Multiply on the fused MOE output.
+    if (scale_value.has_value()) {
+        auto scale_const = op::v0::Constant::create(data_precision, Shape{1, 1}, {*scale_value});
+        norm = std::make_shared<ov::op::v1::Multiply>(norm, scale_const);
+    }
 
     auto transpose_order = op::v0::Constant::create(element::i64, Shape{2}, {1, 0});
     auto transpose = std::make_shared<ov::op::v1::Transpose>(norm, transpose_order);
@@ -112,7 +125,10 @@ build_sigmoid_routing_for_fuse_test(const ov::Output<ov::Node>& routing_weights,
 }
 
 TEST_P(FuseMOE3GemmCompressedTest, CompareFunctions) {
-    const auto& [routing_type, reshape_on_moe_input] = GetParam();
+    const auto& [routing_type, reshape_on_moe_input, with_routed_scale] = GetParam();
+    constexpr float routed_scale_value = 2.5f;
+    // routed_scaling_factor only applies to the SIGMOID_BIAS branch.
+    ASSERT_TRUE(!with_routed_scale || routing_type == MoERoutingType::SIGMOID_BIAS);
     {
         // tokens:32, hidden_size:2048, inter_size:768, experts:128, topk:8
         auto hidden_states = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{4, 8, 2048});
@@ -125,7 +141,8 @@ TEST_P(FuseMOE3GemmCompressedTest, CompareFunctions) {
         auto [unsqueeze_moe, topk_indices] =
             routing_type == MoERoutingType::SOFTMAX
                 ? build_softmax_routing_for_fuse_test(routing_weights, 8)
-                : build_sigmoid_routing_for_fuse_test(routing_weights, element::f16, 128, 8);
+                : build_sigmoid_routing_for_fuse_test(routing_weights, element::f16, 128, 8,
+                                                      with_routed_scale ? std::optional<float>(routed_scale_value) : std::nullopt);
 
         // weight
         auto wei_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
@@ -206,144 +223,38 @@ TEST_P(FuseMOE3GemmCompressedTest, CompareFunctions) {
         std::shared_ptr<ov::Node> result = std::make_shared<ov::intel_gpu::op::MOE3GemmFusedCompressed>(args, config);
 
         // When reshape_on_moe_input is false, MOE3GemmFusedCompressed takes reshaped input from routing subgraph,
-        // so the transformation inserts a reshape-back to restore the original shape.
+        // so the transformation inserts a reshape-back to restore the original shape. The reshape-back is
+        // emitted before the post-op Multiply in the callback, so mirror that order here.
         if (!reshape_on_moe_input) {
             auto hidden_state_shape = std::make_shared<ov::op::v3::ShapeOf>(hidden_states);
             result = std::make_shared<ov::op::v1::Reshape>(result, hidden_state_shape, false);
+        }
+
+        // The transformation re-applies the absorbed routed_scaling_factor as a post-op Multiply.
+        // Scale is already f16, so no Convert insertion is expected.
+        if (with_routed_scale) {
+            auto post_scale = op::v0::Constant::create(element::f16, Shape{1, 1}, {routed_scale_value});
+            result = std::make_shared<ov::op::v1::Multiply>(result, post_scale);
         }
 
         model_ref = std::make_shared<ov::Model>(result, ov::ParameterVector{hidden_states});
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke,
-                         FuseMOE3GemmCompressedTest,
-                         ::testing::Combine(
-                             ::testing::Values(MoERoutingType::SOFTMAX, MoERoutingType::SIGMOID_BIAS),
-                             ::testing::Values(false, true)),
-                         FuseMOE3GemmCompressedTest::get_test_case_name);
-
-namespace {
-// Build a sigmoid+bias routing subgraph with an extra Multiply(routed_scaling_factor) inserted
-// between Divide(eps-normalized) and Transpose — mirroring the optional<Multiply> location in
-// the matcher (the trinity-mini afmoe `routed_scaling_factor` post-norm scaling).
-// Returns {unsqueeze_moe, topk_idx, scale_const}.
-std::tuple<ov::Output<ov::Node>, ov::Output<ov::Node>, std::shared_ptr<ov::op::v0::Constant>>
-build_sigmoid_bias_routing_subgraph_with_scale(const ov::Output<ov::Node>& routing_logits,
-                                               ov::element::Type data_precision,
-                                               size_t number_of_experts,
-                                               size_t topk,
-                                               float scale_value) {
-    using namespace ov::op;
-
-    auto sigmoid = std::make_shared<v0::Sigmoid>(routing_logits);
-    auto bias = v0::Constant::create(data_precision, ov::Shape{1, number_of_experts}, {0.1f});
-    auto sig_add = std::make_shared<v1::Add>(sigmoid, bias);
-
-    auto k = v0::Constant::create(ov::element::i64, ov::Shape{}, {static_cast<int64_t>(topk)});
-    auto router_topk = std::make_shared<v11::TopK>(sig_add, k, -1,
-        v11::TopK::Mode::MAX, v11::TopK::SortType::SORT_VALUES, ov::element::i64);
-    auto convert_topk = std::make_shared<v0::Convert>(router_topk->output(1), ov::element::i32);
-
-    auto gather_el = std::make_shared<v6::GatherElements>(sigmoid, convert_topk, 1);
-    auto reduce_axis = v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
-    auto reduce = std::make_shared<v1::ReduceSum>(gather_el, reduce_axis, true);
-    auto eps = v0::Constant::create(data_precision, ov::Shape{1, 1}, {1e-6f});
-    auto add_eps = std::make_shared<v1::Add>(reduce, eps);
-    auto norm = std::make_shared<v1::Divide>(gather_el, add_eps);
-
-    // ★ The extra Multiply(routed_scaling_factor) — the bit our pattern must absorb
-    //   and the callback must re-apply as a post-multiply on the fused output.
-    auto scale_const = v0::Constant::create(data_precision, ov::Shape{1, 1}, {scale_value});
-    auto norm_scaled = std::make_shared<v1::Multiply>(norm, scale_const);
-
-    auto transpose_order = v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 0});
-    auto transpose = std::make_shared<v1::Transpose>(norm_scaled, transpose_order);
-    auto unsqueeze_const = v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
-    auto unsqueeze_moe = ov::Output<ov::Node>{std::make_shared<v0::Unsqueeze>(transpose, unsqueeze_const)};
-    return {unsqueeze_moe, ov::Output<ov::Node>{convert_topk}, scale_const};
-}
-}  // namespace
-
-// Verifies that the SIGMOID_BIAS routing branch with an extra Multiply(routed_scaling_factor)
-// (as in trinity-mini afmoe) is matched, and that the absorbed scale is re-applied as a
-// post-multiply on the fused MOE output.
-TEST_F(TransformationTestsF, FuseMOE3GemmCompressed_SigmoidBias_RoutedScalingFactor) {
-    constexpr float scale_value = 2.5f;
-    {
-        auto hidden_states = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{32, 2048});
-        auto routers = op::v0::Constant::create(element::f16, Shape{2048, 128}, {0.2f});
-        auto routing_weights = std::make_shared<ov::op::v0::MatMul>(hidden_states, routers);
-
-        auto [unsqueeze_moe, topk_indices, _scale_unused] =
-            build_sigmoid_bias_routing_subgraph_with_scale(routing_weights, element::f16, 128, 8, scale_value);
-
-        auto wei_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
-        auto scale_gate = op::v0::Constant::create(element::f16, Shape{128, 768, 16}, {0.01f});
-        auto zp_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16}, {0});
-        auto wei_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
-        auto scale_up = op::v0::Constant::create(element::f16, Shape{128, 768, 16}, {0.01f});
-        auto zp_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16}, {0});
-        auto wei_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6, 128}, {1});
-        auto scale_down = op::v0::Constant::create(element::f16, Shape{128, 2048, 6}, {0.01f});
-        auto zp_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6}, {0});
-
-        ov::op::internal::MOECompressed::Config config;
-        config.expert_type = ov::op::internal::MOE::Expert_type::GEMM3_SWIGLU;
-        config.has_zp = true;
-        config.hidden_size = 2048;
-        config.inter_size = 768;
-        config.num_expert = 128;
-        config.group_size = 128;
-        config.top_k = 8;
-        config.out_type = ov::element::f16;
-        auto moe_compressed = std::make_shared<ov::op::internal::MOECompressed>(
-            ov::OutputVector{hidden_states, unsqueeze_moe, topk_indices,
-                wei_gate, scale_gate, zp_gate, wei_up, scale_up, zp_up, wei_down, scale_down, zp_down}, config);
-        model = std::make_shared<ov::Model>(moe_compressed, ov::ParameterVector{hidden_states});
-    }
-    manager.register_pass<FuseMOE3GemmCompressed>();
-    {
-        auto hidden_states = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{32, 2048});
-        auto routers = op::v0::Constant::create(element::f16, Shape{2048, 128}, {0.2f});
-        auto routing_weights = std::make_shared<ov::op::v0::MatMul>(hidden_states, routers);
-
-        auto wei_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
-        auto scale_gate = op::v0::Constant::create(element::f16, Shape{128, 768, 16}, {0.01f});
-        auto zp_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16}, {0});
-        auto wei_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
-        auto scale_up = op::v0::Constant::create(element::f16, Shape{128, 768, 16}, {0.01f});
-        auto zp_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16}, {0});
-        auto wei_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6, 128}, {1});
-        auto scale_down = op::v0::Constant::create(element::f16, Shape{128, 2048, 6}, {0.01f});
-        auto zp_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6}, {0});
-
-        ov::op::internal::MOECompressed::Config config;
-        config.expert_type = ov::op::internal::MOE::Expert_type::GEMM3_SWIGLU;
-        config.has_zp = true;
-        config.hidden_size = 2048;
-        config.inter_size = 768;
-        config.num_expert = 128;
-        config.group_size = 128;
-        config.top_k = 8;
-        config.out_type = ov::element::f16;
-        config.routing_type = ov::op::internal::MOECompressed::RoutingType::SIGMOID_BIAS;
-
-        auto routing_bias = op::v0::Constant::create(element::f16, Shape{1, 128}, {0.1f});
-        auto routing_eps = op::v0::Constant::create(element::f16, Shape{1, 1}, {1e-6f});
-
-        auto fused = std::make_shared<ov::intel_gpu::op::MOE3GemmFusedCompressed>(
-            ov::OutputVector{hidden_states, routing_weights,
-                wei_gate, scale_gate, zp_gate, wei_up, scale_up, zp_up, wei_down, scale_down, zp_down,
-                routing_bias, routing_eps}, config);
-
-        // Post-multiply: scale is f16 already, no Convert needed.
-        auto post_scale = op::v0::Constant::create(element::f16, Shape{1, 1}, {scale_value});
-        auto post_mul = std::make_shared<ov::op::v1::Multiply>(fused, post_scale);
-
-        model_ref = std::make_shared<ov::Model>(post_mul, ov::ParameterVector{hidden_states});
-    }
-}
+INSTANTIATE_TEST_SUITE_P(
+    smoke,
+    FuseMOE3GemmCompressedTest,
+    ::testing::ValuesIn(std::vector<FuseMOE3GemmCompressedTestParams>{
+        // {routing_type, reshape_on_moe_input, with_routed_scale}
+        {MoERoutingType::SOFTMAX,      false, false},
+        {MoERoutingType::SOFTMAX,      true,  false},
+        {MoERoutingType::SIGMOID_BIAS, false, false},
+        {MoERoutingType::SIGMOID_BIAS, true,  false},
+        // trinity-mini afmoe: SIGMOID_BIAS + extra Multiply(routed_scaling_factor)
+        {MoERoutingType::SIGMOID_BIAS, false, true},
+        {MoERoutingType::SIGMOID_BIAS, true,  true},
+    }),
+    FuseMOE3GemmCompressedTest::get_test_case_name);
 
 TEST_F(TransformationTestsF, FuseMOE3GemmSharedExpertCompressedTest) {
     {

--- a/src/plugins/intel_gpu/tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp
@@ -8,15 +8,21 @@
 #include "ov_ops/moe_compressed.hpp"
 #include "intel_gpu/op/moe_3gemm_fused_compressed.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/divide.hpp"
+#include "openvino/op/gather.hpp"
 #include "openvino/op/gather_elements.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/reshape.hpp"
+#include "openvino/op/scatter_elements_update.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/sigmoid.hpp"
+#include "openvino/op/slice.hpp"
 #include "openvino/op/softmax.hpp"
 #include "openvino/op/topk.hpp"
 #include "openvino/op/transpose.hpp"
@@ -216,6 +222,162 @@ INSTANTIATE_TEST_SUITE_P(smoke,
                              ::testing::Values(MoERoutingType::SOFTMAX, MoERoutingType::SIGMOID_BIAS),
                              ::testing::Values(false, true)),
                          FuseMOE3GemmCompressedTest::get_test_case_name);
+
+namespace {
+// Build a sigmoid+bias routing subgraph with an extra Multiply(routed_scaling_factor) inserted
+// between Divide(eps-normalized) and Slice — mirroring trinity-mini afmoe lowering.
+// Returns {unsqueeze_moe, topk_idx, scale_const}.
+std::tuple<ov::Output<ov::Node>, ov::Output<ov::Node>, std::shared_ptr<ov::op::v0::Constant>>
+build_sigmoid_bias_routing_subgraph_with_scale(const ov::Output<ov::Node>& routing_logits,
+                                               ov::element::Type data_precision,
+                                               size_t number_of_experts,
+                                               size_t topk,
+                                               float scale_value) {
+    using namespace ov::op;
+
+    auto sigmoid = std::make_shared<v0::Sigmoid>(routing_logits);
+    auto bias = v0::Constant::create(data_precision, ov::Shape{1, number_of_experts}, {0.1f});
+    auto sig_add = std::make_shared<v1::Add>(sigmoid, bias);
+
+    auto router_topk =
+        std::make_shared<v11::TopK>(sig_add,
+                                    v0::Constant::create(ov::element::i64, ov::Shape{}, {static_cast<int64_t>(topk)}),
+                                    -1,
+                                    v11::TopK::Mode::MAX,
+                                    v11::TopK::SortType::SORT_VALUES,
+                                    ov::element::i64);
+    auto convert_topk = std::make_shared<v0::Convert>(router_topk->output(1), ov::element::i32);
+    auto topk_idx = ov::Output<ov::Node>{convert_topk};
+
+    auto gather_el = std::make_shared<v6::GatherElements>(sigmoid, convert_topk, 1);
+    auto reduce =
+        std::make_shared<v1::ReduceSum>(gather_el,
+                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}),
+                                        true);
+    auto eps = v0::Constant::create(data_precision, ov::Shape{1, 1}, {1e-6f});
+    auto add_eps = std::make_shared<v1::Add>(reduce, eps);
+    auto norm = std::make_shared<v1::Divide>(gather_el, add_eps);
+
+    // ★ The extra Multiply(routed_scaling_factor) — the bit our pattern must absorb
+    //   and the callback must re-apply as a post-multiply on the fused output.
+    auto scale_const = v0::Constant::create(data_precision, ov::Shape{1, 1}, {scale_value});
+    auto norm_scaled = std::make_shared<v1::Multiply>(norm, scale_const);
+
+    auto sl_stop = std::make_shared<v3::ShapeOf>(convert_topk, ov::element::i32);
+    auto slice = std::make_shared<v8::Slice>(
+        norm_scaled,
+        v0::Constant::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{0, 0}),
+        sl_stop,
+        v0::Constant::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{1, 1}),
+        v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 1}));
+
+    auto shapeof = std::make_shared<v3::ShapeOf>(convert_topk, ov::element::i64);
+    auto gather = std::make_shared<v8::Gather>(shapeof,
+                                               v0::Constant::create(ov::element::i64, ov::Shape{}, {0}),
+                                               v0::Constant::create(ov::element::i64, ov::Shape{}, {0}));
+    auto unsq_seq =
+        std::make_shared<v0::Unsqueeze>(gather,
+                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}));
+    auto ne_scalar = v0::Constant::create(ov::element::i64, ov::Shape{}, {static_cast<int64_t>(number_of_experts)});
+    auto unsq_ne =
+        std::make_shared<v0::Unsqueeze>(ne_scalar,
+                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}));
+    auto bcast_shape = std::make_shared<v0::Concat>(ov::OutputVector{unsq_seq, unsq_ne}, 0);
+    auto zero = v0::Constant::create(data_precision, ov::Shape{1}, {0});
+    auto bcast = std::make_shared<v3::Broadcast>(zero, bcast_shape);
+    auto scatter = std::make_shared<v12::ScatterElementsUpdate>(
+        bcast,
+        topk_idx,
+        slice,
+        v0::Constant::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1}));
+    auto transp = std::make_shared<v1::Transpose>(
+        scatter,
+        v0::Constant::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{1, 0}));
+    auto one = v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
+    auto reshape_shape = std::make_shared<v0::Concat>(ov::OutputVector{unsq_ne, one, unsq_seq}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(transp, reshape_shape, false);
+    auto unsqueeze_moe = ov::Output<ov::Node>{
+        std::make_shared<v0::Unsqueeze>(reshape,
+                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{3}))};
+    return {unsqueeze_moe, topk_idx, scale_const};
+}
+}  // namespace
+
+// Verifies that the SIGMOID_BIAS routing branch with an extra Multiply(routed_scaling_factor)
+// (as in trinity-mini afmoe) is matched, and that the absorbed scale is re-applied as a
+// post-multiply on the fused MOE output.
+TEST_F(TransformationTestsF, FuseMOE3GemmCompressed_SigmoidBias_RoutedScalingFactor) {
+    constexpr float scale_value = 2.5f;
+    {
+        auto hidden_states = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{32, 2048});
+        auto routers = op::v0::Constant::create(element::f16, Shape{2048, 128}, {0.2f});
+        auto routing_weights = std::make_shared<ov::op::v0::MatMul>(hidden_states, routers);
+
+        auto [unsqueeze_moe, topk_indices, _scale_unused] =
+            build_sigmoid_bias_routing_subgraph_with_scale(routing_weights, element::f16, 128, 8, scale_value);
+
+        auto wei_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
+        auto scale_gate = op::v0::Constant::create(element::f16, Shape{128, 16, 768}, {0.01f});
+        auto zp_gate = op::v0::Constant::create(element::u4, Shape{128, 16, 768}, {0});
+        auto wei_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
+        auto scale_up = op::v0::Constant::create(element::f16, Shape{128, 16, 768}, {0.01f});
+        auto zp_up = op::v0::Constant::create(element::u4, Shape{128, 16, 768, 16}, {0});
+        auto wei_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6, 128}, {1});
+        auto scale_down = op::v0::Constant::create(element::f16, Shape{128, 6, 2048}, {0.01f});
+        auto zp_down = op::v0::Constant::create(element::u4, Shape{128, 6, 2048}, {0});
+
+        ov::intel_gpu::op::MOECompressed::Config config;
+        config.hidden_size = 2048;
+        config.inter_size = 768;
+        config.num_expert = 128;
+        config.group_size = 128;
+        config.top_k = 8;
+        config.out_type = ov::element::f16;
+        auto moe_compressed = std::make_shared<ov::intel_gpu::op::MOECompressed>(
+            ov::OutputVector{hidden_states, unsqueeze_moe, topk_indices,
+                wei_gate, scale_gate, zp_gate, wei_up, scale_up, zp_up, wei_down, scale_down, zp_down}, config);
+        model = std::make_shared<ov::Model>(moe_compressed, ov::ParameterVector{hidden_states});
+    }
+    manager.register_pass<FuseMOE3GemmCompressed>();
+    {
+        auto hidden_states = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{32, 2048});
+        auto routers = op::v0::Constant::create(element::f16, Shape{2048, 128}, {0.2f});
+        auto routing_weights = std::make_shared<ov::op::v0::MatMul>(hidden_states, routers);
+
+        auto wei_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
+        auto scale_gate = op::v0::Constant::create(element::f16, Shape{128, 16, 768}, {0.01f});
+        auto zp_gate = op::v0::Constant::create(element::u4, Shape{128, 16, 768}, {0});
+        auto wei_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
+        auto scale_up = op::v0::Constant::create(element::f16, Shape{128, 16, 768}, {0.01f});
+        auto zp_up = op::v0::Constant::create(element::u4, Shape{128, 16, 768, 16}, {0});
+        auto wei_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6, 128}, {1});
+        auto scale_down = op::v0::Constant::create(element::f16, Shape{128, 6, 2048}, {0.01f});
+        auto zp_down = op::v0::Constant::create(element::u4, Shape{128, 6, 2048}, {0});
+
+        ov::intel_gpu::op::MOECompressed::Config config;
+        config.hidden_size = 2048;
+        config.inter_size = 768;
+        config.num_expert = 128;
+        config.group_size = 128;
+        config.top_k = 8;
+        config.out_type = ov::element::f16;
+        config.routing_type = ov::intel_gpu::op::MOECompressed::RoutingType::SIGMOID_BIAS;
+
+        auto routing_bias = op::v0::Constant::create(element::f16, Shape{1, 128}, {0.1f});
+        auto routing_eps = op::v0::Constant::create(element::f16, Shape{1, 1}, {1e-6f});
+
+        auto fused = std::make_shared<ov::intel_gpu::op::MOE3GemmFusedCompressed>(
+            ov::OutputVector{hidden_states, routing_weights,
+                wei_gate, scale_gate, zp_gate, wei_up, scale_up, zp_up, wei_down, scale_down, zp_down,
+                routing_bias, routing_eps}, config);
+
+        // Post-multiply: scale is f16 already, no Convert needed.
+        auto post_scale = op::v0::Constant::create(element::f16, Shape{1, 1}, {scale_value});
+        auto post_mul = std::make_shared<ov::op::v1::Multiply>(fused, post_scale);
+
+        model_ref = std::make_shared<ov::Model>(post_mul, ov::ParameterVector{hidden_states});
+    }
+}
 
 TEST_F(TransformationTestsF, FuseMOE3GemmSharedExpertCompressedTest) {
     {

--- a/src/plugins/intel_gpu/tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp
@@ -225,7 +225,8 @@ INSTANTIATE_TEST_SUITE_P(smoke,
 
 namespace {
 // Build a sigmoid+bias routing subgraph with an extra Multiply(routed_scaling_factor) inserted
-// between Divide(eps-normalized) and Slice — mirroring trinity-mini afmoe lowering.
+// between Divide(eps-normalized) and Transpose — mirroring the optional<Multiply> location in
+// the matcher (the trinity-mini afmoe `routed_scaling_factor` post-norm scaling).
 // Returns {unsqueeze_moe, topk_idx, scale_const}.
 std::tuple<ov::Output<ov::Node>, ov::Output<ov::Node>, std::shared_ptr<ov::op::v0::Constant>>
 build_sigmoid_bias_routing_subgraph_with_scale(const ov::Output<ov::Node>& routing_logits,
@@ -239,21 +240,14 @@ build_sigmoid_bias_routing_subgraph_with_scale(const ov::Output<ov::Node>& routi
     auto bias = v0::Constant::create(data_precision, ov::Shape{1, number_of_experts}, {0.1f});
     auto sig_add = std::make_shared<v1::Add>(sigmoid, bias);
 
-    auto router_topk =
-        std::make_shared<v11::TopK>(sig_add,
-                                    v0::Constant::create(ov::element::i64, ov::Shape{}, {static_cast<int64_t>(topk)}),
-                                    -1,
-                                    v11::TopK::Mode::MAX,
-                                    v11::TopK::SortType::SORT_VALUES,
-                                    ov::element::i64);
+    auto k = v0::Constant::create(ov::element::i64, ov::Shape{}, {static_cast<int64_t>(topk)});
+    auto router_topk = std::make_shared<v11::TopK>(sig_add, k, -1,
+        v11::TopK::Mode::MAX, v11::TopK::SortType::SORT_VALUES, ov::element::i64);
     auto convert_topk = std::make_shared<v0::Convert>(router_topk->output(1), ov::element::i32);
-    auto topk_idx = ov::Output<ov::Node>{convert_topk};
 
     auto gather_el = std::make_shared<v6::GatherElements>(sigmoid, convert_topk, 1);
-    auto reduce =
-        std::make_shared<v1::ReduceSum>(gather_el,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}),
-                                        true);
+    auto reduce_axis = v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+    auto reduce = std::make_shared<v1::ReduceSum>(gather_el, reduce_axis, true);
     auto eps = v0::Constant::create(data_precision, ov::Shape{1, 1}, {1e-6f});
     auto add_eps = std::make_shared<v1::Add>(reduce, eps);
     auto norm = std::make_shared<v1::Divide>(gather_el, add_eps);
@@ -263,43 +257,11 @@ build_sigmoid_bias_routing_subgraph_with_scale(const ov::Output<ov::Node>& routi
     auto scale_const = v0::Constant::create(data_precision, ov::Shape{1, 1}, {scale_value});
     auto norm_scaled = std::make_shared<v1::Multiply>(norm, scale_const);
 
-    auto sl_stop = std::make_shared<v3::ShapeOf>(convert_topk, ov::element::i32);
-    auto slice = std::make_shared<v8::Slice>(
-        norm_scaled,
-        v0::Constant::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{0, 0}),
-        sl_stop,
-        v0::Constant::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{1, 1}),
-        v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{0, 1}));
-
-    auto shapeof = std::make_shared<v3::ShapeOf>(convert_topk, ov::element::i64);
-    auto gather = std::make_shared<v8::Gather>(shapeof,
-                                               v0::Constant::create(ov::element::i64, ov::Shape{}, {0}),
-                                               v0::Constant::create(ov::element::i64, ov::Shape{}, {0}));
-    auto unsq_seq =
-        std::make_shared<v0::Unsqueeze>(gather,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}));
-    auto ne_scalar = v0::Constant::create(ov::element::i64, ov::Shape{}, {static_cast<int64_t>(number_of_experts)});
-    auto unsq_ne =
-        std::make_shared<v0::Unsqueeze>(ne_scalar,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{0}));
-    auto bcast_shape = std::make_shared<v0::Concat>(ov::OutputVector{unsq_seq, unsq_ne}, 0);
-    auto zero = v0::Constant::create(data_precision, ov::Shape{1}, {0});
-    auto bcast = std::make_shared<v3::Broadcast>(zero, bcast_shape);
-    auto scatter = std::make_shared<v12::ScatterElementsUpdate>(
-        bcast,
-        topk_idx,
-        slice,
-        v0::Constant::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{1}));
-    auto transp = std::make_shared<v1::Transpose>(
-        scatter,
-        v0::Constant::create(ov::element::i32, ov::Shape{2}, std::vector<int32_t>{1, 0}));
-    auto one = v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
-    auto reshape_shape = std::make_shared<v0::Concat>(ov::OutputVector{unsq_ne, one, unsq_seq}, 0);
-    auto reshape = std::make_shared<v1::Reshape>(transp, reshape_shape, false);
-    auto unsqueeze_moe = ov::Output<ov::Node>{
-        std::make_shared<v0::Unsqueeze>(reshape,
-                                        v0::Constant::create(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{3}))};
-    return {unsqueeze_moe, topk_idx, scale_const};
+    auto transpose_order = v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 0});
+    auto transpose = std::make_shared<v1::Transpose>(norm_scaled, transpose_order);
+    auto unsqueeze_const = v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+    auto unsqueeze_moe = ov::Output<ov::Node>{std::make_shared<v0::Unsqueeze>(transpose, unsqueeze_const)};
+    return {unsqueeze_moe, ov::Output<ov::Node>{convert_topk}, scale_const};
 }
 }  // namespace
 
@@ -317,23 +279,25 @@ TEST_F(TransformationTestsF, FuseMOE3GemmCompressed_SigmoidBias_RoutedScalingFac
             build_sigmoid_bias_routing_subgraph_with_scale(routing_weights, element::f16, 128, 8, scale_value);
 
         auto wei_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
-        auto scale_gate = op::v0::Constant::create(element::f16, Shape{128, 16, 768}, {0.01f});
-        auto zp_gate = op::v0::Constant::create(element::u4, Shape{128, 16, 768}, {0});
+        auto scale_gate = op::v0::Constant::create(element::f16, Shape{128, 768, 16}, {0.01f});
+        auto zp_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16}, {0});
         auto wei_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
-        auto scale_up = op::v0::Constant::create(element::f16, Shape{128, 16, 768}, {0.01f});
-        auto zp_up = op::v0::Constant::create(element::u4, Shape{128, 16, 768, 16}, {0});
+        auto scale_up = op::v0::Constant::create(element::f16, Shape{128, 768, 16}, {0.01f});
+        auto zp_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16}, {0});
         auto wei_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6, 128}, {1});
-        auto scale_down = op::v0::Constant::create(element::f16, Shape{128, 6, 2048}, {0.01f});
-        auto zp_down = op::v0::Constant::create(element::u4, Shape{128, 6, 2048}, {0});
+        auto scale_down = op::v0::Constant::create(element::f16, Shape{128, 2048, 6}, {0.01f});
+        auto zp_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6}, {0});
 
-        ov::intel_gpu::op::MOECompressed::Config config;
+        ov::op::internal::MOECompressed::Config config;
+        config.expert_type = ov::op::internal::MOE::Expert_type::GEMM3_SWIGLU;
+        config.has_zp = true;
         config.hidden_size = 2048;
         config.inter_size = 768;
         config.num_expert = 128;
         config.group_size = 128;
         config.top_k = 8;
         config.out_type = ov::element::f16;
-        auto moe_compressed = std::make_shared<ov::intel_gpu::op::MOECompressed>(
+        auto moe_compressed = std::make_shared<ov::op::internal::MOECompressed>(
             ov::OutputVector{hidden_states, unsqueeze_moe, topk_indices,
                 wei_gate, scale_gate, zp_gate, wei_up, scale_up, zp_up, wei_down, scale_down, zp_down}, config);
         model = std::make_shared<ov::Model>(moe_compressed, ov::ParameterVector{hidden_states});
@@ -345,23 +309,25 @@ TEST_F(TransformationTestsF, FuseMOE3GemmCompressed_SigmoidBias_RoutedScalingFac
         auto routing_weights = std::make_shared<ov::op::v0::MatMul>(hidden_states, routers);
 
         auto wei_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
-        auto scale_gate = op::v0::Constant::create(element::f16, Shape{128, 16, 768}, {0.01f});
-        auto zp_gate = op::v0::Constant::create(element::u4, Shape{128, 16, 768}, {0});
+        auto scale_gate = op::v0::Constant::create(element::f16, Shape{128, 768, 16}, {0.01f});
+        auto zp_gate = op::v0::Constant::create(element::u4, Shape{128, 768, 16}, {0});
         auto wei_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16, 128}, {1});
-        auto scale_up = op::v0::Constant::create(element::f16, Shape{128, 16, 768}, {0.01f});
-        auto zp_up = op::v0::Constant::create(element::u4, Shape{128, 16, 768, 16}, {0});
+        auto scale_up = op::v0::Constant::create(element::f16, Shape{128, 768, 16}, {0.01f});
+        auto zp_up = op::v0::Constant::create(element::u4, Shape{128, 768, 16}, {0});
         auto wei_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6, 128}, {1});
-        auto scale_down = op::v0::Constant::create(element::f16, Shape{128, 6, 2048}, {0.01f});
-        auto zp_down = op::v0::Constant::create(element::u4, Shape{128, 6, 2048}, {0});
+        auto scale_down = op::v0::Constant::create(element::f16, Shape{128, 2048, 6}, {0.01f});
+        auto zp_down = op::v0::Constant::create(element::u4, Shape{128, 2048, 6}, {0});
 
-        ov::intel_gpu::op::MOECompressed::Config config;
+        ov::op::internal::MOECompressed::Config config;
+        config.expert_type = ov::op::internal::MOE::Expert_type::GEMM3_SWIGLU;
+        config.has_zp = true;
         config.hidden_size = 2048;
         config.inter_size = 768;
         config.num_expert = 128;
         config.group_size = 128;
         config.top_k = 8;
         config.out_type = ov::element::f16;
-        config.routing_type = ov::intel_gpu::op::MOECompressed::RoutingType::SIGMOID_BIAS;
+        config.routing_type = ov::op::internal::MOECompressed::RoutingType::SIGMOID_BIAS;
 
         auto routing_bias = op::v0::Constant::create(element::f16, Shape{1, 128}, {0.1f});
         auto routing_eps = op::v0::Constant::create(element::f16, Shape{1, 1}, {1e-6f});


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
  - Symptom: Trinity-mini (afmoe) model fails to take the fused MoE path on GPU:
    - The `FuseMOE3GemmCompressed` transformation does not match the routing subgraph, so the model falls back to a non-fused MoE implementation
    - Even if the pattern is forced to match, the OpenCL kernel (`moe_3gemm_swiglu_mlp.cl`) hard-codes `FAKE_GROUP_SIZE = 128` and a `#if SUBGROUP_SIZE == 32` guard, producing wrong/garbage output for weight quantization `group_size = 64` (used by trinity-mini afmoe)
  - Root cause:
    - The afmoe routing branch has an additional `Multiply(routed_scaling_factor)` between `Divide` and `Slice`, which the existing pattern matcher does not allow
    - `FAKE_GROUP_SIZE` and the related inner-loop layout in `moe_3gemm_swiglu_mlp.cl` were tied to hardware sub-group width, not to the actual quantization group size
  - How it was resolved:
    - Transformation — Allow an` optional<Multiply>` between `Divide` and `Slice` in the sigmoid-bias routing pattern. Apply the absorbed scale as a post-op `Multiply` on the fused MoE output. Insert a `Convert` when the scale dtype differs from the fused output dtype
    - Kernel — Compute `FAKE_GROUP_SIZE = min(GATE_UP_GROUP_SIZE, DOWN_GROUP_SIZE, 128)` instead of hard-coding 128, and replace `#if SUBGROUP_SIZE == 32` with `#if ELEMS_PER_LANE == 4` `(ELEMS_PER_LANE = FAKE_GROUP_SIZE / SUBGROUP_SIZE)` at 6 sites so the inner-loop layout follows the actual quantization group size rather than the hardware sub-group width

#### The code and line that caused this issue (if it is not changed directly)
 -  `src/plugins/intel_gpu/src/plugin/transformations/fuse_moe_3gemm_compressed.cpp` — sigmoid-bias routing pattern (`Divide → Slice` chain)
 - `src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl` — `FAKE_GROUP_SIZE` definition and `#if SUBGROUP_SIZE == 32` guards

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
```
# Trinity-mini afmoe, gs=64, sigmoid-bias + routed_scaling_factor
$ OV_GPU_DYNAMIC_QUANTIZATION_THRESHOLD=1 \
  python genai/tools/llm_bench/benchmark.py \
    -d GPU \
    -m <trinity-mini OV_FP16-4BIT_DEFAULT path> \
    -p "What is Perl?" \
    --apply_chat_template --disable_prompt_permutation
```

#### Problematic graph
 - afmoe sigmoid-bias routing has the shape `Sigmoid → Add(bias) → ... → Divide → Multiply(routed_scaling_factor) → Slice → ...` whereas the existing matcher only allowed `Divide → Slice`. The extra `Multiply` blocks the match
 - After the fix, the matcher absorbs the `Multiply`, and the rewritten subgraph becomes `MOE3GemmFusedCompressed → Convert(scale) → Multiply(scale) → ...`(post-op).
<img width="1566" height="207" alt="image" src="https://github.com/user-attachments/assets/cb5cf432-da70-4e8a-b13a-f83125060c26" />

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
   - `tests/unit/transformations/fuse_moe_3gemm_compressed_test.cpp`: new `FuseMOE3GemmCompressed_SigmoidBias_RoutedScalingFactor` test verifying pattern match and post-op Multiply insertion against a reference graph.
   - `tests/unit/test_cases/moe_3gemm_gpu_test.cpp`: extended `random` / `symmetric` / `shared` / `shared_symmetric` instantiations with `group_size = 64` cases (trinity-mini afmoe shape).
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - Reviewed `moe_3gemm_compressed_gpu_random` / `_symmetric_random` / `_shared_random` / `_shared_symmetric_random` — extended in place with the new `group_size = 64` parameter set rather than adding a new suite
   - Reviewed transformation tests for the existing sigmoid-bias routing pattern in `fuse_moe_3gemm_compressed_test.cpp` and added a sibling test that exercises the optional `Multiply(routed_scaling_factor)` branch.
 
### Tickets:
 - [CVS-185030](https://jira.devtools.intel.com/browse/CVS-185030)