### PR TITLE
[GPU] support input/output padding for reorder_data_fsv

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_fsv.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_fsv.cl
@@ -47,22 +47,12 @@ KERNEL (reorder_data_fsv)(
 #endif
     const uint in_b_pitch = in_fs_pitch * IN_FEATURE_SLICE_NUM;
 
-    const uint out_x_pitch = OUT_FSV;
-    const uint out_y_pitch = out_x_pitch * OUTPUT_SIZE_X;
 #ifdef INPUT0_DIMS_5
-    const uint out_z_pitch = out_y_pitch * OUTPUT_SIZE_Y;
-    const uint out_fs_pitch = out_z_pitch * OUTPUT_SIZE_Z;
-#else
-    const uint out_fs_pitch = out_y_pitch * OUTPUT_SIZE_Y;
-#endif
-    const uint out_b_pitch = out_fs_pitch * OUT_FEATURE_SLICE_NUM;
-
-#ifdef INPUT0_DIMS_5
-    const uint out_offset_base = b * out_b_pitch + fs_out * out_fs_pitch + z * out_z_pitch + y * out_y_pitch + x * OUT_FSV;
     const uint in_spatial_base = b * in_b_pitch + z * in_z_pitch + y * in_y_pitch + x * IN_FSV;
+#define OUT_INDEX(f) OUTPUT_GET_INDEX(b, (f), z, y, x)
 #else
-    const uint out_offset_base = b * out_b_pitch + fs_out * out_fs_pitch + y * out_y_pitch + x * OUT_FSV;
     const uint in_spatial_base = b * in_b_pitch + y * in_y_pitch + x * IN_FSV;
+#define OUT_INDEX(f) OUTPUT_GET_INDEX(b, (f), y, x)
 #endif
 
 #ifdef FSV_VECTORIZED
@@ -75,10 +65,10 @@ KERNEL (reorder_data_fsv)(
             const uint f_chunk = f_base + r * VEC_SIZE;
             if (f_chunk < INPUT0_FEATURE_NUM) {
                 INPUT_VEC_TYPE v = VLOAD_VEC(0, input + in_spatial_base + fs_in * in_fs_pitch);
-                VSTORE_VEC(CONVERT_OUT_VEC(v), 0, output + out_offset_base + r * VEC_SIZE);
+                VSTORE_VEC(CONVERT_OUT_VEC(v), 0, output + OUT_INDEX(f_chunk));
             } else {
                 OUTPUT_VEC_TYPE zero = (OUTPUT_VEC_TYPE)(0);
-                VSTORE_VEC(zero, 0, output + out_offset_base + r * VEC_SIZE);
+                VSTORE_VEC(zero, 0, output + OUT_INDEX(f_chunk));
             }
         }
     #else
@@ -87,10 +77,10 @@ KERNEL (reorder_data_fsv)(
         const uint sub = fs_out % RATIO;
         if (f_base < INPUT0_FEATURE_NUM) {
             INPUT_VEC_TYPE v = VLOAD_VEC(0, input + in_spatial_base + fs_in * in_fs_pitch + sub * VEC_SIZE);
-            VSTORE_VEC(CONVERT_OUT_VEC(v), 0, output + out_offset_base);
+            VSTORE_VEC(CONVERT_OUT_VEC(v), 0, output + OUT_INDEX(f_base));
         } else {
             OUTPUT_VEC_TYPE zero = (OUTPUT_VEC_TYPE)(0);
-            VSTORE_VEC(zero, 0, output + out_offset_base);
+            VSTORE_VEC(zero, 0, output + OUT_INDEX(f_base));
         }
     #endif
 #else
@@ -101,10 +91,12 @@ KERNEL (reorder_data_fsv)(
             const uint fs_in = f / IN_FSV;
             const uint fsv_in = f % IN_FSV;
             const uint in_offset = in_spatial_base + fs_in * in_fs_pitch + fsv_in;
-            output[out_offset_base + i] = ACTIVATION(TO_OUTPUT_TYPE(input[in_offset]), ACTIVATION_PARAMS);
+            output[OUT_INDEX(f)] = ACTIVATION(TO_OUTPUT_TYPE(input[in_offset]), ACTIVATION_PARAMS);
         } else {
-            output[out_offset_base + i] = TO_OUTPUT_TYPE(0);
+            output[OUT_INDEX(f)] = TO_OUTPUT_TYPE(0);
         }
     }
 #endif
+
+#undef OUT_INDEX
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_fsv.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_fsv.cl
@@ -38,20 +38,20 @@ KERNEL (reorder_data_fsv)(
     const uint f_base = fs_out * OUT_FSV;
 
     const uint in_x_pitch = IN_FSV;
-    const uint in_y_pitch = in_x_pitch * INPUT0_SIZE_X;
+    const uint in_y_pitch = in_x_pitch * (INPUT0_PAD_BEFORE_SIZE_X + INPUT0_SIZE_X + INPUT0_PAD_AFTER_SIZE_X);
 #ifdef INPUT0_DIMS_5
-    const uint in_z_pitch = in_y_pitch * INPUT0_SIZE_Y;
-    const uint in_fs_pitch = in_z_pitch * INPUT0_SIZE_Z;
+    const uint in_z_pitch = in_y_pitch * (INPUT0_PAD_BEFORE_SIZE_Y + INPUT0_SIZE_Y + INPUT0_PAD_AFTER_SIZE_Y);
+    const uint in_fs_pitch = in_z_pitch * (INPUT0_PAD_BEFORE_SIZE_Z + INPUT0_SIZE_Z + INPUT0_PAD_AFTER_SIZE_Z);
 #else
-    const uint in_fs_pitch = in_y_pitch * INPUT0_SIZE_Y;
+    const uint in_fs_pitch = in_y_pitch * (INPUT0_PAD_BEFORE_SIZE_Y + INPUT0_SIZE_Y + INPUT0_PAD_AFTER_SIZE_Y);
 #endif
     const uint in_b_pitch = in_fs_pitch * IN_FEATURE_SLICE_NUM;
 
 #ifdef INPUT0_DIMS_5
-    const uint in_spatial_base = b * in_b_pitch + z * in_z_pitch + y * in_y_pitch + x * IN_FSV;
+    const uint in_spatial_base = (b + INPUT0_PAD_BEFORE_BATCH_NUM) * in_b_pitch + (INPUT0_PAD_BEFORE_FEATURE_NUM / IN_FSV) * in_fs_pitch + (z + INPUT0_PAD_BEFORE_SIZE_Z) * in_z_pitch + (y + INPUT0_PAD_BEFORE_SIZE_Y) * in_y_pitch + (x + INPUT0_PAD_BEFORE_SIZE_X) * IN_FSV;
 #define OUT_INDEX(f) OUTPUT_GET_INDEX(b, (f), z, y, x)
 #else
-    const uint in_spatial_base = b * in_b_pitch + y * in_y_pitch + x * IN_FSV;
+    const uint in_spatial_base = (b + INPUT0_PAD_BEFORE_BATCH_NUM) * in_b_pitch + (INPUT0_PAD_BEFORE_FEATURE_NUM / IN_FSV) * in_fs_pitch + (y + INPUT0_PAD_BEFORE_SIZE_Y) * in_y_pitch + (x + INPUT0_PAD_BEFORE_SIZE_X) * IN_FSV;
 #define OUT_INDEX(f) OUTPUT_GET_INDEX(b, (f), y, x)
 #endif
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fsv.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fsv.cpp
@@ -96,14 +96,6 @@ bool ReorderKernel_fsv::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    if (output.X().pad.before != 0 || output.X().pad.after != 0 ||
-        output.Y().pad.before != 0 || output.Y().pad.after != 0 ||
-        output.Z().pad.before != 0 || output.Z().pad.after != 0 ||
-        output.Feature().pad.before != 0 || output.Feature().pad.after != 0 ||
-        output.Batch().pad.before != 0 || output.Batch().pad.after != 0) {
-        DO_NOT_USE_THIS_KERNEL(p.layerID);
-    }
-
     return true;
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fsv.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fsv.cpp
@@ -87,15 +87,6 @@ bool ReorderKernel_fsv::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    // Padding not supported
-    if (input.X().pad.before != 0 || input.X().pad.after != 0 ||
-        input.Y().pad.before != 0 || input.Y().pad.after != 0 ||
-        input.Z().pad.before != 0 || input.Z().pad.after != 0 ||
-        input.Feature().pad.before != 0 || input.Feature().pad.after != 0 ||
-        input.Batch().pad.before != 0 || input.Batch().pad.after != 0) {
-        DO_NOT_USE_THIS_KERNEL(p.layerID);
-    }
-
     return true;
 }
 

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -1652,6 +1652,65 @@ TEST(prepare_buffer_fusing, in_place_onednn_concat_static) {
 }
 #endif  // ENABLE_ONEDNN_FOR_GPU
 
+TEST(prepare_buffer_fusing, in_place_concat_with_fsv32_to_fsv16_reorder_regression) {
+    auto& engine = get_test_engine();
+
+    auto in_layout = layout{ov::PartialShape{1, 32, 1, 1, 1}, data_types::f32, format::bfzyx};
+
+    topology topology;
+    topology.add(input_layout("input1", in_layout));
+    topology.add(input_layout("input2", in_layout));
+    topology.add(reorder("input1_fsv16", input_info("input1"), format::b_fs_zyx_fsv16, data_types::f16));
+    topology.add(reorder("input2_fsv32", input_info("input2"), format::b_fs_zyx_fsv32, data_types::f16));
+    topology.add(reorder("input2_fsv16", input_info("input2_fsv32"), format::b_fs_zyx_fsv16, data_types::f16));
+    topology.add(concatenation("concat", {input_info("input1_fsv16"), input_info("input2_fsv16")}, 1));
+    topology.add(reorder("output", input_info("concat"), format::bfzyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(false));
+
+    network network(engine, topology, config);
+
+    auto input_memory1 = engine.allocate_memory(in_layout);
+    auto input_memory2 = engine.allocate_memory(in_layout);
+
+    std::vector<float> input1_vals(32);
+    std::vector<float> input2_vals(32);
+    for (size_t i = 0; i < 32; ++i) {
+        input1_vals[i] = static_cast<float>(i + 1);
+        input2_vals[i] = static_cast<float>(1000 + i + 1);
+    }
+
+    set_values<float>(input_memory1, input1_vals);
+    set_values<float>(input_memory2, input2_vals);
+
+    network.set_input_data("input1", input_memory1);
+    network.set_input_data("input2", input_memory2);
+
+    std::map<cldnn::primitive_id, cldnn::network_output> output;
+    EXPECT_NO_THROW(output = network.execute());
+
+    const auto& concat_inst = network.get_primitive("concat");
+    ASSERT_TRUE(concat_inst->can_be_optimized());
+
+    auto concat_mem = concat_inst->output_memory_ptr();
+    auto input1_fsv16_mem = network.get_primitive("input1_fsv16")->output_memory_ptr();
+    auto input2_fsv16_mem = network.get_primitive("input2_fsv16")->output_memory_ptr();
+
+    ASSERT_EQ(concat_mem.get(), input1_fsv16_mem.get());
+    ASSERT_EQ(concat_mem.get(), input2_fsv16_mem.get());
+
+    auto out_mem = output.at("output").get_memory();
+    cldnn::mem_lock<float> output_ptr(out_mem, get_test_stream());
+
+    ASSERT_EQ(out_mem->count(), 64);
+    for (size_t i = 0; i < 32; ++i) {
+        ASSERT_EQ(output_ptr[i], input1_vals[i]);
+        ASSERT_EQ(output_ptr[i + 32], input2_vals[i]);
+    }
+}
+
 TEST(prepare_buffer_fusing, inner_axis_data_offset_with_gemm_user) {
     tests::random_generator rg(GET_SUITE_NAME);
 

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -1653,6 +1653,8 @@ TEST(prepare_buffer_fusing, in_place_onednn_concat_static) {
 #endif  // ENABLE_ONEDNN_FOR_GPU
 
 TEST(prepare_buffer_fusing, in_place_concat_with_fsv32_to_fsv16_reorder_regression) {
+    // Regression test for fsv32->fsv16 reorder + in-place concat path.
+    // Keep in-place enabled, then verify buffer sharing and output channel order.
     auto& engine = get_test_engine();
 
     auto in_layout = layout{ov::PartialShape{1, 32, 1, 1, 1}, data_types::f32, format::bfzyx};
@@ -1692,18 +1694,21 @@ TEST(prepare_buffer_fusing, in_place_concat_with_fsv32_to_fsv16_reorder_regressi
     EXPECT_NO_THROW(output = network.execute());
 
     const auto& concat_inst = network.get_primitive("concat");
+    // This case is expected to be in-place after prepare_buffer_fusing.
     ASSERT_TRUE(concat_inst->can_be_optimized());
 
     auto concat_mem = concat_inst->output_memory_ptr();
     auto input1_fsv16_mem = network.get_primitive("input1_fsv16")->output_memory_ptr();
     auto input2_fsv16_mem = network.get_primitive("input2_fsv16")->output_memory_ptr();
 
+    // In-place concat means all these primitives point to the same underlying buffer.
     ASSERT_EQ(concat_mem.get(), input1_fsv16_mem.get());
     ASSERT_EQ(concat_mem.get(), input2_fsv16_mem.get());
 
     auto out_mem = output.at("output").get_memory();
     cldnn::mem_lock<float> output_ptr(out_mem, get_test_stream());
 
+    // Validate semantic correctness: first 32 channels from input1, next 32 from input2.
     ASSERT_EQ(out_mem->count(), 64);
     for (size_t i = 0; i < 32; ++i) {
         ASSERT_EQ(output_ptr[i], input1_vals[i]);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -367,6 +367,101 @@ static void compare_bfyx2blocked_with_ref_dynamic(const std::string& kernel_name
         compare_result<float>(outputs_ref, outputs_dyn);
 }
 
+static void compare_fsv_reorder_with_ref_output_padding(const data_types input_data_type,
+    const data_types output_data_type,
+    cldnn::format input_format,
+    cldnn::format output_format,
+    int32_t b_in,
+    int32_t f_in,
+    int32_t x_in,
+    int32_t y_in,
+    int32_t z_in,
+    int32_t w_in,
+    const padding& output_padding) {
+    auto& engine = get_test_engine();
+    if (engine.get_device_info().supports_immad) {
+        return;
+    }
+
+    tensor ts;
+    if (input_format.dimension() == 4) {
+        ts = { b_in, f_in, x_in, y_in };
+    } else if (input_format.dimension() == 5) {
+        ts = { b_in, f_in, x_in, y_in, z_in };
+    } else {
+        ts = { b_in, f_in, x_in, y_in, z_in, w_in };
+    }
+
+    auto input = engine.allocate_memory({ input_data_type, input_format, ts });
+    layout output_layout(output_data_type, output_format, ts, output_padding);
+
+    {
+        auto stream = std::shared_ptr<cldnn::stream>(engine.create_stream(get_test_default_config(engine)));
+        if (input_data_type == data_types::i8 || input_data_type == data_types::u8) {
+            mem_lock<uint8_t> input_ptr{input, *stream};
+            unsigned char i = 1;
+            for (auto it = input_ptr.begin(); it != input_ptr.end(); ++it) {
+                *it = (i++);
+                if (i > 100) {
+                    i = 1;
+                }
+            }
+        } else if (input_data_type == data_types::f16) {
+            mem_lock<ov::float16> input_ptr{input, *stream};
+            ov::float16 i = ov::float16(1.0f);
+            for (auto it = input_ptr.begin(); it != input_ptr.end(); ++it) {
+                *it = i;
+                i = ov::float16(static_cast<float>(i) + 1.0f);
+            }
+        } else {
+            mem_lock<float> input_ptr{input, *stream};
+            float i = 1.f;
+            for (auto it = input_ptr.begin(); it != input_ptr.end(); ++it) {
+                *it = i;
+                i += 1.f;
+            }
+        }
+    }
+
+    topology topo_ref(
+        input_layout("input", input->get_layout()),
+        reorder("reorder", input_info("input"), output_layout));
+
+    ExecutionConfig config_ref = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc reorder_ref = { output_format, "reorder_data" };
+    config_ref.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"reorder", reorder_ref}}));
+
+    cldnn::network network_ref(engine, topo_ref, config_ref);
+    network_ref.set_input_data("input", input);
+    auto outputs_ref = network_ref.execute();
+
+    ExecutionConfig config_opt = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc reorder_opt = { output_format, "reorder_data_fsv" };
+    config_opt.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"reorder", reorder_opt}}));
+
+    cldnn::network network_opt(engine, topo_ref, config_opt);
+    network_opt.set_input_data("input", input);
+    auto outputs_opt = network_opt.execute();
+
+    auto reorder_inst = network_opt.get_primitive("reorder");
+    auto reorder_impl = reorder_inst->get_impl();
+    ASSERT_TRUE(reorder_impl != nullptr);
+    ASSERT_NE(reorder_impl->get_kernel_name().find("reorder_data_fsv"), std::string::npos);
+
+    if (output_data_type == data_types::i8)
+        compare_result<int8_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::u8)
+        compare_result<uint8_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::i32)
+        compare_result<int32_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::i64)
+        compare_result<int64_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::f16)
+        compare_result<int16_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::f32)
+        compare_result<float>(outputs_ref, outputs_opt);
+}
+
 TEST(reorder_gpu_optimization, dynamic_bfyx_to_blocked_f32) {
     // bfzyx -> b_fs_zyx_fsv32 (nnUNet pattern)
     compare_bfyx2blocked_with_ref_dynamic("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::b_fs_zyx_fsv32, 1, 320, 8, 8, 8, 0);
@@ -434,6 +529,63 @@ TEST(reorder_gpu_optimization, dynamic_fsv_reorder_cross_type) {
     compare_bfyx2blocked_with_ref_dynamic("reorder_data_fsv", data_types::u8, data_types::f32, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv32, 1, 32, 8, 8, 4, 0);
     // Cross-type: f16 -> f32 with format change
     compare_bfyx2blocked_with_ref_dynamic("reorder_data_fsv", data_types::f16, data_types::f32, format::b_fs_yx_fsv32, format::b_fs_yx_fsv16, 2, 48, 16, 8, 0, 0);
+}
+
+TEST(reorder_gpu_optimization, fsv_reorder_output_padding_feature_axis) {
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_yx_fsv16, format::b_fs_yx_fsv32,
+                                                2, 48, 13, 5, 0, 0,
+                                                padding({0, 32, 0, 0}, {0, 16, 0, 0}));
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_yx_fsv32, format::b_fs_yx_fsv16,
+                                                2, 64, 11, 7, 0, 0,
+                                                padding({0, 16, 0, 0}, {0, 8, 0, 0}));
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv32,
+                                                1, 48, 7, 5, 3, 0,
+                                                padding({0, 32, 0, 0, 0}, {0, 16, 0, 0, 0}));
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
+                                                1, 64, 9, 4, 2, 0,
+                                                padding({0, 16, 0, 0, 0}, {0, 8, 0, 0, 0}));
+}
+
+TEST(reorder_gpu_optimization, fsv_reorder_output_padding_spatial_axis) {
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_yx_fsv16, format::b_fs_yx_fsv32,
+                                                2, 48, 13, 5, 0, 0,
+                                                padding({0, 0, 2, 3}, {0, 0, 1, 4}));
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_yx_fsv32, format::b_fs_yx_fsv16,
+                                                2, 64, 11, 7, 0, 0,
+                                                padding({0, 0, 1, 2}, {0, 0, 3, 1}));
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv32,
+                                                1, 48, 7, 5, 3, 0,
+                                                padding({0, 0, 2, 2, 2}, {0, 0, 1, 1, 1}));
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
+                                                1, 64, 9, 4, 2, 0,
+                                                padding({0, 0, 1, 1, 1}, {0, 0, 2, 2, 2}));
+}
+
+TEST(reorder_gpu_optimization, fsv_reorder_output_padding_batch_axis) {
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_yx_fsv16, format::b_fs_yx_fsv32,
+                                                2, 48, 13, 5, 0, 0,
+                                                padding({1, 0, 0, 0}, {2, 0, 0, 0}));
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_yx_fsv32, format::b_fs_yx_fsv16,
+                                                3, 64, 11, 7, 0, 0,
+                                                padding({2, 0, 0, 0}, {1, 0, 0, 0}));
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv32,
+                                                2, 48, 7, 5, 3, 0,
+                                                padding({1, 0, 0, 0, 0}, {2, 0, 0, 0, 0}));
+    compare_fsv_reorder_with_ref_output_padding(data_types::f32, data_types::f32,
+                                                format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
+                                                3, 64, 9, 4, 2, 0,
+                                                padding({2, 0, 0, 0, 0}, {1, 0, 0, 0, 0}));
 }
 
 TEST(reorder_gpu_optimization, bfyx_to_fsv16_without_f_remainder) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -462,6 +462,140 @@ static void compare_fsv_reorder_with_ref_output_padding(const data_types input_d
         compare_result<float>(outputs_ref, outputs_opt);
 }
 
