### PR TITLE
[NPUW] Fix GQA broadcast shape to match AttentionBroadcast pattern

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_attention.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_attention.cpp
@@ -64,15 +64,23 @@ ov::Output<ov::Node> make_repeat_kv(const ov::Output<ov::Node>& kv,
     if (shared_broadcast_shape.get_node()) {
         broadcast_shape_output = shared_broadcast_shape;
     } else {
+        // 4-input Concat {Gather, any, any, any} required by NPUW's AttentionBroadcast
+        // pattern (sdpa.cpp); a 3-input form only hits the AttentionBroadcast2 fallback.
         auto shape_of_kv = std::make_shared<ov::opset11::ShapeOf>(kv, ov::element::i64);
+        shape_of_kv->set_friendly_name(name + "_shapeof");
         auto gather_axis = ov::opset11::Constant::create(ov::element::i64, ov::Shape{}, {0});
         auto idx_01 = ov::opset11::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
         auto batch_kv_heads = std::make_shared<ov::opset11::Gather>(shape_of_kv, idx_01, gather_axis);
+        batch_kv_heads->set_friendly_name(name + "_batch_kv_heads");
         auto n_rep_const = ov::opset11::Constant::create(ov::element::i64, ov::Shape{1}, {static_cast<int64_t>(n_rep)});
-        auto idx_23 = ov::opset11::Constant::create(ov::element::i64, ov::Shape{2}, {2, 3});
-        auto seq_head_dim = std::make_shared<ov::opset11::Gather>(shape_of_kv, idx_23, gather_axis);
-        auto broadcast_shape =
-            std::make_shared<ov::opset11::Concat>(ov::OutputVector{batch_kv_heads, n_rep_const, seq_head_dim}, 0);
+        auto idx_2 = ov::opset11::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+        auto seq_dim = std::make_shared<ov::opset11::Gather>(shape_of_kv, idx_2, gather_axis);
+        seq_dim->set_friendly_name(name + "_seq_dim");
+        auto head_dim_const =
+            ov::opset11::Constant::create(ov::element::i64, ov::Shape{1}, {static_cast<int64_t>(head_dim)});
+        auto broadcast_shape = std::make_shared<ov::opset11::Concat>(
+            ov::OutputVector{batch_kv_heads, n_rep_const, seq_dim, head_dim_const},
+            0);
         broadcast_shape->set_friendly_name(name + "_broadcast_shape");
         broadcast_shape_output = broadcast_shape->output(0);
     }

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
@@ -89,6 +89,17 @@ inline std::shared_ptr<ov::Model> build_dynamic_attention_llm_model() {
     return model;
 }
 
+inline LLMConfig make_test_model_config_gqa() {
+    auto cfg = make_test_model_config();
+    cfg.num_kv_heads = 2;  // num_heads=4 / num_kv_heads=2 -> n_rep=2
+    return cfg;
+}
+
+inline std::shared_ptr<ov::Model> build_llm_gqa_test_model() {
+    ModelBuilder mb;
+    return mb.build_llm(make_test_model_config_gqa());
+}
+
 inline std::shared_ptr<ov::Model> build_llm_test_model_with_kv_fake_convert(const ov::element::Type fake_convert_type) {
     auto model = build_llm_test_model();
     auto scale = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.0f});

--- a/src/plugins/intel_npu/tests/unit/npuw/pipeline_passes/optimize_value_tensors_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pipeline_passes/optimize_value_tensors_test.cpp
@@ -116,4 +116,20 @@ TEST_F(OptimizeValueTensorsPassTest, AtLeastOneMatMulHasTransposeBSet) {
     EXPECT_TRUE(any_matmul_has_transpose_b(generate.model));
 }
 
+// Same as above but on a GQA model (num_kv_heads < num_heads), which exercises
+// the TransposeValueTensors_GQA pattern instead of the MHA one.
+TEST_F(OptimizeValueTensorsPassTest, AtLeastOneMatMulHasTransposeBSet_GQA) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(ov::test::npuw::build_llm_gqa_test_model(),
+                                                     {{"NPUW_LLM_OPTIMIZE_V_TENSORS", "YES"}},
+                                                     recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& generate = require_sub_model_containing(recorder, "_kv");
+
+    EXPECT_TRUE(any_matmul_has_transpose_b(generate.model));
+}
+
 }  // namespace


### PR DESCRIPTION
The make_repeat_kv broadcast shape Concat used 3 inputs which only matched NPUW's AttentionBroadcast2 pattern. Models should produce a 4-input Concat which is what RegularizeSDPA's AttentionBroadcast pattern matches to precalculate the broadcast shape as a static constant.

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
