### PR TITLE
[LPT] Replace stripped FakeQuantize with Clamp to preserve activation range

### DIFF
--- a/src/common/low_precision_transformations/src/qdq_stripping.cpp
+++ b/src/common/low_precision_transformations/src/qdq_stripping.cpp
@@ -260,9 +260,10 @@ bool FQStrippingTransformation::run_on_model(const std::shared_ptr<ov::Model>& f
         auto input_high_const = ov::util::get_constant_from_source(fq->input_value(2));
         if (input_low_const && input_high_const && ov::shape_size(input_low_const->get_shape()) == 1 &&
             ov::shape_size(input_high_const->get_shape()) == 1) {
-            auto clamp = std::make_shared<ov::op::v0::Clamp>(fq->input_value(0),
-                                                             input_low_const->cast_vector<double>()[0],
-                                                             input_high_const->cast_vector<double>()[0]);
+            const double low = input_low_const->cast_vector<double>()[0];
+            const double high = input_high_const->cast_vector<double>()[0];
+            OPENVINO_ASSERT(low <= high, "FQ stripping: input_low (", low, ") > input_high (", high, ")");
+            auto clamp = std::make_shared<ov::op::v0::Clamp>(fq->input_value(0), low, high);
             ov::copy_runtime_info(fq, clamp);
             OPENVINO_ASSERT(replace_node_update_name(fq, clamp), "FQ stripping failed");
         } else {

--- a/src/common/low_precision_transformations/src/qdq_stripping.cpp
+++ b/src/common/low_precision_transformations/src/qdq_stripping.cpp
@@ -97,8 +97,8 @@ private:
         if (is_forward && is_scale_invariant(n)) {
             return;
         }
-        // Note: the set of supported nodes is intentionally limited to avoid overcomplicating the adjuster logic and make it safer.
-        // The current set is enough for covering all existing models which require scale adjustment.
+        // Note: the set of supported nodes is intentionally limited to avoid overcomplicating the adjuster logic and
+        // make it safer. The current set is enough for covering all existing models which require scale adjustment.
         if (!ov::is_type_any_of<ov::op::v1::Add,
                                 ov::op::v0::Constant,
                                 ov::op::v0::Convert,
@@ -256,7 +256,18 @@ bool FQStrippingTransformation::run_on_model(const std::shared_ptr<ov::Model>& f
             adjuster.adjust();
         }
 
-        OPENVINO_ASSERT(replace_output_update_name(fq->output(0), fq->input_value(0)), "FQ stripping failed");
+        auto input_low_const = ov::util::get_constant_from_source(fq->input_value(1));
+        auto input_high_const = ov::util::get_constant_from_source(fq->input_value(2));
+        if (input_low_const && input_high_const && ov::shape_size(input_low_const->get_shape()) == 1 &&
+            ov::shape_size(input_high_const->get_shape()) == 1) {
+            auto clamp = std::make_shared<ov::op::v0::Clamp>(fq->input_value(0),
+                                                             input_low_const->cast_vector<double>()[0],
+                                                             input_high_const->cast_vector<double>()[0]);
+            ov::copy_runtime_info(fq, clamp);
+            OPENVINO_ASSERT(replace_node_update_name(fq, clamp), "FQ stripping failed");
+        } else {
+            OPENVINO_ASSERT(replace_output_update_name(fq->output(0), fq->input_value(0)), "FQ stripping failed");
+        }
         model_changed = true;
     }
 

--- a/src/common/low_precision_transformations/src/qdq_stripping.cpp
+++ b/src/common/low_precision_transformations/src/qdq_stripping.cpp
@@ -60,11 +60,15 @@ public:
         : m_scale_divisor(scale_divisor),
           m_fq(fq.get()) {}
 
-    void adjust() {
+    bool adjust(bool apply_scaling = true) {
         propagate_backward(m_fq);
         propagate_forward(m_fq);
 
-        if (scale_adjustment_possible()) {
+        if (!scale_adjustment_possible()) {
+            return false;
+        }
+
+        if (apply_scaling) {
             for (auto& input : m_pending_adjustments) {
                 auto original_const = input.get_source_output();
                 auto divisor_const =
@@ -75,6 +79,7 @@ public:
                 input.replace_source_output(new_const);
             }
         }
+        return true;
     }
 
 private:
@@ -250,12 +255,17 @@ bool FQStrippingTransformation::run_on_model(const std::shared_ptr<ov::Model>& f
         const auto max_dq_scale = *std::max_element(dq_scale_values.begin(), dq_scale_values.end());
         constexpr auto threshold = 1.0f;
 
-        if (need_weights_adjustment && max_dq_scale > threshold) {
-            constexpr auto ratio = 10.0f;
-            ScaleAdjuster adjuster(max_dq_scale * ratio, fq);
-            adjuster.adjust();
+        constexpr auto ratio = 10.0f;
+        const bool need_scaling = need_weights_adjustment && max_dq_scale > threshold;
+        ScaleAdjuster adjuster(max_dq_scale * ratio, fq);
+        if (adjuster.adjust(need_scaling)) {
+            // All paths lead to scale-invariant layers: safe to remove FQ without clamping.
+            OPENVINO_ASSERT(replace_output_update_name(fq->output(0), fq->input_value(0)), "FQ stripping failed");
+            model_changed = true;
+            continue;
         }
 
+        // Replace FQ with Clamp to preserve value range constraint.
         auto input_low_const = ov::util::get_constant_from_source(fq->input_value(1));
         auto input_high_const = ov::util::get_constant_from_source(fq->input_value(2));
         if (input_low_const && input_high_const && ov::shape_size(input_low_const->get_shape()) == 1 &&
@@ -267,7 +277,8 @@ bool FQStrippingTransformation::run_on_model(const std::shared_ptr<ov::Model>& f
             ov::copy_runtime_info(fq, clamp);
             OPENVINO_ASSERT(replace_node_update_name(fq, clamp), "FQ stripping failed");
         } else {
-            OPENVINO_ASSERT(replace_output_update_name(fq->output(0), fq->input_value(0)), "FQ stripping failed");
+            // Per-channel: can't use Clamp, keep FQ as is.
+            continue;
         }
         model_changed = true;
     }

--- a/src/common/low_precision_transformations/tests/subgraph/src/qdq_stripping.cpp
+++ b/src/common/low_precision_transformations/tests/subgraph/src/qdq_stripping.cpp
@@ -43,28 +43,35 @@ TEST_P(QDQStrippingTest, smoke_LPT_SharedDQ) {
     const auto& [need_weights_adjustment, quantization_precision] = GetParam();
     const auto input_shape = ov::PartialShape{1, 3, 8, 8};
     model = QDQStrippingFunction::build_shared_dq_pattern(input_shape, quantization_precision);
-    model_ref = QDQStrippingFunction::build_shared_dq_pattern_ref(input_shape, need_weights_adjustment);
+    model_ref =
+        QDQStrippingFunction::build_shared_dq_pattern_ref(input_shape, quantization_precision, need_weights_adjustment);
 }
 
 TEST_P(QDQStrippingTest, NeedScalingMulMatMul) {
     const auto& [need_weights_adjustment, quantization_precision] = GetParam();
     const auto input_shape = ov::PartialShape{1, 3, 8, 8};
     model = QDQStrippingFunction::build_mul_matmul_pattern(input_shape, quantization_precision);
-    model_ref = QDQStrippingFunction::build_mul_matmul_pattern_ref(input_shape, need_weights_adjustment);
+    model_ref = QDQStrippingFunction::build_mul_matmul_pattern_ref(input_shape,
+                                                                   quantization_precision,
+                                                                   need_weights_adjustment);
 }
 
 TEST_P(QDQStrippingTest, NeedScalingMatMulWithBias) {
     const auto& [need_weights_adjustment, quantization_precision] = GetParam();
     const auto input_shape = ov::PartialShape{1, 128};
     model = QDQStrippingFunction::build_matmul_with_bias_pattern(input_shape, quantization_precision);
-    model_ref = QDQStrippingFunction::build_matmul_with_bias_pattern_ref(input_shape, need_weights_adjustment);
+    model_ref = QDQStrippingFunction::build_matmul_with_bias_pattern_ref(input_shape,
+                                                                         quantization_precision,
+                                                                         need_weights_adjustment);
 }
 
 TEST_P(QDQStrippingTest, NeedScalingResidualBlock) {
     const auto& [need_weights_adjustment, quantization_precision] = GetParam();
     const auto input_shape = ov::PartialShape{1, 3, 8, 8};
     model = QDQStrippingFunction::build_residual_block_pattern(input_shape, quantization_precision);
-    model_ref = QDQStrippingFunction::build_residual_block_pattern_ref(input_shape, need_weights_adjustment);
+    model_ref = QDQStrippingFunction::build_residual_block_pattern_ref(input_shape,
+                                                                       quantization_precision,
+                                                                       need_weights_adjustment);
 }
 
 TEST_P(QDQStrippingTest, NeedScalingResidualBlockNoFinalMVN) {
@@ -73,14 +80,17 @@ TEST_P(QDQStrippingTest, NeedScalingResidualBlockNoFinalMVN) {
     model = QDQStrippingFunction::build_residual_block_pattern(input_shape,
                                                                quantization_precision,
                                                                /*skip_final_mvn=*/true);
-    model_ref = QDQStrippingFunction::build_residual_block_pattern_ref(input_shape, false, true);
+    model_ref =
+        QDQStrippingFunction::build_residual_block_pattern_ref(input_shape, quantization_precision, false, true);
 }
 
 TEST_P(QDQStrippingTest, NeedScalingForwardBias) {
     const auto& [need_weights_adjustment, quantization_precision] = GetParam();
     const auto input_shape = ov::PartialShape{1, 128};
     model = QDQStrippingFunction::build_forward_bias_pattern(input_shape, quantization_precision);
-    model_ref = QDQStrippingFunction::build_forward_bias_pattern_ref(input_shape, need_weights_adjustment);
+    model_ref = QDQStrippingFunction::build_forward_bias_pattern_ref(input_shape,
+                                                                     quantization_precision,
+                                                                     need_weights_adjustment);
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke_LPT,

--- a/src/common/low_precision_transformations/tests/subgraph/src/qdq_stripping.cpp
+++ b/src/common/low_precision_transformations/tests/subgraph/src/qdq_stripping.cpp
@@ -80,8 +80,10 @@ TEST_P(QDQStrippingTest, NeedScalingResidualBlockNoFinalMVN) {
     model = QDQStrippingFunction::build_residual_block_pattern(input_shape,
                                                                quantization_precision,
                                                                /*skip_final_mvn=*/true);
-    model_ref =
-        QDQStrippingFunction::build_residual_block_pattern_ref(input_shape, quantization_precision, false, true);
+    model_ref = QDQStrippingFunction::build_residual_block_pattern_ref(input_shape,
+                                                                       quantization_precision,
+                                                                       need_weights_adjustment,
+                                                                       true);
 }
 
 TEST_P(QDQStrippingTest, NeedScalingForwardBias) {
@@ -91,6 +93,14 @@ TEST_P(QDQStrippingTest, NeedScalingForwardBias) {
     model_ref = QDQStrippingFunction::build_forward_bias_pattern_ref(input_shape,
                                                                      quantization_precision,
                                                                      need_weights_adjustment);
+}
+
+TEST_P(QDQStrippingTest, ConvChainNoScaleInvariant) {
+    const auto& [need_weights_adjustment, quantization_precision] = GetParam();
+    const auto input_shape = ov::PartialShape{1, 3, 8, 8};
+    model = QDQStrippingFunction::build_conv_chain_pattern(input_shape, ov::element::i16);
+    model_ref =
+        QDQStrippingFunction::build_conv_chain_pattern_ref(input_shape, ov::element::i16, need_weights_adjustment);
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke_LPT,

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/qdq_stripping.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/qdq_stripping.hpp
@@ -51,32 +51,38 @@ public:
     static std::shared_ptr<ov::Model> build_shared_dq_pattern(const ov::PartialShape& input_shape,
                                                               const ov::element::Type& quantization_precision);
     static std::shared_ptr<ov::Model> build_shared_dq_pattern_ref(const ov::PartialShape& input_shape,
+                                                                  const ov::element::Type& quantization_precision,
                                                                   bool need_weights_adjustment = true);
 
     static std::shared_ptr<ov::Model> build_mul_matmul_pattern(const ov::PartialShape& input_shape,
                                                                const ov::element::Type& quantization_precision);
     static std::shared_ptr<ov::Model> build_mul_matmul_pattern_ref(const ov::PartialShape& input_shape,
+                                                                   const ov::element::Type& quantization_precision,
                                                                    bool need_weights_adjustment = true);
 
     static std::shared_ptr<ov::Model> build_matmul_with_bias_pattern(const ov::PartialShape& input_shape,
                                                                      const ov::element::Type& quantization_precision);
-    static std::shared_ptr<ov::Model> build_matmul_with_bias_pattern_ref(const ov::PartialShape& input_shape,
-                                                                         bool need_weights_adjustment = true);
+    static std::shared_ptr<ov::Model> build_matmul_with_bias_pattern_ref(
+        const ov::PartialShape& input_shape,
+        const ov::element::Type& quantization_precision,
+        bool need_weights_adjustment = true);
 
     static std::shared_ptr<ov::Model> build_residual_block_pattern(const ov::PartialShape& input_shape,
                                                                    const ov::element::Type& quantization_precision,
                                                                    bool skip_final_mvn = false);
     static std::shared_ptr<ov::Model> build_residual_block_pattern_ref(const ov::PartialShape& input_shape,
+                                                                       const ov::element::Type& quantization_precision,
                                                                        bool need_weights_adjustment = true,
                                                                        bool skip_final_mvn = false);
 
     static std::shared_ptr<ov::Model> build_forward_bias_pattern(const ov::PartialShape& input_shape,
                                                                  const ov::element::Type& quantization_precision);
     static std::shared_ptr<ov::Model> build_forward_bias_pattern_ref(const ov::PartialShape& input_shape,
+                                                                     const ov::element::Type& quantization_precision,
                                                                      bool need_weights_adjustment = true);
 
 private:
-    // Builds one residual block: MVN → Conv+bias [→ optional FQ] + shortcut → Add.
+    // Builds one residual block: MVN → Conv+bias [→ optional FQ or Clamp] + shortcut → Add.
     // Shared by build_residual_block_pattern (source) and build_residual_block_pattern_ref (ref).
     static ov::Output<ov::Node> create_residual_block(
         const ov::Output<ov::Node>& input,
@@ -84,7 +90,8 @@ private:
         float weight_scale,
         float bias_scale,
         bool add_shortcut_conv = false,
-        std::optional<std::pair<float, float>> branch_fq_range = std::nullopt);
+        std::optional<std::pair<float, float>> branch_fq_range = std::nullopt,
+        std::optional<std::pair<float, float>> branch_clamp_range = std::nullopt);
 };
 
 }  // namespace subgraph

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/qdq_stripping.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/qdq_stripping.hpp
@@ -81,6 +81,13 @@ public:
                                                                      const ov::element::Type& quantization_precision,
                                                                      bool need_weights_adjustment = true);
 
+    // Conv chain without scale-invariant layers (no Softmax/MVN).
+    static std::shared_ptr<ov::Model> build_conv_chain_pattern(const ov::PartialShape& input_shape,
+                                                               const ov::element::Type& quantization_precision);
+    static std::shared_ptr<ov::Model> build_conv_chain_pattern_ref(const ov::PartialShape& input_shape,
+                                                                   const ov::element::Type& quantization_precision,
+                                                                   bool need_weights_adjustment = true);
+
 private:
     // Builds one residual block: MVN → Conv+bias [→ optional FQ or Clamp] + shortcut → Add.
     // Shared by build_residual_block_pattern (source) and build_residual_block_pattern_ref (ref).

--- a/src/tests/ov_helpers/ov_lpt_models/src/qdq_stripping.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/qdq_stripping.cpp
@@ -183,7 +183,7 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_shared_dq_pattern_ref(
     const auto& qp_1 = q_params.first;
     const auto& qp_2 = q_params.second;
 
-    // Input FQ stripped → Clamp(qp_1.i_l, qp_1.i_h)
+    // No scale-invariant layer → always Clamp (regardless of need_weights_adjustment).
     auto input_clamp = std::make_shared<ov::op::v0::Clamp>(params[0], qp_1.i_l, qp_1.i_h);
 
     size_t seed = 1;
@@ -208,9 +208,7 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_shared_dq_pattern_ref(
         auto bias_const = ov::test::utils::make_constant(ov::element::f32, ov::Shape{1, 32, 1, 1}, bias_gen_data);
         auto conv_biased = std::make_shared<ov::op::v1::Add>(conv, bias_const);
 
-        // Intermediate FQ stripped → Clamp(qp_2.i_l, qp_2.i_h)
-        auto clamp = std::make_shared<ov::op::v0::Clamp>(conv_biased, qp_2.i_l, qp_2.i_h);
-        return clamp;
+        return ov::Output<ov::Node>(std::make_shared<ov::op::v0::Clamp>(conv_biased, qp_2.i_l, qp_2.i_h));
     };
 
     auto left_branch = create_branch(1e-4f);
@@ -266,7 +264,7 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_mul_matmul_pattern(
 
 std::shared_ptr<ov::Model> QDQStrippingFunction::build_mul_matmul_pattern_ref(
     const ov::PartialShape& input_shape,
-    const ov::element::Type& quantization_precision,
+    const ov::element::Type& /*quantization_precision*/,
     bool need_weights_adjustment) {
     auto param1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape);
     auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape);
@@ -287,15 +285,8 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_mul_matmul_pattern_ref(
     auto softmax_mul1 = std::make_shared<ov::op::v8::Softmax>(mul1, 1);
     auto matmul = std::make_shared<ov::op::v0::MatMul>(mul1, mul2, false, true);
 
-    // FQ stripped → Clamp(qp.i_l, qp.i_h)
-    static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
-        {ov::element::Type_t::u16, {0.f, 131070.f, 0.f, 65535.f, 0}},
-        {ov::element::Type_t::i16, {-65536.f, 65534.f, -32768.f, 32767.f, 0}},
-    };
-    const auto& qp = quantization_params.at(quantization_precision);
-    auto clamp = std::make_shared<ov::op::v0::Clamp>(matmul, qp.i_l, qp.i_h);
-
-    auto softmax = std::make_shared<ov::op::v8::Softmax>(clamp, 1);
+    // Adjuster always succeeds (Softmax is scale-invariant) → identity bypass for both CPU and GPU.
+    auto softmax = std::make_shared<ov::op::v8::Softmax>(matmul, 1);
 
     return std::make_shared<ov::Model>(ov::OutputVector{softmax_mul1, softmax}, params, "QDQStripping");
 }
@@ -351,7 +342,7 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_matmul_with_bias_pattern(
 
 std::shared_ptr<ov::Model> QDQStrippingFunction::build_matmul_with_bias_pattern_ref(
     const ov::PartialShape& input_shape,
-    const ov::element::Type& quantization_precision,
+    const ov::element::Type& /*quantization_precision*/,
     bool need_weights_adjustment) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape)};
 
@@ -372,16 +363,10 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_matmul_with_bias_pattern_
     auto bias = build_weights_dq(ov::element::i8, {32}, 200.0f / scale_divisor, -128, 2);
     auto matmul_biased = std::make_shared<ov::op::v1::Add>(matmul, bias);
 
-    // FQ stripped → Clamp(qp.i_l, qp.i_h)
-    static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
-        {ov::element::Type_t::u16, {0.f, 262140.f, 0.f, 65535.f, 0}},
-        {ov::element::Type_t::i16, {-131072.f, 131068.f, -32768.f, 32767.f, 0}},
-    };
-    const auto& qp = quantization_params.at(quantization_precision);
-    auto clamp = std::make_shared<ov::op::v0::Clamp>(matmul_biased, qp.i_l, qp.i_h);
-
+    // Adjuster always succeeds (MVN is scale-invariant) → identity bypass for both CPU and GPU.
     auto reduction_axes = ov::op::v0::Constant::create(ov::element::i64, {1}, {-1});
-    auto mvn = std::make_shared<ov::op::v6::MVN>(clamp, reduction_axes, true, 1e-3f, ov::op::MVNEpsMode::INSIDE_SQRT);
+    auto mvn =
+        std::make_shared<ov::op::v6::MVN>(matmul_biased, reduction_axes, true, 1e-3f, ov::op::MVNEpsMode::INSIDE_SQRT);
 
     return std::make_shared<ov::Model>(ov::OutputVector{mvn}, params, "QDQStripping");
 }
@@ -532,8 +517,11 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_residual_block_pattern_re
     bool skip_final_mvn) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape)};
 
