### PR TITLE
[`NPU`] [`ENCRYPTION`] [`RELEASE BRANCH`] Throw OV exception instead of warning for older drivers

### DIFF
--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
@@ -325,8 +325,8 @@ Can be used for both model caching and user requested export or import of compil
 
 .. note::
 
-   If user compiles a model using ``Compiler-In-Driver``, currently there is no secure compilation available in driver until ``32.0.100.4724`` (inclusively) and a warning
-   describing this potential security flaw will be issued if encryption callbacks were set.
+   If user compiles a model using ``Compiler-In-Driver``, currently there is no secure compilation available in driver until ``32.0.100.4724`` (inclusively) and an exception will be thrown
+   for older drivers during compilation if encryption callbacks were set.
 
 Usage example:
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -401,8 +401,7 @@ GraphDescriptor ZeGraphExtWrappers::getGraphDescriptor(SerializedIR serializedIR
     }
     if (secureCompile) {
         if (_graphExtVersion < ZE_MAKE_VERSION(1, 17)) {
-            _logger.warning("Secure compilation was requested, but the current driver version does not support it. "
-                            "Ignoring the flag.");
+            OPENVINO_THROW("Secure compilation was requested, but the current driver version does not support it.");
         } else {
             _logger.debug("getGraphDescriptor - set ZE_GRAPH_FLAG_SECURE_COMPILE");
             flags |= ZE_GRAPH_FLAG_SECURE_COMPILE;

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.cpp
@@ -12,11 +12,7 @@ using namespace ov::test::behavior;
 
 namespace {
 
-std::vector<ov::AnyMap> config = {
-    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
-     ov::cache_encryption_callbacks(ov::EncryptionCallbacks{ov::util::codec_xor, ov::util::codec_xor})},
-    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-     ov::cache_encryption_callbacks(ov::EncryptionCallbacks{ov::util::codec_xor, ov::util::codec_xor})}};
+std::vector<ov::AnyMap> config = {{}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          OVCompileModelLoadFromFileTestBaseNPU,

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/caching_tests.hpp
@@ -46,37 +46,6 @@ TEST_P(OVCompileModelLoadFromFileTestBaseNPU, BlobWithOVHeaderAligmentCanBeImpor
                 ::testing::HasSubstr("getGraphDescriptor - set ZE_GRAPH_FLAG_INPUT_GRAPH_PERSISTENT"));
 }
 
-TEST_P(OVCompileModelLoadFromFileTestBaseNPU, EncryptionCallbacksSetSecureCompileFlag) {
-    core->set_property(ov::cache_dir(m_cacheFolderName));
-
-    if (::intel_npu::ZeroInitStructsHolder::getInstance()->getGraphDdiTable().version() < ZE_MAKE_VERSION(1, 17)) {
-        GTEST_SKIP()
-            << "Secure compilation when blob encryption is requested requires ze_graph_ext version 1.17 or higher.";
-    }
-
-    if (auto it = configuration.find(ov::intel_npu::compiler_type.name()); it != configuration.end()) {
-        if (it->second.as<ov::intel_npu::CompilerType>() == ov::intel_npu::CompilerType::PLUGIN) {
-            GTEST_SKIP() << "Compiler in Plugin doesn't need yet secure compilation when blob encryption is requested.";
-        }
-    }
-
-    std::stringstream custom_logger;
-    ov::util::LogCallback custom_log_callback = [&](std::string_view s) {
-        custom_logger << s << std::endl;
-    };
-    ov::util::set_log_callback(custom_log_callback);
-    struct ResetLogCallbackGuard {
-        ~ResetLogCallbackGuard() {
-            ov::util::reset_log_callback();
-        }
-    } reset_log_callback_guard;
-
-    configuration.emplace(ov::log::level(ov::log::Level::DEBUG));
-    std::ignore = core->compile_model(m_modelName, targetDevice, configuration);
-    EXPECT_THAT(custom_logger.str(), ::testing::HasSubstr("getGraphDescriptor - set ZE_GRAPH_FLAG_SECURE_COMPILE"));
-    configuration.erase(ov::log::level.name());
-}
-
 }  // namespace behavior
 }  // namespace test
 }  // namespace ov

