### PR TITLE
[GPU] Fix null dereference risk in GPU cache load zero-copy path

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -420,7 +420,8 @@ struct data : public primitive_base<data> {
 
         bool enable_zero_copy_mode = ib.is_mmap_tensor_4K_aligned() && ib.get_engine().get_device_info().arch >= gpu_arch::xe2 &&
                                      ib.get_engine().get_device_info().dev_type == device_type::integrated_gpu &&
-                                     _allocation_type == allocation_type::usm_host && !weightless_caching;
+                                     _allocation_type == allocation_type::usm_host && !weightless_caching &&
+                                     model_tensor_base != nullptr;
         if (!enable_zero_copy_mode) {
             mem = ib.get_engine().allocate_memory(output_layout, _allocation_type, false);
         }


### PR DESCRIPTION
### Details:
- Fixes a potential null dereference in the GPU plugin cache load path (CID 2544383, FORWARD_NULL).

### Tickets:
 - 188209

### AI Assistance:
 - AI assistance used: yes
 - AI: fix issue
 - User: review
