### PR TITLE
[CPU] StatefulSDPAFusion: detect shared KV-cache via Variable-id sets

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -42,7 +42,6 @@
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
-#include "openvino/pass/validate.hpp"
 #include "transformations/common_optimizations/simplify_shape_of_sub_graph.hpp"
 #include "transformations/cpu_opset/common/op/sdpa.hpp"
 #include "transformations/defs.hpp"
@@ -137,11 +136,13 @@ SharedSdpaSet compute_shared_kv_sdpas(const std::shared_ptr<const ov::Model>& mo
     return shared;
 }
 
+}  // namespace
+
 class StatefulSDPAFusionMatcher : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("StatefulSDPAFusionMatcher");
 
-    explicit StatefulSDPAFusionMatcher(SharedSdpaSet shared_sdpas) {
+    explicit StatefulSDPAFusionMatcher(const SharedSdpaSet& shared_sdpas) {
         MATCHER_SCOPE(StatefulSDPAFusion);
         using namespace ov::pass::pattern;
 
@@ -258,7 +259,7 @@ public:
             // crashes at runtime with "null input states" in MatchSdpaKvCache.
             // The shared set is precomputed by the StatefulSDPAFusion ModelPass
             // wrapper via a backward data-path BFS — see compute_shared_kv_sdpas.
-            if (shared_sdpas.count(sdp_node.get())) {
+            if (shared_sdpas.find(sdp_node.get()) != shared_sdpas.end()) {
                 return false;
             }
             if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {
@@ -436,13 +437,11 @@ public:
     }
 };
 
-}  // namespace
-
 bool StatefulSDPAFusion::run_on_model(const std::shared_ptr<ov::Model>& m) {
     RUN_ON_MODEL_SCOPE(StatefulSDPAFusion);
-    auto shared = compute_shared_kv_sdpas(m);
+    const auto shared = compute_shared_kv_sdpas(m);
     ov::pass::Manager manager(get_pass_config(), "StatefulSDPAFusionImpl");
-    manager.register_pass<StatefulSDPAFusionMatcher>(std::move(shared));
+    manager.register_pass<StatefulSDPAFusionMatcher>(shared);
     return manager.run_passes(m);
 }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -9,8 +9,10 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <tuple>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -28,10 +30,14 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/gather.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/parameter.hpp"
 #include "openvino/op/read_value.hpp"
 #include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/transpose.hpp"
+#include "openvino/pass/manager.hpp"
+#include "openvino/pass/validate.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
@@ -52,281 +58,393 @@ using namespace ov::pass;
 
 namespace ov::intel_cpu {
 
-StatefulSDPAFusion::StatefulSDPAFusion() {
-    MATCHER_SCOPE(StatefulSDPAFusion);
-    using namespace ov::pass::pattern;
+namespace {
 
-    auto beam_idx = any_input(type_matches(element::i32) && shape_matches("[?]"));
-    auto cur_q = any_input();
-    auto cur_k = any_input();
-    auto cur_v = any_input();
-    auto atten_sink = any_input();
+using SharedSdpaSet = std::unordered_set<const ov::Node*>;
 
-    auto past_k = wrap_type<ov::op::v6::ReadValue>();
-    auto past_v = wrap_type<ov::op::v6::ReadValue>();
+// Build the set of v13::SDPA nodes whose KV-cache is shared with another SDPA
+// in the same model.
+//
+// For each v13::ScaledDotProductAttention we walk backward from its K-input
+// (port 1) and V-input (port 2) along data (floating-point) edges only,
+// halting at the boundary ops below. ReadValue nodes encountered on the way
+// are recorded as "source" RVs for that SDPA. After all SDPAs are visited we
+// invert the mapping: if any RV is the source for ≥ 2 SDPAs, every SDPA
+// reading that RV (transitively, via the data path captured here) is shared.
+//
+// Halt boundaries (do not recurse through their inputs):
+//   - ReadValue: target — record as source and stop.
+//   - MatMul:    k_proj / v_proj boundary; the activation residual stream
+//                lives upstream and connects every layer.
+//   - v13::SDPA: prevents re-entering previous layers' attention output
+//                via residual connections.
+//   - Parameter / Constant: DAG leaves.
+//
+// Edge filter: only floating-point input ports are followed. i32 / i64
+// shape / indices / axes / order edges (and the int8 weight Convert chain)
+// are skipped, which structurally excludes the ShapeOf-rooted positional-ID
+// / RoPE fanout that caused CVS-185220 with the original forward BFS.
+SharedSdpaSet compute_shared_kv_sdpas(const std::shared_ptr<const ov::Model>& model) {
+    std::unordered_map<const ov::op::v6::ReadValue*, std::unordered_set<const ov::Node*>>
+        rv_to_sdpas;
 
-    auto convert_past_k = wrap_type<ov::op::v0::Convert>({past_k});
-    auto convert_past_v = wrap_type<ov::op::v0::Convert>({past_v});
-
-    auto gather_input_k =
-        wrap_type<ov::op::v8::Gather>({past_k | convert_past_k, beam_idx, "axis_beam"}, {{"batch_dims", 0}});
-    auto gather_input_v =
-        wrap_type<ov::op::v8::Gather>({past_v | convert_past_v, beam_idx, "axis_beam"}, {{"batch_dims", 0}});
-
-    auto concat_k = wrap_type<ov::op::v0::Concat>({gather_input_k, cur_k});
-    auto concat_v = wrap_type<ov::op::v0::Concat>({gather_input_v, cur_v});
-
-    std::shared_ptr<Node> mq_reshape_k, reshape_k, unsqueeze_k, computed_bcst_k, multiply_k, computed_bcst3_k;
-    std::tie(mq_reshape_k, reshape_k, unsqueeze_k, computed_bcst_k, multiply_k, computed_bcst3_k) =
-        ov::op::util::match_multi_query_bcst(concat_k);
-    std::shared_ptr<Node> mq_reshape_v, reshape_v, unsqueeze_v, computed_bcst_v, multiply_v, computed_bcst3_v;
-    std::tie(mq_reshape_v, reshape_v, unsqueeze_v, computed_bcst_v, multiply_v, computed_bcst3_v) =
-        ov::op::util::match_multi_query_bcst(concat_v);
-    auto present_k = concat_k | mq_reshape_k;
-    auto present_v = concat_v | mq_reshape_v;
-
-    // canonical q/k/v shape definition: [B,H,...L,S]
-    auto sdp0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v});
-    auto sdp1 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v, any_input()});
-    auto sdp2 =
-        wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v, any_input(), any_input()});
-    // gpt-oss
-    auto sdp3 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
-        {cur_q, present_k, present_v, any_input(), any_input(), atten_sink});
-
-    // non-canonical q/k/v shape definitions, for example: [L, B, H, S]/[B, L, H, S]
-    auto order_k = wrap_type<ov::op::v0::Constant>();
-    auto order_v = wrap_type<ov::op::v0::Constant>();
-    auto order_q = wrap_type<ov::op::v0::Constant>();
-    auto transpose_q = wrap_type<ov::op::v1::Transpose>({cur_q, order_q});
-    auto transpose_k = wrap_type<ov::op::v1::Transpose>({present_k, order_k});
-    auto transpose_v = wrap_type<ov::op::v1::Transpose>({present_v, order_v});
-
-    auto sdp_trans0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({transpose_q, transpose_k, transpose_v});
-    auto sdp_trans1 =
-        wrap_type<ov::op::v13::ScaledDotProductAttention>({transpose_q, transpose_k, transpose_v, any_input()});
-    auto sdp_trans2 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
-        {transpose_q, transpose_k, transpose_v, any_input(), any_input()});
-    // gpt-oss
-    auto sdp_trans3 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
-        {transpose_q, transpose_k, transpose_v, any_input(), any_input(), atten_sink});
-
-    auto sdp = sdp0 | sdp1 | sdp2 | sdp3 | sdp_trans0 | sdp_trans1 | sdp_trans2 | sdp_trans3;
-
-    ov::matcher_pass_callback callback = [=](Matcher& m) {
-        const auto& pattern_map = m.get_pattern_value_map();
-        auto root = m.get_match_root();
-
-        // Check concat axes equality first
-        const auto concat_k_node = ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_k).get_node_shared_ptr());
-        const auto concat_v_node = ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_v).get_node_shared_ptr());
-        if (concat_k_node->get_axis() != concat_v_node->get_axis()) {
-            return false;
+    auto walk_backward = [&](const ov::Node* sdpa, size_t input_idx) {
+        if (input_idx >= sdpa->get_input_size()) {
+            return;
         }
-
-        auto find_assign =
-            [&](const ov::Output<ov::Node>& out, ov::op::v6::Assign*& assign, ov::op::v0::Convert*& cvt) {
-                auto present_to = out.get_target_inputs();
-                for (const auto& to : present_to) {
-                    auto* to_node = to.get_node();
-                    if (auto* convert = ov::as_type<ov::op::v0::Convert>(to_node)) {
-                        auto cvt_targets = convert->get_output_target_inputs(0);
-                        if (cvt_targets.size() == 1) {
-                            to_node = cvt_targets.begin()->get_node();
-                            cvt = convert;
-                        }
-                    }
-                    assign = ov::as_type<ov::op::v6::Assign>(to_node);
-                    if (assign) {
-                        return true;
-                    }
+        std::unordered_set<const ov::Node*> visited;
+        std::deque<const ov::Node*> queue;
+        const auto* start = sdpa->get_input_node_ptr(input_idx);
+        visited.insert(start);
+        queue.push_back(start);
+        while (!queue.empty()) {
+            const auto* n = queue.front();
+            queue.pop_front();
+            if (const auto* rv = ov::as_type<const ov::op::v6::ReadValue>(n)) {
+                rv_to_sdpas[rv].insert(sdpa);
+                continue;
+            }
+            if (ov::is_type_any_of<ov::op::v0::MatMul,
+                                   ov::op::v13::ScaledDotProductAttention,
+                                   ov::op::v0::Parameter,
+                                   ov::op::v0::Constant>(n)) {
+                continue;
+            }
+            for (size_t i = 0; i < n->get_input_size(); ++i) {
+                if (!n->get_input_element_type(i).is_real()) {
+                    continue;
                 }
-                return false;
-            };
-        auto check_valid_children_type = [](const ov::Output<ov::Node>& out) {
-            auto children = out.get_target_inputs();
-            return std::all_of(children.begin(), children.end(), [](const ov::Input<ov::Node>& child) {
-                auto* node = child.get_node();
-                return any_of(node->get_type_info(),
-                              ov::op::v13::ScaledDotProductAttention::get_type_info_static(),
-                              ov::op::v0::ShapeOf::get_type_info_static(),
-                              ov::op::v3::ShapeOf::get_type_info_static(),
-                              ov::op::v0::Convert::get_type_info_static(),
-                              ov::op::v8::Gather::get_type_info_static());
-            });
-        };
-
-        const auto sdp_node = ov::as_type_ptr<ov::op::v13::ScaledDotProductAttention>(root);
-        const auto past_k_node = ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_k).get_node_shared_ptr());
-        const auto past_v_node = ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_v).get_node_shared_ptr());
-        // Skip SDPAs whose KV-cache Variable is shared with another SDPA: the fused
-        // ScaledDotProductAttentionWithKVCache kernel does not support shared KV-cache and
-        // partial fusion leaves the model in an inconsistent state.
-        // Walk forward from past_k / past_v, stopping at SDPA boundaries, and count
-        // how many SDPAs are reachable. Anchoring on the ReadValue (rather than on
-        // direct input node pointers) is robust to intermediate Transpose/Reshape/
-        // Convert/Gather/Broadcast ops between the cache source and the SDPA blocks.
-        auto count_reachable_sdpas = [](ov::Node* start) {
-            size_t cnt = 0;
-            std::unordered_set<ov::Node*> visited;
-            ov::op::util::visit_path_forward(
-                start,
-                visited,
-                [](ov::Node*) {},
-                [&](ov::Node* n) {
-                    if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(n)) {
-                        ++cnt;
-                        return true;
-                    }
-                    return false;
-                });
-            return cnt;
-        };
-        if (count_reachable_sdpas(past_k_node.get()) > 1 || count_reachable_sdpas(past_v_node.get()) > 1) {
-            return false;
-        }
-        if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {
-            return false;
-        }
-        for (auto&& item : {concat_k_node, concat_v_node}) {
-            auto&& children = item->get_output_target_inputs(0);
-            switch (children.size()) {
-            case 2:
-                // pass, as the existence of Assign will be checked later
-                break;
-            case 3:
-                // the first one leads to SDPA, otherwise the matcher doesn't find the pattern
-                // the second one leads to Assign, and this is checked later
-                // the third child is allowed to be a ShapeOf op only, thus one of them must be ShapeOf
-                if (!std::any_of(children.begin(), children.end(), [](const ov::Input<ov::Node>& child) {
-                        return ov::is_type_any_of<ov::op::v3::ShapeOf, ov::op::v0::ShapeOf>(child.get_node());
-                    })) {
-                    return false;
+                const auto* src = n->get_input_node_ptr(i);
+                if (visited.insert(src).second) {
+                    queue.push_back(src);
                 }
-                break;
-            default:
-                return false;
             }
         }
-
-        ov::op::v6::Assign* assign_k_node = nullptr;
-        ov::op::v6::Assign* assign_v_node = nullptr;
-        ov::op::v0::Convert* assign_cvt_k_node = nullptr;
-        ov::op::v0::Convert* assign_cvt_v_node = nullptr;
-        if (!find_assign(concat_k_node, assign_k_node, assign_cvt_k_node)) {
-            return false;
-        }
-        if (past_k_node->get_variable_id() != assign_k_node->get_variable_id()) {
-            return false;
-        }
-
-        if (!find_assign(concat_v_node, assign_v_node, assign_cvt_v_node)) {
-            return false;
-        }
-        if (past_v_node->get_variable_id() != assign_v_node->get_variable_id()) {
-            return false;
-        }
-
-        auto is_optional_one_child = [&pattern_map](const std::vector<std::shared_ptr<Node>>& nodes) {
-            return std::all_of(nodes.begin(), nodes.end(), [&](const std::shared_ptr<Node>& node) {
-                if (pattern_map.count(node)) {
-                    auto p = pattern_map.at(node).get_node_shared_ptr();
-                    return p->get_output_target_inputs(0).size() == 1;
-                }
-                return true;
-            });
-        };
-        if (!is_optional_one_child({convert_past_k,
-                                    convert_past_v,
-                                    transpose_q,
-                                    transpose_k,
-                                    transpose_v,
-                                    reshape_k,
-                                    unsqueeze_k,
-                                    computed_bcst_k,
-                                    multiply_k,
-                                    reshape_v,
-                                    unsqueeze_v,
-                                    computed_bcst_v,
-                                    multiply_v,
-                                    mq_reshape_k,
-                                    mq_reshape_v,
-                                    computed_bcst3_k,
-                                    computed_bcst3_v})) {
-            return false;
-        }
-
-        // past_k & past_v must be reordered by same beam_idx
-        const auto gather_k_node =
-            ov::as_type_ptr<ov::op::v8::Gather>(pattern_map.at(gather_input_k).get_node_shared_ptr());
-        const auto gather_v_node =
-            ov::as_type_ptr<ov::op::v8::Gather>(pattern_map.at(gather_input_v).get_node_shared_ptr());
-        if (gather_k_node->input_value(1) != gather_v_node->input_value(1) ||
-            gather_k_node->get_output_target_inputs(0).size() != 1 ||
-            gather_v_node->get_output_target_inputs(0).size() != 1) {
-            return false;
-        }
-
-        OutputVector args = sdp_node->input_values();
-        args[0] = pattern_map.at(cur_q);
-        args[1] = pattern_map.at(cur_k);
-        args[2] = pattern_map.at(cur_v);
-        args.push_back(pattern_map.at(beam_idx));
-        args.push_back(gather_k_node->input_value(0));
-        args.push_back(gather_v_node->input_value(0));
-        ov::intel_cpu::ScaledDotProductAttentionWithKVCache::Config config;
-
-        config.is_causal = sdp_node->get_causal();
-        config.fuse_concat = true;
-
-        if (pattern_map.count(order_q) && pattern_map.count(order_k) && pattern_map.count(order_v)) {
-            const auto order_q_node =
-                ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_q).get_node_shared_ptr());
-            const auto order_k_node =
-                ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_k).get_node_shared_ptr());
-            const auto order_v_node =
-                ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_v).get_node_shared_ptr());
-            const auto& permute_q = order_q_node->cast_vector<int32_t>();
-            const auto& permute_k = order_k_node->cast_vector<int32_t>();
-            const auto& permute_v = order_v_node->cast_vector<int32_t>();
-            if (permute_q != permute_k || permute_q != permute_v) {
-                return false;
-            }
-            config.permute_axes.resize(permute_q.size());
-            for (size_t i = 0; i < permute_q.size(); i++) {
-                config.permute_axes[i] = static_cast<size_t>(permute_q[i]);
-            }
-        }
-
-        const auto& old_node = sdp_node;
-        auto new_node = std::make_shared<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(args, config);
-        new_node->set_friendly_name(old_node->get_friendly_name());
-        copy_runtime_info(old_node, new_node);
-        ov::replace_node(old_node, {new_node->output(0)});
-        if (assign_cvt_k_node) {
-            assign_cvt_k_node->set_arguments({new_node->output(1)});
-        } else {
-            assign_k_node->set_arguments({new_node->output(1)});
-        }
-
-        if (assign_cvt_v_node) {
-            assign_cvt_v_node->set_arguments({new_node->output(2)});
-        } else {
-            assign_v_node->set_arguments({new_node->output(2)});
-        }
-
-        // Markup pattern:
-        // ReadValue->Convert(Optional)->ScaledDotProductAttentionWithKVCache->Convert(Optional)->Assign, so that
-        // ReadValue can't be replaced with ReadValueWithSubgraph in this pattern.
-        // TODO: Temporarily skip this pattern. If MemoryInputSDPA supports Subgraph in the future, it may be deleted.
-        past_k_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
-        past_v_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
-
-        return true;
     };
 
