### PR TITLE
[GPU][TESTS] Fix race condition in GpuCacheDirWithDotsParamTest

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/serialize.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/serialize.cpp
@@ -73,11 +73,7 @@ protected:
     std::string cacheDir;
 
     void SetUp() override {
-        std::stringstream ss;
-        ss << std::hex << std::hash<std::string>{}(std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()));
-
-        // Base (no trailing slash first)
-        cacheDir = ss.str() + GetParam();
+        cacheDir = ov::test::utils::generateTestFilePrefix() + GetParam();
 
         // Clean previous
         ov::test::utils::removeFilesWithExt(cacheDir, "blob");


### PR DESCRIPTION
### Details:
  - Fix race condition in `GpuCacheDirWithDotsParamTest` that causes intermittent `[GPU] Failed to write 4 bytes to stream! Wrote 0` in CI parallel execution.

### Description of the issue (symptom, root-cause, how it was resolved)
  - **Symptom**: `CacheDirDotVariants/GpuCacheDirWithDotsParamTest.smoke_PopulateAndReuseCache/1` fails intermittently in CI with:
    ```
    Check 'written_size == size' failed at binary_buffer.hpp:27:
    [GPU] Failed to write 4 bytes to stream! Wrote 0
    ```
  - **Root Cause**:
    - The test constructs `cacheDir` from `std::hash<std::string>{}(test_name) + GetParam()`, which is fully deterministic — every process resolves to the same on-disk path (`7815f5b1e52eaecf/test_encoder/test_encoder.encrypted/`).
    - When gtest-parallel dispatches multiple workers concurrently, one process's `removeDir(cacheDir)` in `SetUp()`/`TearDown()` deletes the `.blob` file while another process is mid-write via `write_cache_entry()` → `export_model()` → `sputn()`.
    - On Docker overlay2 (CI), the unlink invalidates the open fd's writable backing, causing `sputn()` to return 0.

  - **Resolution**:
    - Replace the deterministic hash prefix with `ov::test::utils::generateTestFilePrefix()`, which incorporates thread ID and timestamp to guarantee a unique cache directory per process invocation.

#### The code and line that caused this issue (if it is not changed directly)
https://github.com/openvinotoolkit/openvino/blob/ea2a3c905f17df89af7b5f02f32893606d76529e/src/plugins/intel_gpu/tests/functional/subgraph_tests/serialize.cpp#L75-L94

#### Reproduction step and snapshot (if applicable)
```bash
# Single process — always passes:
ov_gpu_func_tests --gtest_filter="CacheDirDotVariants/GpuCacheDirWithDotsParamTest.smoke_PopulateAndReuseCache/1"

# 30 parallel processes — ~30% failure rate:
for i in $(seq 1 30); do
  (ov_gpu_func_tests --gtest_filter="...smoke_PopulateAndReuseCache/1" --gtest_repeat=3 > run_$i.log 2>&1) &
done; wait
grep -l FAILED run_*.log | wc -l  # → 9/30 failed
```

#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
   - No new test needed — the existing test now correctly uses a unique path and will no longer race.
 - [v] Did you review existing test that can be extended to cover this scenario? The fix is within the existing test itself.

### Tickets:
  - *CVS-182616*