### PR TITLE
[GPU] Add wildcard matching support for force_implementations

### DIFF
--- a/src/plugins/intel_gpu/docs/gpu_debug_utils.md
+++ b/src/plugins/intel_gpu/docs/gpu_debug_utils.md
@@ -201,7 +201,7 @@ You can force a specific implementation for chosen primitives by setting ```OV_G
      Supported forms:
      - ```'layer_name:primitive_id'``` for exact primitive match
      - ```layer_name``` to force all runtime primitives generated from this layer
-     - wildcard pattern with ```*``` (for example, ```Concat_*``` or ```'layer_name:*'```)
+    - wildcard pattern with ```*``` (for example, ```concat:*``` or ```'layer_name:*'```)
      Use quotation marks when the name contains a colon, otherwise the colon is treated as a separator.
  - ```Impl``` is the forced implementation name, available: ```any```, ```ocl```, ```cm```, ```sycl```, ```onednn```, ```common```, ```cpu```
  - ```Kernel``` is the name of the kernel you'd like to be executed. Please note that currently forcing the specific kernel works only for ```ocl``` implementation
@@ -211,13 +211,15 @@ You can force a specific implementation for chosen primitives by setting ```OV_G
 
  `OV_GPU_FORCE_IMPLEMENTATIONS={Name:Impl:Kernel:Layout},{Name:Impl:Kernel:Layout},...`
 
+For pattern or layer-name matches, only `Impl` is applied. `Kernel` and `Layout` are supported for exact primitive names only.
+
 For example, to force the `ocl` implementation for all `Concat` runtime primitives in a model, you can use a wildcard pattern:
 
 ```sh
-export OV_GPU_FORCE_IMPLEMENTATIONS="{Concat_*:ocl::}"
+export OV_GPU_FORCE_IMPLEMENTATIONS="{'concat:*':ocl::any}"
 ```
 
-This matches all runtime primitive names that start with `Concat_` and leaves `Kernel` and `Layout` unspecified.
+This matches all runtime primitive names that start with `concat:` and leaves `Kernel` unspecified and `Layout` as `any`.
 
 ## Layer in/out buffer dumps
 

--- a/src/plugins/intel_gpu/docs/gpu_debug_utils.md
+++ b/src/plugins/intel_gpu/docs/gpu_debug_utils.md
@@ -197,7 +197,12 @@ When the source is dumped, it contains a huge amount of macros(`#define`). For r
 You can force a specific implementation for chosen primitives by setting ```OV_GPU_FORCE_IMPLEMENTATIONS``` option. Variable expects strings with the following format:
 
 `OV_GPU_FORCE_IMPLEMENTATIONS={Name:Impl:Kernel:Layout}`, where
- - ```Name``` is the name of the primitive, for which you'd like to force a specific implementation. Name used in this context has the following form: ```'layer_name:primitive_id'```. Use quotation marks, otherwise the colon in the name will be treated as a separator.
+ - ```Name``` is the name of the primitive, for which you'd like to force a specific implementation.
+     Supported forms:
+     - ```'layer_name:primitive_id'``` for exact primitive match
+     - ```layer_name``` to force all runtime primitives generated from this layer
+     - wildcard pattern with ```*``` (for example, ```Concat_*``` or ```'layer_name:*'```)
+     Use quotation marks when the name contains a colon, otherwise the colon is treated as a separator.
  - ```Impl``` is the forced implementation name, available: ```any```, ```ocl```, ```cm```, ```sycl```, ```onednn```, ```common```, ```cpu```
  - ```Kernel``` is the name of the kernel you'd like to be executed. Please note that currently forcing the specific kernel works only for ```ocl``` implementation
  - ```Layout``` is the output layout. The full list of available layouts is available [here](../include/intel_gpu/runtime/format.hpp)
