### PR TITLE
[GPU] modify matching patterns for increase_position_ids_for_ltx_video

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -311,12 +311,25 @@ IncreasePositionIdsPrecisionForLtxVideo::IncreasePositionIdsPrecisionForLtxVideo
     // A single match is sufficient — subsequent RoPE nodes reuse the precision-upgraded shared path.
     //
     //   Multiply → Add(Constant) → Transpose → Reshape
-    //                                              |
-    //                               +--------------+---------------+
-    //                               |                              |
-    // Sin path (RoPE input 2):    Sin → T → U → B → GND → T → Concat_sin
-    // Cos path (RoPE input 1):    Cos → T → U → B → GND → T → Concat_cos
-    //                                                              |
+    //                                              │
+    //                                     ┌────────┴────────┐
+    //                                     │                 │
+    //                                    Sin               Cos
+    //                                     │                 │
+    //                                  Transpose         Transpose
+    //                                     │                 │
+    //                                  Unsqueeze         Unsqueeze
+    //                                     │                 │
+    //                                  Broadcast         Broadcast
+    //                                     │                 │
+    //                                  GatherND          GatherND
+    //                                     │                 │
+    //                                  Transpose         Transpose
+    //                                     │                 │
+    //                                  Concat_sin        Concat_cos
+    //                                     │                 │
+    //                                     └────────┬────────┘
+    //                                              │
     //                              RoPE(x, Concat_cos, Concat_sin)
 
     // Upstream: Multiply → Add(Constant) → Transpose → Reshape
@@ -359,12 +372,6 @@ IncreasePositionIdsPrecisionForLtxVideo::IncreasePositionIdsPrecisionForLtxVideo
         auto cos_node = ov::as_type_ptr<ov::op::v0::Cos>(pattern_map.at(cos).get_node_shared_ptr());
         auto sin_node = ov::as_type_ptr<ov::op::v0::Sin>(pattern_map.at(sin).get_node_shared_ptr());
 
-        if (!mul_node || !cos_node || !sin_node)
-            return false;
-
-        if (transformation_callback(mul_node))
-            return false;
-
         const auto desired_et = ov::element::f32;
         const auto original_et = mul_node->get_output_element_type(0);
         if (original_et == desired_et)
@@ -373,8 +380,7 @@ IncreasePositionIdsPrecisionForLtxVideo::IncreasePositionIdsPrecisionForLtxVideo
         size_t input_idx = 0;
         bool is_changed = insert_converts_before_if_needed(mul_node, desired_et, input_idx);
         if (is_changed) {
-            if (constant_node)
-                insert_converts_after_if_needed(constant_node, desired_et, input_idx);
+            insert_converts_after_if_needed(constant_node, desired_et, input_idx);
             size_t output_idx = 0;
             insert_converts_after_if_needed(cos_node, original_et, output_idx);
             insert_converts_after_if_needed(sin_node, original_et, output_idx);

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -358,14 +358,14 @@ IncreasePositionIdsPrecisionForLtxVideo::IncreasePositionIdsPrecisionForLtxVideo
     auto cos_concat = wrap_type<ov::op::v0::Concat>({any_input(), cos_transpose2});
 
     // RoPE: input 0 = x, input 1 = cos_concat, input 2 = sin_concat
-    auto rope = wrap_type<ov::op::internal::RoPE>({any_input(), cos_concat, sin_concat});
+    auto rope = wrap_type<ov::op::internal::RoPE>({any_input(), cos_concat, sin_concat},
+        [](const ov::Output<ov::Node>& output) {
+            auto node = ov::as_type_ptr<ov::op::internal::RoPE>(output.get_node_shared_ptr());
+            return node && node->get_config().is_ltx_video;
+        });
 
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
-
-        auto rope_node = ov::as_type_ptr<ov::op::internal::RoPE>(m.get_match_root());
-        if (!rope_node || !rope_node->get_config().is_ltx_video)
-            return false;
 
         auto mul_node = ov::as_type_ptr<ov::op::v1::Multiply>(pattern_map.at(mul).get_node_shared_ptr());
         auto constant_node = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(add_constant).get_node_shared_ptr());

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -25,6 +25,7 @@
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/gather.hpp"
+#include "openvino/op/gather_nd.hpp"
 #include "openvino/op/strided_slice.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/broadcast.hpp"
