### PR TITLE
[GPU] Fix perf drop of 4bit-KV-cache of VLM

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
@@ -118,8 +118,12 @@ public:
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
         // Check if INT4 KV cache is in use (micro kernel doesn't support INT4 for non-PA SDPA)
+        // Only apply this check when the SDPA node actually uses compressed KV cache (i8/u8/i4/u4 K/V inputs).
+        // Vision Encoder SDPA nodes have f16 K/V inputs and should not be affected by the global config.
+        const auto k_dt = new_params.input_layouts[1].data_type;
+        const bool is_kv_compressed = data_type_traits::is_i8_u8(k_dt) || data_type_traits::is_i4_u4(k_dt);
         const auto kv_cache_dt = new_params.get_program().get_config().get_kv_cache_precision();
-        const bool is_int4_kv = ov::element::Type(kv_cache_dt).bitwidth() == 4;
+        const bool is_int4_kv = is_kv_compressed && ov::element::Type(kv_cache_dt).bitwidth() == 4;
 
         if (has_stage(regular_micro_multi_tokens) && is_prefill && !is_indirect && !is_int4_kv) {
             GPU_DEBUG_TRACE_DETAIL << "execute regular_micro_multi_tokens for prefill \n";

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/sdpa.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/sdpa.cpp
@@ -26,6 +26,7 @@
 #include "transformations/common_optimizations/sdpa_fusion.hpp"
 #include "transformations/op_conversions/scaled_dot_product_attention_decomposition.hpp"
 #include "intel_gpu/runtime/engine.hpp"
+#include "openvino/runtime/intel_gpu/properties.hpp"
 
 namespace {
 // validate the batch axis padding for sdpa_micro kernel.
@@ -76,6 +77,22 @@ protected:
         }
     }
 };
+
+// Validate that non-PA SDPA with f16 K/V inputs is not incorrectly blocked
+// from using micro kernel when KV_CACHE_PRECISION is globally set to u4.
+// This simulates a Vision Encoder SDPA node running alongside a PA-based LLM
+// that uses INT4 KV cache. The global config should not affect the Vision Encoder path.
+class SDPAWithInt4KVCacheConfig : public SDPA {
+protected:
+    void SetUp() override {
+        SDPA::SetUp();
+        configuration.insert(ov::hint::kv_cache_precision(ov::element::u4));
+    }
+};
+
+TEST_F(SDPAWithInt4KVCacheConfig, smoke_Inference) {
+    run();
+}
 
 class SDPAFusion : virtual public ov::test::SubgraphBaseStaticTest,
                    public testing::WithParamInterface<std::tuple<ov::PartialShape,  // 0: query shape


### PR DESCRIPTION
some VLMs showed performance drop when 4bit KV-cache is enabled with PA backend.

### Details:
When KV_CACHE_PRECISION=u4 is set globally, all non-PA SDPA nodes — including Vision Encoder self-attention — are blocked from using the fast sdpa_micro__prefill kernel and fall back to the slower sdpa_opt__multi_reg kernel.

This happens because the check in sdpa_opt.cpp reads the global config get_kv_cache_precision() without verifying whether the SDPA node actually uses compressed KV cache

### Tickets:
 - CVS-185922

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
    Analyze validation report to summarize performance issue table of VLMs in the report.
