### PR TITLE
Fix CPU Minimum NaN propagation

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
@@ -2092,7 +2092,7 @@ void jit_minimum_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     auto src2 = TReg(in_vec_idxs[1]);
     auto dst = TReg(out_vec_idxs[0]);
 
-    h->fminnm(dst.s, src1.s, src2.s);
+    h->fmin(dst.s, src1.s, src2.s);
 }
 
 std::set<std::vector<element::Type>> jit_minimum_emitter::get_supported_precisions(

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
@@ -2528,14 +2528,27 @@ std::set<std::vector<element::Type>> jit_maximum_emitter::get_supported_precisio
 }
 /// MINIMUM ///
 jit_minimum_emitter::jit_minimum_emitter(jit_generator_t* host, cpu_isa_t host_isa, const element::Type exec_prc)
-    : jit_emitter(host, host_isa, exec_prc) {}
+    : jit_emitter(host, host_isa, exec_prc) {
+    prepare_table();
+}
 
 jit_minimum_emitter::jit_minimum_emitter(jit_generator_t* host,
                                          cpu_isa_t host_isa,
                                          const std::shared_ptr<ov::Node>& node)
-    : jit_emitter(host, host_isa, get_arithmetic_binary_exec_precision(node)) {}
+    : jit_emitter(host, host_isa, get_arithmetic_binary_exec_precision(node)) {
+    prepare_table();
+}
 
 size_t jit_minimum_emitter::get_inputs_num() const {
+    return 2;
+}
+
+size_t jit_minimum_emitter::aux_vecs_count() const {
+    return 3;
+}
+
+size_t jit_minimum_emitter::aux_gprs_count() const {
+    // One GPR is used as a table load temporary, and one is reserved by the base emitter for p_table.
     return 2;
 }
 
@@ -2556,13 +2569,28 @@ void jit_minimum_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     auto src0 = VReg(in_vec_idxs[0]);
     auto src1 = VReg(in_vec_idxs[1]);
     auto dst = VReg(out_vec_idxs[0]);
+    auto qnan = VReg(aux_vec_idxs[0]);
+    auto src0_orig = VReg(aux_vec_idxs[1]);
+    auto src1_orig = VReg(aux_vec_idxs[2]);
+    auto tmp = Reg(aux_gpr_idxs[0]);
 
+    h->vmv_v_v(src0_orig, src0);
+    h->vmv_v_v(src1_orig, src1);
+    load_table_val("qnan", qnan, tmp);
     h->vfmin_vv(dst, src0, src1);
+    h->vmfne_vv(mask_vreg(), src0_orig, src0_orig);
+    h->vmerge_vvm(dst, dst, qnan);
+    h->vmfne_vv(mask_vreg(), src1_orig, src1_orig);
+    h->vmerge_vvm(dst, dst, qnan);
 }
 
 std::set<std::vector<element::Type>> jit_minimum_emitter::get_supported_precisions(
     [[maybe_unused]] const std::shared_ptr<ov::Node>& node) {
     return {{element::f32, element::f32}};
+}
+
+void jit_minimum_emitter::register_table_entries() {
+    push_arg_entry_of("qnan", 0x7FC00000);
 }
 
 /// LOGICAL AND ///

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
@@ -681,6 +681,8 @@ public:
     jit_minimum_emitter(jit_generator_t* host, cpu_isa_t host_isa, const std::shared_ptr<ov::Node>& node);
 
     size_t get_inputs_num() const override;
+    size_t aux_vecs_count() const override;
+    size_t aux_gprs_count() const override;
 
     static std::set<std::vector<element::Type>> get_supported_precisions(
         const std::shared_ptr<ov::Node>& node = nullptr);
@@ -689,6 +691,7 @@ private:
     void emit_impl(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const override;
     template <cpu_isa_t isa>
     void emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const;
+    void register_table_entries() override;
 };
 
 class jit_mod_emitter : public jit_emitter {

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
@@ -674,11 +674,15 @@ std::set<std::vector<element::Type>> jit_maximum_emitter::get_supported_precisio
 jit_minimum_emitter::jit_minimum_emitter(x64::jit_generator_t* host,
                                          x64::cpu_isa_t host_isa,
                                          const std::shared_ptr<ov::Node>& node)
-    : jit_emitter(host, host_isa, get_arithmetic_binary_exec_precision(node)) {}
+    : jit_emitter(host, host_isa, get_arithmetic_binary_exec_precision(node)) {
+    prepare_table();
+}
 jit_minimum_emitter::jit_minimum_emitter(x64::jit_generator_t* host,
                                          x64::cpu_isa_t host_isa,
                                          ov::element::Type exec_prc)
-    : jit_emitter(host, host_isa, exec_prc) {}
+    : jit_emitter(host, host_isa, exec_prc) {
+    prepare_table();
+}
 
 size_t jit_minimum_emitter::get_inputs_num() const {
     return 2;
@@ -718,19 +722,62 @@ void jit_minimum_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
         }
     };
 