@@ -304,46 +305,64 @@ IncreasePositionIdsPrecisionForQwen3VL::IncreasePositionIdsPrecisionForQwen3VL()
 
 IncreasePositionIdsPrecisionForLtxVideo::IncreasePositionIdsPrecisionForLtxVideo() {
     using namespace ov::pass::pattern;
-    using ov::pass::pattern::op::Or;
 
-    // for ltx-video pattern
+    // LTX-Video RoPE position encoding pattern (anchored on fused RoPE).
+    // Position encoding is computed once and shared across all 28 transformer blocks (56 RoPE nodes).
+    // A single match is sufficient — subsequent RoPE nodes reuse the precision-upgraded shared path.
+    //
+    //   Multiply → Add(Constant) → Transpose → Reshape
+    //                                              |
+    //                               +--------------+---------------+
+    //                               |                              |
+    // Sin path (RoPE input 2):    Sin → T → U → B → GND → T → Concat_sin
+    // Cos path (RoPE input 1):    Cos → T → U → B → GND → T → Concat_cos
+    //                                                              |
+    //                              RoPE(x, Concat_cos, Concat_sin)
+
+    // Upstream: Multiply → Add(Constant) → Transpose → Reshape
     auto mul = wrap_type<ov::op::v1::Multiply>({any_input(), any_input()});
     auto add_constant = wrap_type<ov::op::v0::Constant>();
     auto add = wrap_type<ov::op::v1::Add>({mul, add_constant});
-    auto transpose = wrap_type<ov::op::v1::Transpose>({add, any_input()});
-    auto reshape = wrap_type<ov::op::v1::Reshape>({transpose, any_input()});
+    auto transpose_up = wrap_type<ov::op::v1::Transpose>({add, any_input()});
+    auto reshape = wrap_type<ov::op::v1::Reshape>({transpose_up, any_input()});
+
+    // Sin path: Sin → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat
     auto sin = wrap_type<ov::op::v0::Sin>({reshape});
+    auto sin_transpose = wrap_type<ov::op::v1::Transpose>({sin, any_input()});
+    auto sin_unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({sin_transpose, any_input()});
+    auto sin_broadcast = wrap_type<ov::op::v3::Broadcast>({sin_unsqueeze, any_input()});
+    auto sin_gathernd = wrap_type<ov::op::v8::GatherND>({sin_broadcast, any_input()});
+    auto sin_transpose2 = wrap_type<ov::op::v1::Transpose>({sin_gathernd, any_input()});
+    auto sin_concat = wrap_type<ov::op::v0::Concat>({any_input(), sin_transpose2});
+
+    // Cos path: Cos → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat
     auto cos = wrap_type<ov::op::v0::Cos>({reshape});
-    auto gather_1 = wrap_type<ov::op::v8::Gather>({cos, any_input(), {-1}}, {{"batch_dims", 0}});
-    auto gather_3 = wrap_type<ov::op::v8::Gather>({sin, any_input(), {-1}}, {{"batch_dims", 0}});
-    auto slice = wrap_type<ov::op::v1::StridedSlice>({gather_1, {0, 0, 0}, {0, 0, 2}, {1, 1, 1}});
-    auto shape_of = wrap_type<ov::op::v3::ShapeOf>({slice});
-    auto broadcast_zero_like = wrap_type<ov::op::v3::Broadcast>({{0}, shape_of});
-    auto broadcast_ones_like = wrap_type<ov::op::v3::Broadcast>({{1}, shape_of});
-    auto concat = wrap_type<ov::op::v0::Concat>({broadcast_ones_like, gather_1});
-    auto concat_1 = wrap_type<ov::op::v0::Concat>({broadcast_zero_like, gather_3});
-    auto rms = wrap_type<ov::op::internal::RMS>({any_input(), any_input()});
-    auto mul_2 = wrap_type<ov::op::v1::Multiply>({rms, concat});
-    auto reshape_2 = wrap_type<ov::op::v1::Reshape>({any_input(), any_input()});
-    auto mul_3 = wrap_type<ov::op::v1::Multiply>({reshape_2, concat_1});
-    auto add_1 = wrap_type<ov::op::v1::Add>({mul_2, mul_3});
-    auto reshape_3 = wrap_type<ov::op::v1::Reshape>({add_1, any_input()});
-    auto tranpose_1 = wrap_type<ov::op::v1::Transpose>({reshape_3, any_input()});
-    auto sdpa = wrap_type<ov::op::v13::ScaledDotProductAttention>({any_input(), tranpose_1, any_input()});
+    auto cos_transpose = wrap_type<ov::op::v1::Transpose>({cos, any_input()});
+    auto cos_unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({cos_transpose, any_input()});
+    auto cos_broadcast = wrap_type<ov::op::v3::Broadcast>({cos_unsqueeze, any_input()});
+    auto cos_gathernd = wrap_type<ov::op::v8::GatherND>({cos_broadcast, any_input()});
+    auto cos_transpose2 = wrap_type<ov::op::v1::Transpose>({cos_gathernd, any_input()});
+    auto cos_concat = wrap_type<ov::op::v0::Concat>({any_input(), cos_transpose2});
+
+    // RoPE: input 0 = x, input 1 = cos_concat, input 2 = sin_concat
+    auto rope = wrap_type<ov::op::internal::RoPE>({any_input(), cos_concat, sin_concat});
 
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
+        auto rope_node = ov::as_type_ptr<ov::op::internal::RoPE>(m.get_match_root());
+        if (!rope_node || !rope_node->get_config().is_ltx_video)
+            return false;
+
         auto mul_node = ov::as_type_ptr<ov::op::v1::Multiply>(pattern_map.at(mul).get_node_shared_ptr());
         auto constant_node = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(add_constant).get_node_shared_ptr());
