### PR TITLE
[GPU] RoPE for Qwen3.5

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -32,6 +32,7 @@
 #include "openvino/op/variadic_split.hpp"
 #include "ov_ops/rms.hpp"
 #include "ov_ops/rotary_positional_embeddings.hpp"
+#include "openvino/pass/pattern/op/optional.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/utils/utils.hpp"
@@ -202,8 +203,10 @@ IncreasePositionIdsPrecisionForQwen3VL::IncreasePositionIdsPrecisionForQwen3VL()
     // Key difference from Qwen2.5-VL: Unsqueeze is decomposed to Reshape.
     auto position_ids = any_input();
     auto convert_to_i32 = wrap_type<ov::op::v0::Convert>({position_ids});
-    auto reshape_unsqueeze = wrap_type<ov::op::v1::Reshape>({convert_to_i32, wrap_type<ov::op::v0::Constant>()});
-    auto unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({convert_to_i32, any_input()});
+    auto reshape_0 = optional<ov::op::v1::Reshape>({convert_to_i32, wrap_const()});
+    auto stridedslice_0 = optional<ov::op::v1::StridedSlice>({reshape_0, any_input(), any_input(), any_input()});
+    auto reshape_unsqueeze = wrap_type<ov::op::v1::Reshape>({stridedslice_0, wrap_const()});
+    auto unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({stridedslice_0, any_input()});
     auto reshape_or_unsqueeze = std::make_shared<Or>(OutputVector{reshape_unsqueeze, unsqueeze});
     auto convert_to_f16 = wrap_type<ov::op::v0::Convert>({reshape_or_unsqueeze});
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
@@ -729,102 +729,99 @@ TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForQwen25VL) {
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
 
+namespace {
+
+// Shared builder for Qwen3-family RoPE precision tests. The `insert_pre_convert` callback
+// takes the i32 Convert output of `position_ids` and returns the node whose output feeds the
+// f16/f32 Convert on the MatMul path, letting each test inject model-specific pre-Convert ops
+// (e.g. Reshape/StridedSlice). When `is_ref` is true, the returned model carries the f16<->f32
+// Convert nodes that IncreasePositionIdsPrecision is expected to insert.
+template <typename InsertPreConvert>
+std::shared_ptr<ov::Model> build_qwen3vl_rope_model(InsertPreConvert&& insert_pre_convert, bool is_ref) {
+    auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{3, -1});
+    auto input_convert = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
+    auto input_reshape = insert_pre_convert(input_convert);
+    auto convert_2 = std::make_shared<ov::op::v0::Convert>(input_reshape,
+                                                           is_ref ? ov::element::f32 : ov::element::f16);
+
+    auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(input_convert, ov::element::i32);
+    auto gather_0 = std::make_shared<ov::op::v8::Gather>(shape_of,
+        std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
+        std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+    auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
+            gather_0,
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{64}),
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1})}, 0);
+    auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
+        std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 1, 64, 1}), concat);
+
+    std::shared_ptr<ov::Node> matmul_lhs = broadcast;
+    if (is_ref) {
+        matmul_lhs = std::make_shared<ov::op::v0::Convert>(broadcast, ov::element::f32);
+    }
+    auto matmul = std::make_shared<ov::op::v0::MatMul>(matmul_lhs, convert_2);
+
+    auto reshape_transpose = std::make_shared<ov::op::v1::Reshape>(matmul,
+        std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{3, -1, 1, 64}), true);
+    auto gather_ch0 = std::make_shared<ov::op::v8::Gather>(reshape_transpose,
+        std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
+        std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
+
+    auto concat_2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{gather_ch0, gather_ch0}, 2);
+
+    std::shared_ptr<ov::Node> cos = std::make_shared<ov::op::v0::Cos>(concat_2);
+    std::shared_ptr<ov::Node> sin = std::make_shared<ov::op::v0::Sin>(concat_2);
+    if (is_ref) {
+        cos = std::make_shared<ov::op::v0::Convert>(cos, ov::element::f16);
+        sin = std::make_shared<ov::op::v0::Convert>(sin, ov::element::f16);
+    }
+    auto cos_unsqueeze = std::make_shared<ov::op::v1::Reshape>(cos,
+        std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{-1, 1, 1, 128}), true);
+    auto sin_unsqueeze = std::make_shared<ov::op::v1::Reshape>(sin,
+        std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{-1, 1, 1, 128}), true);
+
+    auto input_2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 8, -1, 128});
+    auto rope = std::make_shared<ov::op::internal::RoPE>(
+        ov::OutputVector{input_2, cos_unsqueeze, sin_unsqueeze}, ov::op::internal::RoPE::Config());
+
+    return std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{position_ids, input_2});
+}
+
+}  // namespace
+
 TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForQwen3VL) {
     // Qwen3-VL pattern: position_ids -> Convert(i64->i32) -> Reshape(unsqueeze) -> Convert(i32->f16)
     //   -> MatMul(Broadcast, Convert) -> Reshape(transpose) -> Gather -> Concat(self,self)
     //   -> Sin/Cos -> Reshape(unsqueeze) -> RoPE
-    {
-        auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ 3, -1 });
-        auto input_convert = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
+    auto insert_pre_convert = [](const std::shared_ptr<ov::Node>& input_convert) -> std::shared_ptr<ov::Node> {
         // Qwen3-VL uses Reshape instead of Unsqueeze
-        auto input_reshape = std::make_shared<ov::op::v1::Reshape>(input_convert,
+        return std::make_shared<ov::op::v1::Reshape>(input_convert,
                 std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{3, -1, 1, 1}), true);
-        auto convert_2 = std::make_shared<ov::op::v0::Convert>(input_reshape, ov::element::f16);
+    };
+    model = build_qwen3vl_rope_model(insert_pre_convert, /*is_ref=*/false);
+    manager.register_pass<IncreasePositionIdsPrecision>();
+    model_ref = build_qwen3vl_rope_model(insert_pre_convert, /*is_ref=*/true);
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
 