--- a/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.cpp
@@ -4,6 +4,8 @@
 
 #include "zero_graph.hpp"
 
+#include "openvino/util/codec_xor.hpp"
+
 namespace {
 const std::vector<ov::AnyMap> configsGraphCompilationTests = {{},
                                                               {ov::cache_dir("test")},
@@ -32,6 +34,17 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          IsOptionSupported,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(emptyConfigsTests),
+                                            graphExtVersions),
+                         ZeroGraphTest::getTestCaseName);
+
+const std::vector<ov::AnyMap> configEncryptionCallbacks = {
+    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
+     ov::cache_encryption_callbacks(ov::EncryptionCallbacks{ov::util::codec_xor, ov::util::codec_xor})}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
+                         EncryptionCallbacks,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(configEncryptionCallbacks),
                                             graphExtVersions),
                          ZeroGraphTest::getTestCaseName);
 

--- a/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/zero_graph.hpp
@@ -13,12 +13,14 @@
 #include "common/utils.hpp"
 #include "common/zero_init_mock.hpp"
 #include "common_test_utils/subgraph_builders/multi_single_conv.hpp"
+#include "driver_compiler_adapter.hpp"
 #include "intel_npu/utils/utils.hpp"
 #include "intel_npu/utils/zero/zero_mem.hpp"
 #include "intel_npu/utils/zero/zero_mem_pool.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
 #include "model_serializer.hpp"
 #include "openvino/runtime/intel_npu/properties.hpp"
+#include "plugin_compiler_adapter.hpp"
 #include "ze_graph_ext_wrappers.hpp"
 
 using namespace intel_npu;
@@ -401,6 +403,37 @@ TEST_P(IsOptionSupported, PropertySupportedByDriver) {
     } else {
         ASSERT_TRUE(isOptionSupportedResult.has_value());
         ASSERT_TRUE(isOptionSupportedResult.value());
+    }
+}
+
+using EncryptionCallbacks = ZeroGraphTest;
+
+TEST_P(EncryptionCallbacks, EncryptionCallbacksSetSecureCompileFlag) {
+    model = ov::test::utils::make_conv_pool_relu({1, 3, 227, 227}, ov::element::f32);
+
+    auto options = std::make_shared<::intel_npu::OptionsDesc>();
+    options->add<::intel_npu::COMPILER_TYPE>();
+    options->add<::intel_npu::CACHE_ENCRYPTION_CALLBACKS>();
+    auto npu_config = std::make_unique<::intel_npu::FilteredConfig>(options);
+    for (const auto& [propertyName, propertyValue] : configuration) {
+        npu_config->enable(propertyName, true);
+    }
+    npu_config->updateAny(configuration);
+
+    std::shared_ptr<::intel_npu::ICompilerAdapter> compiler;
+    compiler = npu_config->get<::intel_npu::COMPILER_TYPE>() == ov::intel_npu::CompilerType::DRIVER
+                   ? std::dynamic_pointer_cast<::intel_npu::ICompilerAdapter>(
+                         std::make_shared<::intel_npu::DriverCompilerAdapter>(zeroInitStruct))
+                   : std::dynamic_pointer_cast<::intel_npu::ICompilerAdapter>(
+                         std::make_shared<::intel_npu::PluginCompilerAdapter>(zeroInitStruct));
+
+    if (zeroInitStruct->getGraphDdiTable().version() < ZE_MAKE_VERSION(1, 17)) {
+        OV_EXPECT_THROW(compiler->compile(model, *npu_config),
+                        ov::Exception,
+                        testing::HasSubstr(
+                            "Secure compilation was requested, but the current driver version does not support it."));
+    } else {
+        OV_ASSERT_NO_THROW(compiler->compile(model, *npu_config));
     }
 }
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -927,4 +927,43 @@ Example:
         </filters>
     </skip_config>
 
