### PR TITLE
[GHA] CC workflow simplified for Linux

### DIFF
--- a/.github/workflows/linux_conditional_compilation.yml
+++ b/.github/workflows/linux_conditional_compilation.yml
@@ -160,11 +160,6 @@ jobs:
       - name: System info
         uses: ./openvino/.github/actions/system_info
 
-      - name: Install python dependencies
-        run: |
-          # For getting rid of SSL issues during model downloading for unit tests
-          python3 -m pip install certifi
-
       #
       # Build
       #

--- a/.github/workflows/linux_conditional_compilation.yml
+++ b/.github/workflows/linux_conditional_compilation.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set mock output images if pipeline should be skipped
         if: ${{ needs.smart_ci.outputs.skip_workflow == 'True' }}
         id: mock_image
-        run: echo "images={\"ov_test\":{\"ubuntu_22_04_x64\":\"mock\"},\"ov_build\":{\"ubuntu_22_04_x64_cc\":\"mock\"}}" >> "$GITHUB_OUTPUT"
+        run: echo "images={\"ov_build\":{\"ubuntu_22_04_x64_cc\":\"mock\"}}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         if: ${{ needs.smart_ci.outputs.skip_workflow != 'True' }}
@@ -89,12 +89,13 @@ jobs:
         with:
           images: |
             ov_build/ubuntu_22_04_x64_cc
-            ov_test/ubuntu_22_04_x64
           registry: 'openvinogithubactions.azurecr.io'
           dockerfiles_root_dir: '.github/dockerfiles'
           changed_components: ${{ needs.smart_ci.outputs.changed_components }}
 
-  Build:
+  # check SELECTIVE_BUILD_STAT in CC 'COLLECT' AND 'ON' modes
+
+  Build_And_Run_Collect_Mode:
     needs: [Docker, Smart_CI]
     if: ${{ github.event_name != 'merge_group' && needs.smart_ci.outputs.skip_workflow != 'True' }}
     timeout-minutes: 150
@@ -122,7 +123,6 @@ jobs:
       GITHUB_WORKSPACE: '/__w/openvino/openvino'
       OPENVINO_REPO: /__w/openvino/openvino/openvino
       INSTALL_DIR: /__w/openvino/openvino/openvino_install
-      INSTALL_TEST_DIR: /__w/openvino/openvino/tests_install
       BUILD_DIR: /__w/openvino/openvino/openvino_build
       SELECTIVE_BUILD_STAT_DIR: /__w/openvino/openvino/selective_build_stat
       MODELS_PATH: /__w/openvino/openvino/testdata
@@ -162,17 +162,8 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          # For running ONNX frontend unit tests
-          python3 -m pip install --force-reinstall -r ${OPENVINO_REPO}/src/frontends/onnx/tests/requirements.txt
-
-          # For running TensorFlow frontend unit tests
-          python3 -m pip install -r ${OPENVINO_REPO}/src/frontends/tensorflow/tests/requirements.txt
-
-          # For running TensorFlow Lite frontend unit tests
-          python3 -m pip install -r ${OPENVINO_REPO}/src/frontends/tensorflow_lite/tests/requirements.txt
-
-          # For running Paddle frontend unit tests
-          python3 -m pip install -r ${OPENVINO_REPO}/src/frontends/paddle/tests/requirements.txt
+          # For getting rid of SSL issues during model downloading for unit tests
+          python3 -m pip install certifi
 
       #
       # Build
@@ -184,7 +175,7 @@ jobs:
             -G "${{ env.CMAKE_GENERATOR }}" \
             -DCMAKE_CXX_STANDARD=20 \
             -DBUILD_SHARED_LIBS=OFF \
-            -DENABLE_TESTS=ON \
+            -DENABLE_TESTS=OFF \
             -DENABLE_NCC_STYLE=OFF \
             -DENABLE_PROFILING_ITT=FULL \
             -DSELECTIVE_BUILD=COLLECT \