-        auto cos_node = pattern_map.count(cos) > 0 ?
-                            ov::as_type_ptr<ov::op::v0::Cos>(pattern_map.at(cos).get_node_shared_ptr())
-                            : nullptr;
-        auto sin_node = pattern_map.count(sin) > 0 ?
-                            ov::as_type_ptr<ov::op::v0::Sin>(pattern_map.at(sin).get_node_shared_ptr())
-                            : nullptr;
+        auto cos_node = ov::as_type_ptr<ov::op::v0::Cos>(pattern_map.at(cos).get_node_shared_ptr());
+        auto sin_node = ov::as_type_ptr<ov::op::v0::Sin>(pattern_map.at(sin).get_node_shared_ptr());
 
-        if (!mul_node || transformation_callback(mul_node))
+        if (!mul_node || !cos_node || !sin_node)
+            return false;
+
+        if (transformation_callback(mul_node))
             return false;
 
         const auto desired_et = ov::element::f32;
@@ -357,15 +376,13 @@ IncreasePositionIdsPrecisionForLtxVideo::IncreasePositionIdsPrecisionForLtxVideo
             if (constant_node)
                 insert_converts_after_if_needed(constant_node, desired_et, input_idx);
             size_t output_idx = 0;
-            if (cos_node)
-                insert_converts_after_if_needed(cos_node, original_et, output_idx);
-            if (sin_node)
-                insert_converts_after_if_needed(sin_node, original_et, output_idx);
+            insert_converts_after_if_needed(cos_node, original_et, output_idx);
+            insert_converts_after_if_needed(sin_node, original_et, output_idx);
         }
         return true;
     };
 
-    auto m = std::make_shared<ov::pass::pattern::Matcher>(sdpa, "IncreasePositionIdsPrecisionForLtxVideo");
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(rope, "IncreasePositionIdsPrecisionForLtxVideo");
     this->register_matcher(m, callback);
 }
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
@@ -26,6 +26,7 @@
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/gather.hpp"
+#include "openvino/op/gather_nd.hpp"
 #include "openvino/op/strided_slice.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/broadcast.hpp"
