### PR TITLE
[GPU] Old/new shape infer aligned for GEMM

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -215,6 +215,7 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
     // Also check if constant users is a backprop convolution - in that case O and I need to be swapped.
     for (auto& node : constUsers) {
         auto outOp = node.get_node();
+        bool apply_rank2_matmul_wa = false;
         size_t user_index = node.get_index();
         auto is_convert_matmul_pattern = [&](ov::Node* convert_node, size_t& matmul_input_index_ref) -> bool {
             if (ov::is_type<ov::op::v0::Convert>(convert_node) && !p.use_new_shape_infer()) {
@@ -222,6 +223,10 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
                 for (auto& consumer_input : convert_consumers) {
                     if (ov::is_type<ov::op::v0::MatMul>(consumer_input.get_node()) && consumer_input.get_index() < 2) {
                         matmul_input_index_ref = consumer_input.get_index();
+                        auto* matmul = consumer_input.get_node();
+                        const size_t opposite_input_idx = (matmul_input_index_ref == 0) ? 1 : 0;
+                        const auto opposite_rank = matmul->get_input_partial_shape(opposite_input_idx).rank();
+                        apply_rank2_matmul_wa = opposite_rank.is_static() && opposite_rank.get_length() > 2;
                         return true;
                     }
                 }
@@ -300,9 +305,11 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
                     : (const_static_max_dims - 2);
                 reshaped_const_dims[const_idx] = constDims[0];
                 constDims = std::move(reshaped_const_dims);
-            } else if (constDims.size() == 2) {
+            } else if (constDims.size() == 2 && user_index == 0 && apply_rank2_matmul_wa) {
                 ov::Shape reshaped_const_dims(const_static_max_dims, 1);
-                const auto offset = const_static_max_dims - constDims.size();
+                // For MatMul input0, gemm::transform_input_layouts takes the first input_rank dims.
+                // Keep [M, K] in leading positions and append trailing 1s.
+                const size_t offset = 0;
                 for (size_t i = 0; i < constDims.size(); ++i) {
                     reshaped_const_dims[offset + i] = constDims[i];
                 }

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -216,17 +216,12 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
     for (auto& node : constUsers) {
         auto outOp = node.get_node();
         size_t user_index = node.get_index();
-        bool apply_rank2_matmul_wa = false;
         auto is_convert_matmul_pattern = [&](ov::Node* convert_node, size_t& matmul_input_index_ref) -> bool {
             if (ov::is_type<ov::op::v0::Convert>(convert_node) && !p.use_new_shape_infer()) {
                 auto convert_consumers = convert_node->get_output_target_inputs(0);
                 for (auto& consumer_input : convert_consumers) {
                     if (ov::is_type<ov::op::v0::MatMul>(consumer_input.get_node()) && consumer_input.get_index() < 2) {
                         matmul_input_index_ref = consumer_input.get_index();
-                        auto* matmul = consumer_input.get_node();
-                        const size_t opposite_input_idx = (matmul_input_index_ref == 0) ? 1 : 0;
-                        const auto opposite_rank = matmul->get_input_partial_shape(opposite_input_idx).rank();
-                        apply_rank2_matmul_wa = opposite_rank.is_static() && opposite_rank.get_length() > 2;
                         return true;
                     }
                 }
@@ -305,7 +300,7 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
                     : (const_static_max_dims - 2);
                 reshaped_const_dims[const_idx] = constDims[0];
                 constDims = std::move(reshaped_const_dims);
-            } else if (constDims.size() == 2 && user_index == 0 && apply_rank2_matmul_wa) {
+            } else if (constDims.size() == 2) {
                 ov::Shape reshaped_const_dims(const_static_max_dims, 1);
                 const auto offset = const_static_max_dims - constDims.size();
                 for (size_t i = 0; i < constDims.size(); ++i) {

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -216,12 +216,17 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
     for (auto& node : constUsers) {
         auto outOp = node.get_node();
         size_t user_index = node.get_index();
+        bool apply_rank2_matmul_wa = false;
         auto is_convert_matmul_pattern = [&](ov::Node* convert_node, size_t& matmul_input_index_ref) -> bool {
             if (ov::is_type<ov::op::v0::Convert>(convert_node) && !p.use_new_shape_infer()) {
                 auto convert_consumers = convert_node->get_output_target_inputs(0);
                 for (auto& consumer_input : convert_consumers) {
                     if (ov::is_type<ov::op::v0::MatMul>(consumer_input.get_node()) && consumer_input.get_index() < 2) {
                         matmul_input_index_ref = consumer_input.get_index();
+                        auto* matmul = consumer_input.get_node();
+                        const size_t opposite_input_idx = (matmul_input_index_ref == 0) ? 1 : 0;
+                        const auto opposite_rank = matmul->get_input_partial_shape(opposite_input_idx).rank();
+                        apply_rank2_matmul_wa = opposite_rank.is_static() && opposite_rank.get_length() > 2;
                         return true;
                     }
                 }
@@ -300,7 +305,7 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
                     : (const_static_max_dims - 2);
                 reshaped_const_dims[const_idx] = constDims[0];
                 constDims = std::move(reshaped_const_dims);
-            } else if (constDims.size() == 2) {
+            } else if (constDims.size() == 2 && user_index == 0 && apply_rank2_matmul_wa) {
                 ov::Shape reshaped_const_dims(const_static_max_dims, 1);
                 const auto offset = const_static_max_dims - constDims.size();
                 for (size_t i = 0; i < constDims.size(); ++i) {

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
@@ -445,6 +445,94 @@ INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput_basic_1,
                                             ::testing::ValuesIn({ov::element::f16})),
                          MatMulConversionConstantInput::getTestCaseName);
 
+using MatmulConversionConstantInput0LargeOutParams = std::tuple<std::vector<InputShape>,  // input shapes
+                                                                 ov::element::Type>;        // infer precision
+
+// Keep this reproducer case: it targets legacy MatMul_cldnn_out_reshape mismatch
+// with output element count 98960 when constant is consumed as MatMul input0.
+class MatMulConversionConstantInput0LargeOut : public testing::WithParamInterface<MatmulConversionConstantInput0LargeOutParams>,
+                                               virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<MatmulConversionConstantInput0LargeOutParams>& obj) {
+        const auto& [input_shapes, input_precision] = obj.param;
+
+        std::ostringstream result;
+        result << "IS=(";
+        for (const auto& shape : input_shapes) {
+            result << ov::test::utils::partialShape2str({shape.first}) << "_";
+        }
+        result << ")_TS=";
+        for (const auto& shape : input_shapes) {
+            result << "(";
+            if (!shape.second.empty()) {
+                auto itr = shape.second.begin();
+                do {
+                    result << ov::test::utils::vec2str(*itr);
+                } while (++itr != shape.second.end() && result << "_");
+            }
+            result << ")_";
+        }
+        result << "infer_precision=" << input_precision;
+        return result.str();
+    }
+
+protected:
+    std::shared_ptr<ov::Model> init_subgraph(std::vector<ov::PartialShape>& input_shapes) {
+        const auto input_precision = ov::element::f32;
+
+        const ov::Shape const_shape = ov::Shape{98960, 64};
+        auto t0 = ov::test::utils::create_and_fill_tensor(input_precision, const_shape, in_data);
+        auto c0 = std::make_shared<ov::op::v0::Constant>(t0);
+        auto input0 = std::make_shared<ov::op::v0::Parameter>(input_precision, input_shapes[0]);
+        auto matmul_1 = std::make_shared<ov::op::v0::MatMul>(c0, input0, false, false);
+
+        return std::make_shared<ov::Model>(ov::OutputVector{matmul_1}, ov::ParameterVector{input0},
+                                           "MatMulConversionConstantInput0LargeOut");
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        const auto& funcInputs = function->inputs();
+        for (size_t i = 0; i < funcInputs.size(); ++i) {
+            const auto& funcInput = funcInputs[i];
+            auto tensor = ov::test::utils::create_and_fill_tensor(ov::element::f32, targetInputStaticShapes[i], in_data);
+            inputs.insert({funcInput.get_node_shared_ptr(), tensor});
+        }
+    }
+
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+        abs_threshold = 0.01f;
+        in_data.start_from = -0.5;
+        in_data.range = 1;
+        in_data.resolution = 10;
+
+        const auto& [input_shapes, infer_precision] = GetParam();
+        init_input_shapes(input_shapes);
+
+        inType = outType = ov::element::f32;
+        function = init_subgraph(inputDynamicShapes);
+        this->configuration.insert({ov::hint::inference_precision(infer_precision)});
+    }
+
+private:
+    ov::test::utils::InputGenerateData in_data;
+};
+
+TEST_P(MatMulConversionConstantInput0LargeOut, Inference) {
+    run();
+}
+
+const std::vector<std::vector<InputShape>> matmul_conversion_input_shapes_input0_large_out = {
+    {{{}, {{1, 64, 1}}}},
+};
+
+INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput0_large_out,
+                         MatMulConversionConstantInput0LargeOut,
+                         ::testing::Combine(::testing::ValuesIn(matmul_conversion_input_shapes_input0_large_out),
+                                            ::testing::ValuesIn({ov::element::f16})),
+                         MatMulConversionConstantInput0LargeOut::getTestCaseName);
+
 using MatmulConversionConstantNDParams = std::tuple<ov::Shape,               // constant shape
                                                     std::vector<InputShape>,  // input shapes
                                                     ov::element::Type>;       // infer precision

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
@@ -6,8 +6,6 @@
 #include "common_test_utils/file_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
-#include <cstdlib>
-
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/result.hpp"
@@ -420,16 +418,6 @@ protected:
         in_data.range = 1;
         in_data.resolution = 10;
 
-        if (const auto* prev = std::getenv("OV_GPU_ALLOW_NEW_SHAPE_INFER")) {
-            had_prev_allow_new_shape_infer = true;
-            prev_allow_new_shape_infer = prev;
-        }
-#ifdef _WIN32
-        _putenv_s("OV_GPU_ALLOW_NEW_SHAPE_INFER", "0");
-#else
-        setenv("OV_GPU_ALLOW_NEW_SHAPE_INFER", "0", 1);
-#endif
-
         const auto& [input_shapes, infer_precision] = GetParam();
 
         init_input_shapes(input_shapes);
@@ -438,28 +426,9 @@ protected:
         function = init_subgraph(inputDynamicShapes);
         this->configuration.insert({ov::hint::inference_precision(infer_precision)});
     }
-    
-void TearDown() override {
-    if (had_prev_allow_new_shape_infer) {
-#ifdef _WIN32
-        _putenv_s("OV_GPU_ALLOW_NEW_SHAPE_INFER", prev_allow_new_shape_infer.c_str());
-#else
-        setenv("OV_GPU_ALLOW_NEW_SHAPE_INFER", prev_allow_new_shape_infer.c_str(), 1);
-#endif
-    } else {
-#ifdef _WIN32
-        _putenv_s("OV_GPU_ALLOW_NEW_SHAPE_INFER", "");
-#else
-        unsetenv("OV_GPU_ALLOW_NEW_SHAPE_INFER");
-#endif
-    }
-        ov::test::SubgraphBaseTest::TearDown();
-    }
 
 private:
         ov::test::utils::InputGenerateData in_data;
-        std::string prev_allow_new_shape_infer;
-        bool had_prev_allow_new_shape_infer = false;
 };
 
 TEST_P(MatMulConversionConstantInput, Inference) {
@@ -470,34 +439,9 @@ const std::vector<std::vector<InputShape>> matmul_conversion_input_shapes_basic_
     {{{}, {{1, 192, 33, 64, 1}}}},
 };
 
-// Compact variant of the legacy Constant->Convert->MatMul scenario:
-// const is rank-2 [64,64], opposite MatMul input rank is > 2.
-const std::vector<std::vector<InputShape>> matmul_conversion_input_shapes_basic_1_small = {
-    {{{}, {{1, 3, 2, 64, 1}}}},
-};
-
-// Complementary legacy case:
-// const is rank-2 [64,64], but opposite MatMul input is also rank-2.
-// The guarded WA must not reshape this case.
-const std::vector<std::vector<InputShape>> matmul_conversion_input_shapes_basic_2d = {
-    {{{}, {{64, 32}}}},
-};
-
 INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput_basic_1,
                          MatMulConversionConstantInput,
                          ::testing::Combine(::testing::ValuesIn(matmul_conversion_input_shapes_basic_1),
-                                            ::testing::ValuesIn({ov::element::f16})),
-                         MatMulConversionConstantInput::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput_basic_1_small,
-                         MatMulConversionConstantInput,
-                         ::testing::Combine(::testing::ValuesIn(matmul_conversion_input_shapes_basic_1_small),
-                                            ::testing::ValuesIn({ov::element::f16})),
-                         MatMulConversionConstantInput::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput_basic_2d,
-                         MatMulConversionConstantInput,
-                         ::testing::Combine(::testing::ValuesIn(matmul_conversion_input_shapes_basic_2d),
                                             ::testing::ValuesIn({ov::element::f16})),
                          MatMulConversionConstantInput::getTestCaseName);
 
@@ -608,4 +552,5 @@ INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantNDInput_3d,
                                             ::testing::ValuesIn(matmul_conversion_3d_input_shapes),
                                             ::testing::ValuesIn({ov::element::f16})),
                          MatMulConversionConstantNDInput::getTestCaseName);
