### PR TITLE
[GPU] Add permute kernel for 4D X<->Y swap (order {0,1,3,2})

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_xy_swap.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_xy_swap.cl
@@ -1,0 +1,88 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "include/batch_headers/fetch_data.cl"
+
+// Optimized 4D Transpose that swaps the last two dimensions (Y<->X), i.e.
+//   out[b, f, y, x] = in[b, f, x, y]
+//
+// Each workgroup processes a TILE_SIZE x TILE_SIZE block of the input and
+// writes the transposed block to the output. The workgroup has fixed size
+// WG_DIM x WG_DIM, so when TILE_SIZE > WG_DIM each work-item handles
+// ELEMS_PER_DIM = TILE_SIZE / WG_DIM elements along each axis (a
+// ELEMS_PER_DIM x ELEMS_PER_DIM sub-tile per WI).
+//
+// Loads and stores are coalesced along the innermost dimension of each side
+// (input X on read, output X = input Y on write). SLM is used to absorb the
+// transposition; +1 inner padding eliminates 32-bank conflicts on the
+// transposed column read.
+//
+// JIT defines:
+//   TILE_SIZE      - tile edge length in elements
+//   WG_DIM         - WG size along each of X/Y (kept at 16 for SIMD8 occupancy)
+//   ELEMS_PER_DIM  - TILE_SIZE / WG_DIM
+//
+// Required WG size: (WG_DIM, WG_DIM, 1).
+// GWS: (INPUT0_SIZE_X / ELEMS_PER_DIM, INPUT0_SIZE_Y / ELEMS_PER_DIM, B*F).
+// Input X and Y must both be multiples of TILE_SIZE (enforced by Validate).
+
+__attribute__((reqd_work_group_size(WG_DIM, WG_DIM, 1)))
+KERNEL(permute_xy_swap)(
+    OPTIONAL_SHAPE_INFO_ARG
+    const __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output
+#if HAS_FUSED_OPS_DECLS
+    , FUSED_OPS_DECLS
+#endif
+)
+{
+    const uint lx = (uint)get_local_id(0);    // 0 .. WG_DIM-1
+    const uint ly = (uint)get_local_id(1);    // 0 .. WG_DIM-1
+    const uint tx = (uint)get_group_id(0);    // tile index along input X
+    const uint ty = (uint)get_group_id(1);    // tile index along input Y
+    const uint bf = (uint)get_global_id(2);
+    const uint f  = bf % INPUT0_FEATURE_NUM;
+    const uint b  = bf / INPUT0_FEATURE_NUM;
+
+    // +1 inner padding avoids SLM bank conflicts on the transposed read.
+    __local INPUT0_TYPE tile[TILE_SIZE][TILE_SIZE + 1];
+
+    // ---- Phase 1: ELEMS_PER_DIM x ELEMS_PER_DIM coalesced reads per WI. ----
+    // Each (dy, dx) sub-step issues a 16-wide coalesced load along input X.
+    __attribute__((opencl_unroll_hint))
+    for (uint dy = 0; dy < ELEMS_PER_DIM; ++dy) {
+        const uint sub_y = ly + dy * WG_DIM;       // 0 .. TILE_SIZE-1
+        const uint in_y  = ty * TILE_SIZE + sub_y;
+        __attribute__((opencl_unroll_hint))
+        for (uint dx = 0; dx < ELEMS_PER_DIM; ++dx) {
+            const uint sub_x = lx + dx * WG_DIM;   // 0 .. TILE_SIZE-1
+            const uint in_x  = tx * TILE_SIZE + sub_x;
+            tile[sub_y][sub_x] = input[INPUT0_GET_INDEX(b, f, in_y, in_x)];
+        }
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // ---- Phase 2: ELEMS_PER_DIM x ELEMS_PER_DIM coalesced writes per WI. ----
+    // Output tile origin is (out_y_base=tx*TILE_SIZE, out_x_base=ty*TILE_SIZE).
+    // out[..., out_y, out_x] = in[..., out_x, out_y] = tile[out_x_local][out_y_local].
+    __attribute__((opencl_unroll_hint))
+    for (uint dy = 0; dy < ELEMS_PER_DIM; ++dy) {
+        const uint sub_y = ly + dy * WG_DIM;       // local row in output tile
+        const uint out_y = tx * TILE_SIZE + sub_y;
+        __attribute__((opencl_unroll_hint))
+        for (uint dx = 0; dx < ELEMS_PER_DIM; ++dx) {
+            const uint sub_x = lx + dx * WG_DIM;   // local col in output tile
+            const uint out_x = ty * TILE_SIZE + sub_x;
+            const INPUT0_TYPE val = tile[sub_x][sub_y];  // transposed SLM read
+
+#if HAS_FUSED_OPS
+            FUSED_OPS;
+            output[OUTPUT_GET_INDEX(b, f, out_y, out_x)] = FUSED_OPS_RESULT;
+#else
+            output[OUTPUT_GET_INDEX(b, f, out_y, out_x)] = ACTIVATION(val, ACTIVATION_PARAMS);
+#endif
+        }
+    }
+}

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_selector.cpp
@@ -8,6 +8,7 @@
 #include "permute_kernel_tile_8x8_4x4_fsv.h"
 #include "permute_kernel_bfzyx_to_bfyxz.h"
 #include "permute_kernel_f_y_axes.h"
+#include "permute_kernel_xy_swap.h"
 
 namespace kernel_selector {
 
@@ -17,6 +18,7 @@ permute_kernel_selector::permute_kernel_selector() {
     Attach<PermuteKernel_tile_8x8_4x4_fsv>();
     Attach<PermuteKernel_bfzyx_to_bfyxz>();
     Attach<PermuteKernel_f_y_axes>();
+    Attach<PermuteKernel_xy_swap>();
 }
 
 KernelsData permute_kernel_selector::GetBestKernels(const Params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.cpp
@@ -1,0 +1,141 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "permute_kernel_xy_swap.h"
+
+#include "common_tools.h"
+#include "kernel_selector_utils.h"
+
+namespace kernel_selector {
+
+namespace {
+
+// Workgroup tile is square. The WG dimensions are fixed at WG_DIM x WG_DIM to
+// keep the SIMD8 scheduling that performed best in our measurements.
+// TILE_SIZE may be a multiple of WG_DIM, in which case each WI handles a
+// (TILE_SIZE / WG_DIM)^2 sub-block.
+constexpr size_t kWgDim = 16;
+
+// Preferred tile sizes, tried in descending order. For 1-byte data types, a
+// 64x64 tile keeps SLM usage comparable to the 32x32 tile for f32 and reduces
+// the number of workgroups on aligned shapes. The largest tile that divides
+// both X and Y is used.
+constexpr size_t kTileCandidates[] = {32, 16};
+constexpr size_t kOneByteTileCandidates[] = {64, 32, 16};
+
+size_t PickTileSize(const permute_params& params) {
+    const auto x = params.inputs[0].X().v;
+    const auto y = params.inputs[0].Y().v;
+
+    const auto pick_tile = [x, y](const auto& candidates) -> size_t {
+        for (const auto t : candidates) {
+            if ((x % t) == 0 && (y % t) == 0)
+                return t;
+        }
+        return 0;  // no tile size applies
+    };
+
+    const bool is_one_byte_type = BytesPerElement(params.inputs[0].GetDType()) == 1;
+    return is_one_byte_type ? pick_tile(kOneByteTileCandidates) : pick_tile(kTileCandidates);
+}
+
+bool IsXYSwapOrder(const std::vector<uint16_t>& order) {
+    // 4D only, last two dims swapped, others identity.
+    // cldnn order produced from IE {0,1,3,2} is also {0,1,3,2} for 4D inputs.
+    if (order.size() != 4)
+        return false;
+    return order[0] == 0 && order[1] == 1 && order[2] == 3 && order[3] == 2;
+}
+
+}  // namespace
+
+ParamsKey PermuteKernel_xy_swap::GetSupportedKey() const {
+    ParamsKey k;
+    k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::F32);
+    k.EnableInputDataType(Datatype::INT8);
+    k.EnableInputDataType(Datatype::UINT8);
+    k.EnableInputDataType(Datatype::INT32);
+    k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::F32);
+    k.EnableOutputDataType(Datatype::INT8);
+    k.EnableOutputDataType(Datatype::UINT8);
+    k.EnableOutputDataType(Datatype::INT32);
+    k.EnableDifferentTypes();
+    k.EnableInputLayout(DataLayout::bfyx);
+    k.EnableOutputLayout(DataLayout::bfyx);
+    k.EnableTensorOffset();
+    k.EnableTensorPitches();
+    k.EnableBatching();
+    return k;
+}
+
+JitConstants PermuteKernel_xy_swap::GetJitConstants(const permute_params& params,
+                                                    const CommonDispatchData& dispatchData) const {
+    auto jit = Parent::GetJitConstants(params, dispatchData);
+    const size_t tile_size = PickTileSize(params);
+    const size_t elems_per_dim = tile_size / kWgDim;
+    jit.AddConstant(MakeJitConstant("TILE_SIZE", tile_size));
+    jit.AddConstant(MakeJitConstant("WG_DIM", kWgDim));
+    jit.AddConstant(MakeJitConstant("ELEMS_PER_DIM", elems_per_dim));
+
+    if (!params.fused_ops.empty()) {
+        // Output layout indices for fused ops (bfyx in IE naming).
+        const std::vector<std::string> idx_order = {"b", "f", "out_y", "out_x"};
+        const FusedOpsConfiguration conf = {"", idx_order, "val", params.inputs[0].GetDType(), 1};
+        jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
+    }
+    return jit;
+}
+
+CommonDispatchData PermuteKernel_xy_swap::SetDefault(const permute_params& params) const {
+    CommonDispatchData dispatchData;
+    const auto& in = params.inputs[0];
+    const size_t tile_size = PickTileSize(params);
+    const size_t elems_per_dim = tile_size / kWgDim;
+    // One WG covers a TILE_SIZE x TILE_SIZE block; with WG = WG_DIM x WG_DIM,
+    // each WI does ELEMS_PER_DIM^2 work, so GWS shrinks accordingly.
+    dispatchData.gws = {in.X().v / elems_per_dim, in.Y().v / elems_per_dim, in.Batch().v * in.Feature().v};
+    dispatchData.lws = {kWgDim, kWgDim, 1};
+    return dispatchData;
+}
+
+bool PermuteKernel_xy_swap::Validate(const Params& p) const {
+    if (!Parent::Validate(p)) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    const auto& params = static_cast<const permute_params&>(p);
+
+    // Only the X<->Y swap pattern on plain bfyx layouts.
+    if (!IsXYSwapOrder(params.order)) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    if (params.inputs[0].GetLayout() != DataLayout::bfyx ||
+        params.outputs[0].GetLayout() != DataLayout::bfyx) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    // No dynamic shapes for this initial implementation: tile size and divisibility
+    // are checked at compile time.
+    if (params.has_dynamic_tensors()) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    if (params.inputs[0].PitchesDifferFromLogicalDims() ||
+        params.outputs[0].PitchesDifferFromLogicalDims()) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    // Require X and Y to be tile-aligned for at least one supported tile size.
+    if (PickTileSize(params) == 0) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    return true;
+}
+
+KernelsPriority PermuteKernel_xy_swap::GetKernelsPriority(const Params& /*params*/) const {
+    // Prefer over the reference kernel when this kernel applies.
+    return FORCE_PRIORITY_2;
+}
+
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.h
@@ -1,0 +1,36 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "permute_kernel_base.h"
+
+namespace kernel_selector {
+
+// Optimized kernel for 4D Transpose that swaps only the last two axes (Y and X).
+// Pattern (cldnn order): {0, 1, 3, 2}
+// Equivalent IE order:   {0, 1, 3, 2}  (e.g., bfyx -> bfxy, swap last two dims)
+//
+// Uses SLM-tiled cooperative loads/stores to recover coalesced global memory
+// access on both read (input X innermost) and write (output X = input Y).
+class PermuteKernel_xy_swap : public PermuteKernelBase {
+public:
+    using Parent = PermuteKernelBase;
+    using Parent::Parent;
+    PermuteKernel_xy_swap() : PermuteKernelBase("permute_xy_swap") {}
+    ~PermuteKernel_xy_swap() override = default;
+
+    bool Validate(const Params& p) const override;
+    KernelsPriority GetKernelsPriority(const Params& params) const override;
+    ParamsKey GetSupportedKey() const override;
+
+protected:
+    JitConstants GetJitConstants(const permute_params& params, const CommonDispatchData& dispatchData) const override;
+    CommonDispatchData SetDefault(const permute_params& params) const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return {FusedOpType::REORDER, FusedOpType::ACTIVATION, FusedOpType::QUANTIZE, FusedOpType::ELTWISE};
+    }
+};
+
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/tests/unit/fusions/permute_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/permute_fusion_test.cpp
@@ -191,6 +191,18 @@ public:
 #define CASE_PERMUTE_TILE_BFYX_TO_BYFX_8 {1, 4, 1, 32 }, { 1, 32, 1, 4 }, { 0, 2, 1, 3 }, tensor{ 0 }, data_types::f32, format::bfyx, data_types::f32, format::b_fs_yx_fsv32
 #define CASE_PERMUTE_TILE_BFYX_TO_BYFX_9 {1, 16, 1, 2 }, { 1, 2, 1, 16 }, { 0, 2, 1, 3 }, tensor{ 0 }, data_types::f32, format::bfyx, data_types::f32, format::bfyx
 
+// permute_xy_swap
+// Order {0,1,3,2} on bfyx with X and Y both divisible by 16 (or 32) selects PermuteKernel_xy_swap
+// (FORCE_PRIORITY_2). Tensor argument order is {B, F, X, Y}; order {0,1,3,2} swaps X<->Y, so out
+// shape is {B, F, Y, X}.
+#define CASE_PERMUTE_XY_SWAP_F32_0 { 1, 8, 16, 16 }, { 1, 8, 16, 16 }, { 0, 1, 3, 2 }, tensor{ 0 }, data_types::f32, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_XY_SWAP_F32_1 { 1, 4, 32, 32 }, { 1, 4, 32, 32 }, { 0, 1, 3, 2 }, tensor{ 0 }, data_types::f32, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_XY_SWAP_F32_2 { 2, 4, 32, 16 }, { 2, 4, 16, 32 }, { 0, 1, 3, 2 }, tensor{ 0 }, data_types::f32, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_XY_SWAP_F16_0 { 1, 8, 16, 16 }, { 1, 8, 16, 16 }, { 0, 1, 3, 2 }, tensor{ 0 }, data_types::f16, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_XY_SWAP_F16_1 { 1, 4, 32, 32 }, { 1, 4, 32, 32 }, { 0, 1, 3, 2 }, tensor{ 0 }, data_types::f16, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_XY_SWAP_S8_0 { 1, 8, 16, 16 }, { 1, 8, 16, 16 }, { 0, 1, 3, 2 }, tensor{ 0 }, data_types::i8, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_XY_SWAP_U8_0 { 1, 8, 16, 16 }, { 1, 8, 16, 16 }, { 0, 1, 3, 2 }, tensor{ 0 }, data_types::u8, format::bfyx, data_types::f32, format::bfyx
+
 class permute_activation_scale_eltwise: public PermuteFusingTest {};
 TEST_P(permute_activation_scale_eltwise, basic) {
     auto p = GetParam();
@@ -295,7 +307,16 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, permute_activation_scale_eltwise, ::testin
     permute_params{ CASE_PERMUTE_TILE_BFYX_TO_BYFX_4, 2, 5 },
     permute_params{ CASE_PERMUTE_TILE_BFYX_TO_BYFX_5, 2, 5 },
     permute_params{ CASE_PERMUTE_TILE_BFYX_TO_BYFX_6, 2, 5 },
-    permute_params{ CASE_PERMUTE_TILE_BFYX_TO_BYFX_7, 2, 5 }
+    permute_params{ CASE_PERMUTE_TILE_BFYX_TO_BYFX_7, 2, 5 },
+
+    // Fusing tests for permute_xy_swap
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_0, 2, 5 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_1, 2, 5 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_2, 2, 5 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F16_0, 2, 5 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F16_1, 2, 5 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_S8_0, 2, 5 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_U8_0, 2, 5 }
 }));
 
 class permute_quant_u8: public PermuteFusingTest {};
