### PR TITLE
Disable "opt_gptq" in model hub tests temporarily

### DIFF
--- a/tests/model_hub_tests/pytorch/test_llm.py
+++ b/tests/model_hub_tests/pytorch/test_llm.py
@@ -596,7 +596,7 @@ class TestLLMModel(TestTorchConvertModel):
         ]
         if platform.machine() not in ['arm', 'armv7l', 'aarch64', 'arm64', 'ARM64']:
             models.extend([
-                ("opt_gptq", "katuni4ka/opt-125m-gptq"),
+                #("opt_gptq", "katuni4ka/opt-125m-gptq"),
                 ("llama", "TinyLlama/TinyLlama-1.1B-Chat-v1.0"),
                 ("llama_awq", "casperhansen/tinyllama-1b-awq"),
             ])

--- a/tests/model_hub_tests/pytorch/test_llm.py
+++ b/tests/model_hub_tests/pytorch/test_llm.py
@@ -658,7 +658,7 @@ class TestLLMModel(TestTorchConvertModel):
             return []
         return [
             ("llama_awq", "casperhansen/tinyllama-1b-awq"),
-            ("opt_gptq", "katuni4ka/opt-125m-gptq"),
+            #("opt_gptq", "katuni4ka/opt-125m-gptq"),
         ]
 
     @pytest.mark.parametrize("type,name", get_supported_export_precommit_models())


### PR DESCRIPTION
There's ongoing failure in Model Hub Tests, which blocks many non-related pull requests. Let's disable the test temporarily