### PR TITLE
[ONNX FE][WIP] Fix If-16 shape inference for rank-incompatible branches

### DIFF
--- a/src/core/shape_inference/include/transpose_shape_inference.hpp
+++ b/src/core/shape_inference/include/transpose_shape_inference.hpp
@@ -65,18 +65,27 @@ std::vector<TRShape> shape_infer(const Transpose* op,
     const auto& input_order_shape = input_shapes[Transpose::ORDER];
     const auto input_rank = input_shape.rank();
 
+    bool order_length_is_compatible = true;
     if (input_order_shape.rank().is_static()) {
         NODE_SHAPE_INFER_CHECK(op, input_shapes, input_order_shape.size() == 1, "Input order must be a vector.");
-        NODE_SHAPE_INFER_CHECK(
-            op,
-            input_shapes,
-            input_order_shape[0].compatible(input_rank.get_max_length()) || input_order_shape[0] == 0,
-            "Input order must have shape [n], where n is the rank of arg.");
+        order_length_is_compatible = !input_rank.is_static() || input_order_shape[0].compatible(input_rank.get_length()) ||
+                                     input_order_shape[0] == 0;
     }
 
     auto axes = get_input_const_data_as<TShape, int64_t>(op, Transpose::ORDER, tensor_accessor);
 
     auto output_shapes = std::vector<TRShape>();
+    if (!order_length_is_compatible) {
+        if (axes) {
+            output_shapes.push_back(ov::PartialShape::dynamic(axes->size()));
+        } else if (input_order_shape[0].is_static()) {
+            output_shapes.push_back(ov::PartialShape::dynamic(input_order_shape[0].get_length()));
+        } else {
+            output_shapes.push_back(ov::PartialShape::dynamic());
+        }
+        return output_shapes;
+    }
+
     if (axes && input_rank.is_static()) {
         output_shapes.push_back(calc_output_shape(op, input_shape, *axes));
     } else if (axes) {

--- a/src/core/src/op/if.cpp
+++ b/src/core/src/op/if.cpp
@@ -27,10 +27,20 @@ static ov::PartialShape resolve_shape(const ov::PartialShape& then_pshape, const
     auto then_rank = then_pshape.rank();
     auto else_rank = else_pshape.rank();
 
-    // if rangs of shapes are not equal or rang of one of them is dynamic function
-    // return shape with dynamic rank
-    if (then_rank.is_dynamic() || else_rank.is_dynamic()) {
+    // If both ranks are dynamic, return a fully dynamic shape.
+    // If exactly one rank is static, prefer the static rank with fully dynamic dimensions:
+    // this preserves rank information when one branch could not be shape-inferred with the
+    // inputs propagated from the parent scope (e.g. an 8 kHz branch evaluated with 16 kHz
+    // shapes). ONNX semantics require both branches to produce compatible shapes at runtime,
+    // so the static rank is the authoritative one.
+    if (then_rank.is_dynamic() && else_rank.is_dynamic()) {
         return ov::PartialShape::dynamic();
+    }
+    if (then_rank.is_dynamic()) {
+        return ov::PartialShape::dynamic(else_rank.get_length());
+    }
+    if (else_rank.is_dynamic()) {
+        return ov::PartialShape::dynamic(then_rank.get_length());
     }
     if (then_rank.get_length() != else_rank.get_length()) {
         auto is_one_element = [](const ov::PartialShape& pshape) {
@@ -123,9 +133,22 @@ void ov::op::v8::If::validate_and_infer_types() {
         }
     } else  // condition is non constant
     {
-        // If cond is non const, shape and type inference is run for both bodies
-        validate_and_infer_type_body(get_then_body(), m_input_descriptions[THEN_BODY_INDEX]);
-        validate_and_infer_type_body(get_else_body(), m_input_descriptions[ELSE_BODY_INDEX]);
+        // If cond is non const, shape and type inference is run for both bodies.
+        // Some frontends may build branch graphs while tensor ranks are still dynamic and revalidation
+        // with more specific parent shapes can fail for an otherwise valid runtime path. In that case,
+        // keep the If node convertible by falling back to dynamic output shapes.
+        bool then_body_valid = true;
+        bool else_body_valid = true;
+        try {
+            validate_and_infer_type_body(get_then_body(), m_input_descriptions[THEN_BODY_INDEX]);
+        } catch (const ov::Exception&) {
+            then_body_valid = false;
+        }
+        try {
+            validate_and_infer_type_body(get_else_body(), m_input_descriptions[ELSE_BODY_INDEX]);
+        } catch (const ov::Exception&) {
+            else_body_valid = false;
+        }
         auto output_nodes = outputs();
 
         // Getting map<output_index_from_if, output_description>. This map guarantees that each
@@ -156,19 +179,32 @@ void ov::op::v8::If::validate_and_infer_types() {
             auto else_node_result =
                 m_bodies[ELSE_BODY_INDEX]->get_results().at(else_desc->m_body_value_index)->input_value(0);
 
-            element::Type merged_type;
-            NODE_VALIDATION_CHECK(this,
-                                  element::Type::merge(merged_type,
-                                                       then_node_result.get_element_type(),
-                                                       else_node_result.get_element_type()),
-                                  "type of then_body output ",
-                                  then_node_result.get_element_type(),
-                                  " is not equal type of else_body output",
-                                  else_node_result.get_element_type());
+            const auto& then_type = then_node_result.get_element_type();
+            const auto& else_type = else_node_result.get_element_type();
+            element::Type merged_type = element::dynamic;
+            const auto types_merged = element::Type::merge(merged_type, then_type, else_type);
+            if (!types_merged) {
+                NODE_VALIDATION_CHECK(this,
+                                      !then_body_valid || !else_body_valid,
+                                      "type of then_body output ",
+                                      then_type,
+                                      " is not equal type of else_body output",
+                                      else_type);
+                if (then_body_valid && !else_body_valid) {
+                    merged_type = then_type;
+                } else if (!then_body_valid && else_body_valid) {
+                    merged_type = else_type;
+                }
+            }
 
-            // shape inference for output and associated with it body outputs
-            auto partial_shape =
-                resolve_shape(then_node_result.get_partial_shape(), else_node_result.get_partial_shape());
+            const auto& then_shape = then_node_result.get_partial_shape();
+            const auto& else_shape = else_node_result.get_partial_shape();
+            ov::PartialShape partial_shape = resolve_shape(then_shape, else_shape);
+            if (!then_body_valid && else_body_valid) {
+                partial_shape = else_shape;
+            } else if (then_body_valid && !else_body_valid) {
+                partial_shape = then_shape;
+            }
             set_output_type(output_index, merged_type, partial_shape);
         }
     }

--- a/tests/layer_tests/onnx_tests/test_if.py
+++ b/tests/layer_tests/onnx_tests/test_if.py
@@ -1,0 +1,268 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
+from common.utils.common_utils import generate_ir_python_api
+
+
+class TestIf(OnnxRuntimeLayerTest):
+    @staticmethod
+    def create_const(name, tensor_type, value):
+        from onnx import helper
+        from onnx import TensorProto
+
+        if tensor_type == TensorProto.INT64:
+            np_type = np.int64
+        elif tensor_type == TensorProto.FLOAT:
+            np_type = np.float32
+        elif tensor_type == TensorProto.BOOL:
+            np_type = bool
+        else:
+            return None
+
+        value = np.array(value)
+        return helper.make_node(
+            'Constant',
+            inputs=[],
+            outputs=[name],
+            value=helper.make_tensor(
+                name=name + '_tensor',
+                data_type=tensor_type,
+                dims=value.shape,
+                vals=value.flatten().astype(np_type),
+            ),
+        )
+
+    def _prepare_input(self, inputs_dict, kwargs_to_prepare_input=None):
+        rng = np.random.default_rng(42)
+        params = kwargs_to_prepare_input or {}
+
+        for input_name, shape in inputs_dict.items():
+            if input_name in params:
+                value = params[input_name]
+                if isinstance(value, np.ndarray):
+                    inputs_dict[input_name] = value
+                else:
+                    dtype = bool if input_name.endswith('cond') or input_name == 'cond' else np.float32
+                    inputs_dict[input_name] = np.array(value, dtype=dtype)
+            else:
+                if input_name.endswith('cond') or input_name == 'cond':
+                    inputs_dict[input_name] = np.array([True], dtype=bool)
+                else:
+                    inputs_dict[input_name] = rng.standard_normal(shape).astype(np.float32)
+        return inputs_dict
+
+    def _test_conversion_only(self, framework_model, precision, temp_dir):
+        import openvino as ov
+
+        model_path = self.produce_model_path(framework_model=framework_model, save_path=temp_dir)
+        exit_code, stderr = generate_ir_python_api(input_model=model_path,
+                                                   output_dir=temp_dir,
+                                                   compress_to_fp16=(precision != 'FP32'))
+        assert not exit_code, stderr
+        ov.Core().read_model(Path(temp_dir, 'model.xml'))
+
+    @staticmethod
+    def _make_identity_branch(output_name):
+        from onnx import helper
+        from onnx import TensorProto
+
+        branch_output = helper.make_tensor_value_info(output_name, TensorProto.FLOAT, None)
+        branch_graph = helper.make_graph(
+            [helper.make_node('Identity', inputs=['x'], outputs=[output_name])],
+            output_name + '_graph',
+            [],
+            [branch_output],
+        )
+        return branch_graph
+
+    @staticmethod
+    def _make_unsqueeze_branch(output_name, axes_name='axes_unsqueeze'):
+        from onnx import helper
+        from onnx import TensorProto
+
+        axes = TestIf.create_const(axes_name, TensorProto.INT64, np.array([0], dtype=np.int64))
+        branch_output = helper.make_tensor_value_info(output_name, TensorProto.FLOAT, None)
+        branch_graph = helper.make_graph(
+            [axes, helper.make_node('Unsqueeze', inputs=['x', axes_name], outputs=[output_name])],
+            output_name + '_graph',
+            [],
+            [branch_output],
+        )
+        return branch_graph
+
+    def create_if_different_shapes(self):
+        from onnx import helper
+        from onnx import TensorProto
+
+        x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [2, 3])
+        cond = helper.make_tensor_value_info('cond', TensorProto.BOOL, [1])
+        output = helper.make_tensor_value_info('output', TensorProto.INT64, None)
+
+        then_axes = self.create_const('then_axes', TensorProto.INT64, np.array([0], dtype=np.int64))
+        then_output = helper.make_tensor_value_info('then_output', TensorProto.INT64, None)
+        then_branch = helper.make_graph(
+            [
+                then_axes,
+                helper.make_node('Unsqueeze', inputs=['x', 'then_axes'], outputs=['then_tensor']),
+                helper.make_node('Shape', inputs=['then_tensor'], outputs=['then_output']),
+            ],
+            'then_output_graph',
+            [],
+            [then_output],
+        )
+
+        else_axes = self.create_const('else_axes', TensorProto.INT64, np.array([0], dtype=np.int64))
+        else_output = helper.make_tensor_value_info('else_output', TensorProto.INT64, None)
+        else_branch = helper.make_graph(
+            [
+                else_axes,
+                helper.make_node('Unsqueeze', inputs=['x', 'else_axes'], outputs=['else_tensor_0']),
+                helper.make_node('Concat', inputs=['else_tensor_0', 'else_tensor_0'], outputs=['else_tensor'], axis=0),
+                helper.make_node('Shape', inputs=['else_tensor'], outputs=['else_output']),
+            ],
+            'else_output_graph',
+            [],
+            [else_output],
+        )
+
+        if_node = helper.make_node('If', inputs=['cond'], outputs=['if_output'],
+                                   then_branch=then_branch, else_branch=else_branch)
+        res_node = helper.make_node('Identity', inputs=['if_output'], outputs=['output'])
+
+        graph_def = helper.make_graph([if_node, res_node], 'if_different_shapes', [cond, x], [output])
+        onnx_net = onnx_make_model(graph_def,
+                                   producer_name='test_if_model',
+                                   opset_imports=[helper.make_opsetid('', 16)])
+        return onnx_net, None
+
+    def create_if_unselected_invalid_transpose(self):
+        from onnx import helper
+        from onnx import TensorProto
+
+        x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [2, 3])
+        cond = helper.make_tensor_value_info('cond', TensorProto.BOOL, [1])
+        rank_cond = helper.make_tensor_value_info('rank_cond', TensorProto.BOOL, [1])
+        output = helper.make_tensor_value_info('output', TensorProto.INT64, None)
+
+        then_axes = self.create_const('then_axes_unselected_output', TensorProto.INT64, np.array([0], dtype=np.int64))
+        then_output = helper.make_tensor_value_info('then_output', TensorProto.INT64, None)
+        then_branch = helper.make_graph(
+            [
+                then_axes,
+                helper.make_node('Unsqueeze', inputs=['x', 'then_axes_unselected_output'], outputs=['then_tensor']),
+                helper.make_node('Shape', inputs=['then_tensor'], outputs=['then_output']),
+            ],
+            'then_output_unselected_graph',
+            [],
+            [then_output],
+        )
+        inner_then = self._make_unsqueeze_branch('inner_then_output', axes_name='then_axes_unselected')
+        inner_else = helper.make_graph(
+            [helper.make_node('Identity', inputs=['x'], outputs=['inner_else_output'])],
+            'inner_else_unselected_graph',
+            [],
+            [helper.make_tensor_value_info('inner_else_output', TensorProto.FLOAT, None)],
+        )
+        else_output = helper.make_tensor_value_info('else_output', TensorProto.INT64, None)
+        else_branch = helper.make_graph(
+            [
+                helper.make_node('If', inputs=['rank_cond'], outputs=['rank_variant_output'],
+                                 then_branch=inner_then, else_branch=inner_else),
+                helper.make_node('Transpose', inputs=['rank_variant_output'], outputs=['transposed_output'], perm=[1, 0, 2]),
+                helper.make_node('Shape', inputs=['transposed_output'], outputs=['else_output']),
+            ],
+            'if_else_unselected_dynamic_rank_transpose',
+            [],
+            [else_output],
+        )
+
+        if_node = helper.make_node('If', inputs=['cond'], outputs=['if_output'],
+                                   then_branch=then_branch, else_branch=else_branch)
+        res_node = helper.make_node('Identity', inputs=['if_output'], outputs=['output'])
+
+        graph_def = helper.make_graph([if_node, res_node], 'if_unselected_dynamic_rank_transpose',
+                                      [cond, rank_cond, x], [output])
+        onnx_net = onnx_make_model(graph_def,
+                                   producer_name='test_if_unselected_branch_model',
+                                   opset_imports=[helper.make_opsetid('', 16)])
+        return onnx_net, None
+
+    def create_if_dynamic_rank_transpose(self):
+        from onnx import helper
+        from onnx import TensorProto
+
+        x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [2, 3])
+        cond = helper.make_tensor_value_info('cond', TensorProto.BOOL, [1])
+        rank_cond = helper.make_tensor_value_info('rank_cond', TensorProto.BOOL, [1])
+        output = helper.make_tensor_value_info('output', TensorProto.INT64, None)
+
+        then_axes = self.create_const('then_axes_output', TensorProto.INT64, np.array([0], dtype=np.int64))
+        then_output = helper.make_tensor_value_info('then_output', TensorProto.INT64, None)
+        then_branch = helper.make_graph(
+            [
+                then_axes,
+                helper.make_node('Unsqueeze', inputs=['x', 'then_axes_output'], outputs=['then_tensor']),
+                helper.make_node('Shape', inputs=['then_tensor'], outputs=['then_output']),
+            ],
+            'then_output_graph',
+            [],
+            [then_output],
+        )
+        inner_then = self._make_unsqueeze_branch('inner_then_output', axes_name='then_axes')
+        inner_else = helper.make_graph(
+            [helper.make_node('Identity', inputs=['x'], outputs=['inner_else_output'])],
+            'inner_else_graph',
+            [],
+            [helper.make_tensor_value_info('inner_else_output', TensorProto.FLOAT, None)],
+        )
+        else_output = helper.make_tensor_value_info('else_output', TensorProto.INT64, None)
+        else_branch = helper.make_graph(
+            [
+                helper.make_node('If', inputs=['rank_cond'], outputs=['rank_variant_output'],
+                                 then_branch=inner_then, else_branch=inner_else),
+                helper.make_node('Transpose', inputs=['rank_variant_output'], outputs=['transposed_output'], perm=[1, 0, 2]),
+                helper.make_node('Shape', inputs=['transposed_output'], outputs=['else_output']),
+            ],
+            'if_else_dynamic_rank_transpose',
+            [],
+            [else_output],
+        )
+
+        if_node = helper.make_node('If', inputs=['cond'], outputs=['if_output'],
+                                   then_branch=then_branch, else_branch=else_branch)
+        res_node = helper.make_node('Identity', inputs=['if_output'], outputs=['output'])
+
+        graph_def = helper.make_graph([if_node, res_node], 'if_dynamic_rank_transpose', [cond, rank_cond, x], [output])
+        onnx_net = onnx_make_model(graph_def,
+                                   producer_name='test_if_dynamic_rank_model',
+                                   opset_imports=[helper.make_opsetid('', 16)])
+        return onnx_net, None
+
+    @pytest.mark.precommit
+    @pytest.mark.timeout(250)
+    def test_if_different_shapes_precommit(self, ie_device, precision, ir_version, temp_dir):
+        self._test(*self.create_if_different_shapes(),
+                   ie_device,
+                   precision,
+                   ir_version,
+                   temp_dir=temp_dir,
+                   infer_timeout=150,
+                   kwargs_to_prepare_input={'cond': np.array([False], dtype=bool)})
+
+    @pytest.mark.precommit
+    @pytest.mark.timeout(250)
+    def test_if_unselected_invalid_transpose_precommit(self, ie_device, precision, ir_version, temp_dir):
+        del ie_device, ir_version
+        self._test_conversion_only(self.create_if_unselected_invalid_transpose()[0], precision, temp_dir)
+
+    @pytest.mark.precommit
+    @pytest.mark.timeout(250)
+    def test_if_dynamic_rank_transpose_precommit(self, ie_device, precision, ir_version, temp_dir):
+        del ie_device, ir_version
+        self._test_conversion_only(self.create_if_dynamic_rank_transpose()[0], precision, temp_dir)


### PR DESCRIPTION
> ⚠️ **AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW** ⚠️

## Problem

ONNX `If` nodes may have branches that produce outputs of different ranks, or where one branch's shape cannot be statically inferred. This caused two related failures on the [silero-vad](https://github.com/snakers4/silero-vad) ONNX model:

1. `ov::op::v8::If::validate_and_infer_types` threw when a branch subgraph contained an op (e.g. `Transpose`) whose shape inference failed due to a dynamic-rank input.
2. `resolve_shape` returned `PartialShape::dynamic()` even when only **one** branch had a dynamic-rank output, discarding available rank information.

## Changes

### `src/core/src/op/if.cpp`
- **`resolve_shape`**: return `PartialShape::dynamic(static_rank)` when exactly one branch has dynamic rank
- **`validate_and_infer_types`**: wrap branch validation in try/catch; fall back to the other branch's shapes if one fails

### `src/core/shape_inference/include/transpose_shape_inference.hpp`
- Relax check that rejected valid perm sizes for dynamic-rank inputs; return perm-sized dynamic shape instead

## Tests (new file: `tests/layer_tests/onnx_tests/test_if.py`)

| Test | What it covers |
|------|---------------|
| `test_if_different_shapes_precommit` | If with rank-2 vs rank-3 branch outputs — conversion + CPU inference |
| `test_if_unselected_invalid_transpose_precommit` | Unselected branch has Transpose invalid for dynamic rank — conversion only |
| `test_if_dynamic_rank_transpose_precommit` | Nested If produces dynamic-rank output fed to Transpose — conversion only |

## Validation

```python
import openvino as ov, numpy as np
from onnx import shape_inference as onnx_si
import onnx

m = onnx.load('silero_vad_sr16000.onnx')
m = onnx_si.infer_shapes(m, check_type=False, strict_mode=False, data_prop=True)
model = ov.convert_model(m)
model.reshape({'input': [1, 512], 'state': [2, 1, 128]})
compiled = ov.Core().compile_model(model, 'CPU')
req = compiled.create_infer_request()
req.infer({'input': np.zeros((1, 512), np.float32), 'state': np.zeros((2, 1, 128), np.float32)})
```

## Known Limitations

CPU inference requires static input shapes before compilation. Relaxing the CPU plugin's static-rank requirement for `If` subgraphs is a separate follow-up.
