### PR TITLE
[NPUW][MoE] Fix missing MoE runtime behavior attachment on cache import

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -912,6 +912,16 @@ void ov::npuw::CompiledModel::CompiledModelDesc::serialize(ov::npuw::s11n::Strea
                                                         ov::npuw::attn::BehaviorKind::Pyramid);
             } else if (ov::npuw::attn::get_compiled_hfa(pipeline.context) != nullptr) {
                 ov::npuw::attn::attach_runtime_behavior(pipeline, pipeline.context, ov::npuw::attn::BehaviorKind::HFA);
+            } else if (ov::npuw::moe::get_compiled_experts(pipeline.context) != nullptr) {
+                ov::npuw::moe::attach_runtime_behavior(pipeline,
+                                                       pipeline.context,
+                                                       ov::npuw::moe::BehaviorRole::EXPERTS,
+                                                       true);
+            } else if (ov::npuw::moe::get_compiled_downstream(pipeline.context) != nullptr) {
+                ov::npuw::moe::attach_runtime_behavior(pipeline,
+                                                       pipeline.context,
+                                                       ov::npuw::moe::BehaviorRole::DOWNSTREAM,
+                                                       true);
             }
         }
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/moe/moe_subgraph.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/moe/moe_subgraph.cpp
@@ -59,20 +59,24 @@ ov::npuw::v1::subgraphs::RuntimeBehaviorFactory make_runtime_factory() {
     };
 }
 
-void attach_runtime_behavior(ov::npuw::v1::subgraphs::CompiledPipeline& compiled_pipeline,
-                             ov::npuw::v1::subgraphs::Context& compiled_context,
+}  // namespace
+
+void attach_runtime_behavior(v1::subgraphs::CompiledPipeline& compiled_pipeline,
+                             v1::subgraphs::Context& compiled_context,
                              const BehaviorRole role,
                              const bool handles_function_prologue) {
     compiled_context.put<BehaviorRole>(role);
     compiled_pipeline.registration.group = ov::npuw::patterns::moe::GPTOSSExpert::group_name();
     compiled_pipeline.registration.name = behavior_name(role);
-    ov::npuw::v1::subgraphs::RuntimeBehaviorSpec spec;
+    v1::subgraphs::RuntimeBehaviorSpec spec;
     spec.registration = compiled_pipeline.registration;
     spec.context = compiled_context;
     spec.factory = make_runtime_factory();
     spec.handles_function_prologue = handles_function_prologue;
     compiled_pipeline.runtime_behavior = std::move(spec);
 }
+
+namespace {
 
 template <typename T>
 T* get_compiled_state(ov::npuw::v1::subgraphs::Context& context) {

--- a/src/plugins/intel_npu/src/plugin/npuw/moe/moe_subgraph.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/moe/moe_subgraph.hpp
@@ -53,6 +53,11 @@ void serialize_compiled_state(v1::subgraphs::Context& context,
                               ov::npuw::s11n::Stream& stream,
                               const ov::npuw::s11n::SubmodelDeserializeCtx* submodel_ctx);
 
+void attach_runtime_behavior(v1::subgraphs::CompiledPipeline& pipeline,
+                             v1::subgraphs::Context& context,
+                             BehaviorRole role,
+                             bool handles_function_prologue);
+
 std::vector<ov::npuw::v1::subgraphs::ScopedPatternRegistration> register_patterns(
     ov::npuw::v1::subgraphs::PatternRegistry& registry,
     std::size_t moe_chunk_size);


### PR DESCRIPTION
### Details:
When loading a compiled MoE model from blob cache, serialize_compiled_state() restores the MoEExperts/MoEDownstream objects but attach_runtime_behavior() was never called on the import path.
This left pipeline.runtime_behavior unset, causing the subgraph to fall back to default (non-MoE) execution and produce incorrect results on every second run.

Fixed by:
Expose attach_runtime_behavior() in moe_subgraph as a public API and call it directly from compiled_model.cpp after moe::serialize_compiled_state() on the read path, mirroring the existing pattern used by the attention subsystem.

Validate in:
https://cje-ir-prod01.devtools.intel.com/sai-npu-experience/job/Staging/job/xiong/job/Validate/42/

### Tickets:
 - *[EISW-220018](https://jira.devtools.intel.com/browse/EISW-220018)*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
