### PR TITLE
Fix ACL baseline flags for AArch64 multi-ISA

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_async_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_async_infer_request.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 import numpy as np
 import pytest
 import time
-import platform
 
 import openvino.opset13 as ops
 from openvino import (
@@ -327,11 +326,6 @@ def test_start_async(device, share_inputs):
 ])
 @pytest.mark.parametrize("share_inputs", [True, False])
 def test_async_mixed_values(device, ov_type, numpy_dtype, share_inputs):
-    if share_inputs and ov_type == Type.i16 and numpy_dtype == np.int16 and (
-        platform.machine().lower() in {"aarch64", "arm64"}
-    ):
-        pytest.skip("Illegal instruction on ARM64 for Type.i16/np.int16 with share_inputs=True, ticket: 179098")
-
     request, tensor1, array1 = generate_concat_compiled_model_with_data(
         device=device, ov_type=ov_type, numpy_dtype=numpy_dtype
     )

--- a/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
+++ b/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
@@ -322,6 +322,13 @@ elseif(NOT TARGET arm_compute::arm_compute)
             set(local_extra_cxx_flags "${local_extra_cxx_flags} -DENABLE_SME -DARM_COMPUTE_ENABLE_SME -DARM_COMPUTE_ENABLE_SME2")
         endif()
 
+        # Keep ACL common code portable in AArch64 multi-ISA builds. SVE/SVE2
+        # objects are still built separately with their own architecture flags.
+        if(LINUX AND AARCH64 AND OV_CPU_AARCH64_USE_MULTI_ISA AND
+           (OV_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCXX))
+            set(local_extra_cxx_flags "${local_extra_cxx_flags} -march=armv8-a")
+        endif()
+
         # Export flags
         set(extra_cxx_flags "${local_extra_cxx_flags}" PARENT_SCOPE)
         set(extra_link_flags "${local_extra_link_flags}" PARENT_SCOPE)


### PR DESCRIPTION
### Details

This change fixes an AArch64 multi-ISA cross-compilation issue where Arm Compute Library common/baseline code could be built with SVE instructions and then executed on non-SVE ARM64 targets.

The fix adds baseline `-march=armv8-a` only to the ACL SCons `extra_cxx_flags` generated by OpenVINO's ACL integration layer for Linux AArch64 multi-ISA builds with GCC or Clang. This keeps the common ACL code portable for baseline ARMv8 systems while preserving the generated SVE/SVE2 paths built by the CPU plugin multi-ISA flow.

The Python async infer request skip for the affected ARM64 `int16` case is removed because the runtime issue is fixed instead of hidden.

### Root cause

In a cross-compiled AArch64 multi-ISA build, SVE instructions may appear in common code that is not protected by runtime SVE dispatch. On non-SVE systems such as Raspberry Pi Cortex-A72, executing that path causes SIGILL / `Illegal instruction`.

### Validation

- Cross-compiled OpenVINO AArch64 wheel on Ampere with GCC 14.3.0
- Verified ACL SCons command contains `extra_cxx_flags=... -march=armv8-a`
- Verified build flags do not contain `-fno-vectorize` / `-fno-slp-vectorize`
- Verified SVE generated objects are still built, including `cross-compiled/SVE/softmax.cpp.o`, `mha_single_token.cpp.o`, `attn_quant.cpp.o`, and `executor_pa.cpp.o`
- Installed the freshly built wheel on Raspberry Pi Cortex-A72 without SVE support
- `test_runtime/test_async_infer_request.py::test_async_mixed_values`: 26 passed
- Previous stress run with the same baseline-arch fix: repeated `test_async_mixed_values` 100 times, all iterations passed
- Previous full file run: `test_runtime/test_async_infer_request.py`: 60 passed, 3 skipped
- `git diff --check`
