### PR TITLE
[Build] Add RelWithDebInfo to OPENVINO_LIB_PATHS

### DIFF
--- a/scripts/setupvars/setupvars.bat
+++ b/scripts/setupvars/setupvars.bat
@@ -38,7 +38,7 @@ if exist "%OpenVINO_DIR%\OpenVINOGenAIConfig.cmake" (
    :: If GenAI is installed, export it as well.
    set "OpenVINOGenAI_DIR=%OpenVINO_DIR%"
 )
-set "OPENVINO_LIB_PATHS=%INTEL_OPENVINO_DIR%\runtime\bin\intel64\Release;%INTEL_OPENVINO_DIR%\runtime\bin\intel64\Debug;%OPENVINO_LIB_PATHS%"
+set "OPENVINO_LIB_PATHS=%INTEL_OPENVINO_DIR%\runtime\bin\intel64\Release;%INTEL_OPENVINO_DIR%\runtime\bin\intel64\RelWithDebInfo;%INTEL_OPENVINO_DIR%\runtime\bin\intel64\Debug;%OPENVINO_LIB_PATHS%"
 
 :: TBB
 if exist %INTEL_OPENVINO_DIR%\runtime\3rdparty\tbb (

--- a/scripts/setupvars/setupvars.ps1
+++ b/scripts/setupvars/setupvars.ps1
@@ -14,7 +14,7 @@ if (Test-Path -Path "$Env:OpenVINO_DIR/OpenVINOGenAIConfig.cmake")
     # If GenAI is installed, export it as well.
     $Env:OpenVINOGenAI_DIR = $Env:OpenVINO_DIR
 }
-$Env:OPENVINO_LIB_PATHS = "$Env:INTEL_OPENVINO_DIR/runtime/bin/intel64/Release;$Env:INTEL_OPENVINO_DIR/runtime/bin/intel64/Debug;$Env:OPENVINO_LIB_PATHS"
+$Env:OPENVINO_LIB_PATHS = "$Env:INTEL_OPENVINO_DIR/runtime/bin/intel64/Release;$Env:INTEL_OPENVINO_DIR/runtime/bin/intel64/RelWithDebInfo;$Env:INTEL_OPENVINO_DIR/runtime/bin/intel64/Debug;$Env:OPENVINO_LIB_PATHS"
 
 # TBB
 if (Test-Path -Path "$Env:INTEL_OPENVINO_DIR/runtime/3rdparty/tbb")


### PR DESCRIPTION
### Details:
Include `runtime/bin/intel64/RelWithDebInfo` in the library search paths for both setupvars.bat and setupvars.ps1.

Order: Release -> RelWithDebInfo -> Debug.

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no*