+
 } // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
@@ -6,6 +6,8 @@
 #include "common_test_utils/file_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
+#include <cstdlib>
+
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/result.hpp"
@@ -418,6 +420,16 @@ protected:
         in_data.range = 1;
         in_data.resolution = 10;
 
+        if (const auto* prev = std::getenv("OV_GPU_ALLOW_NEW_SHAPE_INFER")) {
+            had_prev_allow_new_shape_infer = true;
+            prev_allow_new_shape_infer = prev;
+        }
+#ifdef _WIN32
+        _putenv_s("OV_GPU_ALLOW_NEW_SHAPE_INFER", "0");
+#else
+        setenv("OV_GPU_ALLOW_NEW_SHAPE_INFER", "0", 1);
+#endif
+
         const auto& [input_shapes, infer_precision] = GetParam();
 
         init_input_shapes(input_shapes);
@@ -426,9 +438,28 @@ protected:
         function = init_subgraph(inputDynamicShapes);
         this->configuration.insert({ov::hint::inference_precision(infer_precision)});
     }
+    
+void TearDown() override {
+    if (had_prev_allow_new_shape_infer) {
+#ifdef _WIN32
+        _putenv_s("OV_GPU_ALLOW_NEW_SHAPE_INFER", prev_allow_new_shape_infer.c_str());
+#else
+        setenv("OV_GPU_ALLOW_NEW_SHAPE_INFER", prev_allow_new_shape_infer.c_str(), 1);
+#endif
+    } else {
+#ifdef _WIN32
+        _putenv_s("OV_GPU_ALLOW_NEW_SHAPE_INFER", "");
+#else
+        unsetenv("OV_GPU_ALLOW_NEW_SHAPE_INFER");
+#endif
+    }
+        ov::test::SubgraphBaseTest::TearDown();
+    }
 
 private:
         ov::test::utils::InputGenerateData in_data;
