### PR TITLE
CVS-167265-Support dilation>1 for ConvolutionBackpropData and GroupConvolutionBackpropData on GPU Plugin

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
@@ -46,7 +46,8 @@ void pre_replace_deconv::run(program& p) {
             // limit optimization to stride = 1
             // iterators shouldn't be used here because of incorrect iterator functionality in mutable_array_ref<>
             bool unit_stride = all_ones(deconv_prim->stride);
-            if (unit_stride) {
+            bool unit_dilation = all_ones(deconv_prim->dilations);
+            if (unit_stride && unit_dilation) {
                 auto groups = deconv_node.get_groups();
 
                 bool perform_opt = false;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -38,7 +38,7 @@ public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<deconvolution>();
         const auto& stride = primitive->stride;
-        const ov::Strides dilation(impl_param.get_output_layout().get_spatial_rank(), 1);
+        const auto& dilation = primitive->dilations;
 
         const auto& pad = primitive->pad;
         const auto& groups = primitive->groups;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -38,7 +38,9 @@ public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<deconvolution>();
         const auto& stride = primitive->stride;
-        const auto& dilation = primitive->dilations;
+        auto spatial_rank = impl_param.get_output_layout().get_spatial_rank();
+        auto dilation = primitive->dilations;
+        dilation.resize(spatial_rank, 1);
 
         const auto& pad = primitive->pad;
         const auto& groups = primitive->groups;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -26,7 +26,7 @@ static std::shared_ptr<dnnl::deconvolution_forward::primitive_desc> get_deconvol
     auto output_layout = impl_params.get_output_layout();
 
     dnnl::memory::dims stride(prim->stride.begin(), prim->stride.end());
-    dnnl::memory::dims dilation(stride.size(), 1);
+    dnnl::memory::dims dilation(prim->dilations.begin(), prim->dilations.end());
     dnnl::memory::dims pad_l(prim->pad.begin(), prim->pad.end());
     dnnl::memory::dims pad_r(prim->pad.begin(), prim->pad.end());
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -26,7 +26,9 @@ static std::shared_ptr<dnnl::deconvolution_forward::primitive_desc> get_deconvol
     auto output_layout = impl_params.get_output_layout();
 
     dnnl::memory::dims stride(prim->stride.begin(), prim->stride.end());
-    dnnl::memory::dims dilation(prim->dilations.begin(), prim->dilations.end());
+    auto dilations_ov = prim->dilations;
+    dilations_ov.resize(stride.size(), 1);
+    dnnl::memory::dims dilation(dilations_ov.begin(), dilations_ov.end());
     dnnl::memory::dims pad_l(prim->pad.begin(), prim->pad.end());
     dnnl::memory::dims pad_r(prim->pad.begin(), prim->pad.end());
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/deconvolution_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/deconvolution_gpu_ref.cl
@@ -47,9 +47,9 @@ KERNEL(deconvolution_gpu_yxfb_ref)(
     const uint batch_offset  = b_f % INPUT0_BATCH_NUM;
 #endif
 
-    const int x = (int)out_x + PADDING_SIZE_X - (FILTER_SIZE_X - 1);
-    const int y = (int)out_y + PADDING_SIZE_Y - (FILTER_SIZE_Y - 1);
-    const int z = (int)out_z + PADDING_SIZE_Z - (FILTER_SIZE_Z - 1);
+    const int x = (int)out_x + PADDING_SIZE_X - (FILTER_SIZE_X - 1) * DILATION_SIZE_X;
+    const int y = (int)out_y + PADDING_SIZE_Y - (FILTER_SIZE_Y - 1) * DILATION_SIZE_Y;
+    const int z = (int)out_z + PADDING_SIZE_Z - (FILTER_SIZE_Z - 1) * DILATION_SIZE_Z;
 
 #if GROUPED
     const uint g = (ofm_offset / FILTER_OFM_NUM);
@@ -66,21 +66,21 @@ KERNEL(deconvolution_gpu_yxfb_ref)(
 
     for (uint k = 0; k < FILTER_SIZE_Z; k++)
     {
-        const int input_offset_z = z + k;
+        const int input_offset_z = z + k * DILATION_SIZE_Z;
         const bool zero_z = (input_offset_z >= INPUT0_SIZE_Z * STRIDE_SIZE_Z) || (input_offset_z < 0) || ((input_offset_z % STRIDE_SIZE_Z) != 0);
 
         if(!zero_z)
         {
             for (uint i = 0; i < FILTER_SIZE_Y; i++)
             {
-                const int input_offset_y = y + i;
+                const int input_offset_y = y + i * DILATION_SIZE_Y;
                 const bool zero_y = (input_offset_y >= INPUT0_SIZE_Y * STRIDE_SIZE_Y) || (input_offset_y < 0) || ((input_offset_y % STRIDE_SIZE_Y) != 0);
 
                 if(!zero_y)
                 {
                     for (uint j = 0; j < FILTER_SIZE_X; j++)
                     {
-                        const int input_offset_x = x + j;
+                        const int input_offset_x = x + j * DILATION_SIZE_X;
                         const bool zero_x = (input_offset_x >= INPUT0_SIZE_X * STRIDE_SIZE_X) || (input_offset_x < 0) || ((input_offset_x % STRIDE_SIZE_X) != 0);
 
                         if(!zero_x)

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.cpp
@@ -33,6 +33,7 @@ ParamsKey DeconvolutionKernel_b_fs_zyx_fsv16::GetSupportedKey() const {
     k.EnableNonBiasTerm();
     k.EnableBatching();
     k.EnableDifferentTypes();
+    k.EnableDilation();
     return k;
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.cpp
@@ -142,10 +142,10 @@ Datatype DeconvolutionKernelBase::GetAccumulatorType(const deconvolution_params&
     if (params.inputs[0].GetDType() == Datatype::INT8 || params.inputs[0].GetDType() == Datatype::UINT8)
         return Datatype::INT32;
 
-    // input is either fp32 or fp16
-    // for fp32->fp16 accumulate to fp16, otherwise accumulate to input type
-    if (params.outputs[0].GetDType() == Datatype::F16)
-        return Datatype::F16;
+    // Use fp32 accumulator for fp16 to avoid precision loss during accumulation,
+    // especially for dilated deconvolutions with large kernel/channel counts.
+    if (params.inputs[0].GetDType() == Datatype::F16)
+        return Datatype::F32;
 
     return params.inputs[0].GetDType();
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.cpp
@@ -142,9 +142,10 @@ Datatype DeconvolutionKernelBase::GetAccumulatorType(const deconvolution_params&
     if (params.inputs[0].GetDType() == Datatype::INT8 || params.inputs[0].GetDType() == Datatype::UINT8)
         return Datatype::INT32;
 
-    // Use fp32 accumulator for fp16 to avoid precision loss during accumulation,
-    // especially for dilated deconvolutions with large kernel/channel counts.
-    if (params.inputs[0].GetDType() == Datatype::F16)
+    // Use fp32 accumulator for dilated fp16 deconvolutions to avoid precision loss
+    // during accumulation with large effective kernel sizes.
+    if (params.inputs[0].GetDType() == Datatype::F16 &&
+        (params.dilation.x > 1 || params.dilation.y > 1 || params.dilation.z > 1))
         return Datatype::F32;
 
     return params.inputs[0].GetDType();

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.cpp
@@ -148,6 +148,11 @@ Datatype DeconvolutionKernelBase::GetAccumulatorType(const deconvolution_params&
         (params.dilation.x > 1 || params.dilation.y > 1 || params.dilation.z > 1))
         return Datatype::F32;
 
+    // input is either fp32 or fp16
+    // for fp32->fp16 accumulate to fp16, otherwise accumulate to input type
+    if (params.outputs[0].GetDType() == Datatype::F16)
+        return Datatype::F16;
+
     return params.inputs[0].GetDType();
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_ref.cpp
@@ -62,6 +62,7 @@ ParamsKey DeconvolutionKernelRef::GetSupportedKey() const {
     k.EnableGroupedConvolution();
     k.EnableDifferentTypes();
     k.EnableDifferentInputWeightsTypes();
+    k.EnableDilation();
     return k;
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
@@ -99,11 +99,6 @@ static void CreateConvolutionBackpropDataOp(ProgramBuilder& p, const std::shared
     std::string layerName = layer_type_name_ID(op);
 
     auto dilations = op->get_dilations();
-    for (auto d : dilations) {
-        if (d != 1) {
-            OPENVINO_THROW("Unsupported dilation in ConvolutionBackpropData ", op->get_friendly_name());
-        }
-    }
 
     auto weightsName = inputs[1];
     // WA: For the cases like Const(weights)->Sub(zp)->Deconv. And also for the cases with real runtime weights.
@@ -184,11 +179,6 @@ static void CreateGroupConvolutionBackpropDataOp(ProgramBuilder& p, const std::s
     std::string layerName = layer_type_name_ID(op);
 
     auto dilations = op->get_dilations();
-    for (auto d : dilations) {
-        if (d != 1) {
-            OPENVINO_THROW("Unsupported dilation in GroupConvolutionBackpropData ", op->get_friendly_name());
-        }
-    }
 
     uint32_t groups = static_cast<uint32_t>(op->get_input_shape(1)[0]);
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -7,6 +7,29 @@
 #include "single_op_tests/convolution_backprop_data.hpp"
 #include "common_test_utils/test_constants.hpp"
 
+namespace ov {
+namespace test {
+
+class ConvolutionBackpropDataDilationTest : public ConvolutionBackpropDataLayerTest {
+protected:
+    void SetUp() override {
+        ConvolutionBackpropDataLayerTest::SetUp();
+        // FP16 deconv with dilation has inherent quantization error (~0.25 for values >128)
+        const auto& [convParams, model_type, shapes, output_shapes, dev] = this->GetParam();
+        if (model_type == ov::element::f16) {
+            abs_threshold = 0.5;
+            rel_threshold = 0.01;
+        }
+    }
+};
+
+TEST_P(ConvolutionBackpropDataDilationTest, Inference) {
+    run();
+}
+
+}  // namespace test
+}  // namespace ov
+
 namespace {
 using ov::test::ConvolutionBackpropDataLayerTest;
 using ov::test::convBackpropDataLayerTestParamsSet;
@@ -247,4 +270,35 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData1D_ExplicitPadding, Convol
                                 ::testing::ValuesIn(emptyOutputShape),
                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
+
+/* ============= 2D ConvolutionBackpropData with Dilation > 1 ============= */
+const std::vector<ov::element::Type> netPrecisionsDilation = {ov::element::f32, ov::element::f16};
+
+const std::vector<std::vector<ov::Shape>> inputShapesDilation2D = {{{1, 1, 3, 3}}, {{1, 3, 10, 10}}, {{1, 16, 5, 5}}};
+const std::vector<std::vector<size_t>> kernelsDilation2D = {{2, 2}, {3, 3}};
+const std::vector<std::vector<size_t>> stridesDilation2D = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBeginsDilation2D = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEndsDilation2D = {{0, 0}, {1, 1}};
+const std::vector<std::vector<size_t>> dilationsDilation2D = {{2, 2}, {3, 3}};
+const std::vector<size_t> numOutChannelsDilation = {1, 5};
+
+const auto conv2DParams_Dilation_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernelsDilation2D),
+                                                                      ::testing::ValuesIn(stridesDilation2D),
+                                                                      ::testing::ValuesIn(padBeginsDilation2D),
+                                                                      ::testing::ValuesIn(padEndsDilation2D),
+                                                                      ::testing::ValuesIn(dilationsDilation2D),
+                                                                      ::testing::ValuesIn(numOutChannelsDilation),
+                                                                      ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                      ::testing::ValuesIn(emptyOutputPadding));
+
+using ov::test::ConvolutionBackpropDataDilationTest;
+INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData2D_Dilation,
+                         ConvolutionBackpropDataDilationTest,
+                         ::testing::Combine(conv2DParams_Dilation_ExplicitPadding,
+                                            ::testing::ValuesIn(netPrecisionsDilation),
+                                            ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapesDilation2D)),
+                                            ::testing::ValuesIn(emptyOutputShape),
+                                            ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                         ConvolutionBackpropDataLayerTest::getTestCaseName);
+
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -14,7 +14,10 @@ class ConvolutionBackpropDataDilationTest : public ConvolutionBackpropDataLayerT
 protected:
     void SetUp() override {
         ConvolutionBackpropDataLayerTest::SetUp();
-        // FP16 deconv with dilation has inherent quantization error (~0.25 for values >128)
+        // FP16 outputs have limited precision (~1/1024 mantissa). For dilated deconv with
+        // larger spatial inputs, output values can be large enough that FP16 rounding error
+        // exceeds the default epsilon-based threshold. This is not an accumulator issue
+        // (accumulator is already FP32 for dilated FP16) but an output representation limit.
         const auto& [convParams, model_type, shapes, output_shapes, dev] = this->GetParam();
         if (model_type == ov::element::f16) {
             abs_threshold = 0.5;

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/group_convolution_backprop_data.cpp
@@ -7,6 +7,29 @@
 #include "single_op_tests/group_convolution_backprop_data.hpp"
 #include "common_test_utils/test_constants.hpp"
 
+namespace ov {
+namespace test {
+
+class GroupConvBackpropDilationTest : public GroupConvBackpropLayerTest {
+protected:
+    void SetUp() override {
+        GroupConvBackpropLayerTest::SetUp();
+        // FP16 deconv with dilation has inherent quantization error (~0.25 for values >128)
+        const auto& [convParams, model_type, shapes, output_shapes, dev] = this->GetParam();
+        if (model_type == ov::element::f16) {
+            abs_threshold = 0.5;
+            rel_threshold = 0.01;
+        }
+    }
+};
+
+TEST_P(GroupConvBackpropDilationTest, Inference) {
+    run();
+}
+
+}  // namespace test
+}  // namespace ov
+
 namespace {
 using ov::test::GroupConvBackpropLayerTest;
 
@@ -125,4 +148,37 @@ INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData3D_AutoPadValid, GroupConvBa
                                 ::testing::ValuesIn(emptyOutputShape),
                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
+
+/* ============= 2D GroupConvolutionBackpropData with Dilation > 1 ============= */
+const std::vector<ov::element::Type> netPrecisionsDilation = {ov::element::f32, ov::element::f16};
+
+const std::vector<std::vector<ov::Shape>> inputShapesDilation2D = {{{1, 16, 5, 5}}, {{1, 32, 10, 10}}};
+const std::vector<std::vector<size_t>> kernelsDilation2D = {{2, 2}, {3, 3}};
+const std::vector<std::vector<size_t>> stridesDilation2D = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBeginsDilation2D = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEndsDilation2D = {{0, 0}};
+const std::vector<std::vector<size_t>> dilationsDilation2D = {{2, 2}};
+const std::vector<size_t> numOutChannelsDilation = {16, 32};
+const std::vector<size_t> numGroupsDilation = {2, 8};
+
+const auto groupConvBackpropData2DParams_Dilation = ::testing::Combine(::testing::ValuesIn(kernelsDilation2D),
+                                                                       ::testing::ValuesIn(stridesDilation2D),
+                                                                       ::testing::ValuesIn(padBeginsDilation2D),
+                                                                       ::testing::ValuesIn(padEndsDilation2D),
+                                                                       ::testing::ValuesIn(dilationsDilation2D),
+                                                                       ::testing::ValuesIn(numOutChannelsDilation),
+                                                                       ::testing::ValuesIn(numGroupsDilation),
+                                                                       ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                       ::testing::ValuesIn(emptyOutputPadding));
+
+using ov::test::GroupConvBackpropDilationTest;
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData2D_Dilation,
+                         GroupConvBackpropDilationTest,
+                         ::testing::Combine(groupConvBackpropData2DParams_Dilation,
+                                            ::testing::ValuesIn(netPrecisionsDilation),
+                                            ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapesDilation2D)),
+                                            ::testing::ValuesIn(emptyOutputShape),
+                                            ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                         GroupConvBackpropLayerTest::getTestCaseName);
+
 }  // namespace


### PR DESCRIPTION
### Details:
 #### Summary

Enable dilation > 1 support for `ConvolutionBackpropData` and `GroupConvolutionBackpropData` on GPU plugin.

#### Fix

1. Remove the hard-coded dilation check that throws
2. Properly pass dilation parameters through the op creation and kernel selector paths
3. Add `EnableDilation()` to both ref and optimized (b_fs_zyx_fsv16) kernel's `GetSupportedKey()`
4. Fix dilation arithmetic in the ref OpenCL kernel

#### Validation

- **128/128** dilation functional tests pass (`ov_gpu_func_tests --gtest_filter="*Dilation*"`)
- Optimized kernel (`gen9_common_conv_bwd_data`) confirmed selected via graph dump on multi-conv models
- WebNN E2E: dilation test cases now pass on GPU

### Tickets:
 - [*CVS-167265*](https://jira.devtools.intel.com/browse/CVS-167265)

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