-    if (isa == x64::sse41) {
+    const auto emit_min = [&]() {
+        if (isa != x64::sse41) {
+            uni_vmin(vmm_dst, vmm_src0, vmm_src1);
+            return;
+        }
+
         if (vmm_src0.getIdx() != vmm_dst.getIdx()) {
             h->uni_vmovups(vmm_dst, vmm_src0);
         }
         uni_vmin(vmm_dst, vmm_dst, vmm_src1);
+    };
+
+    if (exec_prc_ == ov::element::f32) {
+        if (isa == x64::avx512_core) {
+            auto vmm_src0_orig = Vmm(aux_vec_idxs[0]);
+            auto vmm_src1_orig = Vmm(aux_vec_idxs[1]);
+            h->uni_vmovups(vmm_src0_orig, vmm_src0);
+            h->uni_vmovups(vmm_src1_orig, vmm_src1);
+            emit_min();
+            h->vcmpps(k_mask, vmm_src0_orig, vmm_src0_orig, _cmp_neq_uq);
+            h->vblendmps(vmm_dst | k_mask, vmm_dst, table_val("qnan"));
+            h->vcmpps(k_mask, vmm_src1_orig, vmm_src1_orig, _cmp_neq_uq);
+            h->vblendmps(vmm_dst | k_mask, vmm_dst, table_val("qnan"));
+        } else {
+            auto vmm_mask = Vmm(aux_vec_idxs[0]);
+            auto vmm_src0_orig = Vmm(aux_vec_idxs[1]);
+            auto vmm_src1_orig = Vmm(aux_vec_idxs[2]);
+            h->uni_vmovups(vmm_src0_orig, vmm_src0);
+            h->uni_vmovups(vmm_src1_orig, vmm_src1);
+            emit_min();
+            h->uni_vcmpps(vmm_mask, vmm_src0_orig, vmm_src0_orig, _cmp_neq_uq);
+            h->uni_vblendvps(vmm_dst, vmm_dst, table_val("qnan"), vmm_mask);
+            h->uni_vcmpps(vmm_mask, vmm_src1_orig, vmm_src1_orig, _cmp_neq_uq);
+            h->uni_vblendvps(vmm_dst, vmm_dst, table_val("qnan"), vmm_mask);
+        }
     } else {
-        uni_vmin(vmm_dst, vmm_src0, vmm_src1);
+        emit_min();
     }
 }
 
 std::set<std::vector<element::Type>> jit_minimum_emitter::get_supported_precisions(
     [[maybe_unused]] const std::shared_ptr<ov::Node>& node) {
     return {{element::f32, element::f32}, {element::i32, element::i32}};
+}
+
+void jit_minimum_emitter::register_table_entries() {
+    if (exec_prc_ == ov::element::f32) {
+        push_arg_entry_of("qnan", 0x7FC00000, true);
+    }
+}
+
+size_t jit_minimum_emitter::aux_vecs_count() const {
+    if (exec_prc_ != ov::element::f32) {
+        return 0;
+    }
+    return host_isa_ == x64::avx512_core ? 2 : 3;
 }
 
 /// SQUARED_DIFFERENCE ///

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.hpp
@@ -246,6 +246,9 @@ private:
 
     template <dnnl::impl::cpu::x64::cpu_isa_t isa>
     void emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const;
