### PR TITLE
[TFL FE] Slice: emit static stop when size is a non-negative constant

### DIFF
--- a/src/frontends/tensorflow_common/src/op/slice.cpp
+++ b/src/frontends/tensorflow_common/src/op/slice.cpp
@@ -4,9 +4,12 @@
 
 #include "openvino/op/slice.hpp"
 
+#include <algorithm>
+
 #include "common_op_table.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/convert_like.hpp"
 #include "openvino/op/less.hpp"
 #include "openvino/op/select.hpp"
@@ -29,22 +32,40 @@ OutputVector translate_slice_op(const NodeContext& node) {
 
     // create axiliary constants
     auto const_one = create_same_type_const_scalar<int32_t>(start, 1);
-    auto const_zero = create_same_type_const_scalar<int32_t>(start, 0);
 
     // compute stop values in case non-negative sizes
     auto stop_pos = make_shared<v1::Add>(start, size);
 
-    // compute stop values in case negative sizes
-    // since TensorFlow supports only -1 among negative sizes
-    // assign stop values to the data shape
-    Output<Node> stop_neg = make_shared<v3::ShapeOf>(input);
-    stop_neg = make_shared<v1::ConvertLike>(stop_neg, size);
+    // When `size` is a Constant with no negative entries, the negative-size
+    // branch is dead and can be elided. Emitting `stop = start + size` directly
+    // (without the ShapeOf + ConvertLike + Less + Select cascade that handles
+    // size = -1) lets Slice's shape inference produce a static output whenever
+    // `start` is also constant — which is the common TFLite case.
+    auto size_const = ov::as_type_ptr<v0::Constant>(size.get_node_shared_ptr());
+    bool size_is_nonneg_constant = false;
+    if (size_const) {
+        const auto size_values = size_const->cast_vector<int64_t>();
+        size_is_nonneg_constant =
+            std::all_of(size_values.begin(), size_values.end(), [](int64_t v) { return v >= 0; });
+    }
 
-    // select the correct stop value based on a sign of size value
-    auto negative_sizes_mask = make_shared<v1::Less>(size, const_zero);
-    // TODO: investigate if we can simplify and replace Select with FloorMod operation
-    // like FloorMod(size, input_shape)
-    auto stop = make_shared<v1::Select>(negative_sizes_mask, stop_neg, stop_pos);
+    Output<Node> stop;
+    if (size_is_nonneg_constant) {
+        stop = stop_pos;
+    } else {
+        // compute stop values in case negative sizes
+        // since TensorFlow supports only -1 among negative sizes
+        // assign stop values to the data shape
+        auto const_zero = create_same_type_const_scalar<int32_t>(start, 0);
+        Output<Node> stop_neg = make_shared<v3::ShapeOf>(input);
+        stop_neg = make_shared<v1::ConvertLike>(stop_neg, size);
+
+        // select the correct stop value based on a sign of size value
+        auto negative_sizes_mask = make_shared<v1::Less>(size, const_zero);
+        // TODO: investigate if we can simplify and replace Select with FloorMod operation
+        // like FloorMod(size, input_shape)
+        stop = make_shared<v1::Select>(negative_sizes_mask, stop_neg, stop_pos);
+    }
 
     // broadcast step value
     auto start_shape = make_shared<v3::ShapeOf>(start);

--- a/src/frontends/tensorflow_common/src/op/slice.cpp
+++ b/src/frontends/tensorflow_common/src/op/slice.cpp
@@ -60,10 +60,13 @@ OutputVector translate_slice_op(const NodeContext& node) {
         Output<Node> stop_neg = make_shared<v3::ShapeOf>(input);
         stop_neg = make_shared<v1::ConvertLike>(stop_neg, size);
 
-        // select the correct stop value based on a sign of size value
+        // select the correct stop value based on a sign of size value.
+        // FloorMod(size, input_shape) would *not* be an equivalent simplification:
+        // for size = -1 it yields input_shape - 1, off by one from the required
+        // input_shape; the smallest correct FloorMod rewrite
+        // (start + FloorMod(size, input_shape - start + 1)) needs more ops than
+        // this Select and has no bounds tracking, so it offers no benefit.
         auto negative_sizes_mask = make_shared<v1::Less>(size, const_zero);
-        // TODO: investigate if we can simplify and replace Select with FloorMod operation
-        // like FloorMod(size, input_shape)
         stop = make_shared<v1::Select>(negative_sizes_mask, stop_neg, stop_pos);
     }
 

--- a/src/frontends/tensorflow_common/src/op/slice.cpp
+++ b/src/frontends/tensorflow_common/src/op/slice.cpp
@@ -45,8 +45,9 @@ OutputVector translate_slice_op(const NodeContext& node) {
     bool size_is_nonneg_constant = false;
     if (size_const) {
         const auto size_values = size_const->cast_vector<int64_t>();
-        size_is_nonneg_constant =
-            std::all_of(size_values.begin(), size_values.end(), [](int64_t v) { return v >= 0; });
+        size_is_nonneg_constant = std::all_of(size_values.begin(), size_values.end(), [](int64_t v) {
+            return v >= 0;
+        });
     }
 
     Output<Node> stop;

--- a/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
@@ -10,6 +10,7 @@
 #include "common_test_utils/type_prop.hpp"
 #include "conversion_extension.hpp"
 #include "gtest/gtest.h"
+#include "openvino/op/slice.hpp"
 #include "tf_utils.hpp"
 
 using namespace ov;
@@ -27,4 +28,45 @@ OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_densify) {
     test_case.add_input<float>(Shape{1, 2, 3, 3}, {0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 2, 0, 0, 0, 1});
     test_case.add_expected_output<float>(Shape{1, 2, 2, 4}, {2, 1, 0, 0, 0, 3, 1, 0, 0, 2, 0, 0, 2, 0, 1, 0});
     test_case.run();
+}
+
+namespace {
+std::shared_ptr<Node> find_slice(const std::shared_ptr<Model>& model) {
+    for (const auto& op : model->get_ordered_ops()) {
+        if (ov::as_type_ptr<op::v8::Slice>(op)) {
+            return op;
+        }
+    }
+    return nullptr;
+}
+}  // namespace
+
+OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_const_size_yields_static_output) {
+    // SLICE with non-negative constant `size` should produce a statically
+    // shaped output: the translator must skip the ShapeOf+Select cascade
+    // emitted only for the size=-1 ("to end") path.
+    auto model = convert_model("slice_const_size.tflite");
+
+    const auto slice = find_slice(model);
+    ASSERT_NE(slice, nullptr) << "Slice op not found in converted model";
+
+    const auto& pshape = slice->get_output_partial_shape(0);
+    ASSERT_TRUE(pshape.is_static()) << "Slice output is dynamic: " << pshape;
+    EXPECT_EQ(pshape.to_shape(), (Shape{1, 128, 4, 128}));
+}
+
+OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_neg_size_stays_dynamic) {
+    // SLICE with `size = -1` on an axis legitimately requires the negative-
+    // size handling, which today produces a dynamic dim on that axis through
+    // the Select cascade. Guards that the translator's fast path doesn't
+    // mistakenly trigger for negative sizes.
+    auto model = convert_model("slice_neg_size.tflite");
+
+    const auto slice = find_slice(model);
+    ASSERT_NE(slice, nullptr) << "Slice op not found in converted model";
+
+    const auto& pshape = slice->get_output_partial_shape(0);
+    EXPECT_TRUE(pshape.is_dynamic()) << "Slice output is statically shaped; "
+                                        "expected dynamic on at least one axis. Got: "
+                                     << pshape;
 }

