### PR TITLE
[GPU] Integrate oneDNN main branch

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
@@ -34,9 +34,7 @@ enum class gpu_arch {
     xe_hpc = 6,
     xe2 = 7,
     xe3 = 8,
-    xe3p_35_10 = 9,
-    xe3p_35_11 = 10,
-    xe3p_unknown = 11,
+    xe3p = 9,
 };
 
 /// @brief Defines version of GFX IP

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1533,8 +1533,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
     case gpu_arch::xe3:
         config = choose_config_xe2(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);
         break;
-    case gpu_arch::xe3p_35_10:
-    case gpu_arch::xe3p_35_11:
+    case gpu_arch::xe3p:
         config = choose_config_xe3p(static_cast<int32_t>(k_head_size), nkeys_v, thin_q, is_quantized, is_integrated, is_paged_attention, is_prefill);
         break;
     default: {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -222,6 +222,11 @@ protected:
                                                                             dnnl::memory::data_type& wzp_data_type) {
         auto attrs = impl_params.attrs_onednn;
 
+        // accumulation_mode::any allows oneDNN to use f16 as the accumulation type.
+        if (impl_params.get_input_layout(0).data_type == data_types::f16) {
+            attrs->set_accumulation_mode(dnnl::accumulation_mode::any);
+        }
+
         if (arg.activations_zero_points_term()) {
             auto& a_zp = arg.activations_zero_points();
             auto a_zp_dtype = a_zp.get_output_layout().data_type;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -366,9 +366,7 @@ enum class gpu_arch {
     xe_hpc = 6,
     xe2 = 7,
     xe3 = 8,
-    xe3p_35_10 = 9,
-    xe3p_35_11 = 10,
-    xe3p_unknown = 11,
+    xe3p = 9,
 };
 
 

--- a/src/plugins/intel_gpu/src/runtime/device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/device.cpp
@@ -85,9 +85,7 @@ static bool is_xe2_or_xe3_family(gpu_arch arch) {
     switch (arch) {
     case gpu_arch::xe2:
     case gpu_arch::xe3:
-    case gpu_arch::xe3p_35_10:
-    case gpu_arch::xe3p_35_11:
-    case gpu_arch::xe3p_unknown:
+    case gpu_arch::xe3p:
         return true;
     default:
         return false;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -63,9 +63,7 @@ gpu_arch convert_ngen_arch(ngen::HW gpu_arch) {
         case ngen::HW::XeHPC: return gpu_arch::xe_hpc;
         case ngen::HW::Xe2: return gpu_arch::xe2;
         case ngen::HW::Xe3: return gpu_arch::xe3;
-        case ngen::HW::XE3P_35_10: return gpu_arch::xe3p_35_10;
-        case ngen::HW::XE3P_35_11: return gpu_arch::xe3p_35_11;
-        case ngen::HW::XE3P_UNKNOWN: return gpu_arch::xe3p_unknown;
+        case ngen::HW::Xe3p: return gpu_arch::xe3p;
         case ngen::HW::Gen10:
         case ngen::HW::Unknown: return gpu_arch::unknown;
     }

--- a/src/plugins/intel_gpu/src/runtime/ze/ze_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_device.cpp
@@ -47,9 +47,7 @@ gpu_arch convert_ngen_arch(ngen::HW gpu_arch) {
         case ngen::HW::XeHPC: return gpu_arch::xe_hpc;
         case ngen::HW::Xe2: return gpu_arch::xe2;
         case ngen::HW::Xe3: return gpu_arch::xe3;
-        case ngen::HW::XE3P_35_10: return gpu_arch::xe3p_35_10;
-        case ngen::HW::XE3P_35_11: return gpu_arch::xe3p_35_11;
-        case ngen::HW::XE3P_UNKNOWN: return gpu_arch::xe3p_unknown;
+        case ngen::HW::Xe3p: return gpu_arch::xe3p;
         case ngen::HW::Gen10:
         case ngen::HW::Unknown: return gpu_arch::unknown;
     }


### PR DESCRIPTION
### Description of the issue (symptom, root-cause, how it was resolved)

- Integrated oneDNN main branch, which unified Xe3P hardware variant enum values (`XE3P_35_10`, `XE3P_35_11`, `XE3P_UNKNOWN` → `Xe3p`). Updated OpenVINO `gpu_arch` enum and all mapping switch-cases in OCL/ZE device detection and SDPA kernel selection accordingly.

- **Symptom**: `convolution_depthwise_gpu_fsv16` and `convolution_depthwise_gpu_bfyx` unit tests fail for large kernels (k=8x8, k=17x8, f=16, stride=2) after oneDNN main integration.
- **Root-cause**: oneDNN main changed the default accumulation type from `f16` to `f32` for f16 forward MAD convolutions on Xe JIT IR path.
- **Resolution**: Set `accumulation_mode::any` for f16 input convolutions, which allows oneDNN to use f16 as the accumulation type and restores correct behavior.

#### The code and line that caused this issue (if it is not changed directly)
- `intel_gpu/thirdparty/onednn_gpu/src/gpu/intel/conv/jit/plan.cpp` — `get_accumulation_type()`: returns `f32` by default for f16 MAD fwd conv; only returns `f16` when `accumulation_mode == accumulation_mode::any`

#### Reproduction step and snapshot (if applicable)

```
$ ./ov_gpu_unit_tests \
    --gtest_filter="*convolution_depthwise_gpu*in15x15_k8x8_f16_stride2_pad0*:*convolution_depthwise_gpu*in15x15_k17x8_f16_stride2_pad0*" \
    --device_suffix=1
```

Failing tests:
- `convolution_depthwise_gpu_fsv16.depthwise_conv_b_fs_yx_fsv16/in15x15_k8x8_f16_stride2_pad0`
- `convolution_depthwise_gpu_fsv16.depthwise_conv_b_fs_yx_fsv16/in15x15_k17x8_f16_stride2_pad0`
- `convolution_depthwise_gpu_bfyx` variants of the same params

#### Problematic graph
- N/A

#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
  - Already exists 
- [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 185514
 - 185641
