### PR TITLE
[GPU] Remove unused variable from CM PA generator

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
@@ -386,9 +386,8 @@ JitConstants PagedAttentionGeneratorMultiToken::get_jit_constants(const kernel_i
 }
 
 DispatchDataFunc PagedAttentionGeneratorMultiToken::get_dispatch_data_func() const {
-    const size_t xattn_block_size = _xattn_block_size;
     constexpr size_t wg_size = PagedAttentionGeneratorMultiToken::_wg_size;
-    return DispatchDataFunc{[xattn_block_size, wg_size](const RuntimeParams& params, KernelData& kd, ImplRuntimeParams* rt_params) {
+    return DispatchDataFunc{[wg_size](const RuntimeParams& params, KernelData& kd, ImplRuntimeParams* rt_params) {
         auto& wgs = kd.params.workGroups;
         auto& scalars = kd.params.scalars;
         auto desc = params.typed_desc<paged_attention>();


### PR DESCRIPTION
### Details:
In `PagedAttentionGeneratorMultiToken::get_dispatch_data_func()` there is an unused variable which triggers build error when `-Werror,-Wunused-lambda-capture` flags are set. In this PR the unused variable is removed.

### Tickets:
 - 186929

### AI Assistance:
 - *AI assistance used: no*
