### PR TITLE
Pin `kernels` Python module version to fix PyTorch Models Tests (#36136)

### DIFF
--- a/tests/model_hub_tests/pytorch/envs/llm.txt
+++ b/tests/model_hub_tests/pytorch/envs/llm.txt
@@ -8,6 +8,10 @@ huggingface-hub==1.10.1
 autoawq==0.2.9; platform_system == "Linux" and platform_machine == "x86_64"
 triton==3.6.0; platform_system == "Linux" and platform_machine == "x86_64"
 gptqmodel==6.0.3; platform_system == "Linux" and platform_machine == "x86_64" and python_version < "3.12"
+# `gptqmodel` depends on `kernels`, but doesn't have upper boundary for version, which caused test failures after
+# `kernels` was updated to 0.15.1
+kernels==0.14.1; platform_machine == "x86_64" and python_version < "3.12"
+
 peft==0.18.1; platform_system == "Linux" and platform_machine == "x86_64" and python_version < "3.12"
 
 # optimum (required by transformers' GptqHfQuantizer for GPTQ model loading)


### PR DESCRIPTION
### Details:
After `kernels` got an update on PyPI, we started to have failures in PyTorch Models Tests job at PyTorch LLM Model Tests. This PR should fix it

### Tickets:
 - *CVS-187808*

### AI Assistance:
 - *AI assistance used: no*
