### PR TITLE
Fix the compilation of models with w4a16 FC layers.

### DIFF
--- a/src/frontends/tensorflow_lite/src/tflite_ops/tflite_quantize.hpp
+++ b/src/frontends/tensorflow_lite/src/tflite_ops/tflite_quantize.hpp
@@ -15,7 +15,7 @@ namespace ov {
 namespace frontend {
 namespace tensorflow_lite {
 
-class TFLQuantize : public ov::frontend::tensorflow::InternalOperation {
+class TENSORFLOW_LITE_FRONTEND_API TFLQuantize : public ov::frontend::tensorflow::InternalOperation {
 public:
     OPENVINO_OP("TFLQuantize", "ov::frontend::tensorflow_lite::util", ov::frontend::tensorflow::InternalOperation);
 

--- a/src/frontends/tensorflow_lite/src/utils.cpp
+++ b/src/frontends/tensorflow_lite/src/utils.cpp
@@ -132,12 +132,34 @@ void ov::frontend::tensorflow_lite::apply_quantization(ov::Output<ov::Node>& out
     return;
 }
 
+namespace {
+// Returns f16/bf16 if any non-TFLQuantize sibling input already carries that
+// half-precision activation type; otherwise element::dynamic. Used to keep a
+// constant weight dequantized to the activation precision (e.g. fp16 MatMul)
+// instead of forcing an unnecessary fp32 cast.
+ov::element::Type detect_half_precision_sibling(const ov::OutputVector& inputs) {
+    for (const auto& in : inputs) {
+        if (ov::is_type<ov::frontend::tensorflow_lite::TFLQuantize>(in.get_node_shared_ptr()))
+            continue;
+        const auto& t = in.get_element_type();
+        if (t == ov::element::f16 || t == ov::element::bf16)
+            return t;
+    }
+    return ov::element::dynamic;
+}
+}  // namespace
+
 void ov::frontend::tensorflow_lite::dequantize_inputs(OutputVector& deq_inputs) {
+    const auto half_sibling = detect_half_precision_sibling(deq_inputs);
     for (auto& deq_input : deq_inputs) {
-        auto input = deq_input.get_node_shared_ptr();
+        const auto input = deq_input.get_node_shared_ptr();
         if (!ov::is_type<ov::frontend::tensorflow_lite::TFLQuantize>(input))
             continue;
-        deq_input = std::make_shared<opset10::Convert>(deq_input, element::f32);
+        const bool weight_is_constant =
+            input->get_input_size() > 0 && ov::is_type<opset10::Constant>(input->get_input_node_shared_ptr(0));
+        const auto target =
+            (half_sibling != element::dynamic && weight_is_constant) ? half_sibling : element::f32;
+        deq_input = std::make_shared<opset10::Convert>(deq_input, target);
     }
 }
 

--- a/src/frontends/tensorflow_lite/src/utils.hpp
+++ b/src/frontends/tensorflow_lite/src/utils.hpp
@@ -21,7 +21,7 @@ ov::PartialShape get_ov_shape(const flatbuffers::Vector<int32_t>* tf_shape,
                               const flatbuffers::Vector<int32_t>* tf_shape_sig);
 std::shared_ptr<QuantizationInfo> get_quantization(const tflite::QuantizationParameters* tf_quantization);
 void apply_quantization(ov::Output<ov::Node>& output, ov::element::Type type);
-void dequantize_inputs(OutputVector& deq_inputs);
+TENSORFLOW_LITE_FRONTEND_API void dequantize_inputs(OutputVector& deq_inputs);
 std::shared_ptr<SparsityInfo> get_sparsity(const flatbuffers::Vector<int32_t>* tf_shape,
                                            const tflite::SparsityParameters* tf_sparsity,
                                            const ov::element::Type target_type,

--- a/src/frontends/tensorflow_lite/tests/CMakeLists.txt
+++ b/src/frontends/tensorflow_lite/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ else()
 endif()
 
 get_target_property(TENSORFLOW_LITE_FRONTEND_SRC_DIR openvino_tensorflow_lite_frontend SOURCE_DIR)
+target_link_libraries(${TARGET_NAME} PRIVATE openvino::frontend::tensorflow_common)
 
 add_subdirectory(standalone_build)
 add_dependencies(${TARGET_NAME} tensorflow_lite_fe_standalone_build_test)

--- a/src/frontends/tensorflow_lite/tests/dequantize_inputs.cpp
+++ b/src/frontends/tensorflow_lite/tests/dequantize_inputs.cpp
@@ -1,0 +1,160 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Unit tests for the half-precision sibling exception in
+// ov::frontend::tensorflow_lite::dequantize_inputs.
+//
+// Default behavior dequantizes TFLQuantize-wrapped inputs to f32. The narrow
+// exception switches the dequant target to f16/bf16 when:
+//   1) the TFLQuantize wraps a Constant (i.e. a quantized weight), AND
+//   2) some non-quantized sibling input is f16 or bf16 (a half-precision
+//      activation produced earlier in the graph).
+// Non-constant TFLQuantize (i.e. quantized activations destined for the
+// FakeQuantize lowering path) must remain at f32 to preserve the assumptions
+// of downstream Low Precision Transformations.
+
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "openvino/core/node_output.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/frontend/tensorflow_lite/quantization_info.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/parameter.hpp"
+// Relative include into the frontend's private headers. We intentionally avoid
+// adding the FE's private src/ to the test target's include path because doing
+// so would shadow the shared utils.hpp used by other test sources.
+#include "../src/tflite_ops/tflite_quantize.hpp"
+
+// Forward-declare to avoid pulling in utils.hpp, which transitively includes the
+// flatbuffer schema headers that are private to the frontend's build.
+namespace ov {
+namespace frontend {
+namespace tensorflow_lite {
+TENSORFLOW_LITE_FRONTEND_API void dequantize_inputs(OutputVector& deq_inputs);
+}  // namespace tensorflow_lite
+}  // namespace frontend
+}  // namespace ov
+
+using namespace ov;
+using ov::frontend::tensorflow_lite::QuantizationInfo;
+using ov::frontend::tensorflow_lite::TFLQuantize;
+using ov::frontend::tensorflow_lite::dequantize_inputs;
+
+namespace {
+
+std::shared_ptr<QuantizationInfo> make_per_tensor_quant_info() {
+    return std::make_shared<QuantizationInfo>(std::vector<float>{0.5f},
+                                              std::vector<int64_t>{0},
+                                              /*axis=*/0);
+}
+
+// Builds a TFLQuantize wrapping either a Constant (weight path) or a Parameter
+// (activation path). Returns the TFLQuantize output.
+Output<Node> make_tfl_quantize(bool weight_is_constant, element::Type storage_type) {
+    std::shared_ptr<Node> producer;
+    if (weight_is_constant) {
+        // Use a 4x4 i8 weight; the exact dtype isn't checked by dequantize_inputs,
+        // only that the producer is a Constant.
+        producer = op::v0::Constant::create(storage_type, Shape{4, 4}, std::vector<int8_t>(16, 1));
+    } else {
+        producer = std::make_shared<op::v0::Parameter>(storage_type, PartialShape{1, 16});
+    }
+    return std::make_shared<TFLQuantize>(producer->output(0), make_per_tensor_quant_info(), storage_type)->output(0);
+}
+
+// Runs dequantize_inputs on a [sibling, tfl_quantize] OutputVector and returns
+// the inserted Convert's destination type. Asserts that a Convert was actually
+// inserted at the TFLQuantize slot.
+element::Type run_dequant(bool weight_is_constant,
+                          element::Type weight_storage_type,
+                          element::Type sibling_type) {
+    auto sibling = std::make_shared<op::v0::Parameter>(sibling_type, PartialShape{1, 16})->output(0);
+    auto tfl_q = make_tfl_quantize(weight_is_constant, weight_storage_type);
+
+    OutputVector inputs{sibling, tfl_q};
+    dequantize_inputs(inputs);
+
+    auto convert = ov::as_type_ptr<op::v0::Convert>(inputs[1].get_node_shared_ptr());
+    EXPECT_TRUE(convert) << "dequantize_inputs did not insert a Convert at the TFLQuantize slot";
+    if (!convert)
+        return element::dynamic;
+    return convert->get_destination_type();
+}
+
+}  // namespace
+
+// ----- Constant weight + half-precision sibling: exception fires -----
+
+TEST(TFLDequantizeInputs, ConstantWeightWithF16SiblingDequantsToF16) {
+    EXPECT_EQ(run_dequant(/*weight_is_constant=*/true,
+                          /*weight_storage_type=*/element::i4,
+                          /*sibling_type=*/element::f16),
+              element::f16);
+}
+
+TEST(TFLDequantizeInputs, ConstantWeightWithBF16SiblingDequantsToBF16) {
+    EXPECT_EQ(run_dequant(/*weight_is_constant=*/true,
+                          /*weight_storage_type=*/element::i8,
+                          /*sibling_type=*/element::bf16),
+              element::bf16);
+}
+
+// ----- Backward-compat: f32 sibling (or no sibling) must keep f32 -----
+
+TEST(TFLDequantizeInputs, ConstantWeightWithF32SiblingStaysF32) {
+    EXPECT_EQ(run_dequant(/*weight_is_constant=*/true,
+                          /*weight_storage_type=*/element::i8,
+                          /*sibling_type=*/element::f32),
+              element::f32);
+}
+
+TEST(TFLDequantizeInputs, ConstantWeightNoSiblingStaysF32) {
+    // Only the TFLQuantize-wrapped weight, no sibling input at all.
+    auto tfl_q = make_tfl_quantize(/*weight_is_constant=*/true, element::i8);
+    OutputVector inputs{tfl_q};
+    dequantize_inputs(inputs);
+
+    auto convert = ov::as_type_ptr<op::v0::Convert>(inputs[0].get_node_shared_ptr());
+    ASSERT_TRUE(convert);
+    EXPECT_EQ(convert->get_destination_type(), element::f32);
+}
+
+// ----- Non-constant (quantized activation) must NEVER get retyped -----
+// This is the key safety property: the FakeQuantize lowering branch of
+// TFLQuantizeReplacer feeds LPT, which has f32 assumptions.
+
+TEST(TFLDequantizeInputs, NonConstantActivationWithF16SiblingStaysF32) {
+    EXPECT_EQ(run_dequant(/*weight_is_constant=*/false,
+                          /*weight_storage_type=*/element::i8,
+                          /*sibling_type=*/element::f16),
+              element::f32);
+}
+
+TEST(TFLDequantizeInputs, NonConstantActivationWithBF16SiblingStaysF32) {
+    EXPECT_EQ(run_dequant(/*weight_is_constant=*/false,
+                          /*weight_storage_type=*/element::i8,
+                          /*sibling_type=*/element::bf16),
+              element::f32);
+}
+
+// ----- Mixed-input ordering shouldn't matter: half_sibling search must be
+// independent of input position relative to the TFLQuantize. -----
+
+TEST(TFLDequantizeInputs, F16SiblingDetectedRegardlessOfOrdering) {
+    // TFLQuantize comes first, f16 sibling second.
+    auto tfl_q = make_tfl_quantize(/*weight_is_constant=*/true, element::i4);
+    auto sibling = std::make_shared<op::v0::Parameter>(element::f16, PartialShape{1, 16})->output(0);
+    OutputVector inputs{tfl_q, sibling};
+    dequantize_inputs(inputs);
+
+    auto convert = ov::as_type_ptr<op::v0::Convert>(inputs[0].get_node_shared_ptr());
+    ASSERT_TRUE(convert);
+    EXPECT_EQ(convert->get_destination_type(), element::f16);
+    // Sibling slot must be untouched.
+    EXPECT_EQ(inputs[1].get_element_type(), element::f16);
+    EXPECT_EQ(inputs[1].get_node_shared_ptr(), sibling.get_node_shared_ptr());
+}


### PR DESCRIPTION
### Details:
 - Fix model compilation failure when there is FC layers with fp16 activation and i4
 quantized weight. Without the fix the tfl fe dequantize the weight to fp32 and a mismatch of type between
the activation and dequantized weight is reported.

### Tickets:
 - *CVS-187863*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
