### PR TITLE
[LPT] Remove mandatory weight folding in ConvolutionTransformation

### DIFF
--- a/src/common/low_precision_transformations/src/convolution.cpp
+++ b/src/common/low_precision_transformations/src/convolution.cpp
@@ -69,6 +69,16 @@ size_t ConvolutionTransformation::getInputChannels(const std::shared_ptr<ov::Nod
 bool ConvolutionTransformation::transform(ov::pass::pattern::Matcher &m) {
     auto convolution = m.get_match_root();
 
+    // check if the match is from a functional Mul rather than dequantization
+    // TODO: make the check general
+    {
+        const auto actInput = convolution->get_input_node_shared_ptr(0);
+        const auto nonDQFactor = ov::as_type_ptr<ov::opset1::Convolution>(actInput->get_input_node_shared_ptr(1));
+        if (nonDQFactor != nullptr) {
+            return false;
+        }
+    }
+
     if (!canConvolutionBeTransformed(convolution, defaultPrecisions)) {
         const auto weightInput = convolution->get_input_node_shared_ptr(1);
         const auto reshapeFromWeights = ov::as_type_ptr<ov::opset1::Reshape>(weightInput);
@@ -105,16 +115,6 @@ bool ConvolutionTransformation::transform(ov::pass::pattern::Matcher &m) {
 
     if (updatePrecisions && !fqOnWeightsWasDecomposed) {
         return false;
-    }
-
-    // check if the match is from a functional Mul rather than dequantization
-    // TODO: make the check general
-    {
-        const auto actInput = convolution->get_input_node_shared_ptr(0);
-        const auto nonDQFactor = ov::as_type_ptr<ov::opset1::Convolution>(actInput->get_input_node_shared_ptr(1));
-        if (nonDQFactor != nullptr) {
-            return false;
-        }
     }
 
     FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(convolution, defaultPrecisions);

--- a/src/common/low_precision_transformations/src/convolution.cpp
+++ b/src/common/low_precision_transformations/src/convolution.cpp
@@ -107,6 +107,16 @@ bool ConvolutionTransformation::transform(ov::pass::pattern::Matcher &m) {
         return false;
     }
 
+    // check if the match is from a functional Mul rather than dequantization
+    // TODO: make the check general
+    {
+        const auto actInput = convolution->get_input_node_shared_ptr(0);
+        const auto nonDQFactor = ov::as_type_ptr<ov::opset1::Convolution>(actInput->get_input_node_shared_ptr(1));
+        if (nonDQFactor != nullptr) {
+            return false;
+        }
+    }
+
     FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(convolution, defaultPrecisions);
 
     std::shared_ptr<Node> newMultiplyAfter;

--- a/src/common/low_precision_transformations/src/convolution.cpp
+++ b/src/common/low_precision_transformations/src/convolution.cpp
@@ -69,38 +69,8 @@ size_t ConvolutionTransformation::getInputChannels(const std::shared_ptr<ov::Nod
 bool ConvolutionTransformation::transform(ov::pass::pattern::Matcher &m) {
     auto convolution = m.get_match_root();
 
-    // check if the match is from a functional Mul rather than dequantization
-    // TODO: make the check general
-    {
-        const auto actInput = convolution->get_input_node_shared_ptr(0);
-        const auto nonDQFactor = ov::as_type_ptr<ov::opset1::Convolution>(actInput->get_input_node_shared_ptr(1));
-        if (nonDQFactor != nullptr) {
-            return false;
-        }
-    }
-
     if (!canConvolutionBeTransformed(convolution, defaultPrecisions)) {
-        const auto weightInput = convolution->get_input_node_shared_ptr(1);
-        const auto reshapeFromWeights = ov::as_type_ptr<ov::opset1::Reshape>(weightInput);
-        FakeQuantizeDequantization dequantization = reshapeFromWeights == nullptr ?
-                                                    NetworkHelper::getDequantization(convolution, defaultPrecisions, 1ul) :
-                                                    NetworkHelper::getDequantization(reshapeFromWeights, defaultPrecisions);
-        if (dequantization.empty()) {
-            const auto fqOnWeights = getFakeQuantizeOnWeights(convolution);
-            std::shared_ptr<ov::Node> resultConstant = NetworkHelper::fold_fake_quantize(fqOnWeights);
-            if (reshapeFromWeights != nullptr) {
-                resultConstant = fold_reshape<ov::opset1::Reshape>(
-                        resultConstant,
-                        reshapeFromWeights->input_value(1),
-                        false);
-            }
-            if (ov::is_type<ov::opset1::Constant>(resultConstant)) {
-                replace_node(weightInput, resultConstant);
-            }
-        } else {
-            NetworkHelper::foldDequantization(dequantization.multiply, 0, defaultPrecisions, true);
-        }
-        return true;
+        return false;
     }
 
     convolution = NetworkHelper::separateInStandaloneBranch(convolution, defaultPrecisions);

--- a/src/common/low_precision_transformations/tests/convolution_qdq_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_qdq_transformation.cpp
@@ -240,61 +240,6 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
     // Actual:
     //
     // Parameter   Constant   Constant Constant
-    //  |U8         |U8        |FP32    |I8
-    //  |           |          |        |
-    // Convert    Convert     Convert  Convert
-    //   \FP32    /FP32        |FP32   /FP32
-    //    \      /             |      /
-    //    Subtract  Constant  Subtract  Constant
-    //      \FP32   /FP32      |FP32   /FP32
-    //       \     /           |      /
-    //       Multiply         Multiply
-    //         \FP32         /FP32
-    //          \           /
-    //           Convolution
-    //
-    // Transformed:
-    //
-    // Parameter   Constant
-    //  |U8         |U8
-    //  |           |
-    // Convert    Convert
-    //   \FP32    /FP32
-    //    \      /
-    //    Subtract  Constant
-    //      \FP32   /FP32
-    //       \     /
-    //       Multiply       Constant
-    //         \FP32         /FP32
-    //          \           /
-    //           Convolution
-    {
-        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
-        // ActualValues
-        {
-            ov::element::u8,
-            {{ov::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::u8, true }, { 0.02f }},
-            {{ov::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::i8, true }, { 0.03f }},
-            { std::vector<float>{ 2.f }, ov::element::f32},
-            {},
-            ov::element::f32,
-            {}
-        },
-        // ExpectedValues
-        {
-            ov::element::u8,
-            {{ov::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::u8, true }, { 0.02f }},
-            {},
-            { std::vector<float>{ -3.75f }, ov::element::f32},
-            {},
-            ov::element::f32,
-            {}
-        }
-    },
-
-    // Actual:
-    //
-    // Parameter   Constant   Constant Constant
     //  |U8         |U8        |I8      |I8
     //  |           |          |        |
     // Convert    Convert     Convert  Convert
@@ -453,6 +398,32 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
             {{}, {}, {{ 0.0006f }, ov::element::f16, {}, false, 1, ov::element::f32}}
         }
     },
+
+    // fp32 base weight value [not transformed]
+    {
+        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
+        // ActualValues
+        {
+            ov::element::u8,
+            {{ov::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::u8, true }, { 0.02f }},
+            {{ov::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::i8, true }, { 0.03f }},
+            { std::vector<float>{ 2.f }, ov::element::f32},
+            {},
+            ov::element::f32,
+            {}
+        },
+        // ExpectedValues
+        {
+            ov::element::u8,
+            {{ov::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::u8, true }, { 0.02f }},
+            {{ov::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::i8, true }, { 0.03f }},
+            { std::vector<float>{ 2.f }, ov::element::f32},
+            {},
+            ov::element::f32,
+            {}
+        }
+    },
+
     // incorrect zero point on activations [not transformed]
     {
         LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
@@ -482,14 +453,18 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
                 { {1000.f}, element::f32, {}, false },
                 { {0.02f}, element::f32, {}, false }
             },
-            {},
-            { std::vector<float>{ -3.75f }, ov::element::f32},
+            {
+                { ov::element::f32, false },
+                { {127.f}, element::f32, {}, false },
+                { {0.03f}, element::f32, {}, false }
+            },
+            { std::vector<float>{ 2.f }, ov::element::i8},
             {},
             ov::element::f32,
             {}
         }
     },
-    // incorrect zero point on weights [not transformed, weights folded]
+    // incorrect zero point on weights [not transformed]
     {
         LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
         // ActualValues
@@ -518,8 +493,12 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
                 { {127.f}, element::f32, {}, false, 1ul, element::u8, true },
                 { {0.02f}, element::f32, {}, false }
             },
-            {},
-            { std::vector<float>{ -29.94f }, ov::element::f32},
+            {
+                { ov::element::f32, false },
+                { {1000.f}, element::f32, {}, false },
+                { {0.03f}, element::f32, {}, false }
+            },
+            { std::vector<float>{ 2.f }, ov::element::i8},
             {},
             ov::element::f32,
             {}
@@ -570,8 +549,12 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
                 { {127.f}, element::f32, {}, false, 1ul, element::u8, true },
                 { {0.02f}, element::f32, {}, false }
             },
-            {},
-            { std::vector<float>{ -3.75 }, ov::element::f32},
+            {
+                { ov::element::f32, false },
+                { {127.f}, element::f32, {}, false, 1ul, element::i8, true },
+                { {0.03f}, element::f32, {}, false }
+            },
+            { std::vector<float>{ 2.f }, ov::element::i8},
             {},
             ov::element::f32,
             {}

--- a/src/common/low_precision_transformations/tests/convolution_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_transformation.cpp
@@ -300,10 +300,8 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
                 {{ 128.f, 0.f, 128.f }, ov::element::f32, { 1, 3, 1, 1 }},
                 {{ 0.02f, 0.01f, 0.03f }, ov::element::f32, {1, 3, 1, 1}}
             },
