### PR TITLE
[PyOV] Add check for returned empty map from get_property

### DIFF
--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -106,6 +106,10 @@ py::object from_ov_any_map(const ov::AnyMap& map) {
 }
 
 py::object from_ov_any(const ov::Any& any) {
+    // Empty Any (e.g. write-only property queried via get_property)
+    if (any.empty()) {
+        return py::none();
+    }
     // Check for py::object
     if (any.is<std::shared_ptr<py::object>>()) {
         return *any.as<std::shared_ptr<py::object>>();

--- a/src/bindings/python/tests/test_graph/test_any.py
+++ b/src/bindings/python/tests/test_graph/test_any.py
@@ -73,6 +73,12 @@ def test_any_class():
     assert value.value.text == "test"
 
 
+def test_any_empty():
+    ovany = OVAny(None)
+    assert ovany.value is None
+    assert ovany.get() is None
+
+
 @pytest.mark.parametrize(("value", "dtype"), [
     ("some_value", str),
     (31.23456, float),


### PR DESCRIPTION
### Details:
 - encryption WO property returns an empty map when get_property is queried

### Tickets:
 - *C-186974*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
