### PR TITLE
[NPU][Tests] Pass NPU platform for test configs with PLUGIN compiler

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/compatibility_string.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/compatibility_string.hpp
@@ -94,7 +94,11 @@ TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsIsSupported) {
     // Forcing CIP as the current compiler type
     auto model = ov::test::utils::make_conv_pool_relu();
     ov::CompiledModel compiledModel;
-    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(model, deviceName, ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN)));
+    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(
+        model, deviceName,
+        {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+         ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+             ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}));
 
     std::vector<ov::PropertyName> properties;
     // Test that RUNTIME_REQUIREMENTS is supported for a model compiled with CIP
@@ -134,8 +138,12 @@ TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsIsNotSupportedForWS
     auto model = core.read_model(model_xml.str(), model_weights);
 
     ov::CompiledModel compiledModel;
-    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(model, deviceName, {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-                                                          ov::enable_weightless(true) }));
+    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(
+        model, deviceName,
+        {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+         ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+             ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),
+         ov::enable_weightless(true)}));
 
     std::vector<ov::PropertyName> properties;
     // Test that RUNTIME_REQUIREMENTS is not supported for a weightless model
@@ -151,7 +159,11 @@ TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsExportImport) {
     // Forcing CIP as the current compiler type
     auto model = ov::test::utils::make_conv_pool_relu();
     ov::CompiledModel compiledModel;
-    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(model, deviceName, ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN)));
+    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(
+        model, deviceName,
+        {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+         ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+             ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}));
     std::string reference_requirements;
     OV_ASSERT_NO_THROW(reference_requirements = compiledModel.get_property(ov::runtime_requirements));
 
@@ -178,7 +190,11 @@ TEST_P(ClassCompatibilityStringTestSuite, CompatibilityStringGenerateAndCheck) {
     // Forcing CIP as the current compiler type
     auto model = ov::test::utils::make_conv_pool_relu();
     ov::CompiledModel compiledModel;
-    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(model, deviceName, ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN)));
+    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(
+        model, deviceName,
+        {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+         ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+             ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}));
 
     std::string requirements;
     OV_ASSERT_NO_THROW(requirements = compiledModel.get_property(ov::runtime_requirements));

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/model_cache.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/model_cache.cpp
@@ -17,11 +17,15 @@ std::vector<ov::AnyMap> config = {
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),  // only CIP is allowed for ONE_SHOT
+     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+        ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ONE_SHOT),
      ov::enable_mmap(false)},  // enable_mmap for both `import_model(stream)` and `import_model(tensor)` paths
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+        ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ONE_SHOT),
      ov::enable_mmap(true)},
     {ov::enable_weightless(true),
@@ -37,11 +41,15 @@ std::vector<ov::AnyMap> config = {
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+        ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ITERATIVE),
      ov::enable_mmap(false)},
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+        ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ITERATIVE),
      ov::enable_mmap(true)}};
 

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.cpp
@@ -16,7 +16,10 @@ std::vector<ov::AnyMap> config = {
     {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
      ov::cache_encryption_callbacks(ov::EncryptionCallbacks{ov::util::codec_xor, ov::util::codec_xor})},
     {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-     ov::cache_encryption_callbacks(ov::EncryptionCallbacks{ov::util::codec_xor, ov::util::codec_xor})}};
+     ov::cache_encryption_callbacks(ov::EncryptionCallbacks{ov::util::codec_xor, ov::util::codec_xor}),
+     // platform needed for NPU_COMPILER_TYPE_PLUGIN
+     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+        ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          OVCompileModelLoadFromFileTestBaseNPU,

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/model_cache.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/model_cache.cpp
@@ -18,11 +18,15 @@ std::vector<ov::AnyMap> config = {
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),  // only CIP is allowed for ONE_SHOT
+     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+        ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ONE_SHOT),
      ov::enable_mmap(false)},  // enable_mmap for both `import_model(stream)` and `import_model(tensor)` paths
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+        ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ONE_SHOT),
      ov::enable_mmap(true)},
     {ov::enable_weightless(true),
@@ -38,11 +42,15 @@ std::vector<ov::AnyMap> config = {
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+        ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ITERATIVE),
      ov::enable_mmap(false)},
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
+     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+        ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ITERATIVE),
      ov::enable_mmap(true)}};
 


### PR DESCRIPTION
### Details:
 - *Updated test configs: explicit NPU platform when PLUGIN compiler is used.*
 - *Tests: `ClassCompatibilityStringTestSuite`, `OVCompileModelLoadFromFileTestBaseNPU`, `WeightlessCacheAccuracy`, `OVWeightlessCacheAccuracyNPU`.*

### Tickets:
 - *E-215905, E-215070, E-214833*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
