### PR TITLE
Fix exact int32 Div on CPU

### DIFF
--- a/src/frontends/onnx/frontend/src/op/div.cpp
+++ b/src/frontends/onnx/frontend/src/op/div.cpp
@@ -20,7 +20,9 @@ ONNX_OP("Div", OPSET_RANGE(1, 6), ai_onnx::opset_1::div);
 
 namespace opset_7 {
 ov::OutputVector div(const ov::frontend::onnx::Node& node) {
-    return {std::make_shared<ov::op::v1::Divide>(node.get_ov_inputs().at(0), node.get_ov_inputs().at(1))};
+    return {std::make_shared<ov::op::v1::Divide>(node.get_ov_inputs().at(0),
+                                                 node.get_ov_inputs().at(1),
+                                                 false)};
 }
 
 ONNX_OP("Div", OPSET_SINCE(7), ai_onnx::opset_7::div);

--- a/src/frontends/onnx/tests/tests_python/test_ops_binary.py
+++ b/src/frontends/onnx/tests/tests_python/test_ops_binary.py
@@ -5,7 +5,7 @@
 import numpy as np
 import onnx
 import pytest
-from onnx.helper import make_graph, make_model, make_tensor_value_info
+from onnx.helper import make_graph, make_model, make_tensor_value_info, np_dtype_to_tensor_dtype
 
 from tests.tests_python.utils import run_model
 
@@ -24,6 +24,24 @@ def import_and_compute(op_type, input_data_left, input_data_right, opset=7, **no
     model = make_model(graph, producer_name="OpenVINO ONNX Frontend")
     model.opset_import[0].version = opset
     inputs = [i.astype(np.float32) for i in inputs]  # WA for new Python API
+    return run_model(model, inputs)[0]
+
+
+def import_and_compute_typed(op_type, input_data_left, input_data_right, dtype, opset=7, **node_attributes):
+    inputs = [np.array(input_data_left, dtype=dtype), np.array(input_data_right, dtype=dtype)]
+    onnx_node = onnx.helper.make_node(op_type, inputs=["x", "y"], outputs=["z"], **node_attributes)
+    tensor_type = np_dtype_to_tensor_dtype(np.dtype(dtype))
+    output_shape = np.broadcast_shapes(*[value.shape for value in inputs])
+
+    input_tensors = [
+        make_tensor_value_info(name, tensor_type, value.shape)
+        for name, value in zip(onnx_node.input, inputs)
+    ]
+    output_tensors = [make_tensor_value_info(name, tensor_type, output_shape) for name in onnx_node.output]
+
+    graph = make_graph([onnx_node], "compute_graph", input_tensors, output_tensors)
+    model = make_model(graph, producer_name="OpenVINO ONNX Frontend")
+    model.opset_import[0].version = opset
     return run_model(model, inputs)[0]
 
 
@@ -132,3 +150,15 @@ def test_div():
         import_and_compute("Div", [[10, 20, 30], [40, 50, 60]], [2, 5, 6], opset=6, broadcast=1),
         np.array([[5, 4, 5], [20, 10, 10]], dtype=np.float32),
     )
+
+
+def test_div_int32_uses_truncating_onnx_semantics():
+    output = import_and_compute_typed(
+        "Div",
+        [-7, 7, -7, 7, 777777777],
+        [3, -3, -3, 3, 11],
+        np.int32,
+        opset=14,
+    )
+
+    assert np.array_equal(output, np.array([-2, -2, 2, 2, 70707070], dtype=np.int32))

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
@@ -390,7 +390,7 @@ void jit_divide_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
 
 std::set<std::vector<element::Type>> jit_divide_emitter::get_supported_precisions(
     [[maybe_unused]] const std::shared_ptr<ov::Node>& node) {
-    return {{element::f32, element::f32}, {element::i32, element::i32}};
+    return {{element::f32, element::f32}};
 }
 
 size_t jit_divide_emitter::aux_vecs_count() const {

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -153,6 +153,8 @@ const std::map<const ov::DiscreteTypeInfo, Eltwise::Initializer>& Eltwise::getIn
          [](const std::shared_ptr<ov::Node>& op, Eltwise& node) {
              node.algorithm = Algorithm::EltwiseDivide;
              node.m_attrs.broadcastingPolicy = determineBroadcastingPolicy(op);
+             const auto divide = ov::as_type_ptr<ov::op::v1::Divide>(op);
+             node.m_attrs.data.pythondiv = divide->is_pythondiv();
          }},
         {ov::op::v0::SquaredDifference::get_type_info_static(),
          []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Eltwise& node) {

--- a/src/plugins/intel_cpu/src/nodes/executors/eltwise_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/eltwise_config.hpp
@@ -30,17 +30,19 @@ struct EltwiseData {
     float alpha = 0.0F;
     float beta = 0.0F;
     float gamma = 0.0F;
+    bool pythondiv = true;
 
     bool operator==(const EltwiseData& rhs) const noexcept {
         return algo == rhs.algo && onednnAlgorithm == rhs.onednnAlgorithm && alpha == rhs.alpha && beta == rhs.beta &&
-               gamma == rhs.gamma;
+               gamma == rhs.gamma && pythondiv == rhs.pythondiv;
     }
 };
 
 inline std::ostream& operator<<(std::ostream& os, const EltwiseData& eltwiseData) {
     os << "EltwiseData(algo: " << algToString(eltwiseData.algo)
        << ", onednnAlgorithm: " << static_cast<int>(eltwiseData.onednnAlgorithm) << ", alpha: " << eltwiseData.alpha
-       << ", beta: " << eltwiseData.beta << ", gamma: " << eltwiseData.gamma << ")";
+       << ", beta: " << eltwiseData.beta << ", gamma: " << eltwiseData.gamma
+       << ", pythondiv: " << eltwiseData.pythondiv << ")";
     return os;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/eltwise_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/eltwise_implementations.cpp
@@ -52,6 +52,11 @@ static bool isBitwiseAlgorithm(const EltwiseConfig& config) {
                   Algorithm::EltwiseBitwiseRightShift);
 }
 
+static bool isIntegerReferenceAlgorithm(const EltwiseConfig& config) {
+    const auto algorithm = config.attrs.data.algo;
+    return any_of(algorithm, Algorithm::EltwiseDivide, Algorithm::EltwiseFloor);
+}
+
 [[maybe_unused]] static bool isChannelFirstApplicable(const EltwiseConfig& config) {
     auto acceptableRank = [](const size_t rank) {
         return any_of(rank, 1U, 2U, 3U, 4U, 5U);
@@ -144,6 +149,12 @@ static const TypeMapping eltwiseReferenceTypeMapping {
     {{_any, _any},        {just<f32>(), just<f32>()}},
 };
 
+static const TypeMapping integerReferenceTypeMapping {
+    // {src, dst}         pt<src, dst>
+    {{_i32, _i32},         {bypass(), bypass()}},
+    {{_any, _any},         {just<f32>(), just<f32>()}},
+};
+
 static const TypeMapping bitwiseReferenceTypeMapping {
     // {src, dst}         pt<src, dst>
     {{_u8 | _i8 | _u16 | _i16 | _i32, _u8 | _i8 | _u16 | _i16 | _i32},        {bypass(), bypass()}},
@@ -157,6 +168,16 @@ static const TypeMapping aclEltwiseTypeMapping {
     {{_any, _any},                 {just<f32>(), just<f32>()}},
 };
 // clang-format on
+
+static const TypeMapping& getReferenceTypeMapping(const EltwiseConfig& config) {
+    if (isBitwiseAlgorithm(config)) {
+        return bitwiseReferenceTypeMapping;
+    }
+    if (isIntegerReferenceAlgorithm(config)) {
+        return integerReferenceTypeMapping;
+    }
+    return eltwiseReferenceTypeMapping;
+}
 
 struct createOptimalConfigDefault {
     std::optional<EltwiseConfig> operator()(const EltwiseConfig& config) const {
@@ -381,7 +402,7 @@ const std::vector<ExecutorImplementation<EltwiseAttrs>>& getImplementations() {
                 return true;
             },
             [](const EltwiseConfig& config) -> std::optional<EltwiseConfig> {
-                const auto& typeMapping = isBitwiseAlgorithm(config) ? bitwiseReferenceTypeMapping : eltwiseReferenceTypeMapping;
+                const auto& typeMapping = getReferenceTypeMapping(config);
                 return createOptimalConfigCommon(config,
                                                  typeMapping,
                                                  LayoutConfig{LayoutType::ncsp, LayoutType::ncsp},
@@ -401,7 +422,7 @@ const std::vector<ExecutorImplementation<EltwiseAttrs>>& getImplementations() {
             },
             // createOptimalConfig
             [](const EltwiseConfig& config) -> std::optional<EltwiseConfig> {
-                const auto& typeMapping = isBitwiseAlgorithm(config) ? bitwiseReferenceTypeMapping : eltwiseReferenceTypeMapping;
+                const auto& typeMapping = getReferenceTypeMapping(config);
                 return createOptimalConfigCommon(config,
                                                  typeMapping,
                                                  LayoutConfig{LayoutType::nspc, LayoutType::nspc},

--- a/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.cpp
@@ -404,6 +404,11 @@ bool EltwiseJitExecutor::supports(const EltwiseAttrs& attrs,
     }
 
 #if defined(OPENVINO_ARCH_X86_64)
+    if (any_of(algorithm, Algorithm::EltwiseDivide, Algorithm::EltwiseFloor) &&
+        (contains(input_precisions, ov::element::i32) || contains(output_precisions, ov::element::i32))) {
+        return false;
+    }
+
     return true;
 
 #elif defined(OPENVINO_ARCH_ARM64)

--- a/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.h
+++ b/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.h
@@ -52,6 +52,7 @@ class EltwiseJitExecutor : public IEltwiseExecutor {
                 seed = hash_combine(seed, eltwiseData.alpha);
                 seed = hash_combine(seed, eltwiseData.beta);
                 seed = hash_combine(seed, eltwiseData.gamma);
+                seed = hash_combine(seed, eltwiseData.pythondiv);
                 return seed;
             };
             std::for_each(eltwise_data.begin(), eltwise_data.end(), [&](const EltwiseData& item) {

--- a/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.cpp
@@ -34,6 +34,14 @@
 #include "utils/general_utils.h"
 
 namespace ov::intel_cpu {
+namespace {
+
+bool useIntegerRefExecutor(const EltwiseRefKey& key) {
+    const auto algorithm = key.eltwise_data.front().algo;
+    return any_of(algorithm, Algorithm::EltwiseDivide, Algorithm::EltwiseFloor);
+}
+
+}  // namespace
 
 size_t EltwiseRefKey::hash() const {
     using namespace dnnl::impl;
@@ -45,6 +53,7 @@ size_t EltwiseRefKey::hash() const {
         seed = hash_combine(seed, eltwiseData.alpha);
         seed = hash_combine(seed, eltwiseData.beta);
         seed = hash_combine(seed, eltwiseData.gamma);
+        seed = hash_combine(seed, eltwiseData.pythondiv);
         return seed;
     };
     std::for_each(eltwise_data.begin(), eltwise_data.end(), [&](const EltwiseData& item) {
@@ -87,6 +96,9 @@ static EltwiseExecutorPtr createRefExecutorByPrecision(const EltwiseRefKey& key)
     case ov::element::u16:
         return std::make_shared<BitwiseRefExecutor<uint16_t>>(key);
     case ov::element::i32:
+        if (useIntegerRefExecutor(key)) {
+            return std::make_shared<IntegerRefExecutor<int32_t>>(key);
+        }
         return std::make_shared<BitwiseRefExecutor<int32_t>>(key);
     case ov::element::f16:
         return std::make_shared<EltwiseRefExecutor<dnnl::impl::float16_t>>(key);
@@ -415,6 +427,45 @@ bool EltwiseRefExecutor<T, Enable>::supports([[maybe_unused]] const EltwiseConfi
     return true;
 }
 
+// IntegerRefExecutor implementation
+template <typename T, typename Enable>
+IntegerRefExecutor<T, Enable>::IntegerRefExecutor(const EltwiseRefKey& key) : EltwiseRefBaseExecutor<T>(key) {}
+
+template <typename T, typename Enable>
+void IntegerRefExecutor<T, Enable>::exec(const jit_eltwise_call_args_ptrs& args_ptrs,
+                                         const VectorDims& dims_out,
+                                         [[maybe_unused]] const CpuParallelPtr& cpu_parallel) {
+    parallel_nt(0, [&](const int ithr, const int nthr) {
+        size_t start = 0;
+        size_t end = 0;
+        splitter(this->m_fullWorkAmount, nthr, ithr, start, end);
+
+        std::vector<size_t> counters(dims_out.size(), 0);
+
+        for (size_t iwork = start; iwork < end; ++iwork) {
+            std::vector<T> src_f(this->m_inputNum);
+            T* dst_ptr_f = nullptr;
+            this->init_ptr(args_ptrs, dims_out, counters, iwork, src_f, dst_ptr_f);
+
+            switch (this->m_opData.algo) {
+            case Algorithm::EltwiseDivide:
+                OPENVINO_ASSERT(src_f[1] != 0, "Integer division by zero is not supported");
+                *dst_ptr_f = src_f[0] / src_f[1];
+                if (this->m_opData.pythondiv && ((src_f[0] < 0) != (src_f[1] < 0)) && src_f[0] % src_f[1] != 0) {
+                    --(*dst_ptr_f);
+                }
+                break;
+            case Algorithm::EltwiseFloor:
+                *dst_ptr_f = src_f[0];
+                break;
+            default:
+                OPENVINO_THROW("Unsupported operation type for Integer Eltwise executor: ",
+                               algToString(this->m_opData.algo));
+            }
+        }
+    });
+}
+
 // BitwiseRefExecutor implementation
 template <typename T, typename Enable>
 BitwiseRefExecutor<T, Enable>::BitwiseRefExecutor(const EltwiseRefKey& key) : EltwiseRefBaseExecutor<T>(key) {}
@@ -485,6 +536,8 @@ template class EltwiseRefBaseExecutor<int32_t>;
 
 template class EltwiseRefExecutor<float>;
 template class EltwiseRefExecutor<dnnl::impl::float16_t>;
+
+template class IntegerRefExecutor<int32_t>;
 
 template class BitwiseRefExecutor<int8_t>;
 template class BitwiseRefExecutor<uint8_t>;

--- a/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.hpp
@@ -88,6 +88,19 @@ public:
 };
 
 template <typename T>
+constexpr bool supported_integer_ref_types_v = one_of_v<T, int32_t>;
+
+template <typename T, typename Enable = std::enable_if_t<supported_integer_ref_types_v<T>>>
+class IntegerRefExecutor : public EltwiseRefBaseExecutor<T> {
+public:
+    IntegerRefExecutor(const EltwiseRefKey& key);
+
+    void exec(const jit_eltwise_call_args_ptrs& args_ptrs,
+              const VectorDims& dims_out,
+              [[maybe_unused]] const CpuParallelPtr& cpu_parallel) override;
+};
+
+template <typename T>
 constexpr bool supported_bitwise_ref_types_v = one_of_v<T, int8_t, uint8_t, int16_t, uint16_t, int32_t>;
 
 template <typename T, typename Enable = std::enable_if_t<supported_bitwise_ref_types_v<T>>>

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_integer_divide.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_integer_divide.cpp
@@ -28,7 +28,9 @@ DecomposeIntegerDivide::DecomposeIntegerDivide() {
                          }
 
                          auto new_divide =
-                             std::make_shared<ov::op::v1::Divide>(divide->input_value(0), divide->input_value(1));
+                             std::make_shared<ov::op::v1::Divide>(divide->input_value(0),
+                                                                  divide->input_value(1),
+                                                                  divide->is_pythondiv());
                          auto new_floor = std::make_shared<ov::op::v0::Floor>(new_divide);
                          new_floor->set_friendly_name(divide->get_friendly_name());
                          ov::copy_runtime_info(divide, new_floor);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/convert_range.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/convert_range.cpp
@@ -8,10 +8,19 @@
 #include "openvino/core/graph_util.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/convert.hpp"
+#include "openvino/op/divide.hpp"
 #include "openvino/op/gather.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/parameter.hpp"
 #include "openvino/op/range.hpp"
+#include "openvino/op/result.hpp"
 #include "openvino/op/shape_of.hpp"
+#include "openvino/runtime/core.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 using namespace CPUTestUtils;
 
@@ -152,6 +161,53 @@ TEST_P(ConvertRangeSubgraphCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
     run();
     checkResults();
+}
+
+std::shared_ptr<ov::Model> make_int32_divide_model(const ov::Shape& shape, const bool pythondiv) {
+    auto lhs = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, shape);
+    auto rhs = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, shape);
+    auto div = std::make_shared<ov::op::v1::Divide>(lhs, rhs, pythondiv);
+    auto result = std::make_shared<ov::op::v0::Result>(div);
+    return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{lhs, rhs});
+}
+
+void run_int32_divide_test(const std::vector<int32_t>& lhs,
+                           const std::vector<int32_t>& rhs,
+                           const std::vector<int32_t>& expected,
+                           const bool pythondiv) {
+    ASSERT_EQ(lhs.size(), rhs.size());
+    ASSERT_EQ(lhs.size(), expected.size());
+
+    const ov::Shape shape{lhs.size()};
+    std::vector<int32_t> lhs_data = lhs;
+    std::vector<int32_t> rhs_data = rhs;
+    std::vector<int32_t> output(ov::shape_size(shape));
+
+    ov::Core core;
+    auto compiled_model = core.compile_model(make_int32_divide_model(shape, pythondiv), ov::test::utils::DEVICE_CPU);
+    auto infer_request = compiled_model.create_infer_request();
+    infer_request.set_input_tensor(0, ov::Tensor{ov::element::i32, shape, lhs_data.data()});
+    infer_request.set_input_tensor(1, ov::Tensor{ov::element::i32, shape, rhs_data.data()});
+    infer_request.set_output_tensor(ov::Tensor{ov::element::i32, shape, output.data()});
+    infer_request.infer();
+
+    EXPECT_EQ(output, expected);
+}
+
+TEST(Int32DivideAccuracyCPUTest, LargeValuesMatchTruncatingIntegerDivision) {
+    const std::vector<int32_t> lhs = {777777777, 1111111111, 1900000000, -1999999999};
+    const std::vector<int32_t> rhs = {11, 11, 11, 11};
+    const std::vector<int32_t> expected = {70707070, 101010101, 172727272, -181818181};
+
+    run_int32_divide_test(lhs, rhs, expected, false);
+}
+
+TEST(Int32DivideAccuracyCPUTest, NegativeValuesHonorRoundingMode) {
+    const std::vector<int32_t> lhs = {-7, 7, -7, 7};
+    const std::vector<int32_t> rhs = {3, -3, -3, 3};
+
+    run_int32_divide_test(lhs, rhs, {-2, -2, 2, 2}, false);
+    run_int32_divide_test(lhs, rhs, {-3, -3, 2, 2}, true);
 }
 
 const std::vector<std::map<std::string, ov::element::Type>> additionalConfig = {


### PR DESCRIPTION
### Details:
 - Route CPU `i32` `Divide`/`Floor` away from the JIT path that converted through `f32`, avoiding precision loss on large integer values.
 - Preserve `Divide::is_pythondiv()` through CPU eltwise attrs, runtime-cache keys, and integer-divide decomposition.
 - Import ONNX opset >= 7 `Div` with truncating integer semantics (`pythondiv=false`) and add regression coverage for large/negative `int32` values.

### Tickets:
 - Fixes #35830

### Validation:
 - `cmake --build build-ov35830-cpu --target ov_cpu_func_tests_subset -j16`
 - `./bin/intel64/Release/ov_cpu_func_tests_subset --gtest_filter='Int32DivideAccuracyCPUTest.*' --gtest_color=no` (2 tests passed)
 - `git diff --check`
 - `python3 -m py_compile src/frontends/onnx/tests/tests_python/test_ops_binary.py`
 - Attempted `PYTHONPATH=src/frontends/onnx python3 -m pytest -q src/frontends/onnx/tests/tests_python/test_ops_binary.py::test_div_int32_uses_truncating_onnx_semantics`; blocked locally because this environment does not have the required `onnx`/`openvino` Python packages and the reduced C++ build did not produce Python bindings.

### AI Assistance:
 - AI assistance used: yes
 - AI was used to draft and iterate on the implementation and tests.
 - Human validation performed: local C++ build, targeted CPU regression tests, whitespace check, Python syntax check, duplicate PR/issue checks, and manual review of the final diff.