### PR TITLE
[TF/TFLite] Fold gratuitous Slice ShapeOf+Select cascade

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/eliminate_gratuitous_slice_cascade.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/eliminate_gratuitous_slice_cascade.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov {
+namespace pass {
+
+class TRANSFORMATIONS_API EliminateGratuitousSliceCascade;
+
+}  // namespace pass
+}  // namespace ov
+
+/**
+ * @ingroup ov_transformation_common_api
+ * @brief Folds the gratuitous
+ *        `Select(Constant<all-false>, ConvertLike(ShapeOf(X), _), Add(Constant, Constant))`
+ *        cascade emitted by the TF/TFLite Slice translator (translate_slice_op) into a single
+ *        Constant carrying the literal `start + size` values. The else-branch may already be
+ *        a folded Constant; in that case the matcher just replaces Select with it.
+ *
+ * Why this exists: pipelines that consume the model without a follow-up ConstantFolding
+ * pass (notably NPUW's pre-partition stage) otherwise carry the dynamic Select node into
+ * partitioning, where `to_shape()` on the Slice output throws.
+ */
+class ov::pass::EliminateGratuitousSliceCascade : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("EliminateGratuitousSliceCascade");
+    EliminateGratuitousSliceCascade();
+};

--- a/src/common/transformations/src/transformations/common_optimizations/eliminate_gratuitous_slice_cascade.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/eliminate_gratuitous_slice_cascade.cpp
@@ -5,7 +5,9 @@
 #include "transformations/common_optimizations/eliminate_gratuitous_slice_cascade.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "itt.hpp"
@@ -81,6 +83,41 @@ bool is_less_with_all_nonneg_size(const std::shared_ptr<ov::Node>& node) {
     });
 }
 
