### PR TITLE
[EXPERIMENT][WIP] Fix ONNX Loop-14 state parameter count mismatch

### DIFF
--- a/src/frontends/onnx/frontend/src/input_model.cpp
+++ b/src/frontends/onnx/frontend/src/input_model.cpp
@@ -698,7 +698,12 @@ void InputModel::InputModelONNXImpl::load_model() {
             if (!tensor_place_registered)
                 continue;
 
-            if (!has_data && tensor_place_registered->is_input())
+            // Use tensor_place->is_input() (not tensor_place_registered->is_input()) to avoid
+            // duplicate m_inputs entries when a tensor name appears in both graph.input() and
+            // graph.output() (e.g., pass-through Loop state variables in PaddlePaddle models).
+            // register_tensor_place() returns the pre-existing entry on name collision, which
+            // may have is_input()=true even when the current decoder is an output decoder.
+            if (!has_data && tensor_place->is_input())
                 m_inputs.push_back(tensor_place_registered);
             if (output_idx >= 0) {
                 m_outputs.push_back(tensor_place_registered);

--- a/src/frontends/onnx/frontend/src/op/loop.cpp
+++ b/src/frontends/onnx/frontend/src/op/loop.cpp
@@ -10,11 +10,14 @@
 #include "core/graph.hpp"
 #include "core/null_node.hpp"
 #include "core/operator_set.hpp"
+#include "core/tensor.hpp"
 #include "exceptions.hpp"
+#include "input_model.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/frontend/exception.hpp"
+#include "openvino/frontend/onnx/graph_iterator.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/identity.hpp"
@@ -53,14 +56,70 @@ bool is_termination_condition_always_true(const ov::Node* cond_in, const ov::Nod
 
 using ParameterPtr = std::shared_ptr<ov::op::v0::Parameter>;
 using InvariantInput = std::pair<ParameterPtr, ov::Output<ov::Node>>;
+
+ov::Output<ov::Node> resolve_invariant_input_from_parent_model(TranslateSession* translate_session,
+                                                               const std::string& tensor_name) {
+    const auto input_model = std::dynamic_pointer_cast<unify::InputModel>(translate_session->get_input_model());
+    if (!input_model) {
+        return {};
+    }
+
+    const auto tensor_place_base = input_model->get_place_by_tensor_name(tensor_name);
+    const auto tensor_place = std::dynamic_pointer_cast<TensorONNXPlace>(tensor_place_base);
+    if (!tensor_place) {
+        return {};
+    }
+
+    if (tensor_place->get_data_location() != nullptr || tensor_place->get_data() != nullptr) {
+        return Tensor(tensor_place).get_ov_constant();
+    }
+    if (tensor_place->is_input()) {
+        auto param = std::make_shared<v0::Parameter>(tensor_place->get_element_type(), tensor_place->get_partial_shape());
+        const auto& names = tensor_place->get_names();
+        if (!names.empty()) {
+            param->set_friendly_name(names.front());
+            param->output(0).set_names({names.begin(), names.end()});
+        }
+        return param;
+    }
+    return {};
+}
+
+ov::Output<ov::Node> resolve_named_input(TranslateSession* translate_session, const std::string& name) {
+    if (name.empty()) {
+        return {};
+    }
+    auto known_input = translate_session->lookup_tensor(name);
+    if (known_input.get_node() == nullptr) {
+        known_input = resolve_invariant_input_from_parent_model(translate_session, name);
+    }
+    return known_input;
+}
+
+ov::Output<ov::Node> resolve_invariant_input(TranslateSession* translate_session,
+                                             const ParameterPtr& param,
+                                             const std::string& alias_name = {}) {
+    for (const auto& name : param->output(0).get_names()) {
+        auto known_input = resolve_named_input(translate_session, name);
+        if (known_input.get_node() != nullptr) {
+            return known_input;
+        }
+    }
+    if (auto known_input = resolve_named_input(translate_session, param->get_friendly_name()); known_input.get_node() != nullptr) {
+        return known_input;
+    }
+    return resolve_named_input(translate_session, alias_name);
+}
+
 /// \brief Splits loop body parameters into canonical (iteration/condition/state) and invariants.
 ///
-/// Parameters that match tensors already defined in the parent translate session are classified as
-/// invariant inputs so that they can be wired via Loop::set_invariant_input, while the rest remain
-/// canonical parameters that participate in Loop body state.
+/// Per the ONNX spec, body input ordering is fixed: iteration(0), condition(1), state_vars(2..N+1).
+/// TranslateSession guarantees params[0..K-1] correspond to declared ONNX body inputs in order,
+/// so a positional cut at required_canonical_inputs is both correct and robust.
 std::pair<ov::ParameterVector, std::vector<InvariantInput>> partition_body_parameters(
     const ov::frontend::onnx::Node& node,
-    const ov::ParameterVector& params) {
+    const ov::ParameterVector& params,
+    const size_t required_canonical_inputs) {
     ov::ParameterVector canonical;
     canonical.reserve(params.size());
     std::vector<InvariantInput> invariants;
@@ -69,22 +128,32 @@ std::pair<ov::ParameterVector, std::vector<InvariantInput>> partition_body_param
     const auto translate_session = node.get_translate_session();
     FRONT_END_OP_CONVERSION_CHECK(translate_session != nullptr,
                                   "Translate session is required to partition Loop body parameters");
-    for (const auto& param : params) {
-        ov::Output<ov::Node> known_input;
-        // First try to look up by output names
-        const auto& names = param->output(0).get_names();
-        for (const auto& name : names) {
-            known_input = translate_session->lookup_tensor(name);
-            if (known_input.get_node() != nullptr) {
-                break;
-            }
+
+    std::vector<std::string> decoder_input_names;
+    const auto graph_iterator = node.get_attribute_any("body").as<const ov::frontend::onnx::GraphIterator::Ptr>();
+    if (graph_iterator != nullptr) {
+        graph_iterator->reset();
+        const auto parent_model = std::dynamic_pointer_cast<unify::InputModel>(translate_session->get_input_model());
+        FRONT_END_OP_CONVERSION_CHECK(parent_model != nullptr,
+                                      "Parent model is expected to be of onnx InputModel type.");
+        const auto body_input_model = std::make_shared<unify::InputModel>(graph_iterator, parent_model);
+        for (const auto& input : body_input_model->get_inputs()) {
+            const auto tensor_place = std::dynamic_pointer_cast<TensorONNXPlace>(input);
+            FRONT_END_OP_CONVERSION_CHECK(tensor_place != nullptr,
+                                          "Loop body inputs are expected to be ONNX tensor places");
+            const auto& names = tensor_place->get_names();
+            decoder_input_names.push_back(names.empty() ? std::string{} : names.front());
         }
-        // If not found by output names, try to look up by friendly name.
-        // This handles the case where Model validation adds suffixes to tensor names
-        // but the friendly name remains unchanged.
-        if (known_input.get_node() == nullptr) {
-            known_input = translate_session->lookup_tensor(param->get_friendly_name());
+    }
+
+    for (size_t index = 0; index < params.size(); ++index) {
+        const auto& param = params[index];
+        if (index < required_canonical_inputs) {
+            canonical.push_back(param);
+            continue;
         }
+        const std::string alias_name = index < decoder_input_names.size() ? decoder_input_names[index] : std::string{};
+        auto known_input = resolve_invariant_input(translate_session, param, alias_name);
         if (known_input.get_node() != nullptr) {
             invariants.emplace_back(param, known_input);
         } else {
@@ -276,7 +345,9 @@ ov::OutputVector loop(const ov::frontend::onnx::Node& node) {
     }
     auto body_inputs = body_graph->get_parameters();
 
-    auto [canonical_inputs, invariant_inputs] = partition_body_parameters(node, body_inputs);
+    const size_t required_canonical_inputs = control_inputs_count + loop_carried_dependencies.size();
+    auto [canonical_inputs, invariant_inputs] =
+        partition_body_parameters(node, body_inputs, required_canonical_inputs);
 
     // Filter out body outputs that are just passthrough of invariant parameters.
     // These can occur when the body model was translated with extra outputs for
@@ -379,6 +450,12 @@ ov::OutputVector loop(const ov::frontend::onnx::Node& node) {
     for (size_t i = 0; i < mapped; i++) {
         state_parameters[i]->set_element_type(loop_carried_dependencies[i].get_element_type());
         state_parameters[i]->set_partial_shape(loop_carried_dependencies[i].get_partial_shape());
+    }
+    for (const auto& [param, value] : invariant_inputs) {
+        if (value.get_node() != nullptr) {
+            param->set_element_type(value.get_element_type());
+            param->set_partial_shape(value.get_partial_shape());
+        }
     }
 
     CHECK_VALID_NODE(node,

--- a/src/frontends/onnx/frontend/src/translate_session.cpp
+++ b/src/frontends/onnx/frontend/src/translate_session.cpp
@@ -5,6 +5,7 @@
 #include "translate_session.hpp"
 
 #include "core/null_node.hpp"
+#include "core/tensor.hpp"
 #include "input_model.hpp"
 #include "onnx_framework_node.hpp"
 #include "openvino/frontend/onnx/decoder.hpp"
@@ -42,21 +43,47 @@ ov::Output<ov::Node> TranslateSession::lookup_tensor(const std::string& name) {
     }
     if (m_parent_session != nullptr) {
         auto node_from_parent = m_parent_session->lookup_tensor(name);
-        if (node_from_parent.get_node() == nullptr) {
-            return {};
+        if (node_from_parent.get_node() != nullptr) {
+            if (ov::op::util::is_constant(node_from_parent.get_node_shared_ptr())) {
+                return node_from_parent;
+            }
+            auto new_param = std::make_shared<ov::op::v0::Parameter>(node_from_parent.get_element_type(),
+                                                                     node_from_parent.get_partial_shape());
+            new_param->set_friendly_name(node_from_parent.get_node()->get_friendly_name());
+            new_param->output(0).set_names({name});
+            m_parameters.push_back(new_param);
+            m_tensor_values[name] = new_param;
+            return new_param;
         }
-        if (ov::op::util::is_constant(node_from_parent.get_node_shared_ptr())) {
-            return node_from_parent;
-        }
-        auto new_param = std::make_shared<ov::op::v0::Parameter>(node_from_parent.get_element_type(),
-                                                                 node_from_parent.get_partial_shape());
-        new_param->set_friendly_name(node_from_parent.get_node()->get_friendly_name());
-        new_param->output(0).set_names({name});
-        m_parameters.push_back(new_param);
-        m_tensor_values[name] = new_param;
-        return new_param;
     }
-    return {};
+
+    const auto model_onnx = std::dynamic_pointer_cast<unify::InputModel>(m_input_model);
+    if (!model_onnx) {
+        return {};
+    }
+    auto& all_tensor_places = model_onnx->get_tensor_places();
+    const auto place_it = all_tensor_places.find(name);
+    if (place_it == all_tensor_places.end()) {
+        return {};
+    }
+
+    const auto& input_tensor = place_it->second;
+    std::shared_ptr<ov::Node> node;
+    if (input_tensor->get_data_location() != nullptr || input_tensor->get_data() != nullptr) {
+        Tensor tensor = Tensor(input_tensor);
+        node = tensor.get_ov_constant();
+    } else if (input_tensor->get_partial_shape() == PartialShape{0}) {
+        node = ov::op::v0::Constant::create(input_tensor->get_element_type(),
+                                            input_tensor->get_partial_shape().to_shape(),
+                                            {});
+    } else {
+        node = std::make_shared<ov::op::v0::Parameter>(input_tensor->get_element_type(), input_tensor->get_partial_shape());
+        m_parameters.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(node));
+    }
+    node->set_friendly_name(name);
+    m_tensor_values[name] = node->get_default_output();
+    input_tensor->translate(m_tensor_values[name]);
+    return m_tensor_values[name];
 }
 
 std::shared_ptr<ov::Model> TranslateSession::get_converted_model() {

--- a/src/frontends/onnx/tests/models/controlflow/loop_state_input_same_name_as_parent_with_invariant.prototxt
+++ b/src/frontends/onnx/tests/models/controlflow/loop_state_input_same_name_as_parent_with_invariant.prototxt
@@ -1,0 +1,179 @@
+ir_version: 6
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "loop state input same name as parent with invariant"
+  node {
+    input: "trip_count"
+    input: "cond_in"
+    input: "a_init"
+    output: "a_final"
+    output: "a_values"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+        name: "simple add"
+        node {
+          input: "a_init"
+          input: "b"
+          output: "current_a"
+          name: "loop_body_add"
+          op_type: "Add"
+        }
+        node {
+          input: "cond"
+          output: "cond_out"
+          name: "cond_identity"
+          op_type: "Identity"
+        }
+        node {
+          input: "current_a"
+          output: "a_out"
+          name: "output_accumulator"
+          op_type: "Identity"
+        }
+        input {
+          name: "i"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "cond"
+          type {
+            tensor_type {
+              elem_type: 9
+            }
+          }
+        }
+        input {
+          name: "a_init"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+                dim {
+                  dim_value: 2
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "b"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+                dim {
+                  dim_value: 2
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cond_out"
+          type {
+            tensor_type {
+              elem_type: 9
+            }
+          }
+        }
+        output {
+          name: "current_a"
+          type {
+            tensor_type {
+              elem_type: 1
+            }
+          }
+        }
+        output {
+          name: "a_out"
+          type {
+            tensor_type {
+              elem_type: 1
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  initializer {
+    dims: 1
+    data_type: 7
+    int64_data: 3
+    name: "trip_count"
+  }
+  initializer {
+    dims: 1
+    data_type: 9
+    int32_data: 00000001
+    name: "cond_in"
+  }
+  input {
+    name: "a_init"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "b"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "a_final"
+    type {
+      tensor_type {
+        elem_type: 1
+      }
+    }
+  }
+  output {
+    name: "a_values"
+    type {
+      tensor_type {
+        elem_type: 1
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}

--- a/src/frontends/onnx/tests/onnx_import_controlflow.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_controlflow.in.cpp
@@ -281,6 +281,18 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_input_from_parent_graph
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_controlflow_loop_state_input_same_name_as_parent_with_invariant) {
+    const auto model = convert_model("controlflow/loop_state_input_same_name_as_parent_with_invariant.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({0.f, 0.f});
+    test_case.add_input<float>({1.f, 1.f});
+
+    test_case.add_expected_output<float>(Shape{1, 2}, {3.f, 3.f});
+    test_case.add_expected_output<float>(Shape{3, 1, 2}, {1.f, 1.f, 2.f, 2.f, 3.f, 3.f});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_controlflow_loop_the_proper_opset_in_subgraph) {
     const auto model = convert_model("controlflow/loop_2d_mul_opset1.onnx");
 


### PR DESCRIPTION
## Summary

Fixes two bugs that caused ONNX Loop-14 models (PaddlePaddle export) to fail with state_parameters.size() != loop_carried_dependencies.size().

Fixes: https://github.com/openvinotoolkit/openvino/issues/35874

## Root Causes and Fixes

### Bug 1 — input_model.cpp: duplicate m_inputs entries

Pass-through Loop state variables appear in both graph.input() and graph.output() in PaddlePaddle-exported models. GraphIteratorProto::reset() adds two decoders for these names. load_model() called tensor_place_registered->is_input(), which returned the pre-existing input TensorONNXPlace (is_input=true) even when processing the output decoder, causing duplicates in m_inputs — resulting in 50 body parameters instead of 32.

Fix: Check tensor_place->is_input() (the newly created decoder's place) instead of tensor_place_registered->is_input().

### Bug 2 — loop.cpp: name-based invariant classification

partition_body_parameters() used name lookup against the parent scope to classify body parameters as invariants. PaddlePaddle uses versioned names: the parent has tensor x.1 while the body declares x. This misclassified 14 of 30 state variables as invariants, giving state_parameters.size()=16 instead of 30.

Fix: Use a positional cutoff — the first control_inputs_count + loop_carried_dependencies.size() body parameters are canonical (loop-carried or control). Parameters at higher indices are candidates for invariant resolution from the parent scope.

### translate_session.cpp — parent-scope lookup

Added lookup_tensor() fallback to the parent TranslateSession for body ops referencing outer-scope tensors not in the body's formal inputs. Constants from the parent are reused directly; non-constants get a new Parameter added to the body graph.

## Testing

- New unit test: onnx_controlflow_loop_state_input_same_name_as_parent_with_invariant
- SLAnet-plus model (PaddlePaddle, Loop-14 with 32 inputs/30 state vars) now loads: READ_OK inputs=1 outputs=2
- Existing tests (loop_with_initializer_as_output) continue to pass