### PR TITLE
Fix CPU TopK int64 precision handling

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -59,6 +59,15 @@ using namespace Xbyak;
 
 namespace ov::intel_cpu::node {
 
+static inline bool isTopKJitSupportedPrecision(const ov::element::Type& precision) {
+    return any_of(precision,
+                  ov::element::f32,
+                  ov::element::bf16,
+                  ov::element::i32,
+                  ov::element::i8,
+                  ov::element::u8);
+}
+
 #if defined(OPENVINO_ARCH_X86_64)
 #    define GET_OFF(field) offsetof(jit_topk_call_args, field)
 
@@ -1997,7 +2006,9 @@ void TopK::initSupportedPrimitiveDescriptors() {
     static const ov::element::Type supportedPrecision[] = {ov::element::f32,
                                                            ov::element::bf16,
                                                            ov::element::i32,
+                                                           ov::element::i64,
                                                            ov::element::i8,
+                                                           ov::element::u64,
                                                            ov::element::u8};
 
     ov::element::Type dataPrecision = getOriginalOutputPrecisionAtPort(TOPK_DATA);
@@ -2012,18 +2023,22 @@ void TopK::initSupportedPrimitiveDescriptors() {
         }
     }
 
-    std::vector<std::pair<LayoutType, LayoutType>> dataFomats{{LayoutType::ncsp, LayoutType::ncsp},
+    const bool canUseJit = impl_type != impl_desc_type::ref && isTopKJitSupportedPrecision(dataPrecision);
+    const bool useReferenceAny = any_of(dataPrecision, ov::element::i64, ov::element::u64);
+    const auto selectedImplType = canUseJit ? impl_type : (useReferenceAny ? impl_desc_type::ref_any : impl_type);
+    std::vector<std::pair<LayoutType, LayoutType>> dataFomats{{LayoutType::ncsp, LayoutType::ncsp}};
 #if defined(OPENVINO_ARCH_X86_64)
-                                                              {LayoutType::nspc, LayoutType::nspc},
-                                                              {LayoutType::nCsp16c, LayoutType::nCsp16c},
-                                                              {LayoutType::nCsp8c, LayoutType::nCsp8c}
+    if (canUseJit) {
+        dataFomats.emplace_back(LayoutType::nspc, LayoutType::nspc);
+        dataFomats.emplace_back(LayoutType::nCsp16c, LayoutType::nCsp16c);
+        dataFomats.emplace_back(LayoutType::nCsp8c, LayoutType::nCsp8c);
+    }
 #endif
-    };
 
     for (const auto& df : dataFomats) {
         addSupportedPrimDesc({{df.first, dataPrecision}, {LayoutType::ncsp, ov::element::i32}},
                              {{df.second, dataPrecision}, {df.second, ov::element::i32}},
-                             impl_type);
+                             selectedImplType);
     }
 }
 
@@ -2091,6 +2106,10 @@ void TopK::prepareParams() {
                     ") exceeds the axis dimension (",
                     src_dims[axis],
                     ").");