+// Accept the two forms of the Select's condition input that the matcher can fold:
+//   - a pre-folded boolean Constant (TransposeSinking's inner CF already collapsed `Less(size, 0)`)
+//   - a live `Less(size_const, zero_const)` with non-negative size
+// Both must evaluate to all-false so the Select picks the else branch.
+bool is_acceptable_cascade_condition(const std::shared_ptr<ov::Node>& cond) {
+    return is_all_false_bool_constant(cond) || is_less_with_all_nonneg_size(cond);
+}
+
+// The Select's else branch in the gratuitous cascade is either:
+//   - a pre-folded v0::Constant (Add(start_const, size_const) already collapsed), or
+//   - a live `v1::Add(v0::Constant, v0::Constant)` (translator output before CF).
+// Returned shape carries exactly one of these forms.
+struct ElseBranch {
+    std::shared_ptr<v0::Constant> folded;   // set iff already a single Constant
+    std::shared_ptr<v1::Add> add;           // set iff Add(C, C)
+    std::shared_ptr<v0::Constant> start_n;  // set iff Add(C, C)
+    std::shared_ptr<v0::Constant> size_n;   // set iff Add(C, C)
+};
+
+std::optional<ElseBranch> try_extract_else_branch(const std::shared_ptr<ov::Node>& node) {
+    if (auto folded = ov::as_type_ptr<v0::Constant>(node)) {
+        return ElseBranch{folded, nullptr, nullptr, nullptr};
+    }
+    auto add = ov::as_type_ptr<v1::Add>(node);
+    if (!add) {
+        return std::nullopt;
+    }
+    auto start_n = ov::as_type_ptr<v0::Constant>(add->input_value(0).get_node_shared_ptr());
+    auto size_n = ov::as_type_ptr<v0::Constant>(add->input_value(1).get_node_shared_ptr());
+    if (!start_n || !size_n) {
+        return std::nullopt;
+    }
+    return ElseBranch{nullptr, add, start_n, size_n};
+}
+
 }  // namespace
 
 ov::pass::EliminateGratuitousSliceCascade::EliminateGratuitousSliceCascade() {
@@ -93,63 +130,50 @@ ov::pass::EliminateGratuitousSliceCascade::EliminateGratuitousSliceCascade() {
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
-
-        auto select_value = pattern_map.at(select_pat);
-        auto select_node = ov::as_type_ptr<v1::Select>(select_value.get_node_shared_ptr());
+        auto select_node = ov::as_type_ptr<v1::Select>(pattern_map.at(select_pat).get_node_shared_ptr());
         if (!select_node) {
             return false;
         }
 
-        // The condition is either:
-        //   - a pre-folded boolean Constant (TransposeSinking's inner CF already collapsed
-        //     `Less(size, 0)`), or
-        //   - a live `Less(size_const, zero_const)` with statically-known non-negative size.
-        // Either way, it must evaluate to all-false so the Select picks the else branch.
-        const auto cond_raw = select_node->input_value(0).get_node_shared_ptr();
-        if (!is_all_false_bool_constant(cond_raw) && !is_less_with_all_nonneg_size(cond_raw)) {
+        if (!is_acceptable_cascade_condition(select_node->input_value(0).get_node_shared_ptr())) {
             return false;
         }
 
-        // The else-branch is either a pre-folded Constant (Add of two Constants already
-        // collapsed) or a live `Add(start_const, size_const)`.
-        // In both cases, replace the Select with a single Constant carrying the literal
-        // `start + size` values. Emitting a Constant — not just `Add(C, C)` — makes the
-        // downstream Slice statically inferable even in pipelines that do not run a
-        // ConstantFolding pass after this matcher (notably NPUW's pre-partition stage).
-        const auto else_raw = select_node->input_value(2).get_node_shared_ptr();
-
-        if (auto folded = ov::as_type_ptr<v0::Constant>(else_raw)) {
-            return ov::replace_output_update_name(select_node->output(0), folded->output(0));
-        }
-
-        auto add_node = ov::as_type_ptr<v1::Add>(else_raw);
-        if (!add_node) {
-            return false;
-        }
-        auto start_n = ov::as_type_ptr<v0::Constant>(add_node->input_value(0).get_node_shared_ptr());
-        auto size_n = ov::as_type_ptr<v0::Constant>(add_node->input_value(1).get_node_shared_ptr());
-        if (!start_n || !size_n) {
+        auto else_opt = try_extract_else_branch(select_node->input_value(2).get_node_shared_ptr());
+        if (!else_opt) {
             return false;
         }
 
-        const auto start_vals = start_n->cast_vector<int64_t>();
-        const auto size_vals = size_n->cast_vector<int64_t>();
+        // Pre-folded Constant — replace Select directly.
+        if (else_opt->folded) {
+            return ov::replace_output_update_name(select_node->output(0), else_opt->folded->output(0));
+        }
+
+        // Live Add(C, C) — synthesise a single Constant carrying start + size.
+        // Emitting a Constant (not just `Add(C, C)`) makes the downstream Slice statically
+        // inferable even in pipelines that do not run a follow-up ConstantFolding pass
+        // (notably NPUW's pre-partition stage).
+        const auto start_vals = else_opt->start_n->cast_vector<int64_t>();
+        const auto size_vals = else_opt->size_n->cast_vector<int64_t>();
         if (start_vals.empty() || start_vals.size() != size_vals.size()) {
             return false;
         }
-        std::vector<int64_t> stop_vals(start_vals.size());
-        for (size_t i = 0; i < start_vals.size(); ++i) {
-            stop_vals[i] = start_vals[i] + size_vals[i];
-        }
-
-        const auto add_out_pshape = add_node->get_output_partial_shape(0);
+        const auto add_out_pshape = else_opt->add->get_output_partial_shape(0);
         if (add_out_pshape.is_dynamic()) {
             return false;
         }
-        const auto add_et = add_node->get_element_type();
-        auto new_constant = std::make_shared<v0::Constant>(add_et, add_out_pshape.get_shape(), stop_vals);
-        ov::copy_runtime_info({select_node, add_node, start_n, size_n}, new_constant);
 
+        std::vector<int64_t> stop_vals(start_vals.size());
+        std::transform(start_vals.begin(),
+                       start_vals.end(),
+                       size_vals.begin(),
+                       stop_vals.begin(),
+                       std::plus<int64_t>());
+
+        auto new_constant = std::make_shared<v0::Constant>(else_opt->add->get_element_type(),
+                                                           add_out_pshape.get_shape(),
+                                                           stop_vals);
+        ov::copy_runtime_info({select_node, else_opt->add, else_opt->start_n, else_opt->size_n}, new_constant);
         return ov::replace_output_update_name(select_node->output(0), new_constant->output(0));
     };
 

--- a/src/common/transformations/src/transformations/common_optimizations/eliminate_gratuitous_slice_cascade.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/eliminate_gratuitous_slice_cascade.cpp
@@ -1,0 +1,158 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/eliminate_gratuitous_slice_cascade.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert_like.hpp"
+#include "openvino/op/less.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+namespace v3 = ov::op::v3;
+
+namespace {
+
+// Returns true iff `node` is a v0::Constant whose values are all `false`.
+bool is_all_false_bool_constant(const std::shared_ptr<ov::Node>& node) {
+    auto cnst = ov::as_type_ptr<v0::Constant>(node);
+    if (!cnst || cnst->get_element_type() != ov::element::boolean) {
+        return false;
+    }
+    const auto vals = cnst->get_vector<bool>();
+    if (vals.empty()) {
+        return false;
+    }
+    return std::none_of(vals.begin(), vals.end(), [](bool v) {
+        return v;
+    });
+}
+
+// Returns true iff `node` is a v0::Constant whose values are all 0 (integer types).
+bool is_all_zero_int_constant(const std::shared_ptr<ov::Node>& node) {
+    auto cnst = ov::as_type_ptr<v0::Constant>(node);
+    if (!cnst) {
+        return false;
+    }
+    const auto vals = cnst->cast_vector<int64_t>();
+    if (vals.empty()) {
+        return false;
+    }
+    return std::all_of(vals.begin(), vals.end(), [](int64_t v) {
+        return v == 0;
+    });
+}
+
+// Returns true iff `node` is `Less(size_const, zero_const)` where size_const has only
+// non-negative values and zero_const is all zeros — i.e. the original
+// `negative_sizes_mask = Less(size, 0)` produced by translate_slice_op, in the case
+// where the Slice's `size` is statically known to be non-negative.
+bool is_less_with_all_nonneg_size(const std::shared_ptr<ov::Node>& node) {
+    auto less = ov::as_type_ptr<v1::Less>(node);
+    if (!less) {
+        return false;
+    }
+    auto lhs = ov::as_type_ptr<v0::Constant>(less->input_value(0).get_node_shared_ptr());
+    auto rhs = ov::as_type_ptr<v0::Constant>(less->input_value(1).get_node_shared_ptr());
+    if (!lhs || !rhs) {
+        return false;
+    }
+    if (!is_all_zero_int_constant(rhs)) {
+        return false;
+    }
+    const auto lhs_vals = lhs->cast_vector<int64_t>();
+    if (lhs_vals.empty()) {
+        return false;
+    }
+    return std::all_of(lhs_vals.begin(), lhs_vals.end(), [](int64_t v) {
+        return v >= 0;
+    });
+}
+
+}  // namespace
+
+ov::pass::EliminateGratuitousSliceCascade::EliminateGratuitousSliceCascade() {
+    MATCHER_SCOPE(EliminateGratuitousSliceCascade);
+
+    auto data_pat = pattern::any_input();
+    auto shape_of_pat = pattern::wrap_type<v3::ShapeOf>({data_pat});
+    auto cvtlike_pat = pattern::wrap_type<v1::ConvertLike>({shape_of_pat, pattern::any_input()});
+    auto select_pat = pattern::wrap_type<v1::Select>({pattern::any_input(), cvtlike_pat, pattern::any_input()});
+
+    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+
+        auto select_value = pattern_map.at(select_pat);
+        auto select_node = ov::as_type_ptr<v1::Select>(select_value.get_node_shared_ptr());
+        if (!select_node) {
+            return false;
+        }
+
+        // The condition is either:
+        //   - a pre-folded boolean Constant (TransposeSinking's inner CF already collapsed
+        //     `Less(size, 0)`), or
+        //   - a live `Less(size_const, zero_const)` with statically-known non-negative size.
+        // Either way, it must evaluate to all-false so the Select picks the else branch.
+        const auto cond_raw = select_node->input_value(0).get_node_shared_ptr();
+        if (!is_all_false_bool_constant(cond_raw) && !is_less_with_all_nonneg_size(cond_raw)) {
+            return false;
+        }
+
+        // The else-branch is either a pre-folded Constant (Add of two Constants already
+        // collapsed) or a live `Add(start_const, size_const)`.
+        // In both cases, replace the Select with a single Constant carrying the literal
+        // `start + size` values. Emitting a Constant — not just `Add(C, C)` — makes the
+        // downstream Slice statically inferable even in pipelines that do not run a
+        // ConstantFolding pass after this matcher (notably NPUW's pre-partition stage).
+        const auto else_raw = select_node->input_value(2).get_node_shared_ptr();
+
+        if (auto folded = ov::as_type_ptr<v0::Constant>(else_raw)) {
+            return ov::replace_output_update_name(select_node->output(0), folded->output(0));
+        }
+
+        auto add_node = ov::as_type_ptr<v1::Add>(else_raw);
+        if (!add_node) {
+            return false;
+        }
+        auto start_n = ov::as_type_ptr<v0::Constant>(add_node->input_value(0).get_node_shared_ptr());
+        auto size_n = ov::as_type_ptr<v0::Constant>(add_node->input_value(1).get_node_shared_ptr());
+        if (!start_n || !size_n) {
+            return false;
+        }
+
+        const auto start_vals = start_n->cast_vector<int64_t>();
+        const auto size_vals = size_n->cast_vector<int64_t>();
+        if (start_vals.empty() || start_vals.size() != size_vals.size()) {
+            return false;
+        }
+        std::vector<int64_t> stop_vals(start_vals.size());
+        for (size_t i = 0; i < start_vals.size(); ++i) {
+            stop_vals[i] = start_vals[i] + size_vals[i];
+        }
+
+        const auto add_out_pshape = add_node->get_output_partial_shape(0);
+        if (add_out_pshape.is_dynamic()) {
+            return false;
+        }
+        const auto add_et = add_node->get_element_type();
+        auto new_constant = std::make_shared<v0::Constant>(add_et, add_out_pshape.get_shape(), stop_vals);
+        ov::copy_runtime_info({select_node, add_node, start_n, size_n}, new_constant);
+
+        return ov::replace_output_update_name(select_node->output(0), new_constant->output(0));
+    };
+
+    auto m = std::make_shared<pattern::Matcher>(select_pat, matcher_name);
+    register_matcher(m, callback);
+}

--- a/src/common/transformations/src/transformations/common_optimizations/eliminate_gratuitous_slice_cascade.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/eliminate_gratuitous_slice_cascade.cpp
@@ -170,9 +170,8 @@ ov::pass::EliminateGratuitousSliceCascade::EliminateGratuitousSliceCascade() {
                        stop_vals.begin(),
                        std::plus<int64_t>());
 
-        auto new_constant = std::make_shared<v0::Constant>(else_opt->add->get_element_type(),
-                                                           add_out_pshape.get_shape(),
-                                                           stop_vals);
+        auto new_constant =
+            std::make_shared<v0::Constant>(else_opt->add->get_element_type(), add_out_pshape.get_shape(), stop_vals);
         ov::copy_runtime_info({select_node, else_opt->add, else_opt->start_n, else_opt->size_n}, new_constant);
         return ov::replace_output_update_name(select_node->output(0), new_constant->output(0));
     };

--- a/src/common/transformations/tests/common_optimizations/eliminate_gratuitous_slice_cascade_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/eliminate_gratuitous_slice_cascade_test.cpp
@@ -1,0 +1,220 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/eliminate_gratuitous_slice_cascade.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert_like.hpp"
+#include "openvino/op/less.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/pass/manager.hpp"
+
+using namespace ov;
+
+namespace {
+
+// Builds the exact subgraph that translate_slice_op emits, but with the Less and Add
+// already constant-folded (as TransposeSinking's inner CF does in the read_model path).
+// The Select is fed by:
+//   - cond:  Constant<bool>(`cond_values`)
+//   - then:  ConvertLike(ShapeOf(Parameter<input_shape>), size_constant)
+//   - else:  Add(start_constant, size_constant)   (kept as Add — matcher must compute start+size)
+// The Select feeds Slice's stop input.
+std::shared_ptr<Model> build_slice_cascade_model(const PartialShape& input_shape,
+                                                 const std::vector<int32_t>& start_vals,
+                                                 const std::vector<int32_t>& size_vals,
+                                                 const std::vector<bool>& cond_vals,
+                                                 bool add_inputs_constant = true) {
+    const auto rank = start_vals.size();
+    auto data = std::make_shared<op::v0::Parameter>(element::f32, input_shape);
+
+    auto start_const = op::v0::Constant::create(element::i32, Shape{rank}, start_vals);
+    std::shared_ptr<Node> size_input;
+    if (add_inputs_constant) {
+        size_input = op::v0::Constant::create(element::i32, Shape{rank}, size_vals);
+    } else {
+        size_input = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{static_cast<int64_t>(rank)});
+    }
+    auto cond_const = op::v0::Constant::create(element::boolean, Shape{rank}, cond_vals);
+
+    auto shape_of = std::make_shared<op::v3::ShapeOf>(data);
+    auto then_branch = std::make_shared<op::v1::ConvertLike>(shape_of, size_input);
+    auto else_branch = std::make_shared<op::v1::Add>(start_const, size_input);
+
+    auto stop = std::make_shared<op::v1::Select>(cond_const, then_branch, else_branch);
+    auto const_one = op::v0::Constant::create(element::i32, Shape{rank}, std::vector<int32_t>(rank, 1));
+    auto slice = std::make_shared<op::v8::Slice>(data, start_const, stop, const_one);
+
+    ParameterVector params{data};
+    if (!add_inputs_constant) {
+        params.push_back(ov::as_type_ptr<op::v0::Parameter>(size_input));
+    }
+    return std::make_shared<Model>(OutputVector{slice}, params);
+}
+
+}  // namespace
+
+// Positive case: condition is all-false, Add inputs are both Constants, size is non-negative.
+// Matcher must fire: Select is removed; Slice's stop input is fed by a Constant; Slice
+// output shape resolves to static.
+TEST(EliminateGratuitousSliceCascade, all_nonneg_size_folds_cascade_into_constant) {
+    auto model = build_slice_cascade_model(/*input_shape=*/PartialShape{1, 128, 8, 256},
+                                           /*start=*/{0, 0, 0, 0},
+                                           /*size=*/{1, 128, 4, 128},
+                                           /*cond=*/{false, false, false, false});
+
+    pass::Manager manager;
+    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 0);
+
+    const auto results = model->get_results();
+    ASSERT_EQ(results.size(), 1u);
+    const auto slice = ov::as_type_ptr<op::v8::Slice>(results[0]->get_input_node_shared_ptr(0));
+    ASSERT_NE(slice, nullptr);
+
+    // Slice's stop input must now be a Constant produced by the matcher.
+    auto stop_producer = slice->get_input_node_shared_ptr(2);
+    auto stop_const = ov::as_type_ptr<op::v0::Constant>(stop_producer);
+    ASSERT_NE(stop_const, nullptr);
+    EXPECT_EQ(stop_const->cast_vector<int64_t>(), (std::vector<int64_t>{1, 128, 4, 128}));
+
+    // Slice output shape must be static after the pass + validate.
+    EXPECT_TRUE(slice->get_output_partial_shape(0).is_static());
+    EXPECT_EQ(slice->get_output_partial_shape(0).get_shape(), Shape({1, 128, 4, 128}));
+}
+
+// Same as above but condition is a live Less(size_const, zero_const) — the form emitted
+// straight by the translator, before any ConstantFolding has run. Matcher must still fire.
+TEST(EliminateGratuitousSliceCascade, live_less_condition_folds_cascade) {
+    auto data = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 128, 8, 256});
+    auto start_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{0, 0, 0, 0});
+    auto size_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 128, 4, 128});
+    auto zero_scalar = op::v0::Constant::create(element::i32, Shape{}, std::vector<int32_t>{0});
+    auto less = std::make_shared<op::v1::Less>(size_const, zero_scalar);
+    auto shape_of = std::make_shared<op::v3::ShapeOf>(data);
+    auto cvtlike = std::make_shared<op::v1::ConvertLike>(shape_of, size_const);
+    auto add = std::make_shared<op::v1::Add>(start_const, size_const);
+    auto select = std::make_shared<op::v1::Select>(less, cvtlike, add);
+    auto step = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 1, 1, 1});
+    auto slice = std::make_shared<op::v8::Slice>(data, start_const, select, step);
+    auto model = std::make_shared<Model>(OutputVector{slice}, ParameterVector{data});
+
+    pass::Manager manager;
+    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 0);
+    auto stop_const = ov::as_type_ptr<op::v0::Constant>(slice->get_input_node_shared_ptr(2));
+    ASSERT_NE(stop_const, nullptr);
+    EXPECT_EQ(stop_const->cast_vector<int64_t>(), (std::vector<int64_t>{1, 128, 4, 128}));
+    EXPECT_TRUE(slice->get_output_partial_shape(0).is_static());
+    EXPECT_EQ(slice->get_output_partial_shape(0).get_shape(), Shape({1, 128, 4, 128}));
+}
+
+// Negative case: a Less with a non-negative-size lhs but a non-zero rhs would not produce
+// an all-false mask — matcher must not fire.
+TEST(EliminateGratuitousSliceCascade, less_with_nonzero_rhs_keeps_cascade) {
+    auto data = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 128, 8, 256});
+    auto start_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{0, 0, 0, 0});
+    auto size_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 128, 4, 128});
+    auto wrong_rhs = op::v0::Constant::create(element::i32, Shape{}, std::vector<int32_t>{2});
+    auto less = std::make_shared<op::v1::Less>(size_const, wrong_rhs);
+    auto shape_of = std::make_shared<op::v3::ShapeOf>(data);
+    auto cvtlike = std::make_shared<op::v1::ConvertLike>(shape_of, size_const);
+    auto add = std::make_shared<op::v1::Add>(start_const, size_const);
+    auto select = std::make_shared<op::v1::Select>(less, cvtlike, add);
+    auto step = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 1, 1, 1});
+    auto slice = std::make_shared<op::v8::Slice>(data, start_const, select, step);
+    auto model = std::make_shared<Model>(OutputVector{slice}, ParameterVector{data});
+
+    pass::Manager manager;
+    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
+}
+
+// Negative case: a Less whose lhs has a negative value (the legitimate `size=-1`
+// cascade path) must not be folded — matcher must not fire.
+TEST(EliminateGratuitousSliceCascade, less_with_neg_size_keeps_cascade) {
+    auto data = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 128, 8, 256});
+    auto start_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{0, 0, 0, 0});
+    auto size_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 128, 4, -1});
+    auto zero_scalar = op::v0::Constant::create(element::i32, Shape{}, std::vector<int32_t>{0});
+    auto less = std::make_shared<op::v1::Less>(size_const, zero_scalar);
+    auto shape_of = std::make_shared<op::v3::ShapeOf>(data);
+    auto cvtlike = std::make_shared<op::v1::ConvertLike>(shape_of, size_const);
+    auto add = std::make_shared<op::v1::Add>(start_const, size_const);
+    auto select = std::make_shared<op::v1::Select>(less, cvtlike, add);
+    auto step = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 1, 1, 1});
+    auto slice = std::make_shared<op::v8::Slice>(data, start_const, select, step);
+    auto model = std::make_shared<Model>(OutputVector{slice}, ParameterVector{data});
+
+    pass::Manager manager;
+    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
+}
+
+// Negative case A: condition is mixed (some true, some false). The original Less mask
+// would not be all-false, so the rewrite is algebraically invalid — matcher must NOT fire.
+TEST(EliminateGratuitousSliceCascade, mixed_condition_keeps_cascade) {
+    auto model = build_slice_cascade_model(/*input_shape=*/PartialShape{1, 128, 8, 256},
+                                           /*start=*/{0, 0, 0, 0},
+                                           /*size=*/{1, 128, 4, 128},
+                                           /*cond=*/{false, false, false, true});
+
+    pass::Manager manager;
+    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
+}
+
+// Negative case B: Add's inputs are not both Constants (size is a Parameter here). The
+// matcher cannot synthesise a literal stop Constant, so it must NOT fire — Select stays.
+TEST(EliminateGratuitousSliceCascade, non_constant_add_input_keeps_cascade) {
+    auto model = build_slice_cascade_model(/*input_shape=*/PartialShape{1, 128, 8, 256},
+                                           /*start=*/{0, 0, 0, 0},
+                                           /*size=*/{1, 128, 4, 128},
+                                           /*cond=*/{false, false, false, false},
+                                           /*add_inputs_constant=*/false);
+
+    pass::Manager manager;
+    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
+}
+
+// Negative case C: A generic Select whose then-branch isn't ConvertLike(ShapeOf(...)) — the
+// matcher's pattern is intentionally narrow and must not touch unrelated Select nodes.
+TEST(EliminateGratuitousSliceCascade, unrelated_select_pattern_is_preserved) {
+    auto x = std::make_shared<op::v0::Parameter>(element::i32, Shape{4});
+    auto y = std::make_shared<op::v0::Parameter>(element::i32, Shape{4});
+    auto cond = op::v0::Constant::create(element::boolean, Shape{4}, std::vector<bool>{false, false, false, false});
+    auto select = std::make_shared<op::v1::Select>(cond, x, y);
+    auto model = std::make_shared<Model>(OutputVector{select}, ParameterVector{x, y});
+
+    pass::Manager manager;
+    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
+}

