### PR TITLE
[GPU] Fix FP16 overflow in fsv16 MVN kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_b_fs_yx_fsv16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_b_fs_yx_fsv16.cl
@@ -512,6 +512,7 @@ KERNEL(mvn_final)(
             MEAN_TYPE normalized = (TO_MEAN_TYPE(in_pack[si]) - mean) * inv_variance;
             OUTPUT_TYPE result;
 #           if HAS_FUSED_OPS
+                ACTIVATION_TYPE normalized_activation = TO_ACTIVATION_TYPE(normalized);
                 FUSED_OPS;
                 result = FUSED_OPS_RESULT;
 #           else
@@ -554,6 +555,7 @@ KERNEL(mvn_final)(
             MEAN_TYPE normalized = (TO_MEAN_TYPE(in_pack[si]) - mean) * inv_variance;
             OUTPUT_TYPE result;
 #           if HAS_FUSED_OPS
+                ACTIVATION_TYPE normalized_activation = TO_ACTIVATION_TYPE(normalized);
                 FUSED_OPS;
                 result = FUSED_OPS_RESULT;
 #           else
@@ -616,6 +618,7 @@ KERNEL(mvn_final)(
             MEAN_TYPE normalized = (TO_MEAN_TYPE(in_pack[si]) - mean) * inv_variance;
             OUTPUT_TYPE result;
 #           if HAS_FUSED_OPS
+                ACTIVATION_TYPE normalized_activation = TO_ACTIVATION_TYPE(normalized);
                 FUSED_OPS;
                 result = FUSED_OPS_RESULT;
 #           else
@@ -655,6 +658,7 @@ KERNEL(mvn_final)(
         unroll_for(uint set_idx = 0; set_idx < FSV; ++set_idx) {
             MEAN_TYPE normalized = (TO_MEAN_TYPE(in_pack[set_idx]) - _sub_group_shuffle(mean, set_idx)) * _sub_group_shuffle(inv_variance, set_idx);
 #           if HAS_FUSED_OPS
+                ACTIVATION_TYPE normalized_activation = TO_ACTIVATION_TYPE(normalized);
                 FUSED_OPS;
                 result[set_idx] = FUSED_OPS_RESULT;
 #           else
@@ -697,6 +701,7 @@ KERNEL(mvn_final)(
         unroll_for(uint set_idx = 0; set_idx < FSV; ++set_idx) {
             MEAN_TYPE normalized = (TO_MEAN_TYPE(in_pack[set_idx]) - _sub_group_shuffle(mean, set_idx)) * _sub_group_shuffle(inv_variance, set_idx);
 #           if HAS_FUSED_OPS
+                ACTIVATION_TYPE normalized_activation = TO_ACTIVATION_TYPE(normalized);
                 FUSED_OPS;
                 result[set_idx] = FUSED_OPS_RESULT;
 #           else
@@ -727,6 +732,7 @@ KERNEL(mvn_final)(
         unroll_for(uint set_idx = 0; set_idx < FSV; ++set_idx) {
             MEAN_TYPE normalized = (TO_MEAN_TYPE(in_pack[set_idx]) - _sub_group_shuffle(mean, set_idx)) * _sub_group_shuffle(inv_variance, set_idx);
 #           if HAS_FUSED_OPS
+                ACTIVATION_TYPE normalized_activation = TO_ACTIVATION_TYPE(normalized);
                 FUSED_OPS;
                 result[set_idx] = FUSED_OPS_RESULT;
 #           else

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_b_fs_yx_fsv16.cpp
@@ -168,7 +168,7 @@ JitConstants MVNKernel_b_fs_yx_fsv16::GetJitConstants(const mvn_params& params, 
                          "(output_spatial % OUTPUT_SIZE_X)"};
         }
 
-        auto conf = FusedOpsConfiguration("", idx_order, "normalized", activation_dt);
+        auto conf = FusedOpsConfiguration("", idx_order, "normalized_activation", activation_dt);
         if (params.has_dynamic_tensors()) {
             conf.SetBoundaryCheck(FusedOpsConfiguration::BoundaryCheck::ENABLED);
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_b_fs_yx_fsv16.cpp
@@ -128,7 +128,7 @@ JitConstants MVNKernel_b_fs_yx_fsv16::GetJitConstants(const mvn_params& params, 
 
     auto activation_dt = GetActivationType(params);
     jits.Merge(MakeTypeJitConstants(activation_dt, "ACTIVATION"));
-    jits.Merge(MakeTypeJitConstants(activation_dt, "MEAN"));
+    jits.Merge(MakeTypeJitConstants(Datatype::F32, "MEAN"));
     jits.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
     jits.AddConstant(MakeJitConstant("SIMD", simd));
     jits.AddConstant(MakeJitConstant("LWS", dispatchData.lws[0]));

--- a/src/plugins/intel_gpu/tests/unit/fusions/mvn_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/mvn_fusion_test.cpp
@@ -117,7 +117,7 @@ TEST_P(mvn_activation, basic) {
         reorder("reorder_bfyx", input_info("act"), format::bfyx, data_types::f32)
     );
 
-    tolerance = 1e-5f;
+    tolerance = default_tolerance(p.default_type);
     execute(p);
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/mvn_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/mvn_gpu_test.cpp
@@ -802,16 +802,18 @@ struct mvn_random_test_bsv32 : ::testing::TestWithParam<mvn_basic_test_params> {
 
     template <typename T>
     void compare_outputs(const cldnn::memory::ptr out_ref, const cldnn::memory::ptr out_opt) {
-        auto output_lay = out_ref->get_layout();
-        auto opt_output_lay = out_opt->get_layout();
+        auto lockable_out_ref = copy_to_lockable_memory(out_ref);
+        auto lockable_out_opt = copy_to_lockable_memory(out_opt);
+        auto output_lay = lockable_out_ref->get_layout();
+        auto opt_output_lay = lockable_out_opt->get_layout();
 
         size_t b = output_lay.batch();
         size_t f = output_lay.feature();
         size_t x = output_lay.spatial(0);
         size_t y = output_lay.spatial(1);
         size_t z = output_lay.spatial(2);
-        cldnn::mem_lock<T> ref_ptr(out_ref, get_test_stream());
-        cldnn::mem_lock<T> opt_ptr(out_opt, get_test_stream());
+        cldnn::mem_lock<T> ref_ptr(lockable_out_ref, get_test_stream());
+        cldnn::mem_lock<T> opt_ptr(lockable_out_opt, get_test_stream());
 
         float tolerance = (output_lay.data_type == data_types::f16) ? 5.e-2f : 1.e-2f;
 
@@ -846,13 +848,26 @@ struct mvn_random_test_bsv32 : ::testing::TestWithParam<mvn_basic_test_params> {
         }
     }
 
+    cldnn::memory::ptr copy_to_lockable_memory(const cldnn::memory::ptr& mem) {
+        if (mem->get_allocation_type() != allocation_type::usm_device) {
+            return mem;
+        }
+
+        auto& engine = get_test_engine();
+        auto host_mem = engine.allocate_memory(mem->get_layout(),
+                                               engine.get_lockable_preferred_memory_allocation_type());
+        host_mem->copy_from(get_test_stream(), *mem, true);
+        return host_mem;
+    }
+
     void execute(const mvn_basic_test_params& params, bool is_caching_test) {
         auto& size = params.input_size;
         auto& output_pad = params.output_pad;
         auto& engine = get_test_engine();
         bool is_5d = size.spatial[2] > 1;
         auto ref_fmt = is_5d ? format::bfzyx : format::bfyx;
-        auto input = engine.allocate_memory({params.input_type, ref_fmt, params.input_size});
+        auto input = engine.allocate_memory({params.input_type, ref_fmt, params.input_size},
+                                            engine.get_lockable_preferred_memory_allocation_type());
         switch (params.input_type) {
             case data_types::f32:
                 fill_random_data<float>(input, -127, 127);
@@ -956,6 +971,11 @@ struct mvn_test_case_generator_bsv32 : std::vector<mvn_basic_test_params> {
         return *this;
     }
 
+    mvn_test_case_generator_bsv32& fsv_large_spatial_tests(format::type fmt, data_types in_dt) {
+        push_back(mvn_basic_test_params{fmt, in_dt, {1, 16, 257, 256}, true, false, false, padding()});
+        return *this;
+    }
+
     mvn_test_case_generator_bsv32& fsv_zyx_tests(format::type fmt, data_types in_dt) {
         push_back(mvn_basic_test_params{fmt, in_dt, {2, 32, 5, 13, 7}, false, false, false, padding()});
         push_back(mvn_basic_test_params{fmt, in_dt, {2, 32, 5, 13, 7}, true, false, false, padding()});
@@ -986,6 +1006,11 @@ INSTANTIATE_TEST_SUITE_P(mvn_fsv16_f16,
                         mvn_random_test_bsv32,
                         testing::ValuesIn(mvn_test_case_generator_bsv32()
                                               .fsv_tests(format::b_fs_yx_fsv16, data_types::f16)));
+
+INSTANTIATE_TEST_SUITE_P(mvn_fsv16_f16_large_spatial,
+                        mvn_random_test_bsv32,
+                        testing::ValuesIn(mvn_test_case_generator_bsv32()
+                                              .fsv_large_spatial_tests(format::b_fs_yx_fsv16, data_types::f16)));
 
 INSTANTIATE_TEST_SUITE_P(mvn_fsv16_f32,
                         mvn_random_test_bsv32,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/mvn_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/mvn_gpu_test.cpp
@@ -802,18 +802,16 @@ struct mvn_random_test_bsv32 : ::testing::TestWithParam<mvn_basic_test_params> {
 
     template <typename T>
     void compare_outputs(const cldnn::memory::ptr out_ref, const cldnn::memory::ptr out_opt) {
-        auto lockable_out_ref = copy_to_lockable_memory(out_ref);
-        auto lockable_out_opt = copy_to_lockable_memory(out_opt);
-        auto output_lay = lockable_out_ref->get_layout();
-        auto opt_output_lay = lockable_out_opt->get_layout();
+        auto output_lay = out_ref->get_layout();
+        auto opt_output_lay = out_opt->get_layout();
 
         size_t b = output_lay.batch();
         size_t f = output_lay.feature();
         size_t x = output_lay.spatial(0);
         size_t y = output_lay.spatial(1);
         size_t z = output_lay.spatial(2);
-        cldnn::mem_lock<T> ref_ptr(lockable_out_ref, get_test_stream());
-        cldnn::mem_lock<T> opt_ptr(lockable_out_opt, get_test_stream());
+        cldnn::mem_lock<T> ref_ptr(out_ref, get_test_stream());
+        cldnn::mem_lock<T> opt_ptr(out_opt, get_test_stream());
 
         float tolerance = (output_lay.data_type == data_types::f16) ? 5.e-2f : 1.e-2f;
 
@@ -848,26 +846,13 @@ struct mvn_random_test_bsv32 : ::testing::TestWithParam<mvn_basic_test_params> {
         }
     }
 
-    cldnn::memory::ptr copy_to_lockable_memory(const cldnn::memory::ptr& mem) {
-        if (mem->get_allocation_type() != allocation_type::usm_device) {
-            return mem;
-        }
-
-        auto& engine = get_test_engine();
-        auto host_mem = engine.allocate_memory(mem->get_layout(),
-                                               engine.get_lockable_preferred_memory_allocation_type());
-        host_mem->copy_from(get_test_stream(), *mem, true);
-        return host_mem;
-    }
-
     void execute(const mvn_basic_test_params& params, bool is_caching_test) {
         auto& size = params.input_size;
         auto& output_pad = params.output_pad;
         auto& engine = get_test_engine();
         bool is_5d = size.spatial[2] > 1;
         auto ref_fmt = is_5d ? format::bfzyx : format::bfyx;
-        auto input = engine.allocate_memory({params.input_type, ref_fmt, params.input_size},
-                                            engine.get_lockable_preferred_memory_allocation_type());
+        auto input = engine.allocate_memory({params.input_type, ref_fmt, params.input_size});
         switch (params.input_type) {
             case data_types::f32:
                 fill_random_data<float>(input, -127, 127);


### PR DESCRIPTION
### Details
- Fixes FP16 overflow in `mvn_gpu_b_fs_yx_fsv16` by using F32 for `MEAN_TYPE` and variance-related intermediate buffers.
- The previous implementation used the activation type for mean/variance accumulation. For FP16 inputs, large spatial reductions can overflow during `sum((x - mean)^2)` accumulation before variance normalization.
- The issue was observed with Torchvision RAFT Large FP16 on GPU, where blocked `b_fs_yx_fsv16` MVN was selected for large-spatial instance normalization nodes.
- The regression test uses shape `{1, 16, 257, 256}`. Its spatial reduction size is `257 * 256 = 65792`, which exceeds the FP16 finite max value `65504` when squared deviations are accumulated with values of order 1 or larger.
- Keeps fused-op behavior consistent by converting the final normalized value back to `ACTIVATION_TYPE` before passing it to fused ops.
- Adds a GPU unit test that forces the `mvn_gpu_b_fs_yx_fsv16` implementation.


```mermaid
%%{init: {"flowchart": {"htmlLabels": true}}}%%
flowchart TB
  classDef conv fill:#e8f1ff,stroke:#2b6cb0,stroke-width:1px,color:#111
  classDef reorder fill:#fff4df,stroke:#b7791f,stroke-width:1px,color:#111
  classDef mvn fill:#e8f7ee,stroke:#2f855a,stroke-width:1px,color:#111

  subgraph GOOD["Good dump: 2026.2.0 / ffa272df85"]
    direction TB
    GConv1["<div style='min-width: 420px; text-align: left; white-space: nowrap;'>type: Convolution<br/>layout: b_fs_yx_fsv16<br/>shape: dynamic [2, 64, -1, -1]<br/>runtime shape: [2, 64, 260, 480]<br/>primitive: undef</div>"]
    GReorder1["<div style='min-width: 420px; text-align: left; white-space: nowrap;'>type: Reorder<br/>layout: bfyx<br/>shape: dynamic [2, 64, -1, -1]<br/>runtime shape: [2, 64, 260, 480]<br/>primitive: reorder_data__f16</div>"]
    GMVN["<div style='min-width: 420px; text-align: left; white-space: nowrap;'>type: MVN<br/>layout: bfyx<br/>shape: dynamic [2, 64, -1, -1]<br/>runtime shape: [2, 64, 260, 480]<br/>primitive: mvn_gpu_bfyx_opt__f16</div>"]
    GReorder2["<div style='min-width: 420px; text-align: left; white-space: nowrap;'>type: Reorder<br/>layout: b_fs_yx_fsv16<br/>shape: dynamic [2, 64, -1, -1]<br/>runtime shape: [2, 64, 260, 480]<br/>primitive: reorder_data__f16</div>"]
    GConv2["<div style='min-width: 420px; text-align: left; white-space: nowrap;'>type: Convolution<br/>layout: b_fs_yx_fsv16<br/>shape: dynamic [2, 64, -1, -1]<br/>runtime shape: [2, 64, 260, 480]<br/>primitive: undef</div>"]

    GConv1 --> GReorder1 --> GMVN --> GReorder2 --> GConv2
  end

  subgraph BAD["Bad dump: 2026.3.0 / 48b684f1ba"]
    direction TB
    BConv1["<div style='min-width: 420px; text-align: left; white-space: nowrap;'>type: Convolution<br/>layout: b_fs_yx_fsv16<br/>shape: dynamic [2, 64, -1, -1]<br/>runtime shape: [2, 64, 260, 480]<br/>primitive: undef</div>"]
    BMVN["<div style='min-width: 420px; text-align: left; white-space: nowrap;'>type: MVN<br/>layout: b_fs_yx_fsv16<br/>shape: dynamic [2, 64, -1, -1]<br/>runtime shape: [2, 64, 260, 480]<br/>primitive: mvn_gpu_b_fs_yx_fsv16__f16</div>"]
    BConv2["<div style='min-width: 420px; text-align: left; white-space: nowrap;'>type: Convolution<br/>layout: b_fs_yx_fsv16<br/>shape: dynamic [2, 64, -1, -1]<br/>runtime shape: [2, 64, 260, 480]<br/>primitive: undef</div>"]

    BConv1 --> BMVN --> BConv2
  end

  class GConv1,GConv2,BConv1,BConv2 conv
  class GReorder1,GReorder2 reorder
  class GMVN,BMVN mvn
```

### Validation:
- Passed: (new test-case for ticket issue)
  `bin\intel64\Release\ov_gpu_unit_tests.exe --gtest_filter="*mvn_fsv16_f16_large_spatial*" --device_suffix=1`

### Tests:
- `mvn_fsv16_f16_large_spatial/mvn_random_test_bsv32.random/0`
- `mvn_fsv16_f16_large_spatial/mvn_random_test_bsv32.random_cached/0`

### Tickets:
 - 186526

### AI Assistance:
 - AI assistance used: yes
 - AI: find a root-cause, fix issue, add tests
 - User: validation, code review