### PR TITLE
[GPU] Enable SDPA Fusion for 3D inputs and implicit GQA broadcasting (#36029)

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.cpp
@@ -20,6 +20,7 @@
 #include "ov_ops/rotary_positional_embeddings.hpp"
 #include "transformations/utils/utils.hpp"
 #include "openvino/core/graph_util.hpp"
+#include <optional>
 
 namespace ov::intel_gpu {
 using ov::pass::pattern::op::Or;
@@ -40,21 +41,23 @@ UnsqueezeBroadcastReshapeSDPAFusion::UnsqueezeBroadcastReshapeSDPAFusion() {
     auto input_attn_mask_m = any_input();
     auto input_scale_m = any_input();
     auto input_b_kvcache_m = wrap_type<ov::intel_gpu::op::KVCache>({any_input(), any_input()});
-    auto input_b_rope_m = wrap_type<ov::op::internal::RoPE>({any_input(), any_input(), any_input()});
     auto input_c_kvcache_m = wrap_type<ov::intel_gpu::op::KVCache>({any_input(), any_input()});
-    auto input_c_transpose_m = wrap_type<ov::op::v1::Transpose>({any_input(), any_input()});
-    auto input_c_reshape_m = optional<ov::op::v1::Reshape>({any_input(), any_input()});
 
+    auto input_b_rope_m = wrap_type<ov::op::internal::RoPE>({any_input(), any_input(), any_input()});
     auto concat_b_m = optional<ov::op::v0::Concat>({any_input(), any_input()});
-    auto concat_c_m = optional<ov::op::v0::Concat>({input_c_reshape_m, any_input()});
-
     auto pre_reshape_input_b_m = std::make_shared<Or>(OutputVector{input_b_rope_m, concat_b_m});
+
+    auto input_c_transpose_m = wrap_type<ov::op::v1::Transpose>({any_input(), any_input()});
+    auto input_c_reshape_m = optional<ov::op::v1::Reshape>({input_c_transpose_m, any_input()});
+    auto concat_c_m = optional<ov::op::v0::Concat>({any_input(), any_input()});
     auto pre_reshape_input_c_m = std::make_shared<Or>(OutputVector{input_c_transpose_m, input_c_reshape_m, concat_c_m});
 
     auto axes_const_b_m = wrap_type<ov::op::v0::Constant>();
     auto axes_const_c_m = wrap_type<ov::op::v0::Constant>();
+
     auto unsqueeze_b_m = wrap_type<ov::op::v0::Unsqueeze>({input_b_kvcache_m, axes_const_b_m}, unsqueeze_predicate);
     auto unsqueeze_c_m = wrap_type<ov::op::v0::Unsqueeze>({input_c_kvcache_m, axes_const_c_m}, unsqueeze_predicate);
+
     auto pre_reshape_b_m = wrap_type<ov::op::v1::Reshape>({pre_reshape_input_b_m, any_input()}, unsqueeze_predicate);
     auto pre_reshape_c_m = wrap_type<ov::op::v1::Reshape>({pre_reshape_input_c_m, any_input()}, unsqueeze_predicate);
 
@@ -142,16 +145,108 @@ UnsqueezeBroadcastReshapeSDPAFusion::UnsqueezeBroadcastReshapeSDPAFusion() {
             return false;
         }
 
+        auto ensure_4d = [&](const ov::Output<ov::Node>& input,
+                             const std::shared_ptr<ov::Node>& orig_5d_expansion,
+                             const std::shared_ptr<ov::Node>& orig_broadcast) -> std::optional<ov::Output<ov::Node>> {
+            const auto& pshape = input.get_partial_shape();
+
+            // If it's already 4D, we don't need to do anything
+            if (pshape.rank().is_static() && pshape.rank().get_length() == 4) {
+                return input;
+            }
+
+            // Check which axis the Broadcast node is expanding
+            auto pshape_in = orig_broadcast->get_input_partial_shape(0);
+            auto pshape_out = orig_broadcast->get_output_partial_shape(0);
+            int broadcast_axis = -1;
+
+            for (size_t i = 0; i < pshape_in.size(); ++i) {
+                if (pshape_in[i].is_static() && pshape_out[i].is_static()) {
+                    if (pshape_in[i].get_length() == 1 && pshape_out[i].get_length() > 1) {
+                        broadcast_axis = static_cast<int>(i);
+                        break;
+                    }
+                }
+            }
+
+            if (broadcast_axis == -1) return std::nullopt;
+
+            // handle if the 5D expansion was a reshape
+            if (auto reshape_node = ov::as_type_ptr<ov::op::v1::Reshape>(orig_5d_expansion)) {
+                auto pshape = reshape_node->get_output_partial_shape(0);
+                bool orig_special_zero = reshape_node->get_special_zero();
+                std::vector<int64_t> shape_vec;
+                for (const auto& dim : pshape) {
+                    if (dim.is_static()) {
+                        shape_vec.push_back(dim.get_length());
+                    } else {
+                       shape_vec.push_back(orig_special_zero ? 0 : -1);
+                    }
+                }
+                // Remove the broadcast axis
+                shape_vec.erase(shape_vec.begin() + broadcast_axis);
+
+                auto new_shape_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, shape_vec);
+                auto new_reshape = std::make_shared<ov::op::v1::Reshape>(input, new_shape_const, orig_special_zero);
+                new_reshape->set_friendly_name(input.get_node()->get_friendly_name() + "_dynamic_4d_reshape");
+                ov::copy_runtime_info({orig_5d_expansion, orig_broadcast}, {new_shape_const, new_reshape});
+                return new_reshape->output(0);
+            }
+
+            if (auto unsqueeze_node = ov::as_type_ptr<ov::op::v0::Unsqueeze>(orig_5d_expansion)) {
+                auto pshape = unsqueeze_node->get_output_partial_shape(0);
+                std::vector<int64_t> shape_vec;
+                for (const auto& dim : pshape) {
+                    if (dim.is_static()) {
+                        shape_vec.push_back(dim.get_length());
+                    } else {
+                        shape_vec.push_back(0);
+                    }
+                }
+
+                // Remove the broadcast axis
+                shape_vec.erase(shape_vec.begin() + broadcast_axis);
+
+                auto new_shape_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, shape_vec);
+                auto new_reshape = std::make_shared<ov::op::v1::Reshape>(input, new_shape_const, true);
+                new_reshape->set_friendly_name(input.get_node()->get_friendly_name() + "_dynamic_4d_unsqueeze_to_reshape");
+                ov::copy_runtime_info({orig_5d_expansion, orig_broadcast}, {new_shape_const, new_reshape});
+                return new_reshape->output(0);
+            }
+
+            return std::nullopt;
+        };
+
+        std::shared_ptr<ov::Node> k_5d;
+        if (pattern_map.count(pre_reshape_b_m)) k_5d = pattern_map.at(pre_reshape_b_m).get_node_shared_ptr();
+        else if (pattern_map.count(unsqueeze_b_m)) k_5d = pattern_map.at(unsqueeze_b_m).get_node_shared_ptr();
+
+        std::shared_ptr<ov::Node> v_5d;
+        if (pattern_map.count(pre_reshape_c_m)) v_5d = pattern_map.at(pre_reshape_c_m).get_node_shared_ptr();
+        else if (pattern_map.count(unsqueeze_c_m)) v_5d = pattern_map.at(unsqueeze_c_m).get_node_shared_ptr();
+
+        auto k_bc = pattern_map.at(broadcast_b_m).get_node_shared_ptr();
+        auto v_bc = pattern_map.at(broadcast_c_m).get_node_shared_ptr();
+
         OutputVector data_inputs;
         data_inputs.push_back(pattern_map.at(input_a_m).get_node_shared_ptr());               // Q input
-        if (pattern_map.find(input_b_kvcache_m) != pattern_map.end())
-            data_inputs.push_back(pattern_map.at(input_b_kvcache_m).get_node_shared_ptr());   // K input from KVCache
-        if (pattern_map.find(pre_reshape_input_b_m) != pattern_map.end())
-            data_inputs.push_back(pattern_map.at(pre_reshape_input_b_m).get_node_shared_ptr());  // K input from Concat / RoPE
-        if (pattern_map.find(input_c_kvcache_m) != pattern_map.end())
-            data_inputs.push_back(pattern_map.at(input_c_kvcache_m).get_node_shared_ptr());   // V input from KVCache
-        if (pattern_map.find(pre_reshape_input_c_m) != pattern_map.end())
-            data_inputs.push_back(pattern_map.at(pre_reshape_input_c_m).get_node_shared_ptr()); // V input from Transpose / Reshape / Concat
+        if (pattern_map.count(unsqueeze_b_m) || pattern_map.count(pre_reshape_b_m)) {
+            ov::Output<ov::Node> key_input = k_5d->input_value(0);
+            auto opt_key_input = ensure_4d(key_input, k_5d, k_bc);
+            if (!opt_key_input) return false;
+            data_inputs.push_back(opt_key_input.value());
+        } else {
+            return false;
+        }
+
+        if (pattern_map.count(unsqueeze_c_m) || pattern_map.count(pre_reshape_c_m)) {
+            ov::Output<ov::Node> value_input = v_5d->input_value(0);
+            auto opt_value_input = ensure_4d(value_input, v_5d, v_bc);
+            if (!opt_value_input) return false;
+            data_inputs.push_back(opt_value_input.value());
+        } else {
+            return false;
+        }
 
         auto sdpa = ov::as_type_ptr<op::SDPA>(m.get_match_root());
         if (pattern_map.find(sdpa_with_attn_mask_m) != pattern_map.end()) {

--- a/src/plugins/intel_gpu/tests/unit/transformations/unsqueeze_broadcast_reshape_sdpa_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/unsqueeze_broadcast_reshape_sdpa_fusion_test.cpp
@@ -372,6 +372,128 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeSDPAFusion7) {
     }
 }
 
