### PR TITLE
[ONNX] Store decoder with shared_ptr instead of raw pointer

### DIFF
--- a/src/frontends/onnx/frontend/src/core/node.cpp
+++ b/src/frontends/onnx/frontend/src/core/node.cpp
@@ -354,12 +354,12 @@ Node::Node(const NodeProto& node_proto, Graph* graph)
               }},
       m_decoder(nullptr),
       m_translate_session(nullptr) {}
-Node::Node(const DecoderBaseOperation& decoder, TranslateSession* translate_session)
+Node::Node(std::shared_ptr<const DecoderBaseOperation> decoder, TranslateSession* translate_session)
     : m_pimpl{nullptr,
               [](Impl* impl) {
 
               }},
-      m_decoder(&decoder),
+      m_decoder(std::move(decoder)),
       m_translate_session(translate_session) {}
 
 Node::Node(Node&& other) noexcept

--- a/src/frontends/onnx/frontend/src/core/node.hpp
+++ b/src/frontends/onnx/frontend/src/core/node.hpp
@@ -48,7 +48,7 @@ public:
     Node() = delete;
     // TODO: hide this ctor since it uses protobufs generated structures
     Node(const NodeProto& node_proto, Graph* graph);
-    Node(const DecoderBaseOperation& decoder, TranslateSession* translate_session);
+    Node(std::shared_ptr<const DecoderBaseOperation> decoder, TranslateSession* translate_session);
 
     Node(Node&&) noexcept;
     Node(const Node&);
@@ -124,7 +124,7 @@ private:
     // compilation fails; the compiler is unable to parameterize an allocator's
     // default deleter due to incomple type.
     std::unique_ptr<Impl, void (*)(Impl*)> m_pimpl;
-    const DecoderBaseOperation* m_decoder;
+    std::shared_ptr<const DecoderBaseOperation> m_decoder;
     TranslateSession* m_translate_session;
 };
 

--- a/src/frontends/onnx/frontend/src/translate_session.cpp
+++ b/src/frontends/onnx/frontend/src/translate_session.cpp
@@ -126,7 +126,7 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
         ov::OutputVector ov_outputs(out_size);
         const Operator* translator =
             m_translator_map->get_operator(decoder->get_domain(), decoder->get_op_type(), decoder->get_op_set());
-        ov::frontend::onnx::Node node_context(*decoder, this);
+        ov::frontend::onnx::Node node_context(decoder, this);
         std::string error_message{};
         try {
             if (translator == nullptr) {


### PR DESCRIPTION
### Details:
 - Fix use-after-free in ONNX Frontend when translating subgraphs (`If`/`Loop`/`Scan`): `ONNXFrameworkNode` / `NotSupportedONNXNode` / nested `Node` objects held raw `const DecoderBaseOperation*` pointers into decoders owned by a sub-`InputModel` that was destroyed right after subgraph translation, causing crashes in later passes (e.g. `collect_unconverted_ops`).
 - Change `Node::m_decoder` from raw pointer to `std::shared_ptr<const DecoderBaseOperation>` so the decoder's lifetime is tied to the `Node`. `OpPlace` already owns decoders by `shared_ptr`, so the call site just forwards it. 5 lines across 3 files.

### Tickets:
 - CVS-187784

### AI Assistance:
 - AI assistance used: yes
 - AI investigated the crash and prepared the fix.