@@ -324,6 +345,16 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, permute_quant_u8, ::testing::ValuesIn(std:
     permute_params{ CASE_PERMUTE_F16_0, 2, 3 },
     permute_params{ CASE_PERMUTE_F16_1, 2, 3 },
     permute_params{ CASE_PERMUTE_F32_8, 2, 3 },
+
+    // Fusing tests for permute_xy_swap.
+    // Note: this suite quantizes the permute output directly to u8; there is no
+    // matching quantize kernel for `i8 -> u8` or `u8 -> u8` at these shapes, so
+    // int-input cases are intentionally excluded here.
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_0, 2, 3 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_1, 2, 3 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_2, 2, 3 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F16_0, 2, 3 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F16_1, 2, 3 },
 }));
 
 class permute_scale_actv_eltw_scale_actv_quant_i8: public PermuteFusingTest {};
@@ -402,6 +433,15 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, permute_scale_actv_eltw_scale_actv_quant_i
     permute_params{ CASE_PERMUTE_U8_3D_1, 2, 8 },
     permute_params{ CASE_PERMUTE_U8_3D_2, 2, 8 },
     permute_params{ CASE_PERMUTE_U8_3D_3, 2, 8 },
+
+    // Fusing tests for permute_xy_swap
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_0, 2, 8 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_1, 2, 8 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_2, 2, 8 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F16_0, 2, 8 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F16_1, 2, 8 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_S8_0, 2, 8 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_U8_0, 2, 8 },
 }));
 
 class permute_scale_eltwise_actv_scale_actv: public PermuteFusingTest {};
