### PR TITLE
[GPU] Rebind optimized-out resample output to oneDNN sum-reuse destination

### DIFF
--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -243,8 +243,6 @@ resample_inst::typed_primitive_inst(network& network, resample_node const& node)
 
 void resample_inst::on_execute() {
     update_output_memory();
-    if (can_be_optimized())
-        rebind_onednn_reuse_optimized_dst_if_needed(*this);
 }
 
 void resample_inst::update_output_memory() {
@@ -256,8 +254,14 @@ void resample_inst::update_output_memory() {
     if (input_memory_ptr() == nullptr)
         return;
 
-    if (_outputs[0] && get_network().get_engine().is_the_same_buffer(output_memory(), input_memory()))
+    // compile time: resample's input/output memory is not the same
+    // runtime     : resample's input/output memory should be the same (case 1),
+    //               unless resample's input (namely dependency's output) is changed by a previous rebind (case 2).
+    if (_outputs[0] && get_network().get_engine().is_the_same_buffer(output_memory(), input_memory())) {
+        // runtime:  rebind for case 1, the user instances are already initialized here.
+        rebind_onednn_reuse_optimized_dst_if_needed(*this);
         return;
+    }
 
     // Can_be_optimized nodes are allocating from memory_pool too. In this case,
     // we need release the legacy output memory from memory pool explicitly.
@@ -266,6 +270,15 @@ void resample_inst::update_output_memory() {
         get_network().get_memory_pool().release_memory(_outputs[0].get(), get_node().get_unique_id(), get_node().id(), get_network_id());
     }
     _outputs[0] = _network.get_engine().reinterpret_buffer(input_memory(), _impl_params->get_output_layout());
+
+    const auto& users = get_user_insts();
+    // compile time: instance users are not initialized yet, skip the rebind and do it during runtime (case 1).
+    // runtime:      instance users are already initialized, do the rebind here (case 2).
+    if (!users.empty()) {
+        // runtime:  rebind for case 2.
+        rebind_onednn_reuse_optimized_dst_if_needed(*this);
+    }
+
     _mem_allocated = false;
 }
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -28,7 +28,8 @@ void rebind_onednn_reuse_optimized_dst_if_needed(primitive_inst& inst) {
 
         if (user_inst->dependencies().at(reused_eltwmem_idx).first != &inst)
             continue;
-
+        if (engine.is_the_same_buffer(*user_inst->output_memory_ptr(), *output))
+            continue;
         auto new_mem = engine.reinterpret_buffer(*output, user_inst->get_output_layout());
         user_inst->set_output_memory(new_mem, false);
     }

--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -270,15 +270,7 @@ void resample_inst::update_output_memory() {
         get_network().get_memory_pool().release_memory(_outputs[0].get(), get_node().get_unique_id(), get_node().id(), get_network_id());
     }
     _outputs[0] = _network.get_engine().reinterpret_buffer(input_memory(), _impl_params->get_output_layout());
-
-    const auto& users = get_user_insts();
-    // compile time: instance users are not initialized yet, skip the rebind and do it during runtime (case 1).
-    // runtime:      instance users are already initialized, do the rebind here (case 2).
-    if (!users.empty()) {
-        // runtime:  rebind for case 2.
-        rebind_onednn_reuse_optimized_dst_if_needed(*this);
-    }
-
+    rebind_onednn_reuse_optimized_dst_if_needed(*this);
     _mem_allocated = false;
 }
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -7,10 +7,34 @@
 #include "json_object.h"
 #include "memory_accessor.hpp"
 #include "primitive_type_base.h"
