### PR TITLE
[TESTS] Improve tensor compare failure output

### DIFF
--- a/src/tests/debug_capabilities.md
+++ b/src/tests/debug_capabilities.md
@@ -1,0 +1,22 @@
+# Test Debug Capabilities
+
+Environment variables that influence test diagnostics output.
+
+## Tensor comparison
+
+Used by `ov::test::utils::compare()` (see `common_test_utils/src/ov_tensor_utils.cpp`).
+
+### `OV_TEST_MAX_DIFFS_TO_PRINT`
+
+Maximum number of mismatched elements to print on comparison failure.
+
+- Default: `0` — only the coordinate with the largest diff is printed.
+- Any positive integer — print up to N first mismatched coordinates in addition to the max diff line.
+- `-1` — print all mismatched coordinates.
+- Invalid / non-numeric values yield `0`.
+
+Example:
+
+```sh
+OV_TEST_MAX_DIFFS_TO_PRINT=32 ./bin/intel64/Release/ov_cpu_func_tests --gtest_filter=...
+```

--- a/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
@@ -4,7 +4,9 @@
 
 #include "common_test_utils/ov_tensor_utils.hpp"
 
+#include <cstdlib>
 #include <iomanip>
+#include <sstream>
 
 #include "common_test_utils/data_utils.hpp"
 #include "openvino/core/type/element_iterator.hpp"
