### PR TITLE
[CPU] Fix int64 dynamic Power accuracy

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -733,14 +733,23 @@ bool Eltwise::canFuse(const NodePtr& node) const {
         return all_of_values(node->getOriginalInputPrecisions(), ov::element::i32);
     };
 
-    if (!EltwiseJitExecutor::supports(m_attrs, inputShapes.front().getRank())) {
+    if (!EltwiseJitExecutor::supports(m_attrs,
+                                      inputShapes.front().getRank(),
+                                      getOriginalInputPrecisions(),
+                                      getOriginalOutputPrecisions())) {
         return false;
     }
 
-#if defined(OPENVINO_ARCH_ARM64) || defined(OPENVINO_ARCH_RISCV64)
     const auto* eltwise = dynamic_cast<const Eltwise*>(node.get());
-    if (eltwise == nullptr ||
-        !EltwiseJitExecutor::supports(eltwise->attrs(), eltwise->getInputShapeAtPort(0).getRank())) {
+    if (eltwise != nullptr &&
+        !EltwiseJitExecutor::supports(eltwise->attrs(),
+                                      eltwise->getInputShapeAtPort(0).getRank(),
+                                      eltwise->getOriginalInputPrecisions(),
+                                      eltwise->getOriginalOutputPrecisions())) {
+        return false;
+    }
+#if defined(OPENVINO_ARCH_ARM64) || defined(OPENVINO_ARCH_RISCV64)
+    if (eltwise == nullptr) {
         return false;
     }
 #endif
@@ -1122,7 +1131,10 @@ bool Eltwise::canFuseParent(const NodePtr& parentNode) const {
     }
     const auto& input_precisions = parentNode->getOriginalInputPrecisions();
 
-    return EltwiseJitExecutor::supports(m_attrs, inputShapes.front().getRank(), input_precisions);
+    return EltwiseJitExecutor::supports(m_attrs,
+                                        inputShapes.front().getRank(),
+                                        input_precisions,
+                                        getOriginalOutputPrecisions());
 #else
     const auto isSuitableParentNode = [](const Node* parentNode) {
         return parentNode->getType() == Type::Convert &&
@@ -1151,7 +1163,7 @@ bool Eltwise::canFuseConvert(const NodePtr& convertNode) {
     // Convert can be fused into Eltwise only if jit implementation is supported
     return EltwiseJitExecutor::supports(m_attrs,
                                         inputShapes.front().getRank(),
-                                        {},
+                                        getOriginalInputPrecisions(),
                                         {convertNode->getOriginalOutputPrecisionAtPort(0)});
 }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/eltwise_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/eltwise_implementations.cpp
@@ -52,6 +52,17 @@ static bool isBitwiseAlgorithm(const EltwiseConfig& config) {
                   Algorithm::EltwiseBitwiseRightShift);
 }
 
+static bool hasInt64Precision(const EltwiseConfig& config) {
+    return std::any_of(config.descs.begin(), config.descs.end(), [](const auto& entry) {
+        const auto& desc = entry.second;
+        return !desc->empty() && desc->getPrecision() == ov::element::i64;
+    });
+}
+
+static bool isInt64DynamicPower(const EltwiseConfig& config) {
+    return config.attrs.data.algo == Algorithm::EltwisePowerDynamic && hasInt64Precision(config);
+}
+
 [[maybe_unused]] static bool isChannelFirstApplicable(const EltwiseConfig& config) {
     auto acceptableRank = [](const size_t rank) {
         return any_of(rank, 1U, 2U, 3U, 4U, 5U);
@@ -144,6 +155,12 @@ static const TypeMapping eltwiseReferenceTypeMapping {
     {{_any, _any},        {just<f32>(), just<f32>()}},
 };
 
+static const TypeMapping integerPowerReferenceTypeMapping {
+    // {src, dst}         pt<src, dst>
+    {{_i64, _i64},         {bypass(), bypass()}},
+    {{_any, _any},         {just<f32>(), just<f32>()}},
+};
+
 static const TypeMapping bitwiseReferenceTypeMapping {
     // {src, dst}         pt<src, dst>
     {{_u8 | _i8 | _u16 | _i16 | _i32, _u8 | _i8 | _u16 | _i16 | _i32},        {bypass(), bypass()}},
@@ -165,6 +182,13 @@ struct createOptimalConfigDefault {
 
     LayoutConfig layoutConfig;
 };
+
+static const TypeMapping& getReferenceTypeMapping(const EltwiseConfig& config) {
+    if (isInt64DynamicPower(config)) {
+        return integerPowerReferenceTypeMapping;
+    }
+    return isBitwiseAlgorithm(config) ? bitwiseReferenceTypeMapping : eltwiseReferenceTypeMapping;
+}
 
 [[maybe_unused]] static std::optional<executor::Config<EltwiseAttrs>> createOptimalConfigEltwise(
     const executor::Config<EltwiseAttrs>& config,
@@ -381,7 +405,7 @@ const std::vector<ExecutorImplementation<EltwiseAttrs>>& getImplementations() {
                 return true;
             },
             [](const EltwiseConfig& config) -> std::optional<EltwiseConfig> {
-                const auto& typeMapping = isBitwiseAlgorithm(config) ? bitwiseReferenceTypeMapping : eltwiseReferenceTypeMapping;
+                const auto& typeMapping = getReferenceTypeMapping(config);
                 return createOptimalConfigCommon(config,
                                                  typeMapping,
                                                  LayoutConfig{LayoutType::ncsp, LayoutType::ncsp},
@@ -401,7 +425,7 @@ const std::vector<ExecutorImplementation<EltwiseAttrs>>& getImplementations() {
             },
             // createOptimalConfig
             [](const EltwiseConfig& config) -> std::optional<EltwiseConfig> {
-                const auto& typeMapping = isBitwiseAlgorithm(config) ? bitwiseReferenceTypeMapping : eltwiseReferenceTypeMapping;
+                const auto& typeMapping = getReferenceTypeMapping(config);
                 return createOptimalConfigCommon(config,
                                                  typeMapping,
                                                  LayoutConfig{LayoutType::nspc, LayoutType::nspc},

--- a/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.cpp
@@ -375,8 +375,8 @@ void EltwiseJitExecutor::exec(const jit_eltwise_call_args_ptrs& args_ptrs,
 
 bool EltwiseJitExecutor::supports(const EltwiseAttrs& attrs,
                                   const size_t rank,
-                                  [[maybe_unused]] const std::vector<ov::element::Type>& input_precisions,
-                                  [[maybe_unused]] const std::vector<ov::element::Type>& output_precisions) {
+                                  const std::vector<ov::element::Type>& input_precisions,
+                                  const std::vector<ov::element::Type>& output_precisions) {
 #if defined(OPENVINO_ARCH_X86_64)
     const auto isISASupportedByJIT = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::sse41);
 #elif defined(OPENVINO_ARCH_ARM64)
@@ -396,6 +396,16 @@ bool EltwiseJitExecutor::supports(const EltwiseAttrs& attrs,
     }
 
     const auto algorithm = attrs.data.algo;
+    const auto hasInt64Precision = [](const std::vector<ov::element::Type>& precisions) {
+        return std::any_of(precisions.begin(), precisions.end(), [](const ov::element::Type& precision) {
+            return precision == ov::element::i64;
+        });
+    };
+    if (algorithm == Algorithm::EltwisePowerDynamic &&
+        (hasInt64Precision(input_precisions) || hasInt64Precision(output_precisions))) {
+        return false;
+    }
+
     if (any_of(algorithm,
                Algorithm::EltwiseLog,
                Algorithm::EltwiseBitwiseLeftShift,

--- a/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.cpp
@@ -14,9 +14,11 @@
 #include <common/utils.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
+#include <type_traits>
 #include <vector>
 
 #include "cpu/primitive_attr_postops.hpp"
@@ -88,12 +90,18 @@ static EltwiseExecutorPtr createRefExecutorByPrecision(const EltwiseRefKey& key)
         return std::make_shared<BitwiseRefExecutor<uint16_t>>(key);
     case ov::element::i32:
         return std::make_shared<BitwiseRefExecutor<int32_t>>(key);
+    case ov::element::i64:
+        if (key.eltwise_data.front().algo == Algorithm::EltwisePowerDynamic) {
+            return std::make_shared<IntegerPowerRefExecutor<int64_t>>(key);
+        }
+        break;
     case ov::element::f16:
         return std::make_shared<EltwiseRefExecutor<dnnl::impl::float16_t>>(key);
     default:
-        // Use float reference executor for any other precision
-        return std::make_shared<EltwiseRefExecutor<float>>(key);
+        break;
     }
+    // Use float reference executor for any other precision
+    return std::make_shared<EltwiseRefExecutor<float>>(key);
 }
 
 EltwiseExecutorPtr createEltwiseRefExecutor(const std::vector<VectorDims>& inDims,
@@ -474,6 +482,79 @@ bool BitwiseRefExecutor<T, Enable>::isSupportedConfiguration(const EltwiseConfig
                   Algorithm::EltwiseBitwiseRightShift);
 }
 
+template <typename T>
+T integerPower(T base, T exponent) {
+    if (exponent < 0) {
+        if (base == static_cast<T>(1)) {
+            return static_cast<T>(1);
+        }
+        if (base == static_cast<T>(-1)) {
+            return (exponent % static_cast<T>(2) == 0) ? static_cast<T>(1) : static_cast<T>(-1);
+        }
+        return static_cast<T>(0);
+    }
+
+    using UnsignedT = std::make_unsigned_t<T>;
+    auto toSignedBits = [](UnsignedT value) {
+        T result;
+        static_assert(sizeof(result) == sizeof(value));
+        std::memcpy(&result, &value, sizeof(result));
+        return result;
+    };
+    const bool negativeBase = base < 0;
+    UnsignedT multiplier = negativeBase ? static_cast<UnsignedT>(0) - static_cast<UnsignedT>(base)
+                                        : static_cast<UnsignedT>(base);
+    UnsignedT result = 1;
+    T remainingExponent = exponent;
+
+    while (remainingExponent > 0) {
+        if (remainingExponent % static_cast<T>(2) != 0) {
+            result *= multiplier;
+        }
+        remainingExponent /= static_cast<T>(2);
+        if (remainingExponent > 0) {
+            multiplier *= multiplier;
+        }
+    }
+
+    if (negativeBase && exponent % static_cast<T>(2) != 0) {
+        result = static_cast<UnsignedT>(0) - result;
+    }
+    return toSignedBits(result);
+}
+
+template <typename T, typename Enable>
+IntegerPowerRefExecutor<T, Enable>::IntegerPowerRefExecutor(const EltwiseRefKey& key)
+    : EltwiseRefBaseExecutor<T>(key) {}
+
+template <typename T, typename Enable>
+void IntegerPowerRefExecutor<T, Enable>::exec(const jit_eltwise_call_args_ptrs& args_ptrs,
+                                              const VectorDims& dims_out,
+                                              [[maybe_unused]] const CpuParallelPtr& cpu_parallel) {
+    parallel_nt(0, [&](const int ithr, const int nthr) {
+        size_t start = 0;
+        size_t end = 0;
+        splitter(this->m_fullWorkAmount, nthr, ithr, start, end);
+
+        std::vector<size_t> counters(dims_out.size(), 0);
+
+        for (size_t iwork = start; iwork < end; ++iwork) {
+            std::vector<T> src_f(this->m_inputNum);
+            T* dst_ptr_f = nullptr;
+            this->init_ptr(args_ptrs, dims_out, counters, iwork, src_f, dst_ptr_f);
+
+            switch (this->m_opData.algo) {
+            case Algorithm::EltwisePowerDynamic:
+                *dst_ptr_f = integerPower(src_f[0], src_f[1]);
+                break;
+            default:
+                OPENVINO_THROW("Unsupported operation type for Integer Power Eltwise executor: ",
+                               algToString(this->m_opData.algo));
+            }
+        }
+    });
+}
+
 // Explicit template instantiations
 template class EltwiseRefBaseExecutor<float>;
 template class EltwiseRefBaseExecutor<dnnl::impl::float16_t>;
@@ -482,6 +563,7 @@ template class EltwiseRefBaseExecutor<uint8_t>;
 template class EltwiseRefBaseExecutor<int16_t>;
 template class EltwiseRefBaseExecutor<uint16_t>;
 template class EltwiseRefBaseExecutor<int32_t>;
+template class EltwiseRefBaseExecutor<int64_t>;
 
 template class EltwiseRefExecutor<float>;
 template class EltwiseRefExecutor<dnnl::impl::float16_t>;
@@ -491,5 +573,7 @@ template class BitwiseRefExecutor<uint8_t>;
 template class BitwiseRefExecutor<int16_t>;
 template class BitwiseRefExecutor<uint16_t>;
 template class BitwiseRefExecutor<int32_t>;
+
+template class IntegerPowerRefExecutor<int64_t>;
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.hpp
@@ -102,6 +102,19 @@ public:
     static bool isSupportedConfiguration(const EltwiseConfig& config);
 };
 
+template <typename T>
+constexpr bool supported_integer_power_ref_types_v = one_of_v<T, int64_t>;
+
+template <typename T, typename Enable = std::enable_if_t<supported_integer_power_ref_types_v<T>>>
+class IntegerPowerRefExecutor : public EltwiseRefBaseExecutor<T> {
+public:
+    IntegerPowerRefExecutor(const EltwiseRefKey& key);
+
+    void exec(const jit_eltwise_call_args_ptrs& args_ptrs,
+              const VectorDims& dims_out,
+              [[maybe_unused]] const CpuParallelPtr& cpu_parallel) override;
+};
+
 EltwiseExecutorPtr createEltwiseRefExecutor(const std::vector<VectorDims>& inDims,
                                             const VectorDims& outBlkDims,
                                             const ov::element::Type& outPrc,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -2,15 +2,131 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
 #include <vector>
-#include "single_op_tests/eltwise.hpp"
+
 #include "common_test_utils/test_constants.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/power.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "single_op_tests/eltwise.hpp"
 
 namespace {
 using ov::test::EltwiseLayerTest;
 using ov::test::utils::InputLayerType;
 using ov::test::utils::OpType;
 using ov::test::utils::EltwiseTypes;
+
+class Int64PowerLayerCPUTest : public ov::test::SubgraphBaseStaticTest {
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_CPU;
+
+        const ov::Shape baseShape{2, 10};
+        const ov::Shape exponentShape{1, 10};
+        auto base = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, baseShape);
+        auto exponent = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, exponentShape);
+        auto power = std::make_shared<ov::op::v1::Power>(base, exponent);
+        function = std::make_shared<ov::Model>(ov::OutputVector{power}, ov::ParameterVector{base, exponent});
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        const auto& functionInputs = function->inputs();
+
+        ov::Tensor baseTensor(ov::element::i64, targetInputStaticShapes[0]);
+        ov::Tensor exponentTensor(ov::element::i64, targetInputStaticShapes[1]);
+
+        constexpr std::array<int64_t, 20> bases = {
+            13,  17,  19,  23,  -2, -3, 5,  7,  2, -2,
+            -13, -17, -19, -23, 2,  3,  1, -1, 1, -1,
+        };
+        constexpr std::array<int64_t, 10> exponents = {8, 7, 7, 6, 3, 2, 1, 0, -1, -2};
+        std::copy(bases.begin(), bases.end(), baseTensor.data<int64_t>());
+        std::copy(exponents.begin(), exponents.end(), exponentTensor.data<int64_t>());
+
+        inputs.insert({functionInputs[0].get_node_shared_ptr(), baseTensor});
+        inputs.insert({functionInputs[1].get_node_shared_ptr(), exponentTensor});
+    }
+};
+
+TEST_F(Int64PowerLayerCPUTest, CompareWithRefs) {
+    run();
+}
+
+class Int64PowerFusedEltwiseLayerCPUTest : public ov::test::SubgraphBaseStaticTest {
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_CPU;
+
+        const ov::Shape inputShape{4};
+        auto base = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inputShape);
+        auto exponent = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inputShape);
+        auto power = std::make_shared<ov::op::v1::Power>(base, exponent);
+        auto addValue = ov::op::v0::Constant::create(ov::element::i64, inputShape, {1, 2, 3, 4});
+        auto add = std::make_shared<ov::op::v1::Add>(power, addValue);
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{base, exponent});
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        const auto& functionInputs = function->inputs();
+
+        ov::Tensor baseTensor(ov::element::i64, targetInputStaticShapes[0]);
+        ov::Tensor exponentTensor(ov::element::i64, targetInputStaticShapes[1]);
+
+        constexpr std::array<int64_t, 4> bases = {13, 17, 19, 23};
+        constexpr std::array<int64_t, 4> exponents = {8, 7, 7, 6};
+        std::copy(bases.begin(), bases.end(), baseTensor.data<int64_t>());
+        std::copy(exponents.begin(), exponents.end(), exponentTensor.data<int64_t>());
+
+        inputs.insert({functionInputs[0].get_node_shared_ptr(), baseTensor});
+        inputs.insert({functionInputs[1].get_node_shared_ptr(), exponentTensor});
+    }
+};
+
+TEST_F(Int64PowerFusedEltwiseLayerCPUTest, CompareWithRefs) {
+    run();
+}
+
+class Int64PowerFusedChildLayerCPUTest : public ov::test::SubgraphBaseStaticTest {
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_CPU;
+
+        const ov::Shape inputShape{4};
+        auto base = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inputShape);
+        auto exponent = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inputShape);
+        auto addValue = ov::op::v0::Constant::create(ov::element::i64, inputShape, {1, 2, 3, 4});
+        auto add = std::make_shared<ov::op::v1::Add>(base, addValue);
+        auto power = std::make_shared<ov::op::v1::Power>(add, exponent);
+        function = std::make_shared<ov::Model>(ov::OutputVector{power}, ov::ParameterVector{base, exponent});
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        const auto& functionInputs = function->inputs();
+
+        ov::Tensor baseTensor(ov::element::i64, targetInputStaticShapes[0]);
+        ov::Tensor exponentTensor(ov::element::i64, targetInputStaticShapes[1]);
+
+        constexpr std::array<int64_t, 4> bases = {12, 15, 16, 19};
+        constexpr std::array<int64_t, 4> exponents = {8, 7, 7, 6};
+        std::copy(bases.begin(), bases.end(), baseTensor.data<int64_t>());
+        std::copy(exponents.begin(), exponents.end(), exponentTensor.data<int64_t>());
+
+        inputs.insert({functionInputs[0].get_node_shared_ptr(), baseTensor});
+        inputs.insert({functionInputs[1].get_node_shared_ptr(), exponentTensor});
+    }
+};
+
+TEST_F(Int64PowerFusedChildLayerCPUTest, CompareWithRefs) {
+    run();
+}
 
 std::vector<std::vector<ov::Shape>> in_shapes_static = {
         {{2}},


### PR DESCRIPTION
### Details:
 - Fixes CPU `Power` with `int64` inputs by keeping `EltwisePowerDynamic` out of JIT when any input or output precision is `i64`.
 - Preserves `i64` in the reference eltwise type mapping for dynamic integer Power, and dispatches to an exact `int64_t` integer Power reference executor.
 - Disables JIT fusion paths that could hide `i64` dynamic Power as a fused parent/child operation.
 - Adds focused CPU regressions for the original issue values, broadcasting, negative bases, exponent 0/1, negative exponents, `Power -> Add`, and non-neutral `Add -> Power`.

### Tickets:
 - Fixes #35838

### Validation:
 - `cmake --build build --target openvino_intel_cpu_plugin ov_cpu_func_tests -j2`
 - `./bin/intel64/Release/ov_cpu_func_tests --gtest_filter=Int64PowerLayerCPUTest.CompareWithRefs:Int64PowerFusedEltwiseLayerCPUTest.CompareWithRefs:Int64PowerFusedChildLayerCPUTest.CompareWithRefs --gtest_color=no`
 - `git diff --check`
 - The Python ONNX reproducer from #35838 was not run locally because the checkout environment does not have the `openvino`, `onnx`, or `onnxruntime` Python modules installed.

### AI Assistance:
 - AI assistance used: yes
 - Codex prepared the patch, checked for duplicate open PRs, ran local build/test validation, and used strict review/test gate agents before publication.