### PR TITLE
[TRANSFORMATIONS] Add NormalizeDequantizeFP16 pass to enable QDQ fusion for FP16 models

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/normalize_fp16_dequantize.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/normalize_fp16_dequantize.hpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov {
+namespace pass {
+
+class TRANSFORMATIONS_API NormalizeDequantizeFP16;
+
+}  // namespace pass
+}  // namespace ov
+
+/**
+ * @ingroup ov_transformation_common_api
+ * @brief NormalizeDequantizeFP16 handles the case where the Dequantize output
+ * is FP16 instead of FP32. In ONNX QDQ models, Quantize is decomposed into a
+ * FakeQuantize followed by a Convert(->int), and Dequantize is decomposed into
+ * Convert(int->float) -> [Subtract(zp)] -> Multiply(scale). When the Dequantize
+ * output is FP16, ConvertQuantizeDequantize cannot match the pattern and fuse the
+ * entire sequence back into a single FakeQuantize.
+ *
+ * This pass rewrites the Dequantize output from FP16 to FP32 by inserting a
+ * single FP16 cast at the end, leaving the FakeQuantize unchanged:
+ *
+ *   Convert(int->f16) -> [Subtract(f16_zp)] -> Multiply(f16_scale)
+ *
+ * becomes:
+ *
+ *   Convert(int->f32) -> [Subtract(f32_zp)] -> Multiply(f32_scale) -> Convert(f32->f16)
+ *
+ * ConvertQuantizeDequantize can then detect and fuse the full sequence into a
+ * single FakeQuantize, eliminating the Convert, Subtract, and Multiply nodes.
+ */
+class ov::pass::NormalizeDequantizeFP16 : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("NormalizeDequantizeFP16");
+    NormalizeDequantizeFP16();
+};

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -52,6 +52,7 @@
 #include "transformations/common_optimizations/nearest_neighbor_upsampling_fusion.hpp"
 #include "transformations/common_optimizations/nonzero_horizontal_fusion.hpp"
 #include "transformations/common_optimizations/nop_elimination.hpp"
+#include "transformations/common_optimizations/normalize_fp16_dequantize.hpp"
 #include "transformations/common_optimizations/normalize_l2_fusion.hpp"
 #include "transformations/common_optimizations/optimize_strided_slice.hpp"
 #include "transformations/common_optimizations/pack_multi_head_attention.hpp"
@@ -181,6 +182,7 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
         REGISTER_PASS(manager, LSTMStatesBroadcast)
         REGISTER_PASS(manager, ReshapeSinkingMatMul)
     }
+    REGISTER_PASS(manager, NormalizeDequantizeFP16)
     REGISTER_PASS(manager, ConvertQuantizeDequantize)
     REGISTER_PASS(manager, SimplifyShapeOfSubGraph, m_use_shapes)
 

