### PR TITLE
[TRANSFORMATIONS] Fix EliminateIdentityConvert behavior with multiple Convert consumers

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -492,12 +492,20 @@ EliminateIdentityConvert::EliminateIdentityConvert() {
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_map();
         auto convert_begin = pattern_map.at(convert_pattern);
+        auto identity = pattern_map.at(convert_identity_pattern);
         auto convert_end = pattern_map.at(convert_identity_convert_pattern);
 
-        if (convert_begin->get_input_element_type(0) == convert_end->get_element_type()) {
-            return replace_output_update_name(convert_end->output(0), convert_begin->input_value(0));
+        if (convert_begin->get_input_element_type(0) != convert_end->get_element_type()) {
+            return false;
         }
-        return false;
+
+        if (identity->output(0).get_target_inputs().size() == 1) {
+            identity->input(0).replace_source_output(convert_begin->input_value(0));
+            identity->validate_and_infer_types();
+            copy_runtime_info({convert_begin, identity, convert_end}, identity);
+            return replace_output_update_name(convert_end->output(0), identity->output(0));
+        }
+        return replace_output_update_name(convert_end->output(0), convert_begin->input_value(0));
     };
     auto m = std::make_shared<pattern::Matcher>(convert_identity_convert_pattern, matcher_name);
     this->register_matcher(m, callback);

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -492,14 +492,10 @@ EliminateIdentityConvert::EliminateIdentityConvert() {
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_map();
         auto convert_begin = pattern_map.at(convert_pattern);
-        auto identity = pattern_map.at(convert_identity_pattern);
         auto convert_end = pattern_map.at(convert_identity_convert_pattern);
 
         if (convert_begin->get_input_element_type(0) == convert_end->get_element_type()) {
-            convert_begin->output(0).replace(convert_begin->input_value(0));
-            identity->validate_and_infer_types();
-            convert_end->output(0).replace(identity->output(0));
-            return true;
+            return replace_output_update_name(convert_end->output(0), convert_begin->input_value(0));
         }
         return false;
     };

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2205,5 +2205,5 @@ TEST_F(TransformationTestsF, EliminateIdentityConvert_convert_multiple_consumers
 
     manager.register_pass<ov::pass::EliminateIdentityConvert>();
 
-    model_ref = model;
+    model_ref = model->clone();
 }

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -16,6 +16,7 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "openvino/core/model.hpp"
+#include "openvino/op/identity.hpp"
 #include "openvino/op/ops.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
@@ -2152,4 +2153,57 @@ TEST_F(TransformationTestsF, ScatterNDUpdates15Elimination) {
         auto result = std::make_shared<op::v0::Result>(relu);
         model_ref = std::make_shared<ov::Model>(OutputVector{result}, ParameterVector{data, indices, updates});
     }
+}
+
+TEST_F(TransformationTestsF, EliminateIdentityConvert_convert_multiple_consumers_node_after) {
+    {
+        auto param = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 55, 1});
+        auto convert_to_f32 = std::make_shared<op::v0::Convert>(param, element::f32);
+        auto identity = std::make_shared<op::v16::Identity>(convert_to_f32);
+        auto convert_to_f16 = std::make_shared<op::v0::Convert>(identity, element::f16);
+        auto relu = std::make_shared<op::v0::Relu>(convert_to_f16);
+
+        auto constant = op::v0::Constant::create(element::f32, Shape{1, 1, 1}, {1.0f});
+        auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, convert_to_f32}, 1);
+
+        auto result1 = std::make_shared<op::v0::Result>(relu);
+        auto result2 = std::make_shared<op::v0::Result>(concat);
+
+        model = std::make_shared<ov::Model>(OutputVector{result1, result2}, ParameterVector{param});
+    }
+    {
+        auto param = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 55, 1});
+        auto convert_to_f32 = std::make_shared<op::v0::Convert>(param, element::f32);
+        auto relu = std::make_shared<op::v0::Relu>(param);
+
+        auto constant = op::v0::Constant::create(element::f32, Shape{1, 1, 1}, {1.0f});
+        auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, convert_to_f32}, 1);
+
+        auto result1 = std::make_shared<op::v0::Result>(relu);
+        auto result2 = std::make_shared<op::v0::Result>(concat);
+
+        model_ref = std::make_shared<ov::Model>(OutputVector{result1, result2}, ParameterVector{param});
+    }
+    manager.register_pass<ov::pass::EliminateIdentityConvert>();
+}
+
+// Same model as above, but without additional nodes on the Identity path. Second Convert goes to Result directly.
+// replace_output_update_name refuses to have Parameter->Result, so the graph stays unchanged.
+TEST_F(TransformationTestsF, EliminateIdentityConvert_convert_multiple_consumers_no_node_after) {
+    auto param = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 55, 1});
+    auto convert_to_f32 = std::make_shared<op::v0::Convert>(param, element::f32);
+    auto identity = std::make_shared<op::v16::Identity>(convert_to_f32);
+    auto convert_to_f16 = std::make_shared<op::v0::Convert>(identity, element::f16);
+
+    auto constant = op::v0::Constant::create(element::f32, Shape{1, 1, 1}, {1.0f});
+    auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, convert_to_f32}, 1);
+
+    auto result1 = std::make_shared<op::v0::Result>(convert_to_f16);
+    auto result2 = std::make_shared<op::v0::Result>(concat);
+
+    model = std::make_shared<ov::Model>(OutputVector{result1, result2}, ParameterVector{param});
+
+    manager.register_pass<ov::pass::EliminateIdentityConvert>();
+
+    model_ref = model;
 }

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -2174,7 +2174,8 @@ TEST_F(TransformationTestsF, EliminateIdentityConvert_convert_multiple_consumers
     {
         auto param = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 55, 1});
         auto convert_to_f32 = std::make_shared<op::v0::Convert>(param, element::f32);
