### PR TITLE
[GPU] Fix SDPA config for xe3 to choose xe2 config

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -793,7 +793,7 @@ sdpa_config_t* choose_config_xe2(int head_size, int seq, bool thin_q, bool quant
     }
     return choose_config_xehpc(head_size, seq, thin_q, quantized, is_integrated, is_pa, is_prefill);
 }
-sdpa_config_t* choose_config_xe3(int head_size, int seq, bool thin_q, bool quantized, bool is_integrated, bool is_pa, bool is_prefill) {
+sdpa_config_t* choose_config_xe3p(int head_size, int seq, bool thin_q, bool quantized, bool is_integrated, bool is_pa, bool is_prefill) {
     if (head_size <= 128) {
         return &xe3_h128;
     }
@@ -1535,7 +1535,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
         break;
     case gpu_arch::xe3p_35_10:
     case gpu_arch::xe3p_35_11:
-        config = choose_config_xe3(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);
+        config = choose_config_xe3p(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);
         break;
     default: {
         config = choose_config_xe2(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1530,9 +1530,9 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
         config = choose_config_xehpc(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);
         break;
     case gpu_arch::xe2:
+    case gpu_arch::xe3:
         config = choose_config_xe2(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);
         break;
-    case gpu_arch::xe3:
     case gpu_arch::xe3p_35_10:
     case gpu_arch::xe3p_35_11:
         config = choose_config_xe3(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);


### PR DESCRIPTION
## Issue
- After merging [PR#35667](https://github.com/openvinotoolkit/openvino/pull/35667), a performance regression was observed for multiple LLM workloads on PTL platforms.
- The regression mainly appeared in the 1st token latency with large input sequence lengths (e.g. 1024 ->256).

## Root cause
- The issue was caused by applying `xe3p` config to `xe3` platforms.
- PTL platforms belong to `xe3`, but `xe3p` config was not suitable for `xe3`, and resulted in LLM performance drop.

## Solution
- The config for `xe3` was reverted to the previous `xe2` config instead of using `xe3p` config.
- After reverting, the performance results returned to the expectation.