-    // y_scale(10) * ratio(10) = 100. When need_weights_adjustment=false, no division.
-    const float scale_divisor = need_weights_adjustment ? 100.f : 1.f;
+    // Adjuster succeeds when scale-invariant layer exists (!skip_final_mvn).
+    // Weights are only actually scaled when need_weights_adjustment=true AND scale > threshold.
+    const bool adjuster_succeeded = !skip_final_mvn;
+    // y_scale(10) * ratio(10) = 100. Only applied when need_weights_adjustment=true.
+    const float scale_divisor = (need_weights_adjustment && adjuster_succeeded) ? 100.f : 1.f;
 
     static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
         {ov::element::Type_t::u16, {0.f, 655350.f, 0.f, 65535.f, 0}},
@@ -541,11 +529,10 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_residual_block_pattern_re
     };
     const auto& qp = quantization_params.at(quantization_precision);
 
-    // Branch FQ range (original values before potential division)
     float branch_fq_lo = (quantization_precision == ov::element::u16) ? 0.f : -32800.f;
     float branch_fq_hi = (quantization_precision == ov::element::u16) ? 65600.f : 32800.f;
 
-    // Preceding Conv+bias: NOT scaled (backward propagation must stop at Conv1+bias).
+    // Preceding Conv+bias: NOT scaled.
     auto preceding_weight =
         build_weights_dq(ov::element::i8, ov::Shape{3, 3, 3, 3}, 1.0f / 27.0f, 0, std::nullopt, std::vector<int>{1});
     auto preceding_conv = std::make_shared<ov::op::v1::Convolution>(params[0],
@@ -557,7 +544,6 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_residual_block_pattern_re
     auto preceding_bias = build_weights_dq(ov::element::i8, {3}, 1.0f, 0, std::nullopt, std::vector<int>{1});
     auto preceding_conv_biased = add_bias(preceding_conv, preceding_bias);
 
-    // Conv1 weight scale: 0.003/100 = 3e-05
     auto weight1 = build_weights_dq(ov::element::i8, ov::Shape{32, 3, 3, 3}, 0.003f / scale_divisor, -128, 1);
     auto conv1 = std::make_shared<ov::op::v1::Convolution>(preceding_conv_biased,
                                                            weight1,
@@ -566,21 +552,28 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_residual_block_pattern_re
                                                            ov::CoordinateDiff{1, 1},
                                                            ov::Strides{1, 1});
 
-    // Bias1 scale: 0.001/100 = 1e-05
     auto bias1 = build_weights_dq(ov::element::i8, {32}, 0.001f / scale_divisor, 0);
     auto conv1_biased = add_bias(conv1, bias1);
 
-    // Main FQ stripped → Clamp(qp.i_l, qp.i_h)
-    auto main_clamp = std::make_shared<ov::op::v0::Clamp>(conv1_biased, qp.i_l, qp.i_h);
+    // FQ → Clamp unless adjuster succeeded (all paths lead to scale-invariant layers).
+    const bool use_clamp = !adjuster_succeeded;
+    ov::Output<ov::Node> main_stripped = conv1_biased;
+    if (use_clamp) {
+        main_stripped = std::make_shared<ov::op::v0::Clamp>(conv1_biased, qp.i_l, qp.i_h);
+    }
 
-    // Forward-path FQ stripped → Clamp with bounds divided by scale_divisor (from forward propagation)
-    auto fq_pass_clamp = std::make_shared<ov::op::v0::Clamp>(main_clamp,
-                                                             static_cast<double>(qp.i_l / scale_divisor),
-                                                             static_cast<double>(qp.i_h / scale_divisor));
+    // Forward-path FQ
+    ov::Output<ov::Node> fq_pass_stripped = main_stripped;
+    if (use_clamp) {
+        fq_pass_stripped = std::make_shared<ov::op::v0::Clamp>(main_stripped, qp.i_l, qp.i_h);
+    }
 
-    // Residual blocks: branch FQs stripped → Clamp with bounds divided by scale_divisor
-    std::pair<float, float> clamp_range{branch_fq_lo / scale_divisor, branch_fq_hi / scale_divisor};
-    auto add1 = create_residual_block(fq_pass_clamp,
+    // Residual blocks
+    std::optional<std::pair<float, float>> clamp_range = std::nullopt;
+    if (use_clamp) {
+        clamp_range = std::pair<float, float>{branch_fq_lo, branch_fq_hi};
+    }
+    auto add1 = create_residual_block(fq_pass_stripped,
                                       2,
                                       0.003f / scale_divisor,
                                       0.001f / scale_divisor,
@@ -653,7 +646,7 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_forward_bias_pattern(
 
 std::shared_ptr<ov::Model> QDQStrippingFunction::build_forward_bias_pattern_ref(
     const ov::PartialShape& input_shape,
-    const ov::element::Type& quantization_precision,
+    const ov::element::Type& /*quantization_precision*/,
     bool need_weights_adjustment) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape)};
 
@@ -666,17 +659,10 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_forward_bias_pattern_ref(
     auto bias1 = build_weights_dq(ov::element::i8, {32}, 200.0f / scale_divisor, -128, 2);
     auto matmul1_biased = std::make_shared<ov::op::v1::Add>(matmul1, bias1);
 
-    // FQ stripped → Clamp(qp.i_l, qp.i_h)
-    static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
-        {ov::element::Type_t::u16, {0.f, 262140.f, 0.f, 65535.f, 0}},
-        {ov::element::Type_t::i16, {-131072.f, 131068.f, -32768.f, 32767.f, 0}},
-    };
-    const auto& qp = quantization_params.at(quantization_precision);
-    auto clamp = std::make_shared<ov::op::v0::Clamp>(matmul1_biased, qp.i_l, qp.i_h);
-
+    // Adjuster always succeeds (MVN is scale-invariant) → identity bypass for both CPU and GPU.
     // MatMul2: weight NOT adjusted, bias2 adjusted by forward propagation
     auto weight2 = build_weights_dq(ov::element::i8, ov::Shape{32, 32}, 0.001f, -128, 3);
-    auto matmul2 = std::make_shared<ov::op::v0::MatMul>(clamp, weight2, false, false);
+    auto matmul2 = std::make_shared<ov::op::v0::MatMul>(matmul1_biased, weight2, false, false);
 
     auto bias2 = build_weights_dq(ov::element::i8, {32}, 100.0f / scale_divisor, -128, 4);
     auto matmul2_biased = std::make_shared<ov::op::v1::Add>(matmul2, bias2);
@@ -685,6 +671,91 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_forward_bias_pattern_ref(
     auto mvn =
         std::make_shared<ov::op::v6::MVN>(matmul2_biased, reduction_axes, true, 1e-3f, ov::op::MVNEpsMode::INSIDE_SQRT);
     return std::make_shared<ov::Model>(ov::OutputVector{mvn}, params, "QDQStripping");
+}
+std::shared_ptr<ov::Model> QDQStrippingFunction::build_conv_chain_pattern(
+    const ov::PartialShape& input_shape,
+    const ov::element::Type& quantization_precision) {
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape)};
+
+    // Small-scale FQ (similar to CVS-186600 ResNet50): dq_scale << 1.0
+    // i16 bounds must be exactly output_range * scale for fq_ranges_are_the_same to hold after
+    // ConvertQuantizeDequantize
+    static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
+        {ov::element::Type_t::u16, {0.f, 5.f, 0.f, 65535.f, 0}},
+        {ov::element::Type_t::i16, {-2.5000381469726562f, 2.4999618530273438f, -32768.f, 32767.f, 0}},
+    };
+    const auto& qp = quantization_params.at(quantization_precision);
+
+    // Input FQ → Q → DQ chain
+    auto input_fq = build_fq(params[0], qp);
+    auto input_q = std::make_shared<ov::op::v0::Convert>(input_fq, quantization_precision);
+    auto input_dq_convert = std::make_shared<ov::op::v0::Convert>(input_q, ov::element::f32);
+    auto input_dq = build_dq(input_dq_convert, quantization_precision, qp, false);
+
+    // Conv1
+    auto weight1 = build_weights_dq(ov::element::i8, ov::Shape{32, 3, 3, 3}, 0.001f, 0, 1);
+    auto conv1 = std::make_shared<ov::op::v1::Convolution>(input_dq,
+                                                           weight1,
+                                                           ov::Strides{1, 1},
+                                                           ov::CoordinateDiff{1, 1},
+                                                           ov::CoordinateDiff{1, 1},
+                                                           ov::Strides{1, 1});
+
+    // Intermediate FQ → Q → DQ chain after Conv1
+    auto fq2 = build_fq(conv1, qp);
+    auto q2 = std::make_shared<ov::op::v0::Convert>(fq2, quantization_precision);
+    auto dq2_convert = std::make_shared<ov::op::v0::Convert>(q2, ov::element::f32);
+    auto dq2 = build_dq(dq2_convert, quantization_precision, qp, false);
+
+    // Conv2
+    auto weight2 = build_weights_dq(ov::element::i8, ov::Shape{32, 32, 3, 3}, 0.001f, 0, 3);
+    auto conv2 = std::make_shared<ov::op::v1::Convolution>(dq2,
+                                                           weight2,
+                                                           ov::Strides{1, 1},
+                                                           ov::CoordinateDiff{1, 1},
+                                                           ov::CoordinateDiff{1, 1},
+                                                           ov::Strides{1, 1});
+
+    return std::make_shared<ov::Model>(ov::OutputVector{conv2}, params, "QDQStripping");
+}
+
+std::shared_ptr<ov::Model> QDQStrippingFunction::build_conv_chain_pattern_ref(
+    const ov::PartialShape& input_shape,
+    const ov::element::Type& quantization_precision,
+    bool /*need_weights_adjustment*/) {
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape)};
+
+    static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
+        {ov::element::Type_t::u16, {0.f, 5.f, 0.f, 65535.f, 0}},
+        {ov::element::Type_t::i16, {-2.5000381469726562f, 2.4999618530273438f, -32768.f, 32767.f, 0}},
+    };
+    const auto& qp = quantization_params.at(quantization_precision);
+
+    // No scale-invariant layer → adjuster always fails → always Clamp.
+    auto input_stripped = std::make_shared<ov::op::v0::Clamp>(params[0], qp.i_l, qp.i_h);
+
+    // Conv1
+    auto weight1 = build_weights_dq(ov::element::i8, ov::Shape{32, 3, 3, 3}, 0.001f, 0, 1);
+    auto conv1 = std::make_shared<ov::op::v1::Convolution>(input_stripped,
+                                                           weight1,
+                                                           ov::Strides{1, 1},
+                                                           ov::CoordinateDiff{1, 1},
+                                                           ov::CoordinateDiff{1, 1},
+                                                           ov::Strides{1, 1});
+
+    // Intermediate FQ stripped → always Clamp (no scale-invariant layer downstream).
+    auto intermediate_stripped = std::make_shared<ov::op::v0::Clamp>(conv1, qp.i_l, qp.i_h);
+
+    // Conv2
+    auto weight2 = build_weights_dq(ov::element::i8, ov::Shape{32, 32, 3, 3}, 0.001f, 0, 3);
+    auto conv2 = std::make_shared<ov::op::v1::Convolution>(intermediate_stripped,
+                                                           weight2,
+                                                           ov::Strides{1, 1},
+                                                           ov::CoordinateDiff{1, 1},
+                                                           ov::CoordinateDiff{1, 1},
+                                                           ov::Strides{1, 1});
+
+    return std::make_shared<ov::Model>(ov::OutputVector{conv2}, params, "QDQStripping");
 }
 }  // namespace subgraph
 }  // namespace builder