-            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ -1.25f }),
-            {},
-            ov::element::f32,
-            {}
+            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ 2.f }),
+            { 255ul, Shape({ 1, 1, 1, 1 }), { 0.f }, { 254.f }, { -1.27f }, { 1.27f } }
         }
     },
     // float input
@@ -328,10 +326,8 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
                 {{ 128.f }, ov::element::f32, { 1, 1, 1, 1 }},
                 {{ 0.02f }, ov::element::f32, {1, 1, 1, 1}}
             },
-            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ -1.25f }),
-            {},
-            ov::element::f32,
-            {}
+            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ 2.f }),
+            { 255ul, Shape({ 1, 1, 1, 1 }), { 0.f }, { 254.f }, { -1.27f }, { 1.27f } }
         }
     },
     // without dequantization operations
@@ -367,11 +363,9 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
         // ExpectedValues
         {
             ov::element::f32,
-            {{}, {}, { {0.02f}, element::f32 }},
-            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ -1.25f }),
-            {},
-            ov::element::f32,
-            {}
+            {{}, {}, { 0.02f }},
+            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ 2.f }),
+            { 255ul, Shape({ 1, 1, 1, 1 }), { 0.f }, { 254.f }, { -1.27f }, { 1.27f } }
         }
     },
     // without zero point
@@ -408,10 +402,8 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
         {
             ov::element::u8,
             {{element::f32}, { 1000.f }, { {0.02f}, element::f32 }},
-            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ -1.25f }),
-            {},
-            ov::element::f32,
-            {}
+            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ 2.f }),
+            { 255ul, Shape({ 1, 1, 1, 1 }), { 0.f }, { 254.f }, { -1.27f }, { 1.27f } }
         }
     },
     // TODO: uncomment: remove precisionsOnActivations & precisionsOnWeights
