### PR TITLE
[GPU] Fix perf regression in fc_bf_tiled DQ scale path by using f16 scale composition

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
@@ -1278,8 +1278,10 @@ inline void FUNC(fc_bf_tiled_kernel_dyn_quan)(
                         #endif
 
                         #if COMPRESSED_WEIGHTS_INT8
-                            ACCUM_DQ_TYPE modified_calc_buff = ((int *)(&acc_tmp[fi]))[bi] - ((float)(wei_zp[fi]) * activation_sum[bi]);
-                            ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += (convert_half)(convert_float(modified_calc_buff) * (float)ds * (float)de_quantize_scale[bi]);
+                            // Keep zero-point correction in fp32. Storing this value in int truncates
+                            // the activation_sum term and diverges from the per-token path below.
+                            float modified_calc_buff = ((float)((int *)(&acc_tmp[fi]))[bi]) - ((float)(wei_zp[fi]) * activation_sum[bi]);
+                            ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += (convert_half)(modified_calc_buff * (float)ds * (float)de_quantize_scale[bi]);
                         #else
                             // Compose DQ and decompression scales before applying them to the accumulator.
                             // This reduces fp16 intermediate overflow risk on the f16 scale path, but it is not
@@ -1312,8 +1314,10 @@ inline void FUNC(fc_bf_tiled_kernel_dyn_quan)(
                         #endif
 
                         #if COMPRESSED_WEIGHTS_INT8
-                            ACCUM_DQ_TYPE modified_calc_buff = ((float)((int *)(&acc_tmp[fi]))[bi]) - ((float)(wei_zp[fi]) * activation_sum[bi]);
-                            ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += (convert_half)(convert_float(modified_calc_buff) * (float)ds * (float)de_quantize_scale[bi]);
+                            // Keep zero-point correction in fp32. Storing this value in int truncates
+                            // the activation_sum term and diverges from the per-token path below.
+                            float modified_calc_buff = ((float)((int *)(&acc_tmp[fi]))[bi]) - ((float)(wei_zp[fi]) * activation_sum[bi]);
+                            ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += (convert_half)(modified_calc_buff * (float)ds * (float)de_quantize_scale[bi]);
                         #else
                             // Compose DQ and decompression scales before applying them to the accumulator.
                             // This reduces fp16 intermediate overflow risk on the f16 scale path, but it is not

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
@@ -1281,7 +1281,10 @@ inline void FUNC(fc_bf_tiled_kernel_dyn_quan)(
                             ACCUM_DQ_TYPE modified_calc_buff = ((int *)(&acc_tmp[fi]))[bi] - ((float)(wei_zp[fi]) * activation_sum[bi]);
                             ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += (convert_half)(convert_float(modified_calc_buff) * (float)ds * (float)de_quantize_scale[bi]);
                         #else
-                            ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += (convert_half)(convert_float(((int *)(&acc_tmp[fi]))[bi]) * (float)de_quantize_scale[bi] * (float)ds);
+                            // Compose DQ and decompression scales before applying them to the accumulator.
+                            // This reduces fp16 intermediate overflow risk on the f16 scale path, but it is not
+                            // a mathematical overflow guard: very large accumulators or final f16 values can still overflow.
+                            ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += convert_half(((int *)(&acc_tmp[fi]))[bi]) * (de_quantize_scale[bi] * ds);
                         #endif
                         acc_tmp[fi][bi] = 0;
                     }
@@ -1312,7 +1315,10 @@ inline void FUNC(fc_bf_tiled_kernel_dyn_quan)(
                             ACCUM_DQ_TYPE modified_calc_buff = ((float)((int *)(&acc_tmp[fi]))[bi]) - ((float)(wei_zp[fi]) * activation_sum[bi]);
                             ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += (convert_half)(convert_float(modified_calc_buff) * (float)ds * (float)de_quantize_scale[bi]);
                         #else
-                            ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += (convert_half)(convert_float(((int *)(&acc_tmp[fi]))[bi]) * (float)de_quantize_scale[bi] * (float)ds);
+                            // Compose DQ and decompression scales before applying them to the accumulator.
+                            // This reduces fp16 intermediate overflow risk on the f16 scale path, but it is not
+                            // a mathematical overflow guard: very large accumulators or final f16 values can still overflow.
+                            ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += convert_half(((int *)(&acc_tmp[fi]))[bi]) * (de_quantize_scale[bi] * ds);
                         #endif
                         acc_tmp[fi][bi] = 0;
                     }
@@ -1327,9 +1333,14 @@ inline void FUNC(fc_bf_tiled_kernel_dyn_quan)(
                 ACCUMULATOR_TYPE ds = d_scales[fi % DECOMPRESSION_SCALE_LENGTH];
                 #if COMPRESSED_WEIGHTS_INT8
                     float modified_calc_buff = ((float)((int *)(&acc_tmp[fi]))[bi]) - ((float)(wei_zp[fi]) * activation_sum[bi]);
-                    ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] = (convert_half)(modified_calc_buff) * de_quantize_scale[bi] * ds;
+                    // Keep zero-point corrected scaling in fp32 before the final f16 conversion to avoid
+                    // fp16 intermediate overflow. The final f16 value can still overflow if the true result
+                    // is outside the fp16 range.
+                    ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] = (convert_half)(modified_calc_buff * (float)de_quantize_scale[bi] * (float)ds);
                 #else
-                    ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] = convert_half(((int *)(&acc_tmp[fi]))[bi]) * de_quantize_scale[bi] * ds;
+                    // Compose DQ and decompression scales first to reduce fp16 intermediate overflow risk.
+                    // This is still not a mathematical overflow guard if the accumulator or final f16 value is too large.
+                    ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] = convert_half(((int *)(&acc_tmp[fi]))[bi]) * (de_quantize_scale[bi] * ds);
                 #endif
             }
         }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1510,8 +1510,8 @@ public:
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -16.0f, 16.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
+        set_values(weights_mem, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
         set_values(scale_mem, scale_data);
@@ -1631,8 +1631,8 @@ public:
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
+        set_values(weights_mem, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
         set_values(scale_mem, scale_data);
@@ -1736,8 +1736,8 @@ public:
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -1.0f, 1.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
+        set_values(weights_mem, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -1.0f, 1.0f);
         set_values(scale_mem, scale_data);
@@ -1836,9 +1836,9 @@ public:
         std::fill(input_data.begin(), input_data.end(), 1);
         set_values(input_mem, input_data);
 
-        auto weigths_data = std::vector<uint8_t>(weights_mem->count() / 2);
-        std::fill(weigths_data.begin(), weigths_data.end(), 0x11);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = std::vector<uint8_t>(weights_mem->count() / 2);
+        std::fill(weights_data.begin(), weights_data.end(), 0x11);
+        set_values(weights_mem, weights_data);
 
         auto scale_data = std::vector<ov::float16>(scale_mem->count());
         std::fill(scale_data.begin(), scale_data.end(), 1);
@@ -1901,9 +1901,9 @@ public:
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
-        set_values(weights_mem1, weigths_data);
-        set_values(weights_mem2, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
+        set_values(weights_mem1, weights_data);
+        set_values(weights_mem2, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
         set_values(scale_mem, scale_data);
@@ -2021,8 +2021,8 @@ public:
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 255);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 255);
+        set_values(weights_mem, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -2.0f, 2.0f);
         set_values(scale_mem, scale_data);
@@ -2166,8 +2166,8 @@ public:
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 255);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 255);
+        set_values(weights_mem, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -2.0f, 2.0f);
         set_values(scale_mem, scale_data);
