### PR TITLE
Support f32 input and bf16 output in Gather JIT kernel

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.cpp
@@ -81,7 +81,13 @@ jitUniGatherKernel<isa>::jitUniGatherKernel(const jGatherConfParams& jcp)
         permMask8bitUni = permMask8bitA5;
         permMask16bitUni = permMask16bitA5;
     }
-    dstStep = is_real16_to_f32 ? 2 * vlen : (is_f32_to_bf16 ? vlen / 2 : vlen);
+    if (is_real16_to_f32) {
+        dstStep = 2 * vlen;
+    } else if (is_f32_to_bf16) {
+        dstStep = vlen / 2;
+    } else {
+        dstStep = vlen;
+    }
     if (is_real16_to_f32 || is_f32_to_bf16) {
         convert_emitter =
             std::make_unique<jit_convert_saturation_emitter>(this, isa, jcp.in_prec, jcp.out_prec, ov::element::f32);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.cpp
@@ -81,8 +81,8 @@ jitUniGatherKernel<isa>::jitUniGatherKernel(const jGatherConfParams& jcp)
         permMask8bitUni = permMask8bitA5;
         permMask16bitUni = permMask16bitA5;
     }
-    dstStep = is_real16_to_f32 ? 2 * vlen : vlen;
-    if (is_real16_to_f32) {
+    dstStep = is_real16_to_f32 ? 2 * vlen : (is_f32_to_bf16 ? vlen / 2 : vlen);
+    if (is_real16_to_f32 || is_f32_to_bf16) {
         convert_emitter =
             std::make_unique<jit_convert_saturation_emitter>(this, isa, jcp.in_prec, jcp.out_prec, ov::element::f32);
     }
@@ -814,6 +814,19 @@ void jitUniGatherKernel<isa>::store(const Xbyak::Reg64& reg_dst, Vmm& vmmSrc) {
             uni_vmovups(ptr[reg_dst + vlen], ymmTemp);
             uni_vpxor(vmmZeros, vmmZeros, vmmZeros);
         }
+    } else if (is_f32_to_bf16) {
+        if (isa == x64::avx512_core) {
+            Xbyak::Zmm zmmTmp(31);
+            Xbyak::Ymm ymmTmp(31);
+            convert_emitter->emit_code({static_cast<size_t>(vmmSrc.getIdx())}, {static_cast<size_t>(zmmTmp.getIdx())});
+            vmovdqu16(ptr[reg_dst], ymmTmp);
+        } else {
+            Xbyak::Ymm ymmTmp(vmmZeros.getIdx());
+            Xbyak::Xmm xmmTmp(vmmZeros.getIdx());
+            convert_emitter->emit_code({static_cast<size_t>(vmmSrc.getIdx())}, {static_cast<size_t>(ymmTmp.getIdx())});
+            uni_vmovdqu(ptr[reg_dst], xmmTmp);
+            uni_vpxor(vmmZeros, vmmZeros, vmmZeros);
+        }
     } else {
         uni_vmovups(ptr[reg_dst], vmmSrc);
     }