@@ -377,181 +378,123 @@ TEST_F(TransformationTestsF, IncreasePositionIdsSliceGatherUnsqueezeRoPE) {
 }
 
 TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideo) {
+    // Test graph matches the post-RoPE-fusion pattern:
+    //   Multiply → Add(Const) → Transpose → Reshape → Sin/Cos → T → U → B → GND → T → Concat → RoPE
     {
-        auto input_1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 3, -1 });
-        auto input_2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, -1, 2048 });
+        auto param_mul_in = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 64});
+        auto param_x = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 64, 16});
 
-        auto constant_01 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 2, 1 });
-        auto transpose = std::make_shared<ov::op::v1::Transpose>(input_1, constant_01);
-        auto constant_02 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 1 }, { -1 });
-        auto unsqueeze_1 = std::make_shared<ov::op::v0::Unsqueeze>(transpose, constant_02);
-        auto constant_03 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1, 1, 1, 341  }, { 3.14f });
-        auto multiply = std::make_shared<ov::op::v1::Multiply>(unsqueeze_1, constant_03);
+        // Upstream: Multiply → Add(Constant) → Transpose → Reshape
+        auto mul_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 1, 64}, {3.14f});
+        auto multiply = std::make_shared<ov::op::v1::Multiply>(param_mul_in, mul_const);
 
-        auto constant_04 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1, 1, 1, 341 }, { 1e-6 });
-        auto add = std::make_shared<ov::op::v1::Add>(multiply, constant_04);
+        auto add_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 1, 64}, {1e-6f});
+        auto add = std::make_shared<ov::op::v1::Add>(multiply, add_const);
 
-        auto constant_05 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 0, 1, 3, 2 });
-        auto transpose_1 = std::make_shared<ov::op::v1::Transpose>(add, constant_05);
+        auto transpose_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto transpose_up = std::make_shared<ov::op::v1::Transpose>(add, transpose_order);
 
-        auto constant_06 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 0, 1023 });
-        auto reshape_1 = std::make_shared<ov::op::v1::Reshape>(transpose_1, constant_06, true);
+        auto reshape_shape = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {1, 64, 3});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(transpose_up, reshape_shape, false);
 
-        auto cos = std::make_shared<ov::op::v0::Cos>(reshape_1);
-        auto sin = std::make_shared<ov::op::v0::Sin>(reshape_1);
+        // Sin path: Sin → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat
+        auto sin_node = std::make_shared<ov::op::v0::Sin>(reshape);
+        auto sin_t_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto sin_transpose = std::make_shared<ov::op::v1::Transpose>(sin_node, sin_t_order);
+        auto sin_unsq_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
+        auto sin_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(sin_transpose, sin_unsq_axis);
+        auto sin_bcast_shape = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {2, 1, 3, 64});
+        auto sin_broadcast = std::make_shared<ov::op::v3::Broadcast>(sin_unsqueeze, sin_bcast_shape);
+        auto sin_gnd_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1, 8, 3}, {0});
+        auto sin_gathernd = std::make_shared<ov::op::v8::GatherND>(sin_broadcast, sin_gnd_indices);
+        auto sin_t2_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto sin_transpose2 = std::make_shared<ov::op::v1::Transpose>(sin_gathernd, sin_t2_order);
+        auto sin_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {0.0f});
+        auto sin_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{sin_concat_other, sin_transpose2}, -1);
 
-        auto constant_07 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 2046 }, { 0 });
-        auto constant_08 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 2046 }, { 0 });
-        auto constant_09 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
-        auto constant_10 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
+        // Cos path: Cos → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat
+        auto cos_node = std::make_shared<ov::op::v0::Cos>(reshape);
+        auto cos_t_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto cos_transpose = std::make_shared<ov::op::v1::Transpose>(cos_node, cos_t_order);
+        auto cos_unsq_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
+        auto cos_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(cos_transpose, cos_unsq_axis);
+        auto cos_bcast_shape = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {2, 1, 3, 64});
+        auto cos_broadcast = std::make_shared<ov::op::v3::Broadcast>(cos_unsqueeze, cos_bcast_shape);
+        auto cos_gnd_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1, 8, 3}, {0});
+        auto cos_gathernd = std::make_shared<ov::op::v8::GatherND>(cos_broadcast, cos_gnd_indices);
+        auto cos_t2_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto cos_transpose2 = std::make_shared<ov::op::v1::Transpose>(cos_gathernd, cos_t2_order);
+        auto cos_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {1.0f});
+        auto cos_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{cos_concat_other, cos_transpose2}, -1);
 
