### PR TITLE
[GPU] Fix compilation failure for uncompressed (FP16) MoE models

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <vector>
+
+#include "openvino/core/type/element_type.hpp"
 #include "openvino/pass/graph_rewrite.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "transformations_visibility.hpp"
@@ -87,7 +90,11 @@ class TRANSFORMATIONS_API ConvertTiledMoeBlockToGatherMatmuls;
 class ov::pass::ConvertTiledMoeBlockTo2GatherMatmuls : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("ConvertTiledMoeBlockTo2GatherMatmuls");
-    ConvertTiledMoeBlockTo2GatherMatmuls();
+    // supported_weights_types (when non-empty) restricts the match to expert blocks whose
+    // weight source constant has one of the listed element types — used by consumers with
+    // a compressed-only GatherMatmul backend (e.g. the GPU plugin) to leave dense Tile/MatMul
+    // blocks unchanged. An empty list (default) accepts any weight type.
+    ConvertTiledMoeBlockTo2GatherMatmuls(const std::vector<ov::element::Type>& supported_weights_types = {});
 };
 
 // ============================================================================
@@ -147,15 +154,15 @@ public:
 class ov::pass::ConvertTiledMoeBlockTo3GatherMatmuls : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("ConvertTiledMoeBlockTo3GatherMatmuls");
-    ConvertTiledMoeBlockTo3GatherMatmuls();
+    ConvertTiledMoeBlockTo3GatherMatmuls(const std::vector<ov::element::Type>& supported_weights_types = {});
 };
 
 // CPU uses BGM-producing passes only (stops at BGMs)
 class ov::pass::ConvertTiledMoeBlockToGatherMatmuls : public ov::pass::GraphRewrite {
 public:
     OPENVINO_GRAPH_REWRITE_RTTI("ConvertTiledMoeBlockToGatherMatmuls");
-    ConvertTiledMoeBlockToGatherMatmuls() {
-        add_matcher<ov::pass::ConvertTiledMoeBlockTo2GatherMatmuls>();
-        add_matcher<ov::pass::ConvertTiledMoeBlockTo3GatherMatmuls>();
+    explicit ConvertTiledMoeBlockToGatherMatmuls(const std::vector<ov::element::Type>& supported_weights_types = {}) {
+        add_matcher<ov::pass::ConvertTiledMoeBlockTo2GatherMatmuls>(supported_weights_types);
+        add_matcher<ov::pass::ConvertTiledMoeBlockTo3GatherMatmuls>(supported_weights_types);
     }
 };

--- a/src/common/transformations/include/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.hpp
@@ -90,10 +90,6 @@ class TRANSFORMATIONS_API ConvertTiledMoeBlockToGatherMatmuls;
 class ov::pass::ConvertTiledMoeBlockTo2GatherMatmuls : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("ConvertTiledMoeBlockTo2GatherMatmuls");
-    // supported_weights_types (when non-empty) restricts the match to expert blocks whose
-    // weight source constant has one of the listed element types — used by consumers with
-    // a compressed-only GatherMatmul backend (e.g. the GPU plugin) to leave dense Tile/MatMul
-    // blocks unchanged. An empty list (default) accepts any weight type.
     ConvertTiledMoeBlockTo2GatherMatmuls(const std::vector<ov::element::Type>& supported_weights_types = {});
 };
 

--- a/src/common/transformations/src/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.cpp
@@ -4,10 +4,7 @@
 
 #include "transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.hpp"
 
-#include <algorithm>
 #include <initializer_list>
-#include <utility>
-#include <vector>
 
 #include "itt.hpp"
 #include "openvino/core/graph_util.hpp"
@@ -31,6 +28,7 @@
 #include "openvino/pass/pattern/op/optional.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "ov_ops/gather_matmul.hpp"
+#include "transformations/pattern_blocks/compressed_weights_block.hpp"
 
 namespace {
 using namespace ov::pass;
@@ -51,42 +49,12 @@ void validate_nodes(const pattern::PatternValueMap& map, const std::initializer_
     }
 };
 