--- a/src/tests/ov_helpers/ov_lpt_models/src/qdq_stripping.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/qdq_stripping.cpp
@@ -8,6 +8,7 @@
 #include "common_test_utils/type_ranges.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/broadcast.hpp"
+#include "openvino/op/clamp.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
@@ -163,9 +164,27 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_shared_dq_pattern(
     return std::make_shared<ov::Model>(ov::OutputVector{add_branches}, params, "QDQStripping");
 }
 
-std::shared_ptr<ov::Model> QDQStrippingFunction::build_shared_dq_pattern_ref(const ov::PartialShape& input_shape,
-                                                                             bool need_weights_adjustment) {
+std::shared_ptr<ov::Model> QDQStrippingFunction::build_shared_dq_pattern_ref(
+    const ov::PartialShape& input_shape,
+    const ov::element::Type& quantization_precision,
+    bool need_weights_adjustment) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape)};
+
+    static const std::unordered_map<ov::element::Type_t, std::pair<QuantizationParams, QuantizationParams>>
+        quantization_params{
+            {ov::element::Type_t::u16,
+             {{0.f, 10.f, 0.f, 65535.f, 0}, {-624.4578838348389f, 634.7373962402344f, 0.f, 65535.f, 32500}}},
+            {ov::element::Type_t::i16,
+             {{-5.0000762939453125f, 4.9999237060546875f, -32768.f, 32767.f, 0},
+              {-630.0096435546875f, 629.9904174804688f, -32768.f, 32767.f, 0}}},
+        };
+
+    const auto& q_params = quantization_params.at(quantization_precision);
+    const auto& qp_1 = q_params.first;
+    const auto& qp_2 = q_params.second;
+
+    // Input FQ stripped → Clamp(qp_1.i_l, qp_1.i_h)
+    auto input_clamp = std::make_shared<ov::op::v0::Clamp>(params[0], qp_1.i_l, qp_1.i_h);
 
     size_t seed = 1;
     auto create_branch = [&](float weight_scale_value) {
@@ -178,7 +197,7 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_shared_dq_pattern_ref(con
             ov::test::utils::make_constant(ov::element::f32, {}, std::vector<float>{weight_scale_value});
         auto weight_dequantized = std::make_shared<ov::op::v1::Multiply>(weight_convert, weight_scale);
 
-        auto conv = std::make_shared<ov::op::v1::Convolution>(params[0],
+        auto conv = std::make_shared<ov::op::v1::Convolution>(input_clamp,
                                                               weight_dequantized,
                                                               ov::Strides{1, 1},
                                                               ov::CoordinateDiff{1, 1},
@@ -188,7 +207,10 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_shared_dq_pattern_ref(con
         ov::test::utils::InputGenerateData bias_gen_data(-2.0, 4, 100, seed++);
         auto bias_const = ov::test::utils::make_constant(ov::element::f32, ov::Shape{1, 32, 1, 1}, bias_gen_data);
         auto conv_biased = std::make_shared<ov::op::v1::Add>(conv, bias_const);
-        return conv_biased;
+
+        // Intermediate FQ stripped → Clamp(qp_2.i_l, qp_2.i_h)
+        auto clamp = std::make_shared<ov::op::v0::Clamp>(conv_biased, qp_2.i_l, qp_2.i_h);
+        return clamp;
     };
 
     auto left_branch = create_branch(1e-4f);
@@ -242,8 +264,10 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_mul_matmul_pattern(
     return std::make_shared<ov::Model>(ov::OutputVector{softmax_mul1, softmax}, params, "QDQStripping");
 }
 
-std::shared_ptr<ov::Model> QDQStrippingFunction::build_mul_matmul_pattern_ref(const ov::PartialShape& input_shape,
-                                                                              bool need_weights_adjustment) {
+std::shared_ptr<ov::Model> QDQStrippingFunction::build_mul_matmul_pattern_ref(
+    const ov::PartialShape& input_shape,
+    const ov::element::Type& quantization_precision,
+    bool need_weights_adjustment) {
     auto param1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape);
     auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape);
     ov::ParameterVector params{param1, param2};
@@ -262,7 +286,16 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_mul_matmul_pattern_ref(co
 
     auto softmax_mul1 = std::make_shared<ov::op::v8::Softmax>(mul1, 1);
     auto matmul = std::make_shared<ov::op::v0::MatMul>(mul1, mul2, false, true);
-    auto softmax = std::make_shared<ov::op::v8::Softmax>(matmul, 1);
+
+    // FQ stripped → Clamp(qp.i_l, qp.i_h)
+    static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
+        {ov::element::Type_t::u16, {0.f, 131070.f, 0.f, 65535.f, 0}},
+        {ov::element::Type_t::i16, {-65536.f, 65534.f, -32768.f, 32767.f, 0}},
+    };
+    const auto& qp = quantization_params.at(quantization_precision);
+    auto clamp = std::make_shared<ov::op::v0::Clamp>(matmul, qp.i_l, qp.i_h);
+
+    auto softmax = std::make_shared<ov::op::v8::Softmax>(clamp, 1);
 
     return std::make_shared<ov::Model>(ov::OutputVector{softmax_mul1, softmax}, params, "QDQStripping");
 }
@@ -316,8 +349,10 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_matmul_with_bias_pattern(
     return std::make_shared<ov::Model>(ov::OutputVector{mvn}, params, "QDQStripping");
 }
 
-std::shared_ptr<ov::Model> QDQStrippingFunction::build_matmul_with_bias_pattern_ref(const ov::PartialShape& input_shape,
-                                                                                    bool need_weights_adjustment) {
+std::shared_ptr<ov::Model> QDQStrippingFunction::build_matmul_with_bias_pattern_ref(
+    const ov::PartialShape& input_shape,
+    const ov::element::Type& quantization_precision,
+    bool need_weights_adjustment) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape)};
 
     // Original weight_scale=0.02. With weights adjustment: divided by scale_divisor=40 → 0.0005
@@ -337,10 +372,16 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_matmul_with_bias_pattern_
     auto bias = build_weights_dq(ov::element::i8, {32}, 200.0f / scale_divisor, -128, 2);
     auto matmul_biased = std::make_shared<ov::op::v1::Add>(matmul, bias);
 
-    // FQ stripped, CQDQ removed Convert+DQ → Add output goes directly to MVN
+    // FQ stripped → Clamp(qp.i_l, qp.i_h)
+    static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
+        {ov::element::Type_t::u16, {0.f, 262140.f, 0.f, 65535.f, 0}},
+        {ov::element::Type_t::i16, {-131072.f, 131068.f, -32768.f, 32767.f, 0}},
+    };
+    const auto& qp = quantization_params.at(quantization_precision);
+    auto clamp = std::make_shared<ov::op::v0::Clamp>(matmul_biased, qp.i_l, qp.i_h);
+
     auto reduction_axes = ov::op::v0::Constant::create(ov::element::i64, {1}, {-1});
-    auto mvn =
-        std::make_shared<ov::op::v6::MVN>(matmul_biased, reduction_axes, true, 1e-3f, ov::op::MVNEpsMode::INSIDE_SQRT);
+    auto mvn = std::make_shared<ov::op::v6::MVN>(clamp, reduction_axes, true, 1e-3f, ov::op::MVNEpsMode::INSIDE_SQRT);
 
     return std::make_shared<ov::Model>(ov::OutputVector{mvn}, params, "QDQStripping");
 }