@@ -471,11 +463,9 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
         // ExpectedValues
         {
             ov::element::u8,
-            {{ ov::element::f32 }, { 128.f }, { 0.02f }},
-            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ -1.25f }),
-            {},
-            ov::element::f32,
-            {}
+            {{ov::element::f32}, { 128.f }, { 0.02f }},
+            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ 2.f }),
+            { 255ul, Shape({ 1, 1, 1, 1 }), { 0.f }, { 254.f }, { -1.27f }, { 1.27f } }
         }
     },
     // without zero point
@@ -491,11 +481,9 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
         // ExpectedValues
         {
             ov::element::u8,
-            {{ ov::element::f32 }, {}, { 0.02f }},
-            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ -1.25f }),
-            {},
-            ov::element::f32,
-            {}
+            {{ov::element::f32}, {}, { 0.02f }},
+            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{ 2.f }),
+            { 255ul, Shape({ 1, 1, 1, 1 }), { 0.f }, { 254.f }, { -1.27f }, { 1.27f } }
         }
     },
 };

--- a/src/common/low_precision_transformations/tests/group_convolution_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/group_convolution_transformation.cpp
@@ -378,10 +378,8 @@ const std::vector<GroupConvolutionTestValues> testValuesGroupConv = {
         {
             ov::element::f32,
             {{}, {}, {0.02f}},
-            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{-1.25f}),
-            {},
-            {},
-            ov::element::f32,
+            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{2.f}),
+            {255ul, Shape({1, 1, 1, 1}), {0.f}, {254.f}, {-1.27f}, {1.27f}},
             {}
         }
     },
@@ -864,10 +862,8 @@ const std::vector<GroupConvolutionTestValues> testValuesForDepthWiseConv = {
         {
             ov::element::f32,
             {{}, {}, {0.02f}},
-            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{-1.25f}),
-            {},
-            {},
-            ov::element::f32,
+            op::v0::Constant::create(ov::element::f32, ov::Shape{}, std::vector<float>{2.f}),
+            {255ul, Shape({1, 1, 1, 1}), {0.f}, {254.f}, {-1.27f}, {1.27f}},
             {}
         }
     },


### PR DESCRIPTION
### Details:
 - Removes weight dequantization in `!canConvolutionBeTransformed()` cases
 - Serves to prevent improper weight constant folding on false matches from activation multiplication

### Tickets:
 - CVS-186993

### AI Assistance:
 - AI assistance used: no