@@ -505,6 +545,15 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, permute_scale_eltwise_actv_scale_actv, ::t
 
     // Fusing tests for permute_f_y_axes
     permute_params{ CASE_PERMUTE_TILE_BFYX_TO_BYFX_0, 2, 7 },
+
+    // Fusing tests for permute_xy_swap
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_0, 2, 7 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_1, 2, 7 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F32_2, 2, 7 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F16_0, 2, 7 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_F16_1, 2, 7 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_S8_0, 2, 7 },
+    permute_params{ CASE_PERMUTE_XY_SWAP_U8_0, 2, 7 },
 }));
 
 /* ------------------------------------------------------------------------------------------------------------ */

--- a/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
@@ -2374,6 +2374,43 @@ TEST_P(permute_f_y_axes_tile, combined) {
     run_test<cldnn::data_types::i64>(p.sizes, p.format_fsv, "permute_f_y_axes", {0, 2, 1, 3});
 }
 
+// permute_xy_swap kernel: optimized 4D X<->Y transpose ({0, 1, 3, 2}).
+// Constraints (see PermuteKernel_xy_swap::Validate):
+//   * 4D plain bfyx layout only.
+//   * Order must be {0, 1, 3, 2}.
+//   * Both X and Y must be divisible by one of the supported tile sizes (32 or 16).
+//   * No dynamic shapes; pitches must equal logical dims.
+// Sizes here use the test convention {B, F, Y, X}.
+class permute_xy_swap : public TiledPermuteTest {};
+
+INSTANTIATE_TEST_SUITE_P(smoke_permute_xy_swap,
+                         permute_xy_swap,
+                         ::testing::ValuesIn(std::vector<TiledPermuteParam>{
+                             // tile=32 path (both X and Y divisible by 32)
+                             {{1, 1, 32, 32}, format::bfyx},
+                             {{1, 4, 64, 32}, format::bfyx},
+                             {{2, 8, 32, 64}, format::bfyx},
+                             {{4, 4, 64, 64}, format::bfyx},
+                             // tile=16 path (X or Y not divisible by 32 but both by 16)
+                             {{1, 1, 16, 16}, format::bfyx},
+                             {{1, 8, 16, 32}, format::bfyx},
+                             {{2, 4, 48, 48}, format::bfyx},
+                             {{1, 16, 16, 64}, format::bfyx},
+                             // larger / batched
+                             {{1, 32, 128, 64}, format::bfyx},
+                             {{4, 16, 64, 128}, format::bfyx},
+                         }),
+                         TiledPermuteTest::PrintToStringParamName);
+
+TEST_P(permute_xy_swap, combined) {
+    auto p = GetParam();
+    run_test<cldnn::data_types::f32>(p.sizes, p.format_fsv, "permute_xy_swap", {0, 1, 3, 2});
+    run_test<cldnn::data_types::f16>(p.sizes, p.format_fsv, "permute_xy_swap", {0, 1, 3, 2});
+    run_test<cldnn::data_types::u8>(p.sizes, p.format_fsv, "permute_xy_swap", {0, 1, 3, 2});
+    run_test<cldnn::data_types::i8>(p.sizes, p.format_fsv, "permute_xy_swap", {0, 1, 3, 2});
+    run_test<cldnn::data_types::i32>(p.sizes, p.format_fsv, "permute_xy_swap", {0, 1, 3, 2});
+}
+
 struct TiledPerformancePermuteTest : TiledPermuteTest
 {
     static double get_exectime(const std::map<cldnn::primitive_id, cldnn::network_output>& outputs,


### PR DESCRIPTION
Introduces PermuteKernel_xy_swap, which transposes the last two axes of 4D bfyx tensors via a TILE_SIZE x TILE_SIZE SLM tile (TILE_SIZE in {32, 16}, WG = 16 x 16) to make both reads and writes coalesced. Supports F16/F32/INT8/UINT8/INT32 with fused ops on static, tile-aligned shapes; registered ahead of the reference permute kernel via FORCE_PRIORITY_2.

### Tickets:
[CVS-187336](https://jira.devtools.intel.com/browse/CVS-187336)