### PR TITLE
Python: Expose GQA Extension in Python bindings

### DIFF
--- a/src/bindings/python/src/openvino/op/__init__.py
+++ b/src/bindings/python/src/openvino/op/__init__.py
@@ -11,6 +11,7 @@ Low level wrappers for the c++ api in ov::op.
 from openvino._pyopenvino.op import Constant
 from openvino._pyopenvino.op import assign
 from openvino._pyopenvino.op import _PagedAttentionExtension
+from openvino._pyopenvino.op import _GroupQueryAttentionExtension
 from openvino._pyopenvino.op import Parameter
 from openvino._pyopenvino.op import if_op
 from openvino._pyopenvino.op import loop

--- a/src/bindings/python/src/pyopenvino/graph/ops/internal/gqa_extension.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/internal/gqa_extension.cpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "pyopenvino/graph/ops/internal/gqa_extension.hpp"
+
+#include "openvino/core/op_extension.hpp"
+#include "openvino/op/op.hpp"
+#include "openvino/op/group_query_attention.hpp"
+#include "pyopenvino/core/common.hpp"
+
+namespace py = pybind11;
+
+void regclass_graph_op_GroupQueryAttention(py::module m) {
+    using ov::op::internal::GroupQueryAttention;
+
+    py::class_<ov::OpExtension<GroupQueryAttention>,
+               std::shared_ptr<ov::OpExtension<GroupQueryAttention>>,
+               ov::Extension>(m, "_GroupQueryAttentionExtension")
+        .def(py::init<>())
+        .doc() = "Extension that registers GroupQueryAttention for IR deserialization. "
+                 "Pass an instance to core.add_extension() before reading an IR that contains this op.";
+}

--- a/src/bindings/python/src/pyopenvino/graph/ops/internal/gqa_extension.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/internal/gqa_extension.cpp
@@ -5,8 +5,8 @@
 #include "pyopenvino/graph/ops/internal/gqa_extension.hpp"
 
 #include "openvino/core/op_extension.hpp"
-#include "openvino/op/op.hpp"
 #include "openvino/op/group_query_attention.hpp"
+#include "openvino/op/op.hpp"
 #include "pyopenvino/core/common.hpp"
 
 namespace py = pybind11;

--- a/src/bindings/python/src/pyopenvino/graph/ops/internal/gqa_extension.hpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/internal/gqa_extension.hpp
@@ -1,0 +1,11 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+void regclass_graph_op_GroupQueryAttention(py::module m);

--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #include <pybind11/pybind11.h>
 

--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -57,6 +57,7 @@
 #include "pyopenvino/graph/ops/if.hpp"
 #include "pyopenvino/graph/ops/loop.hpp"
 #include "pyopenvino/graph/ops/paged_attention_extension.hpp"
+#include "pyopenvino/graph/ops/internal/gqa_extension.hpp"
 #include "pyopenvino/graph/ops/parameter.hpp"
 #include "pyopenvino/graph/ops/read_value.hpp"
 #include "pyopenvino/graph/ops/result.hpp"
@@ -242,6 +243,7 @@ PYBIND11_MODULE(_pyopenvino, m) {
     regclass_graph_op_Assign(m_op);
     regclass_graph_op_Constant(m_op);
     regclass_graph_op_PagedAttentionExtension(m_op);
+    regclass_graph_op_GroupQueryAttention(m_op);
     regclass_graph_op_Parameter(m_op);
     regclass_graph_op_ReadValue(m_op);
     regclass_graph_op_Result(m_op);

--- a/src/bindings/python/tests/test_graph/test_gqa_extension.py
+++ b/src/bindings/python/tests/test_graph/test_gqa_extension.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from openvino import Core, Extension
+from openvino.op import _GroupQueryAttentionExtension
+
+
+def test_gqa_extension_is_extension():
+    ext = _GroupQueryAttentionExtension()
+    assert isinstance(ext, Extension)
+
+
+def test_gqa_extension_add_to_core():
+    ext = _GroupQueryAttentionExtension()
+    core = Core()
+    core.add_extension(ext)  # must not raise


### PR DESCRIPTION
### Details:

A little change to help debug models with GQA represented directly in the OV IR.

Can be used as easy as

```
core = ov.Core()
core.add_extension(ov.op._GroupQueryAttentionExtension())
```

### Tickets:
 - EISW-180918

### AI Assistance:
 - *AI assistance used: yes*
 - AI figured the missing bits to expose the operation as OpExtension (I only exported it as a Node similar to how PagedAttention worked)