@@ -351,10 +392,10 @@ ov::Output<ov::Node> QDQStrippingFunction::create_residual_block(
     float weight_scale,
     float bias_scale,
     bool add_shortcut_conv,
-    std::optional<std::pair<float, float>> branch_fq_range) {
+    std::optional<std::pair<float, float>> branch_fq_range,
+    std::optional<std::pair<float, float>> branch_clamp_range) {
     auto reduction_axes = ov::op::v0::Constant::create(ov::element::i64, {3}, {1, 2, 3});
-    auto mvn =
-        std::make_shared<ov::op::v6::MVN>(input, reduction_axes, true, 1e-3f, ov::op::MVNEpsMode::INSIDE_SQRT);
+    auto mvn = std::make_shared<ov::op::v6::MVN>(input, reduction_axes, true, 1e-3f, ov::op::MVNEpsMode::INSIDE_SQRT);
 
     auto weight = build_weights_dq(ov::element::i8, ov::Shape{32, 32, 3, 3}, weight_scale, -128, seed);
     auto conv = std::make_shared<ov::op::v1::Convolution>(mvn,
@@ -376,6 +417,9 @@ ov::Output<ov::Node> QDQStrippingFunction::create_residual_block(
         auto bfq_ol = ov::op::v0::Constant::create(ov::element::f32, {}, {fq_lo});
         auto bfq_oh = ov::op::v0::Constant::create(ov::element::f32, {}, {fq_hi});
         conv_branch = std::make_shared<ov::op::v0::FakeQuantize>(conv_biased, bfq_il, bfq_ih, bfq_ol, bfq_oh, 65536);
+    } else if (branch_clamp_range) {
+        auto [clamp_lo, clamp_hi] = *branch_clamp_range;
+        conv_branch = std::make_shared<ov::op::v0::Clamp>(conv_biased, clamp_lo, clamp_hi);
     }
 
     // Shortcut: optionally add 1×1 Conv+bias (tests forward propagation through shortcut Conv).
@@ -481,13 +525,25 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_residual_block_pattern(
     return std::make_shared<ov::Model>(ov::OutputVector{final_mvn}, params, "QDQStripping");
 }
 
-std::shared_ptr<ov::Model> QDQStrippingFunction::build_residual_block_pattern_ref(const ov::PartialShape& input_shape,
-                                                                                  bool need_weights_adjustment,
-                                                                                  bool skip_final_mvn) {
+std::shared_ptr<ov::Model> QDQStrippingFunction::build_residual_block_pattern_ref(
+    const ov::PartialShape& input_shape,
+    const ov::element::Type& quantization_precision,
+    bool need_weights_adjustment,
+    bool skip_final_mvn) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape)};
 
     // y_scale(10) * ratio(10) = 100. When need_weights_adjustment=false, no division.
     const float scale_divisor = need_weights_adjustment ? 100.f : 1.f;
+
+    static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
+        {ov::element::Type_t::u16, {0.f, 655350.f, 0.f, 65535.f, 0}},
+        {ov::element::Type_t::i16, {-327680.f, 327670.f, -32768.f, 32767.f, 0}},
+    };
+    const auto& qp = quantization_params.at(quantization_precision);
+
+    // Branch FQ range (original values before potential division)
+    float branch_fq_lo = (quantization_precision == ov::element::u16) ? 0.f : -32800.f;
+    float branch_fq_hi = (quantization_precision == ov::element::u16) ? 65600.f : 32800.f;
 
     // Preceding Conv+bias: NOT scaled (backward propagation must stop at Conv1+bias).
     auto preceding_weight =
