### PR TITLE
[GPU] Fix for ExperimentalDetectronROI levels

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/experimental_detectron_roi_feature_extractor_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/experimental_detectron_roi_feature_extractor_ref.cl
@@ -11,10 +11,10 @@ inline int FUNC(get_pyramid_level_index)(uint level, uint c, uint y, uint x) {
 }
 
 inline int FUNC(get_pyramid_level_for_roi)(const __global INPUT0_TYPE* current_roi) {
-    const INPUT0_TYPE canonical_scale = 224.0;
+    const INPUT0_TYPE canonical_scale = TO_INPUT0_TYPE(224.0f);
     const int canonical_level = 2;
 
-    int result = NUM_PYRAMID_LEVELS;
+    int result = 0;
 
     const INPUT0_TYPE x0 = current_roi[0];
     const INPUT0_TYPE y0 = current_roi[1];
@@ -23,7 +23,9 @@ inline int FUNC(get_pyramid_level_for_roi)(const __global INPUT0_TYPE* current_r
 
     const INPUT0_TYPE area = (x1 - x0) * (y1 - y0);
     if (area > 0) {
-        result = (int)round(canonical_level + log2(sqrt(area) / canonical_scale));
+        INPUT0_TYPE level_value = sqrt(area) / canonical_scale;
+        level_value = log2(level_value + TO_INPUT0_TYPE(1e-6f));
+        result = (int)floor(level_value + canonical_level);
         result = max(0, min(result, NUM_PYRAMID_LEVELS - 1));
     }
     return result;
@@ -42,7 +44,7 @@ KERNEL(experimental_detectron_roi_feature_extractor_ref)(const __global INPUT0_T
 
     const __global INPUT0_TYPE* current_roi_ptr = &src_rois[r * INPUT0_BATCH_PITCH];
 
-    const int level = FUNC_CALL(get_pyramid_level_for_roi)(current_roi_ptr);
+    const int level = max(0, min(FUNC_CALL(get_pyramid_level_for_roi)(current_roi_ptr), NUM_PYRAMID_LEVELS - 1));
 
     const __global INPUT1_TYPE* current_level_ptr = LEVEL_PTRS[level];
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
@@ -252,7 +252,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     {
         ACTIVATION_TYPE dequantized = my_chunk[output_idx] / my_sum;
         FUSED_OPS_MAIN;
-        output[aligned_data_offset + get_sub_group_local_id() + i * get_sub_group_size()] = FUSED_OPS_RESULT_MAIN;
+        output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] = FUSED_OPS_RESULT_MAIN;
     }
 
     if (in_data_set_idx < aligned_offset)
@@ -433,7 +433,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     {
         ACTIVATION_TYPE dequantized = output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] / my_sum;
         FUSED_OPS_MAIN;
-        output[aligned_data_offset + get_sub_group_local_id() + i * get_sub_group_size()] = FUSED_OPS_RESULT_MAIN;
+        output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] = FUSED_OPS_RESULT_MAIN;
     }
 
     if (in_data_set_idx < aligned_offset)

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
@@ -157,7 +157,7 @@ JitConstants SoftmaxKernel_bf::GetJitConstants(const softmax_params& params, Dis
 
     if (!params.fused_ops.empty()) {
         FusedOpsConfiguration conf_main = {"_MAIN",
-                                           {"data_set_offset", "in_data_set_idx + i * workers_per_data_set", "0", "0"},
+                                           {"data_set_offset", "in_data_set_idx + output_idx * workers_per_data_set", "0", "0"},
                                            "dequantized",
                                            activation_dt};
         FusedOpsConfiguration conf_leftovers = {"_LEFTOVERS",

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/experimental_detectron_roifeatureextractor.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/experimental_detectron_roifeatureextractor.cpp
@@ -3,9 +3,113 @@
 //
 
 #include "single_op_tests/experimental_detectron_roifeatureextractor.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
 
 namespace {
 using ov::test::ExperimentalDetectronROIFeatureExtractorLayerTest;
+
+class ExperimentalDetectronROIFeatureExtractorDegenerateTestGPU : public ExperimentalDetectronROIFeatureExtractorLayerTest {
+protected:
+        void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+                inputs.clear();
+                const auto& funcInputs = function->inputs();
+
+                for (size_t i = 0; i < funcInputs.size(); ++i) {
+                        const auto& shape = targetInputStaticShapes[i];
+                        ov::Tensor tensor;
+
+                        if (i == 0) {
+                                tensor = ov::Tensor(funcInputs[i].get_element_type(), shape);
+                                auto* rois = tensor.data<float>();
+                                const size_t roisNum = shape[0];
+
+                                for (size_t r = 0; r < roisNum; ++r) {
+                                        // Deliberately generate non-positive ROI areas to exercise
+                                        // pyramid-level edge handling in the kernel.
+                                        // NOTE: x1<x0 and y1>y0 => negative area, x1==x0 and y1==y0 => zero area.
+                                        rois[4 * r + 0] = 10.0f;
+                                        rois[4 * r + 1] = 10.0f;
+                                        if ((r & 1) == 0) {
+                                                rois[4 * r + 2] = 5.0f;
+                                                rois[4 * r + 3] = 15.0f;
+                                        } else {
+                                                rois[4 * r + 2] = 10.0f;
+                                                rois[4 * r + 3] = 10.0f;
+                                        }
+                                }
+                        } else {
+                                const float levelValue = static_cast<float>(i);
+                                tensor = ov::Tensor(funcInputs[i].get_element_type(), shape);
+                                auto* data = tensor.data<float>();
+                                std::fill(data, data + tensor.get_size(), levelValue);
+                        }
+
+                        inputs.insert({funcInputs[i].get_node_shared_ptr(), tensor});
+                }
+        }
+
+        void run() override {
+                SKIP_IF_CURRENT_TEST_IS_DISABLED();
+
+                ASSERT_FALSE(targetStaticShapes.empty() && !function->get_parameters().empty())
+                        << "Target Static Shape is empty!!!";
+
+                compile_model();
+                for (const auto& targetStaticShapeVec : targetStaticShapes) {
+                        generate_inputs(targetStaticShapeVec);
+                        ASSERT_NO_THROW(infer());
+
+                        const auto output = inferRequest.get_output_tensor(0);
+                        ASSERT_EQ(output.get_element_type(), ov::element::f32);
+                        const auto* actual = output.data<float>();
+                        for (size_t idx = 0; idx < output.get_size(); ++idx) {
+                                ASSERT_NEAR(actual[idx], 1.0f, 1e-4f);
+                        }
+                }
+        }
+};
+
+class ExperimentalDetectronROIFeatureExtractorLevelSelectionTestGPU : public ExperimentalDetectronROIFeatureExtractorLayerTest {
+protected:
+        void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+                inputs.clear();
+                const auto& funcInputs = function->inputs();
+
+                for (size_t i = 0; i < funcInputs.size(); ++i) {
+                        const auto& shape = targetInputStaticShapes[i];
+                        ov::Tensor tensor(funcInputs[i].get_element_type(), shape);
+
+                        if (i == 0) {
+                                auto* rois = tensor.data<float>();
+                                const size_t roisNum = shape[0];
+                                for (size_t r = 0; r < roisNum; ++r) {
+                                        // Area=170*170. This sits near a pyramid boundary where
+                                        // floor and round produce different levels.
+                                        rois[4 * r + 0] = 0.0f;
+                                        rois[4 * r + 1] = 0.0f;
+                                        rois[4 * r + 2] = 170.0f;
+                                        rois[4 * r + 3] = 170.0f;
+                                }
+                        } else {
+                                // Fill each level input with a distinct constant to make level
+                                // selection observable in the output tensor values.
+                                const float levelValue = static_cast<float>(i);
+                                auto* data = tensor.data<float>();
+                                std::fill(data, data + tensor.get_size(), levelValue);
+                        }
+
+                        inputs.insert({funcInputs[i].get_node_shared_ptr(), tensor});
+                }
+        }
+};
+
+TEST_P(ExperimentalDetectronROIFeatureExtractorDegenerateTestGPU, Inference) {
+        run();
+}
+
+TEST_P(ExperimentalDetectronROIFeatureExtractorLevelSelectionTestGPU, Inference) {
+        run();
+}
 
 const std::vector<int64_t> outputSize = {7, 14};
 const std::vector<int64_t> samplingRatio = {1, 2, 3};
@@ -29,6 +133,39 @@ INSTANTIATE_TEST_SUITE_P(smoke_ExperimentalROI_static, ExperimentalDetectronROIF
                                  ::testing::ValuesIn(samplingRatio),
                                  ::testing::ValuesIn(pyramidScales),
                                  ::testing::Values(false),
+                                 ::testing::Values(ov::element::f32),
+                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                         ExperimentalDetectronROIFeatureExtractorLayerTest::getTestCaseName);
+
+const std::vector<std::vector<ov::test::InputShape>> static_input_shape_degenerate = {
+        // Mirrors the crashing workload dimensions (gws ~= 49 x 80 x 500).
+        ov::test::static_shapes_to_test_representation({{500, 4}, {1, 80, 200, 336}, {1, 80, 100, 168}, {1, 80, 50, 84}, {1, 80, 25, 42}})
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_DegenerateRoiArea,
+                         ExperimentalDetectronROIFeatureExtractorDegenerateTestGPU,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(static_input_shape_degenerate),
+                                 ::testing::Values(7),
+                                 ::testing::Values(2),
+                                 ::testing::Values(std::vector<int64_t>{8, 16, 32, 64}),
+                                 ::testing::Values(false, true),
+                                 ::testing::Values(ov::element::f32),
+                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                         ExperimentalDetectronROIFeatureExtractorLayerTest::getTestCaseName);
+
+const std::vector<std::vector<ov::test::InputShape>> static_input_shape_level_selection = {
+        ov::test::static_shapes_to_test_representation({{8, 4}, {1, 80, 200, 336}, {1, 80, 100, 168}, {1, 80, 50, 84}, {1, 80, 25, 42}})
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_LevelSelectionRegression,
+                         ExperimentalDetectronROIFeatureExtractorLevelSelectionTestGPU,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(static_input_shape_level_selection),
+                                 ::testing::Values(7),
+                                 ::testing::Values(2),
+                                 ::testing::Values(std::vector<int64_t>{8, 16, 32, 64}),
+                                 ::testing::Values(false, true),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(ov::test::utils::DEVICE_GPU)),
                          ExperimentalDetectronROIFeatureExtractorLayerTest::getTestCaseName);

--- a/src/plugins/intel_gpu/tests/unit/fusions/softmax_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/softmax_fusion_test.cpp
@@ -69,7 +69,6 @@ public:
 
 }  // namespace
 
