### PR TITLE
[CPU][ARM] ACL-specific int8 AvgPool cases handling

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -714,7 +714,24 @@ void Pooling::initSupportedPrimitiveDescriptors() {
         };
 
         pushDesc(LayoutType::ncsp);
-        pushDesc(LayoutType::nspc);
+        const bool hasIncludePadding = !poolingAttrs.exclude_pad &&
+                                       (poolingAttrs.auto_pad ||
+                                        std::any_of(poolingAttrs.data_pad_begin.cbegin(),
+                                                    poolingAttrs.data_pad_begin.cend(),
+                                                    [](ptrdiff_t value) {
+                                                        return value != 0;
+                                                    }) ||
+                                        std::any_of(poolingAttrs.data_pad_end.cbegin(),
+                                                    poolingAttrs.data_pad_end.cend(),
+                                                    [](ptrdiff_t value) {
+                                                        return value != 0;
+                                                    }));
+        // Keep fused AvgPool+FQ on ncsp only for ACL NHWC quantized AvgPool include-padding cases.
+        const bool forceNcspAclDesc = algorithm == Algorithm::PoolingAvg && isFusedWith(Type::FakeQuantize) &&
+                                      hasIncludePadding;
+        if (!forceNcspAclDesc) {
+            pushDesc(LayoutType::nspc);
+        }
 
         return;
     }

--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -714,23 +714,7 @@ void Pooling::initSupportedPrimitiveDescriptors() {
         };
 
         pushDesc(LayoutType::ncsp);
-        const bool hasIncludePadding =
-            !poolingAttrs.exclude_pad &&
-            (poolingAttrs.auto_pad ||
-             std::any_of(poolingAttrs.data_pad_begin.cbegin(),
-                         poolingAttrs.data_pad_begin.cend(),
-                         [](ptrdiff_t value) {
-                             return value != 0;
-                         }) ||
-             std::any_of(poolingAttrs.data_pad_end.cbegin(), poolingAttrs.data_pad_end.cend(), [](ptrdiff_t value) {
-                 return value != 0;
-             }));
-        // Keep fused AvgPool+FQ on ncsp only for ACL NHWC quantized AvgPool include-padding cases.
-        const bool forceNcspAclDesc =
-            algorithm == Algorithm::PoolingAvg && isFusedWith(Type::FakeQuantize) && hasIncludePadding;
-        if (!forceNcspAclDesc) {
-            pushDesc(LayoutType::nspc);
-        }
+        pushDesc(LayoutType::nspc);
 
         return;
     }

--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -714,21 +714,20 @@ void Pooling::initSupportedPrimitiveDescriptors() {
         };
 
         pushDesc(LayoutType::ncsp);
-        const bool hasIncludePadding = !poolingAttrs.exclude_pad &&
-                                       (poolingAttrs.auto_pad ||
-                                        std::any_of(poolingAttrs.data_pad_begin.cbegin(),
-                                                    poolingAttrs.data_pad_begin.cend(),
-                                                    [](ptrdiff_t value) {
-                                                        return value != 0;
-                                                    }) ||
-                                        std::any_of(poolingAttrs.data_pad_end.cbegin(),
-                                                    poolingAttrs.data_pad_end.cend(),
-                                                    [](ptrdiff_t value) {
-                                                        return value != 0;
-                                                    }));
+        const bool hasIncludePadding =
+            !poolingAttrs.exclude_pad &&
+            (poolingAttrs.auto_pad ||
+             std::any_of(poolingAttrs.data_pad_begin.cbegin(),
+                         poolingAttrs.data_pad_begin.cend(),
+                         [](ptrdiff_t value) {
+                             return value != 0;
+                         }) ||
+             std::any_of(poolingAttrs.data_pad_end.cbegin(), poolingAttrs.data_pad_end.cend(), [](ptrdiff_t value) {
+                 return value != 0;
+             }));
         // Keep fused AvgPool+FQ on ncsp only for ACL NHWC quantized AvgPool include-padding cases.
-        const bool forceNcspAclDesc = algorithm == Algorithm::PoolingAvg && isFusedWith(Type::FakeQuantize) &&
-                                      hasIncludePadding;
+        const bool forceNcspAclDesc =
+            algorithm == Algorithm::PoolingAvg && isFusedWith(Type::FakeQuantize) && hasIncludePadding;
         if (!forceNcspAclDesc) {
             pushDesc(LayoutType::nspc);
         }

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <memory>
 #include <set>
 #include <vector>
@@ -134,10 +135,12 @@
 
 // LPT transformations
 #include "low_precision/add.hpp"
+#include "low_precision/avg_pool.hpp"
 #include "low_precision/convert_subtract_constant.hpp"
 #include "low_precision/low_precision.hpp"
 #include "low_precision/multiply_to_group_convolution.hpp"
 #include "low_precision/network_helper.hpp"
+#include "low_precision/resolve_precision_attribute.hpp"
 #include "low_precision/rt_info/bias_attribute.hpp"
 #include "transformations/low_precision/mark_dequantization_subgraph.hpp"
 
@@ -249,6 +252,10 @@
 #    include "transformations/cpu_opset/common/op/sdpa.hpp"
 #    include "transformations/cpu_opset/common/pass/decompose_integer_divide.hpp"
 #    include "transformations/utils.hpp"
+#    if defined(OV_CPU_WITH_ACL)
+#        include "nodes/executors/acl/acl_pooling.hpp"
+#        include "nodes/executors/acl/acl_utils.hpp"
+#    endif
 #else
 #    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "openvino/op/gru_sequence.hpp"
