### PR TITLE
[EXPERIMENT][WIP] [CPU] Fix Select shape inference for hybrid SSM+attention models

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/simplify_select_broadcast.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/simplify_select_broadcast.cpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "simplify_select_broadcast.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "openvino/core/node.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+namespace ov::intel_cpu::pass {
+
+namespace {
+
+/**
+ * Returns true if the node is a scalar constant (rank 0 or single-element rank-1 with shape {}).
+ */
+bool is_scalar_constant(const std::shared_ptr<ov::Node>& node) {
+    auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);
+    if (!constant) {
+        return false;
+    }
+    return constant->get_shape().empty();  // rank-0 == scalar
+}
+
+/**
+ * Attempts to simplify input `broadcast_idx` of the Select node.
+ * If the input at `broadcast_idx` is a Broadcast of a scalar constant, replace it with
+ * that scalar constant and return true.
+ */
+bool try_simplify_input(ov::op::v1::Select* select_node,
+                        std::size_t broadcast_idx,
+                        ov::pass::pattern::Matcher& m) {
+    auto& pattern_value_map = m.get_pattern_value_map();
+    (void)pattern_value_map;
+
+    const auto broadcast_input = select_node->input_value(broadcast_idx);
+    auto broadcast = ov::as_type_ptr<ov::op::v3::Broadcast>(broadcast_input.get_node_shared_ptr());
+    if (!broadcast) {
+        return false;
+    }
+
+    // The Broadcast must be consumed only by this Select.
+    if (broadcast->get_output_target_inputs(0).size() != 1) {
+        return false;
+    }
+
+    // The data input to Broadcast (index 0) must be a scalar constant.
+    const auto broadcast_data = broadcast->input_value(0).get_node_shared_ptr();
+    if (!is_scalar_constant(broadcast_data)) {
+        return false;
+    }
+
+    // Replace the Broadcast with the scalar constant.
+    copy_runtime_info(broadcast, select_node->shared_from_this());
+    select_node->input(broadcast_idx).replace_source_output(broadcast->input_value(0));
+
+    return true;
+}
+
+}  // namespace
+
+SimplifySelectBroadcast::SimplifySelectBroadcast() {
+    MATCHER_SCOPE(SimplifySelectBroadcast);
+
+    // Match any Select node with NUMPY auto-broadcast.
+    auto select_pattern = ov::pass::pattern::wrap_type<ov::op::v1::Select>();
+
+    ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_value_map = m.get_pattern_value_map();
+        auto select_node_ptr = ov::as_type_ptr<ov::op::v1::Select>(m.get_match_root());
+        if (!select_node_ptr) {
+            return false;
+        }
+
+        // Only handle NUMPY auto-broadcast (default for aten::where exports).
+        if (select_node_ptr->get_auto_broadcast() != ov::op::AutoBroadcastType::NUMPY) {
+            return false;
+        }
+
+        bool changed = false;
+
+        // Check input 1 (on_true) and input 2 (on_false) — both are data inputs.
+        // Input 0 is the condition boolean mask; skip it.
+        for (std::size_t idx : {std::size_t{1}, std::size_t{2}}) {
+            changed |= try_simplify_input(select_node_ptr.get(), idx, m);
+        }
+
+        return changed;
+    };
+
+    auto matcher = std::make_shared<ov::pass::pattern::Matcher>(select_pattern, matcher_name);
+    register_matcher(matcher, callback);
+}
+
+}  // namespace ov::intel_cpu::pass

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/simplify_select_broadcast.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/simplify_select_broadcast.hpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+
+namespace ov::intel_cpu::pass {
+
+/**
+ * @ingroup ov_transformation_cpu_api
+ * @brief SimplifySelectBroadcast replaces Broadcast(scalar_const, dynamic_shape) with
+ * the scalar_const directly when it appears as an input to a Select operation.
+ *
+ * This transformation handles a pattern found in hybrid SSM+attention models (e.g., Qwen3.5/
+ * qwen3_5_text architecture) where the aten::where/Select operation receives a Broadcast of
+ * a constant scalar whose shape is derived from the SSM layer output. This shape may be
+ * incompatible with the Select condition tensor at runtime (e.g., during prefill when the
+ * SSM sequence length differs from the full-attention KV cache length), causing a shape
+ * inference failure in the EltwiseShapeInfer:
+ *   "Eltwise shape infer input shapes dim index: 2 mismatch"
+ *
+ * Pattern:
+ *   Select(condition, on_true, Broadcast(scalar_const, shape_from_somewhere))
+ *   OR
+ *   Select(condition, Broadcast(scalar_const, shape_from_somewhere), on_false)
+ *
+ * Replacement:
+ *   Select(condition, on_true, scalar_const)
+ *   OR
+ *   Select(condition, scalar_const, on_false)
+ *
+ * Semantic correctness: Broadcast(scalar_const, shape) fills a tensor with the constant value.
+ * Since Select with NUMPY broadcast already broadcasts scalar inputs to the output shape,
+ * replacing Broadcast(scalar_const, shape) with scalar_const produces identical values. The
+ * output shape is then determined by the broadcast of {condition, on_true/on_false (scalar)},
+ * which avoids the shape incompatibility.
+ *
+ * Preconditions:
+ *  1. The Select uses NUMPY auto-broadcast.
+ *  2. One of the Select data inputs (on_true or on_false, i.e., input index 1 or 2) is a
+ *     Broadcast node whose first input (the data being broadcast) is a scalar constant.
+ *  3. The Broadcast is consumed only by the Select (consumers_count == 1).
+ */
+class SimplifySelectBroadcast : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("SimplifySelectBroadcast");
+    SimplifySelectBroadcast();
+};
+
+}  // namespace ov::intel_cpu::pass

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -145,6 +145,7 @@
 #include "transformations/cpu_opset/common/pass/insert_convert_after_extension.hpp"
 #include "transformations/cpu_opset/common/pass/ngram_fusion.hpp"
 #include "transformations/cpu_opset/common/pass/permute_slice_n_interpolation.hpp"
