### PR TITLE
[CPU][RV64] Implemented JIT Emitter for Swish operation

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
@@ -29,6 +29,7 @@
 #include "openvino/op/relu.hpp"
 #include "snippets/op/powerstatic.hpp"
 #include "transformations/cpu_opset/common/op/leaky_relu.hpp"
+#include "transformations/cpu_opset/common/op/swish_cpu.hpp"
 #include "utils/general_utils.h"
 #include "xbyak_riscv/xbyak_riscv.hpp"
 #include "xbyak_riscv/xbyak_riscv_csr.hpp"
@@ -1756,6 +1757,98 @@ void jit_hswish_emitter::emit_data() const {
     hsigmoid_emitter->emit_data();
     jit_emitter::emit_data();
 }
+
+// SWISH
+jit_swish_emitter::jit_swish_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,
+                                     float alpha,
+                                     ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                                     ov::element::Type exec_prc)
+    : jit_emitter(host, host_isa, exec_prc),
+      alpha_(alpha) {
+    prepare_table();
+    sigmoid_emitter = std::make_unique<jit_sigmoid_emitter>(host, host_isa, exec_prc);
+    push_arg_entry_of("swish_alpha", dnnl::impl::float2int(alpha_));
+}
+
+jit_swish_emitter::jit_swish_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,
+                                     ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                                     const std::shared_ptr<ov::Node>& node,
+                                     ov::element::Type exec_prc)
+    : jit_emitter(host, host_isa, exec_prc) {
+    const auto swish = ov::as_type_ptr<SwishNode>(node);
+    if (swish == nullptr) {
+        OV_CPU_JIT_EMITTER_THROW("Can't cast to SwishNode");
+    }
+    alpha_ = swish->get_alpha();
+    prepare_table();
+    sigmoid_emitter = std::make_unique<jit_sigmoid_emitter>(host, host_isa, exec_prc);
+}
+
+size_t jit_swish_emitter::get_inputs_num() const {
+    return 1;
+}
+
+size_t jit_swish_emitter::aux_gprs_count() const {
+    return sigmoid_emitter->aux_gprs_count();
+}
+
+size_t jit_swish_emitter::aux_vecs_count() const {
+    return sigmoid_emitter->aux_vecs_count() + 1;
+}
+
+size_t jit_swish_emitter::aux_fp_gprs_count() const {
+    return sigmoid_emitter->aux_fp_gprs_count();
+}
+void jit_swish_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs,
+                                  const std::vector<size_t>& out_vec_idxs) const {
+    if (host_isa_ == ov::intel_cpu::riscv64::cpu_isa_t::gv) {
+        emit_isa<ov::intel_cpu::riscv64::cpu_isa_t::gv>(in_vec_idxs, out_vec_idxs);
+    } else {
+        OV_CPU_JIT_EMITTER_THROW("Can't create jit eltwise kernel");
+    }
+}
+template <ov::intel_cpu::riscv64::cpu_isa_t isa>
+void jit_swish_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
+                                 const std::vector<size_t>& out_vec_idxs) const {
+    OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "Unsupported precision: ", exec_prc_);
+
+    auto src = VReg(in_vec_idxs[0]);
+    auto dst = VReg(out_vec_idxs[0]);
+    // we take the last auxiliary vector to save x
+    auto aux_save = VReg(aux_vec_idxs.back());
+    // saving the original value of x
+    h->vmv_v_v(aux_save, src);  // aux_save = src
+    // load alpha and multiply src = alpha * x
+    auto alpha_reg = FReg(aux_fp_gpr_idxs[0]);
+    load_table_val("swish_alpha", alpha_reg);
+    h->vfmul_vf(src, src, alpha_reg);
+    // we call the sigmoid emitter, which puts the result in dst
+    // we pass all auxiliary registers to it, except the last one
+    std::vector<size_t> sigmoid_aux_vec_idxs(aux_vec_idxs.begin(),
+                                             aux_vec_idxs.begin() + sigmoid_emitter->aux_vecs_count());
+    // call sigmoid
+    sigmoid_emitter->emit_code({static_cast<size_t>(src.getIdx())},
+                               {static_cast<size_t>(dst.getIdx())},
+                               {sigmoid_aux_vec_idxs},
+                               aux_gpr_idxs,
+                               aux_fp_gpr_idxs);
+
+    h->vfmul_vv(dst, dst, aux_save);  // dst = x * sigmoid(x)
+}
+std::set<std::vector<element::Type>> jit_swish_emitter::get_supported_precisions(
+    [[maybe_unused]] const std::shared_ptr<ov::Node>& node) {
+    return {{element::f32}};
+}
+
+void jit_swish_emitter::register_table_entries() {
+    push_arg_entry_of("swish_alpha", dnnl::impl::float2int(alpha_));
+}
+
+void jit_swish_emitter::emit_data() const {
+    sigmoid_emitter->emit_data();
+    jit_emitter::emit_data();
+}
+
 // LESS ///
 jit_less_emitter::jit_less_emitter(jit_generator_t* host, cpu_isa_t host_isa, element::Type exec_prc)
     : jit_emitter(host, host_isa, exec_prc) {

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
@@ -10,6 +10,7 @@ namespace ov::intel_cpu::riscv64 {
 
 class jit_exp_emitter;
 class jit_tanh_emitter;
+class jit_sigmoid_emitter;
 
 class jit_abs_emitter : public jit_emitter {
 public:
@@ -519,6 +520,40 @@ private:
     template <ov::intel_cpu::riscv64::cpu_isa_t isa>
     void emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const;
 };
+
+class jit_swish_emitter : public jit_emitter {
+public:
+    jit_swish_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,
+                      float alpha,
+                      ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                      ov::element::Type exec_prc = ov::element::f32);
+    jit_swish_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,
+                      ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                      const std::shared_ptr<ov::Node>& node,
+                      ov::element::Type exec_prc = ov::element::f32);
+    static std::set<std::vector<element::Type>> get_supported_precisions(
+        const std::shared_ptr<ov::Node>& node = nullptr);
+    size_t get_inputs_num() const override;
+
+    size_t aux_gprs_count() const override;
+
+    size_t aux_vecs_count() const override;
+
+    size_t aux_fp_gprs_count() const override;
+
+    void register_table_entries() override;
+
+    void emit_data() const override;
+
+private:
+    std::unique_ptr<jit_sigmoid_emitter> sigmoid_emitter{nullptr};
+    float alpha_ = 1.0F;
+
+    void emit_impl(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const override;
+    template <ov::intel_cpu::riscv64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const;
+};
+
 class jit_less_emitter : public jit_emitter {
 public:
     jit_less_emitter(jit_generator_t* host, cpu_isa_t host_isa, element::Type exec_prc = element::f32);

--- a/src/plugins/intel_cpu/src/emitters/snippets/riscv64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/riscv64/cpu_generator.cpp
@@ -98,6 +98,7 @@
 #include "snippets/op/vector_buffer.hpp"
 #include "snippets/target_machine.hpp"
 #include "transformations/snippets/common/op/fused_mul_add.hpp"
+#include "transformations/cpu_opset/common/op/swish_cpu.hpp"
 #include "transformations/snippets/common/op/load_convert.hpp"
 #include "transformations/snippets/common/op/store_convert.hpp"
 #include "utils.hpp"

--- a/src/plugins/intel_cpu/src/emitters/snippets/riscv64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/riscv64/cpu_generator.cpp
@@ -444,7 +444,7 @@ std::shared_ptr<ov::snippets::Generator> CPUGenerator::clone() const {
 
 ov::snippets::RegType CPUGenerator::get_specific_op_out_reg_type(const ov::Output<ov::Node>& out) const {
     const auto op = out.get_node_shared_ptr();
-    if (ov::is_type<intel_cpu::FusedMulAdd>(op)) {
+    if (ov::is_type_any_of<intel_cpu::FusedMulAdd, intel_cpu::SwishNode>(op)) {
         return ov::snippets::RegType::vec;
     }
     return ov::snippets::RegType::undefined;

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -645,6 +645,11 @@ void Eltwise::initSupportedPrimitiveDescriptors() {
 
     // Initialize attributes
     m_attrs.data.algo = getAlgorithm();
+#if defined(OPENVINO_ARCH_RISCV64)
+    if (m_attrs.data.algo == Algorithm::EltwiseSwish) {
+        m_attrs.data.onednnAlgorithm = dnnl::algorithm::undef;
+    }
+#endif
     m_attrs.postOps = getPostOps(fusedWith, ov::element::dynamic);
     m_attrs.opsList = {getType()};
 
@@ -670,7 +675,7 @@ void Eltwise::initSupportedPrimitiveDescriptors() {
 
     // Prepare memory descriptor arguments for a factory
     MemoryDescArgs descs;
-    for (int i = 0; i < static_cast<int>(srcDescs.size()); i++) {
+    for (size_t i = 0; i < srcDescs.size(); i++) {
         descs[ARG_SRC + i] = srcDescs[i];
     }
     descs[ARG_DST] = dstDesc;
@@ -687,7 +692,7 @@ void Eltwise::initSupportedPrimitiveDescriptors() {
         const auto& outputDesc = nodeDescriptors.at(ARG_DST);
         const auto outputPrecision = outputDesc->getPrecision();
 
-        for (int i = 0; i < static_cast<int>(srcDescs.size()); i++) {
+        for (size_t i = 0; i < srcDescs.size(); i++) {
             if (auto it = nodeDescriptors.find(ARG_SRC + i); it != nodeDescriptors.end()) {
                 const auto& [_, desc] = *it;
                 const int isInPlace =
@@ -840,7 +845,7 @@ ov::element::Type Eltwise::getRuntimePrecision() const {
 }
 
 void Eltwise::createPrimitive() {
-    for (int i = 0; i < static_cast<int>(getParentEdges().size()); i++) {
+    for (size_t i = 0; i < getParentEdges().size(); i++) {
         m_memory[ARG_SRC + i] = getSrcMemoryAtPort(i);
     }
     m_memory[ARG_DST] = getDstMemoryAtPort(0);
@@ -997,8 +1002,8 @@ void Eltwise::appendPostOpsImpl(dnnl::post_ops& ops,
         m_depthwiseDataSize = 2 * channelSize;
 
         // always align for legacy scale/shift post ops
-        constexpr size_t bufferAlignment = 16;
-        size_t bufferPaddingSize = rnd_up(channelSize, bufferAlignment) - channelSize;
+        constexpr int bufferAlignment = 16;
+        int bufferPaddingSize = rnd_up(channelSize, bufferAlignment) - channelSize;
         m_depthwiseData.resize(m_depthwiseDataSize + bufferPaddingSize, 0);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.cpp
@@ -491,6 +491,7 @@ bool EltwiseJitExecutor::supports(const EltwiseAttrs& attrs,
                 Algorithm::EltwiseSqrt,
                 Algorithm::EltwiseSquaredDifference,
                 Algorithm::EltwiseSubtract,
+                Algorithm::EltwiseSwish,
                 Algorithm::EltwiseTanh)) {
         return false;
     }

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -267,6 +267,7 @@ std::string ActivationLayerCPUTest::getPrimitiveType(const utils::ActivationType
             (activation_type == utils::ActivationTypes::Sigmoid) ||
             (activation_type == utils::ActivationTypes::SoftSign) ||
             (activation_type == utils::ActivationTypes::Sqrt) ||
+            (activation_type == utils::ActivationTypes::Swish) ||
             (activation_type == utils::ActivationTypes::Tanh) ||
             (activation_type == utils::ActivationTypes::ErfInv))
             return "jit";

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -478,9 +478,9 @@ const std::vector<std::regex>& disabled_test_patterns() {
             std::regex(R"(.*proposal_params/.*)"),
             // Quantized models unsupported
             std::regex(R"(.*Quantized.*)"),
-            std::regex(R"(smoke_Snippets(?!_(Eltwise|ThreeInputsEltwise|PrecisionPropagation_Convertion|Convert.*|Select|BroadcastSelect|Transpose[^/_]*|Reduce|Softmax(?=/)|AddSoftmax)(/|_)).*)"),
+            std::regex(R"(smoke_Snippets(?!_(Eltwise|ThreeInputsEltwise|Swish|PrecisionPropagation_Convertion|Convert.*|Select|BroadcastSelect|Transpose[^/_]*|Reduce|Softmax(?=/)|AddSoftmax)(/|_)).*)"),
             std::regex(R"(.*smoke_Snippets_TransposeMatMulBias/ExplicitTransposeMatMulBias.*)"),
-            std::regex(R"(.*_enforceSnippets=1.*)"),
+            std::regex(R"((?!.*Swish).*_enforceSnippets=1.*)"),
 #endif
 #if !defined(OPENVINO_ARCH_X86_64)
             // very time-consuming test


### PR DESCRIPTION
### Details:
 - Added jit emitter for swish activation function on risc-v architecture with rvv vector instructions(uses rvv instructions generated via xbyak framework)
 - Registered emitter in the eltwise factory and priority system for RISC-V
 - Used existing pattern of "register_table_entries" and "load_table_val" for constant handling

### Testing: 
 -  All Swish functional tests (60 test cases) passed in qemu risc-v emulator with rvv enabled
 - Tested on real risc-v hardware (Orange Pi)

### Tickets:
 - *ticket-id*

### AI Assistance:
 - AI assistance used: yes
 - AI was used to clarify the xbyak api for risc-v vector code generation, to assist with studying the repository structure and navigating the openvino codebase, and to help with debugging compilation and runtime errors.
   