+    <!-- E#213889 -->
+    <skip_config>
+        <message>Older drivers cannot compile models with encryption callback</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*CompileModelWithCacheEncryptionTest.CanImportModelWithoutException.*NPU3720.*</filter>
+            <filter>.*OVClassCompiledModelPropertiesTests.CanUseCache.*CACHE_ENCRYPTION_CALLBACKS.*NPU3720.*</filter>
+            <filter>.*OVClassCompileModelWithCorrectPropertiesTest.CompileModelWithCorrectPropertiesTest.*CACHE_ENCRYPTION_CALLBACKS.*NPU3720.*</filter>
+            <filter>.*OVClassCompiledModelGetPropertyTest_MODEL_PRIORITY.GetMetricNoThrow.*CACHE_ENCRYPTION_CALLBACKS.*NPU3720.*</filter>
+            <filter>.*OVClassCompiledModelGetPropertyTest_DEVICE_PRIORITY.GetMetricNoThrow.*CACHE_ENCRYPTION_CALLBACKS.*NPU3720.*</filter>
+            <filter>.*OVClassCompiledModelGetPropertyTest_EXEC_DEVICES.CanGetExecutionDeviceInfo.*CACHE_ENCRYPTION_CALLBACKS.*NPU3720.*</filter>
+            <filter>.*OVCompileModelGetExecutionDeviceTests.CanGetExecutionDeviceInfo.*CACHE_ENCRYPTION_CALLBACKS.*NPU3720.*</filter>
+            <filter>.*WeightlessCacheAccuracy.ReadConcatSplitAssign.*config=_.*NPU3720.*</filter>
+            <filter>.*WeightlessCacheAccuracy.SingleConcatWithConstant.*config=_.*NPU3720.*</filter>
+            <filter>.*WeightlessCacheAccuracy.TiWithLstmCell.*config=_.*NPU3720.*</filter>
+            <filter>.*OVHoldersTestNPU.CompileModelWithEncryptionWorksAfterConfigDeallocate.*NPU3720.*</filter>
+            <filter>.*ClassPluginPropertiesTestSuite5NPU.CanSetMutablePropertiesToCompiledModel.*CACHE_ENCRYPTION_CALLBACKS.*NPU3720.*</filter>
+            <filter>.*OVWeightlessCacheAccuracyNPU.SimpleTestModel.*config=_.*NPU3720.*</filter>
+            <filter>.*OVWeightlessCacheAccuracyNPU.TestModelWeightlessWithDummyConstants.*config=_.*NPU3720.*</filter>
+            <filter>.*OVWeightlessCacheAccuracyNPU.TestModelLightInitSchedule.*config=_.*NPU3720.*</filter>
+            <filter>.*OVWeightlessCacheAccuracyNPU.TestModelWeightlessWithDuplicateConstants.*config=_.*NPU3720.*</filter>
+            <filter>.*OVCompiledGraphImportExportTestNPU.ImportingEncryptedBlobThrows.*NPU3720.*</filter>
+            <filter>.*OVCompiledGraphImportExportTestNPU.DifferentSizesOfEncryptedVsDecryptedBlobWorks.*NPU3720.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>PV driver cannot compile models securely</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <driver_version>1688</driver_version>
+        </enable_rules>
+        <filters>
+            <filter>.*OVHoldersTestNPU.CompileModelWithEncryptionWorksAfterConfigDeallocate.*</filter>
+        </filters>
+    </skip_config>
+
 </skip_configs>


### PR DESCRIPTION
### Details:
 - *Forbids compilation for older drivers if user sets encryption callback e.g. `ov::cache_encryption_callbacks(ov::EncryptionCallbacks{ov::codec_xor, nullptr})`*
 - Applies to all ze graph extensions lower than version `1.17`

### Tickets:
 - *C148679*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
