### PR TITLE
[GPU][CM] Fix unused lambda capture in paged_attention_gen

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
@@ -386,7 +386,6 @@ JitConstants PagedAttentionGeneratorMultiToken::get_jit_constants(const kernel_i
 }
 
 DispatchDataFunc PagedAttentionGeneratorMultiToken::get_dispatch_data_func() const {
-    constexpr size_t wg_size = PagedAttentionGeneratorMultiToken::_wg_size;
     return DispatchDataFunc{[](const RuntimeParams& params, KernelData& kd, ImplRuntimeParams* rt_params) {
         auto& wgs = kd.params.workGroups;
         auto& scalars = kd.params.scalars;
@@ -403,8 +402,8 @@ DispatchDataFunc PagedAttentionGeneratorMultiToken::get_dispatch_data_func() con
         const size_t wg_count = rtp->multi_token_wg_count;
         OPENVINO_ASSERT(wg_count > 0, "Invalid multi_token_wg_count in runtime params");
 
-        wgs.global = {1, heads_num, wg_count * wg_size};
-        wgs.local = {1, 1, wg_size};
+        wgs.global = {1, heads_num, wg_count * PagedAttentionGeneratorMultiToken::_wg_size};
+        wgs.local = {1, 1, PagedAttentionGeneratorMultiToken::_wg_size};
 
         if (DEBUG_ENABLED) {  // Debug
             std::cout << "PagedAttentionGeneratorMultiToken::get_dispatch_data_func: \n"

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
@@ -387,7 +387,7 @@ JitConstants PagedAttentionGeneratorMultiToken::get_jit_constants(const kernel_i
 
 DispatchDataFunc PagedAttentionGeneratorMultiToken::get_dispatch_data_func() const {
     constexpr size_t wg_size = PagedAttentionGeneratorMultiToken::_wg_size;
-    return DispatchDataFunc{[wg_size](const RuntimeParams& params, KernelData& kd, ImplRuntimeParams* rt_params) {
+    return DispatchDataFunc{[](const RuntimeParams& params, KernelData& kd, ImplRuntimeParams* rt_params) {
         auto& wgs = kd.params.workGroups;
         auto& scalars = kd.params.scalars;
         auto desc = params.typed_desc<paged_attention>();


### PR DESCRIPTION
### Summary
Fixes a build failure caused by -Werror,-Wunused-lambda-capture in fuzzing/nightly build.
Removes an unnecessary lambda capture of wg_size in multi-token dispatch code.
No functional behavior change is intended.

### Root Cause
In PagedAttentionGeneratorMultiToken::get_dispatch_data_func, the lambda captured wg_size.
wg_size is a constexpr and does not need to be captured.
Clang reports this as unused-lambda-capture, and the build fails due to -Werror.

### Changes
Updated lambda capture list from [wg_size] to [] in the dispatch function.
Kept all runtime logic and dispatch values unchanged.

### Tickets:
 - 187809

### AI Assistance:
 - AI assistance used: yes
 - AI: fix issue
 - User: review
