### PR TITLE
[GPU][Core] Add UINT2 compressed weights support with transpose and ZP fixes

### DIFF
--- a/src/core/reference/include/openvino/reference/transpose.hpp
+++ b/src/core/reference/include/openvino/reference/transpose.hpp
@@ -64,5 +64,11 @@ void transpose_4bit(const uint8_t* data,
                     const std::vector<int64_t>& axes_order,
                     const Shape& out_shape);
 
+void transpose_2bit(const uint8_t* data,
+                    uint8_t* out,
+                    const Shape& data_shape,
+                    const std::vector<int64_t>& axes_order,
+                    const Shape& out_shape);
+
 }  // namespace reference
 }  // namespace ov

--- a/src/core/reference/src/op/transpose.cpp
+++ b/src/core/reference/src/op/transpose.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "openvino/core/shape.hpp"
+#include "openvino/core/type/element_iterator.hpp"
 #include "openvino/reference/reshape.hpp"
 #include "openvino/reference/utils/coordinate_index.hpp"
 #include "openvino/reference/utils/coordinate_transform.hpp"
@@ -125,6 +126,27 @@ void transpose_4bit(const uint8_t* data,
         }
     } else {
         OPENVINO_THROW("Transpose for i4/u4 dtype is supported only for ndims <= 3");
+    }
+}
+
+void transpose_2bit(const uint8_t* data,
+                    uint8_t* out,
+                    const Shape& data_shape,
+                    const std::vector<int64_t>& axes_order,
+                    const Shape& out_shape) {
+    const size_t ndim = data_shape.size();
+    auto in_it = ov::element::iterator<ov::element::u2>(reinterpret_cast<const int8_t*>(data));
+    auto out_it = ov::element::iterator<ov::element::u2>(reinterpret_cast<int8_t*>(out));
+
+    ov::Coordinate src_coord(ndim);
+    const ov::CoordinateTransformBasic dst_transform{out_shape};
+    for (const auto& dst_coord : dst_transform) {
+        for (size_t j = 0; j < ndim; ++j)
+            src_coord[axes_order[j]] = dst_coord[j];
+
+        const size_t dst_idx = ov::coordinate_index(dst_coord, out_shape);
+        const size_t src_idx = ov::coordinate_index(src_coord, data_shape);
+        *(out_it + dst_idx) = *(in_it + src_idx);
     }
 }
 

