### PR TITLE
[GPU] Fix to clone shared Convert always in ConvertMaMulToFullyConnected

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -200,17 +200,12 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         }
 
         // Connect Convert to new input if needed
-        if (is_convert && transpose_node && !can_reuse_transpose) {
+        if (is_convert) {
             auto convert = pattern_map.at(weights_m).get_node_shared_ptr();
             auto new_convert = convert->clone_with_new_inputs({fc_input_b});
             new_ops.push_back(new_convert);
             new_convert->validate_and_infer_types();
             fc_input_b = new_convert;
-        } else if (is_convert) {
-            auto convert = pattern_map.at(weights_m).get_node_shared_ptr();
-            convert->input(0).replace_source_output(fc_input_b);
-            convert->validate_and_infer_types();
-            fc_input_b = convert;
         }
 
         auto no_bias = std::make_shared<op::Placeholder>();

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -700,6 +700,40 @@ TEST(TransformationTests, ConvertMatMulToFullyConnectedExceptionTest_sibling_mat
     ASSERT_TRUE(success == false);
 }
 
+TEST(TransformationTests, ConvertMatMulToFullyConnected_clone_shared_convert) {
+    auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 10, 32});
+    auto input2 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 10, 64});
+    auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{64, 32}, {1});
+    auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f32);
+    ov::mark_as_decompression(convert);
+
+    auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+    auto fc1 = std::make_shared<op::FullyConnected>(input1, convert, no_bias);
+    auto matmul2 = std::make_shared<ov::opset1::MatMul>(input2, convert, false, false);
+
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{fc1, matmul2},
+                                             ov::ParameterVector{input1, input2});
+
+    ov::pass::Manager manager;
+    manager.register_pass<ov::intel_gpu::ConvertMatMulToFullyConnected>();
+    // Without the fix, the pass mutates the shared Convert in-place and breaks fc1's
+    // weight shape, causing validate_and_infer_types to throw inside run_passes.
+    ASSERT_NO_THROW(manager.run_passes(model));
+
+    size_t fc_count = 0;
+    size_t matmul_count = 0;
+    for (auto& op : model->get_ops()) {
+        std::string type_name(op->get_type_name());
+        if (type_name.find("FullyConnected") != std::string::npos) {
+            ++fc_count;
+        } else if (type_name == "MatMul") {
+            ++matmul_count;
+        }
+    }
+    ASSERT_EQ(fc_count, 2u);
+    ASSERT_EQ(matmul_count, 0u);
+}
+
 TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedExceptionTest) {
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 10, 64});


### PR DESCRIPTION
## Issue
When running `benchmark_app` on the `text-spotting-0004-recognizer-decoder` model (FP16) on GPU, the following runtime error is raised during model compilation:
```
Incompatible MatMul matrix dimension. First input dimension=29 at COL_INDEX_DIM=2
doesn't match the second input dimension=512 at ROW_INDEX_DIM=0
```

## Root Cause
The `ConvertMatMulToFullyConnected` pass mutates a potentially shared `Convert` node on the weights path via `replace_source_output` instead of cloning it.

Consider two MatMuls that share the same `Convert` output:
- `MatMul_A` consumes the `Convert` output as **weights** (port 1)
- `MatMul_B` consumes the same `Convert` output as **activations** (port 0), or as weights with a different `transpose_b`
<img width="721" height="319" alt="image" src="https://github.com/user-attachments/assets/d2f8b5a9-cabd-4992-b34a-4e14175bd653" />

When `MatMul_A` is processed and its `transpose_b == false`, the callback inserts a new `Transpose` in front of `Convert` and rewires `Convert`'s input via `convert->input(0).replace_source_output(...)`. This changes `Convert`'s output shape (e.g., from `[K, N]` to `[N, K]`) and **silently corrupts every other consumer of `Convert`**, including the sibling MatMul that uses it as activations.

The previous conditional clone path (`transpose_node && !can_reuse_transpose`) only covered the case where an original `Transpose` existed in the IR between the `Convert` and the source weights. It missed the symmetric case where the `Transpose` is newly created by `create_transpose()` at line 193, which is exactly the path triggered by this model — leading to in-place mutation of the shared `Convert`.

## Solution
- Always clone the `Convert` node with the new input instead of mutating it in-place.
- This makes the transformation safe regardless of whether the `Convert` is shared.
- If the original `Convert` has no other consumers, it becomes a dead node and is cleaned up by subsequent passes; if it does, the original graph integrity is preserved for those consumers.

## Ticket
- CVS-185095