--- a/src/common/transformations/tests/common_optimizations/eliminate_gratuitous_slice_cascade_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/eliminate_gratuitous_slice_cascade_test.cpp
@@ -7,12 +7,12 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/op/add.hpp"
-#include "openvino/op/broadcast.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert_like.hpp"
 #include "openvino/op/less.hpp"
@@ -26,40 +26,70 @@ using namespace ov;
 
 namespace {
 
-// Builds the exact subgraph that translate_slice_op emits, but with the Less and Add
-// already constant-folded (as TransposeSinking's inner CF does in the read_model path).
-// The Select is fed by:
-//   - cond:  Constant<bool>(`cond_values`)
-//   - then:  ConvertLike(ShapeOf(Parameter<input_shape>), size_constant)
-//   - else:  Add(start_constant, size_constant)   (kept as Add — matcher must compute start+size)
-// The Select feeds Slice's stop input.
-std::shared_ptr<Model> build_slice_cascade_model(const PartialShape& input_shape,
-                                                 const std::vector<int32_t>& start_vals,
-                                                 const std::vector<int32_t>& size_vals,
-                                                 const std::vector<bool>& cond_vals,
-                                                 bool add_inputs_constant = true) {
-    const auto rank = start_vals.size();
-    auto data = std::make_shared<op::v0::Parameter>(element::f32, input_shape);
+// Parameterized case for the gratuitous-Slice-cascade matcher.
+//
+// All six cases share the same topology:
+//     Slice(data, start_const, Select(cond, ConvertLike(ShapeOf(data), size), Add(start, size)), step)
+// They differ along four axes:
+//   - cond_form        : the Select's condition is either a pre-folded boolean Constant
+//                        (TransposeSinking's inner CF already collapsed `Less(size, 0)`)
+//                        or a live `Less(size_const, zero_scalar)`.
+//   - bool_cond_vals   : values for the pre-folded boolean Constant (used iff cond_form == BoolConstant).
+//   - less_rhs_val     : rhs of the live `Less` (used iff cond_form == LiveLess). The lhs is the
+//                        same `size` Constant used by the Add — matching the translator output.
+//   - size_is_parameter: when true, `size` is a Parameter (forces the matcher off — no folded
+//                        start+size Constant is synthesisable).
+// `expect_fold` controls the assertion: the matcher must fire (Select count → 0; Slice's stop is
+// now a Constant carrying `expected_stop_vals`; Slice output is static) or not fire (Select count
+// stays 1).
+struct CascadeCase {
+    enum class CondForm { BoolConstant, LiveLess };
 
-    auto start_const = op::v0::Constant::create(element::i32, Shape{rank}, start_vals);
+    std::string name;
+    PartialShape input_shape;
+
+    CondForm cond_form;
+    std::vector<bool> bool_cond_vals;  // iff CondForm::BoolConstant
+    int32_t less_rhs_val;              // iff CondForm::LiveLess
+
+    std::vector<int32_t> start_vals;
+    std::vector<int32_t> size_vals;
+    bool size_is_parameter;
+
+    bool expect_fold;
+    std::vector<int64_t> expected_stop_vals;
+};
+
+std::shared_ptr<Model> build_cascade_model(const CascadeCase& c) {
+    const auto rank = c.start_vals.size();
+    auto data = std::make_shared<op::v0::Parameter>(element::f32, c.input_shape);
+    auto start_const = op::v0::Constant::create(element::i32, Shape{rank}, c.start_vals);
+
     std::shared_ptr<Node> size_input;
-    if (add_inputs_constant) {
-        size_input = op::v0::Constant::create(element::i32, Shape{rank}, size_vals);
-    } else {
+    if (c.size_is_parameter) {
         size_input = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{static_cast<int64_t>(rank)});
+    } else {
+        size_input = op::v0::Constant::create(element::i32, Shape{rank}, c.size_vals);
     }
-    auto cond_const = op::v0::Constant::create(element::boolean, Shape{rank}, cond_vals);
+
+    std::shared_ptr<Node> cond_node;
+    if (c.cond_form == CascadeCase::CondForm::BoolConstant) {
+        cond_node = op::v0::Constant::create(element::boolean, Shape{rank}, c.bool_cond_vals);
+    } else {
+        // The live `Less` mirrors translator output: lhs is the same size Constant used by Add.
+        auto less_rhs = op::v0::Constant::create(element::i32, Shape{}, std::vector<int32_t>{c.less_rhs_val});
+        cond_node = std::make_shared<op::v1::Less>(size_input, less_rhs);
+    }
 
     auto shape_of = std::make_shared<op::v3::ShapeOf>(data);
-    auto then_branch = std::make_shared<op::v1::ConvertLike>(shape_of, size_input);
-    auto else_branch = std::make_shared<op::v1::Add>(start_const, size_input);
-
-    auto stop = std::make_shared<op::v1::Select>(cond_const, then_branch, else_branch);
-    auto const_one = op::v0::Constant::create(element::i32, Shape{rank}, std::vector<int32_t>(rank, 1));
-    auto slice = std::make_shared<op::v8::Slice>(data, start_const, stop, const_one);
+    auto cvtlike = std::make_shared<op::v1::ConvertLike>(shape_of, size_input);
+    auto add = std::make_shared<op::v1::Add>(start_const, size_input);
+    auto select = std::make_shared<op::v1::Select>(cond_node, cvtlike, add);
+    auto step = op::v0::Constant::create(element::i32, Shape{rank}, std::vector<int32_t>(rank, 1));
+    auto slice = std::make_shared<op::v8::Slice>(data, start_const, select, step);
 
     ParameterVector params{data};
-    if (!add_inputs_constant) {
+    if (c.size_is_parameter) {
         params.push_back(ov::as_type_ptr<op::v0::Parameter>(size_input));
     }
     return std::make_shared<Model>(OutputVector{slice}, params);
@@ -67,18 +97,20 @@ std::shared_ptr<Model> build_slice_cascade_model(const PartialShape& input_shape
 
 }  // namespace
 
-// Positive case: condition is all-false, Add inputs are both Constants, size is non-negative.
-// Matcher must fire: Select is removed; Slice's stop input is fed by a Constant; Slice
-// output shape resolves to static.
-TEST(EliminateGratuitousSliceCascade, all_nonneg_size_folds_cascade_into_constant) {
-    auto model = build_slice_cascade_model(/*input_shape=*/PartialShape{1, 128, 8, 256},
-                                           /*start=*/{0, 0, 0, 0},
-                                           /*size=*/{1, 128, 4, 128},
-                                           /*cond=*/{false, false, false, false});
+class EliminateGratuitousSliceCascadeP : public testing::WithParamInterface<CascadeCase>, public testing::Test {};
+
+TEST_P(EliminateGratuitousSliceCascadeP, MatcherBehavesAsPredicted) {
+    const auto& param = GetParam();
+    auto model = build_cascade_model(param);
 
     pass::Manager manager;
     manager.register_pass<pass::EliminateGratuitousSliceCascade>();
     manager.run_passes(model);
+
+    if (!param.expect_fold) {
+        EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
+        return;
+    }
 
     EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 0);
 
@@ -87,124 +119,96 @@ TEST(EliminateGratuitousSliceCascade, all_nonneg_size_folds_cascade_into_constan
     const auto slice = ov::as_type_ptr<op::v8::Slice>(results[0]->get_input_node_shared_ptr(0));
     ASSERT_NE(slice, nullptr);
 
-    // Slice's stop input must now be a Constant produced by the matcher.
-    auto stop_producer = slice->get_input_node_shared_ptr(2);
-    auto stop_const = ov::as_type_ptr<op::v0::Constant>(stop_producer);
-    ASSERT_NE(stop_const, nullptr);
-    EXPECT_EQ(stop_const->cast_vector<int64_t>(), (std::vector<int64_t>{1, 128, 4, 128}));
-
-    // Slice output shape must be static after the pass + validate.
-    EXPECT_TRUE(slice->get_output_partial_shape(0).is_static());
-    EXPECT_EQ(slice->get_output_partial_shape(0).get_shape(), Shape({1, 128, 4, 128}));
-}
-
-// Same as above but condition is a live Less(size_const, zero_const) — the form emitted
-// straight by the translator, before any ConstantFolding has run. Matcher must still fire.
-TEST(EliminateGratuitousSliceCascade, live_less_condition_folds_cascade) {
-    auto data = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 128, 8, 256});
-    auto start_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{0, 0, 0, 0});
-    auto size_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 128, 4, 128});
-    auto zero_scalar = op::v0::Constant::create(element::i32, Shape{}, std::vector<int32_t>{0});
-    auto less = std::make_shared<op::v1::Less>(size_const, zero_scalar);
-    auto shape_of = std::make_shared<op::v3::ShapeOf>(data);
-    auto cvtlike = std::make_shared<op::v1::ConvertLike>(shape_of, size_const);
-    auto add = std::make_shared<op::v1::Add>(start_const, size_const);
-    auto select = std::make_shared<op::v1::Select>(less, cvtlike, add);
-    auto step = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 1, 1, 1});
-    auto slice = std::make_shared<op::v8::Slice>(data, start_const, select, step);
-    auto model = std::make_shared<Model>(OutputVector{slice}, ParameterVector{data});
-
-    pass::Manager manager;
-    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
-    manager.run_passes(model);
-
-    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 0);
     auto stop_const = ov::as_type_ptr<op::v0::Constant>(slice->get_input_node_shared_ptr(2));
     ASSERT_NE(stop_const, nullptr);
