### PR TITLE
[TRANSFORMATIONS][GPU] Fuse llama.cpp interleaved RoPE into RoPE op

### DIFF
--- a/src/common/transformations/include/ov_ops/rotary_positional_embeddings.hpp
+++ b/src/common/transformations/include/ov_ops/rotary_positional_embeddings.hpp
@@ -23,18 +23,19 @@ public:
     struct Config {
         size_t slice_start = 0;  // slice inner-most dimensions of input
         size_t slice_stop = 0;
-        bool input_trans0213 = false;   // transpose input dim 1&2
-        bool output_trans0213 = false;  // implies trans0213 happens after RoPE
-        bool is_interleaved = false;    // coordinates are interleaved
-        size_t rotary_ndims = 0;        // dimensions to be embedded (d in the description)
-        bool is_chatglm = false;        // chatglm is special which overrides other setting
-        bool support_2d_rope = false;   // 2d rope mode, Support 2 dimentional rope which is independant of batch and
-                                        // each head. change input order to [batch, head_cnt, 4608] to support 2d rope
-        bool is_qwen = false;           // Qwen is special which overrides other setting
-        bool use_rope_cache = false;    // use precomputed RoPE cache for trigonometric values (cosine and sine)
-        bool support_3d_rope = false;   // use same logic as RoPEFusionGPTNEOX(4), used by gpu plugin
-        bool is_ltx_video = false;      // ltx-video specific 3D spatial-temporal RoPE
-        size_t cos_sin_ndims = 0;       // last dimension of con/sin table
+        bool input_trans0213 = false;    // transpose input dim 1&2
+        bool output_trans0213 = false;   // implies trans0213 happens after RoPE
+        bool is_interleaved = false;     // coordinates are interleaved
+        bool interleaved_input = false;  // read interleaved lanes but write half-split (llama.cpp NORMAL RoPE)
+        size_t rotary_ndims = 0;         // dimensions to be embedded (d in the description)
+        bool is_chatglm = false;         // chatglm is special which overrides other setting
+        bool support_2d_rope = false;    // 2d rope mode, Support 2 dimentional rope which is independant of batch and
+                                         // each head. change input order to [batch, head_cnt, 4608] to support 2d rope
+        bool is_qwen = false;            // Qwen is special which overrides other setting
+        bool use_rope_cache = false;     // use precomputed RoPE cache for trigonometric values (cosine and sine)
+        bool support_3d_rope = false;    // use same logic as RoPEFusionGPTNEOX(4), used by gpu plugin
+        bool is_ltx_video = false;       // ltx-video specific 3D spatial-temporal RoPE
+        size_t cos_sin_ndims = 0;        // last dimension of con/sin table
         size_t head_cnt = 0;
         size_t head_size = 0;
         int gather_position_arg_id =

--- a/src/common/transformations/include/ov_ops/rotary_positional_embeddings.hpp
+++ b/src/common/transformations/include/ov_ops/rotary_positional_embeddings.hpp
@@ -35,7 +35,7 @@ public:
         bool use_rope_cache = false;     // use precomputed RoPE cache for trigonometric values (cosine and sine)
         bool support_3d_rope = false;    // use same logic as RoPEFusionGPTNEOX(4), used by gpu plugin
         bool is_ltx_video = false;       // ltx-video specific 3D spatial-temporal RoPE
-        size_t cos_sin_ndims = 0;        // last dimension of con/sin table
+        size_t cos_sin_ndims = 0;        // last dimension of cos/sin table
         size_t head_cnt = 0;
         size_t head_size = 0;
         int gather_position_arg_id =

--- a/src/common/transformations/include/transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp
@@ -23,6 +23,7 @@ class TRANSFORMATIONS_API RoPEFusionCosSinPreprocess;
 class TRANSFORMATIONS_API RoPEShareCosSin;
 class TRANSFORMATIONS_API RoPEFusionGPTOSS;
 class TRANSFORMATIONS_API RoPEFusionLtxVideo;
+class TRANSFORMATIONS_API RoPEFusionLlamaCpp;
 
 }  // namespace pass
 }  // namespace ov
@@ -103,6 +104,12 @@ class ov::pass::RoPEFusionLtxVideo : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("RoPEFusionLtxVideo");
     RoPEFusionLtxVideo();
