### PR TITLE
[CPU][Experiment]refactor: move fork softmax from onednn to x64

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/x64/softmax_fork_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/softmax_fork_executor.cpp
@@ -1,0 +1,188 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "nodes/executors/x64/softmax_fork_executor.hpp"
+
+#include <algorithm>
+
+#include "common/memory_desc_wrapper.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/utils.hpp"
+#include "nodes/kernels/x64/jit_softmax_fork_kernel_f32.hpp"
+#include "openvino/core/except.hpp"
+
+using namespace dnnl::impl;
+using namespace dnnl::impl::cpu::x64;
+
+namespace ov::intel_cpu {
+
+template <cpu_isa_t isa>
+struct SoftmaxForkExecutor::KernelExecutor : public SoftmaxForkExecutor::IKernelExecutor {
+    explicit KernelExecutor(const jit_softmax_conf_t& jpp) : kernel(jpp) {}
+
+    status_t create() override {
+        return kernel.create_kernel();
+    }
+
+    void run(const jit_softmax_call_s* args) const override {
+        kernel(args);
+    }
+
+    jit_softmax_fork_kernel_f32<isa> kernel;
+};
+
+SoftmaxForkExecutor::SoftmaxForkExecutor(const std::vector<size_t>& dims,
+                                         size_t axis,
+                                         ov::element::Type precision,
+                                         const dnnl::memory::desc& srcDesc)
+    : m_dims(dims),
+      m_axis(axis),
+      m_precision(precision),
+      m_srcDesc(srcDesc) {
+    if (m_dims.empty() || m_axis >= m_dims.size()) {
+        return;
+    }
+
+    const auto ndims = m_dims.size();
+    if (ndims == 3) {
+        return;
+    }
+
+    dnnl::impl::memory_desc_wrapper src_d(m_srcDesc.get());
+    const auto srcDataType = src_d.data_type();
+    if (!utils::one_of(srcDataType, data_type::f32, data_type::bf16)) {
+        return;
+    }
+
+    auto dat_tag = utils::pick(ndims - 3,
+                               dnnl::impl::format_tag::ncw,
+                               dnnl::impl::format_tag::nchw,
+                               dnnl::impl::format_tag::ncdhw);
+    if (!src_d.is_dense(true) || src_d.matches_one_of_tag(dat_tag) != dat_tag) {
+        return;
+    }
+
+    m_jpp.outer_size = utils::array_product(m_dims.data(), m_axis);
+    m_jpp.channels = m_dims[m_axis];
+    m_jpp.inner_size = utils::array_product(m_dims.data() + m_axis + 1, ndims - m_axis - 1);
+
+    if (m_jpp.outer_size < 1 || m_jpp.channels < 1 || m_jpp.inner_size < 1) {
+        return;
+    }
+
+    if (!utils::one_of(m_precision, ov::element::f32, ov::element::bf16)) {
+        return;
+    }
+
+    m_isSupported = true;
+}
+
+bool SoftmaxForkExecutor::isSupported() const {
+    return m_isSupported;
+}
+
+status_t SoftmaxForkExecutor::init() {
+    if (!m_isSupported) {
+        return status::unimplemented;
+    }
+
+    if (mayiuse(avx512_core)) {
+        return initForIsa<avx512_core>();
+    } else if (mayiuse(avx2)) {
+        return initForIsa<avx2>();
+    } else if (mayiuse(sse41)) {
+        return initForIsa<sse41>();
+    } else {
+        return status::unimplemented;
+    }
+}
+
+template <cpu_isa_t isa>
+status_t SoftmaxForkExecutor::initForIsa() {
+    softmax_desc_t desc = {};
+    desc.src_desc = *m_srcDesc.get();
+    desc.dst_desc = *m_srcDesc.get();
+    desc.softmax_axis = static_cast<int>(m_axis);
+
+    dnnl::impl::memory_desc_wrapper src_d(m_srcDesc.get());
+    dnnl::impl::memory_desc_wrapper dst_d(m_srcDesc.get());
+
+    jit_softmax_conf_t jpp = {};
+    const auto confStatus = jit_softmax_fork_kernel_f32<isa>::init_conf(jpp, desc, src_d, dst_d);
+    if (confStatus != status::success) {
+        return confStatus;
+    }
+
+    // Keep oneDNN a3ca91c4 behavior: fork path only for inner_size > 1.
+    if (jpp.inner_size <= 1) {
+        return status::unimplemented;
+    }
+
+    m_jpp = jpp;
+    m_kernelExecutor = std::make_unique<KernelExecutor<isa>>(m_jpp);
+    return m_kernelExecutor->create();
+}
+
+void SoftmaxForkExecutor::execute(const uint8_t* src, uint8_t* dst) const {
+    if (!m_kernelExecutor) {
+        OPENVINO_THROW("SoftmaxForkExecutor is not initialized");
+    }
+
+    const auto outerSize = m_jpp.outer_size;
+    const auto dim = m_jpp.channels * m_jpp.inner_size;
+    const auto& jpp = m_jpp;
+    dnnl::impl::memory_desc_wrapper data_d(m_srcDesc.get());
+
+    if (jpp.inner_size > 1) {
+        const size_t workAmount = outerSize;
+
+        auto ker = [&](const int ithr, const int nthr) {
+            size_t start = 0;
+            size_t end = 0;
+
+            balance211(workAmount, nthr, ithr, start, end);
+
+            for (size_t iwork = start; iwork < end; ++iwork) {
+                const size_t ou = iwork;
+                auto args = jit_softmax_call_s();
+                args.channels = jpp.channels;
+                args.work = jpp.inner_size;
+                const size_t off = data_d.off_l(ou * dim);
+                args.src = src + off * jpp.dt_size;
+                args.dst = dst + off * jpp.dt_size;
+
+                m_kernelExecutor->run(&args);
+            }
+        };
+
+        parallel(0, ker);
+    } else {
+        const int ouBlocks = dnnl::impl::utils::div_up(outerSize, jpp.outer_block);
+        const size_t workAmount = ouBlocks;
+
+        auto ker = [&](const int ithr, const int nthr) {
+            size_t start = 0;
+            size_t end = 0;
+
+            balance211(workAmount, nthr, ithr, start, end);
+
+            for (size_t iwork = start; iwork < end; ++iwork) {
+                const size_t oub = iwork;
+                const size_t work = nstl::min(jpp.outer_block, outerSize - oub * jpp.outer_block);
+
+                auto args = jit_softmax_call_s();
+                args.channels = jpp.channels;
+                args.work = work;
+                const size_t off = data_d.off_l(oub * jpp.outer_block * dim);
+                args.src = src + off * jpp.dt_size;
+                args.dst = dst + off * jpp.dt_size;
+
+                m_kernelExecutor->run(&args);
+            }
+        };
+
+        parallel(0, ker);
+    }
+}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/softmax_fork_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/softmax_fork_executor.cpp
@@ -1,15 +1,24 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #include "nodes/executors/x64/softmax_fork_executor.hpp"
 
-#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
 
-#include "common/memory_desc_wrapper.hpp"
+#include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
+#include "common/memory_desc_wrapper.hpp"
+#include "common/nstl.hpp"
+#include "common/opdesc.hpp"
 #include "common/utils.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
 #include "nodes/kernels/x64/jit_softmax_fork_kernel_f32.hpp"
+#include "oneapi/dnnl/dnnl.hpp"
 #include "openvino/core/except.hpp"
+#include "openvino/core/type/element_type.hpp"
 
 using namespace dnnl::impl;
 using namespace dnnl::impl::cpu::x64;
@@ -88,13 +97,15 @@ status_t SoftmaxForkExecutor::init() {
 
     if (mayiuse(avx512_core)) {
         return initForIsa<avx512_core>();
-    } else if (mayiuse(avx2)) {
-        return initForIsa<avx2>();
-    } else if (mayiuse(sse41)) {
-        return initForIsa<sse41>();
-    } else {
-        return status::unimplemented;
     }
+    if (mayiuse(avx2)) {
+        return initForIsa<avx2>();
+    }
+    if (mayiuse(sse41)) {
+        return initForIsa<sse41>();
+    }
+
+    return status::unimplemented;
 }
 
 template <cpu_isa_t isa>
@@ -157,7 +168,7 @@ void SoftmaxForkExecutor::execute(const uint8_t* src, uint8_t* dst) const {
 
         parallel(0, ker);
     } else {
-        const int ouBlocks = dnnl::impl::utils::div_up(outerSize, jpp.outer_block);
+        const size_t ouBlocks = dnnl::impl::utils::div_up(outerSize, jpp.outer_block);
         const size_t workAmount = ouBlocks;
 
         auto ker = [&](const int ithr, const int nthr) {

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/softmax_fork_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/softmax_fork_executor.hpp
@@ -1,14 +1,14 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #pragma once
 
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <vector>
-
 #include <oneapi/dnnl/dnnl.hpp>
+#include <vector>
 
 #include "common/c_types_map.hpp"
 #include "cpu/x64/cpu_isa_traits.hpp"
@@ -45,7 +45,7 @@ private:
     size_t m_axis = 0;
     ov::element::Type m_precision;
     dnnl::memory::desc m_srcDesc;
-    dnnl::impl::cpu::x64::jit_softmax_conf_t m_jpp {};
+    dnnl::impl::cpu::x64::jit_softmax_conf_t m_jpp{};
     bool m_isSupported = false;
     std::unique_ptr<IKernelExecutor> m_kernelExecutor;
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/softmax_fork_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/softmax_fork_executor.hpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <oneapi/dnnl/dnnl.hpp>
+
+#include "common/c_types_map.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "nodes/kernels/x64/jit_softmax_fork_kernel_f32.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+namespace ov::intel_cpu {
+
+class SoftmaxForkExecutor {
+public:
+    SoftmaxForkExecutor(const std::vector<size_t>& dims,
+                        size_t axis,
+                        ov::element::Type precision,
+                        const dnnl::memory::desc& srcDesc);
+
+    [[nodiscard]] bool isSupported() const;
+    [[nodiscard]] dnnl::impl::status_t init();
+    void execute(const uint8_t* src, uint8_t* dst) const;
+
+private:
+    struct IKernelExecutor {
+        virtual ~IKernelExecutor() = default;
+        virtual dnnl::impl::status_t create() = 0;
+        virtual void run(const dnnl::impl::cpu::x64::jit_softmax_call_s* args) const = 0;
+    };
+
+    template <dnnl::impl::cpu::x64::cpu_isa_t isa>
+    struct KernelExecutor;
+
+    template <dnnl::impl::cpu::x64::cpu_isa_t isa>
+    dnnl::impl::status_t initForIsa();
+
+    std::vector<size_t> m_dims;
+    size_t m_axis = 0;
+    ov::element::Type m_precision;
+    dnnl::memory::desc m_srcDesc;
+    dnnl::impl::cpu::x64::jit_softmax_conf_t m_jpp {};
+    bool m_isSupported = false;
+    std::unique_ptr<IKernelExecutor> m_kernelExecutor;
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_softmax_fork_kernel_f32.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_softmax_fork_kernel_f32.cpp
@@ -1,0 +1,745 @@
+/*******************************************************************************
+* Copyright 2019-2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/x64/jit_generator.hpp"
+#include "jit_softmax_fork_kernel_f32.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+
+using namespace Xbyak;
+
+#define GET_OFF(field) offsetof(jit_softmax_call_s, field)
+
+template<cpu_isa_t isa>
+jit_softmax_fork_kernel_f32<isa>::jit_softmax_fork_kernel_f32(jit_softmax_conf_t ajpp)
+    : jit_generator_t(jit_name(), isa), jpp(ajpp) {
+    if (jpp.dt == data_type::bf16 && !mayiuse(avx512_core_bf16)) {
+        bf16_emu_.reset(new bf16_emulation_t(this, bf16_emu_zmm_1, bf16_emu_zmm_2, bf16_emu_zmm_3,
+                                             bf16_emu_gpr, bf16_emu_zmm_4, bf16_emu_zmm_5));
+    }
+}
+
+
+template <cpu_isa_t isa>
+status_t jit_softmax_fork_kernel_f32<isa>::init_conf(jit_softmax_conf_t &jpp,
+                   const softmax_desc_t &pd, const memory_desc_wrapper &src_d,
+                   const memory_desc_wrapper &dst_d) {
+    auto ndims = pd.src_desc.ndims;
+    auto dims = pd.src_desc.dims;
+    auto axis = pd.softmax_axis;
+
+    jpp.dt = src_d.data_type();
+    jpp.dt_size = src_d.data_type_size();
+
+    size_t nregs = cpu_isa_traits_t<isa>::n_vregs;
+
+    if (jpp.dt == data_type::bf16) {
+        if (isa != avx512_core) {
+            return status::unimplemented;
+        }
+        else if (!mayiuse(avx512_core_bf16)) {
+            nregs -= 5; // reserved for the bf16 emulator
+        }
+    }
+
+    size_t aux_simd_registers = 5; // 3 aux for exp + one + (-FTL_MAX)
+    size_t regs_for_one_unroll = 2;
+    size_t max_inner_unroll = (nregs - aux_simd_registers) / regs_for_one_unroll;
+    size_t max_channels_unroll = 4;
+
+    jpp.outer_size = utils::array_product(dims, axis);
+    jpp.channels = dims[axis];
+    jpp.inner_size = utils::array_product(dims + axis + 1, ndims - axis - 1);
+
+    if (jpp.outer_size < 1 || jpp.channels < 1 || jpp.inner_size < 1) {
+        return status::unimplemented;
+    }
+
+    jpp.ur_inner = max_inner_unroll;
+    jpp.ur_channel = nstl::min(max_channels_unroll, jpp.channels);
+    jpp.outer_block = 2 * cpu_isa_traits_t<isa>::vlen / sizeof(float);
+
+    if (jpp.inner_size == 1) {
+        // limit max jit code size for dense case
+        if (jpp.channels > 128) {
+            return status::unimplemented;
+        }
+
+        // ref implementation is faster for small work amount
+        if (jpp.channels * jpp.outer_size < 16) {
+            return status::unimplemented;
+        }
+    }
+
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+int jit_softmax_fork_kernel_f32<isa>::id_vreg_max(int ur_inner) {
+    return 5+ur_inner;
+}
+
+template <cpu_isa_t isa>
+int jit_softmax_fork_kernel_f32<isa>::id_vreg_denom(int ur_inner) {
+    return 5+jpp.ur_inner + ur_inner;
+}
+
+template <cpu_isa_t isa>
+int jit_softmax_fork_kernel_f32<isa>::id_vreg_src(int ur_inner) {
+    return 5+2*jpp.ur_inner;
+}
+
+template <cpu_isa_t isa>
+auto jit_softmax_fork_kernel_f32<isa>::vreg_max(int ur_inner) -> Vmm {
+    return Vmm(id_vreg_max(ur_inner));
+}
+
+template <cpu_isa_t isa>
+auto jit_softmax_fork_kernel_f32<isa>::vreg_denom(int ur_inner) -> Vmm {
+    return Vmm(id_vreg_denom(ur_inner));
+}
+
+template <cpu_isa_t isa>
+auto jit_softmax_fork_kernel_f32<isa>::vreg_src(int ur_inner) -> Vmm {
+    return Vmm(id_vreg_src(ur_inner));
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::load_vector(Vmm vmm_src_, const Xbyak::Address &op) {
+    switch (jpp.dt) {
+        case data_type::f32:
+            uni_vmovups(vmm_src_, op);
+            break;
+        case data_type::bf16:
+            uni_vpmovzxwd(vmm_src_, op);
+            uni_vpslld(vmm_src_, vmm_src_, 16);
+            break;
+        default:
+            assert(!"unknown data type");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::load_scalar(Xmm xmm_src_, const Xbyak::Address &op) {
+    switch (jpp.dt) {
+        case data_type::f32:
+            movss(xmm_src_, op);
+            break;
+        case data_type::bf16:
+            pinsrw(xmm_src_, op, 0x0);
+            uni_vpslld(xmm_src_, xmm_src_, 16);
+            break;
+        default:
+            assert(!"unknown data type");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::store_vector(const Xbyak::Address &op, Vmm vmm_dst_) {
+    Ymm ymm_dst_ = Ymm(vmm_dst_.getIdx());
+    switch (jpp.dt) {
+        case data_type::f32:
+            uni_vmovups(op, vmm_dst_);
+            break;
+        case data_type::bf16:
+            if (mayiuse(avx512_core_bf16))
+                vcvtneps2bf16(ymm_dst_, vmm_dst_);
+            else
+                bf16_emu_->vcvtneps2bf16(ymm_dst_, Zmm(vmm_dst_.getIdx()));
+            vmovdqu16(op, ymm_dst_);
+            break;
+        default:
+            assert(!"unknown data type");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::store_scalar(const Xbyak::Address &op, Xmm xmm_dst_) {
+    switch (jpp.dt) {
+        case data_type::f32:
+            movss(op, xmm_dst_);
+            break;
+        case data_type::bf16:
+            if (mayiuse(avx512_core_bf16))
+                vcvtneps2bf16(xmm_dst_, xmm_dst_);
+            else
+                bf16_emu_->vcvtneps2bf16(xmm_dst_, Ymm(xmm_dst_.getIdx()));
+            pextrw(op, xmm_dst_, 0x0);
+            break;
+        default:
+            assert(!"unknown dst_dt");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::prepare_table() {
+    const unsigned int cvals[] = {
+            0x3f800000, // [0] 1.0f
+            0x3f000000, // [1] 0.5f
+            0x3fb8aa3b, // [2] log2ef = 1.44269502f
+            0x3f317218, // [3] ln2f =   0.69314718f
+            0x0000007f, // [4] 0x7f
+            // exp(x) polynom
+            0x3f800001, // [5] p0 = 1.0000001f
+            0x3efffe85, // [6] p2 = 0.4999887f
+            0x3e2aaa3e, // [7] p3 = 0.16666505f
+            0x3d2bb1b1, // [8] p4 = 0.041917507f
+            0x3c091ec1, // [9] p5 = 0.008369149f
+            0x42b0c0a5, //[10] max logf = 88.3762589f
+            0xc1766666  //[11] min logf = -14.5f
+    };
+
+    align(64);
+    L(l_table);
+    for (size_t i = 0; i < sizeof(cvals) / sizeof(cvals[0]); ++i) {
+        for (size_t d = 0; d < vlen / sizeof(float); ++d) {
+            dd(cvals[i]);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::simd_expf(const Vmm &vmm_src) {
+    uni_vminps(vmm_src, vmm_src, ptr[imm_addr64 + 10 * vlen]);
+    uni_vmaxps(vmm_src, vmm_src, ptr[imm_addr64 + 11 * vlen]);
+    uni_vmovups(vmm_aux0, vmm_src);
+    //calculate exp(x)
+    // fx = x * log2ef + 0.5
+    uni_vmulps(vmm_src, vmm_src, ptr[imm_addr64 + 2 * vlen]);
+    uni_vaddps(vmm_src, vmm_src, ptr[imm_addr64 + 1 * vlen]);
+
+    // tmp = floorf(fx)
+    if (isa < avx512_core) {
+        uni_vroundps(vmm_aux1, vmm_src, _op_floor);
+    } else {
+        vcvtps2dq(vmm_aux1 | T_rd_sae, vmm_src);
+        vcvtdq2ps(vmm_aux1, vmm_aux1);
+
+        vcmpps(k_mask_tmp, vmm_aux1, vmm_src, _cmp_gt_os);
+        vmovups(vmm_aux2 | k_mask_tmp | T_z, zword[imm_addr64 + 0 * vlen]);
+
+        uni_vsubps(vmm_aux1, vmm_aux1, vmm_aux2);
+    }
+    //keep fx for further computations
+    uni_vmovups(vmm_src, vmm_aux1); //vmm_src = fx
+    // compute 2^n
+    uni_vcvtps2dq(vmm_aux2, vmm_src);
+    uni_vpaddd(vmm_aux2, vmm_aux2, ptr[imm_addr64 + 4 * vlen]);
+    uni_vpslld(vmm_aux2, vmm_aux2, 23); //Vmm(6) = 2^-fx
+
+    //x = x - fx * ln2
+    uni_vfnmadd231ps(vmm_aux0, vmm_aux1, ptr[imm_addr64 + 3 * vlen]);
+    // y = p5
+    uni_vmovups(vmm_src, ptr[imm_addr64 + 9 * vlen]);
+    // y = y * x + p4
+    uni_vfmadd213ps(vmm_src, vmm_aux0, ptr[imm_addr64 + 8 * vlen]);
+    // y = y * x + p3
+    uni_vfmadd213ps(vmm_src, vmm_aux0, ptr[imm_addr64 + 7 * vlen]);
+    // y = y * x + p2
+    uni_vfmadd213ps(vmm_src, vmm_aux0, ptr[imm_addr64 + 6 * vlen]);
+    // y = y * x + p1
+    uni_vfmadd213ps(vmm_src, vmm_aux0, vmm_one);
+    // y = y * x + p0
+    uni_vfmadd213ps(vmm_src, vmm_aux0, ptr[imm_addr64 + 5 * vlen]);  //exp(q)
+    // y = y * 2^n
+    uni_vmulps(vmm_src, vmm_src, vmm_aux2);
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::scalar_expf(const Xmm &xmm_src) {
+    minss(xmm_src, ptr[imm_addr64 + 10 * vlen]);
+    maxss(xmm_src, ptr[imm_addr64 + 11 * vlen]);
+    movups(xmm_aux0, xmm_src);
+    //calculate exp(x)
+    // fx = x * log2ef + 0.5
+    mulss(xmm_src, ptr[imm_addr64 + 2 * vlen]);
+    addss(xmm_src, ptr[imm_addr64 + 1 * vlen]);
+    // tmp = floorf(fx)
+    roundss(xmm_aux1, xmm_src, _op_floor);
+    //keep fx for further computations
+    movups(xmm_src, xmm_aux1); //xmm_src = fx
+    // compute 2^n
+    cvtps2dq(xmm_aux2, xmm_src);
+    paddd(xmm_aux2, ptr[imm_addr64 + 4 * vlen]);
+    pslld(xmm_aux2, 23); //Xmm(6) = 2^-fx
+
+    //calculation fx * ln2
+    mulss(xmm_aux1, ptr[imm_addr64 + 3 * vlen]);
+    //x = x - fx * ln2
+    subss(xmm_aux0, xmm_aux1);
+    // y = p5
+    movups(xmm_src, ptr[imm_addr64 + 9 * vlen]);
+    // y = y * x + p4
+    mulss(xmm_src, xmm_aux0);
+    addss(xmm_src, ptr[imm_addr64 + 8 * vlen]);
+
+    // y = y * x + p3
+    mulss(xmm_src, xmm_aux0);
+    addss(xmm_src, ptr[imm_addr64 + 7 * vlen]);
+    // y = y * x + p2
+    mulss(xmm_src, xmm_aux0);
+    addss(xmm_src, ptr[imm_addr64 + 6 * vlen]);
+
+    // y = y * x + p1
+    mulss(xmm_src, xmm_aux0);
+    addss(xmm_src, xmm_one);
+
+    // y = y * x + p0
+    mulss(xmm_src, xmm_aux0);
+    addss(xmm_src, ptr[imm_addr64 + 5 * vlen]); //exp(q)
+
+    // y = y * 2^n
+    mulps(xmm_src, xmm_aux2);
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::simd_loop_max(int ur_inner) {
+    Label loop_channel_blocks;
+    Label loop_channel_tail;
+    Label loop_channel_end;
+
+    for (int i = 0; i < ur_inner; ++i) {
+        uni_vbroadcastss(vreg_max(i), xmm_float_min);
+    }
+
+    mov(reg_ch_work, reg_channels);
+    mov(reg_src_ptr, reg_src_base_ptr);
+
+    L(loop_channel_blocks); {
+        cmp(reg_ch_work, jpp.ur_channel);
+        jl(loop_channel_tail, T_NEAR);
+
+        for (int i = 0; i < ur_inner; ++i) {
+            for (int c = 0; c < (int)jpp.ur_channel; ++c) {
+                load_vector(vreg_src(i), ptr[reg_src_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size]);
+                uni_vmaxps(vreg_max(i), vreg_max(i), vreg_src(i));
+            }
+        }
+
+        sub(reg_ch_work, jpp.ur_channel);
+        add(reg_src_ptr, jpp.ur_channel * jpp.inner_size * jpp.dt_size);
+
+        jmp(loop_channel_blocks, T_NEAR);
+    }
+
+    L(loop_channel_tail); {
+        cmp(reg_ch_work, 0);
+        jle(loop_channel_end, T_NEAR);
+
+        for (int i = 0; i < ur_inner; ++i) {
+            load_vector(vreg_src(i), ptr[reg_src_ptr + i * simd_w * jpp.dt_size]);
+            uni_vmaxps(vreg_max(i), vreg_max(i), vreg_src(i));
+        }
+
+        add(reg_src_ptr, jpp.inner_size * jpp.dt_size);
+
+        dec(reg_ch_work);
+        jmp(loop_channel_tail, T_NEAR);
+    }
+
+    L(loop_channel_end);
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::simd_loop_exp(int ur_inner) {
+    Label loop_channel_blocks;
+    Label loop_channel_tail;
+    Label loop_channel_end;
+
+    for (int i = 0; i < ur_inner; ++i) {
+        uni_vpxor(vreg_denom(i), vreg_denom(i), vreg_denom(i));
+    }
+
+    mov(reg_ch_work, reg_channels);
+
+    mov(reg_src_ptr, reg_src_base_ptr);
+    mov(reg_dst_ptr, reg_dst_base_ptr);
+
+    L(loop_channel_blocks); {
+        cmp(reg_ch_work, jpp.ur_channel);
+        jl(loop_channel_tail, T_NEAR);
+
+        for (int i = 0; i < ur_inner; ++i) {
+            for (int c = 0; c < (int)jpp.ur_channel; ++c) {
+                load_vector(vreg_src(i), ptr[reg_src_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size]);
+                uni_vsubps(vreg_src(i),vreg_src(i), vreg_max(i));
+                simd_expf(vreg_src(i));
+                uni_vaddps(vreg_denom(i), vreg_denom(i), vreg_src(i));
+                store_vector(ptr[reg_dst_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size], vreg_src(i));
+            }
+        }
+
+        sub(reg_ch_work, jpp.ur_channel);
+        add(reg_src_ptr, jpp.ur_channel * jpp.inner_size * jpp.dt_size);
+        add(reg_dst_ptr, jpp.ur_channel * jpp.inner_size * jpp.dt_size);
+
+        jmp(loop_channel_blocks, T_NEAR);
+    }
+
+    L(loop_channel_tail); {
+        cmp(reg_ch_work, 0);
+        jle(loop_channel_end, T_NEAR);
+
+        for (int i = 0; i < ur_inner; ++i) {
+            load_vector(vreg_src(i), ptr[reg_src_ptr + i * simd_w * jpp.dt_size]);
+            uni_vsubps(vreg_src(i), vreg_src(i), vreg_max(i));
+            simd_expf(vreg_src(i));
+            uni_vaddps(vreg_denom(i), vreg_denom(i), vreg_src(i));
+            store_vector(ptr[reg_dst_ptr + i * simd_w * jpp.dt_size], vreg_src(i));
+        }
+
+        add(reg_src_ptr, jpp.inner_size * jpp.dt_size);
+        add(reg_dst_ptr, jpp.inner_size * jpp.dt_size);
+
+        dec(reg_ch_work);
+        jmp(loop_channel_tail, T_NEAR);
+    }
+
+    L(loop_channel_end);
+}
+
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::simd_loop_div(int ur_inner) {
+    Label loop_channel_blocks;
+    Label loop_channel_tail;
+    Label loop_channel_end;
+
+    for (int i = 0; i < ur_inner; ++i) {
+        if (isa == sse41) {
+            uni_vmovups(vmm_aux0, vmm_one);
+            uni_vdivps(vmm_aux0, vmm_aux0, vreg_denom(i));
+            uni_vmovups(vreg_denom(i), vmm_aux0);
+        } else {
+            uni_vdivps(vreg_denom(i), vmm_one, vreg_denom(i));
+        }
+    }
+
+    mov(reg_ch_work, reg_channels);
+
+    mov(reg_src_ptr, reg_src_base_ptr);
+    mov(reg_dst_ptr, reg_dst_base_ptr);
+
+    L(loop_channel_blocks); {
+        cmp(reg_ch_work, jpp.ur_channel);
+        jl(loop_channel_tail, T_NEAR);
+
+        for (int i = 0; i < ur_inner; ++i) {
+            for (int c = 0; c < (int)jpp.ur_channel; ++c) {
+                load_vector(vreg_src(i), ptr[reg_dst_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size]);
+                uni_vmulps(vreg_src(i), vreg_src(i), vreg_denom(i));
+                store_vector(ptr[reg_dst_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size], vreg_src(i));
+            }
+        }
+
+        sub(reg_ch_work, jpp.ur_channel);
+        add(reg_src_ptr, jpp.ur_channel * jpp.inner_size * jpp.dt_size);
+        add(reg_dst_ptr, jpp.ur_channel * jpp.inner_size * jpp.dt_size);
+
+        jmp(loop_channel_blocks, T_NEAR);
+    }
+
+    L(loop_channel_tail); {
+        cmp(reg_ch_work, 0);
+        jle(loop_channel_end, T_NEAR);
+
+        for (int i = 0; i < ur_inner; ++i) {
+            load_vector(vreg_src(i), ptr[reg_dst_ptr + i * simd_w * jpp.dt_size]);
+            uni_vmulps(vreg_src(i), vreg_src(i), vreg_denom(i));
+            store_vector(ptr[reg_dst_ptr + i * simd_w * jpp.dt_size], vreg_src(i));
+        }
+
+        add(reg_src_ptr, jpp.inner_size * jpp.dt_size);
+        add(reg_dst_ptr, jpp.inner_size * jpp.dt_size);
+
+        dec(reg_ch_work);
+        jmp(loop_channel_tail, T_NEAR);
+    }
+
+    L(loop_channel_end);
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::scalar_loop_max() {
+    Label loop_channel_tail;
+    Label loop_channel_end;
+
+    movups(xmm_max, xmm_float_min);
+    mov(reg_src_ptr, reg_src_base_ptr);
+    mov(reg_ch_work, reg_channels);
+
+    L(loop_channel_tail); {
+        cmp(reg_ch_work, 0);
+        jle(loop_channel_end, T_NEAR);
+
+        load_scalar(xmm_src, ptr[reg_src_ptr]);
+        maxss(xmm_max, xmm_src);
+
+        add(reg_src_ptr, jpp.inner_size * jpp.dt_size);
+
+        dec(reg_ch_work);
+        jmp(loop_channel_tail);
+    }
+
+    L(loop_channel_end);
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::scalar_loop_exp() {
+    Label loop_channel_tail;
+    Label loop_channel_end;
+
+    mov(reg_src_ptr, reg_src_base_ptr);
+    mov(reg_dst_ptr, reg_dst_base_ptr);
+
+    mov(reg_ch_work, reg_channels);
+
+    pxor(xmm_denom, xmm_denom);
+
+    L(loop_channel_tail); {
+        cmp(reg_ch_work, 0);
+        jle(loop_channel_end, T_NEAR);
+
+        load_scalar(xmm_src, ptr[reg_src_ptr]);
+        subss(xmm_src, xmm_max);
+        scalar_expf(xmm_src);
+        addss(xmm_denom, xmm_src);
+        store_scalar(ptr[reg_dst_ptr], xmm_src);
+
+        add(reg_src_ptr, jpp.inner_size * jpp.dt_size);
+        add(reg_dst_ptr, jpp.inner_size * jpp.dt_size);
+
+        dec(reg_ch_work);
+        jmp(loop_channel_tail);
+    }
+
+    L(loop_channel_end);
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::scalar_loop_div() {
+    Label loop_channel_tail;
+    Label loop_channel_end;
+
+    mov(reg_src_ptr, reg_src_base_ptr);
+    mov(reg_dst_ptr, reg_dst_base_ptr);
+    mov(reg_ch_work, reg_channels);
+
+    L(loop_channel_tail); {
+        cmp(reg_ch_work, 0);
+        jle(loop_channel_end, T_NEAR);
+
+        load_scalar(xmm_src, ptr[reg_dst_ptr]);
+        divss(xmm_src, xmm_denom);
+        store_scalar(ptr[reg_dst_ptr], xmm_src);
+
+        add(reg_src_ptr, jpp.inner_size * jpp.dt_size);
+        add(reg_dst_ptr, jpp.inner_size * jpp.dt_size);
+
+        dec(reg_ch_work);
+        jmp(loop_channel_tail);
+    }
+
+    L(loop_channel_end);
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::dense_loop(int ou_block) {
+    for (int ou = 0; ou < ou_block; ou++) {
+        movups(xmm_max, xmm_float_min);
+        for (int ch = 0; ch < (int)jpp.channels; ch++) {
+            load_scalar(xmm_src, ptr[reg_src_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size]);
+            maxss(xmm_max, xmm_src);
+        }
+
+        for (int ch = 0; ch < (int)jpp.channels; ch++) {
+            load_scalar(xmm_src, ptr[reg_src_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size]);
+            subss(xmm_src, xmm_max);
+            store_scalar(ptr[reg_dst_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size], xmm_src);
+        }
+    }
+
+    int full_work = ou_block * (int)jpp.channels;
+    int i = 0;
+    for (; i <= full_work - simd_w; i += simd_w) {
+        load_vector(vreg_src(0), ptr[reg_dst_base_ptr + i * jpp.dt_size]);
+        simd_expf(vreg_src(0));
+        store_vector(ptr[reg_dst_base_ptr + i * jpp.dt_size], vreg_src(0));
+    }
+
+    for (; i < full_work; i++) {
+        load_scalar(xmm_src, ptr[reg_dst_base_ptr + i * jpp.dt_size]);
+        scalar_expf(xmm_src);
+        store_scalar(ptr[reg_dst_base_ptr + i * jpp.dt_size], xmm_src);
+    }
+
+    for (int ou = 0; ou < ou_block; ou++) {
+        pxor(xmm_denom, xmm_denom);
+        for (int ch = 0; ch < (int)jpp.channels; ch++) {
+            load_scalar(xmm_src, ptr[reg_dst_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size]);
+            addss(xmm_denom, xmm_src);
+        }
+
+        movss(xmm_one, ptr[imm_addr64 + 0 * vlen]);
+        divss(xmm_one, xmm_denom);
+        movss(xmm_denom, xmm_one);
+        for (int ch = 0; ch < (int)jpp.channels; ch++) {
+            load_scalar(xmm_src, ptr[reg_dst_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size]);
+            mulss(xmm_src, xmm_denom);
+            store_scalar(ptr[reg_dst_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size], xmm_src);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::generate() {
+    this->preamble();
+    if (bf16_emu_) bf16_emu_->init_vcvtneps2bf16();
+
+    if (jpp.inner_size == 1) {
+        this->generate_dense();
+    } else {
+        mov(reg_src_base_ptr, ptr[abi_param1 + GET_OFF(src)]);
+        mov(reg_dst_base_ptr, ptr[abi_param1 + GET_OFF(dst)]);
+        mov(reg_work_amount, ptr[abi_param1 + GET_OFF(work)]);
+        mov(reg_channels, ptr[abi_param1 + GET_OFF(channels)]);
+
+        mov(reg_min, float2int(-FLT_MAX));
+        movq(xmm_float_min, reg_min);
+
+        mov(imm_addr64, jit_softmax_fork_kernel_f32<isa>::l_table);
+        uni_vmovups(vmm_one, ptr[imm_addr64 + 0 * vlen]);
+
+        cmp(reg_work_amount, jpp.ur_inner * simd_w);
+        jl(loop_simd, T_NEAR);
+
+        L(loop_simd_unroll);
+        {
+            simd_loop_max(jpp.ur_inner);
+            simd_loop_exp(jpp.ur_inner);
+            simd_loop_div(jpp.ur_inner);
+
+            add(reg_src_base_ptr, jpp.ur_inner * simd_w * jpp.dt_size);
+            add(reg_dst_base_ptr, jpp.ur_inner * simd_w * jpp.dt_size);
+
+            sub(reg_work_amount, jpp.ur_inner * simd_w);
+            cmp(reg_work_amount, jpp.ur_inner * simd_w);
+            jge(loop_simd_unroll, T_NEAR);
+        }
+
+        L(loop_simd);
+        {
+            cmp(reg_work_amount, simd_w);
+            jl(loop_scalar, T_NEAR);
+
+            simd_loop_max(1);
+            simd_loop_exp(1);
+            simd_loop_div(1);
+
+            add(reg_src_base_ptr, simd_w * jpp.dt_size);
+            add(reg_dst_base_ptr, simd_w * jpp.dt_size);
+
+            sub(reg_work_amount, simd_w);
+            jmp(loop_simd, T_NEAR);
+        }
+
+        L(loop_scalar);
+        {
+            cmp(reg_work_amount, 0);
+            jle(loop_end, T_NEAR);
+
+            scalar_loop_max();
+            scalar_loop_exp();
+            scalar_loop_div();
+
+            add(reg_src_base_ptr, jpp.dt_size);
+            add(reg_dst_base_ptr, jpp.dt_size);
+
+            dec(reg_work_amount);
+            jmp(loop_scalar, T_NEAR);
+        }
+
+        L(loop_end);
+
+        this->postamble();
+
+        prepare_table();
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_softmax_fork_kernel_f32<isa>::generate_dense() {
+    mov(reg_src_base_ptr, ptr[abi_param1 + GET_OFF(src)]);
+    mov(reg_dst_base_ptr, ptr[abi_param1 + GET_OFF(dst)]);
+    mov(reg_work_amount, ptr[abi_param1 + GET_OFF(work)]);
+
+    mov(reg_min, float2int(-FLT_MAX));
+    movq(xmm_float_min, reg_min);
+
+    mov(imm_addr64, jit_softmax_fork_kernel_f32<isa>::l_table);
+    uni_vmovups(vmm_one, ptr[imm_addr64 + 0 * vlen]);
+
+    int outer_tail = jpp.outer_size % jpp.outer_block;
+    Label ou_loop_tail_label;
+    Label ou_loop_tail_1_label;
+    Label ou_loop_exit_label;
+
+    cmp(reg_work_amount, jpp.outer_block);
+    jne(ou_loop_tail_label, T_NEAR);
+
+    dense_loop(jpp.outer_block);
+
+    jmp(ou_loop_exit_label, T_NEAR);
+
+    L(ou_loop_tail_label);
+    cmp(reg_work_amount, outer_tail);
+    jne(ou_loop_tail_1_label, T_NEAR);
+
+    dense_loop(outer_tail);
+
+    jmp(ou_loop_exit_label, T_NEAR);
+
+    L(ou_loop_tail_1_label); {
+        cmp(reg_work_amount, 1);
+        jl(ou_loop_exit_label, T_NEAR);
+
+        dense_loop(1);
+
+        add(reg_src_base_ptr, jpp.dt_size * jpp.channels);
+        add(reg_dst_base_ptr, jpp.dt_size * jpp.channels);
+        dec(reg_work_amount);
+
+        jmp(ou_loop_tail_1_label, T_NEAR);
+    }
+
+    L(ou_loop_exit_label);
+
+    this->postamble();
+
+    prepare_table();
+}
+
+template struct jit_softmax_fork_kernel_f32<sse41>;
+template struct jit_softmax_fork_kernel_f32<avx2>;
+template struct jit_softmax_fork_kernel_f32<avx512_core>;
+
+}
+}
+}
+}

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_softmax_fork_kernel_f32.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_softmax_fork_kernel_f32.cpp
@@ -1,47 +1,52 @@
-/*******************************************************************************
-* Copyright 2019-2020 Intel Corporation
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*******************************************************************************/
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
 
-#include "cpu/x64/jit_generator.hpp"
 #include "jit_softmax_fork_kernel_f32.hpp"
 
-namespace dnnl {
-namespace impl {
-namespace cpu {
-namespace x64 {
+#include <xbyak/xbyak.h>
+
+#include <cassert>
+#include <cfloat>
+#include <common/c_types_map.hpp>
+#include <common/memory_desc_wrapper.hpp>
+#include <common/nstl.hpp>
+#include <common/opdesc.hpp>
+#include <common/utils.hpp>
+#include <cpu/x64/cpu_isa_traits.hpp>
+#include <cpu/x64/jit_avx512_core_bf16cvt.hpp>
+#include <cpu/x64/jit_generator.hpp>
+#include <cstddef>
+#include <memory>
+
+namespace dnnl::impl::cpu::x64 {
 
 using namespace Xbyak;
 
 #define GET_OFF(field) offsetof(jit_softmax_call_s, field)
 
-template<cpu_isa_t isa>
+template <cpu_isa_t isa>
 jit_softmax_fork_kernel_f32<isa>::jit_softmax_fork_kernel_f32(jit_softmax_conf_t ajpp)
-    : jit_generator_t(jit_name(), isa), jpp(ajpp) {
+    : jit_generator_t(jit_name(), isa),
+      jpp(ajpp) {
     if (jpp.dt == data_type::bf16 && !mayiuse(avx512_core_bf16)) {
-        bf16_emu_.reset(new bf16_emulation_t(this, bf16_emu_zmm_1, bf16_emu_zmm_2, bf16_emu_zmm_3,
-                                             bf16_emu_gpr, bf16_emu_zmm_4, bf16_emu_zmm_5));
+        bf16_emu_ = std::make_unique<bf16_emulation_t>(this,
+                                                       bf16_emu_zmm_1,
+                                                       bf16_emu_zmm_2,
+                                                       bf16_emu_zmm_3,
+                                                       bf16_emu_gpr,
+                                                       bf16_emu_zmm_4,
+                                                       bf16_emu_zmm_5);
     }
 }
 
-
 template <cpu_isa_t isa>
-status_t jit_softmax_fork_kernel_f32<isa>::init_conf(jit_softmax_conf_t &jpp,
-                   const softmax_desc_t &pd, const memory_desc_wrapper &src_d,
-                   const memory_desc_wrapper &dst_d) {
+status_t jit_softmax_fork_kernel_f32<isa>::init_conf(jit_softmax_conf_t& jpp,
+                                                     const softmax_desc_t& pd,
+                                                     const memory_desc_wrapper& src_d,
+                                                     [[maybe_unused]] const memory_desc_wrapper& dst_d) {
     auto ndims = pd.src_desc.ndims;
-    auto dims = pd.src_desc.dims;
+    const auto* dims = pd.src_desc.dims;
     auto axis = pd.softmax_axis;
 
     jpp.dt = src_d.data_type();
@@ -53,12 +58,12 @@ status_t jit_softmax_fork_kernel_f32<isa>::init_conf(jit_softmax_conf_t &jpp,
         if (isa != avx512_core) {
             return status::unimplemented;
         }
-        else if (!mayiuse(avx512_core_bf16)) {
-            nregs -= 5; // reserved for the bf16 emulator
+        if (!mayiuse(avx512_core_bf16)) {
+            nregs -= 5;  // reserved for the bf16 emulator
         }
     }
 
-    size_t aux_simd_registers = 5; // 3 aux for exp + one + (-FTL_MAX)
+    size_t aux_simd_registers = 5;  // 3 aux for exp + one + (-FTL_MAX)
     size_t regs_for_one_unroll = 2;
     size_t max_inner_unroll = (nregs - aux_simd_registers) / regs_for_one_unroll;
     size_t max_channels_unroll = 4;
@@ -92,17 +97,17 @@ status_t jit_softmax_fork_kernel_f32<isa>::init_conf(jit_softmax_conf_t &jpp,
 
 template <cpu_isa_t isa>
 int jit_softmax_fork_kernel_f32<isa>::id_vreg_max(int ur_inner) {
-    return 5+ur_inner;
+    return 5 + ur_inner;
 }
 
 template <cpu_isa_t isa>
 int jit_softmax_fork_kernel_f32<isa>::id_vreg_denom(int ur_inner) {
-    return 5+jpp.ur_inner + ur_inner;
+    return 5 + jpp.ur_inner + ur_inner;
 }
 
 template <cpu_isa_t isa>
-int jit_softmax_fork_kernel_f32<isa>::id_vreg_src(int ur_inner) {
-    return 5+2*jpp.ur_inner;
+int jit_softmax_fork_kernel_f32<isa>::id_vreg_src([[maybe_unused]] int ur_inner) {
+    return 5 + 2 * jpp.ur_inner;
 }
 
 template <cpu_isa_t isa>
@@ -121,106 +126,108 @@ auto jit_softmax_fork_kernel_f32<isa>::vreg_src(int ur_inner) -> Vmm {
 }
 
 template <cpu_isa_t isa>
-void jit_softmax_fork_kernel_f32<isa>::load_vector(Vmm vmm_src_, const Xbyak::Address &op) {
+void jit_softmax_fork_kernel_f32<isa>::load_vector(Vmm vmm_src_, const Xbyak::Address& op) {
     switch (jpp.dt) {
-        case data_type::f32:
-            uni_vmovups(vmm_src_, op);
-            break;
-        case data_type::bf16:
-            uni_vpmovzxwd(vmm_src_, op);
-            uni_vpslld(vmm_src_, vmm_src_, 16);
-            break;
-        default:
-            assert(!"unknown data type");
+    case data_type::f32:
+        uni_vmovups(vmm_src_, op);
+        break;
+    case data_type::bf16:
+        uni_vpmovzxwd(vmm_src_, op);
+        uni_vpslld(vmm_src_, vmm_src_, 16);
+        break;
+    default:
+        assert(!"unknown data type");
     }
 }
 
 template <cpu_isa_t isa>
-void jit_softmax_fork_kernel_f32<isa>::load_scalar(Xmm xmm_src_, const Xbyak::Address &op) {
+void jit_softmax_fork_kernel_f32<isa>::load_scalar(Xmm xmm_src_, const Xbyak::Address& op) {
     switch (jpp.dt) {
-        case data_type::f32:
-            movss(xmm_src_, op);
-            break;
-        case data_type::bf16:
-            pinsrw(xmm_src_, op, 0x0);
-            uni_vpslld(xmm_src_, xmm_src_, 16);
-            break;
-        default:
-            assert(!"unknown data type");
+    case data_type::f32:
+        movss(xmm_src_, op);
+        break;
+    case data_type::bf16:
+        pinsrw(xmm_src_, op, 0x0);
+        uni_vpslld(xmm_src_, xmm_src_, 16);
+        break;
+    default:
+        assert(!"unknown data type");
     }
 }
 
 template <cpu_isa_t isa>
-void jit_softmax_fork_kernel_f32<isa>::store_vector(const Xbyak::Address &op, Vmm vmm_dst_) {
-    Ymm ymm_dst_ = Ymm(vmm_dst_.getIdx());
+void jit_softmax_fork_kernel_f32<isa>::store_vector(const Xbyak::Address& op, Vmm vmm_dst_) {
+    auto ymm_dst_ = Ymm(vmm_dst_.getIdx());
     switch (jpp.dt) {
-        case data_type::f32:
-            uni_vmovups(op, vmm_dst_);
-            break;
-        case data_type::bf16:
-            if (mayiuse(avx512_core_bf16))
-                vcvtneps2bf16(ymm_dst_, vmm_dst_);
-            else
-                bf16_emu_->vcvtneps2bf16(ymm_dst_, Zmm(vmm_dst_.getIdx()));
-            vmovdqu16(op, ymm_dst_);
-            break;
-        default:
-            assert(!"unknown data type");
+    case data_type::f32:
+        uni_vmovups(op, vmm_dst_);
+        break;
+    case data_type::bf16:
+        if (mayiuse(avx512_core_bf16)) {
+            vcvtneps2bf16(ymm_dst_, vmm_dst_);
+        } else {
+            bf16_emu_->vcvtneps2bf16(ymm_dst_, Zmm(vmm_dst_.getIdx()));
+        }
+        vmovdqu16(op, ymm_dst_);
+        break;
+    default:
+        assert(!"unknown data type");
     }
 }
 
 template <cpu_isa_t isa>
-void jit_softmax_fork_kernel_f32<isa>::store_scalar(const Xbyak::Address &op, Xmm xmm_dst_) {
+void jit_softmax_fork_kernel_f32<isa>::store_scalar(const Xbyak::Address& op, Xmm xmm_dst_) {
     switch (jpp.dt) {
-        case data_type::f32:
-            movss(op, xmm_dst_);
-            break;
-        case data_type::bf16:
-            if (mayiuse(avx512_core_bf16))
-                vcvtneps2bf16(xmm_dst_, xmm_dst_);
-            else
-                bf16_emu_->vcvtneps2bf16(xmm_dst_, Ymm(xmm_dst_.getIdx()));
-            pextrw(op, xmm_dst_, 0x0);
-            break;
-        default:
-            assert(!"unknown dst_dt");
+    case data_type::f32:
+        movss(op, xmm_dst_);
+        break;
+    case data_type::bf16:
+        if (mayiuse(avx512_core_bf16)) {
+            vcvtneps2bf16(xmm_dst_, xmm_dst_);
+        } else {
+            bf16_emu_->vcvtneps2bf16(xmm_dst_, Ymm(xmm_dst_.getIdx()));
+        }
+        pextrw(op, xmm_dst_, 0x0);
+        break;
+    default:
+        assert(!"unknown dst_dt");
     }
 }
 
 template <cpu_isa_t isa>
 void jit_softmax_fork_kernel_f32<isa>::prepare_table() {
     const unsigned int cvals[] = {
-            0x3f800000, // [0] 1.0f
-            0x3f000000, // [1] 0.5f
-            0x3fb8aa3b, // [2] log2ef = 1.44269502f
-            0x3f317218, // [3] ln2f =   0.69314718f
-            0x0000007f, // [4] 0x7f
-            // exp(x) polynom
-            0x3f800001, // [5] p0 = 1.0000001f
-            0x3efffe85, // [6] p2 = 0.4999887f
-            0x3e2aaa3e, // [7] p3 = 0.16666505f
-            0x3d2bb1b1, // [8] p4 = 0.041917507f
-            0x3c091ec1, // [9] p5 = 0.008369149f
-            0x42b0c0a5, //[10] max logf = 88.3762589f
-            0xc1766666  //[11] min logf = -14.5f
+        0x3f800000,  // [0] 1.0f
+        0x3f000000,  // [1] 0.5f
+        0x3fb8aa3b,  // [2] log2ef = 1.44269502f
+        0x3f317218,  // [3] ln2f =   0.69314718f
+        0x0000007f,  // [4] 0x7f
+        // exp(x) polynom
+        0x3f800001,  // [5] p0 = 1.0000001f
+        0x3efffe85,  // [6] p2 = 0.4999887f
+        0x3e2aaa3e,  // [7] p3 = 0.16666505f
+        0x3d2bb1b1,  // [8] p4 = 0.041917507f
+        0x3c091ec1,  // [9] p5 = 0.008369149f
+        0x42b0c0a5,  //[10] max logf = 88.3762589f
+        0xc1766666   //[11] min logf = -14.5f
     };
 
     align(64);
     L(l_table);
-    for (size_t i = 0; i < sizeof(cvals) / sizeof(cvals[0]); ++i) {
+    for (const auto cval : cvals) {
         for (size_t d = 0; d < vlen / sizeof(float); ++d) {
-            dd(cvals[i]);
+            dd(cval);
         }
     }
 }
 
 template <cpu_isa_t isa>
-void jit_softmax_fork_kernel_f32<isa>::simd_expf(const Vmm &vmm_src) {
+void jit_softmax_fork_kernel_f32<isa>::simd_expf(const Vmm& vmm_src) {
     uni_vminps(vmm_src, vmm_src, ptr[imm_addr64 + 10 * vlen]);
     uni_vmaxps(vmm_src, vmm_src, ptr[imm_addr64 + 11 * vlen]);
     uni_vmovups(vmm_aux0, vmm_src);
-    //calculate exp(x)
-    // fx = x * log2ef + 0.5
+    // calculate exp(x)
+    //  fx = x * log2ef + 0.5
     uni_vmulps(vmm_src, vmm_src, ptr[imm_addr64 + 2 * vlen]);
     uni_vaddps(vmm_src, vmm_src, ptr[imm_addr64 + 1 * vlen]);
 
@@ -236,14 +243,14 @@ void jit_softmax_fork_kernel_f32<isa>::simd_expf(const Vmm &vmm_src) {
 
         uni_vsubps(vmm_aux1, vmm_aux1, vmm_aux2);
     }
-    //keep fx for further computations
-    uni_vmovups(vmm_src, vmm_aux1); //vmm_src = fx
+    // keep fx for further computations
+    uni_vmovups(vmm_src, vmm_aux1);  // vmm_src = fx
     // compute 2^n
     uni_vcvtps2dq(vmm_aux2, vmm_src);
     uni_vpaddd(vmm_aux2, vmm_aux2, ptr[imm_addr64 + 4 * vlen]);
-    uni_vpslld(vmm_aux2, vmm_aux2, 23); //Vmm(6) = 2^-fx
+    uni_vpslld(vmm_aux2, vmm_aux2, 23);  // Vmm(6) = 2^-fx
 
-    //x = x - fx * ln2
+    // x = x - fx * ln2
     uni_vfnmadd231ps(vmm_aux0, vmm_aux1, ptr[imm_addr64 + 3 * vlen]);
     // y = p5
     uni_vmovups(vmm_src, ptr[imm_addr64 + 9 * vlen]);
@@ -256,32 +263,32 @@ void jit_softmax_fork_kernel_f32<isa>::simd_expf(const Vmm &vmm_src) {
     // y = y * x + p1
     uni_vfmadd213ps(vmm_src, vmm_aux0, vmm_one);
     // y = y * x + p0
-    uni_vfmadd213ps(vmm_src, vmm_aux0, ptr[imm_addr64 + 5 * vlen]);  //exp(q)
+    uni_vfmadd213ps(vmm_src, vmm_aux0, ptr[imm_addr64 + 5 * vlen]);  // exp(q)
     // y = y * 2^n
     uni_vmulps(vmm_src, vmm_src, vmm_aux2);
 }
 
 template <cpu_isa_t isa>
-void jit_softmax_fork_kernel_f32<isa>::scalar_expf(const Xmm &xmm_src) {
+void jit_softmax_fork_kernel_f32<isa>::scalar_expf(const Xmm& xmm_src) {
     minss(xmm_src, ptr[imm_addr64 + 10 * vlen]);
     maxss(xmm_src, ptr[imm_addr64 + 11 * vlen]);
     movups(xmm_aux0, xmm_src);
-    //calculate exp(x)
-    // fx = x * log2ef + 0.5
+    // calculate exp(x)
+    //  fx = x * log2ef + 0.5
     mulss(xmm_src, ptr[imm_addr64 + 2 * vlen]);
     addss(xmm_src, ptr[imm_addr64 + 1 * vlen]);
     // tmp = floorf(fx)
     roundss(xmm_aux1, xmm_src, _op_floor);
-    //keep fx for further computations
-    movups(xmm_src, xmm_aux1); //xmm_src = fx
+    // keep fx for further computations
+    movups(xmm_src, xmm_aux1);  // xmm_src = fx
     // compute 2^n
     cvtps2dq(xmm_aux2, xmm_src);
     paddd(xmm_aux2, ptr[imm_addr64 + 4 * vlen]);
-    pslld(xmm_aux2, 23); //Xmm(6) = 2^-fx
+    pslld(xmm_aux2, 23);  // Xmm(6) = 2^-fx
 
-    //calculation fx * ln2
+    // calculation fx * ln2
     mulss(xmm_aux1, ptr[imm_addr64 + 3 * vlen]);
-    //x = x - fx * ln2
+    // x = x - fx * ln2
     subss(xmm_aux0, xmm_aux1);
     // y = p5
     movups(xmm_src, ptr[imm_addr64 + 9 * vlen]);
@@ -302,7 +309,7 @@ void jit_softmax_fork_kernel_f32<isa>::scalar_expf(const Xmm &xmm_src) {
 
     // y = y * x + p0
     mulss(xmm_src, xmm_aux0);
-    addss(xmm_src, ptr[imm_addr64 + 5 * vlen]); //exp(q)
+    addss(xmm_src, ptr[imm_addr64 + 5 * vlen]);  // exp(q)
 
     // y = y * 2^n
     mulps(xmm_src, xmm_aux2);
@@ -321,13 +328,14 @@ void jit_softmax_fork_kernel_f32<isa>::simd_loop_max(int ur_inner) {
     mov(reg_ch_work, reg_channels);
     mov(reg_src_ptr, reg_src_base_ptr);
 
-    L(loop_channel_blocks); {
+    L(loop_channel_blocks);
+    {
         cmp(reg_ch_work, jpp.ur_channel);
         jl(loop_channel_tail, T_NEAR);
 
         for (int i = 0; i < ur_inner; ++i) {
-            for (int c = 0; c < (int)jpp.ur_channel; ++c) {
-                load_vector(vreg_src(i), ptr[reg_src_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size]);
+            for (int c = 0; c < static_cast<int>(jpp.ur_channel); ++c) {
+                load_vector(vreg_src(i), ptr[reg_src_ptr + (i * simd_w + c * jpp.inner_size) * jpp.dt_size]);
                 uni_vmaxps(vreg_max(i), vreg_max(i), vreg_src(i));
             }
         }
@@ -338,7 +346,8 @@ void jit_softmax_fork_kernel_f32<isa>::simd_loop_max(int ur_inner) {
         jmp(loop_channel_blocks, T_NEAR);
     }
 
-    L(loop_channel_tail); {
+    L(loop_channel_tail);
+    {
         cmp(reg_ch_work, 0);
         jle(loop_channel_end, T_NEAR);
 
@@ -371,17 +380,18 @@ void jit_softmax_fork_kernel_f32<isa>::simd_loop_exp(int ur_inner) {
     mov(reg_src_ptr, reg_src_base_ptr);
     mov(reg_dst_ptr, reg_dst_base_ptr);
 
-    L(loop_channel_blocks); {
+    L(loop_channel_blocks);
+    {
         cmp(reg_ch_work, jpp.ur_channel);
         jl(loop_channel_tail, T_NEAR);
 
         for (int i = 0; i < ur_inner; ++i) {
-            for (int c = 0; c < (int)jpp.ur_channel; ++c) {
-                load_vector(vreg_src(i), ptr[reg_src_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size]);
-                uni_vsubps(vreg_src(i),vreg_src(i), vreg_max(i));
+            for (int c = 0; c < static_cast<int>(jpp.ur_channel); ++c) {
+                load_vector(vreg_src(i), ptr[reg_src_ptr + (i * simd_w + c * jpp.inner_size) * jpp.dt_size]);
+                uni_vsubps(vreg_src(i), vreg_src(i), vreg_max(i));
                 simd_expf(vreg_src(i));
                 uni_vaddps(vreg_denom(i), vreg_denom(i), vreg_src(i));
-                store_vector(ptr[reg_dst_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size], vreg_src(i));
+                store_vector(ptr[reg_dst_ptr + (i * simd_w + c * jpp.inner_size) * jpp.dt_size], vreg_src(i));
             }
         }
 
@@ -392,7 +402,8 @@ void jit_softmax_fork_kernel_f32<isa>::simd_loop_exp(int ur_inner) {
         jmp(loop_channel_blocks, T_NEAR);
     }
 
-    L(loop_channel_tail); {
+    L(loop_channel_tail);
+    {
         cmp(reg_ch_work, 0);
         jle(loop_channel_end, T_NEAR);
 
@@ -413,7 +424,6 @@ void jit_softmax_fork_kernel_f32<isa>::simd_loop_exp(int ur_inner) {
 
     L(loop_channel_end);
 }
-
 
 template <cpu_isa_t isa>
 void jit_softmax_fork_kernel_f32<isa>::simd_loop_div(int ur_inner) {
@@ -436,15 +446,16 @@ void jit_softmax_fork_kernel_f32<isa>::simd_loop_div(int ur_inner) {
     mov(reg_src_ptr, reg_src_base_ptr);
     mov(reg_dst_ptr, reg_dst_base_ptr);
 
-    L(loop_channel_blocks); {
+    L(loop_channel_blocks);
+    {
         cmp(reg_ch_work, jpp.ur_channel);
         jl(loop_channel_tail, T_NEAR);
 
         for (int i = 0; i < ur_inner; ++i) {
-            for (int c = 0; c < (int)jpp.ur_channel; ++c) {
-                load_vector(vreg_src(i), ptr[reg_dst_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size]);
+            for (int c = 0; c < static_cast<int>(jpp.ur_channel); ++c) {
+                load_vector(vreg_src(i), ptr[reg_dst_ptr + (i * simd_w + c * jpp.inner_size) * jpp.dt_size]);
                 uni_vmulps(vreg_src(i), vreg_src(i), vreg_denom(i));
-                store_vector(ptr[reg_dst_ptr + (i*simd_w + c*jpp.inner_size) * jpp.dt_size], vreg_src(i));
+                store_vector(ptr[reg_dst_ptr + (i * simd_w + c * jpp.inner_size) * jpp.dt_size], vreg_src(i));
             }
         }
 
@@ -455,7 +466,8 @@ void jit_softmax_fork_kernel_f32<isa>::simd_loop_div(int ur_inner) {
         jmp(loop_channel_blocks, T_NEAR);
     }
 
-    L(loop_channel_tail); {
+    L(loop_channel_tail);
+    {
         cmp(reg_ch_work, 0);
         jle(loop_channel_end, T_NEAR);
 
@@ -484,7 +496,8 @@ void jit_softmax_fork_kernel_f32<isa>::scalar_loop_max() {
     mov(reg_src_ptr, reg_src_base_ptr);
     mov(reg_ch_work, reg_channels);
 
-    L(loop_channel_tail); {
+    L(loop_channel_tail);
+    {
         cmp(reg_ch_work, 0);
         jle(loop_channel_end, T_NEAR);
 
@@ -512,7 +525,8 @@ void jit_softmax_fork_kernel_f32<isa>::scalar_loop_exp() {
 
     pxor(xmm_denom, xmm_denom);
 
-    L(loop_channel_tail); {
+    L(loop_channel_tail);
+    {
         cmp(reg_ch_work, 0);
         jle(loop_channel_end, T_NEAR);
 
@@ -541,7 +555,8 @@ void jit_softmax_fork_kernel_f32<isa>::scalar_loop_div() {
     mov(reg_dst_ptr, reg_dst_base_ptr);
     mov(reg_ch_work, reg_channels);
 
-    L(loop_channel_tail); {
+    L(loop_channel_tail);
+    {
         cmp(reg_ch_work, 0);
         jle(loop_channel_end, T_NEAR);
 
@@ -563,19 +578,19 @@ template <cpu_isa_t isa>
 void jit_softmax_fork_kernel_f32<isa>::dense_loop(int ou_block) {
     for (int ou = 0; ou < ou_block; ou++) {
         movups(xmm_max, xmm_float_min);
-        for (int ch = 0; ch < (int)jpp.channels; ch++) {
+        for (int ch = 0; ch < static_cast<int>(jpp.channels); ch++) {
             load_scalar(xmm_src, ptr[reg_src_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size]);
             maxss(xmm_max, xmm_src);
         }
 
-        for (int ch = 0; ch < (int)jpp.channels; ch++) {
+        for (int ch = 0; ch < static_cast<int>(jpp.channels); ch++) {
             load_scalar(xmm_src, ptr[reg_src_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size]);
             subss(xmm_src, xmm_max);
             store_scalar(ptr[reg_dst_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size], xmm_src);
         }
     }
 
-    int full_work = ou_block * (int)jpp.channels;
+    int full_work = ou_block * static_cast<int>(jpp.channels);
     int i = 0;
     for (; i <= full_work - simd_w; i += simd_w) {
         load_vector(vreg_src(0), ptr[reg_dst_base_ptr + i * jpp.dt_size]);
@@ -591,7 +606,7 @@ void jit_softmax_fork_kernel_f32<isa>::dense_loop(int ou_block) {
 
     for (int ou = 0; ou < ou_block; ou++) {
         pxor(xmm_denom, xmm_denom);
-        for (int ch = 0; ch < (int)jpp.channels; ch++) {
+        for (int ch = 0; ch < static_cast<int>(jpp.channels); ch++) {
             load_scalar(xmm_src, ptr[reg_dst_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size]);
             addss(xmm_denom, xmm_src);
         }
@@ -599,7 +614,7 @@ void jit_softmax_fork_kernel_f32<isa>::dense_loop(int ou_block) {
         movss(xmm_one, ptr[imm_addr64 + 0 * vlen]);
         divss(xmm_one, xmm_denom);
         movss(xmm_denom, xmm_one);
-        for (int ch = 0; ch < (int)jpp.channels; ch++) {
+        for (int ch = 0; ch < static_cast<int>(jpp.channels); ch++) {
             load_scalar(xmm_src, ptr[reg_dst_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size]);
             mulss(xmm_src, xmm_denom);
             store_scalar(ptr[reg_dst_base_ptr + (ou * jpp.channels + ch) * jpp.dt_size], xmm_src);
@@ -610,7 +625,9 @@ void jit_softmax_fork_kernel_f32<isa>::dense_loop(int ou_block) {
 template <cpu_isa_t isa>
 void jit_softmax_fork_kernel_f32<isa>::generate() {
     this->preamble();
-    if (bf16_emu_) bf16_emu_->init_vcvtneps2bf16();
+    if (bf16_emu_) {
+        bf16_emu_->init_vcvtneps2bf16();
+    }
 
     if (jpp.inner_size == 1) {
         this->generate_dense();
@@ -715,7 +732,8 @@ void jit_softmax_fork_kernel_f32<isa>::generate_dense() {
 
     jmp(ou_loop_exit_label, T_NEAR);
 
-    L(ou_loop_tail_1_label); {
+    L(ou_loop_tail_1_label);
+    {
         cmp(reg_work_amount, 1);
         jl(ou_loop_exit_label, T_NEAR);
 
@@ -739,7 +757,4 @@ template struct jit_softmax_fork_kernel_f32<sse41>;
 template struct jit_softmax_fork_kernel_f32<avx2>;
 template struct jit_softmax_fork_kernel_f32<avx512_core>;
 
-}
-}
-}
-}
+}  // namespace dnnl::impl::cpu::x64

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_softmax_fork_kernel_f32.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_softmax_fork_kernel_f32.hpp
@@ -1,0 +1,153 @@
+/*******************************************************************************
+* Copyright 2019-2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef OV_CPU_X64_JIT_SOFTMAX_FORK_KERNEL_HPP
+#define OV_CPU_X64_JIT_SOFTMAX_FORK_KERNEL_HPP
+
+#include <cfloat>
+
+#include "common/memory_desc_wrapper.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/jit_generator.hpp"
+#include "cpu/x64/jit_avx512_core_bf16cvt.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+
+using namespace Xbyak;
+
+struct jit_softmax_conf_t {
+    size_t outer_size = 0;
+    size_t channels = 0;
+    size_t inner_size = 0;
+    size_t ur_channel = 0;
+    size_t ur_inner = 0;
+    size_t outer_block = 0;
+    size_t dt_size = 0;
+    data_type_t dt = data_type::undef;
+};
+
+struct jit_softmax_call_s {
+    const uint8_t* src = nullptr;
+    uint8_t* dst = nullptr;
+
+    size_t channels = 0;
+    size_t work = 0;
+};
+
+template <cpu_isa_t isa>
+struct jit_softmax_fork_kernel_f32 : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_softmax_kernel_f32)
+    using Vmm = typename utils::conditional3<isa == sse41, Xmm,
+            isa == avx2, Ymm, Zmm>::type;
+
+    jit_softmax_fork_kernel_f32(jit_softmax_conf_t ajpp);
+
+    jit_softmax_conf_t jpp;
+
+    static status_t init_conf(jit_softmax_conf_t &jpp,
+                       const softmax_desc_t &pd,
+                       const memory_desc_wrapper &src_d,
+                       const memory_desc_wrapper &dst_d);
+
+    void prepare_table();
+    void simd_expf(const Vmm &vmm_src);
+    void scalar_expf(const Xmm &xmm_src);
+
+    void simd_loop_max(int ur_inner);
+    void simd_loop_exp(int ur_inner);
+    void simd_loop_div(int ur_inner);
+
+    void scalar_loop_max();
+    void scalar_loop_exp();
+    void scalar_loop_div();
+
+    void dense_loop(int ou_block);
+    void generate_dense();
+private:
+    const int simd_w = cpu_isa_traits_t<isa>::vlen / sizeof(float);
+    const int vlen = cpu_isa_traits_t<isa>::vlen;
+
+    Reg64 reg_work_amount   = rax;
+    Reg64 reg_src_base_ptr  = rbx;
+    Reg64 reg_dst_base_ptr  = rsi;
+    Reg64 reg_src_ptr       = r8;
+    Reg64 reg_dst_ptr       = r9;
+    Reg64 reg_channels      = r12;
+    Reg64 reg_ch_work       = r13;
+    Reg64 reg_min           = rdx;
+    Reg64 imm_addr64        = r14;
+    Reg64 bf16_emu_gpr      = r15;
+
+    Vmm vmm_aux0            = Vmm(0);
+    Vmm vmm_aux1            = Vmm(1);
+    Vmm vmm_aux2            = Vmm(2);
+    Xmm xmm_aux0            = Xmm(0);
+    Xmm xmm_aux1            = Xmm(1);
+    Xmm xmm_aux2            = Xmm(2);
+
+    Xmm xmm_float_min       = Xmm(3);
+    Xmm xmm_one             = Xmm(4);
+    Vmm vmm_one             = Vmm(4);
+
+    Xmm xmm_max             = Xmm(5);
+    Xmm xmm_denom           = Xmm(6);
+    Xmm xmm_src             = Xmm(7);
+
+    Zmm bf16_emu_zmm_1      = Zmm(27);
+    Zmm bf16_emu_zmm_2      = Zmm(28);
+    Zmm bf16_emu_zmm_3      = Zmm(29);
+    Zmm bf16_emu_zmm_4      = Zmm(30);
+    Zmm bf16_emu_zmm_5      = Zmm(31);
+
+    Opmask k_mask_tmp       = Opmask(2);
+
+    unsigned char _cmp_gt_os = isa == avx512_core ? 14 : 6;
+
+    int id_vreg_max(int ur_inner);
+    int id_vreg_denom(int ur_inner);
+    int id_vreg_src(int ur_inner);
+
+    auto vreg_max(int ur_inner) -> Vmm;
+    auto vreg_denom(int ur_inner) -> Vmm;
+    auto vreg_src(int ur_inner) -> Vmm;
+
+    void load_vector(Vmm vmm_src, const Xbyak::Address &op);
+    void load_scalar(Xmm xmm_src, const Xbyak::Address &op);
+    void store_vector(const Xbyak::Address &op, Vmm vmm_dst);
+    void store_scalar(const Xbyak::Address &op, Xmm xmm_dst);
+
+    Label loop_simd_unroll;
+    Label loop_simd;
+    Label loop_scalar;
+    Label loop_end;
+    Label l_table;
+
+    std::unique_ptr<bf16_emulation_t> bf16_emu_;
+
+    unsigned char _op_floor = 1;
+
+    void generate() override;
+};
+
+}
+}
+}
+}
+
+#endif

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_softmax_fork_kernel_f32.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_softmax_fork_kernel_f32.hpp
@@ -1,18 +1,6 @@
-/*******************************************************************************
-* Copyright 2019-2020 Intel Corporation
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*******************************************************************************/
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
 
 #ifndef OV_CPU_X64_JIT_SOFTMAX_FORK_KERNEL_HPP
 #define OV_CPU_X64_JIT_SOFTMAX_FORK_KERNEL_HPP
@@ -21,13 +9,10 @@
 
 #include "common/memory_desc_wrapper.hpp"
 #include "cpu/x64/cpu_isa_traits.hpp"
-#include "cpu/x64/jit_generator.hpp"
 #include "cpu/x64/jit_avx512_core_bf16cvt.hpp"
+#include "cpu/x64/jit_generator.hpp"
 
-namespace dnnl {
-namespace impl {
-namespace cpu {
-namespace x64 {
+namespace dnnl::impl::cpu::x64 {
 
 using namespace Xbyak;
 
@@ -53,21 +38,20 @@ struct jit_softmax_call_s {
 template <cpu_isa_t isa>
 struct jit_softmax_fork_kernel_f32 : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_softmax_kernel_f32)
-    using Vmm = typename utils::conditional3<isa == sse41, Xmm,
-            isa == avx2, Ymm, Zmm>::type;
+    using Vmm = typename utils::conditional3<isa == sse41, Xmm, isa == avx2, Ymm, Zmm>::type;
 
     jit_softmax_fork_kernel_f32(jit_softmax_conf_t ajpp);
 
     jit_softmax_conf_t jpp;
 
-    static status_t init_conf(jit_softmax_conf_t &jpp,
-                       const softmax_desc_t &pd,
-                       const memory_desc_wrapper &src_d,
-                       const memory_desc_wrapper &dst_d);
+    static status_t init_conf(jit_softmax_conf_t& jpp,
+                              const softmax_desc_t& pd,
+                              const memory_desc_wrapper& src_d,
+                              const memory_desc_wrapper& dst_d);
 
     void prepare_table();
-    void simd_expf(const Vmm &vmm_src);
-    void scalar_expf(const Xmm &xmm_src);
+    void simd_expf(const Vmm& vmm_src);
+    void scalar_expf(const Xmm& xmm_src);
 
     void simd_loop_max(int ur_inner);
     void simd_loop_exp(int ur_inner);
@@ -79,43 +63,44 @@ struct jit_softmax_fork_kernel_f32 : public jit_generator_t {
 
     void dense_loop(int ou_block);
     void generate_dense();
+
 private:
     const int simd_w = cpu_isa_traits_t<isa>::vlen / sizeof(float);
     const int vlen = cpu_isa_traits_t<isa>::vlen;
 
-    Reg64 reg_work_amount   = rax;
-    Reg64 reg_src_base_ptr  = rbx;
-    Reg64 reg_dst_base_ptr  = rsi;
-    Reg64 reg_src_ptr       = r8;
-    Reg64 reg_dst_ptr       = r9;
-    Reg64 reg_channels      = r12;
-    Reg64 reg_ch_work       = r13;
-    Reg64 reg_min           = rdx;
-    Reg64 imm_addr64        = r14;
-    Reg64 bf16_emu_gpr      = r15;
+    Reg64 reg_work_amount = rax;
+    Reg64 reg_src_base_ptr = rbx;
+    Reg64 reg_dst_base_ptr = rsi;
+    Reg64 reg_src_ptr = r8;
+    Reg64 reg_dst_ptr = r9;
+    Reg64 reg_channels = r12;
+    Reg64 reg_ch_work = r13;
+    Reg64 reg_min = rdx;
+    Reg64 imm_addr64 = r14;
+    Reg64 bf16_emu_gpr = r15;
 
-    Vmm vmm_aux0            = Vmm(0);
-    Vmm vmm_aux1            = Vmm(1);
-    Vmm vmm_aux2            = Vmm(2);
-    Xmm xmm_aux0            = Xmm(0);
-    Xmm xmm_aux1            = Xmm(1);
-    Xmm xmm_aux2            = Xmm(2);
+    Vmm vmm_aux0 = Vmm(0);
+    Vmm vmm_aux1 = Vmm(1);
+    Vmm vmm_aux2 = Vmm(2);
+    Xmm xmm_aux0 = Xmm(0);
+    Xmm xmm_aux1 = Xmm(1);
+    Xmm xmm_aux2 = Xmm(2);
 
-    Xmm xmm_float_min       = Xmm(3);
-    Xmm xmm_one             = Xmm(4);
-    Vmm vmm_one             = Vmm(4);
+    Xmm xmm_float_min = Xmm(3);
+    Xmm xmm_one = Xmm(4);
+    Vmm vmm_one = Vmm(4);
 
-    Xmm xmm_max             = Xmm(5);
-    Xmm xmm_denom           = Xmm(6);
-    Xmm xmm_src             = Xmm(7);
+    Xmm xmm_max = Xmm(5);
+    Xmm xmm_denom = Xmm(6);
+    Xmm xmm_src = Xmm(7);
 
-    Zmm bf16_emu_zmm_1      = Zmm(27);
-    Zmm bf16_emu_zmm_2      = Zmm(28);
-    Zmm bf16_emu_zmm_3      = Zmm(29);
-    Zmm bf16_emu_zmm_4      = Zmm(30);
-    Zmm bf16_emu_zmm_5      = Zmm(31);
+    Zmm bf16_emu_zmm_1 = Zmm(27);
+    Zmm bf16_emu_zmm_2 = Zmm(28);
+    Zmm bf16_emu_zmm_3 = Zmm(29);
+    Zmm bf16_emu_zmm_4 = Zmm(30);
+    Zmm bf16_emu_zmm_5 = Zmm(31);
 
-    Opmask k_mask_tmp       = Opmask(2);
+    Opmask k_mask_tmp = Opmask(2);
 
     unsigned char _cmp_gt_os = isa == avx512_core ? 14 : 6;
 
@@ -127,10 +112,10 @@ private:
     auto vreg_denom(int ur_inner) -> Vmm;
     auto vreg_src(int ur_inner) -> Vmm;
 
-    void load_vector(Vmm vmm_src, const Xbyak::Address &op);
-    void load_scalar(Xmm xmm_src, const Xbyak::Address &op);
-    void store_vector(const Xbyak::Address &op, Vmm vmm_dst);
-    void store_scalar(const Xbyak::Address &op, Xmm xmm_dst);
+    void load_vector(Vmm vmm_src, const Xbyak::Address& op);
+    void load_scalar(Xmm xmm_src, const Xbyak::Address& op);
+    void store_vector(const Xbyak::Address& op, Vmm vmm_dst);
+    void store_scalar(const Xbyak::Address& op, Xmm xmm_dst);
 
     Label loop_simd_unroll;
     Label loop_simd;
@@ -145,9 +130,6 @@ private:
     void generate() override;
 };
 
-}
-}
-}
-}
+}  // namespace dnnl::impl::cpu::x64
 
 #endif

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -9,6 +9,7 @@
 
 #include <common/utils.hpp>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
@@ -181,6 +182,9 @@ void SoftMax::createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
 }
 
 void SoftMax::prepareParams() {
+    executionPath = ExecutionPath::OneDnn;
+    customJitExec.reset();
+
     auto inpDesc = getParentEdgeAt(0)->getMemory().getDescWithType<DnnlMemoryDesc>();
     const NodeDesc* selected_pd = getSelectedPrimitiveDescriptor();
 
@@ -229,6 +233,48 @@ void SoftMax::prepareParams() {
     execPtr = result.first;
     CPU_NODE_ASSERT(execPtr, "Primitive descriptor was not found.");
 
+    // Keep original priority semantics while allowing easy extension
+    // of fallback implementations by appending new factories.
+    const auto selectedImplType = execPtr->getImplementationType();
+    if (!(selectedImplType & jit)) {
+        const std::vector<std::function<bool()>> fallbackChain = {
+            [&]() {
+                return tryInitCustomJitExecutor(inpDesc);
+            },
+        };
+
+        for (const auto& fallback : fallbackChain) {
+            if (fallback()) {
+                return;
+            }
+        }
+    }
+
+    initOneDnnPrimitiveArgs();
+}
+
+bool SoftMax::tryInitCustomJitExecutor(const DnnlMemoryDescPtr& inpDesc) {
+    const auto inShape = getInputShapeAtPort(0);
+    if (!inShape.isStatic()) {
+        return false;
+    }
+
+    const auto& dims = inShape.getStaticDims();
+    const auto precision = getOriginalInputPrecisionAtPort(0);
+    auto customExec = std::make_unique<ov::intel_cpu::SoftmaxForkExecutor>(dims,
+                                                                            axis,
+                                                                            precision,
+                                                                            inpDesc->getDnnlDesc());
+    if (!customExec->isSupported() || customExec->init() != dnnl::impl::status::success) {
+        return false;
+    }
+
+    customJitExec = std::move(customExec);
+    executionPath = ExecutionPath::CustomJit;
+    return true;
+}
+
+void SoftMax::initOneDnnPrimitiveArgs() {
     auto scratchpadMem = getScratchPadMem(execPtr->getScratchPadDesc());
 
     primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->getPrimitive();
@@ -241,6 +287,14 @@ void SoftMax::prepareParams() {
 }
 
 void SoftMax::execute(const dnnl::stream& strm) {
+    if (executionPath == ExecutionPath::CustomJit) {
+        CPU_NODE_ASSERT(customJitExec, "Custom Softmax executor path selected but executor is not initialized");
+        const auto* src = getSrcDataAtPortAs<const uint8_t>(0);
+        auto* dst = getDstDataAtPortAs<uint8_t>(0);
+        customJitExec->execute(src, dst);
+        return;
+    }
+
     if (execPtr) {
         execPtr->exec(primArgs, strm);
     } else {

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -9,12 +9,12 @@
 
 #include <common/utils.hpp>
 #include <cstddef>
-#include <functional>
 #include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <shape_inference/shape_inference_pass_through.hpp>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/primitive_hashing_utils.hpp"
@@ -35,6 +35,13 @@
 #include "openvino/op/softmax.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
+
+#ifdef OPENVINO_ARCH_X86_64
+#    include <common/c_types_map.hpp>
+#    include <cstdint>
+
+#    include "nodes/executors/x64/softmax_fork_executor.hpp"
+#endif
 
 using namespace dnnl;
 
@@ -183,7 +190,9 @@ void SoftMax::createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
 
 void SoftMax::prepareParams() {
     executionPath = ExecutionPath::OneDnn;
+#ifdef OPENVINO_ARCH_X86_64
     customJitExec.reset();
+#endif
 
     auto inpDesc = getParentEdgeAt(0)->getMemory().getDescWithType<DnnlMemoryDesc>();
     const NodeDesc* selected_pd = getSelectedPrimitiveDescriptor();
@@ -236,23 +245,20 @@ void SoftMax::prepareParams() {
     // Keep original priority semantics while allowing easy extension
     // of fallback implementations by appending new factories.
     const auto selectedImplType = execPtr->getImplementationType();
+#ifdef OPENVINO_ARCH_X86_64
     if (!(selectedImplType & jit)) {
-        const std::vector<std::function<bool()>> fallbackChain = {
-            [&]() {
-                return tryInitCustomJitExecutor(inpDesc);
-            },
-        };
-
-        for (const auto& fallback : fallbackChain) {
-            if (fallback()) {
-                return;
-            }
+        if (tryInitCustomJitExecutor(inpDesc)) {
+            return;
         }
     }
+#else
+    (void)selectedImplType;
+#endif
 
     initOneDnnPrimitiveArgs();
 }
 
+#ifdef OPENVINO_ARCH_X86_64
 bool SoftMax::tryInitCustomJitExecutor(const DnnlMemoryDescPtr& inpDesc) {
     const auto inShape = getInputShapeAtPort(0);
     if (!inShape.isStatic()) {
@@ -261,10 +267,8 @@ bool SoftMax::tryInitCustomJitExecutor(const DnnlMemoryDescPtr& inpDesc) {
 
     const auto& dims = inShape.getStaticDims();
     const auto precision = getOriginalInputPrecisionAtPort(0);
-    auto customExec = std::make_unique<ov::intel_cpu::SoftmaxForkExecutor>(dims,
-                                                                            axis,
-                                                                            precision,
-                                                                            inpDesc->getDnnlDesc());
+    auto customExec =
+        std::make_unique<ov::intel_cpu::SoftmaxForkExecutor>(dims, axis, precision, inpDesc->getDnnlDesc());
     if (!customExec->isSupported() || customExec->init() != dnnl::impl::status::success) {
         return false;
     }
@@ -273,6 +277,7 @@ bool SoftMax::tryInitCustomJitExecutor(const DnnlMemoryDescPtr& inpDesc) {
     executionPath = ExecutionPath::CustomJit;
     return true;
 }
+#endif
 
 void SoftMax::initOneDnnPrimitiveArgs() {
     auto scratchpadMem = getScratchPadMem(execPtr->getScratchPadDesc());
@@ -287,6 +292,7 @@ void SoftMax::initOneDnnPrimitiveArgs() {
 }
 
 void SoftMax::execute(const dnnl::stream& strm) {
+#ifdef OPENVINO_ARCH_X86_64
     if (executionPath == ExecutionPath::CustomJit) {
         CPU_NODE_ASSERT(customJitExec, "Custom Softmax executor path selected but executor is not initialized");
         const auto* src = getSrcDataAtPortAs<const uint8_t>(0);
@@ -294,6 +300,7 @@ void SoftMax::execute(const dnnl::stream& strm) {
         customJitExec->execute(src, dst);
         return;
     }
+#endif
 
     if (execPtr) {
         execPtr->exec(primArgs, strm);

--- a/src/plugins/intel_cpu/src/nodes/softmax.h
+++ b/src/plugins/intel_cpu/src/nodes/softmax.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <cstddef>
-#include <functional>
+#include <cstdint>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
@@ -14,8 +14,12 @@
 #include "graph_context.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "node.h"
-#include "nodes/executors/x64/softmax_fork_executor.hpp"
 #include "openvino/core/node.hpp"
+#include "utils/arch_macros.h"
+
+#ifdef OPENVINO_ARCH_X86_64
+#    include "nodes/executors/x64/softmax_fork_executor.hpp"
+#endif
 
 namespace ov::intel_cpu::node {
 
@@ -36,17 +40,18 @@ public:
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 private:
-    enum class ExecutionPath {
-        OneDnn,
-        CustomJit
-    };
+    enum class ExecutionPath : std::uint8_t { OneDnn, CustomJit };
 
+#ifdef OPENVINO_ARCH_X86_64
     bool tryInitCustomJitExecutor(const DnnlMemoryDescPtr& inpDesc);
+#endif
     void initOneDnnPrimitiveArgs();
 
     using executorPtr = std::shared_ptr<DnnlExecutorLegacy>;
     executorPtr execPtr = nullptr;
+#ifdef OPENVINO_ARCH_X86_64
     std::unique_ptr<ov::intel_cpu::SoftmaxForkExecutor> customJitExec;
+#endif
     ExecutionPath executionPath = ExecutionPath::OneDnn;
     size_t axis = 0;
 };

--- a/src/plugins/intel_cpu/src/nodes/softmax.h
+++ b/src/plugins/intel_cpu/src/nodes/softmax.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
@@ -13,6 +14,7 @@
 #include "graph_context.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "node.h"
+#include "nodes/executors/x64/softmax_fork_executor.hpp"
 #include "openvino/core/node.hpp"
 
 namespace ov::intel_cpu::node {
@@ -34,8 +36,18 @@ public:
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 private:
+    enum class ExecutionPath {
+        OneDnn,
+        CustomJit
+    };
+
+    bool tryInitCustomJitExecutor(const DnnlMemoryDescPtr& inpDesc);
+    void initOneDnnPrimitiveArgs();
+
     using executorPtr = std::shared_ptr<DnnlExecutorLegacy>;
     executorPtr execPtr = nullptr;
+    std::unique_ptr<ov::intel_cpu::SoftmaxForkExecutor> customJitExec;
+    ExecutionPath executionPath = ExecutionPath::OneDnn;
     size_t axis = 0;
 };
 


### PR DESCRIPTION
### Details:
 - *move the forked softmax jit kernel to x64*
 - *revert patch https://github.com/openvinotoolkit/oneDNN/commit/a3ca91c4b783ff50823edac3dfa29c6afaa3a1ee*

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
