### PR TITLE
[ONNX FE] Support com.microsoft::DynamicQuantizeLSTM

### DIFF
--- a/.github/agents-prototype/skills/add-fe-op/onnx.md
+++ b/.github/agents-prototype/skills/add-fe-op/onnx.md
@@ -271,7 +271,7 @@ cmake --build build --target clang_format_fix_all -j$(nproc)
 - [ ] **`ONNX_OP` registration added** — macro at bottom of the new `.cpp` translator file (not in `ops_bridge.cpp`).
 - [ ] **Test model added** — `.prototxt` covers basic case and edge cases.
 - [ ] **C++ test added** — at least one test in `onnx_import.in.cpp`.
-- [ ] **All ONNX tests pass** — `ctest -R ov_onnx_frontend_tests` green.
+- [ ] **Tests pass** — build `ov_onnx_frontend_tests`, run the full suite, confirm the new test is present and green with no regressions. Do not report success without running it.
 - [ ] **clang-format applied** — no formatting diffs.
 - [ ] **Supported ops doc updated** — `src/frontends/onnx/docs/supported_ops.md` (if maintained).
 
@@ -289,6 +289,10 @@ cmake --build build --target clang_format_fix_all -j$(nproc)
 | **Broadcasting edge cases** | ONNX uses Numpy-style broadcasting; verify with scalar and 0-rank tensor inputs. |
 | **Not handling empty attribute list** | Some attributes may have list type with empty default; `get_attribute_value<std::vector<int64_t>>("axis", {})`. |
 | **Mark operations missing** | For complex/quantized/sequence types, the normalize-step won't resolve correctly without the corresponding Mark operation. |
+| **Not checking for a closely related existing translator** | If the new op is a quantized/extended variant of an existing op (e.g., `DynamicQuantizeLSTM` vs `LSTM`), read that translator first. Reuse shared utilities (`recurrent.hpp` for RNN-family, etc.) rather than duplicating helper code. |
+| **Speculative input handling** | Only handle input ranks/layouts defined by the spec. Adding speculative rank-N handling for cases the spec doesn't define creates dead code that may silently produce wrong outputs (wrong rank on outputs, missing bidirectional guard, etc.). When in doubt, `CHECK_VALID_NODE` to reject unsupported input shapes. |
+| **Silently dropping unsupported optional inputs** | If an optional input (e.g., peephole weights) cannot be represented in the OV subgraph, reject it with an explicit `CHECK_VALID_NODE` error rather than ignoring it. Silent drops produce wrong results. |
+| **Hand-rolling dequantization subgraphs** | For ops with quantized inputs (int8/uint8 + scale + zero_point), use `ov::decomposition::low_precision_dequantize` (`#include "openvino/decompositions/low_precision_dequantize.hpp"`) instead of manually building Convert→Subtract→Multiply. The helper produces the canonical pattern recognised by `ov::pass::MarkDequantization` and protects the Convert from constant folding, enabling downstream LPT and weight-decompression optimisations. **Scale axis alignment:** `low_precision_dequantize` uses numpy right-aligned autobroadcast, so the scale/zero_point quantization axes must be the trailing dimensions of the weight tensor. If they are not, align them by appending size-1 dimensions: when the scale is a `Constant` (the normal case in quantized models), create a new `Constant` with the reshaped shape via `Constant(const Constant&, Shape)` — no graph node is inserted and `MarkDequantization` still fires. When the scale is a runtime input (e.g. in tests), fall back to an `Unsqueeze` node — LPT will not fire but correctness is preserved. Add both a runtime-input test and a graph-constant test to cover both code paths. |
 
 ---
 

--- a/src/frontends/onnx/docs/supported_ops.md
+++ b/src/frontends/onnx/docs/supported_ops.md
@@ -231,7 +231,7 @@ OpenVINO provides support for operations of Default Opset (empty in table below)
 |com.microsoft           |DequantizeBFP                                           |                        |1                               |                                |
 |com.microsoft           |DequantizeLinear                                        |1                       |1                               |                                |
 |com.microsoft           |DequantizeWithOrder                                     |                        |1                               |                                |
-|com.microsoft           |DynamicQuantizeLSTM                                     |                        |1                               |                                |
+|com.microsoft           |DynamicQuantizeLSTM                                     |1                       |1                               |Peephole input P not supported|
 |com.microsoft           |DynamicQuantizeMatMul                                   |1                       |1                               |                                |
 |com.microsoft           |DynamicTimeWarping                                      |                        |1                               |                                |
 |com.microsoft           |EPContext                                               |                        |1                               |                                |

--- a/src/frontends/onnx/docs/supported_ops.md
+++ b/src/frontends/onnx/docs/supported_ops.md
@@ -231,7 +231,7 @@ OpenVINO provides support for operations of Default Opset (empty in table below)
 |com.microsoft           |DequantizeBFP                                           |                        |1                               |                                |
 |com.microsoft           |DequantizeLinear                                        |1                       |1                               |                                |
 |com.microsoft           |DequantizeWithOrder                                     |                        |1                               |                                |
