### PR TITLE
[TEST] Activate save-report retry timeout for functional tests

### DIFF
--- a/src/tests/functional/plugin/shared/src/main.cpp
+++ b/src/tests/functional/plugin/shared/src/main.cpp
@@ -15,6 +15,7 @@ int main(int argc, char *argv[]) {
     ov::test::utils::is_print_rel_influence_coef = false;
     bool print_custom_help = false;
     std::string outputFolderPath(".");
+    ov::test::utils::OpSummary::setSaveReportTimeout(5);
     for (int i = 0; i < argc; ++i) {
         if (std::string(argv[i]) == "--disable_tests_skipping") {
             ov::test::utils::disable_tests_skipping = true;

--- a/src/tests/functional/plugin/shared/src/main.cpp
+++ b/src/tests/functional/plugin/shared/src/main.cpp
@@ -15,7 +15,7 @@ int main(int argc, char *argv[]) {
     ov::test::utils::is_print_rel_influence_coef = false;
     bool print_custom_help = false;
     std::string outputFolderPath(".");
-    ov::test::utils::OpSummary::setSaveReportTimeout(5);
+    ov::test::utils::OpSummary::setSaveReportTimeout(60);
     for (int i = 0; i < argc; ++i) {
         if (std::string(argv[i]) == "--disable_tests_skipping") {
             ov::test::utils::disable_tests_skipping = true;

--- a/src/tests/test_utils/functional_test_utils/src/summary/api_summary.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/summary/api_summary.cpp
@@ -5,6 +5,7 @@
 #include "functional_test_utils/summary/api_summary.hpp"
 
 #include <pugixml.hpp>
+#include <thread>
 
 #include "common_test_utils/file_utils.hpp"
 
@@ -222,6 +223,9 @@ void ApiSummary::saveReport() {
     bool result = false;
     do {
         result = doc.save_file(outputFilePath.c_str());
+        if (!result && std::chrono::system_clock::now() < exitTime) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
     } while (!result && std::chrono::system_clock::now() < exitTime);
 
     if (!result) {

--- a/src/tests/test_utils/functional_test_utils/src/summary/op_summary.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/summary/op_summary.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <pugixml.hpp>
+#include <thread>
 
 #include "common_test_utils/file_utils.hpp"
 #include "functional_test_utils/summary/op_info.hpp"
@@ -363,6 +364,9 @@ void OpSummary::saveReport() {
     bool result = false;
     do {
         result = doc.save_file(outputFilePath.c_str());
+        if (!result && std::chrono::system_clock::now() < exitTime) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
     } while (!result && std::chrono::system_clock::now() < exitTime);
 
     if (!result) {


### PR DESCRIPTION
### Details:
  - Activate the existing save-report retry mechanism for ordinary functional tests to prevent random CI failures on transient I/O errors.

### Description of the issue (symptom, root-cause, how it was resolved)
  - **Symptom**: Random GHA CI jobs fail with `"Failed to write report to ./report_*_*.xml" thrown in auxiliary test code`, even though all test cases pass (`[  PASSED  ]`). The failure is non-deterministic and not reproducible on bare-metal machines.

  - **Root Cause**:
    - `op_summary.cpp` / `api_summary.cpp` call `pugixml::save_file()` (which calls `fopen()`) during gtest. On GHA's Docker overlay2 filesystem, `fopen()` occasionally returns a transient error (e.g. EIO).
    - The code has a `do/while` retry loop gated by `saveReportTimeout`, but `saveReportTimeout` defaults to `0` in `summary.cpp:54`. With a zero-second budget, `exitTime = now + 0s`, so the loop body executes exactly once — the retry mechanism is dead code.
    - The conformance test runner sets `saveReportTimeout = 60` via `--save_report_timeout` flag (defined in `gflag_config.hpp:57`), but ordinary func tests (`main.cpp`) never call `setSaveReportTimeout()`, leaving it at 0.
    - Additionally, the retry loop had no `sleep_for()` between attempts, meaning even with a non-zero timeout it would busy-spin.

  - **Resolution**:
    - `main.cpp`: Call `OpSummary::setSaveReportTimeout(5)` before the argument-parsing loop, giving the retry loop a 5-second budget. Users can still override via `--save_report_timeout=N`.
    - `op_summary.cpp` / `api_summary.cpp`: Add `sleep_for(500ms)` between retry attempts to avoid busy-spinning and give the filesystem time to recover.

#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [v] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
  - *CVS-182877*
