### PR TITLE
Preserve int64 CumSum precision on CPU

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 
@@ -19,8 +20,12 @@
 #include "nodes/fullyconnected.h"
 #include "nodes/gathermatmul.h"
 #include "openvino/cc/pass/itt.hpp"
+#include "openvino/core/graph_util.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/cum_sum.hpp"
+#include "openvino/op/parameter.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/validate.hpp"
@@ -34,8 +39,46 @@
 #include "transformations/op_conversions/convert_fc_to_compressed.hpp"
 #include "transformations/op_conversions/convert_fc_to_quantized_legacy.hpp"
 #include "transformations/op_conversions/convert_gather_matmul_to_compressed.hpp"
+#include "transformations/rt_info/keep_const_precision.hpp"
 
 namespace ov::intel_cpu {
+
+inline void keep_integer_cumsum_data_precision(const std::shared_ptr<ov::Model>& model) {
+    ov::traverse_nodes(model, [](const std::shared_ptr<ov::Node>& node) {
+        if (!ov::is_type<ov::op::v0::CumSum>(node)) {
+            return;
+        }
+
+        const auto data = node->input_value(0);
+        const auto data_type = data.get_element_type();
+        if (data_type != ov::element::i64 && data_type != ov::element::u64) {
+            return;
+        }
+
+        const auto source = data.get_node_shared_ptr();
+        if (!ov::is_type_any_of<ov::op::v0::Constant, ov::op::v0::Parameter>(source) ||
+            source->get_output_size() != 1) {
+            return;
+        }
+
+        const auto consumers = data.get_target_inputs();
+        if (std::all_of(consumers.begin(), consumers.end(), [](const ov::Input<ov::Node>& input) {
+                return input.get_index() == 0 && ov::is_type<ov::op::v0::CumSum>(input.get_node());
+            })) {
+            ov::enable_keep_const_precision(source);
+        }
+    });
+}
+
+class KeepIntegerCumSumDataPrecision : public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("KeepIntegerCumSumDataPrecision");
+
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override {
+        keep_integer_cumsum_data_precision(model);
+        return false;
+    }
+};
 
 inline void ConvertToCPUSpecificOpset(std::shared_ptr<ov::Model>& model, const Config& config) {
     RUN_ON_FUNCTION_SCOPE(ConvertToCPUSpecificOpset);
@@ -88,6 +131,7 @@ inline void ConvertToCPUSpecificOpset(std::shared_ptr<ov::Model>& model, const C
         ov::pass::ReshapeSequenceFusion);  // after transformation "MoveEltwiseUpThroughDataMov" there can be reshaped
                                            // sequences that should be eliminated or fused
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::ConstantFolding);
+    CPU_REGISTER_PASS_COMMON(manager, KeepIntegerCumSumDataPrecision);
     CPU_REGISTER_PASS_COMMON(manager,
                              ov::pass::ConvertPrecision,
                              precisions_map{{ov::element::i64, ov::element::i32}},

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -662,6 +662,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     // Do not insert pass::Validate between pass::InsertConvertAfterExtension and pass::ConvertPrecision.
     // This may result in the loss of the original Element type of the Output .
     // element type convert is disabled.
+    CPU_REGISTER_PASS_COMMON(manager, KeepIntegerCumSumDataPrecision);
     CPU_REGISTER_PASS_COMMON(manager,
                              ov::pass::ConvertPrecision,
                              precisions,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/cum_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/cum_sum.cpp
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <cstdint>
+
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
+#include "openvino/op/convert.hpp"
 #include "openvino/op/cum_sum.hpp"
 
 using namespace CPUTestUtils;
@@ -15,6 +18,20 @@ using cumSumParams = std::tuple<ov::element::Type,  // data precision
                                 std::int64_t,       // axis
                                 bool,               // exclusive
                                 bool>;              // reverse
+
+static void fillLargeInt64Values(ov::Tensor& tensor) {
+    auto* data = tensor.data<std::int64_t>();
+    static constexpr std::int64_t values[] = {
+        std::int64_t{1} << 33,
+        std::int64_t{1} << 34,
+        std::int64_t{1} << 35,
+        5,
+        7,
+    };
+    for (size_t i = 0; i < tensor.get_size(); ++i) {
+        data[i] = values[i % (sizeof(values) / sizeof(values[0]))];
+    }
+}
 
 class CumSumLayerCPUTest : public testing::WithParamInterface<cumSumParams>,
                            public SubgraphBaseTest,
@@ -55,6 +72,49 @@ protected:
         function = std::make_shared<ov::Model>(ov::OutputVector{cumSum}, params, "CumSumLayerCPUTest");
         functionRefs = function->clone();
     }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        SubgraphBaseTest::generate_inputs(targetInputStaticShapes);
+
+        for (const auto& param : function->get_parameters()) {
+            if (param->get_element_type() != ov::element::i64) {
+                continue;
+            }
+
+            auto& tensor = inputs.at(param);
+            fillLargeInt64Values(tensor);
+        }
+    }
+};
+
+class CumSumExplicitConvertCPUTest : public SubgraphBaseTest, public CPUTestsBase {
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_CPU;
+        inType = ElementType::i64;
+        selectedType = makeSelectedTypeStr("ref_any", ov::element::i32);
+
+        init_input_shapes({{{-1}, {{5}}}});
+
+        auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inputDynamicShapes.front());
+        auto convert = std::make_shared<ov::op::v0::Convert>(param, ov::element::i32);
+        auto axisNode = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, std::vector<int64_t>{0});
+        auto cumSum = std::make_shared<ov::op::v0::CumSum>(convert, axisNode, false, false);
+
+        function = std::make_shared<ov::Model>(ov::OutputVector{cumSum},
+                                               ov::ParameterVector{param},
+                                               "CumSumExplicitConvertCPUTest");
+        functionRefs = function->clone();
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        SubgraphBaseTest::generate_inputs(targetInputStaticShapes);
+
+        for (const auto& param : function->get_parameters()) {
+            auto& tensor = inputs.at(param);
+            fillLargeInt64Values(tensor);
+        }
+    }
 };
 
 TEST_P(CumSumLayerCPUTest, CompareWithRefs) {
@@ -62,7 +122,13 @@ TEST_P(CumSumLayerCPUTest, CompareWithRefs) {
     CheckPluginRelatedResults(compiledModel, "CumSum");
 }
 
+TEST_F(CumSumExplicitConvertCPUTest, CompareWithRefs) {
+    run();
+    CheckPluginRelatedResults(compiledModel, "CumSum");
+}
+
 const std::vector<ov::element::Type> inputPrecision = {ov::element::i8, ov::element::bf16, ov::element::f32};
+const std::vector<ov::element::Type> int64InputPrecision = {ov::element::i64};
 
 const std::vector<int64_t> axes = {0, 1, 2, 3, 4, 5, 6};
 const std::vector<int64_t> negativeAxes = {-1, -2, -3, -4, -5, -6};
@@ -90,11 +156,19 @@ const std::vector<InputShape> inShapes = {
 
     {{{2, 5}, -1, {4, 8}, -1, -1, {3, 7}, -1}, {{2, 4, 6, 5, 4, 3, 1}, {3, 5, 6, 6, 5, 3, 1}, {5, 7, 4, 6, 3, 7, 2}}}};
 
+const std::vector<InputShape> int64InShapes = {{{-1}, {{5}}}};
+
 const auto testCasesAxis_0 = ::testing::Combine(::testing::ValuesIn(inputPrecision),
                                                 ::testing::ValuesIn(inShapes),
                                                 ::testing::Values(axes[0]),
                                                 ::testing::ValuesIn(exclusive),
                                                 ::testing::ValuesIn(reverse));
+
+const auto testCasesInt64Axis_0 = ::testing::Combine(::testing::ValuesIn(int64InputPrecision),
+                                                     ::testing::ValuesIn(int64InShapes),
+                                                     ::testing::Values(axes[0]),
+                                                     ::testing::Values(false),
+                                                     ::testing::Values(false));
 
 const auto testCasesAxis_1 =
     ::testing::Combine(::testing::ValuesIn(inputPrecision),
@@ -148,6 +222,10 @@ const auto testCasesAxis_negative =
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefsNumpy_axis_0,
                          CumSumLayerCPUTest,
                          testCasesAxis_0,
+                         CumSumLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefsNumpy_int64_axis_0,
+                         CumSumLayerCPUTest,
+                         testCasesInt64Axis_0,
                          CumSumLayerCPUTest::getTestCaseName);
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefsNumpy_axis_1,
                          CumSumLayerCPUTest,


### PR DESCRIPTION
### Details:
 - Preserve direct `i64`/`u64` `CumSum` data precision in the CPU transformation pipeline before the generic `ConvertPrecision` pass can narrow it to `i32`.
 - Scope the precision preservation to direct `Parameter` and `Constant` sources used only as `CumSum` data inputs, so explicit user-authored converts still keep their existing semantics.
 - Add CPU functional coverage for large `i64` CumSum inputs and a guard case for explicit `Convert(i64 -> i32) -> CumSum`.

### Tickets:
 - Fixes #35837

### AI Assistance:
 - AI assistance used: yes
 - AI was used to inspect the issue, identify the CPU precision-conversion path, implement the scoped fix, and draft regression coverage. Validation was performed with targeted CPU functional tests, an adjacent CumSum subset, `git diff --check`, strict review, test verification, and publish gate review.