-    EXPECT_EQ(stop_const->cast_vector<int64_t>(), (std::vector<int64_t>{1, 128, 4, 128}));
-    EXPECT_TRUE(slice->get_output_partial_shape(0).is_static());
-    EXPECT_EQ(slice->get_output_partial_shape(0).get_shape(), Shape({1, 128, 4, 128}));
+    EXPECT_EQ(stop_const->cast_vector<int64_t>(), param.expected_stop_vals);
+
+    ASSERT_TRUE(slice->get_output_partial_shape(0).is_static());
+    Shape expected_out;
+    for (size_t i = 0; i < param.expected_stop_vals.size(); ++i) {
+        expected_out.push_back(static_cast<size_t>(param.expected_stop_vals[i] - param.start_vals[i]));
+    }
+    EXPECT_EQ(slice->get_output_partial_shape(0).get_shape(), expected_out);
 }
 
-// Negative case: a Less with a non-negative-size lhs but a non-zero rhs would not produce
-// an all-false mask — matcher must not fire.
-TEST(EliminateGratuitousSliceCascade, less_with_nonzero_rhs_keeps_cascade) {
-    auto data = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 128, 8, 256});
-    auto start_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{0, 0, 0, 0});
-    auto size_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 128, 4, 128});
-    auto wrong_rhs = op::v0::Constant::create(element::i32, Shape{}, std::vector<int32_t>{2});
-    auto less = std::make_shared<op::v1::Less>(size_const, wrong_rhs);
-    auto shape_of = std::make_shared<op::v3::ShapeOf>(data);
-    auto cvtlike = std::make_shared<op::v1::ConvertLike>(shape_of, size_const);
-    auto add = std::make_shared<op::v1::Add>(start_const, size_const);
-    auto select = std::make_shared<op::v1::Select>(less, cvtlike, add);
-    auto step = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 1, 1, 1});
-    auto slice = std::make_shared<op::v8::Slice>(data, start_const, select, step);
-    auto model = std::make_shared<Model>(OutputVector{slice}, ParameterVector{data});
+INSTANTIATE_TEST_SUITE_P(
+    EliminateGratuitousSliceCascade,
+    EliminateGratuitousSliceCascadeP,
+    ::testing::ValuesIn(std::vector<CascadeCase>{
+        // Positive: condition is all-false bool Constant, Add inputs are both Constants → fold.
+        {"all_nonneg_size_folds_cascade_into_constant",
+         PartialShape{1, 128, 8, 256},
+         CascadeCase::CondForm::BoolConstant,
+         /*bool_cond_vals=*/{false, false, false, false},
+         /*less_rhs_val=*/0,
+         /*start_vals=*/{0, 0, 0, 0},
+         /*size_vals=*/{1, 128, 4, 128},
+         /*size_is_parameter=*/false,
+         /*expect_fold=*/true,
+         /*expected_stop_vals=*/{1, 128, 4, 128}},
+        // Positive: condition is a live `Less(size_const, 0)` with non-negative size → fold.
+        {"live_less_condition_folds_cascade",
+         PartialShape{1, 128, 8, 256},
+         CascadeCase::CondForm::LiveLess,
+         /*bool_cond_vals=*/{},
+         /*less_rhs_val=*/0,
+         /*start_vals=*/{0, 0, 0, 0},
+         /*size_vals=*/{1, 128, 4, 128},
+         /*size_is_parameter=*/false,
+         /*expect_fold=*/true,
+         /*expected_stop_vals=*/{1, 128, 4, 128}},
+        // Negative: live `Less` rhs is non-zero → not the original `Less(size, 0)` mask → keep.
+        {"less_with_nonzero_rhs_keeps_cascade",
+         PartialShape{1, 128, 8, 256},
+         CascadeCase::CondForm::LiveLess,
+         /*bool_cond_vals=*/{},
+         /*less_rhs_val=*/2,
+         /*start_vals=*/{0, 0, 0, 0},
+         /*size_vals=*/{1, 128, 4, 128},
+         /*size_is_parameter=*/false,
+         /*expect_fold=*/false,
+         /*expected_stop_vals=*/{}},
+        // Negative: live `Less` lhs has a negative value (legitimate `size=-1` cascade) → keep.
+        {"less_with_neg_size_keeps_cascade",
+         PartialShape{1, 128, 8, 256},
+         CascadeCase::CondForm::LiveLess,
+         /*bool_cond_vals=*/{},
+         /*less_rhs_val=*/0,
+         /*start_vals=*/{0, 0, 0, 0},
+         /*size_vals=*/{1, 128, 4, -1},
+         /*size_is_parameter=*/false,
+         /*expect_fold=*/false,
+         /*expected_stop_vals=*/{}},
+        // Negative: pre-folded condition is mixed → not all-false → keep.
+        {"mixed_condition_keeps_cascade",
+         PartialShape{1, 128, 8, 256},
+         CascadeCase::CondForm::BoolConstant,
+         /*bool_cond_vals=*/{false, false, false, true},
+         /*less_rhs_val=*/0,
+         /*start_vals=*/{0, 0, 0, 0},
+         /*size_vals=*/{1, 128, 4, 128},
+         /*size_is_parameter=*/false,
+         /*expect_fold=*/false,
+         /*expected_stop_vals=*/{}},
+        // Negative: Add's size operand is a Parameter, not a Constant → cannot synthesise stop → keep.
+        {"non_constant_add_input_keeps_cascade",
+         PartialShape{1, 128, 8, 256},
+         CascadeCase::CondForm::BoolConstant,
+         /*bool_cond_vals=*/{false, false, false, false},
+         /*less_rhs_val=*/0,
+         /*start_vals=*/{0, 0, 0, 0},
+         /*size_vals=*/{1, 128, 4, 128},
+         /*size_is_parameter=*/true,
+         /*expect_fold=*/false,
+         /*expected_stop_vals=*/{}},
+    }),
+    [](const testing::TestParamInfo<CascadeCase>& info) {
+        return info.param.name;
+    });
 
