### PR TITLE
[SIT] Add prefill options for nrmse

### DIFF
--- a/src/plugins/intel_npu/tools/single-image-test/argument_parse_helpers.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/argument_parse_helpers.cpp
@@ -92,6 +92,18 @@ DEFINE_string(rrmse_loss_threshold, std::to_string(metric_defaults::rrmse_loss_t
         "Threshold for 'rrmse' mode. Can be a single value or per-layer: 'layer1:0.1;layer2:0.2'");
 DEFINE_string(nrmse_loss_threshold, std::to_string(metric_defaults::nrmse_loss_threshold),
         "Threshold for 'nrmse' mode. Can be a single value or per-layer: 'logits:0.03;pred_boxes:0.05'");
+DEFINE_string(nrmse_prefill_seq_len_axis, "",
+        "Optional. Per-output sequence-length axis used by the 'nrmse' mode to slice prefill LLM "
+        "outputs (KV cache / hidden state). Semicolon-separated list of 'layer:axis' pairs, e.g. "
+        "'present.0.key:2;present.0.value:3;Result_logits:1'. Combined with --nrmse_prefill_seq_len_size, "
+        "the output tensor is sliced to its last N elements along the specified axis before computing "
+        "NRMSE. If either flag is missing for a given layer, the full tensor is compared.");
+DEFINE_string(nrmse_prefill_seq_len_size, "",
+        "Optional. Per-output number of elements to keep along the sequence-length axis (= prompt "
+        "length) when computing NRMSE on prefill LLM outputs. Semicolon-separated 'layer:N' pairs, "
+        "e.g. 'present.0.key:7;present.0.value:7;Result_logits:7'. Used together with "
+        "--nrmse_prefill_seq_len_axis. If either flag is missing for a given layer, the full tensor "
+        "is compared.");
 DEFINE_string(l2norm_threshold, std::to_string(metric_defaults::l2norm_threshold),
         "Threshold for 'l2norm' mode. Can be a single value or per-layer: 'layer1:1.0;layer2:2.0'");
 DEFINE_string(overlap_threshold, std::to_string(metric_defaults::overlap_threshold),
@@ -188,6 +200,10 @@ void utils::parseCommandLine(int argc, char* argv[]) {
             std::cout << "    mAP Threshold:     " << FLAGS_map_threshold << std::endl;
         } else if (strEq(FLAGS_mode, "nrmse")) {
             std::cout << "    Threshold:        " << FLAGS_nrmse_loss_threshold << std::endl;
+            if (!FLAGS_nrmse_prefill_seq_len_axis.empty() || !FLAGS_nrmse_prefill_seq_len_size.empty()) {
+                std::cout << "    Prefill seq-len axis: " << FLAGS_nrmse_prefill_seq_len_axis << std::endl;
+                std::cout << "    Prefill seq-len size: " << FLAGS_nrmse_prefill_seq_len_size << std::endl;
+            }
         } else if (strEq(FLAGS_mode, "l2norm")) {
             std::cout << "    Threshold:        " << FLAGS_l2norm_threshold << std::endl;
         }

--- a/src/plugins/intel_npu/tools/single-image-test/argument_parse_helpers.hpp
+++ b/src/plugins/intel_npu/tools/single-image-test/argument_parse_helpers.hpp
@@ -84,6 +84,8 @@ DECLARE_string(raw_tolerance);
 DECLARE_string(cosim_threshold);
 DECLARE_string(rrmse_loss_threshold);
 DECLARE_string(nrmse_loss_threshold);
+DECLARE_string(nrmse_prefill_seq_len_axis);
+DECLARE_string(nrmse_prefill_seq_len_size);
 DECLARE_string(l2norm_threshold);
 DECLARE_string(overlap_threshold);
 DECLARE_string(map_threshold);

--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -1561,6 +1561,54 @@ bool testRRMSE(const TensorMap& outputs, const TensorMap& references, const Layo
 // e.g. '--mode nrmse --nrmse_loss_threshold 0.01'
 // e.g. '--mode nrmse --nrmse_loss_threshold "logits:0.03;pred_boxes:0.05"'
 //
+// Optional per-output prefill slicing for LLM KV cache / hidden state outputs:
+//   --nrmse_prefill_seq_len_axis "<layer>:<axis>;..."
+//   --nrmse_prefill_seq_len_size "<layer>:<N>;..."
+// Keeps only the last N elements along the specified axis before computing NRMSE.
+//
+
+// Return a new contiguous tensor containing the last `len` elements of `src` along `axis`.
+// The element type and all other dimensions are preserved.
+static ov::Tensor sliceLastNAlongAxis(const ov::Tensor& src, size_t axis, size_t len) {
+    const auto& shape = src.get_shape();
+    OPENVINO_ASSERT(axis < shape.size(),
+                    "nrmse_prefill_seq_len_axis ", axis,
+                    " is out of range for tensor of rank ", shape.size());
+    OPENVINO_ASSERT(len > 0 && len <= shape[axis],
+                    "nrmse_prefill_seq_len_size ", len,
+                    " is out of range for axis ", axis, " of size ", shape[axis]);
+    if (len == shape[axis]) {
+        return src;
+    }
+
+    ov::Shape newShape = shape;
+    newShape[axis] = len;
+    ov::Tensor dst(src.get_element_type(), newShape);
+
+    size_t outer = 1;
+    for (size_t i = 0; i < axis; ++i) {
+        outer *= shape[i];
+    }
+    const size_t mid = shape[axis];
+    size_t inner = 1;
+    for (size_t i = axis + 1; i < shape.size(); ++i) {
+        inner *= shape[i];
+    }
+
+    const size_t elemSize = src.get_element_type().size();
+    const size_t innerBytes = inner * elemSize;
+    const size_t srcStart = mid - len;
+
+    const auto* srcData = static_cast<const uint8_t*>(src.data());
+    auto* dstData = static_cast<uint8_t*>(dst.data());
+
+    for (size_t o = 0; o < outer; ++o) {
+        const uint8_t* srcRow = srcData + (o * mid + srcStart) * innerBytes;
+        uint8_t* dstRow = dstData + (o * len) * innerBytes;
+        std::memcpy(dstRow, srcRow, len * innerBytes);
+    }
+    return dst;
+}
 
 bool computeNRMSE(const ov::Tensor& output, const ov::Tensor& reference, double threshold) {
     if (output.get_shape() != reference.get_shape()) {
@@ -1778,6 +1826,12 @@ bool testNRMSE(const TensorMap& outputs, const TensorMap& references, const Layo
     // Parse per-layer thresholds
     auto thresholdMap = utils::parsePerLayerValues(FLAGS_nrmse_loss_threshold, metric_defaults::nrmse_loss_threshold);
 
+    // Parse optional per-layer prefill seq-len axis/size maps used to slice LLM
+    // KV-cache / hidden-state outputs to the last N positions along the sequence axis.
+    // Only entries that appear in BOTH maps are honored; otherwise the full tensor is compared.
+    auto seqLenAxisMap = utils::parsePerLayerValues(FLAGS_nrmse_prefill_seq_len_axis, 0.0);
+    auto seqLenSizeMap = utils::parsePerLayerValues(FLAGS_nrmse_prefill_seq_len_size, 0.0);
+
     bool allPassed = true;
     for (auto& [tensorName, output] : outputs) {
         auto referencesIterator = references.find(tensorName);
@@ -1785,6 +1839,26 @@ bool testNRMSE(const TensorMap& outputs, const TensorMap& references, const Layo
         bool applySoftMax = FLAGS_apply_soft_max;
 
         double layerThreshold = utils::getValueForLayer(thresholdMap, tensorName);
+
+        // Optional prefill slicing: applied only when both axis and size are explicitly
+        // specified for this layer. When only one of the two is given, the full tensor
+        // is compared and a warning is emitted.
+        ov::Tensor outputForCompare = output;
+        ov::Tensor referenceForCompare = referencesIterator->second;
+        const bool hasAxis = seqLenAxisMap.find(tensorName) != seqLenAxisMap.end();
+        const bool hasSize = seqLenSizeMap.find(tensorName) != seqLenSizeMap.end();
+        if (hasAxis && hasSize) {
+            const size_t axis = static_cast<size_t>(seqLenAxisMap.at(tensorName));
+            const size_t keep = static_cast<size_t>(seqLenSizeMap.at(tensorName));
+            std::cout << "Slicing NRMSE input '" << tensorName << "' to last " << keep
+                      << " element(s) along axis " << axis << std::endl;
+            outputForCompare = sliceLastNAlongAxis(outputForCompare, axis, keep);
+            referenceForCompare = sliceLastNAlongAxis(referenceForCompare, axis, keep);
+        } else if (hasAxis != hasSize) {
+            std::cout << "Warning: only one of --nrmse_prefill_seq_len_axis / "
+                         "--nrmse_prefill_seq_len_size is set for layer '"
+                      << tensorName << "'; comparing full tensor." << std::endl;
+        }
 
         BlobTestMethod blobComparator = [applySoftMax, layerThreshold](ov::Tensor outputTensor, ov::Tensor referenceTensor) {
             if (applySoftMax) {
@@ -1811,8 +1885,8 @@ bool testNRMSE(const TensorMap& outputs, const TensorMap& references, const Layo
         };
 
         if (!test_blobs_in_batch(tensorName,
-                                 splitBatchedTensor(output, tensorName, outputLayouts),
-                                 splitBatchedTensor(referencesIterator->second, tensorName, outputLayouts),
+                                 splitBatchedTensor(outputForCompare, tensorName, outputLayouts),
+                                 splitBatchedTensor(referenceForCompare, tensorName, outputLayouts),
                                  blobComparator)) {
             allPassed = false;
         }


### PR DESCRIPTION
### Details:
 - *Added **--nrmse_prefill_seq_len_axis** "_\<layer\>:\<axis\>;..._" and **--nrmse_prefill_seq_len_size** "_\<layer\>:\<N\>;..._" options for nrmse* 

### Tickets:
 - *EISW-217673*

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks): AI for slicing logic and manually tested on real machines*
