### PR TITLE
Fix ACL baseline flags for AArch64 multi-ISA

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_async_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_async_infer_request.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 import numpy as np
 import pytest
 import time
-import platform
 
 import openvino.opset13 as ops
 from openvino import (
@@ -327,11 +326,6 @@ def test_start_async(device, share_inputs):
 ])
 @pytest.mark.parametrize("share_inputs", [True, False])
 def test_async_mixed_values(device, ov_type, numpy_dtype, share_inputs):
-    if share_inputs and ov_type == Type.i16 and numpy_dtype == np.int16 and (
-        platform.machine().lower() in {"aarch64", "arm64"}
-    ):
-        pytest.skip("Illegal instruction on ARM64 for Type.i16/np.int16 with share_inputs=True, ticket: 179098")
-
     request, tensor1, array1 = generate_concat_compiled_model_with_data(
         device=device, ov_type=ov_type, numpy_dtype=numpy_dtype
     )

--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -113,6 +113,15 @@ endif()
 set(OV_CPU_ARM_TARGET_ARCH ${OV_CPU_ARM_TARGET_ARCH_DEFAULT} CACHE STRING "Architecture for ARM ComputeLibrary")
 set_property(CACHE OV_CPU_ARM_TARGET_ARCH PROPERTY STRINGS ${OV_CPU_ARM_TARGET_ARCHS})
 
+set(OV_CPU_ARM_COMPUTE_CXX_FLAGS)
+if(LINUX AND AARCH64 AND OV_CPU_AARCH64_USE_MULTI_ISA)
+    if(OV_COMPILER_IS_CLANG)
+        set(OV_CPU_ARM_COMPUTE_CXX_FLAGS "-march=armv8-a")
+    elseif(CMAKE_COMPILER_IS_GNUCXX)
+        set(OV_CPU_ARM_COMPUTE_CXX_FLAGS "-march=armv8-a")
+    endif()
+endif()
+
 if(X86 OR X86_64 OR AARCH64)
     # disable mlas with webassembly and intel compiler on windows
     if(EMSCRIPTEN OR (WIN32 AND AARCH64) OR MINGW OR
@@ -133,7 +142,17 @@ else()
 endif()
 ov_dependent_option(ENABLE_KLEIDIAI_FOR_CPU "Enable KleidiAI for OpenVINO CPU Plugin" ${ENABLE_KLEIDIAI_FOR_CPU_DEFAULT} "AARCH64" OFF)
 
+if(OV_CPU_ARM_COMPUTE_CXX_FLAGS)
+    set(OV_CPU_CXX_FLAGS_SAVE "${CMAKE_CXX_FLAGS}")
+    string(APPEND CMAKE_CXX_FLAGS " ${OV_CPU_ARM_COMPUTE_CXX_FLAGS}")
+endif()
+
 add_subdirectory(thirdparty)
+
+if(DEFINED OV_CPU_CXX_FLAGS_SAVE)
+    set(CMAKE_CXX_FLAGS "${OV_CPU_CXX_FLAGS_SAVE}")
+    unset(OV_CPU_CXX_FLAGS_SAVE)
+endif()
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOMINMAX")


### PR DESCRIPTION
### Details

This change fixes an AArch64 multi-ISA cross-compilation issue where Arm Compute Library common/baseline code could be built with SVE instructions and then executed on non-SVE ARM64 targets.

The fix adds baseline `-march=armv8-a` flags only while configuring/building the CPU plugin thirdparty dependencies for Linux AArch64 multi-ISA builds with GCC or Clang. This keeps the common ACL code portable for baseline ARMv8 systems while preserving the generated SVE/SVE2 paths built by the CPU plugin multi-ISA flow.

The Python async infer request skip for the affected ARM64 `int16` case is removed because the runtime issue is fixed instead of hidden.

### Root cause

In a cross-compiled AArch64 multi-ISA build, SVE instructions may appear in common code that is not protected by runtime SVE dispatch. On non-SVE systems such as Raspberry Pi Cortex-A72, executing that path causes SIGILL / `Illegal instruction`.

### Validation

- Cross-compiled OpenVINO AArch64 wheel on Ampere with GCC 14.3.0
- Verified build flags contain `-march=armv8-a` and do not contain `-fno-vectorize` / `-fno-slp-vectorize`
- Verified SVE generated objects are still built, including `cross-compiled/SVE/softmax.cpp.o`, `mha_single_token.cpp.o`, and `executor_pa.cpp.o`
- Installed the wheel on Raspberry Pi Cortex-A72 without SVE support
- `test_runtime/test_async_infer_request.py::test_async_mixed_values`: 26 passed
- Repeated `test_async_mixed_values` 100 times: all iterations passed
- `test_runtime/test_async_infer_request.py`: 60 passed, 3 skipped
- `git diff --check`