-        auto gather_1 = std::make_shared<ov::op::v8::Gather>(cos, constant_07, constant_09);
-        auto gather_3 = std::make_shared<ov::op::v8::Gather>(sin, constant_08, constant_10);
+        // RoPE with is_ltx_video = true
+        ov::op::internal::RoPE::Config rope_config;
+        rope_config.is_ltx_video = true;
+        rope_config.rotary_ndims = 64;
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{param_x, cos_concat, sin_concat}, rope_config);
 
-        auto constant_11 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 0, 0 });
-        auto constant_12 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 0, 2 });
-        auto constant_13 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 1, 1, 1 });
-        auto slice = std::make_shared<ov::op::v1::StridedSlice>(gather_1, constant_11, constant_12, constant_13, std::vector<int64_t>{}, std::vector<int64_t>{});
-
-        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(slice);
-        auto constant_14 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ }, { 1 });
-        auto constant_15 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ }, { 0 });
-        auto broadcast_ones_like = std::make_shared<ov::op::v3::Broadcast>(constant_14, shape_of);
-        auto broadcast_zeros_like = std::make_shared<ov::op::v3::Broadcast>(constant_15, shape_of);
-
-        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{broadcast_ones_like, gather_1}, -1);
-        auto concat_1 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{broadcast_zeros_like, gather_3}, -1);
-
-        auto constant_16 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 1, 1, 2048 }, { 0 });
-        auto rms = std::make_shared<ov::op::internal::RMS>(input_2, constant_16, 1e-19);
-
-        auto constant_17 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 0, 0, 1024, 2 });
-        auto reshape_2 = std::make_shared<ov::op::v1::Reshape>(rms, constant_17, true);
-
-        auto constant_18 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
-        auto split_1 = std::make_shared<ov::op::v1::Split>(reshape_2, constant_18, 2);
-
-        auto constant_19 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ }, { -1 });
-        auto multiply_2 = std::make_shared<ov::op::v1::Multiply>(split_1->output(0), constant_19);
-
-        auto constant_20 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
-        auto squeeze_1 = std::make_shared<ov::op::v0::Squeeze>(multiply_2, constant_20);
-
-        auto constant_21 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
-        auto unsqueeze_2 = std::make_shared<ov::op::v0::Unsqueeze>(squeeze_1, constant_21);
-
-        auto concat_stack_1 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{unsqueeze_2, split_1->output(1)}, -1);
-        auto constant_22 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 0, 2048 });
-        auto reshape_3 = std::make_shared<ov::op::v1::Reshape>(concat_stack_1, constant_22, true);
-
-        auto multiply_3 = std::make_shared<ov::op::v1::Multiply>(rms, concat);
-        auto multiply_4 = std::make_shared<ov::op::v1::Multiply>(reshape_3, concat_1);
-
-        auto add_1 = std::make_shared<ov::op::v1::Add>(multiply_3, multiply_4);
-        auto constant_23 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 0, 0, 32, 64 });
-        auto reshape_4 = std::make_shared<ov::op::v1::Reshape>(add_1, constant_23, true);
-        auto constant_24 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 0, 2, 1, 3 });
-        auto transpose_3 = std::make_shared<ov::op::v1::Transpose>(reshape_4, constant_24);
-
-        auto input_3 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, -1, 32, 64 });
-        auto input_4 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, -1, 32, 64 });
-        auto transpose_2 = std::make_shared<ov::op::v1::Transpose>(input_3, constant_24);
-        auto transpose_4 = std::make_shared<ov::op::v1::Transpose>(input_4, constant_24);
-        auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(transpose_2, transpose_3, transpose_4, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_1, input_2, input_3, input_4});
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{param_mul_in, param_x});
         manager.register_pass<IncreasePositionIdsPrecision>();
     }
     {
-        auto input_1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 3, -1 });
-        auto input_2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, -1, 2048 });
+        auto param_mul_in = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 64});
+        auto param_x = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 64, 16});
 
