### PR TITLE
[CPU][ARM] Call `ConvolutionTransformation` transformation for "Conv-Add-FQ" subgraph only

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -972,7 +972,8 @@ void Transformations::runLptPasses(const std::vector<ov::element::Type>& default
     CPU_SET_CALLBACK_ARM(
         lptManager,
         [](const_node_ptr& node) -> bool {
-            return match_conv_stride_oc_ic_limit(node, {1, 1}, ov::Shape{3, 3}, 512);
+            return match_conv_stride_oc_ic_limit(node, {1, 1}, ov::Shape{3, 3}, 512) ||
+                   !match_acl_int8_conv_add_multiply_chain(node);
         },
         ConvolutionTransformation);
     CPU_SET_CALLBACK_COMMON(

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -12,6 +12,7 @@
 
 #include "low_precision/network_helper.hpp"
 #include "low_precision/resolve_precision_attribute.hpp"
+#include "openvino/core/descriptor/output.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
@@ -33,6 +34,16 @@
 using namespace ov::pass::pattern;
 
 namespace ov::intel_cpu {
+
+template <typename NodeType>
+std::shared_ptr<ov::Node> get_consumer(const ov::Output<NodeType>& output) {
+    const auto& consumers = output.get_target_inputs();
+    if (consumers.size() != 1) {
+        return nullptr;
+    }
+
+    return consumers.begin()->get_node()->shared_from_this();
+}
 
 bool match_fq_mul_conv_bias_same_types(const std::shared_ptr<const ov::Node>& node, FQMulAddPattern pattern) {
     auto convMulAdd_conv = wrap_type<ov::op::v1::Convolution>();
@@ -127,12 +138,12 @@ bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& nod
         return true;
     }
 
-    const auto& consumers = avg_pool->output(0).get_target_inputs();
-    if (consumers.size() != 1) {
+    const auto fq_consumer = get_consumer(avg_pool->output(0));
+    if (!fq_consumer) {
         return true;
     }
 
-    const auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(consumers.begin()->get_node()->shared_from_this());
+    const auto fq = ov::as_type_ptr<ov::op::v0::FakeQuantize>(fq_consumer);
     if (!fq) {
         return true;
     }
@@ -149,23 +160,27 @@ bool match_acl_int8_conv_add_multiply_chain(const std::shared_ptr<const ov::Node
         return false;
     }
 
-    const auto& conv_consumers = conv->output(0).get_target_inputs();
-    if (conv_consumers.size() != 1) {
+    const auto first_consumer = get_consumer(conv->output(0));
+    if (!first_consumer) {
         return false;
     }
 
-    const auto first_consumer = conv_consumers.begin()->get_node()->shared_from_this();
+    if (ov::is_type<ov::op::v0::FakeQuantize>(first_consumer)) {
+        return true;
+    }
+
     const auto add = ov::as_type_ptr<const ov::op::v1::Add>(first_consumer);
     if (!add) {
         return false;
     }
 
-    const auto& add_consumers = add->output(0).get_target_inputs();
-    if (add_consumers.size() != 1) {
+    // Accept Conv->FQ and Conv->Add->FQ only.
+    // Activations between bias and FQ are not supported here yet, some of them will be enabled later
+    const auto second_consumer = get_consumer(add->output(0));
+    if (!second_consumer) {
         return false;
     }
 
-    const auto second_consumer = add_consumers.begin()->get_node()->shared_from_this();
     return ov::is_type<ov::op::v0::FakeQuantize>(second_consumer);
 }
 

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -35,8 +35,7 @@ using namespace ov::pass::pattern;
 
 namespace ov::intel_cpu {
 
-template <typename NodeType>
-std::shared_ptr<ov::Node> get_consumer(const ov::Output<NodeType>& output) {
+std::shared_ptr<ov::Node> get_consumer(const ov::Output<ov::Node>& output) {
     const auto& consumers = output.get_target_inputs();
     if (consumers.size() != 1) {
         return nullptr;

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -35,7 +35,8 @@ using namespace ov::pass::pattern;
 
 namespace ov::intel_cpu {
 
-std::shared_ptr<ov::Node> get_consumer(const ov::Output<ov::Node>& output) {
+template <typename NodeType>
+std::shared_ptr<ov::Node> get_consumer(const ov::Output<NodeType>& output) {
     const auto& consumers = output.get_target_inputs();
     if (consumers.size() != 1) {
         return nullptr;

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -14,6 +14,7 @@
 #include "low_precision/resolve_precision_attribute.hpp"
 #include "openvino/core/descriptor/output.hpp"
 #include "openvino/core/node.hpp"
+#include "openvino/core/node_output.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -35,6 +35,8 @@ using namespace ov::pass::pattern;
 
 namespace ov::intel_cpu {
 
+namespace {
+
 std::shared_ptr<ov::Node> get_consumer(const ov::Output<const ov::Node>& output) {
     const auto& consumers = output.get_target_inputs();
     if (consumers.size() != 1) {
@@ -43,6 +45,8 @@ std::shared_ptr<ov::Node> get_consumer(const ov::Output<const ov::Node>& output)
 
     return consumers.begin()->get_node()->shared_from_this();
 }
+
+}  // namespace
 
 bool match_fq_mul_conv_bias_same_types(const std::shared_ptr<const ov::Node>& node, FQMulAddPattern pattern) {
     auto convMulAdd_conv = wrap_type<ov::op::v1::Convolution>();

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -35,8 +35,7 @@ using namespace ov::pass::pattern;
 
 namespace ov::intel_cpu {
 
-template <typename NodeType>
-std::shared_ptr<ov::Node> get_consumer(const ov::Output<NodeType>& output) {
+std::shared_ptr<ov::Node> get_consumer(const ov::Output<const ov::Node>& output) {
     const auto& consumers = output.get_target_inputs();
     if (consumers.size() != 1) {
         return nullptr;

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -143,6 +143,32 @@ bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& nod
            dequantization.data.get_element_type() != resolved_precision.precision;
 }
 
+bool match_acl_int8_conv_add_multiply_chain(const std::shared_ptr<const ov::Node>& node) {
+    const auto conv = ov::as_type_ptr<const ov::op::v1::Convolution>(node);
+    if (!conv) {
+        return false;
+    }
+
+    const auto& conv_consumers = conv->output(0).get_target_inputs();
+    if (conv_consumers.size() != 1) {
+        return false;
+    }
+
+    const auto first_consumer = conv_consumers.begin()->get_node()->shared_from_this();
+    const auto add = ov::as_type_ptr<const ov::op::v1::Add>(first_consumer);
+    if (!add) {
+        return false;
+    }
+
+    const auto& add_consumers = add->output(0).get_target_inputs();
+    if (add_consumers.size() != 1) {
+        return false;
+    }
+
+    const auto second_consumer = add_consumers.begin()->get_node()->shared_from_this();
+    return ov::is_type<ov::op::v0::FakeQuantize>(second_consumer);
+}
+
 bool match_conv_stride_oc_ic_limit(const std::shared_ptr<const ov::Node>& node,
                                    const std::vector<int64_t>& strides,
                                    const ov::Shape& kernel_shape,

--- a/src/plugins/intel_cpu/src/transformations/utils.hpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.hpp
@@ -62,6 +62,8 @@ bool match_acl_int8_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node
 bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& node,
                                       const std::vector<ov::element::Type>& defaultPrecisions);
 
+bool match_acl_int8_conv_add_multiply_chain(const std::shared_ptr<const ov::Node>& node);
+
 bool match_conv_stride_oc_ic_limit(const std::shared_ptr<const ov::Node>& node,
                                    const std::vector<int64_t>& strides,
                                    const ov::Shape& kernel_shape,


### PR DESCRIPTION
### Details:
 - Call `ConvolutionTransformation` transformation for `Conv-Add-FQ` and `Conv-FQ` subgraphs only
 - Activations between bias and FQ are not supported here yet, some of them will be enabled later

### Tickets:
 - CVS-188070

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