@@ -2309,8 +2309,8 @@ public:
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
+        set_values(weights_mem, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
         set_values(scale_mem, scale_data);
@@ -2446,8 +2446,8 @@ public:
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -1.0f, 1.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 5);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 5);
+        set_values(weights_mem, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -1.0f, 1.0f);
         set_values(scale_mem, scale_data);
@@ -2590,9 +2590,9 @@ public:
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
-        set_values(weights_mem1, weigths_data);
-        set_values(weights_mem2, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
+        set_values(weights_mem1, weights_data);
+        set_values(weights_mem2, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
         set_values(scale_mem, scale_data);
@@ -2733,8 +2733,8 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
 
         set_values<int8_t>(dcomp_zp_mem, {8});
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 5);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 5);
+        set_values(weights_mem, weights_data);
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -2.0f, 2.0f);
         set_values(scale_mem, scale_data);
@@ -2939,8 +2939,8 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -1.0f, 1.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num, 0, 10);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num, 0, 10);
+        set_values(weights_mem, weights_data);
 
         auto bias_data = rg.generate_random_1d<ov::float16>(ofm_num, -2.0f, 2.0f);;
         set_values(bias_mem, bias_data);
@@ -3741,11 +3741,11 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         set_values(input_mem, input_data);
 
         if (weight_mode == WeightMode::Bit4) {
-            auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 4);
-            set_values(weights_mem, weigths_data);
+            auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 4);
+            set_values(weights_mem, weights_data);
         } else {
-            auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num, 0, 4);
-            set_values(weights_mem, weigths_data);
+            auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num, 0, 4);
+            set_values(weights_mem, weights_data);
         }
 
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * scale_num, -2.f, 2.f);
@@ -3878,8 +3878,8 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
+        set_values(weights_mem, weights_data);
 
         // Decompression scales up to 60. This triggers intermediate overflow:
         //   convert_half(1500) * 60 = 90,000 > 65,504 -> INF in old code
