### PR TITLE
[GPU] Fix lora/moe kernel compilation on modern NEO drivers (Gen 9.5+)

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_horizontal_fused.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_horizontal_fused.cl
@@ -97,18 +97,18 @@ KERNEL(horizontal_fused_second_token_a)(OPTIONAL_SHAPE_INFO_ARG
         __attribute__((opencl_unroll_hint))
         for (int i = 0; i < gemma_sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx))[get_sub_group_local_id()]);
 #else
-            sum += AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx))[get_sub_group_local_id()]);
 #endif
         }
     } else {
         // Can't unroll, tail handling
         for (int i = 0; i < sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx))[get_sub_group_local_id()]);
 #else
-            sum += AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx))[get_sub_group_local_id()]);
 #endif
         }
     }
@@ -208,9 +208,9 @@ KERNEL(second_token_b)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 
 #if ACCUMULATOR_TYPE_SIZE == 4
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __local uint*)(reduce_ptr + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(((const __local uint*)(reduce_ptr + kk))[get_sub_group_local_id()]);
 #else
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __local ushort*)(reduce_ptr + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(((const __local ushort*)(reduce_ptr + kk))[get_sub_group_local_id()]);
 #endif
         input *= scale;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_horizontal_fused.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_horizontal_fused.cl
@@ -98,18 +98,18 @@ KERNEL(horizontal_fused_second_token_a)(OPTIONAL_SHAPE_INFO_ARG
         __attribute__((opencl_unroll_hint))
         for (int i = 0; i < gemma_sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm_us((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #endif
         }
     } else {
         // Can't unroll, tail handling
         for (int i = 0; i < sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm_us((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #endif
         }
     }
@@ -209,9 +209,9 @@ KERNEL(second_token_b)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 
 #if ACCUMULATOR_TYPE_SIZE == 4
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(reduce_ptr + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm((const __local uint*)(reduce_ptr + kk)));
 #else
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(reduce_ptr + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm_us((const __local ushort*)(reduce_ptr + kk)));
 #endif
         input *= scale;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_horizontal_fused.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_horizontal_fused.cl
@@ -4,6 +4,19 @@
 
 #include "include/batch_headers/fetch_data.cl"
 
+// __local-pointer overloads of intel_sub_group_block_read* are only declared
+// when cl_intel_subgroup_local_block_io is advertised. NEO 23.x+ no longer
+// declares them implicitly. Use the intrinsic on drivers that expose the
+// extension; fall back to the equivalent per-lane indexed gather (lane i
+// receives word i, matching the block-read distribution).
+#ifdef cl_intel_subgroup_local_block_io
+inline uint   slm_block_read_uint  (const __local uint*   p) { return intel_sub_group_block_read   (p); }
+inline ushort slm_block_read_ushort(const __local ushort* p) { return intel_sub_group_block_read_us(p); }
+#else
+inline uint   slm_block_read_uint  (const __local uint*   p) { return p[get_sub_group_local_id()]; }
+inline ushort slm_block_read_ushort(const __local ushort* p) { return p[get_sub_group_local_id()]; }
+#endif
+
 #ifdef SECOND_TOKEN_A
 __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE)))
 KERNEL(horizontal_fused_second_token_a)(OPTIONAL_SHAPE_INFO_ARG
@@ -97,18 +110,18 @@ KERNEL(horizontal_fused_second_token_a)(OPTIONAL_SHAPE_INFO_ARG
         __attribute__((opencl_unroll_hint))
         for (int i = 0; i < gemma_sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx))[get_sub_group_local_id()]);
+            sum += AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx))[get_sub_group_local_id()]);
+            sum += AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #endif
         }
     } else {
         // Can't unroll, tail handling
         for (int i = 0; i < sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx))[get_sub_group_local_id()]);
+            sum += AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx))[get_sub_group_local_id()]);
+            sum += AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #endif
         }
     }
@@ -208,9 +221,9 @@ KERNEL(second_token_b)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 
 #if ACCUMULATOR_TYPE_SIZE == 4
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(((const __local uint*)(reduce_ptr + kk))[get_sub_group_local_id()]);
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(reduce_ptr + kk)));
 #else
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(((const __local ushort*)(reduce_ptr + kk))[get_sub_group_local_id()]);
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(reduce_ptr + kk)));
 #endif
         input *= scale;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_horizontal_fused.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_horizontal_fused.cl
@@ -3,19 +3,7 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
-
-// __local-pointer overloads of intel_sub_group_block_read* are only declared
-// when cl_intel_subgroup_local_block_io is advertised. NEO 23.x+ no longer
-// declares them implicitly. Use the intrinsic on drivers that expose the
-// extension; fall back to the equivalent per-lane indexed gather (lane i
-// receives word i, matching the block-read distribution).
-#ifdef cl_intel_subgroup_local_block_io
-inline uint   slm_block_read_uint  (const __local uint*   p) { return intel_sub_group_block_read   (p); }
-inline ushort slm_block_read_ushort(const __local ushort* p) { return intel_sub_group_block_read_us(p); }
-#else
-inline uint   slm_block_read_uint  (const __local uint*   p) { return p[get_sub_group_local_id()]; }
-inline ushort slm_block_read_ushort(const __local ushort* p) { return p[get_sub_group_local_id()]; }
-#endif
+#include "include/batch_headers/sub_group_block_read.cl"
 
 #ifdef SECOND_TOKEN_A
 __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE)))
@@ -110,18 +98,18 @@ KERNEL(horizontal_fused_second_token_a)(OPTIONAL_SHAPE_INFO_ARG
         __attribute__((opencl_unroll_hint))
         for (int i = 0; i < gemma_sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #endif
         }
     } else {
         // Can't unroll, tail handling
         for (int i = 0; i < sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(fma_buff + i * MAX_GEMMA_N + n_idx)));
 #endif
         }
     }
@@ -221,9 +209,9 @@ KERNEL(second_token_b)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 
 #if ACCUMULATOR_TYPE_SIZE == 4
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(reduce_ptr + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(reduce_ptr + kk)));
 #else
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(reduce_ptr + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(reduce_ptr + kk)));
 #endif
         input *= scale;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_opt.cl
@@ -3,19 +3,7 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
-
-// __local-pointer overloads of intel_sub_group_block_read* are only declared
-// when cl_intel_subgroup_local_block_io is advertised. NEO 23.x+ no longer
-// declares them implicitly. Use the intrinsic on drivers that expose the
-// extension; fall back to the equivalent per-lane indexed gather (lane i
-// receives word i, matching the block-read distribution).
-#ifdef cl_intel_subgroup_local_block_io
-inline uint   slm_block_read_uint  (const __local uint*   p) { return intel_sub_group_block_read   (p); }
-inline ushort slm_block_read_ushort(const __local ushort* p) { return intel_sub_group_block_read_us(p); }
-#else
-inline uint   slm_block_read_uint  (const __local uint*   p) { return p[get_sub_group_local_id()]; }
-inline ushort slm_block_read_ushort(const __local ushort* p) { return p[get_sub_group_local_id()]; }
-#endif
+#include "include/batch_headers/sub_group_block_read.cl"
 
 #ifdef SECOND_TOKEN_A
 __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE)))
@@ -69,9 +57,9 @@ KERNEL(second_token_a)(OPTIONAL_SHAPE_INFO_ARG
 
         for (int kk = 0; kk < klen_sg; kk += SUBGROUP_SIZE) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            uint input = slm_block_read_uint((const __local uint*)(A_ptr + kk));
+            uint input = _sub_group_block_read_l((const __local uint*)(A_ptr + kk));
 #else
-            ushort input = slm_block_read_ushort((const __local ushort*)(A_ptr + kk));
+            ushort input = _sub_group_block_read_l_us((const __local ushort*)(A_ptr + kk));
 #endif
             __attribute__((opencl_unroll_hint))
             for (int j = 0; j < SUBGROUP_SIZE; j++) {
@@ -101,18 +89,18 @@ KERNEL(second_token_a)(OPTIONAL_SHAPE_INFO_ARG
         __attribute__((opencl_unroll_hint))
         for (int i = 0; i < GEMMA_SGK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #endif
         }
     } else {
         // Can't unroll, tail handling.
         for (int i = 0; i < sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #endif
         }
     }
@@ -176,10 +164,10 @@ KERNEL(second_token_b)(OPTIONAL_SHAPE_INFO_ARG
     for (int kk = 0; kk < LORA_RANK; kk += SUBGROUP_SIZE) {
 #if ACCUMULATOR_TYPE_SIZE == 4
         ACCUMULATOR_TYPE scale = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __global uint*)(state_alpha + kk)));
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(reduce + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(reduce + kk)));
 #else
         ACCUMULATOR_TYPE scale = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __global ushort*)(state_alpha + kk)));
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(reduce + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(reduce + kk)));
 #endif
         input *= scale;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_opt.cl
