### PR TITLE
[GPU] fix CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST issue in resample_scale_activation_eltwise testcase on b580

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_fs_b_yx_fsv32_to_bfyx.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_fs_b_yx_fsv32_to_bfyx.cl
@@ -23,7 +23,11 @@ KERNEL (reorder_fs_b_yx_fsv32_to_bfyx)(
 
     __attribute__((opencl_unroll_hint(X_BLOCK_SIZE)))
     for (int i = 0; i < X_BLOCK_SIZE; i++) {
-        in_data[sglid * X_BLOCK_SIZE + i] = input[in_idx + (i * FSV) + sglid];
+                const bool valid_f = f < INPUT0_FEATURE_NUM;
+                const bool valid_x = x + i < INPUT0_SIZE_X;
+                in_data[sglid * X_BLOCK_SIZE + i] = (valid_f && valid_x)
+                        ? input[in_idx + (i * FSV) + sglid]
+                        : (CALC_TYPE)0;
     }
 
     __attribute__((opencl_unroll_hint(X_BLOCK_SIZE)))

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_fs_b_yx_fsv32_to_bfyx.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_fs_b_yx_fsv32_to_bfyx.cl
@@ -23,11 +23,11 @@ KERNEL (reorder_fs_b_yx_fsv32_to_bfyx)(
 
     __attribute__((opencl_unroll_hint(X_BLOCK_SIZE)))
     for (int i = 0; i < X_BLOCK_SIZE; i++) {
-                const bool valid_f = f < INPUT0_FEATURE_NUM;
-                const bool valid_x = x + i < INPUT0_SIZE_X;
-                in_data[sglid * X_BLOCK_SIZE + i] = (valid_f && valid_x)
-                        ? input[in_idx + (i * FSV) + sglid]
-                        : (CALC_TYPE)0;
+        const bool valid_f = f < INPUT0_FEATURE_NUM;
+        const bool valid_x = x + i < INPUT0_SIZE_X;
+        in_data[sglid * X_BLOCK_SIZE + i] = (valid_f && valid_x)
+            ? input[in_idx + (i * FSV) + sglid]
+            : (CALC_TYPE)0;
     }
 
     __attribute__((opencl_unroll_hint(X_BLOCK_SIZE)))

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -186,6 +186,15 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_different
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::f32, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
 }
 
+TEST(reorder_gpu_optimization, compare_with_ref__fs_b_yx_fsv32_to_bfyx_f16_leftovers) {
+    // X leftover in fs_b_yx_fsv32 -> bfyx
+    compare_bfyx2blocked_with_ref("reorder_fs_b_yx_fsv32_to_bfyx", data_types::f16, data_types::f16,
+                                  format::fs_b_yx_fsv32, format::bfyx, 2, 32, 7, 8, 0, 0, false);
+    // Cover feature leftover as well
+    compare_bfyx2blocked_with_ref("reorder_fs_b_yx_fsv32_to_bfyx", data_types::f16, data_types::f16,
+                                  format::fs_b_yx_fsv32, format::bfyx, 2, 33, 7, 8, 0, 0, false);
+}
+
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_blocked_f32) {
     // bfyx_to_b_fs_yx_fsv4
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfyx, format::b_fs_yx_fsv4, 4, 32, 16, 4, 0, 0, false);


### PR DESCRIPTION
### Details
fixed CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST for testcase `fusings_gpu/resample_scale_activation_eltwise.basic/14`

### Description of the issue
#### Symptom
The `fusings_gpu/resample_scale_activation_eltwise.basic/14` testcase failed on B580 GPU, which maps to the FP16 fs_b_yx_fsv32 case with output shape 2x32x8x7.

#### Root cause
For the failing testcase, OUTPUT_SIZE_X is 7 while the kernel processes X in blocks of 8. On the last X block, the kernel read input lanes where x + i is outside valid input bounds.

#### How to fix it
Guard the load path for leftover lanes.

#### The code and line that caused this issue
https://github.com/openvinotoolkit/openvino/blob/9f012f8984e3fd4a0c744351771a29d2c276a1f0/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_fs_b_yx_fsv32_to_bfyx.cl#L25-L27

#### Reproduction step and snapshot
```
./ov_gpu_unit_tests --gtest_filter='fusings_gpu/resample_scale_activation_eltwise.basic/14'
```

#### Problematic graph
N/A

#### Checklist 
 - [x] Is it a proper fix? (not a workaround) 
 - [x] Did you include test case for this fix, if necessary? 
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - CVS-185089

### AI Assistance:
 - *AI assistance used: yes*
 - *use AI to find suspicious memory access*