-
 /* ----------------------------------------------------------------------------------------------------- */
 /* ---------------------------------------- SoftMax cases ---------------------------------------------- */
 /* ----------------------------------------------------------------------------------------------------- */
@@ -82,6 +81,13 @@ public:
 #define CASE_SOFTMAX_FP16_2 {1, 15, 4, 5}, data_types::f16, format::bfyx, 3, data_types::f16, format::bfyx
 #define CASE_SOFTMAX_FP16_3 {1, 15, 1, 1}, data_types::f16, format::bfyx, 1, data_types::f16, format::bfyx
 #define CASE_SOFTMAX_FP16_4 {1, 15, 1, 2}, data_types::f16, format::bfyx, 2, data_types::f16, format::bfyx
+
+// Keep batch > 1 and use larger odd feature count to force both packed and tail
+// fused-output write loops in softmax_gpu_bf (the pre-fix bug used wrong index in tail writes).
+#define CASE_SOFTMAX_FP32_BF_FUSED_INDEXING {2, 8193, 1, 1}, data_types::f32, format::bfyx, 1, data_types::f32, format::bfyx
+// Runtime reproducer for stale tail write index in softmax_gpu_bf:
+// feature=7000 is large enough to trigger scalar tail handling in common dispatch configurations.
+#define CASE_SOFTMAX_FP32_BF_BUG_REPRO {1, 7000, 1, 1}, data_types::f32, format::bfyx, 1, data_types::f32, format::bfyx
 
 class softmax_quantize : public SoftmaxPrimitiveFusingTest {};
 TEST_P(softmax_quantize, basic) {
@@ -126,13 +132,77 @@ TEST_P(softmax_activation, basic) {
     execute(p);
 }
 
+class softmax_eltwise_activation : public SoftmaxPrimitiveFusingTest {};
+TEST_P(softmax_eltwise_activation, basic) {
+    auto p = GetParam();
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        data("eltwise_data", get_mem(get_single_element_layout(p), 1.25f)),
+        softmax("softmax", input_info("input"), p.dimension),
+        eltwise("scale", { input_info("softmax"), input_info("eltwise_data") }, eltwise_mode::prod, p.default_type),
+        activation("log", input_info("scale"), activation_func::log),
+        reorder("reorder_bfyx", input_info("log"), get_output_layout(p))
+    );
+
+    tolerance = default_tolerance(p.data_type);
+    execute(p);
+}
+
+class softmax_eltwise_per_element : public SoftmaxPrimitiveFusingTest {};
+TEST_P(softmax_eltwise_per_element, basic) {
+    auto p = GetParam();
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        data("eltwise_data", get_mem(get_input_layout(p), min_random, max_random)),
+        softmax("softmax", input_info("input"), p.dimension),
+        eltwise("sum", { input_info("softmax"), input_info("eltwise_data") }, eltwise_mode::sum, p.default_type),
+        reorder("reorder_bfyx", input_info("sum"), get_output_layout(p))
+    );
+
+    tolerance = default_tolerance(p.data_type);
+    execute(p);
+}
+
+class softmax_activation_bug_repro : public SoftmaxPrimitiveFusingTest {};
+TEST_P(softmax_activation_bug_repro, basic) {
+    auto p = GetParam();
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        softmax("softmax", input_info("input"), p.dimension),
+        activation("log", input_info("softmax"), activation_func::log),
+        reorder("reorder_bfyx", input_info("log"), get_output_layout(p))
+    );
+
+    tolerance = default_tolerance(p.data_type);
+    execute(p);
+}
+
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_activation,
     ::testing::ValuesIn(std::vector<softmax_test_params>{
                         softmax_test_params{ CASE_SOFTMAX_FP32_3, 2, 3, "softmax_gpu_bf" },
                         softmax_test_params{ CASE_SOFTMAX_FP32_4, 2, 3, "softmax_gpu_bf" },
+                        softmax_test_params{ CASE_SOFTMAX_FP32_BF_FUSED_INDEXING, 2, 3, "softmax_gpu_bf" },
                         softmax_test_params{ CASE_SOFTMAX_FP16_3, 2, 3, "softmax_gpu_bf" },
                         softmax_test_params{ CASE_SOFTMAX_FP16_4, 2, 3, "softmax_gpu_bf" }
 }));
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_eltwise_activation,
+    ::testing::ValuesIn(std::vector<softmax_test_params>{
+                        softmax_test_params{ CASE_SOFTMAX_FP32_BF_FUSED_INDEXING, 3, 4, "softmax_gpu_bf" },
+                        softmax_test_params{ CASE_SOFTMAX_FP16_3, 3, 4, "softmax_gpu_bf" }
+}));
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_eltwise_per_element,
+    ::testing::ValuesIn(std::vector<softmax_test_params>{
+                        softmax_test_params{ CASE_SOFTMAX_FP32_BF_FUSED_INDEXING, 3, 3, "softmax_gpu_bf" },
+                        softmax_test_params{ CASE_SOFTMAX_FP16_3, 3, 3, "softmax_gpu_bf" }
+}));
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_activation_bug_repro,
+    ::testing::ValuesIn(std::vector<softmax_test_params>{
+                        softmax_test_params{ CASE_SOFTMAX_FP32_BF_BUG_REPRO, 2, 3, "softmax_gpu_bf" }
+}));
+
 
 class softmax_quantize_fusing_through : public SoftmaxPrimitiveFusingTest {};
 TEST_P(softmax_quantize_fusing_through, reshape) {


### PR DESCRIPTION
### Details:
 - *In [experimental_detectron_roi_feature_extractor_ref.cl](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/experimental_detectron_roi_feature_extractor_ref.cl), ROI-to-pyramid-level mapping could produce invalid behavior for degenerate/non-positive-area ROIs. Need to use reference-consistent level math.*
 - *In [softmax_gpu_bf.cl](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl), fused-op output writes used the wrong loop variable (`i` instead of `output_idx`) in two places, causing incorrect output indexing/corruption risk.*

### Tickets:
 - *CVS-184513*

### AI Assistance:
 - *AI assistance used: yes*