+#include "transformations/cpu_opset/common/pass/simplify_select_broadcast.hpp"
 #include "transformations/cpu_opset/common/pass/stateful_sdpa_fusion.hpp"
 #include "transformations/cpu_opset/common/pass/swap_convert_transpose.hpp"
 #include "transformations/cpu_opset/convert_to_cpu_specific_opset.hpp"
@@ -646,6 +647,11 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::ConvertNMS4ToNMS9);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::ConvertNMS5ToNMS9);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::TransposeMatMul);
+    // Simplify Select(cond, on_true, Broadcast(scalar_const, shape)) to
+    // Select(cond, on_true, scalar_const) to avoid shape-inference failures in hybrid
+    // SSM+attention architectures (e.g. qwen3_5_text) where the Broadcast shape is
+    // derived from the SSM output and may be incompatible with the attention KV length.
+    CPU_REGISTER_PASS_COMMON(manager, ov::intel_cpu::pass::SimplifySelectBroadcast);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::ConstantFolding);
     CPU_REGISTER_PASS_ARM64(manager, ov::pass::HardSigmoidDecomposition);
 

--- a/src/plugins/intel_cpu/tests/unit/transformations/simplify_select_broadcast_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/simplify_select_broadcast_test.cpp
@@ -1,0 +1,214 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "transformations/cpu_opset/common/pass/simplify_select_broadcast.hpp"
+#include "transformations/init_node_info.hpp"
+
+using namespace testing;
+
+/**
+ * Tests for SimplifySelectBroadcast transformation.
+ *
+ * Pattern being simplified:
+ *   Select(condition, on_true_scalar_const, Broadcast(on_false_scalar_const, target_shape))
+ *   → Select(condition, on_true_scalar_const, on_false_scalar_const)
+ *
+ * Motivation: In hybrid SSM+attention models (e.g. qwen3_5_text), the attention mask is
+ * constructed as:
+ *   Select(bool_mask, -65504, Broadcast(0.0, [B,1,Q,Q]))
+ * where Q comes from SSM output length, but bool_mask has shape [B,1,kv_len,Q].
+ * When kv_len ≠ Q and both > 1, EltwiseShapeInfer raises a dim-mismatch error.
+ */
+class SimplifySelectBroadcastTest : public TransformationTestsF {
+public:
+    SimplifySelectBroadcastTest() : TransformationTestsF() {
+        comparator.enable(FunctionsComparator::CmpValues::NAMES);
+    }
+};
+
+// ---------------------------------------------------------
+// Test 1: Basic case — on_false is a Broadcast of a scalar constant.
+//         Select(cond, scalar_A, Broadcast(scalar_B, shape)) → Select(cond, scalar_A, scalar_B)
+// ---------------------------------------------------------
+TEST_F(SimplifySelectBroadcastTest, OnFalseBroadcastScalar) {
+    const ov::element::Type et = ov::element::f32;
+    const ov::Shape cond_shape{1, 1, 4, 4};
+
+    {
+        // Input graph
+        auto cond = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, cond_shape);
+        auto on_true = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{-65504.0f});
+        auto on_false_src = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{0.0f});
+
+        // Broadcast(0.0, shape_of_cond)
+        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(cond);
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
+            on_false_src,
+            shape_of,
+            ov::op::BroadcastType::NUMPY);
+
+        auto select = std::make_shared<ov::op::v1::Select>(cond, on_true, broadcast);
+        select->set_friendly_name("Select");
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{select}, ov::ParameterVector{cond});
+        manager.register_pass<ov::intel_cpu::pass::SimplifySelectBroadcast>();
+    }
+    {
+        // Expected graph after transformation
+        auto cond = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, cond_shape);
+        auto on_true = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{-65504.0f});
+        auto on_false_src = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{0.0f});
+
+        auto select = std::make_shared<ov::op::v1::Select>(cond, on_true, on_false_src);
+        select->set_friendly_name("Select");
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{select}, ov::ParameterVector{cond});
+    }
+}
+
+// ---------------------------------------------------------
+// Test 2: on_true is a Broadcast of a scalar constant.
+//         Select(cond, Broadcast(scalar_A, shape), scalar_B) → Select(cond, scalar_A, scalar_B)
+// ---------------------------------------------------------
+TEST_F(SimplifySelectBroadcastTest, OnTrueBroadcastScalar) {
+    const ov::element::Type et = ov::element::f32;
+    const ov::Shape cond_shape{2, 1, 3, 3};
+
+    {
+        auto cond = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, cond_shape);
+        auto on_true_src = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{1.0f});
+        auto on_false = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{0.0f});
+
+        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(cond);
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
+            on_true_src,
+            shape_of,
+            ov::op::BroadcastType::NUMPY);
+
+        auto select = std::make_shared<ov::op::v1::Select>(cond, broadcast, on_false);
+        select->set_friendly_name("Select");
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{select}, ov::ParameterVector{cond});
+        manager.register_pass<ov::intel_cpu::pass::SimplifySelectBroadcast>();
+    }
+    {
+        auto cond = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, cond_shape);
+        auto on_true_src = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{1.0f});
+        auto on_false = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{0.0f});
+
+        auto select = std::make_shared<ov::op::v1::Select>(cond, on_true_src, on_false);
+        select->set_friendly_name("Select");
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{select}, ov::ParameterVector{cond});
+    }
+}
+
+// ---------------------------------------------------------
+// Test 3: Negative — Broadcast of a non-scalar constant should NOT be simplified.
+// ---------------------------------------------------------
+TEST_F(SimplifySelectBroadcastTest, NoSimplifyNonScalarBroadcast) {
+    const ov::element::Type et = ov::element::f32;
+    const ov::Shape cond_shape{1, 1, 4, 4};
+
+    {
+        auto cond = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, cond_shape);
+        auto on_true = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{-65504.0f});
+
+        // Non-scalar broadcast source: shape {4}
+        auto on_false_src = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{4}, std::vector<float>{0.f, 1.f, 2.f, 3.f});
+        auto target_shape = std::make_shared<ov::op::v0::Constant>(ov::element::i64,
+                                                                    ov::Shape{4},
+                                                                    std::vector<int64_t>{1, 1, 4, 4});
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
+            on_false_src,
+            target_shape,
+            ov::op::BroadcastType::NUMPY);
+
+        auto select = std::make_shared<ov::op::v1::Select>(cond, on_true, broadcast);
+        select->set_friendly_name("Select");
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{select}, ov::ParameterVector{cond});
+        manager.register_pass<ov::intel_cpu::pass::SimplifySelectBroadcast>();
+    }
+    {
+        // Reference is unchanged (no simplification expected).
+        auto cond = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, cond_shape);
+        auto on_true = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{-65504.0f});
+
+        auto on_false_src = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{4}, std::vector<float>{0.f, 1.f, 2.f, 3.f});
+        auto target_shape = std::make_shared<ov::op::v0::Constant>(ov::element::i64,
+                                                                    ov::Shape{4},
+                                                                    std::vector<int64_t>{1, 1, 4, 4});
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
+            on_false_src,
+            target_shape,
+            ov::op::BroadcastType::NUMPY);
+
+        auto select = std::make_shared<ov::op::v1::Select>(cond, on_true, broadcast);
+        select->set_friendly_name("Select");
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{select}, ov::ParameterVector{cond});
+    }
+}
+
+// ---------------------------------------------------------
+// Test 4: Negative — Broadcast output with multiple consumers: do NOT simplify.
+// ---------------------------------------------------------
+TEST_F(SimplifySelectBroadcastTest, NoSimplifyMultipleConsumers) {
+    const ov::element::Type et = ov::element::f32;
+    const ov::Shape cond_shape{1, 1, 4, 4};
+
+    {
+        auto cond = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, cond_shape);
+        auto on_true = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{-65504.0f});
+        auto on_false_src = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{0.0f});
+
+        auto target_shape = std::make_shared<ov::op::v0::Constant>(ov::element::i64,
+                                                                    ov::Shape{4},
+                                                                    std::vector<int64_t>{1, 1, 4, 4});
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
+            on_false_src,
+            target_shape,
+            ov::op::BroadcastType::NUMPY);
+
+        auto select = std::make_shared<ov::op::v1::Select>(cond, on_true, broadcast);
+        select->set_friendly_name("Select");
+
+        // Second consumer of broadcast — prevents simplification.
+        auto second_consumer = std::make_shared<ov::op::v1::Select>(cond, broadcast, on_true);
+        second_consumer->set_friendly_name("Select2");
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{select, second_consumer}, ov::ParameterVector{cond});
+        manager.register_pass<ov::intel_cpu::pass::SimplifySelectBroadcast>();
+    }
+    {
+        auto cond = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, cond_shape);
+        auto on_true = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{-65504.0f});
+        auto on_false_src = std::make_shared<ov::op::v0::Constant>(et, ov::Shape{}, std::vector<float>{0.0f});
+
+        auto target_shape = std::make_shared<ov::op::v0::Constant>(ov::element::i64,
+                                                                    ov::Shape{4},
+                                                                    std::vector<int64_t>{1, 1, 4, 4});
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
+            on_false_src,
+            target_shape,
+            ov::op::BroadcastType::NUMPY);
+
+        auto select = std::make_shared<ov::op::v1::Select>(cond, on_true, broadcast);
+        select->set_friendly_name("Select");
+
+        auto second_consumer = std::make_shared<ov::op::v1::Select>(cond, broadcast, on_true);
+        second_consumer->set_friendly_name("Select2");
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{select, second_consumer}, ov::ParameterVector{cond});
+    }
+}


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY MEAT AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created automatically by the Intel MEAT (Model Enablement Automation Toolkit) agent.
> It addresses a model enablement blocker found during Qwen/Qwen3.6-27B inference validation.
> **DO NOT MERGE** without manual review and testing by an OpenVINO CPU plugin maintainer.

