### PR TITLE
[CPU] refactor-cpu-convert-serial-parallel

### DIFF
--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -500,7 +500,7 @@ void DnnlPostOpsComposer::appendBinary(const dnnl::algorithm alg, const std::vec
     ops.append_binary(alg, memoryDesc.getDnnlDesc());
     auto mem = std::make_shared<Memory>(engine, memoryDesc);
     // convert will just copy in case of non-ARM
-    cpu_convert(data.data(), mem->getData(), ov::element::f32, binaryType, data.size());
+    cpu_parallel_convert(data.data(), mem->getData(), ov::element::f32, binaryType, data.size());
 
     cpuArgs[DNNL_ARG_ATTR_MULTIPLE_POST_OP(ops.len() - 1) | DNNL_ARG_SRC_1] = mem;
     dnnlArgs[DNNL_ARG_ATTR_MULTIPLE_POST_OP(ops.len() - 1) | DNNL_ARG_SRC_1] = mem->getPrimitive();

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -45,7 +45,6 @@
 #include "memory_desc/cpu_memory_desc_utils.h"
 #include "memory_state.h"
 #include "node.h"
-#include "nodes/common/cpu_convert.h"
 #include "nodes/common/cpu_memcpy.h"
 #include "nodes/convert.h"
 #include "nodes/input.h"

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -36,7 +36,6 @@
 #include "memory_desc/cpu_memory_desc_utils.h"
 #include "node.h"
 #include "nodes/bin_conv.h"
-#include "nodes/common/cpu_convert.h"
 #include "nodes/concat.h"
 #include "nodes/conv.h"
 #include "nodes/deconv.h"

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -27,7 +27,6 @@
 #include "memory_desc/cpu_memory_desc.h"
 #include "memory_desc/cpu_memory_desc_utils.h"
 #include "node.h"
-#include "nodes/common/cpu_convert.h"
 #include "openvino/core/except.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/node_output.hpp"

--- a/src/plugins/intel_cpu/src/memory_state.cpp
+++ b/src/plugins/intel_cpu/src/memory_state.cpp
@@ -102,10 +102,10 @@ ov::SoPtr<ov::ITensor> VariableStateBase::get_state() const {
             auto external_prc = current_ext_desc->getPrecision();
 
             cpu_parallel_convert(internal_state_mem()->getData(),
-                        mem->getData(),
-                        internal_prc,
-                        external_prc,
-                        elements_to_convert);
+                                 mem->getData(),
+                                 internal_prc,
+                                 external_prc,
+                                 elements_to_convert);
             return std::make_shared<Tensor>(mem);
         }
     }
@@ -354,10 +354,10 @@ void VariableStateKVcache::set_state_impl(const ov::SoPtr<ov::ITensor>& state) {
                 size_t valid_seq = std::min(m_spec.group_size, L0 - group_id * m_spec.group_size);
                 buffers[ithr].resize<float>({valid_seq, S});
                 cpu_parallel_convert(external.ptr_v(valid_seq, b, h),
-                            buffers[ithr].ptr<float>(),
-                            external.m_dt,
-                            element::f32,
-                            valid_seq * S);
+                                     buffers[ithr].ptr<float>(),
+                                     external.m_dt,
+                                     element::f32,
+                                     valid_seq * S);
                 attn_quant_by_channel_u8(buffers[ithr].ptr<float>(),
                                          internal.ptr<uint8_t>(group_id * m_spec.group_size, b, h),
                                          valid_seq,

--- a/src/plugins/intel_cpu/src/memory_state.cpp
+++ b/src/plugins/intel_cpu/src/memory_state.cpp
@@ -101,7 +101,7 @@ ov::SoPtr<ov::ITensor> VariableStateBase::get_state() const {
                 internal_state_mem()->getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
             auto external_prc = current_ext_desc->getPrecision();
 
-            cpu_convert(internal_state_mem()->getData(),
+            cpu_parallel_convert(internal_state_mem()->getData(),
                         mem->getData(),
                         internal_prc,
                         external_prc,
@@ -290,7 +290,7 @@ ov::SoPtr<ov::ITensor> VariableStateKVcache::get_state() const {
                                            S,
                                            m_scale_zp.ptr<float>(group_id * 2, b_kv, h),
                                            m_scale_zp.ptr<float>(group_id * 2 + 1, b_kv, h));
-                cpu_convert(buffers[ithr].ptr<float>(), output.ptr_v(m, b, h), element::f32, output.m_dt, S);
+                cpu_parallel_convert(buffers[ithr].ptr<float>(), output.ptr_v(m, b, h), element::f32, output.m_dt, S);
             });
         } else {
             parallel_for3d(L0, B, H, [&](size_t ithr, size_t m, size_t b, size_t h) {
@@ -302,13 +302,13 @@ ov::SoPtr<ov::ITensor> VariableStateKVcache::get_state() const {
                                     m_spec.group_size,
                                     m_scale_zp.ptr<float>(m, b_kv, h, group_id * 2));
                 }
-                cpu_convert(buffers[ithr].ptr<float>(), output.ptr_v(m, b, h), element::f32, output.m_dt, S);
+                cpu_parallel_convert(buffers[ithr].ptr<float>(), output.ptr_v(m, b, h), element::f32, output.m_dt, S);
             });
         }
     } else {
         parallel_for3d(L0, B, H, [&](size_t m, size_t b, size_t h) {
             auto b_kv = static_cast<size_t>(beam_table.at<int32_t>({b, m}));
-            cpu_convert(pastkv.ptr_v(m, b_kv, h), output.ptr_v(m, b, h), pastkv.m_dt, output.m_dt, S);
+            cpu_parallel_convert(pastkv.ptr_v(m, b_kv, h), output.ptr_v(m, b, h), pastkv.m_dt, output.m_dt, S);
         });
     }
 