-    auto m = std::make_shared<ov::pass::pattern::Matcher>(sdp, matcher_name);
-    this->register_matcher(m, callback);
+    for (const auto& op : model->get_ops()) {
+        if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(op)) {
+            walk_backward(op.get(), 1);  // K
+            walk_backward(op.get(), 2);  // V
+        }
+    }
+
+    SharedSdpaSet shared;
+    for (const auto& [rv, sdpas] : rv_to_sdpas) {
+        if (sdpas.size() > 1) {
+            shared.insert(sdpas.begin(), sdpas.end());
+        }
+    }
+    return shared;
+}
+
+class StatefulSDPAFusionMatcher : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("StatefulSDPAFusionMatcher");
+
+    explicit StatefulSDPAFusionMatcher(SharedSdpaSet shared_sdpas) {
+        MATCHER_SCOPE(StatefulSDPAFusion);
+        using namespace ov::pass::pattern;
+
+        auto beam_idx = any_input(type_matches(element::i32) && shape_matches("[?]"));
+        auto cur_q = any_input();
+        auto cur_k = any_input();
+        auto cur_v = any_input();
+        auto atten_sink = any_input();
+
+        auto past_k = wrap_type<ov::op::v6::ReadValue>();
+        auto past_v = wrap_type<ov::op::v6::ReadValue>();
+
+        auto convert_past_k = wrap_type<ov::op::v0::Convert>({past_k});
+        auto convert_past_v = wrap_type<ov::op::v0::Convert>({past_v});
+
+        auto gather_input_k =
+            wrap_type<ov::op::v8::Gather>({past_k | convert_past_k, beam_idx, "axis_beam"}, {{"batch_dims", 0}});
+        auto gather_input_v =
+            wrap_type<ov::op::v8::Gather>({past_v | convert_past_v, beam_idx, "axis_beam"}, {{"batch_dims", 0}});
+
+        auto concat_k = wrap_type<ov::op::v0::Concat>({gather_input_k, cur_k});
+        auto concat_v = wrap_type<ov::op::v0::Concat>({gather_input_v, cur_v});
+
+        std::shared_ptr<Node> mq_reshape_k, reshape_k, unsqueeze_k, computed_bcst_k, multiply_k, computed_bcst3_k;
+        std::tie(mq_reshape_k, reshape_k, unsqueeze_k, computed_bcst_k, multiply_k, computed_bcst3_k) =
+            ov::op::util::match_multi_query_bcst(concat_k);
+        std::shared_ptr<Node> mq_reshape_v, reshape_v, unsqueeze_v, computed_bcst_v, multiply_v, computed_bcst3_v;
+        std::tie(mq_reshape_v, reshape_v, unsqueeze_v, computed_bcst_v, multiply_v, computed_bcst3_v) =
+            ov::op::util::match_multi_query_bcst(concat_v);
+        auto present_k = concat_k | mq_reshape_k;
+        auto present_v = concat_v | mq_reshape_v;
+
+        // canonical q/k/v shape definition: [B,H,...L,S]
+        auto sdp0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v});
+        auto sdp1 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v, any_input()});
+        auto sdp2 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
+            {cur_q, present_k, present_v, any_input(), any_input()});
+        // gpt-oss
+        auto sdp3 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
+            {cur_q, present_k, present_v, any_input(), any_input(), atten_sink});
+
+        // non-canonical q/k/v shape definitions, for example: [L, B, H, S]/[B, L, H, S]
+        auto order_k = wrap_type<ov::op::v0::Constant>();
+        auto order_v = wrap_type<ov::op::v0::Constant>();
+        auto order_q = wrap_type<ov::op::v0::Constant>();
+        auto transpose_q = wrap_type<ov::op::v1::Transpose>({cur_q, order_q});
+        auto transpose_k = wrap_type<ov::op::v1::Transpose>({present_k, order_k});
+        auto transpose_v = wrap_type<ov::op::v1::Transpose>({present_v, order_v});
+
+        auto sdp_trans0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({transpose_q, transpose_k, transpose_v});
+        auto sdp_trans1 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
+            {transpose_q, transpose_k, transpose_v, any_input()});
+        auto sdp_trans2 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
+            {transpose_q, transpose_k, transpose_v, any_input(), any_input()});
+        // gpt-oss
+        auto sdp_trans3 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
+            {transpose_q, transpose_k, transpose_v, any_input(), any_input(), atten_sink});
+
+        auto sdp = sdp0 | sdp1 | sdp2 | sdp3 | sdp_trans0 | sdp_trans1 | sdp_trans2 | sdp_trans3;
+
+        ov::matcher_pass_callback callback = [=](Matcher& m) {
+            const auto& pattern_map = m.get_pattern_value_map();
+            auto root = m.get_match_root();
+
+            // Check concat axes equality first
+            const auto concat_k_node =
+                ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_k).get_node_shared_ptr());
+            const auto concat_v_node =
+                ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_v).get_node_shared_ptr());
+            if (concat_k_node->get_axis() != concat_v_node->get_axis()) {
+                return false;
+            }
+
+            auto find_assign =
+                [&](const ov::Output<ov::Node>& out, ov::op::v6::Assign*& assign, ov::op::v0::Convert*& cvt) {
+                    auto present_to = out.get_target_inputs();
+                    for (const auto& to : present_to) {
+                        auto* to_node = to.get_node();
+                        if (auto* convert = ov::as_type<ov::op::v0::Convert>(to_node)) {
+                            auto cvt_targets = convert->get_output_target_inputs(0);
+                            if (cvt_targets.size() == 1) {
+                                to_node = cvt_targets.begin()->get_node();
+                                cvt = convert;
+                            }
+                        }
+                        assign = ov::as_type<ov::op::v6::Assign>(to_node);
+                        if (assign) {
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+            auto check_valid_children_type = [](const ov::Output<ov::Node>& out) {
+                auto children = out.get_target_inputs();
+                return std::all_of(children.begin(), children.end(), [](const ov::Input<ov::Node>& child) {
+                    auto* node = child.get_node();
+                    return any_of(node->get_type_info(),
+                                  ov::op::v13::ScaledDotProductAttention::get_type_info_static(),
+                                  ov::op::v0::ShapeOf::get_type_info_static(),
+                                  ov::op::v3::ShapeOf::get_type_info_static(),
+                                  ov::op::v0::Convert::get_type_info_static(),
+                                  ov::op::v8::Gather::get_type_info_static());
+                });
+            };
+
+            const auto sdp_node = ov::as_type_ptr<ov::op::v13::ScaledDotProductAttention>(root);
+            const auto past_k_node =
+                ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_k).get_node_shared_ptr());
+            const auto past_v_node =
+                ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_v).get_node_shared_ptr());
+            // Refuse fusion when this SDPA's KV-cache is shared with another
+            // SDPA in the same model. ScaledDotProductAttentionWithKVCache binds
+            // a single MemoryInput per K/V state; a partially-fused shared chain
+            // crashes at runtime with "null input states" in MatchSdpaKvCache.
+            // The shared set is precomputed by the StatefulSDPAFusion ModelPass
+            // wrapper via a backward data-path BFS — see compute_shared_kv_sdpas.
+            if (shared_sdpas.count(sdp_node.get())) {
+                return false;
+            }
+            if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {
+                return false;
+            }
+            for (auto&& item : {concat_k_node, concat_v_node}) {
+                auto&& children = item->get_output_target_inputs(0);
+                switch (children.size()) {
+                case 2:
+                    // pass, as the existence of Assign will be checked later
+                    break;
+                case 3:
+                    // the first one leads to SDPA, otherwise the matcher doesn't find the pattern
+                    // the second one leads to Assign, and this is checked later
+                    // the third child is allowed to be a ShapeOf op only, thus one of them must be ShapeOf
+                    if (!std::any_of(children.begin(), children.end(), [](const ov::Input<ov::Node>& child) {
+                            return ov::is_type_any_of<ov::op::v3::ShapeOf, ov::op::v0::ShapeOf>(child.get_node());
+                        })) {
+                        return false;
+                    }
+                    break;
+                default:
+                    return false;
+                }
+            }
+
+            ov::op::v6::Assign* assign_k_node = nullptr;
+            ov::op::v6::Assign* assign_v_node = nullptr;
+            ov::op::v0::Convert* assign_cvt_k_node = nullptr;
+            ov::op::v0::Convert* assign_cvt_v_node = nullptr;
+            if (!find_assign(concat_k_node, assign_k_node, assign_cvt_k_node)) {
+                return false;
+            }
+            if (past_k_node->get_variable_id() != assign_k_node->get_variable_id()) {
+                return false;
+            }
+
+            if (!find_assign(concat_v_node, assign_v_node, assign_cvt_v_node)) {
+                return false;
+            }
+            if (past_v_node->get_variable_id() != assign_v_node->get_variable_id()) {
+                return false;
+            }
+
+            auto is_optional_one_child = [&pattern_map](const std::vector<std::shared_ptr<Node>>& nodes) {
+                return std::all_of(nodes.begin(), nodes.end(), [&](const std::shared_ptr<Node>& node) {
+                    if (pattern_map.count(node)) {
+                        auto p = pattern_map.at(node).get_node_shared_ptr();
+                        return p->get_output_target_inputs(0).size() == 1;
+                    }
+                    return true;
+                });
+            };
+            if (!is_optional_one_child({convert_past_k,
+                                        convert_past_v,
+                                        transpose_q,
+                                        transpose_k,
+                                        transpose_v,
+                                        reshape_k,
+                                        unsqueeze_k,
+                                        computed_bcst_k,
+                                        multiply_k,
+                                        reshape_v,
+                                        unsqueeze_v,
+                                        computed_bcst_v,
+                                        multiply_v,
+                                        mq_reshape_k,
+                                        mq_reshape_v,
+                                        computed_bcst3_k,
+                                        computed_bcst3_v})) {
+                return false;
+            }
+
+            // past_k & past_v must be reordered by same beam_idx
+            const auto gather_k_node =
+                ov::as_type_ptr<ov::op::v8::Gather>(pattern_map.at(gather_input_k).get_node_shared_ptr());
+            const auto gather_v_node =
+                ov::as_type_ptr<ov::op::v8::Gather>(pattern_map.at(gather_input_v).get_node_shared_ptr());
+            if (gather_k_node->input_value(1) != gather_v_node->input_value(1) ||
+                gather_k_node->get_output_target_inputs(0).size() != 1 ||
+                gather_v_node->get_output_target_inputs(0).size() != 1) {
+                return false;
+            }
+
+            OutputVector args = sdp_node->input_values();
+            args[0] = pattern_map.at(cur_q);
+            args[1] = pattern_map.at(cur_k);
+            args[2] = pattern_map.at(cur_v);
+            args.push_back(pattern_map.at(beam_idx));
+            args.push_back(gather_k_node->input_value(0));
+            args.push_back(gather_v_node->input_value(0));
+            ov::intel_cpu::ScaledDotProductAttentionWithKVCache::Config config;
+
+            config.is_causal = sdp_node->get_causal();
+            config.fuse_concat = true;
+
+            if (pattern_map.count(order_q) && pattern_map.count(order_k) && pattern_map.count(order_v)) {
+                const auto order_q_node =
+                    ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_q).get_node_shared_ptr());
+                const auto order_k_node =
+                    ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_k).get_node_shared_ptr());
+                const auto order_v_node =
+                    ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_v).get_node_shared_ptr());
+                const auto& permute_q = order_q_node->cast_vector<int32_t>();
+                const auto& permute_k = order_k_node->cast_vector<int32_t>();
+                const auto& permute_v = order_v_node->cast_vector<int32_t>();
+                if (permute_q != permute_k || permute_q != permute_v) {
+                    return false;
+                }
+                config.permute_axes.resize(permute_q.size());
+                for (size_t i = 0; i < permute_q.size(); i++) {
+                    config.permute_axes[i] = static_cast<size_t>(permute_q[i]);
+                }
+            }
+
+            const auto& old_node = sdp_node;
+            auto new_node = std::make_shared<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(args, config);
+            new_node->set_friendly_name(old_node->get_friendly_name());
+            copy_runtime_info(old_node, new_node);
+            ov::replace_node(old_node, {new_node->output(0)});
+            if (assign_cvt_k_node) {
+                assign_cvt_k_node->set_arguments({new_node->output(1)});
+            } else {
+                assign_k_node->set_arguments({new_node->output(1)});
+            }
+
+            if (assign_cvt_v_node) {
+                assign_cvt_v_node->set_arguments({new_node->output(2)});
+            } else {
+                assign_v_node->set_arguments({new_node->output(2)});
+            }
+
+            // Re-route any ShapeOf consumer of the (now-obsolete) K/V Concat
+            // to the fused node's new K/V output. The Concat has the same
+            // post-cache tensor shape as the fused output, so this rewrite
+            // is semantically a no-op. Without it, the ShapeOf keeps the
+            // old Concat -> Gather chain reachable via the global
+            // positional-ID / attention-mask computation in models that
+            // take this case-3 path (Gemma3n layer 0), which in turn leaves
+            // the old Gather as a child of the ReadValue's MemoryInput;
+            // MatchSdpaKvCache rejects non-{SDPA,ShapeOf} children and the
+            // fused kernel then crashes with "null input states" at execute
+            // time. In the Mixtral multi-query-broadcast case the ShapeOf's
+            // consumers are themselves absorbed by the matcher pattern, so
+            // after this re-route the entire multi-query chain is dead and
+            // gets collapsed by subsequent dead-code elimination.
+            auto reroute_shape_of_consumers = [&](const std::shared_ptr<Node>& concat_node,
+                                                   const ov::Output<ov::Node>& replacement) {
+                std::vector<ov::Input<Node>> shape_of_inputs;
+                for (const auto& target : concat_node->get_output_target_inputs(0)) {
+                    auto* child = target.get_node();
+                    if (ov::is_type_any_of<ov::op::v0::ShapeOf, ov::op::v3::ShapeOf>(child)) {
+                        shape_of_inputs.push_back(target);
+                    }
+                }
+                for (const auto& inp : shape_of_inputs) {
+                    inp.replace_source_output(replacement);
+                }
+            };
+            reroute_shape_of_consumers(concat_k_node, new_node->output(1));
+            reroute_shape_of_consumers(concat_v_node, new_node->output(2));
+
+            // Markup pattern:
+            // ReadValue->Convert(Optional)->ScaledDotProductAttentionWithKVCache->Convert(Optional)->Assign, so that
+            // ReadValue can't be replaced with ReadValueWithSubgraph in this pattern.
+            // TODO: Temporarily skip this pattern. If MemoryInputSDPA supports Subgraph in the future, it may be
+            // deleted.
+            past_k_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
+            past_v_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
+            return true;
+        };
+
+        auto m = std::make_shared<ov::pass::pattern::Matcher>(sdp, matcher_name);
+        this->register_matcher(m, callback);
+    }
+};
+
+}  // namespace
+
+bool StatefulSDPAFusion::run_on_model(const std::shared_ptr<ov::Model>& m) {
+    RUN_ON_MODEL_SCOPE(StatefulSDPAFusion);
+    auto shared = compute_shared_kv_sdpas(m);
+    ov::pass::Manager manager(get_pass_config(), "StatefulSDPAFusionImpl");
+    manager.register_pass<StatefulSDPAFusionMatcher>(std::move(shared));
+    return manager.run_passes(m);
 }
 
 bool SDPASubgraphFusion::run_on_model(const std::shared_ptr<ov::Model>& f) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -37,12 +37,12 @@
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/pass/manager.hpp"
-#include "openvino/pass/validate.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/pass/validate.hpp"
 #include "transformations/common_optimizations/simplify_shape_of_sub_graph.hpp"
 #include "transformations/cpu_opset/common/op/sdpa.hpp"
 #include "transformations/defs.hpp"
@@ -85,8 +85,7 @@ using SharedSdpaSet = std::unordered_set<const ov::Node*>;
 // are skipped, which structurally excludes the ShapeOf-rooted positional-ID
 // / RoPE fanout that caused CVS-185220 with the original forward BFS.
 SharedSdpaSet compute_shared_kv_sdpas(const std::shared_ptr<const ov::Model>& model) {
-    std::unordered_map<const ov::op::v6::ReadValue*, std::unordered_set<const ov::Node*>>
-        rv_to_sdpas;
+    std::unordered_map<const ov::op::v6::ReadValue*, std::unordered_set<const ov::Node*>> rv_to_sdpas;
 
     auto walk_backward = [&](const ov::Node* sdpa, size_t input_idx) {
         if (input_idx >= sdpa->get_input_size()) {
@@ -178,8 +177,8 @@ public:
         // canonical q/k/v shape definition: [B,H,...L,S]
         auto sdp0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v});
         auto sdp1 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v, any_input()});
-        auto sdp2 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
-            {cur_q, present_k, present_v, any_input(), any_input()});
+        auto sdp2 =
+            wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v, any_input(), any_input()});
         // gpt-oss
         auto sdp3 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
             {cur_q, present_k, present_v, any_input(), any_input(), atten_sink});
@@ -193,8 +192,8 @@ public:
         auto transpose_v = wrap_type<ov::op::v1::Transpose>({present_v, order_v});
 
         auto sdp_trans0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({transpose_q, transpose_k, transpose_v});
-        auto sdp_trans1 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
-            {transpose_q, transpose_k, transpose_v, any_input()});
+        auto sdp_trans1 =
+            wrap_type<ov::op::v13::ScaledDotProductAttention>({transpose_q, transpose_k, transpose_v, any_input()});
         auto sdp_trans2 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
             {transpose_q, transpose_k, transpose_v, any_input(), any_input()});
         // gpt-oss