@@ -205,6 +210,14 @@ You can force a specific implementation for chosen primitives by setting ```OV_G
  You can force implementation for more than 1 primitive:
 
  `OV_GPU_FORCE_IMPLEMENTATIONS={Name:Impl:Kernel:Layout},{Name:Impl:Kernel:Layout},...`
+
+For example, to force the `ocl` implementation for all `Concat` runtime primitives in a model, you can use a wildcard pattern:
+
+```sh
+export OV_GPU_FORCE_IMPLEMENTATIONS="{Concat_*:ocl::}"
+```
+
+This matches all runtime primitive names that start with `Concat_` and leaves `Kernel` and `Layout` unspecified.
 
 ## Layer in/out buffer dumps
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
@@ -115,16 +115,21 @@ void graph_initializations::run(program& p) {
     for (auto& kv : forcing_map) {
         bool found_match = false;
 
+        // Try exact primitive id match first
         if (p.has_node(kv.first)) {
             p.get_node(kv.first).set_forced_impl_type(kv.second.impl_type);
             found_match = true;
             continue;
         }
 
-        if (is_pattern_key(kv.first) || !has_primitive_suffix(kv.first)) {
+        // Not an exact match - check if it's a pattern or layer-name key
+        // For these keys, only impl_type can be forced
+        const bool is_pattern_or_layer_name = is_pattern_key(kv.first) || !has_primitive_suffix(kv.first);
+        if (is_pattern_or_layer_name) {
             validate_pattern_forcing_desc(kv.first, kv.second);
         }
 
+        // Try pattern/layer-name matching
         for (auto& node_kv : p.nodes_map) {
             const auto& node_id = node_kv.first;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
@@ -72,16 +72,19 @@ bool is_layer_name_match(const primitive_id& key, const primitive_id& node_id) {
     const auto lower_key = to_lower_copy(key);
     const auto lower_node = to_lower_copy(node_id);
 
-    if (lower_node == lower_key) {
-        return true;
-    }
+    const bool is_prefix = lower_node.rfind(lower_key + ":", 0) == 0;
+    const bool is_suffix = lower_node.size() > lower_key.size() &&
+                           lower_node.compare(lower_node.size() - lower_key.size(), lower_key.size(), lower_key) == 0 &&
+                           lower_node[lower_node.size() - lower_key.size() - 1] == ':';
+    return is_prefix || is_suffix;
+}
 
-    const std::string prefix = lower_key + ":";
-    if (lower_node.rfind(prefix, 0) == 0) {
-        return true;
+void validate_pattern_forcing_desc(const primitive_id& key, const ov::intel_gpu::ImplementationDesc& desc) {
+    if (!desc.kernel_name.empty() || desc.output_format != format::any) {
+        OPENVINO_THROW("[GPU] force_implementations pattern or layer-name key '",
+                       key,
+                       "' can only force implementation type. Use an exact primitive id to force kernel or layout.");
     }
-
-    return lower_node.find(lower_key) != std::string::npos;
 }
 
 }  // namespace
@@ -115,13 +118,15 @@ void graph_initializations::run(program& p) {
         if (p.has_node(kv.first)) {
             p.get_node(kv.first).set_forced_impl_type(kv.second.impl_type);
             found_match = true;
+            continue;
+        }
+
+        if (is_pattern_key(kv.first) || !has_primitive_suffix(kv.first)) {
+            validate_pattern_forcing_desc(kv.first, kv.second);
         }
 
         for (auto& node_kv : p.nodes_map) {
             const auto& node_id = node_kv.first;
-            if (node_id == kv.first) {
-                continue;
-            }
 
             bool matched = false;
             if (is_pattern_key(kv.first)) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
@@ -11,10 +11,80 @@
 #include <memory>
 #include <utility>
 #include <map>
+#include <algorithm>
+#include <cctype>
 
 using namespace cldnn;
 
 namespace cldnn {
+
+namespace {
+
+std::string to_lower_copy(const std::string& s) {
+    std::string out;
+    out.resize(s.size());
+    std::transform(s.begin(), s.end(), out.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return out;
+}
+
+bool wildcard_match(const std::string& pattern, const std::string& value) {
+    const auto lower_pattern = to_lower_copy(pattern);
+    const auto lower_value = to_lower_copy(value);
+
+    size_t p = 0;
+    size_t v = 0;
+    size_t star = std::string::npos;
+    size_t match = 0;
+
+    while (v < lower_value.size()) {
+        if (p < lower_pattern.size() && lower_pattern[p] == lower_value[v]) {
+            ++p;
+            ++v;
+        } else if (p < lower_pattern.size() && lower_pattern[p] == '*') {
+            star = p++;
+            match = v;
+        } else if (star != std::string::npos) {
+            p = star + 1;
+            v = ++match;
+        } else {
+            return false;
+        }
+    }
+
+    while (p < lower_pattern.size() && lower_pattern[p] == '*') {
+        ++p;
+    }
+
+    return p == lower_pattern.size();
+}
+
+bool is_pattern_key(const primitive_id& key) {
+    return key.find('*') != primitive_id::npos;
+}
+
+bool has_primitive_suffix(const primitive_id& key) {
+    return key.find(':') != primitive_id::npos;
+}
+
+bool is_layer_name_match(const primitive_id& key, const primitive_id& node_id) {
+    const auto lower_key = to_lower_copy(key);
+    const auto lower_node = to_lower_copy(node_id);
+
+    if (lower_node == lower_key) {
+        return true;
+    }
+
+    const std::string prefix = lower_key + ":";
+    if (lower_node.rfind(prefix, 0) == 0) {
+        return true;
+    }
+
+    return lower_node.find(lower_key) != std::string::npos;
+}
+
+}  // namespace
 
 void graph_initializations::set_outputs(program& p) {
     auto custom_outputs = p.get_config().get_custom_outputs();
@@ -40,9 +110,35 @@ void graph_initializations::run(program& p) {
     auto forcing_map = p.get_config().get_force_implementations();
     std::vector<primitive_id> missing_forced_nodes;
     for (auto& kv : forcing_map) {
+        bool found_match = false;
+
         if (p.has_node(kv.first)) {
             p.get_node(kv.first).set_forced_impl_type(kv.second.impl_type);
-        } else {
+            found_match = true;
+        }
+
+        for (auto& node_kv : p.nodes_map) {
+            const auto& node_id = node_kv.first;
+            if (node_id == kv.first) {
+                continue;
+            }
+
+            bool matched = false;
+            if (is_pattern_key(kv.first)) {
+                matched = wildcard_match(kv.first, node_id);
+            } else if (!has_primitive_suffix(kv.first)) {
+                matched = is_layer_name_match(kv.first, node_id);
+            }
+
+            if (!matched) {
+                continue;
+            }
+
+            node_kv.second->set_forced_impl_type(kv.second.impl_type);
+            found_match = true;
+        }
+
+        if (!found_match) {
             missing_forced_nodes.push_back(kv.first);
         }
     }

--- a/src/plugins/intel_gpu/tests/unit/module_tests/force_implementations_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/force_implementations_test.cpp
@@ -70,6 +70,21 @@ TEST(force_implementations, parse_ImplForcingMap_colon_in_name) {
     ASSERT_EQ(layer_desc.output_format, format::any);
 }
 
+TEST(force_implementations, parse_ImplForcingMap_wildcard_with_colon_in_name) {
+    const std::string force_impl_string = "{'concat:*':ocl::any}";
+    ov::Any any(force_impl_string);
+
+    ImplForcingMap map;
+    OV_ASSERT_NO_THROW(map = any.as<ImplForcingMap>());
+    ASSERT_EQ(map.size(), 1);
+
+    ASSERT_NE(map.find("concat:*"), map.end());
+    const auto& concat_desc = map.at("concat:*");
+    ASSERT_EQ(concat_desc.impl_type, impl_types::ocl);
+    ASSERT_EQ(concat_desc.kernel_name, "");
+    ASSERT_EQ(concat_desc.output_format, format::any);
+}
+
 
 TEST(force_implementations, force_ocl_for_gemm) {
     auto& engine = get_test_engine();


### PR DESCRIPTION
## Summary

This PR adds wildcard and layer-name matching support to `force_implementations` in the Intel GPU plugin and updates the debug documentation with a valid usage example.

## Changes

- Added wildcard pattern matching for `force_implementations` keys during graph initialization
- Added support for matching:
  - exact primitive IDs
  - layer names
  - wildcard patterns such as `concat:*` or `'layer_name:*'`
- Preserved exact primitive ID behavior for `Kernel` and `Layout` forcing
- Added validation so pattern/layer-name matches only apply `Impl`; `Kernel` and `Layout` remain supported only for exact primitive names
- Updated `gpu_debug_utils.md` with the supported name formats and a concat wildcard example
- Added parser coverage for wildcard keys containing a colon

## Motivation

Previously, `force_implementations` required exact primitive IDs, which made it inconvenient to force an implementation for multiple runtime primitives generated from the same layer type or naming pattern.

With this change, users can force implementations more flexibly for debugging and performance analysis while keeping exact primitive forcing behavior unchanged.

## Example

```sh
export OV_GPU_FORCE_IMPLEMENTATIONS="{'concat:*':ocl::any}"