-        auto constant_01 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 2, 1 });
-        auto transpose = std::make_shared<ov::op::v1::Transpose>(input_1, constant_01);
-        auto constant_02 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 1 }, { -1 });
-        auto unsqueeze_1 = std::make_shared<ov::op::v0::Unsqueeze>(transpose, constant_02);
-        auto constant_03 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1, 1, 1, 341  }, { 3.14f });
+        // Upstream with converts: Convert(f16→f32) before Multiply inputs, Convert on Add constant
+        auto convert_mul_in = std::make_shared<ov::op::v0::Convert>(param_mul_in, ov::element::f32);
+        auto mul_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 1, 64}, {3.14f});
+        auto convert_mul_const = std::make_shared<ov::op::v0::Convert>(mul_const, ov::element::f32);
+        auto multiply = std::make_shared<ov::op::v1::Multiply>(convert_mul_in, convert_mul_const);
 
-        auto convert_1 = std::make_shared<ov::op::v0::Convert>(unsqueeze_1, ov::element::f32);
-        auto convert_2 = std::make_shared<ov::op::v0::Convert>(constant_03, ov::element::f32);
-        auto multiply = std::make_shared<ov::op::v1::Multiply>(convert_1, convert_2);
+        auto add_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 1, 64}, {1e-6f});
+        auto convert_add_const = std::make_shared<ov::op::v0::Convert>(add_const, ov::element::f32);
+        auto add = std::make_shared<ov::op::v1::Add>(multiply, convert_add_const);
 
-        auto constant_04 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1, 1, 1, 341 }, { 1e-6 });
-        auto convert_3 = std::make_shared<ov::op::v0::Convert>(constant_04, ov::element::f32);
-        auto add = std::make_shared<ov::op::v1::Add>(multiply, convert_3);
+        auto transpose_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto transpose_up = std::make_shared<ov::op::v1::Transpose>(add, transpose_order);
 
-        auto constant_05 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 0, 1, 3, 2 });
-        auto transpose_1 = std::make_shared<ov::op::v1::Transpose>(add, constant_05);
+        auto reshape_shape = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {1, 64, 3});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(transpose_up, reshape_shape, false);
 
-        auto constant_06 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 0, 1023 });
-        auto reshape_1 = std::make_shared<ov::op::v1::Reshape>(transpose_1, constant_06, true);
+        // Sin path with Convert(f32→f16) after Sin
+        auto sin_node = std::make_shared<ov::op::v0::Sin>(reshape);
+        auto convert_sin = std::make_shared<ov::op::v0::Convert>(sin_node, ov::element::f16);
+        auto sin_t_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto sin_transpose = std::make_shared<ov::op::v1::Transpose>(convert_sin, sin_t_order);
+        auto sin_unsq_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
+        auto sin_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(sin_transpose, sin_unsq_axis);
+        auto sin_bcast_shape = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {2, 1, 3, 64});
+        auto sin_broadcast = std::make_shared<ov::op::v3::Broadcast>(sin_unsqueeze, sin_bcast_shape);
+        auto sin_gnd_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1, 8, 3}, {0});
+        auto sin_gathernd = std::make_shared<ov::op::v8::GatherND>(sin_broadcast, sin_gnd_indices);
+        auto sin_t2_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto sin_transpose2 = std::make_shared<ov::op::v1::Transpose>(sin_gathernd, sin_t2_order);
+        auto sin_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {0.0f});
+        auto sin_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{sin_concat_other, sin_transpose2}, -1);
 