@@ -514,10 +570,32 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_residual_block_pattern_re
     auto bias1 = build_weights_dq(ov::element::i8, {32}, 0.001f / scale_divisor, 0);
     auto conv1_biased = add_bias(conv1, bias1);
 
-    // Residual blocks: all branch FQs stripped, all weight/bias scales divided by scale_divisor
-    auto add1 = create_residual_block(conv1_biased, 2, 0.003f / scale_divisor, 0.001f / scale_divisor);
-    auto add2 = create_residual_block(add1, 3, 0.003f / scale_divisor, 0.001f / scale_divisor);
-    auto add3 = create_residual_block(add2, 4, 0.003f / scale_divisor, 0.001f / scale_divisor, true);
+    // Main FQ stripped → Clamp(qp.i_l, qp.i_h)
+    auto main_clamp = std::make_shared<ov::op::v0::Clamp>(conv1_biased, qp.i_l, qp.i_h);
+
+    // Forward-path FQ stripped → Clamp with bounds divided by scale_divisor (from forward propagation)
+    auto fq_pass_clamp = std::make_shared<ov::op::v0::Clamp>(main_clamp,
+                                                             static_cast<double>(qp.i_l / scale_divisor),
+                                                             static_cast<double>(qp.i_h / scale_divisor));
+
+    // Residual blocks: branch FQs stripped → Clamp with bounds divided by scale_divisor
+    std::pair<float, float> clamp_range{branch_fq_lo / scale_divisor, branch_fq_hi / scale_divisor};
+    auto add1 = create_residual_block(fq_pass_clamp,
+                                      2,
+                                      0.003f / scale_divisor,
+                                      0.001f / scale_divisor,
+                                      false,
+                                      std::nullopt,
+                                      clamp_range);
+    auto add2 = create_residual_block(add1,
+                                      3,
+                                      0.003f / scale_divisor,
+                                      0.001f / scale_divisor,
+                                      false,
+                                      std::nullopt,
+                                      clamp_range);
+    auto add3 =
+        create_residual_block(add2, 4, 0.003f / scale_divisor, 0.001f / scale_divisor, true, std::nullopt, clamp_range);
 
     if (skip_final_mvn) {
         return std::make_shared<ov::Model>(ov::OutputVector{add3}, params, "QDQStripping");
@@ -573,8 +651,10 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_forward_bias_pattern(
     return std::make_shared<ov::Model>(ov::OutputVector{mvn}, params, "QDQStripping");
 }
 
-std::shared_ptr<ov::Model> QDQStrippingFunction::build_forward_bias_pattern_ref(const ov::PartialShape& input_shape,
-                                                                                bool need_weights_adjustment) {
+std::shared_ptr<ov::Model> QDQStrippingFunction::build_forward_bias_pattern_ref(
+    const ov::PartialShape& input_shape,
+    const ov::element::Type& quantization_precision,
+    bool need_weights_adjustment) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape)};
 
     const float scale_divisor = need_weights_adjustment ? 40.f : 1.f;
