### PR TITLE
[CPU][Tests] Fix params for Power eltwise test inputs generator

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.cpp
@@ -53,6 +53,7 @@ ov::Tensor EltwiseLayerCPUTest::generate_eltwise_input(const ov::element::Type& 
         switch (eltwiseType) {
         case utils::EltwiseTypes::POWER:
             params = gen_params(6, -3);
+            break;
         case utils::EltwiseTypes::MOD:
         case utils::EltwiseTypes::FLOOR_MOD:
             params = gen_params(2, 2, 8);


### PR DESCRIPTION
### Details:
Add missing `break` in `EltwiseLayerCPUTest::generate_eltwise_input` switch for `EltwiseTypes::POWER` case

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: no*