### PR TITLE
[GPU] Robust INT8 dynamic quantization handling for hybrid linear-attn (GatedDeltaNet) models

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -22,7 +22,8 @@ namespace ov::intel_gpu {
 DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size,
                                                             bool asymmetric,
                                                             bool precomputed_reduction,
-                                                            bool use_gs128_for_int8_per_token)
+                                                            bool use_gs128_for_int8_per_token,
+                                                            bool use_gs128_for_linear_attention)
     : ov::pass::MatcherPass() {
     using namespace ov::pass::pattern;
     using QuantizationType = ov::op::internal::DynamicQuantize::QuantizationType;
@@ -51,7 +52,7 @@ DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size
         const bool has_static_wzp = m_fc->get_input_size() > 4 && optional_w_zp->get_output_partial_shape(0).rank().is_static();
         const bool is_wei_i8_u8 = cldnn::one_of(m_fc->get_input_element_type(1), {ov::element::i8, ov::element::u8});
 
-        if (DynamicQuantizeFullyConnected::ShouldUseGs128(is_wei_i8_u8, use_gs128_for_int8_per_token, adj_group_size)) {
+        if (DynamicQuantizeFullyConnected::ShouldUseGs128(is_wei_i8_u8, use_gs128_for_int8_per_token, adj_group_size, use_gs128_for_linear_attention)) {
             adj_group_size = 128;
         }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -54,6 +54,10 @@ DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size
         if (DynamicQuantizeFullyConnected::ShouldUseGs128(is_wei_i8_u8, use_gs128_for_int8_per_token, adj_group_size)) {
             adj_group_size = 128;
         }
+        if (DynamicQuantizeFullyConnected::ShouldUseGs128ForLinearAttnOutProj(m_fc->get_friendly_name(), adj_group_size)) {
+            GPU_DEBUG_LOG << "Dynamic quantization: WA force group_size=128 for linear_attn.out_proj " << m_fc->get_friendly_name() << std::endl;
+            adj_group_size = 128;
+        }
 
         // Add precomputed_reduction connection, if possible
         if (precomputed_reduction && adj_group_size != UINT64_MAX && adj_group_size > 0 && has_static_wzp) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -54,10 +54,6 @@ DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size
         if (DynamicQuantizeFullyConnected::ShouldUseGs128(is_wei_i8_u8, use_gs128_for_int8_per_token, adj_group_size)) {
             adj_group_size = 128;
         }
-        if (DynamicQuantizeFullyConnected::ShouldUseGs128ForLinearAttnOutProj(m_fc->get_friendly_name(), adj_group_size)) {
-            GPU_DEBUG_LOG << "Dynamic quantization: WA force group_size=128 for linear_attn.out_proj " << m_fc->get_friendly_name() << std::endl;
-            adj_group_size = 128;
-        }
 
         // Add precomputed_reduction connection, if possible
         if (precomputed_reduction && adj_group_size != UINT64_MAX && adj_group_size > 0 && has_static_wzp) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <string>
-
 #include "openvino/pass/graph_rewrite.hpp"
 
 namespace ov::intel_gpu {
@@ -16,11 +14,6 @@ public:
     DynamicQuantizeFullyConnected(uint64_t group_size, bool asymmetric = false, bool precompute_sum = true, bool use_gs128_for_int8_per_token = false);
     static bool ShouldUseGs128(uint64_t is_wei_i8u8, bool use_gs128_for_int8_per_token, uint64_t group_size) {
         return (is_wei_i8u8 && use_gs128_for_int8_per_token && group_size == UINT64_MAX);
-    }
-    // WA: Mamba2 linear_attn.out_proj input has a wide dynamic range and is unstable
-    // under per-token INT8 dyn-quant; force gs=128 for this FC only.
-    static bool ShouldUseGs128ForLinearAttnOutProj(const std::string& friendly_name, uint64_t group_size) {
-        return group_size == UINT64_MAX && friendly_name.find("linear_attn.out_proj") != std::string::npos;
     }
 };
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "openvino/pass/graph_rewrite.hpp"
 
 namespace ov::intel_gpu {
@@ -14,6 +16,11 @@ public:
     DynamicQuantizeFullyConnected(uint64_t group_size, bool asymmetric = false, bool precompute_sum = true, bool use_gs128_for_int8_per_token = false);
     static bool ShouldUseGs128(uint64_t is_wei_i8u8, bool use_gs128_for_int8_per_token, uint64_t group_size) {
         return (is_wei_i8u8 && use_gs128_for_int8_per_token && group_size == UINT64_MAX);
+    }
+    // WA: Mamba2 linear_attn.out_proj input has a wide dynamic range and is unstable
+    // under per-token INT8 dyn-quant; force gs=128 for this FC only.
+    static bool ShouldUseGs128ForLinearAttnOutProj(const std::string& friendly_name, uint64_t group_size) {
+        return group_size == UINT64_MAX && friendly_name.find("linear_attn.out_proj") != std::string::npos;
     }
 };
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.hpp
@@ -11,9 +11,9 @@ namespace ov::intel_gpu {
 class DynamicQuantizeFullyConnected: public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("DynamicQuantizeFullyConnected");
-    DynamicQuantizeFullyConnected(uint64_t group_size, bool asymmetric = false, bool precompute_sum = true, bool use_gs128_for_int8_per_token = false);
-    static bool ShouldUseGs128(uint64_t is_wei_i8u8, bool use_gs128_for_int8_per_token, uint64_t group_size) {
-        return (is_wei_i8u8 && use_gs128_for_int8_per_token && group_size == UINT64_MAX);
+    DynamicQuantizeFullyConnected(uint64_t group_size, bool asymmetric = false, bool precompute_sum = true, bool use_gs128_for_int8_per_token = false, bool use_gs128_for_linear_attention = false);
+    static bool ShouldUseGs128(bool is_wei_i8u8, bool use_gs128_for_int8_per_token, uint64_t group_size, bool use_gs128_for_linear_attention) {
+        return group_size == UINT64_MAX && (use_gs128_for_linear_attention || (is_wei_i8u8 && use_gs128_for_int8_per_token));
     }
 };
 

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -45,6 +45,7 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convolution.hpp"
+#include "openvino/op/gated_delta_net.hpp"
 #include "openvino/op/gather.hpp"
 #include "openvino/op/group_conv.hpp"
 #include "openvino/op/gru_cell.hpp"
@@ -66,6 +67,7 @@
 #include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/paged_attention.hpp"
+#include "openvino/op/paged_gated_delta_net.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/util/read_value_base.hpp"
 #include "openvino/op/util/sub_graph_base.hpp"
@@ -398,6 +400,22 @@ extern bool check_cm_jit_support(cldnn::engine& e, const cldnn::ExecutionConfig&
 }  // namespace cldnn
 
 namespace ov::intel_gpu {
+
+namespace {
+// Detect whether the model contains a linear-attention (Mamba2 / Gated DeltaNet)
+// block. Such hybrid-attention models have an SSM gated output whose activation
+// has a wide dynamic range and is unstable under per-token INT8 dyn-quant; we
+// force the dyn-quant group size to 128 for the whole model when detected.
+bool is_hybrid_linear_attention_model(const ov::Model& model) {
+    for (const auto& op : model.get_ordered_ops()) {
+        if (ov::is_type<ov::op::internal::GatedDeltaNet>(op) ||
+            ov::is_type<ov::op::internal::PagedGatedDeltaNet>(op)) {
+            return true;
+        }
+    }
+    return false;
+}
+}  // namespace
 
 bool TransformationsPipeline::fuse_type_to_convert(const std::shared_ptr<ov::Node>& node, const precisions_map& precisions) {
     auto convert = ov::as_type_ptr<ov::opset10::Convert>(node);
@@ -1576,6 +1594,15 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             auto dynamic_quantization_group_size_max = config.get_dynamic_quantization_group_size_max();
             const bool precomputed_reduction = config.get_dynamic_quantization_precomputed_reduction();
 
+            // WA: hybrid linear-attention (Mamba2 / Gated DeltaNet) models are unstable
+            // under per-token INT8 dyn-quant on `linear_attn.out_proj`. Force gs=128 for
+            // the whole model if a linear-attention block is detected.
+            if (dynamic_quantization_group_size == UINT64_MAX && is_hybrid_linear_attention_model(*func)) {
+                GPU_DEBUG_LOG << "Dynamic quantization: hybrid linear-attention model detected, "
+                              << "forcing group_size=128 (per-token disabled)" << std::endl;
+                dynamic_quantization_group_size = 128;
+            }
+
             const bool group_dyn_quan_allowed = m_context->get_engine().get_device_info().supports_non_uniform_work_group;
             // WA: when platform does not support non-uniform-work-group, it may fail to run dynamic quantization for gs128.
             // This is unlikely to happen. But this WA is added just in case.
@@ -1609,10 +1636,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 uint64_t adj_group_size = dynamic_quantization_group_size;
                 const bool is_wei_i8u8 = cldnn::one_of(root->get_input_element_type(1), {ov::element::i8, ov::element::u8});
                 if (ov::intel_gpu::DynamicQuantizeFullyConnected::ShouldUseGs128(is_wei_i8u8, use_gs128_for_int8_per_token, adj_group_size)) {
-                    adj_group_size = 128;
-                }
-                if (ov::intel_gpu::DynamicQuantizeFullyConnected::ShouldUseGs128ForLinearAttnOutProj(root->get_friendly_name(), adj_group_size)) {
-                    GPU_DEBUG_LOG << "Dynamic quantization: WA force group_size=128 for linear_attn.out_proj " << root->get_friendly_name() << std::endl;
                     adj_group_size = 128;
                 }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1611,6 +1611,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 if (ov::intel_gpu::DynamicQuantizeFullyConnected::ShouldUseGs128(is_wei_i8u8, use_gs128_for_int8_per_token, adj_group_size)) {
                     adj_group_size = 128;
                 }
+                if (ov::intel_gpu::DynamicQuantizeFullyConnected::ShouldUseGs128ForLinearAttnOutProj(root->get_friendly_name(), adj_group_size)) {
+                    GPU_DEBUG_LOG << "Dynamic quantization: WA force group_size=128 for linear_attn.out_proj " << root->get_friendly_name() << std::endl;
+                    adj_group_size = 128;
+                }
 
                 const auto& input_shape = root->get_input_partial_shape(0);
                 const size_t input_rank = input_shape.size();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1597,12 +1597,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             // WA: hybrid linear-attention (Mamba2 / Gated DeltaNet) models are unstable
             // under per-token INT8 dyn-quant on `linear_attn.out_proj`. Force gs=128 for
             // the whole model if a linear-attention block is detected.
-            if (dynamic_quantization_group_size == UINT64_MAX && is_hybrid_linear_attention_model(*func)) {
-                GPU_DEBUG_LOG << "Dynamic quantization: hybrid linear-attention model detected, "
-                              << "forcing group_size=128 (per-token disabled)" << std::endl;
-                dynamic_quantization_group_size = 128;
-            }
-
+            const bool use_gs128_for_linear_attention = is_hybrid_linear_attention_model(*func);
             const bool group_dyn_quan_allowed = m_context->get_engine().get_device_info().supports_non_uniform_work_group;
             // WA: when platform does not support non-uniform-work-group, it may fail to run dynamic quantization for gs128.
             // This is unlikely to happen. But this WA is added just in case.
@@ -1635,7 +1630,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 }
                 uint64_t adj_group_size = dynamic_quantization_group_size;
                 const bool is_wei_i8u8 = cldnn::one_of(root->get_input_element_type(1), {ov::element::i8, ov::element::u8});
-                if (ov::intel_gpu::DynamicQuantizeFullyConnected::ShouldUseGs128(is_wei_i8u8, use_gs128_for_int8_per_token, adj_group_size)) {
+                if (ov::intel_gpu::DynamicQuantizeFullyConnected::ShouldUseGs128(is_wei_i8u8, use_gs128_for_int8_per_token, adj_group_size, use_gs128_for_linear_attention)) {
                     adj_group_size = 128;
                 }
 
@@ -1690,7 +1685,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 manager.register_pass<ov::intel_gpu::DynamicQuantizeFullyConnected>(dynamic_quantization_group_size,
                                                                                     asymmetric_dyn_quant,
                                                                                     precomputed_reduction,
-                                                                                    use_gs128_for_int8_per_token);
+                                                                                    use_gs128_for_int8_per_token,
+                                                                                    use_gs128_for_linear_attention);
             }
         }
 


### PR DESCRIPTION
### Details:
 - Models containing hybrid linear-attention blocks (e.g., Mamba2, GatedDeltaNet block) produce SSM-gated outputs with a wide dynamic range. When per-token INT8 dynamic activation quantization is applied,  it can cause severe output collapse and accuracy loss due to quantization instability.
 - Enforces `group size=128` for INT8 dynamic activation quantization when such models are detected, preventing output collapse and accuracy loss
 - Empirically validated on Qwen3.5 and 3.6 dense and MoE models (e.g., `Qwen3.6-35B-A3B`); E2E and accuracy test confirmed

### Tickets:
 - [CVS-186558](https://jira.devtools.intel.com/browse/CVS-186558)

### AI Assistance:
 - *AI assistance used: no*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