@@ -4004,8 +4004,8 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -20.0f, 20.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
+        set_values(weights_mem, weights_data);
 
         // Moderate decompression scales. Combined with large activations, intermediate overflows.
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -30.0f, 30.0f);
@@ -4133,8 +4133,8 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, 0.25f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
-        set_values(weights_mem, weigths_data);
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
+        set_values(weights_mem, weights_data);
 
         // Large positive decompression scales [30, 60] to keep stress deterministic.
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 30.0f, 60.0f);
@@ -5184,8 +5184,8 @@ TEST(fully_connected_3d_onednn_gpu, compressed_int4_scale_static) {
     auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
     set_values(input_mem, input_data);
 
-    auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
-    set_values(weights_mem, weigths_data);
+    auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
+    set_values(weights_mem, weights_data);
 
     auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
     set_values(scale_mem, scale_data);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -4097,6 +4097,257 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
                       << ", avg_diff: " << (count > 0 ? avg / count : 0.f) << std::endl;
         ASSERT_LT(max_diff, 512) << "max_diff = " << max_diff;
     }
+
+    // Stricter variant: asserts zero INF in output regardless of reference.
+    // The existing test allows INF when reference also has INF, which means a kernel
+    // that produces intermediate overflow can still pass. This test enforces that no
+    // INF appears at all, so any FP16 intermediate overflow is caught unconditionally.
+    //
+    // Parameter design:
+    //   input [-2, 2]  → dq_scale ~ 0.016  → int_acc typical ~1400
+    //   ds [-60, 60]   → combined_scale ~ 0.94  → TRUE result ~1300 < 65504 (FP16 safe)
+    //   FP16 intermediate: convert_half(1400) * 60 = 84000 > 65504 → overflow in old code
+    //   FP32 path: float(1400) * 0.016 * 60 = 1344 → no overflow
+    //
+    // Covers empty-output failures caused by gate projection overflow.
+    void test_compressed_int4_dyn_quan_large_activation_strict_no_inf(bool is_dynamic, long int batch_num) {
+        tests::random_generator rg(GET_SUITE_NAME);
+        auto& engine = get_test_engine();
+
+        if (engine.get_device_info().dev_type == device_type::discrete_gpu)
+            GTEST_SKIP();
+
+        long int ifm_num = 256;
+        long int ofm_num = 64;
+        long int scales_group_size = 128;
+
+        auto input_ps = ov::PartialShape{ batch_num, 1, ifm_num };
+        auto dyn_input_ps = ov::PartialShape{ -1, 1, ifm_num };
+        auto input_mem = engine.allocate_memory({ input_ps, data_types::f16, format::bfyx });
+        auto weights_mem = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u4, format::bfyx });
+        auto scale_mem = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx });
+
+        // Small activations [-2, 2]: dq_scale ~ 0.016, int_acc ~1400.
+        // True result (float) = 1400 * 0.016 * 60 ~ 1344 << 65504 — always FP16-safe.
+        // FP16 intermediate: convert_half(1400) * 60 = 84000 > 65504 — overflows in old code.
+        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
+        set_values(input_mem, input_data);
+
+        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
+        set_values(weights_mem, weigths_data);
+
+        // Large decompression scales [-60, 60] to trigger intermediate overflow in FP16 path.
+        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -60.0f, 60.0f);
+        set_values(scale_mem, scale_data);
+
+        auto in_layout = is_dynamic ? layout{ dyn_input_ps, data_types::f16, format::bfyx }
+                                    : layout{ input_ps, data_types::f16, format::bfyx };
+
+        auto fc_prim = fully_connected("fc_prim", input_info("input"), "weights", "", "scale", "", data_types::f16, 3, 2);
+        fc_prim.decompression_zero_point_scalar = 0;
+
+        auto get_ref_results = [&]() {
+            topology topology(
+                input_layout("input", in_layout),
+                data("weights", weights_mem),
+                data("scale", scale_mem),
+                fc_prim
+            );
+
+            auto config = get_test_default_config(engine);
+            config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+            ov::intel_gpu::ImplementationDesc fc_impl_desc = { format::bfyx, "fully_connected_gpu_bfyx_ref", impl_types::ocl };
+            config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"fc_prim", fc_impl_desc}}));
+
+            network network(engine, topology, config);
+            network.set_input_data("input", input_mem);
+
+            auto outputs = network.execute();
+            OPENVINO_ASSERT(outputs.size() == 1);
+            OPENVINO_ASSERT(outputs.begin()->first == "fc_prim");
+
+            auto output_layout = outputs.begin()->second.get_layout();
+            auto output_mem = outputs.begin()->second.get_memory();
+
+            return engine.reinterpret_buffer(*output_mem, output_layout);
+        };
+
+        topology topology(
+            input_layout("input", in_layout),
+            data("weights", weights_mem),
+            data("scale", scale_mem),
+            fc_prim
+        );
+
+        auto config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_user_property(ov::hint::dynamic_quantization_group_size(32));
+
+        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+        network->set_input_data("input", input_mem);
+
+        auto outputs = network->execute();
+        ASSERT_EQ(outputs.size(), size_t(1));
+
+        auto output_mem = outputs.begin()->second.get_memory();
+        auto ref_output_mem = get_ref_results();
+        cldnn::mem_lock<ov::float16> output_ptr(output_mem, get_test_stream());
+        cldnn::mem_lock<ov::float16> ref_ptr(ref_output_mem, get_test_stream());
+
+        size_t inf_count = 0, nan_count = 0;
+        for (size_t i = 0; i < output_ptr.size(); i++) {
+            float v = static_cast<float>(output_ptr[i]);
+            if (std::isinf(v)) inf_count++;
+            if (std::isnan(v)) nan_count++;
+        }
+        ASSERT_EQ(nan_count, 0u) << "Output contains NaN (possible cascade from INF)";
+        ASSERT_EQ(inf_count, 0u) << "Output contains " << inf_count
+            << " INF values - FP16 intermediate overflow detected";
+
+        float max_diff = 0.f;
+        float avg = 0.f;
+        size_t count = 0;
+        for (size_t i = 0; i < ref_ptr.size(); ++i) {
+            float ref_val = static_cast<float>(ref_ptr[i]);
+            float test_val = static_cast<float>(output_ptr[i]);
+            if (std::isinf(ref_val) || std::isinf(test_val))
+                continue;
+            auto abs_diff = std::abs(ref_val - test_val);
+            if (max_diff < abs_diff)
+                max_diff = abs_diff;
+            avg += abs_diff;
+            count++;
+        }
+        GPU_DEBUG_LOG << "---> strict_int4 count: " << count << ", max_diff:" << max_diff
+                      << ", avg_diff: " << (count > 0 ? avg / count : 0.f) << std::endl;
+        ASSERT_LT(max_diff, 512) << "max_diff = " << max_diff;
+    }
+
+    // Test INT8 PER_TOKEN DQ path for FP16 overflow.
+    // The PER_TOKEN INT8 path had a bug where modified_calc_buff was down-cast to FP16
+    // before multiplication: (convert_half)(modified_calc_buff) * dq * ds.
+    // With large modified_calc_buff, this intermediate exceeds FP16 max (65504) → INF.
+    //
+    // Parameter design:
+    //   weights [0,255] UINT8, zp=0 → effective range [0,255], large int_acc
+    //   input [-0.5, 0.5] → dq_scale ~ 0.004 → int_acc ~690K >> 65504 (OLD: convert_half → INF)
+    //   ds [-4, 4]         → TRUE result = 690K * 0.004 * 4 ~ 10K << 65504 (FIXED: FP32, safe)
+    //   FP16 intermediate (old): convert_half(690K) = INF → INF * ds = INF
+    //   FP32 path (fixed):  float(690K) * 0.004 * 4 = 10K — well within FP16 range
+    void test_compressed_int8_per_token_dyn_quan_strict_no_inf(bool is_dynamic, long int batch_num) {
+        tests::random_generator rg(GET_SUITE_NAME);
+        auto& engine = get_test_engine();
+
+        long int ifm_num = 256;
+        long int ofm_num = 64;
+        long int scales_group_size = 128;
+
+        auto input_ps = ov::PartialShape{ batch_num, 1, ifm_num };
+        auto dyn_input_ps = ov::PartialShape{ -1, 1, ifm_num };
+        auto input_mem = engine.allocate_memory({ input_ps, data_types::f16, format::bfyx });
+        auto weights_mem = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u8, format::bfyx });
+        auto scale_mem = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx });
+
+        // Small activations: dq_scale = 0.5/127 ~ 0.004.
+        // INT8 weights [0,255] produce large int_acc ~690K >> 65504 per group.
+        // True result = 690K * 0.004 * 4 ~ 10K << 65504: always FP16-safe.
+        // Old code: convert_half(690K) = INF → NaN cascade.
+        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -0.5f, 0.5f);
+        set_values(input_mem, input_data);
+
+        // UINT8 weights [0, 255]: large range ensures int_acc >> 65504.
+        auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num, 0, 255);
+        set_values(weights_mem, weights_data);
+
+        // Small ds [-4, 4]: keeps true result safe while int_acc is large.
+        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
+        set_values(scale_mem, scale_data);
+
+        auto in_layout = is_dynamic ? layout{ dyn_input_ps, data_types::f16, format::bfyx }
+                                    : layout{ input_ps, data_types::f16, format::bfyx };
+
+        auto fc_prim = fully_connected("fc_prim", input_info("input"), "weights", "", "scale", "", data_types::f16, 3, 2);
+        fc_prim.decompression_zero_point_scalar = 0;
+
+        auto get_ref_results = [&]() {
+            topology topology(
+                input_layout("input", in_layout),
+                data("weights", weights_mem),
+                data("scale", scale_mem),
+                fc_prim
+            );
+
+            auto config = get_test_default_config(engine);
+            config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+            ov::intel_gpu::ImplementationDesc fc_impl_desc = { format::bfyx, "fully_connected_gpu_bfyx_ref", impl_types::ocl };
+            config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"fc_prim", fc_impl_desc}}));
+
+            network network(engine, topology, config);
+            network.set_input_data("input", input_mem);
+
+            auto outputs = network.execute();
+            OPENVINO_ASSERT(outputs.size() == 1);
+            OPENVINO_ASSERT(outputs.begin()->first == "fc_prim");
+
+            auto output_layout = outputs.begin()->second.get_layout();
+            auto output_mem = outputs.begin()->second.get_memory();
+
+            return engine.reinterpret_buffer(*output_mem, output_layout);
+        };
+
+        topology topology(
+            input_layout("input", in_layout),
+            data("weights", weights_mem),
+            data("scale", scale_mem),
+            fc_prim
+        );
+
+        auto config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        // PER_TOKEN: quantize_group_size == ifm_num activates PER_TOKEN_SIZE_DYN_QUANTIZE path
+        config.set_user_property(ov::hint::dynamic_quantization_group_size(ifm_num));
+
+        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+        network->set_input_data("input", input_mem);
+
+        auto outputs = network->execute();
+        ASSERT_EQ(outputs.size(), size_t(1));
+
+        auto output_mem = outputs.begin()->second.get_memory();
+        auto ref_output_mem = get_ref_results();
+        cldnn::mem_lock<ov::float16> output_ptr(output_mem, get_test_stream());
+        cldnn::mem_lock<ov::float16> ref_ptr(ref_output_mem, get_test_stream());
+
+        size_t inf_count = 0, nan_count = 0;
+        for (size_t i = 0; i < output_ptr.size(); i++) {
+            float v = static_cast<float>(output_ptr[i]);
+            if (std::isinf(v)) inf_count++;
+            if (std::isnan(v)) nan_count++;
+        }
+        ASSERT_EQ(nan_count, 0u) << "Output contains NaN (INT8 PER_TOKEN path overflow cascade)";
+        ASSERT_EQ(inf_count, 0u) << "Output contains " << inf_count
+            << " INF values — INT8 PER_TOKEN FP16 intermediate overflow detected";
+
+        float max_diff = 0.f;
+        float avg = 0.f;
+        size_t count = 0;
+        for (size_t i = 0; i < ref_ptr.size(); ++i) {
+            float ref_val = static_cast<float>(ref_ptr[i]);
+            float test_val = static_cast<float>(output_ptr[i]);
+            if (std::isinf(ref_val) || std::isinf(test_val))
+                continue;
+            auto abs_diff = std::abs(ref_val - test_val);
+            if (max_diff < abs_diff)
+                max_diff = abs_diff;
+            avg += abs_diff;
+            count++;
+        }
+        GPU_DEBUG_LOG << "---> strict_int8_per_token count: " << count << ", max_diff:" << max_diff
+                      << ", avg_diff: " << (count > 0 ? avg / count : 0.f) << std::endl;
+        ASSERT_LT(max_diff, 512) << "max_diff = " << max_diff;
+    }
 };
 
 using shared_dims = std::tuple<size_t, size_t, size_t>;
