### PR TITLE
[core] supporting quotation marks in names parsing in ov::Any

### DIFF
--- a/src/core/include/openvino/core/any.hpp
+++ b/src/core/include/openvino/core/any.hpp
@@ -234,7 +234,17 @@ struct Read<
 
         while (c != '}') {
             std::string key, value;
-            std::getline(is, key, ':');
+            if (is.peek() == '\'' || is.peek() == '"') {
+                // enabling keys with ":" sign
+                is >> c;
+                char separator = c;
+                std::getline(is, key, separator);
+                OPENVINO_ASSERT(is.get() == ':',
+                                "Parsing error: Separator (:) needed after key name. format: {" +
+                                    std::string(1, separator) + "key" + std::string(1, separator) + ":value}");
+            } else {
+                std::getline(is, key, ':');
+            }
             size_t enclosed_container_level = 0;
 
             while (is.good()) {

--- a/src/core/tests/any.cpp
+++ b/src/core/tests/any.cpp
@@ -801,5 +801,53 @@ TEST_F(AnyTests, AnyAsOtherTypeIsIncosisoinet) {
     EXPECT_EQ(a_str, "30");
 }
 
+// Tests below validate only the parser used for OV_GPU_FORCE_IMPLEMENTATIONS attribute parsing, but do not
+// validate the function itself. The provided primitive names, implementation types, layouts, and kernel names are
+// treated as parser input only and may not correspond to real or available runtime values.
+
+using MapStrStr = std::map<std::string, std::string>;
+
+TEST_F(AnyTests, ParseForceImplementationsMap_Simple) {
+    const std::string force_impl_string = "{conv1:impl:kernelname:any}";
+    ov::Any any(force_impl_string);
+
+    MapStrStr map;
+    OV_ASSERT_NO_THROW(map = any.as<MapStrStr>());
+    ASSERT_EQ(map.size(), 1);
+
+    ASSERT_NE(map.find("conv1"), map.end());
+    ASSERT_EQ(map["conv1"], "impl:kernelname:any");
+}
+
+TEST_F(AnyTests, ParseForceImplementationsMap_MultipleEntries) {
+    const std::string force_impl_string = "{conv1:impl1::any,conv2:impl2:kernel:any,pool1:impl3::layout}";
+    ov::Any any(force_impl_string);
+
+    MapStrStr map;
+    OV_ASSERT_NO_THROW(map = any.as<MapStrStr>());
+    ASSERT_EQ(map.size(), 3);
+
+    ASSERT_NE(map.find("conv1"), map.end());
+    ASSERT_EQ(map["conv1"], "impl1::any");
+
+    ASSERT_NE(map.find("conv2"), map.end());
+    ASSERT_EQ(map["conv2"], "impl2:kernel:any");
+
+    ASSERT_NE(map.find("pool1"), map.end());
+    ASSERT_EQ(map["pool1"], "impl3::layout");
+}
+
+TEST_F(AnyTests, ParseForceImplementationsMap_SemicolonsInName) {
+    const std::string force_impl_string = "{\"layer:name\":impl::any}";
+    ov::Any any(force_impl_string);
+
+    MapStrStr map;
+    OV_ASSERT_NO_THROW(map = any.as<MapStrStr>());
+    ASSERT_EQ(map.size(), 1);
+
+    ASSERT_NE(map.find("layer:name"), map.end());
+    ASSERT_EQ(map["layer:name"], "impl::any");
+}
+
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - enabling ":" sign in key names for variables parser
 - PR created as a result of [PR#35629](https://github.com/openvinotoolkit/openvino/pull/35629)

### Tickets:
 - CVS-186782

### AI Assistance:
 - *AI assistance used: no*
