### PR TITLE
[GHA] lock kernels version

### DIFF
--- a/tests/model_hub_tests/pytorch/envs/llm.txt
+++ b/tests/model_hub_tests/pytorch/envs/llm.txt
@@ -2,6 +2,7 @@
 # These are NOT needed by test_hf_transformers.py
 
 transformers==5.5.3
+kernels==0.14.1
 huggingface-hub==1.10.1
 
 # quantized model deps


### PR DESCRIPTION
### Details:
 - The new version  causes a CI errors (0.15.1)

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
