### PR TITLE
Preserve int64 scalar Broadcast constants on CPU

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
@@ -115,7 +115,7 @@ bool TileBroadcastCommon::canBeExecutedInNSPCLayout(VectorDims srcBlockedDims, V
 std::vector<NodeDesc> TileBroadcastCommon::getSupportedConfigs(const Node* node, size_t outSize) {
     std::vector<NodeDesc> supportedPrimitiveDescriptors;
     auto precision = node->getOriginalInputPrecisionAtPort(0);
-    auto dataType = DnnlExtensionUtils::ElementTypeToDataType(precision);
+    const auto dataType = DnnlExtensionUtils::ElementTypeToDataType(precision, DnnlExtensionUtils::nothrow_tag{});
 
     const auto& srcDims = node->getInputShapeAtPort(0).getDims();
     const auto& inDataShape = node->getInputShapeAtPort(0);
@@ -148,7 +148,9 @@ std::vector<NodeDesc> TileBroadcastCommon::getSupportedConfigs(const Node* node,
 
     config.outConfs.resize(outSize);
 
-    auto pushDesc = [&](dnnl::memory::format_tag inFormat, dnnl::memory::format_tag outFormat) {
+    auto pushDesc = [&](dnnl::memory::data_type dataType,
+                        dnnl::memory::format_tag inFormat,
+                        dnnl::memory::format_tag outFormat) {
         config.inConfs[0].setMemDesc(
             std::make_shared<DnnlBlockedMemoryDesc>(node->getInputShapeAtPort(0), dataType, inFormat));
         for (auto& outConf : config.outConfs) {
@@ -160,33 +162,34 @@ std::vector<NodeDesc> TileBroadcastCommon::getSupportedConfigs(const Node* node,
         supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
     };
 
-    if (!repeats.empty() && inDataShape.getRank() == outDataShapeRank && (any_of(outDataShapeRank, 4U, 5U))) {
+    if (dataType && !repeats.empty() && inDataShape.getRank() == outDataShapeRank &&
+        (any_of(outDataShapeRank, 4U, 5U))) {
         if (canBeExecutedInBlockedLayout(srcDims, repeats, 16)) {
             if (outDataShapeRank == 4) {
-                pushDesc(dnnl::memory::format_tag::nChw16c, dnnl::memory::format_tag::nChw16c);
+                pushDesc(*dataType, dnnl::memory::format_tag::nChw16c, dnnl::memory::format_tag::nChw16c);
             } else {
-                pushDesc(dnnl::memory::format_tag::nCdhw16c, dnnl::memory::format_tag::nCdhw16c);
+                pushDesc(*dataType, dnnl::memory::format_tag::nCdhw16c, dnnl::memory::format_tag::nCdhw16c);
             }
         }
         if (canBeExecutedInBlockedLayout(srcDims, repeats, 8)) {
             if (outDataShapeRank == 4) {
-                pushDesc(dnnl::memory::format_tag::nChw8c, dnnl::memory::format_tag::nChw8c);
+                pushDesc(*dataType, dnnl::memory::format_tag::nChw8c, dnnl::memory::format_tag::nChw8c);
             } else {
-                pushDesc(dnnl::memory::format_tag::nCdhw8c, dnnl::memory::format_tag::nCdhw8c);
+                pushDesc(*dataType, dnnl::memory::format_tag::nCdhw8c, dnnl::memory::format_tag::nCdhw8c);
             }
         }
         if (canBeExecutedInNSPCLayout(srcDims, repeats)) {
             if (outDataShapeRank == 4) {
-                pushDesc(dnnl::memory::format_tag::nhwc, dnnl::memory::format_tag::nhwc);
+                pushDesc(*dataType, dnnl::memory::format_tag::nhwc, dnnl::memory::format_tag::nhwc);
             } else {
-                pushDesc(dnnl::memory::format_tag::ndhwc, dnnl::memory::format_tag::ndhwc);
+                pushDesc(*dataType, dnnl::memory::format_tag::ndhwc, dnnl::memory::format_tag::ndhwc);
             }
         }
     }
 
     auto inFmt = DnnlExtensionUtils::GetPlainFormatByRank(inDataShape.getRank());
     auto outFmt = DnnlExtensionUtils::GetPlainFormatByRank(outDataShapeRank);
-    if (any_of(dnnl::memory::format_tag::undef, inFmt, outFmt)) {
+    if (!dataType || any_of(dnnl::memory::format_tag::undef, inFmt, outFmt)) {
         config.inConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(precision, node->getInputShapeAtPort(0)));
         for (size_t i = 0; i < config.outConfs.size(); i++) {
             config.outConfs[i].inPlace(-1);
@@ -196,7 +199,7 @@ std::vector<NodeDesc> TileBroadcastCommon::getSupportedConfigs(const Node* node,
         }
         supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
     } else {
-        pushDesc(inFmt, outFmt);
+        pushDesc(*dataType, inFmt, outFmt);
     }
 
     return supportedPrimitiveDescriptors;

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -283,6 +283,33 @@ namespace ov::intel_cpu {
 
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
 
+class KeepScalarBroadcastConstantPrecision : public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("KeepScalarBroadcastConstantPrecision");
+
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override {
+        bool changed = false;
+        for (const auto& node : model->get_ordered_ops()) {
+            if (!ov::as_type_ptr<ov::op::v1::Broadcast>(node) && !ov::as_type_ptr<ov::op::v3::Broadcast>(node)) {
+                continue;
+            }
+
+            const auto data = ov::as_type_ptr<ov::op::v0::Constant>(node->input_value(0).get_node_shared_ptr());
+            if (!data || !data->get_shape().empty()) {
+                continue;
+            }
+
+            const auto& data_type = data->get_element_type();
+            if ((data_type == ov::element::i64 || data_type == ov::element::u64) &&
+                !ov::is_keep_const_precision(data)) {
+                ov::enable_keep_const_precision(data);
+                changed = true;
+            }
+        }
+        return changed;
+    }
+};
+
 bool Transformations::is_decompression_multiply(const_node_ptr& node) {
     auto is_1x1_conv = [](const ov::Node* node) {
         const auto* conv = ov::as_type<const ov::op::v1::Convolution>(node);
@@ -662,6 +689,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     // Do not insert pass::Validate between pass::InsertConvertAfterExtension and pass::ConvertPrecision.
     // This may result in the loss of the original Element type of the Output .
     // element type convert is disabled.
+    CPU_REGISTER_PASS_COMMON(manager, KeepScalarBroadcastConstantPrecision);
     CPU_REGISTER_PASS_COMMON(manager,
                              ov::pass::ConvertPrecision,
                              precisions,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/broadcast.cpp
@@ -7,6 +7,11 @@
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
 #include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/runtime/core.hpp"
+#include "openvino/runtime/tensor.hpp"
 
 using namespace CPUTestUtils;
 
@@ -177,6 +182,32 @@ protected:
 TEST_P(BroadcastLayerCPUTest, CompareWithRefs) {
     run();
     CheckPluginRelatedResults(compiledModel, "Broadcast");
+}
+
+TEST(BroadcastLayerCPUTest, ScalarInt64ConstantKeepsPrecision) {
+    constexpr int64_t fill_value = 7LL * (1LL << 45);
+    const ov::Shape output_shape{4};
+
+    auto scalar = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {fill_value});
+    auto target_shape = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
+    auto broadcast = std::make_shared<ov::op::v3::Broadcast>(scalar, target_shape, ov::op::BroadcastType::NUMPY);
+    auto result = std::make_shared<ov::op::v0::Result>(broadcast);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{target_shape});
+
+    ov::Core core;
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_CPU);
+    auto infer_request = compiled_model.create_infer_request();
+
+    int64_t shape_value = static_cast<int64_t>(output_shape.front());
+    infer_request.set_input_tensor(ov::Tensor{ov::element::i64, ov::Shape{1}, &shape_value});
+    infer_request.infer();
+
+    const auto output = infer_request.get_output_tensor();
+    ASSERT_EQ(output.get_shape(), output_shape);
+
+    const auto* data = output.data<const int64_t>();
+    const std::vector<int64_t> actual(data, data + ov::shape_size(output_shape));
+    EXPECT_EQ(actual, std::vector<int64_t>(ov::shape_size(output_shape), fill_value));
 }
 
 namespace {


### PR DESCRIPTION
### Details:
 - Preserves scalar `i64`/`u64` Broadcast constants before CPU precision conversion so large ONNX `ConstantOfShape` fill values are not narrowed to `i32`.
 - Lets Tile/Broadcast fall back to CPU blocked descriptors when an element type has no oneDNN data type mapping, allowing the existing byte-copy implementation to handle preserved 64-bit values.
 - Adds a CPU Broadcast regression covering the reported large `int64` scalar fill value.

### Tickets:
 - Fixes #35891

### Validation:
 - `cmake --build build-ov35891-cpu --target ov_cpu_func_tests_subset -j16`
 - `./bin/intel64/Release/ov_cpu_func_tests_subset --gtest_filter='BroadcastLayerCPUTest.ScalarInt64ConstantKeepsPrecision' --gtest_color=no`
 - `./bin/intel64/Release/ov_cpu_func_tests_subset --gtest_filter='*BroadcastLayerCPUTest*' --gtest_color=no` (109 passed, 36 skipped by existing configuration)
 - `git diff --check`

### AI Assistance:
 - AI assistance used: yes
 - AI was used to prepare this patch and run local validation.
 - Human validation performed: duplicate issue/PR checks, focused regression, broader Broadcast subset, and local diff review.