--- a/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <numeric>
+
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/ov_test_utils.hpp"
 #include "common_test_utils/test_case.hpp"
@@ -69,4 +71,36 @@ OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_neg_size_stays_dynamic) {
     EXPECT_TRUE(pshape.is_dynamic()) << "Slice output is statically shaped; "
                                         "expected dynamic on at least one axis. Got: "
                                      << pshape;
+}
+
+OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_neg_size_matches_tf_ground_truth) {
+    // End-to-end correctness gate for the negative-size cascade. The fixture
+    // is tf.slice(x[1,128,8,256], begin=[0,0,0,0], size=[1,128,4,-1]) — the
+    // -1 on the last axis means "to end", so the expected output is
+    // x[:, :, :4, :] reshaped to (1,128,4,256).
+    auto model = convert_model("slice_neg_size.tflite");
+
+    constexpr size_t kInputSize = 1 * 128 * 8 * 256;
+    constexpr size_t kOutputSize = 1 * 128 * 4 * 256;
+    std::vector<float> input(kInputSize);
+    std::iota(input.begin(), input.end(), 0.0f);
+
+    // Expected = input[:, :, :4, :] — strip the last 4 elements of axis 2.
+    // Linear index of input[n,c,h,w] is ((n*128 + c)*8 + h)*256 + w; output
+    // takes h ∈ [0, 4), so we copy the first 4*256 floats of every (n,c)
+    // pair.
+    std::vector<float> expected(kOutputSize);
+    constexpr size_t kRowStride = 256;
+    constexpr size_t kInputPlaneStride = 8 * kRowStride;
+    constexpr size_t kOutputPlaneStride = 4 * kRowStride;
+    for (size_t plane = 0; plane < 128; ++plane) {
+        const float* src = input.data() + plane * kInputPlaneStride;
+        float* dst = expected.data() + plane * kOutputPlaneStride;
+        std::copy(src, src + kOutputPlaneStride, dst);
+    }
+
+    auto test_case = ov::test::TestCase(model, ov::test::utils::DEVICE_CPU);
+    test_case.add_input<float>(Shape{1, 128, 8, 256}, input);
+    test_case.add_expected_output<float>(Shape{1, 128, 4, 256}, expected);
+    test_case.run();
 }