-        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(input_convert, ov::element::i32);
-        auto gather_0 = std::make_shared<ov::op::v8::Gather>(shape_of,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
-        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{
-                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
-                gather_0,
-                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{64}),
-                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1})}, 0);
-        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
-            std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 1, 64, 1}), concat);
-        auto matmul = std::make_shared<ov::op::v0::MatMul>(broadcast, convert_2);
-
-        // Reshape(transpose) -> Gather(select channel 0)
-        auto reshape_transpose = std::make_shared<ov::op::v1::Reshape>(matmul,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{3, -1, 1, 64}), true);
-        auto gather_ch0 = std::make_shared<ov::op::v8::Gather>(reshape_transpose,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
-
-        // Concat(self, self) to produce [?, 1, 128]
-        auto concat_2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{gather_ch0, gather_ch0}, 2);
-
-        auto cos = std::make_shared<ov::op::v0::Cos>(concat_2);
-        auto sin = std::make_shared<ov::op::v0::Sin>(concat_2);
-        auto cos_unsqueeze = std::make_shared<ov::op::v1::Reshape>(cos,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{-1, 1, 1, 128}), true);
-        auto sin_unsqueeze = std::make_shared<ov::op::v1::Reshape>(sin,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{-1, 1, 1, 128}), true);
-
-        auto input_2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 8, -1, 128});
-        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{input_2, cos_unsqueeze, sin_unsqueeze},
-                ov::op::internal::RoPE::Config());
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{position_ids, input_2});
-        manager.register_pass<IncreasePositionIdsPrecision>();
-    }
-    {
-        auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ 3, -1 });
-        auto input_convert = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
-        auto input_reshape = std::make_shared<ov::op::v1::Reshape>(input_convert,
+TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForQwen35) {
+    // Qwen3.5 pattern: identical to Qwen3-VL but with an extra Reshape + StridedSlice inserted
+    // between Convert(i64->i32) and the pre-Convert(f16) Reshape.
+    auto insert_pre_convert = [](const std::shared_ptr<ov::Node>& input_convert) -> std::shared_ptr<ov::Node> {
+        auto input_reshape_0 = std::make_shared<ov::op::v1::Reshape>(input_convert,
+                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{4, -1, 1}), true);
+        auto begin = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto end = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
+        auto stride = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto input_slice_0 = std::make_shared<ov::op::v1::StridedSlice>(input_reshape_0, begin, end, stride,
+                                                                       std::vector<int64_t>{}, std::vector<int64_t>{});
+        return std::make_shared<ov::op::v1::Reshape>(input_slice_0,
                 std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{3, -1, 1, 1}), true);
-        // Changed: Convert to f32 instead of f16
-        auto convert_2 = std::make_shared<ov::op::v0::Convert>(input_reshape, ov::element::f32);
-
-        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(input_convert, ov::element::i32);
-        auto gather_0 = std::make_shared<ov::op::v8::Gather>(shape_of,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
-        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{
-                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1}),
-                gather_0,
-                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{64}),
-                std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{1}, std::vector<int64_t>{1})}, 0);
-        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(
-            std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 1, 64, 1}), concat);
-        // Changed: Insert Convert(f16->f32) after Broadcast
-        auto broadcast_to_f32 = std::make_shared<ov::op::v0::Convert>(broadcast, ov::element::f32);
-        auto matmul = std::make_shared<ov::op::v0::MatMul>(broadcast_to_f32, convert_2);
-
-        auto reshape_transpose = std::make_shared<ov::op::v1::Reshape>(matmul,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{3, -1, 1, 64}), true);
-        auto gather_ch0 = std::make_shared<ov::op::v8::Gather>(reshape_transpose,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}),
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int64_t>{0}));
-
-        auto concat_2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{gather_ch0, gather_ch0}, 2);
-
-        auto cos = std::make_shared<ov::op::v0::Cos>(concat_2);
-        auto sin = std::make_shared<ov::op::v0::Sin>(concat_2);
-        // Changed: Insert Convert(f32->f16) after Cos and Sin
-        auto cos_to_f16 = std::make_shared<ov::op::v0::Convert>(cos, ov::element::f16);
-        auto sin_to_f16 = std::make_shared<ov::op::v0::Convert>(sin, ov::element::f16);
-        auto cos_unsqueeze = std::make_shared<ov::op::v1::Reshape>(cos_to_f16,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{-1, 1, 1, 128}), true);
-        auto sin_unsqueeze = std::make_shared<ov::op::v1::Reshape>(sin_to_f16,
-            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{-1, 1, 1, 128}), true);
-
-        auto input_2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 8, -1, 128});
-        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{input_2, cos_unsqueeze, sin_unsqueeze},
-                ov::op::internal::RoPE::Config());
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{position_ids, input_2});
-    }
+    };
+    model = build_qwen3vl_rope_model(insert_pre_convert, /*is_ref=*/false);
+    manager.register_pass<IncreasePositionIdsPrecision>();
+    model_ref = build_qwen3vl_rope_model(insert_pre_convert, /*is_ref=*/true);
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
 


### PR DESCRIPTION
### Details:
 - updated `IncreasePositionIdsPrecisionForQwen3VL` to support Qwen3.5

### Tickets:
 - 186472

### AI Assistance:
 - AI assistance used: yes
 - AI created test cases for the new RoPE pattern and updated them to reuse duplicated codes.
