### PR TITLE
[NPU] Disable test before NPU driver updated

### DIFF
--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -924,4 +924,16 @@ Example:
         </filters>
     </skip_config>
 
+    <!-- E#216296 -->
+    <skip_config>
+        <message>Test failed with compile error.</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*SerializationTestNPUW.CompiledModelPhase0CompatibilityExportSucceedsWithStaticAttention.*</filter>
+        </filters>
+    </skip_config>
+
 </skip_configs>


### PR DESCRIPTION
### Details:
 - *Disable test `SerializationTestNPUW.CompiledModelPhase0CompatibilityExportSucceedsWithStaticAttention` which fails with compile error for latest NPU driver / compiler.*

### Tickets:
 - *E#216296*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
