### PR TITLE
[ONNX FE] Wrap SequenceInsert output in SequenceMark

### DIFF
--- a/src/frontends/onnx/frontend/src/op/sequence_insert.cpp
+++ b/src/frontends/onnx/frontend/src/op/sequence_insert.cpp
@@ -28,11 +28,24 @@ ov::OutputVector sequence_insert(const ov::frontend::onnx::Node& node) {
     const auto& sequence_input = inputs[0];
     const auto& to_insert = inputs[1];
 
-    // Create a SequenceInsert helper op that will be resolved by a transformation pass
+    // Create a SequenceInsert helper op that will be resolved by a transformation pass.
+    // Wrap the result in a SequenceMark so that downstream consumers (e.g. ConcatFromSequence
+    // or SequenceAt) can use SequenceMark::get_sequence() to walk through a chain of
+    // SequenceInsert nodes and collect all inserted elements. This mirrors what the PyTorch
+    // frontend does for aten::append. Without the wrapping SequenceMark, a chain of
+    // SequenceInsert nodes feeding into ConcatFromSequence (as produced for models like
+    // ConvNeXt/Swin) cannot be matched by the SequenceConcatReplacer pattern.
+    std::shared_ptr<ov::frontend::SequenceInsert> seq_insert;
     if (inputs.size() == 3) {
-        return {std::make_shared<ov::frontend::SequenceInsert>(sequence_input, to_insert, inputs[2])};
+        seq_insert = std::make_shared<ov::frontend::SequenceInsert>(sequence_input, to_insert, inputs[2]);
+    } else {
+        seq_insert = std::make_shared<ov::frontend::SequenceInsert>(sequence_input, to_insert);
     }
-    return {std::make_shared<ov::frontend::SequenceInsert>(sequence_input, to_insert)};
+    auto sequence = std::make_shared<ov::frontend::SequenceMark>(ov::OutputVector{seq_insert});
+    ov::op::util::FrameworkNodeAttrs attrs;
+    attrs.set_type_name("SequenceInsert");
+    sequence->set_attrs(attrs);
+    return {sequence};
 }
 
 ONNX_OP("SequenceInsert", OPSET_SINCE(1), ai_onnx::opset_11::sequence_insert);

--- a/src/frontends/onnx/tests/models/controlflow/sequence_insert_chain_concat.prototxt
+++ b/src/frontends/onnx/tests/models/controlflow/sequence_insert_chain_concat.prototxt
@@ -1,0 +1,108 @@
+ir_version: 7
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "sequence_insert_chain_concat"
+  node {
+    input: "input_a"
+    output: "seq0"
+    op_type: "SequenceConstruct"
+  }
+  node {
+    input: "seq0"
+    input: "input_b"
+    output: "seq1"
+    op_type: "SequenceInsert"
+  }
+  node {
+    input: "seq1"
+    input: "input_c"
+    output: "seq2"
+    op_type: "SequenceInsert"
+  }
+  node {
+    input: "seq2"
+    input: "input_d"
+    output: "seq3"
+    op_type: "SequenceInsert"
+  }
+  node {
+    input: "seq3"
+    output: "output"
+    op_type: "ConcatFromSequence"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "new_axis"
+      i: 0
+      type: INT
+    }
+  }
+  input {
+    name: "input_a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "input_b"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "input_c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "input_d"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 14
+}

--- a/src/frontends/onnx/tests/models/controlflow/sequence_insert_chain_new_axis.prototxt
+++ b/src/frontends/onnx/tests/models/controlflow/sequence_insert_chain_new_axis.prototxt
@@ -1,0 +1,94 @@
+ir_version: 7
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "sequence_insert_chain_new_axis"
+  node {
+    output: "seq0"
+    op_type: "SequenceEmpty"
+  }
+  node {
+    input: "seq0"
+    input: "input_a"
+    output: "seq1"
+    op_type: "SequenceInsert"
+  }
+  node {
+    input: "seq1"
+    input: "input_b"
+    output: "seq2"
+    op_type: "SequenceInsert"
+  }
+  node {
+    input: "seq2"
+    input: "input_c"
+    output: "seq3"
+    op_type: "SequenceInsert"
+  }
+  node {
+    input: "seq3"
+    output: "output"
+    op_type: "ConcatFromSequence"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "new_axis"
+      i: 1
+      type: INT
+    }
+  }
+  input {
+    name: "input_a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "input_b"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "input_c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 14
+}

--- a/src/frontends/onnx/tests/onnx_import_controlflow.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_controlflow.in.cpp
@@ -906,3 +906,38 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_sequence_construct_concat) {
     test_case.add_expected_output<float>(Shape{3, 2}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
     test_case.run();
 }
+
+/// @brief Test SequenceConstruct -> SequenceInsert chain -> ConcatFromSequence pattern
+/// Reproduces the pattern produced by exporters for vision transformer style models
+/// (ConvNeXt, Swin family) where a sequence is built up via repeated SequenceInsert calls
+/// outside any Loop and then collapsed by ConcatFromSequence. Verifies that
+/// SequenceMark::get_sequence() correctly walks the chain of SequenceInsert nodes.
+OPENVINO_TEST(${BACKEND_NAME}, onnx_sequence_insert_chain_concat) {
+    const auto model = convert_model("controlflow/sequence_insert_chain_concat.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    // Four input tensors of shape [2]
+    test_case.add_input<float>({1.f, 2.f});  // input_a
+    test_case.add_input<float>({3.f, 4.f});  // input_b
+    test_case.add_input<float>({5.f, 6.f});  // input_c
+    test_case.add_input<float>({7.f, 8.f});  // input_d
+
+    // axis=0, new_axis=0: concatenate four [2] tensors -> [8]
+    test_case.add_expected_output<float>(Shape{8}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f});
+    test_case.run();
+}
+
+/// @brief Test SequenceEmpty -> SequenceInsert chain -> ConcatFromSequence with new_axis=1
+/// Exercises the same chain pattern starting from an empty sequence and stacking along a new axis.
+OPENVINO_TEST(${BACKEND_NAME}, onnx_sequence_insert_chain_new_axis) {
+    const auto model = convert_model("controlflow/sequence_insert_chain_new_axis.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({1.f, 2.f});  // input_a
+    test_case.add_input<float>({3.f, 4.f});  // input_b
+    test_case.add_input<float>({5.f, 6.f});  // input_c
+
+    // axis=0, new_axis=1: stack three [2] tensors -> [3, 2]
+    test_case.add_expected_output<float>(Shape{3, 2}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
+    test_case.run();
+}


### PR DESCRIPTION
### Details:
 - ONNX `SequenceInsert` was emitted as a bare framework node. `SequenceConcatReplacer` Case 1 requires a `SequenceMark` input, so `SequenceConstruct -> SequenceInsert(s) -> ConcatFromSequence` chains fell through to the Loop branch and failed.
 - Wrap each `SequenceInsert` output in a `SequenceMark`, matching the PyTorch `aten::append` convention. `SequenceMark::get_sequence()` already walks `SequenceMark(SequenceInsert(...))` chains, so consumers need no changes.
 - Added regression tests `onnx_sequence_insert_chain_concat` and `onnx_sequence_insert_chain_new_axis`.

### Tickets:
 - *CVS-187757*

### AI Assistance:
 - AI assistance used: yes
 - Used to localize the root cause, draft the fix, and generate the prototxt models. Validated by building and running the new tests plus the broader sequence suite on CPU and INTERPRETER.