-        auto relu = std::make_shared<op::v0::Relu>(param);
+        auto identity = std::make_shared<op::v16::Identity>(param);
+        auto relu = std::make_shared<op::v0::Relu>(identity);
 
         auto constant = op::v0::Constant::create(element::f32, Shape{1, 1, 1}, {1.0f});
         auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, convert_to_f32}, 1);
@@ -2188,15 +2189,83 @@ TEST_F(TransformationTestsF, EliminateIdentityConvert_convert_multiple_consumers
 }
 
 // Same model as above, but without additional nodes on the Identity path. Second Convert goes to Result directly.
-// replace_output_update_name refuses to have Parameter->Result, so the graph stays unchanged.
+// Identity has only one consumer (Convert_B), so we can safely rewire it and redirect Result to Identity.
 TEST_F(TransformationTestsF, EliminateIdentityConvert_convert_multiple_consumers_no_node_after) {
+    {
+        auto param = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 55, 1});
+        auto convert_to_f32 = std::make_shared<op::v0::Convert>(param, element::f32);
+        auto identity = std::make_shared<op::v16::Identity>(convert_to_f32);
+        auto convert_to_f16 = std::make_shared<op::v0::Convert>(identity, element::f16);
+
+        auto constant = op::v0::Constant::create(element::f32, Shape{1, 1, 1}, {1.0f});
+        auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, convert_to_f32}, 1);
+
+        auto result1 = std::make_shared<op::v0::Result>(convert_to_f16);
+        auto result2 = std::make_shared<op::v0::Result>(concat);
+
+        model = std::make_shared<ov::Model>(OutputVector{result1, result2}, ParameterVector{param});
+    }
+    {
+        auto param = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 55, 1});
+        auto convert_to_f32 = std::make_shared<op::v0::Convert>(param, element::f32);
+        auto identity = std::make_shared<op::v16::Identity>(param);
+
+        auto constant = op::v0::Constant::create(element::f32, Shape{1, 1, 1}, {1.0f});
+        auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, convert_to_f32}, 1);
+
+        auto result1 = std::make_shared<op::v0::Result>(identity);
+        auto result2 = std::make_shared<op::v0::Result>(concat);
+
+        model_ref = std::make_shared<ov::Model>(OutputVector{result1, result2}, ParameterVector{param});
+    }
+    manager.register_pass<ov::pass::EliminateIdentityConvert>();
+}
+
+// Identity has multiple consumers (Convert_B + Concat). Convert_B feeds Relu (not Result).
+// The pass redirects Relu to take Parameter directly (bypassing the convert pair).
+TEST_F(TransformationTestsF, EliminateIdentityConvert_identity_multiple_consumers_node_after) {
+    {
+        auto param = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 55, 1});
+        auto convert_to_f32 = std::make_shared<op::v0::Convert>(param, element::f32);
+        auto identity = std::make_shared<op::v16::Identity>(convert_to_f32);
+        auto convert_to_f16 = std::make_shared<op::v0::Convert>(identity, element::f16);
+        auto relu = std::make_shared<op::v0::Relu>(convert_to_f16);
+
+        auto constant = op::v0::Constant::create(element::f32, Shape{1, 1, 1}, {1.0f});
+        auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, identity}, 1);
+
+        auto result1 = std::make_shared<op::v0::Result>(relu);
+        auto result2 = std::make_shared<op::v0::Result>(concat);
+
+        model = std::make_shared<ov::Model>(OutputVector{result1, result2}, ParameterVector{param});
+    }
+    {
+        auto param = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 55, 1});
+        auto convert_to_f32 = std::make_shared<op::v0::Convert>(param, element::f32);
+        auto identity = std::make_shared<op::v16::Identity>(convert_to_f32);
+        auto relu = std::make_shared<op::v0::Relu>(param);
+
+        auto constant = op::v0::Constant::create(element::f32, Shape{1, 1, 1}, {1.0f});
+        auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, identity}, 1);
+
+        auto result1 = std::make_shared<op::v0::Result>(relu);
+        auto result2 = std::make_shared<op::v0::Result>(concat);
+
+        model_ref = std::make_shared<ov::Model>(OutputVector{result1, result2}, ParameterVector{param});
+    }
+    manager.register_pass<ov::pass::EliminateIdentityConvert>();
+}
+
+// Identity has multiple consumers (Convert_B + Concat). Convert_B feeds Result directly.
+// replace_output_update_name refuses Parameter->Result, so the graph stays unchanged.
+TEST_F(TransformationTestsF, EliminateIdentityConvert_identity_multiple_consumers_no_node_after) {
     auto param = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 55, 1});
     auto convert_to_f32 = std::make_shared<op::v0::Convert>(param, element::f32);
     auto identity = std::make_shared<op::v16::Identity>(convert_to_f32);
     auto convert_to_f16 = std::make_shared<op::v0::Convert>(identity, element::f16);
 
     auto constant = op::v0::Constant::create(element::f32, Shape{1, 1, 1}, {1.0f});
-    auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, convert_to_f32}, 1);
+    auto concat = std::make_shared<op::v0::Concat>(OutputVector{constant, identity}, 1);
 
     auto result1 = std::make_shared<op::v0::Result>(convert_to_f16);
     auto result2 = std::make_shared<op::v0::Result>(concat);


### PR DESCRIPTION
### Details:
EliminateIdentityConvert pass collapses structures like:
```Convert_A(f16→f32) → Identity(f32) → Convert_B(f32→f16)``` into just ```Identity(f16)```

However, when ```Convert_A``` has multiple consumers that would lead into deleting the Convert that needs to stay for other nodes.

Fix this by using safe per-input rewiring. When Identity has a single consumer, reconnect its input to bypass Convert_A and redirect Convert_B's consumers to Identity (preserving it at the original precision). When Identity has multiple consumers, redirect only Convert_B's consumers to the input of Convert_A without modifying Identity's type.

### Tickets:
 - [CVS-179088](https://jira.devtools.intel.com/browse/CVS-179088)
 - GH Issue: https://github.com/openvinotoolkit/openvino/issues/33446

### AI Assistance:
 - *AI assistance used: no

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
