### PR TITLE
Relax reshape checks for compressed conv1x1 transformation

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
@@ -66,19 +66,6 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
     auto weight_input_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{weight_mult_m, weight_reshape_m});
     auto conv1x1_m = ov::pass::pattern::wrap_type<ov::op::v1::Convolution>({a_m, weight_input_m});
 
-    // Optional bias
-    auto bias_const_m = wrap_type<ov::op::v0::Constant>(pattern::shape_matches("[1, ?, 1, 1]"));
-    auto bias_m = ov::pass::pattern::wrap_type<ov::op::v1::Add>({conv1x1_m, bias_const_m});
-    auto bias_out_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{conv1x1_m, bias_m});
-
-    auto convert_m = ov::pass::pattern::wrap_type<ov::op::v0::Convert>({bias_out_m});
-    auto conv_out_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{bias_out_m, convert_m});
-
-    auto c_order_m = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
-    auto transpose_output_m = ov::pass::pattern::wrap_type<ov::op::v1::Transpose>({conv_out_m, c_order_m});
-    auto reshape_output_m = ov::pass::pattern::wrap_type<ov::op::v1::Reshape>({conv_out_m, c_order_m});
-    auto output_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{transpose_output_m, reshape_output_m});
-
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
@@ -92,17 +79,54 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
         auto weight_reshape = (pattern_map.count(weight_reshape_m) > 0)
                                   ? pattern_map.at(weight_reshape_m).get_node_shared_ptr()
                                   : nullptr;