+#include "program_helpers.h"
 #include "resample_inst.h"
 
 namespace cldnn {
 GPU_DEFINE_PRIMITIVE_TYPE_ID(resample)
+
+namespace {
+
+void rebind_onednn_reuse_optimized_dst_if_needed(primitive_inst& inst) {
+    auto output = inst.output_memory_ptr();
+    if (!output)
+        return;
+
+    auto& engine = inst.get_network().get_engine();
+    for (auto* user_inst : inst.get_user_insts()) {
+        auto reused_eltwmem_idx = onednn_add_fusing_helpers::get_reused_eltwmem_idx(user_inst->get_node());
+        if (reused_eltwmem_idx < 0)
+            continue;
+
+        if (user_inst->dependencies().at(reused_eltwmem_idx).first != &inst)
+            continue;
+
+        auto new_mem = engine.reinterpret_buffer(*output, user_inst->get_output_layout());
+        user_inst->set_output_memory(new_mem, false);
+    }
+}
+
+}  // namespace
 
 layout resample_inst::calc_output_layout(resample_node const& node, kernel_impl_params const& impl_param) {
     auto desc = impl_param.typed_desc<resample>();
@@ -219,6 +243,7 @@ resample_inst::typed_primitive_inst(network& network, resample_node const& node)
 
 void resample_inst::on_execute() {
     update_output_memory();
+    rebind_onednn_reuse_optimized_dst_if_needed(*this);
 }
 
 void resample_inst::update_output_memory() {

--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -243,7 +243,8 @@ resample_inst::typed_primitive_inst(network& network, resample_node const& node)
 
 void resample_inst::on_execute() {
     update_output_memory();
-    rebind_onednn_reuse_optimized_dst_if_needed(*this);
+    if (can_be_optimized())
+        rebind_onednn_reuse_optimized_dst_if_needed(*this);
 }
 
 void resample_inst::update_output_memory() {

--- a/src/plugins/intel_gpu/tests/unit/passes/basic_memory_dependencies_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/basic_memory_dependencies_test.cpp
@@ -108,30 +108,37 @@ TEST(basic_memory_dependencies, optimized_resample_to_onednn_sum_reuse_correctne
     tests::random_generator rg;
     rg.set_seed("optimized_resample_to_onednn_sum_reuse_correctness");
     {
-        auto rnd = rg.generate_random_1d<ov::float16>(weight_layout.count(), -1, 1);
+        auto rnd = rg.generate_random_1d<ov::float16>(weight_layout.count(), -0.25f, 0.25f);
         set_values(weight_mem, rnd);
     }
 
-    topology topology;
-    topology.add(input_layout("input", in_layout));
-    topology.add(data("weight", weight_mem));
-    topology.add(convolution("conv1", input_info("input"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
-    topology.add(convolution("conv2", input_info("input"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    auto add_test_topology = [&](topology& topology) {
+        topology.add(input_layout("input", in_layout));
+        topology.add(data("weight", weight_mem));
+        topology.add(convolution("conv1", input_info("input"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+        topology.add(convolution("conv2", input_info("input"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
     // Extra conv on conv3 branch makes conv3's processing number > resample's,
     // so the fusion swap heuristic in prepare_primitive_fusing keeps eltwise(sum)
     // fused INTO conv3 (the oneDNN conv) instead of moving it into resample.
     // This is required for oneDNN sum-reuse: conv3 writes its sum DST into the
     // buffer that gets rebind from the optimized-out resample's output.
-    topology.add(convolution("conv2b", input_info("conv2"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
-    topology.add(convolution("conv3", input_info("conv2b"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
-    topology.add(resample("resample", input_info("conv1"), tensor(1, 16, 32, 32), 1,
-                          ov::op::v4::Interpolate::InterpolateMode::NEAREST));
-    topology.add(eltwise("eltwise", input_info("conv3"), input_info("resample"), eltwise_mode::sum));
-    topology.add(reorder("reorder", input_info("eltwise"), format::bfyx, data_types::f32));
+        topology.add(convolution("conv2b", input_info("conv2"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+        topology.add(convolution("conv3", input_info("conv2b"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+        topology.add(resample("resample", input_info("conv1"), tensor(1, 16, 32, 32), 1,
+                              ov::op::v4::Interpolate::InterpolateMode::NEAREST));
+        topology.add(eltwise("eltwise", input_info("conv3"), input_info("resample"), eltwise_mode::sum));
+        topology.add(reorder("reorder", input_info("eltwise"), format::bfyx, data_types::f32));
+    };
+
+    topology test_topology;
+    add_test_topology(test_topology);
+
+    topology ref_topology;
+    add_test_topology(ref_topology);
 
     auto input_mem = engine.allocate_memory(in_layout);
     {
-        auto rnd = rg.generate_random_1d<ov::float16>(in_layout.count(), -1, 1);
+        auto rnd = rg.generate_random_1d<ov::float16>(in_layout.count(), -0.25f, 0.25f);
         set_values(input_mem, rnd);
     }
 
@@ -151,7 +158,16 @@ TEST(basic_memory_dependencies, optimized_resample_to_onednn_sum_reuse_correctne
                                                                                           {"conv3", conv3_impl},
                                                                                           {"eltwise", eltwise_impl}}));
 
-    auto prog = program::build_program(engine, topology, config);
+    // Reference: disable optimize_data so resample is executed as a normal node
+    // and the optimized-out alias/rebind path is bypassed.
+    ExecutionConfig config_ref = get_test_default_config(engine);
+    config_ref.set_property(ov::intel_gpu::optimize_data(false));
+
+    network net_ref(engine, ref_topology, config_ref);
+    net_ref.set_input_data("input", input_mem);
+    auto outputs_ref = net_ref.execute();
+
+    auto prog = program::build_program(engine, test_topology, config);
     network net(prog, 0);
 
     auto resample_inst = net.get_primitive("resample");
@@ -199,7 +215,24 @@ TEST(basic_memory_dependencies, optimized_resample_to_onednn_sum_reuse_correctne
         << "oneDNN sum-reuse rebind failed: optimized-out resample output buffer "
         << "should alias conv3's reused sum destination buffer.";
 
+    auto out_ref = outputs_ref.at("reorder").get_memory();
     auto out_mem = outputs.at("reorder").get_memory();
+    ASSERT_NE(out_ref, nullptr);
     ASSERT_NE(out_mem, nullptr);
+    ASSERT_EQ(out_ref->count(), out_mem->count());
+
+    cldnn::mem_lock<float> ref_ptr(out_ref, get_test_stream());
+    cldnn::mem_lock<float> opt_ptr(out_mem, get_test_stream());
+
+    const float rel_tolerance = 5e-3f;
+    const float abs_tolerance = 3e-2f;
+    const float abs_tolerance_limit = 5e-2f;
+    for (size_t i = 0; i < out_ref->count(); i++) {
+        ASSERT_TRUE(are_equal(ref_ptr[i], opt_ptr[i], rel_tolerance, abs_tolerance, abs_tolerance_limit))
+            << "Mismatch at index " << i
+            << ": ref=" << ref_ptr[i] << " opt=" << opt_ptr[i]
+            << " rel_tolerance=" << rel_tolerance
+            << " abs_tolerance=" << abs_tolerance;
+    }
 }
 #endif  // ENABLE_ONEDNN_FOR_GPU

--- a/src/plugins/intel_gpu/tests/unit/passes/basic_memory_dependencies_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/basic_memory_dependencies_test.cpp
@@ -13,6 +13,8 @@
 #include "convolution_inst.h"
 #include "reshape_inst.h"
 #include "reorder_inst.h"
+#include "resample_inst.h"
+#include "program_helpers.h"
 
 #include <memory>
 
@@ -90,3 +92,114 @@ TEST(basic_memory_dependencies, inplace_chain_eltwise_sum_correctness) {
                "through an in-place chain";
     }
 }
+
+#ifdef ENABLE_ONEDNN_FOR_GPU
+// regression coverage: optimized-out resample feeds oneDNN conv with fused sum.
+TEST(basic_memory_dependencies, optimized_resample_to_onednn_sum_reuse_correctness) {
+    auto& engine = get_test_engine();
+
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    auto in_layout = layout{ov::PartialShape({1, 16, 32, 32}), data_types::f16, format::bfyx};
+    auto weight_layout = layout{ov::PartialShape({16, 16, 1, 1}), data_types::f16, format::bfyx};
+    auto weight_mem = engine.allocate_memory(weight_layout);
+
+    tests::random_generator rg;
+    rg.set_seed("optimized_resample_to_onednn_sum_reuse_correctness");
+    {
+        auto rnd = rg.generate_random_1d<ov::float16>(weight_layout.count(), -1, 1);
+        set_values(weight_mem, rnd);
+    }
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weight", weight_mem));
+    topology.add(convolution("conv1", input_info("input"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    topology.add(convolution("conv2", input_info("input"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    // Extra conv on conv3 branch makes conv3's processing number > resample's,
+    // so the fusion swap heuristic in prepare_primitive_fusing keeps eltwise(sum)
+    // fused INTO conv3 (the oneDNN conv) instead of moving it into resample.
+    // This is required for oneDNN sum-reuse: conv3 writes its sum DST into the
+    // buffer that gets rebind from the optimized-out resample's output.
+    topology.add(convolution("conv2b", input_info("conv2"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    topology.add(convolution("conv3", input_info("conv2b"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    topology.add(resample("resample", input_info("conv1"), tensor(1, 16, 32, 32), 1,
+                          ov::op::v4::Interpolate::InterpolateMode::NEAREST));
+    topology.add(eltwise("eltwise", input_info("conv3"), input_info("resample"), eltwise_mode::sum));
+    topology.add(reorder("reorder", input_info("eltwise"), format::bfyx, data_types::f32));
+
+    auto input_mem = engine.allocate_memory(in_layout);
+    {
+        auto rnd = rg.generate_random_1d<ov::float16>(in_layout.count(), -1, 1);
+        set_values(input_mem, rnd);
+    }
+
+    ov::intel_gpu::ImplementationDesc conv1_impl = {format::b_fs_yx_fsv16, "", impl_types::onednn};
+    ov::intel_gpu::ImplementationDesc conv2_impl = {format::b_fs_yx_fsv16, "", impl_types::onednn};
+    ov::intel_gpu::ImplementationDesc conv2b_impl = {format::b_fs_yx_fsv16, "", impl_types::onednn};
+    ov::intel_gpu::ImplementationDesc resample_impl = {format::b_fs_yx_fsv16, "", impl_types::ocl};
+    ov::intel_gpu::ImplementationDesc conv3_impl = {format::b_fs_yx_fsv16, "", impl_types::onednn};
+    ov::intel_gpu::ImplementationDesc eltwise_impl = {format::b_fs_yx_fsv16, "", impl_types::ocl};
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv1", conv1_impl},
+                                                                                          {"conv2", conv2_impl},
+                                                                                          {"conv2b", conv2b_impl},
+                                                                                          {"resample", resample_impl},
+                                                                                          {"conv3", conv3_impl},
+                                                                                          {"eltwise", eltwise_impl}}));
+
+    auto prog = program::build_program(engine, topology, config);
+    network net(prog, 0);
+
+    auto resample_inst = net.get_primitive("resample");
+    ASSERT_TRUE(resample_inst->can_be_optimized());
+    auto& conv3_node = net.get_program()->get_node("conv3");
+    ASSERT_EQ(conv3_node.get_preferred_impl_type(), impl_types::onednn);
+    auto& resample_node = net.get_program()->get_node("resample");
+    ASSERT_EQ(resample_node.get_output_layout().format, format::b_fs_yx_fsv16);
+    ASSERT_EQ(conv3_node.get_output_layout().format, format::b_fs_yx_fsv16);
+
+    // eltwise(sum) must be fused INTO conv3 (oneDNN), with resample as the outer dependency.
+    bool has_sum_fusion_in_conv3 = false;
+    for (const auto& fused_desc : conv3_node.get_fused_primitives()) {
+        if (!fused_desc.is_type<eltwise>() || !fused_desc.has_outer_dep())
+            continue;
+        const auto add_fusing_type = onednn_add_fusing_helpers::get_add_fusing_type(conv3_node, fused_desc);
+        if (add_fusing_type != onednn_add_fusing_helpers::add_fusing_type::sum)
+            continue;
+        const auto outer_dep_idx = static_cast<size_t>(fused_desc.outer_dep_start_idx);
+        if (outer_dep_idx >= conv3_node.get_dependencies().size())
+            continue;
+        if (conv3_node.get_dependencies()[outer_dep_idx].first->id() == resample_node.id()) {
+            has_sum_fusion_in_conv3 = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(has_sum_fusion_in_conv3)
+        << "ICNet pattern requires eltwise(sum) fused INTO conv3 with resample as outer dep";
+
+    // conv3 should expose a valid reused eltwise mem idx pointing to resample.
+    int conv3_reused_idx = onednn_add_fusing_helpers::get_reused_eltwmem_idx(conv3_node);
+    ASSERT_GE(conv3_reused_idx, 0);
+    auto conv3_inst = net.get_primitive("conv3");
+    ASSERT_LT(static_cast<size_t>(conv3_reused_idx), conv3_inst->dependencies().size());
+    ASSERT_EQ(conv3_inst->dependencies()[conv3_reused_idx].first->id(), std::string("resample"));
+
+    net.set_input_data("input", input_mem);
+    auto outputs = net.execute();
+
+    // After execute, rebind_onednn_reuse_optimized_dst_if_needed should bind
+    // resample's output buffer to conv3's reused sum DST -- they must alias.
+    auto resample_mem = resample_inst->output_memory_ptr();
+    auto conv3_mem = conv3_inst->output_memory_ptr();
+    ASSERT_TRUE(engine.is_the_same_buffer(*resample_mem, *conv3_mem))
+        << "oneDNN sum-reuse rebind failed: optimized-out resample output buffer "
+        << "should alias conv3's reused sum destination buffer.";
+
+    auto out_mem = outputs.at("reorder").get_memory();
+    ASSERT_NE(out_mem, nullptr);
+}
+#endif  // ENABLE_ONEDNN_FOR_GPU


### PR DESCRIPTION
### Details
Fixes incorrect inference results when an optimized-out `resample` feeds a oneDNN convolution with a fused `eltwise(sum)` residual.

### Description of the issue

#### Symptom
On dGPU (Arc A770) with oneDNN enabled, the ICNet model produces wrong inference outputs when resample is optimized out and its' input is reinterpreted to output.

#### Root cause
When a oneDNN convolution has a fused eltwise(sum) post-op, the plugin enables sum-reuse during primitive initialization by reusing the residual input buffer as the convolution destination buffer. In this pattern, the residual comes from resample.

The issue appears later at runtime when resample is optimized out. In resample::update_output_memory(), the resample output is re-aliased to its input buffer. After that, the logical output of resample no longer points to the original residual buffer selected during initialization.

However, the oneDNN convolution destination buffer is not updated accordingly. As a result, the residual input seen by the fused sum and the reused oneDNN destination buffer no longer refer to the same memory. The root cause is the missing runtime rebind of the oneDNN sum-reuse destination after an optimized-out resample changes its output memory alias.

#### The code and line that caused this issue
https://github.com/openvinotoolkit/openvino/blob/94bad439ea7960b74568d99f525ca30bfbcb9ef0/src/plugins/intel_gpu/src/graph/resample.cpp#L236-L242

#### How to fix it
Rebind the oneDNN user's output buffer after the optimized-out resample updates its output alias at runtime. This keeps the oneDNN convolution destination buffer aligned with the current logical output buffer of the optimized-out resample, restoring the intended sum-reuse behavior without changing the existing oneDNN fusion logic.

#### Reproduction step and snapshot
```
python scripts/accuracy/accuracy_check.py -td GPU.1 -c icnet-camvid-ava-0001.yml -m icnet_model -s omz-validation-datasets/ --annotations annotations -d dataset_definitions.yml --target_tags FP16 --inference_precision_hint fp16 -ss 1
```

#### Problematic graph
<img width="271" height="362" alt="image" src="https://github.com/user-attachments/assets/3d59660d-11a8-4e85-aefc-f3d533c2c0ca" />

### Tickets:
 - *CVS-177466*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI helped to analyze the input/output buffers relationship*