@@ -407,7 +406,7 @@ public:
             // after this re-route the entire multi-query chain is dead and
             // gets collapsed by subsequent dead-code elimination.
             auto reroute_shape_of_consumers = [&](const std::shared_ptr<Node>& concat_node,
-                                                   const ov::Output<ov::Node>& replacement) {
+                                                  const ov::Output<ov::Node>& replacement) {
                 std::vector<ov::Input<Node>> shape_of_inputs;
                 for (const auto& target : concat_node->get_output_target_inputs(0)) {
                     auto* child = target.get_node();

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -182,10 +182,8 @@ public:
             // those are reader-only SDPAs sharing the cache, and
             // ScaledDotProductAttentionWithKVCache currently only supports a
             // single owner-writer per K / V state.
-            if (processed_k_variable_ids.find(past_k_node->get_variable_id()) !=
-                    processed_k_variable_ids.end() ||
-                processed_v_variable_ids.find(past_v_node->get_variable_id()) !=
-                    processed_v_variable_ids.end()) {
+            if (processed_k_variable_ids.find(past_k_node->get_variable_id()) != processed_k_variable_ids.end() ||
+                processed_v_variable_ids.find(past_v_node->get_variable_id()) != processed_v_variable_ids.end()) {
                 return false;
             }
             if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -182,8 +182,10 @@ public:
             // those are reader-only SDPAs sharing the cache, and
             // ScaledDotProductAttentionWithKVCache currently only supports a
             // single owner-writer per K / V state.
-            if (processed_k_variable_ids.count(past_k_node->get_variable_id()) ||
-                processed_v_variable_ids.count(past_v_node->get_variable_id())) {
+            if (processed_k_variable_ids.find(past_k_node->get_variable_id()) !=
+                    processed_k_variable_ids.end() ||
+                processed_v_variable_ids.find(past_v_node->get_variable_id()) !=
+                    processed_v_variable_ids.end()) {
                 return false;
             }
             if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -168,10 +168,8 @@ StatefulSDPAFusion::StatefulSDPAFusion() {
         // currently only supports a single owner-writer per K / V state.
         // Sets are keyed by Variable id (not by ReadValue node pointer) so the corner case of
         // two distinct v6::ReadValue nodes aliasing the same Variable is still detected as shared.
-        if (m_processed_k_variable_ids.find(past_k_node->get_variable_id()) !=
-                m_processed_k_variable_ids.end() ||
-            m_processed_v_variable_ids.find(past_v_node->get_variable_id()) !=
-                m_processed_v_variable_ids.end()) {
+        if (m_processed_k_variable_ids.find(past_k_node->get_variable_id()) != m_processed_k_variable_ids.end() ||
+            m_processed_v_variable_ids.find(past_v_node->get_variable_id()) != m_processed_v_variable_ids.end()) {
             return false;
         }
         if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -189,29 +189,6 @@ public:
             if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {
                 return false;
             }
-            // Defense-in-depth against the writer-fused-reader-plain topology
-            // (one ReadValue with multiple non-ShapeOf consumers, only one of
-            // them feeding an Assign). If the writer fuses, the reader's
-            // Gather / Convert child stays attached to the MemoryInput;
-            // GraphOptimizer::MatchSdpaKvCache only promotes a MemoryInput
-            // whose children are in {SDPA, ShapeOf}, so without this guard
-            // the unpromoted MemoryInput leaves the fused node's K / V state
-            // unbound and the kernel then crashes with "null input states"
-            // at execute time. The orthogonal "two ReadValues aliasing one
-            // Variable" corner case is covered separately by
-            // processed_*_variable_ids.
-            auto count_data_consumers = [](const std::shared_ptr<ov::Node>& rv) {
-                size_t count = 0;
-                for (const auto& target : rv->get_output_target_inputs(0)) {
-                    if (!ov::is_type_any_of<ov::op::v0::ShapeOf, ov::op::v3::ShapeOf>(target.get_node())) {
-                        ++count;
-                    }
-                }
-                return count;
-            };
-            if (count_data_consumers(past_k_node) > 1 || count_data_consumers(past_v_node) > 1) {
-                return false;
-            }
             for (auto&& item : {concat_k_node, concat_v_node}) {
                 auto&& children = item->get_output_target_inputs(0);
                 switch (children.size()) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <deque>
 #include <memory>
+#include <string>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -60,16 +60,47 @@ namespace ov::intel_cpu {
 namespace {
 
 using SharedSdpaSet = std::unordered_set<const ov::Node*>;
+using KvVarOwnerMap = std::unordered_map<std::string, const ov::Node*>;
+
+// Layout deliberately mirrors StateManagementPattern::find_or_create_kv_param
+// in the SDPAToPagedAttention path: same map shape (variable_id + "/k" | "/v"
+// keys), same suffix scheme. Once ScaledDotProductAttentionWithKVCache learns
+// a reader-only binding mode (analogous to PagedAttentionExtension's
+// write_kv_cache=false flag), this helper can flip from "refuse fusion for
+// every shared SDPA" to "fuse the owner with write, fuse the readers without
+// write" by changing only the matcher callback's response — the discovery
+// logic stays the same.
+//
+// Returns true if (variable_id, suffix) was already registered for another
+// SDPA (=> this SDPA is a non-owner reader); false on the first occurrence
+// (=> this SDPA is the tentative owner). On "true", BOTH the current SDPA
+// and the previously-registered owner are inserted into 'shared': the owner
+// only retroactively becomes "shared" when a second reader appears.
+bool find_or_mark_kv_owner(const std::string& variable_id,
+                           const char* suffix,
+                           const ov::Node* sdpa,
+                           KvVarOwnerMap& owners,
+                           SharedSdpaSet& shared) {
+    const auto key = variable_id + suffix;
+    auto it = owners.find(key);
+    if (it != owners.end()) {
+        shared.insert(it->second);
+        shared.insert(sdpa);
+        return true;
+    }
+    owners.emplace(key, sdpa);
+    return false;
+}
 
 // Build the set of v13::SDPA nodes whose KV-cache is shared with another SDPA
 // in the same model.
 //
 // For each v13::ScaledDotProductAttention we walk backward from its K-input
 // (port 1) and V-input (port 2) along data (floating-point) edges only,
-// halting at the boundary ops below. ReadValue nodes encountered on the way
-// are recorded as "source" RVs for that SDPA. After all SDPAs are visited we
-// invert the mapping: if any RV is the source for ≥ 2 SDPAs, every SDPA
-// reading that RV (transitively, via the data path captured here) is shared.
+// halting at the boundary ops below. Every ReadValue reached is bucketed by
+// (variable_id + "/k" | "/v"); whenever a key is observed for the second
+// time, both the current SDPA and the previously-recorded owner are flagged
+// as shared.
 //
 // Halt boundaries (do not recurse through their inputs):
 //   - ReadValue: target — record as source and stop.
@@ -82,11 +113,18 @@ using SharedSdpaSet = std::unordered_set<const ov::Node*>;
 // Edge filter: only floating-point input ports are followed. i32 / i64
 // shape / indices / axes / order edges (and the int8 weight Convert chain)
 // are skipped, which structurally excludes the ShapeOf-rooted positional-ID
-// / RoPE fanout that caused CVS-185220 with the original forward BFS.
+// / RoPE fanout that caused the StatefulSDPAFusion regression with the
+// original forward BFS.
+//
+// Keying on variable_id rather than on the ReadValue pointer is what catches
+// the corner case in which two distinct ReadValue nodes alias the same
+// Variable: their cache memory is the same slot, so any fusion must treat
+// them as shared even though their node pointers differ.
 SharedSdpaSet compute_shared_kv_sdpas(const std::shared_ptr<const ov::Model>& model) {
-    std::unordered_map<const ov::op::v6::ReadValue*, std::unordered_set<const ov::Node*>> rv_to_sdpas;
+    KvVarOwnerMap owners;
+    SharedSdpaSet shared;
 
-    auto walk_backward = [&](const ov::Node* sdpa, size_t input_idx) {
+    auto walk_and_register = [&](const ov::Node* sdpa, size_t input_idx, const char* suffix) {
         if (input_idx >= sdpa->get_input_size()) {
             return;
         }
@@ -99,7 +137,7 @@ SharedSdpaSet compute_shared_kv_sdpas(const std::shared_ptr<const ov::Model>& mo
             const auto* n = queue.front();
             queue.pop_front();
             if (const auto* rv = ov::as_type<const ov::op::v6::ReadValue>(n)) {
-                rv_to_sdpas[rv].insert(sdpa);
+                find_or_mark_kv_owner(rv->get_variable_id(), suffix, sdpa, owners, shared);
                 continue;
             }
             if (ov::is_type_any_of<ov::op::v0::MatMul,
@@ -120,19 +158,16 @@ SharedSdpaSet compute_shared_kv_sdpas(const std::shared_ptr<const ov::Model>& mo
         }
     };
 
-    for (const auto& op : model->get_ops()) {
+    // Topological order so the "owner" recorded for each variable_id is the
+    // topologically-earliest SDPA that reaches it — this is the SDPA that a
+    // future reader-only fusion mode would keep as the writer.
+    for (const auto& op : model->get_ordered_ops()) {
         if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(op)) {
-            walk_backward(op.get(), 1);  // K
-            walk_backward(op.get(), 2);  // V
+            walk_and_register(op.get(), 1, "/k");
+            walk_and_register(op.get(), 2, "/v");
         }
     }
 
-    SharedSdpaSet shared;
-    for (const auto& [rv, sdpas] : rv_to_sdpas) {
-        if (sdpas.size() > 1) {
-            shared.insert(sdpas.begin(), sdpas.end());
-        }
-    }
     return shared;
 }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -9,11 +9,9 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <deque>
 #include <memory>
 #include <string>
 #include <tuple>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -31,8 +29,6 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/gather.hpp"
-#include "openvino/op/matmul.hpp"
-#include "openvino/op/parameter.hpp"
 #include "openvino/op/read_value.hpp"
 #include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/shape_of.hpp"
@@ -58,127 +54,16 @@ using namespace ov::pass;
 
 namespace ov::intel_cpu {
 
-namespace {
-
-using SharedSdpaSet = std::unordered_set<const ov::Node*>;
-using KvVarOwnerMap = std::unordered_map<std::string, const ov::Node*>;
-
-// Layout deliberately mirrors StateManagementPattern::find_or_create_kv_param
-// in the SDPAToPagedAttention path: same map shape (variable_id + "/k" | "/v"
-// keys), same suffix scheme. Once ScaledDotProductAttentionWithKVCache learns
-// a reader-only binding mode (analogous to PagedAttentionExtension's
-// write_kv_cache=false flag), this helper can flip from "refuse fusion for
-// every shared SDPA" to "fuse the owner with write, fuse the readers without
-// write" by changing only the matcher callback's response — the discovery
-// logic stays the same.
-//
-// Returns true if (variable_id, suffix) was already registered for another
-// SDPA (=> this SDPA is a non-owner reader); false on the first occurrence
-// (=> this SDPA is the tentative owner). On "true", BOTH the current SDPA
-// and the previously-registered owner are inserted into 'shared': the owner
-// only retroactively becomes "shared" when a second reader appears.
-bool find_or_mark_kv_owner(const std::string& variable_id,
-                           const char* suffix,
-                           const ov::Node* sdpa,
-                           KvVarOwnerMap& owners,
-                           SharedSdpaSet& shared) {
-    const auto key = variable_id + suffix;
-    auto it = owners.find(key);
-    if (it != owners.end()) {
-        shared.insert(it->second);
-        shared.insert(sdpa);
-        return true;
-    }
-    owners.emplace(key, sdpa);
-    return false;
-}
-
-// Build the set of v13::SDPA nodes whose KV-cache is shared with another SDPA
-// in the same model.
-//
-// For each v13::ScaledDotProductAttention we walk backward from its K-input
-// (port 1) and V-input (port 2) along data (floating-point) edges only,
-// halting at the boundary ops below. Every ReadValue reached is bucketed by
-// (variable_id + "/k" | "/v"); whenever a key is observed for the second
-// time, both the current SDPA and the previously-recorded owner are flagged
-// as shared.
-//
-// Halt boundaries (do not recurse through their inputs):
-//   - ReadValue: target — record as source and stop.
-//   - MatMul:    k_proj / v_proj boundary; the activation residual stream
-//                lives upstream and connects every layer.
-//   - v13::SDPA: prevents re-entering previous layers' attention output
-//                via residual connections.
-//   - Parameter / Constant: DAG leaves.
-//
-// Edge filter: only floating-point input ports are followed. i32 / i64
-// shape / indices / axes / order edges (and the int8 weight Convert chain)
-// are skipped, which structurally excludes the ShapeOf-rooted positional-ID
-// / RoPE fanout that caused the StatefulSDPAFusion regression with the
-// original forward BFS.
-//
-// Keying on variable_id rather than on the ReadValue pointer is what catches
-// the corner case in which two distinct ReadValue nodes alias the same
-// Variable: their cache memory is the same slot, so any fusion must treat
-// them as shared even though their node pointers differ.
-SharedSdpaSet compute_shared_kv_sdpas(const std::shared_ptr<const ov::Model>& model) {
-    KvVarOwnerMap owners;
-    SharedSdpaSet shared;
-
-    auto walk_and_register = [&](const ov::Node* sdpa, size_t input_idx, const char* suffix) {
-        if (input_idx >= sdpa->get_input_size()) {
-            return;
-        }
-        std::unordered_set<const ov::Node*> visited;
-        std::deque<const ov::Node*> queue;
-        const auto* start = sdpa->get_input_node_ptr(input_idx);
-        visited.insert(start);
-        queue.push_back(start);
-        while (!queue.empty()) {
-            const auto* n = queue.front();
-            queue.pop_front();
-            if (const auto* rv = ov::as_type<const ov::op::v6::ReadValue>(n)) {
-                find_or_mark_kv_owner(rv->get_variable_id(), suffix, sdpa, owners, shared);
-                continue;
-            }
-            if (ov::is_type_any_of<ov::op::v0::MatMul,
-                                   ov::op::v13::ScaledDotProductAttention,
-                                   ov::op::v0::Parameter,
-                                   ov::op::v0::Constant>(n)) {
-                continue;
-            }
-            for (size_t i = 0; i < n->get_input_size(); ++i) {
-                if (!n->get_input_element_type(i).is_real()) {
-                    continue;
-                }
-                const auto* src = n->get_input_node_ptr(i);
-                if (visited.insert(src).second) {
-                    queue.push_back(src);
-                }
-            }
-        }
-    };
-
-    // Topological order so the "owner" recorded for each variable_id is the
-    // topologically-earliest SDPA that reaches it — this is the SDPA that a
-    // future reader-only fusion mode would keep as the writer.
-    for (const auto& op : model->get_ordered_ops()) {
-        if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(op)) {
-            walk_and_register(op.get(), 1, "/k");
-            walk_and_register(op.get(), 2, "/v");
-        }
-    }
-
-    return shared;
-}
-
-}  // namespace
-
 class StatefulSDPAFusionMatcher : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("StatefulSDPAFusionMatcher");
 
-    explicit StatefulSDPAFusionMatcher(const SharedSdpaSet& shared_sdpas) {
+    // Sets are keyed by ov::op::util::Variable identifier rather than by
+    // ReadValue node pointer so that the corner case of two distinct
+    // v6::ReadValue nodes aliasing the same Variable (same cache slot) is
+    // still detected as shared.
+    StatefulSDPAFusionMatcher(std::unordered_set<std::string>& processed_k_variable_ids,
+                              std::unordered_set<std::string>& processed_v_variable_ids) {
         MATCHER_SCOPE(StatefulSDPAFusion);
         using namespace ov::pass::pattern;
 
@@ -239,7 +124,7 @@ public:
 
         auto sdp = sdp0 | sdp1 | sdp2 | sdp3 | sdp_trans0 | sdp_trans1 | sdp_trans2 | sdp_trans3;
 
-        ov::matcher_pass_callback callback = [=](Matcher& m) {
+        ov::matcher_pass_callback callback = [=, &processed_k_variable_ids, &processed_v_variable_ids](Matcher& m) {
             const auto& pattern_map = m.get_pattern_value_map();
             auto root = m.get_match_root();
 
@@ -289,13 +174,16 @@ public:
                 ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_k).get_node_shared_ptr());
             const auto past_v_node =
                 ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_v).get_node_shared_ptr());
-            // Refuse fusion when this SDPA's KV-cache is shared with another
-            // SDPA in the same model. ScaledDotProductAttentionWithKVCache binds
-            // a single MemoryInput per K/V state; a partially-fused shared chain
-            // crashes at runtime with "null input states" in MatchSdpaKvCache.
-            // The shared set is precomputed by the StatefulSDPAFusion ModelPass
-            // wrapper via a backward data-path BFS — see compute_shared_kv_sdpas.
-            if (shared_sdpas.find(sdp_node.get()) != shared_sdpas.end()) {
+            // KV-cache sharing detection. GraphRewrite traverses ops in
+            // topological order, so the SDPA that owns the K / V cache write
+            // path (the one feeding the matching Assign) is matched first.
+            // We record its past_k / past_v Variable id here and refuse
+            // fusion for any subsequent SDPA that reads the same Variable —
+            // those are reader-only SDPAs sharing the cache, and
+            // ScaledDotProductAttentionWithKVCache currently only supports a
+            // single owner-writer per K / V state.
+            if (processed_k_variable_ids.count(past_k_node->get_variable_id()) ||
+                processed_v_variable_ids.count(past_v_node->get_variable_id())) {
                 return false;
             }
             if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {
@@ -465,6 +353,12 @@ public:
             // deleted.
             past_k_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
             past_v_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
+
+            // Mark the K / V Variable ids as owned by the SDPA we just
+            // fused — any later match referencing the same Variable is a
+            // reader of the shared cache and must be skipped.
+            processed_k_variable_ids.insert(past_k_node->get_variable_id());
+            processed_v_variable_ids.insert(past_v_node->get_variable_id());
             return true;
         };
 
@@ -475,9 +369,10 @@ public:
 
 bool StatefulSDPAFusion::run_on_model(const std::shared_ptr<ov::Model>& m) {
     RUN_ON_MODEL_SCOPE(StatefulSDPAFusion);
-    const auto shared = compute_shared_kv_sdpas(m);
+    std::unordered_set<std::string> processed_k_variable_ids;
+    std::unordered_set<std::string> processed_v_variable_ids;
     ov::pass::Manager manager(get_pass_config(), "StatefulSDPAFusionImpl");
-    manager.register_pass<StatefulSDPAFusionMatcher>(shared);
+    manager.register_pass<StatefulSDPAFusionMatcher>(processed_k_variable_ids, processed_v_variable_ids);
     return manager.run_passes(m);
 }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -189,6 +189,29 @@ public:
             if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {
                 return false;
             }
+            // Defense-in-depth against the writer-fused-reader-plain topology
+            // (one ReadValue with multiple non-ShapeOf consumers, only one of
+            // them feeding an Assign). If the writer fuses, the reader's
+            // Gather / Convert child stays attached to the MemoryInput;
+            // GraphOptimizer::MatchSdpaKvCache only promotes a MemoryInput
+            // whose children are in {SDPA, ShapeOf}, so without this guard
+            // the unpromoted MemoryInput leaves the fused node's K / V state
+            // unbound and the kernel then crashes with "null input states"
+            // at execute time. The orthogonal "two ReadValues aliasing one
+            // Variable" corner case is covered separately by
+            // processed_*_variable_ids.
+            auto count_data_consumers = [](const std::shared_ptr<ov::Node>& rv) {
+                size_t count = 0;
+                for (const auto& target : rv->get_output_target_inputs(0)) {
+                    if (!ov::is_type_any_of<ov::op::v0::ShapeOf, ov::op::v3::ShapeOf>(target.get_node())) {
+                        ++count;
+                    }
+                }
+                return count;
+            };
+            if (count_data_consumers(past_k_node) > 1 || count_data_consumers(past_v_node) > 1) {
+                return false;
+            }
             for (auto&& item : {concat_k_node, concat_v_node}) {
                 auto&& children = item->get_output_target_inputs(0);
                 switch (children.size()) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -33,7 +33,6 @@
 #include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/transpose.hpp"
-#include "openvino/pass/manager.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
@@ -54,326 +53,299 @@ using namespace ov::pass;
 
 namespace ov::intel_cpu {
 
-class StatefulSDPAFusionMatcher : public ov::pass::MatcherPass {
-public:
-    OPENVINO_MATCHER_PASS_RTTI("StatefulSDPAFusionMatcher");
+StatefulSDPAFusion::StatefulSDPAFusion() {
+    MATCHER_SCOPE(StatefulSDPAFusion);
+    using namespace ov::pass::pattern;
 
-    // Sets are keyed by ov::op::util::Variable identifier rather than by
-    // ReadValue node pointer so that the corner case of two distinct
-    // v6::ReadValue nodes aliasing the same Variable (same cache slot) is
-    // still detected as shared.
-    StatefulSDPAFusionMatcher(std::unordered_set<std::string>& processed_k_variable_ids,
-                              std::unordered_set<std::string>& processed_v_variable_ids) {
-        MATCHER_SCOPE(StatefulSDPAFusion);
-        using namespace ov::pass::pattern;
+    auto beam_idx = any_input(type_matches(element::i32) && shape_matches("[?]"));
+    auto cur_q = any_input();
+    auto cur_k = any_input();
+    auto cur_v = any_input();
+    auto atten_sink = any_input();
 
-        auto beam_idx = any_input(type_matches(element::i32) && shape_matches("[?]"));
-        auto cur_q = any_input();
-        auto cur_k = any_input();
-        auto cur_v = any_input();
-        auto atten_sink = any_input();
+    auto past_k = wrap_type<ov::op::v6::ReadValue>();
+    auto past_v = wrap_type<ov::op::v6::ReadValue>();
 
-        auto past_k = wrap_type<ov::op::v6::ReadValue>();
-        auto past_v = wrap_type<ov::op::v6::ReadValue>();
+    auto convert_past_k = wrap_type<ov::op::v0::Convert>({past_k});
+    auto convert_past_v = wrap_type<ov::op::v0::Convert>({past_v});
 
-        auto convert_past_k = wrap_type<ov::op::v0::Convert>({past_k});
-        auto convert_past_v = wrap_type<ov::op::v0::Convert>({past_v});
+    auto gather_input_k =
+        wrap_type<ov::op::v8::Gather>({past_k | convert_past_k, beam_idx, "axis_beam"}, {{"batch_dims", 0}});
+    auto gather_input_v =
+        wrap_type<ov::op::v8::Gather>({past_v | convert_past_v, beam_idx, "axis_beam"}, {{"batch_dims", 0}});
 
-        auto gather_input_k =
-            wrap_type<ov::op::v8::Gather>({past_k | convert_past_k, beam_idx, "axis_beam"}, {{"batch_dims", 0}});
-        auto gather_input_v =
-            wrap_type<ov::op::v8::Gather>({past_v | convert_past_v, beam_idx, "axis_beam"}, {{"batch_dims", 0}});
+    auto concat_k = wrap_type<ov::op::v0::Concat>({gather_input_k, cur_k});
+    auto concat_v = wrap_type<ov::op::v0::Concat>({gather_input_v, cur_v});
 
-        auto concat_k = wrap_type<ov::op::v0::Concat>({gather_input_k, cur_k});
-        auto concat_v = wrap_type<ov::op::v0::Concat>({gather_input_v, cur_v});
+    std::shared_ptr<Node> mq_reshape_k, reshape_k, unsqueeze_k, computed_bcst_k, multiply_k, computed_bcst3_k;
+    std::tie(mq_reshape_k, reshape_k, unsqueeze_k, computed_bcst_k, multiply_k, computed_bcst3_k) =
+        ov::op::util::match_multi_query_bcst(concat_k);
+    std::shared_ptr<Node> mq_reshape_v, reshape_v, unsqueeze_v, computed_bcst_v, multiply_v, computed_bcst3_v;
+    std::tie(mq_reshape_v, reshape_v, unsqueeze_v, computed_bcst_v, multiply_v, computed_bcst3_v) =
+        ov::op::util::match_multi_query_bcst(concat_v);
+    auto present_k = concat_k | mq_reshape_k;
+    auto present_v = concat_v | mq_reshape_v;
 
-        std::shared_ptr<Node> mq_reshape_k, reshape_k, unsqueeze_k, computed_bcst_k, multiply_k, computed_bcst3_k;
-        std::tie(mq_reshape_k, reshape_k, unsqueeze_k, computed_bcst_k, multiply_k, computed_bcst3_k) =
-            ov::op::util::match_multi_query_bcst(concat_k);
-        std::shared_ptr<Node> mq_reshape_v, reshape_v, unsqueeze_v, computed_bcst_v, multiply_v, computed_bcst3_v;
-        std::tie(mq_reshape_v, reshape_v, unsqueeze_v, computed_bcst_v, multiply_v, computed_bcst3_v) =
-            ov::op::util::match_multi_query_bcst(concat_v);
-        auto present_k = concat_k | mq_reshape_k;
-        auto present_v = concat_v | mq_reshape_v;
+    // canonical q/k/v shape definition: [B,H,...L,S]
+    auto sdp0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v});
+    auto sdp1 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v, any_input()});
+    auto sdp2 =
+        wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v, any_input(), any_input()});
+    // gpt-oss
+    auto sdp3 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
+        {cur_q, present_k, present_v, any_input(), any_input(), atten_sink});
 
-        // canonical q/k/v shape definition: [B,H,...L,S]
-        auto sdp0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v});
-        auto sdp1 = wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v, any_input()});
-        auto sdp2 =
-            wrap_type<ov::op::v13::ScaledDotProductAttention>({cur_q, present_k, present_v, any_input(), any_input()});
-        // gpt-oss
-        auto sdp3 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
-            {cur_q, present_k, present_v, any_input(), any_input(), atten_sink});
+    // non-canonical q/k/v shape definitions, for example: [L, B, H, S]/[B, L, H, S]
+    auto order_k = wrap_type<ov::op::v0::Constant>();
+    auto order_v = wrap_type<ov::op::v0::Constant>();
+    auto order_q = wrap_type<ov::op::v0::Constant>();
+    auto transpose_q = wrap_type<ov::op::v1::Transpose>({cur_q, order_q});
+    auto transpose_k = wrap_type<ov::op::v1::Transpose>({present_k, order_k});
+    auto transpose_v = wrap_type<ov::op::v1::Transpose>({present_v, order_v});
 
-        // non-canonical q/k/v shape definitions, for example: [L, B, H, S]/[B, L, H, S]
-        auto order_k = wrap_type<ov::op::v0::Constant>();
-        auto order_v = wrap_type<ov::op::v0::Constant>();
-        auto order_q = wrap_type<ov::op::v0::Constant>();
-        auto transpose_q = wrap_type<ov::op::v1::Transpose>({cur_q, order_q});
-        auto transpose_k = wrap_type<ov::op::v1::Transpose>({present_k, order_k});
-        auto transpose_v = wrap_type<ov::op::v1::Transpose>({present_v, order_v});
+    auto sdp_trans0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({transpose_q, transpose_k, transpose_v});
+    auto sdp_trans1 =
+        wrap_type<ov::op::v13::ScaledDotProductAttention>({transpose_q, transpose_k, transpose_v, any_input()});
+    auto sdp_trans2 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
+        {transpose_q, transpose_k, transpose_v, any_input(), any_input()});
+    // gpt-oss
+    auto sdp_trans3 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
+        {transpose_q, transpose_k, transpose_v, any_input(), any_input(), atten_sink});
 
-        auto sdp_trans0 = wrap_type<ov::op::v13::ScaledDotProductAttention>({transpose_q, transpose_k, transpose_v});
-        auto sdp_trans1 =
-            wrap_type<ov::op::v13::ScaledDotProductAttention>({transpose_q, transpose_k, transpose_v, any_input()});
-        auto sdp_trans2 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
-            {transpose_q, transpose_k, transpose_v, any_input(), any_input()});
-        // gpt-oss
-        auto sdp_trans3 = wrap_type<ov::op::v13::ScaledDotProductAttention>(
-            {transpose_q, transpose_k, transpose_v, any_input(), any_input(), atten_sink});
+    auto sdp = sdp0 | sdp1 | sdp2 | sdp3 | sdp_trans0 | sdp_trans1 | sdp_trans2 | sdp_trans3;
 
-        auto sdp = sdp0 | sdp1 | sdp2 | sdp3 | sdp_trans0 | sdp_trans1 | sdp_trans2 | sdp_trans3;
+    ov::matcher_pass_callback callback = [=, this](Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto root = m.get_match_root();
 
-        ov::matcher_pass_callback callback = [=, &processed_k_variable_ids, &processed_v_variable_ids](Matcher& m) {
-            const auto& pattern_map = m.get_pattern_value_map();
-            auto root = m.get_match_root();
+        // Check concat axes equality first
+        const auto concat_k_node = ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_k).get_node_shared_ptr());
+        const auto concat_v_node = ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_v).get_node_shared_ptr());
+        if (concat_k_node->get_axis() != concat_v_node->get_axis()) {
+            return false;
+        }
 
