### PR TITLE
[GPU] Reject grouped conv with OC/groups < sub_group_size in bfyx_f16

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16.cpp
@@ -184,8 +184,7 @@ bool ConvolutionKernel_b_fs_yx_fsv16::Validate(const Params& p) const {
                                           (tuning_data.feature_block_size / inFeaturesPerGroup > 1) &&
                                           (outFeaturesPerGroup != 1) &&
                                           (inFeaturesPerGroup != 1);
-        auto grouped = inFeaturesPerGroup % tuning_data.sub_group_size == 0 &&
-                       (outFeaturesPerGroup % tuning_data.sub_group_size == 0 || tuning_data.sub_group_size % outFeaturesPerGroup == 0);
+        auto grouped = inFeaturesPerGroup % tuning_data.sub_group_size == 0 && outFeaturesPerGroup % tuning_data.sub_group_size == 0;
 
         if (!multipleGroupsInputPreload && !grouped)
             DO_NOT_USE_THIS_KERNEL(p.layerID);


### PR DESCRIPTION
### Details:
 The GROUPED loop in convolution_gpu_bfyx_f16 cannot correctly handle
groups_per_sub_group > 1, which occurs when OC/groups < 16. The
Validate() function allowed this case through via the condition
"sub_group_size % outFeaturesPerGroup == 0".

Tighten the grouped validation to require OC/groups >= sub_group_size,
forcing fallback to the reference kernel for these shapes.

### Tickets:
https://jira.devtools.intel.com/browse/CVS-186873

### AI Assistance:
 - *AI assistance used: no / yes*
 - AI used for RCA. Verified with background replacement model.