+
+    void register_table_entries() override;
+    size_t aux_vecs_count() const override;
 };
 
 class jit_squared_difference_emitter : public jit_emitter {

--- a/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.cpp
@@ -336,7 +336,13 @@ void EltwiseRefExecutor<T, Enable>::exec(const jit_eltwise_call_args_ptrs& args_
                 *dst_ptr_f = std::max(src_f[0], src_f[1]);
                 break;
             case Algorithm::EltwiseMinimum:
-                *dst_ptr_f = std::min(src_f[0], src_f[1]);
+                if (std::isnan(static_cast<float>(src_f[0]))) {
+                    *dst_ptr_f = src_f[0];
+                } else if (std::isnan(static_cast<float>(src_f[1]))) {
+                    *dst_ptr_f = src_f[1];
+                } else {
+                    *dst_ptr_f = std::min(src_f[0], src_f[1]);
+                }
                 break;
             case Algorithm::EltwiseExp:
                 *dst_ptr_f = expf(src_f[0]);

--- a/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
@@ -572,10 +572,11 @@ void jit_uni_eltwise_generic<isa>::apply_post_ops() const {
     int input_idx = eltwise_emitter->get_inputs_num();
     int eltwise_post_op_idx = 0;
     for (size_t i = 1; i < eltwise_data_.size(); i++) {
-        OPENVINO_ASSERT(post_op_emitters[eltwise_post_op_idx], "Post-op emitter is missed for code emission!");
+        const auto& post_op_emitter = post_op_emitters[eltwise_post_op_idx];
+        OPENVINO_ASSERT(post_op_emitter, "Post-op emitter is missed for code emission!");
         std::vector<size_t> in_idxs;
         in_idxs.push_back(dst_vec().getIdx());
-        for (size_t j = 1; j < post_op_emitters[eltwise_post_op_idx]->get_inputs_num(); j++) {
+        for (size_t j = 1; j < post_op_emitter->get_inputs_num(); j++) {
             in_idxs.push_back(src_vec(input_idx++).getIdx());
         }
 
@@ -587,25 +588,21 @@ void jit_uni_eltwise_generic<isa>::apply_post_ops() const {
         const auto max_aux_vec_available = get_max_aux_vec_count();
 
         std::vector<size_t> aux_vec_idxs;
-        for (size_t i = 0; i < std::min(eltwise_emitter->aux_vecs_count(), max_aux_vec_available); i++) {
+        for (size_t i = 0; i < std::min(post_op_emitter->aux_vecs_count(), max_aux_vec_available); i++) {
             aux_vec_idxs.push_back(aux_vec(i).getIdx());
         }
 
         std::vector<size_t> aux_gpr_idxs;
-        for (size_t i = 0; i < std::min(eltwise_emitter->aux_gprs_count(), max_aux_gpr_available); i++) {
+        for (size_t i = 0; i < std::min(post_op_emitter->aux_gprs_count(), max_aux_gpr_available); i++) {
             aux_gpr_idxs.push_back(aux_gpr(i).getIdx());
         }
 
         std::vector<size_t> aux_fp_gpr_idxs;
-        for (size_t i = 0; i < std::min(eltwise_emitter->aux_fp_gprs_count(), max_aux_fp_gpr_available); i++) {
+        for (size_t i = 0; i < std::min(post_op_emitter->aux_fp_gprs_count(), max_aux_fp_gpr_available); i++) {
             aux_fp_gpr_idxs.push_back(aux_fp_gpr(i).getIdx());
         }
 
-        post_op_emitters[eltwise_post_op_idx]->emit_code(in_idxs,
-                                                         out_idxs,
-                                                         aux_vec_idxs,
-                                                         aux_gpr_idxs,
-                                                         aux_fp_gpr_idxs);
+        post_op_emitter->emit_code(in_idxs, out_idxs, aux_vec_idxs, aux_gpr_idxs, aux_fp_gpr_idxs);
 
         eltwise_post_op_idx++;
     }

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
@@ -5,6 +5,10 @@
 #include "single_op_tests/minimum_maximum.hpp"
 #include "common_test_utils/test_constants.hpp"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 namespace {
 using ov::test::MaxMinLayerTest;
 using ov::test::utils::InputLayerType;
@@ -35,6 +39,83 @@ const std::vector<InputLayerType> second_input_types = {
         InputLayerType::PARAMETER,
 };
 
+class MaxMinNaNLayerTest : public MaxMinLayerTest {
+protected:
+    void generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) override {
+        const auto& params = GetParam();
+        const auto op_type = std::get<1>(params);
+        const auto model_type = std::get<2>(params);
+        const auto second_input_type = std::get<3>(params);
+        ASSERT_EQ(op_type, MinMaxOpType::MINIMUM);
+        ASSERT_EQ(model_type, ov::element::f32);
+        ASSERT_EQ(second_input_type, InputLayerType::PARAMETER);
+        ASSERT_EQ(target_input_static_shapes.size(), 2);
+        ASSERT_EQ(ov::shape_size(target_input_static_shapes[0]), ov::shape_size(target_input_static_shapes[1]));
+
+        inputs.clear();
+        const std::vector<std::vector<float>> input_values = {
+            {std::numeric_limits<float>::quiet_NaN(), 5.F, std::numeric_limits<float>::quiet_NaN(), -2.F},
+            {3.F, std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(), -4.F},
+        };
+
+        const auto& func_inputs = function->inputs();
+        for (size_t input_idx = 0; input_idx < func_inputs.size(); ++input_idx) {
+            ov::Tensor tensor{ov::element::f32, target_input_static_shapes[input_idx]};
+            auto* data = tensor.data<float>();
+            const auto tensor_size = tensor.get_size();
+            for (size_t i = 0; i < tensor_size; ++i) {
+                data[i] = input_values[input_idx][i % input_values[input_idx].size()];
+            }
+            inputs.insert({func_inputs[input_idx].get_node_shared_ptr(), tensor});
+        }
+
+        expected_output = ov::Tensor{ov::element::f32, target_input_static_shapes[0]};
+        const auto* lhs = inputs.at(func_inputs[0].get_node_shared_ptr()).data<const float>();
+        const auto* rhs = inputs.at(func_inputs[1].get_node_shared_ptr()).data<const float>();
+        auto* expected = expected_output.data<float>();
+        for (size_t i = 0; i < expected_output.get_size(); ++i) {
+            if (std::isnan(lhs[i])) {
+                expected[i] = lhs[i];
+            } else if (std::isnan(rhs[i])) {
+                expected[i] = rhs[i];
+            } else {
+                expected[i] = std::min(lhs[i], rhs[i]);
+            }
+        }
+    }
+
+    std::vector<ov::Tensor> calculate_refs() override {
+        return {expected_output};
+    }
+
+    void compare(const std::vector<ov::Tensor>& expected, const std::vector<ov::Tensor>& actual) override {
+        ASSERT_EQ(expected.size(), 1);
+        ASSERT_EQ(actual.size(), 1);
+        ASSERT_EQ(expected[0].get_shape(), actual[0].get_shape());
+
+        const auto* expected_data = expected[0].data<const float>();
+        const auto* actual_data = actual[0].data<const float>();
+        for (size_t i = 0; i < expected[0].get_size(); ++i) {
+            if (std::isnan(expected_data[i])) {
+                EXPECT_TRUE(std::isnan(actual_data[i])) << "at index " << i;
+            } else {
+                EXPECT_EQ(expected_data[i], actual_data[i]) << "at index " << i;
+            }
+        }
+    }
+
+private:
+    ov::Tensor expected_output;
+};
+
+const std::vector<std::vector<ov::Shape>> nan_input_shapes_static = {
+        {{4}, {4}},
+};
+
+TEST_P(MaxMinNaNLayerTest, Inference) {
+    run();
+}
+
 INSTANTIATE_TEST_SUITE_P(smoke_maximum, MaxMinLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
@@ -43,5 +124,14 @@ INSTANTIATE_TEST_SUITE_P(smoke_maximum, MaxMinLayerTest,
                                 ::testing::ValuesIn(second_input_types),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         MaxMinLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_minimum_nan, MaxMinNaNLayerTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(nan_input_shapes_static)),
+                                ::testing::Values(MinMaxOpType::MINIMUM),
+                                ::testing::Values(ov::element::f32),
+                                ::testing::Values(InputLayerType::PARAMETER),
+                                ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                        MaxMinNaNLayerTest::getTestCaseName);
 
 }  // namespace


### PR DESCRIPTION
### Details:
 - Propagate NaNs for CPU `Minimum` instead of returning the finite operand when one input is NaN.
 - Update the x64 JIT emitter to preserve f32 operands, compute the existing minimum, and blend qNaN into lanes where either original input was NaN. The qNaN table is only registered for f32 so the i32 path keeps its existing resource behavior.
 - Update the aarch64 JIT emitter to use NaN-propagating `fmin` instead of minimum-number `fminnm`.
 - Update the riscv64 JIT emitter to preserve original operands, reserve the required aux registers, and blend qNaN for NaN inputs. Also size RISC-V fused post-op aux pools from the current post-op emitter so fused `Minimum` gets the registers it needs.
 - Update the reference CPU minimum path and add a CPU f32 regression with NaNs in both operand positions.

### Tickets:
 - Closes #35839

### AI Assistance:
 - AI assistance used: yes
 - AI was used to inspect the issue, implement the architecture-specific CPU emitter changes, and draft regression coverage. Human validation was performed with strict code review, test-gate review, duplicate checks, an incremental CPU functional-test build, targeted CPU regression execution, adjacent Min/Max smoke coverage, and `git diff --check`.

### Validation:
 - `cmake --build build --target ov_cpu_func_tests -j2` -> built target successfully
 - `./bin/intel64/Release/ov_cpu_func_tests --gtest_filter='*smoke_minimum_nan*' --gtest_color=no` -> 1 passed
 - `./bin/intel64/Release/ov_cpu_func_tests --gtest_filter='smoke_maximum/MaxMinLayerTest.*' --gtest_color=no` -> 56 passed
 - `git diff --check` -> passed