-        auto bias_out = (pattern_map.count(bias_m) > 0) ? pattern_map.at(bias_m).get_node_shared_ptr() : nullptr;
-        auto bias_const =
-            (pattern_map.count(bias_const_m) > 0) ? pattern_map.at(bias_const_m).get_node_shared_ptr() : nullptr;
-        auto convert_out =
-            (pattern_map.count(convert_m) > 0) ? pattern_map.at(convert_m).get_node_shared_ptr() : nullptr;
-        auto out_order = (pattern_map.count(c_order_m) > 0) ? pattern_map.at(c_order_m).get_node_shared_ptr() : nullptr;
-        auto reshape_out = (pattern_map.count(reshape_output_m) > 0)
-                               ? pattern_map.at(reshape_output_m).get_node_shared_ptr()
-                               : nullptr;
         if (!conv1x1 || transformation_callback(conv1x1)) {
             return false;
+        }
+
+        // Dynamically detect optional bias, convert, and output transpose/reshape
+        // by walking consumers forward from conv1x1.
+        auto get_single_consumer = [](const std::shared_ptr<Node>& node) -> std::shared_ptr<Node> {
+            auto consumers = node->get_output_target_inputs(0);
+            return (consumers.size() == 1) ? consumers.begin()->get_node()->shared_from_this() : nullptr;
+        };
+
+        std::shared_ptr<Node> outermost = conv1x1;
+        std::shared_ptr<Node> bias_add = nullptr;
+        std::shared_ptr<ov::op::v0::Constant> bias_const = nullptr;
+        std::shared_ptr<Node> convert_out = nullptr;
+
+        // Walk through optional bias (Add with constant shaped [1, ?, 1, 1])
+        if (auto consumer = get_single_consumer(outermost)) {
+            if (ov::is_type<ov::op::v1::Add>(consumer)) {
+                for (size_t i = 0; i < consumer->get_input_size(); i++) {
+                    if (auto c = ov::as_type_ptr<ov::op::v0::Constant>(consumer->get_input_node_shared_ptr(i))) {
+                        auto s = c->get_shape();
+                        if (s.size() == 4 && s[0] == 1 && s[2] == 1 && s[3] == 1) {
+                            bias_add = consumer;
+                            bias_const = c;
+                            outermost = consumer;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        // Walk through optional Convert
+        if (auto consumer = get_single_consumer(outermost)) {
+            if (ov::is_type<ov::op::v0::Convert>(consumer)) {
+                convert_out = consumer;
+                outermost = consumer;
+            }
+        }
+        // Detect output transpose or reshape consumer
+        std::shared_ptr<ov::Node> consumer_transpose = nullptr;
+        std::shared_ptr<ov::Node> consumer_reshape = nullptr;
+        if (auto consumer = get_single_consumer(outermost)) {
+            if (ov::is_type<ov::op::v1::Transpose>(consumer)) {
+                consumer_transpose = consumer;
+            } else if (ov::is_type<ov::op::v1::Reshape>(consumer)) {
+                consumer_reshape = consumer;
+            }
         }
 
         auto weight = pattern_map.at(weights_m).get_node_shared_ptr();
@@ -253,8 +277,8 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
         auto matmul = std::make_shared<ov::op::v0::MatMul>(activation, scaled_weight, false, true);
         ov::copy_runtime_info(conv1x1, matmul);
         std::shared_ptr<Node> matmul_out;
-        if (bias_out) {
-            auto bias = ov::as_type_ptr<ov::op::v0::Constant>(bias_const);
+        if (bias_add) {
+            auto bias = bias_const;
             OPENVINO_ASSERT(bias != nullptr);
 
             ov::Shape bias_shape = bias->get_shape();
@@ -269,8 +293,8 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
             MatcherPass::register_new_node(Reshape_bias);
             Reshape_bias->set_friendly_name(bias->get_friendly_name() + "_Reshape_bias");
 
-            matmul_out = bias_out->clone_with_new_inputs({matmul, Reshape_bias});
-            ov::copy_runtime_info(bias_out, matmul_out);
+            matmul_out = bias_add->clone_with_new_inputs({matmul, Reshape_bias});
+            ov::copy_runtime_info(bias_add, matmul_out);
         } else {
             matmul_out = matmul;
         }
@@ -287,36 +311,39 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
             matmul_out = unsqueeze;
         }
 
-        if (reshape_out) {
-            if (convert_out) {
-                auto convert_final = convert_out->clone_with_new_inputs({matmul_out});
-                auto reshape_final = reshape_out->clone_with_new_inputs({convert_final, out_order});
-                reshape_final->set_friendly_name(m.get_match_root()->get_friendly_name());
-                ov::copy_runtime_info(convert_out, convert_final);
-                ov::copy_runtime_info(m.get_matched_nodes(), reshape_final);
-                ov::replace_node(m.get_match_root(), reshape_final);
-            } else {
-                auto reshape_final = reshape_out->clone_with_new_inputs({matmul_out, out_order});
-                reshape_final->set_friendly_name(m.get_match_root()->get_friendly_name());
-                ov::copy_runtime_info(m.get_matched_nodes(), reshape_final);
-                ov::replace_node(m.get_match_root(), reshape_final);
-            }
+        // Build final output, optionally wrapping in Convert
+        std::shared_ptr<Node> final_out = matmul_out;
+        if (convert_out) {
+            auto convert_final = convert_out->clone_with_new_inputs({matmul_out});
+            ov::copy_runtime_info(convert_out, convert_final);
+            final_out = convert_final;
+        }
+
+        if (consumer_transpose) {
+            // Transpose consumer found - absorb it, matmul replaces conv+transpose
+            final_out->set_friendly_name(consumer_transpose->get_friendly_name());
+            ov::copy_runtime_info(m.get_matched_nodes(), final_out);
+            ov::replace_node(consumer_transpose, final_out);
+        } else if (consumer_reshape) {
+            // Reshape consumer found - clone reshape with matmul output
+            auto reshape_order = consumer_reshape->get_input_node_shared_ptr(1);
+            auto reshape_final = consumer_reshape->clone_with_new_inputs({final_out, reshape_order});
+            reshape_final->set_friendly_name(consumer_reshape->get_friendly_name());
+            ov::copy_runtime_info(m.get_matched_nodes(), reshape_final);
+            ov::replace_node(consumer_reshape, reshape_final);
         } else {
-            if (convert_out) {
-                auto convert_final = convert_out->clone_with_new_inputs({matmul_out});
-                convert_final->set_friendly_name(m.get_match_root()->get_friendly_name());
-                ov::copy_runtime_info(m.get_matched_nodes(), convert_final);
-                ov::replace_node(m.get_match_root(), convert_final);
-            } else {
-                matmul_out->set_friendly_name(m.get_match_root()->get_friendly_name());
-                ov::copy_runtime_info(m.get_matched_nodes(), matmul_out);
-                ov::replace_node(m.get_match_root(), matmul_out);
-            }
+            // No transpose or reshape consumer - add NHWC->NCHW transpose
+            auto nhwc_to_nchw_order = std::make_shared<ov::op::v0::Constant>(
+                ov::element::i64, ov::Shape{4}, std::vector<int64_t>{0, 3, 1, 2});
+            auto transpose_to_nchw = std::make_shared<ov::op::v1::Transpose>(final_out, nhwc_to_nchw_order);
+            transpose_to_nchw->set_friendly_name(outermost->get_friendly_name());
+            ov::copy_runtime_info(m.get_matched_nodes(), transpose_to_nchw);
+            ov::replace_node(outermost, transpose_to_nchw);
         }
 
         return true;
     };
 
-    auto m = std::make_shared<ov::pass::pattern::Matcher>(output_m, matcher_name);
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(conv1x1_m, matcher_name);
     this->register_matcher(m, callback);
 }

--- a/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
@@ -43,8 +43,9 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
     auto reshape_activations_m =
         ov::pass::pattern::wrap_type<ov::op::v1::Reshape>({first_input_m, a_order_m},
                                                           pattern::shape_matches("[?, hidden_in, 1, 1]"));
+    auto direct_activation_m = ov::pass::pattern::any_input();
     auto a_m =
-        std::make_shared<ov::pass::pattern::op::Or>(OutputVector{transpose_activations_m, reshape_activations_m});
+        std::make_shared<ov::pass::pattern::op::Or>(OutputVector{transpose_activations_m, reshape_activations_m, direct_activation_m});
 
     auto weights_const_m = wrap_type<ov::op::v0::Constant>(pattern::shape_matches("[?, ?, 1, 1]") ||
                                                            pattern::shape_matches("[?, ?, ?, 1, 1]"));
@@ -132,7 +133,17 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
         auto weight = pattern_map.at(weights_m).get_node_shared_ptr();
         auto scale = pattern_map.at(weights_scales_m).get_node_shared_ptr();
         auto zp = (pattern_map.count(weights_zp_m) > 0) ? pattern_map.at(weights_zp_m).get_node_shared_ptr() : nullptr;
-        auto activation = pattern_map.at(first_input_m).get_node_shared_ptr();
+
+        // Determine activation source based on which pattern branch matched
+        std::shared_ptr<Node> activation;
+        bool has_input_transpose = pattern_map.count(transpose_activations_m) > 0;
+        bool has_input_reshape = pattern_map.count(reshape_activations_m) > 0;
+        if (has_input_transpose || has_input_reshape) {
+            activation = pattern_map.at(first_input_m).get_node_shared_ptr();
+        } else {
+            // Direct activation (no transpose/reshape) - use the conv's input directly
+            activation = pattern_map.at(direct_activation_m).get_node_shared_ptr();
+        }
 
         auto reshape_const_to_2d = [](std::shared_ptr<ov::Node> node) {
             auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);
@@ -242,7 +253,7 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
         //    direct use it in matmul.
         // 2. reshape from [..., num_head, head_dim]
         //    can't use it directly, need reshape it to [..., hidden_in], then use in matmul.
-        if (pattern_map.count(reshape_activations_m)) {
+        if (has_input_reshape) {
             auto reshape_activations = pattern_map.at(reshape_activations_m).get_node_shared_ptr();
             auto shape_in = reshape_activations->get_input_partial_shape(0);
             auto shape_out = reshape_activations->get_output_partial_shape(0);
@@ -255,6 +266,15 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
                 ov::copy_runtime_info(reshape_activations, reshape_activations_new);
                 activation = reshape_activations_new;
             }
+        } else if (!has_input_transpose && !has_input_reshape) {
+            // No transpose or reshape on activation input - activation is in NCHW [N, C, H, W].
+            // Insert NCHW->NHWC transpose [0, 2, 3, 1] so matmul gets [..., C] as last dim.
+            auto nchw_to_nhwc_order = std::make_shared<ov::op::v0::Constant>(
+                ov::element::i64, ov::Shape{4}, std::vector<int64_t>{0, 2, 3, 1});
+            auto transpose_input = std::make_shared<ov::op::v1::Transpose>(activation, nchw_to_nhwc_order);
+            transpose_input->set_friendly_name(activation->get_friendly_name() + "_nchw_to_nhwc");
+            ov::copy_runtime_info(conv1x1, transpose_input);
+            activation = transpose_input;
         }
 
         // If the activation has a static leading dimension of 1, squeeze it.

--- a/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
@@ -44,8 +44,8 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
         ov::pass::pattern::wrap_type<ov::op::v1::Reshape>({first_input_m, a_order_m},
                                                           pattern::shape_matches("[?, hidden_in, 1, 1]"));
     auto direct_activation_m = ov::pass::pattern::any_input();
-    auto a_m =
-        std::make_shared<ov::pass::pattern::op::Or>(OutputVector{transpose_activations_m, reshape_activations_m, direct_activation_m});
+    auto a_m = std::make_shared<ov::pass::pattern::op::Or>(
+        OutputVector{transpose_activations_m, reshape_activations_m, direct_activation_m});
 
     auto weights_const_m = wrap_type<ov::op::v0::Constant>(pattern::shape_matches("[?, ?, 1, 1]") ||
                                                            pattern::shape_matches("[?, ?, ?, 1, 1]"));
@@ -269,8 +269,9 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
         } else if (!has_input_transpose && !has_input_reshape) {
             // No transpose or reshape on activation input - activation is in NCHW [N, C, H, W].
             // Insert NCHW->NHWC transpose [0, 2, 3, 1] so matmul gets [..., C] as last dim.
-            auto nchw_to_nhwc_order = std::make_shared<ov::op::v0::Constant>(
-                ov::element::i64, ov::Shape{4}, std::vector<int64_t>{0, 2, 3, 1});
+            auto nchw_to_nhwc_order = std::make_shared<ov::op::v0::Constant>(ov::element::i64,
+                                                                             ov::Shape{4},
+                                                                             std::vector<int64_t>{0, 2, 3, 1});
             auto transpose_input = std::make_shared<ov::op::v1::Transpose>(activation, nchw_to_nhwc_order);
             transpose_input->set_friendly_name(activation->get_friendly_name() + "_nchw_to_nhwc");
             ov::copy_runtime_info(conv1x1, transpose_input);
@@ -353,8 +354,9 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
             ov::replace_node(consumer_reshape, reshape_final);
         } else {
             // No transpose or reshape consumer - add NHWC->NCHW transpose
-            auto nhwc_to_nchw_order = std::make_shared<ov::op::v0::Constant>(
-                ov::element::i64, ov::Shape{4}, std::vector<int64_t>{0, 3, 1, 2});
+            auto nhwc_to_nchw_order = std::make_shared<ov::op::v0::Constant>(ov::element::i64,
+                                                                             ov::Shape{4},
+                                                                             std::vector<int64_t>{0, 3, 1, 2});
             auto transpose_to_nchw = std::make_shared<ov::op::v1::Transpose>(final_out, nhwc_to_nchw_order);
             transpose_to_nchw->set_friendly_name(outermost->get_friendly_name());
             ov::copy_runtime_info(m.get_matched_nodes(), transpose_to_nchw);

--- a/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
@@ -47,18 +47,23 @@ struct Conv1x1ToMatmulTestParams {
 
 std::shared_ptr<ov::Model> gen_model(const Conv1x1ToMatmulTestParams& p) {
     size_t input_batch = p.with_batched_input ? 4 : 1;
-    size_t input_h = (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) ? 2 : 1;
-    size_t input_w = (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) ? 5 : 10;
-    auto input_shape = (p.activation_op_type._Starts_with("None"))
+    size_t input_h =
+        ((p.activation_op_type == "Reshape" || p.activation_op_type == "Reshape_None") && p.with_act_new_reshape) ? 2
+                                                                                                                  : 1;
+    size_t input_w =
+        ((p.activation_op_type == "Reshape" || p.activation_op_type == "Reshape_None") && p.with_act_new_reshape) ? 5
+                                                                                                                  : 10;
+    auto input_shape = (p.activation_op_type == "None_Transpose" || p.activation_op_type == "None_Reshape" ||
+                        p.activation_op_type == "None")
                            ? ov::Shape{input_batch, input_w, 1, input_h}
                            : ov::Shape{(size_t)input_batch, 1, input_h, input_w};
     auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, input_shape);
 
     std::shared_ptr<ov::Node> act_node = input;
-    if (p.activation_op_type._Starts_with("Transpose")) {
+    if ((p.activation_op_type == "Transpose" || p.activation_op_type == "Transpose_None")) {
         auto transpose_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {0, 3, 1, 2});
         act_node = std::make_shared<ov::opset1::Transpose>(input, transpose_const);
-    } else if (p.activation_op_type._Starts_with("Reshape")) {
+    } else if ((p.activation_op_type == "Reshape" || p.activation_op_type == "Reshape_None")) {
         auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {(int)input_batch, 10, 1, 1});
         act_node = std::make_shared<ov::opset1::Reshape>(input, reshape_const, false);
     }
@@ -132,9 +137,14 @@ std::shared_ptr<ov::Model> gen_model(const Conv1x1ToMatmulTestParams& p) {
 
 std::shared_ptr<ov::Model> gen_model_ref(const Conv1x1ToMatmulTestParams& p) {
     size_t input_batch = p.with_batched_input ? 4 : 1;
-    size_t input_h = (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) ? 2 : 1;
-    size_t input_w = (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) ? 5 : 10;
-    auto input_shape = (p.activation_op_type._Starts_with("None"))
+    size_t input_h =
+        ((p.activation_op_type == "Reshape" || p.activation_op_type == "Reshape_None") && p.with_act_new_reshape) ? 2
+                                                                                                                  : 1;
+    size_t input_w =
+        ((p.activation_op_type == "Reshape" || p.activation_op_type == "Reshape_None") && p.with_act_new_reshape) ? 5
+                                                                                                                  : 10;
+    auto input_shape = (p.activation_op_type == "None_Transpose" || p.activation_op_type == "None_Reshape" ||
+                        p.activation_op_type == "None")
                            ? ov::Shape{input_batch, input_w, 1, input_h}
                            : ov::Shape{(size_t)input_batch, 1, input_h, input_w};
     auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, input_shape);
@@ -178,15 +188,17 @@ std::shared_ptr<ov::Model> gen_model_ref(const Conv1x1ToMatmulTestParams& p) {
     }
 
     std::shared_ptr<ov::Node> act_node = input;
-    if (p.activation_op_type._Starts_with("None")) {
+    if (p.activation_op_type == "None_Transpose" || p.activation_op_type == "None_Reshape" ||
+        p.activation_op_type == "None") {
         auto transpose_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 3, 1});
         act_node = std::make_shared<ov::opset1::Transpose>(act_node, transpose_const);
     }
-    if (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) {
+    if ((p.activation_op_type == "Reshape" || p.activation_op_type == "Reshape_None") && p.with_act_new_reshape) {
         auto reshape_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {1, 1, (int)input_batch, 10});
         act_node = std::make_shared<ov::opset1::Reshape>(act_node, reshape_const, false);
     }
-    if (input_batch == 1 || (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape)) {
+    if (input_batch == 1 ||
+        ((p.activation_op_type == "Reshape" || p.activation_op_type == "Reshape_None") && p.with_act_new_reshape)) {
         auto squeeze_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{3}, {1, (int)input_batch, 10});
         act_node = std::make_shared<ov::opset1::Reshape>(act_node, squeeze_const, false);
     }
@@ -197,7 +209,8 @@ std::shared_ptr<ov::Model> gen_model_ref(const Conv1x1ToMatmulTestParams& p) {
         auto bias_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 1, 1, 15}, {1});
         current_node = std::make_shared<ov::opset1::Add>(current_node, bias_const);
     }
-    if (input_batch == 1 || ((p.activation_op_type._Starts_with("Reshape")) && p.with_act_new_reshape)) {
+    if (input_batch == 1 ||
+        (((p.activation_op_type == "Reshape" || p.activation_op_type == "Reshape_None")) && p.with_act_new_reshape)) {
         auto unsqueeze_const =
             ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {1, 1, (int)input_batch, 15});
         current_node = std::make_shared<ov::opset1::Reshape>(current_node, unsqueeze_const, false);

--- a/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
@@ -46,18 +46,20 @@ struct Conv1x1ToMatmulTestParams {
 };
 
 std::shared_ptr<ov::Model> gen_model(const Conv1x1ToMatmulTestParams& p) {
-    int input_batch = p.with_batched_input ? 4 : 1;
-    auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16,
-                                                         (p.activation_op_type == "Reshape" && p.with_act_new_reshape)
-                                                             ? ov::Shape{(size_t)input_batch, 1, 2, 5}
-                                                             : ov::Shape{(size_t)input_batch, 1, 1, 10});
+    size_t input_batch = p.with_batched_input ? 4 : 1;
+    size_t input_h = (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) ? 2 : 1;
+    size_t input_w = (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) ? 5 : 10;
+    auto input_shape = (p.activation_op_type._Starts_with("None"))
+                           ? ov::Shape{input_batch, input_w, 1, input_h}
+                           : ov::Shape{(size_t)input_batch, 1, input_h, input_w};
+    auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, input_shape);
 
-    std::shared_ptr<ov::Node> act_node;
-    if (p.activation_op_type == "Transpose") {
+    std::shared_ptr<ov::Node> act_node = input;
+    if (p.activation_op_type._Starts_with("Transpose")) {
         auto transpose_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {0, 3, 1, 2});
         act_node = std::make_shared<ov::opset1::Transpose>(input, transpose_const);
-    } else {
-        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {input_batch, 10, 1, 1});
+    } else if (p.activation_op_type._Starts_with("Reshape")) {
+        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {(int)input_batch, 10, 1, 1});
         act_node = std::make_shared<ov::opset1::Reshape>(input, reshape_const, false);
     }
 