@@ -5135,6 +5386,28 @@ TEST_F(fully_connected_gpu_tests, compressed_int4_dyn_quan_large_activation_no_o
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_dyn_quan_large_activation_no_overflow_dynamic) {
     this->test_compressed_int4_dyn_quan_large_activation_no_overflow(true, 512);
+}
+
+// Strict variant: ASSERT_EQ(inf_count, 0) - no INF allowed regardless of reference.
+// Catches FP16 intermediate overflow that the non-strict test may miss when
+// reference also produces INF after an intermediate-overflow pattern is reintroduced.
+TEST_F(fully_connected_gpu_tests, compressed_int4_dyn_quan_large_activation_strict_no_inf) {
+    this->test_compressed_int4_dyn_quan_large_activation_strict_no_inf(false, 512);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_dyn_quan_large_activation_strict_no_inf_dynamic) {
+    this->test_compressed_int4_dyn_quan_large_activation_strict_no_inf(true, 512);
+}
+
+// INT8 PER_TOKEN path: verifies that the fixed FP32 multiplication prevents overflow.
+// Old code: (convert_half)(modified_calc_buff) * dq * ds → FP16 intermediate overflow.
+// Fixed:    (convert_half)(modified_calc_buff * (float)dq * (float)ds) → FP32, no overflow.
+TEST_F(fully_connected_gpu_tests, compressed_int8_per_token_dyn_quan_strict_no_inf) {
+    this->test_compressed_int8_per_token_dyn_quan_strict_no_inf(false, 512);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int8_per_token_dyn_quan_strict_no_inf_dynamic) {
+    this->test_compressed_int8_per_token_dyn_quan_strict_no_inf(true, 512);
 }
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic_quantize_batch_1) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -4104,8 +4104,8 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
     // INF appears at all, so any FP16 intermediate overflow is caught unconditionally.
     //
     // Parameter design:
-    //   input [-2, 2]  → dq_scale ~ 0.016  → int_acc typical ~1400
-    //   ds [-60, 60]   → combined_scale ~ 0.94  → TRUE result ~1300 < 65504 (FP16 safe)
+    //   input [0.25, 2]  -> dq_scale ~ 0.016  -> high positive int_acc (reduced cancellation)
+    //   ds [30, 60]      -> combined_scale ~ 0.7  -> TRUE result still far below 65504 (FP16 safe)
     //   FP16 intermediate: convert_half(1400) * 60 = 84000 > 65504 → overflow in old code
     //   FP32 path: float(1400) * 0.016 * 60 = 1344 → no overflow
     //
@@ -4127,17 +4127,17 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         auto weights_mem = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u4, format::bfyx });
         auto scale_mem = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx });
 
-        // Small activations [-2, 2]: dq_scale ~ 0.016, int_acc ~1400.
+        // Positive activations [0.25, 2]: dq_scale ~ 0.016, high positive int_acc.
         // True result (float) = 1400 * 0.016 * 60 ~ 1344 << 65504 — always FP16-safe.
         // FP16 intermediate: convert_half(1400) * 60 = 84000 > 65504 — overflows in old code.
-        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
+        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, 0.25f, 2.0f);
         set_values(input_mem, input_data);
 
         auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
         set_values(weights_mem, weigths_data);
 