-|com.microsoft           |DynamicQuantizeLSTM                                     |1                       |1                               |Peephole input P not supported|
+|com.microsoft           |DynamicQuantizeLSTM                                     |1                       |1                               |Peephole input P not supported  |
 |com.microsoft           |DynamicQuantizeMatMul                                   |1                       |1                               |                                |
 |com.microsoft           |DynamicTimeWarping                                      |                        |1                               |                                |
 |com.microsoft           |EPContext                                               |                        |1                               |                                |

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
@@ -1,0 +1,435 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/operator_set.hpp"
+#include "exceptions.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/lstm_sequence.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
+#include "openvino/util/common_util.hpp"
+#include "utils/common.hpp"
+#include "utils/reshape.hpp"
+#include "utils/split.hpp"
+
+namespace ov {
+namespace frontend {
+namespace onnx {
+namespace com_microsoft {
+namespace {
+
+enum class DynamicQuantizeLSTMInput {
+    X,
+    W,
+    R,
+    B,
+    SEQUENCE_LENS,
+    INITIAL_H,
+    INITIAL_C,
+};
+
+struct PreparedQuantizedWeights {
+    ov::Output<ov::Node> weights;
+    int64_t original_rank;
+};
+
+ov::Output<ov::Node> normalize_tensor_rank(const ov::Output<ov::Node>& input,
+                                           int64_t target_rank,
+                                           const std::string& input_name) {
+    const auto& input_rank = input.get_partial_shape().rank();
+
+    if (input_rank.is_dynamic()) {
+        return input;
+    }
+
+    if (input_rank.get_length() == target_rank) {
+        return input;
+    }
+
+    if (input_rank.get_length() > target_rank) {
+        const auto dims_to_squeeze = input_rank.get_length() - target_rank;
+        const auto& input_shape = input.get_partial_shape();
+
+        for (int64_t i = 0; i < dims_to_squeeze; ++i) {
+            if (input_shape[i].is_static() && input_shape[i].get_length() != 1) {
+                OPENVINO_THROW("DynamicQuantizeLSTM input '",
+                               input_name,
+                               "' has rank ",
+                               input_rank.get_length(),
+                               " but expected ",
+                               target_rank,
+                               ". Leading dimension [",
+                               i,
+                               "] is ",
+                               input_shape[i].get_length(),
+                               " but must be 1 to squeeze.");
+            }
+        }
+
+        std::vector<int64_t> axes_to_squeeze;
+        axes_to_squeeze.reserve(dims_to_squeeze);
+        for (int64_t i = 0; i < dims_to_squeeze; ++i) {
+            axes_to_squeeze.push_back(i);
+        }
+
+        auto axes_const =
+            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{axes_to_squeeze.size()}, axes_to_squeeze);
+        return std::make_shared<ov::op::v0::Squeeze>(input, axes_const);
+    }
+
+    const auto dims_to_unsqueeze = target_rank - input_rank.get_length();
+    if (dims_to_unsqueeze != 1) {
+        OPENVINO_THROW("DynamicQuantizeLSTM input '",
+                       input_name,
+                       "' has rank ",
+                       input_rank.get_length(),
+                       " but expected ",
+                       target_rank,
+                       ". Rank difference is ",
+                       dims_to_unsqueeze,
+                       " but only 1 is supported.");
+    }
+
+    auto axes_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+    return std::make_shared<ov::op::v0::Unsqueeze>(input, axes_const);
+}
+
+PreparedQuantizedWeights prepare_quantized_weights(const ov::frontend::onnx::Node& node,
+                                                   const ov::Output<ov::Node>& weights,
+                                                   int64_t hidden_size,
+                                                   const std::string& input_name) {
+    const auto& rank = weights.get_partial_shape().rank();
+    CHECK_VALID_NODE(node,
+                     rank.is_static() && (rank.get_length() == 2 || rank.get_length() == 3),
+                     "DynamicQuantizeLSTM input '",
+                     input_name,
+                     "' must have static rank 2 or 3. Got rank: ",
+                     rank);
+
+    const auto gate_axis_size = 4 * hidden_size;
+    auto prepared_weights = weights;
+
+    if (rank.get_length() == 2) {
+        const auto& shape = prepared_weights.get_partial_shape();
+        const auto dim0_matches = shape[0].is_static() && shape[0].get_length() == gate_axis_size;
+        const auto dim1_matches = shape[1].is_static() && shape[1].get_length() == gate_axis_size;
+
+        CHECK_VALID_NODE(node,
+                         dim0_matches || dim1_matches,
+                         "DynamicQuantizeLSTM input '",
+                         input_name,
+                         "' must have one dimension equal to 4*hidden_size (",
+                         gate_axis_size,
+                         "). Got shape: ",
+                         shape);
+
+        if (!dim0_matches && dim1_matches) {
+            prepared_weights = ov::op::util::reorder_axes(prepared_weights, {1, 0});
+        }
+
+        auto axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+        prepared_weights = std::make_shared<ov::op::v0::Unsqueeze>(prepared_weights, axis);
+    } else {
+        const auto& shape = prepared_weights.get_partial_shape();
+        const auto dim1_matches = shape[1].is_static() && shape[1].get_length() == gate_axis_size;
+        const auto dim2_matches = shape[2].is_static() && shape[2].get_length() == gate_axis_size;
+
+        CHECK_VALID_NODE(node,
+                         dim1_matches || dim2_matches,
+                         "DynamicQuantizeLSTM input '",
+                         input_name,
+                         "' must have either axis 1 or axis 2 equal to 4*hidden_size (",
+                         gate_axis_size,
+                         "). Got shape: ",
+                         shape);
+
+        if (!dim1_matches && dim2_matches) {
+            prepared_weights = ov::op::util::reorder_axes(prepared_weights, {0, 2, 1});
+        }
+    }
+
+    return {prepared_weights, rank.get_length()};
+}
+
+ov::Output<ov::Node> align_dequant_param(const ov::frontend::onnx::Node& node,
+                                         const ov::Output<ov::Node>& param,
+                                         int64_t weight_rank,
+                                         const std::string& input_name) {
+    const auto& rank = param.get_partial_shape().rank();
+
+    if (rank.is_dynamic() || rank.get_length() == 0) {
+        return param;
+    }
+
+    CHECK_VALID_NODE(node,
+                     rank.get_length() == 1 || rank.get_length() == 2,
+                     "DynamicQuantizeLSTM input '",
+                     input_name,
+                     "' must be a scalar, rank-1, or rank-2 tensor. Got rank: ",
+                     rank.get_length());
+
+    if (weight_rank == 2) {
+        CHECK_VALID_NODE(node,
+                         rank.get_length() == 1,
+                         "DynamicQuantizeLSTM rank-2 weights require rank-1 scale/zero_point for input '",
+                         input_name,
+                         "'.");
+        auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {0, 2});
+        return std::make_shared<ov::op::v0::Unsqueeze>(param, axes);
+    }
+
+    if (rank.get_length() == 1) {
+        auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 2});
+        return std::make_shared<ov::op::v0::Unsqueeze>(param, axes);
+    }
+
+    auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+    return std::make_shared<ov::op::v0::Unsqueeze>(param, axes);
+}
+
+ov::Output<ov::Node> dequantize_weights(const ov::frontend::onnx::Node& node,
+                                        const PreparedQuantizedWeights& prepared_weights,
+                                        const ov::Output<ov::Node>& scale,
+                                        const ov::Output<ov::Node>& zero_point,
+                                        const std::string& weights_name) {
+    auto dequantized =
+        ov::Output<ov::Node>(std::make_shared<ov::op::v0::Convert>(prepared_weights.weights, scale.get_element_type()));
+    auto aligned_scale = align_dequant_param(node, scale, prepared_weights.original_rank, weights_name + "_scale");
+
+    if (zero_point.get_node_shared_ptr()) {
+        auto aligned_zero_point = align_dequant_param(node,
+                                                      zero_point,
+                                                      prepared_weights.original_rank,
+                                                      weights_name + "_zero_point");
+        aligned_zero_point = std::make_shared<ov::op::v0::Convert>(aligned_zero_point, scale.get_element_type());
+        dequantized = std::make_shared<ov::op::v1::Subtract>(dequantized, aligned_zero_point);
+    }
+
+    return std::make_shared<ov::op::v1::Multiply>(dequantized, aligned_scale);
+}
+
+struct DynamicQuantizeLSTMInputMap {
+    explicit DynamicQuantizeLSTMInputMap(const ov::frontend::onnx::Node& node, int64_t hidden_size) {
+        const auto& ng_inputs = node.get_ov_inputs();
+        constexpr std::size_t gates_count{4};
+
+        auto input_x = normalize_tensor_rank(ng_inputs.at(0), 3, "X");
+        m_input_map[DynamicQuantizeLSTMInput::X] = ov::op::util::reorder_axes(input_x, {1, 0, 2});
+
+        CHECK_VALID_NODE(node,
+                         ng_inputs.at(1).get_element_type() == ov::element::i8 ||
+                             ng_inputs.at(1).get_element_type() == ov::element::u8,
+                         "DynamicQuantizeLSTM input 'W' must have element type int8 or uint8. Got: ",
+                         ng_inputs.at(1).get_element_type());
+        CHECK_VALID_NODE(node,
+                         ng_inputs.at(2).get_element_type() == ov::element::i8 ||
+                             ng_inputs.at(2).get_element_type() == ov::element::u8,
+                         "DynamicQuantizeLSTM input 'R' must have element type int8 or uint8. Got: ",
+                         ng_inputs.at(2).get_element_type());
+        CHECK_VALID_NODE(node,
+                         ng_inputs.at(8).get_element_type() == ov::element::f32,
+                         "DynamicQuantizeLSTM input 'W_scale' must have element type float32. Got: ",
+                         ng_inputs.at(8).get_element_type());
+        CHECK_VALID_NODE(node,
+                         ng_inputs.at(10).get_element_type() == ov::element::f32,
+                         "DynamicQuantizeLSTM input 'R_scale' must have element type float32. Got: ",
+                         ng_inputs.at(10).get_element_type());
+
+        ov::Output<ov::Node> w_zero_point;
+        if (common::is_input_valid(node, 9)) {
+            w_zero_point = ng_inputs.at(9);
+            CHECK_VALID_NODE(node,
+                             w_zero_point.get_element_type() == ov::element::i8 ||
+                                 w_zero_point.get_element_type() == ov::element::u8,
+                             "DynamicQuantizeLSTM input 'W_zero_point' must have element type int8 or uint8. Got: ",
+                             w_zero_point.get_element_type());
+        }
+
+        ov::Output<ov::Node> r_zero_point;
+        if (common::is_input_valid(node, 11)) {
+            r_zero_point = ng_inputs.at(11);
+            CHECK_VALID_NODE(node,
+                             r_zero_point.get_element_type() == ov::element::i8 ||
+                                 r_zero_point.get_element_type() == ov::element::u8,
+                             "DynamicQuantizeLSTM input 'R_zero_point' must have element type int8 or uint8. Got: ",
+                             r_zero_point.get_element_type());
+        }
+
+        auto prepared_w = prepare_quantized_weights(node, ng_inputs.at(1), hidden_size, "W");
+        auto prepared_r = prepare_quantized_weights(node, ng_inputs.at(2), hidden_size, "R");
+
+        m_input_map[DynamicQuantizeLSTMInput::W] =
+            ov::op::util::convert_lstm_node_format(dequantize_weights(node, prepared_w, ng_inputs.at(8), w_zero_point, "W"),
+                                                   ov::op::util::LSTMWeightsFormat::IOFC,
+                                                   ov::op::util::LSTMWeightsFormat::FICO,
+                                                   1);
+        m_input_map[DynamicQuantizeLSTMInput::R] =
+            ov::op::util::convert_lstm_node_format(dequantize_weights(node, prepared_r, ng_inputs.at(10), r_zero_point, "R"),
+                                                   ov::op::util::LSTMWeightsFormat::IOFC,
+                                                   ov::op::util::LSTMWeightsFormat::FICO,
+                                                   1);
+
+        auto shape_of_x = std::make_shared<ov::op::v3::ShapeOf>(m_input_map[DynamicQuantizeLSTMInput::X]);
+        auto axes = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
+        auto batch_size_node = std::make_shared<ov::op::v8::Gather>(shape_of_x,
+                                                                    ov::op::v0::Constant::create(ov::element::i32,
+                                                                                                  ov::Shape{1},
+                                                                                                  {0}),
+                                                                    axes);
+        auto seq_length_node = std::make_shared<ov::op::v8::Gather>(shape_of_x,
+                                                                    ov::op::v0::Constant::create(ov::element::i32,
+                                                                                                  ov::Shape{1},
+                                                                                                  {1}),
+                                                                    axes);
+
+        auto shape_of_r = std::make_shared<ov::op::v3::ShapeOf>(m_input_map[DynamicQuantizeLSTMInput::R]);
+        auto num_directions_node = std::make_shared<ov::op::v8::Gather>(shape_of_r,
+                                                                        ov::op::v0::Constant::create(ov::element::i32,
+                                                                                                      ov::Shape{1},
+                                                                                                      {0}),
+                                                                        axes);
+        auto hidden_size_node = std::make_shared<ov::op::v8::Gather>(shape_of_r,
+                                                                     ov::op::v0::Constant::create(ov::element::i32,
+                                                                                                   ov::Shape{1},
+                                                                                                   {2}),
+                                                                     axes);
+
+        if (common::is_input_valid(node, 3)) {
+            auto bias = normalize_tensor_rank(ng_inputs.at(3), 2, "B");
+            auto split_bias = ov::op::util::make_split(bias, 2, 1);
+            m_input_map[DynamicQuantizeLSTMInput::B] = std::make_shared<ov::op::v1::Add>(split_bias.at(0), split_bias.at(1));
+            m_input_map[DynamicQuantizeLSTMInput::B] =
+                ov::op::util::convert_lstm_node_format(m_input_map[DynamicQuantizeLSTMInput::B],
+                                                       ov::op::util::LSTMWeightsFormat::IOFC,
+                                                       ov::op::util::LSTMWeightsFormat::FICO,
+                                                       1);
+        } else {
+            auto b_shape = std::make_shared<ov::op::v0::Concat>(
+                ov::OutputVector{num_directions_node,
+                                 std::make_shared<ov::op::v1::Multiply>(
+                                     ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {gates_count}),
+                                     hidden_size_node)},
+                0);
+            m_input_map[DynamicQuantizeLSTMInput::B] = std::make_shared<ov::op::v3::Broadcast>(
+                ov::op::v0::Constant::create(m_input_map[DynamicQuantizeLSTMInput::X].get_element_type(), ov::Shape{}, {0}),
+                b_shape);
+        }
+
+        if (common::is_input_valid(node, 4)) {
+            m_input_map[DynamicQuantizeLSTMInput::SEQUENCE_LENS] = ng_inputs.at(4);
+        } else {
+            m_input_map[DynamicQuantizeLSTMInput::SEQUENCE_LENS] =
+                std::make_shared<ov::op::v3::Broadcast>(seq_length_node, batch_size_node);
+        }
+
+        if (common::is_input_valid(node, 5)) {
+            auto init_h = normalize_tensor_rank(ng_inputs.at(5), 3, "initial_h");
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_H] = ov::op::util::reorder_axes(init_h, {1, 0, 2});
+        } else {
+            auto init_h_shape = std::make_shared<ov::op::v0::Concat>(
+                ov::OutputVector{batch_size_node, num_directions_node, hidden_size_node},
+                0);
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_H] = std::make_shared<ov::op::v3::Broadcast>(
+                ov::op::v0::Constant::create(m_input_map[DynamicQuantizeLSTMInput::X].get_element_type(), ov::Shape{}, {0}),
+                init_h_shape);
+        }
+
+        if (common::is_input_valid(node, 6)) {
+            auto init_c = normalize_tensor_rank(ng_inputs.at(6), 3, "initial_c");
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_C] = ov::op::util::reorder_axes(init_c, {1, 0, 2});
+        } else {
+            auto init_c_shape = std::make_shared<ov::op::v0::Concat>(
+                ov::OutputVector{batch_size_node, num_directions_node, hidden_size_node},
+                0);
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_C] = std::make_shared<ov::op::v3::Broadcast>(
+                ov::op::v0::Constant::create(m_input_map[DynamicQuantizeLSTMInput::X].get_element_type(), ov::Shape{}, {0}),
+                init_c_shape);
+        }
+    }
+
+    ov::Output<ov::Node>& at(const DynamicQuantizeLSTMInput& key) {
+        return m_input_map.at(key);
+    }
+
+    std::map<DynamicQuantizeLSTMInput, ov::Output<ov::Node>> m_input_map;
+};
+
+struct LSTMAttributes {
+    explicit LSTMAttributes(const ov::frontend::onnx::Node& node)
+        : m_hidden_size{node.get_attribute_value<std::int64_t>("hidden_size")},
+          m_clip_threshold{node.get_attribute_value<float>("clip", 0.f)},
+          m_activations{node.get_attribute_value<std::vector<std::string>>("activations", {"sigmoid", "tanh", "tanh"})},
+          m_activation_alpha{node.get_attribute_value<std::vector<float>>("activation_alpha", std::vector<float>{})},
+          m_activation_beta{node.get_attribute_value<std::vector<float>>("activation_beta", std::vector<float>{})},
+          m_input_forget{static_cast<bool>(node.get_attribute_value<std::int64_t>("input_forget", 0))} {
+        m_clip_threshold = std::abs(m_clip_threshold);
+        const auto direction = ov::util::to_lower(node.get_attribute_value<std::string>("direction", "forward"));
+        m_direction = ov::as_enum<ov::op::RecurrentSequenceDirection>(direction);
+    }
+
+    ov::op::RecurrentSequenceDirection m_direction;
+    std::int64_t m_hidden_size;
+    float m_clip_threshold;
+    std::vector<std::string> m_activations;
+    std::vector<float> m_activation_alpha;
+    std::vector<float> m_activation_beta;
+    bool m_input_forget;
+};
+
+}  // namespace
+
+namespace opset_1 {
+
+ov::OutputVector dynamic_quantize_lstm(const ov::frontend::onnx::Node& node) {
+    common::default_op_checks(node, 11, 12);
+
+    LSTMAttributes attributes{node};
+    DynamicQuantizeLSTMInputMap input_map{node, attributes.m_hidden_size};
+
+    auto lstm_sequence = std::make_shared<ov::op::v5::LSTMSequence>(input_map.at(DynamicQuantizeLSTMInput::X),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::INITIAL_H),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::INITIAL_C),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::SEQUENCE_LENS),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::W),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::R),
+                                                                    input_map.at(DynamicQuantizeLSTMInput::B),
+                                                                    attributes.m_hidden_size,
+                                                                    attributes.m_direction,
+                                                                    attributes.m_activation_alpha,
+                                                                    attributes.m_activation_beta,
+                                                                    attributes.m_activations,
+                                                                    attributes.m_clip_threshold);
+
+    const auto Y = lstm_sequence->output(0);
+    const auto Y_h = lstm_sequence->output(1);
+    const auto Y_c = lstm_sequence->output(2);
+
+    return {ov::op::util::reorder_axes(Y, {2, 1, 0, 3}),
+            ov::op::util::reorder_axes(Y_h, {1, 0, 2}),
+            ov::op::util::reorder_axes(Y_c, {1, 0, 2})};
+}
+
+ONNX_OP("DynamicQuantizeLSTM", OPSET_SINCE(1), com_microsoft::opset_1::dynamic_quantize_lstm, MICROSOFT_DOMAIN);
+
+}  // namespace opset_1
+}  // namespace com_microsoft
+}  // namespace onnx
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
@@ -6,26 +6,21 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <string>
 #include <vector>
 
 #include "core/operator_set.hpp"
 #include "exceptions.hpp"
