### PR TITLE
[GPU] Fix grouped conv cross-group accumulation in convolution_gpu_bfyx_f16

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
@@ -72,6 +72,7 @@ KERNEL(convolution_bfyx_f16)(
     int groups_per_sub_group = 1;
     if (prev_group_leftover < 16)
         groups_per_sub_group += ((FEATURE_SLICE_SIZE - prev_group_leftover - 1) / FILTER_OFM_NUM) + 1;
+    const uint my_group = group + (sglid / FILTER_OFM_NUM);
 #else
     const int group = 0;
     const int groups_per_sub_group = 1;
@@ -158,8 +159,6 @@ KERNEL(convolution_bfyx_f16)(
 #if GROUPED
     for (uint g = group; g < group + groups_per_sub_group; g++) {
         const uint my_group = group + (sglid / FILTER_OFM_NUM);
-        if (groups_per_sub_group > 1 && g != my_group)
-            continue;
         const uint in_split_offset = g * input_fs_pitch * (FILTER_IFM_NUM / FEATURE_SLICE_SIZE);
         const uint filter_split_offset = g * FILTER_GROUPS_PITCH;
         const uint filter_offset = (feature_block % (FILTER_OFM_NUM / FEATURE_SLICE_SIZE)) * filter_os_pitch;
@@ -306,7 +305,34 @@ KERNEL(convolution_bfyx_f16)(
                                                                     icb * filter_is_pitch +
                                                                     kh * filter_y_pitch +
                                                                     kw * filter_x_pitch +
-                                                                    8 * filter_isv_pitch);
+                                                                   8 * filter_isv_pitch);
+#if GROUPED
+                    if (groups_per_sub_group > 1) {
+                            uint correct_lane = sglid % FILTER_OFM_NUM;
+                            wei0.s0 = sub_group_shuffle(wei0.s0, correct_lane);
+                            wei0.s1 = sub_group_shuffle(wei0.s1, correct_lane);
+                            wei0.s2 = sub_group_shuffle(wei0.s2, correct_lane);
+                            wei0.s3 = sub_group_shuffle(wei0.s3, correct_lane);
+                            wei0.s4 = sub_group_shuffle(wei0.s4, correct_lane);
+                            wei0.s5 = sub_group_shuffle(wei0.s5, correct_lane);
+                            wei0.s6 = sub_group_shuffle(wei0.s6, correct_lane);
+                            wei0.s7 = sub_group_shuffle(wei0.s7, correct_lane);
+                            wei1.s0 = sub_group_shuffle(wei1.s0, correct_lane);
+                            wei1.s1 = sub_group_shuffle(wei1.s1, correct_lane);
+                            wei1.s2 = sub_group_shuffle(wei1.s2, correct_lane);
+                            wei1.s3 = sub_group_shuffle(wei1.s3, correct_lane);
+                            wei1.s4 = sub_group_shuffle(wei1.s4, correct_lane);
+                            wei1.s5 = sub_group_shuffle(wei1.s5, correct_lane);
+                            wei1.s6 = sub_group_shuffle(wei1.s6, correct_lane);
+                            wei1.s7 = sub_group_shuffle(wei1.s7, correct_lane);
+
+                            // Zero weights for lanes not in this group
+                            if (g != my_group) {
+                                wei0 = (FILTER_TYPE8)(0);
+                                wei1 = (FILTER_TYPE8)(0);
+                            }
+                    }
+#endif
                     const vec_t src0  = GET_SRC(src, 0);
                     const vec_t src1  = GET_SRC(src, 1);
                     const vec_t src2  = GET_SRC(src, 2);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
@@ -158,7 +158,6 @@ KERNEL(convolution_bfyx_f16)(
 #else
 #if GROUPED
     for (uint g = group; g < group + groups_per_sub_group; g++) {
-        const uint my_group = group + (sglid / FILTER_OFM_NUM);
         const uint in_split_offset = g * input_fs_pitch * (FILTER_IFM_NUM / FEATURE_SLICE_SIZE);
         const uint filter_split_offset = g * FILTER_GROUPS_PITCH;
         const uint filter_offset = (feature_block % (FILTER_OFM_NUM / FEATURE_SLICE_SIZE)) * filter_os_pitch;
@@ -305,7 +304,7 @@ KERNEL(convolution_bfyx_f16)(
                                                                     icb * filter_is_pitch +
                                                                     kh * filter_y_pitch +
                                                                     kw * filter_x_pitch +
-                                                                   8 * filter_isv_pitch);
+                                                                    8 * filter_isv_pitch);
 #if GROUPED
                     if (groups_per_sub_group > 1) {
                             uint correct_lane = sglid % FILTER_OFM_NUM;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
@@ -308,22 +308,8 @@ KERNEL(convolution_bfyx_f16)(
 #if GROUPED
                     if (groups_per_sub_group > 1) {
                             uint correct_lane = sglid % FILTER_OFM_NUM;
-                            wei0.s0 = sub_group_shuffle(wei0.s0, correct_lane);
-                            wei0.s1 = sub_group_shuffle(wei0.s1, correct_lane);
-                            wei0.s2 = sub_group_shuffle(wei0.s2, correct_lane);
-                            wei0.s3 = sub_group_shuffle(wei0.s3, correct_lane);
-                            wei0.s4 = sub_group_shuffle(wei0.s4, correct_lane);
-                            wei0.s5 = sub_group_shuffle(wei0.s5, correct_lane);
-                            wei0.s6 = sub_group_shuffle(wei0.s6, correct_lane);
-                            wei0.s7 = sub_group_shuffle(wei0.s7, correct_lane);
-                            wei1.s0 = sub_group_shuffle(wei1.s0, correct_lane);
-                            wei1.s1 = sub_group_shuffle(wei1.s1, correct_lane);
-                            wei1.s2 = sub_group_shuffle(wei1.s2, correct_lane);
-                            wei1.s3 = sub_group_shuffle(wei1.s3, correct_lane);
-                            wei1.s4 = sub_group_shuffle(wei1.s4, correct_lane);
-                            wei1.s5 = sub_group_shuffle(wei1.s5, correct_lane);
-                            wei1.s6 = sub_group_shuffle(wei1.s6, correct_lane);
-                            wei1.s7 = sub_group_shuffle(wei1.s7, correct_lane);
+                          wei0 = _sub_group_shuffle(wei0, correct_lane);
+                          wei1 = _sub_group_shuffle(wei1, correct_lane);
 
                             // Zero weights for lanes not in this group
                             if (g != my_group) {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
@@ -308,8 +308,15 @@ KERNEL(convolution_bfyx_f16)(
 #if GROUPED
                     if (groups_per_sub_group > 1) {
                             uint correct_lane = sglid % FILTER_OFM_NUM;
-                          wei0 = _sub_group_shuffle(wei0, correct_lane);
-                          wei1 = _sub_group_shuffle(wei1, correct_lane);
+                            #if FILTER_TYPE_SIZE == 2
+                               short8 w0 = intel_sub_group_shuffle(as_short8(wei0), correct_lane);
+                               short8 w1 = intel_sub_group_shuffle(as_short8(wei1), correct_lane);
+                               wei0 = AS_FILTER_TYPE8(w0);
+                               wei1 = AS_FILTER_TYPE8(w1);
+                            #else
+                               wei0 = _sub_group_shuffle(wei0, correct_lane);
+                               wei1 = _sub_group_shuffle(wei1, correct_lane);
+                            #endif
 
                             // Zero weights for lanes not in this group
                             if (g != my_group) {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
@@ -157,6 +157,9 @@ KERNEL(convolution_bfyx_f16)(
 #else
 #if GROUPED
     for (uint g = group; g < group + groups_per_sub_group; g++) {
+        const uint my_group = group + (sglid / FILTER_OFM_NUM);
+        if (groups_per_sub_group > 1 && g != my_group)
+            continue;
         const uint in_split_offset = g * input_fs_pitch * (FILTER_IFM_NUM / FEATURE_SLICE_SIZE);
         const uint filter_split_offset = g * FILTER_GROUPS_PITCH;
         const uint filter_offset = (feature_block % (FILTER_OFM_NUM / FEATURE_SLICE_SIZE)) * filter_os_pitch;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -5777,8 +5777,6 @@ TEST(convolution_f16_fsv16, grouped_conv_bfyx_f16_multi_group_per_subgroup) {
         const int ic_per_group = tc.input_f / tc.groups;
         const int oc_per_group = tc.output_f / tc.groups;
 
-        const int output_xy = 1 + (tc.input_xy + 2 * tc.pad - tc.filter_xy) / tc.stride;
-
         // Generate random input [batch, IC, H, W]
         auto input_data = rg.generate_random_4d<ov::float16>(tc.batch_num, tc.input_f, tc.input_xy, tc.input_xy, -1, 1);
         auto input_data_bfyx = flatten_4d(format::bfyx, input_data);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -5729,6 +5729,138 @@ TEST(convolution_f16_fsv16, preload_groups_when_groups_is_not_greater_than_one) 
     }
 }
 
+// Regression test for grouped convolution in convolution_gpu_bfyx_f16 kernel
+// when OC/groups < sub_group_size (16) and IC/groups == sub_group_size.
+// When OC/groups < 16, multiple groups are packed into one 16-lane sub-group.
+// The GROUPED loop must isolate each lane to its own group's data and weights.
+
+TEST(convolution_f16_fsv16, grouped_conv_bfyx_f16_multi_group_per_subgroup) {
+ 
+    tests::random_generator rg(GET_SUITE_NAME);
+    auto& engine = get_test_engine();
+
+    if (!engine.get_device_info().supports_fp16) {
+        GTEST_SKIP() << "The test is skipped (cl_khr_fp16 is not supported).";
+    }
+
+    if (engine.get_device_info().supports_immad) {
+        // On platforms with oneDNN (XeHP+), this OpenCL kernel is not used
+        GTEST_SKIP() << "The test is skipped for oneDNN platforms.";
+    }
+
+    struct test_case {
+        int batch_num;
+        int input_f;
+        int output_f;
+        int groups;
+        int filter_xy;
+        int input_xy;
+        int stride;
+        int pad;
+    };
+
+    std::vector<test_case> test_cases = {
+        // Original bug: groups=32, IC/g=16, OC/g=4, 3x3
+        {1, 512, 128, 32, 3, 16, 1, 1},
+        // OC/g=2: 8 groups per sub-group
+        {1, 128, 16, 8, 3, 16, 1, 1},
+        // OC/g=8: 2 groups per sub-group
+        {1, 256, 128, 16, 3, 16, 1, 1},
+        // OC/g=4, 1x1 kernel variant
+        {1, 512, 128, 32, 1, 16, 1, 0},
+        // OC/g=16: groups_per_sub_group=1, regression check (should always work)
+        {1, 256, 256, 16, 3, 16, 1, 1},
+    };
+
+    for (size_t tci = 0; tci < test_cases.size(); ++tci) {
+        const auto& tc = test_cases[tci];
+        const int ic_per_group = tc.input_f / tc.groups;
+        const int oc_per_group = tc.output_f / tc.groups;
+
+        const int output_xy = 1 + (tc.input_xy + 2 * tc.pad - tc.filter_xy) / tc.stride;
+
+        // Generate random input [batch, IC, H, W]
+        auto input_data = rg.generate_random_4d<ov::float16>(tc.batch_num, tc.input_f, tc.input_xy, tc.input_xy, -1, 1);
+        auto input_data_bfyx = flatten_4d(format::bfyx, input_data);
+        auto input_size = tensor(tc.batch_num, tc.input_f, tc.input_xy, tc.input_xy);
+        auto input_mem = engine.allocate_memory({data_types::f16, format::bfyx, input_size});
+        set_values(input_mem, input_data_bfyx);
+
+        // Generate random weights [groups, OC/g, IC/g, kH, kW]
+        // generate_random_4d generates [OC, IC/g, kH, kW] which maps to goiyx
+        auto weights_size = tensor(group(tc.groups), batch(oc_per_group), feature(ic_per_group), spatial(tc.filter_xy, tc.filter_xy));
+        auto weights_data = rg.generate_random_4d<ov::float16>(tc.output_f, ic_per_group, tc.filter_xy, tc.filter_xy, -1, 1);
+        auto weights_data_bfyx = flatten_4d(format::bfyx, weights_data);
+        auto weights_mem = engine.allocate_memory({data_types::f16, format::goiyx, weights_size});
+        set_values(weights_mem, weights_data_bfyx);
+
+        // Compute reference per output feature using grouped reference_convolve
+        auto reference_result = VVVVF<ov::float16>(tc.batch_num, VVVF<ov::float16>(tc.output_f));
+        for (int bi = 0; bi < tc.batch_num; ++bi) {
+            for (int ofi = 0; ofi < tc.output_f; ++ofi) {
+                int g = ofi / oc_per_group;
+                int f_begin = g * ic_per_group;
+                int f_end = (g + 1) * ic_per_group;
+
+                reference_result[bi][ofi] = reference_convolve<ov::float16>(input_data[bi],
+                                                                            weights_data[ofi],
+                                                                            tc.stride,
+                                                                            tc.stride,
+                                                                            0,  // bias
+                                                                            1,
+                                                                            1,  // dilation
+                                                                            tc.pad,
+                                                                            tc.pad,  // input padding
+                                                                            0,
+                                                                            0,  // output padding
+                                                                            f_begin,
+                                                                            f_end,  // f_begin, f_end
+                                                                            false,  // depthwise
+                                                                            true);  // grouped
+            }
+        }
+
+        // Build GPU topology with b_fs_yx_fsv16 to target convolution_gpu_bfyx_f16
+        topology topo(input_layout("input", input_mem->get_layout()), data("weights", weights_mem));
+
+        topo.add(reorder("input_fsv16", input_info("input"), {data_types::f16, format::b_fs_yx_fsv16, input_size}));
+
+        auto conv = convolution("conv_fsv16",
+                                input_info("input_fsv16"),
+                                "weights",
+                                no_bias,
+                                tc.groups,
+                                {(uint64_t)tc.stride, (uint64_t)tc.stride},
+                                {1, 1},
+                                {tc.pad, tc.pad},
+                                {tc.pad, tc.pad},
+                                false);
+        topo.add(conv);
+        topo.add(reorder("out", input_info("conv_fsv16"), format::bfyx, data_types::f16));
+
+        // Force b_fs_yx_fsv16 to ensure the bfyx_f16 kernel is selected
+        ExecutionConfig config = get_test_default_config(engine);
+        ov::intel_gpu::ImplementationDesc conv_impl = {format::b_fs_yx_fsv16, ""};
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv_fsv16", conv_impl}}));
+        config.set_property(ov::intel_gpu::optimize_data(true));
+
+        network network(engine, topo, config);
+        network.set_input_data("input", input_mem);
+        auto outputs = network.execute();
+
+        auto out_mem = outputs.at("out").get_memory();
+        cldnn::mem_lock<ov::float16> out_ptr(out_mem, get_test_stream());
+        auto flatten_ref = flatten_4d(format::bfyx, reference_result);
+
+        for (size_t i = 0; i < flatten_ref.size(); i++) {
+            auto equal = are_equal(flatten_ref[i], out_ptr[i], 1e-2f);
+            ASSERT_TRUE(equal) << "Case " << tci << " (groups=" << tc.groups << ", IC=" << tc.input_f << ", OC=" << tc.output_f << ", OC/g=" << oc_per_group
+                               << ", k=" << tc.filter_xy << "x" << tc.filter_xy << "): mismatch at idx=" << i << " ref=" << static_cast<float>(flatten_ref[i])
+                               << " gpu=" << static_cast<float>(out_ptr[i]);
+        }
+    }
+}
+
 using TestParamType_convolution_gpu_with_crop = ::testing::tuple<int,   // 0 - Filter size
     int,   // 1 - Input size
     int,   // 2 - Input/output features


### PR DESCRIPTION
### Details:
When OC/groups < sub_group_size (e.g. 4) and IC/groups == sub_group_size,
multiple groups are packed into one 16-lane sub-group. The GROUPED loop
in the kernel accumulated across all group iterations for every lane,
mixing results from unrelated groups and producing incorrect output.

This only manifested on XeLP (ARL-S) where native OpenCL kernels are
used. XeHP (ARL-H) is unaffected as oneDNN handles grouped convolutions.

Add a per-lane group mask so each lane only accumulates during its own
group's iteration.

### Tickets:
 - [*ticket-id*](https://jira.devtools.intel.com/browse/CVS-186873)

### AI Assistance:
 - *AI assistance used: yes*
 - AI used for RCA. the tests were performed manually for grouped convolution with OC/groups < 16. Also, on Background replacement model, the black image is corrected. 
