### PR TITLE
[GPU] WA: Fix attention sink handling in FlashAttnV2 PA SDPA path

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1359,17 +1359,22 @@ public:
 
     bool supports_micro_sdpa(const kernel_impl_params& params) const {
         auto& engine = params.get_program().get_engine();
+        const auto desc = params.typed_desc<paged_attention>();
 
         if (params.get_device_info().supports_immad) {
             const auto supports_microkernels = cldnn::query_microkernels_supported(engine, params.get_program().get_config());
             if (params.get_device_info().arch < gpu_arch::xe_hpg || !supports_microkernels) {
                 return false;
             }
+            // WA: Disable micro SDPA on xe3p for head_size <= 64 due to oneDNN micro-kernel
+            // accuracy issues (produces inf/nan) after oneDNN main branch integration.
+            if (params.get_device_info().arch == gpu_arch::xe3p && desc->k_head_size <= 64) {
+                return false;
+            }
         } else {
             return false;
         }
 
-        const auto desc = params.typed_desc<paged_attention>();
         ov::Dimension head_num = desc->heads_num;
         ov::Dimension kv_heads_num = desc->kv_heads_num;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1185,6 +1185,10 @@ public:
             args.push_back({ArgumentDescriptor::Types::INPUT, PagedAttentionInputIdx::TOKEN_TYPE_IDS});  // token_type_ids
         }
 
+        if (desc->has_sink_input) {
+            args.push_back({ArgumentDescriptor::Types::INPUT, PagedAttentionInputIdx::SINKS});  // sink
+        }
+
         args.push_back({ArgumentDescriptor::Types::OUTPUT, 0});
 
         args.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 0});
@@ -1255,6 +1259,12 @@ public:
 
         if (desc->has_token_type_ids) {
             jit.make("HAS_TOKEN_TYPE_IDS", 1);
+        }
+
+        if (desc->has_sink_input) {
+            const auto& sink_layout = params.input_layouts[PagedAttentionInputIdx::SINKS];
+            jit.make("SINK_DATA_T", to_ocl_type(sink_layout.data_type));
+            jit.make("HAS_SINK_INPUT", 1);
         }
 
         return jit;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
