### PR TITLE
[TRANSFORMATIONS] Fix shared constant reshape in MoveEltwiseUpThroughDataMovScalar

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
@@ -121,7 +121,8 @@ ov::pass::MoveEltwiseUpThroughDataMovScalar::MoveEltwiseUpThroughDataMovScalar(
                 auto old_eltwise_const = ov::as_type_ptr<ov::opset8::Constant>(eltwise->get_input_node_shared_ptr(i));
                 if (old_eltwise_const->get_shape().size() != 0) {
                     auto new_constant = std::make_shared<ov::opset8::Constant>(*old_eltwise_const.get(), ov::Shape{});
-                    ov::replace_node_update_name(old_eltwise_const, new_constant);
+                    copy_runtime_info(old_eltwise_const, new_constant);
+                    eltwise->input(i).replace_source_output(new_constant->output(0));
                 }
             }
         }

--- a/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
@@ -121,7 +121,7 @@ ov::pass::MoveEltwiseUpThroughDataMovScalar::MoveEltwiseUpThroughDataMovScalar(
                 auto old_eltwise_const = ov::as_type_ptr<ov::opset8::Constant>(eltwise->get_input_node_shared_ptr(i));
                 if (old_eltwise_const->get_shape().size() != 0) {
                     auto new_constant = std::make_shared<ov::opset8::Constant>(*old_eltwise_const.get(), ov::Shape{});
-                    copy_runtime_info(old_eltwise_const, new_constant);
+                    ov::copy_runtime_info(old_eltwise_const, new_constant);
                     eltwise->input(i).replace_source_output(new_constant->output(0));
                 }
             }

--- a/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
@@ -19,6 +19,7 @@
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/sigmoid.hpp"
 #include "openvino/op/squeeze.hpp"
+#include "openvino/op/strided_slice.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/opsets/opset8_decl.hpp"
@@ -506,5 +507,66 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelReshapeMultiply) {
         auto reshape = std::make_shared<v1::Reshape>(multiply, reshape_constant, false);
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{input});
+    }
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, SharedConstantNotReshapedForOtherConsumers) {
+    const ov::Shape data_shape{1, 3, 224, 224};
+    const std::vector<int64_t> input_order = {3, 2, 1, 0};
+    const int64_t unsqueeze_axis = 2;
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::i64, data_shape);
+
+        auto transpose_const =
+            ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
+        auto transpose = std::make_shared<ov::opset8::Transpose>(input, transpose_const);
+
+        auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
+        auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(transpose, unsqueeze_const);
+
+        auto shared_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+
+        auto multiply = std::make_shared<v1::Multiply>(unsqueeze, shared_const);
+
+        auto slice_input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{4});
+        auto begin = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+        auto stride = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+        auto slice = std::make_shared<v1::StridedSlice>(slice_input,
+                                                        begin,
+                                                        shared_const,
+                                                        stride,
+                                                        std::vector<int64_t>{0},
+                                                        std::vector<int64_t>{0});
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{multiply, slice},
+                                            ov::ParameterVector{input, slice_input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::i64, data_shape);
+
+        auto shared_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+        auto scalar_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {2});
+        auto multiply = std::make_shared<v1::Multiply>(input, scalar_const);
+
+        auto transpose_const =
+            ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
+        auto transpose = std::make_shared<ov::opset8::Transpose>(multiply, transpose_const);
+
+        auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
+        auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(transpose, unsqueeze_const);
+
+        auto slice_input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{4});
+        auto begin = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+        auto stride = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+        auto slice = std::make_shared<v1::StridedSlice>(slice_input,
+                                                        begin,
+                                                        shared_const,
+                                                        stride,
+                                                        std::vector<int64_t>{0},
+                                                        std::vector<int64_t>{0});
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze, slice},
+                                                ov::ParameterVector{input, slice_input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
@@ -566,7 +566,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SharedConstantNotReshapedForOtherConsume
                                                         std::vector<int64_t>{0},
                                                         std::vector<int64_t>{0});
 
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze, slice},
-                                                ov::ParameterVector{input, slice_input});
+        model_ref =
+            std::make_shared<ov::Model>(ov::OutputVector{unsqueeze, slice}, ov::ParameterVector{input, slice_input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
@@ -538,8 +538,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SharedConstantNotReshapedForOtherConsume
                                                         std::vector<int64_t>{0},
                                                         std::vector<int64_t>{0});
 
-        model = std::make_shared<ov::Model>(ov::OutputVector{multiply, slice},
-                                            ov::ParameterVector{input, slice_input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{multiply, slice}, ov::ParameterVector{input, slice_input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {

--- a/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
@@ -515,22 +515,21 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SharedConstantNotReshapedForOtherConsume
     const std::vector<int64_t> input_order = {3, 2, 1, 0};
     const int64_t unsqueeze_axis = 2;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::i64, data_shape);
+        auto input = std::make_shared<v0::Parameter>(ov::element::i64, data_shape);
 
-        auto transpose_const =
-            ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
-        auto transpose = std::make_shared<ov::opset8::Transpose>(input, transpose_const);
+        auto transpose_const = v0::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
+        auto transpose = std::make_shared<v1::Transpose>(input, transpose_const);
 
-        auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
-        auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(transpose, unsqueeze_const);
+        auto unsqueeze_const = v0::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
+        auto unsqueeze = std::make_shared<v0::Unsqueeze>(transpose, unsqueeze_const);
 
-        auto shared_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+        auto shared_const = v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});
 
         auto multiply = std::make_shared<v1::Multiply>(unsqueeze, shared_const);
 
-        auto slice_input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{4});
-        auto begin = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {0});
-        auto stride = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+        auto slice_input = std::make_shared<v0::Parameter>(ov::element::f32, ov::Shape{4});
+        auto begin = v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+        auto stride = v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
         auto slice = std::make_shared<v1::StridedSlice>(slice_input,
                                                         begin,
                                                         shared_const,
@@ -542,22 +541,21 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SharedConstantNotReshapedForOtherConsume
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::i64, data_shape);
+        auto input = std::make_shared<v0::Parameter>(ov::element::i64, data_shape);
 