@@ -116,12 +118,12 @@ std::shared_ptr<ov::Model> gen_model(const Conv1x1ToMatmulTestParams& p) {
         current_node = std::make_shared<ov::op::v0::Convert>(current_node, ov::element::f32);
     }
 
-    std::shared_ptr<ov::Node> out_node;
-    if (p.activation_op_type == "Transpose") {
+    std::shared_ptr<ov::Node> out_node = current_node;
+    if (p.activation_op_type == "Transpose" || p.activation_op_type == "None_Transpose") {
         auto transpose_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {0, 2, 3, 1});
         out_node = std::make_shared<ov::opset1::Transpose>(current_node, transpose_const);
-    } else {
-        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {input_batch, 1, 1, 15});
+    } else if (p.activation_op_type == "Reshape" || p.activation_op_type == "None_Reshape") {
+        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {(int)input_batch, 1, 1, 15});
         out_node = std::make_shared<ov::opset1::Reshape>(current_node, reshape_const, false);
     }
 
@@ -129,11 +131,13 @@ std::shared_ptr<ov::Model> gen_model(const Conv1x1ToMatmulTestParams& p) {
 }
 
 std::shared_ptr<ov::Model> gen_model_ref(const Conv1x1ToMatmulTestParams& p) {
-    int input_batch = p.with_batched_input ? 4 : 1;
-    auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16,
-                                                         (p.activation_op_type == "Reshape" && p.with_act_new_reshape)
-                                                             ? ov::Shape{(size_t)input_batch, 1, 2, 5}
-                                                             : ov::Shape{(size_t)input_batch, 1, 1, 10});
+    size_t input_batch = p.with_batched_input ? 4 : 1;
+    size_t input_h = (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) ? 2 : 1;
+    size_t input_w = (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) ? 5 : 10;
+    auto input_shape = (p.activation_op_type._Starts_with("None"))
+                           ? ov::Shape{input_batch, input_w, 1, input_h}
+                           : ov::Shape{(size_t)input_batch, 1, input_h, input_w};
+    auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, input_shape);
 
     std::shared_ptr<ov::Node> weights_node;
     ov::ParameterVector params = {input};
