### PR TITLE
[inference] Identify failing port in check_tensor shape mismatch error

### DIFF
--- a/src/inference/src/dev/isync_infer_request.cpp
+++ b/src/inference/src/dev/isync_infer_request.cpp
@@ -275,15 +275,6 @@ void ov::ISyncInferRequest::check_tensor(const ov::Output<const ov::Node>& port,
                     " != ",
                     port.get_element_type());
     bool is_dynamic = port.get_partial_shape().is_dynamic();
-    std::string port_tensor_names;
-    {
-        const char* sep = "";
-        for (const auto& name : port.get_tensor().get_names()) {
-            port_tensor_names += sep;
-            port_tensor_names += name;
-            sep = ",";
-        }
-    }
     OPENVINO_ASSERT(is_dynamic || port.get_shape() == tensor->get_shape(),
                     "The ",
                     tensor_type,
@@ -293,11 +284,7 @@ void ov::ISyncInferRequest::check_tensor(const ov::Output<const ov::Node>& port,
                     tensor->get_shape(),
                     " expecting ",
                     port.get_shape(),
-                    ". Port: friendly_name='",
-                    port.get_node()->get_friendly_name(),
-                    "', tensor_names={",
-                    port_tensor_names,
-                    "}.");
+                    ".");
     OPENVINO_ASSERT(
         std::dynamic_pointer_cast<ov::IRemoteTensor>(tensor._ptr) || tensor->data() != nullptr || is_dynamic,
         "Tensor data equal nullptr!");

--- a/src/inference/src/dev/isync_infer_request.cpp
+++ b/src/inference/src/dev/isync_infer_request.cpp
@@ -275,6 +275,15 @@ void ov::ISyncInferRequest::check_tensor(const ov::Output<const ov::Node>& port,
                     " != ",
                     port.get_element_type());
     bool is_dynamic = port.get_partial_shape().is_dynamic();
+    std::string port_tensor_names;
+    {
+        const char* sep = "";
+        for (const auto& name : port.get_tensor().get_names()) {
+            port_tensor_names += sep;
+            port_tensor_names += name;
+            sep = ",";
+        }
+    }
     OPENVINO_ASSERT(is_dynamic || port.get_shape() == tensor->get_shape(),
                     "The ",
                     tensor_type,
@@ -284,7 +293,11 @@ void ov::ISyncInferRequest::check_tensor(const ov::Output<const ov::Node>& port,
                     tensor->get_shape(),
                     " expecting ",
                     port.get_shape(),
-                    ".");
+                    ". Port: friendly_name='",
+                    port.get_node()->get_friendly_name(),
+                    "', tensor_names={",
+                    port_tensor_names,
+                    "}.");
     OPENVINO_ASSERT(
         std::dynamic_pointer_cast<ov::IRemoteTensor>(tensor._ptr) || tensor->data() != nullptr || is_dynamic,
         "Tensor data equal nullptr!");

--- a/src/tests/test_utils/common_test_utils/src/ov_test_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_test_utils.cpp
@@ -4,11 +4,15 @@
 
 #include "common_test_utils/ov_test_utils.hpp"
 
+#include <sstream>
+
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/ov_plugin_cache.hpp"
 #include "common_test_utils/test_constants.hpp"
 #include "openvino/op/tensor_iterator.hpp"
+#include "openvino/op/util/node_util.hpp"
 #include "openvino/runtime/core.hpp"
+#include "openvino/util/common_util.hpp"
 #include "openvino/util/file_util.hpp"
 #include "template/properties.hpp"
 