-// True if every weight has a source constant in `supported_types` somewhere in its producer
-// subgraph. Walking up is robust to the dequantization shape (Convert/Subtract/Multiply/
-// Reshape/Transpose) — the weight node itself is already up-converted to f16/f32 and
-// would not reveal compression.
-bool weights_match_supported_types(const std::initializer_list<ov::Output<ov::Node>> weights,
-                                   const std::vector<ov::element::Type>& supported_types) {
-    if (supported_types.empty()) {
-        return true;
+// Build a per-expert MatMul weight pattern
+std::shared_ptr<ov::Node> make_expert_weight_pattern(const std::vector<ov::element::Type>& supported_weights_types) {
+    if (supported_weights_types.empty()) {
+        return pattern::any_input();
     }
-    auto is_supported = [&](const ov::element::Type& t) {
-        return std::find(supported_types.begin(), supported_types.end(), t) != supported_types.end();
-    };
-    // Dequantization chains are short; bound the walk to avoid cycles.
-    constexpr size_t max_depth = 8;
-    for (const auto& weight : weights) {
-        std::vector<std::pair<const ov::Node*, size_t>> stack = {{weight.get_node(), 0}};
-        bool found = false;
-        while (!stack.empty()) {
-            const auto [node, depth] = stack.back();
-            stack.pop_back();
-            if (is_supported(node->get_output_element_type(0))) {
-                found = true;
-                break;
-            }
-            if (depth >= max_depth) {
-                continue;
-            }
-            for (size_t i = 0; i < node->get_input_size(); ++i) {
-                stack.push_back({node->get_input_node_ptr(i), depth + 1});
-            }
-        }
-        if (!found) {
-            return false;
-        }
-    }
-    return true;
+    return std::make_shared<pattern::op::CompressedWeightsBlock>(supported_weights_types, std::set<size_t>{3});
 }
 
 std::shared_ptr<ov::op::v0::Unsqueeze> introduce_n_experts_dim(const ov::Output<ov::Node>& data) {
@@ -109,14 +77,14 @@ struct MOE2GEMMPatternNodes {
     std::shared_ptr<ov::Node> mul3, reduce_sum;
 };
 
-MOE2GEMMPatternNodes build_2gemm_pattern() {
+MOE2GEMMPatternNodes build_2gemm_pattern(const std::vector<ov::element::Type>& supported_weights_types) {
     MOE2GEMMPatternNodes p;
 
     p.experts_input = pattern::wrap_type<v1::Reshape>({pattern::any_input(), pattern::any_input()});
     p.tile = pattern::wrap_type<v0::Tile>({p.experts_input, pattern::any_input()}, pattern::consumers_count(1));
     p.after_tile_reshape = pattern::wrap_type<v1::Reshape>({p.tile, pattern::any_input()}, pattern::consumers_count(1));
     p.gate_up_matmul = pattern::wrap_type<v0::MatMul>(
-        {p.after_tile_reshape, pattern::any_input()},
+        {p.after_tile_reshape, make_expert_weight_pattern(supported_weights_types)},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
     p.gate_up_bias = pattern::wrap_const();
     p.gate_up_add = pattern::wrap_type<v1::Add>({p.gate_up_matmul, p.gate_up_bias}, pattern::consumers_count(2));
@@ -141,7 +109,7 @@ MOE2GEMMPatternNodes build_2gemm_pattern() {
 
     // Down projection
     p.down_proj_matmul = pattern::wrap_type<v0::MatMul>(
-        {p.multiply2, pattern::any_input()},
+        {p.multiply2, make_expert_weight_pattern(supported_weights_types)},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
     p.down_proj_bias = pattern::wrap_const();
     p.down_proj_add = pattern::wrap_type<v1::Add>({p.down_proj_matmul, p.down_proj_bias}, pattern::consumers_count(1));
@@ -177,7 +145,7 @@ struct MOE3GEMMPatternNodes {
     std::shared_ptr<ov::Node> mul3, reduce_sum;
 };
 
-MOE3GEMMPatternNodes build_3gemm_pattern() {
+MOE3GEMMPatternNodes build_3gemm_pattern(const std::vector<ov::element::Type>& supported_weights_types) {
     MOE3GEMMPatternNodes p;
 
     p.experts_input = pattern::any_input();
@@ -186,19 +154,19 @@ MOE3GEMMPatternNodes build_3gemm_pattern() {
 
     // First GEMM (activation gate)
     p.gate_matmul = pattern::wrap_type<v0::MatMul>(
-        {p.after_tile_reshape, pattern::any_input()},
+        {p.after_tile_reshape, make_expert_weight_pattern(supported_weights_types)},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
     p.swish = pattern::wrap_type<v4::Swish, v7::Gelu>({p.gate_matmul}, pattern::consumers_count(1));
     // Second GEMM (up_projection)
     p.up_matmul = pattern::wrap_type<v0::MatMul>(
-        {p.after_tile_reshape, pattern::any_input()},
+        {p.after_tile_reshape, make_expert_weight_pattern(supported_weights_types)},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
     // Join: Multiply (SwiGLU)
     p.swiglu = pattern::wrap_type<v1::Multiply>({p.swish, p.up_matmul}, pattern::consumers_count(1));
 
     // Third GEMM (down_projection)
     p.down_matmul = pattern::wrap_type<v0::MatMul>(
-        {p.swiglu, pattern::any_input()},
+        {p.swiglu, make_expert_weight_pattern(supported_weights_types)},
         pattern::consumers_count(1) && pattern::attrs_match({{"transpose_a", false}, {"transpose_b", true}}));
     p.end_reshape_target_shape = pattern::any_input();
     p.end_reshape =
@@ -235,7 +203,7 @@ ConvertTiledMoeBlockTo2GatherMatmuls::ConvertTiledMoeBlockTo2GatherMatmuls(
     const std::vector<ov::element::Type>& supported_weights_types) {
     MATCHER_SCOPE(ConvertTiledMoeBlockTo2GatherMatmuls);
 
-    auto p = build_2gemm_pattern();
+    auto p = build_2gemm_pattern(supported_weights_types);
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto& pm = m.get_pattern_value_map();
@@ -250,12 +218,6 @@ ConvertTiledMoeBlockTo2GatherMatmuls::ConvertTiledMoeBlockTo2GatherMatmuls(
         const auto gate_up_mm_node = pm.at(p.gate_up_matmul).get_node_shared_ptr();
         const auto gate_up_add_node = pm.at(p.gate_up_add).get_node_shared_ptr();
         const auto gate_up_bias_node = pm.at(p.gate_up_bias).get_node_shared_ptr();
-
-        const auto down_proj_mm_for_check = pm.at(p.down_proj_matmul).get_node_shared_ptr();
-        if (!weights_match_supported_types({gate_up_mm_node->input_value(1), down_proj_mm_for_check->input_value(1)},
-                                           supported_weights_types)) {
-            return false;
-        }
 
         // GatherMatmul A shape: [n_activated_experts, batch_size * seq_length, hidden_size]
         // Number of activated experts is always 1 for the first GatherMatmul
@@ -333,7 +295,7 @@ ConvertTiledMoeBlockTo3GatherMatmuls::ConvertTiledMoeBlockTo3GatherMatmuls(
     const std::vector<ov::element::Type>& supported_weights_types) {
     MATCHER_SCOPE(ConvertTiledMoeBlockTo3GatherMatmuls);
 
-    auto p = build_3gemm_pattern();
+    auto p = build_3gemm_pattern(supported_weights_types);
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto& pm = m.get_pattern_value_map();
@@ -348,13 +310,6 @@ ConvertTiledMoeBlockTo3GatherMatmuls::ConvertTiledMoeBlockTo3GatherMatmuls(
         const auto gate_mm_node = pm.at(p.gate_matmul).get_node_shared_ptr();
         const auto up_mm_node = pm.at(p.up_matmul).get_node_shared_ptr();
         const auto down_mm_node = pm.at(p.down_matmul).get_node_shared_ptr();
-
-        if (!weights_match_supported_types({gate_mm_node->input_value(1),
-                                            up_mm_node->input_value(1),
-                                            down_mm_node->input_value(1)},
-                                           supported_weights_types)) {
-            return false;
-        }
 
         // GatherMatmul A shape: [n_activated_experts, batch_size * seq_length, hidden_size]
         // Number of activated experts is always 1 for the first GatherMatmul

--- a/src/common/transformations/src/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.cpp
@@ -4,7 +4,10 @@
 
 #include "transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.hpp"
 
+#include <algorithm>
 #include <initializer_list>
+#include <utility>
+#include <vector>
 
 #include "itt.hpp"
 #include "openvino/core/graph_util.hpp"
@@ -47,6 +50,44 @@ void validate_nodes(const pattern::PatternValueMap& map, const std::initializer_
         map.at(node).get_node_shared_ptr()->validate_and_infer_types();
     }
 };
+
+// True if every weight has a source constant in `supported_types` somewhere in its producer
+// subgraph. Walking up is robust to the dequantization shape (Convert/Subtract/Multiply/
+// Reshape/Transpose) — the weight node itself is already up-converted to f16/f32 and
+// would not reveal compression.
+bool weights_match_supported_types(const std::initializer_list<ov::Output<ov::Node>> weights,
+                                   const std::vector<ov::element::Type>& supported_types) {
+    if (supported_types.empty()) {
+        return true;
+    }
+    auto is_supported = [&](const ov::element::Type& t) {
+        return std::find(supported_types.begin(), supported_types.end(), t) != supported_types.end();
+    };
+    // Dequantization chains are short; bound the walk to avoid cycles.
+    constexpr size_t max_depth = 8;
+    for (const auto& weight : weights) {
+        std::vector<std::pair<const ov::Node*, size_t>> stack = {{weight.get_node(), 0}};
+        bool found = false;
+        while (!stack.empty()) {
+            const auto [node, depth] = stack.back();
+            stack.pop_back();
+            if (is_supported(node->get_output_element_type(0))) {
+                found = true;
+                break;
+            }
+            if (depth >= max_depth) {
+                continue;
+            }
+            for (size_t i = 0; i < node->get_input_size(); ++i) {
+                stack.push_back({node->get_input_node_ptr(i), depth + 1});
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
 
 std::shared_ptr<ov::op::v0::Unsqueeze> introduce_n_experts_dim(const ov::Output<ov::Node>& data) {
     auto zero_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, 0);
@@ -190,7 +231,8 @@ using ov::op::internal::GatherMatmul;
 // BGM-producing passes (IR → GatherMatmul)
 // ============================================================================
 
-ConvertTiledMoeBlockTo2GatherMatmuls::ConvertTiledMoeBlockTo2GatherMatmuls() {
+ConvertTiledMoeBlockTo2GatherMatmuls::ConvertTiledMoeBlockTo2GatherMatmuls(
+    const std::vector<ov::element::Type>& supported_weights_types) {
     MATCHER_SCOPE(ConvertTiledMoeBlockTo2GatherMatmuls);
 
     auto p = build_2gemm_pattern();
@@ -208,6 +250,12 @@ ConvertTiledMoeBlockTo2GatherMatmuls::ConvertTiledMoeBlockTo2GatherMatmuls() {
         const auto gate_up_mm_node = pm.at(p.gate_up_matmul).get_node_shared_ptr();
         const auto gate_up_add_node = pm.at(p.gate_up_add).get_node_shared_ptr();
         const auto gate_up_bias_node = pm.at(p.gate_up_bias).get_node_shared_ptr();
+
+        const auto down_proj_mm_for_check = pm.at(p.down_proj_matmul).get_node_shared_ptr();
+        if (!weights_match_supported_types({gate_up_mm_node->input_value(1), down_proj_mm_for_check->input_value(1)},
+                                           supported_weights_types)) {
+            return false;
+        }
 
         // GatherMatmul A shape: [n_activated_experts, batch_size * seq_length, hidden_size]
         // Number of activated experts is always 1 for the first GatherMatmul
@@ -281,7 +329,8 @@ ConvertTiledMoeBlockTo2GatherMatmuls::ConvertTiledMoeBlockTo2GatherMatmuls() {
     this->register_matcher(matcher, callback);
 }
 
-ConvertTiledMoeBlockTo3GatherMatmuls::ConvertTiledMoeBlockTo3GatherMatmuls() {
+ConvertTiledMoeBlockTo3GatherMatmuls::ConvertTiledMoeBlockTo3GatherMatmuls(
+    const std::vector<ov::element::Type>& supported_weights_types) {
     MATCHER_SCOPE(ConvertTiledMoeBlockTo3GatherMatmuls);
 
     auto p = build_3gemm_pattern();
@@ -299,6 +348,13 @@ ConvertTiledMoeBlockTo3GatherMatmuls::ConvertTiledMoeBlockTo3GatherMatmuls() {
         const auto gate_mm_node = pm.at(p.gate_matmul).get_node_shared_ptr();
         const auto up_mm_node = pm.at(p.up_matmul).get_node_shared_ptr();
         const auto down_mm_node = pm.at(p.down_matmul).get_node_shared_ptr();
+
+        if (!weights_match_supported_types({gate_mm_node->input_value(1),
+                                            up_mm_node->input_value(1),
+                                            down_mm_node->input_value(1)},
+                                           supported_weights_types)) {
+            return false;
+        }
 
         // GatherMatmul A shape: [n_activated_experts, batch_size * seq_length, hidden_size]
         // Number of activated experts is always 1 for the first GatherMatmul

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -573,14 +573,18 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         // Gated on supports_immad (systolic-only) and oneDNN (required for expert GEMM dispatch).
         // Note: even though we are already inside `if (supports_immad)`, oneDNN can still be explicitly disabled by the user.
         if (device_info.supports_immad && config.get_use_onednn()) {
-            manager.register_pass<ov::pass::ConvertTiledMoeBlockToGatherMatmuls>();
+            const std::vector<ov::element::Type> supported_compressed_weights_types{ov::element::u4,
+                                                                                    ov::element::i4,
+                                                                                    ov::element::i8,
+                                                                                    ov::element::u8};
+            // The chain has no GPU backend for uncompressed (FP16) experts; leave them as dense Tile/MatMul.
+            manager.register_pass<ov::pass::ConvertTiledMoeBlockToGatherMatmuls>(supported_compressed_weights_types);
 
             // f32 listed because this pass runs before ConvertPrecision (line ~588);
             // f32 activations are lowered to f16 before reaching the f16-only DPAS kernels.
             manager.register_pass<ov::pass::ConvertGatherMatmulToGatherMatmulCompressed>(
                 std::vector<ov::element::Type>{ov::element::f32, ov::element::f16},
-                std::vector<ov::element::Type>{ov::element::u4, ov::element::i4,
-                                               ov::element::i8, ov::element::u8});
+                supported_compressed_weights_types);
             manager.register_pass<ov::intel_gpu::FuseMoERouter>();
 
             if (!disable_moe_opt) {

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -577,7 +577,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                                                                                     ov::element::i4,
                                                                                     ov::element::i8,
                                                                                     ov::element::u8};
-            // The chain has no GPU backend for uncompressed (FP16) experts; leave them as dense Tile/MatMul.
             manager.register_pass<ov::pass::ConvertTiledMoeBlockToGatherMatmuls>(supported_compressed_weights_types);
 
             // f32 listed because this pass runs before ConvertPrecision (line ~588);

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/moe.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/moe.cpp
@@ -50,12 +50,13 @@ using MoECompressedParams = std::tuple<MoeTestShapeParams,
                                        bool,                                // force_gather_matmul
                                        MoEActivationType,                   // gate activation type (GEMM3 only)
                                        bool,                                // use_per_expert_scale (GEMM3+SOFTMAX only)
-                                       bool>;                               // use_layernorm_multiply (gemma4 pattern)
+                                       bool,                                // use_layernorm_multiply (gemma4 pattern)
+                                       bool>;                               // use_weight_decompression (false = uncompressed FP16)
 
 class MoECompressedFusionTest : public testing::WithParamInterface<MoECompressedParams>, virtual public ov::test::SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MoECompressedParams>& info) {
-        const auto& [moe_params, pattern_type, routing_type, wp, dp, sp, dm, ds, rd, gs, gi, fgm, act, pes, lnm] = info.param;
+        const auto& [moe_params, pattern_type, routing_type, wp, dp, sp, dm, ds, rd, gs, gi, fgm, act, pes, lnm, uwd] = info.param;
         std::ostringstream result;
         result << "IS=" << ov::test::utils::partialShape2str({moe_params.data_shape.first}) << "_";
         result << "TS=";
@@ -77,13 +78,14 @@ public:
         result << "FGM=" << fgm << "_";
         result << "act=" << (act == MoEActivationType::GELU ? "GELU" : act == MoEActivationType::GELU_ERF ? "GELU_ERF" : "SWISH") << "_";
         result << "PES=" << pes << "_";
-        result << "LNM=" << lnm;
+        result << "LNM=" << lnm << "_";
+        result << "UWD=" << uwd;
         return result.str();
     }
 
 protected:
     void SetUp() override {
-        const auto& [moe_params, pattern_type, routing_type, wp, dp, sp, dm, ds, rd, gs, gi, fgm, act, pes, lnm] = GetParam();
+        const auto& [moe_params, pattern_type, routing_type, wp, dp, sp, dm, ds, rd, gs, gi, fgm, act, pes, lnm, uwd] = GetParam();
         if (fgm) {
             set_disable_moe_opt();
         }
@@ -109,7 +111,7 @@ protected:
             function = ov::test::initMoE3GeMMSubgraph(shape_params,
                                                       ov::element::f32,  // data_precision
                                                       wp,                // weights_precision
-                                                      true,              // use_weight_decompression
+                                                      uwd,               // use_weight_decompression
                                                       dp,                // decompression_precision
                                                       sp,                // scale_precision
                                                       dm,                // decompression_multiply_type
@@ -127,7 +129,7 @@ protected:
             function = ov::test::initMoE2GeMMSubgraph(shape_params,
                                                       ov::element::f32,  // data_precision
                                                       wp,                // weights_precision
-                                                      true,              // use_weight_decompression
+                                                      uwd,               // use_weight_decompression
                                                       dp,                // decompression_precision
                                                       sp,                // scale_precision
                                                       dm,                // decompression_multiply_type
@@ -143,11 +145,14 @@ protected:
         const auto& params = function->get_parameters();
         ASSERT_EQ(params.size(), 1);
         // RMSNorm output ≈ N(0,1); needed to exercise swish/SwiGLU on negative inputs.
+        // Uncompressed experts (see moe_params_smoke_uncompressed) use a smaller input to
+        // keep the gate/up/down accumulations within the f16 range.
+        const float stddev = std::get<15>(GetParam()) ? 1.0f : 0.05f;
         inputs.insert({params[0],
                        ov::test::utils::create_and_fill_tensor_normal_distribution(params[0]->get_element_type(),
                                                                                    target_input_static_shapes[0],
                                                                                    /*mean=*/0.0f,
-                                                                                   /*stddev=*/1.0f,
+                                                                                   stddev,
                                                                                    /*seed=*/1234)});
     }
 
@@ -157,6 +162,14 @@ protected:
         const auto force_gather_matmul = std::get<11>(GetParam());
         const auto use_per_expert_scale = std::get<13>(GetParam());
         const auto layer_norm_mul = std::get<14>(GetParam());
+        const auto use_weight_decompression = std::get<15>(GetParam());
+        if (!use_weight_decompression) {
+            // Uncompressed experts: the compressed-only expert chain is rejected, so the
+            // dense Tile/MatMul ops run natively. moe_router_fused is independent and may still run.
+            ov::test::CheckNumberOfNodesWithType(compiledModel, "moe_3gemm_fused_compressed", 0);
+            ov::test::CheckNumberOfNodesWithType(compiledModel, "gather_matmul", 0);
+            return;
+        }
         if (force_gather_matmul) {
             // GEMM3: gate, up, down → 3 GatherMatmul ops; GEMM2: fused gate_up + down → 2.
             ov::test::CheckNumberOfNodesWithType(compiledModel, "gather_matmul", pattern_type == MoePatternType::GEMM3 ? 3 : 2);
@@ -240,6 +253,17 @@ const std::vector<MoeTestShapeParams> moe_params_smoke = {
     },
 };
 
+// Uncompressed experts use raw f16 weights with no dequantization scaling, so the
+// gate/up/down accumulations overflow f16 unless hidden/intermediate are kept small.
+const std::vector<MoeTestShapeParams> moe_params_smoke_uncompressed = {
+    {
+        {{-1, -1, 64}, {{1, 8, 64}, {1, 1, 64}, {1, 4, 64}}},  // seq_len=dynamic, hidden_size=64
+        2,                                                     // topk
+        4,                                                     // number_of_experts
+        64                                                     // intermediate_size
+    },
+};
+
 // Compressed weights — full GatherMatmul → MOECompressed → FuseMoERouter pipeline.
 const std::vector<ov::element::Type> weights_precisions = {
     ov::element::u8,
@@ -266,7 +290,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MoE3GemmCompressedFusion,
                                             ::testing::Values(false),      // force_gather_matmul
                                             ::testing::Values(MoEActivationType::SWISH),
                                             ::testing::Values(false),   // use_per_expert_scale
-                                            ::testing::Values(false)),  // use_layernorm_multiply
+                                            ::testing::Values(false),   // use_layernorm_multiply
+                                            ::testing::Values(true)),   // use_weight_decompression
                          MoECompressedFusionTest::getTestCaseName);
 
 // GPT-OSS 2-GEMM pattern (combined gate/up MatMul + Slice/Clamp/Add/Swish).
@@ -287,7 +312,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MoE2GemmCompressedFusion,
                                             ::testing::Values(false),  // force_gather_matmul
                                             ::testing::Values(MoEActivationType::SWISH),
                                             ::testing::Values(false),   // use_per_expert_scale
-                                            ::testing::Values(false)),  // use_layernorm_multiply
+                                            ::testing::Values(false),   // use_layernorm_multiply
+                                            ::testing::Values(true)),   // use_weight_decompression
                          MoECompressedFusionTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_MoEGatherMatmul,
@@ -306,7 +332,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MoEGatherMatmul,
                                             ::testing::Values(true),       // force_gather_matmul
                                             ::testing::Values(MoEActivationType::SWISH),
                                             ::testing::Values(false),   // use_per_expert_scale
-                                            ::testing::Values(false)),  // use_layernorm_multiply
+                                            ::testing::Values(false),   // use_layernorm_multiply
+                                            ::testing::Values(true)),   // use_weight_decompression
                          MoECompressedFusionTest::getTestCaseName);
 
 // 2-GEMM unfused: covers GatherMatmul OCL clamp/bias/swiglu compile path.
@@ -326,7 +353,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MoE2GemmGatherMatmul,
                                             ::testing::Values(true),  // force_gather_matmul
                                             ::testing::Values(MoEActivationType::SWISH),
                                             ::testing::Values(false),   // use_per_expert_scale
-                                            ::testing::Values(false)),  // use_layernorm_multiply
+                                            ::testing::Values(false),   // use_layernorm_multiply
+                                            ::testing::Values(true)),   // use_weight_decompression
                          MoECompressedFusionTest::getTestCaseName);
 
 // Gemma-4 style: Gelu activation + SOFTMAX routing with a per-expert scale table (Const[N] → Gather(topk_idx) → Multiply).
@@ -345,8 +373,31 @@ INSTANTIATE_TEST_SUITE_P(smoke_MoE3GemmGeluCompressed,
                                             ::testing::Values(size_t{0}),  // gate_idx unused for GEMM3
                                             ::testing::Values(false),      // force_gather_matmul
                                             ::testing::Values(MoEActivationType::GELU, MoEActivationType::GELU_ERF),
-                                            ::testing::Values(true, false),   // use_per_expert_scale
-                                            ::testing::Values(true, false)),  // use_layernorm_multiply
+                                            ::testing::Values(true, false),  // use_per_expert_scale
+                                            ::testing::Values(true, false),  // use_layernorm_multiply
+                                            ::testing::Values(true)),        // use_weight_decompression
+                         MoECompressedFusionTest::getTestCaseName);
+
+// Uncompressed (FP16) experts: dense Tile/MatMul ops run natively
+// (would otherwise fail with "MOE ... is not supported").
+INSTANTIATE_TEST_SUITE_P(smoke_MoE3GemmUncompressed,
+                         MoECompressedFusionTest,
+                         ::testing::Combine(::testing::ValuesIn(moe_params_smoke_uncompressed),
+                                            ::testing::Values(MoePatternType::GEMM3),
+                                            ::testing::ValuesIn(routing_types),
+                                            ::testing::Values(ov::element::f16),  // weights_precision (uncompressed)
+                                            ::testing::Values(ov::element::f16),  // decompression_precision
+                                            ::testing::Values(ov::element::f16),  // scale_precision
+                                            ::testing::Values(ov::test::utils::DecompressionType::full),
+                                            ::testing::Values(ov::test::utils::DecompressionType::full),
+                                            ::testing::Values(true),  // reshape_on_decompression
+                                            ::testing::Values(128),
+                                            ::testing::Values(size_t{0}),  // gate_idx unused for GEMM3
+                                            ::testing::Values(false),      // force_gather_matmul
+                                            ::testing::Values(MoEActivationType::SWISH),
+                                            ::testing::Values(false),   // use_per_expert_scale
+                                            ::testing::Values(false),   // use_layernorm_multiply
+                                            ::testing::Values(false)),  // use_weight_decompression
                          MoECompressedFusionTest::getTestCaseName);
 
 }  // namespace


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)

 - **Symptom**: FP16 MoE models (e.g. `lfm2-8b-a1b`) fail to compile on GPU with `MOE(extension) is not supported` (program_builder.cpp:230); the same IR runs on CPU.
 - **Root cause**: The GPU MoE chain (ConvertTiledMoeBlockToGatherMatmuls → ConvertGatherMatmulToGatherMatmulCompressed → MoeOpFusion → FuseMOE3GemmCompressed) is compressed-only. For FP16 weights it produces a plain `MOE` op that has no GPU factory, so it throws at program build.
 - **Resolution**: Add a `supported_weights_types` parameter to `ConvertTiledMoeBlockTo{2,3}GatherMatmuls`, mirroring `ConvertGatherMatmulToGatherMatmulCompressed`. The matcher uses `CompressedWeightsBlock` at each per-expert weight, so blocks with uncompressed weights are rejected at the matcher level and the original Tile/MatMul dense ops run natively on GPU (the same path CPU takes). The GPU plugin passes `{u4, i4, i8, u8}`; CPU uses the default empty list (unchanged behavior). INT4/INT8 are unaffected.

#### The code and line that caused this issue (if it is not changed directly)
 - `intel_gpu/src/plugin/program_builder.cpp:230` — throws when no factory exists for plain `MOE`.
 - `common/transformations/.../convert_tiled_moe_block_to_gather_matmuls.{hpp,cpp}` — adds `supported_weights_types` parameter; the matcher uses `CompressedWeightsBlock` to reject uncompressed weights.
 - `intel_gpu/src/plugin/transformations_pipeline.cpp` — `TransformationsPipeline::apply` passes the compressed weight list to the pass.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 ```
 $ python tools/llm_bench/benchmark.py -d GPU -m <lfm2-8b-a1b>/pytorch/ov/FP16 \
     -p "What is Perl?" --apply_chat_template --disable_prompt_permutation
 ```
 - Before: `RuntimeError: … MOE(extension) is not supported`
 - After: compiles and runs. WWB similarity 0.9775 (CPU 0.9859, INT4 0.9214); no INT4 regression.

#### Problematic graph
 - Dense tiled MoE: `Tile -> MatMul x3 (gate/up/down, SwiGLU) -> ReduceSum`.
 - Before: chain produces plain `MOE` → no GPU factory ✗.
 - After (FP16): chain skipped, dense ops run natively. INT4/INT8: unchanged (fused kernel).

#### Checklist
 - [x] Is it a proper fix? (not a workaround) — routes uncompressed MoE through supported native ops; not an env flag.
 - [x] Did you include test case for this fix, if necessary? — `smoke_MoE3GemmUncompressed` in `subgraph_tests/dynamic/moe.cpp`: asserts no `moe_3gemm_fused_compressed`/`gather_matmul` node and validates vs reference.
 - [x] Did you review existing test that can be extended? — extended `MoECompressedFusionTest` (added `use_weight_decompression`); compressed instantiations unchanged.

### Tickets:
 - [CVS-187916](https://jira.devtools.intel.com/browse/CVS-187916)