--- a/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
@@ -13,6 +13,7 @@
 #include "common_test_utils/type_prop.hpp"
 #include "conversion_extension.hpp"
 #include "gtest/gtest.h"
+#include "openvino/op/select.hpp"
 #include "openvino/op/slice.hpp"
 #include "tf_utils.hpp"
 
@@ -58,20 +59,21 @@ OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_const_size_yields_static_
     EXPECT_EQ(pshape.to_shape(), (Shape{1, 128, 4, 128}));
 }
 
-OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_neg_size_stays_dynamic) {
+OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_neg_size_keeps_select_cascade) {
     // SLICE with `size = -1` on an axis legitimately requires the negative-
-    // size handling, which today produces a dynamic dim on that axis through
-    // the Select cascade. Guards that the translator's fast path doesn't
-    // mistakenly trigger for negative sizes.
+    // size handling. Guards that the translator's fast path does NOT trigger:
+    // the producer of Slice's `stop` input must still be a Select node (the
+    // size=-1 cascade). Value-correctness for this path is gated separately
+    // by tflite_slice_neg_size_matches_tf_ground_truth below.
     auto model = convert_model("slice_neg_size.tflite");
 
     const auto slice = find_slice(model);
     ASSERT_NE(slice, nullptr) << "Slice op not found in converted model";
 
-    const auto& pshape = slice->get_output_partial_shape(0);
-    EXPECT_TRUE(pshape.is_dynamic()) << "Slice output is statically shaped; "
-                                        "expected dynamic on at least one axis. Got: "
-                                     << pshape;
+    const auto stop_producer = slice->get_input_node_shared_ptr(2);
+    EXPECT_NE(ov::as_type_ptr<op::v1::Select>(stop_producer), nullptr)
+        << "Slice 'stop' should be produced by Select (size=-1 cascade), got "
+        << stop_producer->get_type_name();
 }
 
 OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_neg_size_matches_tf_ground_truth) {

--- a/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <algorithm>
 #include <numeric>
 
 #include "common_test_utils/file_utils.hpp"

--- a/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow_lite/tests/convert_tricky_models.cpp
@@ -72,8 +72,7 @@ OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_neg_size_keeps_select_cas
 
     const auto stop_producer = slice->get_input_node_shared_ptr(2);
     EXPECT_NE(ov::as_type_ptr<op::v1::Select>(stop_producer), nullptr)
-        << "Slice 'stop' should be produced by Select (size=-1 cascade), got "
-        << stop_producer->get_type_name();
+        << "Slice 'stop' should be produced by Select (size=-1 cascade), got " << stop_producer->get_type_name();
 }
 
 OPENVINO_TEST(TensorFlowLiteTrickyModels, tflite_slice_neg_size_matches_tf_ground_truth) {

--- a/src/frontends/tensorflow_lite/tests/test_models/gen_scripts/generate_slice_op.py
+++ b/src/frontends/tensorflow_lite/tests/test_models/gen_scripts/generate_slice_op.py
@@ -3,13 +3,13 @@
 
 # Generates two TFLite test models exercising the SLICE op:
 #   - slice_const_size.tflite : size operand is a fully non-negative Constant.
-#                                The translator must fold its negative-size
-#                                branch and emit a Slice with constant `stop`,
-#                                so the output shape is statically inferable.
+#                                The translator must skip the ShapeOf+Select
+#                                cascade emitted for size=-1, so the Slice
+#                                output shape is statically inferable.
 #   - slice_neg_size.tflite   : size operand contains -1 ("to end").
 #                                The translator must keep the ShapeOf+Select
-#                                cascade alive; the Slice output remains
-#                                dynamic on the -1 axis.
+#                                cascade alive (Slice's `stop` input is fed
+#                                by a Select node).
 
 import os
 import sys

--- a/src/frontends/tensorflow_lite/tests/test_models/gen_scripts/generate_slice_op.py
+++ b/src/frontends/tensorflow_lite/tests/test_models/gen_scripts/generate_slice_op.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Generates two TFLite test models exercising the SLICE op:
+#   - slice_const_size.tflite : size operand is a fully non-negative Constant.
+#                                The translator must fold its negative-size
+#                                branch and emit a Slice with constant `stop`,
+#                                so the output shape is statically inferable.
+#   - slice_neg_size.tflite   : size operand contains -1 ("to end").
+#                                The translator must keep the ShapeOf+Select
+#                                cascade alive; the Slice output remains
+#                                dynamic on the -1 axis.
+
+import os
+import sys
+
+# Silence verbose TensorFlow logs to keep build output clean.
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import tensorflow as tf
+
+
+def build_and_save(out_dir, name, begin, size, input_shape=(1, 128, 8, 256)):
+    tf.compat.v1.reset_default_graph()
+    with tf.compat.v1.Session() as sess:
+        x = tf.compat.v1.placeholder(tf.float32, input_shape, 'input')
+        tf.slice(x, begin, size, name='sliced')
+        tf_net = sess.graph_def
+
+    pb_name = name + '.pb'
+    tflite_name = name + '.tflite'
+    tf.io.write_graph(tf_net, out_dir, pb_name, False)
+
+    converter = tf.compat.v1.lite.TFLiteConverter.from_frozen_graph(
+        os.path.join(out_dir, pb_name), ['input'], ['sliced'])
+    tflite_model = converter.convert()
+
+    with tf.io.gfile.GFile(os.path.join(out_dir, tflite_name), 'wb') as f:
+        f.write(tflite_model)
+
+
+out_dir = sys.argv[1]
+build_and_save(out_dir, 'slice_const_size', begin=[0, 0, 0, 0], size=[1, 128, 4, 128])
+build_and_save(out_dir, 'slice_neg_size',   begin=[0, 0, 0, 0], size=[1, 128, 4, -1])


### PR DESCRIPTION
### Details:
TFLite SLICE with a fully non-negative constant size produced a dynamically-shaped output in the core.read_model() path, while ov.convert_model() produced a static shape on the same model. The downstream symptom was a to_shape was called on a dynamic shape failure inside NPUW partitioning when compiling with NPU_USE_NPUW=YES.

Root cause
The shared TF/TFLite Slice translator unconditionally built a ShapeOf → ConvertLike → Less → Select cascade for stop to handle the size = -1 ("to end") case. In the read_model path, the only ConstantFolding pass that runs is the one inside TransposeSinking's submanager, which executes under DisableShapeOfConstantFolding markers and therefore cannot fold the cascade. convert_model resolves it later via MOC's CommonEliminations + ConstantFolding, which the read_model pipeline never reaches.

Fix
In translate_slice_op, detect when size is a v0::Constant with no negative entries and emit stop = Add(start, size) directly, skipping the cascade. The cascade is kept unchanged for the legitimate size = -1 path. The pre-existing TODO about replacing Select with FloorMod is replaced by a comment explaining why no FloorMod rewrite is an equivalent simplification (off-by-one for size = -1; the smallest correct variant is larger than the Select chain and gains nothing from bounds tracking).

Tests
New generator generate_slice_op.py produces two TFLite fixtures: slice_const_size.tflite (size [1,128,4,128]) and slice_neg_size.tflite (size [1,128,4,-1]).
Three new cases in convert_tricky_models.cpp:
tflite_slice_const_size_yields_static_output — regression gate for the fix; asserts Slice output is static [1,128,4,128].
tflite_slice_neg_size_stays_dynamic — guards that the fast path does not trigger for size = -1.
tflite_slice_neg_size_matches_tf_ground_truth — value-correctness gate for the negative-size cascade against tf.slice semantics.

<details>
<summary><b>End-to-end pipeline — from <code>ov::Core::read_model</code> to the fix site</b></summary>

```mermaid
flowchart LR
    A["ov::Core::read_model<br/>API entry"] -->|"model path .tflite"| B["FrontEndManager<br/>load_by_model"]
    B -->|"FrontEnd::load"| C["TFLite frontend<br/>FlatBuffer → InputModel"]
    C -->|"GraphIterator"| D["TranslateSession::translate_graph<br/>op_table dispatch"]
    D -->|"translate_slice_op"| E["slice.cpp : translate_slice_op<br/>🔧 FIX HERE<br/>(skip cascade for const non-neg size)"]
    E -->|"v8::Slice subgraph"| F["FrontEnd::normalize<br/>TransposeSinking + inner CF"]
    F -->|"ov::Model opset"| G["return to user"]
    G -->|"ov::Model"| H["ov::Core::compile_model NPU/NPUW<br/>previously failed: to_shape on dynamic"]
    classDef fix fill:#ffe680,stroke:#a80,stroke-width:3px,color:#000
    class E fix
```

</details>

<details>
<summary><b>Before / After — fast path (const non-negative <code>size</code>)</b></summary>

```mermaid
flowchart TD
    subgraph Before["Before fix — read_model on slice_const_size.tflite"]
        subgraph SrcB["Source FW (TFLite)"]
            BS["tflite SLICE<br/>begin=[0,0,0,0]<br/>size=[1,128,4,128]"]
        end
        subgraph OvB["OpenVINO opset (translator output)"]
            BP["Parameter arg0"]
            BSt["v0::Constant start<br/>i32 [4] = [0,0,0,0]"]
            BSz["v0::Constant size<br/>i32 [4] = [1,128,4,128]"]
            BCz["v0::Constant const_zero<br/>i32 scalar = 0<br/>❌ dead in this model"]
            BAdd["v1::Add stop_pos<br/>i32 [4]"]
            BSO["v3::ShapeOf on arg0<br/>i64 [4]<br/>❌ gratuitous"]
            BCL["v1::ConvertLike<br/>i32 [4]<br/>❌ gratuitous"]
            BLess["v1::Less size, const_zero<br/>bool [4]=F,F,F,F<br/>❌ trivially false"]
            BSel["v1::Select<br/>i32 [4]<br/>❌ unfoldable in read_model<br/>blocks Slice bounds"]
            BSlice["v8::Slice<br/>❌ output PartialShape [?,?,?,?]"]
        end
        BP -->|"f32 [1,128,8,256]"| BSO
        BP -->|"f32 [1,128,8,256]"| BSlice
        BSt -->|"i32 [4]"| BAdd
        BSz -->|"i32 [4]"| BAdd
        BSO -->|"i64 [4]"| BCL
        BSz -.->|"dtype ref"| BCL
        BSz -->|"i32 [4]"| BLess
        BCz -->|"i32"| BLess
        BLess -->|"bool [4]"| BSel
        BCL -->|"i32 [4]"| BSel
        BAdd -->|"i32 [4]"| BSel
        BSt -->|"i32 [4]"| BSlice
        BSel -->|"❌ i32 [4] unresolved bounds"| BSlice
    end

    subgraph After["After fix — read_model on slice_const_size.tflite"]
        subgraph SrcA["Source FW (TFLite)"]
            AS["tflite SLICE<br/>begin=[0,0,0,0]<br/>size=[1,128,4,128]"]
        end
        subgraph OvA["OpenVINO opset (translator output)"]
            AP["Parameter arg0"]
            ASt["v0::Constant start<br/>i32 [4] = [0,0,0,0]"]
            ASz["v0::Constant size<br/>i32 [4] = [1,128,4,128]<br/>✅ checked non-negative"]
            AAdd["v1::Add stop_pos<br/>i32 [4]<br/>✅ Constant-foldable"]
            ASlice["v8::Slice<br/>✅ output PartialShape [1,128,4,128]"]
        end
        AP -->|"f32 [1,128,8,256]"| ASlice
        ASt -->|"i32 [4]"| AAdd
        ASz -->|"i32 [4]"| AAdd
        ASt -->|"i32 [4]"| ASlice
        AAdd -->|"✅ i32 [4] bounds resolvable"| ASlice
    end

    classDef bad fill:#ffd6d6,stroke:#a00,stroke-width:2px,color:#000
    classDef good fill:#d6ffd6,stroke:#0a0,stroke-width:2px,color:#000
    class BCz,BSO,BCL,BLess,BSel,BSlice bad
    class ASz,AAdd,ASlice good
```

</details>

<details>
<summary><b>Why <code>read_model</code> and <code>convert_model</code> diverge pre-fix</b></summary>

```mermaid
flowchart TD
    M["model.tflite<br/>simple_slice_op.tflite"]

    M --> RM["ov::Core::read_model(path)"]
    M --> CM["ov::convert_model(path)"]

    subgraph FE["Shared frontend stage — IDENTICAL in both paths"]
        direction TB
        T["translate_slice_op (slice.cpp)<br/>builds cascade:<br/>Add, ShapeOf, ConvertLike, Less, Select"]
        TS["FrontEnd::normalize() / TransposeSinkingGeneral<br/>inner submanager runs:<br/>DisableShapeOfConstantFolding → ConstantFolding → EnableShapeOfConstantFolding<br/>inner CF runs while ShapeOf is marked un-foldable ⇒ cascade survives"]
        T --> TS
    end

    RM --> FE
    CM --> FE

    FE -->|"ov::Model after frontend:<br/>cascade alive,<br/>Slice.out PartialShape [?,?,?,?]"| DIV(("divergence point"))

    DIV -->|"read_model:<br/>NO further CF runs<br/>(32 passes total, 5 applied)"| READ_OUT["❌ ov::Model returned to user<br/>Slice output [?,?,?,?]<br/>NPUW partitioning calls to_shape() → fail"]

    DIV -->|"convert_model:<br/>continues into MOC<br/>(213 passes total, 17 applied)"| MOC_IN

    subgraph MOC["MOC pipeline (only in convert_model path)<br/>moc_transformations.cpp lines 213-219"]
        direction TB
        MOC_IN["pre/post-processing,<br/>SmartReshape, ... ~17 applied passes"]
        CE["CommonEliminations (GraphRewrite):<br/>SelectWithOneValueCondition rewrites<br/>Select(Less=all-false, ConvertLike, Add) → Add<br/>(snapshot: Model1_094 had ShapeOf=1/Select=1,<br/>Model1_095 has ShapeOf=0/Select=0)"]
        CF["ov::pass::ConstantFolding:<br/>folds Add(Const,Const) → Const,<br/>dead ShapeOf/ConvertLike removed"]
        MOC_IN --> CE --> CF
    end

    MOC --> CONV_OUT["✅ ov::Model returned to user<br/>Slice output [1,128,4,128]"]

    READ_OUT -.->|"customer-facing failure trigger"| FIX["The fix lives in translate_slice_op:<br/>for non-negative constant size, emit stop = Add(start,size) directly,<br/>skipping the cascade altogether.<br/>After the fix BOTH paths produce a static Slice — divergence eliminated at the source."]

    classDef bad fill:#ffd6d6,stroke:#a00,stroke-width:2px,color:#000
    classDef good fill:#d6ffd6,stroke:#0a0,stroke-width:2px,color:#000
    classDef fix fill:#ffe680,stroke:#a80,stroke-width:3px,color:#000
    class READ_OUT bad
    class CONV_OUT good
    class FIX fix
```

</details>

### Tickets:
 - 176224

