### PR TITLE
[GPU] Fix weight reorder index calculation for grouped convolutions with IFM padding

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_opt.cl
@@ -49,8 +49,13 @@ KERNEL(reorder_weights_opt)(const __global INPUT0_TYPE* input, __global OUTPUT_T
     const int g_io = get_global_id(0);
 #if OSV_FIRST
 #if OUTPUT_GROUPED
+#if defined(IFM_PADDING)
+    const int i = (g_io % (IFM_PADDED_NUM / SECOND_BLOCK_SIZE)) * SECOND_BLOCK_SIZE;
+    const int g = (g_io / (IFM_PADDED_NUM / SECOND_BLOCK_SIZE));
+#else
     const int i = (g_io % (OUTPUT_IFM_NUM / SECOND_BLOCK_SIZE)) * SECOND_BLOCK_SIZE;
     const int g = (g_io / (OUTPUT_IFM_NUM / SECOND_BLOCK_SIZE));
+#endif
 #else
     const int i = g_io * SECOND_BLOCK_SIZE;
 #endif  // OUTPUT_GROUPED

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.cpp
@@ -213,6 +213,7 @@ JitConstants ReorderWeightsOpt::GetJitConstants(const reorder_weights_params& pa
         if (isv_size > 1 && (output.IFM().v % isv_size) != 0) {
             jit.AddConstant(MakeJitConstant("IFM_PADDING", 1));
             jit.AddConstant(MakeJitConstant("ACTUAL_IFM_NUM", output.IFM().v));
+            jit.AddConstant(MakeJitConstant("IFM_PADDED_NUM", Align(output.IFM().v, isv_size)));
         }
     }
 

--- a/src/plugins/intel_gpu/tests/unit/module_tests/weights_reorder_factory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/weights_reorder_factory_test.cpp
@@ -9,6 +9,7 @@
 #include "intel_gpu/graph/program.hpp"
 #include "intel_gpu/primitives/input_layout.hpp"
 #include "intel_gpu/primitives/data.hpp"
+#include "intel_gpu/primitives/reorder.hpp"
 
 #include "reorder_inst.h"
 #include "fully_connected_inst.h"
@@ -95,6 +96,96 @@ TEST(weights_factory, reorder_test) {
             auto tensor_coord = tensor(std::vector<tensor::value_type>{o, i}, 0);
             size_t input_idx = output_weights_layout.get_linear_offset(tensor_coord);
             ASSERT_EQ(weights_data_vec[o * input_f + i], output_ptr[input_idx]);
+        }
+    }
+}
+
+// Regression test for grouped convolution weight reorder: goiyx -> g_os_is_yx_isv16_osv16
+
+TEST(weights_factory, grouped_conv_reorder_goiyx_to_g_os_is_yx_isv16_osv16) {
+    auto& engine = get_test_engine();
+    tests::random_generator rg(GET_SUITE_NAME);
+
+    const int groups = 32;
+    const int oc_per_group = 4;
+    const int ic_per_group = 4;
+    const int filter_x = 3;
+    const int filter_y = 3;
+
+    // Allocate weights in goiyx format [groups, OC/group, IC/group, filter_y, filter_x]
+    auto weights_size = tensor(group(groups), batch(oc_per_group), feature(ic_per_group), spatial(filter_x, filter_y));
+    auto weights_input_layout = layout(data_types::f32, format::goiyx, weights_size);
+    auto weights_data_input = engine.allocate_memory(weights_input_layout);
+    auto weights_data_vec = rg.generate_random_1d<float>(
+        static_cast<int>(weights_input_layout.get_linear_size()), -1, 1);
+    set_values(weights_data_input, weights_data_vec);
+
+    // Directly construct the output layout in g_os_is_yx_isv16_osv16 format
+    auto weights_output_layout = layout(data_types::f32, format::g_os_is_yx_isv16_osv16, weights_size);
+
+    // Create WeightsReorderParams directly (no convolution needed)
+    auto weights_reorder_params = std::make_shared<WeightsReorderParams>(
+        weights_input_layout, weights_output_layout, false, true);
+
+    // Build a minimal network just to get program/stream context for kernel compilation
+    cldnn::topology topology{
+        input_layout("input", layout{ ov::PartialShape{ 1, 1 }, data_types::f32, format::bfyx }),
+        reorder("out", input_info("input"), layout{ ov::PartialShape{ 1, 1 }, data_types::f32, format::bfyx })
+    };
+
+    ExecutionConfig config = get_test_default_config(engine);
+    cldnn::network network(engine, topology, config);
+
+    // Construct kernel_impl_params for the weights reorder
+    auto reorder_kernel_params = std::make_shared<kernel_impl_params>();
+    reorder_kernel_params->desc = std::make_shared<reorder>("weights_reorder", input_info(), weights_reorder_params);
+    reorder_kernel_params->unique_id = weights_reorder_params->hash();
+    reorder_kernel_params->input_layouts.push_back(weights_reorder_params->get_input_layout());
+    reorder_kernel_params->output_layouts.push_back(weights_reorder_params->get_output_layout());
+    reorder_kernel_params->prog = network.get_program().get();
+
+    // Create reorder implementation
+    auto factory = reorder::type_id()->get_best_impl(impl_types::ocl, shape_types::static_shape);
+    auto reorder_impl = factory->create(*reorder_kernel_params);
+    ASSERT_TRUE(reorder_impl != nullptr);
+
+    // Compile and execute the reorder kernel
+    auto& kernel_cache = network.get_program()->get_kernels_cache();
+    auto kernels = kernel_cache.compile(*reorder_kernel_params, reorder_impl->get_kernels_source());
+    ASSERT_TRUE(kernels.size() == 1);
+    reorder_impl->set_kernels(kernels);
+
+    auto weights_data_output = engine.allocate_memory(weights_output_layout);
+
+    kernel_arguments_data args;
+    args.inputs.push_back(weights_data_input);
+    args.outputs.push_back(weights_data_output);
+
+    auto reorder_inst = std::make_shared<cldnn::reorder_inst>(network);
+    reorder_inst->set_impl(reorder_impl->clone());
+    reorder_inst->get_impl()->set_arguments(*reorder_inst, args);
+    reorder_inst->get_impl()->execute({}, *reorder_inst);
+
+    OV_ASSERT_NO_THROW(network.get_stream().finish());
+
+    // Verify: each element at logical position [g, o, i, y, x] in the source goiyx layout
+    // must appear at the correct position in the g_os_is_yx_isv16_osv16 output layout.
+    cldnn::mem_lock<float> output_ptr(weights_data_output, get_test_stream());
+
+    for (int g = 0; g < groups; ++g) {
+        for (int o = 0; o < oc_per_group; ++o) {
+            for (int i = 0; i < ic_per_group; ++i) {
+                for (int y = 0; y < filter_y; ++y) {
+                    for (int x = 0; x < filter_x; ++x) {
+                        auto src_coord = tensor(group(g), batch(o), feature(i), spatial(x, y, 0, 0));
+                        size_t src_offset = weights_input_layout.get_linear_offset(src_coord);
+                        size_t dst_offset = weights_output_layout.get_linear_offset(src_coord);
+                        ASSERT_EQ(weights_data_vec[src_offset], output_ptr[dst_offset])
+                            << "at g=" << g << " o=" << o << " i=" << i
+                            << " y=" << y << " x=" << x;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Details:
When IFM requires padding (e.g., `IFM/group=4` with `ISV=16`), the GWS dimension 0 is expanded to cover zero-fill positions `(G * ifm_padded / ifm_block)`. However, the kernel still decomposed `g_io` using the unpadded `OUTPUT_IFM_NUM`, causing incorrect group index `g` computation.
When `IFM_PADDING` is defined for grouped `OSV_FIRST` layouts, use the padded IFM count `IFM_PADDED_NUM` for `g_io -> (i, g)` decomposition, consistent with the expanded GWS.

### Tickets:
 - CVS-187455

### AI Assistance:
 - *AI assistance used: yes*