@@ -1066,7 +1079,7 @@ void jitUniGatherKernel<isa>::tail(bool isShortIdx, bool shiftFirst, bool blocke
 
         uni_vmovups(vAux0, vmmZeros);
         uniVpGatherDd(vAux0, ptr[regSrc + vSrcShift], kGatherMask);
-        if (jcp.dataTypeSize == 4) {
+        if (jcp.dataTypeSize == 4 && !is_f32_to_bf16) {
             uni_vmovups_tail(ptr[regDst], kAuxMask1, vAux0);
             sub(regWorkAmount, dataElPerVec);
         } else {
@@ -1132,41 +1145,58 @@ void jitUniGatherKernel<isa>::storeVectorPart(const Xbyak::Reg64& rDst,
     Xbyak::Label lEnd;
     Xbyak::Xmm xAux(vAux.getIdx());
     for (size_t j = 0; j < vlen / vlenXmm; j++) {
+        if (is_f32_to_bf16) {
+            Vmm vAuxFull(vAux.getIdx());
+            uni_vpxor(vAuxFull, vAuxFull, vAuxFull);
+        }
         if (isa == x64::avx2) {
             vextracti128(xAux, vmmSrc, j);
         } else if (isa == x64::avx512_core) {
             vextracti64x2(xAux, vmmSrc, j);
         }
 
-        for (int k = 0; k < 4; k++) {
-            cmp(rToStoreCounter, 0);
-            jle(lEnd, T_NEAR);
+        if (is_f32_to_bf16) {
+            convert_emitter->emit_code({static_cast<size_t>(xAux.getIdx())}, {static_cast<size_t>(xmmTemp.getIdx())});
+            for (int k = 0; k < 4; k++) {
+                cmp(rToStoreCounter, 0);
+                jle(lEnd, T_NEAR);
 
-            if (jcp.dataTypeSize == 4) {
-                uni_vpextrd(ptr[rDst], xAux, k);
-            } else if (jcp.dataTypeSize == 2) {
-                if (jcp.in_prec == jcp.out_prec) {
-                    uni_vpextrw(ptr[rDst], xAux, k * 2);
-                } else if (jcp.out_prec == element::f32) {
-                    // xAux should not changed
-                    convert_emitter->emit_code({static_cast<size_t>(xAux.getIdx())},
-                                               {static_cast<size_t>(ymmTemp.getIdx())});
-                    if (k < 2) {
-                        uni_vpextrd(ptr[rDst], xmmTemp, k * 2);
-                    } else {
-                        vperm2f128(ymmTemp, ymmTemp, ymmTemp, 0x1);
-                        uni_vpextrd(ptr[rDst], xmmTemp, k * 2 - 4);
-                    }
-                }
-            } else if (jcp.dataTypeSize == 1) {
-                uni_vpextrb(ptr[rDst], xAux, k * 4);
+                uni_vpextrw(ptr[rDst], xmmTemp, k);
+
+                add(rDst, jcp.out_prec.size());
+                sub(rToStoreCounter, 1);
             }
+        } else {
+            for (int k = 0; k < 4; k++) {
+                cmp(rToStoreCounter, 0);
+                jle(lEnd, T_NEAR);
 
-            add(rDst, jcp.out_prec.size());
-            sub(rToStoreCounter, 1);
+                if (jcp.dataTypeSize == 4) {
+                    uni_vpextrd(ptr[rDst], xAux, k);
+                } else if (jcp.dataTypeSize == 2) {
+                    if (jcp.in_prec == jcp.out_prec) {
+                        uni_vpextrw(ptr[rDst], xAux, k * 2);
+                    } else if (jcp.out_prec == element::f32) {
+                        // xAux should not changed
+                        convert_emitter->emit_code({static_cast<size_t>(xAux.getIdx())},
+                                                   {static_cast<size_t>(ymmTemp.getIdx())});
+                        if (k < 2) {
+                            uni_vpextrd(ptr[rDst], xmmTemp, k * 2);
+                        } else {
+                            vperm2f128(ymmTemp, ymmTemp, ymmTemp, 0x1);
+                            uni_vpextrd(ptr[rDst], xmmTemp, k * 2 - 4);
+                        }
+                    }
+                } else if (jcp.dataTypeSize == 1) {
+                    uni_vpextrb(ptr[rDst], xAux, k * 4);
+                }
+
+                add(rDst, jcp.out_prec.size());
+                sub(rToStoreCounter, 1);
+            }
         }
     }
-    if (is_real16_to_f32) {
+    if (is_real16_to_f32 || is_f32_to_bf16) {
         uni_vpxor(vmmZeros, vmmZeros, vmmZeros);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
@@ -91,7 +91,8 @@ struct jitGatherKernelBase {
           dataElPerVec(vlen / jcp.dataTypeSize),
           idxElPerVec(vlen / indicesTypeSize),
           is_real16_to_f32((jcp.in_prec == element::f16 || jcp.in_prec == element::bf16) &&
-                           jcp.out_prec == element::f32) {}
+                           jcp.out_prec == element::f32),
+          is_f32_to_bf16(jcp.in_prec == element::f32 && jcp.out_prec == element::bf16) {}
     virtual ~jitGatherKernelBase() = default;
 
     virtual void create_ker() = 0;
@@ -122,6 +123,7 @@ protected:
     int shortPermIdx[16]{};
     int shortBeforeAxisDiff[16]{};
     const bool is_real16_to_f32 = false;
+    const bool is_f32_to_bf16 = false;
 };
 
 template <dnnl::impl::cpu::x64::cpu_isa_t isa>

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather.cpp
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/op/gather.hpp"
+
 #include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/matmul.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
 #include "utils/general_utils.h"
-#include "openvino/op/gather.hpp"
 
 using namespace CPUTestUtils;
 namespace ov {
@@ -63,7 +66,7 @@ public:
 protected:
     void SetUp() override {
         const ElementType intInputsPrecision = ElementType::i64;
-        const auto &[inputShapes, axisAndBatchDims, netPrecision, isAxisConstant, cpuParams, additionalConfig] =
+        const auto& [inputShapes, axisAndBatchDims, netPrecision, isAxisConstant, cpuParams, additionalConfig] =
             this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         axis = std::get<0>(axisAndBatchDims);
@@ -72,7 +75,8 @@ protected:
         init_input_shapes(inputShapes);
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
+        if (intel_cpu::contains_key_value(additionalConfig,
+                                          {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             selectedType = makeSelectedTypeStr(selectedType, netPrecision);
@@ -123,11 +127,15 @@ protected:
                 const auto dataTypeSize = funcInput.get_element_type().size();
                 in_data.start_from = 0;
                 in_data.range = dataTypeSize == 4 ? 0x7FFFFFFF : dataTypeSize == 2 ? 0xFFFF : 0xFF;
-                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[0], in_data);
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                 targetInputStaticShapes[0],
+                                                                 in_data);
             } else if (funcInput.get_node()->get_friendly_name() == "indices") {
                 in_data.start_from = -axisDim;
                 in_data.range = axisDim * 2;
-                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[1], in_data);
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                 targetInputStaticShapes[1],
+                                                                 in_data);
             } else if (funcInput.get_node()->get_friendly_name() == "axis") {
                 in_data.start_from = axis;
                 in_data.range = 1;
@@ -153,7 +161,7 @@ class GatherInPlaceLayerTestCPU : public testing::WithParamInterface<GatherInPla
                                   public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<GatherInPlaceLayerTestCPUParams>& obj) {
-        const auto &[inputShapes, indices, axis, netPrecision, cpuParams] = obj.param;
+        const auto& [inputShapes, indices, axis, netPrecision, cpuParams] = obj.param;
         std::ostringstream result;
         result << "IS=(";
 
@@ -177,7 +185,7 @@ protected:
     void SetUp() override {
         constexpr ElementType intInputsPrecision = ElementType::i64;
         constexpr int batchDims = 0;
-        const auto &[inputShapes, indices, axis, netPrecision, cpuParams] = this->GetParam();
+        const auto& [inputShapes, indices, axis, netPrecision, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes({inputShapes});
@@ -196,6 +204,51 @@ protected:
     }
 };
 
+class GatherF32ToBF16OutputTestCPU : virtual public ov::test::SubgraphBaseTest {
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_CPU;
+        configuration.insert({ov::hint::inference_precision.name(), ov::element::bf16});
+        init_input_shapes({{{}, {{33}}}});
+
+        std::vector<float> dataValues(64);
+        for (size_t index = 0; index < dataValues.size(); ++index) {
+            dataValues[index] = static_cast<float>(index) / 8.F;
+        }
+
+        std::vector<float> weightsValues(16);
+        for (size_t index = 0; index < weightsValues.size(); ++index) {
+            weightsValues[index] = static_cast<float>(static_cast<int>(index % 13) - 6) / 16.F;
+        }
+
+        auto data = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{64, 1}, dataValues);
+        auto indices = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inputDynamicShapes.front());
+        indices->set_friendly_name("indices");
+        auto axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+        auto gather = std::make_shared<ov::op::v8::Gather>(data, indices, axis);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(
+            gather,
+            ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 16}, weightsValues));
+
+        function = std::make_shared<ov::Model>(matmul, ov::ParameterVector{indices}, "GatherF32ToBF16OutputCPU");
+
+        rel_threshold = 0.01;
+        abs_threshold = 0.01;
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        ov::Tensor indicesTensor{ov::element::i64, targetInputStaticShapes.front()};
+        auto* indicesData = indicesTensor.data<int64_t>();
+        const auto indicesCount = ov::shape_size(targetInputStaticShapes.front());
+        for (size_t index = 0; index < indicesCount; ++index) {
+            indicesData[index] = static_cast<int64_t>(index % 64);
+        }
+
+        inputs.insert({function->get_parameters().front(), indicesTensor});
+    }
+};
+
 TEST_P(GatherLayerTestCPU, CompareWithRefs) {
     run();
     CheckPluginRelatedResults(compiledModel, "Gather");
@@ -204,6 +257,13 @@ TEST_P(GatherLayerTestCPU, CompareWithRefs) {
 TEST_P(GatherInPlaceLayerTestCPU, CompareWithRefs) {
     run();
     CheckPluginRelatedResults(compiledModel, "Gather");
+}
+
+TEST_F(GatherF32ToBF16OutputTestCPU, smoke_static_f32_input_bf16_output) {
+    if (!ov::with_cpu_x86_bfloat16()) {
+        GTEST_SKIP();
+    }
+    run();
 }
 
 namespace {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather.cpp
@@ -204,12 +204,14 @@ protected:
     }
 };
 
-class GatherF32ToBF16OutputTestCPU : virtual public ov::test::SubgraphBaseTest {
+class GatherF32ToBF16OutputTestCPU : public testing::WithParamInterface<size_t>,
+                                     virtual public ov::test::SubgraphBaseTest {
 protected:
     void SetUp() override {
+        const auto indicesSize = GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         configuration.insert({ov::hint::inference_precision.name(), ov::element::bf16});
-        init_input_shapes({{{}, {{33}}}});
+        init_input_shapes({{{}, {{indicesSize}}}});
 
         std::vector<float> dataValues(64);
         for (size_t index = 0; index < dataValues.size(); ++index) {
@@ -259,7 +261,7 @@ TEST_P(GatherInPlaceLayerTestCPU, CompareWithRefs) {
     CheckPluginRelatedResults(compiledModel, "Gather");
 }
 
-TEST_F(GatherF32ToBF16OutputTestCPU, smoke_static_f32_input_bf16_output) {
+TEST_P(GatherF32ToBF16OutputTestCPU, smoke_static_f32_input_bf16_output) {
     if (!ov::with_cpu_x86_bfloat16()) {
         GTEST_SKIP();
     }
@@ -271,6 +273,12 @@ const std::vector<ElementType> netPrecisions = {ElementType::f32, ElementType::b
 
 std::vector<ov::AnyMap> additionalConfig = {{{ov::hint::inference_precision(ov::element::f32)}},
                                             {{ov::hint::inference_precision(ov::element::bf16)}}};
+
+const std::vector<size_t> gatherF32ToBF16IndicesSizes = {33, 32, 15, 8, 7};
+
+INSTANTIATE_TEST_SUITE_P(smoke_static_f32_input_bf16_output,
+                         GatherF32ToBF16OutputTestCPU,
+                         ::testing::ValuesIn(gatherF32ToBF16IndicesSizes));
 
 std::vector<bool> isAxisConst{true, false};
 const CPUSpecificParams cpuParamsRef{{}, {}, {"ref_any"}, "ref_any"};

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather.cpp
@@ -205,13 +205,24 @@ protected:
 };
 
 class GatherF32ToBF16OutputTestCPU : public testing::WithParamInterface<size_t>,
-                                     virtual public ov::test::SubgraphBaseTest {
+                                     virtual public ov::test::SubgraphBaseTest,
+                                     public CPUTestsBase {
 protected:
     void SetUp() override {
         const auto indicesSize = GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         configuration.insert({ov::hint::inference_precision.name(), ov::element::bf16});
         init_input_shapes({{{}, {{indicesSize}}}});
+
+        if (ov::with_cpu_x86_avx512f()) {
+            selectedType = "jit_avx512";
+        } else if (ov::with_cpu_x86_avx2()) {
+            selectedType = "jit_avx2";
+        } else {
+            selectedType = "ref";
+        }
+        // Set expected precision for Gather node to F32 (input precision)
+        selectedType = makeSelectedTypeStr(selectedType, ElementType::f32);
 
         std::vector<float> dataValues(64);
         for (size_t index = 0; index < dataValues.size(); ++index) {
@@ -266,6 +277,7 @@ TEST_P(GatherF32ToBF16OutputTestCPU, smoke_static_f32_input_bf16_output) {
         GTEST_SKIP();
     }
     run();
+    CheckPluginRelatedResults(compiledModel, "Gather");
 }
 
 namespace {


### PR DESCRIPTION
### Details:
 - *This PR adds f32 input and bf16 output support for Gather JIT kernel. Previously gather could be selected for a runtime configuration where the input precision is f32 and output precision is bf16, but the JIT kernel did not handle the conversion correctly which lead to the  incorrect memory writes of Gather output buffer.*
 - *Add test case*

### Tickets:
 - *CVS-186196*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
