### PR TITLE
[TRANSFORMATIONS] Disable MatMul-Multiply fusion in case of increasing activation values

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/matmul_multiply_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/matmul_multiply_fusion.cpp
@@ -26,16 +26,17 @@ namespace v1 = ov::op::v1;
 static std::shared_ptr<Node> fuse_const_to_weights(const std::shared_ptr<Node>& matmul,
                                                    const Output<Node>& weights,
                                                    std::shared_ptr<v0::Constant> mul_const) {
-    auto const_shape = mul_const->get_shape();
+    const auto& const_shape = mul_const->get_shape();
     auto const_rank = static_cast<int64_t>(const_shape.size());
     const auto& weights_shape = weights.get_partial_shape();
     int64_t weights_rank = static_cast<int64_t>(weights_shape.rank().get_length());
+    bool is_dynamic_weights = !ov::is_type<v0::Constant>(weights.get_node());
+    const auto& weights_el_type = weights.get_element_type();
 
-    // Don't fuse amplifying scalar into non-constant weights in f16/bf16 to avoid potential overflow.
-    if (weights.get_element_type().is_real() && weights.get_element_type().size() <= 2 &&
-        !ov::is_type<v0::Constant>(weights.get_node()) && shape_size(const_shape) == 1) {
-        auto values = mul_const->cast_vector<float>();
-        if (!values.empty() && std::abs(values[0]) > 1.0) {
+    // Don't fuse amplifying scalar into non-constant weights in f16/bf16/f8 to avoid potential overflow.
+    if (weights_el_type.is_real() && weights_el_type.size() <= 2 && is_dynamic_weights) {
+        float value;
+        if (op::util::get_constant_value(mul_const, value) && std::abs(value) > 1.0f) {
             return nullptr;
         }
     }
@@ -64,7 +65,7 @@ static std::shared_ptr<Node> fuse_const_to_weights(const std::shared_ptr<Node>& 
     // If weights is not a constant node - disallow Multiply constant
     // that extends weights rank. This is LPT requirement in case where
     // weights are meant to be quantized.
-    if (const_rank > weights_rank && !ov::is_type<v0::Constant>(weights.get_node())) {
+    if (const_rank > weights_rank && is_dynamic_weights) {
         return nullptr;
     }
 

--- a/src/common/transformations/src/transformations/common_optimizations/matmul_multiply_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/matmul_multiply_fusion.cpp
@@ -31,6 +31,15 @@ static std::shared_ptr<Node> fuse_const_to_weights(const std::shared_ptr<Node>& 
     const auto& weights_shape = weights.get_partial_shape();
     int64_t weights_rank = static_cast<int64_t>(weights_shape.rank().get_length());
 
+    // Don't fuse amplifying scalar into non-constant weights in f16/bf16 to avoid potential overflow.
+    if (weights.get_element_type().is_real() && weights.get_element_type().size() <= 2 &&
+        !ov::is_type<v0::Constant>(weights.get_node()) && shape_size(const_shape) == 1) {
+        auto values = mul_const->cast_vector<float>();
+        if (!values.empty() && std::abs(values[0]) > 1.0) {
+            return nullptr;
+        }
+    }
+
     // Fuse if const is a scalar
     if (ov::is_scalar(const_shape)) {
         return std::make_shared<v1::Multiply>(weights, mul_const);

--- a/src/common/transformations/tests/common_optimizations/matmul_multiply_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/matmul_multiply_fusion.cpp
@@ -119,7 +119,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionBlockedForFP16DynamicWeightsAmp
     auto data = std::make_shared<opset8::Parameter>(element::f16, Shape{2, 3});
     auto weights = std::make_shared<opset8::Parameter>(element::f16, Shape{2, 3});
     auto matmul = std::make_shared<opset8::MatMul>(data, weights, true, false);
-    auto mul_const = opset8::Constant::create(element::f16, Shape{1, 1, 1}, {2});
+    auto mul_const = opset8::Constant::create(element::f16, Shape{1, 1}, {2});
     auto mul = std::make_shared<opset8::Multiply>(matmul, mul_const);
     model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data, weights});
 

--- a/src/common/transformations/tests/common_optimizations/matmul_multiply_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/matmul_multiply_fusion.cpp
@@ -115,6 +115,41 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionNonSingleConsumer) {
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
 
+TEST_F(TransformationTestsF, MatMulMultiplyFusionBlockedForFP16DynamicWeightsAmplifyingScale) {
+    auto data = std::make_shared<opset8::Parameter>(element::f16, Shape{2, 3});
+    auto weights = std::make_shared<opset8::Parameter>(element::f16, Shape{2, 3});
+    auto matmul = std::make_shared<opset8::MatMul>(data, weights, true, false);
+    auto mul_const = opset8::Constant::create(element::f16, Shape{1, 1, 1}, {2});
+    auto mul = std::make_shared<opset8::Multiply>(matmul, mul_const);
+    model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data, weights});
+
+    manager.register_pass<ov::pass::MatMulMultiplyFusion>();
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
+TEST_F(TransformationTestsF, MatMulMultiplyFusionAllowedForFP16DynamicWeightsReducingScale) {
+    {
+        auto data = std::make_shared<opset8::Parameter>(element::f16, Shape{2, 3});
+        auto weights = std::make_shared<opset8::Parameter>(element::f16, Shape{2, 3});
+        auto matmul = std::make_shared<opset8::MatMul>(data, weights, false, true);
+        auto mul_const = opset8::Constant::create(element::f16, Shape{1, 1}, {0.5f});
+        auto mul = std::make_shared<opset8::Multiply>(matmul, mul_const);
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data, weights});
+
+        manager.register_pass<ov::pass::MatMulMultiplyFusion>();
+    }
+
+    {
+        auto data = std::make_shared<opset8::Parameter>(element::f16, Shape{2, 3});
+        auto weights = std::make_shared<opset8::Parameter>(element::f16, Shape{2, 3});
+        auto mul_const = opset8::Constant::create(element::f16, Shape{1, 1}, {0.5f});
+        auto mul = std::make_shared<opset8::Multiply>(weights, mul_const);
+        auto matmul = std::make_shared<opset8::MatMul>(data, mul, false, true);
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data, weights});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
 using MatMulMultiplyFusionParams = std::tuple<PartialShape, Shape, bool, Shape, Shape, bool>;
 
 class MatMulMultiplyFusionDynamicShapes : public testing::WithParamInterface<MatMulMultiplyFusionParams>,


### PR DESCRIPTION
### Details:
 - `MatMulMultiplyFusion` transforms `MatMul(A, B) → Multiply(×scalar)` into `MatMul(A, B×scalar)` by absorbing the post-multiply constant into the weights input
 - Scaling dynamic activations with large magnitudes and using fp16 data type lead to overflow in Gemma-4-26B-A4B-it-int4 model (hidden states with values up to ~14000 are multiplied by √1152 ≈ 33.9375 produces values ​​higher than 65504)
 - `MatMul` significantly reduces the amplitude of the values ​​(as intended in the original graph) and when scaling after it, there are no problems with overflow
 - So the transformation was disabled for cases when multiply constant has |value| > 1 and the weights input is a non-constant node with element type fp16 or bf16