@@ -209,7 +200,6 @@ jobs:
       - name: Cmake install - OpenVINO
         run: |
           cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -P ${BUILD_DIR}/cmake_install.cmake
-          cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_TEST_DIR} -DCOMPONENT=tests -P ${BUILD_DIR}/cmake_install.cmake
 
       - name: Build C++ samples - OpenVINO build tree
         run: |
@@ -218,9 +208,6 @@ jobs:
 
       - name: Build C samples - OpenVINO install tree
         run: ${INSTALL_DIR}/samples/c/build_samples.sh -i ${INSTALL_DIR} -b ${BUILD_DIR}/c_samples
-
-      - name: Ctest - OpenVINO unit tests
-        run: ctest -C ${{ env.CMAKE_BUILD_TYPE }} --test-dir ${BUILD_DIR} -V -L UNIT
 
       - name: Perform code tracing via ITT collector
         run: |
@@ -237,17 +224,6 @@ jobs:
 
           pushd ${INSTALL_DIR}
             tar -cvf - install_dependencies/install_openvino_dependencies.sh | pigz > ${BUILD_DIR}/openvino_package.tar.gz
-          popd
-
-          cp -v ${OPENVINO_REPO}/temp/Linux_x86_64/tbb/lib/lib* ${INSTALL_TEST_DIR}/tests
-          pushd ${INSTALL_TEST_DIR}
-            tar -cvf - \
-              tests/ov_cpu_func_tests \
-              tests/libopenvino_template_extension.so \
-              tests/libhwloc* \
-              tests/libtbb* \
-              tests/functional_test_utils/layer_tests_summary/* \
-              | pigz > ${BUILD_DIR}/openvino_tests.tar.gz
           popd
 
       #
@@ -285,17 +261,9 @@ jobs:
           path: ${{ env.BUILD_DIR }}/openvino_selective_build_stat.tar.gz
           if-no-files-found: 'error'
 
-      - name: Upload OpenVINO tests package
-        if: ${{ always() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: openvino_tests
-          path: ${{ env.BUILD_DIR }}/openvino_tests.tar.gz
-          if-no-files-found: 'error'
-
-  CC_Build:
+  Build_And_Run_On_Mode:
     name: Conditional Compilation
-    needs: [Build, Docker]
+    needs: [Build_And_Run_Collect_Mode, Docker]
     timeout-minutes: 30
     defaults:
       run:
@@ -362,6 +330,7 @@ jobs:
       - name: CMake configure - CC ON
         run: |
           cmake \
+            -DENABLE_TESTS=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DSELECTIVE_BUILD=ON \
             -DENABLE_TEMPLATE=OFF \
@@ -397,19 +366,9 @@ jobs:
       - name: Run with CC-ed runtime
         run: ${OPENVINO_REPO}/bin/intel64/Release/benchmark_app -niter 1 -nireq 1 -m ${MODELS_PATH}/models/test_model/test_model_fp32.xml -d CPU
 
-  CPU_Functional_Tests:
-    name: CPU functional tests
-    if: fromJSON(needs.smart_ci.outputs.affected_components).CPU.test
-    needs: [ Docker, Build, Smart_CI ]
-    uses: ./.github/workflows/job_cpu_functional_tests.yml
-    with:
-      runner: 'aks-linux-8-cores-32gb'
-      image: ${{ fromJSON(needs.docker.outputs.images).ov_test.ubuntu_22_04_x64 }}
-      python-version: '3.11'
-
   Overall_Status:
     name: ci/gha_overall_status_linux_cc
-    needs: [Smart_CI, Build, CC_Build, CPU_Functional_Tests]
+    needs: [Smart_CI, Build_And_Run_Collect_Mode, Build_And_Run_On_Mode]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Details:
 - *CC is checked in the same pipeline with a simple benchmark_app testcase. That is enough to verify the selective-build flow end to end: collect stats, rebuild with CC enabled, and run inference successfully. Full functional tests do not add extra CC-specific signal here, they mostly repeat broader test coverage.*

### Tickets:
 - *186705*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