@@ -57,9 +57,9 @@ KERNEL(second_token_a)(OPTIONAL_SHAPE_INFO_ARG
 
         for (int kk = 0; kk < klen_sg; kk += SUBGROUP_SIZE) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            uint input = _sub_group_block_read_l((const __local uint*)(A_ptr + kk));
+            uint input = _sub_group_block_read_slm((const __local uint*)(A_ptr + kk));
 #else
-            ushort input = _sub_group_block_read_l_us((const __local ushort*)(A_ptr + kk));
+            ushort input = _sub_group_block_read_slm_us((const __local ushort*)(A_ptr + kk));
 #endif
             __attribute__((opencl_unroll_hint))
             for (int j = 0; j < SUBGROUP_SIZE; j++) {
@@ -89,18 +89,18 @@ KERNEL(second_token_a)(OPTIONAL_SHAPE_INFO_ARG
         __attribute__((opencl_unroll_hint))
         for (int i = 0; i < GEMMA_SGK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm_us((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #endif
         }
     } else {
         // Can't unroll, tail handling.
         for (int i = 0; i < sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm_us((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #endif
         }
     }
@@ -164,10 +164,10 @@ KERNEL(second_token_b)(OPTIONAL_SHAPE_INFO_ARG
     for (int kk = 0; kk < LORA_RANK; kk += SUBGROUP_SIZE) {
 #if ACCUMULATOR_TYPE_SIZE == 4
         ACCUMULATOR_TYPE scale = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __global uint*)(state_alpha + kk)));
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_l((const __local uint*)(reduce + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm((const __local uint*)(reduce + kk)));
 #else
         ACCUMULATOR_TYPE scale = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __global ushort*)(state_alpha + kk)));
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_l_us((const __local ushort*)(reduce + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(_sub_group_block_read_slm_us((const __local ushort*)(reduce + kk)));
 #endif
         input *= scale;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_opt.cl
@@ -56,9 +56,9 @@ KERNEL(second_token_a)(OPTIONAL_SHAPE_INFO_ARG
 
         for (int kk = 0; kk < klen_sg; kk += SUBGROUP_SIZE) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            uint input = intel_sub_group_block_read((const __local uint*)(A_ptr + kk));
+            uint input = ((const __local uint*)(A_ptr + kk))[get_sub_group_local_id()];
 #else
-            ushort input = intel_sub_group_block_read_us((const __local ushort*)(A_ptr + kk));
+            ushort input = ((const __local ushort*)(A_ptr + kk))[get_sub_group_local_id()];
 #endif
             __attribute__((opencl_unroll_hint))
             for (int j = 0; j < SUBGROUP_SIZE; j++) {
@@ -88,18 +88,18 @@ KERNEL(second_token_a)(OPTIONAL_SHAPE_INFO_ARG
         __attribute__((opencl_unroll_hint))
         for (int i = 0; i < GEMMA_SGK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx))[get_sub_group_local_id()]);
 #else
-            sum += AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx))[get_sub_group_local_id()]);
 #endif
         }
     } else {
         // Can't unroll, tail handling.
         for (int i = 0; i < sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx))[get_sub_group_local_id()]);
 #else
-            sum += AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
+            sum += AS_ACCUMULATOR_TYPE(((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx))[get_sub_group_local_id()]);
 #endif
         }
     }
@@ -163,10 +163,10 @@ KERNEL(second_token_b)(OPTIONAL_SHAPE_INFO_ARG
     for (int kk = 0; kk < LORA_RANK; kk += SUBGROUP_SIZE) {
 #if ACCUMULATOR_TYPE_SIZE == 4
         ACCUMULATOR_TYPE scale = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __global uint*)(state_alpha + kk)));
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __local uint*)(reduce + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(((const __local uint*)(reduce + kk))[get_sub_group_local_id()]);
 #else
         ACCUMULATOR_TYPE scale = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __global ushort*)(state_alpha + kk)));
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __local ushort*)(reduce + kk)));
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(((const __local ushort*)(reduce + kk))[get_sub_group_local_id()]);
 #endif
         input *= scale;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora_opt.cl
@@ -4,6 +4,19 @@
 
 #include "include/batch_headers/fetch_data.cl"
 
+// __local-pointer overloads of intel_sub_group_block_read* are only declared
+// when cl_intel_subgroup_local_block_io is advertised. NEO 23.x+ no longer
+// declares them implicitly. Use the intrinsic on drivers that expose the
+// extension; fall back to the equivalent per-lane indexed gather (lane i
+// receives word i, matching the block-read distribution).
+#ifdef cl_intel_subgroup_local_block_io
+inline uint   slm_block_read_uint  (const __local uint*   p) { return intel_sub_group_block_read   (p); }
+inline ushort slm_block_read_ushort(const __local ushort* p) { return intel_sub_group_block_read_us(p); }
+#else
+inline uint   slm_block_read_uint  (const __local uint*   p) { return p[get_sub_group_local_id()]; }
+inline ushort slm_block_read_ushort(const __local ushort* p) { return p[get_sub_group_local_id()]; }
+#endif
+
 #ifdef SECOND_TOKEN_A
 __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE)))
 KERNEL(second_token_a)(OPTIONAL_SHAPE_INFO_ARG
@@ -56,9 +69,9 @@ KERNEL(second_token_a)(OPTIONAL_SHAPE_INFO_ARG
 
         for (int kk = 0; kk < klen_sg; kk += SUBGROUP_SIZE) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            uint input = ((const __local uint*)(A_ptr + kk))[get_sub_group_local_id()];
+            uint input = slm_block_read_uint((const __local uint*)(A_ptr + kk));
 #else
-            ushort input = ((const __local ushort*)(A_ptr + kk))[get_sub_group_local_id()];
+            ushort input = slm_block_read_ushort((const __local ushort*)(A_ptr + kk));
 #endif
             __attribute__((opencl_unroll_hint))
             for (int j = 0; j < SUBGROUP_SIZE; j++) {
@@ -88,18 +101,18 @@ KERNEL(second_token_a)(OPTIONAL_SHAPE_INFO_ARG
         __attribute__((opencl_unroll_hint))
         for (int i = 0; i < GEMMA_SGK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx))[get_sub_group_local_id()]);
+            sum += AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx))[get_sub_group_local_id()]);
+            sum += AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #endif
         }
     } else {
         // Can't unroll, tail handling.
         for (int i = 0; i < sgK; i++) {
 #if ACCUMULATOR_TYPE_SIZE == 4
-            sum += AS_ACCUMULATOR_TYPE(((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx))[get_sub_group_local_id()]);
+            sum += AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #else
-            sum += AS_ACCUMULATOR_TYPE(((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx))[get_sub_group_local_id()]);
+            sum += AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(fma_buff + i * MAX_LORA_RANK + n_idx)));
 #endif
         }
     }