-            // Check concat axes equality first
-            const auto concat_k_node =
-                ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_k).get_node_shared_ptr());
-            const auto concat_v_node =
-                ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_v).get_node_shared_ptr());
-            if (concat_k_node->get_axis() != concat_v_node->get_axis()) {
-                return false;
-            }
-
-            auto find_assign =
-                [&](const ov::Output<ov::Node>& out, ov::op::v6::Assign*& assign, ov::op::v0::Convert*& cvt) {
-                    auto present_to = out.get_target_inputs();
-                    for (const auto& to : present_to) {
-                        auto* to_node = to.get_node();
-                        if (auto* convert = ov::as_type<ov::op::v0::Convert>(to_node)) {
-                            auto cvt_targets = convert->get_output_target_inputs(0);
-                            if (cvt_targets.size() == 1) {
-                                to_node = cvt_targets.begin()->get_node();
-                                cvt = convert;
-                            }
-                        }
-                        assign = ov::as_type<ov::op::v6::Assign>(to_node);
-                        if (assign) {
-                            return true;
+        auto find_assign =
+            [&](const ov::Output<ov::Node>& out, ov::op::v6::Assign*& assign, ov::op::v0::Convert*& cvt) {
+                auto present_to = out.get_target_inputs();
+                for (const auto& to : present_to) {
+                    auto* to_node = to.get_node();
+                    if (auto* convert = ov::as_type<ov::op::v0::Convert>(to_node)) {
+                        auto cvt_targets = convert->get_output_target_inputs(0);
+                        if (cvt_targets.size() == 1) {
+                            to_node = cvt_targets.begin()->get_node();
+                            cvt = convert;
                         }
                     }
-                    return false;
-                };
-            auto check_valid_children_type = [](const ov::Output<ov::Node>& out) {
-                auto children = out.get_target_inputs();
-                return std::all_of(children.begin(), children.end(), [](const ov::Input<ov::Node>& child) {
-                    auto* node = child.get_node();
-                    return any_of(node->get_type_info(),
-                                  ov::op::v13::ScaledDotProductAttention::get_type_info_static(),
-                                  ov::op::v0::ShapeOf::get_type_info_static(),
-                                  ov::op::v3::ShapeOf::get_type_info_static(),
-                                  ov::op::v0::Convert::get_type_info_static(),
-                                  ov::op::v8::Gather::get_type_info_static());
-                });
-            };
-
-            const auto sdp_node = ov::as_type_ptr<ov::op::v13::ScaledDotProductAttention>(root);
-            const auto past_k_node =
-                ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_k).get_node_shared_ptr());
-            const auto past_v_node =
-                ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_v).get_node_shared_ptr());
-            // KV-cache sharing detection. GraphRewrite traverses ops in
-            // topological order, so the SDPA that owns the K / V cache write
-            // path (the one feeding the matching Assign) is matched first.
-            // We record its past_k / past_v Variable id here and refuse
-            // fusion for any subsequent SDPA that reads the same Variable —
-            // those are reader-only SDPAs sharing the cache, and
-            // ScaledDotProductAttentionWithKVCache currently only supports a
-            // single owner-writer per K / V state.
-            if (processed_k_variable_ids.find(past_k_node->get_variable_id()) != processed_k_variable_ids.end() ||
-                processed_v_variable_ids.find(past_v_node->get_variable_id()) != processed_v_variable_ids.end()) {
-                return false;
-            }
-            if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {
-                return false;
-            }
-            for (auto&& item : {concat_k_node, concat_v_node}) {
-                auto&& children = item->get_output_target_inputs(0);
-                switch (children.size()) {
-                case 2:
-                    // pass, as the existence of Assign will be checked later
-                    break;
-                case 3:
-                    // the first one leads to SDPA, otherwise the matcher doesn't find the pattern
-                    // the second one leads to Assign, and this is checked later
-                    // the third child is allowed to be a ShapeOf op only, thus one of them must be ShapeOf
-                    if (!std::any_of(children.begin(), children.end(), [](const ov::Input<ov::Node>& child) {
-                            return ov::is_type_any_of<ov::op::v3::ShapeOf, ov::op::v0::ShapeOf>(child.get_node());
-                        })) {
-                        return false;
-                    }
-                    break;
-                default:
-                    return false;
-                }
-            }
-
-            ov::op::v6::Assign* assign_k_node = nullptr;
-            ov::op::v6::Assign* assign_v_node = nullptr;
-            ov::op::v0::Convert* assign_cvt_k_node = nullptr;
-            ov::op::v0::Convert* assign_cvt_v_node = nullptr;
-            if (!find_assign(concat_k_node, assign_k_node, assign_cvt_k_node)) {
-                return false;
-            }
-            if (past_k_node->get_variable_id() != assign_k_node->get_variable_id()) {
-                return false;
-            }
-
-            if (!find_assign(concat_v_node, assign_v_node, assign_cvt_v_node)) {
-                return false;
-            }
-            if (past_v_node->get_variable_id() != assign_v_node->get_variable_id()) {
-                return false;
-            }
-
-            auto is_optional_one_child = [&pattern_map](const std::vector<std::shared_ptr<Node>>& nodes) {
-                return std::all_of(nodes.begin(), nodes.end(), [&](const std::shared_ptr<Node>& node) {
-                    if (pattern_map.count(node)) {
-                        auto p = pattern_map.at(node).get_node_shared_ptr();
-                        return p->get_output_target_inputs(0).size() == 1;
-                    }
-                    return true;
-                });
-            };
-            if (!is_optional_one_child({convert_past_k,
-                                        convert_past_v,
-                                        transpose_q,
-                                        transpose_k,
-                                        transpose_v,
-                                        reshape_k,
-                                        unsqueeze_k,
-                                        computed_bcst_k,
-                                        multiply_k,
-                                        reshape_v,
-                                        unsqueeze_v,
-                                        computed_bcst_v,
-                                        multiply_v,
-                                        mq_reshape_k,
-                                        mq_reshape_v,
-                                        computed_bcst3_k,
-                                        computed_bcst3_v})) {
-                return false;
-            }
-
-            // past_k & past_v must be reordered by same beam_idx
-            const auto gather_k_node =
-                ov::as_type_ptr<ov::op::v8::Gather>(pattern_map.at(gather_input_k).get_node_shared_ptr());
-            const auto gather_v_node =
-                ov::as_type_ptr<ov::op::v8::Gather>(pattern_map.at(gather_input_v).get_node_shared_ptr());
-            if (gather_k_node->input_value(1) != gather_v_node->input_value(1) ||
-                gather_k_node->get_output_target_inputs(0).size() != 1 ||
-                gather_v_node->get_output_target_inputs(0).size() != 1) {
-                return false;
-            }
-
-            OutputVector args = sdp_node->input_values();
-            args[0] = pattern_map.at(cur_q);
-            args[1] = pattern_map.at(cur_k);
-            args[2] = pattern_map.at(cur_v);
-            args.push_back(pattern_map.at(beam_idx));
-            args.push_back(gather_k_node->input_value(0));
-            args.push_back(gather_v_node->input_value(0));
-            ov::intel_cpu::ScaledDotProductAttentionWithKVCache::Config config;
-
-            config.is_causal = sdp_node->get_causal();
-            config.fuse_concat = true;
-
-            if (pattern_map.count(order_q) && pattern_map.count(order_k) && pattern_map.count(order_v)) {
-                const auto order_q_node =
-                    ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_q).get_node_shared_ptr());
-                const auto order_k_node =
-                    ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_k).get_node_shared_ptr());
-                const auto order_v_node =
-                    ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_v).get_node_shared_ptr());
-                const auto& permute_q = order_q_node->cast_vector<int32_t>();
-                const auto& permute_k = order_k_node->cast_vector<int32_t>();
-                const auto& permute_v = order_v_node->cast_vector<int32_t>();
-                if (permute_q != permute_k || permute_q != permute_v) {
-                    return false;
-                }
-                config.permute_axes.resize(permute_q.size());
-                for (size_t i = 0; i < permute_q.size(); i++) {
-                    config.permute_axes[i] = static_cast<size_t>(permute_q[i]);
-                }
-            }
-
-            const auto& old_node = sdp_node;
-            auto new_node = std::make_shared<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(args, config);
-            new_node->set_friendly_name(old_node->get_friendly_name());
-            copy_runtime_info(old_node, new_node);
-            ov::replace_node(old_node, {new_node->output(0)});
-            if (assign_cvt_k_node) {
-                assign_cvt_k_node->set_arguments({new_node->output(1)});
-            } else {
-                assign_k_node->set_arguments({new_node->output(1)});
-            }
-
-            if (assign_cvt_v_node) {
-                assign_cvt_v_node->set_arguments({new_node->output(2)});
-            } else {
-                assign_v_node->set_arguments({new_node->output(2)});
-            }
-
-            // Re-route any ShapeOf consumer of the (now-obsolete) K/V Concat
-            // to the fused node's new K/V output. The Concat has the same
-            // post-cache tensor shape as the fused output, so this rewrite
-            // is semantically a no-op. Without it, the ShapeOf keeps the
-            // old Concat -> Gather chain reachable via the global
-            // positional-ID / attention-mask computation in models that
-            // take this case-3 path (Gemma3n layer 0), which in turn leaves
-            // the old Gather as a child of the ReadValue's MemoryInput;
-            // MatchSdpaKvCache rejects non-{SDPA,ShapeOf} children and the
-            // fused kernel then crashes with "null input states" at execute
-            // time. In the Mixtral multi-query-broadcast case the ShapeOf's
-            // consumers are themselves absorbed by the matcher pattern, so
-            // after this re-route the entire multi-query chain is dead and
-            // gets collapsed by subsequent dead-code elimination.
-            auto reroute_shape_of_consumers = [&](const std::shared_ptr<Node>& concat_node,
-                                                  const ov::Output<ov::Node>& replacement) {
-                std::vector<ov::Input<Node>> shape_of_inputs;
-                for (const auto& target : concat_node->get_output_target_inputs(0)) {
-                    auto* child = target.get_node();
-                    if (ov::is_type_any_of<ov::op::v0::ShapeOf, ov::op::v3::ShapeOf>(child)) {
-                        shape_of_inputs.push_back(target);
+                    assign = ov::as_type<ov::op::v6::Assign>(to_node);
+                    if (assign) {
+                        return true;
                     }
                 }
-                for (const auto& inp : shape_of_inputs) {
-                    inp.replace_source_output(replacement);
-                }
+                return false;
             };
-            reroute_shape_of_consumers(concat_k_node, new_node->output(1));
-            reroute_shape_of_consumers(concat_v_node, new_node->output(2));
-
-            // Markup pattern:
-            // ReadValue->Convert(Optional)->ScaledDotProductAttentionWithKVCache->Convert(Optional)->Assign, so that
-            // ReadValue can't be replaced with ReadValueWithSubgraph in this pattern.
-            // TODO: Temporarily skip this pattern. If MemoryInputSDPA supports Subgraph in the future, it may be
-            // deleted.
-            past_k_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
-            past_v_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
-
-            // Mark the K / V Variable ids as owned by the SDPA we just
-            // fused — any later match referencing the same Variable is a
-            // reader of the shared cache and must be skipped.
-            processed_k_variable_ids.insert(past_k_node->get_variable_id());
-            processed_v_variable_ids.insert(past_v_node->get_variable_id());
-            return true;
+        auto check_valid_children_type = [](const ov::Output<ov::Node>& out) {
+            auto children = out.get_target_inputs();
+            return std::all_of(children.begin(), children.end(), [](const ov::Input<ov::Node>& child) {
+                auto* node = child.get_node();
+                return any_of(node->get_type_info(),
+                              ov::op::v13::ScaledDotProductAttention::get_type_info_static(),
+                              ov::op::v0::ShapeOf::get_type_info_static(),
+                              ov::op::v3::ShapeOf::get_type_info_static(),
+                              ov::op::v0::Convert::get_type_info_static(),
+                              ov::op::v8::Gather::get_type_info_static());
+            });
         };
 
-        auto m = std::make_shared<ov::pass::pattern::Matcher>(sdp, matcher_name);
-        this->register_matcher(m, callback);
-    }
-};
+        const auto sdp_node = ov::as_type_ptr<ov::op::v13::ScaledDotProductAttention>(root);
+        const auto past_k_node = ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_k).get_node_shared_ptr());
+        const auto past_v_node = ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_v).get_node_shared_ptr());
+        // KV-cache sharing detection. GraphRewrite traverses ops in topological order, so the
+        // SDPA that owns the K / V cache write path (the one feeding the matching Assign) is
+        // matched first. Record its past_k / past_v Variable id below on a successful fusion,
+        // and refuse fusion here for any subsequent SDPA that reads the same Variable —
+        // those are reader-only SDPAs sharing the cache, and ScaledDotProductAttentionWithKVCache
+        // currently only supports a single owner-writer per K / V state.
+        // Sets are keyed by Variable id (not by ReadValue node pointer) so the corner case of
+        // two distinct v6::ReadValue nodes aliasing the same Variable is still detected as shared.
+        if (m_processed_k_variable_ids.find(past_k_node->get_variable_id()) !=
+                m_processed_k_variable_ids.end() ||
+            m_processed_v_variable_ids.find(past_v_node->get_variable_id()) !=
+                m_processed_v_variable_ids.end()) {
+            return false;
+        }
+        if (!check_valid_children_type(past_k_node) || !check_valid_children_type(past_v_node)) {
+            return false;
+        }
+        for (auto&& item : {concat_k_node, concat_v_node}) {
+            auto&& children = item->get_output_target_inputs(0);
+            switch (children.size()) {
+            case 2:
+                // pass, as the existence of Assign will be checked later
+                break;
+            case 3:
+                // the first one leads to SDPA, otherwise the matcher doesn't find the pattern
+                // the second one leads to Assign, and this is checked later
+                // the third child is allowed to be a ShapeOf op only, thus one of them must be ShapeOf
+                if (!std::any_of(children.begin(), children.end(), [](const ov::Input<ov::Node>& child) {
+                        return ov::is_type_any_of<ov::op::v3::ShapeOf, ov::op::v0::ShapeOf>(child.get_node());
+                    })) {
+                    return false;
+                }
+                break;
+            default:
+                return false;
+            }
+        }
 
-bool StatefulSDPAFusion::run_on_model(const std::shared_ptr<ov::Model>& m) {
-    RUN_ON_MODEL_SCOPE(StatefulSDPAFusion);
-    std::unordered_set<std::string> processed_k_variable_ids;
-    std::unordered_set<std::string> processed_v_variable_ids;
-    ov::pass::Manager manager(get_pass_config(), "StatefulSDPAFusionImpl");
-    manager.register_pass<StatefulSDPAFusionMatcher>(processed_k_variable_ids, processed_v_variable_ids);
-    return manager.run_passes(m);
+        ov::op::v6::Assign* assign_k_node = nullptr;
+        ov::op::v6::Assign* assign_v_node = nullptr;
+        ov::op::v0::Convert* assign_cvt_k_node = nullptr;
+        ov::op::v0::Convert* assign_cvt_v_node = nullptr;
+        if (!find_assign(concat_k_node, assign_k_node, assign_cvt_k_node)) {
+            return false;
+        }
+        if (past_k_node->get_variable_id() != assign_k_node->get_variable_id()) {
+            return false;
+        }
+
+        if (!find_assign(concat_v_node, assign_v_node, assign_cvt_v_node)) {
+            return false;
+        }
+        if (past_v_node->get_variable_id() != assign_v_node->get_variable_id()) {
+            return false;
+        }
+
+        auto is_optional_one_child = [&pattern_map](const std::vector<std::shared_ptr<Node>>& nodes) {
+            return std::all_of(nodes.begin(), nodes.end(), [&](const std::shared_ptr<Node>& node) {
+                if (pattern_map.count(node)) {
+                    auto p = pattern_map.at(node).get_node_shared_ptr();
+                    return p->get_output_target_inputs(0).size() == 1;
+                }
+                return true;
+            });
+        };
+        if (!is_optional_one_child({convert_past_k,
+                                    convert_past_v,
+                                    transpose_q,
+                                    transpose_k,
+                                    transpose_v,
+                                    reshape_k,
+                                    unsqueeze_k,
+                                    computed_bcst_k,
+                                    multiply_k,
+                                    reshape_v,
+                                    unsqueeze_v,
+                                    computed_bcst_v,
+                                    multiply_v,
+                                    mq_reshape_k,
+                                    mq_reshape_v,
+                                    computed_bcst3_k,
+                                    computed_bcst3_v})) {
+            return false;
+        }
+
+        // past_k & past_v must be reordered by same beam_idx
+        const auto gather_k_node =
+            ov::as_type_ptr<ov::op::v8::Gather>(pattern_map.at(gather_input_k).get_node_shared_ptr());
+        const auto gather_v_node =
+            ov::as_type_ptr<ov::op::v8::Gather>(pattern_map.at(gather_input_v).get_node_shared_ptr());
+        if (gather_k_node->input_value(1) != gather_v_node->input_value(1) ||
+            gather_k_node->get_output_target_inputs(0).size() != 1 ||
+            gather_v_node->get_output_target_inputs(0).size() != 1) {
+            return false;
+        }
+
+        OutputVector args = sdp_node->input_values();
+        args[0] = pattern_map.at(cur_q);
+        args[1] = pattern_map.at(cur_k);
+        args[2] = pattern_map.at(cur_v);
+        args.push_back(pattern_map.at(beam_idx));
+        args.push_back(gather_k_node->input_value(0));
+        args.push_back(gather_v_node->input_value(0));
+        ov::intel_cpu::ScaledDotProductAttentionWithKVCache::Config config;
+
+        config.is_causal = sdp_node->get_causal();
+        config.fuse_concat = true;
+
+        if (pattern_map.count(order_q) && pattern_map.count(order_k) && pattern_map.count(order_v)) {
+            const auto order_q_node =
+                ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_q).get_node_shared_ptr());
+            const auto order_k_node =
+                ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_k).get_node_shared_ptr());
+            const auto order_v_node =
+                ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order_v).get_node_shared_ptr());
+            const auto& permute_q = order_q_node->cast_vector<int32_t>();
+            const auto& permute_k = order_k_node->cast_vector<int32_t>();
+            const auto& permute_v = order_v_node->cast_vector<int32_t>();
+            if (permute_q != permute_k || permute_q != permute_v) {
+                return false;
+            }
+            config.permute_axes.resize(permute_q.size());
+            for (size_t i = 0; i < permute_q.size(); i++) {
+                config.permute_axes[i] = static_cast<size_t>(permute_q[i]);
+            }
+        }
+
+        const auto& old_node = sdp_node;
+        auto new_node = std::make_shared<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(args, config);
+        new_node->set_friendly_name(old_node->get_friendly_name());
+        copy_runtime_info(old_node, new_node);
+        ov::replace_node(old_node, {new_node->output(0)});
+        if (assign_cvt_k_node) {
+            assign_cvt_k_node->set_arguments({new_node->output(1)});
+        } else {
+            assign_k_node->set_arguments({new_node->output(1)});
+        }
+
+        if (assign_cvt_v_node) {
+            assign_cvt_v_node->set_arguments({new_node->output(2)});
+        } else {
+            assign_v_node->set_arguments({new_node->output(2)});
+        }
+
+        // Re-route any ShapeOf consumer of the (now-obsolete) K / V Concat to the fused node's
+        // new K / V output. The Concat has the same post-cache tensor shape as the fused output,
+        // so this rewrite is semantically a no-op. Without it, the ShapeOf keeps the old
+        // Concat -> Gather chain reachable via the global positional-ID / attention-mask
+        // computation in models that take this case-3 path (Gemma3n layer 0), which leaves the
+        // old Gather as a child of the ReadValue's MemoryInput; MatchSdpaKvCache rejects
+        // non-{SDPA, ShapeOf} children and the fused kernel then crashes with "null input states"
+        // at execute time. In the Mixtral multi-query-broadcast case the ShapeOf's consumers are
+        // themselves absorbed by the matcher pattern, so after this re-route the entire
+        // multi-query chain is dead and gets collapsed by subsequent dead-code elimination.
+        auto reroute_shape_of_consumers = [](const std::shared_ptr<Node>& concat_node,
+                                             const ov::Output<ov::Node>& replacement) {
+            std::vector<ov::Input<Node>> shape_of_inputs;
+            for (const auto& target : concat_node->get_output_target_inputs(0)) {
+                auto* child = target.get_node();
+                if (ov::is_type_any_of<ov::op::v0::ShapeOf, ov::op::v3::ShapeOf>(child)) {
+                    shape_of_inputs.push_back(target);
+                }
+            }
+            for (const auto& inp : shape_of_inputs) {
+                inp.replace_source_output(replacement);
+            }
+        };
+        reroute_shape_of_consumers(concat_k_node, new_node->output(1));
+        reroute_shape_of_consumers(concat_v_node, new_node->output(2));
+
+        // Markup pattern:
+        // ReadValue->Convert(Optional)->ScaledDotProductAttentionWithKVCache->Convert(Optional)->Assign, so that
+        // ReadValue can't be replaced with ReadValueWithSubgraph in this pattern.
+        // TODO: Temporarily skip this pattern. If MemoryInputSDPA supports Subgraph in the future, it may be deleted.
+        past_k_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
+        past_v_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
+
+        // Mark the K / V Variable ids as owned by the SDPA we just fused — any later match
+        // referencing the same Variable is a reader of the shared cache and must be skipped.
+        m_processed_k_variable_ids.insert(past_k_node->get_variable_id());
+        m_processed_v_variable_ids.insert(past_v_node->get_variable_id());
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(sdp, matcher_name);
+    this->register_matcher(m, callback);
 }
 
 bool SDPASubgraphFusion::run_on_model(const std::shared_ptr<ov::Model>& f) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -33,11 +33,13 @@
 #include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/transpose.hpp"