@@ -174,12 +178,16 @@ std::shared_ptr<ov::Model> gen_model_ref(const Conv1x1ToMatmulTestParams& p) {
     }
 
     std::shared_ptr<ov::Node> act_node = input;
-    if (p.activation_op_type == "Reshape" && p.with_act_new_reshape) {
-        auto reshape_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {1, 1, input_batch, 10});
-        act_node = std::make_shared<ov::opset1::Reshape>(input, reshape_const, false);
+    if (p.activation_op_type._Starts_with("None")) {
+        auto transpose_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 3, 1});
+        act_node = std::make_shared<ov::opset1::Transpose>(act_node, transpose_const);
     }
-    if (input_batch == 1 || (p.activation_op_type == "Reshape" && p.with_act_new_reshape)) {
-        auto squeeze_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{3}, {1, input_batch, 10});
+    if (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape) {
+        auto reshape_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {1, 1, (int)input_batch, 10});
+        act_node = std::make_shared<ov::opset1::Reshape>(act_node, reshape_const, false);
+    }
+    if (input_batch == 1 || (p.activation_op_type._Starts_with("Reshape") && p.with_act_new_reshape)) {
+        auto squeeze_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{3}, {1, (int)input_batch, 10});
         act_node = std::make_shared<ov::opset1::Reshape>(act_node, squeeze_const, false);
     }
     auto matmul = std::make_shared<ov::op::v0::MatMul>(act_node, mul, false, true);