+template <typename T>
+static void fill_fsv_reorder_input(const memory::ptr& input,
+                                   const layout& input_layout,
+                                   int32_t b_in,
+                                   int32_t f_in,
+                                   int32_t x_in,
+                                   int32_t y_in,
+                                   int32_t z_in,
+                                   int32_t w_in) {
+    mem_lock<T> input_ptr{input, get_test_stream()};
+    std::fill(input_ptr.begin(), input_ptr.end(), T{});
+
+    int32_t value = 1;
+    for (int32_t b = 0; b < b_in; ++b) {
+        for (int32_t f = 0; f < f_in; ++f) {
+            for (int32_t w = 0; w < w_in; ++w) {
+                for (int32_t z = 0; z < z_in; ++z) {
+                    for (int32_t y = 0; y < y_in; ++y) {
+                        for (int32_t x = 0; x < x_in; ++x) {
+                            const auto offset = input_layout.get_linear_offset({b, f, x, y, z, w});
+                            input_ptr[offset] = static_cast<T>(value);
+                            value = value == 100 ? 1 : value + 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+static void compare_fsv_reorder_with_ref_padding(const data_types input_data_type,
+    const data_types output_data_type,
+    cldnn::format input_format,
+    cldnn::format output_format,
+    int32_t b_in,
+    int32_t f_in,
+    int32_t x_in,
+    int32_t y_in,
+    int32_t z_in,
+    int32_t w_in,
+    const padding& input_padding,
+    const padding& output_padding) {
+    auto& engine = get_test_engine();
+    if (engine.get_device_info().supports_immad) {
+        return;
+    }
+
+    tensor ts;
+    if (input_format.dimension() == 4) {
+        ts = { b_in, f_in, x_in, y_in };
+    } else if (input_format.dimension() == 5) {
+        ts = { b_in, f_in, x_in, y_in, z_in };
+    } else {
+        ts = { b_in, f_in, x_in, y_in, z_in, w_in };
+    }
+
+    layout padded_input_layout(input_data_type, input_format, ts, input_padding);
+    auto input = engine.allocate_memory(padded_input_layout);
+    layout output_layout(output_data_type, output_format, ts, output_padding);
+
+    if (input_data_type == data_types::i8) {
+        fill_fsv_reorder_input<int8_t>(input, padded_input_layout, b_in, f_in, x_in, y_in, z_in, w_in);
+    } else if (input_data_type == data_types::u8) {
+        fill_fsv_reorder_input<uint8_t>(input, padded_input_layout, b_in, f_in, x_in, y_in, z_in, w_in);
+    } else if (input_data_type == data_types::f16) {
+        fill_fsv_reorder_input<ov::float16>(input, padded_input_layout, b_in, f_in, x_in, y_in, z_in, w_in);
+    } else {
+        fill_fsv_reorder_input<float>(input, padded_input_layout, b_in, f_in, x_in, y_in, z_in, w_in);
+    }
+
+    topology topo_ref(
+        input_layout("input", input->get_layout()),
+        reorder("reorder", input_info("input"), output_layout));
+
+    ExecutionConfig config_ref = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc reorder_ref = { output_format, "reorder_data" };
+    config_ref.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"reorder", reorder_ref}}));
+
+    cldnn::network network_ref(engine, topo_ref, config_ref);
+    network_ref.set_input_data("input", input);
+    auto outputs_ref = network_ref.execute();
+
+    ExecutionConfig config_opt = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc reorder_opt = { output_format, "reorder_data_fsv" };
+    config_opt.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"reorder", reorder_opt}}));
+
+    cldnn::network network_opt(engine, topo_ref, config_opt);
+    network_opt.set_input_data("input", input);
+    auto outputs_opt = network_opt.execute();
+
+    auto reorder_inst = network_opt.get_primitive("reorder");
+    auto reorder_impl = reorder_inst->get_impl();
+    ASSERT_TRUE(reorder_impl != nullptr);
+    ASSERT_NE(reorder_impl->get_kernel_name().find("reorder_data_fsv"), std::string::npos);
+
+    if (output_data_type == data_types::i8)
+        compare_result<int8_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::u8)
+        compare_result<uint8_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::i32)
+        compare_result<int32_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::i64)
+        compare_result<int64_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::f16)
+        compare_result<int16_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::f32)
+        compare_result<float>(outputs_ref, outputs_opt);
+}
+
+static void compare_fsv_reorder_with_ref_input_padding(const data_types input_data_type,
+    const data_types output_data_type,
+    cldnn::format input_format,
+    cldnn::format output_format,
+    int32_t b_in,
+    int32_t f_in,
+    int32_t x_in,
+    int32_t y_in,
+    int32_t z_in,
+    int32_t w_in,
+    const padding& input_padding) {
+    compare_fsv_reorder_with_ref_padding(input_data_type,
+                                         output_data_type,
+                                         input_format,
+                                         output_format,
+                                         b_in,
+                                         f_in,
+                                         x_in,
+                                         y_in,
+                                         z_in,
+                                         w_in,
+                                         input_padding,
+                                         padding());
+}
+
 TEST(reorder_gpu_optimization, dynamic_bfyx_to_blocked_f32) {
     // bfzyx -> b_fs_zyx_fsv32 (nnUNet pattern)
     compare_bfyx2blocked_with_ref_dynamic("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::b_fs_zyx_fsv32, 1, 320, 8, 8, 8, 0);
@@ -586,6 +720,102 @@ TEST(reorder_gpu_optimization, fsv_reorder_output_padding_batch_axis) {
                                                 format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
                                                 3, 64, 9, 4, 2, 0,
                                                 padding({2, 0, 0, 0, 0}, {1, 0, 0, 0, 0}));
+}
+
+TEST(reorder_gpu_optimization, fsv_reorder_input_padding_feature_axis) {
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_yx_fsv16, format::b_fs_yx_fsv32,
+                                               2, 48, 13, 5, 0, 0,
+                                               padding({0, 32, 0, 0}, {0, 16, 0, 0}));
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_yx_fsv32, format::b_fs_yx_fsv16,
+                                               2, 64, 11, 7, 0, 0,
+                                               padding({0, 16, 0, 0}, {0, 8, 0, 0}));
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv32,
+                                               1, 48, 7, 5, 3, 0,
+                                               padding({0, 32, 0, 0, 0}, {0, 16, 0, 0, 0}));
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
+                                               1, 64, 9, 4, 2, 0,
+                                               padding({0, 16, 0, 0, 0}, {0, 8, 0, 0, 0}));
+}
+
+TEST(reorder_gpu_optimization, fsv_reorder_input_padding_spatial_axis) {
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_yx_fsv16, format::b_fs_yx_fsv32,
+                                               2, 48, 13, 5, 0, 0,
+                                               padding({0, 0, 2, 3}, {0, 0, 1, 4}));
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_yx_fsv32, format::b_fs_yx_fsv16,
+                                               2, 64, 11, 7, 0, 0,
+                                               padding({0, 0, 1, 2}, {0, 0, 3, 1}));
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv32,
+                                               1, 48, 7, 5, 3, 0,
+                                               padding({0, 0, 2, 2, 2}, {0, 0, 1, 1, 1}));
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
+                                               1, 64, 9, 4, 2, 0,
+                                               padding({0, 0, 1, 1, 1}, {0, 0, 2, 2, 2}));
+}
+
+TEST(reorder_gpu_optimization, fsv_reorder_input_padding_batch_axis) {
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_yx_fsv16, format::b_fs_yx_fsv32,
+                                               2, 48, 13, 5, 0, 0,
+                                               padding({1, 0, 0, 0}, {2, 0, 0, 0}));
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_yx_fsv32, format::b_fs_yx_fsv16,
+                                               3, 64, 11, 7, 0, 0,
+                                               padding({2, 0, 0, 0}, {1, 0, 0, 0}));
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv32,
+                                               2, 48, 7, 5, 3, 0,
+                                               padding({1, 0, 0, 0, 0}, {2, 0, 0, 0, 0}));
+    compare_fsv_reorder_with_ref_input_padding(data_types::f32, data_types::f32,
+                                               format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
+                                               3, 64, 9, 4, 2, 0,
+                                               padding({2, 0, 0, 0, 0}, {1, 0, 0, 0, 0}));
+}
+
+TEST(reorder_gpu_optimization, fsv_reorder_input_output_padding_feature_axis) {
+    compare_fsv_reorder_with_ref_padding(data_types::f32, data_types::f32,
+                                         format::b_fs_yx_fsv16, format::b_fs_yx_fsv32,
+                                         2, 48, 13, 5, 0, 0,
+                                         padding({0, 32, 0, 0}, {0, 16, 0, 0}),
+                                         padding({0, 16, 0, 0}, {0, 32, 0, 0}));
+    compare_fsv_reorder_with_ref_padding(data_types::f32, data_types::f32,
+                                         format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
+                                         2, 64, 9, 4, 2, 0,
+                                         padding({0, 16, 0, 0, 0}, {0, 8, 0, 0, 0}),
+                                         padding({0, 32, 0, 0, 0}, {0, 16, 0, 0, 0}));
+}
+
+TEST(reorder_gpu_optimization, fsv_reorder_input_output_padding_spatial_axis) {
+    compare_fsv_reorder_with_ref_padding(data_types::f32, data_types::f32,
+                                         format::b_fs_yx_fsv16, format::b_fs_yx_fsv32,
+                                         2, 48, 13, 5, 0, 0,
+                                         padding({0, 0, 2, 3}, {0, 0, 1, 4}),
+                                         padding({0, 0, 1, 2}, {0, 0, 3, 1}));
+    compare_fsv_reorder_with_ref_padding(data_types::f32, data_types::f32,
+                                         format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
+                                         1, 64, 9, 4, 2, 0,
+                                         padding({0, 0, 1, 1, 1}, {0, 0, 2, 2, 2}),
+                                         padding({0, 0, 2, 2, 2}, {0, 0, 1, 1, 1}));
+}
+
+TEST(reorder_gpu_optimization, fsv_reorder_input_output_padding_batch_axis) {
+    compare_fsv_reorder_with_ref_padding(data_types::f32, data_types::f32,
+                                         format::b_fs_yx_fsv16, format::b_fs_yx_fsv32,
+                                         2, 48, 13, 5, 0, 0,
+                                         padding({1, 0, 0, 0}, {2, 0, 0, 0}),
+                                         padding({2, 0, 0, 0}, {1, 0, 0, 0}));
+    compare_fsv_reorder_with_ref_padding(data_types::f32, data_types::f32,
+                                         format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv16,
+                                         3, 64, 9, 4, 2, 0,
+                                         padding({2, 0, 0, 0, 0}, {1, 0, 0, 0, 0}),
+                                         padding({1, 0, 0, 0, 0}, {2, 0, 0, 0, 0}));
 }
 
 TEST(reorder_gpu_optimization, bfyx_to_fsv16_without_f_remainder) {


### PR DESCRIPTION
### Summary
This PR fixes incorrect writes in the reorder_data_fsv path when output lower-padding is added after kernel selection (e.g., during concat in-place optimization).
It also adds targeted unit tests to prevent regressions.

### Issue
For FSV reorders, the selected kernel could later receive padded output layout updates, but the write-offset computation remained padding-naive.
In affected graphs, this could cause channel-region corruption and severe accuracy drops (e.g., unet3d_mlperf FP16-INT8).

### Root Cause
reorder_data_fsv output offset calculation did not account for output padding.
Kernel validation/selection happened before concat in-place introduced output lower-padding.
No re-validation occurred after padding changed.


```mermaid
flowchart TB

  subgraph B[Baseline FAIL]
    direction TD
    B0["Node: ConvTranspose_72<br>Type: deconvolution<br>Data: i8 b_fs_zyx_fsv16"]
    Bm["Node: MVN_63<br>Type: mvn<br>Data: i8 b_fs_zyx_fsv32"]
    Br["Node: MVN_63_0_reorder_0<br>Type: reorder<br>Data: i8 b_fs_zyx_fsv16<br>Kernel: reorder_data_fsv / ocl"]
    B2["Node: Concat_73_1<br>Type: concatenation axis=1<br>Data: i8 b_fs_zyx_fsv16<br>Status: optimized out"]
    B4["Node: Concat_73_1_0_reorder_22<br>Type: reorder<br>Data: i8 b_fs_zyx_fsv32<br>Kernel: reorder_data_fsv / ocl"]
    Bn["Note: After Concat is optimized out, lower padding is added to the predecessor reorder output (MVN_63_0_reorder_0)<br>However, the reorder_data_fsv kernel does not support padding<br>At kernel selection time, padding=0 so this kernel is selected, and without revalidation the issue occurs"]
    B0 -->|input 0| B2
    Bm --> Br
    Br -->|input 1| B2
    B2 --> B4
    B4 -.-> Bn
  end

  subgraph F[Fix-ALL PASS]
    direction TD
    F0["Node: ConvTranspose_72<br>Type: deconvolution<br>Data: i8 b_fs_zyx_fsv16"]
    Fr0["Node: ConvTranspose_72_0_reorder_50<br>Type: reorder<br>Data: i8 bfzyx<br>Kernel: reorder_data / onednn"]
    Fm["Node: MVN_63<br>Type: mvn<br>Data: f16 b_fs_zyx_fsv32"]
    Fa["Node: LeakyRelu_5<br>Type: activation<br>Data: i8 bfzyx"]
    F2["Node: Concat_73_1<br>Type: concatenation axis=1<br>Data: i8 bfzyx<br>Status: executed"]
    F4["Node: Concat_73_1_0_reorder_52<br>Type: reorder<br>Data: i8 b_fs_zyx_fsv32<br>Kernel: reorder_data_bfyx_to_blocked_format / ocl"]
    Fn["Note: Disabled LeakyRelu + Quantize fusing that would normally be fused into MVN_63<br>As a result, LeakyRelu_5 is created as a separate node and Concat_73_1 is executed"]
    F0 --> Fr0
    Fr0 -->|input 0| F2
    Fm --> Fa
    Fa -->|input 1| F2
    F2 --> F4
    Fa -.-> Fn
  end

  classDef deconv fill:#E6F4FF,stroke:#1F78D1,stroke-width:1.5px,color:#0B2E4F;
  classDef mvn fill:#E6FAF7,stroke:#0F8A7B,stroke-width:1.5px,color:#073E37;
  classDef reorder fill:#FFD9B3,stroke:#C75B00,stroke-width:2.2px,color:#3A1F00;
  classDef act fill:#FFEAF1,stroke:#C43D7A,stroke-width:1.5px,color:#4A1530;
  classDef concat fill:#E8F0FF,stroke:#2F66D0,stroke-width:1.5px,color:#0F244D;
  classDef note fill:#FFFFFF,stroke:#B8B8B8,stroke-width:1.2px,color:#333333;

  class B0,F0 deconv;
  class Bm,Fm mvn;
  class Br,Fr0,B4,F4 reorder;
  class Fa act;
  class B2,F2 concat;
  class Bn,Fn note;
```

### Changes
- make `reorder_data_fsv` input reads padding-aware
- use padding-aware output indexing for writes
- allow padded layouts in `ReorderKernel_fsv` validation
- add regression tests for input/output/both-side padding on feature, spatial, and batch axes
- add an in-place concat regression test for the related FSV reorder path

### Tickets:
 - 187281

### AI Assistance:
 - AI assistance used: yes
 - AI: find root-cause, fix, validation
 - User: review