+#include "openvino/op/util/shape_of_base.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/util/pp.hpp"
 #include "transformations/common_optimizations/simplify_shape_of_sub_graph.hpp"
 #include "transformations/cpu_opset/common/op/sdpa.hpp"
 #include "transformations/defs.hpp"
@@ -114,7 +116,7 @@ StatefulSDPAFusion::StatefulSDPAFusion() {
 
     auto sdp = sdp0 | sdp1 | sdp2 | sdp3 | sdp_trans0 | sdp_trans1 | sdp_trans2 | sdp_trans3;
 
-    ov::matcher_pass_callback callback = [=, this](Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
         auto root = m.get_match_root();
 
@@ -160,14 +162,6 @@ StatefulSDPAFusion::StatefulSDPAFusion() {
         const auto sdp_node = ov::as_type_ptr<ov::op::v13::ScaledDotProductAttention>(root);
         const auto past_k_node = ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_k).get_node_shared_ptr());
         const auto past_v_node = ov::as_type_ptr<ov::op::v6::ReadValue>(pattern_map.at(past_v).get_node_shared_ptr());
-        // KV-cache sharing detection. GraphRewrite traverses ops in topological order, so the
-        // SDPA that owns the K / V cache write path (the one feeding the matching Assign) is
-        // matched first. Record its past_k / past_v Variable id below on a successful fusion,
-        // and refuse fusion here for any subsequent SDPA that reads the same Variable —
-        // those are reader-only SDPAs sharing the cache, and ScaledDotProductAttentionWithKVCache
-        // currently only supports a single owner-writer per K / V state.
-        // Sets are keyed by Variable id (not by ReadValue node pointer) so the corner case of
-        // two distinct v6::ReadValue nodes aliasing the same Variable is still detected as shared.
         if (m_processed_k_variable_ids.find(past_k_node->get_variable_id()) != m_processed_k_variable_ids.end() ||
             m_processed_v_variable_ids.find(past_v_node->get_variable_id()) != m_processed_v_variable_ids.end()) {
             return false;
@@ -302,22 +296,14 @@ StatefulSDPAFusion::StatefulSDPAFusion() {
             assign_v_node->set_arguments({new_node->output(2)});
         }
 
-        // Re-route any ShapeOf consumer of the (now-obsolete) K / V Concat to the fused node's
-        // new K / V output. The Concat has the same post-cache tensor shape as the fused output,
-        // so this rewrite is semantically a no-op. Without it, the ShapeOf keeps the old
-        // Concat -> Gather chain reachable via the global positional-ID / attention-mask
-        // computation in models that take this case-3 path (Gemma3n layer 0), which leaves the
-        // old Gather as a child of the ReadValue's MemoryInput; MatchSdpaKvCache rejects
-        // non-{SDPA, ShapeOf} children and the fused kernel then crashes with "null input states"
-        // at execute time. In the Mixtral multi-query-broadcast case the ShapeOf's consumers are
-        // themselves absorbed by the matcher pattern, so after this re-route the entire
-        // multi-query chain is dead and gets collapsed by subsequent dead-code elimination.
+        // Without this reroute the dead Concat keeps the old Gather alive as a MemoryInput child;
+        // MatchSdpaKvCache rejects non-{SDPA, ShapeOf} children and the fused kernel asserts on null states.
         auto reroute_shape_of_consumers = [](const std::shared_ptr<Node>& concat_node,
                                              const ov::Output<ov::Node>& replacement) {
             std::vector<ov::Input<Node>> shape_of_inputs;
             for (const auto& target : concat_node->get_output_target_inputs(0)) {
                 auto* child = target.get_node();
-                if (ov::is_type_any_of<ov::op::v0::ShapeOf, ov::op::v3::ShapeOf>(child)) {
+                if (ov::is_type<ov::op::util::ShapeOfBase>(child)) {
                     shape_of_inputs.push_back(target);
                 }
             }
@@ -335,8 +321,6 @@ StatefulSDPAFusion::StatefulSDPAFusion() {
         past_k_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
         past_v_node->get_rt_info()["DisableInitSubgraphFusing"] = true;
 
-        // Mark the K / V Variable ids as owned by the SDPA we just fused — any later match
-        // referencing the same Variable is a reader of the shared cache and must be skipped.
         m_processed_k_variable_ids.insert(past_k_node->get_variable_id());
         m_processed_v_variable_ids.insert(past_v_node->get_variable_id());
         return true;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.hpp
@@ -11,10 +11,10 @@
 #include "openvino/pass/pass.hpp"
 
 namespace ov::intel_cpu {
-class StatefulSDPAFusion : public ov::pass::MatcherPass {
+class StatefulSDPAFusion : public ov::pass::ModelPass {
 public:
-    OPENVINO_MATCHER_PASS_RTTI("StatefulSDPAFusion");
-    StatefulSDPAFusion();
+    OPENVINO_MODEL_PASS_RTTI("StatefulSDPAFusion");
+    bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 };
 
 class SDPASubgraphFusion : public ov::pass::ModelPass {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.hpp
@@ -19,11 +19,8 @@ public:
     StatefulSDPAFusion();
 
 private:
-    // Variable ids of past_k / past_v ReadValues whose SDPA has already been
-    // fused. Subsequent matches referencing the same Variable are reader-only
-    // SDPAs sharing the cache and must be skipped — the fused
-    // ScaledDotProductAttentionWithKVCache kernel only supports a single
-    // owner-writer per K / V state.
+    // Variable ids of past_k / past_v whose SDPA has already been fused; later matches on the
+    // same Variable are reader-only SDPAs and must be skipped.
     std::unordered_set<std::string> m_processed_k_variable_ids;
     std::unordered_set<std::string> m_processed_v_variable_ids;
 };

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.hpp
@@ -5,16 +5,27 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <unordered_set>
 
 #include "openvino/core/model.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "openvino/pass/pass.hpp"
 
 namespace ov::intel_cpu {
-class StatefulSDPAFusion : public ov::pass::ModelPass {
+class StatefulSDPAFusion : public ov::pass::MatcherPass {
 public:
-    OPENVINO_MODEL_PASS_RTTI("StatefulSDPAFusion");
-    bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
+    OPENVINO_MATCHER_PASS_RTTI("StatefulSDPAFusion");
+    StatefulSDPAFusion();
+
+private:
+    // Variable ids of past_k / past_v ReadValues whose SDPA has already been
+    // fused. Subsequent matches referencing the same Variable are reader-only
+    // SDPAs sharing the cache and must be skipped — the fused
+    // ScaledDotProductAttentionWithKVCache kernel only supports a single
+    // owner-writer per K / V state.
+    std::unordered_set<std::string> m_processed_k_variable_ids;
+    std::unordered_set<std::string> m_processed_v_variable_ids;
 };
 
 class SDPASubgraphFusion : public ov::pass::ModelPass {

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -407,3 +407,301 @@ TEST_F(TransformationTestsF, StateConcatSDPAMixedSharedAndExclusive) {
     manager.register_pass<SDPASubgraphFusion>();
 }
 
+// Two SDPAs with independent KV-cache Variables, plus a ShapeOf-rooted subgraph
+// hanging off layer-0's Gather output that fans out into both SDPAs'
+// attention-mask input. Mirrors the fan-out pattern observed in Qwen3-0.6B etc.,
+// where ShapeOf of layer 0's cache-after-beam-gather feeds the global
+// positional-ID / RoPE / attention-mask chain shared by every decoder layer.
+// Expectation: StatefulSDPAFusion MUST fuse both SDPAs — the shape/metadata
+// branch rooted at ShapeOf does not imply a shared KV-cache.
+static std::shared_ptr<ov::Model>
+makeNonSharedKVWithSharedShapeOfRopeModel(const ov::PartialShape& inputShape) {
+    auto make_param = [&](element::Type t, const ov::PartialShape& s) {
+        return std::make_shared<ov::op::v0::Parameter>(t, s);
+    };
+    auto beam_idx = make_param(element::i32, ov::PartialShape{-1});
+
+    // Layer 0
+    auto q0 = make_param(element::f32, inputShape);
+    auto k0 = make_param(element::f32, inputShape);
+    auto v0 = make_param(element::f32, inputShape);
+    auto init_k0 = make_param(element::f32, inputShape);
+    auto init_v0 = make_param(element::f32, inputShape);
+    auto var_k0 = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "pastk_0"});
+    auto var_v0 = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "pastv_0"});
+    auto rv_k0 = std::make_shared<ov::op::v6::ReadValue>(init_k0, var_k0);
+    auto rv_v0 = std::make_shared<ov::op::v6::ReadValue>(init_v0, var_v0);
+    auto g_k0 =
+        std::make_shared<ov::op::v8::Gather>(rv_k0, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
+    auto g_v0 =
+        std::make_shared<ov::op::v8::Gather>(rv_v0, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
+    auto c_k0 = std::make_shared<ov::op::v0::Concat>(OutputVector{g_k0, k0}, 2);
+    auto c_v0 = std::make_shared<ov::op::v0::Concat>(OutputVector{g_v0, v0}, 2);
+
+    // Shared shape/metadata subgraph rooted on layer 0's Gather output.
+    // With the data-path allowlist BFS, ShapeOf halts traversal without counting,
+    // so layer 0 cannot "see" layer 1's SDPA through this path.
+    auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(g_k0, element::i64);
+    auto seq_len = std::make_shared<ov::op::v8::Gather>(shape_of,
+                                                       op::v0::Constant::create(element::i64, {1}, {2}),
+                                                       op::v0::Constant::create(element::i64, {}, {0}));
+    auto pos_shape = std::make_shared<ov::op::v0::Concat>(
+        OutputVector{op::v0::Constant::create(element::i64, {1}, {1}),
+                     op::v0::Constant::create(element::i64, {1}, {1}),
+                     op::v0::Constant::create(element::i64, {1}, {1}),
+                     seq_len},
+        0);
+    // Non-zero constant to prevent NopElimination from collapsing the downstream
+    // Add nodes into identities (which would erase the shared fanout entirely).
+    auto pos_const = op::v0::Constant::create(element::f32, {1, 1, 1, 1}, {0.7f});
+    auto pos_bcast = std::make_shared<ov::op::v3::Broadcast>(pos_const, pos_shape);
+
+    auto mask0_param = make_param(element::f32, ov::PartialShape{-1, 8, -1, -1});
+    auto mask1_param = make_param(element::f32, ov::PartialShape{-1, 8, -1, -1});
+    auto mask0 = std::make_shared<op::v1::Add>(mask0_param, pos_bcast);
+    auto mask1 = std::make_shared<op::v1::Add>(mask1_param, pos_bcast);
+
+    auto sdp0 = std::make_shared<ov::opset13::ScaledDotProductAttention>(q0, c_k0, c_v0, mask0, false);
+    auto add0 = std::make_shared<op::v1::Add>(sdp0, op::v0::Constant::create(element::f32, {1}, {1.0f}));
+    auto assign_k0 = std::make_shared<op::v6::Assign>(c_k0, var_k0);
+    auto assign_v0 = std::make_shared<op::v6::Assign>(c_v0, var_v0);
+
+    // Layer 1 — independent Variables, no cache sharing with layer 0
+    auto q1 = make_param(element::f32, inputShape);
+    auto k1 = make_param(element::f32, inputShape);
+    auto v1 = make_param(element::f32, inputShape);
+    auto init_k1 = make_param(element::f32, inputShape);
+    auto init_v1 = make_param(element::f32, inputShape);
+    auto var_k1 = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "pastk_1"});
+    auto var_v1 = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "pastv_1"});
+    auto rv_k1 = std::make_shared<ov::op::v6::ReadValue>(init_k1, var_k1);
+    auto rv_v1 = std::make_shared<ov::op::v6::ReadValue>(init_v1, var_v1);
+    auto g_k1 =
+        std::make_shared<ov::op::v8::Gather>(rv_k1, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
+    auto g_v1 =
+        std::make_shared<ov::op::v8::Gather>(rv_v1, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
+    auto c_k1 = std::make_shared<ov::op::v0::Concat>(OutputVector{g_k1, k1}, 2);
+    auto c_v1 = std::make_shared<ov::op::v0::Concat>(OutputVector{g_v1, v1}, 2);
+
+    auto sdp1 = std::make_shared<ov::opset13::ScaledDotProductAttention>(q1, c_k1, c_v1, mask1, false);
+    auto add1 = std::make_shared<op::v1::Add>(sdp1, op::v0::Constant::create(element::f32, {1}, {1.0f}));
+    auto assign_k1 = std::make_shared<op::v6::Assign>(c_k1, var_k1);
+    auto assign_v1 = std::make_shared<op::v6::Assign>(c_v1, var_v1);
+
+    ResultVector results{std::make_shared<ov::op::v0::Result>(add0), std::make_shared<ov::op::v0::Result>(add1)};
+    SinkVector sinks{assign_k0, assign_v0, assign_k1, assign_v1};
+    ParameterVector params{q0,    k0, v0,          init_k0, init_v0, mask0_param, q1, k1,
+                           v1,    init_k1, init_v1, mask1_param, beam_idx};
+    return std::make_shared<Model>(results, sinks, params, "NonSharedKVWithSharedShapeOfRope");
+}
+
+TEST(StateConcatSDPAExtra, NonSharedKVWithSharedShapeOfRope) {
+#if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
+    GTEST_SKIP() << "Skipping NonSharedKVWithSharedShapeOfRope on Android X64";
+#endif
+    auto inputShape = ov::PartialShape{-1, 8, -1, 64};
+    auto model = makeNonSharedKVWithSharedShapeOfRopeModel(inputShape);
+
+    ov::pass::Manager manager;
+    manager.register_pass<SDPASubgraphFusion>();
+    manager.run_passes(model);
+
+    size_t plain_sdpa = 0;
+    size_t fused_sdpa = 0;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(op)) {
+            ++plain_sdpa;
+        }
+        if (ov::is_type<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(op)) {
+            ++fused_sdpa;
+        }
+    }
+    EXPECT_EQ(plain_sdpa, 0u)
+        << "Both SDPAs must be fused despite a shared ShapeOf-rooted fanout into attention-mask inputs.";
+    EXPECT_EQ(fused_sdpa, 2u) << "Both SDPAs must be fused into ScaledDotProductAttentionWithKVCache.";
+}
+
+// Single (RV, SDPA) pair where the K-Concat has a ShapeOf consumer that
+// reads Concat_K's shape into a standalone output (separate from the SDPA's
+// own inputs). Mirrors Gemma3n layer 0's topology: ShapeOf(Concat_K) seeds
+// the global positional-ID / attention-mask chain shared across *other*
+// layers — not this SDPA's own mask. Fusion must apply, and the ShapeOf
+// consumer must be re-routed off the dead Concat so that the ReadValue's
+// MemoryInput post-fusion only has {fused SDPA, ShapeOf} children. Without
+// the re-route the ShapeOf keeps Concat_K (and therefore Gather, and
+// therefore a Gather child on the MemoryInput) alive — MatchSdpaKvCache
+// would reject and the fused kernel would crash with "null input states"
+// at execute time.
+static std::shared_ptr<ov::Model>
+makeSingleSDPAWithShapeOfOnConcatKModel(const ov::PartialShape& inputShape) {
+    auto q = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto k = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto v = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto init_k = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto init_v = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto beam_idx = std::make_shared<ov::op::v0::Parameter>(element::i32, ov::PartialShape{-1});
+
+    auto var_k = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "pastk"});
+    auto var_v = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "pastv"});
+    auto past_k = std::make_shared<ov::op::v6::ReadValue>(init_k, var_k);
+    auto past_v = std::make_shared<ov::op::v6::ReadValue>(init_v, var_v);
+
+    auto gather_k =
+        std::make_shared<ov::op::v8::Gather>(past_k, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
+    auto gather_v =
+        std::make_shared<ov::op::v8::Gather>(past_v, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
+    auto concat_k = std::make_shared<ov::op::v0::Concat>(OutputVector{gather_k, k}, 2);
+    auto concat_v = std::make_shared<ov::op::v0::Concat>(OutputVector{gather_v, v}, 2);
+
+    // Case-3 third child of Concat_K: ShapeOf feeding an independent Result
+    // (does NOT feed back into this SDPA's inputs — that would close a
+    // cycle after the matcher re-routes the ShapeOf to the fused node's
+    // K-output, which is the correct behavior in any case since the fused
+    // kernel manages the post-cache shape internally).
+    auto shape_of_ck = std::make_shared<ov::op::v3::ShapeOf>(concat_k, element::i64);
+
+    auto sdp = std::make_shared<ov::opset13::ScaledDotProductAttention>(q, concat_k, concat_v, false);
+
+    auto assign_k = std::make_shared<op::v6::Assign>(concat_k, var_k);
+    auto assign_v = std::make_shared<op::v6::Assign>(concat_v, var_v);
+
+    ResultVector results{std::make_shared<ov::op::v0::Result>(sdp),
+                         std::make_shared<ov::op::v0::Result>(shape_of_ck)};
+    SinkVector sinks{assign_k, assign_v};
+    return std::make_shared<Model>(results, sinks,
+                                   ParameterVector{q, k, v, init_k, init_v, beam_idx},
+                                   "SingleSDPAWithShapeOfOnConcatK");
+}
+
+TEST(StateConcatSDPAExtra, ShapeOfOnConcatKRerouteSucceeds) {
+#if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
+    GTEST_SKIP() << "Skipping ShapeOfOnConcatKRerouteSucceeds on Android X64";
+#endif
+    auto inputShape = ov::PartialShape{-1, 8, -1, 64};
+    auto model = makeSingleSDPAWithShapeOfOnConcatKModel(inputShape);
+
+    ov::pass::Manager manager;
+    manager.register_pass<StatefulSDPAFusion>();
+    manager.run_passes(model);
+
+    size_t plain_sdpa = 0;
+    size_t fused_sdpa = 0;
+    std::shared_ptr<ov::Node> fused_node;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(op)) {
+            ++plain_sdpa;
+        }
+        if (ov::is_type<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(op)) {
+            ++fused_sdpa;
+            fused_node = op;
+        }
+    }
+    EXPECT_EQ(plain_sdpa, 0u);
+    EXPECT_EQ(fused_sdpa, 1u);
+    ASSERT_NE(fused_node, nullptr);
+
+    // Every ShapeOf in the model must read from the fused node, not from
+    // the old Concat (which is now dead). This guarantees MatchSdpaKvCache
+    // sees no stray Gather child on the MemoryInput at graph-optimizer time.
+    for (const auto& op : model->get_ordered_ops()) {
+        if (ov::is_type_any_of<ov::op::v0::ShapeOf, ov::op::v3::ShapeOf>(op.get())) {
+            const auto parent = op->get_input_node_shared_ptr(0);
+            EXPECT_FALSE(ov::is_type<ov::op::v0::Concat>(parent))
+                << "ShapeOf " << op->get_friendly_name()
+                << " still reads from Concat " << parent->get_friendly_name()
+                << " — ShapeOf(Concat) re-route to the fused node's K/V output did not happen.";
+        }
+    }
+}
+
+// Positive test modelled after Gemma3n's shared-KV topology: one ReadValue
+// fans out to two Gathers, each feeding its own Concat → multi-query
+// broadcast (Unsqueeze/Broadcast/Reshape) → SDPA. Both SDPAs share the same
+// K-Variable and V-Variable ReadValue. Under the data-path backward BFS in
+// compute_shared_kv_sdpas, both SDPAs' K-input walks converge on the shared
+// ReadValue (through their respective Gathers), so both SDPAs are marked
+// shared and the fusion must be refused for both — otherwise
+// ScaledDotProductAttentionWithKVCache would crash at runtime with "null
+// input states".
+static std::shared_ptr<ov::Model>
+makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape) {
+    auto q1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto k1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto v1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto q2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto k2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto v2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto init_k = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto init_v = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto beam_idx = std::make_shared<ov::op::v0::Parameter>(element::i32, ov::PartialShape{-1});
+
+    auto var_k = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "shared_pastk"});
+    auto var_v = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "shared_pastv"});
+    auto past_k = std::make_shared<ov::op::v6::ReadValue>(init_k, var_k);
+    auto past_v = std::make_shared<ov::op::v6::ReadValue>(init_v, var_v);
+
+    auto build_branch = [&](const std::shared_ptr<ov::op::v0::Parameter>& q,
+                            const std::shared_ptr<ov::op::v0::Parameter>& k_cur,
+                            const std::shared_ptr<ov::op::v0::Parameter>& v_cur) {
+        auto g_k = std::make_shared<ov::op::v8::Gather>(past_k, beam_idx,
+                                                        op::v0::Constant::create(element::i32, {1}, {0}));
+        auto g_v = std::make_shared<ov::op::v8::Gather>(past_v, beam_idx,
+                                                        op::v0::Constant::create(element::i32, {1}, {0}));
+        auto c_k = std::make_shared<ov::op::v0::Concat>(OutputVector{g_k, k_cur}, 2);
+        auto c_v = std::make_shared<ov::op::v0::Concat>(OutputVector{g_v, v_cur}, 2);
+        auto sdp = std::make_shared<ov::opset13::ScaledDotProductAttention>(q, c_k, c_v, false);
+        return sdp;
+    };
+
+    auto sdpa1 = build_branch(q1, k1, v1);
+    auto sdpa2 = build_branch(q2, k2, v2);
+
+    // One Assign pair writes back to the shared Variables (from branch 1).
+    auto assign_k =
+        std::make_shared<op::v6::Assign>(sdpa1->get_input_node_shared_ptr(1), var_k);
+    auto assign_v =
+        std::make_shared<op::v6::Assign>(sdpa1->get_input_node_shared_ptr(2), var_v);
+
+    ResultVector results{std::make_shared<ov::op::v0::Result>(sdpa1),
+                         std::make_shared<ov::op::v0::Result>(sdpa2)};
+    SinkVector sinks{assign_k, assign_v};
+    return std::make_shared<Model>(results, sinks,
+                                   ParameterVector{q1, k1, v1, q2, k2, v2, init_k, init_v, beam_idx},
+                                   "Gemma3nLikeSharedKV");
+}
+
+TEST(StateConcatSDPAExtra, Gemma3nLikeSharedKVDetectedByBackwardBFS) {
+#if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
+    GTEST_SKIP() << "Skipping Gemma3nLikeSharedKVDetectedByBackwardBFS on Android X64";
+#endif
+    auto inputShape = ov::PartialShape{-1, 8, -1, 64};
+    auto model = makeGemma3nLikeSharedKVModel(inputShape);
+
+    ov::pass::Manager manager;
+    manager.register_pass<StatefulSDPAFusion>();
+    manager.run_passes(model);
+
+    size_t plain_sdpa = 0;
+    size_t fused_sdpa = 0;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(op)) {
+            ++plain_sdpa;
+        }
+        if (ov::is_type<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(op)) {
+            ++fused_sdpa;
+        }
+    }
+    EXPECT_EQ(plain_sdpa, 2u)
+        << "Both SDPAs share the same ReadValue (K and V) via backward data-path reachability — "
+           "fusion must be refused for both.";
+    EXPECT_EQ(fused_sdpa, 0u) << "No SDPA may fuse when the KV-cache is shared.";
+}
+

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -623,12 +623,10 @@ TEST(StateConcatSDPAExtra, ShapeOfOnConcatKRerouteSucceeds) {
 // Positive test modelled after Gemma3n's shared-KV topology: one ReadValue
 // fans out to two Gathers, each feeding its own Concat → multi-query
 // broadcast (Unsqueeze/Broadcast/Reshape) → SDPA. Both SDPAs share the same
-// K-Variable and V-Variable ReadValue. Under the data-path backward BFS in
-// compute_shared_kv_sdpas, both SDPAs' K-input walks converge on the shared
-// ReadValue (through their respective Gathers), so both SDPAs are marked
-// shared and the fusion must be refused for both — otherwise
-// ScaledDotProductAttentionWithKVCache would crash at runtime with "null
-// input states".
+// K-Variable and V-Variable through a single ReadValue node. The shared-KV
+// detection sees the same variable_id from both branches and refuses fusion
+// for both SDPAs — otherwise ScaledDotProductAttentionWithKVCache would
+// crash at runtime with "null input states".
 static std::shared_ptr<ov::Model>
 makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape) {
     auto q1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
@@ -678,9 +676,9 @@ makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape) {
                                    "Gemma3nLikeSharedKV");
 }
 