--- a/src/core/src/op/convert.cpp
+++ b/src/core/src/op/convert.cpp
@@ -250,6 +250,7 @@ bool Convert::has_evaluate() const {
         case element::i32:
         case element::i64:
         case element::u1:
+        case element::u2:
         case element::u4:
         case element::u8:
         case element::u16:

--- a/src/core/src/op/transpose.cpp
+++ b/src/core/src/op/transpose.cpp
@@ -55,7 +55,13 @@ bool Transpose::evaluate(TensorVector& outputs, const TensorVector& inputs) cons
         auto& out = outputs[ARG_T];
         out.set_shape(out_shape);
 
-        if (arg_type == ov::element::i4 || arg_type == ov::element::u4) {
+        if (arg_type == ov::element::u2) {
+            reference::transpose_2bit(static_cast<const uint8_t*>(arg.data()),
+                                      static_cast<uint8_t*>(out.data()),
+                                      arg.get_shape(),
+                                      axes_order,
+                                      out_shape);
+        } else if (arg_type == ov::element::i4 || arg_type == ov::element::u4) {
             reference::transpose_4bit(static_cast<const uint8_t*>(arg.data()),
                                       static_cast<uint8_t*>(out.data()),
                                       arg.get_shape(),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -349,10 +349,10 @@ kernel_selector::weights_type to_weights_type(data_types dt) {
 
 data_types from_weights_type(kernel_selector::weights_type dt) {
     switch (dt) {
-        case kernel_selector::weights_type::INT4:
-            return data_types::i4;
         case kernel_selector::weights_type::UINT2:
             return data_types::u2;
+        case kernel_selector::weights_type::INT4:
+            return data_types::i4;
         case kernel_selector::weights_type::UINT4:
             return data_types::u4;
         case kernel_selector::weights_type::INT8:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -242,6 +242,8 @@ bool query_register_file_size_option_supported(cldnn::engine& e, const cldnn::Ex
 
 kernel_selector::data_type to_data_type(data_types dt) {
     switch (dt) {
+        case cldnn::data_types::u2:
+            return kernel_selector::data_type::UINT2;
         case cldnn::data_types::i4:
             return kernel_selector::data_type::INT4;
         case cldnn::data_types::u4:
@@ -279,6 +281,8 @@ kernel_selector::data_type to_data_type(data_types dt) {
 
 data_types from_data_type(kernel_selector::data_type dt) {
     switch (dt) {
+        case kernel_selector::data_type::UINT2:
+            return cldnn::data_types::u2;
         case kernel_selector::data_type::INT4:
             return cldnn::data_types::i4;
         case kernel_selector::data_type::UINT4:
@@ -314,6 +318,8 @@ data_types from_data_type(kernel_selector::data_type dt) {
 
 kernel_selector::weights_type to_weights_type(data_types dt) {
     switch (dt) {
+        case cldnn::data_types::u2:
+            return kernel_selector::weights_type::UINT2;
         case cldnn::data_types::u4:
             return kernel_selector::weights_type::UINT4;
         case cldnn::data_types::i4:
@@ -345,6 +351,8 @@ data_types from_weights_type(kernel_selector::weights_type dt) {
     switch (dt) {
         case kernel_selector::weights_type::INT4:
             return data_types::i4;
+        case kernel_selector::weights_type::UINT2:
+            return data_types::u2;
         case kernel_selector::weights_type::UINT4:
             return data_types::u4;
         case kernel_selector::weights_type::INT8:

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bfyx_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bfyx_ref.cl
@@ -5,6 +5,7 @@
 #include "include/batch_headers/fetch_data.cl"
 #include "include/batch_headers/fetch_weights.cl"
 #include "include/batch_headers/int4_utils.cl"
+#include "include/batch_headers/int2_utils.cl"
 
 KERNEL(fc)(
     OPTIONAL_SHAPE_INFO_ARG
@@ -64,6 +65,13 @@ KERNEL(fc)(
                 ACCUMULATOR_TYPE filter_compressed = ((ACCUMULATOR_TYPE*)(&filter_unpacked))[filter_idx % 2];
                 ACCUMULATOR_TYPE filter_val = (filter_compressed - zp) * scale;
                 dotProd += (ACCUMULATOR_TYPE)(input[input0_idx]) * filter_val;
+            #elif COMPRESSED_WEIGHTS_UINT2
+                FILTER_TYPE filter_packed = weights[filter_idx / 4];
+                MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4) filter_unpacked = UNPACK_UINT2x4(ACCUMULATOR_TYPE, *((UINT2_PACKED_TYPE*)&filter_packed));
+
+                ACCUMULATOR_TYPE filter_compressed = ((ACCUMULATOR_TYPE*)(&filter_unpacked))[filter_idx % 4];
+                ACCUMULATOR_TYPE filter_val = (filter_compressed - zp) * scale;
+                dotProd += (ACCUMULATOR_TYPE)(input[input0_idx]) * filter_val;
             #else
                 dotProd += (ACCUMULATOR_TYPE)(input[input0_idx]) * (ACCUMULATOR_TYPE)(weights[filter_idx]);
             #endif
@@ -109,6 +117,13 @@ KERNEL(fc)(
                     MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 2) filter_unpacked = UNPACK_INT4x2(ACCUMULATOR_TYPE, *((INT4_PACKED_TYPE*)&filter_packed));
 
                     ACCUMULATOR_TYPE filter_compressed = ((ACCUMULATOR_TYPE*)(&filter_unpacked))[filter_idx % 2];
+                    ACCUMULATOR_TYPE filter_val = (filter_compressed - zp) * scale;
+                    dotProd += (ACCUMULATOR_TYPE)(input[input0_idx]) * filter_val;
+                #elif COMPRESSED_WEIGHTS_UINT2
+                    FILTER_TYPE filter_packed = weights[filter_idx / 4];
+                    MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4) filter_unpacked = UNPACK_UINT2x4(ACCUMULATOR_TYPE, *((UINT2_PACKED_TYPE*)&filter_packed));
+
+                    ACCUMULATOR_TYPE filter_compressed = ((ACCUMULATOR_TYPE*)(&filter_unpacked))[filter_idx % 4];
                     ACCUMULATOR_TYPE filter_val = (filter_compressed - zp) * scale;
                     dotProd += (ACCUMULATOR_TYPE)(input[input0_idx]) * filter_val;
                 #else

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/int2_utils.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/int2_utils.cl
@@ -1,0 +1,99 @@
+//  Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// ================================================================================================
+// U2 (2-bit unsigned) support - 4 values per byte
+// ================================================================================================
+
+#include "common.cl"
+
+typedef struct __attribute__ ((packed)) uint2x4_t { uchar s0; } uint2x4_t;
+typedef struct __attribute__ ((packed)) uint2x8_t { uint2x4_t s0; uint2x4_t s1; } uint2x8_t;
+typedef struct __attribute__ ((packed)) uint2x16_t { uint2x4_t s0; uint2x4_t s1; uint2x4_t s2; uint2x4_t s3; } uint2x16_t;
+
+// Unpack 4 U2 values from 1 byte
+inline uchar4 cvt_uint2x4_to_uint8x4(uint2x4_t v) __attribute__((overloadable)) {
+    const uchar v0 = v.s0 & 0x03;           // bits [1:0]
+    const uchar v1 = (v.s0 >> 2) & 0x03;    // bits [3:2]
+    const uchar v2 = (v.s0 >> 4) & 0x03;    // bits [5:4]
+    const uchar v3 = (v.s0 >> 6) & 0x03;    // bits [7:6]
+    return (uchar4)(v0, v1, v2, v3);
+}
+
+// Pack 4 uchar values into 1 U2 byte
+inline uchar cvt_uint8x4_to_uint2x4(uchar4 v) __attribute__((overloadable)) {
+    uchar result = 0;
+    result |= (v.s0 & 0x03);
+    result |= (v.s1 & 0x03) << 2;
+    result |= (v.s2 & 0x03) << 4;
+    result |= (v.s3 & 0x03) << 6;
+    return result;
+}
+
+// Overloads for U2x4 (4 values)
+inline uchar4 unpack_to_uchar(uint2x4_t v) __attribute__((overloadable)) {
+    return cvt_uint2x4_to_uint8x4(v);
+}
+
+inline char4 unpack_to_char(uint2x4_t v) __attribute__((overloadable)) {
+    return convert_char4(cvt_uint2x4_to_uint8x4(v));
+}
+
+// Overloads for U2x8 (8 values from 2 bytes)
+inline uchar8 unpack_to_uchar(uint2x8_t v) __attribute__((overloadable)) {
+    uchar4 v0 = unpack_to_uchar(v.s0);
+    uchar4 v1 = unpack_to_uchar(v.s1);
+    return (uchar8)(v0.s0, v0.s1, v0.s2, v0.s3, v1.s0, v1.s1, v1.s2, v1.s3);
+}
+
+inline char8 unpack_to_char(uint2x8_t v) __attribute__((overloadable)) {
+    return convert_char8(unpack_to_uchar(v));
+}
+
+// Overloads for U2x16 (16 values from 4 bytes)
+inline uchar16 unpack_to_uchar(uint2x16_t v) __attribute__((overloadable)) {
+    uchar4 v0 = unpack_to_uchar(v.s0);
+    uchar4 v1 = unpack_to_uchar(v.s1);
+    uchar4 v2 = unpack_to_uchar(v.s2);
+    uchar4 v3 = unpack_to_uchar(v.s3);
+    return (uchar16)(v0.s0, v0.s1, v0.s2, v0.s3, 
+                     v1.s0, v1.s1, v1.s2, v1.s3,
+                     v2.s0, v2.s1, v2.s2, v2.s3,
+                     v3.s0, v3.s1, v3.s2, v3.s3);
+}
+
+inline char16 unpack_to_char(uint2x16_t v) __attribute__((overloadable)) {
+    return convert_char16(unpack_to_uchar(v));
+}
+
+// Float unpacking for U2x4
+inline float4 unpack_to_float(uint2x4_t v) __attribute__((overloadable)) {
+    return convert_float4(cvt_uint2x4_to_uint8x4(v));
+}
+
+// Float unpacking for U2x8
+inline float8 unpack_to_float(uint2x8_t v) __attribute__((overloadable)) {
+    float4 f0 = unpack_to_float(v.s0);
+    float4 f1 = unpack_to_float(v.s1);
+    return (float8)(f0.s0, f0.s1, f0.s2, f0.s3, f1.s0, f1.s1, f1.s2, f1.s3);
+}
+
+#if defined(cl_khr_fp16)
+// Half unpacking for U2x4
+inline half4 unpack_to_half(uint2x4_t v) __attribute__((overloadable)) {
+    return convert_half4(cvt_uint2x4_to_uint8x4(v));
+}
+
+// Half unpacking for U2x8
+inline half8 unpack_to_half(uint2x8_t v) __attribute__((overloadable)) {
+    half4 f0 = unpack_to_half(v.s0);
+    half4 f1 = unpack_to_half(v.s1);
+    return (half8)(f0.s0, f0.s1, f0.s2, f0.s3, f1.s0, f1.s1, f1.s2, f1.s3);
+}
+#endif
+
+// Macros for generic unpacking
+#define UNPACK_UINT2x4(target_type, v) CAT(unpack_to_, target_type)(v)
+#define UNPACK_UINT2x8(target_type, v) CAT(unpack_to_, target_type)(v)
+#define UNPACK_UINT2x16(target_type, v) CAT(unpack_to_, target_type)(v)

--- a/src/plugins/intel_gpu/src/kernel_selector/common_types.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/common_types.h
@@ -119,6 +119,7 @@ enum class KernelType {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 enum class Datatype {
     UNSUPPORTED,
+    UINT2,
     UINT4,
     INT4,
     INT8,
@@ -145,6 +146,7 @@ enum class WeightsType {
     F32,
     INT8,
     UINT8,
+    UINT2,
     UINT4,
     INT4,
     INT32,

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -1763,7 +1763,7 @@ JitConstants MakeTypeJitConstants(WeightsType weightsType, const std::string& ma
     return MakeTypeJitConstants(Datatype::UNSUPPORTED, macroName);
 }
 
-JitConstants make_int4_packed_type_jit_constant(const std::string& macro_name, WeightsType wt, size_t pack_size) {
+JitConstants make_sub_byte_packed_type_jit_constant(const std::string& macro_name, WeightsType wt, size_t pack_size) {
     OPENVINO_ASSERT(pack_size % 2 == 0 && pack_size != 0 && pack_size <= 16);
     std::string type_string;
     OPENVINO_ASSERT(wt != WeightsType::UINT2 || pack_size % 4 == 0);

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -1607,6 +1607,13 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             type_size = "0.5f";
             is_fp = false;
             break;
+        case Datatype::UINT2:
+            type = "uchar";
+            to_type = "convert_uchar(v)";
+            to_type_sat = "convert_uchar_sat(v)";
+            type_size = "0.25f";
+            is_fp = false;
+            break;
         case Datatype::UINT4:
             type = "uchar";
             to_type = "convert_uchar(v)";
@@ -1734,6 +1741,8 @@ JitConstants MakeTypeJitConstants(WeightsType weightsType, const std::string& ma
             return MakeTypeJitConstants(Datatype::INT8, macroName);
         case WeightsType::UINT8:
             return MakeTypeJitConstants(Datatype::UINT8, macroName);
+        case WeightsType::UINT2:
+            return MakeTypeJitConstants(Datatype::UINT2, macroName);
         case WeightsType::INT4:
             return MakeTypeJitConstants(Datatype::INT4, macroName);
         case WeightsType::UINT4:
@@ -1757,7 +1766,9 @@ JitConstants MakeTypeJitConstants(WeightsType weightsType, const std::string& ma
 JitConstants make_int4_packed_type_jit_constant(const std::string& macro_name, WeightsType wt, size_t pack_size) {
     OPENVINO_ASSERT(pack_size % 2 == 0 && pack_size != 0 && pack_size <= 16);
     std::string type_string;
+    OPENVINO_ASSERT(wt != WeightsType::UINT2 || pack_size % 4 == 0);
     switch (wt) {
+        case WeightsType::UINT2: type_string = "uint2x"; break;
         case WeightsType::UINT4: type_string = "uint4x"; break;
         case WeightsType::INT4: type_string = "int4x"; break;
         default: OPENVINO_THROW("[GPU] Unsupported compressed type");

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.h
@@ -324,7 +324,7 @@ JitConstants MakeConstantLoopUnrollJitConstants(uint32_t loopCount);
 JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroName);
 JitConstants MakeTypeJitConstants(WeightsType weightsType, const std::string& macroName);
 inline JitConstants MakeUnitTypeJitConstants(Datatype dataType) { return MakeTypeJitConstants(dataType, "UNIT"); }
-JitConstants make_int4_packed_type_jit_constant(const std::string& macro_name, WeightsType wt, size_t pack_size);
+JitConstants make_sub_byte_packed_type_jit_constant(const std::string& macro_name, WeightsType wt, size_t pack_size);
 
 class FusedOpsCodeGenerator {
 public:

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
@@ -146,6 +146,7 @@ std::string toString(DataLayout l) {
 
 std::string toString(Datatype dType) {
     switch (dType) {
+        case Datatype::UINT2:  return "UINT2";
         case Datatype::UINT4:  return "UINT4";
         case Datatype::INT4:   return "INT4";
         case Datatype::INT8:   return "INT8";
@@ -168,6 +169,7 @@ std::string toString(WeightsType wType) {
     switch (wType) {
         case WeightsType::F16:    return "F16";
         case WeightsType::F32:    return "F32";
+        case WeightsType::UINT2:  return "UINT2";
         case WeightsType::UINT4:  return "UINT4";
         case WeightsType::INT4:   return "INT4";
         case WeightsType::INT8:   return "INT8";

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
@@ -170,6 +170,9 @@ void ParamsKey::EnableInputWeightsType(WeightsType wt) {
         case WeightsType::UINT4:
             key.inputWeightsType.val.uint4 = 1;
             break;
+        case WeightsType::UINT2:
+            key.inputWeightsType.val.uint2 = 1;
+            break;
         case WeightsType::INT32:
             key.inputWeightsType.val.int32 = 1;
             break;
@@ -199,6 +202,9 @@ void ParamsKey::EnableOutputWeightsType(WeightsType wt) {
             break;
         case WeightsType::UINT4:
             key.outputWeightsType.val.uint4 = 1;
+            break;
+        case WeightsType::UINT2:
+            key.outputWeightsType.val.uint2 = 1;
             break;
         case WeightsType::INT32:
             key.outputWeightsType.val.int32 = 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -246,6 +246,7 @@ public:
 
         union DataTypesKey {
             struct val_t {
+                uint32_t uint2 : 1;
                 uint32_t int4 : 1;
                 uint32_t uint4 : 1;
                 uint32_t int8 : 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.cpp
@@ -28,6 +28,8 @@ JitConstants FullyConnectedKernelBase::GetJitConstants(const fully_connected_par
             jit.AddConstants({MakeJitConstant("COMPRESSED_WEIGHTS_INT8", 1)});
         } else if (params.weights.GetDType() == WeightsType::INT4 || params.weights.GetDType() == WeightsType::UINT4) {
             jit.AddConstants({MakeJitConstant("COMPRESSED_WEIGHTS_INT4", 1)});
+        } else if (params.weights.GetDType() == WeightsType::UINT2) {
+            jit.AddConstants({MakeJitConstant("COMPRESSED_WEIGHTS_UINT2", 1)});
         }
 
         const size_t scale_groups_num = params.decompression_scale.Feature().v;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -353,6 +353,10 @@ bool FullyConnected_bf_tiled::Validate(const Params& params) const {
     if ((wt == WeightsType::UINT4 || wt == WeightsType::INT4) && (weights.IFM().v % 2 != 0)) {
         DO_NOT_USE_THIS_KERNEL(params.layerID);
     }
+    // UINT2 compressed weights are not supported by this kernel; the reference kernel handles them.
+    if (wt == WeightsType::UINT2) {
+        DO_NOT_USE_THIS_KERNEL(params.layerID);
+    }
 
     return true;
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -353,10 +353,6 @@ bool FullyConnected_bf_tiled::Validate(const Params& params) const {
     if ((wt == WeightsType::UINT4 || wt == WeightsType::INT4) && (weights.IFM().v % 2 != 0)) {
         DO_NOT_USE_THIS_KERNEL(params.layerID);
     }
-    // UINT2 compressed weights are not supported by this kernel; the reference kernel handles them.
-    if (wt == WeightsType::UINT2) {
-        DO_NOT_USE_THIS_KERNEL(params.layerID);
-    }
 
     return true;
 }
@@ -692,7 +688,7 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
     WeightsType weights_dt = params.weights.GetDType();
     if (weights_dt == WeightsType::UINT4 || weights_dt == WeightsType::INT4) {
         tile_k_ofm_packed /= 2;
-        jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE", weights_dt, tile_k_ofm));
+        jit.Merge(make_sub_byte_packed_type_jit_constant("INT4_PACKED_TYPE", weights_dt, tile_k_ofm));
         const size_t scale_group_size = get_scale_group_size(params);
         // Do not use SCALE_POST_OP for SLM kernel, since it demonstrates worse performance
         if (scale_group_size % simd == 0 && !dispatchData.use_slm)
@@ -752,13 +748,13 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
         if (weights_dt == WeightsType::INT4 || weights_dt == WeightsType::UINT4) {
             if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16) {
                 jit.AddConstant(MakeJitConstant("FILTER_ACTUAL_LOAD_BLOCK_SIZE", block_read_size / 2));
-                jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE_PRELOAD", params.weights.GetDType(), weights_elements_per_load / 2));
+                jit.Merge(make_sub_byte_packed_type_jit_constant("INT4_PACKED_TYPE_PRELOAD", params.weights.GetDType(), weights_elements_per_load / 2));
             } else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2) {
                 jit.AddConstant(MakeJitConstant("FILTER_ACTUAL_LOAD_BLOCK_SIZE", block_read_size / 2));
-                jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE_PRELOAD", params.weights.GetDType(), weights_elements_per_load / 2));
+                jit.Merge(make_sub_byte_packed_type_jit_constant("INT4_PACKED_TYPE_PRELOAD", params.weights.GetDType(), weights_elements_per_load / 2));
             } else {
                 jit.AddConstant(MakeJitConstant("FILTER_ACTUAL_LOAD_BLOCK_SIZE", block_read_size));
-                jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE_PRELOAD", params.weights.GetDType(), weights_elements_per_load));
+                jit.Merge(make_sub_byte_packed_type_jit_constant("INT4_PACKED_TYPE_PRELOAD", params.weights.GetDType(), weights_elements_per_load));
             }
         } else {
             jit.AddConstant(MakeJitConstant("FILTER_ACTUAL_LOAD_BLOCK_SIZE", block_read_size));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled_dyn_b.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled_dyn_b.cpp
@@ -249,7 +249,7 @@ JitConstants FullyConnected_bf_tiled_dyn_b::GetJitConstants(const fully_connecte
     WeightsType weights_dt = params.weights.GetDType();
     if (weights_dt == WeightsType::UINT4 || weights_dt == WeightsType::INT4) {
         tile_k_ofm_packed /= 2;
-        jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE", weights_dt, tile_k_ofm));
+        jit.Merge(make_sub_byte_packed_type_jit_constant("INT4_PACKED_TYPE", weights_dt, tile_k_ofm));
         const size_t scale_group_size = get_scale_group_size(params);
         if (scale_group_size % simd == 0)
             add_decompress_scale_post_op = true;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bfyx_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bfyx_ref.cpp
@@ -24,6 +24,7 @@ ParamsKey FullyConnected_bfyx_Ref::GetSupportedKey() const {
     k.EnableInputWeightsType(WeightsType::F32);
     k.EnableInputWeightsType(WeightsType::UINT8);
     k.EnableInputWeightsType(WeightsType::INT8);
+    k.EnableInputWeightsType(WeightsType::UINT2);
     k.EnableInputWeightsType(WeightsType::UINT4);
     k.EnableInputWeightsType(WeightsType::INT4);
     k.EnableAllInputLayout();
@@ -83,6 +84,8 @@ JitConstants FullyConnected_bfyx_Ref::GetJitConstants(const fully_connected_para
     auto wt = params.weights.GetDType();
     if (wt == WeightsType::UINT4 || wt == WeightsType::INT4) {
         jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE", wt, 2));
+    } else if (wt == WeightsType::UINT2) {
+        jit.Merge(make_int4_packed_type_jit_constant("UINT2_PACKED_TYPE", wt, 4));
     }
 
     if (!params.fused_ops.empty()) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bfyx_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bfyx_ref.cpp
@@ -83,9 +83,9 @@ JitConstants FullyConnected_bfyx_Ref::GetJitConstants(const fully_connected_para
 
     auto wt = params.weights.GetDType();
     if (wt == WeightsType::UINT4 || wt == WeightsType::INT4) {
-        jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE", wt, 2));
+        jit.Merge(make_sub_byte_packed_type_jit_constant("INT4_PACKED_TYPE", wt, 2));
     } else if (wt == WeightsType::UINT2) {
-        jit.Merge(make_int4_packed_type_jit_constant("UINT2_PACKED_TYPE", wt, 4));
+        jit.Merge(make_sub_byte_packed_type_jit_constant("UINT2_PACKED_TYPE", wt, 4));
     }
 
     if (!params.fused_ops.empty()) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
@@ -285,9 +285,9 @@ JitConstants GatherKernelRef::GetJitConstants(const gather_params& params) const
 
         auto wt = params.inputs[0].GetDType();
         if (wt == Datatype::UINT4) {
-            jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE", WeightsType::UINT4, 2));
+            jit.Merge(make_sub_byte_packed_type_jit_constant("INT4_PACKED_TYPE", WeightsType::UINT4, 2));
         } else if (wt == Datatype::INT4) {
-            jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE", WeightsType::INT4, 2));
+            jit.Merge(make_sub_byte_packed_type_jit_constant("INT4_PACKED_TYPE", WeightsType::INT4, 2));
         }
 
         const size_t scale_groups_num = params.decompression_scale.LogicalSize();

--- a/src/plugins/intel_gpu/src/plugin/transformations/compressed_weights_pattern.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/compressed_weights_pattern.hpp
@@ -11,6 +11,7 @@ using namespace ov::pass::pattern;
         auto compressed_constant = [](const ov::Output<ov::Node>& output) {\
             return (output.get_element_type() == ov::element::u8 || output.get_element_type() == ov::element::i8 ||\
                     output.get_element_type() == ov::element::u4 || output.get_element_type() == ov::element::i4 ||\
+                    output.get_element_type() == ov::element::u2 ||\
                     output.get_element_type() == ov::element::f8e4m3 || output.get_element_type() == ov::element::f8e5m2);\
         };\
         \

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
@@ -96,7 +96,7 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
             // Convert ZP to u8
             if (constant->get_element_type() == ov::element::u8)
                 result = constant;
-            else if (constant->get_element_type() == ov::element::u4)
+            else if (constant->get_element_type() == ov::element::u4 || constant->get_element_type() == ov::element::u2)
                 result = std::make_shared<ov::op::v0::Convert>(node, ov::element::u8);
             // Only unsigned ZP types can be converted to u8.
             else if (weight_u8 && sub_with_convert && !constant->get_element_type().is_signed())

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -536,7 +536,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
     const auto& defaultPrecisions = ov::pass::low_precision::precision_set::get_int8_support();
     const ov::element::TypeVector supported_woq_types =
-        {ov::element::u8, ov::element::i8, ov::element::u4, ov::element::i4};
+        {ov::element::u8, ov::element::i8, ov::element::u4, ov::element::i4, ov::element::u2};
     bool enableInt8;
     bool unroll_loop = config.get_enable_loop_unrolling();
     const bool disable_gated_mlp_fusion = GPU_DEBUG_VALUE_OR(config.get_disable_gated_mlp_fusion(), true);
@@ -625,7 +625,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
         manager.register_pass<ov::pass::TransposeMatMul>();
 
-        manager.register_pass<ov::pass::MarkDequantization>(std::vector<ov::element::Type>{ov::element::i8, ov::element::u8, ov::element::i4, ov::element::u4},
+        manager.register_pass<ov::pass::MarkDequantization>(std::vector<ov::element::Type>{ov::element::i8, ov::element::u8, ov::element::i4, ov::element::u4, ov::element::u2},
                                                             !device_info.supports_immad);
         if (config.get_use_onednn() && m_context->get_engine().get_device_info().arch >= cldnn::gpu_arch::xe3p) {
             manager.register_pass<ov::pass::MarkDequantization>(

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -259,7 +259,7 @@ TEST_P(MatmulWeightsDecompression, Inference) {
 }
 
 const std::vector<ov::element::Type> activations_precisions = {ov::element::f32, ov::element::f16};
-const std::vector<ov::element::Type> weights_precisions = {ov::element::u8, ov::element::u4, ov::element::i4};
+const std::vector<ov::element::Type> weights_precisions = {ov::element::u8, ov::element::u4, ov::element::i4, ov::element::u2};
 const std::vector<bool> transpose_weights = {true, false};
 const std::vector<bool> param_weights = {true, false};
 const std::vector<ShapeParams> input_shapes_basic = {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -6394,19 +6394,157 @@ TEST_P(fc_bf_tiled_dyn_b_accuracy_test, compare_with_ref) {
     test_accuracy(batch_num, ifm_num, ofm_num, with_post_op);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    fully_connected_bf_tiled_dyn_b_accuracy,
-    fc_bf_tiled_dyn_b_accuracy_test,
-    ::testing::Values(
-        // Small batch, IFM < OFM (up/gate projection pattern)
-        std::make_tuple(3L,  256L, 1024L, false),
-        // Prime batch with tail, IFM > OFM (down projection pattern)
-        std::make_tuple(11L, 1024L, 256L, false),
-        // Aligned batch, IFM < OFM
-        std::make_tuple(16L, 256L, 1024L, false),
-        // Large prime batch, IFM < OFM (multi TILE_B + tail)
-        std::make_tuple(29L, 256L, 1024L, false),
-        // With post-op eltwise
-        std::make_tuple(16L, 256L, 1024L, true)
-    )
-);
+INSTANTIATE_TEST_SUITE_P(fully_connected_bf_tiled_dyn_b_accuracy,
+                         fc_bf_tiled_dyn_b_accuracy_test,
+                         ::testing::Values(
+                             // Small batch, IFM < OFM (up/gate projection pattern)
+                             std::make_tuple(3L, 256L, 1024L, false),
+                             // Prime batch with tail, IFM > OFM (down projection pattern)
+                             std::make_tuple(11L, 1024L, 256L, false),
+                             // Aligned batch, IFM < OFM
+                             std::make_tuple(16L, 256L, 1024L, false),
+                             // Large prime batch, IFM < OFM (multi TILE_B + tail)
+                             std::make_tuple(29L, 256L, 1024L, false),
+                             // With post-op eltwise
+                             std::make_tuple(16L, 256L, 1024L, true)));
+
+// Parameterized test fixture for UINT2 fully connected kernel across various matrix dimensions
+class fully_connected_gpu_u2_validation : public ::testing::TestWithParam<std::tuple<int, int, int, int, int, bool>> {
+public:
+    static std::string GetTestCaseName(const testing::TestParamInfo<std::tuple<int, int, int, int, int, bool>>& obj) {
+        int batch = std::get<0>(obj.param);
+        int ifm = std::get<1>(obj.param);
+        int ofm = std::get<2>(obj.param);
+        int group_size = std::get<3>(obj.param);
+        int seq_len = std::get<4>(obj.param);
+        bool use_zp = std::get<5>(obj.param);
+        auto name = "b" + std::to_string(batch) + "_ifm" + std::to_string(ifm) + "_ofm" + std::to_string(ofm) + "_g" + std::to_string(group_size);
+        if (seq_len > 1)
+            name += "_seq" + std::to_string(seq_len);
+        if (use_zp)
+            name += "_zp";
+        return name;
+    }
+};
+
+// Validates UINT2 decompression correctness across multiple sizes using random data vs inline CPU-computed reference
+TEST_P(fully_connected_gpu_u2_validation, various_sizes) {
+    auto& engine = get_test_engine();
+    if (engine.get_device_info().dev_type == device_type::discrete_gpu)
+        GTEST_SKIP();
+
+    const int batch_num = std::get<0>(GetParam());
+    const int ifm_num = std::get<1>(GetParam());
+    const int ofm_num = std::get<2>(GetParam());
+    const int scales_group_size = std::get<3>(GetParam());
+    const int seq_len = std::get<4>(GetParam());  // 1 = 2D path, >1 = 3D (OUTPUT_3D) path
+    const bool use_zp = std::get<5>(GetParam());
+    const bool is_3d = seq_len > 1;
+
+    ASSERT_EQ(ifm_num % 4, 0) << "ifm_num must be multiple of 4 for U2";
+    ASSERT_EQ(ifm_num % scales_group_size, 0) << "ifm_num must be multiple of scales_group_size";
+
+    auto input_shape = is_3d ? ov::PartialShape{batch_num, seq_len, ifm_num} : ov::PartialShape{batch_num, ifm_num};
+    auto input_mem = engine.allocate_memory({input_shape, data_types::f16, format::bfyx});
+    auto weights_mem = engine.allocate_memory({{ofm_num, ifm_num}, data_types::u2, format::bfyx});
+    auto scale_mem = engine.allocate_memory({{ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx});
+    auto zp_mem = use_zp ? engine.allocate_memory({{ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx}) : nullptr;
+
+    tests::random_generator rg(GET_SUITE_NAME);
+    const int input_elems = is_3d ? batch_num * seq_len * ifm_num : batch_num * ifm_num;
+    auto input_data = rg.generate_random_1d<ov::float16>(input_elems, -1.0f, 1.0f);
+    set_values(input_mem, input_data);
+
+    std::vector<uint8_t> packed_weights;
+    std::vector<uint8_t> unpacked_weights;
+    for (int ofm = 0; ofm < ofm_num; ++ofm) {
+        for (int ifm_byte = 0; ifm_byte < ifm_num / 4; ++ifm_byte) {
+            uint8_t packed = 0;
+            for (int i = 0; i < 4; ++i) {
+                uint8_t val = (ifm_byte * 4 + i) % 4;
+                unpacked_weights.push_back(val);
+                packed |= (val << (i * 2));
+            }
+            packed_weights.push_back(packed);
+        }
+    }
+    set_values(weights_mem, packed_weights);
+
+    auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 0.5f, 2.0f);
+    set_values(scale_mem, scale_data);
+
+    std::vector<ov::float16> zp_data;
+    if (use_zp) {
+        zp_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 0.5f, 1.5f);
+        set_values(zp_mem, zp_data);
+    }
+
+    auto in_layout = layout{input_shape, data_types::f16, format::bfyx};
+    const int input_size = is_3d ? 3 : 2;
+
+    topology topology(input_layout("input", in_layout), data("weights", weights_mem), data("scale", scale_mem));
+    if (use_zp)
+        topology.add(data("zp", zp_mem));
+    topology.add(fully_connected("fc_prim", input_info("input"), "weights", "", "scale", use_zp ? "zp" : "", data_types::f16, input_size, 2));
+
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    ov::intel_gpu::ImplementationDesc fc_impl_desc = {format::bfyx, "fully_connected_gpu_bfyx_ref", impl_types::ocl};
+    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"fc_prim", fc_impl_desc}}));
+    config.set_user_property(ov::hint::dynamic_quantization_group_size(0));
+
+    network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+    network->set_input_data("input", input_mem);
+
+    auto outputs = network->execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "fc_prim");
+
+    auto inst = network->get_primitive("fc_prim");
+    auto impl = inst->get_impl();
+    ASSERT_NE(impl, nullptr);
+
+    auto output_mem = outputs.begin()->second.get_memory();
+    cldnn::mem_lock<ov::float16> output_ptr(output_mem, get_test_stream());
+
+    const int outer_count = is_3d ? batch_num * seq_len : batch_num;
+    std::vector<float> expected_output(outer_count * ofm_num);
+    for (int n = 0; n < outer_count; ++n) {
+        for (int ofm = 0; ofm < ofm_num; ++ofm) {
+            float acc = 0.0f;
+            for (int ifm = 0; ifm < ifm_num; ++ifm) {
+                int group_id = ifm / scales_group_size;
+                uint8_t weight_u2 = unpacked_weights[ofm * ifm_num + ifm];
+                float scale = static_cast<float>(scale_data[ofm * (ifm_num / scales_group_size) + group_id]);
+                float zp = use_zp ? static_cast<float>(zp_data[ofm * (ifm_num / scales_group_size) + group_id]) : 0.0f;
+                float weight_f16 = (static_cast<float>(weight_u2) - zp) * scale;
+                float inp = static_cast<float>(input_data[n * ifm_num + ifm]);
+                acc += inp * weight_f16;
+            }
+            expected_output[n * ofm_num + ofm] = acc;
+        }
+    }
+
+    ASSERT_EQ(output_ptr.size(), expected_output.size());
+    for (size_t i = 0; i < expected_output.size(); ++i) {
+        ASSERT_NEAR(expected_output[i], static_cast<float>(output_ptr[i]), 2.0f) << "Mismatch at output index " << i;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke,
+                         fully_connected_gpu_u2_validation,
+                         ::testing::Values(std::make_tuple(1, 4, 4, 4, 1, false),        // minimum size (single group)
+                                           std::make_tuple(2, 16, 8, 4, 1, false),       // multiple batches, small group size
+                                           std::make_tuple(4, 64, 32, 32, 1, false),     // group_size == ifm (single group per row)
+                                           std::make_tuple(1, 128, 64, 32, 1, false),    // larger dimensions, multiple groups
+                                           std::make_tuple(8, 256, 128, 64, 1, false),   // large batch + large matrix
+                                           std::make_tuple(1, 512, 256, 128, 1, false),  // stress test
+                                           std::make_tuple(2, 64, 63, 16, 1, false),     // odd ofm_num
+                                           std::make_tuple(2, 60, 64, 4, 1, false),      // odd number of scale groups
+                                           std::make_tuple(2, 8, 4, 4, 3, false),        // 3D (OUTPUT_3D) path
+                                           std::make_tuple(1, 16, 8, 4, 5, false),       // 3D with longer sequence
+                                           std::make_tuple(2, 16, 8, 4, 1, true),        // with zero-point
+                                           std::make_tuple(1, 64, 32, 16, 1, true),      // with zero-point, larger
+                                           std::make_tuple(2, 8, 4, 4, 3, true)          // 3D with zero-point
+                                           ),
+                         fully_connected_gpu_u2_validation::GetTestCaseName);

--- a/src/plugins/template/tests/functional/op_reference/convert.cpp
+++ b/src/plugins/template/tests/functional/op_reference/convert.cpp
@@ -991,6 +991,29 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<float>{-1, -2, 2, 3},
                       std::vector<uint8_t>{0xEF, 0x32}),
 
+        // destination u2 - minimal essential coverage
+        // Test 1: u8 ? u2 (most common quantization path)
+        ConvertParams(ConversionTypes::CONVERT,
+                      ov::PartialShape{4},
+                      ov::element::u8,
+                      ov::element::u2,
+                      std::vector<uint8_t>{0, 1, 2, 3},
+                      std::vector<uint8_t>{0xE4}),
+        // Test 2: i8 ? u2 (signed to unsigned quantization)
+        ConvertParams(ConversionTypes::CONVERT,
+                      ov::PartialShape{4},
+                      ov::element::i8,
+                      ov::element::u2,
+                      std::vector<int8_t>{0, 1, 2, 3},
+                      std::vector<uint8_t>{0xE4}),
+        // Test 3: f16 ? u2 (actual use case: matmul weights compression)
+        ConvertParams(ConversionTypes::CONVERT,
+                      ov::PartialShape{4},
+                      ov::element::f16,
+                      ov::element::u2,
+                      std::vector<ov::float16>{0, 1, 2, 3},
+                      std::vector<uint8_t>{0xE4}),
+
         // destination u8
         ConvertParams(ConversionTypes::CONVERT,
                       ov::PartialShape{8},

--- a/src/plugins/template/tests/functional/op_reference/transpose.cpp
+++ b/src/plugins/template/tests/functional/op_reference/transpose.cpp
@@ -273,6 +273,46 @@ std::vector<TransposeParams> generateThrowingTransposeParams() {
     };
 }
 
+std::vector<TransposeParams> generateTransposeParamsForSubByte() {
+    std::vector<TransposeParams> params;
+
+    // NOTE: Sub-byte types (u2, u4, i4) pack multiple values per byte.
+    // These tests validate transpose_2bit and transpose_4bit reference implementations.
+    // u2: 4 values per byte (2 bits each), u4/i4: 2 values per byte (4 bits each)
+
+    // u2 transpose test - swap dimensions
+    // Input: [2,2] = [[0,1], [2,3]] with axes {1,0}
+    // Output: [2,2] = [[0,2], [1,3]] = {0,2,1,3}
+    params.push_back(
+        TransposeParams(PartialShape::dynamic(),
+                        reference_tests::Tensor(element::u2, {2, 2}, std::vector<uint8_t>{0xE4}),  // {0,1,2,3}
+                        reference_tests::Tensor(element::i64, {2}, std::vector<int64_t>{1, 0}),
+                        reference_tests::Tensor(element::u2, {2, 2}, std::vector<uint8_t>{0xD8}),  // {0,2,1,3}
+                        "transpose_u2_2d_swap"));
+
+    // u4 transpose test - swap dimensions
+    // Input: [2,2] = [[1,2], [3,4]] with axes {1,0}
+    // Output: [2,2] = [[1,3], [2,4]] = {1,3,2,4}
+    params.push_back(
+        TransposeParams(PartialShape::dynamic(),
+                        reference_tests::Tensor(element::u4, {2, 2}, std::vector<uint8_t>{0x21, 0x43}),  // {1,2,3,4}
+                        reference_tests::Tensor(element::i64, {2}, std::vector<int64_t>{1, 0}),
+                        reference_tests::Tensor(element::u4, {2, 2}, std::vector<uint8_t>{0x31, 0x42}),  // {1,3,2,4}
+                        "transpose_u4_2d_swap"));
+
+    // i4 transpose test - swap dimensions with signed values
+    // Input: [2,2] = [[1,-2], [3,-4]] with axes {1,0}
+    // Output: [2,2] = [[1,3], [-2,-4]] = {1,3,-2,-4}
+    params.push_back(
+        TransposeParams(PartialShape::dynamic(),
+                        reference_tests::Tensor(element::i4, {2, 2}, std::vector<uint8_t>{0xE1, 0xC3}),  // {1,-2,3,-4}
+                        reference_tests::Tensor(element::i64, {2}, std::vector<int64_t>{1, 0}),
+                        reference_tests::Tensor(element::i4, {2, 2}, std::vector<uint8_t>{0x31, 0xCE}),  // {1,3,-2,-4}
+                        "transpose_i4_2d_swap"));
+
+    return params;
+}
+
 std::vector<TransposeParams> generateTransposeCombinedParams() {
     const std::vector<std::vector<TransposeParams>> transposeTypeParams{
         generateTransposeParams<element::Type_t::i8>(),
@@ -288,6 +328,7 @@ std::vector<TransposeParams> generateTransposeCombinedParams() {
         generateThrowingTransposeParams<element::Type_t::f32>(),
         generateThrowingTransposeParams<element::Type_t::i32>(),
         generateTransposeParamsForString(),
+        generateTransposeParamsForSubByte(),
     };
     std::vector<TransposeParams> combinedParams;
 


### PR DESCRIPTION
[GPU][Core] Add UINT2 compressed weights support with transpose and ZP fixes

#### Details:
- Add UINT2 weight decompression support in fully_connected_gpu_bfyx_ref kernel
- Extend ParamsKey to recognize UINT2 weight type for kernel selection
- Add packed u2 transpose (transpose_2bit) in core reference implementation
- Fix u2 zero-point constant not being converted to u8 in GPU FC compressed path
- Reject UINT2 from bf_tiled kernel (unsupported) to fallback to reference kernel
- Recognize u2 as valid compressed constant in GPU compressed weights pattern

#### Implementation changes:
Core changes:
- Added transpose_2bit() declaration and implementation using ov::element::iterator<u2>
- Added u2 dispatch in Transpose::evaluate() before i4/u4 branch

GPU changes:
- Added UINT2 unpack macros (UNPACK_UINT2x4/x8/x16) in int4_utils.cl
- Extended ParamsKey bitfield with uint2 bit and added UINT2 cases in Enable*WeightsType
- Added UINT2 decompression path in fully_connected_gpu_bfyx_ref.cl (both OUTPUT_3D and non-OUTPUT_3D)
- Added COMPRESSED_WEIGHTS_UINT2 jit define and weight type mapping
- Added u2 to convert_const_to_u8 lambda in convert_fc_to_compressed.cpp
- Added u2 to compressed_constant predicate in compressed_weights_pattern.hpp
- Reject UINT2 in FullyConnected_bf_tiled::Validate() to use reference kernel
- Added unit tests for f16:u2:f16 fully connected validation

#### Changed files:
src/core/reference/include/openvino/reference/transpose.hpp
src/core/reference/src/op/transpose.cpp
src/core/src/op/convert.cpp
src/core/src/op/transpose.cpp
src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bfyx_ref.cl
src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/int2_utils.cl
src/plugins/intel_gpu/src/kernel_selector/common_types.h
src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
src/plugins/intel_gpu/src/kernel_selector/jitter.h
src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.cpp
src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled_dyn_b.cpp
src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bfyx_ref.cpp
src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
src/plugins/intel_gpu/src/plugin/transformations/compressed_weights_pattern.hpp
src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
src/plugins/template/tests/functional/op_reference/convert.cpp
src/plugins/template/tests/functional/op_reference/transpose.cpp


#### Reproduction step and snapshot (if applicable. Do not attach for customer model):
NA

#### Problematic graph:
NA

#### Checklist:
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary? Yes
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? NA

#### Tickets:
CVS-188706, MFDNN-15020

#### AI Assistance:
- AI assistance used: yes
- AI was used for logic refinement, variable naming, and commit message structure.