+
+    const auto dataPrecision =
+        getSelectedPrimitiveDescriptor()->getConfig().inConfs[TOPK_DATA].getMemDesc()->getPrecision();
+    jit_mode = jit_mode && isTopKJitSupportedPrecision(dataPrecision);
 
     if (jit_mode) {
         if (!preset_params_done) {
@@ -2171,6 +2190,10 @@ void TopK::createPrimitive() {
         updateLastInputDims();
     }
 
+    auto* selectedPD = getSelectedPrimitiveDescriptor();
+    const auto dataPrecision = selectedPD->getConfig().inConfs[TOPK_DATA].getMemDesc()->getPrecision();
+    jit_mode = jit_mode && isTopKJitSupportedPrecision(dataPrecision);
+
     if (jit_mode) {
         if (!preset_params_done) {
             preset_params();
@@ -2181,8 +2204,7 @@ void TopK::createPrimitive() {
         // Such params are useless for dynamic shapes, instead their jit_topk_call_args counterparts
         // will be used. These params are: top_k, axis_dim, sort_stride, work_amount
         auto jcp = jit_topk_config_params();
-        auto* selectedPD = getSelectedPrimitiveDescriptor();
-        jcp.precision = selectedPD->getConfig().inConfs[TOPK_DATA].getMemDesc()->getPrecision();
+        jcp.precision = dataPrecision;
         jcp.data_size = data_size;
         jcp.blk_size = blk_size;
         jcp.layout = layout;
@@ -2242,10 +2264,8 @@ void TopK::execute([[maybe_unused]] const dnnl::stream& strm) {
         topk_process(src_data, dst_data, dst_idx);
     } else {
         if (layout == TopKLayoutType::topk_ncsp) {
-            const auto* in_ptr = reinterpret_cast<const float*>(src_data);
-            auto* out_ptr = reinterpret_cast<float*>(dst_data);
             auto* out_idx_ptr = reinterpret_cast<int32_t*>(dst_idx);
-            topk_ref(in_ptr, out_ptr, out_idx_ptr);
+            topk_ref(src_data, dst_data, out_idx_ptr);
         } else {
             CPU_NODE_THROW("only support plain layout on machine w/o sse42.");
         }
@@ -2475,33 +2495,33 @@ void TopK::calc_dims_size(const VectorDims& layout_dims) {
     }
 }
 
-void TopK::topk_ref(const float* in_ptr, float* out_ptr, int32_t* dst_idx) {
-    if (mode_max) {
-        topk_ref_process(in_ptr, out_ptr, dst_idx, src_dims, [](float x, float y) -> bool {
-            return x > y;
-        });
-    } else {
-        topk_ref_process(in_ptr, out_ptr, dst_idx, src_dims, [](float x, float y) -> bool {
-            return x < y;
-        });
-    }
-}
+namespace {
 
-void TopK::topk_ref_process(const float* src_data,
-                            float* dst_data,
-                            int32_t* dst_idx,
-                            const VectorDims& in_dims,
-                            std::function<bool(float, float)> compare) const {
-    const auto& cpu_parallel = context->getCpuParallel();
-    int after_num = count(in_dims, axis + 1, in_dims.size());
+template <typename T, typename Compare, typename Parallel>
+void topk_ref_process(const T* src_data,
+                      T* dst_data,
+                      int32_t* dst_idx,
+                      const VectorDims& in_dims,
+                      int axis,
+                      int top_k,
+                      int dim,
+                      int before_num,
+                      bool sort_index,
+                      const Parallel& cpu_parallel,
+                      Compare compare) {
+    size_t after_num_size = 1;
+    for (size_t i = axis + 1; i < in_dims.size(); i++) {
+        after_num_size *= in_dims[i];
+    }
+    const int after_num = static_cast<int>(after_num_size);
 
     cpu_parallel->parallel_for2d(before_num, after_num, [&](int i0, int i1) {
-        std::vector<float> max_values(top_k + 1);
+        std::vector<T> max_values(top_k + 1);
         std::vector<int> max_indexes(top_k + 1);
         int s_index = i0 * dim * after_num + i1;
 
         auto swap_func = [&](int index1, int index2) {
-            float tmp_value = max_values[index1];
+            T tmp_value = max_values[index1];
             max_values[index1] = max_values[index2];
             max_values[index2] = tmp_value;
 
@@ -2554,6 +2574,80 @@ void TopK::topk_ref_process(const float* src_data,
             }
         }
     });
+}
+
+template <typename T>
+void topk_ref_by_mode(const uint8_t* in_ptr,
+                      uint8_t* out_ptr,
+                      int32_t* dst_idx,
+                      const VectorDims& in_dims,
+                      int axis,
+                      int top_k,
+                      int dim,
+                      int before_num,
+                      bool mode_max,
+                      bool sort_index,
+                      const ov::intel_cpu::GraphContext::CPtr& context) {
+    const auto* src_data = reinterpret_cast<const T*>(in_ptr);
+    auto* dst_data = reinterpret_cast<T*>(out_ptr);
+    const auto& cpu_parallel = context->getCpuParallel();
+    if (mode_max) {
+        topk_ref_process(src_data,
+                         dst_data,
+                         dst_idx,
+                         in_dims,
+                         axis,
+                         top_k,
+                         dim,
+                         before_num,
+                         sort_index,
+                         cpu_parallel,
+                         [](T x, T y) -> bool {
+                             return x > y;
+                         });
+    } else {
+        topk_ref_process(src_data,
+                         dst_data,
+                         dst_idx,
+                         in_dims,
+                         axis,
+                         top_k,
+                         dim,
+                         before_num,
+                         sort_index,
+                         cpu_parallel,
+                         [](T x, T y) -> bool {
+                             return x < y;
+                         });
+    }
+}
+
+}  // namespace
+
+void TopK::topk_ref(const uint8_t* in_ptr, uint8_t* out_ptr, int32_t* dst_idx) {
+    const auto precision =
+        getSelectedPrimitiveDescriptor()->getConfig().inConfs[TOPK_DATA].getMemDesc()->getPrecision();
+    if (precision == ov::element::f32) {
+        topk_ref_by_mode<float>(
+            in_ptr, out_ptr, dst_idx, src_dims, axis, top_k, dim, before_num, mode_max, sort_index, context);
+    } else if (precision == ov::element::i32) {
+        topk_ref_by_mode<int32_t>(
+            in_ptr, out_ptr, dst_idx, src_dims, axis, top_k, dim, before_num, mode_max, sort_index, context);
+    } else if (precision == ov::element::i64) {
+        topk_ref_by_mode<int64_t>(
+            in_ptr, out_ptr, dst_idx, src_dims, axis, top_k, dim, before_num, mode_max, sort_index, context);
+    } else if (precision == ov::element::i8) {
+        topk_ref_by_mode<int8_t>(
+            in_ptr, out_ptr, dst_idx, src_dims, axis, top_k, dim, before_num, mode_max, sort_index, context);
+    } else if (precision == ov::element::u64) {
+        topk_ref_by_mode<uint64_t>(
+            in_ptr, out_ptr, dst_idx, src_dims, axis, top_k, dim, before_num, mode_max, sort_index, context);
+    } else if (precision == ov::element::u8) {
+        topk_ref_by_mode<uint8_t>(
+            in_ptr, out_ptr, dst_idx, src_dims, axis, top_k, dim, before_num, mode_max, sort_index, context);
+    } else {
+        CPU_NODE_THROW("has unsupported reference precision: ", precision);
+    }
 }
 
 inline int TopK::count(const VectorDims& dims, size_t start_ind, size_t end_ind) {

--- a/src/plugins/intel_cpu/src/nodes/topk.h
+++ b/src/plugins/intel_cpu/src/nodes/topk.h
@@ -101,7 +101,7 @@ public:
 
 private:
     void topk_process(const uint8_t* in_ptr, uint8_t* out_ptr, uint8_t* out_idx_ptr);
-    void topk_ref(const float* in_ptr, float* out_ptr, int32_t* dst_idx);
+    void topk_ref(const uint8_t* in_ptr, uint8_t* out_ptr, int32_t* dst_idx);
     inline void topk_kernel_process(const uint8_t* in_p,
                                     uint8_t* out_p,
                                     uint8_t* out_idx_p,
@@ -113,11 +113,6 @@ private:
     inline void bitonic_push_idx(int p, int n, std::vector<int>& vec, int& cnt, bool cmp_val = true) const;
     void calc_bitonic_idx(size_t n, int& cnt, bool cmp_val);
     void calc_dims_size(const VectorDims& layout_dims);
-    void topk_ref_process(const float* src_data,
-                          float* dst_data,
-                          int32_t* dst_idx,
-                          const VectorDims& in_dims,
-                          std::function<bool(float, float)> compare) const;
     void preset_params();
     void prepare_original_idx();
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 
@@ -19,10 +20,15 @@
 #include "nodes/fullyconnected.h"
 #include "nodes/gathermatmul.h"
 #include "openvino/cc/pass/itt.hpp"
+#include "openvino/core/graph_util.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/topk.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
+#include "openvino/pass/pass.hpp"
 #include "openvino/pass/validate.hpp"
 #include "ov_ops/fully_connected.hpp"
 #include "transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.hpp"
@@ -34,8 +40,49 @@
 #include "transformations/op_conversions/convert_fc_to_compressed.hpp"
 #include "transformations/op_conversions/convert_fc_to_quantized_legacy.hpp"
 #include "transformations/op_conversions/convert_gather_matmul_to_compressed.hpp"
+#include "transformations/rt_info/keep_const_precision.hpp"
 
 namespace ov::intel_cpu {
+
+inline bool is_topk_data_consumer(const ov::Input<ov::Node>& consumer) {
+    return consumer.get_index() == 0 &&
+           ov::is_type_any_of<ov::op::v1::TopK, ov::op::v3::TopK, ov::op::v11::TopK>(consumer.get_node());
+}
+
+inline void keep_integer_topk_data_precision(const std::shared_ptr<ov::Model>& model) {
+    ov::traverse_nodes(model, [](const std::shared_ptr<ov::Node>& node) {
+        if (!ov::is_type_any_of<ov::op::v1::TopK, ov::op::v3::TopK, ov::op::v11::TopK>(node)) {
+            return;
+        }
+
+        const auto data = node->input_value(0);
+        if (data.get_element_type() != ov::element::i64 && data.get_element_type() != ov::element::u64) {
+            return;
+        }
+
+        const auto source = data.get_node_shared_ptr();
+        if (!ov::is_type_any_of<ov::op::v0::Constant, ov::op::v0::Parameter>(source) ||
+            source->get_output_size() != 1) {
+            return;
+        }
+
+        const auto consumers = data.get_target_inputs();
+        if (std::all_of(consumers.begin(), consumers.end(), is_topk_data_consumer)) {
+            ov::enable_keep_const_precision(source);
+        }
+    });
+}
+
+class KeepIntegerTopKDataPrecision : public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("KeepIntegerTopKDataPrecision");
+    KeepIntegerTopKDataPrecision() = default;
+
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override {
+        keep_integer_topk_data_precision(model);
+        return false;
+    }
+};
 
 inline void ConvertToCPUSpecificOpset(std::shared_ptr<ov::Model>& model, const Config& config) {
     RUN_ON_FUNCTION_SCOPE(ConvertToCPUSpecificOpset);
@@ -88,6 +135,7 @@ inline void ConvertToCPUSpecificOpset(std::shared_ptr<ov::Model>& model, const C
         ov::pass::ReshapeSequenceFusion);  // after transformation "MoveEltwiseUpThroughDataMov" there can be reshaped
                                            // sequences that should be eliminated or fused
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::ConstantFolding);
+    CPU_REGISTER_PASS_COMMON(manager, KeepIntegerTopKDataPrecision);
     CPU_REGISTER_PASS_COMMON(manager,
                              ov::pass::ConvertPrecision,
                              precisions_map{{ov::element::i64, ov::element::i32}},

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -662,6 +662,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     // Do not insert pass::Validate between pass::InsertConvertAfterExtension and pass::ConvertPrecision.
     // This may result in the loss of the original Element type of the Output .
     // element type convert is disabled.
+    CPU_REGISTER_PASS_COMMON(manager, KeepIntegerTopKDataPrecision);
     CPU_REGISTER_PASS_COMMON(manager,
                              ov::pass::ConvertPrecision,
                              precisions,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/topk.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/topk.cpp
@@ -88,6 +88,8 @@ protected:
 
         if (!ov::with_cpu_x86_avx512_core() && netPrecision == ElementType::bf16) {
             selectedType = makeSelectedTypeStr(getPrimitiveType(), ElementType::f32);
+        } else if (netPrecision == ElementType::i64) {
+            selectedType = makeSelectedTypeStr("ref_any", netPrecision);
         } else {
             selectedType = makeSelectedTypeStr(getPrimitiveType(), netPrecision);
         }
@@ -165,6 +167,12 @@ protected:
                 for (size_t i = 0; i < size; ++i) {
                     rawBlobDataPtr[i] = static_cast<int32_t>(data[i]);
                 }
+            }
+        } else if (netPrecision == ElementType::i64) {
+            auto* rawBlobDataPtr = static_cast<int64_t*>(tensor.data());
+            const std::vector<int64_t> data = {1LL << 35, 1LL << 36, 1LL << 37, 5, 7};
+            for (size_t i = 0; i < size; ++i) {
+                rawBlobDataPtr[i] = data[i % data.size()];
             }
         } else if (netPrecision == ElementType::bf16) {
             size_t O = 1, A = 1, I = 1;
@@ -333,6 +341,26 @@ INSTANTIATE_TEST_SUITE_P(smoke_TopK_int32_dynamic,
                                                                ::testing::Values(ElementType::dynamic),
                                                                ::testing::ValuesIn(inputShapesDynamic_int32)),
                                             ::testing::ValuesIn(filterCPUSpecificParams(cpuParams)),
+                                            ::testing::Values(additionalConfig[0])),
+                         TopKLayerCPUTest::getTestCaseName);
+
+std::vector<ov::test::InputShape> inputShapes_int64 = {
+    {{}, {{5}}},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_TopK_int64,
+                         TopKLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(::testing::Values(3),
+                                                               ::testing::Values(0),
+                                                               ::testing::Values(SortMode::MAX),
+                                                               ::testing::Values(std::tuple<SortType, bool>{
+                                                                   SortType::SORT_VALUES,
+                                                                   false}),
+                                                               ::testing::Values(ElementType::i64),
+                                                               ::testing::Values(ElementType::dynamic),
+                                                               ::testing::Values(ElementType::dynamic),
+                                                               ::testing::ValuesIn(inputShapes_int64)),
+                                            ::testing::Values(CPUSpecificParams({}, {}, {"ref_any"}, "ref_any")),
                                             ::testing::Values(additionalConfig[0])),
                          TopKLayerCPUTest::getTestCaseName);
 


### PR DESCRIPTION
### Details:
 - Preserve direct `i64` and `u64` CPU `TopK` data inputs before the generic CPU `ConvertPrecision` pass can narrow them to `i32`.
 - Add `i64`/`u64` CPU `TopK` descriptor support through `ref_any` while keeping the existing JIT path restricted to JIT-supported precisions.
 - Generalize the reference `TopK` execution path to compare typed input data instead of treating every input as `float`, so large integer values are ordered correctly.
 - Add a CPU regression with large `i64` values that exceed exact `f32` representation.

### Tickets:
 - Closes #35824

### AI Assistance:
 - AI assistance used: yes
 - AI was used to inspect the issue, identify the CPU precision-conversion and reference-comparison paths, implement the scoped fix, and draft regression coverage. Human validation was performed with strict code review, test-gate review, duplicate checks, targeted CPU functional tests using a relinked candidate binary/plugin, an adjacent int32 TopK sanity test, and `git diff --check`.

### Validation:
 - `smoke_TopK_int64/TopKLayerCPUTest.CompareWithRefs/*` -> 1 passed
 - `smoke_TopK_int32/TopKLayerCPUTest.CompareWithRefs/k=1_axis=0_mode=max_sort=value_stable=False_netPRC=i32*` -> 3 passed
 - `git diff --check` -> passed