--- a/src/common/transformations/src/transformations/common_optimizations/normalize_fp16_dequantize.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/normalize_fp16_dequantize.cpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/normalize_fp16_dequantize.hpp"
+
+#include <memory>
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/core/validation_util.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/pass/pattern/op/optional.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+
+namespace ov::pass {
+
+// Handles the case where the Dequantize output is FP16 instead of FP32, which
+// prevents ConvertQuantizeDequantize from detecting and fusing the sequence back
+// into a single FakeQuantize. Rewrites the Dequantize output to FP32 by moving
+// the FP16 cast to the end:
+//
+//   FQ -> Conv1(->int) -> Conv2(int->f16) -> [Sub(f16_zp)] -> Mul(f16_scale)
+//                             |
+//                             v
+//   FQ -> Conv1(->int) -> Conv2(int->f32) -> [Sub(f32_zp)] -> Mul(f32_scale) -> Conv(f32->f16)
+
+NormalizeDequantizeFP16::NormalizeDequantizeFP16() {
+    MATCHER_SCOPE(NormalizeDequantizeFP16);
+
+    auto fq_pattern = pattern::wrap_type<v0::FakeQuantize>(
+        {pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
+
+    auto conv1_pattern = pattern::wrap_type<v0::Convert>(
+        {fq_pattern},
+        pattern::type_matches_any({ov::element::u8, ov::element::i8, ov::element::u16, ov::element::i16}) &&
+            pattern::consumers_count(1));
+
+    auto conv2_pattern =
+        pattern::wrap_type<v0::Convert>({conv1_pattern},
+                                        pattern::type_matches(ov::element::f16) && pattern::consumers_count(1));
+
+    auto zp_pattern = pattern::any_input();
+    auto sub_pattern = pattern::optional<v1::Subtract>({conv2_pattern, zp_pattern}, pattern::consumers_count(1));
+
+    auto scale_pattern = pattern::any_input();
+    auto mul_pattern = pattern::wrap_type<v1::Multiply>({sub_pattern, scale_pattern});
+
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
+        const auto& map = m.get_pattern_value_map();
+
+        if (transformation_callback(m.get_match_root()))
+            return false;
+
+        auto to_f32 = [](const Output<Node>& val) -> Output<Node> {
+            if (val.get_element_type() == ov::element::f32)
+                return val;
+            Output<Node> cast = std::make_shared<v0::Convert>(val, ov::element::f32);
+            if (auto cst = ov::util::get_constant_from_source(cast))
+                return cst->output(0);
+            return cast;
+        };
+
+        const bool has_zp = map.count(zp_pattern) > 0;
+        auto scale = to_f32(map.at(scale_pattern));
+        auto zp = has_zp ? to_f32(map.at(zp_pattern)) : Output<Node>{};
+
+        auto conv2_node = map.at(conv2_pattern).get_node_shared_ptr();
+        auto mul_node = map.at(mul_pattern).get_node_shared_ptr();
+
+        // Normalize f16 DQ -> f32 DQ + f16 cast.
+        auto new_conv2 = std::make_shared<v0::Convert>(map.at(conv1_pattern), ov::element::f32);
+
+        NodeVector old_dq_nodes{conv2_node, mul_node};
+        NodeVector new_dq_nodes{new_conv2};
+        Output<Node> prev = new_conv2;
+
+        if (has_zp) {
+            old_dq_nodes.push_back(map.at(sub_pattern).get_node_shared_ptr());
+            auto new_sub = std::make_shared<v1::Subtract>(prev, zp);
+            new_dq_nodes.push_back(new_sub);
+            prev = new_sub;
+        }
+
+        auto new_mul = std::make_shared<v1::Multiply>(prev, scale);
+        new_dq_nodes.push_back(new_mul);
+
+        auto cast_to_f16 = std::make_shared<v0::Convert>(new_mul, ov::element::f16);
+        cast_to_f16->set_friendly_name(mul_node->get_friendly_name());
+        new_dq_nodes.push_back(cast_to_f16);
+
+        copy_runtime_info(old_dq_nodes, new_dq_nodes);
+        replace_node(mul_node, cast_to_f16);
+
+        return true;
+    };
+
+    auto m = std::make_shared<pattern::Matcher>(mul_pattern, matcher_name);
+    register_matcher(m, callback);
+}
+
+}  // namespace ov::pass

--- a/src/common/transformations/tests/common_optimizations/normalize_fp16_dequantize_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/normalize_fp16_dequantize_test.cpp
@@ -1,0 +1,196 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/normalize_fp16_dequantize.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/core/type/float16.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/opsets/opset1_decl.hpp"
+#include "openvino/pass/manager.hpp"
+#include "transformations/init_node_info.hpp"
+
+using namespace testing;
+using namespace ov;
+
+// ---------------------------------------------------------------------------
+// Helper: build an FP16-dequantize chain
+//   FQ(data, il, ih, ol, oh) -> Conv1(->int_type) -> Conv2(->f16)
+//     -> [Subtract(zp_f16)]  -> Multiply(scale_f16)
+// ---------------------------------------------------------------------------
+static std::shared_ptr<Model> build_fp16_dq_model(const Shape& data_shape,
+                                                   float il,
+                                                   float ih,
+                                                   float ol,
+                                                   float oh,
+                                                   size_t levels,
+                                                   element::Type int_type,
+                                                   float scale_f16_val,
+                                                   std::optional<float> zp_f16_val = std::nullopt) {
+    auto data = std::make_shared<opset1::Parameter>(element::f32, data_shape);
+    auto fq_il = opset1::Constant::create(element::f32, Shape{}, {il});
+    auto fq_ih = opset1::Constant::create(element::f32, Shape{}, {ih});
+    auto fq_ol = opset1::Constant::create(element::f32, Shape{}, {ol});
+    auto fq_oh = opset1::Constant::create(element::f32, Shape{}, {oh});
+    auto fq = std::make_shared<opset1::FakeQuantize>(data, fq_il, fq_ih, fq_ol, fq_oh, levels);
+    auto conv1 = std::make_shared<opset1::Convert>(fq, int_type);
+    auto conv2 = std::make_shared<opset1::Convert>(conv1, element::f16);
+
+    Output<Node> dq = conv2;
+    if (zp_f16_val) {
+        auto zp = opset1::Constant::create(element::f16, Shape{}, {ov::float16(*zp_f16_val)});
+        dq = std::make_shared<opset1::Subtract>(dq, zp);
+    }
+    auto scale = opset1::Constant::create(element::f16, Shape{}, {ov::float16(scale_f16_val)});
+    auto mul = std::make_shared<opset1::Multiply>(dq, scale);
+    return std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build the reference model produced by NormalizeDequantizeFP16
+//   FQ(data, il, ih, ol, oh) -> Conv1(->int_type) -> Conv2(->f32)
+//     -> [Subtract(zp_f32)]  -> Multiply(scale_f32)  -> Convert(->f16)
+//
+// The FQ node is left unchanged -- il/ih/ol/oh are the same as the input model.
+// ---------------------------------------------------------------------------
+static std::shared_ptr<Model> build_fp32_dq_ref_model(const Shape& data_shape,
+                                                       float il,
+                                                       float ih,
+                                                       float ol,
+                                                       float oh,
+                                                       size_t levels,
+                                                       element::Type int_type,
+                                                       float scale_f32,
+                                                       std::optional<float> zp_f32 = std::nullopt) {
+    auto data = std::make_shared<opset1::Parameter>(element::f32, data_shape);
+
+    auto fq_il = opset1::Constant::create(element::f32, Shape{}, {il});
+    auto fq_ih = opset1::Constant::create(element::f32, Shape{}, {ih});
+    auto fq_ol = opset1::Constant::create(element::f32, Shape{}, {ol});
+    auto fq_oh = opset1::Constant::create(element::f32, Shape{}, {oh});
+    auto fq = std::make_shared<opset1::FakeQuantize>(data, fq_il, fq_ih, fq_ol, fq_oh, levels);
+    auto conv1 = std::make_shared<opset1::Convert>(fq, int_type);
+    auto conv2 = std::make_shared<opset1::Convert>(conv1, element::f32);
+
+    Output<Node> dq = conv2;
+    if (zp_f32) {
+        auto zp_cst = opset1::Constant::create(element::f32, Shape{}, {*zp_f32});
+        dq = std::make_shared<opset1::Subtract>(dq, zp_cst);
+    }
+    auto scale_cst = opset1::Constant::create(element::f32, Shape{}, {scale_f32});
+    auto mul = std::make_shared<opset1::Multiply>(dq, scale_cst);
+    auto cast_f16 = std::make_shared<opset1::Convert>(mul, element::f16);
+    return std::make_shared<Model>(OutputVector{cast_f16}, ParameterVector{data});
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: u16 quantization, no zero point
+//
+//   FQ(il=-1, ih=1, ol=0, oh=65535, levels=65536)
+//     -> Convert(u16) -> Convert(f16) -> Multiply(Const[f16, 0.25])
+//
+// Expected after pass (FQ unchanged):
+//   FQ(il=-1, ih=1, ol=0, oh=65535, levels=65536)
+//     -> Convert(u16) -> Convert(f32) -> Multiply(Const[f32, 0.25])
+//     -> Convert(f16)
+// ---------------------------------------------------------------------------
+TEST_F(TransformationTestsF, NormalizeDequantizeFP16_U16_NoZeroPoint) {
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+
+    const float scale_f16_as_f32 = float(ov::float16(0.25f));  // exactly 0.25
+
+    model = build_fp16_dq_model({1, 3, 32, 32}, -1.0f, 1.0f, 0.0f, 65535.0f, 65536, element::u16, 0.25f);
+    manager.register_pass<ov::pass::NormalizeDequantizeFP16>();
+
+    model_ref =
+        build_fp32_dq_ref_model({1, 3, 32, 32}, -1.0f, 1.0f, 0.0f, 65535.0f, 65536, element::u16, scale_f16_as_f32);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: u16 quantization, with zero point
+//
+//   FQ(il=-1, ih=1, ol=0, oh=65535, levels=65536)
+//     -> Convert(u16) -> Convert(f16) -> Subtract(Const[f16, 8])
+//     -> Multiply(Const[f16, 0.25])
+//
+// Expected after pass (FQ unchanged):
+//   FQ(il=-1, ih=1, ol=0, oh=65535)
+//     -> Convert(u16) -> Convert(f32) -> Subtract(Const[f32, 8])
+//     -> Multiply(Const[f32, 0.25]) -> Convert(f16)
+// ---------------------------------------------------------------------------
+TEST_F(TransformationTestsF, NormalizeDequantizeFP16_U16_WithZeroPoint) {
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+
+    const float scale_f16_as_f32 = float(ov::float16(0.25f));  // exactly 0.25
+    const float zp_f16_as_f32 = float(ov::float16(8.0f));      // exactly 8.0
+
+    model =
+        build_fp16_dq_model({1, 3, 32, 32}, -1.0f, 1.0f, 0.0f, 65535.0f, 65536, element::u16, 0.25f, zp_f16_as_f32);
+    manager.register_pass<ov::pass::NormalizeDequantizeFP16>();
+
+    model_ref = build_fp32_dq_ref_model({1, 3, 32, 32},
+                                        -1.0f,
+                                        1.0f,
+                                        0.0f,
+                                        65535.0f,
+                                        65536,
+                                        element::u16,
+                                        scale_f16_as_f32,
+                                        zp_f16_as_f32);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: i8 quantization, no zero point
+//
+//   FQ(il=-1, ih=1, ol=-128, oh=127, levels=256)
+//     -> Convert(i8) -> Convert(f16) -> Multiply(Const[f16, 0.5])
+//
+// Expected after pass (FQ unchanged):
+//   FQ(il=-1, ih=1, ol=-128, oh=127)
+//     -> Convert(i8) -> Convert(f32) -> Multiply(Const[f32, 0.5]) -> Convert(f16)
+// ---------------------------------------------------------------------------
+TEST_F(TransformationTestsF, NormalizeDequantizeFP16_I8_NoZeroPoint) {
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+
+    const float scale_f16_as_f32 = float(ov::float16(0.5f));  // exactly 0.5
+
+    model = build_fp16_dq_model({1, 3, 32, 32}, -1.0f, 1.0f, -128.0f, 127.0f, 256, element::i8, 0.5f);
+    manager.register_pass<ov::pass::NormalizeDequantizeFP16>();
+
+    model_ref =
+        build_fp32_dq_ref_model({1, 3, 32, 32}, -1.0f, 1.0f, -128.0f, 127.0f, 256, element::i8, scale_f16_as_f32);
+}
+
+// ---------------------------------------------------------------------------
+// Negative test: pass must NOT fire when Conv2 already outputs f32
+//   FQ -> Convert(u16) -> Convert(f32) -> Multiply(scale_f32)
+// ---------------------------------------------------------------------------
+TEST_F(TransformationTestsF, NormalizeDequantizeFP16_NoEffect_WhenAlreadyF32) {
+    auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 3, 32, 32});
+    auto fq_il = opset1::Constant::create(element::f32, Shape{}, {-1.0f});
+    auto fq_ih = opset1::Constant::create(element::f32, Shape{}, {1.0f});
+    auto fq_ol = opset1::Constant::create(element::f32, Shape{}, {0.0f});
+    auto fq_oh = opset1::Constant::create(element::f32, Shape{}, {65535.0f});
+    auto fq = std::make_shared<opset1::FakeQuantize>(data, fq_il, fq_ih, fq_ol, fq_oh, 65536);
+    auto conv1 = std::make_shared<opset1::Convert>(fq, element::u16);
+    auto conv2 = std::make_shared<opset1::Convert>(conv1, element::f32);  // f32, not f16
+    auto scale = opset1::Constant::create(element::f32, Shape{}, {0.25f});
+    auto mul = std::make_shared<opset1::Multiply>(conv2, scale);
+    model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
+
+    // model_ref is not set -> TearDown clones model before pass and compares;
+    // an unchanged model means the pass correctly had no effect.
+    manager.register_pass<ov::pass::NormalizeDequantizeFP16>();
+}

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -60,6 +60,7 @@
 #include "transformations/common_optimizations/augru_cell_fusion.hpp"
 #include "transformations/common_optimizations/common_optimizations.hpp"
 #include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
+#include "transformations/common_optimizations/normalize_fp16_dequantize.hpp"
 #include "transformations/common_optimizations/fq_mul_fusion.hpp"
 #include "transformations/common_optimizations/fuse_gated_delta_net.hpp"
 #include "transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp"
@@ -510,10 +511,12 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
             // QDQ stripping pipeline
             // 0. Deduplicate identical DQ subgraphs sharing a common Convert node
             qdq_stripping_manager.register_pass<ov::pass::SharedOpOptimization>();
-            // 1. Fuse FQ->Convert->DQ to a single FQ
+            // 1. Normalize FP16 dequantize chains to FP32 so CQD can match them
+            qdq_stripping_manager.register_pass<ov::pass::NormalizeDequantizeFP16>();
+            // 2. Fuse FQ->Convert->DQ to a single FQ
             qdq_stripping_manager.register_pass<ov::pass::ConvertQuantizeDequantize>(TypeVector{i16, u16},
                                                                                      TypeVector{f32});
-            // 2. Strip FQ layers with unsupported levels
+            // 3. Strip FQ layers with unsupported levels
             qdq_stripping_manager.register_pass<FQStrippingTransformation>(std::set<size_t>{levels::int16}, false);
             qdq_stripping_manager.run_passes(model);
         }

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -118,6 +118,7 @@
 #include "transformations/common_optimizations/broadcast_transition.hpp"
 #include "transformations/common_optimizations/common_optimizations.hpp"
 #include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
+#include "transformations/common_optimizations/normalize_fp16_dequantize.hpp"
 #include "transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp"
 #include "transformations/common_optimizations/fuse_gated_delta_net.hpp"
 #include "transformations/common_optimizations/glu_fusion.hpp"
@@ -496,9 +497,11 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             // QDQ stripping pipeline
             // 0. Deduplicate identical DQ subgraphs sharing a common Convert node
             qdq_stripping_manager.register_pass<ov::pass::SharedOpOptimization>();
-            // 1. Fuse FQ->Convert->DQ to a single FQ
+            // 1. Normalize FP16 dequantize chains to FP32 so CQD can match them
+            qdq_stripping_manager.register_pass<ov::pass::NormalizeDequantizeFP16>();
+            // 2. Fuse FQ->Convert->DQ to a single FQ
             qdq_stripping_manager.register_pass<ov::pass::ConvertQuantizeDequantize>(TypeVector{i16, u16}, TypeVector{f32});
-            // 2. Strip FQ layers with unsupported levels
+            // 3. Strip FQ layers with unsupported levels
             const bool need_weights_adjustment = infer_precision == ov::element::f16;
             qdq_stripping_manager.register_pass<FQStrippingTransformation>(std::set<size_t>{levels::int16}, need_weights_adjustment);
             qdq_stripping_manager.run_passes(func);


### PR DESCRIPTION
### Details:
In ONNX QDQ models, Quantize is decomposed into a FakeQuantize followed by a Convert(→int), and Dequantize is decomposed into Convert(int→float) → [Subtract(zp)] → Multiply(scale). ConvertQuantizeDequantize matches this pattern and fuses the full sequence back into a single FakeQuantize, eliminating the Convert, Subtract, and Multiply nodes.

When the Dequantize output is FP16 instead of FP32 — as occurs with FP16 weight models — ConvertQuantizeDequantize cannot match the pattern and the conversion nodes remain in the graph.

NormalizeDequantizeFP16 fixes this by rewriting the Dequantize output to FP32 and moving the FP16 cast to the end:

FakeQuantize → Convert(→int) → Convert(→f16) → [Subtract(zp_f16)] → Multiply(scale_f16)

becomes:

FakeQuantize → Convert(→int) → Convert(→f32) → [Subtract(zp_f32)] → Multiply(scale_f32) → Convert(→f16)

ConvertQuantizeDequantize can then detect and fuse the full sequence into a single FakeQuantize, eliminating the Convert, Subtract, and Multiply nodes. The pass is registered immediately before ConvertQuantizeDequantize in the MOC, CPU QDQ stripping, and GPU QDQ stripping pipelines.

### Tickets:
CVS-186505

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