-TEST(StateConcatSDPAExtra, Gemma3nLikeSharedKVDetectedByBackwardBFS) {
+TEST(StateConcatSDPAExtra, Gemma3nLikeSharedKVRefusesFusion) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
-    GTEST_SKIP() << "Skipping Gemma3nLikeSharedKVDetectedByBackwardBFS on Android X64";
+    GTEST_SKIP() << "Skipping Gemma3nLikeSharedKVRefusesFusion on Android X64";
 #endif
     auto inputShape = ov::PartialShape{-1, 8, -1, 64};
     auto model = makeGemma3nLikeSharedKVModel(inputShape);
@@ -700,8 +698,100 @@ TEST(StateConcatSDPAExtra, Gemma3nLikeSharedKVDetectedByBackwardBFS) {
         }
     }
     EXPECT_EQ(plain_sdpa, 2u)
-        << "Both SDPAs share the same ReadValue (K and V) via backward data-path reachability — "
+        << "Both SDPAs share the same ReadValue (K and V) — "
            "fusion must be refused for both.";
     EXPECT_EQ(fused_sdpa, 0u) << "No SDPA may fuse when the KV-cache is shared.";
+}
+
+// Two distinct v6::ReadValue nodes that reference the SAME Variable (one per
+// branch), each feeding its own Gather → Concat → SDPA. The two SDPAs are
+// reachable from two different ReadValue *nodes*, but the cache memory they
+// read is the same Variable slot — i.e., they share the KV-cache. Under any
+// detection that keys on the ReadValue node pointer, no sharing is found and
+// both SDPAs would (incorrectly) fuse. Under detection keyed on the Variable
+// identifier (variable_id + "/k" | "/v"), the same Variable is observed twice
+// and both SDPAs are correctly marked as shared.
+static std::shared_ptr<ov::Model>
+makeSharedVariableTwoReadValuesModel(const ov::PartialShape& inputShape) {
+    auto q1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto k1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto v1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto q2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto k2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto v2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto init_k1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto init_v1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto init_k2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto init_v2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+    auto beam_idx = std::make_shared<ov::op::v0::Parameter>(element::i32, ov::PartialShape{-1});
+
+    // ONE Variable per K and V — but TWO ReadValue/Assign pairs each.
+    auto var_k = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "shared_var_k"});
+    auto var_v = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{inputShape, element::f32, "shared_var_v"});
+
+    auto rv_k1 = std::make_shared<ov::op::v6::ReadValue>(init_k1, var_k);
+    auto rv_v1 = std::make_shared<ov::op::v6::ReadValue>(init_v1, var_v);
+    auto rv_k2 = std::make_shared<ov::op::v6::ReadValue>(init_k2, var_k);
+    auto rv_v2 = std::make_shared<ov::op::v6::ReadValue>(init_v2, var_v);
+
+    auto build_branch = [&](const std::shared_ptr<ov::op::v0::Parameter>& q,
+                            const std::shared_ptr<ov::op::v0::Parameter>& k_cur,
+                            const std::shared_ptr<ov::op::v0::Parameter>& v_cur,
+                            const std::shared_ptr<ov::op::v6::ReadValue>& rv_k,
+                            const std::shared_ptr<ov::op::v6::ReadValue>& rv_v) {
+        auto g_k = std::make_shared<ov::op::v8::Gather>(rv_k, beam_idx,
+                                                        op::v0::Constant::create(element::i32, {1}, {0}));
+        auto g_v = std::make_shared<ov::op::v8::Gather>(rv_v, beam_idx,
+                                                        op::v0::Constant::create(element::i32, {1}, {0}));
+        auto c_k = std::make_shared<ov::op::v0::Concat>(OutputVector{g_k, k_cur}, 2);
+        auto c_v = std::make_shared<ov::op::v0::Concat>(OutputVector{g_v, v_cur}, 2);
+        auto sdp = std::make_shared<ov::opset13::ScaledDotProductAttention>(q, c_k, c_v, false);
+        auto assign_k = std::make_shared<op::v6::Assign>(c_k, rv_k->get_variable());
+        auto assign_v = std::make_shared<op::v6::Assign>(c_v, rv_v->get_variable());
+        return std::tuple<std::shared_ptr<ov::Node>,
+                          std::shared_ptr<op::v6::Assign>,
+                          std::shared_ptr<op::v6::Assign>>{sdp, assign_k, assign_v};
+    };
+
+    auto [sdpa1, assign_k1, assign_v1] = build_branch(q1, k1, v1, rv_k1, rv_v1);
+    auto [sdpa2, assign_k2, assign_v2] = build_branch(q2, k2, v2, rv_k2, rv_v2);
+
+    ResultVector results{std::make_shared<ov::op::v0::Result>(sdpa1),
+                         std::make_shared<ov::op::v0::Result>(sdpa2)};
+    SinkVector sinks{assign_k1, assign_v1, assign_k2, assign_v2};
+    return std::make_shared<Model>(
+        results, sinks,
+        ParameterVector{q1, k1, v1, q2, k2, v2, init_k1, init_v1, init_k2, init_v2, beam_idx},
+        "SharedVariableTwoReadValues");
+}
+
+TEST(StateConcatSDPAExtra, SharedVariableTwoReadValuesRefusesFusion) {
+#if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
+    GTEST_SKIP() << "Skipping SharedVariableTwoReadValuesRefusesFusion on Android X64";
+#endif
+    auto inputShape = ov::PartialShape{-1, 8, -1, 64};
+    auto model = makeSharedVariableTwoReadValuesModel(inputShape);
+
+    ov::pass::Manager manager;
+    manager.register_pass<StatefulSDPAFusion>();
+    manager.run_passes(model);
+
+    size_t plain_sdpa = 0;
+    size_t fused_sdpa = 0;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(op)) {
+            ++plain_sdpa;
+        }
+        if (ov::is_type<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(op)) {
+            ++fused_sdpa;
+        }
+    }
+    EXPECT_EQ(plain_sdpa, 2u)
+        << "Both SDPAs reference the same Variable through distinct ReadValue nodes — "
+           "the KV-cache slot is shared and fusion must be refused for both.";
+    EXPECT_EQ(fused_sdpa, 0u)
+        << "No SDPA may fuse when two ReadValues alias the same Variable.";
 }
 

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -46,6 +46,43 @@ namespace {
         At_MQ_Reshape,
         At_End
     };
+
+    // Build a plain Gather→Concat→SDPA branch over (rv_k, rv_v).
+    // Returned Concat outputs let the caller wire Assigns or ShapeOf consumers.
+    struct PlainKvBranch {
+        std::shared_ptr<ov::op::v13::ScaledDotProductAttention> sdpa;
+        std::shared_ptr<ov::op::v0::Concat> concat_k;
+        std::shared_ptr<ov::op::v0::Concat> concat_v;
+    };
+
+    inline PlainKvBranch make_plain_kv_branch(const std::shared_ptr<ov::Node>& q,
+                                              const std::shared_ptr<ov::Node>& k_cur,
+                                              const std::shared_ptr<ov::Node>& v_cur,
+                                              const std::shared_ptr<ov::Node>& beam_idx,
+                                              const std::shared_ptr<ov::Node>& rv_k,
+                                              const std::shared_ptr<ov::Node>& rv_v) {
+        auto axis = ov::op::v0::Constant::create(ov::element::i32, {1}, {0});
+        auto g_k = std::make_shared<ov::op::v8::Gather>(rv_k, beam_idx, axis);
+        auto g_v = std::make_shared<ov::op::v8::Gather>(rv_v, beam_idx, axis);
+        auto c_k = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{g_k, k_cur}, 2);
+        auto c_v = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{g_v, v_cur}, 2);
+        auto sdp = std::make_shared<ov::op::v13::ScaledDotProductAttention>(q, c_k, c_v, false);
+        return {sdp, c_k, c_v};
+    }
+
+    // Build a fused ScaledDotProductAttentionWithKVCache branch — used in model_ref.
+    inline std::shared_ptr<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>
+    make_fused_kv_branch(const std::shared_ptr<ov::Node>& q,
+                         const std::shared_ptr<ov::Node>& k_cur,
+                         const std::shared_ptr<ov::Node>& v_cur,
+                         const std::shared_ptr<ov::Node>& beam_idx,
+                         const std::shared_ptr<ov::Node>& rv_k,
+                         const std::shared_ptr<ov::Node>& rv_v) {
+        ov::intel_cpu::ScaledDotProductAttentionWithKVCache::Config config;
+        config.fuse_concat = true;
+        return std::make_shared<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(
+            ov::OutputVector{q, k_cur, v_cur, beam_idx, rv_k, rv_v}, config);
+    }
 } // namespace
 
 static std::shared_ptr<ov::Model> makeSDPA(const ov::PartialShape& inputShape, bool isRef = false, bool hasConvert = false, bool hasMultiquery = false,
@@ -412,91 +449,99 @@ TEST_F(TransformationTestsF, StateConcatSDPAMixedSharedAndExclusive) {
 // attention-mask input. Mirrors the fan-out pattern observed in Qwen3-0.6B etc.,
 // where ShapeOf of layer 0's cache-after-beam-gather feeds the global
 // positional-ID / RoPE / attention-mask chain shared by every decoder layer.
-// Expectation: StatefulSDPAFusion MUST fuse both SDPAs — the shape/metadata
-// branch rooted at ShapeOf does not imply a shared KV-cache.
+// Expectation: SDPASubgraphFusion (= SimplifyGatherShapeOf + StatefulSDPAFusion)
+// MUST fuse both SDPAs — the shape/metadata branch rooted at ShapeOf does not
+// imply a shared KV-cache. The Concat-children check inside the matcher is
+// satisfied because SimplifyGatherShapeOf rewrites ShapeOf(Gather(...)) so
+// that the Gather's output has only one consumer (the Concat).
+//
+// Counts plain vs fused SDPAs explicitly: SDPASubgraphFusion includes
+// SimplifyGatherShapeOf, which mutates the ShapeOf subgraph in ways that
+// would make a precise model_ref fragile to maintain.
 static std::shared_ptr<ov::Model>
 makeNonSharedKVWithSharedShapeOfRopeModel(const ov::PartialShape& inputShape) {
-    auto make_param = [&](element::Type t, const ov::PartialShape& s) {
+    auto make_param = [&](ov::element::Type t, const ov::PartialShape& s) {
         return std::make_shared<ov::op::v0::Parameter>(t, s);
     };
-    auto beam_idx = make_param(element::i32, ov::PartialShape{-1});
+    auto make_var = [&](const std::string& id) {
+        return std::make_shared<ov::op::util::Variable>(
+            ov::op::util::VariableInfo{inputShape, ov::element::f32, id});
+    };
+    auto beam_idx = make_param(ov::element::i32, ov::PartialShape{-1});
 
     // Layer 0
-    auto q0 = make_param(element::f32, inputShape);
-    auto k0 = make_param(element::f32, inputShape);
-    auto v0 = make_param(element::f32, inputShape);
-    auto init_k0 = make_param(element::f32, inputShape);
-    auto init_v0 = make_param(element::f32, inputShape);
-    auto var_k0 = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "pastk_0"});
-    auto var_v0 = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "pastv_0"});
+    auto q0 = make_param(ov::element::f32, inputShape);
+    auto k0 = make_param(ov::element::f32, inputShape);
+    auto v0 = make_param(ov::element::f32, inputShape);
+    auto init_k0 = make_param(ov::element::f32, inputShape);
+    auto init_v0 = make_param(ov::element::f32, inputShape);
+    auto var_k0 = make_var("pastk_0");
+    auto var_v0 = make_var("pastv_0");
     auto rv_k0 = std::make_shared<ov::op::v6::ReadValue>(init_k0, var_k0);
     auto rv_v0 = std::make_shared<ov::op::v6::ReadValue>(init_v0, var_v0);
-    auto g_k0 =
-        std::make_shared<ov::op::v8::Gather>(rv_k0, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
-    auto g_v0 =
-        std::make_shared<ov::op::v8::Gather>(rv_v0, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
-    auto c_k0 = std::make_shared<ov::op::v0::Concat>(OutputVector{g_k0, k0}, 2);
-    auto c_v0 = std::make_shared<ov::op::v0::Concat>(OutputVector{g_v0, v0}, 2);
+    auto axis = ov::op::v0::Constant::create(ov::element::i32, {1}, {0});
+    auto g_k0 = std::make_shared<ov::op::v8::Gather>(rv_k0, beam_idx, axis);
+    auto g_v0 = std::make_shared<ov::op::v8::Gather>(rv_v0, beam_idx, axis);
+    auto c_k0 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{g_k0, k0}, 2);
+    auto c_v0 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{g_v0, v0}, 2);
 
     // Shared shape/metadata subgraph rooted on layer 0's Gather output.
-    // With the data-path allowlist BFS, ShapeOf halts traversal without counting,
-    // so layer 0 cannot "see" layer 1's SDPA through this path.
-    auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(g_k0, element::i64);
-    auto seq_len = std::make_shared<ov::op::v8::Gather>(shape_of,
-                                                       op::v0::Constant::create(element::i64, {1}, {2}),
-                                                       op::v0::Constant::create(element::i64, {}, {0}));
+    auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(g_k0, ov::element::i64);
+    auto seq_len =
+        std::make_shared<ov::op::v8::Gather>(shape_of,
+                                             ov::op::v0::Constant::create(ov::element::i64, {1}, {2}),
+                                             ov::op::v0::Constant::create(ov::element::i64, {}, {0}));
     auto pos_shape = std::make_shared<ov::op::v0::Concat>(
-        OutputVector{op::v0::Constant::create(element::i64, {1}, {1}),
-                     op::v0::Constant::create(element::i64, {1}, {1}),
-                     op::v0::Constant::create(element::i64, {1}, {1}),
-                     seq_len},
+        ov::OutputVector{ov::op::v0::Constant::create(ov::element::i64, {1}, {1}),
+                         ov::op::v0::Constant::create(ov::element::i64, {1}, {1}),
+                         ov::op::v0::Constant::create(ov::element::i64, {1}, {1}),
+                         seq_len},
         0);
-    // Non-zero constant to prevent NopElimination from collapsing the downstream
-    // Add nodes into identities (which would erase the shared fanout entirely).
-    auto pos_const = op::v0::Constant::create(element::f32, {1, 1, 1, 1}, {0.7f});
+    // Non-zero constant prevents NopElimination from collapsing the
+    // downstream Add nodes into identities, which would erase the shared
+    // fanout entirely.
+    auto pos_const = ov::op::v0::Constant::create(ov::element::f32, {1, 1, 1, 1}, {0.7f});
     auto pos_bcast = std::make_shared<ov::op::v3::Broadcast>(pos_const, pos_shape);
 
-    auto mask0_param = make_param(element::f32, ov::PartialShape{-1, 8, -1, -1});
-    auto mask1_param = make_param(element::f32, ov::PartialShape{-1, 8, -1, -1});
-    auto mask0 = std::make_shared<op::v1::Add>(mask0_param, pos_bcast);
-    auto mask1 = std::make_shared<op::v1::Add>(mask1_param, pos_bcast);
+    auto mask0_param = make_param(ov::element::f32, ov::PartialShape{-1, 8, -1, -1});
+    auto mask1_param = make_param(ov::element::f32, ov::PartialShape{-1, 8, -1, -1});
+    auto mask0 = std::make_shared<ov::op::v1::Add>(mask0_param, pos_bcast);
+    auto mask1 = std::make_shared<ov::op::v1::Add>(mask1_param, pos_bcast);
 
-    auto sdp0 = std::make_shared<ov::opset13::ScaledDotProductAttention>(q0, c_k0, c_v0, mask0, false);
-    auto add0 = std::make_shared<op::v1::Add>(sdp0, op::v0::Constant::create(element::f32, {1}, {1.0f}));
-    auto assign_k0 = std::make_shared<op::v6::Assign>(c_k0, var_k0);
-    auto assign_v0 = std::make_shared<op::v6::Assign>(c_v0, var_v0);
+    auto sdp0 = std::make_shared<ov::op::v13::ScaledDotProductAttention>(q0, c_k0, c_v0, mask0, false);
+    auto add0 = std::make_shared<ov::op::v1::Add>(sdp0,
+                                                  ov::op::v0::Constant::create(ov::element::f32, {1}, {1.0f}));
+    auto assign_k0 = std::make_shared<ov::op::v6::Assign>(c_k0, var_k0);
+    auto assign_v0 = std::make_shared<ov::op::v6::Assign>(c_v0, var_v0);
 
     // Layer 1 — independent Variables, no cache sharing with layer 0
-    auto q1 = make_param(element::f32, inputShape);
-    auto k1 = make_param(element::f32, inputShape);
-    auto v1 = make_param(element::f32, inputShape);
-    auto init_k1 = make_param(element::f32, inputShape);
-    auto init_v1 = make_param(element::f32, inputShape);
-    auto var_k1 = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "pastk_1"});
-    auto var_v1 = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "pastv_1"});
+    auto q1 = make_param(ov::element::f32, inputShape);
+    auto k1 = make_param(ov::element::f32, inputShape);
+    auto v1 = make_param(ov::element::f32, inputShape);
+    auto init_k1 = make_param(ov::element::f32, inputShape);
+    auto init_v1 = make_param(ov::element::f32, inputShape);
+    auto var_k1 = make_var("pastk_1");
+    auto var_v1 = make_var("pastv_1");
     auto rv_k1 = std::make_shared<ov::op::v6::ReadValue>(init_k1, var_k1);
     auto rv_v1 = std::make_shared<ov::op::v6::ReadValue>(init_v1, var_v1);
