### PR TITLE
[Draft][DONT SUBMIT][DONT REVIEW][GPU] Enable mmap for loading model weights​ on iGPUs and eliminate h…

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -46,8 +46,6 @@
 
 ov::ICore::~ICore() = default;
 
-constexpr std::size_t STANDARD_PAGE_SIZE = 4096;
-
 namespace {
 
 #ifdef PROXY_PLUGIN_ENABLED
@@ -1537,9 +1535,6 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::compile_model_and_cache(ov::Plugin& 
             // write compiled blob
             cache_content.m_cache_manager->write_cache_entry(cache_content.m_blob_id, [&](std::ostream& stream) {
                 uint32_t header_size_alignment = {};
-                if (plugin.get_name().find("GPU") == 0) {
-                    header_size_alignment = STANDARD_PAGE_SIZE;
-                }
                 if (device_supports_internal_property(plugin, ov::internal::cache_header_alignment.name())) {
                     header_size_alignment =
                         plugin.get_property(ov::internal::cache_header_alignment.name(), {}).as<uint32_t>();

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -1534,7 +1534,7 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::compile_model_and_cache(ov::Plugin& 
             }
             // write compiled blob
             cache_content.m_cache_manager->write_cache_entry(cache_content.m_blob_id, [&](std::ostream& stream) {
-                uint32_t header_size_alignment = {};
+                uint32_t header_size_alignment{};
                 if (device_supports_internal_property(plugin, ov::internal::cache_header_alignment.name())) {
                     header_size_alignment =
                         plugin.get_property(ov::internal::cache_header_alignment.name(), {}).as<uint32_t>();
@@ -1649,14 +1649,11 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::load_model_from_cache(
 
                 ov::util::VariantVisitor model_importer{
                     [&](const ov::Tensor& compiled_blob) -> ov::SoPtr<ov::ICompiledModel> {
-                        auto compiled_blob_without_header =
-                            std::make_shared<ov::Tensor>(compiled_blob,
-                                                         ov::Coordinate{compiled_blob_offset},
-                                                         ov::Coordinate{compiled_blob.get_size()});
-                        auto imported_model =
-                            context ? plugin.import_model(*compiled_blob_without_header, context, update_config)
-                                    : plugin.import_model(*compiled_blob_without_header, update_config);
-                        return ov::SoPtr<ov::ICompiledModel>(imported_model._ptr, compiled_blob_without_header);
+                        const ov::Tensor compiled_blob_without_header{compiled_blob,
+                                                                      {compiled_blob_offset},
+                                                                      {compiled_blob.get_size()}};
+                        return context ? plugin.import_model(compiled_blob_without_header, context, update_config)
+                                       : plugin.import_model(compiled_blob_without_header, update_config);
                     },
                     [&](std::reference_wrapper<std::istream> stream) -> ov::SoPtr<ov::ICompiledModel> {
                         return context ? plugin.import_model(stream, context, update_config)

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -46,6 +46,8 @@
 
 ov::ICore::~ICore() = default;
 
+constexpr std::size_t STANDARD_PAGE_SIZE = 4096;
+
 namespace {
 
 #ifdef PROXY_PLUGIN_ENABLED
@@ -1534,7 +1536,10 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::compile_model_and_cache(ov::Plugin& 
             }
             // write compiled blob
             cache_content.m_cache_manager->write_cache_entry(cache_content.m_blob_id, [&](std::ostream& stream) {
-                uint32_t header_size_alignment{};
+                uint32_t header_size_alignment = {};
+                if (plugin.get_name().find("GPU") == 0) {
+                    header_size_alignment = STANDARD_PAGE_SIZE;
+                }
                 if (device_supports_internal_property(plugin, ov::internal::cache_header_alignment.name())) {
                     header_size_alignment =
                         plugin.get_property(ov::internal::cache_header_alignment.name(), {}).as<uint32_t>();
@@ -1649,11 +1654,14 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::load_model_from_cache(
 
                 ov::util::VariantVisitor model_importer{
                     [&](const ov::Tensor& compiled_blob) -> ov::SoPtr<ov::ICompiledModel> {
-                        const ov::Tensor compiled_blob_without_header{compiled_blob,
-                                                                      {compiled_blob_offset},
-                                                                      {compiled_blob.get_size()}};
-                        return context ? plugin.import_model(compiled_blob_without_header, context, update_config)
-                                       : plugin.import_model(compiled_blob_without_header, update_config);
+                        auto compiled_blob_without_header =
+                            std::make_shared<ov::Tensor>(compiled_blob,
+                                                         ov::Coordinate{compiled_blob_offset},
+                                                         ov::Coordinate{compiled_blob.get_size()});
+                        auto imported_model =
+                            context ? plugin.import_model(*compiled_blob_without_header, context, update_config)
+                                    : plugin.import_model(*compiled_blob_without_header, update_config);
+                        return ov::SoPtr<ov::ICompiledModel>(imported_model._ptr, compiled_blob_without_header);
                     },
                     [&](std::reference_wrapper<std::istream> stream) -> ov::SoPtr<ov::ICompiledModel> {
                         return context ? plugin.import_model(stream, context, update_config)

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
@@ -17,8 +17,8 @@ struct memory;
 
 class BinaryOutputBuffer : public OutputBuffer<BinaryOutputBuffer> {
 public:
-    BinaryOutputBuffer(std::ostream& stream)
-    : OutputBuffer<BinaryOutputBuffer>(this), stream(stream), _impl_params(nullptr), _strm(nullptr) {}
+    BinaryOutputBuffer(std::ostream& stream, bool enctrypted = false)
+    : OutputBuffer<BinaryOutputBuffer>(this), stream(stream), _impl_params(nullptr), _strm(nullptr), _bytes_written(0), _encrypted(enctrypted) {}
 
     virtual ~BinaryOutputBuffer() = default;
 
@@ -27,6 +27,7 @@ public:
         OPENVINO_ASSERT(written_size == size,
                         "[GPU] Failed to write " + std::to_string(size) + " bytes to stream! Wrote " +
                             std::to_string(written_size));
+        _bytes_written += static_cast<size_t>(size); 
     }
 
     virtual void flush() {}
@@ -35,33 +36,37 @@ public:
     void* getKernelImplParams() const { return _impl_params; }
     void set_stream(void* strm) { _strm = strm; }
     void* get_stream() const { return _strm; }
-    size_t get_current_offset() const {
-        std::streampos current_pos = stream.tellp();
-        if (current_pos == std::streampos(-1)) {
-            throw std::runtime_error("Failed to get stream position");
-        }
-        std::streamoff offset = static_cast<std::streamoff>(current_pos);
-        return static_cast<size_t>(offset);
-    }
+    size_t get_current_offset() const { return _bytes_written; }
+    bool is_encrypted() const { return _encrypted; }
+    size_t _bytes_written;
 
 private:
     std::ostream& stream;
     void* _impl_params;
     void* _strm;
+    bool _encrypted;
 };
 
 class BinaryInputBuffer : public InputBuffer<BinaryInputBuffer> {
 public:
-    BinaryInputBuffer(std::istream& stream, engine& engine)
+    BinaryInputBuffer(std::istream& stream, engine& engine, bool encrypted = false)
         : InputBuffer<BinaryInputBuffer>(this, engine),
           _stream(stream),
           _impl_params(nullptr),
-          _tensor_base_ptr(nullptr) {}
-    BinaryInputBuffer(std::istream& stream, engine& engine, const size_t* _tensor_bp)
+          _tensor_base_ptr(nullptr),
+          _bytes_read(0),
+          _encrypted(encrypted) {
+        set_stream_size(_stream);
+    }
+    BinaryInputBuffer(std::istream& stream, engine& engine, const size_t* _tensor_bp, bool encrypted = false)
         : InputBuffer<BinaryInputBuffer>(this, engine),
           _stream(stream),
           _impl_params(nullptr),
-          _tensor_base_ptr(_tensor_bp) {}
+          _tensor_base_ptr(_tensor_bp),
+          _bytes_read(0),
+          _encrypted(encrypted) {
+        set_stream_size(_stream);
+    }
 
     virtual ~BinaryInputBuffer() = default;
 
@@ -69,6 +74,7 @@ public:
         auto const read_size = _stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
         OPENVINO_ASSERT(read_size == size,
             "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
+        _bytes_read += static_cast<size_t>(read_size); 
     }
 
     /// Access the underlying streambuf. Callers that know their backing buffer
@@ -89,56 +95,53 @@ public:
         return _tensor_base_ptr;
     }
 
-    size_t get_stream_size() const {
-        std::streampos current_pos = _stream.tellg();
-        if (current_pos == std::streampos(-1)) {
-            throw std::runtime_error("Failed to get stream position");
+    void set_stream_size(std::istream& stream) {
+        // Dynamically cast to a stringstream
+        if (auto* ss = dynamic_cast<std::stringstream*>(&stream)) {
+            _total_size = ss->str().size();
         }
-        _stream.seekg(0, std::ios::end);
-        std::streampos end_pos = _stream.tellg();
-        _stream.seekg(0, std::ios::beg);
-        std::streampos start_pos = _stream.tellg();
-        _stream.seekg(current_pos);
-        return static_cast<size_t>(end_pos) - static_cast<size_t>(start_pos);
+    }
+
+    size_t get_stream_size() const {
+        return _total_size;
+        /* auto& mutable_stream = const_cast<std::istream&>(_stream);
+        // 1. Clear flags so hidden EOF states don't cause tellg/seekg to fail
+        mutable_stream.clear();
+
+        mutable_stream.seekg(0, std::ios::end);
+        std::streampos end_pos = mutable_stream.tellg();
+
+        // Restore the stream position right away
+        mutable_stream.seekg(static_cast<std::streampos>(_bytes_read));
+        return static_cast<size_t>(end_pos);*/
     }
 
     size_t get_current_offset() const {
-        std::streampos current_pos = _stream.tellg();
-        if (current_pos == std::streampos(-1)) {
-            throw std::runtime_error("Failed to get stream position");
-        }
-        std::streamoff offset = static_cast<std::streamoff>(current_pos);
-        return static_cast<size_t>(offset);
+        return _bytes_read;
     }
 
-    size_t get_current_ptr() {
-        // Get current stream position
-        return _stream.tellg();
-    }
-    
     void seek_current_ptr(std::streamsize size) {
-        // Get current stream position
-        std::streampos current_pos = _stream.tellg();
-        if (current_pos == std::streampos(-1)) {
-            throw std::runtime_error("Failed to get stream position");
-        }
-        // Advance stream position
-        _stream.seekg(current_pos + static_cast<std::streampos>(size));
+        auto& mutable_stream = const_cast<std::istream&>(_stream);
+        mutable_stream.seekg(static_cast<std::streampos>(size), std::ios::cur);
+        _bytes_read += static_cast<size_t>(size);
     }
 
     void setKernelImplParams(void* impl_params) { _impl_params = impl_params; }
     void* getKernelImplParams() const { return _impl_params; }
-
+    size_t _bytes_read;
+    bool is_encrypted() const { return _encrypted; }
 private:
     std::istream& _stream;
     void* _impl_params;
     const size_t* _tensor_base_ptr;
+    size_t _total_size;
+    bool _encrypted;
 };
 
 class EncryptedBinaryOutputBuffer : public BinaryOutputBuffer {
 public:
     EncryptedBinaryOutputBuffer(std::ostream& stream, std::function<std::string(const std::string&)> encrypt)
-        : BinaryOutputBuffer(stream),
+        : BinaryOutputBuffer(stream, true),
           encrypt(encrypt) {
         OPENVINO_ASSERT(encrypt);
     }
@@ -147,6 +150,7 @@ public:
 
     void write(void const* data, std::streamsize size) override {
         plaintext_str.append(reinterpret_cast<const char*>(data), size);
+        _bytes_written += static_cast<size_t>(size); 
     }
 
     void flush() override {
@@ -165,7 +169,7 @@ private:
 class EncryptedBinaryInputBuffer : public BinaryInputBuffer {
 public:
     EncryptedBinaryInputBuffer(std::istream& stream, engine& engine, std::function<std::string(const std::string&)> decrypt)
-        : BinaryInputBuffer(stream, engine),
+        : BinaryInputBuffer(stream, engine, true),
           decrypt(decrypt) {
         OPENVINO_ASSERT(decrypt);
 
@@ -184,6 +188,7 @@ public:
     void read(void* const data, std::streamsize size) override {
         const auto read_size = plaintext_stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
         OPENVINO_ASSERT(read_size == size, "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
+        _bytes_read += static_cast<size_t>(read_size);
     }
 
 private:

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
@@ -35,6 +35,14 @@ public:
     void* getKernelImplParams() const { return _impl_params; }
     void set_stream(void* strm) { _strm = strm; }
     void* get_stream() const { return _strm; }
+    size_t get_current_offset() const {
+        std::streampos current_pos = stream.tellp();
+        if (current_pos == std::streampos(-1)) {
+            throw std::runtime_error("Failed to get stream position");
+        }
+        std::streamoff offset = static_cast<std::streamoff>(current_pos);
+        return static_cast<size_t>(offset);
+    }
 
 private:
     std::ostream& stream;
@@ -45,7 +53,15 @@ private:
 class BinaryInputBuffer : public InputBuffer<BinaryInputBuffer> {
 public:
     BinaryInputBuffer(std::istream& stream, engine& engine)
-    : InputBuffer<BinaryInputBuffer>(this, engine), _stream(stream), _impl_params(nullptr) {}
+        : InputBuffer<BinaryInputBuffer>(this, engine),
+          _stream(stream),
+          _impl_params(nullptr),
+          _tensor_base_ptr(nullptr) {}
+    BinaryInputBuffer(std::istream& stream, engine& engine, const size_t* _tensor_bp)
+        : InputBuffer<BinaryInputBuffer>(this, engine),
+          _stream(stream),
+          _impl_params(nullptr),
+          _tensor_base_ptr(_tensor_bp) {}
 
     virtual ~BinaryInputBuffer() = default;
 
@@ -62,6 +78,53 @@ public:
     std::streambuf* get_streambuf() const {
         return _stream.rdbuf();
     }
+    bool has_tensor_base_ptr() const {
+        return _tensor_base_ptr != nullptr;
+    }
+
+    const size_t* get_tensor_base_ptr() const {
+        if (!_tensor_base_ptr) {
+            throw std::runtime_error("Direct access not available - no tensor base pointer");
+        }
+        return _tensor_base_ptr;
+    }
+
+    size_t get_stream_size() const {
+        std::streampos current_pos = _stream.tellg();
+        if (current_pos == std::streampos(-1)) {
+            throw std::runtime_error("Failed to get stream position");
+        }
+        _stream.seekg(0, std::ios::end);
+        std::streampos end_pos = _stream.tellg();
+        _stream.seekg(0, std::ios::beg);
+        std::streampos start_pos = _stream.tellg();
+        _stream.seekg(current_pos);
+        return static_cast<size_t>(end_pos) - static_cast<size_t>(start_pos);
+    }
+
+    size_t get_current_offset() const {
+        std::streampos current_pos = _stream.tellg();
+        if (current_pos == std::streampos(-1)) {
+            throw std::runtime_error("Failed to get stream position");
+        }
+        std::streamoff offset = static_cast<std::streamoff>(current_pos);
+        return static_cast<size_t>(offset);
+    }
+
+    size_t get_current_ptr() {
+        // Get current stream position
+        return _stream.tellg();
+    }
+    
+    void seek_current_ptr(std::streamsize size) {
+        // Get current stream position
+        std::streampos current_pos = _stream.tellg();
+        if (current_pos == std::streampos(-1)) {
+            throw std::runtime_error("Failed to get stream position");
+        }
+        // Advance stream position
+        _stream.seekg(current_pos + static_cast<std::streampos>(size));
+    }
 
     void setKernelImplParams(void* impl_params) { _impl_params = impl_params; }
     void* getKernelImplParams() const { return _impl_params; }
@@ -69,6 +132,7 @@ public:
 private:
     std::istream& _stream;
     void* _impl_params;
+    const size_t* _tensor_base_ptr;
 };
 
 class EncryptedBinaryOutputBuffer : public BinaryOutputBuffer {
@@ -100,9 +164,7 @@ private:
 
 class EncryptedBinaryInputBuffer : public BinaryInputBuffer {
 public:
-    EncryptedBinaryInputBuffer(std::istream& stream,
-                               engine& engine,
-                               std::function<std::string(const std::string&)> decrypt)
+    EncryptedBinaryInputBuffer(std::istream& stream, engine& engine, std::function<std::string(const std::string&)> decrypt)
         : BinaryInputBuffer(stream, engine),
           decrypt(decrypt) {
         OPENVINO_ASSERT(decrypt);
@@ -113,19 +175,15 @@ public:
         // Not reading directly to plaintext_stream because decrypt(plaintext_stream.str()) would create an additional
         // copy.
         std::string str(bytes, 0);
-        BinaryInputBuffer::read(
-            make_data(const_cast<void*>(reinterpret_cast<const void*>(str.c_str())), str.size()).data,
-            str.size());
+        BinaryInputBuffer::read(make_data(const_cast<void*>(reinterpret_cast<const void*>(str.c_str())), str.size()).data, str.size());
         plaintext_stream.str(decrypt(str));
     }
 
     ~EncryptedBinaryInputBuffer() override = default;
 
     void read(void* const data, std::streamsize size) override {
-        auto const read_size = plaintext_stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
-        OPENVINO_ASSERT(
-            read_size == size,
-            "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
+        const auto read_size = plaintext_stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
+        OPENVINO_ASSERT(read_size == size, "[GPU] Failed to read " + std::to_string(size) + " bytes from stream! Read " + std::to_string(read_size));
     }
 
 private:

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -387,11 +387,21 @@ struct data : public primitive_base<data> {
         bool do_weightless_caching = cache_info->save(ob, data_size);
         if (!do_weightless_caching) {
             if (is_alloc_host_accessible(_allocation_type)) {
-                const uint16_t sub_buffer_offset = 128;
-                size_t pad_dim = (ob.get_current_offset() % sub_buffer_offset == 0) ? 0 : sub_buffer_offset - (ob.get_current_offset() % sub_buffer_offset);
-                if (pad_dim > 0) {
-                    std::vector<uint8_t> pad(pad_dim, 0);
-                    ob << make_data(pad.data(), pad_dim);
+                if (!ob.is_encrypted()) {
+                    std::cout << "SAVE" << ob.get_current_offset();
+                    const uint16_t sub_buffer_offset = 128;
+                    size_t pad_dim = (ob.get_current_offset() % sub_buffer_offset == 0) ? 0 : sub_buffer_offset - (ob.get_current_offset() % sub_buffer_offset);
+                    for (int i = 0; i < pad_dim; i++) {
+                        uint8_t pad_byte = 0;
+                        ob << make_data(&pad_byte, sizeof(uint8_t));
+                    }
+                    /*if (pad_dim > 0) {
+                        std::vector<uint8_t> pad;
+                        pad.resize(pad_dim);
+                        stream* strm = reinterpret_cast<stream*>(ob.get_stream());
+                        mem->copy_to(*strm, pad.data());
+                        ob << make_data(pad.data(), pad_dim);
+                    }*/
                 }
                 ob << make_data(mem->buffer_ptr(), data_size);
             } else {
@@ -432,15 +442,26 @@ struct data : public primitive_base<data> {
 
         if (!is_weightless_caching) {
             if (is_alloc_host_accessible(_allocation_type)) {
-                const uint16_t sub_buffer_offset = 128;
-                size_t pad_dim = (ib.get_current_offset() % sub_buffer_offset == 0) ? 0 : sub_buffer_offset - (ib.get_current_offset() % sub_buffer_offset);
-                if (pad_dim > 0) {
-                    std::vector<uint8_t> pad(pad_dim, 0);
-                    ib >> make_data(pad.data(), pad_dim);
+                if (!ib.is_encrypted()) {
+                    const uint16_t sub_buffer_offset = 128;
+                    size_t pad_dim = (ib.get_current_offset() % sub_buffer_offset == 0) ? 0 : sub_buffer_offset - (ib.get_current_offset() % sub_buffer_offset);
+                    std::cout << "LOAD" << ib.get_current_offset();
+                    for (size_t i = 0; i < pad_dim; i++) {
+                        uint8_t pad_byte = 0;
+                        ib >> make_data(&pad_byte, sizeof(uint8_t));
+                    }
+                    /*if (pad_dim > 0) {
+                        std::vector<uint8_t> pad(pad_dim);
+                        ib >> make_data(pad.data(), pad_dim);
+                        auto& eng = ib.get_engine();
+                        auto& strm = eng.get_service_stream();
+                        mem->copy_from(strm, pad.data());
+                    }*/
                 }
                 if (enable_zero_copy_mode) {
-                    mem = ib.get_engine().create_subbuffer(*model_tensor_base, output_layout, ib.get_current_ptr());      
+                    mem = ib.get_engine().create_subbuffer(*model_tensor_base, output_layout, ib.get_current_offset());      
                     ib.seek_current_ptr(data_size);
+                    //ib >> make_data(std::move(mem->buffer_ptr()), data_size);
                 } else {
                     ib >> make_data(std::move(mem->buffer_ptr()), data_size);
                 }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <climits>
 #include <variant>
-
 #include "intel_gpu/graph/network.hpp"
 #include "intel_gpu/primitives/input_layout.hpp"
 #include "intel_gpu/primitives/reorder.hpp"
@@ -173,8 +172,8 @@ struct weightless_cache_manager {
         return true;
     }
 
-    bool load(BinaryInputBuffer& ib, memory::ptr dst_mem, std::shared_ptr<WeightsMemory> weights_memory) {
-        ib >> do_weightless_caching;
+    bool load(BinaryInputBuffer& ib, memory::ptr dst_mem, std::shared_ptr<WeightsMemory> weights_memory, bool weightless_caching) {
+        do_weightless_caching = weightless_caching;
         if (!do_weightless_caching) {
             return false;
         }
@@ -193,7 +192,6 @@ struct weightless_cache_manager {
         } else {
             original_size = dst_mem->size();
         }
-
         bool do_reorder = false;
         ib >> do_reorder;
         if (do_reorder) {
@@ -389,6 +387,12 @@ struct data : public primitive_base<data> {
         bool do_weightless_caching = cache_info->save(ob, data_size);
         if (!do_weightless_caching) {
             if (is_alloc_host_accessible(_allocation_type)) {
+                const uint16_t sub_buffer_offset = 128;
+                size_t pad_dim = (ob.get_current_offset() % sub_buffer_offset == 0) ? 0 : sub_buffer_offset - (ob.get_current_offset() % sub_buffer_offset);
+                if (pad_dim > 0) {
+                    std::vector<uint8_t> pad(pad_dim, 0);
+                    ob << make_data(pad.data(), pad_dim);
+                }
                 ob << make_data(mem->buffer_ptr(), data_size);
             } else {
                 std::vector<uint8_t> _buf;
@@ -404,23 +408,42 @@ struct data : public primitive_base<data> {
         primitive_base<data>::load(ib);
     }
 
-    void load_weights(BinaryInputBuffer& ib, std::shared_ptr<WeightsMemory> weights_memory) {
+    void load_weights(BinaryInputBuffer& ib, std::shared_ptr<WeightsMemory> weights_memory, memory_ptr model_tensor_base) {
         layout output_layout = layout();
         ib >> output_layout;
 
         allocation_type _allocation_type = allocation_type::unknown;
         ib >> make_data(&_allocation_type, sizeof(_allocation_type));
-
+        
         size_t data_size = 0;
         ib >> make_data(&data_size, sizeof(size_t));
 
-        mem = ib.get_engine().allocate_memory(output_layout, _allocation_type, false);
+        bool weightless_caching = false;
+        ib >> weightless_caching;
 
-        bool is_weightless_caching = cache_info->load(ib, mem, weights_memory);
+        bool enable_zero_copy_mode = ib.has_tensor_base_ptr() && ib.get_engine().get_device_info().arch >= gpu_arch::xe2 &&
+                                     ib.get_engine().get_device_info().dev_type == device_type::integrated_gpu &&
+                                     _allocation_type == allocation_type::usm_host && !weightless_caching;
+        if (!enable_zero_copy_mode) {
+            mem = ib.get_engine().allocate_memory(output_layout, _allocation_type, false);
+        }
+        
+        bool is_weightless_caching = cache_info->load(ib, mem, weights_memory, weightless_caching);
 
         if (!is_weightless_caching) {
             if (is_alloc_host_accessible(_allocation_type)) {
-                ib >> make_data(mem->buffer_ptr(), data_size);
+                const uint16_t sub_buffer_offset = 128;
+                size_t pad_dim = (ib.get_current_offset() % sub_buffer_offset == 0) ? 0 : sub_buffer_offset - (ib.get_current_offset() % sub_buffer_offset);
+                if (pad_dim > 0) {
+                    std::vector<uint8_t> pad(pad_dim, 0);
+                    ib >> make_data(pad.data(), pad_dim);
+                }
+                if (enable_zero_copy_mode) {
+                    mem = ib.get_engine().create_subbuffer(*model_tensor_base, output_layout, ib.get_current_ptr());      
+                    ib.seek_current_ptr(data_size);
+                } else {
+                    ib >> make_data(std::move(mem->buffer_ptr()), data_size);
+                }
             } else {
                 const size_t DATA_BLOCK_SIZE = 4 * 1024 * 1024;
                 auto& eng = ib.get_engine();
@@ -490,8 +513,7 @@ struct data : public primitive_base<data> {
                     while (dst_offset < data_size) {
                         const bool is_blocking = false;
                         const size_t src_offset = 0;
-                        size_t copy_size =
-                            (data_size > (dst_offset + DATA_BLOCK_SIZE)) ? DATA_BLOCK_SIZE : (data_size - dst_offset);
+                        size_t copy_size = (data_size > (dst_offset + DATA_BLOCK_SIZE)) ? DATA_BLOCK_SIZE : (data_size - dst_offset);
                         if (buf_flag) {
                             ib >> make_data(_buf1.data(), copy_size);
                             if (ev2 != nullptr) {

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
@@ -61,6 +61,8 @@ public:
     /// Created subbuffer memory object from the other @p memory and reinterpred the data using specified @p new_layout
     virtual memory_ptr create_subbuffer(const memory& memory, const layout& new_layout, size_t byte_offset) = 0;
 
+    virtual memory_ptr pin_mmapped_host_buffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) = 0;
+
     /// Created memory object from the other @p memory and reinterpred the data using specified @p new_layout
     virtual memory_ptr reinterpret_buffer(const memory& memory, const layout& new_layout) = 0;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -25,6 +25,7 @@ OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, enable_loop_unrolling, true, "Enable/Dis
 OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, disable_winograd_convolution, false, "Enable/Disable winograd convolution implementation if available")
 OV_CONFIG_RELEASE_OPTION(ov::internal, exclusive_async_requests, false, "")
 OV_CONFIG_RELEASE_OPTION(ov::internal, query_model_ratio, 1.0f, "")
+OV_CONFIG_RELEASE_OPTION(ov::internal, cache_header_alignment, 4096, "Header Alignment in bytes for cache blob")
 OV_CONFIG_RELEASE_OPTION(ov, cache_mode, ov::CacheMode::OPTIMIZE_SPEED, "Cache mode defines the trade-off between the model compilation time and the disk space required for the cache")
 OV_CONFIG_RELEASE_OPTION(ov, cache_encryption_callbacks, ov::EncryptionCallbacks{}, "Callbacks used to encrypt/decrypt the model")
 OV_CONFIG_RELEASE_OPTION(ov::hint, dynamic_quantization_group_size, 0, "Dynamic quantization group size")

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1945,7 +1945,7 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     }
 
     ob << allocating_order.size();
-    for (auto const& node_id : allocating_order) {
+    for (const auto& node_id : allocating_order) {
         ob << node_id;
     }
 
@@ -1954,6 +1954,13 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
         ob << state_initializer.first;
         ob << state_initializer.second;
     }
+
+    /* const uint16_t page_alignment = 4096;
+    size_t pad_dim = (ob.get_current_offset() % page_alignment == 0) ? 0 : page_alignment - (ob.get_current_offset() % page_alignment);
+    if (pad_dim > 0) {
+        std::vector<uint8_t> pad(pad_dim, 0);
+        ob << make_data(pad.data(), pad_dim);
+    }*/
 }
 
 void program::load(cldnn::BinaryInputBuffer& ib,
@@ -1975,6 +1982,18 @@ void program::load(cldnn::BinaryInputBuffer& ib,
         } else {
             OPENVINO_THROW("Weights path or model is required for cache mode OPTIMIZE_SIZE");
         }
+    }
+
+    const bool can_use_mmap_zero_copy = ib.has_tensor_base_ptr() && _engine.get_device_info().arch >= gpu_arch::xe2 &&
+                                        _engine.get_device_info().dev_type == device_type::integrated_gpu && !_config.get_enable_weightless();
+    memory_ptr model_tensor_base_ptr = nullptr;
+    if (can_use_mmap_zero_copy) {
+        size_t stream_size = ib.get_stream_size();
+        const tensor::value_type stream_tensor_size = static_cast<tensor::value_type>(stream_size);
+        model_tensor_base_ptr = ib.get_engine().pin_mmapped_host_buffer(ib.get_tensor_base_ptr(),
+                                                                        stream_size,
+                                                                        allocation_type::usm_host,
+                                                                        layout({{stream_tensor_size, 1, 1, 1}, data_types::u8, format::bfyx}));
     }
 
     size_t num_nodes;
@@ -2004,11 +2023,10 @@ void program::load(cldnn::BinaryInputBuffer& ib,
         std::shared_ptr<cldnn::primitive> prim;
         ib >> prim;
         if (auto data_prim = dynamic_cast<cldnn::data*>(prim.get())) {
-            data_prim->load_weights(ib, weights_memory);
+            data_prim->load_weights(ib, weights_memory, model_tensor_base_ptr);
         }
         get_or_create(prim);
     }
-
     size_t num_output_sharing_mutable_datas;
     ib >> num_output_sharing_mutable_datas;
     for (size_t i = 0; i < num_output_sharing_mutable_datas; ++i) {

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -53,6 +53,7 @@
 
 using ms = std::chrono::duration<double, std::ratio<1, 1000>>;
 using Time = std::chrono::high_resolution_clock;
+thread_local const size_t* g_current_tensor_base = nullptr;
 
 namespace ov::intel_gpu {
 
@@ -412,10 +413,9 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model,
     ov::EncryptionCallbacks encryption_callbacks = config.get_cache_encryption_callbacks();
 
     std::unique_ptr<cldnn::BinaryInputBuffer> ib_ptr =
-        encryption_callbacks.decrypt ? std::make_unique<cldnn::EncryptedBinaryInputBuffer>(model,
-                                                                                 context_impl->get_engine(),
-                                                                                 encryption_callbacks.decrypt)
-                           : std::make_unique<cldnn::BinaryInputBuffer>(model, context_impl->get_engine());
+        encryption_callbacks.decrypt
+            ? std::make_unique<cldnn::EncryptedBinaryInputBuffer>(model, context_impl->get_engine(), encryption_callbacks.decrypt)
+            : std::make_unique<cldnn::BinaryInputBuffer>(model, context_impl->get_engine(), g_current_tensor_base);
     auto& ib = *ib_ptr;
 
     ov::CacheMode loaded_cache_mode = ov::CacheMode::OPTIMIZE_SPEED;
@@ -459,9 +459,16 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model
 std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model,
                                                          const ov::SoPtr<ov::IRemoteContext>& context,
                                                          const ov::AnyMap& config) const{
+    // Store tensor base in thread-local storage
+    g_current_tensor_base = static_cast<const size_t*>(model.data());
     ov::intel_gpu::ParallelMemStreamBuf par_buf(model.data(), model.get_byte_size());
     std::istream stream(&par_buf);
-    return import_model(stream, context, config);
+    auto result = import_model(stream, context, config);
+
+    // Clear thread-local storage
+    g_current_tensor_base = nullptr;
+    
+    return result;
 }
 
 ov::Any Plugin::get_property(const std::string& name, const ov::AnyMap& options) const {

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -763,7 +763,8 @@ std::vector<ov::PropertyName> Plugin::get_supported_internal_properties() const 
             ov::PropertyName{ov::internal::compiled_model_runtime_properties.name(), ov::PropertyMutability::RO},
             ov::PropertyName{ov::internal::compiled_model_runtime_properties_supported.name(), ov::PropertyMutability::RO},
             ov::PropertyName{ov::internal::query_model_ratio.name(), PropertyMutability::RW},
-            ov::PropertyName{ov::internal::caching_with_mmap.name(), PropertyMutability::RO}};
+            ov::PropertyName{ov::internal::caching_with_mmap.name(), PropertyMutability::RO},
+            ov::PropertyName{ov::internal::cache_header_alignment.name(), PropertyMutability::RO}};
     return supported_internal_properties;
 }
 

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -678,6 +678,8 @@ ov::Any Plugin::get_metric(const std::string& name, const ov::AnyMap& options) c
         info.device = device_info.pci_info.pci_device;
         info.function = device_info.pci_info.pci_function;
         return decltype(ov::device::pci_info)::value_type {info};
+    } else if (name == ov::internal::cache_header_alignment) {
+        return decltype(ov::internal::cache_header_alignment)::value_type{4096};
     } else {
         OPENVINO_THROW("Unsupported metric key ", name);
     }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
@@ -148,7 +148,7 @@ memory::ptr ocl_engine::create_subbuffer(const memory& memory, const layout& new
                                      memory.get_mem_tracker());
         } else {
             auto buffer = reinterpret_cast<const ocl::gpu_buffer&>(memory).get_buffer();
-            cl_buffer_region sub_buffer_region = { byte_offset, new_layout.get_linear_size() };
+            cl_buffer_region sub_buffer_region = {byte_offset, new_layout.get_linear_size()};
             auto sub_buffer = buffer.createSubBuffer({}, CL_BUFFER_CREATE_TYPE_REGION, &sub_buffer_region);
 
             return std::make_shared<ocl::gpu_buffer>(this,
@@ -160,6 +160,27 @@ memory::ptr ocl_engine::create_subbuffer(const memory& memory, const layout& new
         OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
     }
 }
+
+memory_ptr ocl_engine::pin_mmapped_host_buffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) {
+    auto tracker = std::make_shared<MemoryTracker>(this,
+                                                   const_cast<void*>(mmapped_address),  // Point directly to mmap'd memory
+                                                   data_size,
+                                                   _allocation_type);
+    const uint16_t page_size = 4096;
+    std::uintptr_t mmap_address = reinterpret_cast<std::uintptr_t>(mmapped_address);
+    std::uintptr_t aligned_addr = mmap_address & ~(page_size - 1);
+    void* mmap_aligned_address = reinterpret_cast<void*>(aligned_addr);
+
+    cl_int err = CL_SUCCESS;
+    cl_mem_flags flags = CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR;
+#ifdef CL_MEM_FORCE_HOST_MEMORY_INTEL
+    flags |= CL_MEM_FORCE_HOST_MEMORY_INTEL;
+#endif
+    cl::Buffer buffer(get_cl_context(), flags, data_size, mmap_aligned_address, &err);
+    OPENVINO_ASSERT(err == CL_SUCCESS, "clcreatebuffer with CL_MEM_USE_HOST_PTR and CL_MEM_FORCE_HOST_MEMORY_INTEL failed!");
+    return std::make_shared<ocl::gpu_buffer>(this, output_layout, buffer, tracker);
+}
+
 memory::ptr ocl_engine::reinterpret_buffer(const memory& memory, const layout& new_layout) {
     OPENVINO_ASSERT(memory.get_engine() == this, "[GPU] trying to reinterpret buffer allocated by a different engine");
     OPENVINO_ASSERT(new_layout.format.is_image() == memory.get_layout().format.is_image(),

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp
@@ -27,6 +27,7 @@ public:
     memory_ptr allocate_memory(const layout& layout, allocation_type type, bool reset = true) override;
     memory_ptr reinterpret_handle(const layout& new_layout, shared_mem_params params) override;
     memory_ptr create_subbuffer(const memory& memory, const layout& new_layout, size_t offset) override;
+    memory_ptr pin_mmapped_host_buffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) override;
     memory_ptr reinterpret_buffer(const memory& memory, const layout& new_layout) override;
     bool is_the_same_buffer(const memory& mem1, const memory& mem2) override;
 

--- a/src/plugins/intel_gpu/src/runtime/ze/ze_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_engine.cpp
@@ -157,6 +157,10 @@ memory_ptr ze_engine::create_subbuffer(const memory& memory, const layout& new_l
                              memory.get_mem_tracker());
 }
 
+memory_ptr ze_engine::pin_mmapped_host_buffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) {
+    OPENVINO_NOT_IMPLEMENTED;
+}
+
 bool ze_engine::is_the_same_buffer(const memory& mem1, const memory& mem2) {
     if (mem1.get_engine() != this || mem2.get_engine() != this)
         return false;

--- a/src/plugins/intel_gpu/src/runtime/ze/ze_engine.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_engine.hpp
@@ -24,6 +24,7 @@ public:
     memory_ptr allocate_memory(const layout& layout, allocation_type type, bool reset = true) override;
     memory_ptr reinterpret_handle(const layout& new_layout, shared_mem_params params) override;
     memory_ptr create_subbuffer(const memory& memory, const layout& new_layout, size_t byte_offset) override;
+    memory_ptr pin_mmapped_host_buffer(const void* mmapped_address, size_t data_size, allocation_type _allocation_type, const layout output_layout) override;
     memory_ptr reinterpret_buffer(const memory& memory, const layout& new_layout) override;
     bool is_the_same_buffer(const memory& mem1, const memory& mem2) override;
 


### PR DESCRIPTION
…ost to device copying of weights(LNL+)

Description of the issue(symptom, root-cause, how it was resolved)
- On iGPUs enable mmap feature to access model weights directly on iGPUs.
- OCL provides ::clcreatebuffer API which can take a host_buffer_ptr and map it for direct GPU access.
- Each model Node's weight is mapped with OCL buffer.createsubbuffer API.
- While creating model blob ensure 4096 aligned header(metadata) and 128B aligned individual per-node weights.

The code and line that caused this issue (if it is not changed directly) src/inference/src/dev/core_impl.cpp
src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp src/plugins/intel_gpu/src/graph/program.cpp
src/plugins/intel_gpu/src/plugin/plugin.cpp
src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp src/plugins/intel_gpu/src/runtime/ze/ze_engine.cpp src/plugins/intel_gpu/src/runtime/ze/ze_engine.hpp

Reproduction step and snapshot (if applicable. Do not attach for customer model) STEP-1: Create a blob in the model cache directory. STEP-2: Load from the blob to use the mmap feature which maps the blob to host virtual address space.

Problematic graph
NA

Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary? NA
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? NA

Tickets:
CVS-177982

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