@@ -586,9 +666,17 @@ std::shared_ptr<ov::Model> QDQStrippingFunction::build_forward_bias_pattern_ref(
     auto bias1 = build_weights_dq(ov::element::i8, {32}, 200.0f / scale_divisor, -128, 2);
     auto matmul1_biased = std::make_shared<ov::op::v1::Add>(matmul1, bias1);
 
+    // FQ stripped → Clamp(qp.i_l, qp.i_h)
+    static const std::unordered_map<ov::element::Type_t, QuantizationParams> quantization_params{
+        {ov::element::Type_t::u16, {0.f, 262140.f, 0.f, 65535.f, 0}},
+        {ov::element::Type_t::i16, {-131072.f, 131068.f, -32768.f, 32767.f, 0}},
+    };
+    const auto& qp = quantization_params.at(quantization_precision);
+    auto clamp = std::make_shared<ov::op::v0::Clamp>(matmul1_biased, qp.i_l, qp.i_h);
+
     // MatMul2: weight NOT adjusted, bias2 adjusted by forward propagation
     auto weight2 = build_weights_dq(ov::element::i8, ov::Shape{32, 32}, 0.001f, -128, 3);
-    auto matmul2 = std::make_shared<ov::op::v0::MatMul>(matmul1_biased, weight2, false, false);
+    auto matmul2 = std::make_shared<ov::op::v0::MatMul>(clamp, weight2, false, false);
 
     auto bias2 = build_weights_dq(ov::element::i8, {32}, 100.0f / scale_divisor, -128, 4);
     auto matmul2_biased = std::make_shared<ov::op::v1::Add>(matmul2, bias2);


### PR DESCRIPTION

### Details:
 - *Replace the stripped FakeQuantize with a lightweight Clamp(input_low, input_high) instead of bypass. This preserves the value range constraint (essential for correctness) while still removing the expensive quantization math*


### Tickets:
 - *CVS-186600*

