### PR TITLE
Fix CPU int64 Select and BitwiseAnd

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -214,7 +214,7 @@ public:
     }
 
     [[nodiscard]] dnnl::memory::data_type getDataType() const {
-        return DnnlExtensionUtils::ElementTypeToDataType(getDesc().getPrecision());
+        return DnnlExtensionUtils::ElementTypeToDataTypeForMemory(getDesc().getPrecision());
     }
 
     template <typename T,

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
@@ -115,6 +115,15 @@ dnnl::memory::data_type DnnlExtensionUtils::ElementTypeToDataType(const ov::elem
     return result.value();
 }
 
+dnnl::memory::data_type DnnlExtensionUtils::ElementTypeToDataTypeForMemory(
+    const ov::element::Type& elementType,
+    [[maybe_unused]] DnnlExtensionUtils::throw_tag tag) {
+    if (elementType == ov::element::i64) {
+        return memory::data_type::f64;
+    }
+    return ElementTypeToDataType(elementType);
+}
+
 ov::element::Type DnnlExtensionUtils::DataTypeToElementType(const dnnl::memory::data_type& dataType) {
     switch (dataType) {
     case memory::data_type::f32:

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.h
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.h
@@ -40,6 +40,9 @@ public:
     static dnnl::memory::data_type ElementTypeToDataType(const ov::element::Type& elementType,
                                                          throw_tag tag = throw_tag{});
 
+    static dnnl::memory::data_type ElementTypeToDataTypeForMemory(const ov::element::Type& elementType,
+                                                                  throw_tag tag = throw_tag{});
+
     static std::optional<dnnl::memory::data_type> ElementTypeToDataType(const ov::element::Type& elementType,
                                                                         nothrow_tag tag) noexcept;
 

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
@@ -35,6 +35,8 @@ namespace ov::intel_cpu {
 
 DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(ov::element::Type prc, const Shape& shape, const VectorDims& strides)
     : MemoryDesc(shape, DnnlBlocked) {
+    setLogicalPrecision(prc);
+
     const auto ndims = shape.getRank();
     const auto& dims = shape.getDims();
 
@@ -45,7 +47,7 @@ DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(ov::element::Type prc, const Shape&
             OPENVINO_THROW("Can't create DnnlBlockedMemoryDesc with zero dim, but with non zero strides");
         }
         desc = {DnnlExtensionUtils::convertToDnnlDims(dims),
-                DnnlExtensionUtils::ElementTypeToDataType(prc),
+                DnnlExtensionUtils::ElementTypeToDataTypeForMemory(prc),
                 DnnlExtensionUtils::convertToDnnlDims(strides)};
     } else {
         dnnl::memory::dims plain_strides;
@@ -63,7 +65,7 @@ DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(ov::element::Type prc, const Shape&
         }
 
         desc = {DnnlExtensionUtils::convertToDnnlDims(dims),
-                DnnlExtensionUtils::ElementTypeToDataType(prc),
+                DnnlExtensionUtils::ElementTypeToDataTypeForMemory(prc),
                 plain_strides};
     }
 
@@ -101,11 +103,13 @@ DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(ov::element::Type prc,
                                              const VectorDims& offsetPaddingToData,
                                              const VectorDims& strides)
     : MemoryDesc(shape, DnnlBlocked) {
+    setLogicalPrecision(prc);
+
     using namespace dnnl;
     // scalar case
     if (shape.getRank() == 0) {
         desc.get()->format_kind = dnnl_blocked;
-        desc.get()->data_type = memory::convert_to_c(DnnlExtensionUtils::ElementTypeToDataType(prc));
+        desc.get()->data_type = memory::convert_to_c(DnnlExtensionUtils::ElementTypeToDataTypeForMemory(prc));
         desc.get()->ndims = 1;
         desc.get()->dims[0] = 1;
         desc.get()->padded_dims[0] = 1;
@@ -193,7 +197,7 @@ DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(ov::element::Type prc,
     // Fill general memory desc fields
     desc.get()->format_kind = dnnl_blocked;
     desc.get()->extra.flags = 0;
-    desc.get()->data_type = memory::convert_to_c(DnnlExtensionUtils::ElementTypeToDataType(prc));
+    desc.get()->data_type = memory::convert_to_c(DnnlExtensionUtils::ElementTypeToDataTypeForMemory(prc));
     desc.get()->ndims = dims.size();
     desc.get()->offset0 = DnnlExtensionUtils::convertToDnnlDim(offsetPadding);
     std::copy(dims.begin(), dims.end(), desc.get()->dims);
@@ -259,6 +263,7 @@ DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(const Shape& shape,
     } else {
         desc = dnnl::memory::desc(DnnlExtensionUtils::convertToDnnlDims(dims), dataType, format);
     }
+    setLogicalPrecision(DnnlExtensionUtils::DataTypeToElementType(dataType));
 
     VectorDims perm;
     VectorDims inner_blks;
@@ -507,7 +512,9 @@ MemoryDescPtr DnnlBlockedMemoryDesc::cloneWithNewDimsImp(const VectorDims& dims)
         }
     }
 
-    return DnnlBlockedMemoryDescPtr(new DnnlBlockedMemoryDesc(cloneDescWithNewDims(desc, dims, order).get()));
+    auto clonedDesc = DnnlBlockedMemoryDescPtr(new DnnlBlockedMemoryDesc(cloneDescWithNewDims(desc, dims, order).get()));
+    clonedDesc->setLogicalPrecision(getPrecision());
+    return clonedDesc;
 }
 
 bool DnnlBlockedMemoryDesc::isSame(dnnl::memory::format_tag fmt) const {

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.cpp
@@ -21,16 +21,31 @@
 
 namespace ov::intel_cpu {
 
+namespace {
+
+ov::element::Type dataTypeToDescriptorPrecision(const dnnl::memory::data_type dataType) {
+    if (dataType == dnnl::memory::data_type::undef) {
+        return ov::element::dynamic;
+    }
+    return DnnlExtensionUtils::DataTypeToElementType(dataType);
+}
+
+}  // namespace
+
 DnnlMemoryDesc::DnnlMemoryDesc(const dnnl::memory::desc& desc) : DnnlMemoryDesc(desc.get()) {}
 
 DnnlMemoryDesc::DnnlMemoryDesc(const_dnnl_memory_desc_t cdesc)
     : MemoryDesc(Shape(DnnlExtensionUtils::convertToVectorDims(cdesc->dims, cdesc->ndims)), Dnnl),
-      desc(DnnlExtensionUtils::clone_desc(cdesc)) {
+      desc(DnnlExtensionUtils::clone_desc(cdesc)),
+      precision(dataTypeToDescriptorPrecision(static_cast<dnnl::memory::data_type>(cdesc->data_type))) {
     OPENVINO_ASSERT(getFormatKind() != dnnl::memory::format_kind::any, "Unexpected: Memory format any is prohibited!");
 }
 
 ov::element::Type DnnlMemoryDesc::getPrecision() const {
-    return DnnlExtensionUtils::DataTypeToElementType(getDataType());
+    if (precision != ov::element::dynamic) {
+        return precision;
+    }
+    return dataTypeToDescriptorPrecision(getDataType());
 }
 
 MemoryDescPtr DnnlMemoryDesc::clone() const {

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
@@ -68,7 +68,12 @@ protected:
     dnnl::memory::desc desc;
 
     void setPrecision(ov::element::Type prc) override {
-        desc.get()->data_type = static_cast<dnnl_data_type_t>(DnnlExtensionUtils::ElementTypeToDataType(prc));
+        precision = prc;
+        desc.get()->data_type = static_cast<dnnl_data_type_t>(DnnlExtensionUtils::ElementTypeToDataTypeForMemory(prc));
+    }
+
+    void setLogicalPrecision(ov::element::Type prc) {
+        precision = prc;
     }
 
 private:
@@ -81,6 +86,8 @@ private:
     size_t getCurrentMemSizeImp() const override;
     bool isDefinedImp() const override;
     MemoryDescPtr cloneWithNewDimsImp(const VectorDims& dims) const override;
+
+    ov::element::Type precision = ov::element::dynamic;
 
     friend DnnlMemoryDescPtr DnnlExtensionUtils::makeDescriptor(const dnnl::memory::desc& desc);
     friend DnnlMemoryDescPtr DnnlExtensionUtils::makeDescriptor(const_dnnl_memory_desc_t desc);

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -831,8 +831,7 @@ ov::element::Type Eltwise::getRuntimePrecision() const {
     for (size_t i = 0; i < std::min(getParentEdges().size(), inputsNumLimit); i++) {
         auto parentEdge = getParentEdgeAt(i);
         if (parentEdge && parentEdge->getStatus() == Edge::Status::Validated) {
-            inputPrecisions.emplace_back(
-                DnnlExtensionUtils::DataTypeToElementType((parentEdge->getMemoryPtr()->getDataType())));
+            inputPrecisions.emplace_back(parentEdge->getMemoryPtr()->getDesc().getPrecision());
         }
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/eltwise_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/eltwise_implementations.cpp
@@ -52,6 +52,10 @@ static bool isBitwiseAlgorithm(const EltwiseConfig& config) {
                   Algorithm::EltwiseBitwiseRightShift);
 }
 
+static bool isBitwiseAndAlgorithm(const EltwiseConfig& config) {
+    return config.attrs.data.algo == Algorithm::EltwiseBitwiseAnd;
+}
+
 [[maybe_unused]] static bool isChannelFirstApplicable(const EltwiseConfig& config) {
     auto acceptableRank = [](const size_t rank) {
         return any_of(rank, 1U, 2U, 3U, 4U, 5U);
@@ -133,6 +137,8 @@ static const MappingNotation eltwiseMappingNotation{{ARG_SRC, 0},
                                                     // Support for more than 10 inputs can be added if necessary
                                                     {ARG_DST, 1}};
 
+static const MappingNotation selectMappingNotation{{ARG_SRC, 0}, {ARG_SRC_1, 1}, {ARG_SRC_2, 1}, {ARG_DST, 2}};
+
 // clang-format off
 static const TypeMapping eltwiseTypeMapping {
     // {src, dst}         pt<src, dst>
@@ -148,6 +154,18 @@ static const TypeMapping bitwiseReferenceTypeMapping {
     // {src, dst}         pt<src, dst>
     {{_u8 | _i8 | _u16 | _i16 | _i32, _u8 | _i8 | _u16 | _i16 | _i32},        {bypass(), bypass()}},
     {{_any, _any}, {just<f32>(), just<f32>()}},
+};
+
+static const TypeMapping bitwiseAndReferenceTypeMapping {
+    // {src, dst}         pt<src, dst>
+    {{_u8 | _i8 | _u16 | _i16 | _i32 | _i64, _u8 | _i8 | _u16 | _i16 | _i32 | _i64},        {bypass(), bypass()}},
+    {{_any, _any}, {just<f32>(), just<f32>()}},
+};
+
+static const TypeMapping selectReferenceTypeMapping {
+    // {condition, then/else, dst}         pt<condition, then/else, dst>
+    {{_boolean | _u8 | _i64, _i64, _i64}, {use<1>(), bypass(), bypass()}},
+    {{_any, _any, _any},                  {just<f32>(), just<f32>(), just<f32>()}},
 };
 
 static const TypeMapping aclEltwiseTypeMapping {
@@ -381,9 +399,20 @@ const std::vector<ExecutorImplementation<EltwiseAttrs>>& getImplementations() {
                 return true;
             },
             [](const EltwiseConfig& config) -> std::optional<EltwiseConfig> {
-                const auto& typeMapping = isBitwiseAlgorithm(config) ? bitwiseReferenceTypeMapping : eltwiseReferenceTypeMapping;
+                if (config.attrs.data.algo == Algorithm::EltwiseSelect) {
+                    return createOptimalConfigCommon(config,
+                                                     selectReferenceTypeMapping,
+                                                     LayoutConfig{LayoutType::ncsp, LayoutType::ncsp, LayoutType::ncsp},
+                                                     selectMappingNotation);
+                }
+                const TypeMapping* typeMapping = &eltwiseReferenceTypeMapping;
+                if (isBitwiseAndAlgorithm(config)) {
+                    typeMapping = &bitwiseAndReferenceTypeMapping;
+                } else if (isBitwiseAlgorithm(config)) {
+                    typeMapping = &bitwiseReferenceTypeMapping;
+                }
                 return createOptimalConfigCommon(config,
-                                                 typeMapping,
+                                                 *typeMapping,
                                                  LayoutConfig{LayoutType::ncsp, LayoutType::ncsp},
                                                  eltwiseMappingNotation);
             },
@@ -401,9 +430,20 @@ const std::vector<ExecutorImplementation<EltwiseAttrs>>& getImplementations() {
             },
             // createOptimalConfig
             [](const EltwiseConfig& config) -> std::optional<EltwiseConfig> {
-                const auto& typeMapping = isBitwiseAlgorithm(config) ? bitwiseReferenceTypeMapping : eltwiseReferenceTypeMapping;
+                if (config.attrs.data.algo == Algorithm::EltwiseSelect) {
+                    return createOptimalConfigCommon(config,
+                                                     selectReferenceTypeMapping,
+                                                     LayoutConfig{LayoutType::nspc, LayoutType::nspc, LayoutType::nspc},
+                                                     selectMappingNotation);
+                }
+                const TypeMapping* typeMapping = &eltwiseReferenceTypeMapping;
+                if (isBitwiseAndAlgorithm(config)) {
+                    typeMapping = &bitwiseAndReferenceTypeMapping;
+                } else if (isBitwiseAlgorithm(config)) {
+                    typeMapping = &bitwiseReferenceTypeMapping;
+                }
                 return createOptimalConfigCommon(config,
-                                                 typeMapping,
+                                                 *typeMapping,
                                                  LayoutConfig{LayoutType::nspc, LayoutType::nspc},
                                                  eltwiseMappingNotation);
             },

--- a/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/jit/eltwise.cpp
@@ -404,6 +404,16 @@ bool EltwiseJitExecutor::supports(const EltwiseAttrs& attrs,
     }
 
 #if defined(OPENVINO_ARCH_X86_64)
+    const auto hasI64 = [](const std::vector<ov::element::Type>& precisions) {
+        return std::find(precisions.begin(), precisions.end(), ov::element::i64) != precisions.end();
+    };
+    if (any_of(algorithm,
+               Algorithm::EltwiseSelect,
+               Algorithm::EltwiseBitwiseAnd) &&
+        (hasI64(input_precisions) || hasI64(output_precisions))) {
+        return false;
+    }
+
     return true;
 
 #elif defined(OPENVINO_ARCH_ARM64)

--- a/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.cpp
@@ -77,6 +77,7 @@ bool EltwiseRefKey::operator==(const EltwiseRefKey& rhs) const {
 }
 
 static EltwiseExecutorPtr createRefExecutorByPrecision(const EltwiseRefKey& key) {
+    const auto isBitwiseAnd = key.eltwise_data.front().algo == Algorithm::EltwiseBitwiseAnd;
     switch (key.outPrc) {
     case ov::element::i8:
         return std::make_shared<BitwiseRefExecutor<int8_t>>(key);
@@ -88,6 +89,11 @@ static EltwiseExecutorPtr createRefExecutorByPrecision(const EltwiseRefKey& key)
         return std::make_shared<BitwiseRefExecutor<uint16_t>>(key);
     case ov::element::i32:
         return std::make_shared<BitwiseRefExecutor<int32_t>>(key);
+    case ov::element::i64:
+        if (isBitwiseAnd) {
+            return std::make_shared<BitwiseRefExecutor<int64_t>>(key);
+        }
+        return std::make_shared<EltwiseRefExecutor<int64_t>>(key);
     case ov::element::f16:
         return std::make_shared<EltwiseRefExecutor<dnnl::impl::float16_t>>(key);
     default:
@@ -465,6 +471,9 @@ void BitwiseRefExecutor<T, Enable>::exec(const jit_eltwise_call_args_ptrs& args_
 template <typename T, typename Enable>
 bool BitwiseRefExecutor<T, Enable>::isSupportedConfiguration(const EltwiseConfig& config) {
     const auto algorithm = config.attrs.data.algo;
+    if (config.descs.at(ARG_DST)->getPrecision() == ov::element::i64) {
+        return algorithm == Algorithm::EltwiseBitwiseAnd;
+    }
     return any_of(algorithm,
                   Algorithm::EltwiseBitwiseAnd,
                   Algorithm::EltwiseBitwiseNot,
@@ -482,14 +491,17 @@ template class EltwiseRefBaseExecutor<uint8_t>;
 template class EltwiseRefBaseExecutor<int16_t>;
 template class EltwiseRefBaseExecutor<uint16_t>;
 template class EltwiseRefBaseExecutor<int32_t>;
+template class EltwiseRefBaseExecutor<int64_t>;
 
 template class EltwiseRefExecutor<float>;
 template class EltwiseRefExecutor<dnnl::impl::float16_t>;
+template class EltwiseRefExecutor<int64_t>;
 
 template class BitwiseRefExecutor<int8_t>;
 template class BitwiseRefExecutor<uint8_t>;
 template class BitwiseRefExecutor<int16_t>;
 template class BitwiseRefExecutor<uint16_t>;
 template class BitwiseRefExecutor<int32_t>;
+template class BitwiseRefExecutor<int64_t>;
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/ref/eltwise.hpp
@@ -73,7 +73,7 @@ template <typename T, typename... Ts>
 constexpr bool one_of_v = (std::is_same_v<T, Ts> || ...);
 
 template <typename T>
-constexpr bool supported_eltwise_ref_types_v = one_of_v<T, float, dnnl::impl::float16_t>;
+constexpr bool supported_eltwise_ref_types_v = one_of_v<T, float, dnnl::impl::float16_t, int64_t>;
 
 template <typename T, typename Enable = std::enable_if_t<supported_eltwise_ref_types_v<T>>>
 class EltwiseRefExecutor : public EltwiseRefBaseExecutor<T> {
@@ -88,7 +88,7 @@ public:
 };
 
 template <typename T>
-constexpr bool supported_bitwise_ref_types_v = one_of_v<T, int8_t, uint8_t, int16_t, uint16_t, int32_t>;
+constexpr bool supported_bitwise_ref_types_v = one_of_v<T, int8_t, uint8_t, int16_t, uint16_t, int32_t, int64_t>;
 
 template <typename T, typename Enable = std::enable_if_t<supported_bitwise_ref_types_v<T>>>
 class BitwiseRefExecutor : public EltwiseRefBaseExecutor<T> {

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -33,6 +33,7 @@
 #include "openvino/itt.hpp"
 #include "openvino/op/abs.hpp"
 #include "openvino/op/avg_pool.hpp"
+#include "openvino/op/bitwise_and.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/ceiling.hpp"
 #include "openvino/op/clamp.hpp"
@@ -46,6 +47,7 @@
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/result.hpp"
+#include "openvino/op/select.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/util/attr_types.hpp"
 #include "ov_ops/gather_compressed.hpp"
@@ -282,6 +284,35 @@
 namespace ov::intel_cpu {
 
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
+
+namespace {
+
+bool is_int64_type(const ov::element::Type& type) {
+    return type == ov::element::i64;
+}
+
+void mark_int64_eltwise_inputs_to_keep_precision(const std::shared_ptr<ov::Model>& model) {
+    for (const auto& node : model->get_ordered_ops()) {
+        if (ov::is_type<ov::op::v13::BitwiseAnd>(node)) {
+            for (size_t i = 0; i < node->get_input_size(); ++i) {
+                if (is_int64_type(node->input_value(i).get_element_type())) {
+                    ov::enable_keep_const_precision(node->get_input_node_shared_ptr(i));
+                }
+            }
+            continue;
+        }
+
+        if (const auto select = ov::as_type_ptr<ov::op::v1::Select>(node)) {
+            if (!is_int64_type(select->get_output_element_type(0))) {
+                continue;
+            }
+            ov::enable_keep_const_precision(select->get_input_node_shared_ptr(1));
+            ov::enable_keep_const_precision(select->get_input_node_shared_ptr(2));
+        }
+    }
+}
+
+}  // namespace
 
 bool Transformations::is_decompression_multiply(const_node_ptr& node) {
     auto is_1x1_conv = [](const ov::Node* node) {
@@ -662,6 +693,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     // Do not insert pass::Validate between pass::InsertConvertAfterExtension and pass::ConvertPrecision.
     // This may result in the loss of the original Element type of the Output .
     // element type convert is disabled.
+    mark_int64_eltwise_inputs_to_keep_precision(model);
     CPU_REGISTER_PASS_COMMON(manager,
                              ov::pass::ConvertPrecision,
                              precisions,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.cpp
@@ -13,6 +13,9 @@
 #include "utils/cpu_test_utils.hpp"
 #include "utils/general_utils.h"
 
+#include <array>
+#include <cstdint>
+
 #if defined(OPENVINO_ARCH_RISCV64)
 #   include "nodes/kernels/riscv64/cpu_isa_traits.hpp"
 #endif
@@ -39,6 +42,19 @@ std::string EltwiseLayerCPUTest::getTestCaseName(const testing::TestParamInfo<El
 // which has to be in signed/unsigned int8 type range,
 // 2) start value is defined by type sign: for signed int8 it's zero to have symmetric interval.
 ov::Tensor EltwiseLayerCPUTest::generate_eltwise_input(const ov::element::Type& type, const ov::Shape& shape, const bool adopt_intervals) {
+    if (type == ov::element::i64 && eltwiseType == utils::EltwiseTypes::BITWISE_AND) {
+        ov::Tensor tensor{type, shape};
+        auto* data = tensor.data<int64_t>();
+        const std::array<int64_t, 4> values = {0x0FEDCBA987654321LL,
+                                               0x123456789ABCDEF0LL,
+                                               0x7777777777777777LL,
+                                               0x5555555555555555LL};
+        for (size_t i = 0; i < ov::shape_size(shape); ++i) {
+            data[i] = values[i % values.size()];
+        }
+        return tensor;
+    }
+
     struct gen_params {
         uint32_t range;
         int32_t start_from;
@@ -256,6 +272,10 @@ void EltwiseLayerCPUTest::SetUp() {
                     auto data_ptr = reinterpret_cast<uint32_t*>(data_tensor.data());
                     std::vector<uint32_t> data(data_ptr, data_ptr + ov::shape_size(shape));
                     secondaryInput = ov::op::v0::Constant::create(netType, shape, data);
+                } else if (netType == ElementType::i64) {
+                    auto data_ptr = reinterpret_cast<int64_t*>(data_tensor.data());
+                    std::vector<int64_t> data(data_ptr, data_ptr + ov::shape_size(shape));
+                    secondaryInput = ov::op::v0::Constant::create(netType, shape, data);
                 } else if (netType == ElementType::f16) {
                     auto data_ptr = reinterpret_cast<ov::float16*>(data_tensor.data());
                     std::vector<ov::float16> data(data_ptr, data_ptr + ov::shape_size(shape));
@@ -319,6 +339,10 @@ std::string EltwiseLayerCPUTest::getPrimitiveType(const utils::EltwiseTypes& elt
         }
     }
 #endif
+    if (element_type == ov::element::i64 && eltwise_type == utils::EltwiseTypes::BITWISE_AND) {
+        return "ref";
+    }
+
     return CPUTestsBase::getPrimitiveType();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/eltwise.cpp
@@ -361,6 +361,23 @@ const auto params_4D_bitwise_i32 = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_4D_Bitwise_i32, EltwiseLayerCPUTest, params_4D_bitwise_i32, EltwiseLayerCPUTest::getTestCaseName);
 
+const auto params_4D_bitwise_i64 = ::testing::Combine(
+    ::testing::Combine(
+        ::testing::ValuesIn(bitwise_in_shapes_4D),
+        ::testing::Values(ov::test::utils::EltwiseTypes::BITWISE_AND),
+        ::testing::ValuesIn(secondaryInputTypes()),
+        ::testing::ValuesIn({ov::test::utils::OpType::VECTOR}),
+        ::testing::Values(ov::element::Type_t::i64),
+        ::testing::Values(ov::element::Type_t::dynamic),
+        ::testing::Values(ov::element::Type_t::dynamic),
+        ::testing::Values(ov::test::utils::DEVICE_CPU),
+        ::testing::Values(ov::AnyMap())),
+    ::testing::Values(CPUSpecificParams({}, {}, {}, {})),
+    ::testing::Values(emptyFusingSpec),
+    ::testing::Values(false));
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_4D_Bitwise_i64, EltwiseLayerCPUTest, params_4D_bitwise_i64, EltwiseLayerCPUTest::getTestCaseName);
+
 const auto params_4D_bitwise_NOT = ::testing::Combine(
     ::testing::Combine(
         ::testing::ValuesIn(bitwise_in_shapes_4D),

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/select.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/select.cpp
@@ -5,7 +5,11 @@
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/fusing_test_utils.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/select.hpp"
+
+#include <array>
+#include <cstdint>
 
 using namespace CPUTestUtils;
 namespace ov {
@@ -15,6 +19,20 @@ using selectParams = std::tuple<std::vector<InputShape>,    // input shapes
                                 ElementType,                // Then/Else precision
                                 ov::op::AutoBroadcastSpec,  // broadcast
                                 fusingSpecificParams>;
+
+using selectI64ConstParams = std::tuple<InputShape,                // condition input shape
+                                        ov::Shape,                 // then constant shape
+                                        ov::Shape,                 // else constant shape
+                                        ov::op::AutoBroadcastSpec  // broadcast
+                                        >;
+
+static std::vector<int64_t> make_i64_values(const ov::Shape& shape, const std::array<int64_t, 4>& values) {
+    std::vector<int64_t> data(ov::shape_size(shape));
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = values[i % values.size()];
+    }
+    return data;
+}
 
 class SelectLayerCPUTest : public testing::WithParamInterface<selectParams>,
                            virtual public SubgraphBaseTest,
@@ -47,7 +65,8 @@ protected:
         const auto& [shapes, precision, broadcast, fusingParams] = this->GetParam();
         init_input_shapes(shapes);
         std::tie(inFmts, outFmts, priority, selectedType) = emptyCPUSpec;
-        selectedType = makeSelectedTypeStr(getPrimitiveType(), ov::element::i8);
+        selectedType = precision == ov::element::i64 ? makeSelectedTypeStr("ref", precision)
+                                                     : makeSelectedTypeStr(getPrimitiveType(), ov::element::i8);
 
         ov::element::TypeVector types{ov::element::boolean, precision, precision};
         ov::ParameterVector parameters;
@@ -63,6 +82,38 @@ protected:
     void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
         inputs.clear();
         const auto& modelInputs = function->inputs();
+        if (modelInputs[1].get_element_type() == ov::element::i64) {
+            ov::Tensor condTensor{modelInputs[0].get_element_type(), targetInputStaticShapes[0]};
+            ov::Tensor thenTensor{modelInputs[1].get_element_type(), targetInputStaticShapes[1]};
+            ov::Tensor elseTensor{modelInputs[2].get_element_type(), targetInputStaticShapes[2]};
+
+            auto* condData = condTensor.data<bool>();
+            auto* thenData = thenTensor.data<int64_t>();
+            auto* elseData = elseTensor.data<int64_t>();
+            const std::array<int64_t, 4> thenValues = {(1LL << 45) + 123,
+                                                       (1LL << 52) + 7,
+                                                       (1LL << 55) + 31,
+                                                       (1LL << 60) + 9};
+            const std::array<int64_t, 4> elseValues = {(1LL << 44) + 5,
+                                                       (1LL << 46) + 11,
+                                                       (1LL << 53) + 17,
+                                                       (1LL << 54) + 23};
+            for (size_t i = 0; i < ov::shape_size(targetInputStaticShapes[0]); ++i) {
+                condData[i] = i != 2;
+            }
+            for (size_t i = 0; i < ov::shape_size(targetInputStaticShapes[1]); ++i) {
+                thenData[i] = thenValues[i % thenValues.size()];
+            }
+            for (size_t i = 0; i < ov::shape_size(targetInputStaticShapes[2]); ++i) {
+                elseData[i] = elseValues[i % elseValues.size()];
+            }
+
+            inputs.insert({modelInputs[0].get_node_shared_ptr(), condTensor});
+            inputs.insert({modelInputs[1].get_node_shared_ptr(), thenTensor});
+            inputs.insert({modelInputs[2].get_node_shared_ptr(), elseTensor});
+            return;
+        }
+
         ov::test::utils::InputGenerateData in_data;
         in_data.start_from = -1;
         in_data.range = 3;
@@ -85,6 +136,68 @@ protected:
 };
 
 TEST_P(SelectLayerCPUTest, CompareWithRefs) {
+    run();
+    CheckPluginRelatedResults(compiledModel, std::set<std::string>{"Eltwise", "Subgraph"});
+}
+
+class SelectI64ConstLayerCPUTest : public testing::WithParamInterface<selectI64ConstParams>,
+                                   virtual public SubgraphBaseTest,
+                                   public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<selectI64ConstParams>& obj) {
+        const auto& [conditionShape, thenShape, elseShape, broadcast] = obj.param;
+        std::ostringstream result;
+        result << "Condition_prc_" << ElementType::boolean << "_Then_Else_prc_" << ElementType::i64 << "_";
+        result << "Condition_IS=" << conditionShape.first << "_TS=(";
+        for (const auto& shape : conditionShape.second) {
+            result << ov::test::utils::vec2str(shape) << "_";
+        }
+        result << ")_ThenConst=" << ov::test::utils::vec2str(thenShape) << "_";
+        result << "ElseConst=" << ov::test::utils::vec2str(elseShape) << "_";
+        result << "Broadcast=" << broadcast.m_type;
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        abs_threshold = 0;
+        targetDevice = ov::test::utils::DEVICE_CPU;
+        const auto& [conditionShape, thenShape, elseShape, broadcast] = this->GetParam();
+        init_input_shapes({conditionShape});
+        selectedType = makeSelectedTypeStr("ref", ov::element::i64);
+
+        auto condition = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, inputDynamicShapes[0]);
+        const std::array<int64_t, 4> thenValues = {(1LL << 45) + 123,
+                                                   (1LL << 52) + 7,
+                                                   (1LL << 55) + 31,
+                                                   (1LL << 60) + 9};
+        const std::array<int64_t, 4> elseValues = {(1LL << 44) + 5,
+                                                   (1LL << 46) + 11,
+                                                   (1LL << 53) + 17,
+                                                   (1LL << 54) + 23};
+        auto thenConstant =
+            ov::op::v0::Constant::create(ov::element::i64, thenShape, make_i64_values(thenShape, thenValues));
+        auto elseConstant =
+            ov::op::v0::Constant::create(ov::element::i64, elseShape, make_i64_values(elseShape, elseValues));
+        auto select = std::make_shared<ov::op::v1::Select>(condition, thenConstant, elseConstant, broadcast);
+
+        ov::ParameterVector parameters{condition};
+        function = create_ov_model(ov::element::i64, parameters, select, "Eltwise");
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        const auto& modelInputs = function->inputs();
+        ov::Tensor condTensor{modelInputs[0].get_element_type(), targetInputStaticShapes[0]};
+        auto* condData = condTensor.data<bool>();
+        for (size_t i = 0; i < ov::shape_size(targetInputStaticShapes[0]); ++i) {
+            condData[i] = i % 2 == 0;
+        }
+        inputs.insert({modelInputs[0].get_node_shared_ptr(), condTensor});
+    }
+};
+
+TEST_P(SelectI64ConstLayerCPUTest, CompareWithRefs) {
     run();
     CheckPluginRelatedResults(compiledModel, std::set<std::string>{"Eltwise", "Subgraph"});
 }
@@ -162,6 +275,52 @@ INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefsNone_dynamic,
                          SelectLayerCPUTest,
                          noneCases,
                          SelectLayerCPUTest::getTestCaseName);
+
+const std::vector<std::vector<InputShape>> inShapesI64 = {
+    {
+        {{{4}}, {{4}}},
+        {{{4}}, {{4}}},
+        {{{4}}, {{4}}},
+    },
+};
+
+const std::vector<std::vector<InputShape>> inShapesI64Numpy = {
+    {
+        {{1, 3}, {{1, 3}}},
+        {{2, 3}, {{2, 3}}},
+        {{1, 1}, {{1, 1}}},
+    },
+};
+
+const auto i64Cases = ::testing::Combine(::testing::ValuesIn(inShapesI64),
+                                         ::testing::Values(ElementType::i64),
+                                         ::testing::Values(ov::op::AutoBroadcastType::NONE),
+                                         ::testing::Values(emptyFusingSpec));
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_i64,
+                         SelectLayerCPUTest,
+                         i64Cases,
+                         SelectLayerCPUTest::getTestCaseName);
+
+const auto i64NumpyCases = ::testing::Combine(::testing::ValuesIn(inShapesI64Numpy),
+                                              ::testing::Values(ElementType::i64),
+                                              ::testing::Values(ov::op::AutoBroadcastType::NUMPY),
+                                              ::testing::Values(emptyFusingSpec));
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_i64_Broadcast,
+                         SelectLayerCPUTest,
+                         i64NumpyCases,
+                         SelectLayerCPUTest::getTestCaseName);
+
+const auto i64ConstCases = ::testing::Combine(::testing::Values(InputShape{{1, 3}, {{1, 3}}}),
+                                             ::testing::Values(ov::Shape{2, 3}),
+                                             ::testing::Values(ov::Shape{1, 1}),
+                                             ::testing::Values(ov::op::AutoBroadcastType::NUMPY));
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_i64_ConstBroadcast,
+                         SelectI64ConstLayerCPUTest,
+                         i64ConstCases,
+                         SelectI64ConstLayerCPUTest::getTestCaseName);
 
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
- Preserve CPU `i64` inputs for `Select` and `BitwiseAnd` through the precision conversion pipeline so constants are not converted to `f64`.
- Keep generic oneDNN element-type conversion rejecting `i64`; use `f64` only as an internal 8-byte CPU memory carrier while preserving logical descriptor precision.
- Route `i64` `Select` and `BitwiseAnd` through reference execution and disable JIT for those `i64` cases.
- Add CPU functional coverage for `i64` Select, NUMPY broadcast Select, constant broadcast Select, and `i64` BitwiseAnd.

### Tickets:
- Fixes #35892

### Validation:
- `git diff --check`
- `cmake --build build --target openvino_intel_cpu_plugin ov_cpu_func_tests -j2`
- `cmake --build build --target ov_cpu_func_tests -j2`
- `bin/intel64/Release/ov_cpu_func_tests --gtest_filter='smoke_CompareWithRefs_4D_Bitwise_i64/EltwiseLayerCPUTest.*:smoke_CompareWithRefs_i64/SelectLayerCPUTest.*:smoke_CompareWithRefs_i64_Broadcast/SelectLayerCPUTest.*:smoke_CompareWithRefs_i64_ConstBroadcast/SelectI64ConstLayerCPUTest.*'` -> 7/7 passed
- `bin/intel64/Release/ov_cpu_func_tests --gtest_filter='*SelectLayerCPUTest*' --gtest_color=no` -> 62 run, 47 passed, 15 skipped
- `bin/intel64/Release/ov_cpu_func_tests --gtest_filter='*Bitwise*' --gtest_color=no` -> 536 run, 520 passed, 16 skipped

### AI Assistance:
- AI assistance used: yes
- AI was used to prepare the code/test changes, inspect reviewer risk areas, run duplicate PR checks, and execute local validation. Human validation performed: local diff review, build/test verification, and issue/PR duplicate checks before publishing.