### PR TITLE
[GHA] Switch Ubuntu APT sources to Azure mirrors for igpu tests

### DIFF
--- a/.github/workflows/job_gpu_tests.yml
+++ b/.github/workflows/job_gpu_tests.yml
@@ -54,6 +54,14 @@ jobs:
       GTEST_PARALLEL_SCRIPT: ${{ github.workspace }}/gtest_parallel.py
       NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/IntelProxyRootCA-Base64.crt
     steps:
+
+      - name: Switch Ubuntu APT sources to Azure mirrors
+        run: |
+          # compatible with both Ubuntu 22.04 and 24.04, which have different formats of sources.list files
+          touch /etc/apt/sources.list.d/ubuntu.sources
+          sed -i -E 's|http://(archive\|security).ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sed -i -E 's|http://(archive\|security).ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+
       - name: Download OpenVINO artifacts (package)
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:


### PR DESCRIPTION
### Details:
- switch ubuntu APT sources to azure mirrors, to increase stability

### AI Assistance:
 - *AI assistance used: no
