### PR TITLE
[GPU] Fix incorrect INT8 convolution results caused by _sub_group_shuffle in convolution_gpu_b_fs_yx_fsv4_1x1__u8 kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_b_fs_yx_fsv4_1x1.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_b_fs_yx_fsv4_1x1.cl
@@ -130,7 +130,7 @@ KERNEL(convolution)(
         weights_offset += WEIGHTS_IS_PITCH / FSV * LWG_DEPTH;
 
         unroll_for (uint out_fi = 0; out_fi < FEATURES_PER_WI; ++out_fi) {
-            int wei_i = _sub_group_shuffle(wei_sg[out_fi / SIMD], out_fi % SIMD);
+            volatile int wei_i = _sub_group_shuffle(wei_sg[out_fi / SIMD], out_fi % SIMD);
             FILTER_TYPE4 wei_val = AS_FILTER_TYPE4(wei_i);
 
             dotProd[out_fi] = IMAD(dotProd[out_fi], in_val, wei_val);


### PR DESCRIPTION
### Details:
Add volatile qualifier to _sub_group_shuffle() result in convolution_gpu_b_fs_yx_fsv4_1x1 kernel to get correct weight values within subgroup.

### Description of the issue
#### Symptom
Unit test fusings_gpu/conv_int8_scale.basic/2 will be failed with Intel integrated GPUs (e.g., UHD 770) on Windows11.

#### Root cause
The kernel convolution_gpu_b_fs_yx_fsv4_1x1__u8 computes incorrect INT8 dot products because weight values fed into the IMAD instruction differ from what previous _sub_group_shuffle() originally returned.

#### How to fix it
Add the volatile qualifier to the shuffle result variable to store it to a register for later use (AS_FILTER_TYPE4).

#### The code and line that caused this issue
https://github.com/openvinotoolkit/openvino/blob/51b2fef55c075a40ad3a5e84dea1ffbf68f88b5f/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_b_fs_yx_fsv4_1x1.cl#L133-L134

#### Reproduction step and snapshot
./bin/intel64/Debug/ov_gpu_unit_tests --gtest_filter='fusings_gpu/conv_int8_scale.basic/2'

#### Problematic graph
N/A

#### Checklist 
 - [x] Is it a proper fix? (not a workaround) 
 - [ ] Did you include test case for this fix, if necessary? 
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *CVS-185375*

### AI Assistance:
 - *AI assistance used: yes*
 - *Ask AI to find the reason of the wrong result of AS_FILTER_TYPE4*