### PR TITLE
[Snippets][CPU][RV64] Add Select emitter

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
@@ -3303,6 +3303,55 @@ std::set<std::vector<element::Type>> jit_round_half_to_even_emitter::get_support
     return {{element::f32}};
 }
 
+/// SELECT ///
+jit_select_emitter::jit_select_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,
+                                       ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                                       const std::shared_ptr<ov::Node>& node)
+    : jit_emitter(host, host_isa, get_arithmetic_binary_exec_precision(node)) {}
+
+jit_select_emitter::jit_select_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,
+                                       ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                                       ov::element::Type exec_prc)
+    : jit_emitter(host, host_isa, exec_prc) {}
+
+size_t jit_select_emitter::get_inputs_num() const {
+    return 3;
+}
+
+size_t jit_select_emitter::aux_fp_gprs_count() const {
+    return 1;
+}
+
+void jit_select_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs,
+                                   const std::vector<size_t>& out_vec_idxs) const {
+    if (host_isa_ == ov::intel_cpu::riscv64::cpu_isa_t::gv) {
+        emit_isa<ov::intel_cpu::riscv64::cpu_isa_t::gv>(in_vec_idxs, out_vec_idxs);
+    } else {
+        OV_CPU_JIT_EMITTER_THROW("Can't create jit eltwise kernel");
+    }
+}
+
+template <ov::intel_cpu::riscv64::cpu_isa_t isa>
+void jit_select_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
+                                  const std::vector<size_t>& out_vec_idxs) const {
+    OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "Unsupported precision: ", exec_prc_);
+
+    const auto condition = VReg(in_vec_idxs[0]);
+    const auto then_value = VReg(in_vec_idxs[1]);
+    const auto else_value = VReg(in_vec_idxs[2]);
+    const auto dst = VReg(out_vec_idxs[0]);
+    const auto fzero = FReg(aux_fp_gpr_idxs[0]);
+
+    h->fmv_w_x(fzero, zero);
+    h->vmfgt_vf(mask_vreg(), condition, fzero);
+    h->vmerge_vvm(dst, else_value, then_value);
+}
+
+std::set<std::vector<element::Type>> jit_select_emitter::get_supported_precisions(
+    [[maybe_unused]] const std::shared_ptr<ov::Node>& node) {
+    return {{element::f32, element::f32, element::f32}};
+}
+
 /// Power Static ///
 jit_power_static_emitter::jit_power_static_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,
                                                    ov::intel_cpu::riscv64::cpu_isa_t host_isa,

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
@@ -1031,6 +1031,27 @@ private:
     void emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const;
 };
 
+class jit_select_emitter : public jit_emitter {
+public:
+    jit_select_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,
+                       ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                       ov::element::Type exec_prc = ov::element::f32);
+    jit_select_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,
+                       ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                       const std::shared_ptr<ov::Node>& node);
+
+    size_t get_inputs_num() const override;
+    size_t aux_fp_gprs_count() const override;
+
+    static std::set<std::vector<element::Type>> get_supported_precisions(
+        const std::shared_ptr<ov::Node>& node = nullptr);
+
+private:
+    void emit_impl(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const override;
+    template <ov::intel_cpu::riscv64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const;
+};
+
 class jit_sigmoid_emitter : public jit_emitter {
 public:
     jit_sigmoid_emitter(ov::intel_cpu::riscv64::jit_generator_t* host,

--- a/src/plugins/intel_cpu/src/emitters/snippets/riscv64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/riscv64/cpu_generator.cpp
@@ -64,6 +64,7 @@
 #include "openvino/op/prelu.hpp"
 #include "openvino/op/relu.hpp"
 #include "openvino/op/round.hpp"
+#include "openvino/op/select.hpp"
 #include "openvino/op/sigmoid.hpp"
 #include "openvino/op/softsign.hpp"
 #include "openvino/op/sqrt.hpp"
@@ -302,6 +303,7 @@ CPUTargetMachine::CPUTargetMachine(ov::intel_cpu::riscv64::cpu_isa_t host_isa, o
 
     // fused operations
     jitters[intel_cpu::FusedMulAdd::get_type_info_static()] = emitter_factory.from_node<jit_mul_add_emitter>();
+    jitters[op::v1::Select::get_type_info_static()] = emitter_factory.from_node<jit_select_emitter>();
 
     // binary operations
     jitters[op::v1::Add::get_type_info_static()] = emitter_factory.from_node<jit_add_emitter>();

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -271,7 +271,6 @@
 #if defined(OPENVINO_ARCH_RISCV64)
 #    include "nodes/kernels/riscv64/cpu_isa_traits.hpp"
 #    include "openvino/op/power.hpp"
-#    include "openvino/op/select.hpp"
 #    include "openvino/op/swish.hpp"
 #    include "transformations/cpu_opset/common/op/swish_cpu.hpp"
 #endif

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1412,7 +1412,6 @@ void Transformations::MainSnippets() {
                    || ov::is_type<const ov::op::v4::Swish>(n) ||
                    ov::is_type_any_of<const ov::op::v0::Ceiling,
                                       const ov::op::v1::Power,
-                                      const ov::op::v1::Select,
                                       const ov::intel_cpu::SwishNode>(n)
 #endif
                 ;

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -475,7 +475,7 @@ const std::vector<std::regex>& disabled_test_patterns() {
             std::regex(R"(.*proposal_params/.*)"),
             // Quantized models unsupported
             std::regex(R"(.*Quantized.*)"),
-            std::regex(R"(smoke_Snippets(?!_(Eltwise|ThreeInputsEltwise|PrecisionPropagation_Convertion|Convert.*|Transpose[^/_]*|Reduce|Softmax(?=/)|AddSoftmax)(/|_)).*)"),
+            std::regex(R"(smoke_Snippets(?!_(Eltwise|ThreeInputsEltwise|PrecisionPropagation_Convertion|Convert.*|Select|BroadcastSelect|Transpose[^/_]*|Reduce|Softmax(?=/)|AddSoftmax)(/|_)).*)"),
             std::regex(R"(.*smoke_Snippets_TransposeMatMulBias/ExplicitTransposeMatMulBias.*)"),
             std::regex(R"(.*_enforceSnippets=1.*)"),
 #endif


### PR DESCRIPTION
### Details:
Implement jit_select_emitter for RISC-V and use it

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: yes*
 - The implementation is agentically assisted, manually adjusted after that and checked using func tests on the emulator
