### PR TITLE
[NPU] Refactor property handling to use support predicates and compiled-model context

### DIFF
--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -61,6 +61,9 @@ public:
     void release_memory() override;
 
 private:
+    ov::Any get_model_name_property() const;
+    ov::Any get_runtime_requirements_property() const;
+
     void configure_stream_executors();
 
     Logger _logger;

--- a/src/plugins/intel_npu/src/plugin/include/properties.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/properties.hpp
@@ -76,6 +76,8 @@ public:
     ov::intel_npu::CompilerType determineCompilerTypeForCompatibilityCheck() const;
 
 private:
+    using PropertyGetter = std::function<ov::Any(const Config&)>;
+
     struct CopyState {
         PropertiesType pType;
         FilteredConfig config;
@@ -116,6 +118,19 @@ private:
     // To avoid loading the compiler library and check the support when the property is registered, the check can
     // be performed at a later stage, when the property is actually queried.
     bool disable_compatibility_check_if_needed();
+
+    // Internal registration helpers used by macros to centralize common logic.
+    void registerProperty(const std::string& name,
+                          bool isPublic,
+                          ov::PropertyMutability mutability,
+                          const PropertyGetter& getter);
+
+    void registerConfigProperty(const std::string& name,
+                                const PropertyGetter& getter,
+                                std::optional<bool> visibilityOverride = std::nullopt,
+                                std::optional<ov::PropertyMutability> mutabilityOverride = std::nullopt,
+                                bool requireSetInConfig = false,
+                                bool forcePublicInCompiledModel = false);
 
     /**
      * @brief Checks whether a property was registered by its name

--- a/src/plugins/intel_npu/src/plugin/include/properties.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/properties.hpp
@@ -15,6 +15,11 @@ enum class PropertiesType { PLUGIN, COMPILED_MODEL };
 
 class Properties final {
 public:
+    struct CompiledModelContext {
+        std::function<ov::Any()> getModelName;
+        std::function<ov::Any()> getRuntimeRequirements;
+    };
+
     /**
      * @brief Properties handler constructor
      * @param pType - type of object this handler gets attached to: PLUGIN or COMPILED_MODEL
@@ -24,7 +29,8 @@ public:
     Properties(const PropertiesType pType,
                const FilteredConfig& config,
                const std::shared_ptr<Metrics>& metrics = nullptr,
-               const ov::SoPtr<IEngineBackend>& backend = {nullptr});
+               const ov::SoPtr<IEngineBackend>& backend = {nullptr},
+               const std::shared_ptr<const CompiledModelContext>& compiledModelContext = nullptr);
 
     Properties(const Properties& other);
     Properties& operator=(const Properties& other) = delete;
@@ -89,6 +95,7 @@ private:
         std::string currentlyUsedPlatform;
         bool compilerConfigsFilteredByCompiler;
         bool compatibilityCheckFiltered;
+        std::shared_ptr<const CompiledModelContext> compiledModelContext;
         std::map<std::string, std::tuple<SupportPredicate, ov::PropertyMutability, std::function<ov::Any(const Config&)>>>
             properties;
         std::vector<ov::PropertyName> supportedProperties;
@@ -100,6 +107,7 @@ private:
     FilteredConfig _config;
     std::shared_ptr<Metrics> _metrics;
     ov::SoPtr<IEngineBackend> _backend;
+    std::shared_ptr<const CompiledModelContext> _compiledModelContext;
     Logger _logger;
 
     ov::intel_npu::CompilerType _currentlyUsedCompiler = ov::intel_npu::CompilerType::PREFER_PLUGIN;

--- a/src/plugins/intel_npu/src/plugin/include/properties.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/properties.hpp
@@ -77,6 +77,7 @@ public:
 
 private:
     using PropertyGetter = std::function<ov::Any(const Config&)>;
+    using SupportPredicate = std::function<bool(const FilteredConfig&)>;
 
     struct CopyState {
         PropertiesType pType;
@@ -88,7 +89,7 @@ private:
         std::string currentlyUsedPlatform;
         bool compilerConfigsFilteredByCompiler;
         bool compatibilityCheckFiltered;
-        std::map<std::string, std::tuple<bool, ov::PropertyMutability, std::function<ov::Any(const Config&)>>>
+        std::map<std::string, std::tuple<SupportPredicate, ov::PropertyMutability, std::function<ov::Any(const Config&)>>>
             properties;
         std::vector<ov::PropertyName> supportedProperties;
     };
@@ -110,8 +111,8 @@ private:
     // Boolean to signal that compatibility check was already filtered by compiler support
     bool _compatibilityCheckFiltered = false;
 
-    // properties map: {name -> [supported, mutable, eval function]}
-    std::map<std::string, std::tuple<bool, ov::PropertyMutability, std::function<ov::Any(const Config&)>>> _properties;
+    // properties map: {name -> [support predicate, mutability, value getter]}
+    std::map<std::string, std::tuple<SupportPredicate, ov::PropertyMutability, std::function<ov::Any(const Config&)>>> _properties;
     std::vector<ov::PropertyName> _supportedProperties;
 
     // The compatibility_check property is supported only in case at least one of the compilers (CID or CIP) supports it
@@ -121,7 +122,7 @@ private:
 
     // Internal registration helpers used by macros to centralize common logic.
     void registerProperty(const std::string& name,
-                          bool isPublic,
+                          SupportPredicate predicate,
                           ov::PropertyMutability mutability,
                           const PropertyGetter& getter);
 
@@ -153,6 +154,7 @@ private:
     void registerProperties();
     void registerPluginProperties();
     void registerCompiledModelProperties();
+    void refreshSupportedProperties();
 
     const std::vector<ov::PropertyName> _cachingProperties = [] {
         std::vector<ov::PropertyName> properties = {

--- a/src/plugins/intel_npu/src/plugin/include/properties.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/properties.hpp
@@ -96,9 +96,6 @@ private:
         bool compilerConfigsFilteredByCompiler;
         bool compatibilityCheckFiltered;
         std::shared_ptr<const CompiledModelContext> compiledModelContext;
-        std::map<std::string, std::tuple<SupportPredicate, ov::PropertyMutability, std::function<ov::Any(const Config&)>>>
-            properties;
-        std::vector<ov::PropertyName> supportedProperties;
     };
 
     explicit Properties(CopyState&& state);

--- a/src/plugins/intel_npu/src/plugin/include/properties.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/properties.hpp
@@ -18,6 +18,7 @@ public:
     struct CompiledModelContext {
         std::function<ov::Any()> getModelName;
         std::function<ov::Any()> getRuntimeRequirements;
+        std::function<bool()> hasRuntimeRequirements;
     };
 
     /**

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -37,14 +37,6 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
       _batchSize(batchSize) {
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "CompiledModel::CompiledModel");
 
-    // Support for specific properties might depend on the characteristics of the compiled model.
-    // Adjust lower level config availability to influence the supported properties list if needed
-    FilteredConfig localConfig = config;
-    if (!_graph->get_compatibility_descriptor().has_value()) {
-        _logger.debug("Graph's compatibility descriptor has no value. Disabling RUNTIME_REQUIREMENTS property.");
-        localConfig.enable(ov::runtime_requirements.name(), false);
-    }
-
     auto compiledModelContext = std::make_shared<Properties::CompiledModelContext>();
     compiledModelContext->getModelName = [this]() {
         return get_model_name_property();
@@ -52,10 +44,13 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
     compiledModelContext->getRuntimeRequirements = [this]() {
         return get_runtime_requirements_property();
     };
+    compiledModelContext->hasRuntimeRequirements = [this]() {
+        return _graph->get_compatibility_descriptor().has_value();
+    };
 
     OV_ITT_TASK_CHAIN(COMPILED_MODEL, itt::domains::NPUPlugin, "CompiledModel::CompiledModel", "initialize_properties");
     _propertiesManager = std::make_unique<Properties>(PropertiesType::COMPILED_MODEL,
-                                                      localConfig,
+                                                      config,
                                                       std::shared_ptr<Metrics>{},
                                                       ov::SoPtr<IEngineBackend>{},
                                                       compiledModelContext);

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -45,8 +45,20 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
         localConfig.enable(ov::runtime_requirements.name(), false);
     }
 
+    auto compiledModelContext = std::make_shared<Properties::CompiledModelContext>();
+    compiledModelContext->getModelName = [this]() {
+        return get_model_name_property();
+    };
+    compiledModelContext->getRuntimeRequirements = [this]() {
+        return get_runtime_requirements_property();
+    };
+
     OV_ITT_TASK_CHAIN(COMPILED_MODEL, itt::domains::NPUPlugin, "CompiledModel::CompiledModel", "initialize_properties");
-    _propertiesManager = std::make_unique<Properties>(PropertiesType::COMPILED_MODEL, localConfig);
+    _propertiesManager = std::make_unique<Properties>(PropertiesType::COMPILED_MODEL,
+                                                      localConfig,
+                                                      std::shared_ptr<Metrics>{},
+                                                      ov::SoPtr<IEngineBackend>{},
+                                                      compiledModelContext);
 
     configure_stream_executors();
 
@@ -221,44 +233,43 @@ void CompiledModel::set_property(const ov::AnyMap& properties) {
 }
 
 ov::Any CompiledModel::get_property(const std::string& name) const {
-    // special cases
-    if (name == ov::model_name.name()) {
-        OPENVINO_ASSERT(_graph != nullptr, "Missing graph");
-        return _graph->get_metadata().name;
-    } else if (name == ov::runtime_requirements.name()) {
-        // Reading the (dummy) property content to check if it is supported
-        _propertiesManager->getProperty(name);
+    return _propertiesManager->getProperty(name);
+}
 
-        auto compatibilityDescriptor = _graph->get_compatibility_descriptor();
-        if (compatibilityDescriptor.has_value()) {
-            const auto descriptorView = compatibilityDescriptor.value();
-            _logger.debug("Runtime requirements from the graph %.*s length: %zu",
-                          static_cast<int>(descriptorView.size()),
-                          descriptorView.data(),
-                          descriptorView.size());
-        }
+ov::Any CompiledModel::get_model_name_property() const {
+    OPENVINO_ASSERT(_graph != nullptr, "Missing graph");
+    return _graph->get_metadata().name;
+}
 
-        std::ostringstream requirementsString;
-        Metadata<CURRENT_METADATA_VERSION>(
-            0,  // no real blob
-            CURRENT_OPENVINO_VERSION,
-            std::nullopt,  // weightless blobs are not supported
-            _batchSize,
-            std::nullopt,  // input_layouts are not relevant for the compatibility check
-            std::nullopt,  // output_layouts are not relevant for the compatibility check
-            std::nullopt,  // skip compiler version as well since it is already included in runtime requirements string
-            std::nullopt,  // skip encrypted blob size since it is not relevant for the compatibility check
-            compatibilityDescriptor)
-            .write_as_text(requirementsString);
-        _logger.debug("Runtime requirements string: %s length: %zu",
-                      requirementsString.str().c_str(),
-                      requirementsString.str().length());
+ov::Any CompiledModel::get_runtime_requirements_property() const {
+    OPENVINO_ASSERT(_graph != nullptr, "Missing graph");
 
-        return requirementsString.str();
+    auto compatibilityDescriptor = _graph->get_compatibility_descriptor();
+    if (compatibilityDescriptor.has_value()) {
+        const auto descriptorView = compatibilityDescriptor.value();
+        _logger.debug("Runtime requirements from the graph %.*s length: %zu",
+                      static_cast<int>(descriptorView.size()),
+                      descriptorView.data(),
+                      descriptorView.size());
     }
 
-    // default behaviour
-    return _propertiesManager->getProperty(name);
+    std::ostringstream requirementsString;
+    Metadata<CURRENT_METADATA_VERSION>(
+        0,  // no real blob
+        CURRENT_OPENVINO_VERSION,
+        std::nullopt,  // weightless blobs are not supported
+        _batchSize,
+        std::nullopt,  // input_layouts are not relevant for the compatibility check
+        std::nullopt,  // output_layouts are not relevant for the compatibility check
+        std::nullopt,  // skip compiler version as well since it is already included in runtime requirements string
+        std::nullopt,  // skip encrypted blob size since it is not relevant for the compatibility check
+        compatibilityDescriptor)
+        .write_as_text(requirementsString);
+    _logger.debug("Runtime requirements string: %s length: %zu",
+                  requirementsString.str().c_str(),
+                  requirementsString.str().length());
+
+    return requirementsString.str();
 }
 
 const std::shared_ptr<IGraph>& CompiledModel::get_graph() const {

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -1086,7 +1086,8 @@ std::shared_ptr<ov::ICompiledModel> Plugin::parse(const ov::Tensor& tensorBig,
 
     OV_ITT_TASK_NEXT(PLUGIN_PARSE_MODEL, "parse");
 
-    return std::make_shared<CompiledModel>(modelDummy, shared_from_this(), device, graph, localConfig, batchSize);
+    auto compiledModel = std::make_shared<CompiledModel>(modelDummy, shared_from_this(), device, graph, localConfig, batchSize);
+    return compiledModel;
 }
 
 void Plugin::update_log_level(const ov::AnyMap& properties) const {

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -278,12 +278,18 @@ namespace intel_npu {
  * @note This macro does not offer any compiled-model specific checks, such as
  * if the config options this property maps to has actual value, nor it enforces RO, like previous macros.
  */
-#define TRY_REGISTER_CUSTOM_PROPERTY(OPT_NAME, OPT_TYPE, PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC)  \
-    do {                                                                                                  \
-        std::string o_name = OPT_NAME.name();                                                             \
-        if (_config.isAvailable(o_name)) {                                                                \
-            registerProperty(o_name, PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC);                    \
-        }                                                                                                 \
+#define TRY_REGISTER_CUSTOM_PROPERTY(OPT_NAME, OPT_TYPE, PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC)   \
+    do {                                                                                                   \
+        std::string o_name = OPT_NAME.name();                                                              \
+        if (_config.hasOpt(o_name)) {                                                                      \
+            const bool _vis_val = PROP_VISIBILITY;                                                         \
+            registerProperty(o_name,                                                                       \
+                             [_vis_val, o_name](const FilteredConfig& cfg) {                               \
+                                 return _vis_val && cfg.isAvailable(o_name);                               \
+                             },                                                                            \
+                             PROP_MUTABILITY,                                                              \
+                             PROP_RETFUNC);                                                                \
+        }                                                                                                  \
     } while (0)
 
 /**
@@ -306,7 +312,11 @@ namespace intel_npu {
  */
 #define FORCE_REGISTER_CUSTOM_PROPERTY(OPT_NAME, OPT_TYPE, PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC)     \
     do {                                                                                                       \
-        registerProperty(OPT_NAME.name(), PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC);                    \
+        const bool _vis_val = PROP_VISIBILITY;                                                                 \
+        registerProperty(OPT_NAME.name(),                                                                      \
+                         [_vis_val](const FilteredConfig&) { return _vis_val; },                               \
+                         PROP_MUTABILITY,                                                                      \
+                         PROP_RETFUNC);                                                                        \
     } while (0)
 
 /**
@@ -329,8 +339,9 @@ namespace intel_npu {
  */
 #define REGISTER_SIMPLE_METRIC(PROP_NAME, PROP_VISIBILITY, PROP_RETVAL)                                      \
     do {                                                                                                     \
+        const bool _vis_val = PROP_VISIBILITY;                                                               \
         registerProperty(PROP_NAME.name(),                                                                   \
-                         PROP_VISIBILITY,                                                                    \
+                         [_vis_val](const FilteredConfig&) { return _vis_val; },                             \
                          ov::PropertyMutability::RO,                                                         \
                          [&](const Config& config) -> auto {                                                 \
                              return PROP_RETVAL;                                                             \
@@ -354,9 +365,13 @@ namespace intel_npu {
  * @note This macro does not offer any compiled-model specific checks
  */
 // Macro for defining metrics with custom return function
-#define REGISTER_CUSTOM_METRIC(PROP_NAME, PROP_VISIBILITY, PROP_RETFUNC)                                 \
-    do {                                                                                                 \
-        registerProperty(PROP_NAME.name(), PROP_VISIBILITY, ov::PropertyMutability::RO, PROP_RETFUNC);  \
+#define REGISTER_CUSTOM_METRIC(PROP_NAME, PROP_VISIBILITY, PROP_RETFUNC)                                     \
+    do {                                                                                                     \
+        const bool _vis_val = PROP_VISIBILITY;                                                               \
+        registerProperty(PROP_NAME.name(),                                                                   \
+                         [_vis_val](const FilteredConfig&) { return _vis_val; },                             \
+                         ov::PropertyMutability::RO,                                                         \
+                         PROP_RETFUNC);                                                                      \
     } while (0)
 
 // Local helper function for appending platform name to the config
@@ -436,10 +451,10 @@ Properties::Properties(CopyState&& state)
       _supportedProperties(std::move(state.supportedProperties)) {}
 
 void Properties::registerProperty(const std::string& name,
-                                  bool isPublic,
+                                  SupportPredicate predicate,
                                   ov::PropertyMutability mutability,
                                   const PropertyGetter& getter) {
-    _properties.emplace(name, std::make_tuple(isPublic, mutability, getter));
+    _properties.emplace(name, std::make_tuple(std::move(predicate), mutability, getter));
 }
 
 void Properties::registerConfigProperty(const std::string& name,
@@ -452,21 +467,34 @@ void Properties::registerConfigProperty(const std::string& name,
         return;
     }
 
-    if (!_config.isAvailable(name)) {
+    if (!_config.hasOpt(name)) {
         return;
     }
 
-    bool isPublic = visibilityOverride.value_or(_config.getOpt(name).isPublic());
+    bool baseIsPublic = visibilityOverride.value_or(_config.getOpt(name).isPublic());
     ov::PropertyMutability isMutable = mutabilityOverride.value_or(_config.getOpt(name).mutability());
 
     if (_pType == PropertiesType::COMPILED_MODEL) {
         isMutable = ov::PropertyMutability::RO;
         if (forcePublicInCompiledModel) {
-            isPublic = true;
+            baseIsPublic = true;
         }
     }
 
-    registerProperty(name, isPublic, isMutable, getter);
+    SupportPredicate predicate = [optName = name, baseIsPublic](const FilteredConfig& cfg) {
+        return baseIsPublic && cfg.isAvailable(optName);
+    };
+
+    registerProperty(name, std::move(predicate), isMutable, getter);
+}
+
+void Properties::refreshSupportedProperties() {
+    _supportedProperties.clear();
+    for (const auto& [name, entry] : _properties) {
+        if (std::get<0>(entry)(_config)) {
+            _supportedProperties.emplace_back(ov::PropertyName(name, std::get<1>(entry)));
+        }
+    }
 }
 
 void Properties::registerProperties() {
@@ -489,13 +517,8 @@ void Properties::registerProperties() {
     // 2.3. Common metrics (exposed same way by both Plugin and CompiledModel)
     REGISTER_SIMPLE_METRIC(ov::supported_properties, true, _supportedProperties);
 
-    // 3. Populate supported properties list
-    // ========
-    for (auto& property : _properties) {
-        if (std::get<0>(property.second)) {
-            _supportedProperties.emplace_back(ov::PropertyName(property.first, std::get<1>(property.second)));
-        }
-    }
+    // 3. Populate supported properties list by evaluating predicates
+    refreshSupportedProperties();
 }
 
 void Properties::registerPluginProperties() {
@@ -867,7 +890,7 @@ ov::Any Properties::getProperty(const std::string& name) {
 
         bool needToResetProperties = false;
         if (name == ov::compatibility_check.name() || name == ov::supported_properties.name()) {
-            // Mark that properties need to be registered again if the internal config is updated
+            // Mark that supported properties need to be refreshed if the internal config is updated
             needToResetProperties = disable_compatibility_check_if_needed();
         }
         // Special case for Supported Properties and Caching Properties as they are compiler dependent. So we need to
@@ -913,8 +936,8 @@ ov::Any Properties::getProperty(const std::string& name) {
         }
 
         if (needToResetProperties) {
-            // reset properties for the new options
-            registerProperties();
+            // re-evaluate predicates for the updated config
+            refreshSupportedProperties();
         }
     }
 
@@ -983,8 +1006,8 @@ void Properties::setProperty(const ov::AnyMap& properties) {
                 // filter out options again
                 filterPropertiesByCompilerSupport(_config, compiler.get(), _backend, _logger);
 
-                // reset properties for the new options
-                registerProperties();
+                // re-evaluate predicates for the updated config
+                refreshSupportedProperties();
                 _compilerConfigsFilteredByCompiler = true;
                 _currentlyUsedCompiler = compilerType;
                 _currentlyUsedPlatform = std::move(compilationPlatform);
@@ -1042,7 +1065,7 @@ bool Properties::isPropertySupported(const std::string& name) {
         if (name == ov::compatibility_check.name()) {
             bool disabled = disable_compatibility_check_if_needed();
             if (disabled) {
-                registerProperties();
+                refreshSupportedProperties();
                 return false;
             }
         }
@@ -1093,8 +1116,8 @@ bool Properties::isPropertySupported(const std::string& name) {
             // filter out options again
             filterPropertiesByCompilerSupport(_config, compiler.get(), _backend, _logger);
 
-            // reset properties for the new options
-            registerProperties();
+            // re-evaluate predicates for the updated config
+            refreshSupportedProperties();
             _compilerConfigsFilteredByCompiler = true;
             _currentlyUsedCompiler = compilerType;
             _currentlyUsedPlatform = std::move(compilationPlatform);

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -293,6 +293,27 @@ namespace intel_npu {
     } while (0)
 
 /**
+ * @brief Macro for registering compiled-model properties backed by explicit context callbacks.
+ *
+ * This macro is intended for properties whose support and value are derived from compiled-model state rather than
+ * config availability.
+ *
+ * @param OPT_NAME Class/type of the option (will fetch .name() from it)
+ * @param SUPPORT_EXPR Expression returning whether the property is supported in the current compiled-model context
+ * @param PROP_RETFUNC Custom lambda callback function for the resulting property
+ */
+#define TRY_REGISTER_COMPILEDMODEL_CONTEXT_PROPERTY(OPT_NAME, SUPPORT_EXPR, PROP_RETFUNC)                 \
+    do {                                                                                                  \
+        std::string o_name = OPT_NAME.name();                                                             \
+        if (_config.hasOpt(o_name)) {                                                                     \
+            registerProperty(o_name,                                                                      \
+                             [&](const FilteredConfig& /* unusedConfig */) { return SUPPORT_EXPR; },      \
+                             ov::PropertyMutability::RO,                                                  \
+                             PROP_RETFUNC);                                                               \
+        }                                                                                                 \
+    } while (0)
+
+/**
  * @brief Macro for force registering a fully custom property (no option entry validation.
  *
  * Same as TRY_REGISTER_CUSTOM_PROPERTY but without any checks. It will force register the property.
@@ -839,17 +860,22 @@ void Properties::registerCompiledModelProperties() {
                                    [](const Config& /* unusedConfig */) {
                                        return std::shared_ptr<const ov::Model>(nullptr);
                                    });
-    TRY_REGISTER_CUSTOM_PROPERTY(ov::runtime_requirements,
-                                 RUNTIME_REQUIREMENTS,
-                                 true,
-                                 ov::PropertyMutability::RO,
-                                 [&](const Config& /* unusedConfig */) {
-                                     OPENVINO_ASSERT(_compiledModelContext != nullptr,
-                                                     "CompiledModel context is required for runtime_requirements");
-                                     OPENVINO_ASSERT(_compiledModelContext->getRuntimeRequirements != nullptr,
-                                                     "CompiledModel runtime_requirements callback is not available");
-                                     return _compiledModelContext->getRuntimeRequirements();
-                                 });
+    TRY_REGISTER_COMPILEDMODEL_CONTEXT_PROPERTY(
+        ov::runtime_requirements,
+        [&]() {
+            OPENVINO_ASSERT(_compiledModelContext != nullptr,
+                            "CompiledModel context is required for runtime_requirements");
+            OPENVINO_ASSERT(_compiledModelContext->hasRuntimeRequirements != nullptr,
+                            "CompiledModel runtime_requirements support callback is not available");
+            return _compiledModelContext->hasRuntimeRequirements();
+        }(),
+        [&](const Config& /* unusedConfig */) {
+            OPENVINO_ASSERT(_compiledModelContext != nullptr,
+                            "CompiledModel context is required for runtime_requirements");
+            OPENVINO_ASSERT(_compiledModelContext->getRuntimeRequirements != nullptr,
+                            "CompiledModel runtime_requirements callback is not available");
+            return _compiledModelContext->getRuntimeRequirements();
+        });
 
     // 2. Metrics (static device and enviroment properties)
     // ========

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -418,8 +418,8 @@ Properties::Properties(const PropertiesType pType,
       _config(config),
       _metrics(metrics),
       _backend(backend),
-    _compiledModelContext(compiledModelContext),
-      _logger("Properties", _config.get<LOG_LEVEL>()) {
+            _compiledModelContext(compiledModelContext),
+            _logger("Properties", _config.get<LOG_LEVEL>()) {
     registerProperties();
 }
 
@@ -435,9 +435,7 @@ Properties::Properties(const Properties& other)
                            other._currentlyUsedPlatform,
                            other._compilerConfigsFilteredByCompiler,
                            other._compatibilityCheckFiltered,
-                           other._compiledModelContext,
-                           other._properties,
-                           other._supportedProperties};
+                                                     other._compiledModelContext};
       }()) {}
 
 Properties::Properties(CopyState&& state)
@@ -450,9 +448,9 @@ Properties::Properties(CopyState&& state)
       _currentlyUsedPlatform(std::move(state.currentlyUsedPlatform)),
       _compilerConfigsFilteredByCompiler(state.compilerConfigsFilteredByCompiler),
       _compatibilityCheckFiltered(state.compatibilityCheckFiltered),
-            _compiledModelContext(std::move(state.compiledModelContext)),
-      _properties(std::move(state.properties)),
-      _supportedProperties(std::move(state.supportedProperties)) {}
+            _compiledModelContext(std::move(state.compiledModelContext)) {
+    registerProperties();
+}
 
 void Properties::registerProperty(const std::string& name,
                                   SupportPredicate predicate,
@@ -949,6 +947,9 @@ ov::Any Properties::getProperty(const std::string& name) {
 
     auto&& configIterator = _properties.find(name);
     if (configIterator != _properties.cend()) {
+        if (_config.hasOpt(name) && !_config.isAvailable(name)) {
+            OPENVINO_THROW("Unsupported configuration key: ", name);
+        }
         if (std::get<1>(configIterator->second) == ov::PropertyMutability::WO) {
             _logger.warning("Trying to get WRITE-ONLY property: %s. Returning empty `ov::Any` object",
                             name.c_str());  // throw OV exception instead
@@ -1038,6 +1039,9 @@ void Properties::setProperty(const ov::AnyMap& properties) {
                 OPENVINO_THROW("Unsupported configuration key: ", value.first);
             }
         } else {
+                if (_config.hasOpt(value.first) && !_config.isAvailable(value.first)) {
+                    OPENVINO_THROW("Unsupported configuration key: ", value.first);
+                }
             if (std::get<1>(_properties[value.first]) == ov::PropertyMutability::RO) {
                 OPENVINO_THROW("READ-ONLY configuration key: ", value.first);
             } else if (value.first == ov::cache_encryption_callbacks.name()) {

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -164,32 +164,16 @@ namespace intel_npu {
  */
 #define TRY_REGISTER_SIMPLE_PROPERTY(OPT_NAME, OPT_TYPE)                                                \
     do {                                                                                                \
-        std::string o_name = OPT_NAME.name();                                                           \
-        if (_config.isAvailable(o_name)) {                                                              \
-            bool isPublic = _config.getOpt(o_name).isPublic();                                          \
-            ov::PropertyMutability isMutable = _config.getOpt(o_name).mutability();                     \
-            if (_pType == PropertiesType::COMPILED_MODEL) {                                             \
-                isMutable = ov::PropertyMutability::RO;                                                 \
-            }                                                                                           \
-            _properties.emplace(o_name, std::make_tuple(isPublic, isMutable, [](const Config& config) { \
-                                    return config.get<OPT_TYPE>();                                      \
-                                }));                                                                    \
-        }                                                                                               \
+        registerConfigProperty(OPT_NAME.name(), [](const Config& config) {                              \
+            return config.get<OPT_TYPE>();                                                               \
+        });                                                                                              \
     } while (0)
 
 #define TRY_REGISTER_NPUW_OPTION_PROPERTY(OPT_TYPE)                                                     \
     do {                                                                                                \
-        std::string o_name = std::string(OPT_TYPE::key());                                              \
-        if (_config.isAvailable(o_name)) {                                                              \
-            bool isPublic = _config.getOpt(o_name).isPublic();                                          \
-            ov::PropertyMutability isMutable = _config.getOpt(o_name).mutability();                     \
-            if (_pType == PropertiesType::COMPILED_MODEL) {                                             \
-                isMutable = ov::PropertyMutability::RO;                                                 \
-            }                                                                                           \
-            _properties.emplace(o_name, std::make_tuple(isPublic, isMutable, [](const Config& config) { \
-                                    return config.get<OPT_TYPE>();                                      \
-                                }));                                                                    \
-        }                                                                                               \
+        registerConfigProperty(std::string(OPT_TYPE::key()), [](const Config& config) {                 \
+            return config.get<OPT_TYPE>();                                                               \
+        });                                                                                              \
     } while (0)
 
 /**
@@ -224,21 +208,13 @@ namespace intel_npu {
  */
 #define TRY_REGISTER_COMPILEDMODEL_PROPERTY_IFSET(OPT_NAME, OPT_TYPE)                                   \
     do {                                                                                                \
-        std::string o_name = OPT_NAME.name();                                                           \
-        if (!_config.has(o_name)) {                                                                     \
-            break;                                                                                      \
-        }                                                                                               \
-        if (_config.isAvailable(o_name)) {                                                              \
-            bool isPublic = _config.getOpt(o_name).isPublic();                                          \
-            ov::PropertyMutability isMutable = _config.getOpt(o_name).mutability();                     \
-            if (_pType == PropertiesType::COMPILED_MODEL) {                                             \
-                isMutable = ov::PropertyMutability::RO;                                                 \
-                isPublic = true;                                                                        \
-            }                                                                                           \
-            _properties.emplace(o_name, std::make_tuple(isPublic, isMutable, [](const Config& config) { \
-                                    return config.get<OPT_TYPE>();                                      \
-                                }));                                                                    \
-        }                                                                                               \
+        registerConfigProperty(OPT_NAME.name(), [](const Config& config) {                              \
+            return config.get<OPT_TYPE>();                                                               \
+        },                                                                                               \
+                               std::nullopt,                                                             \
+                               std::nullopt,                                                             \
+                               true,                                                                     \
+                               true);                                                                    \
     } while (0)
 
 /**
@@ -257,16 +233,10 @@ namespace intel_npu {
  */
 #define TRY_REGISTER_VARPUB_PROPERTY(OPT_NAME, OPT_TYPE, PROP_VISIBILITY)                                      \
     do {                                                                                                       \
-        std::string o_name = OPT_NAME.name();                                                                  \
-        if (_config.isAvailable(o_name)) {                                                                     \
-            ov::PropertyMutability isMutable = _config.getOpt(o_name).mutability();                            \
-            if (_pType == PropertiesType::COMPILED_MODEL) {                                                    \
-                isMutable = ov::PropertyMutability::RO;                                                        \
-            }                                                                                                  \
-            _properties.emplace(o_name, std::make_tuple(PROP_VISIBILITY, isMutable, [](const Config& config) { \
-                                    return config.get<OPT_TYPE>();                                             \
-                                }));                                                                           \
-        }                                                                                                      \
+        registerConfigProperty(OPT_NAME.name(), [](const Config& config) {                                    \
+            return config.get<OPT_TYPE>();                                                                     \
+        },                                                                                                     \
+                               PROP_VISIBILITY);                                                               \
     } while (0)
 
 /**
@@ -284,15 +254,7 @@ namespace intel_npu {
  */
 #define TRY_REGISTER_CUSTOMFUNC_PROPERTY(OPT_NAME, OPT_TYPE, PROP_RETFUNC)                   \
     do {                                                                                     \
-        std::string o_name = OPT_NAME.name();                                                \
-        if (_config.isAvailable(o_name)) {                                                   \
-            bool isPublic = _config.getOpt(o_name).isPublic();                               \
-            ov::PropertyMutability isMutable = _config.getOpt(o_name).mutability();          \
-            if (_pType == PropertiesType::COMPILED_MODEL) {                                  \
-                isMutable = ov::PropertyMutability::RO;                                      \
-            }                                                                                \
-            _properties.emplace(o_name, std::make_tuple(isPublic, isMutable, PROP_RETFUNC)); \
-        }                                                                                    \
+        registerConfigProperty(OPT_NAME.name(), PROP_RETFUNC);                               \
     } while (0)
 
 /**
@@ -320,7 +282,7 @@ namespace intel_npu {
     do {                                                                                                  \
         std::string o_name = OPT_NAME.name();                                                             \
         if (_config.isAvailable(o_name)) {                                                                \
-            _properties.emplace(o_name, std::make_tuple(PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC)); \
+            registerProperty(o_name, PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC);                    \
         }                                                                                                 \
     } while (0)
 
@@ -344,7 +306,7 @@ namespace intel_npu {
  */
 #define FORCE_REGISTER_CUSTOM_PROPERTY(OPT_NAME, OPT_TYPE, PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC)     \
     do {                                                                                                       \
-        _properties.emplace(OPT_NAME.name(), std::make_tuple(PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC)); \
+        registerProperty(OPT_NAME.name(), PROP_VISIBILITY, PROP_MUTABILITY, PROP_RETFUNC);                    \
     } while (0)
 
 /**
@@ -367,11 +329,12 @@ namespace intel_npu {
  */
 #define REGISTER_SIMPLE_METRIC(PROP_NAME, PROP_VISIBILITY, PROP_RETVAL)                                      \
     do {                                                                                                     \
-        _properties.emplace(                                                                                 \
-            PROP_NAME.name(),                                                                                \
-            std::make_tuple(PROP_VISIBILITY, ov::PropertyMutability::RO, [&](const Config& config) -> auto { \
-                return PROP_RETVAL;                                                                          \
-            }));                                                                                             \
+        registerProperty(PROP_NAME.name(),                                                                   \
+                         PROP_VISIBILITY,                                                                    \
+                         ov::PropertyMutability::RO,                                                         \
+                         [&](const Config& config) -> auto {                                                 \
+                             return PROP_RETVAL;                                                             \
+                         });                                                                                 \
     } while (0)
 
 /**
@@ -393,8 +356,7 @@ namespace intel_npu {
 // Macro for defining metrics with custom return function
 #define REGISTER_CUSTOM_METRIC(PROP_NAME, PROP_VISIBILITY, PROP_RETFUNC)                                 \
     do {                                                                                                 \
-        _properties.emplace(PROP_NAME.name(),                                                            \
-                            std::make_tuple(PROP_VISIBILITY, ov::PropertyMutability::RO, PROP_RETFUNC)); \
+        registerProperty(PROP_NAME.name(), PROP_VISIBILITY, ov::PropertyMutability::RO, PROP_RETFUNC);  \
     } while (0)
 
 // Local helper function for appending platform name to the config
@@ -472,6 +434,40 @@ Properties::Properties(CopyState&& state)
       _compatibilityCheckFiltered(state.compatibilityCheckFiltered),
       _properties(std::move(state.properties)),
       _supportedProperties(std::move(state.supportedProperties)) {}
+
+void Properties::registerProperty(const std::string& name,
+                                  bool isPublic,
+                                  ov::PropertyMutability mutability,
+                                  const PropertyGetter& getter) {
+    _properties.emplace(name, std::make_tuple(isPublic, mutability, getter));
+}
+
+void Properties::registerConfigProperty(const std::string& name,
+                                        const PropertyGetter& getter,
+                                        std::optional<bool> visibilityOverride,
+                                        std::optional<ov::PropertyMutability> mutabilityOverride,
+                                        bool requireSetInConfig,
+                                        bool forcePublicInCompiledModel) {
+    if (requireSetInConfig && !_config.has(name)) {
+        return;
+    }
+
+    if (!_config.isAvailable(name)) {
+        return;
+    }
+
+    bool isPublic = visibilityOverride.value_or(_config.getOpt(name).isPublic());
+    ov::PropertyMutability isMutable = mutabilityOverride.value_or(_config.getOpt(name).mutability());
+
+    if (_pType == PropertiesType::COMPILED_MODEL) {
+        isMutable = ov::PropertyMutability::RO;
+        if (forcePublicInCompiledModel) {
+            isPublic = true;
+        }
+    }
+
+    registerProperty(name, isPublic, isMutable, getter);
+}
 
 void Properties::registerProperties() {
     // Reset

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -412,11 +412,13 @@ static int64_t getOptimalNumberOfInferRequestsInParallel(const Config& config) {
 Properties::Properties(const PropertiesType pType,
                        const FilteredConfig& config,
                        const std::shared_ptr<Metrics>& metrics,
-                       const ov::SoPtr<IEngineBackend>& backend)
+                 const ov::SoPtr<IEngineBackend>& backend,
+                 const std::shared_ptr<const CompiledModelContext>& compiledModelContext)
     : _pType(pType),
       _config(config),
       _metrics(metrics),
       _backend(backend),
+    _compiledModelContext(compiledModelContext),
       _logger("Properties", _config.get<LOG_LEVEL>()) {
     registerProperties();
 }
@@ -433,6 +435,7 @@ Properties::Properties(const Properties& other)
                            other._currentlyUsedPlatform,
                            other._compilerConfigsFilteredByCompiler,
                            other._compatibilityCheckFiltered,
+                           other._compiledModelContext,
                            other._properties,
                            other._supportedProperties};
       }()) {}
@@ -447,6 +450,7 @@ Properties::Properties(CopyState&& state)
       _currentlyUsedPlatform(std::move(state.currentlyUsedPlatform)),
       _compilerConfigsFilteredByCompiler(state.compilerConfigsFilteredByCompiler),
       _compatibilityCheckFiltered(state.compatibilityCheckFiltered),
+            _compiledModelContext(std::move(state.compiledModelContext)),
       _properties(std::move(state.properties)),
       _supportedProperties(std::move(state.supportedProperties)) {}
 
@@ -841,10 +845,12 @@ void Properties::registerCompiledModelProperties() {
                                  RUNTIME_REQUIREMENTS,
                                  true,
                                  ov::PropertyMutability::RO,
-                                 [](const Config& /* unusedConfig */) {
-                                     // This property is implemented in compiled model directly
-                                     // This implementation here serves only to publish it in supported_properties
-                                     return std::string("");
+                                 [&](const Config& /* unusedConfig */) {
+                                     OPENVINO_ASSERT(_compiledModelContext != nullptr,
+                                                     "CompiledModel context is required for runtime_requirements");
+                                     OPENVINO_ASSERT(_compiledModelContext->getRuntimeRequirements != nullptr,
+                                                     "CompiledModel runtime_requirements callback is not available");
+                                     return _compiledModelContext->getRuntimeRequirements();
                                  });
 
     // 2. Metrics (static device and enviroment properties)
@@ -852,11 +858,11 @@ void Properties::registerCompiledModelProperties() {
     // REGISTER_SIMPLE_METRIC format: (property, public true/false, return value)
     // REGISTER_CUSTOM_METRIC format: (property, public true/false, return value function)
 
-    REGISTER_CUSTOM_METRIC(ov::model_name, true, [](const Config&) {
-        // TODO: log an error here as the code shouldn't have gotten here
-        // this property is implemented in compiled model directly
-        // this implementation here serves only to publish it in supported_properties
-        return std::string("invalid");
+    REGISTER_CUSTOM_METRIC(ov::model_name, true, [&](const Config&) {
+        OPENVINO_ASSERT(_compiledModelContext != nullptr, "CompiledModel context is required for model_name");
+        OPENVINO_ASSERT(_compiledModelContext->getModelName != nullptr,
+                        "CompiledModel model_name callback is not available");
+        return _compiledModelContext->getModelName();
     });
     REGISTER_SIMPLE_METRIC(ov::optimal_number_of_infer_requests,
                            true,


### PR DESCRIPTION
### Details:

This PR refactors the Intel NPU property manager in three incremental steps while preserving existing external behavior.

1. First, it introduces method-based registration helpers in Properties and routes the existing macro-based registration through those helpers. This keeps the current property surface unchanged, but establishes a single internal registration path that is easier to extend and reason about.

2. Second, it separates property registration from property publication. Registered properties now carry explicit support predicates, and supported_properties is rebuilt through a lightweight refresh step instead of relying on full re-registration when compiler or platform context changes. This makes support evaluation clearer and reduces the amount of work done on refresh-sensitive paths such as getProperty, setProperty, and isPropertySupported.

3. Third, it extends the same architecture to compiled-model-specific properties. A narrow compiled-model context is passed into Properties, allowing compiled-model-backed values such as ov::model_name and ov::runtime_requirements to be served through the unified property descriptor pipeline instead of separate hardcoded branches in CompiledModel::get_property.

In effect, this PR moves the NPU property system toward a descriptor-driven model with:
- centralized registration
- predicate-based support evaluation
- explicit refresh of published properties
- unified handling of plugin and compiled-model property callbacks

The intent is architectural cleanup and future extensibility, not user-visible behavior change. Existing property names, mutability rules, and general query flows are preserved.

### Tickets:
 - *CVS-187127*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