+        std::string prev_allow_new_shape_infer;
+        bool had_prev_allow_new_shape_infer = false;
 };
 
 TEST_P(MatMulConversionConstantInput, Inference) {
@@ -439,9 +470,34 @@ const std::vector<std::vector<InputShape>> matmul_conversion_input_shapes_basic_
     {{{}, {{1, 192, 33, 64, 1}}}},
 };
 
+// Compact variant of the legacy Constant->Convert->MatMul scenario:
+// const is rank-2 [64,64], opposite MatMul input rank is > 2.
+const std::vector<std::vector<InputShape>> matmul_conversion_input_shapes_basic_1_small = {
+    {{{}, {{1, 3, 2, 64, 1}}}},
+};
+
+// Complementary legacy case:
+// const is rank-2 [64,64], but opposite MatMul input is also rank-2.
+// The guarded WA must not reshape this case.
+const std::vector<std::vector<InputShape>> matmul_conversion_input_shapes_basic_2d = {
+    {{{}, {{64, 32}}}},
+};
+
 INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput_basic_1,
                          MatMulConversionConstantInput,
                          ::testing::Combine(::testing::ValuesIn(matmul_conversion_input_shapes_basic_1),
+                                            ::testing::ValuesIn({ov::element::f16})),
+                         MatMulConversionConstantInput::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput_basic_1_small,
+                         MatMulConversionConstantInput,
+                         ::testing::Combine(::testing::ValuesIn(matmul_conversion_input_shapes_basic_1_small),
+                                            ::testing::ValuesIn({ov::element::f16})),
+                         MatMulConversionConstantInput::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput_basic_2d,
+                         MatMulConversionConstantInput,
+                         ::testing::Combine(::testing::ValuesIn(matmul_conversion_input_shapes_basic_2d),
                                             ::testing::ValuesIn({ov::element::f16})),
                          MatMulConversionConstantInput::getTestCaseName);
 