---

## [EXPERIMENT][WIP] [CPU] Fix Select shape inference for hybrid SSM+attention models

### Summary

Add `SimplifySelectBroadcast` transformation that replaces `Broadcast(scalar_const, dynamic_shape)` with `scalar_const` directly when the Broadcast is used as a `Select` (aten::where) input.

This fixes a `RuntimeError` occurring in hybrid SSM+full-attention models (e.g., `qwen3_5_text` / Qwen3.6-27B) during multi-turn inference or NNCF calibration.

### Error

```
RuntimeError: [CPU] Select 'aten::where/Select' — Eltwise shape infer input shapes dim index: 2 mismatch
```

### Root Cause

In qwen3_5_text, the attention float mask is constructed as:

```
Select(bool_mask, -65504, Broadcast(0.0, [B, 1, Q, Q]))
```

- `bool_mask` has shape `[B, 1, kv_len, Q]` (causal mask from full-attention KV cache)
- `Broadcast(0.0, …)` uses `[B, 1, Q, Q]` where `Q` = SSM-layer sequence length

When `kv_len ≠ Q` and both `> 1` (multi-turn chat, NNCF calibration), `EltwiseShapeInfer` in the CPU plugin cannot broadcast `[B,1,kv_len,Q]` against `[B,1,Q,Q]` and raises a dimension mismatch at index 2.

