### PR TITLE
[GPU] Add Sign activation support for integer types (#36003)

### DIFF
--- a/src/plugins/intel_gpu/src/graph/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/activation.cpp
@@ -27,6 +27,7 @@ layout activation_inst::calc_output_layout(activation_node const& node, kernel_i
         activation_func::relu,
         activation_func::floor,
         activation_func::clamp,
+        activation_func::sign,
         activation_func::abs };
 
     if (input_node_layout.data_type == data_types::i8 || input_node_layout.data_type == data_types::u8 ||

--- a/src/plugins/intel_gpu/tests/unit/test_cases/activation_simple_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/activation_simple_gpu_test.cpp
@@ -1857,7 +1857,8 @@ TEST(activation_i32_fw_gpu, basic_yxfb_i32_funcs) {
         activation_func::relu,
         activation_func::clamp,
         activation_func::floor,
-        activation_func::abs
+        activation_func::abs,
+        activation_func::sign
     };
 
     for (auto func : funcs) {
@@ -1901,6 +1902,11 @@ TEST(activation_i32_fw_gpu, basic_yxfb_i32_funcs) {
             case activation_func::abs:
                 ASSERT_EQ(std::abs(static_cast<int32_t>(input_ptr[i])), output_ptr[i]);
                 break;
+            case activation_func::sign: {
+                const int32_t val = static_cast<int32_t>(input_ptr[i]);
+                ASSERT_EQ(val > 0 ? 1 : (val == 0 ? 0 : -1), output_ptr[i]);
+                break;
+            }
             default:
                 break;
             }


### PR DESCRIPTION
### Description
 - **Symptom:** yolo26n model fails to compile on GPU with `[GPU] ProgramBuilder build failed! — Requested activation is not supported for integer type` at the `Sign` node (`node_Sign_1348`, i64 input)
 - **Root cause:** `activations_int8` allowlist in `activation_inst::calc_output_layout()` did not include `activation_func::sign`. The list guards `i8/u8/i32` types, and the GPU plugin internally converts the model's `i64` Sign input to `i32`. Since `sign` was absent from the allowlist, it was unconditionally rejected. The Sign OCL kernel itself correctly handles integer types via a ternary/select expression (`input > 0 ? 1 : (input == 0 ? 0 : -1)`) without any type mismatch — the omission was an oversight.
 - **Resolution:** Added `activation_func::sign` to the `activations_int8` allowlist. Unlike the similar PR #29099 (`abs`), no change to activation_kernel_opt.cpp is needed because the Sign macro returns the same signed integer type as the input (no `int4 → uint4` mismatch).

#### The code and line that caused this issue
 - `intel_gpu/src/graph/activation.cpp` — `activation_inst::calc_output_layout()`, `activations_int8` vector (line ~23)

#### Reproduction step and snapshot
 - Model: `yolo26n-pytorch` FP16 (OMZ public)
 ```bash
 python -c "
 import openvino as ov
 core = ov.Core()
 model = core.read_model('yolo26n/openvino_model.xml')
 core.compile_model(model, 'GPU')  # RuntimeError: sign:node_Sign_1348 — Requested activation is not supported for integer type
 "
 ```

#### Problematic graph
 - Single `Sign` node with `int64` input/output shape `[1, 300]`, fed from a `TopK` index output
 - GPU plugin converts `i64 → i32` internally, then the `i32` Sign hits the allowlist check and fails

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - Extended `activation_i32_fw_gpu.basic_yxfb_i32_funcs` in activation_simple_gpu_test.cpp — added `activation_func::sign` to the tested functions list and its corresponding assertion (`val > 0 ? 1 : val == 0 ? 0 : -1`)
 
### Tickets
 - *187077*

### master PR
  - https://github.com/openvinotoolkit/openvino/pull/36003