-        // Large decompression scales [-60, 60] to trigger intermediate overflow in FP16 path.
-        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -60.0f, 60.0f);
+        // Large positive decompression scales [30, 60] to keep stress deterministic.
+        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 30.0f, 60.0f);
         set_values(scale_mem, scale_data);
 
         auto in_layout = is_dynamic ? layout{ dyn_input_ps, data_types::f16, format::bfyx }
@@ -4205,20 +4205,30 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         ASSERT_EQ(inf_count, 0u) << "Output contains " << inf_count
             << " INF values - FP16 intermediate overflow detected";
 
+        size_t ref_inf_count = 0, ref_nan_count = 0;
+        for (size_t i = 0; i < ref_ptr.size(); i++) {
+            float ref_v = static_cast<float>(ref_ptr[i]);
+            if (std::isinf(ref_v))
+                ref_inf_count++;
+            if (std::isnan(ref_v))
+                ref_nan_count++;
+        }
+        ASSERT_EQ(ref_nan_count, 0u) << "Reference output contains NaN";
+        ASSERT_EQ(ref_inf_count, 0u) << "Reference output contains INF";
+
         float max_diff = 0.f;
         float avg = 0.f;
         size_t count = 0;
         for (size_t i = 0; i < ref_ptr.size(); ++i) {
             float ref_val = static_cast<float>(ref_ptr[i]);
             float test_val = static_cast<float>(output_ptr[i]);
-            if (std::isinf(ref_val) || std::isinf(test_val))
-                continue;
             auto abs_diff = std::abs(ref_val - test_val);
             if (max_diff < abs_diff)
                 max_diff = abs_diff;
             avg += abs_diff;
             count++;
         }
