### PR TITLE
[GPU] Prevent converting MatMul to FC when rank_a less than rank_b

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -89,6 +89,15 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         auto rank_a = shape_a.rank().get_length();
         auto rank_b = shape_b.rank().get_length();
 
+        // Reject conversion when rank_a < rank_b on immad-capable devices.
+        // oneDNN FullyConnected expects input rank >= weights rank for proper primitive descriptor creation.
+        // When rank_a < rank_b (e.g., activation[1,4096] x weights[1,3,4096,1]),
+        // the oneDNN FC implementation cannot properly handle the rank mismatch, leading to issues in oneDNN primitive creation.
+        // Fallback to MatMul/GEMM is more appropriate for such cases.
+        if (supports_immad && rank_a < rank_b) {
+            return false;
+        }
+
         /*
          *  get_aligned_shapes function align two input shapes to have the same size and
          *  the same batch dimensions (last two dimensions are not comparable).

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -89,12 +89,10 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         auto rank_a = shape_a.rank().get_length();
         auto rank_b = shape_b.rank().get_length();
 
-        // Reject conversion when rank_a < rank_b on immad-capable devices.
-        // oneDNN FullyConnected expects input rank >= weights rank for proper primitive descriptor creation.
         // When rank_a < rank_b (e.g., activation[1,4096] x weights[1,3,4096,1]),
-        // the oneDNN FC implementation cannot properly handle the rank mismatch, leading to issues in oneDNN primitive creation.
+        // FC implementation cannot properly handle the rank mismatch.
         // Fallback to MatMul/GEMM is more appropriate for such cases.
-        if (supports_immad && rank_a < rank_b) {
+        if (rank_a < rank_b) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -89,9 +89,8 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         auto rank_a = shape_a.rank().get_length();
         auto rank_b = shape_b.rank().get_length();
 
-        // When rank_a < rank_b (e.g., activation[1,4096] x weights[1,3,4096,1]),
-        // FC implementation cannot properly handle the rank mismatch.
-        // Fallback to MatMul/GEMM is more appropriate for such cases.
+        // The fully_connected primitive does not support this situation (rank_a < rank_b).
+        // So, we need to choose GEMM instead of fully_connected.
         if (rank_a < rank_b) {
             return false;
         }

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -728,3 +728,41 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedExceptionTest) {
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul1, matmul2}, ov::ParameterVector{input1});
     }
 }
+
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_rank_a_less_than_rank_b) {
+    {
+        auto activation = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 128});
+        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 256, 128}, {1.0f});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(activation, weights, false, true);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{activation});
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true
+    }
+    {
+        // Expected: MatMul remains unchanged (rank_a=2 < rank_b=4 rejected)
+        auto activation = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 128});
+        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 256, 128}, {1.0f});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(activation, weights, false, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{activation});
+    }
+}
+
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_rank_2_vs_3) {
+    {
+        auto activation = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 128});
+        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 256, 128}, {1.0f});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(activation, weights, false, true);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{activation});
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true
+    }
+    {
+        // Expected: MatMul remains unchanged (rank_a=2 < rank_b=3 rejected)
+        auto activation = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 128});
+        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 256, 128}, {1.0f});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(activation, weights, false, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{activation});
+    }
+}

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -732,35 +732,16 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedExceptionTest) {
 TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_rank_a_less_than_rank_b) {
     {
         auto activation = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 128});
-        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 256, 128}, {1.0f});
+        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 256, 128}, {1.0f});
         auto matmul = std::make_shared<ov::opset1::MatMul>(activation, weights, false, true);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{activation});
         manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true
     }
     {
-        // Expected: MatMul remains unchanged (rank_a=2 < rank_b=4 rejected)
+        // Expected: MatMul remains unchanged (rank_a=2 < rank_b=4 rejected by rank check)
         auto activation = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 128});
-        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 256, 128}, {1.0f});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(activation, weights, false, true);
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{activation});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_rank_2_vs_3) {
-    {
-        auto activation = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 128});
-        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 256, 128}, {1.0f});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(activation, weights, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{activation});
-        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true
-    }
-    {
-        // Expected: MatMul remains unchanged (rank_a=2 < rank_b=3 rejected)
-        auto activation = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 128});
-        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 256, 128}, {1.0f});
+        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 256, 128}, {1.0f});
         auto matmul = std::make_shared<ov::opset1::MatMul>(activation, weights, false, true);
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{activation});


### PR DESCRIPTION
## Issue
 - Crashed with `std::bad_alloc` during graph compilation on immad-capable devices when MatMul is converted to FullyConnected.
 - The error occurs with MatMul having `activation[4096,4096] x weights[1,3,4096,1]`.
```cpp
[ ERROR ] Exception from src/inference/src/cpp/core.cpp:117:
Exception from src/inference/src/dev/plugin.cpp:54:
Check 'false' failed at src/plugins/intel_gpu/src/plugin/program_builder.cpp:165:
[GPU] ProgramBuilder build failed!
Check 'shape_type == shape_types::dynamic_shape || node->selected_impl != nullptr' failed at src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp:51:
[GPU] Failed to select implementation for
name:fullyconnected:MatMul_1944
type: fully_connected
original_type: FullyConnected std::bad_alloc
``` 

## Root cause
- oneDNN FullyConnected impl expects `input_rank >= weights_rank`.
- When `input_rank(2) < weights_rank(4)`, the primitive descriptor creation fails because it cannot properly handle the rank mismatch.

## Graphs
<img width="912" height="770" alt="image" src="https://github.com/user-attachments/assets/d6a430eb-5d34-4022-b103-e5e6576f09bc" />

## Solution
- Reject MatMul to FC conversion when `input_rank < weights_rank`.
- The transformation now returns false early for such cases, allowing fallback to MatMul/GEMM which handles these rank configurations correctly.

## Tickets
 - CVS-185095