@@ -552,5 +608,4 @@ INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantNDInput_3d,
                                             ::testing::ValuesIn(matmul_conversion_3d_input_shapes),
                                             ::testing::ValuesIn({ov::element::f16})),
                          MatMulConversionConstantNDInput::getTestCaseName);
-
 } // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
@@ -445,37 +445,9 @@ INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput_basic_1,
                                             ::testing::ValuesIn({ov::element::f16})),
                          MatMulConversionConstantInput::getTestCaseName);
 
-using MatmulConversionConstantInput0LargeOutParams = std::tuple<std::vector<InputShape>,  // input shapes
-                                                                 ov::element::Type>;        // infer precision
-
 // Keep this reproducer case: it targets legacy MatMul_cldnn_out_reshape mismatch
 // with output element count 98960 when constant is consumed as MatMul input0.
-class MatMulConversionConstantInput0LargeOut : public testing::WithParamInterface<MatmulConversionConstantInput0LargeOutParams>,
-                                               virtual public ov::test::SubgraphBaseTest {
-public:
-    static std::string getTestCaseName(const testing::TestParamInfo<MatmulConversionConstantInput0LargeOutParams>& obj) {
-        const auto& [input_shapes, input_precision] = obj.param;
-
-        std::ostringstream result;
-        result << "IS=(";
-        for (const auto& shape : input_shapes) {
-            result << ov::test::utils::partialShape2str({shape.first}) << "_";
-        }
-        result << ")_TS=";
-        for (const auto& shape : input_shapes) {
-            result << "(";
-            if (!shape.second.empty()) {
-                auto itr = shape.second.begin();
-                do {
-                    result << ov::test::utils::vec2str(*itr);
-                } while (++itr != shape.second.end() && result << "_");
-            }
-            result << ")_";
-        }
-        result << "infer_precision=" << input_precision;
-        return result.str();
-    }
-
+class MatMulConversionConstantInput0LargeOut : virtual public ov::test::SubgraphBaseTest {
 protected:
     std::shared_ptr<ov::Model> init_subgraph(std::vector<ov::PartialShape>& input_shapes) {
         const auto input_precision = ov::element::f32;
@@ -507,7 +479,8 @@ protected:
         in_data.range = 1;
         in_data.resolution = 10;
 
-        const auto& [input_shapes, infer_precision] = GetParam();
+        const std::vector<InputShape> input_shapes = {{{}, {{1, 64, 1}}}};
+        const auto infer_precision = ov::element::f16;
         init_input_shapes(input_shapes);
 
         inType = outType = ov::element::f32;
@@ -519,19 +492,9 @@ private:
     ov::test::utils::InputGenerateData in_data;
 };
 
-TEST_P(MatMulConversionConstantInput0LargeOut, Inference) {
+TEST_F(MatMulConversionConstantInput0LargeOut, Inference) {
     run();
 }
-
-const std::vector<std::vector<InputShape>> matmul_conversion_input_shapes_input0_large_out = {
-    {{{}, {{1, 64, 1}}}},
-};
-
-INSTANTIATE_TEST_SUITE_P(MatMulConversionConstantInput0_large_out,
-                         MatMulConversionConstantInput0LargeOut,
-                         ::testing::Combine(::testing::ValuesIn(matmul_conversion_input_shapes_input0_large_out),
-                                            ::testing::ValuesIn({ov::element::f16})),
-                         MatMulConversionConstantInput0LargeOut::getTestCaseName);
 
 using MatmulConversionConstantNDParams = std::tuple<ov::Shape,               // constant shape
                                                     std::vector<InputShape>,  // input shapes


### PR DESCRIPTION
### Details:
 - Old/new shape infer aligned for MatMul : constrain rank-2 Constant reshape WA to only input0 when the opposite MatMul input rank is static and >2, preventing 2D/2D regressions.
 - The problem initiated by https://github.com/openvinotoolkit/openvino/pull/32817


### Tickets:
 - *177582*

### AI Assistance:
 - *AI assistance used: no* / yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