+};
+
+class ov::pass::RoPEFusionLlamaCpp : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("RoPEFusionLlamaCpp");
+    RoPEFusionLlamaCpp();
 };
 
 /**

--- a/src/common/transformations/src/ov_ops/rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/ov_ops/rotary_positional_embeddings.cpp
@@ -92,7 +92,9 @@ bool RoPE::visit_attributes(ov::AttributeVisitor& visitor) {
     visitor.on_attribute("input_trans0213", m_config.input_trans0213);
     visitor.on_attribute("output_trans0213", m_config.output_trans0213);
     visitor.on_attribute("is_interleaved", m_config.is_interleaved);
+    visitor.on_attribute("interleaved_input", m_config.interleaved_input);
     visitor.on_attribute("rotary_ndims", m_config.rotary_ndims);
+    visitor.on_attribute("cos_sin_ndims", m_config.cos_sin_ndims);
     visitor.on_attribute("is_chatglm", m_config.is_chatglm);
     visitor.on_attribute("support_2d_rope", m_config.support_2d_rope);
     visitor.on_attribute("support_3d_rope", m_config.support_3d_rope);

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -29,6 +29,7 @@
 #include "openvino/op/split.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/strided_slice.hpp"
+#include "openvino/op/subtract.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/util/shape_of_base.hpp"
@@ -65,6 +66,7 @@ bool RoPEFusion::run_on_model(const std::shared_ptr<ov::Model>& model) {
 
     symbolic_ctx_manager->register_pass<ov::pass::RoPEFusionFlux>(true);
     symbolic_ctx_manager->register_pass<ov::pass::RoPEFusionFlux>(false);
+    symbolic_ctx_manager->register_pass<ov::pass::RoPEFusionLlamaCpp>();
     symbolic_ctx_manager->register_pass<ov::pass::RoPEFusionGPTNEOX>(4);
     symbolic_ctx_manager->register_pass<ov::pass::RoPEFusionGPTNEOX>(3);
     symbolic_ctx_manager->register_pass<ov::pass::RoPEFusionGPTJ>();
@@ -1319,6 +1321,172 @@ RoPEFusionLtxVideo::RoPEFusionLtxVideo() {
         ov::replace_node(root, new_node);
         register_new_node(new_node);
 
+        return true;
+    };
+
+    auto m = std::make_shared<pattern::Matcher>(result, matcher_name);
+    this->register_matcher(m, callback);
+}
+
+RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
+    MATCHER_SCOPE(RoPEFusionLlamaCpp);
+    // llama.cpp OV serializer RoPE (stateful, rank-3 input). Interleaved (GPT-J) rotation written as an
+    // explicit 4-term complex multiply, a different topology than RoPEFusionGPTJ's neg-concat form:
+    //   even/odd = Slice(x, {0,1}, end, step=2, axis=-1)
+    //   stack    = Concat(Unsqueeze((even*cos - odd*sin), -2), Unsqueeze((even*sin + odd*cos), -2), -2)
+    //   out      = Reshape(stack, [1, -1, head_cnt, head_size])
+    // Step-2 slices => config.is_interleaved=true (verified bit-exact). Slice begin/end/step are left
+    // unconstrained below; pattern vars x_low/x_high carry the even/odd lanes. Stateless emits a
+    // different 5D-stack topology and is intentionally not matched.
+    auto x = pattern::any_input(pattern::rank_equals(3));
+    auto t_cos = pattern::any_input();
+    auto t_sin = pattern::any_input();
+
+    // Last-axis slice. Accept Slice and StridedSlice (canonicalization varies); attrs are left
+    // unconstrained here and re-validated in the callback.
+    auto x_low_slice = pattern::wrap_type<v8::Slice>(
+        {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
+    auto x_low_strided = pattern::wrap_type<v1::StridedSlice>(
+        {x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
+    auto x_low = std::make_shared<pattern::op::Or>(OutputVector{x_low_slice, x_low_strided});
+
+    auto x_high_slice = pattern::wrap_type<v8::Slice>(
+        {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
+    auto x_high_strided = pattern::wrap_type<v1::StridedSlice>(
+        {x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
+    auto x_high = std::make_shared<pattern::op::Or>(OutputVector{x_high_slice, x_high_strided});
+
+    auto mul_low_cos = pattern::wrap_type<v1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
+    auto mul_low_sin = pattern::wrap_type<v1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
+    auto mul_high_cos = pattern::wrap_type<v1::Multiply>({x_high, t_cos}, {{"auto_broadcast", "numpy"}});
+    auto mul_high_sin = pattern::wrap_type<v1::Multiply>({x_high, t_sin}, {{"auto_broadcast", "numpy"}});
+
+    // y_low = (x_low * cos) - (x_high * sin); accept Subtract or its ConvertSubtract→Add+Negate form.
+    auto neg_high_sin =
+        pattern::wrap_type<v1::Multiply>({mul_high_sin, -1.0f}, {{"auto_broadcast", "numpy"}});
+    auto sub_low_via_subtract =
+        pattern::wrap_type<v1::Subtract>({mul_low_cos, mul_high_sin}, {{"auto_broadcast", "numpy"}});
+    auto sub_low_via_add =
+        pattern::wrap_type<v1::Add>({mul_low_cos, neg_high_sin}, {{"auto_broadcast", "numpy"}});
+    auto sub_low = std::make_shared<pattern::op::Or>(OutputVector{sub_low_via_subtract, sub_low_via_add});
+
+    // y_high = (x_high * cos) + (x_low * sin)
+    auto add_high = pattern::wrap_type<v1::Add>({mul_high_cos, mul_low_sin}, {{"auto_broadcast", "numpy"}});
+
+    // Insert a singleton axis before the last one; prior passes may canonicalize Unsqueeze to Reshape.
+    auto unsq_low_via_unsq = pattern::wrap_type<v0::Unsqueeze>({sub_low, pattern::any_input()});
+    auto unsq_low_via_reshape = pattern::wrap_type<v1::Reshape>({sub_low, pattern::any_input()});
+    auto unsq_low = std::make_shared<pattern::op::Or>(OutputVector{unsq_low_via_unsq, unsq_low_via_reshape});
+
+    auto unsq_high_via_unsq = pattern::wrap_type<v0::Unsqueeze>({add_high, pattern::any_input()});
+    auto unsq_high_via_reshape = pattern::wrap_type<v1::Reshape>({add_high, pattern::any_input()});
+    auto unsq_high = std::make_shared<pattern::op::Or>(OutputVector{unsq_high_via_unsq, unsq_high_via_reshape});
+
+    auto stack = pattern::wrap_type<v0::Concat>({unsq_low, unsq_high});
+    auto result = pattern::wrap_type<v1::Reshape>({stack, pattern::any_input()});
+
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto root = m.get_match_root();
+
+        // half_ndims from x_low's last dim (whichever OR-branch matched).
+        auto find_or_branch = [&](const std::shared_ptr<ov::Node>& a,
+                                  const std::shared_ptr<ov::Node>& b) -> ov::Output<ov::Node> {
+            auto ita = pattern_map.find(a);
+            if (ita != pattern_map.end()) return ita->second;
+            auto itb = pattern_map.find(b);
+            if (itb != pattern_map.end()) return itb->second;
+            return {};
+        };
+        auto x_low_out = find_or_branch(x_low_slice, x_low_strided);
+        if (!x_low_out.get_node_shared_ptr()) {
+            return false;
+        }
+        const auto x_low_pshape = x_low_out.get_partial_shape();
+        if (!x_low_pshape.rank().is_static() || x_low_pshape[x_low_pshape.size() - 1].is_dynamic()) {
+            return false;
+        }
+        const int64_t half_ndims_val = x_low_pshape[x_low_pshape.size() - 1].get_length();
+
+        // Stack must be one rank above the final Reshape, concatenating on the next-to-last axis.
+        auto stack_node =
+            ov::as_type_ptr<v0::Concat>(pattern_map.at(stack).get_node_shared_ptr());
+        if (!stack_node) {
+            return false;
+        }
+        const auto stack_axis = stack_node->get_axis();
+        const auto stack_in_rank = stack_node->get_input_partial_shape(0).rank();
+        if (!stack_in_rank.is_static()) {
+            return false;
+        }
+        const auto reshape_out_pshape = root->get_output_partial_shape(0);
+        if (!reshape_out_pshape.rank().is_static()) {
+            return false;
+        }
+        const auto out_rank = reshape_out_pshape.rank().get_length();
+        const auto stacked_rank = stack_in_rank.get_length();
+        if (stacked_rank != out_rank + 1) {
+            return false;
+        }
+        const auto normalized_axis = stack_axis < 0 ? stack_axis + stacked_rank : stack_axis;
+        if (normalized_axis != stacked_rank - 2) {
+            return false;
+        }
+
+        ov::op::internal::RoPE::Config config;
+        config.rotary_ndims = 2ul * static_cast<size_t>(half_ndims_val);
+        // The matched slices are step-2 (even/odd lanes), i.e. GPT-J interleaved rotation, so the
+        // fused op must run in interleaved mode. Verified bit-exact against the unfused graph.
+        config.is_interleaved = true;
+
+        const auto x_value = pattern_map.at(x);
+
+        // Feed RoPE a rank-4 [seq, head_cnt, 1, head_size] input by inserting a singleton axis before
+        // the last dim, matching the rank-4 layout the other RoPE fusions produce. This keeps head_size
+        // as the innermost dimension, which plugins rely on for an efficient RoPE implementation. Pure
+        // reshape, no data movement.
+        auto singleton_shape = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{0, 0, 1, -1});
+        auto x_expanded = std::make_shared<v1::Reshape>(x_value, singleton_shape, true);  // special_zero
+
+        OutputVector new_args;
+        new_args.push_back(x_expanded);
+        new_args.push_back(pattern_map.at(t_cos));
+        new_args.push_back(pattern_map.at(t_sin));
+
+        auto rope_node = std::make_shared<ov::op::internal::RoPE>(new_args, config);
+        // RoPE keeps the singleton-expanded rank-4 shape; reuse root's reshape target to restore the
+        // layout downstream consumers expect (e.g. KV-cache concat wants [B, L, H, S]).
+        auto new_node = std::make_shared<v1::Reshape>(rope_node, root->input_value(1), false);
+        new_node->set_friendly_name(root->get_friendly_name());
+
+        ov::NodeVector rt_from{
+            pattern_map.at(mul_low_cos).get_node_shared_ptr(),
+            pattern_map.at(mul_low_sin).get_node_shared_ptr(),
+            pattern_map.at(mul_high_cos).get_node_shared_ptr(),
+            pattern_map.at(mul_high_sin).get_node_shared_ptr(),
+            pattern_map.at(add_high).get_node_shared_ptr(),
+            pattern_map.at(stack).get_node_shared_ptr(),
+            root};
+        // OR-branch nodes — only the matched branch is present in pattern_map.
+        for (const auto& or_branch : {x_low_slice,
+                                       x_low_strided,
+                                       x_high_slice,
+                                       x_high_strided,
+                                       sub_low_via_subtract,
+                                       sub_low_via_add,
+                                       neg_high_sin,
+                                       unsq_low_via_unsq,
+                                       unsq_low_via_reshape,
+                                       unsq_high_via_unsq,
+                                       unsq_high_via_reshape}) {
+            auto it = pattern_map.find(or_branch);
+            if (it != pattern_map.end()) {
+                rt_from.push_back(it->second.get_node_shared_ptr());
+            }
+        }
+        ov::copy_runtime_info(rt_from, new_node);
+        ov::replace_node(root, new_node);
+        register_new_node(new_node);
         return true;
     };
 

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -1432,30 +1432,77 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
             return false;
         }
 
+        // The llama.cpp NORMAL RoPE reads interleaved lanes (even = x[0::2], odd = x[1::2]) but writes
+        // a half-split output ([first... | second...]). The RoPE op's two rotation modes are fixed
+        // read==write: is_interleaved=true rotates interleaved->interleaved, false rotates
+        // half-split->half-split. Neither matches "interleaved-in, half-split-out", so we re-pack x to
+        // half-split layout up front and run the op in half-split mode. Setting cos_sin_ndims ==
+        // rotary_ndims/2 puts the kernel's cos/sin table offset at 0, so it multiplies the same
+        // half-length table against both output halves -- matching the unfused math:
+        //   out[k]      = x_low[k]*cos[k] - x_high[k]*sin[k]   (= even*cos - odd*sin = first)
+        //   out[half+k] = x_high[k]*cos[k] + x_low[k]*sin[k]   (= odd*cos  + even*sin = second)
+        // The RoPE op expects rank-4 inputs with x as [B, H, L, S] and cos/sin as [B, 1, L, half];
+        // we're matching a rank-3 x ([L, H, S]) and rank-4 cos/sin ([1, L, 1, half]).
+        const auto x_pshape = pattern_map.at(x).get_partial_shape();
+        const auto cos_pshape = pattern_map.at(t_cos).get_partial_shape();
+        if (!x_pshape.rank().is_static() || x_pshape.rank().get_length() != 3 ||
+            !cos_pshape.rank().is_static() || cos_pshape.rank().get_length() != 4) {
+            return false;
+        }
+
+        // Re-pack x from interleaved [.., even0,odd0,even1,odd1,..] to half-split [.., even.. | odd..]
+        // with explicit Gather indices on the last axis. (A step-2 Slice would express the same thing
+        // more compactly but is not reliable across plugin Slice implementations.)
+        const int64_t ndims = 2 * half_ndims_val;
+        std::vector<int64_t> even_idx(static_cast<size_t>(half_ndims_val));
+        std::vector<int64_t> odd_idx(static_cast<size_t>(half_ndims_val));
+        for (int64_t k = 0; k < half_ndims_val; ++k) {
+            even_idx[static_cast<size_t>(k)] = 2 * k;
+            odd_idx[static_cast<size_t>(k)] = 2 * k + 1;
+        }
+        auto gather_axis = v0::Constant::create(ov::element::i64, {}, {-1});
+        auto even = std::make_shared<v8::Gather>(
+            pattern_map.at(x),
+            v0::Constant::create(ov::element::i64, {static_cast<size_t>(half_ndims_val)}, even_idx),
+            gather_axis);
+        auto odd = std::make_shared<v8::Gather>(
+            pattern_map.at(x),
+            v0::Constant::create(ov::element::i64, {static_cast<size_t>(half_ndims_val)}, odd_idx),
+            gather_axis);
+        auto x_hs = std::make_shared<v0::Concat>(OutputVector{even, odd}, -1);  // [L, H, S] half-split
+
+        // Lift x to rank-4 and transpose to [1, H, L, S] (the input layout RoPE expects). The Transpose
+        // is folded into the RoPE op by RoPEFusionPreprocess via config.input_trans0213.
+        auto x_unsq = std::make_shared<v0::Unsqueeze>(x_hs, v0::Constant::create(ov::element::i64, {1}, {0}));
+        auto x_perm = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{0, 2, 1, 3});
+        ov::Output<ov::Node> x_value = std::make_shared<v1::Transpose>(x_unsq, x_perm);
+
+        // cos/sin: [1, L, 1, half] -> Transpose(0,2,1,3) -> [1, 1, L, half]. No repeat-interleave: the
+        // half-split mode reuses the same half-length table for both halves.
+        auto cos_perm = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{0, 2, 1, 3});
+        auto cos_t = std::make_shared<v1::Transpose>(pattern_map.at(t_cos), cos_perm);
+        auto sin_t = std::make_shared<v1::Transpose>(pattern_map.at(t_sin), cos_perm);
+
         ov::op::internal::RoPE::Config config;
-        config.rotary_ndims = 2ul * static_cast<size_t>(half_ndims_val);
-        // The matched slices are step-2 (even/odd lanes), i.e. GPT-J interleaved rotation, so the
-        // fused op must run in interleaved mode. Verified bit-exact against the unfused graph.
-        config.is_interleaved = true;
-
-        const auto x_value = pattern_map.at(x);
-
-        // Feed RoPE a rank-4 [seq, head_cnt, 1, head_size] input by inserting a singleton axis before
-        // the last dim, matching the rank-4 layout the other RoPE fusions produce. This keeps head_size
-        // as the innermost dimension, which plugins rely on for an efficient RoPE implementation. Pure
-        // reshape, no data movement.
-        auto singleton_shape = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{0, 0, 1, -1});
-        auto x_expanded = std::make_shared<v1::Reshape>(x_value, singleton_shape, true);  // special_zero
+        config.rotary_ndims = static_cast<size_t>(ndims);
+        config.is_interleaved = false;
+        // cos/sin are half-length (rotary_ndims/2); declaring cos_sin_ndims pins the kernel's table
+        // offset to 0 so the same half-length table is reused for both output halves (matches the
+        // unfused math out[half+k] = odd*cos[k] + even*sin[k]). Leaving cos_sin_ndims=0 would make the
+        // kernel index past the table for the second half and corrupt the odd-lane outputs.
+        config.cos_sin_ndims = static_cast<size_t>(half_ndims_val);
 
         OutputVector new_args;
-        new_args.push_back(x_expanded);
-        new_args.push_back(pattern_map.at(t_cos));
-        new_args.push_back(pattern_map.at(t_sin));
+        new_args.push_back(x_value);
+        new_args.push_back(cos_t);
+        new_args.push_back(sin_t);
 
         auto rope_node = std::make_shared<ov::op::internal::RoPE>(new_args, config);
-        // RoPE keeps the singleton-expanded rank-4 shape; reuse root's reshape target to restore the
-        // layout downstream consumers expect (e.g. KV-cache concat wants [B, L, H, S]).
-        auto new_node = std::make_shared<v1::Reshape>(rope_node, root->input_value(1), false);
+        // RoPE output is [1, H, L, S]; transpose back to [1, L, H, S] so the root Reshape target
+        // ([1, -1, head_cnt, head_size]) restores the layout downstream consumers expect.
+        auto out_perm = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{0, 2, 1, 3});
+        auto rope_t = std::make_shared<v1::Transpose>(rope_node, out_perm);
+        auto new_node = std::make_shared<v1::Reshape>(rope_t, root->input_value(1), false);
         new_node->set_friendly_name(root->get_friendly_name());
 
         ov::NodeVector rt_from{pattern_map.at(mul_low_cos).get_node_shared_ptr(),

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -1346,14 +1346,14 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
     // unconstrained here and re-validated in the callback.
     auto x_low_slice = pattern::wrap_type<v8::Slice>(
         {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto x_low_strided = pattern::wrap_type<v1::StridedSlice>(
-        {x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
+    auto x_low_strided =
+        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
     auto x_low = std::make_shared<pattern::op::Or>(OutputVector{x_low_slice, x_low_strided});
 
     auto x_high_slice = pattern::wrap_type<v8::Slice>(
         {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto x_high_strided = pattern::wrap_type<v1::StridedSlice>(
-        {x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
+    auto x_high_strided =
+        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
     auto x_high = std::make_shared<pattern::op::Or>(OutputVector{x_high_slice, x_high_strided});
 
     auto mul_low_cos = pattern::wrap_type<v1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
@@ -1362,12 +1362,10 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
     auto mul_high_sin = pattern::wrap_type<v1::Multiply>({x_high, t_sin}, {{"auto_broadcast", "numpy"}});
 
     // y_low = (x_low * cos) - (x_high * sin); accept Subtract or its ConvertSubtract→Add+Negate form.
-    auto neg_high_sin =
-        pattern::wrap_type<v1::Multiply>({mul_high_sin, -1.0f}, {{"auto_broadcast", "numpy"}});
+    auto neg_high_sin = pattern::wrap_type<v1::Multiply>({mul_high_sin, -1.0f}, {{"auto_broadcast", "numpy"}});
     auto sub_low_via_subtract =
         pattern::wrap_type<v1::Subtract>({mul_low_cos, mul_high_sin}, {{"auto_broadcast", "numpy"}});
-    auto sub_low_via_add =
-        pattern::wrap_type<v1::Add>({mul_low_cos, neg_high_sin}, {{"auto_broadcast", "numpy"}});
+    auto sub_low_via_add = pattern::wrap_type<v1::Add>({mul_low_cos, neg_high_sin}, {{"auto_broadcast", "numpy"}});
     auto sub_low = std::make_shared<pattern::op::Or>(OutputVector{sub_low_via_subtract, sub_low_via_add});
 
     // y_high = (x_high * cos) + (x_low * sin)
@@ -1393,9 +1391,11 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         auto find_or_branch = [&](const std::shared_ptr<ov::Node>& a,
                                   const std::shared_ptr<ov::Node>& b) -> ov::Output<ov::Node> {
             auto ita = pattern_map.find(a);
-            if (ita != pattern_map.end()) return ita->second;
+            if (ita != pattern_map.end())
+                return ita->second;
             auto itb = pattern_map.find(b);
-            if (itb != pattern_map.end()) return itb->second;
+            if (itb != pattern_map.end())
+                return itb->second;
             return {};
         };
         auto x_low_out = find_or_branch(x_low_slice, x_low_strided);
@@ -1409,8 +1409,7 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         const int64_t half_ndims_val = x_low_pshape[x_low_pshape.size() - 1].get_length();
 
         // Stack must be one rank above the final Reshape, concatenating on the next-to-last axis.
-        auto stack_node =
-            ov::as_type_ptr<v0::Concat>(pattern_map.at(stack).get_node_shared_ptr());
+        auto stack_node = ov::as_type_ptr<v0::Concat>(pattern_map.at(stack).get_node_shared_ptr());
         if (!stack_node) {
             return false;
         }
@@ -1459,26 +1458,25 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         auto new_node = std::make_shared<v1::Reshape>(rope_node, root->input_value(1), false);
         new_node->set_friendly_name(root->get_friendly_name());
 
-        ov::NodeVector rt_from{
-            pattern_map.at(mul_low_cos).get_node_shared_ptr(),
-            pattern_map.at(mul_low_sin).get_node_shared_ptr(),
-            pattern_map.at(mul_high_cos).get_node_shared_ptr(),
-            pattern_map.at(mul_high_sin).get_node_shared_ptr(),
-            pattern_map.at(add_high).get_node_shared_ptr(),
-            pattern_map.at(stack).get_node_shared_ptr(),
-            root};
+        ov::NodeVector rt_from{pattern_map.at(mul_low_cos).get_node_shared_ptr(),
+                               pattern_map.at(mul_low_sin).get_node_shared_ptr(),
+                               pattern_map.at(mul_high_cos).get_node_shared_ptr(),
+                               pattern_map.at(mul_high_sin).get_node_shared_ptr(),
+                               pattern_map.at(add_high).get_node_shared_ptr(),
+                               pattern_map.at(stack).get_node_shared_ptr(),
+                               root};
         // OR-branch nodes — only the matched branch is present in pattern_map.
         for (const auto& or_branch : {x_low_slice,
-                                       x_low_strided,
-                                       x_high_slice,
-                                       x_high_strided,
-                                       sub_low_via_subtract,
-                                       sub_low_via_add,
-                                       neg_high_sin,
-                                       unsq_low_via_unsq,
-                                       unsq_low_via_reshape,
-                                       unsq_high_via_unsq,
-                                       unsq_high_via_reshape}) {
+                                      x_low_strided,
+                                      x_high_slice,
+                                      x_high_strided,
+                                      sub_low_via_subtract,
+                                      sub_low_via_add,
+                                      neg_high_sin,
+                                      unsq_low_via_unsq,
+                                      unsq_low_via_reshape,
+                                      unsq_high_via_unsq,
+                                      unsq_high_via_reshape}) {
             auto it = pattern_map.find(or_branch);
             if (it != pattern_map.end()) {
                 rt_from.push_back(it->second.get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -1471,8 +1471,6 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
             return false;
         }
 
-        // The Or returns the matched branch's output; the even/odd step-2 read was already verified by
-        // the slice predicates, so half_ndims comes straight from x_low's (static) last dim.
         auto x_low_out = pattern_map.at(x_low);
         const auto x_low_pshape = x_low_out.get_partial_shape();
         if (!x_low_pshape.rank().is_static() || x_low_pshape[x_low_pshape.size() - 1].is_dynamic()) {

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -1445,8 +1445,12 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
             const int64_t norm_axis = axis < 0 ? axis + x_low_rank : axis;
             return norm_axis == x_low_rank - 1 && step == 2 && begin == expected_begin;
         };
-        // StridedSlice(data, begin, end, strides): per-axis vectors + masks; the last axis carries the
-        // step-2 read. Reject axis-adding/removing masks; require begin[-1] applied (begin_mask off).
+        // StridedSlice(data, begin, end, strides): per-axis vectors + masks. Require a pure last-axis
+        // step-2 read: last axis has stride 2, begin expected_begin (begin_mask off so it applies); all
+        // other axes untouched (stride 1, begin/end fully masked). Reject axis-adding/removing masks.
+        auto mask_set = [](const std::vector<int64_t>& m, size_t i) {
+            return i < m.size() && m[i] == 1;
+        };
         auto is_interleaved_strided = [&](const v1::StridedSlice* ss, int64_t expected_begin) -> bool {
             std::vector<int64_t> begin, strides;
             if (!as_vector_const(ss->input_value(1), begin) || !as_vector_const(ss->input_value(3), strides) ||
@@ -1464,9 +1468,14 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
                 return false;
             }
             const auto& begin_mask = ss->get_begin_mask();
+            const auto& end_mask = ss->get_end_mask();
             const size_t last = static_cast<size_t>(x_low_rank - 1);
-            const bool last_begin_active = last >= begin_mask.size() || begin_mask[last] == 0;
-            return strides[last] == 2 && begin[last] == expected_begin && last_begin_active;
+            for (size_t i = 0; i < last; ++i) {  // non-last axes must be left untouched
+                if (strides[i] != 1 || !mask_set(begin_mask, i) || !mask_set(end_mask, i)) {
+                    return false;
+                }
+            }
+            return strides[last] == 2 && begin[last] == expected_begin && !mask_set(begin_mask, last);
         };
         auto is_interleaved_slice = [&](const ov::Output<ov::Node>& slice_out, int64_t expected_begin) -> bool {
             auto node = slice_out.get_node_shared_ptr();

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -13,6 +13,7 @@
 #include "itt.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/concat.hpp"
@@ -1329,6 +1330,74 @@ RoPEFusionLtxVideo::RoPEFusionLtxVideo() {
     this->register_matcher(m, callback);
 }
 
+namespace {
+// Predicate for the llama.cpp interleaved even/odd read on the last axis: even = x[..., 0::2],
+// odd = x[..., 1::2]. Accepts opset8 Slice (scalar start/stop/step/axis) and its v1::StridedSlice
+// canonicalization (per-axis begin/end/strides + masks). expected_begin is 0 for even, 1 for odd.
+bool is_interleaved_last_axis_read(const ov::Output<ov::Node>& output, int64_t expected_begin) {
+    const auto node = output.get_node_shared_ptr();
+    const auto rank = output.get_partial_shape().rank();
+    if (!rank.is_static()) {
+        return false;
+    }
+    const int64_t r = rank.get_length();
+    auto scalar = [](const ov::Output<ov::Node>& o, int64_t& v) {
+        auto c = ov::as_type_ptr<v0::Constant>(o.get_node_shared_ptr());
+        if (!c || shape_size(c->get_shape()) != 1) {
+            return false;
+        }
+        v = c->cast_vector<int64_t>()[0];
+        return true;
+    };
+    auto vec = [](const ov::Output<ov::Node>& o, std::vector<int64_t>& v) {
+        auto c = ov::as_type_ptr<v0::Constant>(o.get_node_shared_ptr());
+        if (!c) {
+            return false;
+        }
+        v = c->cast_vector<int64_t>();
+        return true;
+    };
+    if (auto slice = ov::as_type_ptr<v8::Slice>(node)) {  // data, start, stop, step, axis
+        int64_t begin = 0, step = 0, axis = 0;
+        if (slice->get_input_size() != 5 || !scalar(slice->input_value(1), begin) ||
+            !scalar(slice->input_value(3), step) || !scalar(slice->input_value(4), axis)) {
+            return false;
+        }
+        return ov::util::normalize_axis(axis, r) == static_cast<size_t>(r - 1) && step == 2 &&
+               begin == expected_begin;
+    }
+    if (auto ss = ov::as_type_ptr<v1::StridedSlice>(node)) {  // data, begin, end, strides + masks
+        std::vector<int64_t> begin, strides;
+        if (!vec(ss->input_value(1), begin) || !vec(ss->input_value(3), strides) ||
+            static_cast<int64_t>(begin.size()) != r || static_cast<int64_t>(strides.size()) != r) {
+            return false;
+        }
+        auto any_set = [](const std::vector<int64_t>& m) {
+            return std::any_of(m.begin(), m.end(), [](int64_t v) {
+                return v != 0;
+            });
+        };
+        if (any_set(ss->get_new_axis_mask()) || any_set(ss->get_shrink_axis_mask()) ||
+            any_set(ss->get_ellipsis_mask())) {
+            return false;
+        }
+        auto mask_set = [](const std::vector<int64_t>& m, size_t i) {
+            return i < m.size() && m[i] == 1;
+        };
+        const auto& begin_mask = ss->get_begin_mask();
+        const auto& end_mask = ss->get_end_mask();
+        const size_t last = static_cast<size_t>(r - 1);
+        for (size_t i = 0; i < last; ++i) {  // non-last axes must be left untouched
+            if (strides[i] != 1 || !mask_set(begin_mask, i) || !mask_set(end_mask, i)) {
+                return false;
+            }
+        }
+        return strides[last] == 2 && begin[last] == expected_begin && !mask_set(begin_mask, last);
+    }
+    return false;
+}
+}  // namespace
+
 RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
     MATCHER_SCOPE(RoPEFusionLlamaCpp);
     // llama.cpp OV serializer RoPE (stateful, rank-3 input). Interleaved (GPT-J) rotation written as an
@@ -1336,26 +1405,36 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
     //   even/odd = Slice(x, {0,1}, end, step=2, axis=-1)
     //   stack    = Concat(Unsqueeze((even*cos - odd*sin), -2), Unsqueeze((even*sin + odd*cos), -2), -2)
     //   out      = Reshape(stack, [1, -1, head_cnt, head_size])
-    // The interleaved read + half-split write is mapped to config.interleaved_input in the callback,
-    // which also re-validates the slice attrs left unconstrained below. Stateless emits a different
+    // The interleaved read + half-split write is mapped to config.interleaved_input in the callback.
+    // The even/odd step-2 read is enforced by the slice predicates below. Stateless emits a different
     // 5D-stack topology and is intentionally not matched.
     auto x = pattern::any_input(pattern::rank_equals(3));
     auto t_cos = pattern::any_input();
     auto t_sin = pattern::any_input();
 
-    // Last-axis even/odd slice. The llama.cpp serializer emits Slice, but a prior pass canonicalizes
-    // it to StridedSlice, so accept both; attrs (step==2, begins {0,1}, last axis) are validated in the
-    // callback (see is_interleaved_slice).
+    // Last-axis even/odd read: even = x[..., 0::2], odd = x[..., 1::2]. The llama.cpp serializer emits
+    // Slice, but a prior pass canonicalizes it to StridedSlice, so accept both; the step-2/begin/axis
+    // attrs are checked by the predicate (interleaved_input below is only correct for this read).
+    auto even_pred = [](const ov::Output<ov::Node>& out) {
+        return is_interleaved_last_axis_read(out, 0);
+    };
+    auto odd_pred = [](const ov::Output<ov::Node>& out) {
+        return is_interleaved_last_axis_read(out, 1);
+    };
     auto x_low_slice = pattern::wrap_type<v8::Slice>(
-        {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto x_low_strided =
-        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
+        {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()},
+        even_pred);
+    auto x_low_strided = pattern::wrap_type<v1::StridedSlice>(
+        {x, pattern::any_input(), pattern::any_input(), pattern::any_input()},
+        even_pred);
     auto x_low = std::make_shared<pattern::op::Or>(OutputVector{x_low_slice, x_low_strided});
 
     auto x_high_slice = pattern::wrap_type<v8::Slice>(
-        {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto x_high_strided =
-        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
+        {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()},
+        odd_pred);
+    auto x_high_strided = pattern::wrap_type<v1::StridedSlice>(
+        {x, pattern::any_input(), pattern::any_input(), pattern::any_input()},
+        odd_pred);
     auto x_high = std::make_shared<pattern::op::Or>(OutputVector{x_high_slice, x_high_strided});
 
     auto mul_low_cos = pattern::wrap_type<v1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
@@ -1393,103 +1472,14 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
             return false;
         }
 
-        // Only the matched OR-branch (Slice or StridedSlice) is present in the pattern map.
-        auto matched_or = [&](const std::shared_ptr<ov::Node>& a,
-                              const std::shared_ptr<ov::Node>& b) -> ov::Output<ov::Node> {
-            auto it = pattern_map.find(a);
-            if (it != pattern_map.end()) {
-                return it->second;
-            }
-            it = pattern_map.find(b);
-            return it != pattern_map.end() ? it->second : ov::Output<ov::Node>{};
-        };
-        auto x_low_out = matched_or(x_low_slice, x_low_strided);
-        auto x_high_out = matched_or(x_high_slice, x_high_strided);
-        if (!x_low_out.get_node_shared_ptr() || !x_high_out.get_node_shared_ptr()) {
-            return false;
-        }
+        // The Or returns the matched branch's output; the even/odd step-2 read was already verified by
+        // the slice predicates, so half_ndims comes straight from x_low's (static) last dim.
+        auto x_low_out = pattern_map.at(x_low);
         const auto x_low_pshape = x_low_out.get_partial_shape();
         if (!x_low_pshape.rank().is_static() || x_low_pshape[x_low_pshape.size() - 1].is_dynamic()) {
             return false;
         }
         const int64_t half_ndims_val = x_low_pshape[x_low_pshape.size() - 1].get_length();
-
-        // Re-validate the slice attrs (left unconstrained in the pattern): the callback sets
-        // interleaved_input=true unconditionally, which is only correct for the llama.cpp interleaved
-        // read even = x[..., 0::2], odd = x[..., 1::2]. Otherwise a half-split (step==1) slice would
-        // fuse with wrong semantics. Both Slice and its StridedSlice canonicalization are validated.
-        const int64_t x_low_rank = x_low_pshape.rank().get_length();
-        auto as_scalar_const = [](const ov::Output<ov::Node>& o, int64_t& out) -> bool {
-            auto c = ov::as_type_ptr<v0::Constant>(o.get_node_shared_ptr());
-            if (!c || shape_size(c->get_shape()) != 1) {
-                return false;
-            }
-            out = c->cast_vector<int64_t>()[0];
-            return true;
-        };
-        auto as_vector_const = [](const ov::Output<ov::Node>& o, std::vector<int64_t>& out) -> bool {
-            auto c = ov::as_type_ptr<v0::Constant>(o.get_node_shared_ptr());
-            if (!c) {
-                return false;
-            }
-            out = c->cast_vector<int64_t>();
-            return true;
-        };
-        // Slice(data, start, stop, step, axis): scalar attrs, explicit axis.
-        auto is_interleaved_v8 = [&](const v8::Slice* slice, int64_t expected_begin) -> bool {
-            int64_t begin = 0, step = 0, axis = 0;
-            if (slice->get_input_size() != 5 || !as_scalar_const(slice->input_value(1), begin) ||
-                !as_scalar_const(slice->input_value(3), step) || !as_scalar_const(slice->input_value(4), axis)) {
-                return false;
-            }
-            const int64_t norm_axis = axis < 0 ? axis + x_low_rank : axis;
-            return norm_axis == x_low_rank - 1 && step == 2 && begin == expected_begin;
-        };
-        // StridedSlice(data, begin, end, strides): per-axis vectors + masks. Require a pure last-axis
-        // step-2 read: last axis has stride 2, begin expected_begin (begin_mask off so it applies); all
-        // other axes untouched (stride 1, begin/end fully masked). Reject axis-adding/removing masks.
-        auto mask_set = [](const std::vector<int64_t>& m, size_t i) {
-            return i < m.size() && m[i] == 1;
-        };
-        auto is_interleaved_strided = [&](const v1::StridedSlice* ss, int64_t expected_begin) -> bool {
-            std::vector<int64_t> begin, strides;
-            if (!as_vector_const(ss->input_value(1), begin) || !as_vector_const(ss->input_value(3), strides) ||
-                static_cast<int64_t>(begin.size()) != x_low_rank ||
-                static_cast<int64_t>(strides.size()) != x_low_rank) {
-                return false;
-            }
-            auto any_set = [](const std::vector<int64_t>& m) {
-                return std::any_of(m.begin(), m.end(), [](int64_t v) {
-                    return v != 0;
-                });
-            };
-            if (any_set(ss->get_new_axis_mask()) || any_set(ss->get_shrink_axis_mask()) ||
-                any_set(ss->get_ellipsis_mask())) {
-                return false;
-            }
-            const auto& begin_mask = ss->get_begin_mask();
-            const auto& end_mask = ss->get_end_mask();
-            const size_t last = static_cast<size_t>(x_low_rank - 1);
-            for (size_t i = 0; i < last; ++i) {  // non-last axes must be left untouched
-                if (strides[i] != 1 || !mask_set(begin_mask, i) || !mask_set(end_mask, i)) {
-                    return false;
-                }
-            }
-            return strides[last] == 2 && begin[last] == expected_begin && !mask_set(begin_mask, last);
-        };
-        auto is_interleaved_slice = [&](const ov::Output<ov::Node>& slice_out, int64_t expected_begin) -> bool {
-            auto node = slice_out.get_node_shared_ptr();
-            if (auto s = ov::as_type_ptr<v8::Slice>(node)) {
-                return is_interleaved_v8(s.get(), expected_begin);
-            }
-            if (auto ss = ov::as_type_ptr<v1::StridedSlice>(node)) {
-                return is_interleaved_strided(ss.get(), expected_begin);
-            }
-            return false;
-        };
-        if (!is_interleaved_slice(x_low_out, 0) || !is_interleaved_slice(x_high_out, 1)) {
-            return false;
-        }
 
         // Stack must be one rank above the final Reshape, concatenating on the next-to-last axis.
         auto stack_node = ov::as_type_ptr<v0::Concat>(pattern_map.at(stack).get_node_shared_ptr());
@@ -1510,8 +1500,7 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         if (stacked_rank != out_rank + 1) {
             return false;
         }
-        const auto normalized_axis = stack_axis < 0 ? stack_axis + stacked_rank : stack_axis;
-        if (normalized_axis != stacked_rank - 2) {
+        if (ov::util::normalize_axis(stack_axis, stacked_rank) != static_cast<size_t>(stacked_rank - 2)) {
             return false;
         }
 
@@ -1523,12 +1512,16 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
             if (it == pattern_map.end()) {
                 return true;  // Reshape branch matched instead; nothing to check here.
             }
-            int64_t axis = 0;
-            if (!as_scalar_const(it->second.get_node_shared_ptr()->input_value(1), axis)) {
+            auto axis_in = it->second.get_node_shared_ptr()->input_value(1);
+            auto axis_c = ov::as_type_ptr<v0::Constant>(axis_in.get_node_shared_ptr());
+            if (!axis_c || shape_size(axis_c->get_shape()) != 1) {
                 return false;
             }
-            const int64_t norm = axis < 0 ? axis + stacked_rank : axis;
-            return norm == stacked_rank - 2;
+            const int64_t axis = axis_c->cast_vector<int64_t>()[0];
+            if (axis < -stacked_rank || axis >= stacked_rank) {
+                return false;
+            }
+            return ov::util::normalize_axis(axis, stacked_rank) == static_cast<size_t>(stacked_rank - 2);
         };
         if (!unsqueeze_axis_ok(unsq_low_via_unsq) || !unsqueeze_axis_ok(unsq_high_via_unsq)) {
             return false;
@@ -1596,7 +1589,7 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         new_node->set_friendly_name(root->get_friendly_name());
 
         ov::NodeVector rt_from{x_low_out.get_node_shared_ptr(),
-                               x_high_out.get_node_shared_ptr(),
+                               pattern_map.at(x_high).get_node_shared_ptr(),
                                pattern_map.at(mul_low_cos).get_node_shared_ptr(),
                                pattern_map.at(mul_low_sin).get_node_shared_ptr(),
                                pattern_map.at(mul_high_cos).get_node_shared_ptr(),

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -1335,26 +1335,19 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
     //   even/odd = Slice(x, {0,1}, end, step=2, axis=-1)
     //   stack    = Concat(Unsqueeze((even*cos - odd*sin), -2), Unsqueeze((even*sin + odd*cos), -2), -2)
     //   out      = Reshape(stack, [1, -1, head_cnt, head_size])
-    // The interleaved read + half-split write is mapped to config.interleaved_input in the callback (see
-    // there). Slice begin/end/step are left unconstrained below; pattern vars x_low/x_high carry the
-    // even/odd lanes. Stateless emits a different 5D-stack topology and is intentionally not matched.
+    // The interleaved read + half-split write is mapped to config.interleaved_input in the callback,
+    // which also re-validates the slice attrs left unconstrained below. Stateless emits a different
+    // 5D-stack topology and is intentionally not matched.
     auto x = pattern::any_input(pattern::rank_equals(3));
     auto t_cos = pattern::any_input();
     auto t_sin = pattern::any_input();
 
-    // Last-axis slice. Accept Slice and StridedSlice (canonicalization varies); attrs are left
-    // unconstrained here and re-validated in the callback.
-    auto x_low_slice = pattern::wrap_type<v8::Slice>(
+    // Last-axis slice; attrs (step==2, begins {0,1}) are validated in the callback (see
+    // is_interleaved_slice). The llama.cpp serializer emits opset8 Slice.
+    auto x_low = pattern::wrap_type<v8::Slice>(
         {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto x_low_strided =
-        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto x_low = std::make_shared<pattern::op::Or>(OutputVector{x_low_slice, x_low_strided});
-
-    auto x_high_slice = pattern::wrap_type<v8::Slice>(
+    auto x_high = pattern::wrap_type<v8::Slice>(
         {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto x_high_strided =
-        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto x_high = std::make_shared<pattern::op::Or>(OutputVector{x_high_slice, x_high_strided});
 
     auto mul_low_cos = pattern::wrap_type<v1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
     auto mul_low_sin = pattern::wrap_type<v1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
@@ -1386,27 +1379,48 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
     matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
         auto root = m.get_match_root();
-
-        // half_ndims from x_low's last dim (whichever OR-branch matched).
-        auto find_or_branch = [&](const std::shared_ptr<ov::Node>& a,
-                                  const std::shared_ptr<ov::Node>& b) -> ov::Output<ov::Node> {
-            auto ita = pattern_map.find(a);
-            if (ita != pattern_map.end())
-                return ita->second;
-            auto itb = pattern_map.find(b);
-            if (itb != pattern_map.end())
-                return itb->second;
-            return {};
-        };
-        auto x_low_out = find_or_branch(x_low_slice, x_low_strided);
-        if (!x_low_out.get_node_shared_ptr()) {
+        auto root_reshape = ov::as_type_ptr<v1::Reshape>(root);
+        if (!root_reshape) {
             return false;
         }
+
+        auto x_low_out = pattern_map.at(x_low);
+        auto x_high_out = pattern_map.at(x_high);
         const auto x_low_pshape = x_low_out.get_partial_shape();
         if (!x_low_pshape.rank().is_static() || x_low_pshape[x_low_pshape.size() - 1].is_dynamic()) {
             return false;
         }
         const int64_t half_ndims_val = x_low_pshape[x_low_pshape.size() - 1].get_length();
+
+        // Re-validate the slice attrs (left unconstrained in the pattern): the callback sets
+        // interleaved_input=true unconditionally, which is only correct for the llama.cpp interleaved
+        // read even = x[..., 0::2], odd = x[..., 1::2]. Otherwise a half-split (step==1) slice would
+        // fuse with wrong semantics.
+        auto as_scalar_const = [](const ov::Output<ov::Node>& o, int64_t& out) -> bool {
+            auto c = ov::as_type_ptr<v0::Constant>(o.get_node_shared_ptr());
+            if (!c || shape_size(c->get_shape()) != 1) {
+                return false;
+            }
+            out = c->cast_vector<int64_t>()[0];
+            return true;
+        };
+        const int64_t x_low_rank = x_low_pshape.rank().get_length();
+        auto is_interleaved_slice = [&](const ov::Output<ov::Node>& slice_out, int64_t expected_begin) -> bool {
+            auto slice = ov::as_type_ptr<v8::Slice>(slice_out.get_node_shared_ptr());
+            if (!slice || slice->get_input_size() != 5) {  // data, start, stop, step, axis
+                return false;
+            }
+            int64_t begin = 0, step = 0, axis = 0;
+            if (!as_scalar_const(slice->input_value(1), begin) || !as_scalar_const(slice->input_value(3), step) ||
+                !as_scalar_const(slice->input_value(4), axis)) {
+                return false;
+            }
+            const int64_t norm_axis = axis < 0 ? axis + x_low_rank : axis;
+            return norm_axis == x_low_rank - 1 && step == 2 && begin == expected_begin;
+        };
+        if (!is_interleaved_slice(x_low_out, 0) || !is_interleaved_slice(x_high_out, 1)) {
+            return false;
+        }
 
         // Stack must be one rank above the final Reshape, concatenating on the next-to-last axis.
         auto stack_node = ov::as_type_ptr<v0::Concat>(pattern_map.at(stack).get_node_shared_ptr());
@@ -1432,6 +1446,25 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
             return false;
         }
 
+        // When the lanes are stacked via Unsqueeze (not the Reshape OR-branch), require its axis to be
+        // the same next-to-last position. The Reshape branch is covered by the stack rank/axis checks
+        // above (it must feed a Concat one rank above the output on axis stacked_rank-2).
+        auto unsqueeze_axis_ok = [&](const std::shared_ptr<ov::Node>& unsq_branch) -> bool {
+            auto it = pattern_map.find(unsq_branch);
+            if (it == pattern_map.end()) {
+                return true;  // Reshape branch matched instead; nothing to check here.
+            }
+            int64_t axis = 0;
+            if (!as_scalar_const(it->second.get_node_shared_ptr()->input_value(1), axis)) {
+                return false;
+            }
+            const int64_t norm = axis < 0 ? axis + stacked_rank : axis;
+            return norm == stacked_rank - 2;
+        };
+        if (!unsqueeze_axis_ok(unsq_low_via_unsq) || !unsqueeze_axis_ok(unsq_high_via_unsq)) {
+            return false;
+        }
+
         // llama.cpp NORMAL RoPE reads interleaved lanes (even = x[0::2], odd = x[1::2]) but writes a
         // half-split output. The RoPE op's interleaved_input mode reproduces exactly that: it reads the
         // even/odd lanes inside the kernel and writes half-split, so no even/odd gather is needed in the
@@ -1439,8 +1472,22 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         // [B, 1, L, half]; here x is rank-3 [L, H, S] and cos/sin rank-4 [1, L, 1, half].
         const auto x_pshape = pattern_map.at(x).get_partial_shape();
         const auto cos_pshape = pattern_map.at(t_cos).get_partial_shape();
+        const auto sin_pshape = pattern_map.at(t_sin).get_partial_shape();
+        // cos and sin are both transposed with a length-4 perm below, so both must be rank-4.
         if (!x_pshape.rank().is_static() || x_pshape.rank().get_length() != 3 || !cos_pshape.rank().is_static() ||
-            cos_pshape.rank().get_length() != 4) {
+            cos_pshape.rank().get_length() != 4 || !sin_pshape.rank().is_static() ||
+            sin_pshape.rank().get_length() != 4) {
+            return false;
+        }
+
+        // Guard the cos_sin_ndims=half_ndims invariant set below (pins the kernel table offset to 0):
+        // a mismatched cos/sin last dim reads past the table; x's last dim must hold both lanes (2*half).
+        const auto& cos_last = cos_pshape[cos_pshape.size() - 1];
+        const auto& sin_last = sin_pshape[sin_pshape.size() - 1];
+        const auto& x_last = x_pshape[x_pshape.size() - 1];
+        if (cos_last.is_dynamic() || cos_last.get_length() != half_ndims_val || sin_last.is_dynamic() ||
+            sin_last.get_length() != half_ndims_val || x_last.is_dynamic() ||
+            x_last.get_length() != 2 * half_ndims_val) {
             return false;
         }
 
@@ -1476,10 +1523,12 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         // layout downstream consumers expect.
         auto out_perm = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{0, 2, 1, 3});
         auto rope_t = std::make_shared<v1::Transpose>(rope_node, out_perm);
-        auto new_node = std::make_shared<v1::Reshape>(rope_t, root->input_value(1), false);
+        auto new_node = std::make_shared<v1::Reshape>(rope_t, root->input_value(1), root_reshape->get_special_zero());
         new_node->set_friendly_name(root->get_friendly_name());
 
-        ov::NodeVector rt_from{pattern_map.at(mul_low_cos).get_node_shared_ptr(),
+        ov::NodeVector rt_from{pattern_map.at(x_low).get_node_shared_ptr(),
+                               pattern_map.at(x_high).get_node_shared_ptr(),
+                               pattern_map.at(mul_low_cos).get_node_shared_ptr(),
                                pattern_map.at(mul_low_sin).get_node_shared_ptr(),
                                pattern_map.at(mul_high_cos).get_node_shared_ptr(),
                                pattern_map.at(mul_high_sin).get_node_shared_ptr(),
@@ -1487,11 +1536,7 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
                                pattern_map.at(stack).get_node_shared_ptr(),
                                root};
         // OR-branch nodes — only the matched branch is present in pattern_map.
-        for (const auto& or_branch : {x_low_slice,
-                                      x_low_strided,
-                                      x_high_slice,
-                                      x_high_strided,
-                                      sub_low_via_subtract,
+        for (const auto& or_branch : {sub_low_via_subtract,
                                       sub_low_via_add,
                                       neg_high_sin,
                                       unsq_low_via_unsq,

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -1335,9 +1335,9 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
     //   even/odd = Slice(x, {0,1}, end, step=2, axis=-1)
     //   stack    = Concat(Unsqueeze((even*cos - odd*sin), -2), Unsqueeze((even*sin + odd*cos), -2), -2)
     //   out      = Reshape(stack, [1, -1, head_cnt, head_size])
-    // Step-2 slices => config.is_interleaved=true (verified bit-exact). Slice begin/end/step are left
-    // unconstrained below; pattern vars x_low/x_high carry the even/odd lanes. Stateless emits a
-    // different 5D-stack topology and is intentionally not matched.
+    // The interleaved read + half-split write is mapped to config.interleaved_input in the callback (see
+    // there). Slice begin/end/step are left unconstrained below; pattern vars x_low/x_high carry the
+    // even/odd lanes. Stateless emits a different 5D-stack topology and is intentionally not matched.
     auto x = pattern::any_input(pattern::rank_equals(3));
     auto t_cos = pattern::any_input();
     auto t_sin = pattern::any_input();
@@ -1432,53 +1432,27 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
             return false;
         }
 
-        // The llama.cpp NORMAL RoPE reads interleaved lanes (even = x[0::2], odd = x[1::2]) but writes
-        // a half-split output ([first... | second...]). The RoPE op's two rotation modes are fixed
-        // read==write: is_interleaved=true rotates interleaved->interleaved, false rotates
-        // half-split->half-split. Neither matches "interleaved-in, half-split-out", so we re-pack x to
-        // half-split layout up front and run the op in half-split mode. Setting cos_sin_ndims ==
-        // rotary_ndims/2 puts the kernel's cos/sin table offset at 0, so it multiplies the same
-        // half-length table against both output halves -- matching the unfused math:
-        //   out[k]      = x_low[k]*cos[k] - x_high[k]*sin[k]   (= even*cos - odd*sin = first)
-        //   out[half+k] = x_high[k]*cos[k] + x_low[k]*sin[k]   (= odd*cos  + even*sin = second)
-        // The RoPE op expects rank-4 inputs with x as [B, H, L, S] and cos/sin as [B, 1, L, half];
-        // we're matching a rank-3 x ([L, H, S]) and rank-4 cos/sin ([1, L, 1, half]).
+        // llama.cpp NORMAL RoPE reads interleaved lanes (even = x[0::2], odd = x[1::2]) but writes a
+        // half-split output. The RoPE op's interleaved_input mode reproduces exactly that: it reads the
+        // even/odd lanes inside the kernel and writes half-split, so no even/odd gather is needed in the
+        // graph. We only adapt the rank/layout: the op wants rank-4 x [B, H, L, S] and cos/sin
+        // [B, 1, L, half]; here x is rank-3 [L, H, S] and cos/sin rank-4 [1, L, 1, half].
         const auto x_pshape = pattern_map.at(x).get_partial_shape();
         const auto cos_pshape = pattern_map.at(t_cos).get_partial_shape();
-        if (!x_pshape.rank().is_static() || x_pshape.rank().get_length() != 3 ||
-            !cos_pshape.rank().is_static() || cos_pshape.rank().get_length() != 4) {
+        if (!x_pshape.rank().is_static() || x_pshape.rank().get_length() != 3 || !cos_pshape.rank().is_static() ||
+            cos_pshape.rank().get_length() != 4) {
             return false;
         }
 
-        // Re-pack x from interleaved [.., even0,odd0,even1,odd1,..] to half-split [.., even.. | odd..]
-        // with explicit Gather indices on the last axis. (A step-2 Slice would express the same thing
-        // more compactly but is not reliable across plugin Slice implementations.)
+        // x: [L, H, S] -> Unsqueeze(0) -> [1, L, H, S] -> Transpose(0,2,1,3) -> [1, H, L, S]. The
+        // Transpose is later folded into the op by RoPEFusionPreprocess (config.input_trans0213).
         const int64_t ndims = 2 * half_ndims_val;
-        std::vector<int64_t> even_idx(static_cast<size_t>(half_ndims_val));
-        std::vector<int64_t> odd_idx(static_cast<size_t>(half_ndims_val));
-        for (int64_t k = 0; k < half_ndims_val; ++k) {
-            even_idx[static_cast<size_t>(k)] = 2 * k;
-            odd_idx[static_cast<size_t>(k)] = 2 * k + 1;
-        }
-        auto gather_axis = v0::Constant::create(ov::element::i64, {}, {-1});
-        auto even = std::make_shared<v8::Gather>(
-            pattern_map.at(x),
-            v0::Constant::create(ov::element::i64, {static_cast<size_t>(half_ndims_val)}, even_idx),
-            gather_axis);
-        auto odd = std::make_shared<v8::Gather>(
-            pattern_map.at(x),
-            v0::Constant::create(ov::element::i64, {static_cast<size_t>(half_ndims_val)}, odd_idx),
-            gather_axis);
-        auto x_hs = std::make_shared<v0::Concat>(OutputVector{even, odd}, -1);  // [L, H, S] half-split
-
-        // Lift x to rank-4 and transpose to [1, H, L, S] (the input layout RoPE expects). The Transpose
-        // is folded into the RoPE op by RoPEFusionPreprocess via config.input_trans0213.
-        auto x_unsq = std::make_shared<v0::Unsqueeze>(x_hs, v0::Constant::create(ov::element::i64, {1}, {0}));
+        auto x_unsq =
+            std::make_shared<v0::Unsqueeze>(pattern_map.at(x), v0::Constant::create(ov::element::i64, {1}, {0}));
         auto x_perm = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{0, 2, 1, 3});
         ov::Output<ov::Node> x_value = std::make_shared<v1::Transpose>(x_unsq, x_perm);
 
-        // cos/sin: [1, L, 1, half] -> Transpose(0,2,1,3) -> [1, 1, L, half]. No repeat-interleave: the
-        // half-split mode reuses the same half-length table for both halves.
+        // cos/sin: [1, L, 1, half] -> Transpose(0,2,1,3) -> [1, 1, L, half].
         auto cos_perm = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{0, 2, 1, 3});
         auto cos_t = std::make_shared<v1::Transpose>(pattern_map.at(t_cos), cos_perm);
         auto sin_t = std::make_shared<v1::Transpose>(pattern_map.at(t_sin), cos_perm);
@@ -1486,10 +1460,10 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         ov::op::internal::RoPE::Config config;
         config.rotary_ndims = static_cast<size_t>(ndims);
         config.is_interleaved = false;
-        // cos/sin are half-length (rotary_ndims/2); declaring cos_sin_ndims pins the kernel's table
-        // offset to 0 so the same half-length table is reused for both output halves (matches the
-        // unfused math out[half+k] = odd*cos[k] + even*sin[k]). Leaving cos_sin_ndims=0 would make the
-        // kernel index past the table for the second half and corrupt the odd-lane outputs.
+        config.interleaved_input = true;
+        // cos/sin are half-length. cos_sin_ndims == rotary_ndims/2 pins the kernel's table offset to 0
+        // so the same half-length table feeds both output halves (out[k] = even*cos - odd*sin,
+        // out[half+k] = odd*cos + even*sin). Leaving it 0 reads past the table on the second half.
         config.cos_sin_ndims = static_cast<size_t>(half_ndims_val);
 
         OutputVector new_args;
@@ -1498,8 +1472,8 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         new_args.push_back(sin_t);
 
         auto rope_node = std::make_shared<ov::op::internal::RoPE>(new_args, config);
-        // RoPE output is [1, H, L, S]; transpose back to [1, L, H, S] so the root Reshape target
-        // ([1, -1, head_cnt, head_size]) restores the layout downstream consumers expect.
+        // RoPE output [1, H, L, S] -> Transpose back to [1, L, H, S] so the root Reshape restores the
+        // layout downstream consumers expect.
         auto out_perm = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{0, 2, 1, 3});
         auto rope_t = std::make_shared<v1::Transpose>(rope_node, out_perm);
         auto new_node = std::make_shared<v1::Reshape>(rope_t, root->input_value(1), false);

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -1363,8 +1363,7 @@ bool is_interleaved_last_axis_read(const ov::Output<ov::Node>& output, int64_t e
             !scalar(slice->input_value(3), step) || !scalar(slice->input_value(4), axis)) {
             return false;
         }
-        return ov::util::normalize_axis(axis, r) == static_cast<size_t>(r - 1) && step == 2 &&
-               begin == expected_begin;
+        return ov::util::normalize_axis(axis, r) == static_cast<size_t>(r - 1) && step == 2 && begin == expected_begin;
     }
     if (auto ss = ov::as_type_ptr<v1::StridedSlice>(node)) {  // data, begin, end, strides + masks
         std::vector<int64_t> begin, strides;
@@ -1424,17 +1423,17 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
     auto x_low_slice = pattern::wrap_type<v8::Slice>(
         {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()},
         even_pred);
-    auto x_low_strided = pattern::wrap_type<v1::StridedSlice>(
-        {x, pattern::any_input(), pattern::any_input(), pattern::any_input()},
-        even_pred);
+    auto x_low_strided =
+        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()},
+                                             even_pred);
     auto x_low = std::make_shared<pattern::op::Or>(OutputVector{x_low_slice, x_low_strided});
 
     auto x_high_slice = pattern::wrap_type<v8::Slice>(
         {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()},
         odd_pred);
-    auto x_high_strided = pattern::wrap_type<v1::StridedSlice>(
-        {x, pattern::any_input(), pattern::any_input(), pattern::any_input()},
-        odd_pred);
+    auto x_high_strided =
+        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()},
+                                             odd_pred);
     auto x_high = std::make_shared<pattern::op::Or>(OutputVector{x_high_slice, x_high_strided});
 
     auto mul_low_cos = pattern::wrap_type<v1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -4,6 +4,7 @@
 
 #include "transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp"
 
+#include <algorithm>
 #include <climits>
 #include <cstdint>
 #include <limits>
@@ -1342,12 +1343,20 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
     auto t_cos = pattern::any_input();
     auto t_sin = pattern::any_input();
 
-    // Last-axis slice; attrs (step==2, begins {0,1}) are validated in the callback (see
-    // is_interleaved_slice). The llama.cpp serializer emits opset8 Slice.
-    auto x_low = pattern::wrap_type<v8::Slice>(
+    // Last-axis even/odd slice. The llama.cpp serializer emits Slice, but a prior pass canonicalizes
+    // it to StridedSlice, so accept both; attrs (step==2, begins {0,1}, last axis) are validated in the
+    // callback (see is_interleaved_slice).
+    auto x_low_slice = pattern::wrap_type<v8::Slice>(
         {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto x_high = pattern::wrap_type<v8::Slice>(
+    auto x_low_strided =
+        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
+    auto x_low = std::make_shared<pattern::op::Or>(OutputVector{x_low_slice, x_low_strided});
+
+    auto x_high_slice = pattern::wrap_type<v8::Slice>(
         {x, pattern::any_input(), pattern::any_input(), pattern::any_input(), pattern::any_input()});
+    auto x_high_strided =
+        pattern::wrap_type<v1::StridedSlice>({x, pattern::any_input(), pattern::any_input(), pattern::any_input()});
+    auto x_high = std::make_shared<pattern::op::Or>(OutputVector{x_high_slice, x_high_strided});
 
     auto mul_low_cos = pattern::wrap_type<v1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
     auto mul_low_sin = pattern::wrap_type<v1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
@@ -1384,8 +1393,21 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
             return false;
         }
 
-        auto x_low_out = pattern_map.at(x_low);
-        auto x_high_out = pattern_map.at(x_high);
+        // Only the matched OR-branch (Slice or StridedSlice) is present in the pattern map.
+        auto matched_or = [&](const std::shared_ptr<ov::Node>& a,
+                              const std::shared_ptr<ov::Node>& b) -> ov::Output<ov::Node> {
+            auto it = pattern_map.find(a);
+            if (it != pattern_map.end()) {
+                return it->second;
+            }
+            it = pattern_map.find(b);
+            return it != pattern_map.end() ? it->second : ov::Output<ov::Node>{};
+        };
+        auto x_low_out = matched_or(x_low_slice, x_low_strided);
+        auto x_high_out = matched_or(x_high_slice, x_high_strided);
+        if (!x_low_out.get_node_shared_ptr() || !x_high_out.get_node_shared_ptr()) {
+            return false;
+        }
         const auto x_low_pshape = x_low_out.get_partial_shape();
         if (!x_low_pshape.rank().is_static() || x_low_pshape[x_low_pshape.size() - 1].is_dynamic()) {
             return false;
@@ -1395,7 +1417,8 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         // Re-validate the slice attrs (left unconstrained in the pattern): the callback sets
         // interleaved_input=true unconditionally, which is only correct for the llama.cpp interleaved
         // read even = x[..., 0::2], odd = x[..., 1::2]. Otherwise a half-split (step==1) slice would
-        // fuse with wrong semantics.
+        // fuse with wrong semantics. Both Slice and its StridedSlice canonicalization are validated.
+        const int64_t x_low_rank = x_low_pshape.rank().get_length();
         auto as_scalar_const = [](const ov::Output<ov::Node>& o, int64_t& out) -> bool {
             auto c = ov::as_type_ptr<v0::Constant>(o.get_node_shared_ptr());
             if (!c || shape_size(c->get_shape()) != 1) {
@@ -1404,19 +1427,56 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
             out = c->cast_vector<int64_t>()[0];
             return true;
         };
-        const int64_t x_low_rank = x_low_pshape.rank().get_length();
-        auto is_interleaved_slice = [&](const ov::Output<ov::Node>& slice_out, int64_t expected_begin) -> bool {
-            auto slice = ov::as_type_ptr<v8::Slice>(slice_out.get_node_shared_ptr());
-            if (!slice || slice->get_input_size() != 5) {  // data, start, stop, step, axis
+        auto as_vector_const = [](const ov::Output<ov::Node>& o, std::vector<int64_t>& out) -> bool {
+            auto c = ov::as_type_ptr<v0::Constant>(o.get_node_shared_ptr());
+            if (!c) {
                 return false;
             }
+            out = c->cast_vector<int64_t>();
+            return true;
+        };
+        // Slice(data, start, stop, step, axis): scalar attrs, explicit axis.
+        auto is_interleaved_v8 = [&](const v8::Slice* slice, int64_t expected_begin) -> bool {
             int64_t begin = 0, step = 0, axis = 0;
-            if (!as_scalar_const(slice->input_value(1), begin) || !as_scalar_const(slice->input_value(3), step) ||
-                !as_scalar_const(slice->input_value(4), axis)) {
+            if (slice->get_input_size() != 5 || !as_scalar_const(slice->input_value(1), begin) ||
+                !as_scalar_const(slice->input_value(3), step) || !as_scalar_const(slice->input_value(4), axis)) {
                 return false;
             }
             const int64_t norm_axis = axis < 0 ? axis + x_low_rank : axis;
             return norm_axis == x_low_rank - 1 && step == 2 && begin == expected_begin;
+        };
+        // StridedSlice(data, begin, end, strides): per-axis vectors + masks; the last axis carries the
+        // step-2 read. Reject axis-adding/removing masks; require begin[-1] applied (begin_mask off).
+        auto is_interleaved_strided = [&](const v1::StridedSlice* ss, int64_t expected_begin) -> bool {
+            std::vector<int64_t> begin, strides;
+            if (!as_vector_const(ss->input_value(1), begin) || !as_vector_const(ss->input_value(3), strides) ||
+                static_cast<int64_t>(begin.size()) != x_low_rank ||
+                static_cast<int64_t>(strides.size()) != x_low_rank) {
+                return false;
+            }
+            auto any_set = [](const std::vector<int64_t>& m) {
+                return std::any_of(m.begin(), m.end(), [](int64_t v) {
+                    return v != 0;
+                });
+            };
+            if (any_set(ss->get_new_axis_mask()) || any_set(ss->get_shrink_axis_mask()) ||
+                any_set(ss->get_ellipsis_mask())) {
+                return false;
+            }
+            const auto& begin_mask = ss->get_begin_mask();
+            const size_t last = static_cast<size_t>(x_low_rank - 1);
+            const bool last_begin_active = last >= begin_mask.size() || begin_mask[last] == 0;
+            return strides[last] == 2 && begin[last] == expected_begin && last_begin_active;
+        };
+        auto is_interleaved_slice = [&](const ov::Output<ov::Node>& slice_out, int64_t expected_begin) -> bool {
+            auto node = slice_out.get_node_shared_ptr();
+            if (auto s = ov::as_type_ptr<v8::Slice>(node)) {
+                return is_interleaved_v8(s.get(), expected_begin);
+            }
+            if (auto ss = ov::as_type_ptr<v1::StridedSlice>(node)) {
+                return is_interleaved_strided(ss.get(), expected_begin);
+            }
+            return false;
         };
         if (!is_interleaved_slice(x_low_out, 0) || !is_interleaved_slice(x_high_out, 1)) {
             return false;
@@ -1526,8 +1586,8 @@ RoPEFusionLlamaCpp::RoPEFusionLlamaCpp() {
         auto new_node = std::make_shared<v1::Reshape>(rope_t, root->input_value(1), root_reshape->get_special_zero());
         new_node->set_friendly_name(root->get_friendly_name());
 
-        ov::NodeVector rt_from{pattern_map.at(x_low).get_node_shared_ptr(),
-                               pattern_map.at(x_high).get_node_shared_ptr(),
+        ov::NodeVector rt_from{x_low_out.get_node_shared_ptr(),
+                               x_high_out.get_node_shared_ptr(),
                                pattern_map.at(mul_low_cos).get_node_shared_ptr(),
                                pattern_map.at(mul_low_sin).get_node_shared_ptr(),
                                pattern_map.at(mul_high_cos).get_node_shared_ptr(),

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -2250,7 +2250,10 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_concat_axis_positive) {
 TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp) {
     // llama.cpp OV serializer RoPE (stateful): rank-3 x, rank-4 cos/sin -> broadcast lifts the
     // Multiply/Unsqueeze chain so the stack is rank-5 and the final Reshape is rank-4. The fused form
-    // wraps RoPE with a singleton-axis Reshape (rank-3 -> rank-4 -> RoPE -> rank-4).
+    // re-packs x to half-split layout (even/odd Gather + Concat), Unsqueeze-lifts it to rank-4, runs
+    // RoPE in half-split mode (is_interleaved=false) with config.input_trans0213=true (the input-side
+    // Transpose is folded into the RoPE op by RoPEFusionPreprocess), then transposes back and Reshapes
+    // to the root layout.
     disable_rt_info_check();
     const int seq_len = 7;
     const int num_heads = 32;
@@ -2288,15 +2291,38 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp) {
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
 
-        auto x4 =
-            makeOP<opset1::Reshape>({x, makeConst(element::i64, Shape{4}, {0, 0, 1, -1})}, {{"special_zero", true}});
+        // Re-pack x from interleaved lanes to half-split with even/odd Gather + Concat, then Unsqueeze
+        // to rank-4 [1, L, H, S]. The input-side Transpose([0,2,1,3]) that the LlamaCpp matcher emits
+        // is consumed by the downstream RoPEFusionPreprocess pass into config.input_trans0213=true.
+        // cos/sin keep their Transpose to [1, 1, L, half]; the post-RoPE Transpose([0,2,1,3]) and root
+        // Reshape stay in the fused graph. All index/axis/perm constants are i64 to match the fused
+        // graph (PRECISIONS is compared by default).
+        std::vector<int64_t> even_idx(half_ndims), odd_idx(half_ndims);
+        for (int k = 0; k < half_ndims; ++k) {
+            even_idx[k] = 2 * k;
+            odd_idx[k] = 2 * k + 1;
+        }
+        auto gather_axis = makeConst(element::i64, Shape{}, std::vector<int64_t>{-1});
+        auto even = makeOP<ov::opset8::Gather>(
+            {x, makeConst(element::i64, Shape{static_cast<size_t>(half_ndims)}, even_idx), gather_axis},
+            {{"batch_dims", 0}});
+        auto odd = makeOP<ov::opset8::Gather>(
+            {x, makeConst(element::i64, Shape{static_cast<size_t>(half_ndims)}, odd_idx), gather_axis},
+            {{"batch_dims", 0}});
+        auto x_hs = makeOP<opset1::Concat>({even, odd}, {{"axis", -1}});
+        auto x_unsq = makeOP<opset1::Unsqueeze>({x_hs, makeConst(element::i64, Shape{1}, std::vector<int64_t>{0})});
 
-        auto rope = makeOP<op::internal::RoPE>({x4, t_cos, t_sin},
+        auto cos_t =
+            makeOP<opset1::Transpose>({t_cos, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
+        auto sin_t =
+            makeOP<opset1::Transpose>({t_sin, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
+
+        auto rope = makeOP<op::internal::RoPE>({x_unsq, cos_t, sin_t},
                                                {{"config.slice_start", 0},
                                                 {"config.slice_stop", 0},
-                                                {"config.input_trans0213", false},
+                                                {"config.input_trans0213", true},
                                                 {"config.output_trans0213", false},
-                                                {"config.is_interleaved", true},
+                                                {"config.is_interleaved", false},
                                                 {"config.rotary_ndims", ndims},
                                                 {"config.is_chatglm", false},
                                                 {"config.support_2d_rope", false},
@@ -2308,7 +2334,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp) {
                                                 {"config.head_size", 0},
                                                 {"config.gather_position_arg_id", 0}});
 
-        auto reshape = makeOP<opset1::Reshape>({rope, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+        auto rope_t =
+            makeOP<opset1::Transpose>({rope, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
+        auto reshape = makeOP<opset1::Reshape>({rope_t, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
                                                {{"special_zero", false}});
 
         model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
@@ -2357,15 +2385,38 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_subtract_canonicalized_to_ad
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
 
-        auto x4 =
-            makeOP<opset1::Reshape>({x, makeConst(element::i64, Shape{4}, {0, 0, 1, -1})}, {{"special_zero", true}});
+        // Re-pack x from interleaved lanes to half-split with even/odd Gather + Concat, then Unsqueeze
+        // to rank-4 [1, L, H, S]. The input-side Transpose([0,2,1,3]) that the LlamaCpp matcher emits
+        // is consumed by the downstream RoPEFusionPreprocess pass into config.input_trans0213=true.
+        // cos/sin keep their Transpose to [1, 1, L, half]; the post-RoPE Transpose([0,2,1,3]) and root
+        // Reshape stay in the fused graph. All index/axis/perm constants are i64 to match the fused
+        // graph (PRECISIONS is compared by default).
+        std::vector<int64_t> even_idx(half_ndims), odd_idx(half_ndims);
+        for (int k = 0; k < half_ndims; ++k) {
+            even_idx[k] = 2 * k;
+            odd_idx[k] = 2 * k + 1;
+        }
+        auto gather_axis = makeConst(element::i64, Shape{}, std::vector<int64_t>{-1});
+        auto even = makeOP<ov::opset8::Gather>(
+            {x, makeConst(element::i64, Shape{static_cast<size_t>(half_ndims)}, even_idx), gather_axis},
+            {{"batch_dims", 0}});
+        auto odd = makeOP<ov::opset8::Gather>(
+            {x, makeConst(element::i64, Shape{static_cast<size_t>(half_ndims)}, odd_idx), gather_axis},
+            {{"batch_dims", 0}});
+        auto x_hs = makeOP<opset1::Concat>({even, odd}, {{"axis", -1}});
+        auto x_unsq = makeOP<opset1::Unsqueeze>({x_hs, makeConst(element::i64, Shape{1}, std::vector<int64_t>{0})});
 
-        auto rope = makeOP<op::internal::RoPE>({x4, t_cos, t_sin},
+        auto cos_t =
+            makeOP<opset1::Transpose>({t_cos, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
+        auto sin_t =
+            makeOP<opset1::Transpose>({t_sin, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
+
+        auto rope = makeOP<op::internal::RoPE>({x_unsq, cos_t, sin_t},
                                                {{"config.slice_start", 0},
                                                 {"config.slice_stop", 0},
-                                                {"config.input_trans0213", false},
+                                                {"config.input_trans0213", true},
                                                 {"config.output_trans0213", false},
-                                                {"config.is_interleaved", true},
+                                                {"config.is_interleaved", false},
                                                 {"config.rotary_ndims", ndims},
                                                 {"config.is_chatglm", false},
                                                 {"config.support_2d_rope", false},
@@ -2377,7 +2428,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_subtract_canonicalized_to_ad
                                                 {"config.head_size", 0},
                                                 {"config.gather_position_arg_id", 0}});
 
-        auto reshape = makeOP<opset1::Reshape>({rope, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+        auto rope_t =
+            makeOP<opset1::Transpose>({rope, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
+        auto reshape = makeOP<opset1::Reshape>({rope_t, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
                                                {{"special_zero", false}});
 
         model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -2288,8 +2288,8 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp) {
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
 
-        auto x4 = makeOP<opset1::Reshape>({x, makeConst(element::i64, Shape{4}, {0, 0, 1, -1})},
-                                          {{"special_zero", true}});
+        auto x4 =
+            makeOP<opset1::Reshape>({x, makeConst(element::i64, Shape{4}, {0, 0, 1, -1})}, {{"special_zero", true}});
 
         auto rope = makeOP<op::internal::RoPE>({x4, t_cos, t_sin},
                                                {{"config.slice_start", 0},
@@ -2357,8 +2357,8 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_subtract_canonicalized_to_ad
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
 
-        auto x4 = makeOP<opset1::Reshape>({x, makeConst(element::i64, Shape{4}, {0, 0, 1, -1})},
-                                          {{"special_zero", true}});
+        auto x4 =
+            makeOP<opset1::Reshape>({x, makeConst(element::i64, Shape{4}, {0, 0, 1, -1})}, {{"special_zero", true}});
 
         auto rope = makeOP<op::internal::RoPE>({x4, t_cos, t_sin},
                                                {{"config.slice_start", 0},

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -22,6 +22,7 @@
 #include "openvino/op/split.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/strided_slice.hpp"
+#include "openvino/op/subtract.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/variadic_split.hpp"
@@ -2243,6 +2244,143 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_concat_axis_positive) {
                                                 {"config.gather_position_arg_id", 0}});
 
         model_ref = std::make_shared<Model>(OutputVector{rope}, ParameterVector{input, t_cos, t_sin});
+    }
+}
+
+TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp) {
+    // llama.cpp OV serializer RoPE (stateful): rank-3 x, rank-4 cos/sin -> broadcast lifts the
+    // Multiply/Unsqueeze chain so the stack is rank-5 and the final Reshape is rank-4. The fused form
+    // wraps RoPE with a singleton-axis Reshape (rank-3 -> rank-4 -> RoPE -> rank-4).
+    disable_rt_info_check();
+    const int seq_len = 7;
+    const int num_heads = 32;
+    const int ndims = 64;
+    const int half_ndims = ndims / 2;
+    using namespace ov;
+    {
+        auto x = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, num_heads, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+
+        auto x_low = makeOP<opset8::Slice>({x, {0}, {half_ndims}, {1}, {-1}});
+        auto x_high = makeOP<opset8::Slice>({x, {half_ndims}, {ndims}, {1}, {-1}});
+
+        auto mul_low_cos = makeOP<opset1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_low_sin = makeOP<opset1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_cos = makeOP<opset1::Multiply>({x_high, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_sin = makeOP<opset1::Multiply>({x_high, t_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto sub_low = makeOP<opset1::Subtract>({mul_low_cos, mul_high_sin}, {{"auto_broadcast", "numpy"}});
+        auto add_high = makeOP<opset1::Add>({mul_high_cos, mul_low_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto unsq_low = makeOP<opset1::Unsqueeze>({sub_low, {-2}});
+        auto unsq_high = makeOP<opset1::Unsqueeze>({add_high, {-2}});
+
+        auto stack = makeOP<opset1::Concat>({unsq_low, unsq_high}, {{"axis", -2}});
+        auto reshape = makeOP<opset1::Reshape>({stack, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+                                               {{"special_zero", false}});
+
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
+    }
+    manager.register_pass<pass::RoPEFusion>();
+    {
+        auto x = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, num_heads, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+
+        auto x4 = makeOP<opset1::Reshape>({x, makeConst(element::i64, Shape{4}, {0, 0, 1, -1})},
+                                          {{"special_zero", true}});
+
+        auto rope = makeOP<op::internal::RoPE>({x4, t_cos, t_sin},
+                                               {{"config.slice_start", 0},
+                                                {"config.slice_stop", 0},
+                                                {"config.input_trans0213", false},
+                                                {"config.output_trans0213", false},
+                                                {"config.is_interleaved", true},
+                                                {"config.rotary_ndims", ndims},
+                                                {"config.is_chatglm", false},
+                                                {"config.support_2d_rope", false},
+                                                {"config.support_3d_rope", false},
+                                                {"config.is_qwen", false},
+                                                {"config.use_rope_cache", false},
+                                                {"config.is_ltx_video", false},
+                                                {"config.head_cnt", 0},
+                                                {"config.head_size", 0},
+                                                {"config.gather_position_arg_id", 0}});
+
+        auto reshape = makeOP<opset1::Reshape>({rope, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+                                               {{"special_zero", false}});
+
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
+    }
+}
+
+TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_subtract_canonicalized_to_add) {
+    // As ConvertToROPE_LlamaCpp, but with the Subtract canonicalized to Add(_, Multiply(_, -1)) by
+    // a prior ConvertSubtractToAdd pass. The matcher must still fold it; the fused result is identical.
+    disable_rt_info_check();
+    const int seq_len = 7;
+    const int num_heads = 32;
+    const int ndims = 64;
+    const int half_ndims = ndims / 2;
+    using namespace ov;
+    {
+        auto x = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, num_heads, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+
+        auto x_low = makeOP<opset8::Slice>({x, {0}, {half_ndims}, {1}, {-1}});
+        auto x_high = makeOP<opset8::Slice>({x, {half_ndims}, {ndims}, {1}, {-1}});
+
+        auto mul_low_cos = makeOP<opset1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_low_sin = makeOP<opset1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_cos = makeOP<opset1::Multiply>({x_high, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_sin = makeOP<opset1::Multiply>({x_high, t_sin}, {{"auto_broadcast", "numpy"}});
+
+        // y_low = mul_low_cos + (mul_high_sin * -1)   (canonicalized Subtract)
+        auto neg_high_sin = makeOP<opset1::Multiply>({mul_high_sin, -1.0f}, {{"auto_broadcast", "numpy"}});
+        auto sub_low = makeOP<opset1::Add>({mul_low_cos, neg_high_sin}, {{"auto_broadcast", "numpy"}});
+        auto add_high = makeOP<opset1::Add>({mul_high_cos, mul_low_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto unsq_low = makeOP<opset1::Unsqueeze>({sub_low, {-2}});
+        auto unsq_high = makeOP<opset1::Unsqueeze>({add_high, {-2}});
+
+        auto stack = makeOP<opset1::Concat>({unsq_low, unsq_high}, {{"axis", -2}});
+        auto reshape = makeOP<opset1::Reshape>({stack, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+                                               {{"special_zero", false}});
+
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
+    }
+    manager.register_pass<pass::RoPEFusion>();
+    {
+        auto x = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, num_heads, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+
+        auto x4 = makeOP<opset1::Reshape>({x, makeConst(element::i64, Shape{4}, {0, 0, 1, -1})},
+                                          {{"special_zero", true}});
+
+        auto rope = makeOP<op::internal::RoPE>({x4, t_cos, t_sin},
+                                               {{"config.slice_start", 0},
+                                                {"config.slice_stop", 0},
+                                                {"config.input_trans0213", false},
+                                                {"config.output_trans0213", false},
+                                                {"config.is_interleaved", true},
+                                                {"config.rotary_ndims", ndims},
+                                                {"config.is_chatglm", false},
+                                                {"config.support_2d_rope", false},
+                                                {"config.support_3d_rope", false},
+                                                {"config.is_qwen", false},
+                                                {"config.use_rope_cache", false},
+                                                {"config.is_ltx_video", false},
+                                                {"config.head_cnt", 0},
+                                                {"config.head_size", 0},
+                                                {"config.gather_position_arg_id", 0}});
+
+        auto reshape = makeOP<opset1::Reshape>({rope, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+                                               {{"special_zero", false}});
+
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
     }
 }
 

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -159,6 +159,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_LLama2_no_gather) {
                                                        {"config.input_trans0213", true},
                                                        {"config.output_trans0213", false},
                                                        {"config.is_interleaved", false},
+                                                       {"config.interleaved_input", false},
                                                        {"config.is_chatglm", false},
                                                        {"config.support_2d_rope", false},
                                                        {"config.support_3d_rope", false},
@@ -168,6 +169,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_LLama2_no_gather) {
                                                        {"config.head_cnt", 0},
                                                        {"config.head_size", 0},
                                                        {"config.rotary_ndims", static_cast<int>(ndims)},
+                                                       {"config.cos_sin_ndims", 0},
                                                        {"config.gather_position_arg_id", 0}});
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{add_Add},
@@ -199,6 +201,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_LLama2_with_gather) {
                                                        {"config.input_trans0213", true},
                                                        {"config.output_trans0213", false},
                                                        {"config.is_interleaved", false},
+                                                       {"config.interleaved_input", false},
                                                        {"config.is_chatglm", false},
                                                        {"config.support_2d_rope", false},
                                                        {"config.support_3d_rope", false},
@@ -208,6 +211,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_LLama2_with_gather) {
                                                        {"config.head_cnt", 0},
                                                        {"config.head_size", 0},
                                                        {"config.rotary_ndims", static_cast<int>(ndims)},
+                                                       {"config.cos_sin_ndims", 0},
                                                        {"config.gather_position_arg_id", 3}});
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{add_Add},
@@ -396,6 +400,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTNEOX_no_gather) {
                                                     {"config.input_trans0213", true},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.is_chatglm", false},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
@@ -405,6 +410,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTNEOX_no_gather) {
                                                     {"config.head_cnt", 0},
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.gather_position_arg_id", 0}});
         model_ref =
             std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, param_cos, param_sin});
@@ -436,6 +442,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTNEOX_with_gather) {
                                                     {"config.input_trans0213", true},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.is_chatglm", false},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
@@ -445,6 +452,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTNEOX_with_gather) {
                                                     {"config.head_cnt", 0},
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.gather_position_arg_id", 3}});
         model_ref =
             std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, gather_idx, batch_limit});
@@ -556,6 +564,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", true},
                                                     {"config.is_interleaved", true},
+                                                    {"config.interleaved_input", false},
                                                     {"config.is_chatglm", false},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
@@ -565,6 +574,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ) {
                                                     {"config.head_cnt", 0},
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.gather_position_arg_id", 0}});
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, cos_sin});
     }
@@ -679,7 +689,9 @@ TEST_P(ConvertToROPETest, ConvertToROPE_chatGLM) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
@@ -768,7 +780,9 @@ TEST_P(ConvertToROPETest, ConvertToROPE_chatGLM_Slice) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
@@ -815,6 +829,7 @@ TEST_P(ConvertToROPETestGPTNEOX_3D, ConvertToROPE_qwen) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.is_chatglm", false},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", true},
@@ -824,6 +839,7 @@ TEST_P(ConvertToROPETestGPTNEOX_3D, ConvertToROPE_qwen) {
                                                     {"config.head_cnt", 0},
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.gather_position_arg_id", 0}});
         model_ref =
             std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, param_cos, param_sin});
@@ -907,6 +923,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_Slice) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", true},
                                                     {"config.is_interleaved", true},
+                                                    {"config.interleaved_input", false},
                                                     {"config.is_chatglm", false},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
@@ -916,6 +933,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_Slice) {
                                                     {"config.head_cnt", 0},
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.gather_position_arg_id", 0}});
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, cos_sin});
     }
@@ -1026,7 +1044,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM_2d_rope) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", true},
                                                     {"config.support_3d_rope", false},
@@ -1138,7 +1158,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM_nano_2d_rope) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", true},
                                                     {"config.support_3d_rope", false},
@@ -1215,7 +1237,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLMHF_2d_rope_GatherND_CPU) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", true},
                                                     {"config.support_3d_rope", false},
@@ -1318,7 +1342,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLMHF_2d_rope_GatherND_GPU) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", true},
                                                     {"config.support_3d_rope", false},
@@ -1411,7 +1437,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLMHF_2d_rope) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", true},
                                                     {"config.support_3d_rope", false},
@@ -1712,7 +1740,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM3_PagedAttention) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
@@ -1793,7 +1823,9 @@ TEST_P(ConvertToROPETest, ConvertToROPE_Qwen_PagedAttention) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", 128},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", false},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
@@ -1879,7 +1911,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_PagedAttention) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", true},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", false},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
@@ -1953,7 +1987,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM4_PagedAttention) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", 64},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", true},
                                                     {"config.support_3d_rope", false},
@@ -2041,7 +2077,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM4_PagedAttention_GPU) {
                                                     {"config.input_trans0213", false},
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", false},
+                                                    {"config.interleaved_input", false},
                                                     {"config.rotary_ndims", 64},
+                                                    {"config.cos_sin_ndims", 0},
                                                     {"config.is_chatglm", true},
                                                     {"config.support_2d_rope", true},
                                                     {"config.support_3d_rope", false},
@@ -2110,7 +2148,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_LtxVideo) {
                                                 {"config.input_trans0213", false},
                                                 {"config.output_trans0213", false},
                                                 {"config.is_interleaved", true},
+                                                {"config.interleaved_input", false},
                                                 {"config.rotary_ndims", rotary_ndims},
+                                                {"config.cos_sin_ndims", 0},
                                                 {"config.is_chatglm", false},
                                                 {"config.support_2d_rope", false},
                                                 {"config.support_3d_rope", true},
@@ -2170,6 +2210,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_negative_axis) {
                                                 {"config.input_trans0213", false},
                                                 {"config.output_trans0213", false},
                                                 {"config.is_interleaved", false},
+                                                {"config.interleaved_input", false},
                                                 {"config.rotary_ndims", ndims},
                                                 {"config.cos_sin_ndims", half_ndims},
                                                 {"config.is_chatglm", false},
@@ -2231,6 +2272,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_concat_axis_positive) {
                                                 {"config.input_trans0213", false},
                                                 {"config.output_trans0213", false},
                                                 {"config.is_interleaved", false},
+                                                {"config.interleaved_input", false},
                                                 {"config.rotary_ndims", ndims},
                                                 {"config.cos_sin_ndims", half_ndims},
                                                 {"config.is_chatglm", false},
@@ -2250,10 +2292,10 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_concat_axis_positive) {
 TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp) {
     // llama.cpp OV serializer RoPE (stateful): rank-3 x, rank-4 cos/sin -> broadcast lifts the
     // Multiply/Unsqueeze chain so the stack is rank-5 and the final Reshape is rank-4. The fused form
-    // re-packs x to half-split layout (even/odd Gather + Concat), Unsqueeze-lifts it to rank-4, runs
-    // RoPE in half-split mode (is_interleaved=false) with config.input_trans0213=true (the input-side
-    // Transpose is folded into the RoPE op by RoPEFusionPreprocess), then transposes back and Reshapes
-    // to the root layout.
+    // Unsqueeze-lifts x to rank-4 and runs RoPE with config.interleaved_input=true (the kernel reads
+    // even/odd lanes and writes half-split) and config.input_trans0213=true (the input-side Transpose
+    // is folded into the RoPE op by RoPEFusionPreprocess), then transposes back and Reshapes to the
+    // root layout.
     disable_rt_info_check();
     const int seq_len = 7;
     const int num_heads = 32;
@@ -2291,26 +2333,14 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp) {
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
 
-        // Re-pack x from interleaved lanes to half-split with even/odd Gather + Concat, then Unsqueeze
-        // to rank-4 [1, L, H, S]. The input-side Transpose([0,2,1,3]) that the LlamaCpp matcher emits
-        // is consumed by the downstream RoPEFusionPreprocess pass into config.input_trans0213=true.
-        // cos/sin keep their Transpose to [1, 1, L, half]; the post-RoPE Transpose([0,2,1,3]) and root
-        // Reshape stay in the fused graph. All index/axis/perm constants are i64 to match the fused
-        // graph (PRECISIONS is compared by default).
-        std::vector<int64_t> even_idx(half_ndims), odd_idx(half_ndims);
-        for (int k = 0; k < half_ndims; ++k) {
-            even_idx[k] = 2 * k;
-            odd_idx[k] = 2 * k + 1;
-        }
-        auto gather_axis = makeConst(element::i64, Shape{}, std::vector<int64_t>{-1});
-        auto even = makeOP<ov::opset8::Gather>(
-            {x, makeConst(element::i64, Shape{static_cast<size_t>(half_ndims)}, even_idx), gather_axis},
-            {{"batch_dims", 0}});
-        auto odd = makeOP<ov::opset8::Gather>(
-            {x, makeConst(element::i64, Shape{static_cast<size_t>(half_ndims)}, odd_idx), gather_axis},
-            {{"batch_dims", 0}});
-        auto x_hs = makeOP<opset1::Concat>({even, odd}, {{"axis", -1}});
-        auto x_unsq = makeOP<opset1::Unsqueeze>({x_hs, makeConst(element::i64, Shape{1}, std::vector<int64_t>{0})});
+        // x keeps its interleaved layout (no even/odd gather/concat): the RoPE op's interleaved_input
+        // mode reads the even/odd lanes inside the kernel. x is just Unsqueeze-lifted to rank-4
+        // [1, L, H, S]. The input-side Transpose([0,2,1,3]) the LlamaCpp matcher emits is consumed by
+        // the downstream RoPEFusionPreprocess pass into config.input_trans0213=true. cos/sin keep their
+        // Transpose to [1, 1, L, half]; the post-RoPE Transpose([0,2,1,3]) and root Reshape stay in the
+        // fused graph. All axis/perm constants are i64 to match the fused graph (PRECISIONS is compared
+        // by default).
+        auto x_unsq = makeOP<opset1::Unsqueeze>({x, makeConst(element::i64, Shape{1}, std::vector<int64_t>{0})});
 
         auto cos_t =
             makeOP<opset1::Transpose>({t_cos, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
@@ -2323,7 +2353,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp) {
                                                 {"config.input_trans0213", true},
                                                 {"config.output_trans0213", false},
                                                 {"config.is_interleaved", false},
+                                                {"config.interleaved_input", true},
                                                 {"config.rotary_ndims", ndims},
+                                                {"config.cos_sin_ndims", half_ndims},
                                                 {"config.is_chatglm", false},
                                                 {"config.support_2d_rope", false},
                                                 {"config.support_3d_rope", false},
@@ -2385,26 +2417,14 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_subtract_canonicalized_to_ad
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
 
-        // Re-pack x from interleaved lanes to half-split with even/odd Gather + Concat, then Unsqueeze
-        // to rank-4 [1, L, H, S]. The input-side Transpose([0,2,1,3]) that the LlamaCpp matcher emits
-        // is consumed by the downstream RoPEFusionPreprocess pass into config.input_trans0213=true.
-        // cos/sin keep their Transpose to [1, 1, L, half]; the post-RoPE Transpose([0,2,1,3]) and root
-        // Reshape stay in the fused graph. All index/axis/perm constants are i64 to match the fused
-        // graph (PRECISIONS is compared by default).
-        std::vector<int64_t> even_idx(half_ndims), odd_idx(half_ndims);
-        for (int k = 0; k < half_ndims; ++k) {
-            even_idx[k] = 2 * k;
-            odd_idx[k] = 2 * k + 1;
-        }
-        auto gather_axis = makeConst(element::i64, Shape{}, std::vector<int64_t>{-1});
-        auto even = makeOP<ov::opset8::Gather>(
-            {x, makeConst(element::i64, Shape{static_cast<size_t>(half_ndims)}, even_idx), gather_axis},
-            {{"batch_dims", 0}});
-        auto odd = makeOP<ov::opset8::Gather>(
-            {x, makeConst(element::i64, Shape{static_cast<size_t>(half_ndims)}, odd_idx), gather_axis},
-            {{"batch_dims", 0}});
-        auto x_hs = makeOP<opset1::Concat>({even, odd}, {{"axis", -1}});
-        auto x_unsq = makeOP<opset1::Unsqueeze>({x_hs, makeConst(element::i64, Shape{1}, std::vector<int64_t>{0})});
+        // x keeps its interleaved layout (no even/odd gather/concat): the RoPE op's interleaved_input
+        // mode reads the even/odd lanes inside the kernel. x is just Unsqueeze-lifted to rank-4
+        // [1, L, H, S]. The input-side Transpose([0,2,1,3]) the LlamaCpp matcher emits is consumed by
+        // the downstream RoPEFusionPreprocess pass into config.input_trans0213=true. cos/sin keep their
+        // Transpose to [1, 1, L, half]; the post-RoPE Transpose([0,2,1,3]) and root Reshape stay in the
+        // fused graph. All axis/perm constants are i64 to match the fused graph (PRECISIONS is compared
+        // by default).
+        auto x_unsq = makeOP<opset1::Unsqueeze>({x, makeConst(element::i64, Shape{1}, std::vector<int64_t>{0})});
 
         auto cos_t =
             makeOP<opset1::Transpose>({t_cos, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
@@ -2417,7 +2437,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_subtract_canonicalized_to_ad
                                                 {"config.input_trans0213", true},
                                                 {"config.output_trans0213", false},
                                                 {"config.is_interleaved", false},
+                                                {"config.interleaved_input", true},
                                                 {"config.rotary_ndims", ndims},
+                                                {"config.cos_sin_ndims", half_ndims},
                                                 {"config.is_chatglm", false},
                                                 {"config.support_2d_rope", false},
                                                 {"config.support_3d_rope", false},
@@ -2482,6 +2504,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_split_axis_positive) {
                                                 {"config.input_trans0213", false},
                                                 {"config.output_trans0213", false},
                                                 {"config.is_interleaved", false},
+                                                {"config.interleaved_input", false},
                                                 {"config.rotary_ndims", ndims},
                                                 {"config.cos_sin_ndims", half_ndims},
                                                 {"config.is_chatglm", false},

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -2461,6 +2461,93 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_subtract_canonicalized_to_ad
     }
 }
 
+TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_strided_slice) {
+    // As ConvertToROPE_LlamaCpp but the even/odd reads are v1::StridedSlice (step 2 on the last axis),
+    // which is what a prior pass canonicalizes the serializer's Slice into for the real model. The
+    // fused result is identical to the Slice variant.
+    disable_rt_info_check();
+    const int seq_len = 7;
+    const int num_heads = 32;
+    const int ndims = 64;
+    const int half_ndims = ndims / 2;
+    using namespace ov;
+    {
+        auto x = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, num_heads, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+
+        // even = x[..., 0::2], odd = x[..., 1::2] expressed as StridedSlice (strides last axis = 2).
+        auto x_low = makeOP<opset1::StridedSlice>({x, {0, 0, 0}, {0, 0, ndims}, {1, 1, 2}},
+                                                  {{"begin_mask", {1, 1, 0}},
+                                                   {"end_mask", {1, 1, 0}},
+                                                   {"new_axis_mask", {}},
+                                                   {"shrink_axis_mask", {}},
+                                                   {"ellipsis_mask", {}}});
+        auto x_high = makeOP<opset1::StridedSlice>({x, {0, 0, 1}, {0, 0, ndims}, {1, 1, 2}},
+                                                   {{"begin_mask", {1, 1, 0}},
+                                                    {"end_mask", {1, 1, 0}},
+                                                    {"new_axis_mask", {}},
+                                                    {"shrink_axis_mask", {}},
+                                                    {"ellipsis_mask", {}}});
+
+        auto mul_low_cos = makeOP<opset1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_low_sin = makeOP<opset1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_cos = makeOP<opset1::Multiply>({x_high, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_sin = makeOP<opset1::Multiply>({x_high, t_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto sub_low = makeOP<opset1::Subtract>({mul_low_cos, mul_high_sin}, {{"auto_broadcast", "numpy"}});
+        auto add_high = makeOP<opset1::Add>({mul_high_cos, mul_low_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto unsq_low = makeOP<opset1::Unsqueeze>({sub_low, {-2}});
+        auto unsq_high = makeOP<opset1::Unsqueeze>({add_high, {-2}});
+
+        auto stack = makeOP<opset1::Concat>({unsq_low, unsq_high}, {{"axis", -2}});
+        auto reshape = makeOP<opset1::Reshape>({stack, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+                                               {{"special_zero", false}});
+
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
+    }
+    manager.register_pass<pass::RoPEFusion>();
+    {
+        auto x = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, num_heads, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+
+        auto x_unsq = makeOP<opset1::Unsqueeze>({x, makeConst(element::i64, Shape{1}, std::vector<int64_t>{0})});
+
+        auto cos_t =
+            makeOP<opset1::Transpose>({t_cos, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
+        auto sin_t =
+            makeOP<opset1::Transpose>({t_sin, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
+
+        auto rope = makeOP<op::internal::RoPE>({x_unsq, cos_t, sin_t},
+                                               {{"config.slice_start", 0},
+                                                {"config.slice_stop", 0},
+                                                {"config.input_trans0213", true},
+                                                {"config.output_trans0213", false},
+                                                {"config.is_interleaved", false},
+                                                {"config.interleaved_input", true},
+                                                {"config.rotary_ndims", ndims},
+                                                {"config.cos_sin_ndims", half_ndims},
+                                                {"config.is_chatglm", false},
+                                                {"config.support_2d_rope", false},
+                                                {"config.support_3d_rope", false},
+                                                {"config.is_qwen", false},
+                                                {"config.use_rope_cache", false},
+                                                {"config.is_ltx_video", false},
+                                                {"config.head_cnt", 0},
+                                                {"config.head_size", 0},
+                                                {"config.gather_position_arg_id", 0}});
+
+        auto rope_t =
+            makeOP<opset1::Transpose>({rope, makeConst(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 1, 3})});
+        auto reshape = makeOP<opset1::Reshape>({rope_t, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+                                               {{"special_zero", false}});
+
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
+    }
+}
+
 TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_half_split_not_fused) {
     // As ConvertToROPE_LlamaCpp but with half-split slices (step 1) instead of the interleaved step-2
     // read llama.cpp emits. interleaved_input would be wrong here, so the matcher must reject it

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -2307,8 +2307,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp) {
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
 
-        auto x_low = makeOP<opset8::Slice>({x, {0}, {half_ndims}, {1}, {-1}});
-        auto x_high = makeOP<opset8::Slice>({x, {half_ndims}, {ndims}, {1}, {-1}});
+        // Interleaved read: even = x[..., 0::2], odd = x[..., 1::2] (step 2 on the last axis).
+        auto x_low = makeOP<opset8::Slice>({x, {0}, {ndims}, {2}, {-1}});
+        auto x_high = makeOP<opset8::Slice>({x, {1}, {ndims}, {2}, {-1}});
 
         auto mul_low_cos = makeOP<opset1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
         auto mul_low_sin = makeOP<opset1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
@@ -2389,8 +2390,9 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_subtract_canonicalized_to_ad
         auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
         auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
 
-        auto x_low = makeOP<opset8::Slice>({x, {0}, {half_ndims}, {1}, {-1}});
-        auto x_high = makeOP<opset8::Slice>({x, {half_ndims}, {ndims}, {1}, {-1}});
+        // Interleaved read: even = x[..., 0::2], odd = x[..., 1::2] (step 2 on the last axis).
+        auto x_low = makeOP<opset8::Slice>({x, {0}, {ndims}, {2}, {-1}});
+        auto x_high = makeOP<opset8::Slice>({x, {1}, {ndims}, {2}, {-1}});
 
         auto mul_low_cos = makeOP<opset1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
         auto mul_low_sin = makeOP<opset1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
@@ -2457,6 +2459,122 @@ TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_subtract_canonicalized_to_ad
 
         model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
     }
+}
+
+TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_half_split_not_fused) {
+    // As ConvertToROPE_LlamaCpp but with half-split slices (step 1) instead of the interleaved step-2
+    // read llama.cpp emits. interleaved_input would be wrong here, so the matcher must reject it
+    // (model_ref left unset -> the pass must leave the graph unchanged).
+    disable_rt_info_check();
+    const int seq_len = 7;
+    const int num_heads = 32;
+    const int ndims = 64;
+    const int half_ndims = ndims / 2;
+    using namespace ov;
+    {
+        auto x = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, num_heads, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+
+        auto x_low = makeOP<opset8::Slice>({x, {0}, {half_ndims}, {1}, {-1}});
+        auto x_high = makeOP<opset8::Slice>({x, {half_ndims}, {ndims}, {1}, {-1}});
+
+        auto mul_low_cos = makeOP<opset1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_low_sin = makeOP<opset1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_cos = makeOP<opset1::Multiply>({x_high, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_sin = makeOP<opset1::Multiply>({x_high, t_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto sub_low = makeOP<opset1::Subtract>({mul_low_cos, mul_high_sin}, {{"auto_broadcast", "numpy"}});
+        auto add_high = makeOP<opset1::Add>({mul_high_cos, mul_low_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto unsq_low = makeOP<opset1::Unsqueeze>({sub_low, {-2}});
+        auto unsq_high = makeOP<opset1::Unsqueeze>({add_high, {-2}});
+
+        auto stack = makeOP<opset1::Concat>({unsq_low, unsq_high}, {{"axis", -2}});
+        auto reshape = makeOP<opset1::Reshape>({stack, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+                                               {{"special_zero", false}});
+
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
+    }
+    manager.register_pass<pass::RoPEFusion>();
+    // model_ref intentionally left unset: the pass must not fuse this pattern.
+}
+
+TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_sin_rank3_not_fused) {
+    // As ConvertToROPE_LlamaCpp but t_sin is rank-3. The callback builds a length-4 Transpose perm for
+    // sin, so it must reject a non-rank-4 sin instead of throwing during construction.
+    disable_rt_info_check();
+    const int seq_len = 7;
+    const int num_heads = 32;
+    const int ndims = 64;
+    const int half_ndims = ndims / 2;
+    using namespace ov;
+    {
+        auto x = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, num_heads, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, 1, half_ndims});
+
+        auto x_low = makeOP<opset8::Slice>({x, {0}, {ndims}, {2}, {-1}});
+        auto x_high = makeOP<opset8::Slice>({x, {1}, {ndims}, {2}, {-1}});
+
+        auto mul_low_cos = makeOP<opset1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_low_sin = makeOP<opset1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_cos = makeOP<opset1::Multiply>({x_high, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_sin = makeOP<opset1::Multiply>({x_high, t_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto sub_low = makeOP<opset1::Subtract>({mul_low_cos, mul_high_sin}, {{"auto_broadcast", "numpy"}});
+        auto add_high = makeOP<opset1::Add>({mul_high_cos, mul_low_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto unsq_low = makeOP<opset1::Unsqueeze>({sub_low, {-2}});
+        auto unsq_high = makeOP<opset1::Unsqueeze>({add_high, {-2}});
+
+        auto stack = makeOP<opset1::Concat>({unsq_low, unsq_high}, {{"axis", -2}});
+        auto reshape = makeOP<opset1::Reshape>({stack, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+                                               {{"special_zero", false}});
+
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
+    }
+    manager.register_pass<pass::RoPEFusion>();
+    // model_ref intentionally left unset: the pass must not fuse this pattern.
+}
+
+TEST_F(TransformationTestsF, ConvertToROPE_LlamaCpp_wrong_unsqueeze_axis_not_fused) {
+    // As ConvertToROPE_LlamaCpp but the lanes are unsqueezed at axis 0 instead of -2. The stack
+    // rank/concat-axis checks happen to pass (rank still +1, concat still on the next-to-last axis),
+    // so the matcher must reject it via the explicit Unsqueeze-axis check.
+    disable_rt_info_check();
+    const int seq_len = 7;
+    const int num_heads = 32;
+    const int ndims = 64;
+    const int half_ndims = ndims / 2;
+    using namespace ov;
+    {
+        auto x = std::make_shared<opset1::Parameter>(element::f32, PartialShape{seq_len, num_heads, ndims});
+        auto t_cos = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+        auto t_sin = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, seq_len, 1, half_ndims});
+
+        auto x_low = makeOP<opset8::Slice>({x, {0}, {ndims}, {2}, {-1}});
+        auto x_high = makeOP<opset8::Slice>({x, {1}, {ndims}, {2}, {-1}});
+
+        auto mul_low_cos = makeOP<opset1::Multiply>({x_low, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_low_sin = makeOP<opset1::Multiply>({x_low, t_sin}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_cos = makeOP<opset1::Multiply>({x_high, t_cos}, {{"auto_broadcast", "numpy"}});
+        auto mul_high_sin = makeOP<opset1::Multiply>({x_high, t_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto sub_low = makeOP<opset1::Subtract>({mul_low_cos, mul_high_sin}, {{"auto_broadcast", "numpy"}});
+        auto add_high = makeOP<opset1::Add>({mul_high_cos, mul_low_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto unsq_low = makeOP<opset1::Unsqueeze>({sub_low, {0}});
+        auto unsq_high = makeOP<opset1::Unsqueeze>({add_high, {0}});
+
+        auto stack = makeOP<opset1::Concat>({unsq_low, unsq_high}, {{"axis", -2}});
+        auto reshape = makeOP<opset1::Reshape>({stack, makeConst(element::i64, Shape{4}, {1, -1, num_heads, ndims})},
+                                               {{"special_zero", false}});
+
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{x, t_cos, t_sin});
+    }
+    manager.register_pass<pass::RoPEFusion>();
+    // model_ref intentionally left unset: the pass must not fuse this pattern.
 }
 
 TEST_F(TransformationTestsF, ConvertToROPE_GPTOSS_split_axis_positive) {

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -536,6 +536,13 @@ bool RoPE::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::
             errorMessage = "Only RoPE operation is supported";
             return false;
         }
+        // interleaved_input (interleaved read + half-split write) has no CPU executor; the RoPEFusion
+        // pass that sets it is disabled for CPU. Reject explicitly so a model carrying it (e.g. one
+        // transformed for GPU) fails fast here instead of running RotateHalf and silently mis-rotating.
+        if (node->get_config().interleaved_input) {
+            errorMessage = "RoPE with interleaved_input is not supported on CPU";
+            return false;
+        }
     } catch (...) {
         return false;
     }

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1127,6 +1127,9 @@ void Transformations::PostLpt() {
     CPU_REGISTER_PASS_ARM64(postLPTPassManager, ov::pass::RoPEFusion, true);
     CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionFlux);
     CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionLtxVideo);
+    // The LlamaCpp fusion emits config.interleaved_input, a GPU-only kernel mode (interleaved read +
+    // half-split write). The CPU RoPE executor has no such mode, so keep the unfused graph on CPU.
+    CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionLlamaCpp);
     CPU_REGISTER_PASS_X64(postLPTPassManager, CausalMaskPreprocessFusion);
 
 #if defined(OPENVINO_ARCH_X86_64)

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/rope.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/rope.hpp
@@ -45,10 +45,12 @@ struct rope : public primitive_base<rope> {
         seed = hash_combine(seed, config.support_2d_rope);
         seed = hash_combine(seed, config.output_trans0213);
         seed = hash_combine(seed, config.is_interleaved);
+        seed = hash_combine(seed, config.interleaved_input);
         seed = hash_combine(seed, config.is_qwen);
         seed = hash_combine(seed, config.use_rope_cache);
         seed = hash_combine(seed, config.is_ltx_video);
         seed = hash_combine(seed, config.rotary_ndims);
+        seed = hash_combine(seed, config.cos_sin_ndims);
         seed = hash_combine(seed, config.slice_start);
         seed = hash_combine(seed, config.slice_stop);
         seed = hash_combine(seed, gather_rank);
@@ -69,10 +71,12 @@ struct rope : public primitive_base<rope> {
                config.support_2d_rope == rhs_casted.config.support_2d_rope &&
                config.output_trans0213 == rhs_casted.config.output_trans0213 &&
                config.is_interleaved == rhs_casted.config.is_interleaved &&
+               config.interleaved_input == rhs_casted.config.interleaved_input &&
                config.is_qwen == rhs_casted.config.is_qwen &&
                config.use_rope_cache == rhs_casted.config.use_rope_cache &&
                config.is_ltx_video == rhs_casted.config.is_ltx_video &&
                config.rotary_ndims == rhs_casted.config.rotary_ndims &&
+               config.cos_sin_ndims == rhs_casted.config.cos_sin_ndims &&
                config.slice_start == rhs_casted.config.slice_start &&
                config.slice_stop == rhs_casted.config.slice_stop &&
                gather_rank == rhs_casted.gather_rank;
@@ -89,10 +93,12 @@ struct rope : public primitive_base<rope> {
         ob << config.support_3d_rope;
         ob << config.output_trans0213;
         ob << config.is_interleaved;
+        ob << config.interleaved_input;
         ob << config.is_qwen;
         ob << config.use_rope_cache;
         ob << config.is_ltx_video;
         ob << config.rotary_ndims;
+        ob << config.cos_sin_ndims;
         ob << config.slice_start;
         ob << config.slice_stop;
         ob << gather_rank;
@@ -109,10 +115,12 @@ struct rope : public primitive_base<rope> {
         ib >> config.support_3d_rope;
         ib >> config.output_trans0213;
         ib >> config.is_interleaved;
+        ib >> config.interleaved_input;
         ib >> config.is_qwen;
         ib >> config.use_rope_cache;
         ib >> config.is_ltx_video;
         ib >> config.rotary_ndims;
+        ib >> config.cos_sin_ndims;
         ib >> config.slice_start;
         ib >> config.slice_stop;
         ib >> gather_rank;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cl
@@ -412,14 +412,47 @@ uint cos_sin_p = p;
     uint output_idx = OUTPUT_GET_INDEX(b, h, p, 0);
 
 #if VEC_SIZE == 1
+#ifdef INTERLEAVED_INPUT
+    // Read interleaved lanes (even = input[2r], odd = input[2r+1]); write half-split. Lets the
+    // llama.cpp NORMAL RoPE (interleaved-in, half-split-out) run without an explicit gather/concat.
+    ACCUMULATOR_TYPE in1 = TO_ACCUMULATOR_TYPE(input[input_idx + 2 * r]);
+    ACCUMULATOR_TYPE in2 = TO_ACCUMULATOR_TYPE(input[input_idx + 2 * r + 1]);
+#else
     ACCUMULATOR_TYPE in1 = TO_ACCUMULATOR_TYPE(input[input_idx + r]);
     ACCUMULATOR_TYPE in2 = TO_ACCUMULATOR_TYPE(input[input_idx + HALF_ROTARY_NDIMS + r]);
+#endif
 
     ACCUMULATOR_TYPE res = cos[cos_idx + r] * in1 - sin[sin_idx + r] * in2;
     output[output_idx + r] = TO_OUTPUT_TYPE(res);
 
     res = cos[cos_idx + COS_SIN_TABLE_OFFSET + r] * in2 + sin[sin_idx + COS_SIN_TABLE_OFFSET + r] * in1;
     output[output_idx + HALF_ROTARY_NDIMS + r] = TO_OUTPUT_TYPE(res);
+#elif defined(INTERLEAVED_INPUT)
+    // Vectorized interleaved read (see VEC_SIZE==1 branch above): two VEC_SIZE-wide loads at 2*r span
+    // the 2*VEC_SIZE interleaved elements, then UNPACK de-interleaves into even (in1) / odd (in2). The
+    // rotation and half-split write are unchanged from plain RotateHalf.
+    INPUT_VEC_TYPE inv1 = *(INPUT_VEC_TYPE*)(input + input_idx + 2 * r);
+    INPUT_VEC_TYPE inv2 = *(INPUT_VEC_TYPE*)(input + input_idx + 2 * r + VEC_SIZE);
+    INPUT_VEC_TYPE cos1 = *(INPUT_VEC_TYPE*)(cos + cos_idx + r);
+    INPUT_VEC_TYPE cos2 = *(INPUT_VEC_TYPE*)(cos + cos_idx + COS_SIN_TABLE_OFFSET + r);
+    INPUT_VEC_TYPE sin1 = *(INPUT_VEC_TYPE*)(sin + sin_idx + r);
+    INPUT_VEC_TYPE sin2 = *(INPUT_VEC_TYPE*)(sin + sin_idx + COS_SIN_TABLE_OFFSET + r);
+
+#if VEC_SIZE == 8
+    float8 in1, in2;
+    UNPACK_FLOAT_VEC_1(in1, inv1, inv2);
+    UNPACK_FLOAT_VEC_2(in2, inv1, inv2);
+#else  // VEC_SIZE == 16
+    INPUT_VEC_TYPE in1, in2;
+    UNPACK_HALF16_VEC_1(in1, inv1, inv2);
+    UNPACK_HALF16_VEC_2(in2, inv1, inv2);
+#endif
+
+    OUTPUT_VEC_TYPE out1 = cos1 * in1 - sin1 * in2;
+    OUTPUT_VEC_TYPE out2 = cos2 * in2 + sin2 * in1;
+
+    *(OUTPUT_VEC_TYPE*)(output + output_idx + r) = out1;
+    *(OUTPUT_VEC_TYPE*)(output + output_idx + HALF_ROTARY_NDIMS + r) = out2;
 #else
     INPUT_VEC_TYPE in1 = *(INPUT_VEC_TYPE*)(input + input_idx + r);
     INPUT_VEC_TYPE in2 = *(INPUT_VEC_TYPE*)(input + input_idx + HALF_ROTARY_NDIMS + r);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cl
@@ -427,40 +427,31 @@ uint cos_sin_p = p;
 
     res = cos[cos_idx + COS_SIN_TABLE_OFFSET + r] * in2 + sin[sin_idx + COS_SIN_TABLE_OFFSET + r] * in1;
     output[output_idx + HALF_ROTARY_NDIMS + r] = TO_OUTPUT_TYPE(res);
-#elif defined(INTERLEAVED_INPUT)
-    // Vectorized interleaved read (see VEC_SIZE==1 branch above): two VEC_SIZE-wide loads at 2*r span
-    // the 2*VEC_SIZE interleaved elements, then UNPACK de-interleaves into even (in1) / odd (in2). The
-    // rotation and half-split write are unchanged from plain RotateHalf.
-    INPUT_VEC_TYPE inv1 = *(INPUT_VEC_TYPE*)(input + input_idx + 2 * r);
-    INPUT_VEC_TYPE inv2 = *(INPUT_VEC_TYPE*)(input + input_idx + 2 * r + VEC_SIZE);
+#else
     INPUT_VEC_TYPE cos1 = *(INPUT_VEC_TYPE*)(cos + cos_idx + r);
     INPUT_VEC_TYPE cos2 = *(INPUT_VEC_TYPE*)(cos + cos_idx + COS_SIN_TABLE_OFFSET + r);
     INPUT_VEC_TYPE sin1 = *(INPUT_VEC_TYPE*)(sin + sin_idx + r);
     INPUT_VEC_TYPE sin2 = *(INPUT_VEC_TYPE*)(sin + sin_idx + COS_SIN_TABLE_OFFSET + r);
 
+    INPUT_VEC_TYPE in1, in2;
+#ifdef INTERLEAVED_INPUT
+    // Vectorized interleaved read (see VEC_SIZE==1 branch above): two VEC_SIZE-wide loads at 2*r span
+    // the 2*VEC_SIZE interleaved elements, then UNPACK de-interleaves into even (in1) / odd (in2).
+    INPUT_VEC_TYPE inv1 = *(INPUT_VEC_TYPE*)(input + input_idx + 2 * r);
+    INPUT_VEC_TYPE inv2 = *(INPUT_VEC_TYPE*)(input + input_idx + 2 * r + VEC_SIZE);
 #if VEC_SIZE == 8
-    float8 in1, in2;
     UNPACK_FLOAT_VEC_1(in1, inv1, inv2);
     UNPACK_FLOAT_VEC_2(in2, inv1, inv2);
 #else  // VEC_SIZE == 16
-    INPUT_VEC_TYPE in1, in2;
     UNPACK_HALF16_VEC_1(in1, inv1, inv2);
     UNPACK_HALF16_VEC_2(in2, inv1, inv2);
 #endif
-
-    OUTPUT_VEC_TYPE out1 = cos1 * in1 - sin1 * in2;
-    OUTPUT_VEC_TYPE out2 = cos2 * in2 + sin2 * in1;
-
-    *(OUTPUT_VEC_TYPE*)(output + output_idx + r) = out1;
-    *(OUTPUT_VEC_TYPE*)(output + output_idx + HALF_ROTARY_NDIMS + r) = out2;
 #else
-    INPUT_VEC_TYPE in1 = *(INPUT_VEC_TYPE*)(input + input_idx + r);
-    INPUT_VEC_TYPE in2 = *(INPUT_VEC_TYPE*)(input + input_idx + HALF_ROTARY_NDIMS + r);
-    INPUT_VEC_TYPE cos1 = *(INPUT_VEC_TYPE*)(cos + cos_idx + r);
-    INPUT_VEC_TYPE cos2 = *(INPUT_VEC_TYPE*)(cos + cos_idx + COS_SIN_TABLE_OFFSET + r);
-    INPUT_VEC_TYPE sin1 = *(INPUT_VEC_TYPE*)(sin + sin_idx + r);
-    INPUT_VEC_TYPE sin2 = *(INPUT_VEC_TYPE*)(sin + sin_idx + COS_SIN_TABLE_OFFSET + r);
+    in1 = *(INPUT_VEC_TYPE*)(input + input_idx + r);
+    in2 = *(INPUT_VEC_TYPE*)(input + input_idx + HALF_ROTARY_NDIMS + r);
+#endif
 
+    // Rotation and half-split write, shared by the interleaved and plain reads above.
     OUTPUT_VEC_TYPE out1 = cos1 * in1 - sin1 * in2;
     OUTPUT_VEC_TYPE out2 = cos2 * in2 + sin2 * in1;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cpp
@@ -102,6 +102,11 @@ protected:
             jit.make("RotateInterleaved", true);
         } else {
             jit.make("RotateHalf", true);
+            if (desc->config.interleaved_input) {
+                // RotateHalf with interleaved reads: same half-split output (and thus same dispatch),
+                // but the input lanes are gathered even/odd inside the kernel.
+                jit.make("INTERLEAVED_INPUT", true);
+            }
             if (get_vec_size(params) == 1) {
                 jit.make("REVERSED_GWS", true);
             }

--- a/src/plugins/intel_gpu/src/graph/rope.cpp
+++ b/src/plugins/intel_gpu/src/graph/rope.cpp
@@ -82,10 +82,12 @@ std::string rope_inst::to_string(rope_node const& node) {
     rope_info.add("support_2d_rope", desc->config.support_2d_rope);
     rope_info.add("output_trans0213", desc->config.output_trans0213);
     rope_info.add("is_interleaved", desc->config.is_interleaved);
+    rope_info.add("interleaved_input", desc->config.interleaved_input);
     rope_info.add("is_qwen", desc->config.is_qwen);
     rope_info.add("use_rope_cache", desc->config.use_rope_cache);
     rope_info.add("is_ltx_video", desc->config.is_ltx_video);
     rope_info.add("rotary_ndims", desc->config.rotary_ndims);
+    rope_info.add("cos_sin_ndims", desc->config.cos_sin_ndims);
     rope_info.add("slice_start", desc->config.slice_start);
     rope_info.add("slice_stop", desc->config.slice_stop);
     node_info->add("rope info", rope_info);


### PR DESCRIPTION
### Details:
 - Added `RoPEFusionLlamaCpp` MatcherPass that fuses the RoPE subgraph emitted by the llama.cpp OpenVINO serializer into the internal `RoPE` op.
 - This RoPE is interleaved (GPT-J style) but written as a 4-term complex multiply with a stack-then-reshape topology, so neither `RoPEFusionGPTJ` nor `RoPEFusionGPTNEOX` matched it and it stayed decomposed into slice/eltwise/unsqueeze/concat ops.
 - Matches the stateful (rank-3) path; normalizes to the rank-4 layout the other RoPE fusions produce, sets `is_interleaved=false` with `interleaved_input=true`, and accepts canonicalized variants (Subtract↔Add+Negate, Unsqueeze↔Reshape, Slice↔StridedSlice). Slice/StridedSlice attributes are re-validated in the callback (last-axis step-2 read, begins 0/1).
 - llama.cpp NORMAL RoPE reads interleaved lanes but writes a half-split output. To reproduce this without an extra in-graph gather, the GPU `RotateHalf` kernel gained an `INTERLEAVED_INPUT` mode (interleaved read + half-split write), selected by a new `RoPE::Config::interleaved_input`. `cos_sin_ndims` is set so the kernel reuses the half-length cos/sin table for both output halves.
 - `interleaved_input`/`cos_sin_ndims` affect the generated kernel, so both were added to the GPU primitive cache key (`rope.hpp`), `RoPE::visit_attributes`, and `to_string`.
 - The CPU RoPE executor has no interleaved-input mode, so the pass is disabled on CPU (falls back to the unfused graph); the CPU RoPE node also rejects `interleaved_input=true` in `isSupportedOperation` to fail fast if such a node reaches CPU.
 - Added unit tests: positive cases (Slice, canonicalized Subtract→Add, StridedSlice) and negative cases that must not fuse (half-split step-1 slice, non-rank-4 sin, wrong unsqueeze axis).

### Tickets:
 - [CVS-183768](https://jira.devtools.intel.com/browse/CVS-187368)

### AI Assistance:
 - AI assistance used: yes
 - AI helped investigate the matcher mismatch, draft the pass and its tests