### Fix

The transformation `SimplifySelectBroadcast`:
1. Matches any `Select` node (NUMPY broadcast mode)
2. Checks if input 1 (`on_true`) or input 2 (`on_false`) is a `Broadcast` of a scalar constant with exactly one consumer
3. Replaces the `Broadcast` with the scalar constant directly

**Semantic correctness**: `Broadcast(scalar, shape)` fills all positions with the same value. `Select` with NUMPY broadcast already promotes scalar inputs to the output shape, so the replacement is value-equivalent. The output shape is now driven by `{condition, other_input}`, which has consistent semantics.

### Affected Model

- **Model**: [Qwen/Qwen3.6-27B](https://huggingface.co/Qwen/Qwen3.6-27B) (INT4 quantized, 48 SSM + 16 full-attention layers, `qwen3_5_text` architecture)
- **Triggering scenario**: Multi-turn inference / NNCF calibration (when prefill length differs from SSM state length)
- **CPU inference baseline**: Passed (single-turn)
- **WWB score before fix**: 0.7677 (threshold 0.90)

### Changes

| File | Change |
|------|--------|
| `src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/simplify_select_broadcast.hpp` | New — transformation declaration |
| `src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/simplify_select_broadcast.cpp` | New — transformation implementation |
| `src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp` | Register the new pass before ConstantFolding |
| `src/plugins/intel_cpu/tests/unit/transformations/simplify_select_broadcast_test.cpp` | New — 4 unit tests (positive + negative) |

### Testing

- Unit tests: 4 cases covering both `on_true` and `on_false` Broadcast simplification, non-scalar Broadcast (no-op), and multi-consumer Broadcast (no-op)
- Model-level testing pending full build + Qwen3.6-27B re-run

### Notes for Reviewers

- The pass is narrow in scope: only `Select` inputs (not general elementwise ops) and only scalar constants
- A broader solution might handle `broadcast_elementwise_fusion` for `Select`, but that risks changing semantics for non-scalar data
- The precondition `consumers_count == 1` ensures the Broadcast is not used elsewhere (no graph topology change)