-        auto cos = std::make_shared<ov::op::v0::Cos>(reshape_1);
-        auto sin = std::make_shared<ov::op::v0::Sin>(reshape_1);
+        // Cos path with Convert(f32→f16) after Cos
+        auto cos_node = std::make_shared<ov::op::v0::Cos>(reshape);
+        auto convert_cos = std::make_shared<ov::op::v0::Convert>(cos_node, ov::element::f16);
+        auto cos_t_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto cos_transpose = std::make_shared<ov::op::v1::Transpose>(convert_cos, cos_t_order);
+        auto cos_unsq_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
+        auto cos_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(cos_transpose, cos_unsq_axis);
+        auto cos_bcast_shape = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {2, 1, 3, 64});
+        auto cos_broadcast = std::make_shared<ov::op::v3::Broadcast>(cos_unsqueeze, cos_bcast_shape);
+        auto cos_gnd_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1, 8, 3}, {0});
+        auto cos_gathernd = std::make_shared<ov::op::v8::GatherND>(cos_broadcast, cos_gnd_indices);
+        auto cos_t2_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto cos_transpose2 = std::make_shared<ov::op::v1::Transpose>(cos_gathernd, cos_t2_order);
+        auto cos_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {1.0f});
+        auto cos_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{cos_concat_other, cos_transpose2}, -1);
 
-        auto convert_4 = std::make_shared<ov::op::v0::Convert>(cos, ov::element::f16);
-        auto convert_5 = std::make_shared<ov::op::v0::Convert>(sin, ov::element::f16);
+        // RoPE with is_ltx_video = true
+        ov::op::internal::RoPE::Config rope_config;
+        rope_config.is_ltx_video = true;
+        rope_config.rotary_ndims = 64;
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{param_x, cos_concat, sin_concat}, rope_config);
 
-        auto constant_07 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 2046 }, { 0 });
-        auto constant_08 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 2046 }, { 0 });
-        auto constant_09 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
-        auto constant_10 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
-
-        auto gather_1 = std::make_shared<ov::op::v8::Gather>(convert_4, constant_07, constant_09);
-        auto gather_3 = std::make_shared<ov::op::v8::Gather>(convert_5, constant_08, constant_10);
-
-        auto constant_11 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 0, 0 });
-        auto constant_12 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 0, 2 });
-        auto constant_13 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 1, 1, 1 });
-        auto slice = std::make_shared<ov::op::v1::StridedSlice>(gather_1, constant_11, constant_12, constant_13, std::vector<int64_t>{}, std::vector<int64_t>{});
-
-        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(slice);
-        auto constant_14 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ }, { 1 });
-        auto constant_15 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ }, { 0 });
-        auto broadcast_ones_like = std::make_shared<ov::op::v3::Broadcast>(constant_14, shape_of);
-        auto broadcast_zeros_like = std::make_shared<ov::op::v3::Broadcast>(constant_15, shape_of);
-
-        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{broadcast_ones_like, gather_1}, -1);
-        auto concat_1 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{broadcast_zeros_like, gather_3}, -1);
-
-        auto constant_16 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 1, 1, 2048 }, { 0 });
-        auto rms = std::make_shared<ov::op::internal::RMS>(input_2, constant_16, 1e-19);
-
-        auto constant_17 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 0, 0, 1024, 2 });
-        auto reshape_2 = std::make_shared<ov::op::v1::Reshape>(rms, constant_17, true);
-
-        auto constant_18 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
-        auto split_1 = std::make_shared<ov::op::v1::Split>(reshape_2, constant_18, 2);
-
-        auto constant_19 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ }, { -1 });
-        auto multiply_2 = std::make_shared<ov::op::v1::Multiply>(split_1->output(0), constant_19);
-
-        auto constant_20 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
-        auto squeeze_1 = std::make_shared<ov::op::v0::Squeeze>(multiply_2, constant_20);
-
-        auto constant_21 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ }, { -1 });
-        auto unsqueeze_2 = std::make_shared<ov::op::v0::Unsqueeze>(squeeze_1, constant_21);
-
-        auto concat_stack_1 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{unsqueeze_2, split_1->output(1)}, -1);
-        auto constant_22 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 0, 0, 2048 });
-        auto reshape_3 = std::make_shared<ov::op::v1::Reshape>(concat_stack_1, constant_22, true);
-
-        auto multiply_3 = std::make_shared<ov::op::v1::Multiply>(rms, concat);
-        auto multiply_4 = std::make_shared<ov::op::v1::Multiply>(reshape_3, concat_1);
-
-        auto add_1 = std::make_shared<ov::op::v1::Add>(multiply_3, multiply_4);
-        auto constant_23 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 0, 0, 32, 64 });
-        auto reshape_4 = std::make_shared<ov::op::v1::Reshape>(add_1, constant_23, true);
-        auto constant_24 = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 0, 2, 1, 3 });
-        auto transpose_3 = std::make_shared<ov::op::v1::Transpose>(reshape_4, constant_24);
-
-        auto input_3 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, -1, 32, 64 });
-        auto input_4 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, -1, 32, 64 });
-        auto transpose_2 = std::make_shared<ov::op::v1::Transpose>(input_3, constant_24);
-        auto transpose_4 = std::make_shared<ov::op::v1::Transpose>(input_4, constant_24);
-        auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(transpose_2, transpose_3, transpose_4, true);
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_1, input_2, input_3, input_4});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{param_mul_in, param_x});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
@@ -377,7 +377,11 @@ TEST_F(TransformationTestsF, IncreasePositionIdsSliceGatherUnsqueezeRoPE) {
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
 
-TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideo) {
+static void test_IncreasePositionIdsLTXVideo(std::shared_ptr<ov::Model>& model,
+                                             std::shared_ptr<ov::Model>& model_ref,
+                                             ov::pass::Manager& manager,
+                                             FunctionsComparator& comparator,
+                                             bool is_ltx_video) {
     // Test graph matches the post-RoPE-fusion pattern:
     //   Multiply → Add(Const) → Transpose → Reshape → Sin/Cos → T → U → B → GND → T → Concat → RoPE
     {
@@ -427,16 +431,15 @@ TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideo) {
         auto cos_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {1.0f});
         auto cos_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{cos_concat_other, cos_transpose2}, -1);
 
-        // RoPE with is_ltx_video = true
         ov::op::internal::RoPE::Config rope_config;
-        rope_config.is_ltx_video = true;
+        rope_config.is_ltx_video = is_ltx_video;
         rope_config.rotary_ndims = 64;
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{param_x, cos_concat, sin_concat}, rope_config);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{param_mul_in, param_x});
         manager.register_pass<IncreasePositionIdsPrecision>();
     }