@@ -189,20 +197,24 @@ std::shared_ptr<ov::Model> gen_model_ref(const Conv1x1ToMatmulTestParams& p) {
         auto bias_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 1, 1, 15}, {1});
         current_node = std::make_shared<ov::opset1::Add>(current_node, bias_const);
     }
-    if (input_batch == 1 || (p.activation_op_type == "Reshape" && p.with_act_new_reshape)) {
-        auto unsqueeze_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {1, 1, input_batch, 15});
+    if (input_batch == 1 || ((p.activation_op_type._Starts_with("Reshape")) && p.with_act_new_reshape)) {
+        auto unsqueeze_const =
+            ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {1, 1, (int)input_batch, 15});
         current_node = std::make_shared<ov::opset1::Reshape>(current_node, unsqueeze_const, false);
     }
     if (p.with_convert) {
         current_node = std::make_shared<ov::op::v0::Convert>(current_node, ov::element::f32);
     }
 
-    std::shared_ptr<ov::Node> out_node;
-    if (p.activation_op_type == "Reshape") {
-        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {input_batch, 1, 1, 15});
-        out_node = std::make_shared<ov::opset1::Reshape>(current_node, reshape_const, false);
-    } else {
-        out_node = current_node;
+    std::shared_ptr<ov::Node> out_node = current_node;
+    if (p.activation_op_type == "Reshape" || p.activation_op_type == "None_Reshape") {
+        auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {(int)input_batch, 1, 1, 15});
+        out_node = std::make_shared<ov::opset1::Reshape>(out_node, reshape_const, false);
+    }
+    if (p.activation_op_type == "Transpose_None" || p.activation_op_type == "Reshape_None" ||
+        p.activation_op_type == "None") {
+        auto transpose_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {0, 3, 1, 2});
+        out_node = std::make_shared<ov::opset1::Transpose>(out_node, transpose_const);
     }
 
     return std::make_shared<ov::Model>(ov::OutputVector{out_node}, params);
@@ -272,7 +284,13 @@ INSTANTIATE_TEST_SUITE_P(TransformationTests,
                                             ::testing::Bool(),
                                             ::testing::Bool(),
                                             ::testing::Bool(),
-                                            ::testing::Values("Transpose", "Reshape")),
+                                            ::testing::Values("Transpose",
+                                                              "Reshape",
+                                                              "Transpose_None",
+                                                              "Reshape_None",
+                                                              "None_Transpose",
+                                                              "None_Reshape",
+                                                              "None")),
                          ConvertWeightCompressedConv1x1ToMatmulTest::get_test_case_name);
 
 // Checked blocked cases


### PR DESCRIPTION
### Details:
 - This patch relaxes reshape/transpose patterns of `ConvertWeightCompressedConv1x1ToMatmul` to allow transformation of convolution nodes not directly bracketed with activation reshapes
 - Tests added to cover newly fitting options

### Tickets:
 - CVS-186730

### AI Assistance:
 - AI assistance used: no
