### PR TITLE
[ONNX] Fix PRelu slope broadcasting for 1D slope

### DIFF
--- a/src/frontends/onnx/frontend/src/op/prelu.cpp
+++ b/src/frontends/onnx/frontend/src/op/prelu.cpp
@@ -4,7 +4,11 @@
 
 #include "openvino/op/prelu.hpp"
 
+#include <numeric>
+
 #include "core/operator_set.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/unsqueeze.hpp"
 using namespace ov::op;
 
 namespace ov {
@@ -15,7 +19,19 @@ namespace opset_1 {
 ov::OutputVector prelu(const ov::frontend::onnx::Node& node) {
     ov::OutputVector ov_inputs{node.get_ov_inputs()};
     const auto& data = ov_inputs.at(0);
-    const auto& slope = ov_inputs.at(1);
+    auto slope = ov_inputs.at(1);
+    const auto& data_rank = data.get_partial_shape().rank();
+    const auto& slope_rank = slope.get_partial_shape().rank();
+    if (data_rank.is_static() && slope_rank.is_static()) {
+        const auto rank_diff = data_rank.get_length() - slope_rank.get_length();
+        if (rank_diff > 0) {
+            std::vector<int64_t> axes(rank_diff);
+            std::iota(axes.begin(), axes.end(), 0);
+            const auto axes_const =
+                std::make_shared<v0::Constant>(ov::element::i64, ov::Shape{axes.size()}, axes);
+            slope = std::make_shared<v0::Unsqueeze>(slope, axes_const);
+        }
+    }
     return {std::make_shared<v0::PRelu>(data, slope)};
 }
 

--- a/src/frontends/onnx/tests/models/prelu_1d_slope_matches_channel.prototxt
+++ b/src/frontends/onnx/tests/models/prelu_1d_slope_matches_channel.prototxt
@@ -1,0 +1,72 @@
+ir_version: 7
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "X"
+    input: "SLOPE"
+    output: "Y"
+    op_type: "PRelu"
+  }
+  name: "test-model-prelu"
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "SLOPE"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 12
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -2720,6 +2720,25 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_prelu_C_1_1) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_prelu_1d_slope_matches_channel) {
+    auto model = convert_model("prelu_1d_slope_matches_channel.onnx");
+
+    Inputs inputs;
+    inputs.emplace_back(std::vector<float>{-1.0f, -2.0f, -3.0f, -4.0f, -5.0f, -6.0f, -7.0f, -8.0f, -9.0f,
+                                           -10.0f, -11.0f, -12.0f, -13.0f, -14.0f, -15.0f, -16.0f, -17.0f, -18.0f});
+
+    inputs.emplace_back(std::vector<float>{0.5f, 1.5f, 2.5f});
+
+    auto expected_output = std::vector<float>{-0.5f, -3.0f, -7.5f, -2.0f, -7.5f, -15.0f,
+                                              -3.5f, -12.0f, -22.5f, -5.0f, -16.5f, -30.0f,
+                                              -6.5f, -21.0f, -37.5f, -8.0f, -25.5f, -45.0f};
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_multiple_inputs(inputs);
+    test_case.add_expected_output(expected_output);
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_selu) {
     auto model = convert_model("selu.onnx");
 


### PR DESCRIPTION
The ONNX importer passed a 1D slope straight to the shared PRelu op, which carries a Caffe compatibility heuristic that reshapes a 1D slope to channel layout whenever its size happens to match the input channel dim, and that heuristic silently wins over the NumPy broadcasting required by ONNX opset 9 and later. For shapes where the slope length coincides with the channel dim this produced output that disagreed with the ONNX spec and with ONNX Runtime. The change prepends leading unit dimensions to the slope inside the ONNX importer so its rank matches the input, which keeps the heuristic from firing and lets NumPy broadcasting proceed on the trailing dims as the spec describes. A regression test for the [1, 3, 2, 3] over [3] shape from the bug report is added under src/frontends/onnx/tests. Fixes #35958.