-    pass::Manager manager;
-    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
-    manager.run_passes(model);
-
-    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
-}
-
-// Negative case: a Less whose lhs has a negative value (the legitimate `size=-1`
-// cascade path) must not be folded — matcher must not fire.
-TEST(EliminateGratuitousSliceCascade, less_with_neg_size_keeps_cascade) {
-    auto data = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 128, 8, 256});
-    auto start_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{0, 0, 0, 0});
-    auto size_const = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 128, 4, -1});
-    auto zero_scalar = op::v0::Constant::create(element::i32, Shape{}, std::vector<int32_t>{0});
-    auto less = std::make_shared<op::v1::Less>(size_const, zero_scalar);
-    auto shape_of = std::make_shared<op::v3::ShapeOf>(data);
-    auto cvtlike = std::make_shared<op::v1::ConvertLike>(shape_of, size_const);
-    auto add = std::make_shared<op::v1::Add>(start_const, size_const);
-    auto select = std::make_shared<op::v1::Select>(less, cvtlike, add);
-    auto step = op::v0::Constant::create(element::i32, Shape{4}, std::vector<int32_t>{1, 1, 1, 1});
-    auto slice = std::make_shared<op::v8::Slice>(data, start_const, select, step);
-    auto model = std::make_shared<Model>(OutputVector{slice}, ParameterVector{data});
-
-    pass::Manager manager;
-    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
-    manager.run_passes(model);
-
-    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
-}
-
-// Negative case A: condition is mixed (some true, some false). The original Less mask
-// would not be all-false, so the rewrite is algebraically invalid — matcher must NOT fire.
-TEST(EliminateGratuitousSliceCascade, mixed_condition_keeps_cascade) {
-    auto model = build_slice_cascade_model(/*input_shape=*/PartialShape{1, 128, 8, 256},
-                                           /*start=*/{0, 0, 0, 0},
-                                           /*size=*/{1, 128, 4, 128},
-                                           /*cond=*/{false, false, false, true});
-
-    pass::Manager manager;
-    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
-    manager.run_passes(model);
-
-    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
-}
-
-// Negative case B: Add's inputs are not both Constants (size is a Parameter here). The
-// matcher cannot synthesise a literal stop Constant, so it must NOT fire — Select stays.
-TEST(EliminateGratuitousSliceCascade, non_constant_add_input_keeps_cascade) {
-    auto model = build_slice_cascade_model(/*input_shape=*/PartialShape{1, 128, 8, 256},
-                                           /*start=*/{0, 0, 0, 0},
-                                           /*size=*/{1, 128, 4, 128},
-                                           /*cond=*/{false, false, false, false},
-                                           /*add_inputs_constant=*/false);
-
-    pass::Manager manager;
-    manager.register_pass<pass::EliminateGratuitousSliceCascade>();
-    manager.run_passes(model);
-
-    EXPECT_EQ(count_ops_of_type<op::v1::Select>(model), 1);
-}
-
-// Negative case C: A generic Select whose then-branch isn't ConvertLike(ShapeOf(...)) — the
-// matcher's pattern is intentionally narrow and must not touch unrelated Select nodes.
+// A generic Select whose then-branch isn't ConvertLike(ShapeOf(...)) — the matcher's pattern is
+// intentionally narrow and must not touch unrelated Select nodes. Kept as a standalone test
+// because the topology is fundamentally different from the cascade cases above.
 TEST(EliminateGratuitousSliceCascade, unrelated_select_pattern_is_preserved) {
     auto x = std::make_shared<op::v0::Parameter>(element::i32, Shape{4});
     auto y = std::make_shared<op::v0::Parameter>(element::i32, Shape{4});

--- a/src/frontends/tensorflow/src/frontend.cpp
+++ b/src/frontends/tensorflow/src/frontend.cpp
@@ -28,6 +28,7 @@
 #include "openvino/util/file_util.hpp"
 #include "openvino/util/log.hpp"
 #include "tf_framework_node.hpp"
+#include "transformations/common_optimizations/eliminate_gratuitous_slice_cascade.hpp"
 #include "transformations/common_optimizations/eliminate_loop_inputs_outputs.hpp"
 #include "transformations/common_optimizations/remove_concat_zero_dim_input.hpp"
 #include "transformations/common_optimizations/reverse_shape_and_type_infer.hpp"
@@ -427,6 +428,7 @@ void FrontEnd::normalize(const std::shared_ptr<ov::Model>& model) const {
     manager.register_pass<ov::pass::UnrollIf>();
     manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     manager.register_pass<ov::pass::TransposeSinkingGeneral>();
+    manager.register_pass<ov::pass::EliminateGratuitousSliceCascade>();
     manager.register_pass<ov::pass::ReverseShapeAndTypeInfer>();
     manager.register_pass<ov::pass::ResolveNameCollisions>(true);
     manager.run_passes(model);

--- a/src/frontends/tensorflow_lite/src/frontend.cpp
+++ b/src/frontends/tensorflow_lite/src/frontend.cpp
@@ -16,6 +16,7 @@
 #include "tf_framework_node.hpp"
 #include "tflite_transformations/rfft2d_complex_abs.h"
 #include "tflite_transformations/tflite_quantize_resolver.hpp"
+#include "transformations/common_optimizations/eliminate_gratuitous_slice_cascade.hpp"
 #include "transformations/common_optimizations/transpose_sinking.hpp"
 #include "transformations/fp16_compression/mark_decompression_convert_constant_folding.hpp"
 #include "transformations/resolve_names_collisions.hpp"
@@ -278,6 +279,7 @@ void FrontEnd::normalize(const std::shared_ptr<ov::Model>& function) const {
     manager.register_pass<ov::frontend::tensorflow_lite::pass::Rfft2dSimplifier>();
     manager.register_pass<ov::pass::TransposeSinking>();
     manager.register_pass<ov::pass::TransposeSinkingGeneral>();
+    manager.register_pass<ov::pass::EliminateGratuitousSliceCascade>();
     manager.register_pass<ov::pass::ResolveNameCollisions>(true);
     manager.run_passes(function);
 }


### PR DESCRIPTION
### Details:
The TF/TFLite Slice translator (`translate_slice_op`) unconditionally builds a
`Select(Less(size, 0), ConvertLike(ShapeOf(input)), Add(start, size))` cascade
as Slice's `stop` input, even when `start` and `size` are statically known
non-negative Constants. After `read_model`, the cascade survives the
frontend's `normalize()` pipeline: TransposeSinking's inner ConstantFolding
runs under `DisableShapeOfConstantFolding` markers, so it folds `Less` to
`Constant<bool>(false)` but leaves ShapeOf / ConvertLike / Select alive. The
Slice output stays dynamic, and any consumer that needs a static shape (e.g.
NPUW partitioning calling `to_shape()`) throws. `convert_model` does not hit
this because MOC's `SelectWithOneValueCondition` + ConstantFolding remove the
cascade later.

This PR adds `ov::pass::EliminateGratuitousSliceCascade`, a narrow MatcherPass
in `common_optimizations` that recognises the cascade above and replaces the
Select with a single Constant carrying the literal `start + size` values
when:

- the condition reduces to all-false (either as a pre-folded `Constant<bool>`
  or as a live `Less(size_const, zero_const)` with non-negative `size_const`),
  and
- both `Add` inputs are Constants.

Emitting a Constant (rather than just `Add(C, C)`) makes the downstream Slice
statically inferable without relying on a follow-up ConstantFolding pass.

The matcher is registered in TF and TFLite frontends' `normalize()`
pipelines, immediately after `TransposeSinkingGeneral`. It leaves alone:
unrelated Select-with-Constant-condition patterns, the legitimate `size=-1`
("to end") cascade with mixed-sign Less mask, and genuinely dynamic Slice
shapes (e.g. KV-cache slicing on a runtime sequence length).

### Tickets:
 - 176224