@@ -163,10 +176,10 @@ KERNEL(second_token_b)(OPTIONAL_SHAPE_INFO_ARG
     for (int kk = 0; kk < LORA_RANK; kk += SUBGROUP_SIZE) {
 #if ACCUMULATOR_TYPE_SIZE == 4
         ACCUMULATOR_TYPE scale = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read((const __global uint*)(state_alpha + kk)));
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(((const __local uint*)(reduce + kk))[get_sub_group_local_id()]);
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(slm_block_read_uint((const __local uint*)(reduce + kk)));
 #else
         ACCUMULATOR_TYPE scale = AS_ACCUMULATOR_TYPE(intel_sub_group_block_read_us((const __global ushort*)(state_alpha + kk)));
-        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(((const __local ushort*)(reduce + kk))[get_sub_group_local_id()]);
+        ACCUMULATOR_TYPE input = AS_ACCUMULATOR_TYPE(slm_block_read_ushort((const __local ushort*)(reduce + kk)));
 #endif
         input *= scale;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
@@ -115,7 +115,8 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
-            half4 a = as_half4(intel_sub_group_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
+            half4 a = as_half4((ushort4)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE]));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -160,7 +161,8 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
 #    else
             half4 sum0;
             half4 sum1;
-            half8 a = as_half8(intel_sub_group_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
+            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -243,7 +245,8 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
-            half4 a = as_half4(intel_sub_group_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
+            half4 a = as_half4((ushort4)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE]));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -288,7 +291,8 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
 #    else
             float4 sum0;
             float4 sum1;
