### PR TITLE
[GPU][Coverity] Fix overflowed constant in ScatterUpdateKernelRef::GetJitConstants

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -216,7 +216,7 @@ JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params
             std::string def_pitch = "UPDATES_" + GetAxisName(dims, i) + "_PITCH";
             std::string src_pitch = "1";
             jit.AddConstant(MakeJitConstant(def_pitch, src_pitch));
-        } else if (i == (axis_value - 1)) {
+        } else if (axis_value > 0 && i == (axis_value - 1)) {
             get_update_idx_src += default_order[i] + ", ";
             std::string def_pitch = "UPDATES_" + GetAxisName(dims, i) + "_PITCH";
             std::string src_pitch = "(UPDATES_" + GetAxisName(dims, i + 1) + "_PITCH * INDICES_SIZE)";


### PR DESCRIPTION
### Details:
 - axis_value is size_t, so (axis_value - 1) when axis_value == 0 (BATCH axis) wraps to SIZE_MAX causing an unsigned integer underflow. Guard the comparison with axis_value > 0 to prevent the underflow.

### Tickets:
 - 186454

### AI Assistance:
 - AI assistance used: yes
 - AI: analyze issue, implementation
 - User: review