+#include "openvino/decompositions/low_precision_dequantize.hpp"
 #include "openvino/op/add.hpp"
-#include "openvino/op/broadcast.hpp"
-#include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
-#include "openvino/op/convert.hpp"
-#include "openvino/op/gather.hpp"
 #include "openvino/op/lstm_sequence.hpp"
-#include "openvino/op/multiply.hpp"
-#include "openvino/op/shape_of.hpp"
-#include "openvino/op/squeeze.hpp"
-#include "openvino/op/subtract.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/util/common_util.hpp"
 #include "utils/common.hpp"
+#include "utils/recurrent.hpp"
 #include "utils/reshape.hpp"
 #include "utils/split.hpp"
 
@@ -34,6 +29,8 @@ namespace frontend {
 namespace onnx {
 namespace com_microsoft {
 namespace {
+
+using ov::frontend::onnx::recurrent::normalize_tensor_rank;
 
 enum class DynamicQuantizeLSTMInput {
     X,
@@ -45,184 +42,88 @@ enum class DynamicQuantizeLSTMInput {
     INITIAL_C,
 };
 
-struct PreparedQuantizedWeights {
-    ov::Output<ov::Node> weights;
-    int64_t original_rank;
-};
-
-ov::Output<ov::Node> normalize_tensor_rank(const ov::Output<ov::Node>& input,
-                                           int64_t target_rank,
-                                           const std::string& input_name) {
-    const auto& input_rank = input.get_partial_shape().rank();
-
-    if (input_rank.is_dynamic()) {
-        return input;
-    }
-
-    if (input_rank.get_length() == target_rank) {
-        return input;
-    }
-
-    if (input_rank.get_length() > target_rank) {
-        const auto dims_to_squeeze = input_rank.get_length() - target_rank;
-        const auto& input_shape = input.get_partial_shape();
-
-        for (int64_t i = 0; i < dims_to_squeeze; ++i) {
-            if (input_shape[i].is_static() && input_shape[i].get_length() != 1) {
-                OPENVINO_THROW("DynamicQuantizeLSTM input '",
-                               input_name,
-                               "' has rank ",
-                               input_rank.get_length(),
-                               " but expected ",
-                               target_rank,
-                               ". Leading dimension [",
-                               i,
-                               "] is ",
-                               input_shape[i].get_length(),
-                               " but must be 1 to squeeze.");
-            }
-        }
-
-        std::vector<int64_t> axes_to_squeeze;
-        axes_to_squeeze.reserve(dims_to_squeeze);
-        for (int64_t i = 0; i < dims_to_squeeze; ++i) {
-            axes_to_squeeze.push_back(i);
-        }
-
-        auto axes_const =
-            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{axes_to_squeeze.size()}, axes_to_squeeze);
-        return std::make_shared<ov::op::v0::Squeeze>(input, axes_const);
-    }
-
-    const auto dims_to_unsqueeze = target_rank - input_rank.get_length();
-    if (dims_to_unsqueeze != 1) {
-        OPENVINO_THROW("DynamicQuantizeLSTM input '",
-                       input_name,
-                       "' has rank ",
-                       input_rank.get_length(),
-                       " but expected ",
-                       target_rank,
-                       ". Rank difference is ",
-                       dims_to_unsqueeze,
-                       " but only 1 is supported.");
-    }
-
-    auto axes_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
-    return std::make_shared<ov::op::v0::Unsqueeze>(input, axes_const);
-}
-
-PreparedQuantizedWeights prepare_quantized_weights(const ov::frontend::onnx::Node& node,
-                                                   const ov::Output<ov::Node>& weights,
-                                                   int64_t hidden_size,
-                                                   const std::string& input_name) {
+// Transpose quantized gate weights from the com.microsoft layout
+// [num_directions, K, 4*hidden_size] to the standard ONNX LSTM layout
+// [num_directions, 4*hidden_size, K] expected by the dequantization and
+// gate-reordering steps below.
+ov::Output<ov::Node> prepare_quantized_weights(const ov::frontend::onnx::Node& node,
+                                               const ov::Output<ov::Node>& weights,
+                                               int64_t hidden_size,
+                                               const std::string& input_name) {
     const auto& rank = weights.get_partial_shape().rank();
     CHECK_VALID_NODE(node,
-                     rank.is_static() && (rank.get_length() == 2 || rank.get_length() == 3),
+                     rank.is_static() && rank.get_length() == 3,
                      "DynamicQuantizeLSTM input '",
                      input_name,
-                     "' must have static rank 2 or 3. Got rank: ",
+                     "' must have static rank 3. Got rank: ",
                      rank);
 
     const auto gate_axis_size = 4 * hidden_size;
-    auto prepared_weights = weights;
+    const auto& shape = weights.get_partial_shape();
+    const auto dim1_matches = shape[1].is_static() && shape[1].get_length() == gate_axis_size;
+    const auto dim2_matches = shape[2].is_static() && shape[2].get_length() == gate_axis_size;
 
-    if (rank.get_length() == 2) {
-        const auto& shape = prepared_weights.get_partial_shape();
-        const auto dim0_matches = shape[0].is_static() && shape[0].get_length() == gate_axis_size;
-        const auto dim1_matches = shape[1].is_static() && shape[1].get_length() == gate_axis_size;
+    CHECK_VALID_NODE(node,
+                     dim1_matches || dim2_matches,
+                     "DynamicQuantizeLSTM input '",
+                     input_name,
+                     "' must have either axis 1 or axis 2 equal to 4*hidden_size (",
+                     gate_axis_size,
+                     "). Got shape: ",
+                     shape);
 
-        CHECK_VALID_NODE(node,
-                         dim0_matches || dim1_matches,
-                         "DynamicQuantizeLSTM input '",
-                         input_name,
-                         "' must have one dimension equal to 4*hidden_size (",
-                         gate_axis_size,
-                         "). Got shape: ",
-                         shape);
-
-        if (!dim0_matches && dim1_matches) {
-            prepared_weights = ov::op::util::reorder_axes(prepared_weights, {1, 0});
-        }
-
-        auto axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
-        prepared_weights = std::make_shared<ov::op::v0::Unsqueeze>(prepared_weights, axis);
-    } else {
-        const auto& shape = prepared_weights.get_partial_shape();
-        const auto dim1_matches = shape[1].is_static() && shape[1].get_length() == gate_axis_size;
-        const auto dim2_matches = shape[2].is_static() && shape[2].get_length() == gate_axis_size;
-
-        CHECK_VALID_NODE(node,
-                         dim1_matches || dim2_matches,
-                         "DynamicQuantizeLSTM input '",
-                         input_name,
-                         "' must have either axis 1 or axis 2 equal to 4*hidden_size (",
-                         gate_axis_size,
-                         "). Got shape: ",
-                         shape);
-
-        if (!dim1_matches && dim2_matches) {
-            prepared_weights = ov::op::util::reorder_axes(prepared_weights, {0, 2, 1});
-        }
+    if (!dim1_matches && dim2_matches) {
+        return ov::op::util::reorder_axes(weights, {0, 2, 1});
     }
-
-    return {prepared_weights, rank.get_length()};
+    return weights;
 }
 
+// Append trailing size-1 dims to scale/zero_point so right-aligned autobroadcast
+// aligns them to the correct axes of prepared weights [num_dir, 4h, K].
+// For Constants the reshape is applied in-place (no graph node) so MarkDequantization
+// still fires; for runtime tensors an Unsqueeze fallback is used instead.
 ov::Output<ov::Node> align_dequant_param(const ov::frontend::onnx::Node& node,
                                          const ov::Output<ov::Node>& param,
-                                         int64_t weight_rank,
                                          const std::string& input_name) {
-    const auto& rank = param.get_partial_shape().rank();
-
-    if (rank.is_dynamic() || rank.get_length() == 0) {
+    const auto& pshape = param.get_partial_shape();
+    const auto& rank = pshape.rank();
+    if (rank.is_dynamic()) {
         return param;
     }
-
     CHECK_VALID_NODE(node,
                      rank.get_length() == 1 || rank.get_length() == 2,
                      "DynamicQuantizeLSTM input '",
                      input_name,
-                     "' must be a scalar, rank-1, or rank-2 tensor. Got rank: ",
+                     "' must be rank-1 [num_directions] or rank-2 [num_directions, 4*hidden_size]. Got rank: ",
                      rank.get_length());
 
-    if (weight_rank == 2) {
-        CHECK_VALID_NODE(node,
-                         rank.get_length() == 1,
-                         "DynamicQuantizeLSTM rank-2 weights require rank-1 scale/zero_point for input '",
-                         input_name,
-                         "'.");
-        auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {0, 2});
-        return std::make_shared<ov::op::v0::Unsqueeze>(param, axes);
+    const auto const_node = ov::as_type_ptr<ov::op::v0::Constant>(param.get_node_shared_ptr());
+    if (const_node) {
+        ov::Shape new_shape = pshape.to_shape();
+        while (new_shape.size() < 3) {
+            new_shape.push_back(1);
+        }
+        return std::make_shared<ov::op::v0::Constant>(*const_node, new_shape);
     }
 
-    if (rank.get_length() == 1) {
-        auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 2});
-        return std::make_shared<ov::op::v0::Unsqueeze>(param, axes);
-    }
-
-    auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});
-    return std::make_shared<ov::op::v0::Unsqueeze>(param, axes);
+    // Fallback for non-constant inputs: insert Unsqueeze nodes.
+    const auto dims_to_add = static_cast<int64_t>(3) - rank.get_length();
+    std::vector<int64_t> axes(dims_to_add);
+    std::iota(axes.begin(), axes.end(), rank.get_length());
+    auto axes_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{axes.size()}, axes);
+    return std::make_shared<ov::op::v0::Unsqueeze>(param, axes_const);
 }
 
 ov::Output<ov::Node> dequantize_weights(const ov::frontend::onnx::Node& node,
-                                        const PreparedQuantizedWeights& prepared_weights,
+                                        const ov::Output<ov::Node>& prepared_weights,
                                         const ov::Output<ov::Node>& scale,
                                         const ov::Output<ov::Node>& zero_point,
                                         const std::string& weights_name) {
-    auto dequantized =
-        ov::Output<ov::Node>(std::make_shared<ov::op::v0::Convert>(prepared_weights.weights, scale.get_element_type()));
-    auto aligned_scale = align_dequant_param(node, scale, prepared_weights.original_rank, weights_name + "_scale");
-
-    if (zero_point.get_node_shared_ptr()) {
-        auto aligned_zero_point = align_dequant_param(node,
-                                                      zero_point,
-                                                      prepared_weights.original_rank,
-                                                      weights_name + "_zero_point");
-        aligned_zero_point = std::make_shared<ov::op::v0::Convert>(aligned_zero_point, scale.get_element_type());
-        dequantized = std::make_shared<ov::op::v1::Subtract>(dequantized, aligned_zero_point);
-    }
-
-    return std::make_shared<ov::op::v1::Multiply>(dequantized, aligned_scale);
+    const auto aligned_scale = align_dequant_param(node, scale, weights_name + "_scale");
+    const ov::Output<ov::Node> aligned_zp = zero_point.get_node_shared_ptr()
+                                                ? align_dequant_param(node, zero_point, weights_name + "_zero_point")
+                                                : ov::Output<ov::Node>{};
+    return ov::decomposition::low_precision_dequantize(prepared_weights, aligned_scale, aligned_zp);
 }
 
 struct DynamicQuantizeLSTMInputMap {
@@ -230,7 +131,7 @@ struct DynamicQuantizeLSTMInputMap {
         const auto& ng_inputs = node.get_ov_inputs();
         constexpr std::size_t gates_count{4};
 
-        auto input_x = normalize_tensor_rank(ng_inputs.at(0), 3, "X");
+        auto input_x = normalize_tensor_rank(ng_inputs.at(0), 3, "DynamicQuantizeLSTM", "X");
         m_input_map[DynamicQuantizeLSTMInput::X] = ov::op::util::reorder_axes(input_x, {1, 0, 2});
 
         CHECK_VALID_NODE(node,
@@ -251,6 +152,14 @@ struct DynamicQuantizeLSTMInputMap {
                          ng_inputs.at(10).get_element_type() == ov::element::f32,
                          "DynamicQuantizeLSTM input 'R_scale' must have element type float32. Got: ",
                          ng_inputs.at(10).get_element_type());
+
+        // Peephole weights (input P, index 7) are not supported: ov::op::v5::LSTMSequence has
+        // no peephole inputs. Supporting P would require unrolling to per-step ov::op::v0::LSTMCell
+        // calls (which does accept P). Reject rather than silently ignore.
+        // TODO: support peephole input P by unrolling to LSTMCell.
+        CHECK_VALID_NODE(node,
+                         !common::is_input_valid(node, 7),
+                         "DynamicQuantizeLSTM peephole input 'P' is not supported.");
 
         ov::Output<ov::Node> w_zero_point;
         if (common::is_input_valid(node, 9)) {
@@ -275,92 +184,55 @@ struct DynamicQuantizeLSTMInputMap {
         auto prepared_w = prepare_quantized_weights(node, ng_inputs.at(1), hidden_size, "W");
         auto prepared_r = prepare_quantized_weights(node, ng_inputs.at(2), hidden_size, "R");
 
-        m_input_map[DynamicQuantizeLSTMInput::W] =
-            ov::op::util::convert_lstm_node_format(dequantize_weights(node, prepared_w, ng_inputs.at(8), w_zero_point, "W"),
-                                                   ov::op::util::LSTMWeightsFormat::IOFC,
-                                                   ov::op::util::LSTMWeightsFormat::FICO,
-                                                   1);
-        m_input_map[DynamicQuantizeLSTMInput::R] =
-            ov::op::util::convert_lstm_node_format(dequantize_weights(node, prepared_r, ng_inputs.at(10), r_zero_point, "R"),
-                                                   ov::op::util::LSTMWeightsFormat::IOFC,
-                                                   ov::op::util::LSTMWeightsFormat::FICO,
-                                                   1);
+        m_input_map[DynamicQuantizeLSTMInput::W] = ov::op::util::convert_lstm_node_format(
+            dequantize_weights(node, prepared_w, ng_inputs.at(8), w_zero_point, "W"),
+            ov::op::util::LSTMWeightsFormat::IOFC,
+            ov::op::util::LSTMWeightsFormat::FICO,
+            1);
+        m_input_map[DynamicQuantizeLSTMInput::R] = ov::op::util::convert_lstm_node_format(
+            dequantize_weights(node, prepared_r, ng_inputs.at(10), r_zero_point, "R"),
+            ov::op::util::LSTMWeightsFormat::IOFC,
+            ov::op::util::LSTMWeightsFormat::FICO,
+            1);
 
-        auto shape_of_x = std::make_shared<ov::op::v3::ShapeOf>(m_input_map[DynamicQuantizeLSTMInput::X]);
-        auto axes = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
-        auto batch_size_node = std::make_shared<ov::op::v8::Gather>(shape_of_x,
-                                                                    ov::op::v0::Constant::create(ov::element::i32,
-                                                                                                  ov::Shape{1},
-                                                                                                  {0}),
-                                                                    axes);
-        auto seq_length_node = std::make_shared<ov::op::v8::Gather>(shape_of_x,
-                                                                    ov::op::v0::Constant::create(ov::element::i32,
-                                                                                                  ov::Shape{1},
-                                                                                                  {1}),
-                                                                    axes);
-
-        auto shape_of_r = std::make_shared<ov::op::v3::ShapeOf>(m_input_map[DynamicQuantizeLSTMInput::R]);
-        auto num_directions_node = std::make_shared<ov::op::v8::Gather>(shape_of_r,
-                                                                        ov::op::v0::Constant::create(ov::element::i32,
-                                                                                                      ov::Shape{1},
-                                                                                                      {0}),
-                                                                        axes);
-        auto hidden_size_node = std::make_shared<ov::op::v8::Gather>(shape_of_r,
-                                                                     ov::op::v0::Constant::create(ov::element::i32,
-                                                                                                   ov::Shape{1},
-                                                                                                   {2}),
-                                                                     axes);
+        // Data-bearing edges (X, W, R, provided initial states) are built explicitly above
+        // so future activation-quantization insertion has a clear insertion point.
+        const recurrent::LSTMDimensions dims{m_input_map[DynamicQuantizeLSTMInput::X],
+                                             m_input_map[DynamicQuantizeLSTMInput::R]};
+        const auto x_type = m_input_map[DynamicQuantizeLSTMInput::X].get_element_type();
 
         if (common::is_input_valid(node, 3)) {
-            auto bias = normalize_tensor_rank(ng_inputs.at(3), 2, "B");
+            auto bias = normalize_tensor_rank(ng_inputs.at(3), 2, "DynamicQuantizeLSTM", "B");
             auto split_bias = ov::op::util::make_split(bias, 2, 1);
-            m_input_map[DynamicQuantizeLSTMInput::B] = std::make_shared<ov::op::v1::Add>(split_bias.at(0), split_bias.at(1));
+            m_input_map[DynamicQuantizeLSTMInput::B] =
+                std::make_shared<ov::op::v1::Add>(split_bias.at(0), split_bias.at(1));
             m_input_map[DynamicQuantizeLSTMInput::B] =
                 ov::op::util::convert_lstm_node_format(m_input_map[DynamicQuantizeLSTMInput::B],
                                                        ov::op::util::LSTMWeightsFormat::IOFC,
                                                        ov::op::util::LSTMWeightsFormat::FICO,
                                                        1);
         } else {
-            auto b_shape = std::make_shared<ov::op::v0::Concat>(
-                ov::OutputVector{num_directions_node,
-                                 std::make_shared<ov::op::v1::Multiply>(
-                                     ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {gates_count}),
-                                     hidden_size_node)},
-                0);
-            m_input_map[DynamicQuantizeLSTMInput::B] = std::make_shared<ov::op::v3::Broadcast>(
-                ov::op::v0::Constant::create(m_input_map[DynamicQuantizeLSTMInput::X].get_element_type(), ov::Shape{}, {0}),
-                b_shape);
+            m_input_map[DynamicQuantizeLSTMInput::B] = recurrent::default_bias(dims, x_type, gates_count);
         }
 
         if (common::is_input_valid(node, 4)) {
             m_input_map[DynamicQuantizeLSTMInput::SEQUENCE_LENS] = ng_inputs.at(4);
         } else {
-            m_input_map[DynamicQuantizeLSTMInput::SEQUENCE_LENS] =
-                std::make_shared<ov::op::v3::Broadcast>(seq_length_node, batch_size_node);
+            m_input_map[DynamicQuantizeLSTMInput::SEQUENCE_LENS] = recurrent::default_sequence_lens(dims);
         }
 
         if (common::is_input_valid(node, 5)) {
-            auto init_h = normalize_tensor_rank(ng_inputs.at(5), 3, "initial_h");
+            auto init_h = normalize_tensor_rank(ng_inputs.at(5), 3, "DynamicQuantizeLSTM", "initial_h");
             m_input_map[DynamicQuantizeLSTMInput::INITIAL_H] = ov::op::util::reorder_axes(init_h, {1, 0, 2});
         } else {
-            auto init_h_shape = std::make_shared<ov::op::v0::Concat>(
-                ov::OutputVector{batch_size_node, num_directions_node, hidden_size_node},
-                0);
-            m_input_map[DynamicQuantizeLSTMInput::INITIAL_H] = std::make_shared<ov::op::v3::Broadcast>(
-                ov::op::v0::Constant::create(m_input_map[DynamicQuantizeLSTMInput::X].get_element_type(), ov::Shape{}, {0}),
-                init_h_shape);
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_H] = recurrent::default_initial_state(dims, x_type);
         }
 
         if (common::is_input_valid(node, 6)) {
-            auto init_c = normalize_tensor_rank(ng_inputs.at(6), 3, "initial_c");
+            auto init_c = normalize_tensor_rank(ng_inputs.at(6), 3, "DynamicQuantizeLSTM", "initial_c");
             m_input_map[DynamicQuantizeLSTMInput::INITIAL_C] = ov::op::util::reorder_axes(init_c, {1, 0, 2});
         } else {
-            auto init_c_shape = std::make_shared<ov::op::v0::Concat>(
-                ov::OutputVector{batch_size_node, num_directions_node, hidden_size_node},
-                0);
-            m_input_map[DynamicQuantizeLSTMInput::INITIAL_C] = std::make_shared<ov::op::v3::Broadcast>(
-                ov::op::v0::Constant::create(m_input_map[DynamicQuantizeLSTMInput::X].get_element_type(), ov::Shape{}, {0}),
-                init_c_shape);
+            m_input_map[DynamicQuantizeLSTMInput::INITIAL_C] = recurrent::default_initial_state(dims, x_type);
         }
     }
 
@@ -403,19 +275,20 @@ ov::OutputVector dynamic_quantize_lstm(const ov::frontend::onnx::Node& node) {
     LSTMAttributes attributes{node};
     DynamicQuantizeLSTMInputMap input_map{node, attributes.m_hidden_size};
 
-    auto lstm_sequence = std::make_shared<ov::op::v5::LSTMSequence>(input_map.at(DynamicQuantizeLSTMInput::X),
-                                                                    input_map.at(DynamicQuantizeLSTMInput::INITIAL_H),
-                                                                    input_map.at(DynamicQuantizeLSTMInput::INITIAL_C),
-                                                                    input_map.at(DynamicQuantizeLSTMInput::SEQUENCE_LENS),
-                                                                    input_map.at(DynamicQuantizeLSTMInput::W),
-                                                                    input_map.at(DynamicQuantizeLSTMInput::R),
-                                                                    input_map.at(DynamicQuantizeLSTMInput::B),
-                                                                    attributes.m_hidden_size,
-                                                                    attributes.m_direction,
-                                                                    attributes.m_activation_alpha,
-                                                                    attributes.m_activation_beta,
-                                                                    attributes.m_activations,
-                                                                    attributes.m_clip_threshold);
+    auto lstm_sequence =
+        std::make_shared<ov::op::v5::LSTMSequence>(input_map.at(DynamicQuantizeLSTMInput::X),
+                                                   input_map.at(DynamicQuantizeLSTMInput::INITIAL_H),
+                                                   input_map.at(DynamicQuantizeLSTMInput::INITIAL_C),
+                                                   input_map.at(DynamicQuantizeLSTMInput::SEQUENCE_LENS),
+                                                   input_map.at(DynamicQuantizeLSTMInput::W),
+                                                   input_map.at(DynamicQuantizeLSTMInput::R),
+                                                   input_map.at(DynamicQuantizeLSTMInput::B),
+                                                   attributes.m_hidden_size,
+                                                   attributes.m_direction,
+                                                   attributes.m_activation_alpha,
+                                                   attributes.m_activation_beta,
+                                                   attributes.m_activations,
+                                                   attributes.m_clip_threshold);
 
     const auto Y = lstm_sequence->output(0);
     const auto Y_h = lstm_sequence->output(1);

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "core/null_node.hpp"
 #include "core/operator_set.hpp"
 #include "exceptions.hpp"
 #include "openvino/decompositions/low_precision_dequantize.hpp"
@@ -106,7 +107,7 @@ ov::Output<ov::Node> dequantize_weights(const ov::frontend::onnx::Node& node,
                                         const ov::Output<ov::Node>& zero_point,
                                         const std::string& weights_name) {
     const auto aligned_scale = align_dequant_param(node, scale, weights_name + "_scale");
-    const ov::Output<ov::Node> aligned_zp = zero_point.get_node_shared_ptr()
+    const ov::Output<ov::Node> aligned_zp = !ov::op::util::is_null(zero_point)
                                                 ? align_dequant_param(node, zero_point, weights_name + "_zero_point")
                                                 : ov::Output<ov::Node>{};
     return ov::decomposition::low_precision_dequantize(prepared_weights, aligned_scale, aligned_zp);
@@ -131,9 +132,15 @@ struct DynamicQuantizeLSTMInputMap {
                          "DynamicQuantizeLSTM input 'R' must have element type int8 or uint8. Got: ",
                          ng_inputs.at(2).get_element_type());
         CHECK_VALID_NODE(node,
+                         common::is_input_valid(node, 8),
+                         "DynamicQuantizeLSTM mandatory input 'W_scale' (index 8) is missing.");
+        CHECK_VALID_NODE(node,
                          ng_inputs.at(8).get_element_type() == ov::element::f32,
                          "DynamicQuantizeLSTM input 'W_scale' must have element type float32. Got: ",
                          ng_inputs.at(8).get_element_type());
+        CHECK_VALID_NODE(node,
+                         common::is_input_valid(node, 10),
+                         "DynamicQuantizeLSTM mandatory input 'R_scale' (index 10) is missing.");
         CHECK_VALID_NODE(node,
                          ng_inputs.at(10).get_element_type() == ov::element::f32,
                          "DynamicQuantizeLSTM input 'R_scale' must have element type float32. Got: ",
@@ -169,6 +176,21 @@ struct DynamicQuantizeLSTMInputMap {
 
         auto prepared_w = prepare_quantized_weights(node, ng_inputs.at(1), "W");
         auto prepared_r = prepare_quantized_weights(node, ng_inputs.at(2), "R");
+
+        // Validate hidden_size attribute against R's actual shape.
+        // After prepare_quantized_weights, R has layout [num_dir, 4*hidden_size, K].
+        // The original R input had layout [num_dir, K, hidden_size], so K=hidden is dim 1 of prepared_r.
+        // Use the original R input (ng_inputs.at(2)) dim 2 which is hidden_size before transposition.
+        const auto& r_pshape = ng_inputs.at(2).get_partial_shape();
+        if (r_pshape.rank().is_static() && r_pshape[2].is_static()) {
+            CHECK_VALID_NODE(node,
+                             r_pshape[2].get_length() == hidden_size,
+                             "DynamicQuantizeLSTM: 'hidden_size' attribute (",
+                             hidden_size,
+                             ") does not match R input shape dim 2 (",
+                             r_pshape[2].get_length(),
+                             ").");
+        }
 
         m_input_map[DynamicQuantizeLSTMInput::W] = ov::op::util::convert_lstm_node_format(
             dequantize_weights(node, prepared_w, ng_inputs.at(8), w_zero_point, "W"),

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
@@ -48,7 +48,6 @@ enum class DynamicQuantizeLSTMInput {
 // gate-reordering steps below.
 ov::Output<ov::Node> prepare_quantized_weights(const ov::frontend::onnx::Node& node,
                                                const ov::Output<ov::Node>& weights,
-                                               int64_t hidden_size,
                                                const std::string& input_name) {
     const auto& rank = weights.get_partial_shape().rank();
     CHECK_VALID_NODE(node,
@@ -58,24 +57,11 @@ ov::Output<ov::Node> prepare_quantized_weights(const ov::frontend::onnx::Node& n
                      "' must have static rank 3. Got rank: ",
                      rank);
 
-    const auto gate_axis_size = 4 * hidden_size;
-    const auto& shape = weights.get_partial_shape();
-    const auto dim1_matches = shape[1].is_static() && shape[1].get_length() == gate_axis_size;
-    const auto dim2_matches = shape[2].is_static() && shape[2].get_length() == gate_axis_size;
-
-    CHECK_VALID_NODE(node,
-                     dim1_matches || dim2_matches,
-                     "DynamicQuantizeLSTM input '",
-                     input_name,
-                     "' must have either axis 1 or axis 2 equal to 4*hidden_size (",
-                     gate_axis_size,
-                     "). Got shape: ",
-                     shape);
-
-    if (!dim1_matches && dim2_matches) {
-        return ov::op::util::reorder_axes(weights, {0, 2, 1});
-    }
-    return weights;
+    // The com.microsoft spec always provides weights in [num_directions, K, 4*hidden_size] layout.
+    // Transpose unconditionally to the LSTM layout [num_directions, 4*hidden_size, K].
+    // A shape-based heuristic (checking which axis equals 4*hidden_size) is incorrect
+    // when K == 4*hidden_size, and would silently produce wrong results.
+    return ov::op::util::reorder_axes(weights, {0, 2, 1});
 }
 
 // Append trailing size-1 dims to scale/zero_point so right-aligned autobroadcast
@@ -181,8 +167,8 @@ struct DynamicQuantizeLSTMInputMap {
                              r_zero_point.get_element_type());
         }
 
-        auto prepared_w = prepare_quantized_weights(node, ng_inputs.at(1), hidden_size, "W");
-        auto prepared_r = prepare_quantized_weights(node, ng_inputs.at(2), hidden_size, "R");
+        auto prepared_w = prepare_quantized_weights(node, ng_inputs.at(1), "W");
+        auto prepared_r = prepare_quantized_weights(node, ng_inputs.at(2), "R");
 
         m_input_map[DynamicQuantizeLSTMInput::W] = ov::op::util::convert_lstm_node_format(
             dequantize_weights(node, prepared_w, ng_inputs.at(8), w_zero_point, "W"),

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
@@ -178,17 +178,17 @@ struct DynamicQuantizeLSTMInputMap {
         auto prepared_r = prepare_quantized_weights(node, ng_inputs.at(2), "R");
 
         // Validate hidden_size attribute against R's actual shape.
-        // After prepare_quantized_weights, R has layout [num_dir, 4*hidden_size, K].
-        // The original R input had layout [num_dir, K, hidden_size], so K=hidden is dim 1 of prepared_r.
-        // Use the original R input (ng_inputs.at(2)) dim 2 which is hidden_size before transposition.
+        // R input has layout [num_dir, hidden_size, 4*hidden_size] (same [num_dir, K, 4*hidden_size]
+        // convention used by prepare_quantized_weights, where K == hidden_size for R).
+        // So dim 1 of the original R input equals hidden_size.
         const auto& r_pshape = ng_inputs.at(2).get_partial_shape();
-        if (r_pshape.rank().is_static() && r_pshape[2].is_static()) {
+        if (r_pshape.rank().is_static() && r_pshape[1].is_static()) {
             CHECK_VALID_NODE(node,
-                             r_pshape[2].get_length() == hidden_size,
+                             r_pshape[1].get_length() == hidden_size,
                              "DynamicQuantizeLSTM: 'hidden_size' attribute (",
                              hidden_size,
-                             ") does not match R input shape dim 2 (",
-                             r_pshape[2].get_length(),
+                             ") does not match R input shape dim 1 (",
+                             r_pshape[1].get_length(),
                              ").");
         }
 

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/dynamic_quantize_lstm.cpp
@@ -107,7 +107,7 @@ ov::Output<ov::Node> dequantize_weights(const ov::frontend::onnx::Node& node,
                                         const ov::Output<ov::Node>& zero_point,
                                         const std::string& weights_name) {
     const auto aligned_scale = align_dequant_param(node, scale, weights_name + "_scale");
-    const ov::Output<ov::Node> aligned_zp = !ov::op::util::is_null(zero_point)
+    const ov::Output<ov::Node> aligned_zp = (zero_point.get_node() != nullptr && !ov::op::util::is_null(zero_point))
                                                 ? align_dequant_param(node, zero_point, weights_name + "_zero_point")
                                                 : ov::Output<ov::Node>{};
     return ov::decomposition::low_precision_dequantize(prepared_weights, aligned_scale, aligned_zp);

--- a/src/frontends/onnx/frontend/src/op/lstm.cpp
+++ b/src/frontends/onnx/frontend/src/op/lstm.cpp
@@ -6,16 +6,11 @@
 #include "core/operator_set.hpp"
 #include "exceptions.hpp"
 #include "openvino/op/add.hpp"
-#include "openvino/op/broadcast.hpp"
-#include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
-#include "openvino/op/gather.hpp"
 #include "openvino/op/lstm_sequence.hpp"
-#include "openvino/op/multiply.hpp"
-#include "openvino/op/shape_of.hpp"
 #include "openvino/op/squeeze.hpp"
-#include "openvino/op/unsqueeze.hpp"
 #include "openvino/util/common_util.hpp"
+#include "utils/recurrent.hpp"
 #include "utils/reshape.hpp"
 #include "utils/split.hpp"
 using namespace ov::op;
@@ -39,74 +34,7 @@ enum class LSTMInput {
     LSTM_INPUT_P
 };
 
-// Normalize tensor rank to target_rank:
-// - If rank > target: squeeze leading dimensions of size 1 (handles upstream Unsqueeze ops).
-//   Static validation rejects leading dims that are statically != 1.
-// - If rank < target by exactly 1: unsqueeze a leading dimension of size 1
-//   (handles models that omit the num_directions=1 dimension for unidirectional LSTMs).
-// - If rank differs by more than the above, throw an error for malformed input.
-ov::Output<ov::Node> normalize_tensor_rank(const ov::Output<ov::Node>& input,
-                                           int64_t target_rank,
-                                           const std::string& input_name) {
-    const auto& input_rank = input.get_partial_shape().rank();
-
-    if (input_rank.is_dynamic()) {
-        return input;
-    }
-
-    if (input_rank.get_length() == target_rank) {
-        return input;
-    }
-
-    if (input_rank.get_length() > target_rank) {
-        // Squeeze leading dimensions to reduce rank to target_rank
-        const auto dims_to_squeeze = input_rank.get_length() - target_rank;
-
-        // Static validation: check if leading dimensions are statically known and != 1
-        const auto& input_shape = input.get_partial_shape();
-        for (int64_t i = 0; i < dims_to_squeeze; ++i) {
-            if (input_shape[i].is_static() && input_shape[i].get_length() != 1) {
-                OPENVINO_THROW("LSTM input '",
-                               input_name,
-                               "' has rank ",
-                               input_rank.get_length(),
-                               " but expected ",
-                               target_rank,
-                               ". Leading dimension [",
-                               i,
-                               "] is ",
-                               input_shape[i].get_length(),
-                               " but must be 1 to squeeze.");
-            }
-        }
-
-        std::vector<int64_t> axes_to_squeeze;
-        for (int64_t i = 0; i < dims_to_squeeze; ++i) {
-            axes_to_squeeze.push_back(i);
-        }
-
-        auto axes_const = v0::Constant::create(ov::element::i64, Shape{axes_to_squeeze.size()}, axes_to_squeeze);
-        return std::make_shared<v0::Squeeze>(input, axes_const);
-    }
-
-    // input_rank < target_rank: only allow exactly 1 missing dimension (the num_directions dim).
-    // For unidirectional LSTM (forward/reverse), num_directions=1, so some models omit it.
-    // A larger rank deficiency indicates a genuinely malformed model.
-    const auto dims_to_unsqueeze = target_rank - input_rank.get_length();
-    if (dims_to_unsqueeze != 1) {
-        OPENVINO_THROW("LSTM input '",
-                       input_name,
-                       "' has rank ",
-                       input_rank.get_length(),
-                       " but expected ",
-                       target_rank,
-                       ". Rank difference is ",
-                       dims_to_unsqueeze,
-                       " but only 1 (missing num_directions) is supported.");
-    }
-    auto axes_const = v0::Constant::create(ov::element::i64, Shape{1}, std::vector<int64_t>{0});
-    return std::make_shared<v0::Unsqueeze>(input, axes_const);
-}
+using ov::frontend::onnx::recurrent::normalize_tensor_rank;
 
 struct LSTMNgInputMap {
     explicit LSTMNgInputMap(const Node& node) {
@@ -123,7 +51,7 @@ struct LSTMNgInputMap {
         // First normalize rank if needed, THEN reorder axes
         // This is important because Squeeze/Unsqueeze changes dimension indices
         auto input_x = ng_inputs.at(0);
-        input_x = normalize_tensor_rank(input_x, 3, "X");
+        input_x = normalize_tensor_rank(input_x, 3, "LSTM", "X");
         input_x = ov::op::util::reorder_axes(input_x, {1, 0, 2});
 
         m_input_map[LSTMInput::LSTM_INPUT_X] = input_x;
@@ -148,7 +76,7 @@ struct LSTMNgInputMap {
 
         // Weight tensor for the gates.
         // ONNX Shape: [num_directions, 4*hidden_size, input_size]
-        auto input_w = normalize_tensor_rank(ng_inputs.at(1), 3, "W");
+        auto input_w = normalize_tensor_rank(ng_inputs.at(1), 3, "LSTM", "W");
         m_input_map[LSTMInput::LSTM_INPUT_W] =
             ov::op::util::convert_lstm_node_format(input_w,
                                                    ov::op::util::LSTMWeightsFormat::IOFC,
@@ -157,7 +85,7 @@ struct LSTMNgInputMap {
 
         // The recurrence weight tensor.
         // ONNX Shape: [num_directions, 4*hidden_size, hidden_size]
-        auto input_r = normalize_tensor_rank(ng_inputs.at(2), 3, "R");
+        auto input_r = normalize_tensor_rank(ng_inputs.at(2), 3, "LSTM", "R");
         m_input_map[LSTMInput::LSTM_INPUT_R] =
             ov::op::util::convert_lstm_node_format(input_r,
                                                    ov::op::util::LSTMWeightsFormat::IOFC,
@@ -165,33 +93,16 @@ struct LSTMNgInputMap {
                                                    1);
 
         // Get dimensions needed for default inputs creation
-        auto shape_of_x = std::make_shared<v3::ShapeOf>(m_input_map[LSTMInput::LSTM_INPUT_X]);
-        auto axes = v0::Constant::create(ov::element::Type_t::i32, ov::Shape{1}, {0});
-        auto batch_size_node =
-            std::make_shared<v8::Gather>(shape_of_x,
-                                         v0::Constant::create(ov::element::Type_t::i32, ov::Shape{1}, {0}),
-                                         axes);
-        auto seq_length_node =
-            std::make_shared<v8::Gather>(shape_of_x,
-                                         v0::Constant::create(ov::element::Type_t::i32, ov::Shape{1}, {1}),
-                                         axes);
-
-        auto shape_of_r = std::make_shared<v3::ShapeOf>(m_input_map[LSTMInput::LSTM_INPUT_R]);
-        auto num_directions_node =
-            std::make_shared<v8::Gather>(shape_of_r,
-                                         v0::Constant::create(ov::element::Type_t::i32, ov::Shape{1}, {0}),
-                                         axes);
-        auto hidden_size_node =
-            std::make_shared<v8::Gather>(shape_of_r,
-                                         v0::Constant::create(ov::element::Type_t::i32, ov::Shape{1}, {2}),
-                                         axes);
+        const ov::frontend::onnx::recurrent::LSTMDimensions dims{m_input_map[LSTMInput::LSTM_INPUT_X],
+                                                                 m_input_map[LSTMInput::LSTM_INPUT_R]};
+        const auto x_type = m_input_map[LSTMInput::LSTM_INPUT_X].get_element_type();
 
         // ------ Optional inputs ------
         // `B` - The bias tensor for input gate.
         // ONNX Shape: [num_directions, 8*hidden_size]
         // OpenVino Shape: [num_directions, 4*hidden_size]
         if (ng_inputs.size() > 3 && !ov::op::util::is_null(ng_inputs.at(3))) {
-            auto bias = normalize_tensor_rank(ng_inputs.at(3), 2, "B");
+            auto bias = normalize_tensor_rank(ng_inputs.at(3), 2, "LSTM", "B");
             auto split_bias = ov::op::util::make_split(bias, 2, 1);
             m_input_map[LSTMInput::LSTM_INPUT_B] = std::make_shared<v1::Add>(split_bias.at(0), split_bias.at(1));
             m_input_map[LSTMInput::LSTM_INPUT_B] =
@@ -200,23 +111,15 @@ struct LSTMNgInputMap {
                                                        ov::op::util::LSTMWeightsFormat::FICO,
                                                        1);
         } else {
-            auto b_shape = std::make_shared<v0::Concat>(
-                ov::OutputVector{num_directions_node,
-                                 std::make_shared<v1::Multiply>(
-                                     v0::Constant::create(ov::element::Type_t::i64, ov::Shape{1}, {gates_count}),
-                                     hidden_size_node)},
-                0);
-            m_input_map[LSTMInput::LSTM_INPUT_B] = std::make_shared<v3::Broadcast>(
-                v0::Constant::create(m_input_map[LSTMInput::LSTM_INPUT_X].get_element_type(), ov::Shape{}, {0}),
-                b_shape);
+            m_input_map[LSTMInput::LSTM_INPUT_B] =
+                ov::frontend::onnx::recurrent::default_bias(dims, x_type, gates_count);
         }
         // `sequence_lens`- The lengths of the sequences in a batch.
         // Shape: [batch_size]
         if (ng_inputs.size() > 4 && !ov::op::util::is_null(ng_inputs.at(4))) {
             m_input_map[LSTMInput::LSTM_INPUT_SEQ_LENGTHS] = ng_inputs.at(4);
         } else {
-            m_input_map[LSTMInput::LSTM_INPUT_SEQ_LENGTHS] =
-                std::make_shared<v3::Broadcast>(seq_length_node, batch_size_node);
+            m_input_map[LSTMInput::LSTM_INPUT_SEQ_LENGTHS] = ov::frontend::onnx::recurrent::default_sequence_lens(dims);
         }
         // `initial_h` - The initial value of the hidden.
         // ONNX Shape: [num_directions, batch_size, hidden_size]
@@ -224,17 +127,13 @@ struct LSTMNgInputMap {
         if (ng_inputs.size() > 5 && !ov::op::util::is_null(ng_inputs.at(5))) {
             auto init_h = ng_inputs.at(5);
             // First normalize rank, THEN reorder axes
-            init_h = normalize_tensor_rank(init_h, 3, "initial_h");
+            init_h = normalize_tensor_rank(init_h, 3, "LSTM", "initial_h");
             init_h = ov::op::util::reorder_axes(init_h, {1, 0, 2});
 
             m_input_map[LSTMInput::LSTM_INPUT_INIT_H] = init_h;
         } else {
-            auto init_h_shape =
-                std::make_shared<v0::Concat>(ov::OutputVector{batch_size_node, num_directions_node, hidden_size_node},
-                                             0);
-            m_input_map[LSTMInput::LSTM_INPUT_INIT_H] = std::make_shared<v3::Broadcast>(
-                v0::Constant::create(m_input_map[LSTMInput::LSTM_INPUT_X].get_element_type(), ov::Shape{}, {0}),
-                init_h_shape);
+            m_input_map[LSTMInput::LSTM_INPUT_INIT_H] =
+                ov::frontend::onnx::recurrent::default_initial_state(dims, x_type);
         }
         // `initial_c` - The initial value of the cell.
         // ONNX Shape: [num_directions, batch_size, hidden_size]
@@ -242,38 +141,28 @@ struct LSTMNgInputMap {
         if (ng_inputs.size() > 6 && !ov::op::util::is_null(ng_inputs.at(6))) {
             auto init_c = ng_inputs.at(6);
             // First normalize rank, THEN reorder axes
-            init_c = normalize_tensor_rank(init_c, 3, "initial_c");
+            init_c = normalize_tensor_rank(init_c, 3, "LSTM", "initial_c");
             init_c = ov::op::util::reorder_axes(init_c, {1, 0, 2});
 
             m_input_map[LSTMInput::LSTM_INPUT_INIT_C] = init_c;
         } else {
-            auto init_c_shape =
-                std::make_shared<v0::Concat>(ov::OutputVector{batch_size_node, num_directions_node, hidden_size_node},
-                                             0);
-            m_input_map[LSTMInput::LSTM_INPUT_INIT_C] = std::make_shared<v3::Broadcast>(
-                v0::Constant::create(m_input_map[LSTMInput::LSTM_INPUT_X].get_element_type(), ov::Shape{}, {0}),
-                init_c_shape);
+            m_input_map[LSTMInput::LSTM_INPUT_INIT_C] =
+                ov::frontend::onnx::recurrent::default_initial_state(dims, x_type);
         }
         // `P` - The weight tensor for peepholes.
         // ONNX Shape: [num_directions, 3*hidden_size]
         // OpenVino Shape: [num_directions, 4*hidden_size]
         if (ng_inputs.size() > 7 && !ov::op::util::is_null(ng_inputs.at(7))) {
-            auto peepholes = normalize_tensor_rank(ng_inputs.at(7), 2, "P");
+            auto peepholes = normalize_tensor_rank(ng_inputs.at(7), 2, "LSTM", "P");
             m_input_map[LSTMInput::LSTM_INPUT_P] =
                 ov::op::util::convert_lstm_peepholes_format(peepholes,
                                                             ov::op::util::LSTMPeepholesFormat::IOF,
                                                             ov::op::util::LSTMPeepholesFormat::FIO,
                                                             1);
         } else {
-            auto p_shape = std::make_shared<v0::Concat>(
-                ov::OutputVector{num_directions_node,
-                                 std::make_shared<v1::Multiply>(
-                                     v0::Constant::create(ov::element::Type_t::i64, ov::Shape{1}, {P_gates_count}),
-                                     hidden_size_node)},
-                0);
-            m_input_map[LSTMInput::LSTM_INPUT_P] = std::make_shared<v3::Broadcast>(
-                v0::Constant::create(m_input_map[LSTMInput::LSTM_INPUT_X].get_element_type(), ov::Shape{}, {0}),
-                p_shape);
+            // A blank peephole tensor of zeros: [num_directions, 3*hidden_size].
+            m_input_map[LSTMInput::LSTM_INPUT_P] =
+                ov::frontend::onnx::recurrent::default_bias(dims, x_type, P_gates_count);
             m_input_map[LSTMInput::LSTM_INPUT_P].set_names({"P_blank"});
         }
     }

--- a/src/frontends/onnx/frontend/src/utils/recurrent.cpp
+++ b/src/frontends/onnx/frontend/src/utils/recurrent.cpp
@@ -139,6 +139,8 @@ OpInputMap::OpInputMap(const ov::frontend::onnx::Node& node, std::size_t gates_c
     m_map[OpInput::W] = ng_inputs.at(1);
     m_map[OpInput::R] = ng_inputs.at(2);
 
+    // X must be in OV layout [batch, seq, input] (reorder_axes applied above) before LSTMDimensions
+    // is constructed; constructing it earlier would swap batch/seq in all derived default tensors.
     const LSTMDimensions dims{m_map[OpInput::X], m_map[OpInput::R]};
     const auto x_type = m_map[OpInput::X].get_element_type();
 

--- a/src/frontends/onnx/frontend/src/utils/recurrent.cpp
+++ b/src/frontends/onnx/frontend/src/utils/recurrent.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <numeric>
 #include <vector>
 
 #include "core/null_node.hpp"
@@ -17,6 +18,8 @@
 #include "openvino/op/gather.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/shape_of.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/unsqueeze.hpp"
 #include "openvino/util/common_util.hpp"
 #include "utils/reshape.hpp"
 #include "utils/split.hpp"
@@ -28,6 +31,107 @@ namespace ov {
 namespace frontend {
 namespace onnx {
 namespace recurrent {
+
+ov::Output<ov::Node> normalize_tensor_rank(const ov::Output<ov::Node>& input,
+                                           int64_t target_rank,
+                                           const std::string& op_name,
+                                           const std::string& input_name) {
+    const auto& input_rank = input.get_partial_shape().rank();
+
+    if (input_rank.is_dynamic() || input_rank.get_length() == target_rank) {
+        return input;
+    }
+
+    if (input_rank.get_length() > target_rank) {
+        // Squeeze leading dimensions to reduce rank to target_rank.
+        const auto dims_to_squeeze = input_rank.get_length() - target_rank;
+
+        // Static validation: leading dimensions that are statically known and != 1 cannot be squeezed.
+        const auto& input_shape = input.get_partial_shape();
+        for (int64_t i = 0; i < dims_to_squeeze; ++i) {
+            if (input_shape[i].is_static() && input_shape[i].get_length() != 1) {
+                OPENVINO_THROW(op_name,
+                               " input '",
+                               input_name,
+                               "' has rank ",
+                               input_rank.get_length(),
+                               " but expected ",
+                               target_rank,
+                               ". Leading dimension [",
+                               i,
+                               "] is ",
+                               input_shape[i].get_length(),
+                               " but must be 1 to squeeze.");
+            }
+        }
+
+        std::vector<int64_t> axes_to_squeeze(dims_to_squeeze);
+        std::iota(axes_to_squeeze.begin(), axes_to_squeeze.end(), 0);
+        auto axes_const = v0::Constant::create(ov::element::i64, Shape{axes_to_squeeze.size()}, axes_to_squeeze);
+        return std::make_shared<v0::Squeeze>(input, axes_const);
+    }
+
+    // input_rank < target_rank: only allow exactly 1 missing dimension (the num_directions dim).
+    // For unidirectional operators (forward/reverse), num_directions=1, so some models omit it.
+    // A larger rank deficiency indicates a genuinely malformed model.
+    const auto dims_to_unsqueeze = target_rank - input_rank.get_length();
+    if (dims_to_unsqueeze != 1) {
+        OPENVINO_THROW(op_name,
+                       " input '",
+                       input_name,
+                       "' has rank ",
+                       input_rank.get_length(),
+                       " but expected ",
+                       target_rank,
+                       ". Rank difference is ",
+                       dims_to_unsqueeze,
+                       " but only 1 (missing num_directions) is supported.");
+    }
+    auto axes_const = v0::Constant::create(ov::element::i64, Shape{1}, std::vector<int64_t>{0});
+    return std::make_shared<v0::Unsqueeze>(input, axes_const);
+}
+
+namespace {
+// Gather a single dimension (as a rank-1 i32 tensor) from a tensor's runtime shape.
+ov::Output<ov::Node> gather_dim(const ov::Output<ov::Node>& shape_of, int64_t index) {
+    const auto axes = v0::Constant::create(ov::element::i32, Shape{1}, {0});
+    return std::make_shared<v8::Gather>(shape_of, v0::Constant::create(ov::element::i32, Shape{1}, {index}), axes);
+}
+}  // namespace
+
+LSTMDimensions::LSTMDimensions(const ov::Output<ov::Node>& x_ov_layout, const ov::Output<ov::Node>& r_ov_layout) {
+    // X (OpenVINO layout): [batch_size, seq_length, input_size]
+    auto shape_of_x = std::make_shared<v3::ShapeOf>(x_ov_layout);
+    batch_size = gather_dim(shape_of_x, 0);
+    seq_length = gather_dim(shape_of_x, 1);
+
+    // R: [num_directions, gates*hidden_size, hidden_size]
+    auto shape_of_r = std::make_shared<v3::ShapeOf>(r_ov_layout);
+    num_directions = gather_dim(shape_of_r, 0);
+    hidden_size = gather_dim(shape_of_r, 2);
+}
+
+ov::Output<ov::Node> default_bias(const LSTMDimensions& dims,
+                                  const ov::element::Type& element_type,
+                                  int64_t gates_count) {
+    auto b_shape = std::make_shared<v0::Concat>(
+        ov::OutputVector{dims.num_directions,
+                         std::make_shared<v1::Multiply>(v0::Constant::create(ov::element::i64, Shape{1}, {gates_count}),
+                                                        dims.hidden_size)},
+        0);
+    return std::make_shared<v3::Broadcast>(v0::Constant::create(element_type, Shape{}, {0}), b_shape);
+}
+
+ov::Output<ov::Node> default_sequence_lens(const LSTMDimensions& dims) {
+    return std::make_shared<v3::Broadcast>(dims.seq_length, dims.batch_size);
+}
+
+ov::Output<ov::Node> default_initial_state(const LSTMDimensions& dims, const ov::element::Type& element_type) {
+    auto state_shape =
+        std::make_shared<v0::Concat>(ov::OutputVector{dims.batch_size, dims.num_directions, dims.hidden_size}, 0);
+    return std::make_shared<v3::Broadcast>(v0::Constant::create(element_type, Shape{}, {0}), state_shape);
+}
+
 OpInputMap::OpInputMap(const ov::frontend::onnx::Node& node, std::size_t gates_count) {
     const auto& ng_inputs = node.get_ov_inputs();
 
@@ -35,23 +139,8 @@ OpInputMap::OpInputMap(const ov::frontend::onnx::Node& node, std::size_t gates_c
     m_map[OpInput::W] = ng_inputs.at(1);
     m_map[OpInput::R] = ng_inputs.at(2);
 
-    const auto x_pshape = m_map[OpInput::X].get_partial_shape();
-    const auto w_pshape = m_map[OpInput::W].get_partial_shape();
-    const auto r_pshape = m_map[OpInput::R].get_partial_shape();
-
-    // Get dimensions needed for default inputs creation
-    auto shape_of_x = std::make_shared<v3::ShapeOf>(m_map[OpInput::X]);
-    auto axes = v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
-    auto batch_size_node =
-        std::make_shared<v8::Gather>(shape_of_x, v0::Constant::create(ov::element::i32, ov::Shape{1}, {0}), axes);
-    auto seq_length_node =
-        std::make_shared<v8::Gather>(shape_of_x, v0::Constant::create(ov::element::i32, ov::Shape{1}, {1}), axes);
-
-    auto shape_of_r = std::make_shared<v3::ShapeOf>(m_map[OpInput::R]);
-    auto num_directions_node =
-        std::make_shared<v8::Gather>(shape_of_r, v0::Constant::create(ov::element::i32, ov::Shape{1}, {0}), axes);
-    auto hidden_size_node =
-        std::make_shared<v8::Gather>(shape_of_r, v0::Constant::create(ov::element::i32, ov::Shape{1}, {2}), axes);
+    const LSTMDimensions dims{m_map[OpInput::X], m_map[OpInput::R]};
+    const auto x_type = m_map[OpInput::X].get_element_type();
 
     // ------ Optional inputs ------
     if (ng_inputs.size() > 3 && !ov::op::util::is_null(ng_inputs.at(3))) {
@@ -59,30 +148,18 @@ OpInputMap::OpInputMap(const ov::frontend::onnx::Node& node, std::size_t gates_c
         auto split_bias = ov::op::util::make_split(bias, 2, 1);
         m_map[OpInput::B] = std::make_shared<v1::Add>(split_bias.at(0), split_bias.at(1));
     } else {
-        auto b_shape = std::make_shared<v0::Concat>(
-            ov::OutputVector{num_directions_node,
-                             std::make_shared<v1::Multiply>(
-                                 v0::Constant::create(ov::element::Type_t::i64, ov::Shape{1}, {gates_count}),
-                                 hidden_size_node)},
-            0);
-        m_map[OpInput::B] = std::make_shared<v3::Broadcast>(
-            v0::Constant::create(m_map[OpInput::X].get_element_type(), ov::Shape{}, {0}),
-            b_shape);
+        m_map[OpInput::B] = default_bias(dims, x_type, gates_count);
     }
     if (ng_inputs.size() > 4 && !ov::op::util::is_null(ng_inputs.at(4))) {
         m_map[OpInput::SEQ_LENGTHS] = ng_inputs.at(4);
     } else {
-        m_map[OpInput::SEQ_LENGTHS] = std::make_shared<v3::Broadcast>(seq_length_node, batch_size_node);
+        m_map[OpInput::SEQ_LENGTHS] = default_sequence_lens(dims);
     }
     // The initial value of the hidden.
     if (ng_inputs.size() > 5 && !ov::op::util::is_null(ng_inputs.at(5))) {
         m_map[OpInput::INIT_H] = ov::op::util::reorder_axes(ng_inputs.at(5), {1, 0, 2});
     } else {
-        auto init_h_shape =
-            std::make_shared<v0::Concat>(ov::OutputVector{batch_size_node, num_directions_node, hidden_size_node}, 0);
-        m_map[OpInput::INIT_H] = std::make_shared<v3::Broadcast>(
-            v0::Constant::create(m_map[OpInput::X].get_element_type(), ov::Shape{}, {0}),
-            init_h_shape);
+        m_map[OpInput::INIT_H] = default_initial_state(dims, x_type);
     }
 }
 

--- a/src/frontends/onnx/frontend/src/utils/recurrent.hpp
+++ b/src/frontends/onnx/frontend/src/utils/recurrent.hpp
@@ -29,7 +29,7 @@ ov::Output<ov::Node> normalize_tensor_rank(const ov::Output<ov::Node>& input,
                                            const std::string& input_name);
 
 // Runtime dimension values extracted from OV-layout X [batch, seq, input]
-// and R [num_dir, gates*hidden, hidden]. Each member is a rank-1 i32 node.
+// and R [num_dir, gates*hidden, hidden]. Each member is a rank-1 i64 node.
 struct LSTMDimensions {
     LSTMDimensions(const ov::Output<ov::Node>& x_ov_layout, const ov::Output<ov::Node>& r_ov_layout);
 

--- a/src/frontends/onnx/frontend/src/utils/recurrent.hpp
+++ b/src/frontends/onnx/frontend/src/utils/recurrent.hpp
@@ -7,15 +7,48 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
 
 #include "core/node.hpp"
 #include "openvino/core/node.hpp"
+#include "openvino/core/type/element_type.hpp"
 #include "openvino/op/util/attr_types.hpp"
 
 namespace ov {
 namespace frontend {
 namespace onnx {
 namespace recurrent {
+
+// Normalize a recurrent-operator input to target_rank. Dynamic rank is returned unchanged.
+// rank > target: squeeze leading size-1 dims (rejects statically-known non-1 leading dims).
+// rank == target-1: unsqueeze a leading dim (handles models that omit num_directions=1).
+// Larger rank deficiency is rejected. op_name/input_name are used in error messages.
+ov::Output<ov::Node> normalize_tensor_rank(const ov::Output<ov::Node>& input,
+                                           int64_t target_rank,
+                                           const std::string& op_name,
+                                           const std::string& input_name);
+
+// Runtime dimension values extracted from OV-layout X [batch, seq, input]
+// and R [num_dir, gates*hidden, hidden]. Each member is a rank-1 i32 node.
+struct LSTMDimensions {
+    LSTMDimensions(const ov::Output<ov::Node>& x_ov_layout, const ov::Output<ov::Node>& r_ov_layout);
+
+    ov::Output<ov::Node> batch_size;
+    ov::Output<ov::Node> seq_length;
+    ov::Output<ov::Node> num_directions;
+    ov::Output<ov::Node> hidden_size;
+};
+
+// Default values for optional LSTM inputs (element_type typically matches X):
+// default_bias:          zeros [num_directions, gates_count * hidden_size]
+// default_sequence_lens: seq_length broadcast to [batch_size]
+// default_initial_state: zeros [batch_size, num_directions, hidden_size]
+ov::Output<ov::Node> default_bias(const LSTMDimensions& dims,
+                                  const ov::element::Type& element_type,
+                                  int64_t gates_count);
+ov::Output<ov::Node> default_sequence_lens(const LSTMDimensions& dims);
+ov::Output<ov::Node> default_initial_state(const LSTMDimensions& dims, const ov::element::Type& element_type);
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ INPUT NODES PARSING ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ///

--- a/src/frontends/onnx/tests/models/com.microsoft/dynamic_quantize_lstm.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/dynamic_quantize_lstm.prototxt
@@ -1,0 +1,273 @@
+ir_version: 13
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "X"
+    input: "W"
+    input: "R"
+    input: "B"
+    input: "sequence_lens"
+    input: "initial_h"
+    input: "initial_c"
+    input: ""
+    input: "W_scale"
+    input: "W_zero_point"
+    input: "R_scale"
+    input: "R_zero_point"
+    output: "Y"
+    output: "Y_h"
+    output: "Y_c"
+    op_type: "DynamicQuantizeLSTM"
+    attribute {
+      name: "hidden_size"
+      i: 2
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  name: "dq_lstm_test"
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "R"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 16
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "sequence_lens"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "initial_h"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "initial_c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W_scale"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W_zero_point"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "R_scale"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "R_zero_point"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y_h"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y_c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 17
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/com.microsoft/dynamic_quantize_lstm_const_weights.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/dynamic_quantize_lstm_const_weights.prototxt
@@ -1,0 +1,179 @@
+ir_version: 13
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "X"
+    input: "W"
+    input: "R"
+    input: "B"
+    input: "sequence_lens"
+    input: "initial_h"
+    input: "initial_c"
+    input: ""
+    input: "W_scale"
+    input: "W_zero_point"
+    input: "R_scale"
+    input: "R_zero_point"
+    output: "Y"
+    output: "Y_h"
+    output: "Y_c"
+    op_type: "DynamicQuantizeLSTM"
+    attribute {
+      name: "hidden_size"
+      i: 2
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  name: "dq_lstm_const_weights_test"
+  initializer {
+    name: "W"
+    dims: 1
+    dims: 3
+    dims: 8
+    data_type: 3
+    raw_data: "\x0c\xf9\x05\x09\xf5\x03\x04\xfa\x08\x0d\xf7\x02\x07\xfb\x0a\x01\xfc\x06\x0e\xf8\x0c\xf6\x0b\xfd"
+  }
+  initializer {
+    name: "R"
+    dims: 1
+    dims: 2
+    dims: 8
+    data_type: 3
+    raw_data: "\x05\xfd\x04\x07\xfa\x02\x01\xfc\x09\x08\xfb\x03\x06\xf9\x0a\xfe"
+  }
+  initializer {
+    name: "W_scale"
+    dims: 1
+    data_type: 1
+    raw_data: "\xcd\xcc\x4c\x3d"
+  }
+  initializer {
+    name: "W_zero_point"
+    dims: 1
+    data_type: 3
+    raw_data: "\x01"
+  }
+  initializer {
+    name: "R_scale"
+    dims: 1
+    data_type: 1
+    raw_data: "\x0a\xd7\x23\x3d"
+  }
+  initializer {
+    name: "R_zero_point"
+    dims: 1
+    data_type: 3
+    raw_data: "\xfe"
+  }
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 1 }
+          dim { dim_value: 3 }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 1 }
+          dim { dim_value: 16 }
+        }
+      }
+    }
+  }
+  input {
+    name: "sequence_lens"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim { dim_value: 1 }
+        }
+      }
+    }
+  }
+  input {
+    name: "initial_h"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 1 }
+          dim { dim_value: 1 }
+          dim { dim_value: 2 }
+        }
+      }
+    }
+  }
+  input {
+    name: "initial_c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 1 }
+          dim { dim_value: 1 }
+          dim { dim_value: 2 }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 1 }
+          dim { dim_value: 1 }
+          dim { dim_value: 2 }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y_h"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 1 }
+          dim { dim_value: 1 }
+          dim { dim_value: 2 }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y_c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 1 }
+          dim { dim_value: 1 }
+          dim { dim_value: 2 }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 17
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -2545,6 +2545,47 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_dynamic_quantize_matmul_null_b
     test_case.run_with_tolerance_as_fp(0.0055f);
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_dynamic_quantize_lstm) {
+    const auto model = convert_model("com.microsoft/dynamic_quantize_lstm.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    const std::vector<float> input_X{0.25f, -0.5f, 1.0f, 1.5f, 0.75f, -1.25f};
+    const std::vector<int8_t> input_W{12, -7, 5, 9, -11, 3, 4, -6, 8, 13, -9, 2, 7, -5, 10, 1, -4, 6, 14, -8, 12,
+                                      -10, 11, -3};
+    const std::vector<int8_t> input_R{5, -3, 4, 7, -6, 2, 1, -4, 9, 8, -5, 3, 6, -7, 10, -2};
+    const std::vector<float> input_B{0.1f,  -0.2f,  0.05f, 0.3f,  -0.4f, 0.2f,  0.15f, -0.25f,
+                                     -0.05f, 0.12f, -0.18f, 0.22f, -0.08f, 0.09f, -0.11f, 0.07f};
+    const std::vector<int32_t> input_sequence_lens{2};
+    const std::vector<float> input_initial_h{0.2f, -0.1f};
+    const std::vector<float> input_initial_c{0.05f, 0.15f};
+    const std::vector<float> input_W_scale{0.05f};
+    const std::vector<int8_t> input_W_zero_point{1};
+    const std::vector<float> input_R_scale{0.04f};
+    const std::vector<int8_t> input_R_zero_point{-2};
+
+    const std::vector<float> expected_Y{0.11440717f, -0.06565752f, -0.00265372f, -0.20275351f};
+    const std::vector<float> expected_Y_h{-0.00265372f, -0.20275351f};
+    const std::vector<float> expected_Y_c{-0.00976340f, -0.24270093f};
+
+    test_case.add_input<float>(Shape{2, 1, 3}, input_X);
+    test_case.add_input<int8_t>(Shape{1, 3, 8}, input_W);
+    test_case.add_input<int8_t>(Shape{1, 2, 8}, input_R);
+    test_case.add_input<float>(Shape{1, 16}, input_B);
+    test_case.add_input<int32_t>(Shape{1}, input_sequence_lens);
+    test_case.add_input<float>(Shape{1, 1, 2}, input_initial_h);
+    test_case.add_input<float>(Shape{1, 1, 2}, input_initial_c);
+    test_case.add_input<float>(Shape{1}, input_W_scale);
+    test_case.add_input<int8_t>(Shape{1}, input_W_zero_point);
+    test_case.add_input<float>(Shape{1}, input_R_scale);
+    test_case.add_input<int8_t>(Shape{1}, input_R_zero_point);
+
+    test_case.add_expected_output<float>(Shape{2, 1, 1, 2}, expected_Y);
+    test_case.add_expected_output<float>(Shape{1, 1, 2}, expected_Y_h);
+    test_case.add_expected_output<float>(Shape{1, 1, 2}, expected_Y_c);
+
+    test_case.run_with_tolerance_as_fp(1e-6f);
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_skip_simplified_layer_normalization) {
     const auto model = convert_model("com.microsoft/skip_simplified_layer_normalization.onnx");
     auto test_case = ov::test::TestCase(model, s_device);

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -2545,45 +2545,75 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_dynamic_quantize_matmul_null_b
     test_case.run_with_tolerance_as_fp(0.0055f);
 }
 
-OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_dynamic_quantize_lstm) {
+// Shared inputs used by both DynamicQuantizeLSTM tests.
+// Expected values are from ONNX Runtime (ORT uses dynamic activation quantization with integer
+// matmuls; our translator uses weight-only dequantization, so results differ by ~1.5e-3).
+static const std::vector<float> dql_input_X{0.25f, -0.5f, 1.0f, 1.5f, 0.75f, -1.25f};
+static const std::vector<float> dql_input_B{0.1f,
+                                            -0.2f,
+                                            0.05f,
+                                            0.3f,
+                                            -0.4f,
+                                            0.2f,
+                                            0.15f,
+                                            -0.25f,
+                                            -0.05f,
+                                            0.12f,
+                                            -0.18f,
+                                            0.22f,
+                                            -0.08f,
+                                            0.09f,
+                                            -0.11f,
+                                            0.07f};
+static const std::vector<int32_t> dql_input_sequence_lens{2};
+static const std::vector<float> dql_input_initial_h{0.2f, -0.1f};
+static const std::vector<float> dql_input_initial_c{0.05f, 0.15f};
+static const std::vector<float> dql_expected_Y{0.11440717f, -0.06565752f, -0.00265372f, -0.20275351f};
+static const std::vector<float> dql_expected_Y_h{-0.00265372f, -0.20275351f};
+static const std::vector<float> dql_expected_Y_c{-0.00976340f, -0.24270093f};
+
+// W/R/scale are runtime inputs: align_dequant_param uses Unsqueeze nodes (LPT does not fire).
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_dynamic_quantize_lstm_runtime_inputs) {
     const auto model = convert_model("com.microsoft/dynamic_quantize_lstm.onnx");
     auto test_case = ov::test::TestCase(model, s_device);
 
-    const std::vector<float> input_X{0.25f, -0.5f, 1.0f, 1.5f, 0.75f, -1.25f};
-    const std::vector<int8_t> input_W{12, -7, 5, 9, -11, 3, 4, -6, 8, 13, -9, 2, 7, -5, 10, 1, -4, 6, 14, -8, 12,
-                                      -10, 11, -3};
-    const std::vector<int8_t> input_R{5, -3, 4, 7, -6, 2, 1, -4, 9, 8, -5, 3, 6, -7, 10, -2};
-    const std::vector<float> input_B{0.1f,  -0.2f,  0.05f, 0.3f,  -0.4f, 0.2f,  0.15f, -0.25f,
-                                     -0.05f, 0.12f, -0.18f, 0.22f, -0.08f, 0.09f, -0.11f, 0.07f};
-    const std::vector<int32_t> input_sequence_lens{2};
-    const std::vector<float> input_initial_h{0.2f, -0.1f};
-    const std::vector<float> input_initial_c{0.05f, 0.15f};
-    const std::vector<float> input_W_scale{0.05f};
-    const std::vector<int8_t> input_W_zero_point{1};
-    const std::vector<float> input_R_scale{0.04f};
-    const std::vector<int8_t> input_R_zero_point{-2};
+    test_case.add_input<float>(Shape{2, 1, 3}, dql_input_X);
+    test_case.add_input<int8_t>(Shape{1, 3, 8}, {12, -7, 5,  9, -11, 3, 4,  -6, 8,  13,  -9, 2,
+                                                 7,  -5, 10, 1, -4,  6, 14, -8, 12, -10, 11, -3});
+    test_case.add_input<int8_t>(Shape{1, 2, 8}, {5, -3, 4, 7, -6, 2, 1, -4, 9, 8, -5, 3, 6, -7, 10, -2});
+    test_case.add_input<float>(Shape{1, 16}, dql_input_B);
+    test_case.add_input<int32_t>(Shape{1}, dql_input_sequence_lens);
+    test_case.add_input<float>(Shape{1, 1, 2}, dql_input_initial_h);
+    test_case.add_input<float>(Shape{1, 1, 2}, dql_input_initial_c);
+    test_case.add_input<float>(Shape{1}, {0.05f});
+    test_case.add_input<int8_t>(Shape{1}, {1});
+    test_case.add_input<float>(Shape{1}, {0.04f});
+    test_case.add_input<int8_t>(Shape{1}, {-2});
 
-    const std::vector<float> expected_Y{0.11440717f, -0.06565752f, -0.00265372f, -0.20275351f};
-    const std::vector<float> expected_Y_h{-0.00265372f, -0.20275351f};
-    const std::vector<float> expected_Y_c{-0.00976340f, -0.24270093f};
+    test_case.add_expected_output<float>(Shape{2, 1, 1, 2}, dql_expected_Y);
+    test_case.add_expected_output<float>(Shape{1, 1, 2}, dql_expected_Y_h);
+    test_case.add_expected_output<float>(Shape{1, 1, 2}, dql_expected_Y_c);
 
-    test_case.add_input<float>(Shape{2, 1, 3}, input_X);
-    test_case.add_input<int8_t>(Shape{1, 3, 8}, input_W);
-    test_case.add_input<int8_t>(Shape{1, 2, 8}, input_R);
-    test_case.add_input<float>(Shape{1, 16}, input_B);
-    test_case.add_input<int32_t>(Shape{1}, input_sequence_lens);
-    test_case.add_input<float>(Shape{1, 1, 2}, input_initial_h);
-    test_case.add_input<float>(Shape{1, 1, 2}, input_initial_c);
-    test_case.add_input<float>(Shape{1}, input_W_scale);
-    test_case.add_input<int8_t>(Shape{1}, input_W_zero_point);
-    test_case.add_input<float>(Shape{1}, input_R_scale);
-    test_case.add_input<int8_t>(Shape{1}, input_R_zero_point);
+    test_case.run_with_tolerance_as_fp(0.0055f);
+}
 
-    test_case.add_expected_output<float>(Shape{2, 1, 1, 2}, expected_Y);
-    test_case.add_expected_output<float>(Shape{1, 1, 2}, expected_Y_h);
-    test_case.add_expected_output<float>(Shape{1, 1, 2}, expected_Y_c);
+// W/R/scale are graph Constants: align_dequant_param reshapes the Constant directly (no graph
+// node inserted), MarkDequantization matches, and the CPU quantized kernel fires.
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_dynamic_quantize_lstm_const_weights) {
+    const auto model = convert_model("com.microsoft/dynamic_quantize_lstm_const_weights.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
 
-    test_case.run_with_tolerance_as_fp(1e-6f);
+    test_case.add_input<float>(Shape{2, 1, 3}, dql_input_X);
+    test_case.add_input<float>(Shape{1, 16}, dql_input_B);
+    test_case.add_input<int32_t>(Shape{1}, dql_input_sequence_lens);
+    test_case.add_input<float>(Shape{1, 1, 2}, dql_input_initial_h);
+    test_case.add_input<float>(Shape{1, 1, 2}, dql_input_initial_c);
+
+    test_case.add_expected_output<float>(Shape{2, 1, 1, 2}, dql_expected_Y);
+    test_case.add_expected_output<float>(Shape{1, 1, 2}, dql_expected_Y_h);
+    test_case.add_expected_output<float>(Shape{1, 1, 2}, dql_expected_Y_c);
+
+    test_case.run_with_tolerance_as_fp(0.0055f);
 }
 
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_skip_simplified_layer_normalization) {


### PR DESCRIPTION
### Details:
 - *Adds com.microsoft::DynamicQuantizeLSTM (opset 1) translator to the ONNX Frontend*
 - *Dequantizes W/R using ov::decomposition::low_precision_dequantize so MarkDequantization can fire and the CPU/GPU quantized kernel runs when weights are graph constants*
 - *Rejects unsupported peephole input P with a clear error; adds a TODO to support it via LSTMCell unrolling*
 - *Extracts shared recurrent utilities (normalize_tensor_rank, LSTMDimensions, default optional-input helpers) into utils/recurrent.hpp/.cpp, used by both the new translator and lstm.cpp*
 - *Adds two tests: runtime-input variant (Unsqueeze alignment path) and graph-constant variant (MarkDequantization path)*
 - *Updates add-fe-op/onnx.md agent skill with lessons from this implementation*

### Tickets:
 - *CVS-183376*

### AI Assistance:
 - *AI assistance used: yes*
 - *Claude reviewed PR #35680 (original DynamicQuantizeLSTM implementation), identified correctness gaps and duplication, implemented fixes and refactoring.*