+        ASSERT_GT(count, 0u) << "No finite elements were compared";
         GPU_DEBUG_LOG << "---> strict_int4 count: " << count << ", max_diff:" << max_diff
                       << ", avg_diff: " << (count > 0 ? avg / count : 0.f) << std::endl;
         ASSERT_LT(max_diff, 512) << "max_diff = " << max_diff;
@@ -4230,9 +4240,9 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
     // With large modified_calc_buff, this intermediate exceeds FP16 max (65504) → INF.
     //
     // Parameter design:
-    //   weights [0,255] UINT8, zp=0 → effective range [0,255], large int_acc
-    //   input [-0.5, 0.5] → dq_scale ~ 0.004 → int_acc ~690K >> 65504 (OLD: convert_half → INF)
-    //   ds [-4, 4]         → TRUE result = 690K * 0.004 * 4 ~ 10K << 65504 (FIXED: FP32, safe)
+    //   weights [0,255] UINT8, zp=0 -> effective range [0,255], large int_acc
+    //   input [0.25, 0.5] -> dq_scale ~ 0.004 -> high positive int_acc >> 65504 (OLD: convert_half -> INF)
+    //   ds [2, 4]          -> TRUE result stays << 65504 (FIXED: FP32, safe)
     //   FP16 intermediate (old): convert_half(690K) = INF → INF * ds = INF
     //   FP32 path (fixed):  float(690K) * 0.004 * 4 = 10K — well within FP16 range
     void test_compressed_int8_per_token_dyn_quan_strict_no_inf(bool is_dynamic, long int batch_num) {
@@ -4249,19 +4259,19 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         auto weights_mem = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u8, format::bfyx });
         auto scale_mem = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx });
 
-        // Small activations: dq_scale = 0.5/127 ~ 0.004.
+        // Positive activations: dq_scale = 0.5/127 ~ 0.004.
         // INT8 weights [0,255] produce large int_acc ~690K >> 65504 per group.
         // True result = 690K * 0.004 * 4 ~ 10K << 65504: always FP16-safe.
         // Old code: convert_half(690K) = INF → NaN cascade.
-        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -0.5f, 0.5f);
+        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, 0.25f, 0.5f);
         set_values(input_mem, input_data);
 
         // UINT8 weights [0, 255]: large range ensures int_acc >> 65504.
         auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num, 0, 255);
         set_values(weights_mem, weights_data);
 