@@ -282,6 +289,123 @@
 namespace ov::intel_cpu {
 
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
+
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+namespace {
+
+#if defined(OV_CPU_WITH_ACL)
+void copy_pool_attributes(std::vector<ptrdiff_t>& internal_attribute, const std::vector<size_t>& external_attribute) {
+    for (const auto attribute : external_attribute) {
+        internal_attribute.push_back(static_cast<ptrdiff_t>(attribute));
+    }
+}
+
+std::optional<PoolingAttrs> get_avg_pooling_attrs(const std::shared_ptr<const ov::Node>& node) {
+    const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
+    if (!avg_pool) {
+        return std::nullopt;
+    }
+
+    PoolingAttrs pooling_attrs;
+    pooling_attrs.algorithm = Algorithm::PoolingAvg;
+    pooling_attrs.exclude_pad = avg_pool->get_exclude_pad();
+    pooling_attrs.rounding = avg_pool->get_rounding_type();
+    copy_pool_attributes(pooling_attrs.kernel, avg_pool->get_kernel());
+    copy_pool_attributes(pooling_attrs.stride, avg_pool->get_strides());
+    if (const auto avg_pool_v16 = ov::as_type_ptr<const ov::op::v16::AvgPool>(node)) {
+        copy_pool_attributes(pooling_attrs.dilation, avg_pool_v16->get_dilations());
+    } else {
+        pooling_attrs.dilation.resize(pooling_attrs.kernel.size(), 1);
+    }
+    copy_pool_attributes(pooling_attrs.data_pad_begin, avg_pool->get_pads_begin());
+    copy_pool_attributes(pooling_attrs.data_pad_end, avg_pool->get_pads_end());
+    pooling_attrs.auto_pad = any_of(avg_pool->get_auto_pad(), ov::op::PadType::SAME_LOWER, ov::op::PadType::SAME_UPPER);
+    return pooling_attrs;
+}
+
+bool is_acl_supported_int8_avg_pool_fq_chain(const std::shared_ptr<const ov::Node>& avg_pool,
+                                             const std::shared_ptr<ov::op::v0::FakeQuantize>& fq,
+                                             const std::vector<ov::element::Type>& defaultPrecisions) {
+    if (!avg_pool || !fq || avg_pool->get_input_partial_shape(0).is_dynamic() || avg_pool->get_output_partial_shape(0).is_dynamic()) {
+        return false;
+    }
+
+    const auto pooling_attrs = get_avg_pooling_attrs(avg_pool);
+    if (!pooling_attrs) {
+        return false;
+    }
+
+    const auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantization(avg_pool, defaultPrecisions);
+    if (dequantization.empty() || !any_of(dequantization.data.get_element_type(), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
+        return false;
+    }
+
+    const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);
+    if (resolved_precision.empty() || !any_of(resolved_precision.precision, ov::element::Type_t::u8, ov::element::Type_t::i8)) {
+        return false;
+    }
+
+    const auto& input_shape = avg_pool->get_input_shape(0);
+    const auto& output_shape = avg_pool->get_output_shape(0);
+    if (input_shape.size() == 5U) {
+        return false;
+    }
+
+    constexpr auto data_layout = arm_compute::DataLayout::NCHW;
+    arm_compute::TensorInfo src_tensor_info(shapeCast(input_shape),
+                                            1,
+                                            convertToQuantizedType(precisionToAclDataType(dequantization.data.get_element_type())),
+                                            data_layout);
+    arm_compute::TensorInfo dst_tensor_info(shapeCast(output_shape),
+                                            1,
+                                            convertToQuantizedType(precisionToAclDataType(resolved_precision.precision)),
+                                            data_layout);
+
+    arm_compute::PoolingLayerInfo pool_info;
+    return AclPoolingExecutor::isSupported(src_tensor_info,
+                                           dst_tensor_info,
+                                           *pooling_attrs,
+                                           input_shape.size(),
+                                           1,
+                                           data_layout,
+                                           nullptr,
+                                           &pool_info,
+                                           nullptr,
+                                           false);
+}
+#endif
+
+bool should_skip_avg_pool_transformation_on_arm(const const_node_ptr& node,
+                                                [[maybe_unused]] const std::vector<ov::element::Type>& defaultPrecisions) {
+    const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
+    if (!avg_pool) {
+        return false;
+    }
+
+#if defined(OV_CPU_WITH_ACL)
+    for (const auto& consumer : avg_pool->output(0).get_target_inputs()) {
+        const auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(consumer.get_node()->shared_from_this());
+        if (!fq) {
+            continue;
+        }
+
+        const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);
+        if (resolved_precision.empty() ||
+            !any_of(resolved_precision.precision, ov::element::Type_t::u8, ov::element::Type_t::i8)) {
+            continue;
+        }
+
+        if (!is_acl_supported_int8_avg_pool_fq_chain(avg_pool, fq, defaultPrecisions)) {
+            return true;
+        }
+    }
+#endif
+
+    return false;
+}
+
+}  // namespace
+#endif
 
 bool Transformations::is_decompression_multiply(const_node_ptr& node) {
     auto is_1x1_conv = [](const ov::Node* node) {
@@ -980,6 +1104,12 @@ void Transformations::runLptPasses(const std::vector<ov::element::Type>& default
             return ov::marked_as_bias(node);
         },
         AddTransformation);
+    CPU_SET_CALLBACK_ARM(
+        lptManager,
+        [&defaultPrecisions](const_node_ptr& node) -> bool {
+            return should_skip_avg_pool_transformation_on_arm(node, defaultPrecisions);
+        },
+        AvgPoolTransformation);
     CPU_SET_CALLBACK_ARM(
         lptManager,
         [](const_node_ptr& node) -> bool {

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -139,7 +139,6 @@
 #include "low_precision/low_precision.hpp"
 #include "low_precision/multiply_to_group_convolution.hpp"
 #include "low_precision/network_helper.hpp"
-#include "low_precision/resolve_precision_attribute.hpp"
 #include "low_precision/rt_info/bias_attribute.hpp"
 #include "transformations/low_precision/mark_dequantization_subgraph.hpp"
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -285,77 +285,6 @@ namespace ov::intel_cpu {
 
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
 
-#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
-namespace {
-
-bool is_acl_supported_int8_avg_pool_fq_chain(const std::shared_ptr<const ov::Node>& avg_pool,
-                                             const std::shared_ptr<ov::op::v0::FakeQuantize>& fq,
-                                             const std::vector<ov::element::Type>& defaultPrecisions) {
-    if (!avg_pool || !fq) {
-        return false;
-    }
-
-    const auto avg_pool_base = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(avg_pool);
-    if (!avg_pool_base) {
-        return false;
-    }
-
-    const auto& input_pshape = avg_pool->get_input_partial_shape(0);
-    if (input_pshape.is_dynamic() || input_pshape.rank().get_length() == 5) {
-        return false;
-    }
-
-    const auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantization(avg_pool, defaultPrecisions);
-    if (dequantization.empty() || !any_of(dequantization.data.get_element_type(), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
-        return false;
-    }
-
-    const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);
-    if (resolved_precision.empty()) {
-        return false;
-    }
-
-    // ACL rejects NCHW AvgPool with CEIL rounding in the executor wrapper.
-    if (avg_pool_base->get_rounding_type() == op::RoundingType::CEIL) {
-        return false;
-    }
-
-    // CpuPool2dKernel::validate_arguments() requires matching src/dst data types.
-    return dequantization.data.get_element_type() == resolved_precision.precision;
-}
-
-bool should_skip_avg_pool_transformation_on_arm(const const_node_ptr& node,
-                                                [[maybe_unused]] const std::vector<ov::element::Type>& defaultPrecisions) {
-    const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
-    if (!avg_pool) {
-        return false;
-    }
-
-#if defined(OV_CPU_WITH_ACL)
-    for (const auto& consumer : avg_pool->output(0).get_target_inputs()) {
-        const auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(consumer.get_node()->shared_from_this());
-        if (!fq) {
-            continue;
-        }
-
-        const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);
-        if (resolved_precision.empty() ||
-            !any_of(resolved_precision.precision, ov::element::Type_t::u8, ov::element::Type_t::i8)) {
-            continue;
-        }
-
-        if (!is_acl_supported_int8_avg_pool_fq_chain(avg_pool, fq, defaultPrecisions)) {
-            return true;
-        }
-    }
-#endif
-
-    return false;
-}
-
-}  // namespace
-#endif
-
 bool Transformations::is_decompression_multiply(const_node_ptr& node) {
     auto is_1x1_conv = [](const ov::Node* node) {
         const auto* conv = ov::as_type<const ov::op::v1::Convolution>(node);
@@ -1056,7 +985,7 @@ void Transformations::runLptPasses(const std::vector<ov::element::Type>& default
     CPU_SET_CALLBACK_ARM(
         lptManager,
         [&defaultPrecisions](const_node_ptr& node) -> bool {
-            return should_skip_avg_pool_transformation_on_arm(node, defaultPrecisions);
+            return is_acl_supported_int8_avg_pool(node, defaultPrecisions);
         },
         AvgPoolTransformation);
     CPU_SET_CALLBACK_ARM(

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <optional>
 #include <memory>
 #include <set>
 #include <vector>
@@ -252,10 +251,6 @@
 #    include "transformations/cpu_opset/common/op/sdpa.hpp"
 #    include "transformations/cpu_opset/common/pass/decompose_integer_divide.hpp"
 #    include "transformations/utils.hpp"
-#    if defined(OV_CPU_WITH_ACL)
-#        include "nodes/executors/acl/acl_pooling.hpp"
-#        include "nodes/executors/acl/acl_utils.hpp"
-#    endif
 #else
 #    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "openvino/op/gru_sequence.hpp"
@@ -293,45 +288,20 @@ using const_node_ptr = const std::shared_ptr<const ov::Node>;
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 namespace {
 
-#if defined(OV_CPU_WITH_ACL)
-void copy_pool_attributes(std::vector<ptrdiff_t>& internal_attribute, const std::vector<size_t>& external_attribute) {
-    for (const auto attribute : external_attribute) {
-        internal_attribute.push_back(static_cast<ptrdiff_t>(attribute));
-    }
-}
-
-std::optional<PoolingAttrs> get_avg_pooling_attrs(const std::shared_ptr<const ov::Node>& node) {
-    const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
-    if (!avg_pool) {
-        return std::nullopt;
-    }
-
-    PoolingAttrs pooling_attrs;
-    pooling_attrs.algorithm = Algorithm::PoolingAvg;
-    pooling_attrs.exclude_pad = avg_pool->get_exclude_pad();
-    pooling_attrs.rounding = avg_pool->get_rounding_type();
-    copy_pool_attributes(pooling_attrs.kernel, avg_pool->get_kernel());
-    copy_pool_attributes(pooling_attrs.stride, avg_pool->get_strides());
-    if (const auto avg_pool_v16 = ov::as_type_ptr<const ov::op::v16::AvgPool>(node)) {
-        copy_pool_attributes(pooling_attrs.dilation, avg_pool_v16->get_dilations());
-    } else {
-        pooling_attrs.dilation.resize(pooling_attrs.kernel.size(), 1);
-    }
-    copy_pool_attributes(pooling_attrs.data_pad_begin, avg_pool->get_pads_begin());
-    copy_pool_attributes(pooling_attrs.data_pad_end, avg_pool->get_pads_end());
-    pooling_attrs.auto_pad = any_of(avg_pool->get_auto_pad(), ov::op::PadType::SAME_LOWER, ov::op::PadType::SAME_UPPER);
-    return pooling_attrs;
-}
-
 bool is_acl_supported_int8_avg_pool_fq_chain(const std::shared_ptr<const ov::Node>& avg_pool,
                                              const std::shared_ptr<ov::op::v0::FakeQuantize>& fq,
                                              const std::vector<ov::element::Type>& defaultPrecisions) {
-    if (!avg_pool || !fq || avg_pool->get_input_partial_shape(0).is_dynamic() || avg_pool->get_output_partial_shape(0).is_dynamic()) {
+    if (!avg_pool || !fq) {
         return false;
     }
 
-    const auto pooling_attrs = get_avg_pooling_attrs(avg_pool);
-    if (!pooling_attrs) {
+    const auto avg_pool_base = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(avg_pool);
+    if (!avg_pool_base) {
+        return false;
+    }
+
+    const auto& input_pshape = avg_pool->get_input_partial_shape(0);
+    if (input_pshape.is_dynamic() || input_pshape.rank().get_length() == 5) {
         return false;
     }
 
@@ -341,39 +311,18 @@ bool is_acl_supported_int8_avg_pool_fq_chain(const std::shared_ptr<const ov::Nod
     }
 
     const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);
-    if (resolved_precision.empty() || !any_of(resolved_precision.precision, ov::element::Type_t::u8, ov::element::Type_t::i8)) {
+    if (resolved_precision.empty()) {
         return false;
     }
 
-    const auto& input_shape = avg_pool->get_input_shape(0);
-    const auto& output_shape = avg_pool->get_output_shape(0);
-    if (input_shape.size() == 5U) {
+    // ACL rejects NCHW AvgPool with CEIL rounding in the executor wrapper.
+    if (avg_pool_base->get_rounding_type() == op::RoundingType::CEIL) {
         return false;
     }
 
-    constexpr auto data_layout = arm_compute::DataLayout::NCHW;
-    arm_compute::TensorInfo src_tensor_info(shapeCast(input_shape),
-                                            1,
-                                            convertToQuantizedType(precisionToAclDataType(dequantization.data.get_element_type())),
-                                            data_layout);
-    arm_compute::TensorInfo dst_tensor_info(shapeCast(output_shape),
-                                            1,
-                                            convertToQuantizedType(precisionToAclDataType(resolved_precision.precision)),
-                                            data_layout);
-
-    arm_compute::PoolingLayerInfo pool_info;
-    return AclPoolingExecutor::isSupported(src_tensor_info,
-                                           dst_tensor_info,
-                                           *pooling_attrs,
-                                           input_shape.size(),
-                                           1,
-                                           data_layout,
-                                           nullptr,
-                                           &pool_info,
-                                           nullptr,
-                                           false);
+    // CpuPool2dKernel::validate_arguments() requires matching src/dst data types.
+    return dequantization.data.get_element_type() == resolved_precision.precision;
 }
-#endif
 
 bool should_skip_avg_pool_transformation_on_arm(const const_node_ptr& node,
                                                 [[maybe_unused]] const std::vector<ov::element::Type>& defaultPrecisions) {

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -984,7 +984,7 @@ void Transformations::runLptPasses(const std::vector<ov::element::Type>& default
     CPU_SET_CALLBACK_ARM(
         lptManager,
         [&defaultPrecisions](const_node_ptr& node) -> bool {
-            return is_acl_supported_int8_avg_pool(node, defaultPrecisions);
+            return is_acl_int8_avg_pool_lpt_skipped(node, defaultPrecisions);
         },
         AvgPoolTransformation);
     CPU_SET_CALLBACK_ARM(

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -134,7 +134,6 @@
 
 // LPT transformations
 #include "low_precision/add.hpp"
-#include "low_precision/avg_pool.hpp"
 #include "low_precision/convert_subtract_constant.hpp"
 #include "low_precision/low_precision.hpp"
 #include "low_precision/multiply_to_group_convolution.hpp"
@@ -222,6 +221,7 @@
 #endif
 
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+#    include "low_precision/avg_pool.hpp"
 #    include "low_precision/convolution.hpp"
 #    include "low_precision/convolution_backprop_data.hpp"
 #    include "low_precision/fake_quantize.hpp"

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -6,14 +6,20 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <memory>
 #include <string>
 #include <vector>
 
+#if defined(OV_CPU_WITH_ACL)
+#    include "nodes/executors/acl/acl_pooling.hpp"
+#    include "nodes/executors/acl/acl_utils.hpp"
+#endif
 #include "openvino/core/node.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/avg_pool.hpp"
 #include "openvino/op/convolution.hpp"
@@ -24,11 +30,139 @@
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 #include "utils/general_utils.h"
 
 using namespace ov::pass::pattern;
 
 namespace ov::intel_cpu {
+
+namespace {
+
+#if defined(OV_CPU_WITH_ACL)
+void copy_pool_attributes(std::vector<ptrdiff_t>& internal_attribute, const std::vector<size_t>& external_attribute) {
+    for (const auto attribute : external_attribute) {
+        internal_attribute.push_back(static_cast<ptrdiff_t>(attribute));
+    }
+}
+
+std::optional<PoolingAttrs> get_avg_pooling_attrs(const std::shared_ptr<const ov::Node>& node) {
+    const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
+    if (!avg_pool) {
+        return std::nullopt;
+    }
+
+    PoolingAttrs pooling_attrs;
+    pooling_attrs.algorithm = Algorithm::PoolingAvg;
+    pooling_attrs.exclude_pad = avg_pool->get_exclude_pad();
+    pooling_attrs.rounding = avg_pool->get_rounding_type();
+    copy_pool_attributes(pooling_attrs.kernel, avg_pool->get_kernel());
+    copy_pool_attributes(pooling_attrs.stride, avg_pool->get_strides());
+    if (const auto avg_pool_v16 = ov::as_type_ptr<const ov::op::v16::AvgPool>(node)) {
+        copy_pool_attributes(pooling_attrs.dilation, avg_pool_v16->get_dilations());
+    } else {
+        pooling_attrs.dilation.resize(pooling_attrs.kernel.size(), 1);
+    }
+    copy_pool_attributes(pooling_attrs.data_pad_begin, avg_pool->get_pads_begin());
+    copy_pool_attributes(pooling_attrs.data_pad_end, avg_pool->get_pads_end());
+    pooling_attrs.auto_pad = any_of(avg_pool->get_auto_pad(), ov::op::PadType::SAME_LOWER, ov::op::PadType::SAME_UPPER);
+    return pooling_attrs;
+}
+
+std::optional<std::pair<std::vector<float>, std::vector<float>>> get_fq_input_quant_params(
+    const std::shared_ptr<const ov::op::v0::FakeQuantize>& fq) {
+    const auto input_low = ov::util::get_constant_from_source(fq->input_value(1));
+    const auto input_high = ov::util::get_constant_from_source(fq->input_value(2));
+    if (!input_low || !input_high) {
+        return std::nullopt;
+    }
+
+    const auto input_low_values = input_low->cast_vector<float>();
+    const auto input_high_values = input_high->cast_vector<float>();
+    if (input_low_values.empty() || input_high_values.empty()) {
+        return std::nullopt;
+    }
+
+    const size_t channels = std::max(input_low_values.size(), input_high_values.size());
+    std::vector<float> input_scale(channels);
+    std::vector<float> input_shift(channels);
+    const float levels = static_cast<float>(fq->get_levels() - 1);
+
+    for (size_t index = 0; index < channels; ++index) {
+        const auto input_low_value = input_low_values[input_low_values.size() == 1 ? 0 : index];
+        const auto input_high_value = input_high_values[input_high_values.size() == 1 ? 0 : index];
+        const auto range = input_high_value - input_low_value;
+        if (range == 0.0f) {
+            return std::nullopt;
+        }
+        input_scale[index] = levels / range;
+        input_shift[index] = -input_low_value * levels / range;
+    }
+
+    return std::make_pair(std::move(input_scale), std::move(input_shift));
+}
+
+bool is_acl_supported_avg_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node) {
+    const auto fq = ov::as_type_ptr<const ov::op::v0::FakeQuantize>(node);
+    if (!fq || fq->get_input_size() == 0) {
+        return false;
+    }
+
+    const auto avg_pool = fq->get_input_node_shared_ptr(0);
+    if (!avg_pool || avg_pool->get_input_partial_shape(0).is_dynamic() || avg_pool->get_output_partial_shape(0).is_dynamic()) {
+        return false;
+    }
+
+    const auto pooling_attrs = get_avg_pooling_attrs(avg_pool);
+    if (!pooling_attrs) {
+        return false;
+    }
+
+    const auto& input_shape = avg_pool->get_input_shape(0);
+    const auto& output_shape = avg_pool->get_output_shape(0);
+    if (input_shape.size() == 5U) {
+        // Pooling::getSupportedDescriptors() still forces 5D pooling away from ACL.
+        return false;
+    }
+
+    arm_compute::DataLayout data_layout =
+        (input_shape.size() == 5U) ? arm_compute::DataLayout::NDHWC : arm_compute::DataLayout::NCHW;
+    arm_compute::TensorInfo src_tensor_info(shapeCast(input_shape),
+                                            1,
+                                            convertToQuantizedType(precisionToAclDataType(avg_pool->get_input_element_type(0))),
+                                            data_layout);
+    arm_compute::TensorInfo dst_tensor_info(shapeCast(output_shape),
+                                            1,
+                                            convertToQuantizedType(precisionToAclDataType(node->get_output_element_type(0))),
+                                            data_layout);
+
+    if (any_of(avg_pool->get_input_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8) ||
+        any_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
+        const auto fq_quant_params = get_fq_input_quant_params(fq);
+        if (!fq_quant_params) {
+            return false;
+        }
+
+        src_tensor_info.set_quantization_info(arm_compute::QuantizationInfo(1.0F));
+        dst_tensor_info.set_quantization_info(
+            getDstQuantizationInfo(fq_quant_params->first, fq_quant_params->second, node->get_output_element_type(0)));
+    }
+
+    arm_compute::PoolingLayerInfo pool_info;
+    return AclPoolingExecutor::isSupported(src_tensor_info,
+                                           dst_tensor_info,
+                                           *pooling_attrs,
+                                           input_shape.size(),
+                                           1,
+                                           data_layout,
+                                           nullptr,
+                                           &pool_info,
+                                           nullptr,
+                                           false);
+}
+#endif
+
+}  // namespace
 
 bool match_fq_mul_conv_bias_same_types(const std::shared_ptr<const ov::Node>& node, FQMulAddPattern pattern) {
     auto convMulAdd_conv = wrap_type<ov::op::v1::Convolution>();
@@ -72,11 +206,18 @@ bool match_acl_int8_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node
         return false;
     }
 
+    if (!any_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
+        return false;
+    }
+
     const auto pool = node->get_input_node_shared_ptr(0);
     // returns true if Pooling-FQ chain will be fused into int8 pooling and handled by ACL executor
-    return any_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8) &&
-           (ov::is_type_any_of<ov::op::v1::AvgPool, ov::op::v14::AvgPool, ov::op::v16::AvgPool>(pool) ||
-            ov::is_type_any_of<ov::op::v1::MaxPool, ov::op::v8::MaxPool, ov::op::v14::MaxPool>(pool));
+    const bool isMaxPool = ov::is_type_any_of<ov::op::v1::MaxPool, ov::op::v8::MaxPool, ov::op::v14::MaxPool>(pool);
+#if defined(OV_CPU_WITH_ACL)
+    return isMaxPool || is_acl_supported_avg_pooling_fq_chain(node);
+#else
+    return isMaxPool;
+#endif
 }
 
 bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node) {

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -6,11 +6,13 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <optional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "low_precision/network_helper.hpp"
+#include "low_precision/resolve_precision_attribute.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
@@ -26,18 +28,12 @@
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
-#include "low_precision/network_helper.hpp"
-#include "low_precision/resolve_precision_attribute.hpp"
 #include "transformations/utils/utils.hpp"
 #include "utils/general_utils.h"
 
 using namespace ov::pass::pattern;
 
 namespace ov::intel_cpu {
-
-namespace {
-
-}  // namespace
 
 bool match_fq_mul_conv_bias_same_types(const std::shared_ptr<const ov::Node>& node, FQMulAddPattern pattern) {
     auto convMulAdd_conv = wrap_type<ov::op::v1::Convolution>();
@@ -100,7 +96,7 @@ bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node) {
 }
 
 bool is_acl_supported_int8_avg_pool(const std::shared_ptr<const ov::Node>& node,
-                                                const std::vector<ov::element::Type>& defaultPrecisions) {
+                                    const std::vector<ov::element::Type>& defaultPrecisions) {
     const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
     if (!avg_pool) {
         return false;

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -5,6 +5,10 @@
 #include "utils.hpp"
 
 #include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "low_precision/network_helper.hpp"
 #include "low_precision/resolve_precision_attribute.hpp"
@@ -18,8 +22,8 @@
 #include "openvino/op/fake_quantize.hpp"
 #include "openvino/op/max_pool.hpp"
 #include "openvino/op/multiply.hpp"
-#include "openvino/op/util/avg_pool_base.hpp"
 #include "openvino/op/util/attr_types.hpp"
+#include "openvino/op/util/avg_pool_base.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
@@ -125,12 +129,12 @@ bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& nod
 
     const auto& consumers = avg_pool->output(0).get_target_inputs();
     if (consumers.size() != 1) {
-        return false;
+        return true;
     }
 
     const auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(consumers.begin()->get_node()->shared_from_this());
     if (!fq) {
-        return false;
+        return true;
     }
 
     const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -5,11 +5,6 @@
 #include "utils.hpp"
 
 #include <cstddef>
-#include <cstdint>
-#include <memory>
-#include <optional>
-#include <string>
-#include <vector>
 
 #include "low_precision/network_helper.hpp"
 #include "low_precision/resolve_precision_attribute.hpp"
@@ -23,12 +18,12 @@
 #include "openvino/op/fake_quantize.hpp"
 #include "openvino/op/max_pool.hpp"
 #include "openvino/op/multiply.hpp"
+#include "openvino/op/util/avg_pool_base.hpp"
 #include "openvino/op/util/attr_types.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
-#include "transformations/utils/utils.hpp"
 #include "utils/general_utils.h"
 
 using namespace ov::pass::pattern;

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -11,15 +11,10 @@
 #include <string>
 #include <vector>
 
-#if defined(OV_CPU_WITH_ACL)
-#    include "nodes/executors/acl/acl_pooling.hpp"
-#    include "nodes/executors/acl/acl_utils.hpp"
-#endif
 #include "openvino/core/node.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
-#include "openvino/core/validation_util.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/avg_pool.hpp"
 #include "openvino/op/convolution.hpp"
@@ -38,129 +33,6 @@ using namespace ov::pass::pattern;
 namespace ov::intel_cpu {
 
 namespace {
-
-#if defined(OV_CPU_WITH_ACL)
-void copy_pool_attributes(std::vector<ptrdiff_t>& internal_attribute, const std::vector<size_t>& external_attribute) {
-    for (const auto attribute : external_attribute) {
-        internal_attribute.push_back(static_cast<ptrdiff_t>(attribute));
-    }
-}
-
-std::optional<PoolingAttrs> get_avg_pooling_attrs(const std::shared_ptr<const ov::Node>& node) {
-    const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
-    if (!avg_pool) {
-        return std::nullopt;
-    }
-
-    PoolingAttrs pooling_attrs;
-    pooling_attrs.algorithm = Algorithm::PoolingAvg;
-    pooling_attrs.exclude_pad = avg_pool->get_exclude_pad();
-    pooling_attrs.rounding = avg_pool->get_rounding_type();
-    copy_pool_attributes(pooling_attrs.kernel, avg_pool->get_kernel());
-    copy_pool_attributes(pooling_attrs.stride, avg_pool->get_strides());
-    if (const auto avg_pool_v16 = ov::as_type_ptr<const ov::op::v16::AvgPool>(node)) {
-        copy_pool_attributes(pooling_attrs.dilation, avg_pool_v16->get_dilations());
-    } else {
-        pooling_attrs.dilation.resize(pooling_attrs.kernel.size(), 1);
-    }
-    copy_pool_attributes(pooling_attrs.data_pad_begin, avg_pool->get_pads_begin());
-    copy_pool_attributes(pooling_attrs.data_pad_end, avg_pool->get_pads_end());
-    pooling_attrs.auto_pad = any_of(avg_pool->get_auto_pad(), ov::op::PadType::SAME_LOWER, ov::op::PadType::SAME_UPPER);
-    return pooling_attrs;
-}
-
-std::optional<std::pair<std::vector<float>, std::vector<float>>> get_fq_input_quant_params(
-    const std::shared_ptr<const ov::op::v0::FakeQuantize>& fq) {
-    const auto input_low = ov::util::get_constant_from_source(fq->input_value(1));
-    const auto input_high = ov::util::get_constant_from_source(fq->input_value(2));
-    if (!input_low || !input_high) {
-        return std::nullopt;
-    }
-
-    const auto input_low_values = input_low->cast_vector<float>();
-    const auto input_high_values = input_high->cast_vector<float>();
-    if (input_low_values.empty() || input_high_values.empty()) {
-        return std::nullopt;
-    }
-
-    const size_t channels = std::max(input_low_values.size(), input_high_values.size());
-    std::vector<float> input_scale(channels);
-    std::vector<float> input_shift(channels);
-    const float levels = static_cast<float>(fq->get_levels() - 1);
-
-    for (size_t index = 0; index < channels; ++index) {
-        const auto input_low_value = input_low_values[input_low_values.size() == 1 ? 0 : index];
-        const auto input_high_value = input_high_values[input_high_values.size() == 1 ? 0 : index];
-        const auto range = input_high_value - input_low_value;
-        if (range == 0.0f) {
-            return std::nullopt;
-        }
-        input_scale[index] = levels / range;
-        input_shift[index] = -input_low_value * levels / range;
-    }
-
-    return std::make_pair(std::move(input_scale), std::move(input_shift));
-}
-
-bool is_acl_supported_avg_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node) {
-    const auto fq = ov::as_type_ptr<const ov::op::v0::FakeQuantize>(node);
-    if (!fq || fq->get_input_size() == 0) {
-        return false;
-    }
-
-    const auto avg_pool = fq->get_input_node_shared_ptr(0);
-    if (!avg_pool || avg_pool->get_input_partial_shape(0).is_dynamic() || avg_pool->get_output_partial_shape(0).is_dynamic()) {
-        return false;
-    }
-
-    const auto pooling_attrs = get_avg_pooling_attrs(avg_pool);
-    if (!pooling_attrs) {
-        return false;
-    }
-
-    const auto& input_shape = avg_pool->get_input_shape(0);
-    const auto& output_shape = avg_pool->get_output_shape(0);
-    if (input_shape.size() == 5U) {
-        // Pooling::getSupportedDescriptors() still forces 5D pooling away from ACL.
-        return false;
-    }
-
-    arm_compute::DataLayout data_layout =
-        (input_shape.size() == 5U) ? arm_compute::DataLayout::NDHWC : arm_compute::DataLayout::NCHW;
-    arm_compute::TensorInfo src_tensor_info(shapeCast(input_shape),
-                                            1,
-                                            convertToQuantizedType(precisionToAclDataType(avg_pool->get_input_element_type(0))),
-                                            data_layout);
-    arm_compute::TensorInfo dst_tensor_info(shapeCast(output_shape),
-                                            1,
-                                            convertToQuantizedType(precisionToAclDataType(node->get_output_element_type(0))),
-                                            data_layout);
-
-    if (any_of(avg_pool->get_input_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8) ||
-        any_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
-        const auto fq_quant_params = get_fq_input_quant_params(fq);
-        if (!fq_quant_params) {
-            return false;
-        }
-
-        src_tensor_info.set_quantization_info(arm_compute::QuantizationInfo(1.0F));
-        dst_tensor_info.set_quantization_info(
-            getDstQuantizationInfo(fq_quant_params->first, fq_quant_params->second, node->get_output_element_type(0)));
-    }
-
-    arm_compute::PoolingLayerInfo pool_info;
-    return AclPoolingExecutor::isSupported(src_tensor_info,
-                                           dst_tensor_info,
-                                           *pooling_attrs,
-                                           input_shape.size(),
-                                           1,
-                                           data_layout,
-                                           nullptr,
-                                           &pool_info,
-                                           nullptr,
-                                           false);
-}
-#endif
 
 }  // namespace
 
@@ -206,18 +78,11 @@ bool match_acl_int8_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node
         return false;
     }
 
-    if (!any_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
-        return false;
-    }
-
     const auto pool = node->get_input_node_shared_ptr(0);
     // returns true if Pooling-FQ chain will be fused into int8 pooling and handled by ACL executor
-    const bool isMaxPool = ov::is_type_any_of<ov::op::v1::MaxPool, ov::op::v8::MaxPool, ov::op::v14::MaxPool>(pool);
-#if defined(OV_CPU_WITH_ACL)
-    return isMaxPool || is_acl_supported_avg_pooling_fq_chain(node);
-#else
-    return isMaxPool;
-#endif
+    return any_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8) &&
+           (ov::is_type_any_of<ov::op::v1::AvgPool, ov::op::v14::AvgPool, ov::op::v16::AvgPool>(pool) ||
+            ov::is_type_any_of<ov::op::v1::MaxPool, ov::op::v8::MaxPool, ov::op::v14::MaxPool>(pool));
 }
 
 bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node) {

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -107,24 +107,24 @@ bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& nod
                                       const std::vector<ov::element::Type>& defaultPrecisions) {
     const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
     if (!avg_pool) {
-        return false;
+        return true;
     }
 
     const auto& input_pshape = avg_pool->get_input_partial_shape(0);
     const auto input_rank = input_pshape.rank();
     if (input_rank.is_dynamic() || input_rank.get_length() == 5) {
-        return false;
+        return true;
     }
 
     const auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantization(avg_pool, defaultPrecisions);
     if (dequantization.empty() ||
         !any_of(dequantization.data.get_element_type(), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
-        return false;
+        return true;
     }
 
     // ACL rejects NCHW AvgPool with CEIL rounding in the executor wrapper.
     if (avg_pool->get_rounding_type() == op::RoundingType::CEIL) {
-        return false;
+        return true;
     }
 
     const auto& consumers = avg_pool->output(0).get_target_inputs();

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -78,6 +78,11 @@ bool match_acl_int8_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node
     }
 
     const auto pool = node->get_input_node_shared_ptr(0);
+    const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(pool);
+    if (avg_pool && avg_pool->get_rounding_type() == ov::op::RoundingType::CEIL) {
+        return false;
+    }
+
     // returns true if Pooling-FQ chain will be fused into int8 pooling and handled by ACL executor
     return any_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8) &&
            (ov::is_type_any_of<ov::op::v1::AvgPool, ov::op::v14::AvgPool, ov::op::v16::AvgPool>(pool) ||

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -21,10 +21,13 @@
 #include "openvino/op/fake_quantize.hpp"
 #include "openvino/op/max_pool.hpp"
 #include "openvino/op/multiply.hpp"
+#include "openvino/op/util/attr_types.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "low_precision/network_helper.hpp"
+#include "low_precision/resolve_precision_attribute.hpp"
 #include "transformations/utils/utils.hpp"
 #include "utils/general_utils.h"
 
@@ -94,6 +97,50 @@ bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node) {
     return ov::is_type<const ov::op::v0::FakeQuantize>(node) &&
            any_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8) &&
            (match_conv_fq_same_types(node) || match_fq_mul_conv_bias_same_types(node, FQMulAddPattern::ConvAddMul));
+}
+
+bool is_acl_supported_int8_avg_pool(const std::shared_ptr<const ov::Node>& node,
+                                                const std::vector<ov::element::Type>& defaultPrecisions) {
+    const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
+    if (!avg_pool) {
+        return false;
+    }
+
+    const auto& input_pshape = avg_pool->get_input_partial_shape(0);
+    if (input_pshape.is_dynamic() || input_pshape.rank().get_length() == 5) {
+        return false;
+    }
+
+    const auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantization(avg_pool, defaultPrecisions);
+    if (dequantization.empty() ||
+        !any_of(dequantization.data.get_element_type(), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
+        return false;
+    }
+
+    // ACL rejects NCHW AvgPool with CEIL rounding in the executor wrapper.
+    if (avg_pool->get_rounding_type() == op::RoundingType::CEIL) {
+        return false;
+    }
+
+    for (const auto& consumer : avg_pool->output(0).get_target_inputs()) {
+        const auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(consumer.get_node()->shared_from_this());
+        if (!fq) {
+            continue;
+        }
+
+        const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);
+        if (resolved_precision.empty() ||
+            !any_of(resolved_precision.precision, ov::element::Type_t::u8, ov::element::Type_t::i8)) {
+            continue;
+        }
+
+        // CpuPool2dKernel::validate_arguments() requires matching src/dst data types.
+        if (dequantization.data.get_element_type() != resolved_precision.precision) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 bool match_conv_stride_oc_ic_limit(const std::shared_ptr<const ov::Node>& node,

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -138,8 +138,8 @@ bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& nod
     }
 
     const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);
-    return !resolved_precision.empty() &&
-           any_of(resolved_precision.precision, ov::element::Type_t::u8, ov::element::Type_t::i8) &&
+    return resolved_precision.empty() ||
+           !any_of(resolved_precision.precision, ov::element::Type_t::u8, ov::element::Type_t::i8) ||
            dequantization.data.get_element_type() != resolved_precision.precision;
 }
 

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -78,6 +78,10 @@ bool match_acl_int8_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node
     }
 
     const auto pool = node->get_input_node_shared_ptr(0);
+    if (pool->output(0).get_target_inputs().size() != 1) {
+        return false;
+    }
+
     const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(pool);
     if (avg_pool && avg_pool->get_rounding_type() == ov::op::RoundingType::CEIL) {
         return false;
@@ -100,15 +104,16 @@ bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node) {
            (match_conv_fq_same_types(node) || match_fq_mul_conv_bias_same_types(node, FQMulAddPattern::ConvAddMul));
 }
 
-bool is_acl_supported_int8_avg_pool(const std::shared_ptr<const ov::Node>& node,
-                                    const std::vector<ov::element::Type>& defaultPrecisions) {
+bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& node,
+                                      const std::vector<ov::element::Type>& defaultPrecisions) {
     const auto avg_pool = ov::as_type_ptr<const ov::op::util::AvgPoolBase>(node);
     if (!avg_pool) {
         return false;
     }
 
     const auto& input_pshape = avg_pool->get_input_partial_shape(0);
-    if (input_pshape.is_dynamic() || input_pshape.rank().get_length() == 5) {
+    const auto input_rank = input_pshape.rank();
+    if (input_rank.is_dynamic() || input_rank.get_length() == 5) {
         return false;
     }
 
@@ -123,25 +128,20 @@ bool is_acl_supported_int8_avg_pool(const std::shared_ptr<const ov::Node>& node,
         return false;
     }
 
-    for (const auto& consumer : avg_pool->output(0).get_target_inputs()) {
-        const auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(consumer.get_node()->shared_from_this());
-        if (!fq) {
-            continue;
-        }
-
-        const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);
-        if (resolved_precision.empty() ||
-            !any_of(resolved_precision.precision, ov::element::Type_t::u8, ov::element::Type_t::i8)) {
-            continue;
-        }
-
-        // CpuPool2dKernel::validate_arguments() requires matching src/dst data types.
-        if (dequantization.data.get_element_type() != resolved_precision.precision) {
-            return true;
-        }
+    const auto& consumers = avg_pool->output(0).get_target_inputs();
+    if (consumers.size() != 1) {
+        return false;
     }
 
-    return false;
+    const auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(consumers.begin()->get_node()->shared_from_this());
+    if (!fq) {
+        return false;
+    }
+
+    const auto resolved_precision = ov::pass::low_precision::ResolvePrecisionAttribute::getDataPrecision(fq);
+    return !resolved_precision.empty() &&
+           any_of(resolved_precision.precision, ov::element::Type_t::u8, ov::element::Type_t::i8) &&
+           dequantization.data.get_element_type() != resolved_precision.precision;
 }
 
 bool match_conv_stride_oc_ic_limit(const std::shared_ptr<const ov::Node>& node,

--- a/src/plugins/intel_cpu/src/transformations/utils.hpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.hpp
@@ -59,6 +59,9 @@ bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node);
 
 bool match_acl_int8_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node);
 
+bool is_acl_supported_int8_avg_pool(const std::shared_ptr<const ov::Node>& node,
+                                                const std::vector<ov::element::Type>& defaultPrecisions);
+
 bool match_conv_stride_oc_ic_limit(const std::shared_ptr<const ov::Node>& node,
                                    const std::vector<int64_t>& strides,
                                    const ov::Shape& kernel_shape,

--- a/src/plugins/intel_cpu/src/transformations/utils.hpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.hpp
@@ -59,8 +59,8 @@ bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node);
 
 bool match_acl_int8_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node);
 
-bool is_acl_supported_int8_avg_pool(const std::shared_ptr<const ov::Node>& node,
-                                    const std::vector<ov::element::Type>& defaultPrecisions);
+bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& node,
+                                      const std::vector<ov::element::Type>& defaultPrecisions);
 
 bool match_conv_stride_oc_ic_limit(const std::shared_ptr<const ov::Node>& node,
                                    const std::vector<int64_t>& strides,

--- a/src/plugins/intel_cpu/src/transformations/utils.hpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.hpp
@@ -60,7 +60,7 @@ bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node);
 bool match_acl_int8_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node);
 
 bool is_acl_supported_int8_avg_pool(const std::shared_ptr<const ov::Node>& node,
-                                                const std::vector<ov::element::Type>& defaultPrecisions);
+                                    const std::vector<ov::element::Type>& defaultPrecisions);
 
 bool match_conv_stride_oc_ic_limit(const std::shared_ptr<const ov::Node>& node,
                                    const std::vector<int64_t>& strides,


### PR DESCRIPTION
### Details:
 - Added an ARM LPT AvgPool callback in the CPU transformation pipeline to handle ACL-specific int8 AvgPool cases.
 - Introduced helper logic that detects fused AvgPool + FakeQuantize patterns where ACL requires special handling: static non-5D shapes, int8/u8 dequantization, CEIL-rounding rejection, and source/output precision checks.
 - Kept the fused AvgPool include-padding path on the `ncsp` descriptor when the ACL NHWC quantized executor would otherwise select an unsupported layout.

### Tickets:
 - CVS-187861

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