-    auto g_k1 =
-        std::make_shared<ov::op::v8::Gather>(rv_k1, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
-    auto g_v1 =
-        std::make_shared<ov::op::v8::Gather>(rv_v1, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
-    auto c_k1 = std::make_shared<ov::op::v0::Concat>(OutputVector{g_k1, k1}, 2);
-    auto c_v1 = std::make_shared<ov::op::v0::Concat>(OutputVector{g_v1, v1}, 2);
+    auto branch1 = make_plain_kv_branch(q1, k1, v1, beam_idx, rv_k1, rv_v1);
+    // Replace branch1.sdpa with a masked variant to mirror layer 0's mask wiring.
+    auto sdp1 = std::make_shared<ov::op::v13::ScaledDotProductAttention>(q1,
+                                                                         branch1.concat_k,
+                                                                         branch1.concat_v,
+                                                                         mask1,
+                                                                         false);
+    auto add1 = std::make_shared<ov::op::v1::Add>(sdp1,
+                                                  ov::op::v0::Constant::create(ov::element::f32, {1}, {1.0f}));
+    auto assign_k1 = std::make_shared<ov::op::v6::Assign>(branch1.concat_k, var_k1);
+    auto assign_v1 = std::make_shared<ov::op::v6::Assign>(branch1.concat_v, var_v1);
 
-    auto sdp1 = std::make_shared<ov::opset13::ScaledDotProductAttention>(q1, c_k1, c_v1, mask1, false);
-    auto add1 = std::make_shared<op::v1::Add>(sdp1, op::v0::Constant::create(element::f32, {1}, {1.0f}));
-    auto assign_k1 = std::make_shared<op::v6::Assign>(c_k1, var_k1);
-    auto assign_v1 = std::make_shared<op::v6::Assign>(c_v1, var_v1);
-
-    ResultVector results{std::make_shared<ov::op::v0::Result>(add0), std::make_shared<ov::op::v0::Result>(add1)};
-    SinkVector sinks{assign_k0, assign_v0, assign_k1, assign_v1};
-    ParameterVector params{q0,    k0, v0,          init_k0, init_v0, mask0_param, q1, k1,
-                           v1,    init_k1, init_v1, mask1_param, beam_idx};
-    return std::make_shared<Model>(results, sinks, params, "NonSharedKVWithSharedShapeOfRope");
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(add0),
+                             std::make_shared<ov::op::v0::Result>(add1)};
+    ov::SinkVector sinks{assign_k0, assign_v0, assign_k1, assign_v1};
+    ov::ParameterVector params{q0, k0, v0, init_k0, init_v0, mask0_param, q1, k1,
+                               v1, init_k1, init_v1, mask1_param, beam_idx};
+    return std::make_shared<ov::Model>(results, sinks, params, "NonSharedKVWithSharedShapeOfRope");
 }
 
 TEST(StateConcatSDPAExtra, NonSharedKVWithSharedShapeOfRope) {
@@ -537,239 +582,189 @@ TEST(StateConcatSDPAExtra, NonSharedKVWithSharedShapeOfRope) {
 // would reject and the fused kernel would crash with "null input states"
 // at execute time.
 static std::shared_ptr<ov::Model>
-makeSingleSDPAWithShapeOfOnConcatKModel(const ov::PartialShape& inputShape) {
-    auto q = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto k = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto v = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto init_k = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto init_v = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto beam_idx = std::make_shared<ov::op::v0::Parameter>(element::i32, ov::PartialShape{-1});
+makeSingleSDPAWithShapeOfOnConcatKModel(const ov::PartialShape& inputShape, bool isRef = false) {
+    auto q = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto k = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto v = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto init_k = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto init_v = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto beam_idx = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
 
     auto var_k = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "pastk"});
+        ov::op::util::VariableInfo{inputShape, ov::element::f32, "pastk"});
     auto var_v = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "pastv"});
+        ov::op::util::VariableInfo{inputShape, ov::element::f32, "pastv"});
     auto past_k = std::make_shared<ov::op::v6::ReadValue>(init_k, var_k);
     auto past_v = std::make_shared<ov::op::v6::ReadValue>(init_v, var_v);
 
-    auto gather_k =
-        std::make_shared<ov::op::v8::Gather>(past_k, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
-    auto gather_v =
-        std::make_shared<ov::op::v8::Gather>(past_v, beam_idx, op::v0::Constant::create(element::i32, {1}, {0}));
-    auto concat_k = std::make_shared<ov::op::v0::Concat>(OutputVector{gather_k, k}, 2);
-    auto concat_v = std::make_shared<ov::op::v0::Concat>(OutputVector{gather_v, v}, 2);
+    ov::Output<ov::Node> sdp_out;
+    ov::Output<ov::Node> shape_of_input;  // ShapeOf reads K-cache shape from here.
+    std::shared_ptr<ov::op::v6::Assign> assign_k_node;
+    std::shared_ptr<ov::op::v6::Assign> assign_v_node;
+    if (isRef) {
+        auto fused = make_fused_kv_branch(q, k, v, beam_idx, past_k, past_v);
+        sdp_out = fused->output(0);
+        // ShapeOf re-routed onto the fused node's K-output by the matcher.
+        shape_of_input = fused->output(1);
+        assign_k_node = std::make_shared<ov::op::v6::Assign>(fused->output(1), var_k);
+        assign_v_node = std::make_shared<ov::op::v6::Assign>(fused->output(2), var_v);
+    } else {
+        auto branch = make_plain_kv_branch(q, k, v, beam_idx, past_k, past_v);
+        sdp_out = branch.sdpa->output(0);
+        shape_of_input = branch.concat_k->output(0);
+        assign_k_node = std::make_shared<ov::op::v6::Assign>(branch.concat_k, var_k);
+        assign_v_node = std::make_shared<ov::op::v6::Assign>(branch.concat_v, var_v);
+    }
+    auto shape_of_ck = std::make_shared<ov::op::v3::ShapeOf>(shape_of_input, ov::element::i64);
 
-    // Case-3 third child of Concat_K: ShapeOf feeding an independent Result
-    // (does NOT feed back into this SDPA's inputs — that would close a
-    // cycle after the matcher re-routes the ShapeOf to the fused node's
-    // K-output, which is the correct behavior in any case since the fused
-    // kernel manages the post-cache shape internally).
-    auto shape_of_ck = std::make_shared<ov::op::v3::ShapeOf>(concat_k, element::i64);
-
-    auto sdp = std::make_shared<ov::opset13::ScaledDotProductAttention>(q, concat_k, concat_v, false);
-
-    auto assign_k = std::make_shared<op::v6::Assign>(concat_k, var_k);
-    auto assign_v = std::make_shared<op::v6::Assign>(concat_v, var_v);
-
-    ResultVector results{std::make_shared<ov::op::v0::Result>(sdp),
-                         std::make_shared<ov::op::v0::Result>(shape_of_ck)};
-    SinkVector sinks{assign_k, assign_v};
-    return std::make_shared<Model>(results, sinks,
-                                   ParameterVector{q, k, v, init_k, init_v, beam_idx},
-                                   "SingleSDPAWithShapeOfOnConcatK");
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(sdp_out),
+                             std::make_shared<ov::op::v0::Result>(shape_of_ck)};
+    ov::SinkVector sinks{assign_k_node, assign_v_node};
+    return std::make_shared<ov::Model>(results,
+                                       sinks,
+                                       ov::ParameterVector{q, k, v, init_k, init_v, beam_idx},
+                                       "SingleSDPAWithShapeOfOnConcatK");
 }
 
-TEST(StateConcatSDPAExtra, ShapeOfOnConcatKRerouteSucceeds) {
+TEST_F(TransformationTestsF, StateConcatSDPAShapeOfOnConcatKRerouteSucceeds) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
+    test_skipped = true;
     GTEST_SKIP() << "Skipping ShapeOfOnConcatKRerouteSucceeds on Android X64";
 #endif
     auto inputShape = ov::PartialShape{-1, 8, -1, 64};
-    auto model = makeSingleSDPAWithShapeOfOnConcatKModel(inputShape);
-
-    ov::pass::Manager manager;
+    model = makeSingleSDPAWithShapeOfOnConcatKModel(inputShape);
+    model_ref = makeSingleSDPAWithShapeOfOnConcatKModel(inputShape, /*isRef=*/true);
     manager.register_pass<StatefulSDPAFusion>();
-    manager.run_passes(model);
-
-    size_t plain_sdpa = 0;
-    size_t fused_sdpa = 0;
-    std::shared_ptr<ov::Node> fused_node;
-    for (const auto& op : model->get_ordered_ops()) {
-        if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(op)) {
-            ++plain_sdpa;
-        }
-        if (ov::is_type<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(op)) {
-            ++fused_sdpa;
-            fused_node = op;
-        }
-    }
-    EXPECT_EQ(plain_sdpa, 0u);
-    EXPECT_EQ(fused_sdpa, 1u);
-    ASSERT_NE(fused_node, nullptr);
-
-    // Every ShapeOf in the model must read from the fused node, not from
-    // the old Concat (which is now dead). This guarantees MatchSdpaKvCache
-    // sees no stray Gather child on the MemoryInput at graph-optimizer time.
-    for (const auto& op : model->get_ordered_ops()) {
-        if (ov::is_type_any_of<ov::op::v0::ShapeOf, ov::op::v3::ShapeOf>(op.get())) {
-            const auto parent = op->get_input_node_shared_ptr(0);
-            EXPECT_FALSE(ov::is_type<ov::op::v0::Concat>(parent))
-                << "ShapeOf " << op->get_friendly_name()
-                << " still reads from Concat " << parent->get_friendly_name()
-                << " — ShapeOf(Concat) re-route to the fused node's K/V output did not happen.";
-        }
-    }
 }
 
-// Positive test modelled after Gemma3n's shared-KV topology: one ReadValue
-// fans out to two Gathers, each feeding its own Concat → multi-query
-// broadcast (Unsqueeze/Broadcast/Reshape) → SDPA. Both SDPAs share the same
-// K-Variable and V-Variable through a single ReadValue node. The shared-KV
-// detection sees the same variable_id from both branches and refuses fusion
-// for both SDPAs — otherwise ScaledDotProductAttentionWithKVCache would
-// crash at runtime with "null input states".
+// Test modelled after Gemma3n's shared-KV topology: one ReadValue fans out
+// to two Gathers, each feeding its own Concat → SDPA. Both SDPAs share the
+// same K-Variable and V-Variable through a single ReadValue node. The
+// shared-KV detection observes the same variable_id from both matches and
+// keeps the topologically-first SDPA (the cache writer feeding the Assign)
+// fused, while leaving the second SDPA (the reader) as a plain
+// v13::ScaledDotProductAttention. ScaledDotProductAttentionWithKVCache only
+// supports a single owner-writer per K / V state, so the reader must NOT
+// fuse — otherwise the runtime crashes with "null input states".
 static std::shared_ptr<ov::Model>
-makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape) {
-    auto q1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto k1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto v1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto q2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto k2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto v2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto init_k = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto init_v = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto beam_idx = std::make_shared<ov::op::v0::Parameter>(element::i32, ov::PartialShape{-1});
+makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape, bool isRef = false) {
+    auto q1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto k1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto v1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto q2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto k2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto v2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto init_k = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto init_v = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto beam_idx = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
 
     auto var_k = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "shared_pastk"});
+        ov::op::util::VariableInfo{inputShape, ov::element::f32, "shared_pastk"});
     auto var_v = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "shared_pastv"});
+        ov::op::util::VariableInfo{inputShape, ov::element::f32, "shared_pastv"});
     auto past_k = std::make_shared<ov::op::v6::ReadValue>(init_k, var_k);
     auto past_v = std::make_shared<ov::op::v6::ReadValue>(init_v, var_v);
 
-    auto build_branch = [&](const std::shared_ptr<ov::op::v0::Parameter>& q,
-                            const std::shared_ptr<ov::op::v0::Parameter>& k_cur,
-                            const std::shared_ptr<ov::op::v0::Parameter>& v_cur) {
-        auto g_k = std::make_shared<ov::op::v8::Gather>(past_k, beam_idx,
-                                                        op::v0::Constant::create(element::i32, {1}, {0}));
-        auto g_v = std::make_shared<ov::op::v8::Gather>(past_v, beam_idx,
-                                                        op::v0::Constant::create(element::i32, {1}, {0}));
-        auto c_k = std::make_shared<ov::op::v0::Concat>(OutputVector{g_k, k_cur}, 2);
-        auto c_v = std::make_shared<ov::op::v0::Concat>(OutputVector{g_v, v_cur}, 2);
-        auto sdp = std::make_shared<ov::opset13::ScaledDotProductAttention>(q, c_k, c_v, false);
-        return sdp;
-    };
+    ov::Output<ov::Node> sdp1_out, sdp2_out;
+    std::shared_ptr<ov::op::v6::Assign> assign_k, assign_v;
+    if (isRef) {
+        // Branch 1 = writer → fused. Its K / V outputs feed the shared Assigns.
+        auto fused = make_fused_kv_branch(q1, k1, v1, beam_idx, past_k, past_v);
+        sdp1_out = fused->output(0);
+        assign_k = std::make_shared<ov::op::v6::Assign>(fused->output(1), var_k);
+        assign_v = std::make_shared<ov::op::v6::Assign>(fused->output(2), var_v);
+        // Branch 2 = reader → must NOT fuse.
+        auto reader = make_plain_kv_branch(q2, k2, v2, beam_idx, past_k, past_v);
+        sdp2_out = reader.sdpa->output(0);
+    } else {
+        auto branch1 = make_plain_kv_branch(q1, k1, v1, beam_idx, past_k, past_v);
+        auto branch2 = make_plain_kv_branch(q2, k2, v2, beam_idx, past_k, past_v);
+        sdp1_out = branch1.sdpa->output(0);
+        sdp2_out = branch2.sdpa->output(0);
+        // One Assign pair writes back to the shared Variables (from branch 1).
+        assign_k = std::make_shared<ov::op::v6::Assign>(branch1.concat_k, var_k);
+        assign_v = std::make_shared<ov::op::v6::Assign>(branch1.concat_v, var_v);
+    }
 
-    auto sdpa1 = build_branch(q1, k1, v1);
-    auto sdpa2 = build_branch(q2, k2, v2);
-
-    // One Assign pair writes back to the shared Variables (from branch 1).
-    auto assign_k =
-        std::make_shared<op::v6::Assign>(sdpa1->get_input_node_shared_ptr(1), var_k);
-    auto assign_v =
-        std::make_shared<op::v6::Assign>(sdpa1->get_input_node_shared_ptr(2), var_v);
-
-    ResultVector results{std::make_shared<ov::op::v0::Result>(sdpa1),
-                         std::make_shared<ov::op::v0::Result>(sdpa2)};
-    SinkVector sinks{assign_k, assign_v};
-    return std::make_shared<Model>(results, sinks,
-                                   ParameterVector{q1, k1, v1, q2, k2, v2, init_k, init_v, beam_idx},
-                                   "Gemma3nLikeSharedKV");
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(sdp1_out),
+                             std::make_shared<ov::op::v0::Result>(sdp2_out)};
+    ov::SinkVector sinks{assign_k, assign_v};
+    return std::make_shared<ov::Model>(results,
+                                       sinks,
+                                       ov::ParameterVector{q1, k1, v1, q2, k2, v2, init_k, init_v, beam_idx},
+                                       "Gemma3nLikeSharedKV");
 }
 
-TEST(StateConcatSDPAExtra, Gemma3nLikeSharedKVRefusesFusion) {
+TEST_F(TransformationTestsF, StateConcatSDPAGemma3nLikeSharedKV) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
-    GTEST_SKIP() << "Skipping Gemma3nLikeSharedKVRefusesFusion on Android X64";
+    test_skipped = true;
+    GTEST_SKIP() << "Skipping Gemma3nLikeSharedKV on Android X64";
 #endif
     auto inputShape = ov::PartialShape{-1, 8, -1, 64};
-    auto model = makeGemma3nLikeSharedKVModel(inputShape);
-
-    ov::pass::Manager manager;
+    model = makeGemma3nLikeSharedKVModel(inputShape);
+    model_ref = makeGemma3nLikeSharedKVModel(inputShape, /*isRef=*/true);
     manager.register_pass<StatefulSDPAFusion>();
-    manager.run_passes(model);
-
-    size_t plain_sdpa = 0;
-    size_t fused_sdpa = 0;
-    for (const auto& op : model->get_ordered_ops()) {
-        if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(op)) {
-            ++plain_sdpa;
-        }
-        if (ov::is_type<ov::intel_cpu::ScaledDotProductAttentionWithKVCache>(op)) {
-            ++fused_sdpa;
-        }
-    }
-    EXPECT_EQ(plain_sdpa, 2u)
-        << "Both SDPAs share the same ReadValue (K and V) — "
-           "fusion must be refused for both.";
-    EXPECT_EQ(fused_sdpa, 0u) << "No SDPA may fuse when the KV-cache is shared.";
 }
 
 // Two distinct v6::ReadValue nodes that reference the SAME Variable (one per
-// branch), each feeding its own Gather → Concat → SDPA. The two SDPAs are
-// reachable from two different ReadValue *nodes*, but the cache memory they
-// read is the same Variable slot — i.e., they share the KV-cache. Under any
-// detection that keys on the ReadValue node pointer, no sharing is found and
-// both SDPAs would (incorrectly) fuse. Under detection keyed on the Variable
-// identifier (variable_id + "/k" | "/v"), the same Variable is observed twice
-// and both SDPAs are correctly marked as shared.
+// branch), each feeding its own Gather → Concat → SDPA → Assign. The two
+// SDPAs are reachable from two different ReadValue *nodes*, but the cache
+// memory they read is the same Variable slot — i.e., they share the
+// KV-cache. Under detection keyed on the ReadValue node pointer, no sharing
+// is found and both SDPAs would (incorrectly) fuse. Under detection keyed on
+// the Variable identifier, the same Variable is observed twice — the
+// topologically-first (writer) SDPA fuses and the second (reader) is left
+// as a plain v13::ScaledDotProductAttention.
+//
+// Counted manually: TransformationTestsF cannot pair the four Assign sinks
+// here unambiguously because they share only two variable_ids
+// ("shared_var_k", "shared_var_v"), making the variable-id-based sink
+// matching in graph_comparator ambiguous.
 static std::shared_ptr<ov::Model>
 makeSharedVariableTwoReadValuesModel(const ov::PartialShape& inputShape) {
-    auto q1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto k1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto v1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto q2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto k2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto v2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto init_k1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto init_v1 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto init_k2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto init_v2 = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-    auto beam_idx = std::make_shared<ov::op::v0::Parameter>(element::i32, ov::PartialShape{-1});
+    auto q1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto k1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto v1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto q2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto k2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto v2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto init_k1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto init_v1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto init_k2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto init_v2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
+    auto beam_idx = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
 
     // ONE Variable per K and V — but TWO ReadValue/Assign pairs each.
     auto var_k = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "shared_var_k"});
+        ov::op::util::VariableInfo{inputShape, ov::element::f32, "shared_var_k"});
     auto var_v = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{inputShape, element::f32, "shared_var_v"});
+        ov::op::util::VariableInfo{inputShape, ov::element::f32, "shared_var_v"});
 
     auto rv_k1 = std::make_shared<ov::op::v6::ReadValue>(init_k1, var_k);
     auto rv_v1 = std::make_shared<ov::op::v6::ReadValue>(init_v1, var_v);
     auto rv_k2 = std::make_shared<ov::op::v6::ReadValue>(init_k2, var_k);
     auto rv_v2 = std::make_shared<ov::op::v6::ReadValue>(init_v2, var_v);
 
-    auto build_branch = [&](const std::shared_ptr<ov::op::v0::Parameter>& q,
-                            const std::shared_ptr<ov::op::v0::Parameter>& k_cur,
-                            const std::shared_ptr<ov::op::v0::Parameter>& v_cur,
-                            const std::shared_ptr<ov::op::v6::ReadValue>& rv_k,
-                            const std::shared_ptr<ov::op::v6::ReadValue>& rv_v) {
-        auto g_k = std::make_shared<ov::op::v8::Gather>(rv_k, beam_idx,
-                                                        op::v0::Constant::create(element::i32, {1}, {0}));
-        auto g_v = std::make_shared<ov::op::v8::Gather>(rv_v, beam_idx,
-                                                        op::v0::Constant::create(element::i32, {1}, {0}));
-        auto c_k = std::make_shared<ov::op::v0::Concat>(OutputVector{g_k, k_cur}, 2);
-        auto c_v = std::make_shared<ov::op::v0::Concat>(OutputVector{g_v, v_cur}, 2);
-        auto sdp = std::make_shared<ov::opset13::ScaledDotProductAttention>(q, c_k, c_v, false);
-        auto assign_k = std::make_shared<op::v6::Assign>(c_k, rv_k->get_variable());
-        auto assign_v = std::make_shared<op::v6::Assign>(c_v, rv_v->get_variable());
-        return std::tuple<std::shared_ptr<ov::Node>,
-                          std::shared_ptr<op::v6::Assign>,
-                          std::shared_ptr<op::v6::Assign>>{sdp, assign_k, assign_v};
-    };
+    auto branch1 = make_plain_kv_branch(q1, k1, v1, beam_idx, rv_k1, rv_v1);
+    auto branch2 = make_plain_kv_branch(q2, k2, v2, beam_idx, rv_k2, rv_v2);
+    auto assign_k1 = std::make_shared<ov::op::v6::Assign>(branch1.concat_k, var_k);
+    auto assign_v1 = std::make_shared<ov::op::v6::Assign>(branch1.concat_v, var_v);
+    auto assign_k2 = std::make_shared<ov::op::v6::Assign>(branch2.concat_k, var_k);
+    auto assign_v2 = std::make_shared<ov::op::v6::Assign>(branch2.concat_v, var_v);
 