+TEST_F(TransformationTestsF, UnsqueezeBroadReshapeSDPAFusion8) {
+    std::vector<int64_t> in0_order = {0, 1, 2, 3};
+    std::vector<int64_t> in1_order = {0, 1, 2, 3};
+    std::vector<int64_t> in2_order = {0, 1, 2, 3};
+    std::vector<int64_t> out_order = {0, 1, 2, 3};
+    std::vector<int32_t> shape_5d_val = {1, 1, 1, 968, 256};
+    std::vector<int32_t> target_shape_bc = {1, 1, 8, 968, 256};
+    std::vector<int32_t> pattern_4d = {0, 8, -1, 256};
+    const bool is_causal = true;
+
+    {
+        auto input_q = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 8, 968, 256});
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 968, 256});
+        auto cos = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 968, 256});
+        auto sin = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 968, 256});
+        auto input_k_3d = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos, sin}, ov::op::internal::RoPE::Config());
+        auto k_shape_5d = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{5}, shape_5d_val);
+        auto k_5d = std::make_shared<ov::op::v1::Reshape>(input_k_3d, k_shape_5d, false);
+        auto bc_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{5}, target_shape_bc);
+        auto k_bc = std::make_shared<ov::op::v3::Broadcast>(k_5d, bc_const, ov::op::BroadcastType::BIDIRECTIONAL);
+        auto k_shape_4d = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, pattern_4d);
+        auto k_4d = std::make_shared<ov::op::v1::Reshape>(k_bc, k_shape_4d, true);
+        auto v_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 968, 256});
+        auto v_trans_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 1, 2});
+        auto input_v_3d = std::make_shared<ov::op::v1::Transpose>(v_input, v_trans_const);
+        auto v_shape_5d = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{5}, shape_5d_val);
+        auto v_5d = std::make_shared<ov::op::v1::Reshape>(input_v_3d, v_shape_5d, false);
+        auto v_bc = std::make_shared<ov::op::v3::Broadcast>(v_5d, bc_const, ov::op::BroadcastType::BIDIRECTIONAL);
+        auto v_shape_4d = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, pattern_4d);
+        auto v_4d = std::make_shared<ov::op::v1::Reshape>(v_bc, v_shape_4d, true);
+        auto inputs = ov::OutputVector{input_q, k_4d, v_4d};
+        auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(inputs, is_causal, in0_order, in1_order, in2_order, out_order);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, rope_input, cos, sin, v_input});
+        manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeSDPAFusion>();
+    }
+    {
+        auto input_q = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 8, 968, 256});
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 968, 256});
+        auto cos = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 968, 256});
+        auto sin = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 968, 256});
+        auto input_k_3d = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos, sin}, ov::op::internal::RoPE::Config());
+        auto v_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 968, 256});
+        auto v_trans_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 1, 2});
+        auto input_v_3d = std::make_shared<ov::op::v1::Transpose>(v_input, v_trans_const);
+        std::vector<int64_t> ref_4d_shape_val = {1, 1, 968, 256};
+        auto k_ref_shape_4d = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, ref_4d_shape_val);
+        auto v_ref_shape_4d = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, ref_4d_shape_val);
+        auto k_ref_4d = std::make_shared<ov::op::v1::Reshape>(input_k_3d, k_ref_shape_4d, false);
+        auto v_ref_4d = std::make_shared<ov::op::v1::Reshape>(input_v_3d, v_ref_shape_4d, false);
+
+        auto inputs = ov::OutputVector{input_q, k_ref_4d, v_ref_4d};
+        auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(inputs, is_causal, in0_order, in1_order, in2_order, out_order);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, rope_input, cos, sin, v_input});
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
+TEST_F(TransformationTestsF, UnsqueezeBroadReshapeSDPAFusion9) {
+    std::vector<int64_t> in0_order = {0, 1, 2, 3};
+    std::vector<int64_t> in1_order = {0, 1, 2, 3};
+    std::vector<int64_t> in2_order = {0, 1, 2, 3};
+    std::vector<int64_t> out_order = {0, 1, 2, 3};
+
+    // GQA 16x Broadcast Logic (32 Q heads, 2 KV heads)
+    std::vector<int32_t> shape_5d_val = {-1, 1, 2, 1, 128};
+    std::vector<int32_t> target_shape_bc = {1, 1, 1, 16, 1}; // Broadcast by 16x
+    std::vector<int32_t> pattern_4d = {0, 0, 32, 128};
+    const bool is_causal = true;
+
+    {
+        auto input_q = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 32, 128});
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 256});
+        auto cos = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 256});
+        auto sin = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 256});
+        auto input_k = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos, sin}, ov::op::internal::RoPE::Config());
+        auto k_shape_5d = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{5}, shape_5d_val);
+        auto k_5d = std::make_shared<ov::op::v1::Reshape>(input_k, k_shape_5d, true);
+        auto bc_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{5}, target_shape_bc);
+        auto k_bc = std::make_shared<ov::op::v3::Broadcast>(k_5d, bc_const, ov::op::BroadcastType::BIDIRECTIONAL);
+        auto k_shape_4d = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, pattern_4d);
+        auto k_4d = std::make_shared<ov::op::v1::Reshape>(k_bc, k_shape_4d, true);
+
+        auto v_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 256});
+        auto v_trans_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 1, 2});
+        auto input_v = std::make_shared<ov::op::v1::Transpose>(v_input, v_trans_const);
+        auto v_shape_5d = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{5}, shape_5d_val);
+        auto v_5d = std::make_shared<ov::op::v1::Reshape>(input_v, v_shape_5d, true);
+        auto v_bc = std::make_shared<ov::op::v3::Broadcast>(v_5d, bc_const, ov::op::BroadcastType::BIDIRECTIONAL);
+        auto v_shape_4d = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, pattern_4d);
+        auto v_4d = std::make_shared<ov::op::v1::Reshape>(v_bc, v_shape_4d, true);
+
+        auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(
+            ov::OutputVector{input_q, k_4d, v_4d}, is_causal, in0_order, in1_order, in2_order, out_order);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, rope_input, cos, sin, v_input});
+        manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeSDPAFusion>();
+    }
+    {
+        auto input_q = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 32, 128});
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 256});
+        auto cos = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 256});
+        auto sin = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 256});
+        auto input_k = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos, sin}, ov::op::internal::RoPE::Config());
+        auto v_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, 1, 256});
+        auto v_trans_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 1, 2});
+        auto input_v = std::make_shared<ov::op::v1::Transpose>(v_input, v_trans_const);
+        std::vector<int64_t> ref_4d_shape_val = {0, 1, 2, 128};
+        auto k_ref_shape_4d = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, ref_4d_shape_val);
+        auto v_ref_shape_4d = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, ref_4d_shape_val);
+        auto k_ref_4d = std::make_shared<ov::op::v1::Reshape>(input_k, k_ref_shape_4d, true);
+        auto v_ref_4d = std::make_shared<ov::op::v1::Reshape>(input_v, v_ref_shape_4d, true);
+
+        auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(
+            ov::OutputVector{input_q, k_ref_4d, v_ref_4d}, is_causal, in0_order, in1_order, in2_order, out_order);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, rope_input, cos, sin, v_input});
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
 }  // namespace intel_gpu
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
This PR enhances the UnsqueezeBroadcastReshapeSDPAFusion pass to capture more flexible attention topologies, specifically targeting MQA and GQA patterns.

Key Enhancements:
1) 3D Input Support: The pass now successfully intercepts and reshapes 3D Key/Value tensors feeding into Unsqueeze or Reshape nodes.

2) GQA Implicit Broadcasting: Previously, the fusion aborted if the model required expanding KV heads to match a larger number of Query heads. This PR introduces dynamic shape extraction to bypass explicit Broadcast nodes. The SDPA kernel will now perform an implicit broadcast in the registers—for example, natively mapping 2 KV heads across 32 Query heads (a 1:16 ratio)—saving massive memory bandwidth.

### Tickets:
 - CVS-186566, CVS-187072

### AI Assistance:
 - *AI assistance used: yes
 - Debug and test generation