### PR TITLE
[GPU] Disable in-place crop when consumer is MVN requiring alignment

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -26,6 +26,7 @@
 #include "lstm_seq_inst.h"
 #include "border_inst.h"
 #include "lora_inst.h"
+#include "mvn_inst.h"
 
 #include "pass_manager.h"
 #include "program_helpers.h"
@@ -544,6 +545,13 @@ bool crop_in_place_optimization::match(const program_node& node,
             return false;
         if (user->is_type<lora>()) {
             return false;
+        }
+        // MVN canonicalizes the input shape and reads with contiguous pitches; a strided
+        // sub-view from in-place crop would be read incorrectly.
+        if (user->is_type<mvn>()) {
+            const auto& mvn_prim = user->as<mvn>().get_primitive();
+            if (mvn_prim->requires_alignment(crop_layout.get_partial_shape()))
+                return false;
         }
     }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/mvn_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/mvn_gpu_test.cpp
@@ -8,6 +8,7 @@
 #include <intel_gpu/primitives/input_layout.hpp>
 #include <intel_gpu/primitives/mvn.hpp>
 #include <intel_gpu/primitives/reorder.hpp>
+#include <intel_gpu/primitives/crop.hpp>
 #include <intel_gpu/runtime/debug_configuration.hpp>
 
 #include <iostream>
@@ -1125,3 +1126,81 @@ TEST(mvn_bfyx_opt_fused_ops, basic_fused) {
 }
 
 #endif
+
+// In-place crop feeding an MVN that requires alignment must materialize a contiguous
+// buffer: MVN canonicalizes the shape and reads with contiguous pitches, so a strided
+// sub-view from in-place crop would be read incorrectly (only row 0 was correct).
+TEST(mvn_gpu_test, crop_then_mvn_last_axis_contiguous_input) {
+    auto& engine = get_test_engine();
+
+    // [3,4,5,64] -> crop -> [1,2,2,32] -> MVN(axis=-1). tensor ctor: (b, f, x, y).
+    const tensor src_size{3, 4, /*x=*/64, /*y=*/5};
+    const tensor crop_size{1, 2, /*x=*/32, /*y=*/2};
+    const tensor crop_offset{0, 0, 0, 0};
+
+    auto input = engine.allocate_memory({data_types::f32, format::bfyx, src_size});
+
+    tests::random_generator rg(GET_SUITE_NAME);
+    auto input_vec = rg.generate_random_1d<float>(input->count(), -1.f, 1.f);
+    set_values(input, input_vec);
+
+    topology topo;
+    topo.add(input_layout("input", input->get_layout()));
+    topo.add(crop("crop", input_info("input"), crop_size, crop_offset));
+    topo.add(mvn("mvn", input_info("crop"), /*normalize_variance=*/true,
+                 /*epsilon=*/0.f, /*eps_inside_sqrt=*/false,
+                 /*reduction_axes=*/std::vector<int64_t>{3}));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    network network(engine, topo, config);
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    auto output = outputs.at("mvn").get_memory();
+
+    const int64_t B = crop_size.batch[0];
+    const int64_t F = crop_size.feature[0];
+    const int64_t Y = crop_size.spatial[1];
+    const int64_t X = crop_size.spatial[0];
+    std::vector<float> reference(B * F * Y * X);
+
+    const int64_t SF = src_size.feature[0];
+    const int64_t SY = src_size.spatial[1];
+    const int64_t SX = src_size.spatial[0];
+
+    for (int64_t b = 0; b < B; ++b) {
+        for (int64_t f = 0; f < F; ++f) {
+            for (int64_t y = 0; y < Y; ++y) {
+                float mean = 0.f;
+                for (int64_t x = 0; x < X; ++x) {
+                    int64_t src_idx = ((b * SF + f) * SY + y) * SX + x;
+                    mean += input_vec[src_idx];
+                }
+                mean /= static_cast<float>(X);
+                float var = 0.f;
+                for (int64_t x = 0; x < X; ++x) {
+                    int64_t src_idx = ((b * SF + f) * SY + y) * SX + x;
+                    float v = input_vec[src_idx] - mean;
+                    var += v * v;
+                }
+                var /= static_cast<float>(X);
+                float inv_std = 1.f / std::sqrt(var);
+                for (int64_t x = 0; x < X; ++x) {
+                    int64_t src_idx = ((b * SF + f) * SY + y) * SX + x;
+                    int64_t dst_idx = ((b * F + f) * Y + y) * X + x;
+                    reference[dst_idx] = (input_vec[src_idx] - mean) * inv_std;
+                }
+            }
+        }
+    }
+
+    cldnn::mem_lock<float, mem_lock_type::read> out_ptr(output, get_test_stream());
+    ASSERT_EQ(out_ptr.size(), reference.size());
+    const float tolerance = 1e-4f;
+    for (size_t i = 0; i < reference.size(); ++i) {
+        ASSERT_NEAR(out_ptr[i], reference[i], tolerance) << " mismatch at index " << i;
+    }
+}


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - Symptom: GPU inference produced incorrect results for an IR pattern `Parameter → Slice → MVN(axis=-1)`. Compared to CPU, the max absolute diff was ~2.97 (FP32). Inspecting the MVN output buffer showed that only the first row was correct; rows 1..N contained garbage (data read from outside the intended sub-view).
 - Root cause: Two GPU graph optimizations have conflicting assumptions about the MVN input buffer layout:
   - `crop_in_place_optimization` rewrites the crop (Slice) so that its output is a **strided sub-view** of the parent buffer (e.g. `BATCH_PITCH=1280` for `[1,2,2,32]` cropped from `[3,4,5,64]`).
   - The MVN OCL impl's `static_canonicalize_shapes` flattens the input shape (e.g. `[1,2,2,32] → [4,1,1,32]`) and the kernel reads with pitches computed for that contiguous flattened shape (`BATCH_PITCH=32`). The two pitch sets disagree, so only row 0 lands on valid memory.
 - Fix: In `crop_in_place_optimization::match()`, skip the in-place optimization when any consumer is an `mvn` whose `requires_alignment(crop_layout.get_partial_shape())` is `true`. The crop then materializes a contiguous output buffer that matches MVN's pitch assumptions. After the fix, max diff drops to ~1.4e-3 (FP16 noise level).

#### The code and line that caused this issue (if it is not changed directly)
 - `src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp` — `mvn_impl::static_canonicalize_shapes()` flattens dims without accounting for the actual buffer strides of the input.
 - `src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp` — `crop_in_place_optimization::match()` did not exclude MVN consumers that require alignment.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - Unit test: `./ov_gpu_unit_tests --gtest_filter=*crop_then_mvn_last_axis_contiguous_input*`
   - Without the fix: `FAIL` (mismatch starting at index 0)
   - With the fix: `PASS`

#### Problematic graph
```
Parameter [3,4,5,64]
       │
       ▼
   Slice  ──(in-place, strided sub-view: BATCH_PITCH=1280)──▶ [1,2,2,32]
       │
       ▼
     MVN(axes=[-1])  ──(canonicalized to [4,1,1,32], expects BATCH_PITCH=32)
       │
       ▼
    Result   ◀── only row 0 correct; rows 1..3 read OOB memory
```

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
   - `mvn_gpu_test.crop_then_mvn_last_axis_contiguous_input` (fails on master, passes with fix).
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - Reviewed `mvn_random_test*` and crop in-place tests in `crop_gpu_test.cpp`; none combine an in-place crop with an alignment-requiring MVN consumer, so a new dedicated test was added.

### Tickets:
 - [CVS-185315](https://jira.devtools.intel.com/browse/CVS-185315)
