### PR TITLE
[TESTS] Avoid printing MEM_USAGE by default

### DIFF
--- a/src/tests/test_utils/common_test_utils/src/test_common.cpp
+++ b/src/tests/test_utils/common_test_utils/src/test_common.cpp
@@ -30,9 +30,12 @@ TestsCommon::TestsCommon()
 #endif
 {
 #ifndef __APPLE__  // TODO: add getVmSizeInKB() for Apple platform
-    auto memsize = ov::test::utils::getVmSizeInKB();
-    if (memsize != 0) {
-        std::cout << "\nMEM_USAGE=" << memsize << "KB\n";
+    static const bool print_mem_usage = std::getenv("OV_TEST_PRINT_MEM_USAGE") != nullptr;
+    if (print_mem_usage) {
+        auto memsize = ov::test::utils::getVmSizeInKB();
+        if (memsize != 0) {
+            std::cout << "\nMEM_USAGE=" << memsize << "KB\n";
+        }
     }
 #endif
     ov::threading::executor_manager()->clear();


### PR DESCRIPTION
since it is just noise for most normal runs