@@ -334,6 +336,16 @@ ov::Tensor create_and_fill_tensor_consistently(const ov::element::Type element_t
 namespace tensor_comparation {
 constexpr double eps = std::numeric_limits<double>::epsilon();
 
+static ov::Shape flat_index_to_nd(size_t flat, const ov::Shape& shape) {
+    ov::Shape nd(shape.size());
+    size_t rem = flat;
+    for (size_t d = shape.size(); d-- > 0;) {
+        nd[d] = rem % shape[d];
+        rem /= shape[d];
+    }
+    return nd;
+}
+
 inline bool less(const double a, const double b) {
     if (std::isnan(a) || std::isnan(b)) {
         return false;
@@ -412,11 +424,7 @@ protected:
     std::vector<IncorrectValue> incorrect_values_abs;
     double abs_threshold, rel_threshold, mvn_threshold, topk_threshold, mvn_results, topk_results;
     size_t tensor_size;
-    // Track the coord with the largest |actual - expected| so release builds (which only
-    // print one failing coord) surface the coord that actually drives the failure —
-    // otherwise the reader sees the first-in-tensor-order fail, which may be far from worst.
-    double worst_diff = -1.0;
-    IncorrectValue worst_value{0.0, 0.0, 0.0, 0};
+    IncorrectValue max_diff{0.0, 0.0, 0.0, 0};
 
     void emplace_back(double in_actual_value, double in_expected_value, double in_threshold, size_t in_coordinate) {
         incorrect_values_abs.push_back(IncorrectValue(in_actual_value, in_expected_value, in_threshold, in_coordinate));
@@ -443,15 +451,14 @@ public:
         if (less_or_equal(diff, threshold)) {
             return true;
         }
-        if (diff > worst_diff) {
-            worst_diff = diff;
-            worst_value = IncorrectValue(actual, expected, threshold, coordinate);
+        if (diff > std::fabs(max_diff.expected_value - max_diff.actual_value)) {
+            max_diff = IncorrectValue(actual, expected, threshold, coordinate);
         }
         emplace_back(actual, expected, threshold, coordinate);
         return false;
     }
 
-    void check_results() {
+    void check_results(const ov::Shape& shape = {}) {
         topk_results = static_cast<double>(incorrect_values_abs.size()) / (tensor_size ? tensor_size : 1);
         mvn_results /= tensor_size ? tensor_size : 1;
         if (!incorrect_values_abs.empty() && equal(1.f, topk_threshold) ||
@@ -461,37 +468,32 @@ public:
                 .append(std::to_string(abs_threshold))
                 .append(" rel_threshold: ")
                 .append(std::to_string(rel_threshold));
-#ifndef NDEBUG
             msg.append(" incorrect elem counter: ")
                 .append(std::to_string(incorrect_values_abs.size()))
                 .append(" among ")
                 .append(std::to_string(tensor_size))
                 .append(" shapes.");
-            constexpr size_t max_num_to_print = 32;
-#else
-            constexpr size_t max_num_to_print = 1;
-#endif
-            size_t i = 0;
-            if constexpr (max_num_to_print == 1) {
-                if (worst_diff >= 0.0) {
-                    std::cout << "Coordinate: " << std::setw(2) << worst_value.coordinate
-                              << " Expected: " << worst_value.expected_value << " Actual: " << worst_value.actual_value
-                              << " Diff: " << worst_diff << " abs_threshold: " << worst_value.threshold << " (worst of "
-                              << incorrect_values_abs.size() << ")\n";
-                    i = 1;
-                }
-            } else {
-                for (; i < incorrect_values_abs.size() && i < max_num_to_print; ++i) {
-                    auto val = incorrect_values_abs[i];
-                    std::cout << "Coordinate: " << std::setw(2) << val.coordinate << " Expected: " << val.expected_value
-                              << " Actual: " << val.actual_value
-                              << " Diff: " << std::fabs(val.expected_value - val.actual_value)
-                              << " abs_threshold: " << val.threshold << "\n";
-                }
-            }
 
-            if constexpr (max_num_to_print > 1) {
-                std::cout << i << " of " << incorrect_values_abs.size() << " incorrect elements printed" << "\n";
+            static const char* const env = std::getenv("OV_TEST_MAX_DIFFS_TO_PRINT");
+            static const long parsed = env ? std::strtol(env, nullptr, 10) : 0;
+            const size_t max_num_to_print =
+                parsed < 0 ? incorrect_values_abs.size() : static_cast<size_t>(parsed);
+
+            const auto print = [&shape](const char* label, const IncorrectValue& val) {
+                std::cout << label << ": " << flat_index_to_nd(val.coordinate, shape)
+                          << " Expected: " << val.expected_value << " Actual: " << val.actual_value
+                          << " Diff: " << std::fabs(val.expected_value - val.actual_value)
+                          << " abs_threshold: " << val.threshold << "\n";
+            };
+
+            const size_t to_print = std::min(max_num_to_print, incorrect_values_abs.size());
+            if (!incorrect_values_abs.empty()) {
+                std::cout << "Tensor: " << shape << " Mismatch: [" << incorrect_values_abs.size() << "/" << tensor_size
+                          << "] Print: [" << to_print << "/" << incorrect_values_abs.size() << "]\n";
+                print("Coordinate with max diff", max_diff);
+            }
+            for (size_t i = 0; i < to_print; ++i) {
+                print("Coordinate", incorrect_values_abs[i]);
             }
 
             throw std::runtime_error(msg);
@@ -616,14 +618,9 @@ void compare(const ov::Tensor& expected,
             continue;
         }
 
-        bool status = error.update(actual_value, expected_value, i);
-#ifdef NDEBUG
-        if (!status && tensor_comparation::equal(topk_threshold, 1.f)) {
-            break;
-        }
-#endif
+        error.update(actual_value, expected_value, i);
     }
-    error.check_results();
+    error.check_results(expected_shape);
 }
 
 void compare_str(const ov::Tensor& expected, const ov::Tensor& actual) {

--- a/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
@@ -474,10 +474,10 @@ public:
                 .append(std::to_string(tensor_size))
                 .append(" shapes.");
 
-            static const char* const env = std::getenv("OV_TEST_MAX_DIFFS_TO_PRINT");
-            static const long parsed = env ? std::strtol(env, nullptr, 10) : 0;
+            static const char* const num_to_print_env = std::getenv("OV_TEST_MAX_DIFFS_TO_PRINT");
+            static const long num_to_print = num_to_print_env ? std::strtol(num_to_print_env, nullptr, 10) : 0;
             const size_t max_num_to_print =
-                parsed < 0 ? incorrect_values_abs.size() : static_cast<size_t>(parsed);
+                num_to_print < 0 ? incorrect_values_abs.size() : static_cast<size_t>(num_to_print);
 
             const auto print = [&shape](const char* label, const IncorrectValue& val) {
                 std::cout << label << ": " << flat_index_to_nd(val.coordinate, shape)


### PR DESCRIPTION
- track + print coordinate with max diff
- print nD coordinates instead of flat index
- header line: tensor shape, mismatch / total, printed count
- env var OV_TEST_MAX_DIFFS_TO_PRINT controls per-coord print count (default 0)
- always full scan to get max_diff is accurate
- doc: src/tests/debug_capabilities.md

New format:
```
Tensor: [1,2,32,5] Mismatch: [46/320] Print: [5/46]
Coordinate with max diff: [0,1,31,0] Expected: -33.25 Actual: 98 Diff: 131.25 abs_threshold: 0.3425
Coordinate: [0,0,0,0] Expected: 93 Actual: 193 Diff: 100 abs_threshold: 0.94
Coordinate: [0,0,1,2] Expected: -225 Actual: -124 Diff: 101 abs_threshold: 2.26
Coordinate: [0,0,2,4] Expected: 192 Actual: 294 Diff: 102 abs_threshold: 1.93
Coordinate: [0,0,4,1] Expected: 114 Actual: 216 Diff: 102 abs_threshold: 1.15
Coordinate: [0,0,5,3] Expected: -150 Actual: -47 Diff: 103 abs_threshold: 1.51
/home/eduplens/git/openvinotoolkit/openvino/worktree-1/src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp:97: Failure
[ COMPARATION ] COMPARATION FAILED! abs_threshold: 0.010000 rel_threshold: 0.010000 incorrect elem counter: 46 among 320 shapes.
```