@@ -201,7 +201,6 @@ bool SDPAOpt::supports_micro_sdpa(const RuntimeParams& params) {
     const auto& k_layout = params.get_input_layout(1);
     const auto& v_layout = params.get_input_layout(2);
 
-
     // Will check it later to decide whether support micro kernel
     // if (desc->indirect_axis != -1) {
     //     // Micro kernel does not support indirect axis

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
@@ -190,7 +190,9 @@ bool SDPAOpt::supports_micro_sdpa(const RuntimeParams& params) {
         }
         // WA: Disable micro SDPA on xe3p for head_size <= 64 due to oneDNN micro-kernel
         // accuracy issues (produces inf/nan) after oneDNN main branch integration.
-        if (device_info.arch == gpu_arch::xe3p && desc->k_head_size <= 64) {
+        auto extended_input_k_transpose_order = extend_order_in_num_heads_dim(desc->input_k_transpose_order);
+        const auto k_head_size = get_head_size(params.get_input_layout(1), extended_input_k_transpose_order);
+        if (device_info.arch == gpu_arch::xe3p && k_head_size <= 64) {
             return false;
         }
     } else {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
@@ -181,10 +181,16 @@ bool SDPAOpt::supports_micro_sdpa(const RuntimeParams& params) {
 #ifdef ENABLE_ONEDNN_FOR_GPU
     auto& engine = params.get_program().get_engine();
     const auto& device_info = engine.get_device_info();
+    auto desc = params.typed_desc<scaled_dot_product_attention>();
 
     if (device_info.supports_immad) {
         const auto supports_microkernels = cldnn::query_microkernels_supported(engine, params.get_program().get_config());
         if (device_info.arch < gpu_arch::xe_hpg || !supports_microkernels) {
+            return false;
+        }
+        // WA: Disable micro SDPA on xe3p for head_size <= 64 due to oneDNN micro-kernel
+        // accuracy issues (produces inf/nan) after oneDNN main branch integration.
+        if (device_info.arch == gpu_arch::xe3p && desc->k_head_size <= 64) {
             return false;
         }
     } else {
@@ -194,7 +200,7 @@ bool SDPAOpt::supports_micro_sdpa(const RuntimeParams& params) {
     const auto& q_layout = params.get_input_layout(0);
     const auto& k_layout = params.get_input_layout(1);
     const auto& v_layout = params.get_input_layout(2);
-    auto desc = params.typed_desc<scaled_dot_product_attention>();
+
 
     // Will check it later to decide whether support micro kernel
     // if (desc->indirect_axis != -1) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -1221,6 +1221,9 @@ KERNEL(sdpa_opt)(
 #if IS_PAGED_ATTENTION && HAS_TOKEN_TYPE_IDS
     const __global int* token_type_ids,
 #endif
+#if HAS_SINK_INPUT
+    const __global SINK_DATA_T* sink_ptr,
+#endif
     __global OUTPUT_TYPE* output,
 #if IS_KV_COMPRESSED
     const __global KEY_COMPRESSION_SCALE_TYPE* key_scale,
@@ -2545,6 +2548,26 @@ KERNEL(sdpa_opt)(
 #endif /*!IS_FLASHATTEN_V2*/
         } /* end of QK*V calculation */
     } /* end of iter over source sequence length */
+
+#if IS_FLASHATTEN_V2 && defined(HAS_SINK_INPUT)
+    // Apply attention sink after all KV partitions are processed.
+    // Sink adds a virtual logit to the softmax denominator with zero V contribution.
+    {
+        SOFTMAX_ACCUMULATOR_TYPE sink_val = TO_SOFTMAX_ACCUMULATOR_TYPE(sink_ptr[b1_idx]);
+        for (uint seq_idx = 0; seq_idx < seq_idx_end; seq_idx++) {
+            SOFTMAX_ACCUMULATOR_TYPE max_prev = slm_max_val_prev[seq_idx];
+            SOFTMAX_ACCUMULATOR_TYPE max_new = SOFTMAX_ACCUMULATOR_MAX_FUNC(max_prev, sink_val);
+            SOFTMAX_ACCUMULATOR_TYPE correction = native_exp(max_prev - max_new);
+            // Rescale output_acc (all work items do this for their own register)
+            output_acc[seq_idx] = TO_OUTPUT_TYPE(TO_SOFTMAX_ACCUMULATOR_TYPE(output_acc[seq_idx]) * correction);
+            // Update exp_sum (only one thread per seq_idx)
+            if (sgid == 0 && sglid == 0) {
+                slm_exp_sum_prev[seq_idx] = slm_exp_sum_prev[seq_idx] * correction + native_exp(sink_val - max_new);
+            }
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+#endif
 
     // Combine results from multiple SGs and store to output buffer
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -2549,7 +2549,7 @@ KERNEL(sdpa_opt)(
         } /* end of QK*V calculation */
     } /* end of iter over source sequence length */
 
-#if IS_FLASHATTEN_V2 && defined(HAS_SINK_INPUT)
+#if IS_FLASHATTEN_V2 && HAS_SINK_INPUT
     // Apply attention sink after all KV partitions are processed.
     // Sink adds a virtual logit to the softmax denominator with zero V contribution.
     {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -2549,7 +2549,7 @@ KERNEL(sdpa_opt)(
         } /* end of QK*V calculation */
     } /* end of iter over source sequence length */
 
-#if IS_FLASHATTEN_V2 && HAS_SINK_INPUT
+#if HAS_SINK_INPUT
     // Apply attention sink after all KV partitions are processed.
     // Sink adds a virtual logit to the softmax denominator with zero V contribution.
     {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -2566,7 +2566,6 @@ KERNEL(sdpa_opt)(
             }
         }
     }
-    barrier(CLK_LOCAL_MEM_FENCE);
 #endif
 
     // Combine results from multiple SGs and store to output buffer

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -2953,11 +2953,14 @@ static std::vector<int32_t> gen_tokens_ids_test_data(size_t seq_len, int num_ima
     return v;
 }
 
-// Test class to verify FlashAttnV2 sink correction produces same output as V1 path.
-// This exercises the fix for attention sink handling in the FlashAttnV2 online-softmax path.
-class paged_attention_sink_v1_v2_test : public PagedAttentionTest<paged_attention_test_params> {
+
+// Test class to verify FlashAttnV2 multi-token sink correction is actually active.
+// Runs the same prompt twice with FA_V2 enabled: once with non-zero sinks, once with zero sinks.
+// Asserts outputs differ, proving the sink code at line 2552 in sdpa_opt.cl executes.
+// This test is platform-independent (works on any GPU with OpenCL support).
+class paged_attention_sink_v2_effect_test : public PagedAttentionTest<paged_attention_test_params> {
 protected:
-    std::vector<ov::float16> run_pa_with_sinks(paged_attention_test_params& p, bool disable_fa_v2) {
+    std::vector<ov::float16> run_pa_v2_prompt(paged_attention_test_params& p, bool use_nonzero_sinks) {
         ov::element::Type kv_cache_precision = p.kv_cache_precision;
 
         PagedAttentionManager pam(rg,
@@ -2973,15 +2976,14 @@ protected:
                                   p.kv_cache_compression,
                                   p.key_cache_quant_mode,
                                   p.scores_mode == ScoresMode::SNAPKV,
-                                  false,  // has_xattention
+                                  false,
                                   p.rotation_config,
                                   kv_cache_precision);
 
-        // Populate sinks with realistic non-zero values [1, num_heads, 1, 1]
-        // Sink values are per-head scalar logits (typically small negative or small positive)
+        // Populate sinks: non-zero values to test effect, or zero for baseline
         pam.sinks.resize(p.num_heads);
         for (int h = 0; h < p.num_heads; h++) {
-            pam.sinks[h] = ov::float16(-1.0f + 0.3f * h);  // e.g., -1.0, -0.7, -0.4, ...
+            pam.sinks[h] = use_nonzero_sinks ? ov::float16(-1.0f + 0.3f * h) : ov::float16(0.0f);
         }
 
         auto query_mem = pam.get_query_memory();
@@ -3042,7 +3044,6 @@ protected:
         auto qq_bias_layout = qq_bias->get_layout();
         auto qq_bias_begins_layout = qq_bias_begins->get_layout();
 
-        // Make layouts dynamic
         query_layout.set_partial_shape(ov::PartialShape{ -1, p.num_heads * p.k_head_size });
         key_layout.set_partial_shape(ov::PartialShape{ -1, p.num_kv_heads * p.k_head_size });
         value_layout.set_partial_shape(ov::PartialShape{ -1, p.num_kv_heads * p.v_head_size });
@@ -3087,8 +3088,8 @@ protected:
         pa_prim.heads_num = p.num_heads;
         pa_prim.scale_val = pam.get_default_scale();
         pa_prim.has_alibi = false;
-        pa_prim.has_token_type_ids = false;
-        pa_prim.has_sink_input = true;  // We provide non-empty sinks
+        pa_prim.has_token_type_ids = true;  // Force sdpa_opt.cl path (disables micro-SDPA)
+        pa_prim.has_sink_input = true;
         pa_prim.num_outputs = 1;
         pa_prim.has_rotated_blocks = false;
         pa_prim.has_score_aggregation = false;
@@ -3137,7 +3138,8 @@ protected:
         ExecutionConfig config = get_test_default_config(get_test_engine());
         config.set_property(ov::intel_gpu::optimize_data(true));
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
-        config.set_property(ov::intel_gpu::could_use_flashattn_v2(disable_fa_v2));
+        // Enable FlashAttnV2: could_use_flashattn_v2(true) sets IS_FLASHATTEN_V2=1 in the kernel
+        config.set_property(ov::intel_gpu::could_use_flashattn_v2(true));
         config.set_property(ov::internal::key_cache_quant_mode(p.key_cache_quant_mode));
 
         network::ptr network = get_network(get_test_engine(), topology, config, get_test_stream_ptr(), false);
@@ -3182,41 +3184,39 @@ protected:
     }
 };
 
-TEST_P(paged_attention_sink_v1_v2_test, compare_fa_v1_v2_with_sinks) {
+TEST_P(paged_attention_sink_v2_effect_test, verify_sink_changes_v2_output) {
     auto p = GetParam();
 
-    // Use same RNG seed for both runs to get identical input data
+    // Run FlashAttnV2 multi-token path with non-zero sinks
     rg.set_seed(GET_SUITE_NAME);
-    auto output_v1 = run_pa_with_sinks(p, /*disable_fa_v2=*/true);
+    auto output_with_sinks = run_pa_v2_prompt(p, /*use_nonzero_sinks=*/true);
 
+    // Run FlashAttnV2 multi-token path with zero sinks (sink code still runs but has no effect)
     rg.set_seed(GET_SUITE_NAME);
-    auto output_v2 = run_pa_with_sinks(p, /*disable_fa_v2=*/false);
+    auto output_no_sinks = run_pa_v2_prompt(p, /*use_nonzero_sinks=*/false);
 
-    ASSERT_EQ(output_v1.size(), output_v2.size());
+    ASSERT_EQ(output_with_sinks.size(), output_no_sinks.size());
 
-    // V1 and V2 paths may use different accumulation order, allow small tolerance
-    const float sink_tolerance = 5e-3f;
-    for (size_t i = 0; i < output_v1.size(); i++) {
-        ASSERT_NEAR(static_cast<float>(output_v1[i]), static_cast<float>(output_v2[i]), sink_tolerance)
-            << " V1 vs V2 mismatch with sinks at index=" << i;
+    // Verify outputs differ — proving the V2 sink correction code is active
+    bool found_difference = false;
+    for (size_t i = 0; i < output_with_sinks.size(); i++) {
+        if (std::abs(static_cast<float>(output_with_sinks[i]) - static_cast<float>(output_no_sinks[i])) > 1e-4f) {
+            found_difference = true;
+            break;
+        }
     }
+    ASSERT_TRUE(found_difference)
+        << "FlashAttnV2 multi-token output is identical with and without sinks — sink code may not be executing";
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_paged_attention_sink, paged_attention_sink_v1_v2_test, ::testing::ValuesIn(std::vector<paged_attention_test_params>{
-    // head_size=64: triggers FlashAttnV2 fallback on xe3p (no micro-kernel for h64)
-    // Generation phase (single-token) - both V1 and V2 correctly apply sinks
-    // Note: Multi-token prompt cases are excluded because the non-FlashAttnV2 multi-token path
-    // does not apply sinks (separate known limitation), making V1/V2 comparison invalid for prompts.
-    // 2nd token (generation phase with past context)
-    paged_attention_test_params{ {{1, 34}}, 2, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
-    // 2nd token with longer past context
-    paged_attention_test_params{ {{1, 128}}, 2, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
-    // GQA: num_heads=8, num_kv_heads=2
-    paged_attention_test_params{ {{1, 64}}, 8, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
-    // With sliding window (attention sink + sliding window is the common real-world pattern)
-    paged_attention_test_params{ {{1, 128}}, 4, 4, 64, 64, 16, 64, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
-    // Multiple 2nd tokens in batch
-    paged_attention_test_params{ {{1, 34}, {1, 100}}, 2, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
+INSTANTIATE_TEST_SUITE_P(smoke_paged_attention_sink_v2_effect, paged_attention_sink_v2_effect_test, ::testing::ValuesIn(std::vector<paged_attention_test_params>{
+    // Multi-token (prompt) cases that exercise the FlashAttnV2 online-softmax path with sinks.
+    // These directly test the HAS_SINK_INPUT code at line 2552 in sdpa_opt.cl.
+    // Platform-independent: forces FA_V2 regardless of HW micro-kernel availability.
+    paged_attention_test_params{ {{10, 0}}, 2, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
+    paged_attention_test_params{ {{128, 0}}, 4, 4, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
+    // GQA prompt
+    paged_attention_test_params{ {{64, 0}}, 8, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
 }));
 
 INSTANTIATE_TEST_SUITE_P(smoke_paged_attention, paged_attention_test, ::testing::ValuesIn(std::vector<paged_attention_test_params>{

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -1804,11 +1804,21 @@ public:
     cldnn::engine& engine = get_test_engine();
     float tolerance = 2e-3;
     memory::ptr last_key_cache_mem = nullptr;
+    memory::ptr last_output_data_mem = nullptr;
     std::vector<int> last_block_indices;
     std::vector<int> last_block_indices_begins;
 
     void SetUp() override {
         rg.set_seed(GET_SUITE_NAME);
+    }
+
+    std::vector<ov::float16> get_output_data() {
+        OPENVINO_ASSERT(last_output_data_mem != nullptr, "No output data available");
+        std::vector<ov::float16> result(last_output_data_mem->count());
+        mem_lock<ov::float16, mem_lock_type::read> mem_ptr(last_output_data_mem, get_test_stream());
+        for (size_t i = 0; i < last_output_data_mem->count(); i++)
+            result[i] = mem_ptr[i];
+        return result;
     }
 
     void execute(T& p, bool run_reference = true) {
@@ -1877,6 +1887,10 @@ public:
         if (p.token_type_ids.has_value()) {
             pam.token_type_ids = p.token_type_ids.value();
             ASSERT_EQ(pam.token_type_ids.size(), static_cast<size_t>(pam.subsequence_descs.back().num_tokens + pam.subsequence_descs.back().past_len));
+        }
+
+        if (p.has_sink_input && p.sink_values.has_value()) {
+            pam.sinks = p.sink_values.value();
         }
 
         if (p.kv_cache_compression) {
@@ -2056,7 +2070,9 @@ public:
         pa_prim.heads_num = p.num_heads;
         pa_prim.scale_val = pam.get_default_scale();
         pa_prim.has_alibi = false;
-        pa_prim.has_token_type_ids = p.token_type_ids.has_value();
+        pa_prim.has_token_type_ids = p.token_type_ids.has_value() || p.has_sink_input;
+
+        pa_prim.has_sink_input = p.has_sink_input;
 
         int num_outputs = 1;
         if (p.scores_mode != ScoresMode::DISABLED) num_outputs++;
@@ -2129,7 +2145,7 @@ public:
         config.set_property(ov::intel_gpu::optimize_data(true));
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
         // FlashAttn v1 or v2?
-        config.set_property(ov::intel_gpu::could_use_flashattn_v2(p.disable_flashattn_v2));
+        config.set_property(ov::intel_gpu::could_use_flashattn_v2(p.force_flashattn_v2 ? true : p.disable_flashattn_v2));
         config.set_property(ov::internal::key_cache_quant_mode(p.key_cache_quant_mode));
         if (kv_cache_precision != ov::element::dynamic) {
             config.set_property(ov::hint::kv_cache_precision(kv_cache_precision));
@@ -2171,15 +2187,16 @@ public:
 
         auto outputs = network->execute();
 
+        last_output_data_mem = outputs.at("output_data").get_memory();
+
         if (!run_reference) {
             return;
         }
 
-        cldnn::memory::ptr output_data_mem = nullptr;
+        cldnn::memory::ptr output_data_mem = last_output_data_mem;
         cldnn::memory::ptr output_scores_mem = nullptr;
         cldnn::memory::ptr output_diversity_mem = nullptr;
 
-        output_data_mem = outputs.at("output_data").get_memory();
         if (p.scores_mode != ScoresMode::DISABLED) {
             output_scores_mem = outputs.at("output_scores").get_memory();
         }
@@ -2855,6 +2872,14 @@ struct paged_attention_test_params {
     // optional token_type_ids passed to PagedAttention; if set (non-empty), it is forwarded
     // to the op as the TOKEN_TYPE_IDS input. When std::nullopt, a default {0} buffer is used.
     std::optional<std::vector<int>> token_type_ids = std::nullopt;
+
+    // Sink input testing: when true, enables has_sink_input on the primitive and forces
+    // the sdpa_opt.cl path (by setting has_token_type_ids=true to disable micro-SDPA).
+    bool has_sink_input = false;
+    // When set, overrides the default sink values in PAM before memory allocation.
+    std::optional<std::vector<ov::float16>> sink_values = std::nullopt;
+    // When true, forces could_use_flashattn_v2(true) to guarantee the FA_V2 kernel path.
+    bool force_flashattn_v2 = false;
 };
 
 class paged_attention_test : public PagedAttentionTest<paged_attention_test_params> {};
@@ -2958,242 +2983,30 @@ static std::vector<int32_t> gen_tokens_ids_test_data(size_t seq_len, int num_ima
 // Runs the same prompt twice with FA_V2 enabled: once with non-zero sinks, once with zero sinks.
 // Asserts outputs differ, proving the sink code at line 2552 in sdpa_opt.cl executes.
 // This test is platform-independent (works on any GPU with OpenCL support).
-class paged_attention_sink_v2_effect_test : public PagedAttentionTest<paged_attention_test_params> {
-protected:
-    std::vector<ov::float16> run_pa_v2_prompt(paged_attention_test_params& p, bool use_nonzero_sinks) {
-        ov::element::Type kv_cache_precision = p.kv_cache_precision;
-
-        PagedAttentionManager pam(rg,
-                                  get_test_engine(),
-                                  get_test_stream(),
-                                  p.subsequences,
-                                  p.num_heads,
-                                  p.num_kv_heads,
-                                  p.k_head_size,
-                                  p.v_head_size,
-                                  p.block_size,
-                                  p.sliding_window_size,
-                                  p.kv_cache_compression,
-                                  p.key_cache_quant_mode,
-                                  p.scores_mode == ScoresMode::SNAPKV,
-                                  false,
-                                  p.rotation_config,
-                                  kv_cache_precision);
-
-        // Populate sinks: non-zero values to test effect, or zero for baseline
-        pam.sinks.resize(p.num_heads);
-        for (int h = 0; h < p.num_heads; h++) {
-            pam.sinks[h] = use_nonzero_sinks ? ov::float16(-1.0f + 0.3f * h) : ov::float16(0.0f);
-        }
-
-        auto query_mem = pam.get_query_memory();
-        auto key_mem = pam.get_key_memory();
-        auto value_mem = pam.get_value_memory();
-        auto key_cache_mem = pam.get_key_cache_memory();
-        auto value_cache_mem = pam.get_value_cache_memory();
-        auto past_lens_mem = pam.get_past_lens_memory();
-        auto subsequence_begins_mem = pam.get_subsequence_begins_memory();
-        auto block_indices_mem = pam.get_block_indices_memory();
-        auto block_indices_begins_mem = pam.get_block_indices_begins_memory();
-        auto scale_mem = pam.get_scale_memory();
-        auto sliding_window_mem = pam.get_sliding_window_memory();
-        auto alibi_mem = pam.get_alibi_memory();
-        auto max_context_len_mem = pam.get_max_context_len_memory();
-        auto score_aggregation_mem = pam.get_score_aggregation();
-        auto rotated_block_indices_mem = pam.get_rotated_block_indices_memory();
-        auto rotation_deltas_mem = pam.get_rotation_deltas_memory();
-        auto rotation_trig_lut_mem = pam.get_rotation_trig_lut_memory();
-        auto xattention_threshold_mem = pam.get_xattention_threshold_memory();
-        auto xattention_block_size_mem = pam.get_xattention_block_size_memory();
-        auto xattention_stride_mem = pam.get_xattention_stride_memory();
-        auto sinks_mem = pam.get_sinks_memory();
-        auto adaptive_rkv_start_size_mem = pam.get_adaptive_rkv_start_size_memory();
-        auto adaptive_rkv_evictable_sizes_mem = pam.get_adaptive_rkv_evictable_sizes_memory();
-        auto adaptive_rkv_diversity_block_set_indices_mem = pam.get_adaptive_rkv_diversity_block_set_indices_memory();
-        auto adaptive_rkv_diversity_block_set_indices_begins_mem = pam.get_adaptive_rkv_diversity_block_set_indices_begins_memory();
-        auto token_type_ids_mem = pam.get_token_type_ids_memory();
-        auto qq_bias = pam.get_qq_bias_memory();
-        auto qq_bias_begins = pam.get_qq_bias_begins_memory();
-
-        auto query_layout = query_mem->get_layout();
-        auto key_layout = key_mem->get_layout();
-        auto value_layout = value_mem->get_layout();
-        auto key_cache_layout = key_cache_mem->get_layout();
-        auto value_cache_layout = value_cache_mem->get_layout();
-        auto past_lens_layout = past_lens_mem->get_layout();
-        auto subsequence_begins_layout = subsequence_begins_mem->get_layout();
-        auto block_indices_layout = block_indices_mem->get_layout();
-        auto block_indices_begins_layout = block_indices_begins_mem->get_layout();
-        auto scale_layout = scale_mem->get_layout();
-        auto sliding_window_layout = sliding_window_mem->get_layout();
-        auto alibi_layout = alibi_mem->get_layout();
-        auto max_context_len_layout = max_context_len_mem->get_layout();
-        auto score_aggregation_window_layout = score_aggregation_mem->get_layout();
-        auto rotated_block_indices_layout = rotated_block_indices_mem->get_layout();
-        auto rotation_deltas_layout = rotation_deltas_mem->get_layout();
-        auto rotation_trig_lut_layout = rotation_trig_lut_mem->get_layout();
-        auto xattention_threshold_layout = xattention_threshold_mem->get_layout();
-        auto xattention_block_size_layout = xattention_block_size_mem->get_layout();
-        auto xattention_stride_layout = xattention_stride_mem->get_layout();
-        auto sinks_layout = sinks_mem->get_layout();
-        auto adaptive_rkv_start_size_layout = adaptive_rkv_start_size_mem->get_layout();
-        auto adaptive_rkv_evictable_sizes_layout = adaptive_rkv_evictable_sizes_mem->get_layout();
-        auto adaptive_rkv_diversity_block_set_indices_layout = adaptive_rkv_diversity_block_set_indices_mem->get_layout();
-        auto adaptive_rkv_diversity_block_set_indices_begins_layout = adaptive_rkv_diversity_block_set_indices_begins_mem->get_layout();
-        auto token_type_ids_layout = token_type_ids_mem->get_layout();
-        auto qq_bias_layout = qq_bias->get_layout();
-        auto qq_bias_begins_layout = qq_bias_begins->get_layout();
-
-        query_layout.set_partial_shape(ov::PartialShape{ -1, p.num_heads * p.k_head_size });
-        key_layout.set_partial_shape(ov::PartialShape{ -1, p.num_kv_heads * p.k_head_size });
-        value_layout.set_partial_shape(ov::PartialShape{ -1, p.num_kv_heads * p.v_head_size });
-        { auto pshape = key_cache_layout.get_partial_shape(); pshape[0] = -1; key_cache_layout.set_partial_shape(pshape); }
-        { auto pshape = value_cache_layout.get_partial_shape(); pshape[0] = -1; value_cache_layout.set_partial_shape(pshape); }
-        past_lens_layout.set_partial_shape(ov::PartialShape{ -1 });
-        subsequence_begins_layout.set_partial_shape(ov::PartialShape{ -1 });
-        block_indices_layout.set_partial_shape(ov::PartialShape{ -1 });
-        block_indices_begins_layout.set_partial_shape(ov::PartialShape{ -1 });
-        score_aggregation_window_layout.set_partial_shape(ov::PartialShape{ -1 });
-        rotated_block_indices_layout.set_partial_shape(ov::PartialShape{ -1 });
-        rotation_deltas_layout.set_partial_shape(ov::PartialShape{ -1, -1 });
-        rotation_trig_lut_layout.set_partial_shape(ov::PartialShape{ -1, p.k_head_size });
-        xattention_threshold_layout.set_partial_shape(ov::PartialShape{ -1 });
-        adaptive_rkv_evictable_sizes_layout.set_partial_shape(ov::PartialShape{ -1 });
-        adaptive_rkv_diversity_block_set_indices_layout.set_partial_shape(ov::PartialShape{ -1 });
-        adaptive_rkv_diversity_block_set_indices_begins_layout.set_partial_shape(ov::PartialShape{ -1 });
-        qq_bias_layout.set_partial_shape(ov::PartialShape{ -1 });
-        qq_bias_begins_layout.set_partial_shape(ov::PartialShape{ -1 });
-
-        std::vector<input_info> pa_inputs = {
-            input_info("query"), input_info("key"), input_info("value"),
-            input_info("key_cache"), input_info("value_cache"),
-            input_info("past_lens"), input_info("subsequence_begins"),
-            input_info("block_indices"), input_info("block_indices_begins"),
-            input_info("scale"), input_info("sliding_window"), input_info("alibi"),
-            input_info("max_context_len"), input_info("score_aggregation_window"),
-            input_info("rotated_block_indices"), input_info("rotation_deltas"),
-            input_info("rotation_trig_lut_modified"),
-            input_info("xattention_threshold"), input_info("xattention_block_size"),
-            input_info("xattention_stride"), input_info("sinks"),
-            input_info("adaptive_rkv_start_size"), input_info("adaptive_rkv_evictable_sizes"),
-            input_info("adaptive_rkv_diversity_block_set_indices"),
-            input_info("adaptive_rkv_diversity_block_set_indices_begins"),
-            input_info("token_type_ids"), input_info("qq_bias"), input_info("qq_bias_begins")
-        };
-
-        auto pa_prim = paged_attention("paged_attention", pa_inputs);
-        pa_prim.k_head_size = p.k_head_size;
-        pa_prim.v_head_size = p.v_head_size;
-        pa_prim.kv_heads_num = p.num_kv_heads;
-        pa_prim.heads_num = p.num_heads;
-        pa_prim.scale_val = pam.get_default_scale();
-        pa_prim.has_alibi = false;
-        pa_prim.has_token_type_ids = true;  // Force sdpa_opt.cl path (disables micro-SDPA)
-        pa_prim.has_sink_input = true;
-        pa_prim.num_outputs = 1;
-        pa_prim.has_rotated_blocks = false;
-        pa_prim.has_score_aggregation = false;
-        pa_prim.has_adaptive_rkv = false;
-        pa_prim.sliding_window = p.sliding_window_size;
-        pa_prim.is_key_by_channel = false;
-        pa_prim.has_xattention = false;
-        pa_prim.has_qq_bias = false;
-
-        topology topology;
-        topology.add(
-            input_layout("query", query_layout),
-            input_layout("key", key_layout),
-            input_layout("value", value_layout),
-            input_layout("key_cache", key_cache_layout),
-            input_layout("value_cache", value_cache_layout),
-            input_layout("past_lens", past_lens_layout),
-            input_layout("subsequence_begins", subsequence_begins_layout),
-            input_layout("block_indices", block_indices_layout),
-            input_layout("block_indices_begins", block_indices_begins_layout),
-            input_layout("scale", scale_layout),
-            input_layout("sliding_window", sliding_window_layout),
-            input_layout("alibi", alibi_layout),
-            input_layout("max_context_len", max_context_len_layout),
-            input_layout("score_aggregation_window", score_aggregation_window_layout),
-            pa_prim,
-            reorder("output_data", input_info("paged_attention", 0), format::bfyx, data_types::f16)
-        );
-
-        topology.add(input_layout("rotated_block_indices", rotated_block_indices_layout));
-        topology.add(input_layout("rotation_deltas", rotation_deltas_layout));
-        topology.add(input_layout("rotation_trig_lut", rotation_trig_lut_layout));
-        topology.add(activation("rotation_trig_lut_modified", input_info("rotation_trig_lut"), activation_func::none));
-        topology.add(input_layout("xattention_threshold", xattention_threshold_layout));
-        topology.add(input_layout("xattention_block_size", xattention_block_size_layout));
-        topology.add(input_layout("xattention_stride", xattention_stride_layout));
-        topology.add(input_layout("sinks", sinks_layout));
-        topology.add(input_layout("adaptive_rkv_start_size", adaptive_rkv_start_size_layout));
-        topology.add(input_layout("adaptive_rkv_evictable_sizes", adaptive_rkv_evictable_sizes_layout));
-        topology.add(input_layout("adaptive_rkv_diversity_block_set_indices", adaptive_rkv_diversity_block_set_indices_layout));
-        topology.add(input_layout("adaptive_rkv_diversity_block_set_indices_begins", adaptive_rkv_diversity_block_set_indices_begins_layout));
-        topology.add(input_layout("token_type_ids", token_type_ids_layout));
-        topology.add(input_layout("qq_bias", qq_bias_layout));
-        topology.add(input_layout("qq_bias_begins", qq_bias_begins_layout));
-
-        ExecutionConfig config = get_test_default_config(get_test_engine());
-        config.set_property(ov::intel_gpu::optimize_data(true));
-        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
-        // Enable FlashAttnV2: could_use_flashattn_v2(true) sets IS_FLASHATTEN_V2=1 in the kernel
-        config.set_property(ov::intel_gpu::could_use_flashattn_v2(true));
-        config.set_property(ov::internal::key_cache_quant_mode(p.key_cache_quant_mode));
-
-        network::ptr network = get_network(get_test_engine(), topology, config, get_test_stream_ptr(), false);
-        network->set_input_data("query", query_mem);
-        network->set_input_data("key", key_mem);
-        network->set_input_data("value", value_mem);
-        network->set_input_data("key_cache", key_cache_mem);
-        network->set_input_data("value_cache", value_cache_mem);
-        network->set_input_data("past_lens", past_lens_mem);
-        network->set_input_data("subsequence_begins", subsequence_begins_mem);
-        network->set_input_data("block_indices", block_indices_mem);
-        network->set_input_data("block_indices_begins", block_indices_begins_mem);
-        network->set_input_data("scale", scale_mem);
-        network->set_input_data("sliding_window", sliding_window_mem);
-        network->set_input_data("alibi", alibi_mem);
-        network->set_input_data("max_context_len", max_context_len_mem);
-        network->set_input_data("score_aggregation_window", score_aggregation_mem);
-        network->set_input_data("rotated_block_indices", rotated_block_indices_mem);
-        network->set_input_data("rotation_deltas", rotation_deltas_mem);
-        network->set_input_data("rotation_trig_lut", rotation_trig_lut_mem);
-        network->set_input_data("xattention_threshold", xattention_threshold_mem);
-        network->set_input_data("xattention_block_size", xattention_block_size_mem);
-        network->set_input_data("xattention_stride", xattention_stride_mem);
-        network->set_input_data("sinks", sinks_mem);
-        network->set_input_data("adaptive_rkv_start_size", adaptive_rkv_start_size_mem);
-        network->set_input_data("adaptive_rkv_evictable_sizes", adaptive_rkv_evictable_sizes_mem);
-        network->set_input_data("adaptive_rkv_diversity_block_set_indices", adaptive_rkv_diversity_block_set_indices_mem);
-        network->set_input_data("adaptive_rkv_diversity_block_set_indices_begins", adaptive_rkv_diversity_block_set_indices_begins_mem);
-        network->set_input_data("token_type_ids", token_type_ids_mem);
-        network->set_input_data("qq_bias", qq_bias);
-        network->set_input_data("qq_bias_begins", qq_bias_begins);
-
-        auto outputs = network->execute();
-        auto output_data_mem = outputs.at("output_data").get_memory();
-
-        std::vector<ov::float16> result(output_data_mem->count());
-        mem_lock<ov::float16, mem_lock_type::read> mem_ptr(output_data_mem, get_test_stream());
-        for (size_t i = 0; i < output_data_mem->count(); i++)
-            result[i] = mem_ptr[i];
-
-        return result;
-    }
-};
+class paged_attention_sink_v2_effect_test : public PagedAttentionTest<paged_attention_test_params> {};
 
 TEST_P(paged_attention_sink_v2_effect_test, verify_sink_changes_v2_output) {
     auto p = GetParam();
+    p.has_sink_input = true;
+    p.force_flashattn_v2 = true;
 
     // Run FlashAttnV2 multi-token path with non-zero sinks
+    std::vector<ov::float16> nonzero_sinks(p.num_heads);
+    for (int h = 0; h < p.num_heads; h++)
+        nonzero_sinks[h] = ov::float16(-1.0f + 0.3f * h);
+
     rg.set_seed(GET_SUITE_NAME);
-    auto output_with_sinks = run_pa_v2_prompt(p, /*use_nonzero_sinks=*/true);
+    p.sink_values = nonzero_sinks;
+    execute(p, false);
+    auto output_with_sinks = get_output_data();
 
     // Run FlashAttnV2 multi-token path with zero sinks (sink code still runs but has no effect)
+    std::vector<ov::float16> zero_sinks(p.num_heads, ov::float16(0.0f));
+
     rg.set_seed(GET_SUITE_NAME);
-    auto output_no_sinks = run_pa_v2_prompt(p, /*use_nonzero_sinks=*/false);
+    p.sink_values = zero_sinks;
+    execute(p, false);
+    auto output_no_sinks = get_output_data();
 
     ASSERT_EQ(output_with_sinks.size(), output_no_sinks.size());
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -2981,7 +2981,7 @@ static std::vector<int32_t> gen_tokens_ids_test_data(size_t seq_len, int num_ima
 
 // Test class to verify FlashAttnV2 multi-token sink correction is actually active.
 // Runs the same prompt twice with FA_V2 enabled: once with non-zero sinks, once with zero sinks.
-// Asserts outputs differ, proving the sink code at line 2552 in sdpa_opt.cl executes.
+// Asserts outputs differ, proving the sink correction in sdpa_opt.cl executes.
 // This test is platform-independent (works on any GPU with OpenCL support).
 class paged_attention_sink_v2_effect_test : public PagedAttentionTest<paged_attention_test_params> {};
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -2953,6 +2953,272 @@ static std::vector<int32_t> gen_tokens_ids_test_data(size_t seq_len, int num_ima
     return v;
 }
 
+// Test class to verify FlashAttnV2 sink correction produces same output as V1 path.
+// This exercises the fix for attention sink handling in the FlashAttnV2 online-softmax path.
+class paged_attention_sink_v1_v2_test : public PagedAttentionTest<paged_attention_test_params> {
+protected:
+    std::vector<ov::float16> run_pa_with_sinks(paged_attention_test_params& p, bool disable_fa_v2) {
+        ov::element::Type kv_cache_precision = p.kv_cache_precision;
+
+        PagedAttentionManager pam(rg,
+                                  get_test_engine(),
+                                  get_test_stream(),
+                                  p.subsequences,
+                                  p.num_heads,
+                                  p.num_kv_heads,
+                                  p.k_head_size,
+                                  p.v_head_size,
+                                  p.block_size,
+                                  p.sliding_window_size,
+                                  p.kv_cache_compression,
+                                  p.key_cache_quant_mode,
+                                  p.scores_mode == ScoresMode::SNAPKV,
+                                  false,  // has_xattention
+                                  p.rotation_config,
+                                  kv_cache_precision);
+
+        // Populate sinks with realistic non-zero values [1, num_heads, 1, 1]
+        // Sink values are per-head scalar logits (typically small negative or small positive)
+        pam.sinks.resize(p.num_heads);
+        for (int h = 0; h < p.num_heads; h++) {
+            pam.sinks[h] = ov::float16(-1.0f + 0.3f * h);  // e.g., -1.0, -0.7, -0.4, ...
+        }
+
+        auto query_mem = pam.get_query_memory();
+        auto key_mem = pam.get_key_memory();
+        auto value_mem = pam.get_value_memory();
+        auto key_cache_mem = pam.get_key_cache_memory();
+        auto value_cache_mem = pam.get_value_cache_memory();
+        auto past_lens_mem = pam.get_past_lens_memory();
+        auto subsequence_begins_mem = pam.get_subsequence_begins_memory();
+        auto block_indices_mem = pam.get_block_indices_memory();
+        auto block_indices_begins_mem = pam.get_block_indices_begins_memory();
+        auto scale_mem = pam.get_scale_memory();
+        auto sliding_window_mem = pam.get_sliding_window_memory();
+        auto alibi_mem = pam.get_alibi_memory();
+        auto max_context_len_mem = pam.get_max_context_len_memory();
+        auto score_aggregation_mem = pam.get_score_aggregation();
+        auto rotated_block_indices_mem = pam.get_rotated_block_indices_memory();
+        auto rotation_deltas_mem = pam.get_rotation_deltas_memory();
+        auto rotation_trig_lut_mem = pam.get_rotation_trig_lut_memory();
+        auto xattention_threshold_mem = pam.get_xattention_threshold_memory();
+        auto xattention_block_size_mem = pam.get_xattention_block_size_memory();
+        auto xattention_stride_mem = pam.get_xattention_stride_memory();
+        auto sinks_mem = pam.get_sinks_memory();
+        auto adaptive_rkv_start_size_mem = pam.get_adaptive_rkv_start_size_memory();
+        auto adaptive_rkv_evictable_sizes_mem = pam.get_adaptive_rkv_evictable_sizes_memory();
+        auto adaptive_rkv_diversity_block_set_indices_mem = pam.get_adaptive_rkv_diversity_block_set_indices_memory();
+        auto adaptive_rkv_diversity_block_set_indices_begins_mem = pam.get_adaptive_rkv_diversity_block_set_indices_begins_memory();
+        auto token_type_ids_mem = pam.get_token_type_ids_memory();
+        auto qq_bias = pam.get_qq_bias_memory();
+        auto qq_bias_begins = pam.get_qq_bias_begins_memory();
+
+        auto query_layout = query_mem->get_layout();
+        auto key_layout = key_mem->get_layout();
+        auto value_layout = value_mem->get_layout();
+        auto key_cache_layout = key_cache_mem->get_layout();
+        auto value_cache_layout = value_cache_mem->get_layout();
+        auto past_lens_layout = past_lens_mem->get_layout();
+        auto subsequence_begins_layout = subsequence_begins_mem->get_layout();
+        auto block_indices_layout = block_indices_mem->get_layout();
+        auto block_indices_begins_layout = block_indices_begins_mem->get_layout();
+        auto scale_layout = scale_mem->get_layout();
+        auto sliding_window_layout = sliding_window_mem->get_layout();
+        auto alibi_layout = alibi_mem->get_layout();
+        auto max_context_len_layout = max_context_len_mem->get_layout();
+        auto score_aggregation_window_layout = score_aggregation_mem->get_layout();
+        auto rotated_block_indices_layout = rotated_block_indices_mem->get_layout();
+        auto rotation_deltas_layout = rotation_deltas_mem->get_layout();
+        auto rotation_trig_lut_layout = rotation_trig_lut_mem->get_layout();
+        auto xattention_threshold_layout = xattention_threshold_mem->get_layout();
+        auto xattention_block_size_layout = xattention_block_size_mem->get_layout();
+        auto xattention_stride_layout = xattention_stride_mem->get_layout();
+        auto sinks_layout = sinks_mem->get_layout();
+        auto adaptive_rkv_start_size_layout = adaptive_rkv_start_size_mem->get_layout();
+        auto adaptive_rkv_evictable_sizes_layout = adaptive_rkv_evictable_sizes_mem->get_layout();
+        auto adaptive_rkv_diversity_block_set_indices_layout = adaptive_rkv_diversity_block_set_indices_mem->get_layout();
+        auto adaptive_rkv_diversity_block_set_indices_begins_layout = adaptive_rkv_diversity_block_set_indices_begins_mem->get_layout();
+        auto token_type_ids_layout = token_type_ids_mem->get_layout();
+        auto qq_bias_layout = qq_bias->get_layout();
+        auto qq_bias_begins_layout = qq_bias_begins->get_layout();
+
+        // Make layouts dynamic
+        query_layout.set_partial_shape(ov::PartialShape{ -1, p.num_heads * p.k_head_size });
+        key_layout.set_partial_shape(ov::PartialShape{ -1, p.num_kv_heads * p.k_head_size });
+        value_layout.set_partial_shape(ov::PartialShape{ -1, p.num_kv_heads * p.v_head_size });
+        { auto pshape = key_cache_layout.get_partial_shape(); pshape[0] = -1; key_cache_layout.set_partial_shape(pshape); }
+        { auto pshape = value_cache_layout.get_partial_shape(); pshape[0] = -1; value_cache_layout.set_partial_shape(pshape); }
+        past_lens_layout.set_partial_shape(ov::PartialShape{ -1 });
+        subsequence_begins_layout.set_partial_shape(ov::PartialShape{ -1 });
+        block_indices_layout.set_partial_shape(ov::PartialShape{ -1 });
+        block_indices_begins_layout.set_partial_shape(ov::PartialShape{ -1 });
+        score_aggregation_window_layout.set_partial_shape(ov::PartialShape{ -1 });
+        rotated_block_indices_layout.set_partial_shape(ov::PartialShape{ -1 });
+        rotation_deltas_layout.set_partial_shape(ov::PartialShape{ -1, -1 });
+        rotation_trig_lut_layout.set_partial_shape(ov::PartialShape{ -1, p.k_head_size });
+        xattention_threshold_layout.set_partial_shape(ov::PartialShape{ -1 });
+        adaptive_rkv_evictable_sizes_layout.set_partial_shape(ov::PartialShape{ -1 });
+        adaptive_rkv_diversity_block_set_indices_layout.set_partial_shape(ov::PartialShape{ -1 });
+        adaptive_rkv_diversity_block_set_indices_begins_layout.set_partial_shape(ov::PartialShape{ -1 });
+        qq_bias_layout.set_partial_shape(ov::PartialShape{ -1 });
+        qq_bias_begins_layout.set_partial_shape(ov::PartialShape{ -1 });
+
+        std::vector<input_info> pa_inputs = {
+            input_info("query"), input_info("key"), input_info("value"),
+            input_info("key_cache"), input_info("value_cache"),
+            input_info("past_lens"), input_info("subsequence_begins"),
+            input_info("block_indices"), input_info("block_indices_begins"),
+            input_info("scale"), input_info("sliding_window"), input_info("alibi"),
+            input_info("max_context_len"), input_info("score_aggregation_window"),
+            input_info("rotated_block_indices"), input_info("rotation_deltas"),
+            input_info("rotation_trig_lut_modified"),
+            input_info("xattention_threshold"), input_info("xattention_block_size"),
+            input_info("xattention_stride"), input_info("sinks"),
+            input_info("adaptive_rkv_start_size"), input_info("adaptive_rkv_evictable_sizes"),
+            input_info("adaptive_rkv_diversity_block_set_indices"),
+            input_info("adaptive_rkv_diversity_block_set_indices_begins"),
+            input_info("token_type_ids"), input_info("qq_bias"), input_info("qq_bias_begins")
+        };
+
+        auto pa_prim = paged_attention("paged_attention", pa_inputs);
+        pa_prim.k_head_size = p.k_head_size;
+        pa_prim.v_head_size = p.v_head_size;
+        pa_prim.kv_heads_num = p.num_kv_heads;
+        pa_prim.heads_num = p.num_heads;
+        pa_prim.scale_val = pam.get_default_scale();
+        pa_prim.has_alibi = false;
+        pa_prim.has_token_type_ids = false;
+        pa_prim.has_sink_input = true;  // We provide non-empty sinks
+        pa_prim.num_outputs = 1;
+        pa_prim.has_rotated_blocks = false;
+        pa_prim.has_score_aggregation = false;
+        pa_prim.has_adaptive_rkv = false;
+        pa_prim.sliding_window = p.sliding_window_size;
+        pa_prim.is_key_by_channel = false;
+        pa_prim.has_xattention = false;
+        pa_prim.has_qq_bias = false;
+
+        topology topology;
+        topology.add(
+            input_layout("query", query_layout),
+            input_layout("key", key_layout),
+            input_layout("value", value_layout),
+            input_layout("key_cache", key_cache_layout),
+            input_layout("value_cache", value_cache_layout),
+            input_layout("past_lens", past_lens_layout),
+            input_layout("subsequence_begins", subsequence_begins_layout),
+            input_layout("block_indices", block_indices_layout),
+            input_layout("block_indices_begins", block_indices_begins_layout),
+            input_layout("scale", scale_layout),
+            input_layout("sliding_window", sliding_window_layout),
+            input_layout("alibi", alibi_layout),
+            input_layout("max_context_len", max_context_len_layout),
+            input_layout("score_aggregation_window", score_aggregation_window_layout),
+            pa_prim,
+            reorder("output_data", input_info("paged_attention", 0), format::bfyx, data_types::f16)
+        );
+
+        topology.add(input_layout("rotated_block_indices", rotated_block_indices_layout));
+        topology.add(input_layout("rotation_deltas", rotation_deltas_layout));
+        topology.add(input_layout("rotation_trig_lut", rotation_trig_lut_layout));
+        topology.add(activation("rotation_trig_lut_modified", input_info("rotation_trig_lut"), activation_func::none));
+        topology.add(input_layout("xattention_threshold", xattention_threshold_layout));
+        topology.add(input_layout("xattention_block_size", xattention_block_size_layout));
+        topology.add(input_layout("xattention_stride", xattention_stride_layout));
+        topology.add(input_layout("sinks", sinks_layout));
+        topology.add(input_layout("adaptive_rkv_start_size", adaptive_rkv_start_size_layout));
+        topology.add(input_layout("adaptive_rkv_evictable_sizes", adaptive_rkv_evictable_sizes_layout));
+        topology.add(input_layout("adaptive_rkv_diversity_block_set_indices", adaptive_rkv_diversity_block_set_indices_layout));
+        topology.add(input_layout("adaptive_rkv_diversity_block_set_indices_begins", adaptive_rkv_diversity_block_set_indices_begins_layout));
+        topology.add(input_layout("token_type_ids", token_type_ids_layout));
+        topology.add(input_layout("qq_bias", qq_bias_layout));
+        topology.add(input_layout("qq_bias_begins", qq_bias_begins_layout));
+
+        ExecutionConfig config = get_test_default_config(get_test_engine());
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        config.set_property(ov::intel_gpu::could_use_flashattn_v2(disable_fa_v2));
+        config.set_property(ov::internal::key_cache_quant_mode(p.key_cache_quant_mode));
+
+        network::ptr network = get_network(get_test_engine(), topology, config, get_test_stream_ptr(), false);
+        network->set_input_data("query", query_mem);
+        network->set_input_data("key", key_mem);
+        network->set_input_data("value", value_mem);
+        network->set_input_data("key_cache", key_cache_mem);
+        network->set_input_data("value_cache", value_cache_mem);
+        network->set_input_data("past_lens", past_lens_mem);
+        network->set_input_data("subsequence_begins", subsequence_begins_mem);
+        network->set_input_data("block_indices", block_indices_mem);
+        network->set_input_data("block_indices_begins", block_indices_begins_mem);
+        network->set_input_data("scale", scale_mem);
+        network->set_input_data("sliding_window", sliding_window_mem);
+        network->set_input_data("alibi", alibi_mem);
+        network->set_input_data("max_context_len", max_context_len_mem);
+        network->set_input_data("score_aggregation_window", score_aggregation_mem);
+        network->set_input_data("rotated_block_indices", rotated_block_indices_mem);
+        network->set_input_data("rotation_deltas", rotation_deltas_mem);
+        network->set_input_data("rotation_trig_lut", rotation_trig_lut_mem);
+        network->set_input_data("xattention_threshold", xattention_threshold_mem);
+        network->set_input_data("xattention_block_size", xattention_block_size_mem);
+        network->set_input_data("xattention_stride", xattention_stride_mem);
+        network->set_input_data("sinks", sinks_mem);
+        network->set_input_data("adaptive_rkv_start_size", adaptive_rkv_start_size_mem);
+        network->set_input_data("adaptive_rkv_evictable_sizes", adaptive_rkv_evictable_sizes_mem);
+        network->set_input_data("adaptive_rkv_diversity_block_set_indices", adaptive_rkv_diversity_block_set_indices_mem);
+        network->set_input_data("adaptive_rkv_diversity_block_set_indices_begins", adaptive_rkv_diversity_block_set_indices_begins_mem);
+        network->set_input_data("token_type_ids", token_type_ids_mem);
+        network->set_input_data("qq_bias", qq_bias);
+        network->set_input_data("qq_bias_begins", qq_bias_begins);
+
+        auto outputs = network->execute();
+        auto output_data_mem = outputs.at("output_data").get_memory();
+
+        std::vector<ov::float16> result(output_data_mem->count());
+        mem_lock<ov::float16, mem_lock_type::read> mem_ptr(output_data_mem, get_test_stream());
+        for (size_t i = 0; i < output_data_mem->count(); i++)
+            result[i] = mem_ptr[i];
+
+        return result;
+    }
+};
+
+TEST_P(paged_attention_sink_v1_v2_test, compare_fa_v1_v2_with_sinks) {
+    auto p = GetParam();
+
+    // Use same RNG seed for both runs to get identical input data
+    rg.set_seed(GET_SUITE_NAME);
+    auto output_v1 = run_pa_with_sinks(p, /*disable_fa_v2=*/true);
+
+    rg.set_seed(GET_SUITE_NAME);
+    auto output_v2 = run_pa_with_sinks(p, /*disable_fa_v2=*/false);
+
+    ASSERT_EQ(output_v1.size(), output_v2.size());
+
+    // V1 and V2 paths may use different accumulation order, allow small tolerance
+    const float sink_tolerance = 5e-3f;
+    for (size_t i = 0; i < output_v1.size(); i++) {
+        ASSERT_NEAR(static_cast<float>(output_v1[i]), static_cast<float>(output_v2[i]), sink_tolerance)
+            << " V1 vs V2 mismatch with sinks at index=" << i;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_paged_attention_sink, paged_attention_sink_v1_v2_test, ::testing::ValuesIn(std::vector<paged_attention_test_params>{
+    // head_size=64: triggers FlashAttnV2 fallback on xe3p (no micro-kernel for h64)
+    // Generation phase (single-token) - both V1 and V2 correctly apply sinks
+    // Note: Multi-token prompt cases are excluded because the non-FlashAttnV2 multi-token path
+    // does not apply sinks (separate known limitation), making V1/V2 comparison invalid for prompts.
+    // 2nd token (generation phase with past context)
+    paged_attention_test_params{ {{1, 34}}, 2, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
+    // 2nd token with longer past context
+    paged_attention_test_params{ {{1, 128}}, 2, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
+    // GQA: num_heads=8, num_kv_heads=2
+    paged_attention_test_params{ {{1, 64}}, 8, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
+    // With sliding window (attention sink + sliding window is the common real-world pattern)
+    paged_attention_test_params{ {{1, 128}}, 4, 4, 64, 64, 16, 64, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
+    // Multiple 2nd tokens in batch
+    paged_attention_test_params{ {{1, 34}, {1, 100}}, 2, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false },
+}));
+
 INSTANTIATE_TEST_SUITE_P(smoke_paged_attention, paged_attention_test, ::testing::ValuesIn(std::vector<paged_attention_test_params>{
     /* with scores output, use SnapKV */
     paged_attention_test_params{ {{10, 0}}, 2, 2, 64, 64, 16, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, ENABLE_SCORES_SNAPKV, DISABLE_ROTATION, ENABLE_FA_V2, false, 0, {}, false }, // 1st token


### PR DESCRIPTION
### Details:
- On NVL-P (xe3p), the PA SDPA micro-kernel fails to compile for head_size=64 (no matching kernel in xe3_h128 config), falling back to the FlashAttnV2 online-softmax path in sdpa_opt.cl. This path was missing the attention sink correction, causing significant accuracy degradation (~80%) for models using attention sinks (e.g., sliding window + sink tokens).

Fix:
- This is WA code for NVL-P. But fix in sdpa_opt is required. I will remove condition of fallback to sdpa opt when NVL-P has proper sdpa micro kernel config.
- paged_attention_opt.cpp: Bind sink buffer and define HAS_SINK_INPUT JIT for the PagedAttentionSDPAOptGeneratorMultiToken path
- sdpa_opt.cl: Add post-partition sink correction in the FlashAttnV2 IS_FLASHATTEN_V2 path - after all KV partitions are processed, incorporate the sink logit into the softmax denominator rescaling

The sink mechanism injects a per-head scalar logit into softmax without a corresponding V contribution, acting as a dampening factor. Without this correction, full probability mass goes to real KV tokens, inflating the attention output.

### Tickets:
 - 186515

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
 Analyzed with AI support, validation on cross platform by human.
