### PR TITLE
[GPU] Fix CL_OUT_OF_RESOURCES for 1D convolution with large filter on Xe-LPG

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -675,8 +675,24 @@ bool layout_optimizer::convolution_b_fs_yx_fsv16_opt(const layout& input_layout,
                                   output_layout.feature() >= required_feature_num);
     auto in_features_per_group = input_layout.feature() / conv->groups;
     auto out_features_per_group = output_layout.feature() / conv->groups;
-    if (!correct_in_feature && input_layout.feature() <= 4 && out_features_per_group >= feature_block_size)
-        correct_in_feature = true;
+    if (!correct_in_feature && input_layout.feature() <= 4 && out_features_per_group >= feature_block_size) {
+        // Estimate register pressure of bfyx_to_b_fs_yx_fsv16 kernel's line_cache[] array.
+        // Reject b_fs_yx_fsv16 when input_block_size > 64 to prevent CL_OUT_OF_RESOURCES
+        // on register-constrained GPUs (e.g. Xe-LPG with 128 GRFs/thread).
+        constexpr size_t default_block_width = 8;
+        constexpr size_t sg_size = 16;
+        size_t stride_x = conv->stride[conv->stride.size() - 1];
+        size_t dilation_x = conv->dilation[conv->dilation.size() - 1] + 1;
+        size_t filter_x = weights_layout.spatial(0);
+        size_t filter_y = weights_layout.spatial(1);
+        size_t input_line_size = stride_x * (default_block_width - 1) + (filter_x - 1) * dilation_x + 1;
+        if (static_cast<size_t>(input_layout.spatial(0)) < input_line_size)
+            input_line_size = static_cast<size_t>(input_layout.spatial(0));
+        size_t input_block_size = (input_line_size * filter_y + sg_size - 1) / sg_size;
+        if (input_block_size <= 64)
+            correct_in_feature = true;
+    }
+
     bool depthwise = conv->groups == static_cast<uint32_t>(input_layout.feature());  // depthwise conv
     bool grouped = ((feature_block_size % out_features_per_group == 0) &&
                        (feature_block_size % in_features_per_group == 0) &&

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_b_fs_yx_fsv16.cpp
@@ -116,6 +116,16 @@ bool ConvolutionKernel_bfyx_to_bfyx_f16::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
+    // Large private memory (line_cache) combined with fused ops causes register pressure overflow
+    // on some GPU architectures (e.g. Xe-LPG). Reject this kernel in such cases.
+    auto blockWidth = GetAutoTuneOptions(p, -1).blockWidth;
+    size_t input_line_size = std::min(params.stride.x * (blockWidth - 1) + (params.filterSize.x - 1) * params.dilation.x + 1,
+                                      input.X().v + input.X().pad.Total());
+    size_t input_block_size = CeilDiv(input_line_size * params.filterSize.y, sub_group_size);
+    if (input_block_size > 64 && !params.fused_ops.empty()) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
### Description of the issue (symptom, root-cause, how it was resolved)
 - **Symptom**: Convolution with feature=1 and large filter size crashes with CL_OUT_OF_RESOURCES on Xe-LPG GPU. benchmark_app exits silently (SEH crash) without any error message.
 - **Root-cause**: `layout_optimizer::convolution_b_fs_yx_fsv16_opt()` accepted feature=1 via the `input_layout.feature() <= 4` check, routing this convolution into b_fs_yx_fsv16 format. The `bfyx_to_b_fs_yx_fsv16` kernel then allocates `line_cache[1024]` (= 4KB = 128 GRFs), consuming the entire Xe-LPG register file. When fused ops require additional registers, the kernel exceeds hardware GRF budget → CL_OUT_OF_RESOURCES.
 - **Fix A** (layout_optimizer): Estimate register pressure of the `bfyx_to_b_fs_yx_fsv16` kernel's `line_cache[]` array before allowing `b_fs_yx_fsv16` format for small input features (≤4). Reject the format when `input_block_size > 64` to prevent register overflow on GPUs with limited GRF budget (e.g. Xe-LPG, 128 GRFs/thread).
 - **Fix B** (kernel Validate): Add a defensive check in `convolution_kernel_bfyx_to_b_fs_yx_fsv16::Validate()` — reject the kernel when `input_block_size > 64` and fused ops are present, preventing register pressure overflow regardless of the layout selection path.

#### The code and line that caused this issue (if it is not changed directly)
 - `intel_gpu/src/graph/layout_optimizer.cpp` — `convolution_b_fs_yx_fsv16_opt()`, condition `input_layout.feature() <= 4`

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - Run benchmark_app with infer precision f32
 - Without fix: process exits silently after "Benchmarking in inference only mode" (SEH crash due to driver state corruption after CL_OUT_OF_RESOURCES)
 - With fix: inference completes successfully

#### Problematic graph
 - Convolution: Input [1,1,1,48000] (feature=1), Weights [1025,1,1,2048], stride_x=2048
 - With fused Eltwise (Add) operation
 - The single feature channel + large filter size (2048) causes `input_block_size = ceil((2048 * 1) / 16) = 128` elements in private memory per work-item
<img width="646" height="821" alt="image" src="https://github.com/user-attachments/assets/a7336b9b-5ca5-4101-847a-71bd21c7f1f1" />


#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
   - Unit test not feasible: `convolution_b_fs_yx_fsv16_opt()` is private. Fix B's math was verified manually (input_block_size=1024 >> 64 for this model; normal 3×3 convs yield input_block_size≈2, no false positives).
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *187594*