-        // Small ds [-4, 4]: keeps true result safe while int_acc is large.
-        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
+        // Positive ds [2, 4]: keeps true result safe while avoiding cancellation.
+        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 2.0f, 4.0f);
         set_values(scale_mem, scale_data);
 
         auto in_layout = is_dynamic ? layout{ dyn_input_ps, data_types::f16, format::bfyx }
@@ -4330,20 +4340,30 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         ASSERT_EQ(inf_count, 0u) << "Output contains " << inf_count
             << " INF values — INT8 PER_TOKEN FP16 intermediate overflow detected";
 
+        size_t ref_inf_count = 0, ref_nan_count = 0;
+        for (size_t i = 0; i < ref_ptr.size(); i++) {
+            float ref_v = static_cast<float>(ref_ptr[i]);
+            if (std::isinf(ref_v))
+                ref_inf_count++;
+            if (std::isnan(ref_v))
+                ref_nan_count++;
+        }
+        ASSERT_EQ(ref_nan_count, 0u) << "Reference output contains NaN";
+        ASSERT_EQ(ref_inf_count, 0u) << "Reference output contains INF";
+
         float max_diff = 0.f;
         float avg = 0.f;
         size_t count = 0;
         for (size_t i = 0; i < ref_ptr.size(); ++i) {
             float ref_val = static_cast<float>(ref_ptr[i]);
             float test_val = static_cast<float>(output_ptr[i]);
-            if (std::isinf(ref_val) || std::isinf(test_val))
-                continue;
             auto abs_diff = std::abs(ref_val - test_val);
             if (max_diff < abs_diff)
                 max_diff = abs_diff;
             avg += abs_diff;
             count++;
         }
+        ASSERT_GT(count, 0u) << "No finite elements were compared";
         GPU_DEBUG_LOG << "---> strict_int8_per_token count: " << count << ", max_diff:" << max_diff
                       << ", avg_diff: " << (count > 0 ? avg / count : 0.f) << std::endl;
         ASSERT_LT(max_diff, 512) << "max_diff = " << max_diff;


### PR DESCRIPTION
### Details

This PR fixes a performance regression in the GPU `fc_bf_tiled` dynamic quantization path while preserving the overflow protection needed for compressed fully connected kernels.

The regression was observed on Qwen3-8B with 1k input tokens, where first-token latency increased after the previous overflow fix promoted dynamic quantization scale application from f16 to f32.

### Root Cause

The original overflow happened when the kernel applied dynamic quantization and decompression scales sequentially on an f16 accumulator path. For large accumulator values, the intermediate result could exceed the fp16 maximum value before the final scale was applied, producing `INF`.

A previous fix avoided that overflow by promoting the multiplication chain to f32:

```cpp
(convert_half)(convert_float(int_val) * (float)de_quantize_scale[bi] * (float)ds)
```

This avoided the fp16 intermediate overflow, but it also moved hot-path scale application from f16 pipes to f32 pipes. On iGPU, f16 arithmetic has higher throughput than f32, so the broad f32 promotion caused a noticeable first-token latency regression for Qwen3-8B 1k input-token cases.

The INT8 zero-point correction path also had a precision issue in the non-per-token branch: the corrected accumulator value was stored in an integer temporary, which truncated the fractional `activation_sum * weight_zero_point` correction term and made the path inconsistent with the existing per-token implementation.

### Solution

The kernel now composes the two small scale factors first and applies the composed scale to the accumulator:

```cpp
convert_half(int_val) * (de_quantize_scale[bi] * ds)
```

`de_quantize_scale` and `ds` are both small-magnitude scale factors, so their f16 product is bounded and does not overflow. Applying the composed scale once avoids the large intermediate value that caused the original fp16 overflow, while keeping the hot path on f16 arithmetic and recovering the expected iGPU performance.

This f16 scale composition is applied to the non-INT8 dynamic quantization scale paths, including inner-loop, outer-loop, and per-token variants.

For INT8 zero-point correction, the temporary corrected accumulator is kept in `float` only for the correction calculation. This avoids truncating the zero-point correction term and keeps the non-per-token path aligned with the existing per-token path, without reintroducing broad f32 scale promotion on the non-INT8 performance-sensitive path.


### Tickets:
 - 187562

### AI Assistance:
 - AI assistance used: yes
 - AI: fix, validation
 - User: review
