### PR TITLE
[Shape infer] Fix inference crash for an NDA model

### DIFF
--- a/src/core/shape_inference/include/segment_max_shape_inference.hpp
+++ b/src/core/shape_inference/include/segment_max_shape_inference.hpp
@@ -42,7 +42,11 @@ std::vector<TRShape> shape_infer(const SegmentMax* op,
                                    "The number of elements in segment_ids must match the first dimension of data.");
         }
     }
-    const auto segment_ids = ov::op::get_input_const_data_as<TRShape, int64_t>(op, 1, tensor_accessor);
+    const bool segment_ids_is_empty =
+        is_segment_ids_rank_static && segment_ids_shape[0].is_static() && segment_ids_shape[0].get_length() == 0;
+    const std::optional<std::vector<int64_t>> segment_ids =
+        segment_ids_is_empty ? std::nullopt : ov::op::get_input_const_data_as<TRShape, int64_t>(op, 1, tensor_accessor);
+
     if (segment_ids) {
         NODE_VALIDATION_CHECK(op,
                               std::is_sorted(segment_ids->begin(), segment_ids->end()),

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/segment_max_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/segment_max_shape_inference_test.cpp
@@ -116,3 +116,22 @@ INSTANTIATE_TEST_SUITE_P(SegmentMaxStaticShapeInferenceTests,
                                                                 std::vector<int32_t>{2, 6},                         // segment_ids values
                                                                 7,                                                  // num_segments value
                                                                 ov::Shape{7, 6, 24, 1}}));                          // expected output shape
+
+TEST_F(SegmentMaxStaticShapeInferenceTest, empty_segment_ids_with_num_segments_from_tensor_accessor) {
+    const auto data = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape::dynamic());
+    const auto segment_ids = std::make_shared<Parameter>(ov::element::i64, ov::PartialShape::dynamic());
+    const auto num_segments = std::make_shared<Parameter>(ov::element::i64, ov::PartialShape::dynamic());
+    const auto op = make_op(data, segment_ids, num_segments, ov::op::FillMode::ZERO);
+
+    int64_t num_segments_val[] = {5};
+    auto const_inputs = std::unordered_map<size_t, ov::Tensor>{
+        {1, {ov::element::i64, ov::Shape{0}, static_cast<void*>(nullptr)}},
+        {2, {ov::element::i64, ov::Shape{},  num_segments_val}}};
+
+    const auto input_shapes = StaticShapeVector{{0, 12}, {0}, {}};
+    auto shape_infer = make_shape_inference(op);
+    const auto input_shape_refs = make_static_shape_refs(input_shapes);
+    const auto output_shapes = *shape_infer->infer(input_shape_refs, ov::make_tensor_accessor(const_inputs));
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({5, 12}));
+}

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/segment_max_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/segment_max_shape_inference_test.cpp
@@ -117,6 +117,24 @@ INSTANTIATE_TEST_SUITE_P(SegmentMaxStaticShapeInferenceTests,
                                                                 7,                                                  // num_segments value
                                                                 ov::Shape{7, 6, 24, 1}}));                          // expected output shape
 
+TEST_F(SegmentMaxStaticShapeInferenceTest, no_segment_ids_with_num_segments_from_tensor_accessor) {
+    const auto data = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape::dynamic());
+    const auto segment_ids = std::make_shared<Parameter>(ov::element::i64, ov::PartialShape::dynamic());
+    const auto num_segments = std::make_shared<Parameter>(ov::element::i64, ov::PartialShape::dynamic());
+    const auto op = make_op(data, segment_ids, num_segments, ov::op::FillMode::ZERO);
+
+    int64_t num_segments_val[] = {5};
+    auto const_inputs = std::unordered_map<size_t, ov::Tensor>{
+        {2, ov::Tensor{ov::element::i64, ov::Shape{}, num_segments_val}}};
+
+    const auto input_shapes = StaticShapeVector{{0, 12}, {0}, {}};
+    auto shape_infer = make_shape_inference(op);
+    const auto input_shape_refs = make_static_shape_refs(input_shapes);
+    const auto output_shapes = *shape_infer->infer(input_shape_refs, ov::make_tensor_accessor(const_inputs));
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({5, 12}));
+}
+
 TEST_F(SegmentMaxStaticShapeInferenceTest, empty_segment_ids_with_num_segments_from_tensor_accessor) {
     const auto data = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape::dynamic());
     const auto segment_ids = std::make_shared<Parameter>(ov::element::i64, ov::PartialShape::dynamic());


### PR DESCRIPTION
### Details:
 - Fixes the following error during an NDA model inference
 ```bash
RuntimeError: Exception from src/inference/src/cpp/infer_request.cpp:224:
Exception from src/plugins/intel_cpu/src/node.cpp:792:
[CPU] SegmentMax node with name 'anonymized' Check '!!ptr' failed at src/core/shape_inference/include/utils.hpp:50:
ptr is Null
```

### Tickets:
 - CVS-188001