### PR TITLE
[GPU] Fix gemm_tiled_opt incorrect results for 1D transposed weight

### DIFF
--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -207,7 +207,9 @@ std::vector<layout> gemm_inst::transform_input_layouts(const std::shared_ptr<con
             first_input ? transposed_input_pshape.insert(transposed_input_pshape.begin(), 1)
                         : transposed_input_pshape.insert(transposed_input_pshape.end(), 1);
 
-            if (transpose) {
+            // Do not swap weight (2nd input) because TRANSPOSE_Y_LAST expects [Y=K, X=N];
+            // swapping would make input1_offset1 = TILE_K * K instead of TILE_K * N.
+            if (transpose && first_input) {
                 std::swap(transposed_input_pshape[0], transposed_input_pshape[1]);
             }
         }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -1590,6 +1590,74 @@ public:
         }
     }
 
+    void test_transpose_matmul_1d_weight(bool is_input_dynamic, size_t M) {
+        tests::random_generator rg;
+        rg.set_seed(GET_SUITE_NAME);
+
+        auto& engine = get_test_engine();
+
+        const size_t K = 33;
+        ov::Shape in0_shape = {M, K};
+        ov::Shape in1_shape = {K};
+
+        auto in0_layout = is_input_dynamic
+            ? layout{ov::PartialShape::dynamic(in0_shape.size()), data_types::f32, format::bfyx}
+            : layout{ov::PartialShape(in0_shape), data_types::f32, format::bfyx};
+        auto in1_layout = is_input_dynamic
+            ? layout{ov::PartialShape::dynamic(in1_shape.size()), data_types::f32, format::bfyx}
+            : layout{ov::PartialShape(in1_shape), data_types::f32, format::bfyx};
+        auto input0_mem = engine.allocate_memory(layout{ov::PartialShape(in0_shape), data_types::f32, format::bfyx});
+        auto input1_mem = engine.allocate_memory(layout{ov::PartialShape(in1_shape), data_types::f32, format::bfyx});
+
+        auto input0_data = rg.generate_random_1d<float>(ov::shape_size(in0_shape), -2, 2);
+        auto input1_data = rg.generate_random_1d<float>(ov::shape_size(in1_shape), -2, 2);
+        set_values(input0_mem, input0_data);
+        set_values(input1_mem, input1_data);
+
+        topology topology;
+        topology.add(input_layout("input0", in0_layout),
+                     input_layout("input1", in1_layout),
+                     gemm("gemm", { input_info("input0"), input_info("input1") },
+                          data_types::f32, false, true, 1.0f, 0.0f, 2, 1)
+        );
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        ov::intel_gpu::ImplementationDesc gemm_impl = { format::bfyx, "gemm_tiled_opt", impl_types::ocl };
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"gemm", gemm_impl} }));
+        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+        network->set_input_data("input0", input0_mem);
+        network->set_input_data("input1", input1_mem);
+
+        if (is_input_dynamic) {
+            auto inst = network->get_primitive("gemm");
+            auto impl = inst->get_impl();
+            ASSERT_TRUE(impl != nullptr);
+            ASSERT_TRUE(impl->is_dynamic());
+        }
+
+        auto outputs = network->execute();
+        auto output_mem = outputs.at("gemm").get_memory();
+        cldnn::mem_lock<float> output_ptr(output_mem, get_test_stream());
+
+        ov::Shape out_shape = {M};
+        std::vector<float> ref_out(M, 0.f);
+        ov::reference::matmul<float>(input0_data.data(),
+                                     input1_data.data(),
+                                     ref_out.data(),
+                                     in0_shape,
+                                     in1_shape,
+                                     out_shape,
+                                     false,
+                                     true);
+
+        ASSERT_EQ(output_ptr.size(), ref_out.size());
+        for (size_t i = 0; i < ref_out.size(); ++i) {
+            ASSERT_NEAR(output_ptr[i], ref_out[i], 0.001f) << "at " << i;
+        }
+    }
+
     void test_transpose_matmul_f16(size_t num_dims, bool is_input_dynamic, bool is_caching_test, std::vector<size_t> BMKN, std::vector<int64_t> input0_order, std::vector<int64_t> input1_order, const double abs_error = 0.0001) {
         tests::random_generator rg;
         rg.set_seed(GET_SUITE_NAME);
@@ -1812,6 +1880,16 @@ TEST_F(gemm_gpu_tests, transpose_matmul_static_1d_f16) {
 
 TEST_F(gemm_gpu_tests, transpose_matmul_static_1d_f32) {
     this->test_transpose_matmul_f32(1, false, false, /*BMKN*/{19, 37, 23, 29}, /*input0_order*/{0}, /*input1_order*/{1, 0});
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_1d_weight_static) {
+    // 1D weight with transpose_input1=true
+    this->test_transpose_matmul_1d_weight(false, 1200);
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_1d_weight_dynamic) {
+    // Dynamic shape variant of 1D weight transpose test
+    this->test_transpose_matmul_1d_weight(true, 1200);
 }
 
 TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_2d_f16) {


### PR DESCRIPTION
### Description of the issue (symptom, root-cause, how it was resolved)

- **Symptom**: MatMul with 1D weight (rank=1) and `transpose_input1=true` produces non-deterministic and numerically incorrect results on GPU.
- **Root-cause (weight layout)**: `transform_input_layouts` expanded 1D weight `[K]` → `{K, 1}` then unconditionally swapped to `{1, K}` when `transpose=true`. This gave physical layout `[Y=1, X=K]`, making `input1_offset1 = TILE_K × K` instead of `TILE_K × N`. K-tiles beyond the first read out-of-bounds memory, producing deterministically wrong output.
- **Resolution**: (1) Compute `n_size` from `params.outputs[0]` with `output_order`, which correctly returns `N` regardless of input1's rank. (2) Guard the dimension swap to only apply for `first_input` (A matrix); for the second input (B/weight), TRANSPOSE_Y_LAST mode already expects `[Y=K, X=N]` layout, so no swap is needed.

#### The code and line that caused this issue (if it is not changed directly)
- `intel_gpu/src/graph/gemm.cpp` line 210 — `if (transpose)` unconditionally swaps dimensions for 1D weight

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
- MatMul with input0 shape `[B, M, K]`, input1 shape `[K]`, `transpose_b=true`
- GPU output differs from CPU on every inference (non-deterministic), detection scores drop significantly

#### Problematic graph
- MatMul node with 1D second input (weight_rank=1) and `transpose_input1=true` (`input1_transpose_order={0}`)
- The 1D weight triggers the `transposed_input_pshape.size() == 1` expansion path in `transform_input_layouts`, and TRANSPOSE_Y_LAST mode in `gemm_tiled_opt` kernel
<img width="1190" height="1087" alt="image" src="https://github.com/user-attachments/assets/d7e1c63a-92c5-4f2c-80fb-9f6e359c2ca6" />

#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
  - Added `transpose_matmul_1d_weight_static` and `transpose_matmul_1d_weight_dynamic` in `gemm_gpu_test.cpp`
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
  - Reviewed `test_transpose_matmul_f32` / `test_transpose_matmul_f16` with `num_dims=1` — these only cover 1D **input0**, not 1D input1. `set_default_shapes(1, ...)` always sets `input1_shape = {K, N}` (2D). New standalone tests were required.

### Tickets:
 - *186957*