### PR TITLE
[NPUW] Turn off DownsampleInterpolate and ISTFT NPU avoids from Kokoro pipeline

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
@@ -91,8 +91,8 @@ ov::npuw::KokoroCompiledModel::KokoroCompiledModel(const std::shared_ptr<ov::Mod
         properties_model_b["NPUW_ONLINE_PIPELINE"] = "NONE";
     }
     if (!properties_model_b.count("NPUW_ONLINE_AVOID")) {
-        properties_model_b["NPUW_ONLINE_AVOID"] = "P:DownsampleInterpolate/NPU,P:FloorModFP32/NPU,P:CumSumSinGen/"
-                                                  "NPU,P:BoxMullerNoise/NPU,P:AngleComplex/NPU,Op:ISTFT/NPU";
+        properties_model_b["NPUW_ONLINE_AVOID"] = "P:FloorModFP32/NPU,P:CumSumSinGen/NPU,"
+                                                  "P:BoxMullerNoise/NPU,P:AngleComplex/NPU";
     }
     m_model_b_compiled = std::dynamic_pointer_cast<ov::npuw::ICompiledModel>(
         ov::npuw::ICompiledModel::create(split_result.model_b, plugin, properties_model_b));


### PR DESCRIPTION
### Details:
Remove DownsampleInterpolate and ISTFT NPU avoids from Kokoro pipeline
- ISTFT NPU performance fixed with vpux-plugin/pull/24196 (E193060)
- Downsampling Interpolate NPU accuracy fixed with vpux-plugin/pull/25412 (E203948)

NPU4000

Compilation:
before: 54s
after:  83s :small_red_triangle_down:
 
CPU pytorch (baseline):
  Benchmark Report — CPU (PyTorch)

Prompt | Tokens | Iters | Latency(ms) | Gen(s) | Audio(s) | Speedup
-- | -- | -- | -- | -- | -- | --
short | 61 | 5 | 1025.9 | 1.03 | 4.33 | 4.22x
medium | 1006 | 5 | 6984.8 | 18.03 | 60.38 | 3.35x
long | 3987 | 5 | 7963.4 | 75.46 | 243.35 | 3.22x
 
NPU before:
  Benchmark Report — NPU (OpenVINO, NPUW static)

Prompt | Tokens | Iters | Latency(ms) | Gen(s) | Audio(s) | Speedup
-- | -- | -- | -- | -- | -- | --
short | 61 | 5 | 434.9 | 0.43 | 4.33 | 9.95x
medium | 1006 | 5 | 2521.2 | 6.29 | 60.35 | 9.59x
long | 3987 | 5 | 2955.5 | 24.77 | 243.25 | 9.82x

NPU after:
  Benchmark Report — NPU (OpenVINO, NPUW static)

Prompt | Tokens | Iters | Latency(ms) | Gen(s) | Audio(s) | Speedup
-- | -- | -- | -- | -- | -- | --
short | 61 | 5 | 434.5 | 0.43 | 4.33 | 9.97x
medium | 1006 | 5 | 2470.2 | 6.18 | 60.35 | 9.76x ⬆️ 
long | 3987 | 5 | 2913.6 | 24.56 | 243.25 | 9.95x ⬆️ 



### Tickets:
 - E212202

### AI Assistance:
 - *AI assistance used: no*