-        auto shared_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {2});
-        auto scalar_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {2});
+        auto shared_const = v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+        auto scalar_const = v0::Constant::create(ov::element::i64, ov::Shape{}, {2});
         auto multiply = std::make_shared<v1::Multiply>(input, scalar_const);
 
-        auto transpose_const =
-            ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
-        auto transpose = std::make_shared<ov::opset8::Transpose>(multiply, transpose_const);
+        auto transpose_const = v0::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
+        auto transpose = std::make_shared<v1::Transpose>(multiply, transpose_const);
 
-        auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
-        auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(transpose, unsqueeze_const);
+        auto unsqueeze_const = v0::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
+        auto unsqueeze = std::make_shared<v0::Unsqueeze>(transpose, unsqueeze_const);
 
-        auto slice_input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{4});
-        auto begin = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {0});
-        auto stride = ov::opset8::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+        auto slice_input = std::make_shared<v0::Parameter>(ov::element::f32, ov::Shape{4});
+        auto begin = v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+        auto stride = v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
         auto slice = std::make_shared<v1::StridedSlice>(slice_input,
                                                         begin,
                                                         shared_const,


### PR DESCRIPTION
### Details:
  - Fix shared constant corruption in MoveEltwiseUpThroughDataMovScalar that caused "End input must be 1D (has rank: 0)" on mask-rcnn-resnet50-fpn (GPU).

### Description of the issue (symptom, root-cause, how it was resolved)
  - **Symptom**: GPU inference crashes with `"End input must be 1D (has rank: 0)"` on models (e.g. mask-rcnn-resnet50-fpn) where a 1-D constant is shared between an eltwise op and a StridedSlice.

  - **Root Cause**:
    - `ov::replace_node_update_name(old_const, new_scalar_const)` globally replaces ALL consumers of the original constant node with the new scalar constant.
    - When the constant is shared with StridedSlice (which requires rank-1 begin/end inputs), the scalar replacement violates the shape constraint, causing validation failure.

  - **Resolution**:
    - Replaced `replace_node_update_name` with `copy_runtime_info` + `eltwise->input(i).replace_source_output(new_constant->output(0))` to only rewire the eltwise's own input to the scalar copy.
    - Other consumers of the original constant remain untouched and keep the original shape.

#### The code and line that caused this issue (if it is not changed directly)
https://github.com/openvinotoolkit/openvino/blob/1bbe6904c10f089f89c883060b276394d9f40ff1/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp#L124

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
```Bash
./openvino/bin/intel64/Debug/benchmark_app \
  -m /models/mask-rcnn-resnet50-fpn/onnx/onnx/FP32/1/ov/mask-rcnn-resnet50-fpn.xml \
  -nstreams 1 \
  -nireq 1 \
  -b 1 \
  -infer_precision f32 \
  -d GPU \
  -hint none \
  -inference_only=false \
  -niter 1
```

#### Problematic graph
- Before fix:
```
new_const (Const, i32, shape=[], val=800)  ← replaces Unsqueeze_2377 globally
     │
     ├──► Minimum_20248.input(1)    OK (wants scalar)
     │
     └──► Slice_2419.input(2)     Error (gets rank-0, but needs rank-1)
```
- Fix:
```
Unsqueeze_2377 (Const, i32, shape=[1], val=800)  ← preserved
     │
     └──► Slice_2419.input(2)     OK (still rank-1)

new_const (Const, i32, shape=[], val=800)  ← private copy
     │
     └──► Minimum_20248.input(1)    ok(gets scalar)
```

#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [v] Did you include test case for this fix, if necessary?
 - [v] Did you review existing test that can be extended to cover this scenario? Reviewed 

### Tickets:
  - *CVS-166954*
