### PR TITLE
Replace unreliable placekitten.com with placekittens.com

### DIFF
--- a/docs/articles_en/openvino-workflow/model-preparation/convert-model-pytorch.rst
+++ b/docs/articles_en/openvino-workflow/model-preparation/convert-model-pytorch.rst
@@ -68,7 +68,7 @@ inference in the existing PyTorch application to OpenVINO and how to get value f
    import requests, PIL, io, torch
 
    # Get a picture of a cat from the web:
-   img = PIL.Image.open(io.BytesIO(requests.get("https://placekitten.com/200/300").content))
+   img = PIL.Image.open(io.BytesIO(requests.get("https://placekittens.com/200/300").content))
 
    # Torchvision model and input data preparation from https://pytorch.org/vision/stable/models.html
 


### PR DESCRIPTION
The placekitten.com became unreliable.

### Details:
- Updated URL to placekittens.com (with a 's')