### PR TITLE
[gha] Fix and increase timeout for Linux RISC-V

### DIFF
--- a/.github/workflows/linux_riscv.yml
+++ b/.github/workflows/linux_riscv.yml
@@ -244,7 +244,7 @@ jobs:
 
   CPU_Functional_Tests:
     name: CPU functional tests
-    timeout-minutes: 30
+    timeout-minutes: ${{ (inputs.testFilterType == 'CONCISE' || (!inputs.testFilterType && github.event_name != 'schedule')) && 35 || 135 }}
     needs: [Smart_CI, Docker, Build]
     runs-on: aks-linux-4-cores-16gb
     container:
@@ -297,7 +297,6 @@ jobs:
             "${INSTALL_TEST_DIR}"/ov_cpu_func_tests \
             --gtest_print_time=1 \
             --gtest_filter="${GTEST_FILTER}"
-        timeout-minutes: ${{ (inputs.testFilterType == 'CONCISE' || (!inputs.testFilterType && github.event_name != 'schedule')) && 25 || 125 }}
 
   Overall_Status:
     name: ci/gha_overall_status_linux_riscv


### PR DESCRIPTION
### Details:
CPU Functional Tests job in Linux RISC-V workflow started to reach the timeout of 25 minutes quite often. Judging by the metrics, it looks like a natural execution duration growth, so let's increase it.
However, there are two timeouts: one at the job level (30 minutes), and another is on the exact test execution step level:
```
timeout-minutes: ${{ (inputs.testFilterType == 'CONCISE' || (!inputs.testFilterType && github.event_name != 'schedule')) && 25 || 125 }}
```
So the timeout of 125 minutes was never reached in nightly and manual runs, because there's a job level timeout of 30 minutes.
This PR removes step level timeout with a job level timeout with the same condition, but slightly longer.