@@ -353,7 +353,7 @@ void VariableStateKVcache::set_state_impl(const ov::SoPtr<ov::ITensor>& state) {
             parallel_for3d(group_nums, B, H, [&](size_t ithr, size_t group_id, size_t b, size_t h) {
                 size_t valid_seq = std::min(m_spec.group_size, L0 - group_id * m_spec.group_size);
                 buffers[ithr].resize<float>({valid_seq, S});
-                cpu_convert(external.ptr_v(valid_seq, b, h),
+                cpu_parallel_convert(external.ptr_v(valid_seq, b, h),
                             buffers[ithr].ptr<float>(),
                             external.m_dt,
                             element::f32,
@@ -371,7 +371,11 @@ void VariableStateKVcache::set_state_impl(const ov::SoPtr<ov::ITensor>& state) {
             m_scale_zp.resize<float>({L0, B, H, 2 * S / m_spec.group_size});
             parallel_for3d(B, H, L0, [&](size_t ithr, size_t b, size_t h, size_t m) {
                 buffers[ithr].resize<float>({S});
-                cpu_convert(external.ptr_v(m, b, h), buffers[ithr].ptr<float>(), external.m_dt, element::f32, S);
+                cpu_parallel_convert(external.ptr_v(m, b, h),
+                                     buffers[ithr].ptr<float>(),
+                                     external.m_dt,
+                                     element::f32,
+                                     S);
                 for (size_t group_id = 0; group_id < S / m_spec.group_size; group_id++) {
                     attn_quant_u8(buffers[ithr].ptr<float>() + group_id * m_spec.group_size,
                                   internal.ptr<uint8_t>(m, b, h, group_id * m_spec.group_size),

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -1704,10 +1704,10 @@ std::pair<std::vector<float>, std::vector<float>> Node::getScalesAndShifts(const
         const auto elementsCount = constBlob->getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
         buffer.resize(elementsCount);
         cpu_parallel_convert(constBlob->getData(),
-                    buffer.data(),
-                    DnnlExtensionUtils::DataTypeToElementType(constBlob->getDataType()),
-                    ov::element::f32,
-                    elementsCount);
+                             buffer.data(),
+                             DnnlExtensionUtils::DataTypeToElementType(constBlob->getDataType()),
+                             ov::element::f32,
+                             elementsCount);
     };
 
     const auto constPort = getParentEdgeAt(0)->getParent().get() == parentNode ? 1 : 0;

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -1703,7 +1703,7 @@ std::pair<std::vector<float>, std::vector<float>> Node::getScalesAndShifts(const
         auto constBlob = constInputNode->getMemoryPtr();
         const auto elementsCount = constBlob->getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
         buffer.resize(elementsCount);
-        cpu_convert(constBlob->getData(),
+        cpu_parallel_convert(constBlob->getData(),
                     buffer.data(),
                     DnnlExtensionUtils::DataTypeToElementType(constBlob->getDataType()),
                     ov::element::f32,

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -1020,7 +1020,7 @@ struct ConvertTo4BitPrecision<std::tuple<src_t, dst_t>> {
         auto* dst = static_cast<uint8_t*>(ctx.dstPtr);
         // each byte must be fully processed within same thread
         auto work_amount = ctx.size / 2;
-        auto has_tail = ctx.size % work_amount != 0;
+        auto has_tail = (ctx.size % 2) != 0;
         if (ctx.outType == ov::element::nf4) {
             LoopPolicy::run(work_amount, [&](size_t ib) {
                 size_t idx = ib * 2;

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -58,8 +58,9 @@ struct ParallelLoopPolicy {
 struct SequentialLoopPolicy {
     template <typename Body>
     static void run(size_t iterations, Body&& body) {
+        auto&& fn = std::forward<Body>(body);
         for (size_t i = 0; i < iterations; ++i) {
-            body(i);
+            fn(i);
         }
     }
 };
@@ -543,12 +544,12 @@ template <typename LoopPolicy>
 struct ConvertContext {
     using loop_policy = LoopPolicy;
 
-    const void* srcPtr;
-    void* dstPtr;
-    size_t size;
+    const void* srcPtr = nullptr;
+    void* dstPtr = nullptr;
+    size_t size = 0UL;
     ov::element::Type interimPrc;
     ov::element::Type dstPrc;
-    bool converted;
+    bool converted = false;
 
     template <typename T>
     [[nodiscard]] std::tuple<T, T> range() const {

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -46,6 +46,24 @@
 namespace ov::intel_cpu {
 namespace {
 
+// Loop policies select between parallel_for and a plain serial loop at compile time,
+// so cpu_convert and cpu_parallel_convert share the same conversion bodies.
+struct ParallelLoopPolicy {
+    template <typename Body>
+    static void run(size_t iterations, Body&& body) {
+        parallel_for(iterations, std::forward<Body>(body));
+    }
+};
+
+struct SequentialLoopPolicy {
+    template <typename Body>
+    static void run(size_t iterations, Body&& body) {
+        for (size_t i = 0; i < iterations; ++i) {
+            body(i);
+        }
+    }
+};
+
 #if defined(OPENVINO_ARCH_X86_64)
 
 using namespace dnnl::impl::utils;
@@ -521,7 +539,10 @@ const std::tuple<U, U>& Range<T, U>::fit(const ov::element::Type& prec) {
     return _range;
 }
 
+template <typename LoopPolicy>
 struct ConvertContext {
+    using loop_policy = LoopPolicy;
+
     const void* srcPtr;
     void* dstPtr;
     size_t size;
@@ -542,10 +563,12 @@ struct ConvertPrecision;
 
 template <typename src_t, typename dst_t>
 struct ConvertPrecision<std::tuple<src_t, dst_t>> {
-    void operator()(ConvertContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         auto src = static_cast<const src_t*>(ctx.srcPtr);
         auto dst = static_cast<dst_t*>(ctx.dstPtr);
-        auto [lbound, ubound] = ctx.range<src_t>();
+        auto [lbound, ubound] = ctx.template range<src_t>();
 
         // Align with the behavior of ngraph ref and jit implementation. Conversion from f8e4m3-inf
         // to float should output float-inf instead of f8e4m3-max. Proper handling of special values
@@ -553,7 +576,7 @@ struct ConvertPrecision<std::tuple<src_t, dst_t>> {
         if (ov::intel_cpu::any_of_v<src_t, ov::float8_e4m3, ov::float8_e5m2> ||
             ov::intel_cpu::any_of_v<dst_t, ov::float8_e4m3, ov::float8_e5m2> ||
             (std::is_integral_v<src_t> && std::is_integral_v<dst_t> && ctx.dstPrc != ov::element::boolean)) {
-            parallel_for(ctx.size, [&](size_t i) {
+            LoopPolicy::run(ctx.size, [&](size_t i) {
                 dst[i] = static_cast<dst_t>(src[i]);
             });
             ctx.converted = true;
@@ -561,11 +584,11 @@ struct ConvertPrecision<std::tuple<src_t, dst_t>> {
         }
 
         if (std::is_integral_v<src_t> || ctx.interimPrc.is_real() || std::is_integral_v<dst_t>) {
-            parallel_for(ctx.size, [&, lbound = lbound, ubound = ubound](size_t i) {
+            LoopPolicy::run(ctx.size, [&, lbound = lbound, ubound = ubound](size_t i) {
                 dst[i] = static_cast<dst_t>(std::max(std::min(src[i], ubound), lbound));
             });
         } else {
-            parallel_for(ctx.size, [&, lbound = lbound, ubound = ubound](size_t i) {
+            LoopPolicy::run(ctx.size, [&, lbound = lbound, ubound = ubound](size_t i) {
                 dst[i] = static_cast<dst_t>(std::trunc(std::max(std::min(src[i], ubound), lbound)));
             });
         }
@@ -576,17 +599,19 @@ struct ConvertPrecision<std::tuple<src_t, dst_t>> {
 
 template <>
 struct ConvertPrecision<std::tuple<float, ov::intel_cpu::bfloat16_t>> {
-    void operator()(ConvertContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         const auto* src = static_cast<const float*>(ctx.srcPtr);
         auto* dst = static_cast<ov::intel_cpu::bfloat16_t*>(ctx.dstPtr);
 
         if (ctx.interimPrc.is_real()) {
-            parallel_for(ctx.size, [&](size_t i) {
+            LoopPolicy::run(ctx.size, [&](size_t i) {
                 dst[i] = static_cast<ov::intel_cpu::bfloat16_t>(src[i]);
             });
         } else {
-            auto [lbound, ubound] = ctx.range<float>();
-            parallel_for(ctx.size, [&, lbound = lbound, ubound = ubound](size_t i) {
+            auto [lbound, ubound] = ctx.template range<float>();
+            LoopPolicy::run(ctx.size, [&, lbound = lbound, ubound = ubound](size_t i) {
                 dst[i] = static_cast<ov::intel_cpu::bfloat16_t>(std::trunc(std::max(std::min(src[i], ubound), lbound)));
             });
         }
@@ -597,17 +622,20 @@ struct ConvertPrecision<std::tuple<float, ov::intel_cpu::bfloat16_t>> {
 
 template <>
 struct ConvertPrecision<std::tuple<ov::intel_cpu::bfloat16_t, float>> {
-    void operator()(ConvertContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         const auto* src = static_cast<const ov::intel_cpu::bfloat16_t*>(ctx.srcPtr);
         auto* dst = static_cast<float*>(ctx.dstPtr);
 
         if (ctx.interimPrc.is_real()) {
-            parallel_for(ctx.size, [&](size_t i) {
+            LoopPolicy::run(ctx.size, [&](size_t i) {
                 dst[i] = static_cast<float>(src[i]);
             });
         } else {
-            auto [lbound, ubound] = static_cast<std::tuple<float, float>>(ctx.range<ov::intel_cpu::bfloat16_t>());
-            parallel_for(ctx.size, [&, lbound = lbound, ubound = ubound](size_t i) {
+            auto [lbound, ubound] =
+                static_cast<std::tuple<float, float>>(ctx.template range<ov::intel_cpu::bfloat16_t>());
+            LoopPolicy::run(ctx.size, [&, lbound = lbound, ubound = ubound](size_t i) {
                 dst[i] = std::trunc(std::max(std::min(static_cast<float>(src[i]), ubound), lbound));
             });
         }
@@ -619,7 +647,9 @@ struct ConvertPrecision<std::tuple<ov::intel_cpu::bfloat16_t, float>> {
 #if defined(OPENVINO_ARCH_X86_64)
 template <typename src_t>
 struct ConvertPrecision<std::tuple<src_t, ov::float16>> {
-    void operator()(ConvertContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         auto src = static_cast<const src_t*>(ctx.srcPtr);
         auto* dst = static_cast<ov::float16*>(ctx.dstPtr);
 
@@ -627,10 +657,10 @@ struct ConvertPrecision<std::tuple<src_t, ov::float16>> {
         const size_t iterations = ov::intel_cpu::div_up(ctx.size, batch);
         typedef float batch_type[batch];
 
-        auto [lbound, ubound] = ctx.range<src_t>();
+        auto [lbound, ubound] = ctx.template range<src_t>();
 
         if (std::is_integral_v<src_t>) {
-            parallel_for(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
+            LoopPolicy::run(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
                 batch_type tmp;
                 const size_t offset = i * batch;
                 const size_t current_batch_size = std::min(ctx.size - offset, batch);
@@ -640,7 +670,7 @@ struct ConvertPrecision<std::tuple<src_t, ov::float16>> {
                 jit_convert(tmp, dst + offset, current_batch_size);  // fp32 -> fp16
             });
         } else if (ctx.interimPrc.is_real()) {
-            parallel_for(iterations, [&](size_t i) {
+            LoopPolicy::run(iterations, [&](size_t i) {
                 const size_t offset = i * batch;
                 const size_t current_batch_size = std::min(ctx.size - offset, batch);
                 if (std::is_same_v<std::remove_cv_t<src_t>, float>) {  // fp32 -> fp16
@@ -654,7 +684,7 @@ struct ConvertPrecision<std::tuple<src_t, ov::float16>> {
                 }
             });
         } else {
-            parallel_for(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
+            LoopPolicy::run(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
                 batch_type tmp;
                 const size_t offset = i * batch;
                 const size_t current_batch_size = std::min(ctx.size - offset, batch);
@@ -671,7 +701,9 @@ struct ConvertPrecision<std::tuple<src_t, ov::float16>> {
 
 template <typename dst_t>
 struct ConvertPrecision<std::tuple<ov::float16, dst_t>> {
-    void operator()(ConvertContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         const auto* src = static_cast<const ov::float16*>(ctx.srcPtr);
         auto dst = static_cast<dst_t*>(ctx.dstPtr);
 
@@ -679,10 +711,10 @@ struct ConvertPrecision<std::tuple<ov::float16, dst_t>> {
         const size_t iterations = ov::intel_cpu::div_up(ctx.size, batch);
         typedef float batch_type[batch];
 
-        auto [lbound, ubound] = static_cast<std::tuple<float, float>>(ctx.range<ov::float16>());
+        auto [lbound, ubound] = static_cast<std::tuple<float, float>>(ctx.template range<ov::float16>());
 
         if (std::is_integral_v<dst_t>) {
-            parallel_for(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
+            LoopPolicy::run(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
                 batch_type tmp;
                 const size_t offset = i * batch;
                 const size_t current_batch_size = std::min(ctx.size - offset, batch);
@@ -692,7 +724,7 @@ struct ConvertPrecision<std::tuple<ov::float16, dst_t>> {
                 }
             });
         } else if (ctx.interimPrc.is_real()) {
-            parallel_for(iterations, [&](size_t i) {
+            LoopPolicy::run(iterations, [&](size_t i) {
                 const size_t offset = i * batch;
                 const size_t current_batch_size = std::min(ctx.size - offset, batch);
                 if (std::is_same_v<std::remove_cv_t<dst_t>, float>) {  // fp16 -> fp32
@@ -706,7 +738,7 @@ struct ConvertPrecision<std::tuple<ov::float16, dst_t>> {
                 }
             });
         } else {
-            parallel_for(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
+            LoopPolicy::run(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
                 batch_type tmp;
                 const size_t offset = i * batch;
                 const size_t current_batch_size = std::min(ctx.size - offset, batch);
@@ -723,7 +755,9 @@ struct ConvertPrecision<std::tuple<ov::float16, dst_t>> {
 
 template <>
 struct ConvertPrecision<std::tuple<ov::float16, ov::float16>> {
-    void operator()(ConvertContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         const auto* src = static_cast<const ov::float16*>(ctx.srcPtr);
         auto* dst = static_cast<ov::float16*>(ctx.dstPtr);
 
@@ -731,12 +765,12 @@ struct ConvertPrecision<std::tuple<ov::float16, ov::float16>> {
         const size_t iterations = ov::intel_cpu::div_up(ctx.size, batch);
         typedef float batch_type[batch];
 
-        auto [lbound, ubound] = static_cast<std::tuple<float, float>>(ctx.range<ov::float16>());
+        auto [lbound, ubound] = static_cast<std::tuple<float, float>>(ctx.template range<ov::float16>());
 
         if (ctx.interimPrc.is_real()) {
             cpu_memcpy(dst, src, ctx.size * sizeof(ov::float16));
         } else {
-            parallel_for(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
+            LoopPolicy::run(iterations, [&, lbound = lbound, ubound = ubound](size_t i) {
                 batch_type tmp;
                 const size_t offset = i * batch;
                 const size_t current_batch_size = std::min(ctx.size - offset, batch);
@@ -819,7 +853,10 @@ struct ConvertPrecision<std::tuple<ov::float16, ov::float16>> {
         INTEL_CPU_CVT(u1, i32), INTEL_CPU_CVT(u1, u32), INTEL_CPU_CVT(u1, i64), INTEL_CPU_CVT(u1, u64), \
         INTEL_CPU_CVT(u1, boolean)
 
+template <typename LoopPolicy>
 struct ConvertFromBinContext {
+    using loop_policy = LoopPolicy;
+
     const void* srcPtr;
     void* dstPtr;
     size_t size;
@@ -831,12 +868,14 @@ struct ConvertFromBinPrecision;
 
 template <typename src_t, typename dst_t>
 struct ConvertFromBinPrecision<std::tuple<src_t, dst_t>> {
-    void operator()(ConvertFromBinContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         const auto* src = static_cast<const uint8_t*>(ctx.srcPtr);
         auto dst = static_cast<dst_t*>(ctx.dstPtr);
         const size_t nBits = 8;
         const size_t nBytes = rnd_up(ctx.size, nBits);
-        parallel_for(nBytes, [&](size_t byteIndex) {
+        LoopPolicy::run(nBytes, [&](size_t byteIndex) {
             auto currentBitNum = std::min(nBits, ctx.size - byteIndex * nBits);
             for (size_t bitIndex = 0; bitIndex < currentBitNum; ++bitIndex) {
                 dst[byteIndex * nBits + bitIndex] = static_cast<dst_t>((src[byteIndex] & (1 << bitIndex)) >> bitIndex);
@@ -850,7 +889,10 @@ struct ConvertFromBinPrecision<std::tuple<src_t, dst_t>> {
     INTEL_CPU_CVT(u2, f32), INTEL_CPU_CVT(u2, f16), INTEL_CPU_CVT(u2, bf16), INTEL_CPU_CVT(u2, i32), \
         INTEL_CPU_CVT(u2, u8), INTEL_CPU_CVT(u2, i8)
 
+template <typename LoopPolicy>
 struct ConvertFrom2BitContext {
+    using loop_policy = LoopPolicy;
+
     const void* srcPtr;
     void* dstPtr;
     size_t size;
@@ -866,10 +908,12 @@ struct ConvertFrom2BitPrecision;
 
 template <typename src_t, typename dst_t>
 struct ConvertFrom2BitPrecision<std::tuple<src_t, dst_t>> {
-    void operator()(ConvertFrom2BitContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         const auto* src = static_cast<const uint8_t*>(ctx.srcPtr);
         auto dst = static_cast<dst_t*>(ctx.dstPtr);
-        parallel_for(ctx.size, [&](size_t i) {
+        LoopPolicy::run(ctx.size, [&](size_t i) {
             dst[i] = static_cast<dst_t>(get_u2(src[i / 4], (i % 4) * 2));
         });
         ctx.converted = true;
@@ -884,7 +928,10 @@ struct ConvertFrom2BitPrecision<std::tuple<src_t, dst_t>> {
         INTEL_CPU_CVT(nf4, u8), INTEL_CPU_CVT(f4e2m1, f32), INTEL_CPU_CVT(f4e2m1, bf16), INTEL_CPU_CVT(f4e2m1, f16), \
         INTEL_CPU_CVT(f4e2m1, i8), INTEL_CPU_CVT(f4e2m1, u8)
 
+template <typename LoopPolicy>
 struct ConvertFrom4BitContext {
+    using loop_policy = LoopPolicy;
+
     ov::element::Type_t inType;
     const void* srcPtr;
     void* dstPtr;
@@ -915,23 +962,25 @@ struct ConvertFrom4BitPrecision;
 
 template <typename src_t, typename dst_t>
 struct ConvertFrom4BitPrecision<std::tuple<src_t, dst_t>> {
-    void operator()(ConvertFrom4BitContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         const auto* src = static_cast<const uint8_t*>(ctx.srcPtr);
         auto dst = static_cast<dst_t*>(ctx.dstPtr);
         if (ctx.inType == ov::element::nf4) {
-            parallel_for(ctx.size, [&](size_t i) {
+            LoopPolicy::run(ctx.size, [&](size_t i) {
                 dst[i] = static_cast<dst_t>(ConvertNF4::dequantize(get_u4(src[i / 2], (i % 2) != 0U)));
             });
         } else if (ctx.inType == ov::element::u4) {
-            parallel_for(ctx.size, [&](size_t i) {
+            LoopPolicy::run(ctx.size, [&](size_t i) {
                 dst[i] = static_cast<dst_t>(get_u4(src[i / 2], (i % 2) != 0U));
             });
         } else if (ctx.inType == ov::element::i4) {
-            parallel_for(ctx.size, [&](size_t i) {
+            LoopPolicy::run(ctx.size, [&](size_t i) {
                 dst[i] = static_cast<dst_t>(get_i4(src[i / 2], (i % 2) != 0U));
             });
         } else if (ctx.inType == ov::element::f4e2m1) {
-            parallel_for(ctx.size, [&](size_t i) {
+            LoopPolicy::run(ctx.size, [&](size_t i) {
                 dst[i] = static_cast<dst_t>(float4_e2m1::from_bits(get_u4(src[i / 2], (i % 2) != 0U)));
             });
         } else {
@@ -943,7 +992,10 @@ struct ConvertFrom4BitPrecision<std::tuple<src_t, dst_t>> {
 
 #define INTEL_CPU_CVT_TO_4BIT_LIST INTEL_CPU_CVT(f32, nf4), INTEL_CPU_CVT(f16, nf4), INTEL_CPU_CVT(bf16, nf4)
 
+template <typename LoopPolicy>
 struct ConvertTo4BitContext {
+    using loop_policy = LoopPolicy;
+
     ov::element::Type_t outType;
     const void* srcPtr;
     void* dstPtr;
@@ -956,7 +1008,9 @@ struct ConvertTo4BitPrecision;
 
 template <typename src_t, typename dst_t>
 struct ConvertTo4BitPrecision<std::tuple<src_t, dst_t>> {
-    void operator()(ConvertTo4BitContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         auto insert_half_byte = [](uint8_t dst, uint8_t val, bool high_half) -> uint8_t {
             uint8_t shift = high_half ? 4 : 0;
             return dst | static_cast<uint8_t>(val << shift);
@@ -968,7 +1022,7 @@ struct ConvertTo4BitPrecision<std::tuple<src_t, dst_t>> {
         auto work_amount = ctx.size / 2;
         auto has_tail = ctx.size % work_amount != 0;
         if (ctx.outType == ov::element::nf4) {
-            parallel_for(work_amount, [&](size_t ib) {
+            LoopPolicy::run(work_amount, [&](size_t ib) {
                 size_t idx = ib * 2;
                 const auto val = insert_half_byte(0, ConvertNF4::quantize(static_cast<float>(src[idx])), false);
                 dst[ib] = insert_half_byte(val, ConvertNF4::quantize(static_cast<float>(src[idx + 1])), true);
@@ -988,7 +1042,10 @@ struct ConvertTo4BitPrecision<std::tuple<src_t, dst_t>> {
 #define INTEL_CPU_CVT_FROM_BYTE_FP_LIST \
     INTEL_CPU_CVT(f8e8m0, f32), INTEL_CPU_CVT(f8e8m0, bf16), INTEL_CPU_CVT(f8e8m0, f16)
 
+template <typename LoopPolicy>
 struct ConvertFromByteFPContext {
+    using loop_policy = LoopPolicy;
+
     ov::element::Type_t inType;
     const void* srcPtr;
     void* dstPtr;
@@ -1001,11 +1058,13 @@ struct ConvertFromByteFPPrecision;
 
 template <typename src_t, typename dst_t>
 struct ConvertFromByteFPPrecision<std::tuple<src_t, dst_t>> {
-    void operator()(ConvertFromByteFPContext& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         const auto* src = static_cast<const uint8_t*>(ctx.srcPtr);
         auto dst = static_cast<dst_t*>(ctx.dstPtr);
         if (ctx.inType == ov::element::f8e8m0) {
-            parallel_for(ctx.size, [&](size_t i) {
+            LoopPolicy::run(ctx.size, [&](size_t i) {
                 dst[i] = static_cast<dst_t>(float8_e8m0::from_bits(src[i]));
             });
         } else {
@@ -1016,7 +1075,10 @@ struct ConvertFromByteFPPrecision<std::tuple<src_t, dst_t>> {
 };
 
 #if defined(OPENVINO_ARCH_X86_64)
+template <typename LoopPolicy>
 struct ConvertFP8Context {
+    using loop_policy = LoopPolicy;
+
     const void* srcPtr;
     void* dstPtr;
     size_t size;
@@ -1028,12 +1090,14 @@ struct ConvertFP8Precision;
 
 template <typename src_t, typename dst_t>
 struct ConvertFP8Precision<std::tuple<src_t, dst_t>> {
-    void operator()(ConvertFP8Context& ctx) {
+    template <typename Ctx>
+    void operator()(Ctx& ctx) {
+        using LoopPolicy = typename Ctx::loop_policy;
         auto src = static_cast<const src_t*>(ctx.srcPtr);
         auto dst = static_cast<dst_t*>(ctx.dstPtr);
         constexpr size_t batch = 64;
         const size_t iterations = ov::intel_cpu::div_up(ctx.size, batch);
-        parallel_for(iterations, [&](size_t i) {
+        LoopPolicy::run(iterations, [&](size_t i) {
             const size_t offset = i * batch;
             const size_t current_batch_size = std::min(ctx.size - offset, batch);
             jit_convert(src + offset, dst + offset, current_batch_size);
@@ -1044,20 +1108,13 @@ struct ConvertFP8Precision<std::tuple<src_t, dst_t>> {
 };
 #endif
 
-void cpu_convert(const void* srcPtr,
-                 void* dstPtr,
-                 ov::element::Type srcPrc,
-                 ov::element::Type dstPrc,
-                 const size_t size) {
-    cpu_convert(srcPtr, dstPtr, srcPrc, dstPrc, dstPrc, size);
-}
-
-void cpu_convert(const void* srcPtr,
-                 void* dstPtr,
-                 ov::element::Type srcPrc,
-                 ov::element::Type interimPrc,
-                 ov::element::Type dstPrc,
-                 const size_t size) {
+template <typename LoopPolicy>
+static void do_cpu_convert(const void* srcPtr,
+                           void* dstPtr,
+                           ov::element::Type srcPrc,
+                           ov::element::Type interimPrc,
+                           ov::element::Type dstPrc,
+                           const size_t size) {
     if (size == 0) {
         return;
     }
@@ -1070,7 +1127,7 @@ void cpu_convert(const void* srcPtr,
             const auto* str_src = reinterpret_cast<const StringMemory::OvString*>(srcPtr);
             auto* str_dst = reinterpret_cast<StringMemory::OvString*>(dstPtr);
             std::copy(str_src, str_src + size, str_dst);
-        } else if (totalSize >= L2_cache_size) {
+        } else if (std::is_same_v<LoopPolicy, ParallelLoopPolicy> && totalSize >= L2_cache_size) {
             const auto* src = static_cast<const uint8_t*>(srcPtr);
             auto* dst = static_cast<uint8_t*>(dstPtr);
             parallel_nt(0, [&](const size_t ithr, const size_t nthr) {
@@ -1091,7 +1148,7 @@ void cpu_convert(const void* srcPtr,
                         "> precision to: ",
                         dstPrc,
                         ". Not implemented.");
-        ConvertFromBinContext ctx{srcPtr, dstPtr, size, false};
+        ConvertFromBinContext<LoopPolicy> ctx{srcPtr, dstPtr, size, false};
         OV_SWITCH(intel_cpu, ConvertFromBinPrecision, ctx, std::tie(srcPrc, dstPrc), INTEL_CPU_CVT_FROM_BIN_LIST);
         OPENVINO_ASSERT(ctx.converted,
                         "cpu_convert can't convert from: ",
@@ -1101,19 +1158,19 @@ void cpu_convert(const void* srcPtr,
                         "> precision to: ",
                         dstPrc);
     } else if (srcPrc == ov::element::u2) {
-        ConvertFrom2BitContext ctx{srcPtr, dstPtr, size, false};
+        ConvertFrom2BitContext<LoopPolicy> ctx{srcPtr, dstPtr, size, false};
         OV_SWITCH(intel_cpu, ConvertFrom2BitPrecision, ctx, std::tie(srcPrc, dstPrc), INTEL_CPU_CVT_FROM_2BIT_LIST);
         OPENVINO_ASSERT(ctx.converted, "cpu_convert can't convert from: ", srcPrc, " precision to: ", dstPrc);
     } else if (srcPrc.bitwidth() == 4U) {
-        ConvertFrom4BitContext ctx{srcPrc, srcPtr, dstPtr, size, false};
+        ConvertFrom4BitContext<LoopPolicy> ctx{srcPrc, srcPtr, dstPtr, size, false};
         OV_SWITCH(intel_cpu, ConvertFrom4BitPrecision, ctx, std::tie(srcPrc, dstPrc), INTEL_CPU_CVT_FROM_4BIT_LIST);
         OPENVINO_ASSERT(ctx.converted, "cpu_convert can't convert from: ", srcPrc, " precision to: ", dstPrc);
     } else if (dstPrc.bitwidth() == 4U) {
-        ConvertTo4BitContext ctx{dstPrc, srcPtr, dstPtr, size, false};
+        ConvertTo4BitContext<LoopPolicy> ctx{dstPrc, srcPtr, dstPtr, size, false};
         OV_SWITCH(intel_cpu, ConvertTo4BitPrecision, ctx, std::tie(srcPrc, dstPrc), INTEL_CPU_CVT_TO_4BIT_LIST);
         OPENVINO_ASSERT(ctx.converted, "cpu_convert can't convert from: ", srcPrc, " precision to: ", dstPrc);
     } else if (srcPrc == ov::element::f8e8m0) {
-        ConvertFromByteFPContext ctx{srcPrc, srcPtr, dstPtr, size, false};
+        ConvertFromByteFPContext<LoopPolicy> ctx{srcPrc, srcPtr, dstPtr, size, false};
         OV_SWITCH(intel_cpu,
                   ConvertFromByteFPPrecision,
                   ctx,
@@ -1124,15 +1181,49 @@ void cpu_convert(const void* srcPtr,
     } else if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_fp16) &&
                (any_of(srcPrc, ov::element::f8e4m3, ov::element::f8e5m2) ||
                 any_of(dstPrc, ov::element::f8e4m3, ov::element::f8e5m2))) {
-        ConvertFP8Context ctx{srcPtr, dstPtr, size, false};
+        ConvertFP8Context<LoopPolicy> ctx{srcPtr, dstPtr, size, false};
         OV_SWITCH(intel_cpu, ConvertFP8Precision, ctx, std::tie(srcPrc, dstPrc), INTEL_CPU_CVT_FP8_LIST);
         OPENVINO_ASSERT(ctx.converted, "cpu_convert can't convert from: ", srcPrc, " precision to: ", dstPrc);
 #endif
     } else {
-        ConvertContext ctx{srcPtr, dstPtr, size, interimPrc, dstPrc, false};
+        ConvertContext<LoopPolicy> ctx{srcPtr, dstPtr, size, interimPrc, dstPrc, false};
         OV_SWITCH(intel_cpu, ConvertPrecision, ctx, std::tie(srcPrc, dstPrc), INTEL_CPU_CVT_LIST);
         OPENVINO_ASSERT(ctx.converted, "cpu_convert can't convert from: ", srcPrc, " precision to: ", dstPrc);
     }
+}
+
+void cpu_convert(const void* srcPtr,
+                 void* dstPtr,
+                 ov::element::Type srcPrc,
+                 ov::element::Type dstPrc,
+                 const size_t size) {
+    do_cpu_convert<SequentialLoopPolicy>(srcPtr, dstPtr, srcPrc, dstPrc, dstPrc, size);
+}
+
+void cpu_convert(const void* srcPtr,
+                 void* dstPtr,
+                 ov::element::Type srcPrc,
+                 ov::element::Type interimPrc,
+                 ov::element::Type dstPrc,
+                 const size_t size) {
+    do_cpu_convert<SequentialLoopPolicy>(srcPtr, dstPtr, srcPrc, interimPrc, dstPrc, size);
+}
+
+void cpu_parallel_convert(const void* srcPtr,
+                          void* dstPtr,
+                          ov::element::Type srcPrc,
+                          ov::element::Type dstPrc,
+                          const size_t size) {
+    do_cpu_convert<ParallelLoopPolicy>(srcPtr, dstPtr, srcPrc, dstPrc, dstPrc, size);
+}
+
+void cpu_parallel_convert(const void* srcPtr,
+                          void* dstPtr,
+                          ov::element::Type srcPrc,
+                          ov::element::Type interimPrc,
+                          ov::element::Type dstPrc,
+                          const size_t size) {
+    do_cpu_convert<ParallelLoopPolicy>(srcPtr, dstPtr, srcPrc, interimPrc, dstPrc, size);
 }
 
 struct isSupportedContext {

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -50,17 +50,16 @@ namespace {
 // so cpu_convert and cpu_parallel_convert share the same conversion bodies.
 struct ParallelLoopPolicy {
     template <typename Body>
-    static void run(size_t iterations, Body&& body) {
-        parallel_for(iterations, std::forward<Body>(body));
+    static void run(size_t iterations, const Body& body) {
+        parallel_for(iterations, body);
     }
 };
 
 struct SequentialLoopPolicy {
     template <typename Body>
-    static void run(size_t iterations, Body&& body) {
-        auto&& fn = std::forward<Body>(body);
+    static void run(size_t iterations, const Body& body) {
         for (size_t i = 0; i < iterations; ++i) {
-            fn(i);
+            body(i);
         }
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.h
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.h
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#pragma once
+
 #include <cstddef>
 
 #include "openvino/core/type/element_type.hpp"
@@ -9,38 +11,26 @@
 namespace ov::intel_cpu {
 
 /**
- * @brief Copy size elements from buffer specified srcPtr pointer to buffer specified dstPtr.
- * If the precisions srcPrc and dstPrc are different, a conversion from srcPrc to dstPrc is performed.
- * @param srcPtr
- * pointer to the buffer to convert from
- * @param dstPtr
- * pointer to the buffer to convert to
- * @param srcPrc
- * precision the buffer from which convert
- * @param dstPrc
- * precision the buffer to which convert
- * @param size
- * number of elements in buffers to be converted
- * @return none.
+ * @brief Sequential precision conversion. Copies `size` elements from `srcPtr` to
+ * `dstPtr`; if `srcPrc` and `dstPrc` differ, the conversion is performed element-wise.
+ * Use this variant when the call site already runs inside an outer parallel region
+ * (e.g. inside parallel_for / parallel_for2d) to avoid nested parallelism.
+ *
+ * Mirrors the cpu_memcpy / cpu_parallel_memcpy split.
+ *
+ * @param srcPtr  pointer to the buffer to convert from
+ * @param dstPtr  pointer to the buffer to convert to
+ * @param srcPrc  precision of the source buffer
+ * @param dstPrc  precision of the destination buffer
+ * @param size    number of elements in the buffers to be converted
  */
 void cpu_convert(const void* srcPtr, void* dstPtr, ov::element::Type srcPrc, ov::element::Type dstPrc, size_t size);
 
 /**
- * @brief Copy size elements from buffer specified srcPtr pointer to buffer specified dstPtr.
- * If the precisions srcPrc and dstPrc are different, a conversion from srcPrc to dstPrc is performed.
- * @param srcPtr
- * pointer to the buffer to convert from
- * @param dstPtr
- * pointer to the buffer to convert to
- * @param srcPrc
- * precision the buffer from which convert
- * @param interimPrc
- * intermediate precision used for type truncation
- * @param dstPrc
- * precision the buffer to which convert
- * @param size
- * number of elements in buffers to be converted
- * @return none.
+ * @copydoc cpu_convert(const void*, void*, ov::element::Type, ov::element::Type, size_t)
+ *
+ * @param interimPrc  intermediate precision used as a bridge when no direct
+ *                    `srcPrc -> dstPrc` kernel exists
  */
 void cpu_convert(const void* srcPtr,
                  void* dstPtr,
@@ -48,6 +38,36 @@ void cpu_convert(const void* srcPtr,
                  ov::element::Type interimPrc,
                  ov::element::Type dstPrc,
                  size_t size);
+
+/**
+ * @brief Parallel precision conversion. Same semantics as cpu_convert but internally
+ * dispatches the loop body via parallel_for. Use this variant for top-level conversions
+ * not nested inside an outer parallel region.
+ *
+ * @param srcPtr  pointer to the buffer to convert from
+ * @param dstPtr  pointer to the buffer to convert to
+ * @param srcPrc  precision of the source buffer
+ * @param dstPrc  precision of the destination buffer
+ * @param size    number of elements in the buffers to be converted
+ */
+void cpu_parallel_convert(const void* srcPtr,
+                          void* dstPtr,
+                          ov::element::Type srcPrc,
+                          ov::element::Type dstPrc,
+                          size_t size);
+
+/**
+ * @copydoc cpu_parallel_convert(const void*, void*, ov::element::Type, ov::element::Type, size_t)
+ *
+ * @param interimPrc  intermediate precision used as a bridge when no direct
+ *                    `srcPrc -> dstPrc` kernel exists
+ */
+void cpu_parallel_convert(const void* srcPtr,
+                          void* dstPtr,
+                          ov::element::Type srcPrc,
+                          ov::element::Type interimPrc,
+                          ov::element::Type dstPrc,
+                          size_t size);
 
 bool is_supported_convert(ov::element::Type srcPrc, ov::element::Type dstPrc);
 

--- a/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
@@ -296,7 +296,7 @@ void TileBroadcastCommon::optimizedExecute(const MemoryPtr& srcMemory,
         // TODO: 109204
         // cpu_convert have to be used here because its implementation faster than cpu_memcpy
         // in the case when copySize exceeds L2 cache size
-        cpu_convert(srcData, dstData, prc, prc, optimizedParams.copySize / prc.size());
+        cpu_parallel_convert(srcData, dstData, prc, prc, optimizedParams.copySize / prc.size());
     } else if (optimizedParams.srcStrides[5] == 0) {
         if (optimizedParams.dstStrides[0] == optimizedParams.dims[5] * optimizedParams.dstStrides[5]) {
             size_t data_size = optimizedParams.dstStrides[5];

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -782,7 +782,11 @@ void Concat::execWithFuseConvert() {
 
                 size_t numElementsFP16 = nelemToCopy[a] / sizeof(ov::float16);
 
-                cpu_parallel_convert(inputDataFP16, outputDataFP32, ov::element::f16, ov::element::f32, numElementsFP16);
+                cpu_parallel_convert(inputDataFP16,
+                                     outputDataFP32,
+                                     ov::element::f16,
+                                     ov::element::f32,
+                                     numElementsFP16);
             }
         } else {
             // Multi-threaded execution
@@ -802,7 +806,11 @@ void Concat::execWithFuseConvert() {
                     auto* outputDataFP32 =
                         reinterpret_cast<float*>(&reinterpret_cast<uint8_t*>(dstPtr)[dstOffset[a]]) + start;
 
-                    cpu_parallel_convert(inputDataFP16, outputDataFP32, ov::element::f16, ov::element::f32, end - start);
+                    cpu_parallel_convert(inputDataFP16,
+                                         outputDataFP32,
+                                         ov::element::f16,
+                                         ov::element::f32,
+                                         end - start);
                 }
             });
         }
@@ -849,7 +857,11 @@ void Concat::execWithFuseConvert() {
                 // Convert number of bytes to number of elements for this slice
                 size_t numElementsFP16 = nelemToCopy[a] / sizeof(ov::float16);
 
-                cpu_parallel_convert(inputDataFP16, outputDataFP32, ov::element::f16, ov::element::f32, numElementsFP16);
+                cpu_parallel_convert(inputDataFP16,
+                                     outputDataFP32,
+                                     ov::element::f16,
+                                     ov::element::f32,
+                                     numElementsFP16);
             });
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -782,7 +782,7 @@ void Concat::execWithFuseConvert() {
 
                 size_t numElementsFP16 = nelemToCopy[a] / sizeof(ov::float16);
 
-                cpu_convert(inputDataFP16, outputDataFP32, ov::element::f16, ov::element::f32, numElementsFP16);
+                cpu_parallel_convert(inputDataFP16, outputDataFP32, ov::element::f16, ov::element::f32, numElementsFP16);
             }
         } else {
             // Multi-threaded execution
@@ -802,7 +802,7 @@ void Concat::execWithFuseConvert() {
                     auto* outputDataFP32 =
                         reinterpret_cast<float*>(&reinterpret_cast<uint8_t*>(dstPtr)[dstOffset[a]]) + start;
 
-                    cpu_convert(inputDataFP16, outputDataFP32, ov::element::f16, ov::element::f32, end - start);
+                    cpu_parallel_convert(inputDataFP16, outputDataFP32, ov::element::f16, ov::element::f32, end - start);
                 }
             });
         }
@@ -849,7 +849,7 @@ void Concat::execWithFuseConvert() {
                 // Convert number of bytes to number of elements for this slice
                 size_t numElementsFP16 = nelemToCopy[a] / sizeof(ov::float16);
 
-                cpu_convert(inputDataFP16, outputDataFP32, ov::element::f16, ov::element::f32, numElementsFP16);
+                cpu_parallel_convert(inputDataFP16, outputDataFP32, ov::element::f16, ov::element::f32, numElementsFP16);
             });
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "allocation_context.hpp"
-#include "common/cpu_convert.h"
 #include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_memory.h"
 #include "cpu_types.h"

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -22,7 +22,6 @@
 #include "acl_utils.hpp"
 #include "cpu_shape.h"
 #include "memory_desc/cpu_memory_desc.h"
-#include "nodes/common/cpu_convert.h"
 #include "nodes/executors/acl/acl_common_executor.hpp"
 #include "nodes/executors/common/common_utils.hpp"
 #include "nodes/executors/convolution_config.hpp"

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -14,7 +14,6 @@
 
 #include "acl_utils.hpp"
 #include "memory_desc/cpu_memory_desc.h"
-#include "nodes/common/cpu_convert.h"
 #include "nodes/executors/acl/acl_common_executor.hpp"
 #include "nodes/executors/acl/acl_fullyconnected_utils.hpp"
 #include "nodes/executors/debug_messages.hpp"

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
@@ -119,10 +119,10 @@ std::optional<MemoryPtr> acl_fc_executor::convertWeightPrecision(const MemoryPtr
     std::vector<uint8_t> tmpBuff;
     tmpBuff.resize(output->getSize());
     cpu_parallel_convert(data,
-                tmpBuff.data(),
-                DnnlExtensionUtils::DataTypeToElementType(input->getDataType()),
-                weightPrecision,
-                input->getSize() / input->getDesc().getPrecision().size());
+                         tmpBuff.data(),
+                         DnnlExtensionUtils::DataTypeToElementType(input->getDataType()),
+                         weightPrecision,
+                         input->getSize() / input->getDesc().getPrecision().size());
 
     return std::make_shared<Memory>(output->getPrimitive().get_engine(),
                                     output->getDesc().cloneWithNewPrecision(weightPrecision),

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
@@ -118,7 +118,7 @@ std::optional<MemoryPtr> acl_fc_executor::convertWeightPrecision(const MemoryPtr
     const auto* data = static_cast<const uint8_t*>(input->getData());
     std::vector<uint8_t> tmpBuff;
     tmpBuff.resize(output->getSize());
-    cpu_convert(data,
+    cpu_parallel_convert(data,
                 tmpBuff.data(),
                 DnnlExtensionUtils::DataTypeToElementType(input->getDataType()),
                 weightPrecision,

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -17,7 +17,6 @@
 #include "acl_fullyconnected_utils.hpp"
 #include "arm_compute/runtime/NEON/functions/NEGEMMLowpMatrixMultiplyCore.h"
 #include "memory_desc/cpu_memory_desc.h"
-#include "nodes/common/cpu_convert.h"
 #include "nodes/executors/acl/acl_common_executor.hpp"
 #include "nodes/executors/acl/acl_utils.hpp"
 #include "nodes/executors/common/common_utils.hpp"

--- a/src/plugins/intel_cpu/src/nodes/executors/common/ref_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/ref_convert.cpp
@@ -33,11 +33,11 @@ void CommonConvertExecutor::exec(const std::vector<MemoryCPtr>& src, const std::
     assert(dst.size() == 1);
 
     cpu_parallel_convert(src[0]->getData(),
-                dst[0]->getData(),
-                commonConvertParams.srcPrc,
-                commonConvertParams.origPrc,
-                commonConvertParams.dstPrc,
-                commonConvertParams.size);
+                         dst[0]->getData(),
+                         commonConvertParams.srcPrc,
+                         commonConvertParams.origPrc,
+                         commonConvertParams.dstPrc,
+                         commonConvertParams.size);
 }
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/common/ref_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/ref_convert.cpp
@@ -32,7 +32,7 @@ void CommonConvertExecutor::exec(const std::vector<MemoryCPtr>& src, const std::
     assert(src.size() == 1);
     assert(dst.size() == 1);
 
-    cpu_convert(src[0]->getData(),
+    cpu_parallel_convert(src[0]->getData(),
                 dst[0]->getData(),
                 commonConvertParams.srcPrc,
                 commonConvertParams.origPrc,

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -16,7 +16,6 @@
 #include <utility>
 #include <vector>
 
-#include "common/cpu_convert.h"
 #include "common/cpu_memcpy.h"
 #include "config.h"
 #include "cpu_memory.h"

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -52,10 +52,10 @@ void If::PortMapHelper::execute([[maybe_unused]] const dnnl::stream& strm) {
     redefineTo();
 
     cpu_parallel_convert(srcMemPtr->getData(),
-                dstMemPtrs.front()->getData(),
-                srcMemPtr->getDesc().getPrecision(),
-                dstMemPtrs.front()->getDesc().getPrecision(),
-                size);
+                         dstMemPtrs.front()->getData(),
+                         srcMemPtr->getDesc().getPrecision(),
+                         dstMemPtrs.front()->getDesc().getPrecision(),
+                         size);
 }
 
 void If::PortMapHelper::redefineTo() {

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -51,7 +51,7 @@ void If::PortMapHelper::execute([[maybe_unused]] const dnnl::stream& strm) {
     // after subgraph inference we should redefine out memory of 'If'
     redefineTo();
 
-    cpu_convert(srcMemPtr->getData(),
+    cpu_parallel_convert(srcMemPtr->getData(),
                 dstMemPtrs.front()->getData(),
                 srcMemPtr->getDesc().getPrecision(),
                 dstMemPtrs.front()->getDesc().getPrecision(),

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -25,7 +25,6 @@
 #include "memory_desc/cpu_memory_desc_utils.h"
 #include "memory_desc/dnnl_blocked_memory_desc.h"
 #include "node.h"
-#include "nodes/common/cpu_convert.h"
 #include "onednn/iml_type_mapper.h"
 #include "openvino/core/except.hpp"
 #include "openvino/core/node.hpp"

--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -30,7 +30,6 @@
 #include "memory_state.h"
 #include "node.h"
 #include "nodes/common/blocked_desc_creator.h"
-#include "nodes/common/cpu_convert.h"
 #include "nodes/input.h"
 #include "nodes/memory_state_base.h"
 #include "nodes/node_config.h"

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -37,7 +37,6 @@
 #include "memory_desc/cpu_memory_desc.h"
 #include "node.h"
 #include "nodes/common/blocked_desc_creator.h"
-#include "nodes/common/cpu_convert.h"
 #include "nodes/node_config.h"
 #include "onednn/iml_type_mapper.h"
 #include "openvino/cc/selective_build.h"

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -458,7 +458,7 @@ void RegionYolo::execute([[maybe_unused]] const dnnl::stream& strm) {
     const auto* src_data = getSrcDataAtPortAs<const uint8_t>(0);
     auto* dst_data = getDstDataAtPortAs<uint8_t>(0);
 
-    cpu_convert(src_data,
+    cpu_parallel_convert(src_data,
                 dst_data,
                 getParentEdgeAt(0)->getMemory().getDesc().getPrecision(),
                 getChildEdgeAt(0)->getMemory().getDesc().getPrecision(),

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -459,10 +459,10 @@ void RegionYolo::execute([[maybe_unused]] const dnnl::stream& strm) {
     auto* dst_data = getDstDataAtPortAs<uint8_t>(0);
 
     cpu_parallel_convert(src_data,
-                dst_data,
-                getParentEdgeAt(0)->getMemory().getDesc().getPrecision(),
-                getChildEdgeAt(0)->getMemory().getDesc().getPrecision(),
-                output_size);
+                         dst_data,
+                         getParentEdgeAt(0)->getMemory().getDesc().getPrecision(),
+                         getChildEdgeAt(0)->getMemory().getDesc().getPrecision(),
+                         output_size);
 
     for (size_t b = 0; b < B; b++) {
         for (int n = 0; n < num_; n++) {

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -600,7 +600,7 @@ void Reorder::reorderData(const IMemory& input,
                 tmpBuff.resize(output.getSize());
 
                 const auto outPrc = DnnlExtensionUtils::DataTypeToElementType(output.getDataType());
-                cpu_convert(data,
+                cpu_parallel_convert(data,
                             tmpBuff.data(),
                             DnnlExtensionUtils::DataTypeToElementType(input.getDataType()),
                             outPrc,

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -601,10 +601,10 @@ void Reorder::reorderData(const IMemory& input,
 
                 const auto outPrc = DnnlExtensionUtils::DataTypeToElementType(output.getDataType());
                 cpu_parallel_convert(data,
-                            tmpBuff.data(),
-                            DnnlExtensionUtils::DataTypeToElementType(input.getDataType()),
-                            outPrc,
-                            input.getDesc().getShape().getElementsCount());
+                                     tmpBuff.data(),
+                                     DnnlExtensionUtils::DataTypeToElementType(input.getDataType()),
+                                     outPrc,
+                                     input.getDesc().getShape().getElementsCount());
 
                 auto tmpDesc = input.getDesc().cloneWithNewPrecision(outPrc);
                 Memory tmpMem(engine, tmpDesc, tmpBuff.data());

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -1055,10 +1055,10 @@ void RNN::fillBiases() {
             ie_b_ptr = ie_b_vec.data();
 
             cpu_parallel_convert(b_const_blob->getData(),
-                        ie_b_ptr,
-                        DnnlExtensionUtils::DataTypeToElementType(b_const_blob->getDataType()),
-                        ET,
-                        ie_b_vec_size);
+                                 ie_b_ptr,
+                                 DnnlExtensionUtils::DataTypeToElementType(b_const_blob->getDataType()),
+                                 ET,
+                                 ie_b_vec_size);
         } else {
             ie_b_ptr = reinterpret_cast<DataType*>(b_const_blob->getData());
         }

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -950,7 +950,7 @@ void RNN::fillWeights() {
             ie_w_vec.resize(ie_w_vec_size);
             ie_w_ptr = ie_w_vec.data();
 
-            cpu_convert(w_const_blob->getData(), ie_w_ptr, weightPrec, targetWeightPrec, ie_w_vec_size);
+            cpu_parallel_convert(w_const_blob->getData(), ie_w_ptr, weightPrec, targetWeightPrec, ie_w_vec_size);
         } else {
             ie_w_ptr = reinterpret_cast<DataType*>(w_const_blob->getData());
         }
@@ -986,7 +986,7 @@ void RNN::fillWeights() {
             ie_r_vec.resize(ie_r_vec_size);
             ie_r_ptr = ie_r_vec.data();
 
-            cpu_convert(r_const_blob->getData(), ie_r_ptr, weightPrec, targetWeightPrec, ie_r_vec_size);
+            cpu_parallel_convert(r_const_blob->getData(), ie_r_ptr, weightPrec, targetWeightPrec, ie_r_vec_size);
         } else {
             ie_r_ptr = reinterpret_cast<DataType*>(r_const_blob->getData());
         }
@@ -1054,7 +1054,7 @@ void RNN::fillBiases() {
             ie_b_vec.resize(ie_b_vec_size);
             ie_b_ptr = ie_b_vec.data();
 
-            cpu_convert(b_const_blob->getData(),
+            cpu_parallel_convert(b_const_blob->getData(),
                         ie_b_ptr,
                         DnnlExtensionUtils::DataTypeToElementType(b_const_blob->getDataType()),
                         ET,

--- a/src/plugins/intel_cpu/src/nodes/roi_align_rotated.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align_rotated.cpp
@@ -75,10 +75,10 @@ void ROIAlignRotated::executeImpl() {
 
     std::vector<int64_t> batch_indices_vec_scaled_up(batch_indices_size);
     cpu_parallel_convert(getSrcMemoryAtPort(2)->getData(),
-                batch_indices_vec_scaled_up.data(),
-                getSrcMemoryAtPort(2)->getPrecision(),
-                ov::element::i64,
-                batch_indices_size);
+                         batch_indices_vec_scaled_up.data(),
+                         getSrcMemoryAtPort(2)->getPrecision(),
+                         ov::element::i64,
+                         batch_indices_size);
 
     ov::reference::roi_align<T, ov::reference::roi_policy::ROIAlignRotatedOpDefPolicy>(
         getSrcDataAtPortAs<const T>(0),

--- a/src/plugins/intel_cpu/src/nodes/roi_align_rotated.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align_rotated.cpp
@@ -74,7 +74,7 @@ void ROIAlignRotated::executeImpl() {
     const size_t batch_indices_size = getSrcMemoryAtPort(2)->getShape().getElementsCount();
 
     std::vector<int64_t> batch_indices_vec_scaled_up(batch_indices_size);
-    cpu_convert(getSrcMemoryAtPort(2)->getData(),
+    cpu_parallel_convert(getSrcMemoryAtPort(2)->getData(),
                 batch_indices_vec_scaled_up.data(),
                 getSrcMemoryAtPort(2)->getPrecision(),
                 ov::element::i64,

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -76,8 +76,10 @@
 #include "kernels/scaled_attn/mha_single_token.hpp"
 #include "kernels/scaled_attn/softmax.hpp"
 #include "kernels/x64/brgemm_kernel.hpp"
-#include "nodes/common/cpu_convert.h"
 #include "utils/precision_support.h"
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+#    include "nodes/common/cpu_convert.h"
+#endif
 
 using namespace ov::Extensions::Cpu::XARCH;
 using namespace dnnl::impl;

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -861,7 +861,7 @@ struct MHAKernel<ScaledDotProductAttention::KT_ACL, T> {
                         const size_t h_idx = alibi_mask.size(1) > 1 ? h : 0;
                         const size_t m_idx = alibi_mask.size(2) > 1 ? m : 0;
                         const void* alibi_src = alibi_mask.ptr_v(b_idx, h_idx, m_idx, 0);
-                        cpu_convert(alibi_src, alibi_row.data(), alibi_prec, ov::element::f32, kv_len);
+                        cpu_parallel_convert(alibi_src, alibi_row.data(), alibi_prec, ov::element::f32, kv_len);
                         alibi_row_ptr = alibi_row.data();
                     }
                     auto* sink = sink_ptr(m);
@@ -1024,7 +1024,7 @@ struct MHAKernel<ScaledDotProductAttention::KT_ACL, T> {
                         const size_t h_idx = alibi_mask.size(1) > 1 ? h : 0;
                         const size_t m_idx = alibi_mask.size(2) > 1 ? m : 0;
                         const void* alibi_src = alibi_mask.ptr_v(b_idx, h_idx, m_idx, 0);
-                        cpu_convert(alibi_src, alibi_row.data(), alibi_prec, ov::element::f32, kv_len);
+                        cpu_parallel_convert(alibi_src, alibi_row.data(), alibi_prec, ov::element::f32, kv_len);
                         alibi_row_ptr = alibi_row.data();
                     }
                     auto* sink = sink_ptr(m);
@@ -1794,7 +1794,7 @@ struct ScaledDotProductAttention::AttentionExecutor : public ScaledDotProductAtt
                                 const size_t h_idx = alibi_mask.size(1) > 1 ? h : 0;
                                 const size_t m_idx = alibi_mask.size(2) > 1 ? m : 0;
                                 const void* alibi_src = alibi_mask.ptr_v(b_idx, h_idx, m_idx, 0);
-                                cpu_convert(alibi_src, alibi_row.data(), alibi_prec, ov::element::f32, kv_len);
+                                cpu_parallel_convert(alibi_src, alibi_row.data(), alibi_prec, ov::element::f32, kv_len);
                                 alibi_row_ptr = alibi_row.data();
                             }
                             auto* sink = sink_ptr(m);


### PR DESCRIPTION
### Details:
 - *Splits `cpu_convert` into two explicit entry points:
- `cpu_convert(...)` — sequential, safe to call inside an outer
  `parallel_for` / `parallel_for2d`.
- `cpu_parallel_convert(...)` — internally parallelizes the conversion;
  callers that previously relied on the embedded `parallel_for` keep the
  same behavior.*


### Tickets:
 - *CVS-187758*


