### PR TITLE
[GPU] Disable oneDNN LSTMSequence

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -198,6 +198,7 @@ void ExecutionConfig::apply_model_specific_options(const IRemoteContext* context
     apply_rt_info(context, get_rt_info(model), is_LLM, is_paged_attention_model, has_lora);
 
     const auto& ops = model.get_ops();
+    const auto& info = dynamic_cast<const RemoteContextImpl*>(context)->get_engine().get_device_info();
 
     std::function<void(std::shared_ptr<Node>)> process_op = [&, this](std::shared_ptr<Node> op) {
         if (requires_new_shape_infer(op)) {
@@ -213,7 +214,7 @@ void ExecutionConfig::apply_model_specific_options(const IRemoteContext* context
         // Allow using onednn for models with LSTMSequence op as it's much more performant than existing ocl impl
         // Onednn only support on Gen12 (XeLP) and later architectures
         if ((ov::is_type<ov::op::v5::LSTMSequence>(op) || ov::is_type<ov::op::v5::GRUSequence>(op)) &&
-            info.arch >= gpu_arch::xe_lp) {
+            info.arch >= cldnn::gpu_arch::xe_lp) {
             m_use_onednn = true;
         }
 
@@ -242,7 +243,6 @@ void ExecutionConfig::apply_model_specific_options(const IRemoteContext* context
         process_op(op);
     }
 
-    const auto& info = dynamic_cast<const RemoteContextImpl*>(context)->get_engine().get_device_info();
     auto is_auxiliary_kv_update_model = [](const ov::Model& model) {
         if (model.get_rt_info().count("auxiliary_kv_update_model")) {
             return model.get_rt_info<ov::Any>("auxiliary_kv_update_model").template as<bool>();

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -211,7 +211,9 @@ void ExecutionConfig::apply_model_specific_options(const IRemoteContext* context
         }
 
         // Allow using onednn for models with LSTMSequence op as it's much more performant than existing ocl impl
-        if (ov::is_type<ov::op::v5::LSTMSequence>(op) || ov::is_type<ov::op::v5::GRUSequence>(op)) {
+        // Onednn only support on Gen12 (XeLP) and later architectures
+        if ((ov::is_type<ov::op::v5::LSTMSequence>(op) || ov::is_type<ov::op::v5::GRUSequence>(op)) &&
+            info.arch >= gpu_arch::xe_lp) {
             m_use_onednn = true;
         }
 


### PR DESCRIPTION
Onednn only support on Gen12 (XeLP) and later architectures.

### Tickets:
 - *CVS-186310*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
