### PR TITLE
[NPU] Change OV Executors logic

### DIFF
--- a/src/plugins/intel_npu/README.md
+++ b/src/plugins/intel_npu/README.md
@@ -190,7 +190,7 @@ The following properties are supported (may differ based on current system confi
 | `ov::supported_properties`/</br>`SUPPORTED_METRICS`/</br>`SUPPORTED_CONFIG_KEYS` | RO | Returns a list of all supported properties.</br> Can be queried on runtime. | `N/A` | `N/A` |
 | `ov::caching_properties`/</br>`CACHING_PROPERTIES` | RW | Returns a list of all properties that are used by OpenVINO cache to build the hash key. | `N/A` | `N/A` |
 | `ov::compilation_num_threads`/</br>`COMPILATION_NUM_THREADS` | RW | Maximum number of threads that can be used for compilation tasks. | `N/A` | `N/A` |
-| `ov::num_streams`/</br>`NUM_STREAMS` | RO | Not used by the NPU plugin.</br> Always set to 1. | `AUTO/`</br>`INT` | `1` |
+| `ov::num_streams`/</br>`NUM_STREAMS` | RW | Sets the maximum number of threads/streams per executor. The NPU plugin uses 3 executors (start inference, wait for completion, callback), so the effective total is `3 * num_streams`. | `AUTO/`</br>`INT` | `AUTO` |
 | `ov::optimal_number_of_infer_requests`/</br>`OPTIMAL_NUMBER_OF_INFER_REQUESTS` | RO | Returns the optimal number of inference requests to be used by the application. Depends on the platform version and on ov::hint::performance_mode. Please see the table below. | `N/A` | `N/A` |
 | `ov::range_for_async_infer_requests`/</br>`RANGE_FOR_ASYNC_INFER_REQUESTS` | RO | Returns a tuple (bottom, top, step). </br> Not used by the NPU plugin. | `N/A` | `N/A` |
 | `ov::range_for_streams`/</br>`RANGE_FOR_STREAMS` | RO | Returns a tuple (bottom, top).</br> Not used by the NPU plugin. | `N/A`| `N/A` |

--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -691,8 +691,8 @@ struct NUM_STREAMS final : OptionBase<NUM_STREAMS, ov::streams::Num> {
     }
 
     static void validateValue(const ov::streams::Num& num) {
-        if (num < ov::streams::AUTO) {
-            OPENVINO_THROW("NUM_STREAMS can not be set with this value: ",
+        if (num != ov::streams::AUTO && num < 0) {
+            OPENVINO_THROW("NUM_STREAMS cannot be set to this value: ",
                            num,
                            ". Supported values are positive integers or ov::streams::AUTO");
         }

--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -671,32 +671,30 @@ struct NUM_STREAMS final : OptionBase<NUM_STREAMS, ov::streams::Num> {
         return "ov::streams::Num";
     }
 
-    // The only supported number for currently supported platforms.
-    // FIXME: update in the future
     static ov::streams::Num defaultValue() {
-        return ov::streams::Num(1);
+        return ov::streams::AUTO;
     }
 
     static ov::streams::Num parse(std::string_view val) {
         std::istringstream stringStream = std::istringstream(std::string(val));
         ov::streams::Num numberOfStreams;
-
         stringStream >> numberOfStreams;
 
         return numberOfStreams;
     }
 
-    static std::string itoString(const ov::streams::Num& val) {
+    static std::string toString(const ov::streams::Num& val) {
         std::ostringstream stringStream;
-
         stringStream << val;
 
         return stringStream.str();
     }
 
     static void validateValue(const ov::streams::Num& num) {
-        if (defaultValue() != num && ov::streams::AUTO != num) {
-            OPENVINO_THROW("NUM_STREAMS can not be set");
+        if (num < ov::streams::AUTO) {
+            OPENVINO_THROW("NUM_STREAMS can not be set with this value: ",
+                           num,
+                           ". Supported values are positive integers or ov::streams::AUTO");
         }
     }
 
@@ -709,7 +707,7 @@ struct NUM_STREAMS final : OptionBase<NUM_STREAMS, ov::streams::Num> {
     }
 
     static ov::PropertyMutability mutability() {
-        return ov::PropertyMutability::RO;
+        return ov::PropertyMutability::RW;
     }
 };
 

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -902,9 +902,6 @@ void ZeroInferRequest::update_states_if_memory_changed() {
 
 void ZeroInferRequest::infer() {
     OV_ITT_SCOPED_TASK_BASE(itt::domains::InferenceNPU, "SyncInferenceNPU");
-    if (_config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
-        OPENVINO_THROW("Only start async is supported when RUN_INFERENCES_SEQUENTIALLY is enabled!");
-    }
 
     infer_async();
     get_result();

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/device_helpers.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/device_helpers.hpp
@@ -24,6 +24,19 @@ std::string getCompilationPlatform(const std::string_view platform,
  * @brief Gets the device by its ID.
  */
 std::shared_ptr<IDevice> getDeviceById(const ov::SoPtr<IEngineBackend>& engineBackend, const std::string& deviceId);
+
+/**
+ * @brief Gets the optimal number of infer requests in parallel for the given platform and performance mode.
+ * @param platform The platform for which to get the optimal number of infer requests.
+ * @param performanceMode The performance mode for which to get the optimal number of infer requests.
+ * @return The optimal number of infer requests in parallel.
+ * @details Heuristically obtained number. Varies depending on the values of PLATFORM and PERFORMANCE_HINT
+ * Note: This is the value provided by the plugin, application should query and consider it, but may supply its own
+ * preference for number of parallel requests via dedicated configuration
+ */
+uint32_t getOptimalNumberOfInferRequestsInParallel(std::string_view platform,
+                                                   const ov::hint::PerformanceMode performanceMode);
+
 }  // namespace utils
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/device_helpers.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/device_helpers.hpp
@@ -30,8 +30,7 @@ std::shared_ptr<IDevice> getDeviceById(const ov::SoPtr<IEngineBackend>& engineBa
  * @param platform The platform for which to get the optimal number of infer requests.
  * @param performanceMode The performance mode for which to get the optimal number of infer requests.
  * @return The optimal number of infer requests in parallel.
- * @details Heuristically obtained number. Varies depending on the values of PLATFORM and PERFORMANCE_HINT
- * Note: This is the value provided by the plugin, application should query and consider it, but may supply its own
+ * @note This is the value provided by the plugin, application should query and consider it, but may supply its own
  * preference for number of parallel requests via dedicated configuration
  */
 uint32_t getOptimalNumberOfInferRequestsInParallel(std::string_view platform,

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -75,7 +75,7 @@ public:
 
     virtual std::optional<bool> is_profiling_blob() const = 0;
 
-    virtual bool supports_sequential_inference() const = 0;
+    virtual bool supports_in_order_execution() const = 0;
 
     virtual std::optional<std::string_view> get_compatibility_descriptor() const;
 

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -75,6 +75,8 @@ public:
 
     virtual std::optional<bool> is_profiling_blob() const = 0;
 
+    virtual bool supports_sequential_inference() const = 0;
+
     virtual std::optional<std::string_view> get_compatibility_descriptor() const;
 
 protected:

--- a/src/plugins/intel_npu/src/common/src/device_helpers.cpp
+++ b/src/plugins/intel_npu/src/common/src/device_helpers.cpp
@@ -71,4 +71,21 @@ std::shared_ptr<IDevice> utils::getDeviceById(const ov::SoPtr<IEngineBackend>& e
     return nullptr;
 }
 
+uint32_t utils::getOptimalNumberOfInferRequestsInParallel(std::string_view platform,
+                                                          const ov::hint::PerformanceMode performanceMode) {
+    if (platform == ov::intel_npu::Platform::NPU3720) {
+        if (performanceMode == ov::hint::PerformanceMode::THROUGHPUT) {
+            return 4;
+        } else {
+            return 1;
+        }
+    } else {
+        if (performanceMode == ov::hint::PerformanceMode::THROUGHPUT) {
+            return 8;
+        } else {
+            return 1;
+        }
+    }
+}
+
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/common/src/device_helpers.cpp
+++ b/src/plugins/intel_npu/src/common/src/device_helpers.cpp
@@ -73,19 +73,11 @@ std::shared_ptr<IDevice> utils::getDeviceById(const ov::SoPtr<IEngineBackend>& e
 
 uint32_t utils::getOptimalNumberOfInferRequestsInParallel(std::string_view platform,
                                                           const ov::hint::PerformanceMode performanceMode) {
-    if (platform == ov::intel_npu::Platform::NPU3720) {
-        if (performanceMode == ov::hint::PerformanceMode::THROUGHPUT) {
-            return 4;
-        } else {
-            return 1;
-        }
-    } else {
-        if (performanceMode == ov::hint::PerformanceMode::THROUGHPUT) {
-            return 8;
-        } else {
-            return 1;
-        }
+    if (performanceMode != ov::hint::PerformanceMode::THROUGHPUT) {
+        return 1;
     }
+
+    return (platform == ov::intel_npu::Platform::NPU3720) ? 4 : 8;
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler_adapter/include/dynamic_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/dynamic_graph.hpp
@@ -196,6 +196,8 @@ public:
 
     std::optional<bool> is_profiling_blob() const override;
 
+    bool supports_sequential_inference() const override;
+
     std::optional<std::string_view> get_compatibility_descriptor() const override;
 
 private:

--- a/src/plugins/intel_npu/src/compiler_adapter/include/dynamic_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/dynamic_graph.hpp
@@ -196,7 +196,7 @@ public:
 
     std::optional<bool> is_profiling_blob() const override;
 
-    bool supports_sequential_inference() const override;
+    bool supports_in_order_execution() const override;
 
     std::optional<std::string_view> get_compatibility_descriptor() const override;
 

--- a/src/plugins/intel_npu/src/compiler_adapter/include/graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/graph.hpp
@@ -60,7 +60,7 @@ public:
 
     std::optional<bool> is_profiling_blob() const override;
 
-    bool supports_sequential_inference() const override;
+    bool supports_in_order_execution() const override;
 
     void evict_memory() override;
 

--- a/src/plugins/intel_npu/src/compiler_adapter/include/graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/graph.hpp
@@ -60,6 +60,8 @@ public:
 
     std::optional<bool> is_profiling_blob() const override;
 
+    bool supports_sequential_inference() const override;
+
     void evict_memory() override;
 
     std::optional<std::string_view> get_compatibility_descriptor() const override;

--- a/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
@@ -579,6 +579,14 @@ ze_graph_handle_t DynamicGraph::get_handle() const {
     return nullptr;
 }
 
+bool DynamicGraph::supports_sequential_inference() const {
+    if (_zeroInitStruct == nullptr) {
+        return false;
+    }
+
+    return _zeroInitStruct->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1);
+}
+
 void DynamicGraph::initialize_impl(const FilteredConfig& config) {
     _logger.debug("Graph initialize start");
 
@@ -603,8 +611,8 @@ void DynamicGraph::initialize_impl(const FilteredConfig& config) {
         _logger.debug("Set ZE_NPU_COMMAND_QUEUE_OPTION_TURBO in command queue options");
         commandQueueOptions = commandQueueOptions | ZE_NPU_COMMAND_QUEUE_OPTION_TURBO;
     }
-    if (config.has<RUN_INFERENCES_SEQUENTIALLY>() && config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
-        OPENVINO_ASSERT(_zeroInitStruct->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1),
+    if (config.get<RUN_INFERENCES_SEQUENTIALLY>() || config.get<EXCLUSIVE_ASYNC_REQUESTS>()) {
+        OPENVINO_ASSERT(supports_sequential_inference(),
                         "Running inferences sequentially is not supported by the current driver");
         _logger.debug("Set ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC in command queue options");
         commandQueueOptions = commandQueueOptions | ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC;
@@ -612,12 +620,15 @@ void DynamicGraph::initialize_impl(const FilteredConfig& config) {
 
     {
         std::lock_guard<std::mutex> lock(_commandQueueDescMutex);
+        const bool sharedCommonQueue = config.get<SHARED_COMMON_QUEUE>();
+
         _commandQueueDesc = CommandQueueDesc{
             zeroUtils::toZeQueuePriority(config.get<MODEL_PRIORITY>()),
             config.has<WORKLOAD_TYPE>() ? zeroUtils::toZeQueueWorkloadType(config.get<WORKLOAD_TYPE>()) : std::nullopt,
             commandQueueOptions,
-            this,
-            config.get<SHARED_COMMON_QUEUE>()};
+            supports_sequential_inference() && config.get<EXCLUSIVE_ASYNC_REQUESTS>() && sharedCommonQueue ? nullptr
+                                                                                                           : this,
+            sharedCommonQueue};
     }
 
     _logger.debug("Graph initialize finish");

--- a/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
@@ -579,7 +579,7 @@ ze_graph_handle_t DynamicGraph::get_handle() const {
     return nullptr;
 }
 
-bool DynamicGraph::supports_sequential_inference() const {
+bool DynamicGraph::supports_in_order_execution() const {
     if (_zeroInitStruct == nullptr) {
         return false;
     }
@@ -612,7 +612,7 @@ void DynamicGraph::initialize_impl(const FilteredConfig& config) {
         commandQueueOptions = commandQueueOptions | ZE_NPU_COMMAND_QUEUE_OPTION_TURBO;
     }
     if (config.get<RUN_INFERENCES_SEQUENTIALLY>() || config.get<EXCLUSIVE_ASYNC_REQUESTS>()) {
-        OPENVINO_ASSERT(supports_sequential_inference(),
+        OPENVINO_ASSERT(supports_in_order_execution(),
                         "Running inferences sequentially is not supported by the current driver");
         _logger.debug("Set ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC in command queue options");
         commandQueueOptions = commandQueueOptions | ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC;
@@ -626,8 +626,8 @@ void DynamicGraph::initialize_impl(const FilteredConfig& config) {
             zeroUtils::toZeQueuePriority(config.get<MODEL_PRIORITY>()),
             config.has<WORKLOAD_TYPE>() ? zeroUtils::toZeQueueWorkloadType(config.get<WORKLOAD_TYPE>()) : std::nullopt,
             commandQueueOptions,
-            supports_sequential_inference() && config.get<EXCLUSIVE_ASYNC_REQUESTS>() && sharedCommonQueue ? nullptr
-                                                                                                           : this,
+            supports_in_order_execution() && config.get<EXCLUSIVE_ASYNC_REQUESTS>() && sharedCommonQueue ? nullptr
+                                                                                                         : this,
             sharedCommonQueue};
     }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -165,7 +165,7 @@ void Graph::set_argument_value_with_strides(uint32_t id, const void* data, const
     _zeGraphExt->setGraphArgumentValueWithStrides(_graphDesc, id, data, strides);
 }
 
-bool Graph::supports_sequential_inference() const {
+bool Graph::supports_in_order_execution() const {
     if (_zeroInitStruct == nullptr) {
         return false;
     }
@@ -188,7 +188,7 @@ void Graph::initialize_impl(const FilteredConfig& config) {
             commandQueueOptions = commandQueueOptions | ZE_NPU_COMMAND_QUEUE_OPTION_TURBO;
         }
     }
-    if (supports_sequential_inference() &&
+    if (supports_in_order_execution() &&
         (config.get<RUN_INFERENCES_SEQUENTIALLY>() || config.get<EXCLUSIVE_ASYNC_REQUESTS>())) {
         _logger.debug("Set ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC in command queue options");
         commandQueueOptions = commandQueueOptions | ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC;
@@ -201,8 +201,8 @@ void Graph::initialize_impl(const FilteredConfig& config) {
             zeroUtils::toZeQueuePriority(config.get<MODEL_PRIORITY>()),
             config.has<WORKLOAD_TYPE>() ? zeroUtils::toZeQueueWorkloadType(config.get<WORKLOAD_TYPE>()) : std::nullopt,
             commandQueueOptions,
-            supports_sequential_inference() && config.get<EXCLUSIVE_ASYNC_REQUESTS>() && sharedCommonQueue ? nullptr
-                                                                                                           : this,
+            supports_in_order_execution() && config.get<EXCLUSIVE_ASYNC_REQUESTS>() && sharedCommonQueue ? nullptr
+                                                                                                         : this,
             sharedCommonQueue,
         };
     }
@@ -219,7 +219,7 @@ void Graph::initialize_impl(const FilteredConfig& config) {
         _batchSize = determine_batch_size();
     }
 
-    if (!supports_sequential_inference() && config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
+    if (!supports_in_order_execution() && config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
         auto numberOfCommandLists = _batchSize.has_value() ? *_batchSize : 1;
 
         _lastSubmittedEvent.resize(numberOfCommandLists);

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -165,6 +165,14 @@ void Graph::set_argument_value_with_strides(uint32_t id, const void* data, const
     _zeGraphExt->setGraphArgumentValueWithStrides(_graphDesc, id, data, strides);
 }
 
+bool Graph::supports_sequential_inference() const {
+    if (_zeroInitStruct == nullptr) {
+        return false;
+    }
+
+    return _zeroInitStruct->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1);
+}
+
 void Graph::initialize_impl(const FilteredConfig& config) {
     _logger.debug("Graph initialize start");
 
@@ -180,20 +188,22 @@ void Graph::initialize_impl(const FilteredConfig& config) {
             commandQueueOptions = commandQueueOptions | ZE_NPU_COMMAND_QUEUE_OPTION_TURBO;
         }
     }
-    if (_zeroInitStruct->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1) &&
-        config.has<RUN_INFERENCES_SEQUENTIALLY>() && config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
+    if (supports_sequential_inference() &&
+        (config.get<RUN_INFERENCES_SEQUENTIALLY>() || config.get<EXCLUSIVE_ASYNC_REQUESTS>())) {
         _logger.debug("Set ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC in command queue options");
         commandQueueOptions = commandQueueOptions | ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC;
     }
 
     {
         std::lock_guard<std::mutex> lock(_commandQueueDescMutex);
+        const bool sharedCommonQueue = config.get<SHARED_COMMON_QUEUE>();
         _commandQueueDesc = CommandQueueDesc{
             zeroUtils::toZeQueuePriority(config.get<MODEL_PRIORITY>()),
             config.has<WORKLOAD_TYPE>() ? zeroUtils::toZeQueueWorkloadType(config.get<WORKLOAD_TYPE>()) : std::nullopt,
             commandQueueOptions,
-            this,
-            config.get<SHARED_COMMON_QUEUE>(),
+            supports_sequential_inference() && config.get<EXCLUSIVE_ASYNC_REQUESTS>() && sharedCommonQueue ? nullptr
+                                                                                                           : this,
+            sharedCommonQueue,
         };
     }
 
@@ -209,8 +219,7 @@ void Graph::initialize_impl(const FilteredConfig& config) {
         _batchSize = determine_batch_size();
     }
 
-    if (_zeroInitStruct->getCommandQueueDdiTable().version() < ZE_MAKE_VERSION(1, 1) &&
-        config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
+    if (!supports_sequential_inference() && config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
         auto numberOfCommandLists = _batchSize.has_value() ? *_batchSize : 1;
 
         _lastSubmittedEvent.resize(numberOfCommandLists);

--- a/src/plugins/intel_npu/src/plugin/include/async_infer_request.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/async_infer_request.hpp
@@ -16,7 +16,7 @@ class AsyncInferRequest final : public ov::IAsyncInferRequest {
 public:
     explicit AsyncInferRequest(const std::shared_ptr<InferRequest>& inferRequest,
                                const std::shared_ptr<ov::threading::ITaskExecutor>& requestExecutor,
-                               const std::shared_ptr<ov::threading::ITaskExecutor>& getResultExecutor,
+                               const std::shared_ptr<ov::threading::ITaskExecutor>& resultExecutor,
                                const std::shared_ptr<ov::threading::ITaskExecutor>& callbackExecutor);
 
     AsyncInferRequest(const AsyncInferRequest&) = delete;
@@ -25,13 +25,9 @@ public:
 
     ~AsyncInferRequest();
 
-    std::shared_ptr<InferRequest> get_sync_infer_request() {
-        return _syncInferRequest;
-    }
-
 private:
-    std::shared_ptr<InferRequest> _syncInferRequest;
-    std::shared_ptr<ov::threading::ITaskExecutor> _getResultExecutor;
+    std::shared_ptr<InferRequest> _inferRequest;
+    std::shared_ptr<ov::threading::ITaskExecutor> _resultExecutor;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -25,9 +25,8 @@ public:
      * @param plugin Pointer towards the NPU plugin instance
      * @param device Backend specific object through which inference requests can be created
      * @param graph Object holding the graph handle along with distinct fields for metadata
-     * @param profiling Flag indicating if profiling was requested. Setting this to "true" will lead to storing the
-     * "compiler" parameter inside the newly created "CompiledModel".
      * @param config Custom configuration object
+     * @param batchSize Optional batch size value.
      */
     CompiledModel(const std::shared_ptr<const ov::Model>& model,
                   const std::shared_ptr<const ov::IPlugin>& plugin,
@@ -40,7 +39,7 @@ public:
 
     CompiledModel& operator=(const CompiledModel&) = delete;
 
-    ~CompiledModel() override;
+    ~CompiledModel() override = default;
 
     std::shared_ptr<ov::IAsyncInferRequest> create_infer_request() const override;
 
@@ -61,15 +60,16 @@ public:
     void release_memory() override;
 
 private:
-    void configure_stream_executors();
+    // For special config, stream executors must be set accordingly to ensure correct behavior.
+    void configure_stream_executors(const FilteredConfig& config);
 
     Logger _logger;
+
     const std::shared_ptr<IDevice> _device;
-    std::shared_ptr<ov::threading::ITaskExecutor> _resultExecutor;
-
     std::unique_ptr<Properties> _propertiesManager;
-
     std::shared_ptr<IGraph> _graph;
+
+    std::shared_ptr<ov::threading::ITaskExecutor> _resultExecutor = nullptr;
 
     std::optional<int64_t> _batchSize;
 };

--- a/src/plugins/intel_npu/src/plugin/include/metrics.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metrics.hpp
@@ -55,10 +55,10 @@ private:
     };
 
     // Metric to provide a hint for a range for number of async infer requests. (bottom bound, upper bound, step)
-    const std::tuple<uint32_t, uint32_t, uint32_t> _rangeForAsyncInferRequests{1u, 10u, 1u};
+    const std::tuple<uint32_t, uint32_t, uint32_t> _rangeForAsyncInferRequests{1u, 8u, 1u};
 
     // Metric to provide information about a range for streams.(bottom bound, upper bound)
-    const std::tuple<uint32_t, uint32_t> _rangeForStreams{0u, 10u};
+    const std::tuple<uint32_t, uint32_t> _rangeForStreams{0u, 8u};
 
     std::string getDeviceName(const std::string& specifiedDeviceName) const;
     std::shared_ptr<intel_npu::IDevice> getDevice(const std::string& specifiedDeviceName) const;

--- a/src/plugins/intel_npu/src/plugin/include/metrics.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metrics.hpp
@@ -58,7 +58,7 @@ private:
     const std::tuple<uint32_t, uint32_t, uint32_t> _rangeForAsyncInferRequests{1u, 10u, 1u};
 
     // Metric to provide information about a range for streams.(bottom bound, upper bound)
-    const std::tuple<uint32_t, uint32_t> _rangeForStreams{1u, 4u};
+    const std::tuple<uint32_t, uint32_t> _rangeForStreams{0u, 10u};
 
     std::string getDeviceName(const std::string& specifiedDeviceName) const;
     std::shared_ptr<intel_npu::IDevice> getDevice(const std::string& specifiedDeviceName) const;

--- a/src/plugins/intel_npu/src/plugin/include/metrics.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metrics.hpp
@@ -48,6 +48,7 @@ private:
     const ov::SoPtr<IEngineBackend> _backend;
     std::vector<std::string> _supportedMetrics;
     std::vector<std::string> _supportedConfigKeys;
+    static constexpr uint32_t _maxNoOfOptimalInferRequests = 8u;
     const std::vector<std::string> _optimizationCapabilities = {
         ov::device::capability::FP16,
         ov::device::capability::INT8,
@@ -55,10 +56,10 @@ private:
     };
 
     // Metric to provide a hint for a range for number of async infer requests. (bottom bound, upper bound, step)
-    const std::tuple<uint32_t, uint32_t, uint32_t> _rangeForAsyncInferRequests{1u, 8u, 1u};
+    const std::tuple<uint32_t, uint32_t, uint32_t> _rangeForAsyncInferRequests{1u, _maxNoOfOptimalInferRequests, 1u};
 
     // Metric to provide information about a range for streams.(bottom bound, upper bound)
-    const std::tuple<uint32_t, uint32_t> _rangeForStreams{0u, 8u};
+    const std::tuple<uint32_t, uint32_t> _rangeForStreams{0u, _maxNoOfOptimalInferRequests};
 
     std::string getDeviceName(const std::string& specifiedDeviceName) const;
     std::shared_ptr<intel_npu::IDevice> getDevice(const std::string& specifiedDeviceName) const;

--- a/src/plugins/intel_npu/src/plugin/src/async_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/async_infer_request.cpp
@@ -8,19 +8,23 @@
 
 namespace intel_npu {
 
-// clang-format off
-AsyncInferRequest::AsyncInferRequest(const std::shared_ptr<InferRequest>& syncInferRequest,
+AsyncInferRequest::AsyncInferRequest(const std::shared_ptr<InferRequest>& inferRequest,
                                      const std::shared_ptr<ov::threading::ITaskExecutor>& requestExecutor,
-                                     const std::shared_ptr<ov::threading::ITaskExecutor>& getResultExecutor,
+                                     const std::shared_ptr<ov::threading::ITaskExecutor>& resultExecutor,
                                      const std::shared_ptr<ov::threading::ITaskExecutor>& callbackExecutor)
-        : ov::IAsyncInferRequest(syncInferRequest, requestExecutor, callbackExecutor),
-          _syncInferRequest(syncInferRequest), _getResultExecutor(getResultExecutor) {
-    m_pipeline = {
-            {requestExecutor,       [this] { _syncInferRequest->infer_async(); }},
-            {getResultExecutor,     [this] { _syncInferRequest->get_result(); }}
-    };
+    : ov::IAsyncInferRequest(inferRequest, requestExecutor, callbackExecutor),
+      _inferRequest(inferRequest),
+      _resultExecutor(resultExecutor) {
+    if (_resultExecutor) {
+        m_pipeline = {{requestExecutor,
+                       [this] {
+                           _inferRequest->infer_async();
+                       }},
+                      {_resultExecutor, [this] {
+                           _inferRequest->get_result();
+                       }}};
+    }
 }
-// clang-format on
 
 AsyncInferRequest::~AsyncInferRequest() {
     stop_and_wait();

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -9,6 +9,7 @@
 #include <string_view>
 
 #include "async_infer_request.hpp"
+#include "intel_npu/common/device_helpers.hpp"
 #include "intel_npu/common/itt.hpp"
 #include "intel_npu/config/config.hpp"
 #include "intel_npu/config/options.hpp"
@@ -30,7 +31,7 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
                              const std::shared_ptr<IGraph>& graph,
                              const FilteredConfig& config,
                              const std::optional<int64_t>& batchSize)
-    : ICompiledModel(model, plugin),
+    : ICompiledModel(model, plugin, nullptr, nullptr),
       _logger("CompiledModel", config.get<LOG_LEVEL>()),
       _device(device),
       _graph(graph),
@@ -48,14 +49,9 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
     OV_ITT_TASK_CHAIN(COMPILED_MODEL, itt::domains::NPUPlugin, "CompiledModel::CompiledModel", "initialize_properties");
     _propertiesManager = std::make_unique<Properties>(PropertiesType::COMPILED_MODEL, localConfig);
 
-    configure_stream_executors();
+    configure_stream_executors(_propertiesManager->getConfig());
 
     OV_ITT_TASK_SKIP(COMPILED_MODEL);
-}
-
-CompiledModel::~CompiledModel() {
-    _logger.debug("~CompiledModel()");
-    std::dynamic_pointer_cast<ov::threading::IStreamsExecutor>(get_task_executor())->cpu_reset();
 }
 
 std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() const {
@@ -74,10 +70,10 @@ std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() co
                     "Graph is unavailable or failed to initialize. The driver may be missing or too old to run "
                     "inference for this blob.");
 
-    const std::shared_ptr<InferRequest>& syncInferRequest =
+    const std::shared_ptr<InferRequest>& inferRequest =
         _device->createInferRequest(shared_from_this(), _propertiesManager->getConfig());
 
-    return std::make_shared<AsyncInferRequest>(syncInferRequest,
+    return std::make_shared<AsyncInferRequest>(inferRequest,
                                                get_task_executor(),
                                                _resultExecutor,
                                                get_callback_executor());
@@ -270,26 +266,82 @@ void CompiledModel::release_memory() {
     }
 }
 
-void CompiledModel::configure_stream_executors() {
-    std::shared_ptr<ov::threading::ITaskExecutor> task_executor;
-    if (get_plugin()->get_property(ov::internal::exclusive_async_requests.name(), {}).as<bool>()) {
-        task_executor = ov::threading::executor_manager()->get_executor("NPU");
-    } else if (get_property(ov::hint::enable_cpu_pinning.name()).as<bool>()) {
-        auto executor_config = ov::threading::IStreamsExecutor::Config{
-            /* name = */ "Intel NPU plugin executor",
-            /* streams = */ get_plugin()->get_property(ov::num_streams.name(), {}).as<ov::streams::Num>(),
-            /* threads_per_stream = */ 1,
-            /* thread_preferred_core_type = */ ov::hint::SchedulingCoreType::PCORE_ONLY,
-            /* cpu_reservation = */ true};
-        task_executor = std::make_shared<ov::threading::CPUStreamsExecutor>(executor_config);
-    } else {
-        task_executor = std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"NPUPlugin executor"});
+void CompiledModel::configure_stream_executors(const FilteredConfig& config) {
+    if (config.get<EXCLUSIVE_ASYNC_REQUESTS>()) {
+        set_task_executor(
+            ov::threading::executor_manager()->get_executor("Intel NPU plugin start inferences executor"));
+        set_callback_executor(ov::threading::executor_manager()->get_executor("Intel NPU plugin callback executor"));
+
+        if (config.get<SHARED_COMMON_QUEUE>() && _graph->supports_sequential_inference()) {
+            _resultExecutor =
+                ov::threading::executor_manager()->get_executor("Intel NPU plugin wait inferences executor");
+        } else {
+            _resultExecutor = nullptr;
+        }
+        return;
     }
 
-    set_task_executor(std::move(task_executor));
-    const auto executorId = _graph->get_metadata().name + "_NPUResultExecutor";
-    _resultExecutor = ov::threading::executor_manager()->get_executor(executorId);
+    if (config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
+        set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor"}));
+        _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin wait inferences executor"});
+        set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin callback executor"}));
+        return;
+    }
+
+    if (config.get<ENABLE_CPU_PINNING>()) {
+        set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor"}));
+
+        auto waitTaskExecutorConfig = ov::threading::IStreamsExecutor::Config{
+            /* name = */ "Intel NPU plugin wait inferences executor",
+            /* streams = */ 1,
+            /* threads_per_stream = */ 1,
+            /* thread_preferred_core_type = */ ov::hint::SchedulingCoreType::PCORE_ONLY,
+            /* cpu_reservation = */ false,
+            /* cpu_pinning = */ true};
+        _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(waitTaskExecutorConfig);
+
+        auto callbackTaskExecutorConfig = ov::threading::IStreamsExecutor::Config{
+            /* name = */ "Intel NPU plugin callback executor",
+            /* streams = */ 1,
+            /* threads_per_stream = */ 1,
+            /* thread_preferred_core_type = */ ov::hint::SchedulingCoreType::PCORE_ONLY,
+            /* cpu_reservation = */ false,
+            /* cpu_pinning = */ true};
+        set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(callbackTaskExecutorConfig));
+        return;
+    }
+
+    const auto numStreams = config.get<NUM_STREAMS>();
+    if (numStreams == 0) {
+        set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor", numStreams}));
+        _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin wait inferences executor"});
+        set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin callback executor"}));
+    } else if (numStreams > 0) {
+        set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor", numStreams}));
+        _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin wait inferences executor", numStreams});
+        set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin callback executor", numStreams}));
+    } else {
+        const auto numStreamsValue =
+            static_cast<int>(utils::getOptimalNumberOfInferRequestsInParallel(config.get<PLATFORM>(),
+                                                                              ov::hint::PerformanceMode::THROUGHPUT));
+
+        set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor"}));
+        _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin wait inferences executor", numStreamsValue});
+        set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin callback executor", numStreamsValue}));
+    }
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -267,12 +267,15 @@ void CompiledModel::release_memory() {
 }
 
 void CompiledModel::configure_stream_executors(const FilteredConfig& config) {
+    // In case of exclusive async requests, the plugin must use global executors to ensure async infer requests
+    // from different compiled models run in the order they are started. The global executors use a single thread
+    // to ensure sequential execution.
     if (config.get<EXCLUSIVE_ASYNC_REQUESTS>()) {
         set_task_executor(
             ov::threading::executor_manager()->get_executor("Intel NPU plugin start inferences executor"));
         set_callback_executor(ov::threading::executor_manager()->get_executor("Intel NPU plugin callback executor"));
 
-        if (config.get<SHARED_COMMON_QUEUE>() && _graph->supports_sequential_inference()) {
+        if (config.get<SHARED_COMMON_QUEUE>() && _graph->supports_in_order_execution()) {
             _resultExecutor =
                 ov::threading::executor_manager()->get_executor("Intel NPU plugin wait inferences executor");
         } else {
@@ -281,6 +284,8 @@ void CompiledModel::configure_stream_executors(const FilteredConfig& config) {
         return;
     }
 
+    // In case of sequential execution of async requests for the same compiled model, the compiled model must use
+    // dedicated executors with a single thread to ensure sequential execution of its async requests.
     if (config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
         set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
             ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor"}));
@@ -291,57 +296,56 @@ void CompiledModel::configure_stream_executors(const FilteredConfig& config) {
         return;
     }
 
-    if (config.get<ENABLE_CPU_PINNING>()) {
-        set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor"}));
+    struct ExecutorStreams {
+        int task = 1;
+        int wait = 1;
+        int callback = 1;
+    };
 
-        auto waitTaskExecutorConfig = ov::threading::IStreamsExecutor::Config{
-            /* name = */ "Intel NPU plugin wait inferences executor",
-            /* streams = */ 1,
-            /* threads_per_stream = */ 1,
-            /* thread_preferred_core_type = */ ov::hint::SchedulingCoreType::PCORE_ONLY,
-            /* cpu_reservation = */ false,
-            /* cpu_pinning = */ true};
-        _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(waitTaskExecutorConfig);
-
-        auto callbackTaskExecutorConfig = ov::threading::IStreamsExecutor::Config{
-            /* name = */ "Intel NPU plugin callback executor",
-            /* streams = */ 1,
-            /* threads_per_stream = */ 1,
-            /* thread_preferred_core_type = */ ov::hint::SchedulingCoreType::PCORE_ONLY,
-            /* cpu_reservation = */ false,
-            /* cpu_pinning = */ true};
-        set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(callbackTaskExecutorConfig));
-        return;
-    }
-
+    // Determine the number of streams to use for each executor from the num_streams value.
+    ExecutorStreams executorStreams;
     const auto numStreams = config.get<NUM_STREAMS>();
     if (numStreams == 0) {
-        set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor", numStreams}));
-        _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin wait inferences executor"});
-        set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin callback executor"}));
+        executorStreams.task = 0;
     } else if (numStreams > 0) {
-        set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor", numStreams}));
-        _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin wait inferences executor", numStreams});
-        set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin callback executor", numStreams}));
+        executorStreams.task = numStreams;
+        executorStreams.wait = numStreams;
+        executorStreams.callback = numStreams;
     } else {
         const auto numStreamsValue =
             static_cast<int>(utils::getOptimalNumberOfInferRequestsInParallel(config.get<PLATFORM>(),
                                                                               ov::hint::PerformanceMode::THROUGHPUT));
+        executorStreams.wait = numStreamsValue;
+        executorStreams.callback = numStreamsValue;
+    }
+
+    // When CPU pinning is enabled, the plugin will use dedicated executors pinned to P-cores.
+    if (config.get<ENABLE_CPU_PINNING>()) {
+        auto getPinnedConfig = [](const char* name, int streams) {
+            return ov::threading::IStreamsExecutor::Config{/* name = */ name,
+                                                           /* streams = */ streams,
+                                                           /* threads_per_stream = */ 1,
+                                                           /* thread_preferred_core_type = */
+                                                           ov::hint::SchedulingCoreType::PCORE_ONLY,
+                                                           /* cpu_reservation = */ false,
+                                                           /* cpu_pinning = */ true};
+        };
 
         set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor"}));
+            getPinnedConfig("Intel NPU plugin start inferences executor", executorStreams.task)));
         _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin wait inferences executor", numStreamsValue});
+            getPinnedConfig("Intel NPU plugin wait inferences executor", executorStreams.wait));
         set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel NPU plugin callback executor", numStreamsValue}));
+            getPinnedConfig("Intel NPU plugin callback executor", executorStreams.callback)));
+        return;
     }
+
+    set_task_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+        ov::threading::IStreamsExecutor::Config{"Intel NPU plugin start inferences executor", executorStreams.task}));
+    _resultExecutor = std::make_shared<ov::threading::CPUStreamsExecutor>(
+        ov::threading::IStreamsExecutor::Config{"Intel NPU plugin wait inferences executor", executorStreams.wait});
+    set_callback_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(
+        ov::threading::IStreamsExecutor::Config{"Intel NPU plugin callback executor", executorStreams.callback}));
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -150,8 +150,7 @@ std::shared_ptr<ov::ICompiledModel> import_model_npuw(std::istream& stream,
                                                       ov::AnyMap& properties,
                                                       std::shared_ptr<const ov::IPlugin> pluginSO) {
     if (const auto header = ov::npuw::orc::is_orc(stream);
-        header.has_value() &&
-        header->schema_uuid == ov::npuw::orc::schema_npuw::NPUW_ORC_PARTITIONED_SCHEMA) {
+        header.has_value() && header->schema_uuid == ov::npuw::orc::schema_npuw::NPUW_ORC_PARTITIONED_SCHEMA) {
         return ov::npuw::CompiledModel::import_model(stream, pluginSO, properties);
     }
 
@@ -270,7 +269,6 @@ void init_config(const IEngineBackend* backend, OptionsDesc& options, FilteredCo
     REGISTER_OPTION(RUNTIME_REQUIREMENTS);
     REGISTER_OPTION(COMPATIBILITY_CHECK);
 
-
     if (backend) {
         // Options registered only if drivers is present and supports the corresponding extension
         REGISTER_OPTION(MAX_TILES);
@@ -373,14 +371,16 @@ void Plugin::set_property(const ov::AnyMap& properties) {
     _propertiesManager->setProperty(properties);
 }
 
-
-ov::CompatibilityCheck Plugin::validate_compatibility_descriptor(ov::intel_npu::CompilerType compilerType, const ov::AnyMap& arguments) const {
+ov::CompatibilityCheck Plugin::validate_compatibility_descriptor(ov::intel_npu::CompilerType compilerType,
+                                                                 const ov::AnyMap& arguments) const {
     if (arguments.empty() || arguments.find(ov::runtime_requirements.name()) == arguments.end()) {
         return ov::CompatibilityCheck::NOT_APPLICABLE;
     }
 
     const auto& runtimeRequirements = arguments.at(ov::runtime_requirements.name()).as<const std::string&>();
-    _logger.debug("Received runtime_requirements: %s length: %zu", runtimeRequirements.c_str(), runtimeRequirements.length());
+    _logger.debug("Received runtime_requirements: %s length: %zu",
+                  runtimeRequirements.c_str(),
+                  runtimeRequirements.length());
 
     // NPU Plugin's runtime requirements are captured in its metadata.
     // For now plugin's requirements are met if metadata can be retrieved from the tensor
@@ -392,7 +392,8 @@ ov::CompatibilityCheck Plugin::validate_compatibility_descriptor(ov::intel_npu::
     } catch (const std::exception& ex) {
         // Unsupported version, could not read the metadata or an unknown error has occured. Report that the
         // requirements are not met.
-        _logger.debug("Failed to read metadata from the runtime requirements. The requirements are not met. %s", ex.what());
+        _logger.debug("Failed to read metadata from the runtime requirements. The requirements are not met. %s",
+                      ex.what());
         return ov::CompatibilityCheck::UNSUPPORTED;
     }
 
@@ -417,7 +418,8 @@ ov::CompatibilityCheck Plugin::validate_compatibility_descriptor(ov::intel_npu::
             return ov::CompatibilityCheck::UNSUPPORTED;
         }
     } catch (const std::exception&) {
-        _logger.error("Failed to create the recommended compiler type for the compatibility check %d. The requirements are not met.",
+        _logger.error("Failed to create the recommended compiler type for the compatibility check %d. The requirements "
+                      "are not met.",
                       static_cast<int>(compilerType));
         return ov::CompatibilityCheck::NOT_APPLICABLE;
     }

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -127,6 +127,14 @@ void disableCompilerProperties(intel_npu::FilteredConfig& config, const ov::SoPt
     }
 }
 
+// Helper function for retrieving the device name
+std::string get_specified_device_name(const intel_npu::Config& config) {
+    if (config.has<intel_npu::DEVICE_ID>()) {
+        return config.get<intel_npu::DEVICE_ID>();
+    }
+    return std::string();
+}
+
 }  // namespace
 
 namespace intel_npu {
@@ -397,41 +405,6 @@ namespace intel_npu {
                             std::make_tuple(PROP_VISIBILITY, ov::PropertyMutability::RO, PROP_RETFUNC)); \
     } while (0)
 
-// Local helper function for appending platform name to the config
-static Config add_platform_to_the_config(Config config, const std::string_view platform) {
-    config.update({{ov::intel_npu::platform.name(), std::string(platform)}});
-    return config;
-}
-
-// Local helper function for retrieving the device name
-static auto get_specified_device_name(const Config config) {
-    if (config.has<DEVICE_ID>()) {
-        return config.get<DEVICE_ID>();
-    }
-    return std::string();
-}
-
-// Heuristically obtained number. Varies depending on the values of PLATFORM and PERFORMANCE_HINT
-// Note: this is the value provided by the plugin, application should query and consider it, but may supply its own
-// preference for number of parallel requests via dedicated configuration
-static int64_t getOptimalNumberOfInferRequestsInParallel(const Config& config) {
-    const std::string platform = config.get<PLATFORM>();
-
-    if (platform == ov::intel_npu::Platform::NPU3720) {
-        if (config.get<PERFORMANCE_HINT>() == ov::hint::PerformanceMode::THROUGHPUT) {
-            return 4;
-        } else {
-            return 1;
-        }
-    } else {
-        if (config.get<PERFORMANCE_HINT>() == ov::hint::PerformanceMode::THROUGHPUT) {
-            return 8;
-        } else {
-            return 1;
-        }
-    }
-}
-
 Properties::Properties(const PropertiesType pType,
                        const FilteredConfig& config,
                        const std::shared_ptr<Metrics>& metrics,
@@ -632,16 +605,15 @@ void Properties::registerPluginProperties() {
     if (_metrics != nullptr) {
         REGISTER_SIMPLE_METRIC(ov::available_devices, true, _metrics->GetAvailableDevicesNames());
         REGISTER_SIMPLE_METRIC(ov::device::capabilities, true, _metrics->GetOptimizationCapabilities());
-        REGISTER_SIMPLE_METRIC(
-            ov::optimal_number_of_infer_requests,
-            true,
-            static_cast<uint32_t>(getOptimalNumberOfInferRequestsInParallel(add_platform_to_the_config(
-                config,
-                utils::getCompilationPlatform(
-                    config.get<PLATFORM>(),
-                    _backend == nullptr ? config.get<DEVICE_ID>()
-                                        : _backend->getDevice(config.get<DEVICE_ID>())->getName(),
-                    _backend == nullptr ? std::vector<std::string>() : _backend->getDeviceNames())))));
+        REGISTER_SIMPLE_METRIC(ov::optimal_number_of_infer_requests,
+                               true,
+                               utils::getOptimalNumberOfInferRequestsInParallel(
+                                   utils::getCompilationPlatform(
+                                       config.get<PLATFORM>(),
+                                       _backend == nullptr ? config.get<DEVICE_ID>()
+                                                           : _backend->getDevice(config.get<DEVICE_ID>())->getName(),
+                                       _backend == nullptr ? std::vector<std::string>() : _backend->getDeviceNames()),
+                                   config.get<PERFORMANCE_HINT>()));
         REGISTER_SIMPLE_METRIC(ov::range_for_async_infer_requests, true, _metrics->GetRangeForAsyncInferRequest());
         REGISTER_SIMPLE_METRIC(ov::range_for_streams, true, _metrics->GetRangeForStreams());
         REGISTER_SIMPLE_METRIC(ov::device::pci_info, true, _metrics->GetPciInfo(get_specified_device_name(config)));
@@ -750,6 +722,7 @@ void Properties::registerCompiledModelProperties() {
     TRY_REGISTER_SIMPLE_PROPERTY(ov::cache_mode, CACHE_MODE);
 
     // Properties we shall only enable if they were set prior-to-compilation
+    TRY_REGISTER_COMPILEDMODEL_PROPERTY_IFSET(ov::num_streams, NUM_STREAMS);
     TRY_REGISTER_COMPILEDMODEL_PROPERTY_IFSET(ov::intel_npu::compiler_type, COMPILER_TYPE);
     TRY_REGISTER_COMPILEDMODEL_PROPERTY_IFSET(ov::intel_npu::compiler_version, COMPILER_VERSION);
     TRY_REGISTER_COMPILEDMODEL_PROPERTY_IFSET(ov::weights_path, WEIGHTS_PATH);
@@ -782,6 +755,7 @@ void Properties::registerCompiledModelProperties() {
 
     TRY_REGISTER_VARPUB_PROPERTY(ov::intel_npu::batch_mode, BATCH_MODE, false);
     TRY_REGISTER_VARPUB_PROPERTY(ov::intel_npu::shared_common_queue, SHARED_COMMON_QUEUE, false);
+    TRY_REGISTER_VARPUB_PROPERTY(ov::internal::exclusive_async_requests, EXCLUSIVE_ASYNC_REQUESTS, false);
 
     TRY_REGISTER_CUSTOM_PROPERTY(ov::hint::model_priority,
                                  MODEL_PRIORITY,
@@ -839,9 +813,10 @@ void Properties::registerCompiledModelProperties() {
         // this implementation here serves only to publish it in supported_properties
         return std::string("invalid");
     });
-    REGISTER_SIMPLE_METRIC(ov::optimal_number_of_infer_requests,
-                           true,
-                           static_cast<uint32_t>(getOptimalNumberOfInferRequestsInParallel(config)));
+    REGISTER_SIMPLE_METRIC(
+        ov::optimal_number_of_infer_requests,
+        true,
+        utils::getOptimalNumberOfInferRequestsInParallel(config.get<PLATFORM>(), config.get<PERFORMANCE_HINT>()));
     REGISTER_CUSTOM_METRIC(ov::execution_devices, true, [](const Config&) {
         // TODO: log an error here as the code shouldn't have gotten here
         // this property is implemented in compiled model directly

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -57,6 +57,7 @@ public:
     bool operator==(const CommandQueueDesc& other) const;
 
 private:
+    bool uses_global_shared_owner() const;
     bool owner_tag_required() const;
     void update_key();
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -43,14 +43,21 @@ bool CommandQueueDesc::operator==(const CommandQueueDesc& other) const {
     const bool use_owner_tag = owner_tag_required();
     const bool other_use_owner_tag = other.owner_tag_required();
     if (use_owner_tag || other_use_owner_tag) {
-        if (_owner_tag == nullptr || other._owner_tag == nullptr || _owner_tag != other._owner_tag) {
+        if (_owner_tag != other._owner_tag) {
             return false;
         }
     }
 
     return true;
 }
+bool CommandQueueDesc::uses_global_shared_owner() const {
+    return _shared_common_queue && (_options & ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC) != 0 && _owner_tag == nullptr;
+}
 bool CommandQueueDesc::owner_tag_required() const {
+    if (uses_global_shared_owner()) {
+        // Explicitly model the shared-global queue mode: no owner tag is required.
+        return false;
+    }
     return (_options & ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC) != 0 || !_shared_common_queue;
 }
 void CommandQueueDesc::update_key() {
@@ -66,10 +73,9 @@ void CommandQueueDesc::update_key() {
     hash = zero_hashing::hash_combine64(hash, static_cast<uint64_t>(_shared_common_queue));
 
     const bool use_owner_tag = owner_tag_required();
-    if (use_owner_tag) {
-        OPENVINO_ASSERT(_owner_tag != nullptr,
-                        "owner_tag must not be null when ZE_NPU_COMMAND_QUEUE_OPTION_DEVICE_SYNC is set or "
-                        "shared_common_queue is disabled");
+    OPENVINO_ASSERT(!use_owner_tag || _owner_tag != nullptr,
+                    "Owner tag is required for this command queue configuration");
+    if (use_owner_tag && _owner_tag != nullptr) {
         hash = zero_hashing::hash_combine64(hash, std::hash<const void*>{}(_owner_tag));
     }
 

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.cpp
@@ -59,7 +59,6 @@ std::vector<std::pair<std::string, ov::Any>> plugin_internal_mutable_properties 
 std::vector<std::pair<std::string, ov::Any>> plugin_public_immutable_properties = {
     {ov::device::uuid.name(), ov::Any("deadbeef")},
     {ov::supported_properties.name(), {ov::device::full_name.name()}},
-    {ov::num_streams.name(), ov::Any(ov::streams::Num(4))},
     {ov::available_devices.name(), ov::Any(std::vector<std::string>{"deadbeef"})},
     {ov::device::capabilities.name(), ov::Any(std::vector<std::string>{"deadbeef"})},
     {ov::range_for_async_infer_requests.name(),

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.cpp
@@ -12,6 +12,7 @@ using namespace ov::test::behavior;
 namespace {
 
 const std::vector<ov::AnyMap> configsInferRequestRunTests = {{}};
+
 const std::vector<ov::AnyMap> configsBooleanPrecisionInferRequestRunTests = {
     {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
       ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN),
@@ -28,6 +29,16 @@ const std::vector<ov::AnyMap> configsBooleanPrecisionInferRequestRunTests = {
     {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
       ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER)}}};
 
+const std::vector<ov::AnyMap> configsForExclusiveAsyncRequests = {
+    {{ov::internal::exclusive_async_requests(true), ov::intel_npu::tiles(2)}},
+    {{ov::internal::exclusive_async_requests(true),
+      ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)}}};
+
+const std::vector<ov::AnyMap> configsWithDifferentNumStreamsTest = {
+    {{ov::num_streams(0)}},
+    {{ov::num_streams(2)}},
+    {{ov::num_streams(8), ov::hint::enable_cpu_pinning(true)}}};
+
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
                          InferRequestRunTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
@@ -35,9 +46,15 @@ INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
                          InferRequestRunTests::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
-                         ExecutorsConfig,
+                         ExclusiveAsyncRequestsTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
-                                            ::testing::ValuesIn(configsInferRequestRunTests)),
+                                            ::testing::ValuesIn(configsForExclusiveAsyncRequests)),
+                         InferRequestRunTests::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
+                         NumStreamsTests,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(configsWithDifferentNumStreamsTest)),
                          InferRequestRunTests::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.cpp
@@ -35,6 +35,12 @@ INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
                          InferRequestRunTests::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
+                         ExecutorsConfig,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(configsInferRequestRunTests)),
+                         InferRequestRunTests::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
                          BooleanPrecisionInferRequestRunTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configsBooleanPrecisionInferRequestRunTests),

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
@@ -3037,6 +3037,48 @@ TEST_P(ExecutorsConfig, SetNumStreamsTo2CheckResults) {
     }
 }
 
+TEST_P(ExecutorsConfig, SetNumStreamsTo8AndEnableCpuPinningCheckResults) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    auto shape = Shape{1, 2, 64, 64};
+    auto shape_size = ov::shape_size(shape);
+    auto model = createModel(element::f32, shape, "N...");
+
+    configuration[ov::num_streams.name()] = 8;
+    configuration[ov::hint::enable_cpu_pinning.name()] = true;
+    auto compiled_model = core->compile_model(model, target_device, configuration);
+    const uint32_t inferences = 32;
+    std::array<ov::InferRequest, inferences> inference_request;
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i] = compiled_model.create_infer_request();
+
+        auto input_tensor = inference_request[i].get_input_tensor();
+        auto* input_data = reinterpret_cast<float*>(input_tensor.data());
+        for (size_t j = 0; j < shape_size; ++j) {
+            input_data[j] = static_cast<float>(i);
+        }
+    }
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i].start_async();
+    }
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i].wait();
+    }
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        float expected_result = static_cast<float>(i) + 1.f;
+        auto output_tensor = inference_request[i].get_output_tensor();
+        auto* output_tensor_data = reinterpret_cast<float*>(output_tensor.data());
+        for (size_t j = 0; j < shape_size; ++j) {
+            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                << "Inference=" << i << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
+                << " for index " << j;
+        }
+    }
+}
+
 }  // namespace behavior
 }  // namespace test
 }  // namespace ov

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
@@ -959,7 +959,7 @@ TEST_P(RunSeqTests, CheckMultipleRunsSeq0) {
         for (uint32_t i = 0; i < inferences; i++) {
             auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
             for (size_t j = 0; j < shape_size; ++j) {
-                EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                     << "Run=" << z << "Output=" << i << " Expected=" << expected_result
                     << ", actual=" << output_tensor_data[j] << " for index " << j;
             }
@@ -1019,7 +1019,7 @@ TEST_P(RunSeqTests, CheckMultipleRunsSeq1) {
         for (int i = inferences - 1; i >= 0; i--) {
             auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
             for (size_t j = 0; j < shape_size; ++j) {
-                EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                     << "Run=" << z << "Output=" << i << " Expected=" << expected_result
                     << ", actual=" << output_tensor_data[j] << " for index " << j;
             }
@@ -1111,9 +1111,7 @@ TEST_P(RunSeqTests, CheckMultipleRunsSeq3) {
     ov::InferRequest inference_request;
     inference_request = compiled_model.create_infer_request();
 
-    OV_EXPECT_THROW(inference_request.infer(),
-                    ov::Exception,
-                    HasSubstr("Only start async is supported when RUN_INFERENCES_SEQUENTIALLY is enabled!"));
+    OV_ASSERT_NO_THROW(inference_request.infer());
 }
 
 TEST_P(RunSeqTests, CheckMultipleRunsSeq4) {
@@ -1176,7 +1174,7 @@ TEST_P(RunSeqTests, CheckMultipleRunsSeq4) {
                 for (int i = inferences - 1; i >= 0; i--) {
                     auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
                     for (size_t j = 0; j < shape_size; ++j) {
-                        EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                        ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                             << "Run=" << z << "Output=" << i << " Expected=" << expected_result
                             << ", actual=" << output_tensor_data[j] << " for index " << j;
                     }
@@ -1202,7 +1200,7 @@ TEST_P(RunSeqTests, CheckMultipleRunsSeq4) {
                 for (uint32_t i = 0; i < inferences; i++) {
                     auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
                     for (size_t j = 0; j < shape_size; ++j) {
-                        EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                        ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                             << "Run=" << z << "Output=" << i << " Expected=" << expected_result
                             << ", actual=" << output_tensor_data[j] << " for index " << j;
                     }
@@ -1267,7 +1265,7 @@ TEST_P(RunSeqTests, CheckTurboWithMultipleRunsSeq) {
         for (int i = inferences - 1; i >= 0; i--) {
             auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
             for (size_t j = 0; j < shape_size; ++j) {
-                EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                     << "Run=" << z << "Output=" << i << " Expected=" << expected_result
                     << ", actual=" << output_tensor_data[j] << " for index " << j;
             }
@@ -1328,7 +1326,7 @@ TEST_P(BatchingRunSeqTests, CheckMultipleBatchingRunsSeq) {
         for (uint32_t i = 0; i < inferences; i++) {
             auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
             for (size_t j = 0; j < shape_size; ++j) {
-                EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                     << "Run=" << z << "Output=" << i << " Expected=" << expected_result
                     << ", actual=" << output_tensor_data[j] << " for index " << j;
             }
@@ -1371,7 +1369,7 @@ TEST_P(DynamicBatchingTests, DynamicCheckMultipleBatchingRun0) {
     float expected_result = static_cast<float>(batch_size) + 1.f;
     auto* output_tensor_data = reinterpret_cast<float*>(output_tensor.data());
     for (size_t j = 0; j < shape_size; ++j) {
-        EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+        ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
             << "Run=" << batch_size << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
             << " for index " << j;
     }
@@ -1397,7 +1395,7 @@ TEST_P(DynamicBatchingTests, DynamicCheckMultipleBatchingRun0) {
         EXPECT_EQ(output_test_tensor.get_size(), input_host_tensor.get_size());
 
         for (size_t j = 0; j < output_test_tensor.get_size(); ++j) {
-            EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                 << "Run=" << z << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
                 << " for index " << j;
         }
@@ -1436,7 +1434,7 @@ TEST_P(DynamicBatchingTests, DynamicCheckMultipleBatchingRun1) {
     float expected_result = static_cast<float>(batch_size) + 1.f;
     auto* output_tensor_data = reinterpret_cast<float*>(output_tensor.data());
     for (size_t j = 0; j < shape_size; ++j) {
-        EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+        ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
             << "Run=" << batch_size << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
             << " for index " << j;
     }
@@ -1462,7 +1460,7 @@ TEST_P(DynamicBatchingTests, DynamicCheckMultipleBatchingRun1) {
         EXPECT_EQ(output_test_tensor.get_size(), input_host_tensor.get_size());
 
         for (size_t j = 0; j < output_test_tensor.get_size(); ++j) {
-            EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                 << "Run=" << z << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
                 << " for index " << j;
         }
@@ -1499,7 +1497,7 @@ TEST_P(DynamicBatchingTests, DynamicCheckMultipleBatchingRun2) {
     float expected_result = static_cast<float>(batch_size) + 1.f;
     auto* output_tensor_data = reinterpret_cast<float*>(output_tensor.data());
     for (size_t j = 0; j < shape_size; ++j) {
-        EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+        ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
             << "Run=" << batch_size << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
             << " for index " << j;
     }
@@ -1554,7 +1552,7 @@ TEST_P(DynamicBatchingTests, DynamicCheckMultipleBatchingRunsSeq) {
         for (uint32_t i = 0; i < inferences; i++) {
             auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
             for (size_t j = 0; j < shape_size; ++j) {
-                EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                     << "Run=" << z << "Output=" << i << " Expected=" << expected_result
                     << ", actual=" << output_tensor_data[j] << " for index " << j;
             }
@@ -1621,7 +1619,7 @@ TEST_P(SetShapeInferRunTests, checkResultsAfterIOBlobReallocation) {
 
     auto* actual = first_output_tensor.data<float>();
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
+        ASSERT_NEAR(actual[i], 6.f, 1e-5) << "Expected=6, actual=" << actual[i] << " for index " << i;
     }
 
     // imitates blob reallocation
@@ -1643,7 +1641,7 @@ TEST_P(SetShapeInferRunTests, checkResultsAfterIOBlobReallocation) {
 
     actual = second_output_tensor.data<float>();
     for (size_t i = 0; i < shape_size; ++i) {
-        EXPECT_NEAR(actual[i], 10.f, 1e-5) << "Expected=10, actual=" << actual[i] << " for index " << i;
+        ASSERT_NEAR(actual[i], 10.f, 1e-5) << "Expected=10, actual=" << actual[i] << " for index " << i;
     }
 }
 
@@ -1680,7 +1678,7 @@ TEST_P(SetShapeInferRunTests, checkResultsAfterStateTensorsReallocation) {
     auto output_tensor = inference_request.get_tensor("sigmod_state");
     auto output_data = output_tensor.data<float>();
     for (size_t i = 0; i < output_tensor.get_size(); i++) {
-        EXPECT_NEAR(0.5f, output_data[i], 1e-5);
+        ASSERT_NEAR(0.5f, output_data[i], 1e-5);
     }
 
     auto states = inference_request.query_state();
@@ -1692,7 +1690,7 @@ TEST_P(SetShapeInferRunTests, checkResultsAfterStateTensorsReallocation) {
         ASSERT_TRUE(last_state_size != 0) << "State size should not be 0";
 
         for (size_t i = 0; i < last_state_size; ++i) {
-            EXPECT_NEAR(0.0, last_state_data[i], 1e-5);
+            ASSERT_NEAR(0.0, last_state_data[i], 1e-5);
         }
     }
 
@@ -1739,7 +1737,7 @@ TEST_P(SetShapeInferRunTests, checkResultsAfterStateTensorsReallocation) {
         ASSERT_TRUE(last_state_size != 0) << "State size should not be 0";
 
         for (size_t i = 0; i < last_state_size; ++i) {
-            EXPECT_NEAR(input_data[i], last_state_data[i], 1e-5);
+            ASSERT_NEAR(input_data[i], last_state_data[i], 1e-5);
         }
     }
 }
@@ -1848,7 +1846,7 @@ TEST_P(CpuVaTensorsTests, SetMultiplePageAllignedTensors) {
         auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
         EXPECT_EQ(output_tensor_data, output_data[i]);
         for (size_t j = 0; j < shape_size; ++j) {
-            EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                 << "Output=" << i << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
                 << " for index " << j;
         }
@@ -1920,7 +1918,7 @@ TEST_P(CpuVaTensorsTests, SetMultipleAllignedAndNotAllignedTensors) {
     for (int i = 0; i < inferences; i++) {
         auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
         for (size_t j = 0; j < shape_size; ++j) {
-            EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                 << "Output=" << i << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
                 << " for index " << j;
         }
@@ -2003,7 +2001,7 @@ TEST_P(CpuVaTensorsTests, SetMultipleRemoteAllignedAndNotAllignedTensors) {
     for (int i = 0; i < inferences; i++) {
         auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
         for (size_t j = 0; j < shape_size; ++j) {
-            EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
                 << "Output=" << i << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
                 << " for index " << j;
         }
@@ -2069,13 +2067,13 @@ TEST_P(CpuVaTensorsTests, SetAndDestroyDifferentAlignedTensors) {
 
     auto* output_tensor_data = reinterpret_cast<float*>(output_tensor0.data());
     for (size_t j = 0; j < shape_size; ++j) {
-        EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+        ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
             << " Expected=" << expected_result << ", actual=" << output_tensor_data[j] << " for index " << j;
     }
 
     output_tensor_data = reinterpret_cast<float*>(output_tensor1.data());
     for (size_t j = 0; j < shape_size; ++j) {
-        EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+        ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
             << " Expected=" << expected_result << ", actual=" << output_tensor_data[j] << " for index " << j;
     }
 
@@ -2136,7 +2134,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterStateTensorsUseImportCpuVa0) {
     auto output_tensor = inference_request.get_tensor("sigmod_state");
     auto output_data = output_tensor.data<float>();
     for (size_t i = 0; i < output_tensor.get_size(); i++) {
-        EXPECT_NEAR(0.5f, output_data[i], 1e-5);
+        ASSERT_NEAR(0.5f, output_data[i], 1e-5);
     }
 
     states = inference_request.query_state();
@@ -2166,11 +2164,11 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterStateTensorsUseImportCpuVa0) {
 
     auto get_state_data = static_cast<float*>(l0_host_tensor.data());
     for (size_t i = 0; i < get_tensor_state.get_size(); ++i) {
-        EXPECT_NEAR(0.0, get_state_data[i], 1e-5);
-        EXPECT_NEAR(0.0, state_data[0][i], 1e-5);
+        ASSERT_NEAR(0.0, get_state_data[i], 1e-5);
+        ASSERT_NEAR(0.0, state_data[0][i], 1e-5);
 
-        EXPECT_NEAR(input_data[i], state_data[1][i], 1e-5);
-        EXPECT_NEAR(input_data[i], state_data[2][i], 1e-5);
+        ASSERT_NEAR(input_data[i], state_data[1][i], 1e-5);
+        ASSERT_NEAR(input_data[i], state_data[2][i], 1e-5);
     }
 
     inference_request = {};
@@ -2234,7 +2232,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterStateTensorsUseImportCpuVa1) {
     auto output_tensor = inference_request.get_tensor("sigmod_state");
     auto output_data = output_tensor.data<float>();
     for (size_t i = 0; i < output_tensor.get_size(); i++) {
-        EXPECT_NEAR(0.5f, output_data[i], 1e-5);
+        ASSERT_NEAR(0.5f, output_data[i], 1e-5);
     }
 
     states = inference_request.query_state();
@@ -2264,11 +2262,11 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterStateTensorsUseImportCpuVa1) {
 
     auto get_state_data = static_cast<float*>(l0_host_tensor.data());
     for (size_t i = 0; i < get_tensor_state.get_size(); ++i) {
-        EXPECT_NEAR(0.0, get_state_data[i], 1e-5);
-        EXPECT_NEAR(0.0, state_data[0][i], 1e-5);
+        ASSERT_NEAR(0.0, get_state_data[i], 1e-5);
+        ASSERT_NEAR(0.0, state_data[0][i], 1e-5);
 
-        EXPECT_NEAR(input_data[i], state_data[1][i], 1e-5);
-        EXPECT_NEAR(input_data[i], state_data[2][i], 1e-5);
+        ASSERT_NEAR(input_data[i], state_data[1][i], 1e-5);
+        ASSERT_NEAR(input_data[i], state_data[2][i], 1e-5);
     }
 
     inference_request = {};
@@ -2333,7 +2331,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRawMemoryIsDestroyedAndReallocatedAft
         logs.clear();
 
         for (size_t j = 0; j < shape_size; ++j) {
-            EXPECT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
+            ASSERT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
                 << "Run " << i << ": Expected=" << input_data[j] + 1.0f << ", actual=" << output_data[j]
                 << " for index " << j;
         }
@@ -2400,7 +2398,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameRawMemoryMultipleTimes
         logs.clear();
 
         for (size_t j = 0; j < shape_size; ++j) {
-            EXPECT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
+            ASSERT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
                 << "Run " << i << ": Expected=" << input_data[j] + 1.0f << ", actual=" << output_data[j]
                 << " for index " << j;
         }
@@ -2464,7 +2462,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameZeroTensorMultipleTime
         logs.clear();
 
         for (size_t j = 0; j < shape_size; ++j) {
-            EXPECT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
+            ASSERT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
                 << "Run " << i << ": Expected=" << input_data[j] + 1.0f << ", actual=" << output_data[j]
                 << " for index " << j;
         }
@@ -2527,7 +2525,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameZeroHostTensorMultiple
         logs.clear();
 
         for (size_t j = 0; j < shape_size; ++j) {
-            EXPECT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
+            ASSERT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
                 << "Run " << i << ": Expected=" << input_data[j] + 1.0f << ", actual=" << output_data[j]
                 << " for index " << j;
         }
@@ -2570,7 +2568,7 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameRawMemoryMultipleTimes
         OV_ASSERT_NO_THROW(inference_request.infer());
 
         for (size_t j = 0; j < shape_size; ++j) {
-            EXPECT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
+            ASSERT_NEAR(output_data[j], input_data[j] + 1.0f, 1e-5)
                 << "Run " << i << ": Expected=" << input_data[j] + 1.0f << ", actual=" << output_data[j]
                 << " for index " << j;
         }
@@ -2813,6 +2811,230 @@ TEST_P(DynamicBoundsTests, ExpectErrorFromWrongTensorShape) {
     OV_EXPECT_THROW(req.set_output_tensor(output_tensor),
                     ov::Exception,
                     HasSubstr("The tensor shape is not compatible with the model input/output shape"));
+}
+
+using ExecutorsConfig = InferRequestRunTests;
+
+TEST_P(ExecutorsConfig, SetExclusiveAsyncRequestsAndTilesCheckResults) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    ov::threading::executor_manager()->clear();
+    auto shape = Shape{1, 2, 64, 64};
+    auto shape_size = ov::shape_size(shape);
+    auto model = createModel(element::f32, shape, "N...");
+
+    ov::CompiledModel compiled_model0, compiled_model1;
+
+    auto context = core->get_default_context(target_device);
+
+    configuration[ov::internal::exclusive_async_requests.name()] = true;
+    configuration[ov::intel_npu::tiles.name()] = 2;
+    compiled_model0 = core->compile_model(model, target_device, configuration);
+    compiled_model1 = core->compile_model(model, target_device, configuration);
+
+    const uint32_t inferences = 32;
+    std::array<ov::InferRequest, inferences> inference_request;
+    ov::Tensor input_tensor;
+    std::array<ov::Tensor, inferences> output_tensor;
+
+    input_tensor = context.create_host_tensor(ov::element::f32, shape);
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i] =
+            i % 2 == 0 ? compiled_model0.create_infer_request() : compiled_model1.create_infer_request();
+        output_tensor[i] = context.create_host_tensor(ov::element::f32, shape);
+    }
+
+    inference_request[0].set_input_tensor(input_tensor);
+    inference_request[0].set_output_tensor(output_tensor[0]);
+
+    const uint32_t runs = 10;
+    for (uint32_t z = 0; z < runs; z++) {
+        auto* input_data = reinterpret_cast<float*>(input_tensor.data());
+        for (size_t i = 0; i < shape_size; ++i) {
+            input_data[i] = static_cast<float>(z);
+        }
+
+        inference_request[0].start_async();  // Adds '1' to each element
+
+        for (uint32_t i = 1; i < inferences; i++) {
+            inference_request[i].set_input_tensor(output_tensor[i - 1]);
+            inference_request[i].set_output_tensor(output_tensor[i]);
+
+            inference_request[i].start_async();  // Adds '1' to each element
+        }
+
+        inference_request[inferences - 1].wait();
+
+        float expected_result = static_cast<float>(z) + 1.f;
+
+        for (uint32_t i = 0; i < inferences; i++) {
+            auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
+            for (size_t j = 0; j < shape_size; ++j) {
+                ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                    << "Run=" << z << "Output=" << i << " Expected=" << expected_result
+                    << ", actual=" << output_tensor_data[j] << " for index " << j;
+            }
+            expected_result++;
+        }
+    }
+
+    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> initStructs = ::intel_npu::ZeroInitStructsHolder::getInstance();
+    if (initStructs->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1)) {
+        ASSERT_EQ(3u, ov::threading::executor_manager()->get_executors_number());
+    } else {
+        ASSERT_EQ(2u, ov::threading::executor_manager()->get_executors_number());
+    }
+}
+
+TEST_P(ExecutorsConfig, SetExclusiveAsyncRequestsAndThroughputCheckResults) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    ov::threading::executor_manager()->clear();
+    auto shape = Shape{1, 2, 64, 64};
+    auto shape_size = ov::shape_size(shape);
+    auto model = createModel(element::f32, shape, "N...");
+
+    ov::CompiledModel compiled_model0, compiled_model1;
+
+    auto context = core->get_default_context(target_device);
+
+    configuration[ov::internal::exclusive_async_requests.name()] = true;
+    configuration[ov::hint::performance_mode.name()] = ov::hint::PerformanceMode::THROUGHPUT;
+    compiled_model0 = core->compile_model(model, target_device, configuration);
+    compiled_model1 = core->compile_model(model, target_device, configuration);
+
+    const uint32_t inferences = 32;
+    std::array<ov::InferRequest, inferences> inference_request;
+    ov::Tensor input_tensor;
+    std::array<ov::Tensor, inferences> output_tensor;
+
+    input_tensor = context.create_host_tensor(ov::element::f32, shape);
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i] =
+            i % 2 == 0 ? compiled_model0.create_infer_request() : compiled_model1.create_infer_request();
+        output_tensor[i] = context.create_host_tensor(ov::element::f32, shape);
+    }
+
+    inference_request[0].set_input_tensor(input_tensor);
+    inference_request[0].set_output_tensor(output_tensor[0]);
+
+    const uint32_t runs = 10;
+    for (uint32_t z = 0; z < runs; z++) {
+        auto* input_data = reinterpret_cast<float*>(input_tensor.data());
+        for (size_t i = 0; i < shape_size; ++i) {
+            input_data[i] = static_cast<float>(z);
+        }
+
+        inference_request[0].start_async();  // Adds '1' to each element
+
+        for (uint32_t i = 1; i < inferences; i++) {
+            inference_request[i].set_input_tensor(output_tensor[i - 1]);
+            inference_request[i].set_output_tensor(output_tensor[i]);
+
+            inference_request[i].start_async();  // Adds '1' to each element
+        }
+
+        inference_request[inferences - 1].wait();
+
+        float expected_result = static_cast<float>(z) + 1.f;
+
+        for (uint32_t i = 0; i < inferences; i++) {
+            auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
+            for (size_t j = 0; j < shape_size; ++j) {
+                ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                    << "Run=" << z << "Output=" << i << " Expected=" << expected_result
+                    << ", actual=" << output_tensor_data[j] << " for index " << j;
+            }
+            expected_result++;
+        }
+    }
+
+    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> initStructs = ::intel_npu::ZeroInitStructsHolder::getInstance();
+    if (initStructs->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1)) {
+        ASSERT_EQ(3u, ov::threading::executor_manager()->get_executors_number());
+    } else {
+        ASSERT_EQ(2u, ov::threading::executor_manager()->get_executors_number());
+    }
+}
+
+TEST_P(ExecutorsConfig, SetNumStreamsTo0CheckResults) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    auto shape = Shape{1, 2, 64, 64};
+    auto shape_size = ov::shape_size(shape);
+    auto model = createModel(element::f32, shape, "N...");
+
+    configuration[ov::num_streams.name()] = 0;
+    auto compiled_model = core->compile_model(model, target_device, configuration);
+    const uint32_t inferences = 32;
+    std::array<ov::InferRequest, inferences> inference_request;
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i] = compiled_model.create_infer_request();
+
+        auto input_tensor = inference_request[i].get_input_tensor();
+        auto* input_data = reinterpret_cast<float*>(input_tensor.data());
+        for (size_t j = 0; j < shape_size; ++j) {
+            input_data[j] = static_cast<float>(i);
+        }
+    }
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i].start_async();
+    }
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i].wait();
+    }
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        float expected_result = static_cast<float>(i) + 1.f;
+        auto output_tensor = inference_request[i].get_output_tensor();
+        auto* output_tensor_data = reinterpret_cast<float*>(output_tensor.data());
+        for (size_t j = 0; j < shape_size; ++j) {
+            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                << "Inference=" << i << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
+                << " for index " << j;
+        }
+    }
+}
+
+TEST_P(ExecutorsConfig, SetNumStreamsTo2CheckResults) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    auto shape = Shape{1, 2, 64, 64};
+    auto shape_size = ov::shape_size(shape);
+    auto model = createModel(element::f32, shape, "N...");
+
+    configuration[ov::num_streams.name()] = 2;
+    auto compiled_model = core->compile_model(model, target_device, configuration);
+    const uint32_t inferences = 32;
+    std::array<ov::InferRequest, inferences> inference_request;
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i] = compiled_model.create_infer_request();
+
+        auto input_tensor = inference_request[i].get_input_tensor();
+        auto* input_data = reinterpret_cast<float*>(input_tensor.data());
+        for (size_t j = 0; j < shape_size; ++j) {
+            input_data[j] = static_cast<float>(i);
+        }
+    }
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i].start_async();
+    }
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i].wait();
+    }
+
+    for (uint32_t i = 0; i < inferences; i++) {
+        float expected_result = static_cast<float>(i) + 1.f;
+        auto output_tensor = inference_request[i].get_output_tensor();
+        auto* output_tensor_data = reinterpret_cast<float*>(output_tensor.data());
+        for (size_t j = 0; j < shape_size; ++j) {
+            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                << "Inference=" << i << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
+                << " for index " << j;
+        }
+    }
 }
 
 }  // namespace behavior

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
@@ -2813,9 +2813,9 @@ TEST_P(DynamicBoundsTests, ExpectErrorFromWrongTensorShape) {
                     HasSubstr("The tensor shape is not compatible with the model input/output shape"));
 }
 
-using ExecutorsConfig = InferRequestRunTests;
+using ExclusiveAsyncRequestsTests = InferRequestRunTests;
 
-TEST_P(ExecutorsConfig, SetExclusiveAsyncRequestsAndTilesCheckResults) {
+TEST_P(ExclusiveAsyncRequestsTests, SetExclusiveAsyncRequestsCheckResults) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
     ov::threading::executor_manager()->clear();
     auto shape = Shape{1, 2, 64, 64};
@@ -2826,8 +2826,6 @@ TEST_P(ExecutorsConfig, SetExclusiveAsyncRequestsAndTilesCheckResults) {
 
     auto context = core->get_default_context(target_device);
 
-    configuration[ov::internal::exclusive_async_requests.name()] = true;
-    configuration[ov::intel_npu::tiles.name()] = 2;
     compiled_model0 = core->compile_model(model, target_device, configuration);
     compiled_model1 = core->compile_model(model, target_device, configuration);
 
@@ -2885,166 +2883,14 @@ TEST_P(ExecutorsConfig, SetExclusiveAsyncRequestsAndTilesCheckResults) {
     }
 }
 
-TEST_P(ExecutorsConfig, SetExclusiveAsyncRequestsAndThroughputCheckResults) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    ov::threading::executor_manager()->clear();
-    auto shape = Shape{1, 2, 64, 64};
-    auto shape_size = ov::shape_size(shape);
-    auto model = createModel(element::f32, shape, "N...");
+using NumStreamsTests = InferRequestRunTests;
 
-    ov::CompiledModel compiled_model0, compiled_model1;
-
-    auto context = core->get_default_context(target_device);
-
-    configuration[ov::internal::exclusive_async_requests.name()] = true;
-    configuration[ov::hint::performance_mode.name()] = ov::hint::PerformanceMode::THROUGHPUT;
-    compiled_model0 = core->compile_model(model, target_device, configuration);
-    compiled_model1 = core->compile_model(model, target_device, configuration);
-
-    const uint32_t inferences = 32;
-    std::array<ov::InferRequest, inferences> inference_request;
-    ov::Tensor input_tensor;
-    std::array<ov::Tensor, inferences> output_tensor;
-
-    input_tensor = context.create_host_tensor(ov::element::f32, shape);
-    for (uint32_t i = 0; i < inferences; i++) {
-        inference_request[i] =
-            i % 2 == 0 ? compiled_model0.create_infer_request() : compiled_model1.create_infer_request();
-        output_tensor[i] = context.create_host_tensor(ov::element::f32, shape);
-    }
-
-    inference_request[0].set_input_tensor(input_tensor);
-    inference_request[0].set_output_tensor(output_tensor[0]);
-
-    const uint32_t runs = 10;
-    for (uint32_t z = 0; z < runs; z++) {
-        auto* input_data = reinterpret_cast<float*>(input_tensor.data());
-        for (size_t i = 0; i < shape_size; ++i) {
-            input_data[i] = static_cast<float>(z);
-        }
-
-        inference_request[0].start_async();  // Adds '1' to each element
-
-        for (uint32_t i = 1; i < inferences; i++) {
-            inference_request[i].set_input_tensor(output_tensor[i - 1]);
-            inference_request[i].set_output_tensor(output_tensor[i]);
-
-            inference_request[i].start_async();  // Adds '1' to each element
-        }
-
-        inference_request[inferences - 1].wait();
-
-        float expected_result = static_cast<float>(z) + 1.f;
-
-        for (uint32_t i = 0; i < inferences; i++) {
-            auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
-            for (size_t j = 0; j < shape_size; ++j) {
-                ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
-                    << "Run=" << z << "Output=" << i << " Expected=" << expected_result
-                    << ", actual=" << output_tensor_data[j] << " for index " << j;
-            }
-            expected_result++;
-        }
-    }
-
-    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> initStructs = ::intel_npu::ZeroInitStructsHolder::getInstance();
-    if (initStructs->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1)) {
-        ASSERT_EQ(3u, ov::threading::executor_manager()->get_executors_number());
-    } else {
-        ASSERT_EQ(2u, ov::threading::executor_manager()->get_executors_number());
-    }
-}
-
-TEST_P(ExecutorsConfig, SetNumStreamsTo0CheckResults) {
+TEST_P(NumStreamsTests, RunWithDifferentNumStreamsCheckResults) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
     auto shape = Shape{1, 2, 64, 64};
     auto shape_size = ov::shape_size(shape);
     auto model = createModel(element::f32, shape, "N...");
 
-    configuration[ov::num_streams.name()] = 0;
-    auto compiled_model = core->compile_model(model, target_device, configuration);
-    const uint32_t inferences = 32;
-    std::array<ov::InferRequest, inferences> inference_request;
-
-    for (uint32_t i = 0; i < inferences; i++) {
-        inference_request[i] = compiled_model.create_infer_request();
-
-        auto input_tensor = inference_request[i].get_input_tensor();
-        auto* input_data = reinterpret_cast<float*>(input_tensor.data());
-        for (size_t j = 0; j < shape_size; ++j) {
-            input_data[j] = static_cast<float>(i);
-        }
-    }
-
-    for (uint32_t i = 0; i < inferences; i++) {
-        inference_request[i].start_async();
-    }
-
-    for (uint32_t i = 0; i < inferences; i++) {
-        inference_request[i].wait();
-    }
-
-    for (uint32_t i = 0; i < inferences; i++) {
-        float expected_result = static_cast<float>(i) + 1.f;
-        auto output_tensor = inference_request[i].get_output_tensor();
-        auto* output_tensor_data = reinterpret_cast<float*>(output_tensor.data());
-        for (size_t j = 0; j < shape_size; ++j) {
-            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
-                << "Inference=" << i << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
-                << " for index " << j;
-        }
-    }
-}
-
-TEST_P(ExecutorsConfig, SetNumStreamsTo2CheckResults) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    auto shape = Shape{1, 2, 64, 64};
-    auto shape_size = ov::shape_size(shape);
-    auto model = createModel(element::f32, shape, "N...");
-
-    configuration[ov::num_streams.name()] = 2;
-    auto compiled_model = core->compile_model(model, target_device, configuration);
-    const uint32_t inferences = 32;
-    std::array<ov::InferRequest, inferences> inference_request;
-
-    for (uint32_t i = 0; i < inferences; i++) {
-        inference_request[i] = compiled_model.create_infer_request();
-
-        auto input_tensor = inference_request[i].get_input_tensor();
-        auto* input_data = reinterpret_cast<float*>(input_tensor.data());
-        for (size_t j = 0; j < shape_size; ++j) {
-            input_data[j] = static_cast<float>(i);
-        }
-    }
-
-    for (uint32_t i = 0; i < inferences; i++) {
-        inference_request[i].start_async();
-    }
-
-    for (uint32_t i = 0; i < inferences; i++) {
-        inference_request[i].wait();
-    }
-
-    for (uint32_t i = 0; i < inferences; i++) {
-        float expected_result = static_cast<float>(i) + 1.f;
-        auto output_tensor = inference_request[i].get_output_tensor();
-        auto* output_tensor_data = reinterpret_cast<float*>(output_tensor.data());
-        for (size_t j = 0; j < shape_size; ++j) {
-            ASSERT_NEAR(output_tensor_data[j], expected_result, 1e-5)
-                << "Inference=" << i << " Expected=" << expected_result << ", actual=" << output_tensor_data[j]
-                << " for index " << j;
-        }
-    }
-}
-
-TEST_P(ExecutorsConfig, SetNumStreamsTo8AndEnableCpuPinningCheckResults) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    auto shape = Shape{1, 2, 64, 64};
-    auto shape_size = ov::shape_size(shape);
-    auto model = createModel(element::f32, shape, "N...");
-
-    configuration[ov::num_streams.name()] = 8;
-    configuration[ov::hint::enable_cpu_pinning.name()] = true;
     auto compiled_model = core->compile_model(model, target_device, configuration);
     const uint32_t inferences = 32;
     std::array<ov::InferRequest, inferences> inference_request;

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/properties_tests.cpp
@@ -13,7 +13,7 @@ namespace {
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                          InferRequestPropertiesTest,
-                         ::testing::Combine(::testing::Values(2u),
+                         ::testing::Combine(::testing::Values(3u),
                                             ::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(std::vector<ov::AnyMap>{{}})),
                          ov::test::utils::appendPlatformTypeTestName<InferRequestPropertiesTest>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -78,7 +78,7 @@ const std::vector<ov::AnyMap> compat_CorrectPluginDefaultMutableProperties = {
     {{ov::hint::num_requests.name(), 1u}},
     {{ov::log::level.name(), getTestsLogLevelFromEnvironmentOr(ov::log::Level::WARNING)}},
     {{ov::device::id.name(), ""}},
-    {{ov::num_streams.name(), ov::streams::Num(1)}},
+    {{ov::num_streams.name(), ov::streams::AUTO}},
 };
 
 const std::vector<ov::AnyMap> CorrectPluginDefaultMutableProperties = {
@@ -117,7 +117,6 @@ const std::vector<ov::AnyMap> CorrectCompiledModelProperties = {
 };
 
 const std::vector<ov::AnyMap> IncorrectImmutableProperties = {
-    {{ov::streams::num.name(), ov::streams::Num(2)}},
     {{ov::optimal_number_of_infer_requests.name(), 4}},
     {{ov::intel_npu::device_alloc_mem_size.name(), 1024}},
     {{ov::intel_npu::device_total_mem_size.name(), 2048}},

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -913,7 +913,7 @@ Example:
         </enable_rules>
         <filters>
             <filter>.*InferRequestPropertiesTest.canSetExclusiveAsyncRequests.*</filter>
-            <filter>.*ExecutorsConfig.SetExclusiveAsyncRequestsAndTilesCheckResults.*</filter>
+            <filter>.*ExclusiveAsyncRequestsTests.SetExclusiveAsyncRequestsCheckResults.*configItem=NPU_TILES_2.*</filter>
         </filters>
     </skip_config>
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -186,7 +186,6 @@ Example:
     <skip_config>
         <message>TensorIterator layer is not supported</message>
         <filters>
-            <filter>.*ReturnResultNotReadyFromWaitInAsyncModeForTooSmallTimeout.*</filter>
             <filter>.*OVInferRequestDynamicTests.*</filter>
             <filter>.*OVInferenceChaining.*</filter>
         </filters>
@@ -397,17 +396,6 @@ Example:
             <filter>.*IEClassGetMetricAndPrintNoThrow.*</filter>
             <filter>.*CompileModelLoadFromFileTestBase.*</filter>
             <filter>.*CorrectConfigTests.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#85493 -->
-    <skip_config>
-        <message>Runs only on NPU3720 with Level Zero enabled #85493</message>
-        <enable_rules>
-            <device>!3720</device>
-        </enable_rules>
-        <filters>
-            <filter>.*InferRequestRunTests.MultipleExecutorStreamsTestsSyncInfers.*</filter>
         </filters>
     </skip_config>
 
@@ -914,6 +902,18 @@ Example:
             <filter>.*OVPropertiesDefaultSupportedTests.CanSetDefaultValueBackToPlugin.*</filter>
             <filter>.*OVClassCompiledModelGetConfigTest.GetConfigNoThrow.*</filter>
             <filter>.*OVSpecificDeviceGetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>For PV driver streamExecutorNumber is different and NPU_TILES is not supported</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <driver_version>1688</driver_version>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestPropertiesTest.canSetExclusiveAsyncRequests.*</filter>
+            <filter>.*ExecutorsConfig.SetExclusiveAsyncRequestsAndTilesCheckResults.*</filter>
         </filters>
     </skip_config>
 

--- a/src/tests/functional/base_func_tests/include/behavior/ov_infer_request/properties_tests.hpp
+++ b/src/tests/functional/base_func_tests/include/behavior/ov_infer_request/properties_tests.hpp
@@ -108,7 +108,7 @@ TEST_P(InferRequestPropertiesTest, ReusableCPUStreamsExecutor) {
         execNet = core->compile_model(function, target_device, config);
         auto req = execNet.create_infer_request();
         if (target_device == ov::test::utils::DEVICE_NPU) {
-            ASSERT_EQ(1u, ov::threading::executor_manager()->get_executors_number());
+            ASSERT_EQ(0u, ov::threading::executor_manager()->get_executors_number());
             ASSERT_EQ(0u, ov::threading::executor_manager()->get_idle_cpu_streams_executors_number());
         } else if ((target_device == ov::test::utils::DEVICE_AUTO) ||
                    (target_device == ov::test::utils::DEVICE_MULTI)) {


### PR DESCRIPTION
### Details:
Provide a different logic for how many threads per executor are used in the NPU plugin (We have 3 executors per compiled model in the NPU Plugin, one to start inferences, one to wait for inferences, and another one to run the callback):
- In the default case(AUTO), set no of streams per wait and callback executors as the optimal number for inference requests in parallel in case of Throughput mode, and 1 for starting inferences
- Use the num_streams property to change the number of streams per executor in the user set. All the time will have 3(executors) * no of streams. (num_strems property will be R/W after this PR)
- There are special cases when even if the inferences are starting with async_request, they are expected to run sequentially, and for that specific case, we will have only one stream per executor.

### Tickets:
 - *CVS-186966*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
