### PR TITLE
[chore] Fix version comments for GitHub Actions under dependabot control

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -16,7 +16,7 @@ jobs:
       repository-projects: write
     steps:
       - name: Process issue
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v6
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/workflows_scans.yml
+++ b/.github/workflows/workflows_scans.yml
@@ -39,13 +39,13 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v3.29.5
+        uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
         with:
           languages: "actions"
           build-mode: "none"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v3.29.5
+        uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
         with:
           category: "/language:actions"
 


### PR DESCRIPTION
### Details:
Dependabot was unable to update comments alongside action commit SHA in some cases: https://github.com/openvinotoolkit/openvino/pull/35369 https://github.com/openvinotoolkit/openvino/pull/35370

Let's keep it human readable for future updates