-    {
+    if (is_ltx_video) {
         auto param_mul_in = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 64});
         auto param_x = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 64, 16});
 
@@ -488,7 +491,6 @@ TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideo) {
         auto cos_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {1.0f});
         auto cos_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{cos_concat_other, cos_transpose2}, -1);
 
-        // RoPE with is_ltx_video = true
         ov::op::internal::RoPE::Config rope_config;
         rope_config.is_ltx_video = true;
         rope_config.rotary_ndims = 64;
@@ -497,6 +499,14 @@ TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideo) {
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{param_mul_in, param_x});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideo_T) {
+    test_IncreasePositionIdsLTXVideo(model, model_ref, manager, comparator, true);
+}
+
+TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideo_F) {
+    test_IncreasePositionIdsLTXVideo(model, model_ref, manager, comparator, false);
 }
 
 TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForQwen25VL) {


### PR DESCRIPTION
### Details:

**Problem:** LTX-Video model produces corrupted output on GPU due to FP16 precision loss in position_ids.

**Root cause:** The `IncreasePositionIdsPrecisionForLtxVideo` nGraph pass pattern became stale after model updates and the RoPE-for-LTX-Video integration. The old pattern matched the pre-RoPE subgraph (Gather → StridedSlice → Broadcast → manual RoPE via Multiply/Add → SDPA), but the current model uses the fused `RoPE` op with a `GatherND`-based cos/sin path. As a result, position_ids remained in FP16, causing SDPA computation errors that accumulated through FFN layers across all 28 transformer blocks.

**Fix:** Updated the pass to match the current LTX-Video RoPE pattern:
- New pattern: `Multiply → Add → Transpose → Reshape → {Sin,Cos} → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat → RoPE`
- Added `is_ltx_video` config guard so the pass only fires on LTX-Video RoPE nodes
- Updated unit test to reflect the new pattern

### Tickets:

- [CVS-185162](https://jira.devtools.intel.com/browse/CVS-185162)

### AI Assistance:

- AI assistance used: yes
- GitHub Copilot was used for sublayer diff analysis, force-fp32 binary search automation, and debug log analysis. All code changes were manually reviewed and validated with FP16/INT4 accuracy tests.