-            half8 a = as_half8(intel_sub_group_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
+            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
             uchar8 b = intel_sub_group_block_read_uc8((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar8 b2 = intel_sub_group_block_read_uc8((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -663,7 +667,8 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
-            half4 a = as_half4(intel_sub_group_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
+            half4 a = as_half4((ushort4)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE]));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -708,7 +713,8 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
 #    else
             half4 sum0;
             half4 sum1;
-            half8 a = as_half8(intel_sub_group_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
+            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -785,7 +791,8 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
-            half4 a = as_half4(intel_sub_group_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
+            half4 a = as_half4((ushort4)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE]));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)B + K + gk * FAKE_GROUP_SIZE);
 
@@ -830,7 +837,8 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
 #    else
             float4 sum0;
             float4 sum1;
-            half8 a = as_half8(intel_sub_group_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
+            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
             uchar8 b = intel_sub_group_block_read_uc8((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar8 b2 = intel_sub_group_block_read_uc8((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -922,7 +930,8 @@ inline void down_gemv_n2x_f16(const __global half* weight, __global MOE_DTYPE* r
 #    else
             half4 sum0;
             half4 sum1;
-            half8 a = as_half8(intel_sub_group_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
+            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
             half8 b = as_half8(intel_sub_group_block_read_us8((const __global ushort*)B + gk * FAKE_GROUP_SIZE));
             half8 b2 = as_half8(intel_sub_group_block_read_us8((const __global ushort*)B + K + gk * FAKE_GROUP_SIZE));
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
@@ -84,9 +84,15 @@ inline float moe_mlp_fast_erf(float x) {
 // extension; fall back to a per-lane indexed gather producing the same
 // distribution: lane i receives { p[i], p[i+SG], ..., p[i+(N-1)*SG] }.
 #ifdef cl_intel_subgroup_local_block_io
+inline ushort2 slm_block_read_us2(const __local ushort* p) { return intel_sub_group_block_read_us2(p); }
 inline ushort4 slm_block_read_us4(const __local ushort* p) { return intel_sub_group_block_read_us4(p); }
 inline ushort8 slm_block_read_us8(const __local ushort* p) { return intel_sub_group_block_read_us8(p); }
 #else
+inline ushort2 slm_block_read_us2(const __local ushort* p) {
+    const int id = get_sub_group_local_id();
+    return (ushort2)(p[id],
+                     p[id + 1 * SUBGROUP_SIZE]);
+}
 inline ushort4 slm_block_read_us4(const __local ushort* p) {
     const int id = get_sub_group_local_id();
     return (ushort4)(p[id],
@@ -169,7 +175,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
             // Each lane reads 2 K-elements (1 byte = 2 nibbles).
             half sum0;
             half sum1;
-            half2 a = as_half2(intel_sub_group_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(slm_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar b = intel_sub_group_block_read_uc((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar b2 = intel_sub_group_block_read_uc((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -297,7 +303,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
             // Each lane reads 2 K-elements (8-bit weights, 1 byte each).
             float sum0;
             float sum1;
-            half2 a = as_half2(intel_sub_group_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(slm_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -717,7 +723,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
             // Each lane reads 2 K-elements (1 byte = 2 nibbles).
             half sum0;
             half sum1;
-            half2 a = as_half2(intel_sub_group_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(slm_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar b = intel_sub_group_block_read_uc((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar b2 = intel_sub_group_block_read_uc((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -839,7 +845,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
             // Each lane reads 2 K-elements (8-bit weights, 1 byte each).
             float sum0;
             float sum1;
-            half2 a = as_half2(intel_sub_group_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(slm_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)B + K + gk * FAKE_GROUP_SIZE);
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "include/batch_headers/sub_group_block_read.cl"
+
 #define unroll_for __attribute__((opencl_unroll_hint)) for
 
 // Fake group size for compatibility and computation performance balance.
@@ -78,41 +80,6 @@ inline float moe_mlp_fast_erf(float x) {
 #    define DEQUANT_8BIT(v)    convert_half(v)
 #endif
 
-// __local-pointer overloads of intel_sub_group_block_read_usN are only declared
-// when cl_intel_subgroup_local_block_io is advertised. NEO 23.x+ no longer
-// declares them implicitly. Use the intrinsic on drivers that expose the
-// extension; fall back to a per-lane indexed gather producing the same
-// distribution: lane i receives { p[i], p[i+SG], ..., p[i+(N-1)*SG] }.
-#ifdef cl_intel_subgroup_local_block_io
-inline ushort2 slm_block_read_us2(const __local ushort* p) { return intel_sub_group_block_read_us2(p); }
-inline ushort4 slm_block_read_us4(const __local ushort* p) { return intel_sub_group_block_read_us4(p); }
-inline ushort8 slm_block_read_us8(const __local ushort* p) { return intel_sub_group_block_read_us8(p); }
-#else
-inline ushort2 slm_block_read_us2(const __local ushort* p) {
-    const int id = get_sub_group_local_id();
-    return (ushort2)(p[id],
-                     p[id + 1 * SUBGROUP_SIZE]);
-}
-inline ushort4 slm_block_read_us4(const __local ushort* p) {
-    const int id = get_sub_group_local_id();
-    return (ushort4)(p[id],
-                     p[id + 1 * SUBGROUP_SIZE],
-                     p[id + 2 * SUBGROUP_SIZE],
-                     p[id + 3 * SUBGROUP_SIZE]);
-}
-inline ushort8 slm_block_read_us8(const __local ushort* p) {
-    const int id = get_sub_group_local_id();
-    return (ushort8)(p[id],
-                     p[id + 1 * SUBGROUP_SIZE],
-                     p[id + 2 * SUBGROUP_SIZE],
-                     p[id + 3 * SUBGROUP_SIZE],
-                     p[id + 4 * SUBGROUP_SIZE],
-                     p[id + 5 * SUBGROUP_SIZE],
-                     p[id + 6 * SUBGROUP_SIZE],
-                     p[id + 7 * SUBGROUP_SIZE]);
-}
-#endif
-
 #if GATE_UP_ENABLE
 inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
                                 __global half* scales,
@@ -150,7 +117,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
-            half4 a = as_half4(slm_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half4 a = as_half4(_sub_group_block_read_l_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -175,7 +142,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
             // Each lane reads 2 K-elements (1 byte = 2 nibbles).
             half sum0;
             half sum1;
-            half2 a = as_half2(slm_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(_sub_group_block_read_l_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar b = intel_sub_group_block_read_uc((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar b2 = intel_sub_group_block_read_uc((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -195,7 +162,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
 #    else
             half4 sum0;
             half4 sum1;
-            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -278,7 +245,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
-            half4 a = as_half4(slm_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half4 a = as_half4(_sub_group_block_read_l_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -303,7 +270,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
             // Each lane reads 2 K-elements (8-bit weights, 1 byte each).
             float sum0;
             float sum1;
-            half2 a = as_half2(slm_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(_sub_group_block_read_l_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -323,7 +290,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
 #    else
             float4 sum0;
             float4 sum1;
-            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar8 b = intel_sub_group_block_read_uc8((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar8 b2 = intel_sub_group_block_read_uc8((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -698,7 +665,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
-            half4 a = as_half4(slm_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half4 a = as_half4(_sub_group_block_read_l_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -723,7 +690,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
             // Each lane reads 2 K-elements (1 byte = 2 nibbles).
             half sum0;
             half sum1;
-            half2 a = as_half2(slm_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(_sub_group_block_read_l_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar b = intel_sub_group_block_read_uc((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar b2 = intel_sub_group_block_read_uc((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -743,7 +710,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
 #    else
             half4 sum0;
             half4 sum1;
-            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -820,7 +787,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
-            half4 a = as_half4(slm_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half4 a = as_half4(_sub_group_block_read_l_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)B + K + gk * FAKE_GROUP_SIZE);
 
@@ -845,7 +812,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
             // Each lane reads 2 K-elements (8-bit weights, 1 byte each).
             float sum0;
             float sum1;
-            half2 a = as_half2(slm_block_read_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(_sub_group_block_read_l_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)B + K + gk * FAKE_GROUP_SIZE);
 
@@ -865,7 +832,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
 #    else
             float4 sum0;
             float4 sum1;
-            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar8 b = intel_sub_group_block_read_uc8((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar8 b2 = intel_sub_group_block_read_uc8((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -957,7 +924,7 @@ inline void down_gemv_n2x_f16(const __global half* weight, __global MOE_DTYPE* r
 #    else
             half4 sum0;
             half4 sum1;
-            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             half8 b = as_half8(intel_sub_group_block_read_us8((const __global ushort*)B + gk * FAKE_GROUP_SIZE));
             half8 b2 = as_half8(intel_sub_group_block_read_us8((const __global ushort*)B + K + gk * FAKE_GROUP_SIZE));
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
@@ -78,6 +78,35 @@ inline float moe_mlp_fast_erf(float x) {
 #    define DEQUANT_8BIT(v)    convert_half(v)
 #endif
 
+// __local-pointer overloads of intel_sub_group_block_read_usN are only declared
+// when cl_intel_subgroup_local_block_io is advertised. NEO 23.x+ no longer
+// declares them implicitly. Use the intrinsic on drivers that expose the
+// extension; fall back to a per-lane indexed gather producing the same
+// distribution: lane i receives { p[i], p[i+SG], ..., p[i+(N-1)*SG] }.
+#ifdef cl_intel_subgroup_local_block_io
+inline ushort4 slm_block_read_us4(const __local ushort* p) { return intel_sub_group_block_read_us4(p); }
+inline ushort8 slm_block_read_us8(const __local ushort* p) { return intel_sub_group_block_read_us8(p); }
+#else
+inline ushort4 slm_block_read_us4(const __local ushort* p) {
+    const int id = get_sub_group_local_id();
+    return (ushort4)(p[id],
+                     p[id + 1 * SUBGROUP_SIZE],
+                     p[id + 2 * SUBGROUP_SIZE],
+                     p[id + 3 * SUBGROUP_SIZE]);
+}
+inline ushort8 slm_block_read_us8(const __local ushort* p) {
+    const int id = get_sub_group_local_id();
+    return (ushort8)(p[id],
+                     p[id + 1 * SUBGROUP_SIZE],
+                     p[id + 2 * SUBGROUP_SIZE],
+                     p[id + 3 * SUBGROUP_SIZE],
+                     p[id + 4 * SUBGROUP_SIZE],
+                     p[id + 5 * SUBGROUP_SIZE],
+                     p[id + 6 * SUBGROUP_SIZE],
+                     p[id + 7 * SUBGROUP_SIZE]);
+}
+#endif
+
 #if GATE_UP_ENABLE
 inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
                                 __global half* scales,
@@ -115,8 +144,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
-            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
-            half4 a = as_half4((ushort4)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE]));
+            half4 a = as_half4(slm_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -161,8 +189,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
 #    else
             half4 sum0;
             half4 sum1;
-            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
-            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
+            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -245,8 +272,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
-            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
-            half4 a = as_half4((ushort4)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE]));
+            half4 a = as_half4(slm_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -291,8 +317,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
 #    else
             float4 sum0;
             float4 sum1;
-            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
-            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
+            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar8 b = intel_sub_group_block_read_uc8((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar8 b2 = intel_sub_group_block_read_uc8((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -667,8 +692,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
-            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
-            half4 a = as_half4((ushort4)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE]));
+            half4 a = as_half4(slm_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -713,8 +737,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
 #    else
             half4 sum0;
             half4 sum1;
-            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
-            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
+            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -791,8 +814,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
-            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
-            half4 a = as_half4((ushort4)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE]));
+            half4 a = as_half4(slm_block_read_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)B + K + gk * FAKE_GROUP_SIZE);
 
@@ -837,8 +859,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
 #    else
             float4 sum0;
             float4 sum1;
-            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
-            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
+            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar8 b = intel_sub_group_block_read_uc8((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar8 b2 = intel_sub_group_block_read_uc8((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -930,8 +951,7 @@ inline void down_gemv_n2x_f16(const __global half* weight, __global MOE_DTYPE* r
 #    else
             half4 sum0;
             half4 sum1;
-            const __local ushort* x2_p = (const __local ushort*)x2 + gk * FAKE_GROUP_SIZE;
-            half8 a = as_half8((ushort8)(x2_p[id_local], x2_p[id_local + SUBGROUP_SIZE], x2_p[id_local + 2 * SUBGROUP_SIZE], x2_p[id_local + 3 * SUBGROUP_SIZE], x2_p[id_local + 4 * SUBGROUP_SIZE], x2_p[id_local + 5 * SUBGROUP_SIZE], x2_p[id_local + 6 * SUBGROUP_SIZE], x2_p[id_local + 7 * SUBGROUP_SIZE]));
+            half8 a = as_half8(slm_block_read_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             half8 b = as_half8(intel_sub_group_block_read_us8((const __global ushort*)B + gk * FAKE_GROUP_SIZE));
             half8 b2 = as_half8(intel_sub_group_block_read_us8((const __global ushort*)B + K + gk * FAKE_GROUP_SIZE));
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe_3gemm_swiglu_mlp.cl
@@ -117,7 +117,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
-            half4 a = as_half4(_sub_group_block_read_l_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half4 a = as_half4(_sub_group_block_read_slm_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -142,7 +142,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
             // Each lane reads 2 K-elements (1 byte = 2 nibbles).
             half sum0;
             half sum1;
-            half2 a = as_half2(_sub_group_block_read_l_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(_sub_group_block_read_slm_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar b = intel_sub_group_block_read_uc((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar b2 = intel_sub_group_block_read_uc((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -162,7 +162,7 @@ inline void gate_up_gemv_n2x_u4(const __global uchar* weight,
 #    else
             half4 sum0;
             half4 sum1;
-            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_slm_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -245,7 +245,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
-            half4 a = as_half4(_sub_group_block_read_l_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half4 a = as_half4(_sub_group_block_read_slm_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -270,7 +270,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
             // Each lane reads 2 K-elements (8-bit weights, 1 byte each).
             float sum0;
             float sum1;
-            half2 a = as_half2(_sub_group_block_read_l_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(_sub_group_block_read_slm_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -290,7 +290,7 @@ inline void gate_up_gemv_n2x_u8(const __global uchar* weight,
 #    else
             float4 sum0;
             float4 sum1;
-            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_slm_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar8 b = intel_sub_group_block_read_uc8((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar8 b2 = intel_sub_group_block_read_uc8((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -665,7 +665,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             half2 sum0;
             half2 sum1;
-            half4 a = as_half4(_sub_group_block_read_l_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half4 a = as_half4(_sub_group_block_read_slm_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -690,7 +690,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
             // Each lane reads 2 K-elements (1 byte = 2 nibbles).
             half sum0;
             half sum1;
-            half2 a = as_half2(_sub_group_block_read_l_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(_sub_group_block_read_slm_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar b = intel_sub_group_block_read_uc((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar b2 = intel_sub_group_block_read_uc((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -710,7 +710,7 @@ inline void down_gemv_n2x_u4(const __global uchar* weight,
 #    else
             half4 sum0;
             half4 sum1;
-            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_slm_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE / 2);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)(B + (K / 2) + gk * FAKE_GROUP_SIZE / 2));
 
@@ -787,7 +787,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
 #    if ELEMS_PER_LANE == 4
             float2 sum0;
             float2 sum1;
-            half4 a = as_half4(_sub_group_block_read_l_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half4 a = as_half4(_sub_group_block_read_slm_us4((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar4 b = intel_sub_group_block_read_uc4((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar4 b2 = intel_sub_group_block_read_uc4((const __global uchar*)B + K + gk * FAKE_GROUP_SIZE);
 
@@ -812,7 +812,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
             // Each lane reads 2 K-elements (8-bit weights, 1 byte each).
             float sum0;
             float sum1;
-            half2 a = as_half2(_sub_group_block_read_l_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half2 a = as_half2(_sub_group_block_read_slm_us2((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar2 b = intel_sub_group_block_read_uc2((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar2 b2 = intel_sub_group_block_read_uc2((const __global uchar*)B + K + gk * FAKE_GROUP_SIZE);
 
@@ -832,7 +832,7 @@ inline void down_gemv_n2x_u8(const __global uchar* weight,
 #    else
             float4 sum0;
             float4 sum1;
-            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_slm_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             uchar8 b = intel_sub_group_block_read_uc8((const __global uchar*)B + gk * FAKE_GROUP_SIZE);
             uchar8 b2 = intel_sub_group_block_read_uc8((const __global uchar*)(B + K + gk * FAKE_GROUP_SIZE));
 
@@ -924,7 +924,7 @@ inline void down_gemv_n2x_f16(const __global half* weight, __global MOE_DTYPE* r
 #    else
             half4 sum0;
             half4 sum1;
-            half8 a = as_half8(_sub_group_block_read_l_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
+            half8 a = as_half8(_sub_group_block_read_slm_us8((const __local ushort*)x2 + gk * FAKE_GROUP_SIZE));
             half8 b = as_half8(intel_sub_group_block_read_us8((const __global ushort*)B + gk * FAKE_GROUP_SIZE));
             half8 b2 = as_half8(intel_sub_group_block_read_us8((const __global ushort*)B + K + gk * FAKE_GROUP_SIZE));
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_gemv.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_gemv.cl
@@ -223,7 +223,7 @@ __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) KERNEL(fully_connected
     barrier(CLK_LOCAL_MEM_FENCE);
 
     float2 sum_value;
-    sum_value[0] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_even[thr_id]));
+    sum_value[0] = as_float(_sub_group_block_read_slm((const __local uint*)all_sum_even[thr_id]));
     sum_value[0] = sub_group_reduce_add(sum_value[0]);
     if (wi_id == 0) {
         int cur_n = n + thr_id;
@@ -367,8 +367,8 @@ __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) KERNEL(fully_connected
     barrier(CLK_LOCAL_MEM_FENCE);
 
     float2 sum_value;
-    sum_value[0] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_even[thr_id]));
-    sum_value[1] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_odd[thr_id]));
+    sum_value[0] = as_float(_sub_group_block_read_slm((const __local uint*)all_sum_even[thr_id]));
+    sum_value[1] = as_float(_sub_group_block_read_slm((const __local uint*)all_sum_odd[thr_id]));
     sum_value[0] = sub_group_reduce_add(sum_value[0]);
     sum_value[1] = sub_group_reduce_add(sum_value[1]);
 
@@ -563,10 +563,10 @@ __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) KERNEL(fully_connected
     barrier(CLK_LOCAL_MEM_FENCE);
 
     float4 sum_value;
-    sum_value[0] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_0[thr_id]));
-    sum_value[1] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_1[thr_id]));
-    sum_value[2] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_2[thr_id]));
-    sum_value[3] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_3[thr_id]));
+    sum_value[0] = as_float(_sub_group_block_read_slm((const __local uint*)all_sum_0[thr_id]));
+    sum_value[1] = as_float(_sub_group_block_read_slm((const __local uint*)all_sum_1[thr_id]));
+    sum_value[2] = as_float(_sub_group_block_read_slm((const __local uint*)all_sum_2[thr_id]));
+    sum_value[3] = as_float(_sub_group_block_read_slm((const __local uint*)all_sum_3[thr_id]));
 
     for (int i = 0; i < 4; i++) {
         sum_value[i] = sub_group_reduce_add(sum_value[i]);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_gemv.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_gemv.cl
@@ -223,7 +223,7 @@ __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) KERNEL(fully_connected
     barrier(CLK_LOCAL_MEM_FENCE);
 
     float2 sum_value;
-    sum_value[0] = as_float(((const __local uint*)all_sum_even[thr_id])[get_sub_group_local_id()]);
+    sum_value[0] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_even[thr_id]));
     sum_value[0] = sub_group_reduce_add(sum_value[0]);
     if (wi_id == 0) {
         int cur_n = n + thr_id;
@@ -367,8 +367,8 @@ __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) KERNEL(fully_connected
     barrier(CLK_LOCAL_MEM_FENCE);
 
     float2 sum_value;
-    sum_value[0] = as_float(((const __local uint*)all_sum_even[thr_id])[get_sub_group_local_id()]);
-    sum_value[1] = as_float(((const __local uint*)all_sum_odd[thr_id])[get_sub_group_local_id()]);
+    sum_value[0] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_even[thr_id]));
+    sum_value[1] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_odd[thr_id]));
     sum_value[0] = sub_group_reduce_add(sum_value[0]);
     sum_value[1] = sub_group_reduce_add(sum_value[1]);
 
@@ -563,10 +563,10 @@ __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) KERNEL(fully_connected
     barrier(CLK_LOCAL_MEM_FENCE);
 
     float4 sum_value;
-    sum_value[0] = as_float(((const __local uint*)all_sum_0[thr_id])[get_sub_group_local_id()]);
-    sum_value[1] = as_float(((const __local uint*)all_sum_1[thr_id])[get_sub_group_local_id()]);
-    sum_value[2] = as_float(((const __local uint*)all_sum_2[thr_id])[get_sub_group_local_id()]);
-    sum_value[3] = as_float(((const __local uint*)all_sum_3[thr_id])[get_sub_group_local_id()]);
+    sum_value[0] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_0[thr_id]));
+    sum_value[1] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_1[thr_id]));
+    sum_value[2] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_2[thr_id]));
+    sum_value[3] = as_float(_sub_group_block_read_l((const __local uint*)all_sum_3[thr_id]));
 
     for (int i = 0; i < 4; i++) {
         sum_value[i] = sub_group_reduce_add(sum_value[i]);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/sub_group_block_read.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/sub_group_block_read.cl
@@ -43,6 +43,19 @@
 #define BLOCK_READ_FUNC_size8       _sub_group_block_read_ul
 #define BLOCK_READ_FUNC(type_size)  CAT(BLOCK_READ_FUNC_size, type_size)
 
+// __local-pointer variants. cl_intel_subgroups* only defines __global overloads of
+// intel_sub_group_block_read*; the __local overloads come from the separate
+// cl_intel_subgroup_local_block_io extension, which NEO 23.x+ no longer declares
+// implicitly. The _l-suffixed family below routes to the intrinsic when the
+// extension is advertised and falls back to an inline-emulation per-lane gather
+// otherwise — see DECLARE_BLOCK_READ_LOCAL_EMULATION and the macro blocks at the
+// bottom of this file.
+#define BLOCK_READ_FUNC_LOCAL_size1       _sub_group_block_read_l_uc
+#define BLOCK_READ_FUNC_LOCAL_size2       _sub_group_block_read_l_us
+#define BLOCK_READ_FUNC_LOCAL_size4       _sub_group_block_read_l
+#define BLOCK_READ_FUNC_LOCAL_size8       _sub_group_block_read_l_ul
+#define BLOCK_READ_FUNC_LOCAL(type_size)  CAT(BLOCK_READ_FUNC_LOCAL_size, type_size)
+
 #define BLOCK_READN_FUNC_SIZE_DEF(type_size, vector_size)   MAKE_VECTOR_TYPE(BLOCK_READ_FUNC(type_size), vector_size)
 #define BLOCK_READN_FUNC_size1(vector_size)                 BLOCK_READN_FUNC_SIZE_DEF(1, vector_size)
 #define BLOCK_READN_FUNC_size2(vector_size)                 BLOCK_READN_FUNC_SIZE_DEF(2, vector_size)
@@ -50,14 +63,24 @@
 #define BLOCK_READN_FUNC_size8(vector_size)                 BLOCK_READN_FUNC_SIZE_DEF(8, vector_size)
 #define BLOCK_READN_FUNC(type_size, vector_size)            CAT(BLOCK_READN_FUNC_size, type_size)(vector_size)
 
+#define BLOCK_READN_FUNC_LOCAL_SIZE_DEF(type_size, vector_size)   MAKE_VECTOR_TYPE(BLOCK_READ_FUNC_LOCAL(type_size), vector_size)
+#define BLOCK_READN_FUNC_LOCAL_size1(vector_size)                 BLOCK_READN_FUNC_LOCAL_SIZE_DEF(1, vector_size)
+#define BLOCK_READN_FUNC_LOCAL_size2(vector_size)                 BLOCK_READN_FUNC_LOCAL_SIZE_DEF(2, vector_size)
+#define BLOCK_READN_FUNC_LOCAL_size4(vector_size)                 BLOCK_READN_FUNC_LOCAL_SIZE_DEF(4, vector_size)
+#define BLOCK_READN_FUNC_LOCAL_size8(vector_size)                 BLOCK_READN_FUNC_LOCAL_SIZE_DEF(8, vector_size)
+#define BLOCK_READN_FUNC_LOCAL(type_size, vector_size)            CAT(BLOCK_READN_FUNC_LOCAL_size, type_size)(vector_size)
+
 #define BLOCK_READN_RAW(type_size, vector_size, addr_space, ptr, offset)                                        \
     BLOCK_READN_FUNC(type_size, vector_size)((const addr_space BLOCK_READ_TYPE(type_size)*)(ptr) + (offset))
+
+#define BLOCK_READN_RAW_SLM(type_size, vector_size, ptr, offset)                                                \
+    BLOCK_READN_FUNC_LOCAL(type_size, vector_size)((const __local BLOCK_READ_TYPE(type_size)*)(ptr) + (offset))
 
 #define BLOCK_READN(type, vector_size, ptr, offset)                                                             \
     AS_TYPE(MAKE_VECTOR_TYPE(type, vector_size), BLOCK_READN_RAW(TYPE_SIZE(type), vector_size, __global, ptr, offset))
 
 #define BLOCK_READN_SLM(type, vector_size, ptr, offset)                                                         \
-    AS_TYPE(MAKE_VECTOR_TYPE(type, vector_size), BLOCK_READN_RAW(TYPE_SIZE(type), vector_size, __local, ptr, offset))
+    AS_TYPE(MAKE_VECTOR_TYPE(type, vector_size), BLOCK_READN_RAW_SLM(TYPE_SIZE(type), vector_size, ptr, offset))
 
 #define DT_INPUT_BLOCK_READ(ptr, offset)            BLOCK_READN(INPUT0_TYPE, 1, ptr, offset)
 #define DT_INPUT_BLOCK_READ2(ptr, offset)           BLOCK_READN(INPUT0_TYPE, 2, ptr, offset)
@@ -117,6 +140,15 @@
     return ret; \
 }
 
+#define BLOCK_READ_FUNC_NAME_LOCAL(type_size, vec_size) MAKE_VECTOR_TYPE(BLOCK_READ_FUNC_LOCAL(type_size), vec_size)
+#define DECLARE_BLOCK_READ_LOCAL_EMULATION(type_size, vec_size) \
+    inline MAKE_VECTOR_TYPE(BLOCK_READ_TYPE(type_size), vec_size) BLOCK_READ_FUNC_NAME_LOCAL(type_size, vec_size)(const __local BLOCK_READ_TYPE(type_size)* ptr) { \
+    uint idx = get_sub_group_local_id(); \
+    MAKE_VECTOR_TYPE(BLOCK_READ_TYPE(type_size), vec_size) ret; \
+    BLOCK_READ_IMPL(vec_size) \
+    return ret; \
+}
+
 #if defined(cl_intel_subgroups)
     #define _sub_group_block_read(ptr) intel_sub_group_block_read(ptr)
     #define _sub_group_block_read2(ptr) intel_sub_group_block_read2(ptr)
@@ -129,6 +161,18 @@
     DECLARE_BLOCK_READ_EMULATION(4, 8)
 #endif
 
+#if defined(cl_intel_subgroup_local_block_io)
+    #define _sub_group_block_read_l(ptr)  intel_sub_group_block_read(ptr)
+    #define _sub_group_block_read_l2(ptr) intel_sub_group_block_read2(ptr)
+    #define _sub_group_block_read_l4(ptr) intel_sub_group_block_read4(ptr)
+    #define _sub_group_block_read_l8(ptr) intel_sub_group_block_read8(ptr)
+#elif (__OPENCL_C_VERSION__ >= 200)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(4, 1)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(4, 2)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(4, 4)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(4, 8)
+#endif
+
 #if defined(cl_intel_subgroups_short)
     #define _sub_group_block_read_us(ptr) intel_sub_group_block_read_us(ptr)
     #define _sub_group_block_read_us2(ptr) intel_sub_group_block_read_us2(ptr)
@@ -139,6 +183,18 @@
     DECLARE_BLOCK_READ_EMULATION(2, 2)
     DECLARE_BLOCK_READ_EMULATION(2, 4)
     DECLARE_BLOCK_READ_EMULATION(2, 8)
+#endif
+
+#if defined(cl_intel_subgroup_local_block_io)
+    #define _sub_group_block_read_l_us(ptr)  intel_sub_group_block_read_us(ptr)
+    #define _sub_group_block_read_l_us2(ptr) intel_sub_group_block_read_us2(ptr)
+    #define _sub_group_block_read_l_us4(ptr) intel_sub_group_block_read_us4(ptr)
+    #define _sub_group_block_read_l_us8(ptr) intel_sub_group_block_read_us8(ptr)
+#elif (__OPENCL_C_VERSION__ >= 200)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(2, 1)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(2, 2)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(2, 4)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(2, 8)
 #endif
 
 #if defined(cl_intel_subgroups_char)
@@ -155,6 +211,20 @@
     DECLARE_BLOCK_READ_EMULATION(1, 16)
 #endif
 
+#if defined(cl_intel_subgroup_local_block_io)
+    #define _sub_group_block_read_l_uc(ptr)   intel_sub_group_block_read_uc(ptr)
+    #define _sub_group_block_read_l_uc2(ptr)  intel_sub_group_block_read_uc2(ptr)
+    #define _sub_group_block_read_l_uc4(ptr)  intel_sub_group_block_read_uc4(ptr)
+    #define _sub_group_block_read_l_uc8(ptr)  intel_sub_group_block_read_uc8(ptr)
+    #define _sub_group_block_read_l_uc16(ptr) intel_sub_group_block_read_uc16(ptr)
+#elif (__OPENCL_C_VERSION__ >= 200)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 1)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 2)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 4)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 8)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 16)
+#endif
+
 #if defined(cl_intel_subgroups_long)
     #define _sub_group_block_read_ul(ptr)  intel_sub_group_block_read_ul(ptr)
     #define _sub_group_block_read_ul2(ptr) intel_sub_group_block_read_ul2(ptr)
@@ -165,4 +235,16 @@
     DECLARE_BLOCK_READ_EMULATION(8, 2)
     DECLARE_BLOCK_READ_EMULATION(8, 4)
     DECLARE_BLOCK_READ_EMULATION(8, 8)
+#endif
+
+#if defined(cl_intel_subgroup_local_block_io)
+    #define _sub_group_block_read_l_ul(ptr)  intel_sub_group_block_read_ul(ptr)
+    #define _sub_group_block_read_l_ul2(ptr) intel_sub_group_block_read_ul2(ptr)
+    #define _sub_group_block_read_l_ul4(ptr) intel_sub_group_block_read_ul4(ptr)
+    #define _sub_group_block_read_l_ul8(ptr) intel_sub_group_block_read_ul8(ptr)
+#elif (__OPENCL_C_VERSION__ >= 200)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(8, 1)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(8, 2)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(8, 4)
+    DECLARE_BLOCK_READ_LOCAL_EMULATION(8, 8)
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/sub_group_block_read.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/sub_group_block_read.cl
@@ -46,15 +46,15 @@
 // __local-pointer variants. cl_intel_subgroups* only defines __global overloads of
 // intel_sub_group_block_read*; the __local overloads come from the separate
 // cl_intel_subgroup_local_block_io extension, which NEO 23.x+ no longer declares
-// implicitly. The _l-suffixed family below routes to the intrinsic when the
+// implicitly. The _slm-suffixed family below routes to the intrinsic when the
 // extension is advertised and falls back to an inline-emulation per-lane gather
-// otherwise — see DECLARE_BLOCK_READ_LOCAL_EMULATION and the macro blocks at the
+// otherwise — see DECLARE_BLOCK_READ_SLM_EMULATION and the macro blocks at the
 // bottom of this file.
-#define BLOCK_READ_FUNC_LOCAL_size1       _sub_group_block_read_l_uc
-#define BLOCK_READ_FUNC_LOCAL_size2       _sub_group_block_read_l_us
-#define BLOCK_READ_FUNC_LOCAL_size4       _sub_group_block_read_l
-#define BLOCK_READ_FUNC_LOCAL_size8       _sub_group_block_read_l_ul
-#define BLOCK_READ_FUNC_LOCAL(type_size)  CAT(BLOCK_READ_FUNC_LOCAL_size, type_size)
+#define BLOCK_READ_FUNC_SLM_size1       _sub_group_block_read_slm_uc
+#define BLOCK_READ_FUNC_SLM_size2       _sub_group_block_read_slm_us
+#define BLOCK_READ_FUNC_SLM_size4       _sub_group_block_read_slm
+#define BLOCK_READ_FUNC_SLM_size8       _sub_group_block_read_slm_ul
+#define BLOCK_READ_FUNC_SLM(type_size)  CAT(BLOCK_READ_FUNC_SLM_size, type_size)
 
 #define BLOCK_READN_FUNC_SIZE_DEF(type_size, vector_size)   MAKE_VECTOR_TYPE(BLOCK_READ_FUNC(type_size), vector_size)
 #define BLOCK_READN_FUNC_size1(vector_size)                 BLOCK_READN_FUNC_SIZE_DEF(1, vector_size)
@@ -63,18 +63,18 @@
 #define BLOCK_READN_FUNC_size8(vector_size)                 BLOCK_READN_FUNC_SIZE_DEF(8, vector_size)
 #define BLOCK_READN_FUNC(type_size, vector_size)            CAT(BLOCK_READN_FUNC_size, type_size)(vector_size)
 
-#define BLOCK_READN_FUNC_LOCAL_SIZE_DEF(type_size, vector_size)   MAKE_VECTOR_TYPE(BLOCK_READ_FUNC_LOCAL(type_size), vector_size)
-#define BLOCK_READN_FUNC_LOCAL_size1(vector_size)                 BLOCK_READN_FUNC_LOCAL_SIZE_DEF(1, vector_size)
-#define BLOCK_READN_FUNC_LOCAL_size2(vector_size)                 BLOCK_READN_FUNC_LOCAL_SIZE_DEF(2, vector_size)
-#define BLOCK_READN_FUNC_LOCAL_size4(vector_size)                 BLOCK_READN_FUNC_LOCAL_SIZE_DEF(4, vector_size)
-#define BLOCK_READN_FUNC_LOCAL_size8(vector_size)                 BLOCK_READN_FUNC_LOCAL_SIZE_DEF(8, vector_size)
-#define BLOCK_READN_FUNC_LOCAL(type_size, vector_size)            CAT(BLOCK_READN_FUNC_LOCAL_size, type_size)(vector_size)
+#define BLOCK_READN_FUNC_SLM_SIZE_DEF(type_size, vector_size)   MAKE_VECTOR_TYPE(BLOCK_READ_FUNC_SLM(type_size), vector_size)
+#define BLOCK_READN_FUNC_SLM_size1(vector_size)                 BLOCK_READN_FUNC_SLM_SIZE_DEF(1, vector_size)
+#define BLOCK_READN_FUNC_SLM_size2(vector_size)                 BLOCK_READN_FUNC_SLM_SIZE_DEF(2, vector_size)
+#define BLOCK_READN_FUNC_SLM_size4(vector_size)                 BLOCK_READN_FUNC_SLM_SIZE_DEF(4, vector_size)
+#define BLOCK_READN_FUNC_SLM_size8(vector_size)                 BLOCK_READN_FUNC_SLM_SIZE_DEF(8, vector_size)
+#define BLOCK_READN_FUNC_SLM(type_size, vector_size)            CAT(BLOCK_READN_FUNC_SLM_size, type_size)(vector_size)
 
 #define BLOCK_READN_RAW(type_size, vector_size, addr_space, ptr, offset)                                        \
     BLOCK_READN_FUNC(type_size, vector_size)((const addr_space BLOCK_READ_TYPE(type_size)*)(ptr) + (offset))
 
 #define BLOCK_READN_RAW_SLM(type_size, vector_size, ptr, offset)                                                \
-    BLOCK_READN_FUNC_LOCAL(type_size, vector_size)((const __local BLOCK_READ_TYPE(type_size)*)(ptr) + (offset))
+    BLOCK_READN_FUNC_SLM(type_size, vector_size)((const __local BLOCK_READ_TYPE(type_size)*)(ptr) + (offset))
 
 #define BLOCK_READN(type, vector_size, ptr, offset)                                                             \
     AS_TYPE(MAKE_VECTOR_TYPE(type, vector_size), BLOCK_READN_RAW(TYPE_SIZE(type), vector_size, __global, ptr, offset))
@@ -140,9 +140,9 @@
     return ret; \
 }
 
-#define BLOCK_READ_FUNC_NAME_LOCAL(type_size, vec_size) MAKE_VECTOR_TYPE(BLOCK_READ_FUNC_LOCAL(type_size), vec_size)
-#define DECLARE_BLOCK_READ_LOCAL_EMULATION(type_size, vec_size) \
-    inline MAKE_VECTOR_TYPE(BLOCK_READ_TYPE(type_size), vec_size) BLOCK_READ_FUNC_NAME_LOCAL(type_size, vec_size)(const __local BLOCK_READ_TYPE(type_size)* ptr) { \
+#define BLOCK_READ_FUNC_NAME_SLM(type_size, vec_size) MAKE_VECTOR_TYPE(BLOCK_READ_FUNC_SLM(type_size), vec_size)
+#define DECLARE_BLOCK_READ_SLM_EMULATION(type_size, vec_size) \
+    inline MAKE_VECTOR_TYPE(BLOCK_READ_TYPE(type_size), vec_size) BLOCK_READ_FUNC_NAME_SLM(type_size, vec_size)(const __local BLOCK_READ_TYPE(type_size)* ptr) { \
     uint idx = get_sub_group_local_id(); \
     MAKE_VECTOR_TYPE(BLOCK_READ_TYPE(type_size), vec_size) ret; \
     BLOCK_READ_IMPL(vec_size) \
@@ -162,15 +162,15 @@
 #endif
 
 #if defined(cl_intel_subgroup_local_block_io)
-    #define _sub_group_block_read_l(ptr)  intel_sub_group_block_read(ptr)
-    #define _sub_group_block_read_l2(ptr) intel_sub_group_block_read2(ptr)
-    #define _sub_group_block_read_l4(ptr) intel_sub_group_block_read4(ptr)
-    #define _sub_group_block_read_l8(ptr) intel_sub_group_block_read8(ptr)
+    #define _sub_group_block_read_slm(ptr)  intel_sub_group_block_read(ptr)
+    #define _sub_group_block_read_slm2(ptr) intel_sub_group_block_read2(ptr)
+    #define _sub_group_block_read_slm4(ptr) intel_sub_group_block_read4(ptr)
+    #define _sub_group_block_read_slm8(ptr) intel_sub_group_block_read8(ptr)
 #elif (__OPENCL_C_VERSION__ >= 200)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(4, 1)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(4, 2)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(4, 4)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(4, 8)
+    DECLARE_BLOCK_READ_SLM_EMULATION(4, 1)
+    DECLARE_BLOCK_READ_SLM_EMULATION(4, 2)
+    DECLARE_BLOCK_READ_SLM_EMULATION(4, 4)
+    DECLARE_BLOCK_READ_SLM_EMULATION(4, 8)
 #endif
 
 #if defined(cl_intel_subgroups_short)
@@ -186,15 +186,15 @@
 #endif
 
 #if defined(cl_intel_subgroup_local_block_io)
-    #define _sub_group_block_read_l_us(ptr)  intel_sub_group_block_read_us(ptr)
-    #define _sub_group_block_read_l_us2(ptr) intel_sub_group_block_read_us2(ptr)
-    #define _sub_group_block_read_l_us4(ptr) intel_sub_group_block_read_us4(ptr)
-    #define _sub_group_block_read_l_us8(ptr) intel_sub_group_block_read_us8(ptr)
+    #define _sub_group_block_read_slm_us(ptr)  intel_sub_group_block_read_us(ptr)
+    #define _sub_group_block_read_slm_us2(ptr) intel_sub_group_block_read_us2(ptr)
+    #define _sub_group_block_read_slm_us4(ptr) intel_sub_group_block_read_us4(ptr)
+    #define _sub_group_block_read_slm_us8(ptr) intel_sub_group_block_read_us8(ptr)
 #elif (__OPENCL_C_VERSION__ >= 200)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(2, 1)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(2, 2)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(2, 4)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(2, 8)
+    DECLARE_BLOCK_READ_SLM_EMULATION(2, 1)
+    DECLARE_BLOCK_READ_SLM_EMULATION(2, 2)
+    DECLARE_BLOCK_READ_SLM_EMULATION(2, 4)
+    DECLARE_BLOCK_READ_SLM_EMULATION(2, 8)
 #endif
 
 #if defined(cl_intel_subgroups_char)
@@ -212,17 +212,17 @@
 #endif
 
 #if defined(cl_intel_subgroup_local_block_io)
-    #define _sub_group_block_read_l_uc(ptr)   intel_sub_group_block_read_uc(ptr)
-    #define _sub_group_block_read_l_uc2(ptr)  intel_sub_group_block_read_uc2(ptr)
-    #define _sub_group_block_read_l_uc4(ptr)  intel_sub_group_block_read_uc4(ptr)
-    #define _sub_group_block_read_l_uc8(ptr)  intel_sub_group_block_read_uc8(ptr)
-    #define _sub_group_block_read_l_uc16(ptr) intel_sub_group_block_read_uc16(ptr)
+    #define _sub_group_block_read_slm_uc(ptr)   intel_sub_group_block_read_uc(ptr)
+    #define _sub_group_block_read_slm_uc2(ptr)  intel_sub_group_block_read_uc2(ptr)
+    #define _sub_group_block_read_slm_uc4(ptr)  intel_sub_group_block_read_uc4(ptr)
+    #define _sub_group_block_read_slm_uc8(ptr)  intel_sub_group_block_read_uc8(ptr)
+    #define _sub_group_block_read_slm_uc16(ptr) intel_sub_group_block_read_uc16(ptr)
 #elif (__OPENCL_C_VERSION__ >= 200)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 1)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 2)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 4)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 8)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(1, 16)
+    DECLARE_BLOCK_READ_SLM_EMULATION(1, 1)
+    DECLARE_BLOCK_READ_SLM_EMULATION(1, 2)
+    DECLARE_BLOCK_READ_SLM_EMULATION(1, 4)
+    DECLARE_BLOCK_READ_SLM_EMULATION(1, 8)
+    DECLARE_BLOCK_READ_SLM_EMULATION(1, 16)
 #endif
 
 #if defined(cl_intel_subgroups_long)
@@ -238,13 +238,13 @@
 #endif
 
 #if defined(cl_intel_subgroup_local_block_io)
-    #define _sub_group_block_read_l_ul(ptr)  intel_sub_group_block_read_ul(ptr)
-    #define _sub_group_block_read_l_ul2(ptr) intel_sub_group_block_read_ul2(ptr)
-    #define _sub_group_block_read_l_ul4(ptr) intel_sub_group_block_read_ul4(ptr)
-    #define _sub_group_block_read_l_ul8(ptr) intel_sub_group_block_read_ul8(ptr)
+    #define _sub_group_block_read_slm_ul(ptr)  intel_sub_group_block_read_ul(ptr)
+    #define _sub_group_block_read_slm_ul2(ptr) intel_sub_group_block_read_ul2(ptr)
+    #define _sub_group_block_read_slm_ul4(ptr) intel_sub_group_block_read_ul4(ptr)
+    #define _sub_group_block_read_slm_ul8(ptr) intel_sub_group_block_read_ul8(ptr)
 #elif (__OPENCL_C_VERSION__ >= 200)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(8, 1)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(8, 2)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(8, 4)
-    DECLARE_BLOCK_READ_LOCAL_EMULATION(8, 8)
+    DECLARE_BLOCK_READ_SLM_EMULATION(8, 1)
+    DECLARE_BLOCK_READ_SLM_EMULATION(8, 2)
+    DECLARE_BLOCK_READ_SLM_EMULATION(8, 4)
+    DECLARE_BLOCK_READ_SLM_EMULATION(8, 8)
 #endif


### PR DESCRIPTION
### Details
Follow-up to #35661.

`__local`-pointer overloads of `intel_sub_group_block_read*` were dropped from the `cl_intel_subgroups` extension and don't compile on Intel NEO 23.x and newer. The original PR (#35661) fixed this in `fully_connected_gpu_gemv.cl`. Reviewer @Lyamin-Roman flagged that the same pattern exists in three other kernels — this PR fixes those three.

### Affected kernels

| Kernel | Sites | Variant |
|---|---|---|
| `lora_opt.cl` | 8 | scalar uint / ushort |
| `lora_horizontal_fused.cl` | 6 | scalar uint / ushort |
| `moe_3gemm_swiglu_mlp.cl` | 9 | vector us4 / us8 |

### Replacement

**Scalar (`block_read`, `block_read_us`):** `intel_sub_group_block_read(p)` on a SUBGROUP_SIZE-wide sub-group distributes SUBGROUP_SIZE consecutive words such that lane `i` gets word `i`. `p[get_sub_group_local_id()]` produces the same per-lane value.

**Vector (`block_read_us4` / `block_read_us8`):** `intel_sub_group_block_read_usN(p)` distributes `N × SUBGROUP_SIZE` consecutive ushorts such that lane `i` gets `(p[i], p[i+SG], p[i+2·SG], …, p[i+(N-1)·SG])`. Replaced with an explicit `ushortN` initializer pulling those same per-lane offsets. A temporary `const __local ushort* x2_p` is introduced once per call site so the source pointer arithmetic is computed only once.

### Equivalence checks

All three kernels:
- declare a fixed sub-group size via `__attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE)))`,
- keep `id_local = get_sub_group_local_id()` (or `lid`) in scope at each patched site,
- `barrier(CLK_LOCAL_MEM_FENCE)` the SLM writes upstream of these reads,

so the scalar / vector loads land on already-published SLM and the per-lane distribution semantics match the original block-read.

### Tickets
Refs: #35661

cc @Lyamin-Roman @p-durandin

---
### Post-review update (merged shape)
Per review, the per-kernel helpers were consolidated into
`kernel_selector/cl_kernels/include/batch_headers/sub_group_block_read.cl` as a
`_sub_group_block_read_slm*` family (intrinsic when `cl_intel_subgroup_local_block_io`
is advertised, inline emulation otherwise), `BLOCK_READN_SLM` routed through it, and all
four kernels migrated — including retrofitting `fully_connected_gpu_gemv.cl` from #35661.
Follow-up regression test: #36017. Field impact measurements:
[ov-impact-bench](https://github.com/pjordanandrsn/ov-impact-bench).