@@ -142,7 +146,33 @@ ov::TensorVector infer_on_template(const std::shared_ptr<ov::Model>& model,
     auto infer_request = compiled_model.create_infer_request();
 
     for (auto& input : inputs) {
-        infer_request.set_tensor(input.first, input.second);
+        try {
+            infer_request.set_tensor(input.first, input.second);
+        } catch (const std::exception& ex) {
+            const auto& src_param = input.first;
+            const auto& src_tensor = input.second;
+            const ov::Output<const ov::Node> src_port = src_param->output(0);
+            std::ostringstream ports_dump;
+            const auto& compiled_inputs = compiled_model.inputs();
+            for (size_t i = 0; i < compiled_inputs.size(); ++i) {
+                const auto& cp = compiled_inputs[i];
+                ports_dump << "\n  port[" << i << "] " << ov::util::make_default_tensor_name(cp)
+                           << " shape=" << cp.get_shape() << " tensor_names={"
+                           << ov::util::join(cp.get_tensor().get_names(), ",") << "}";
+            }
+            OPENVINO_THROW("infer_on_template: set_tensor failed. Source parameter: ",
+                           ov::util::make_default_tensor_name(src_port),
+                           ", tensor_names={",
+                           ov::util::join(src_port.get_tensor().get_names(), ","),
+                           "}, expected_shape=",
+                           src_port.get_shape(),
+                           ", got_tensor_shape=",
+                           src_tensor.get_shape(),
+                           ". Compiled model inputs:",
+                           ports_dump.str(),
+                           ". Original error: ",
+                           ex.what());
+        }
     }
     infer_request.infer();
 

--- a/src/tests/test_utils/common_test_utils/tests/graph_comparator_tests.cpp
+++ b/src/tests/test_utils/common_test_utils/tests/graph_comparator_tests.cpp
@@ -5,16 +5,19 @@
 #include <gtest/gtest.h>
 
 #include "common_test_utils/graph_comparator.hpp"
+#include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/gru_cell.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/negative.hpp"
+#include "openvino/op/relu.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/tensor_iterator.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/util/variable.hpp"
+#include "openvino/runtime/tensor.hpp"
 
 TEST(GraphComparatorTests, AllEnablePositiveCheck) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
@@ -697,4 +700,31 @@ TEST(GraphComparatorTests, CheckConsumersCountNegative) {
     comparator.enable(FunctionsComparator::NODES).enable(FunctionsComparator::CONSUMERS_COUNT);
     auto res = comparator.compare(function, function_ref);
     ASSERT_FALSE(res.valid) << res.message;
+}
+
+TEST(InferOnTemplateTests, ShapeMismatchDiagnosticContainsPortInfo) {
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{4});
+    input->set_friendly_name("my_param");
+    input->get_output_tensor(0).set_names({"my_tensor"});
+    auto relu = std::make_shared<ov::op::v0::Relu>(input);
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{relu}, ov::ParameterVector{input});
+
+    ov::Tensor wrong_shape_tensor(ov::element::f32, ov::Shape{8});
+    std::map<std::shared_ptr<ov::Node>, ov::Tensor> inputs{{input, wrong_shape_tensor}};
+
+    std::string what;
+    try {
+        ov::test::utils::infer_on_template(model, inputs);
+        FAIL() << "infer_on_template was expected to throw on shape mismatch";
+    } catch (const std::exception& ex) {
+        what = ex.what();
+    }
+
+    EXPECT_NE(what.find("infer_on_template: set_tensor failed"), std::string::npos) << what;
+    EXPECT_NE(what.find("my_param"), std::string::npos) << what;
+    EXPECT_NE(what.find("my_tensor"), std::string::npos) << what;
+    EXPECT_NE(what.find("expected_shape="), std::string::npos) << what;
+    EXPECT_NE(what.find("got_tensor_shape="), std::string::npos) << what;
+    EXPECT_NE(what.find("Compiled model inputs:"), std::string::npos) << what;
+    EXPECT_NE(what.find("Original error:"), std::string::npos) << what;
 }


### PR DESCRIPTION
### Details:
The shape-mismatch assertion in `ov::ISyncInferRequest::check_tensor`
previously emitted only "got X expecting Y" with no indication of which
port was at fault. For models with many inputs/outputs this forced ad
hoc instrumentation of the inference path to localize the failure.

Append the port's `friendly_name` and the set of `tensor_names` to the
existing `OPENVINO_ASSERT`. The assertion condition is unchanged — no
behaviour change.

Before:
    The input tensor size is not equal to the model input type:
    got [1,256] expecting [128,160].

After:
    The input tensor size is not equal to the model input type:
    got [1,256] expecting [128,160]. Port: friendly_name='input_3',
    tensor_names={input.3}.

Existing `IPluginTest` set/get-tensor tests pass unchanged.

### Tickets:
 - 183517