-    auto [sdpa1, assign_k1, assign_v1] = build_branch(q1, k1, v1, rv_k1, rv_v1);
-    auto [sdpa2, assign_k2, assign_v2] = build_branch(q2, k2, v2, rv_k2, rv_v2);
-
-    ResultVector results{std::make_shared<ov::op::v0::Result>(sdpa1),
-                         std::make_shared<ov::op::v0::Result>(sdpa2)};
-    SinkVector sinks{assign_k1, assign_v1, assign_k2, assign_v2};
-    return std::make_shared<Model>(
-        results, sinks,
-        ParameterVector{q1, k1, v1, q2, k2, v2, init_k1, init_v1, init_k2, init_v2, beam_idx},
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(branch1.sdpa),
+                             std::make_shared<ov::op::v0::Result>(branch2.sdpa)};
+    ov::SinkVector sinks{assign_k1, assign_v1, assign_k2, assign_v2};
+    return std::make_shared<ov::Model>(
+        results,
+        sinks,
+        ov::ParameterVector{q1, k1, v1, q2, k2, v2, init_k1, init_v1, init_k2, init_v2, beam_idx},
         "SharedVariableTwoReadValues");
 }
 
-TEST(StateConcatSDPAExtra, SharedVariableTwoReadValuesRefusesFusion) {
+TEST(StateConcatSDPAExtra, SharedVariableTwoReadValuesPartiallyFuses) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
-    GTEST_SKIP() << "Skipping SharedVariableTwoReadValuesRefusesFusion on Android X64";
+    GTEST_SKIP() << "Skipping SharedVariableTwoReadValuesPartiallyFuses on Android X64";
 #endif
     auto inputShape = ov::PartialShape{-1, 8, -1, 64};
     auto model = makeSharedVariableTwoReadValuesModel(inputShape);
@@ -788,10 +783,11 @@ TEST(StateConcatSDPAExtra, SharedVariableTwoReadValuesRefusesFusion) {
             ++fused_sdpa;
         }
     }
-    EXPECT_EQ(plain_sdpa, 2u)
-        << "Both SDPAs reference the same Variable through distinct ReadValue nodes — "
-           "the KV-cache slot is shared and fusion must be refused for both.";
-    EXPECT_EQ(fused_sdpa, 0u)
-        << "No SDPA may fuse when two ReadValues alias the same Variable.";
+    EXPECT_EQ(plain_sdpa, 1u)
+        << "Variable-id-keyed detection must leave the reader SDPA as plain "
+           "v13::ScaledDotProductAttention even though its ReadValue node is "
+           "distinct from the writer's.";
+    EXPECT_EQ(fused_sdpa, 1u)
+        << "The writer (topologically-first) SDPA on the shared Variable must fuse.";
 }
 

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -640,14 +640,14 @@ TEST_F(TransformationTestsF, StateConcatSDPAShapeOfOnConcatKRerouteSucceeds) {
 // Test modelled after Gemma3n's shared-KV topology: one ReadValue fans out
 // to two Gathers, each feeding its own Concat → SDPA. Both SDPAs share the
 // same K-Variable and V-Variable through a single ReadValue node. The
-// past_k / past_v consumer-count guard at matcher entry observes more than
-// one non-ShapeOf consumer of the shared ReadValue and refuses fusion for
-// both branches. Fusing the writer alone is unsafe because the reader's
-// Gather child stays attached to the MemoryInput at graph-optimizer time,
-// MatchSdpaKvCache then refuses to promote the MemoryInput, and the fused
-// kernel crashes with "null input states" at execute time.
+// shared-KV detection observes the same variable_id from both matches and
+// keeps the topologically-first SDPA (the cache writer feeding the Assign)
+// fused, while leaving the second SDPA (the reader) as a plain
+// v13::ScaledDotProductAttention. ScaledDotProductAttentionWithKVCache only
+// supports a single owner-writer per K / V state, so the reader must NOT
+// fuse — otherwise the runtime crashes with "null input states".
 static std::shared_ptr<ov::Model>
-makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape) {
+makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape, bool isRef = false) {
     auto q1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
     auto k1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
     auto v1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
@@ -665,14 +665,29 @@ makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape) {
     auto past_k = std::make_shared<ov::op::v6::ReadValue>(init_k, var_k);
     auto past_v = std::make_shared<ov::op::v6::ReadValue>(init_v, var_v);
 
-    auto branch1 = make_plain_kv_branch(q1, k1, v1, beam_idx, past_k, past_v);
-    auto branch2 = make_plain_kv_branch(q2, k2, v2, beam_idx, past_k, past_v);
-    // One Assign pair writes back to the shared Variables (from branch 1).
-    auto assign_k = std::make_shared<ov::op::v6::Assign>(branch1.concat_k, var_k);
-    auto assign_v = std::make_shared<ov::op::v6::Assign>(branch1.concat_v, var_v);
+    ov::Output<ov::Node> sdp1_out, sdp2_out;
+    std::shared_ptr<ov::op::v6::Assign> assign_k, assign_v;
+    if (isRef) {
+        // Branch 1 = writer → fused. Its K / V outputs feed the shared Assigns.
+        auto fused = make_fused_kv_branch(q1, k1, v1, beam_idx, past_k, past_v);
+        sdp1_out = fused->output(0);
+        assign_k = std::make_shared<ov::op::v6::Assign>(fused->output(1), var_k);
+        assign_v = std::make_shared<ov::op::v6::Assign>(fused->output(2), var_v);
+        // Branch 2 = reader → must NOT fuse.
+        auto reader = make_plain_kv_branch(q2, k2, v2, beam_idx, past_k, past_v);
+        sdp2_out = reader.sdpa->output(0);
+    } else {
+        auto branch1 = make_plain_kv_branch(q1, k1, v1, beam_idx, past_k, past_v);
+        auto branch2 = make_plain_kv_branch(q2, k2, v2, beam_idx, past_k, past_v);
+        sdp1_out = branch1.sdpa->output(0);
+        sdp2_out = branch2.sdpa->output(0);
+        // One Assign pair writes back to the shared Variables (from branch 1).
+        assign_k = std::make_shared<ov::op::v6::Assign>(branch1.concat_k, var_k);
+        assign_v = std::make_shared<ov::op::v6::Assign>(branch1.concat_v, var_v);
+    }
 
-    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(branch1.sdpa),
-                             std::make_shared<ov::op::v0::Result>(branch2.sdpa)};
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(sdp1_out),
+                             std::make_shared<ov::op::v0::Result>(sdp2_out)};
     ov::SinkVector sinks{assign_k, assign_v};
     return std::make_shared<ov::Model>(results,
                                        sinks,
@@ -680,15 +695,14 @@ makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape) {
                                        "Gemma3nLikeSharedKV");
 }
 
-TEST_F(TransformationTestsF, StateConcatSDPAGemma3nLikeSharedKVRefusesFusion) {
+TEST_F(TransformationTestsF, StateConcatSDPAGemma3nLikeSharedKV) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
     test_skipped = true;
-    GTEST_SKIP() << "Skipping Gemma3nLikeSharedKVRefusesFusion on Android X64";
+    GTEST_SKIP() << "Skipping Gemma3nLikeSharedKV on Android X64";
 #endif
-    // Both branches must remain unfused: leaving model_ref unset lets the
-    // fixture compare the transformed model against a clone of the input.
     auto inputShape = ov::PartialShape{-1, 8, -1, 64};
     model = makeGemma3nLikeSharedKVModel(inputShape);
+    model_ref = makeGemma3nLikeSharedKVModel(inputShape, /*isRef=*/true);
     manager.register_pass<StatefulSDPAFusion>();
 }
 

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -444,20 +444,10 @@ TEST_F(TransformationTestsF, StateConcatSDPAMixedSharedAndExclusive) {
     manager.register_pass<SDPASubgraphFusion>();
 }
 
-// Two SDPAs with independent KV-cache Variables, plus a ShapeOf-rooted subgraph
-// hanging off layer-0's Gather output that fans out into both SDPAs'
-// attention-mask input. Mirrors the fan-out pattern observed in Qwen3-0.6B etc.,
-// where ShapeOf of layer 0's cache-after-beam-gather feeds the global
-// positional-ID / RoPE / attention-mask chain shared by every decoder layer.
-// Expectation: SDPASubgraphFusion (= SimplifyGatherShapeOf + StatefulSDPAFusion)
-// MUST fuse both SDPAs — the shape/metadata branch rooted at ShapeOf does not
-// imply a shared KV-cache. The Concat-children check inside the matcher is
-// satisfied because SimplifyGatherShapeOf rewrites ShapeOf(Gather(...)) so
-// that the Gather's output has only one consumer (the Concat).
-//
-// Counts plain vs fused SDPAs explicitly: SDPASubgraphFusion includes
-// SimplifyGatherShapeOf, which mutates the ShapeOf subgraph in ways that
-// would make a precise model_ref fragile to maintain.
+// Layer-0's Gather output feeds a ShapeOf chain shared with both SDPAs' attention-mask input
+// (Qwen3-style RoPE fanout). Both SDPAs must still fuse — shape metadata is not shared cache.
+// SDPA counts checked manually: SimplifyGatherShapeOf inside SDPASubgraphFusion mutates the
+// ShapeOf chain in ways that make a precise post-pass model_ref fragile.
 static std::shared_ptr<ov::Model>
 makeNonSharedKVWithSharedShapeOfRopeModel(const ov::PartialShape& inputShape) {
     auto make_param = [&](ov::element::Type t, const ov::PartialShape& s) {
@@ -570,17 +560,8 @@ TEST(StateConcatSDPAExtra, NonSharedKVWithSharedShapeOfRope) {
     EXPECT_EQ(fused_sdpa, 2u) << "Both SDPAs must be fused into ScaledDotProductAttentionWithKVCache.";
 }
 
-// Single (RV, SDPA) pair where the K-Concat has a ShapeOf consumer that
-// reads Concat_K's shape into a standalone output (separate from the SDPA's
-// own inputs). Mirrors Gemma3n layer 0's topology: ShapeOf(Concat_K) seeds
-// the global positional-ID / attention-mask chain shared across *other*
-// layers — not this SDPA's own mask. Fusion must apply, and the ShapeOf
-// consumer must be re-routed off the dead Concat so that the ReadValue's
-// MemoryInput post-fusion only has {fused SDPA, ShapeOf} children. Without
-// the re-route the ShapeOf keeps Concat_K (and therefore Gather, and
-// therefore a Gather child on the MemoryInput) alive — MatchSdpaKvCache
-// would reject and the fused kernel would crash with "null input states"
-// at execute time.
+// One (RV, SDPA) pair with a ShapeOf reading Concat_K (Gemma3n layer-0 topology).
+// Fusion must apply and the post-fusion reroute must leave ShapeOf reading from the fused K output.
 static std::shared_ptr<ov::Model>
 makeSingleSDPAWithShapeOfOnConcatKModel(const ov::PartialShape& inputShape, bool isRef = false) {
     auto q = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
@@ -637,15 +618,8 @@ TEST_F(TransformationTestsF, StateConcatSDPAShapeOfOnConcatKRerouteSucceeds) {
     manager.register_pass<StatefulSDPAFusion>();
 }
 
-// Test modelled after Gemma3n's shared-KV topology: one ReadValue fans out
-// to two Gathers, each feeding its own Concat → SDPA. Both SDPAs share the
-// same K-Variable and V-Variable through a single ReadValue node. The
-// shared-KV detection observes the same variable_id from both matches and
-// keeps the topologically-first SDPA (the cache writer feeding the Assign)
-// fused, while leaving the second SDPA (the reader) as a plain
-// v13::ScaledDotProductAttention. ScaledDotProductAttentionWithKVCache only
-// supports a single owner-writer per K / V state, so the reader must NOT
-// fuse — otherwise the runtime crashes with "null input states".
+// Gemma3n shared-KV topology: one ReadValue fans out to two SDPAs.
+// Writer (topologically first) fuses; reader stays plain.
 static std::shared_ptr<ov::Model>
 makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape, bool isRef = false) {
     auto q1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
@@ -706,20 +680,9 @@ TEST_F(TransformationTestsF, StateConcatSDPAGemma3nLikeSharedKV) {
     manager.register_pass<StatefulSDPAFusion>();
 }
 
-// Two distinct v6::ReadValue nodes that reference the SAME Variable (one per
-// branch), each feeding its own Gather → Concat → SDPA → Assign. The two
-// SDPAs are reachable from two different ReadValue *nodes*, but the cache
-// memory they read is the same Variable slot — i.e., they share the
-// KV-cache. Under detection keyed on the ReadValue node pointer, no sharing
-// is found and both SDPAs would (incorrectly) fuse. Under detection keyed on
-// the Variable identifier, the same Variable is observed twice — the
-// topologically-first (writer) SDPA fuses and the second (reader) is left
-// as a plain v13::ScaledDotProductAttention.
-//
-// Counted manually: TransformationTestsF cannot pair the four Assign sinks
-// here unambiguously because they share only two variable_ids
-// ("shared_var_k", "shared_var_v"), making the variable-id-based sink
-// matching in graph_comparator ambiguous.
+// Two ReadValue nodes aliasing one Variable: writer fuses, reader stays plain.
+// SDPA counts checked manually — graph_comparator pairs sinks by variable_id only, and 4 Assigns
+// sharing 2 variable_ids cannot be paired unambiguously.
 static std::shared_ptr<ov::Model>
 makeSharedVariableTwoReadValuesModel(const ov::PartialShape& inputShape) {
     auto q1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -640,14 +640,14 @@ TEST_F(TransformationTestsF, StateConcatSDPAShapeOfOnConcatKRerouteSucceeds) {
 // Test modelled after Gemma3n's shared-KV topology: one ReadValue fans out
 // to two Gathers, each feeding its own Concat → SDPA. Both SDPAs share the
 // same K-Variable and V-Variable through a single ReadValue node. The
-// shared-KV detection observes the same variable_id from both matches and
-// keeps the topologically-first SDPA (the cache writer feeding the Assign)
-// fused, while leaving the second SDPA (the reader) as a plain
-// v13::ScaledDotProductAttention. ScaledDotProductAttentionWithKVCache only
-// supports a single owner-writer per K / V state, so the reader must NOT
-// fuse — otherwise the runtime crashes with "null input states".
+// past_k / past_v consumer-count guard at matcher entry observes more than
+// one non-ShapeOf consumer of the shared ReadValue and refuses fusion for
+// both branches. Fusing the writer alone is unsafe because the reader's
+// Gather child stays attached to the MemoryInput at graph-optimizer time,
+// MatchSdpaKvCache then refuses to promote the MemoryInput, and the fused
+// kernel crashes with "null input states" at execute time.
 static std::shared_ptr<ov::Model>
-makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape, bool isRef = false) {
+makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape) {
     auto q1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
     auto k1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
     auto v1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape);
@@ -665,29 +665,14 @@ makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape, bool isRef = fa
     auto past_k = std::make_shared<ov::op::v6::ReadValue>(init_k, var_k);
     auto past_v = std::make_shared<ov::op::v6::ReadValue>(init_v, var_v);
 
-    ov::Output<ov::Node> sdp1_out, sdp2_out;
-    std::shared_ptr<ov::op::v6::Assign> assign_k, assign_v;
-    if (isRef) {
-        // Branch 1 = writer → fused. Its K / V outputs feed the shared Assigns.
-        auto fused = make_fused_kv_branch(q1, k1, v1, beam_idx, past_k, past_v);
-        sdp1_out = fused->output(0);
-        assign_k = std::make_shared<ov::op::v6::Assign>(fused->output(1), var_k);
-        assign_v = std::make_shared<ov::op::v6::Assign>(fused->output(2), var_v);
-        // Branch 2 = reader → must NOT fuse.
-        auto reader = make_plain_kv_branch(q2, k2, v2, beam_idx, past_k, past_v);
-        sdp2_out = reader.sdpa->output(0);
-    } else {
-        auto branch1 = make_plain_kv_branch(q1, k1, v1, beam_idx, past_k, past_v);
-        auto branch2 = make_plain_kv_branch(q2, k2, v2, beam_idx, past_k, past_v);
-        sdp1_out = branch1.sdpa->output(0);
-        sdp2_out = branch2.sdpa->output(0);
-        // One Assign pair writes back to the shared Variables (from branch 1).
-        assign_k = std::make_shared<ov::op::v6::Assign>(branch1.concat_k, var_k);
-        assign_v = std::make_shared<ov::op::v6::Assign>(branch1.concat_v, var_v);
-    }
+    auto branch1 = make_plain_kv_branch(q1, k1, v1, beam_idx, past_k, past_v);
+    auto branch2 = make_plain_kv_branch(q2, k2, v2, beam_idx, past_k, past_v);
+    // One Assign pair writes back to the shared Variables (from branch 1).
+    auto assign_k = std::make_shared<ov::op::v6::Assign>(branch1.concat_k, var_k);
+    auto assign_v = std::make_shared<ov::op::v6::Assign>(branch1.concat_v, var_v);
 
-    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(sdp1_out),
-                             std::make_shared<ov::op::v0::Result>(sdp2_out)};
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(branch1.sdpa),
+                             std::make_shared<ov::op::v0::Result>(branch2.sdpa)};
     ov::SinkVector sinks{assign_k, assign_v};
     return std::make_shared<ov::Model>(results,
                                        sinks,
@@ -695,14 +680,15 @@ makeGemma3nLikeSharedKVModel(const ov::PartialShape& inputShape, bool isRef = fa
                                        "Gemma3nLikeSharedKV");
 }
 
-TEST_F(TransformationTestsF, StateConcatSDPAGemma3nLikeSharedKV) {
+TEST_F(TransformationTestsF, StateConcatSDPAGemma3nLikeSharedKVRefusesFusion) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
     test_skipped = true;
-    GTEST_SKIP() << "Skipping Gemma3nLikeSharedKV on Android X64";
+    GTEST_SKIP() << "Skipping Gemma3nLikeSharedKVRefusesFusion on Android X64";
 #endif
+    // Both branches must remain unfused: leaving model_ref unset lets the
+    // fixture compare the transformed model against a clone of the input.
     auto inputShape = ov::PartialShape{-1, 8, -1, 64};
     model = makeGemma3nLikeSharedKVModel(inputShape);
-    model_ref = makeGemma3nLikeSharedKVModel(inputShape, /*isRef=*/true);
     manager.register_pass<StatefulSDPAFusion>();
 }
 


### PR DESCRIPTION
### Details:
### Details

- Replace the forward-BFS predicate from PR #35323 with two
  `std::unordered_set<std::string>` keyed by `ov::op::util::Variable`
  id (one for K, one for V), kept as private members of
  `StatefulSDPAFusion`. The callback skips a match when its `past_k` /
  `past_v` Variable id is already recorded; on a successful fusion both
  ids are inserted. Topological order in `GraphRewrite` makes the writer
  SDPA match first; later readers on the same Variable stay as plain
  `v13::ScaledDotProductAttention`. Variable-id keying also covers the
  corner case of two distinct `v6::ReadValue` nodes aliasing one
  `Variable`.
- Re-route any `ShapeOf` consumer of the obsolete K / V `Concat` to the
  fused node's K / V output. Without this, the old `Concat → Gather`
  chain stays alive via the positional-ID / attention-mask graph,
  `MatchSdpaKvCache` (`graph_optimizer.cpp:3163-3191`) refuses to
  promote the `MemoryInput`, and the kernel fails at execute time with
  `"null input states"` (`scaled_attn.cpp:2003`).
- `StatefulSDPAFusion` stays a `MatcherPass`. Each
  `SDPASubgraphFusion::run_on_model` call registers a fresh instance,
  so the sets start empty per model.

### Why

The shipped predicate counted every SDPA reachable forward from
`past_k` / `past_v` and leaked across unrelated layers via layer 0's
shared `ShapeOf → RoPE / mask` chain (Qwen3 / Qwen2.5 / SmolLM2 and
similar decoder LLMs). The new check is structural and anchors on
`Variable` identity, so `ShapeOf`-rooted metadata branches play no
role. Models with one `Variable` fanning out to multiple SDPAs
(Gemma3n) still get one writer fused and the readers refused.

### Tests

In `src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp`:

- `StateConcatSDPAExtra.NonSharedKVWithSharedShapeOfRope` — two
  independent-Variable SDPAs sharing a `ShapeOf` chain on the
  attention mask both fuse.
- `StateConcatSDPAShapeOfOnConcatKRerouteSucceeds` — `ShapeOf(Concat_K)`
  is rewritten to read from the fused node's K-output.
- `StateConcatSDPAGemma3nLikeSharedKV` — one `ReadValue` to two SDPAs:
  writer fuses, reader stays plain.
- `StateConcatSDPAExtra.SharedVariableTwoReadValuesPartiallyFuses` —
  two `ReadValue` nodes aliasing one `Variable`: only the first fuses.
### Tickets:
 - 185220, 186060, 186173

