### PR TITLE
[GPU] check nullptr in add_output_chain

### DIFF
--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -485,8 +485,12 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
     std::stack<const primitive_inst*> candidates;
     auto& eng = get_engine();
 
-    const auto& mem_orig = p_inst->output_memory();
-
+    const auto& mem_orig = p_inst->output_memory_ptr();
+#ifdef GPU_DEBUG_CONFIG
+    if (!mem_orig) {
+        GPU_DEBUG_LOG << "output memory not allocated for " << p_inst->id() << " something may have gone wrong" << std::endl;
+    }
+#endif
     auto add_mdata_chain = [&](primitive_inst* p_inst) {
         auto mdata_ptr = dynamic_cast<mutable_data_inst*>(p_inst);
         if (!mdata_ptr)
@@ -495,12 +499,12 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
         // its attached memory with both its inputs and outputs
         for (auto& dep : p_inst->dependencies()) {
             // check dependencies
-            if (dep.first->outputs_allocated() && eng.is_the_same_buffer(mem_orig, dep.first->output_memory())) {
+            if (dep.first->outputs_allocated() && mem_orig && eng.is_the_same_buffer(*mem_orig, dep.first->output_memory())) {
                 chain.push_back(const_cast<primitive_inst*>(dep.first));
             }
             // then second order dependencies
             for (auto& second_dep : dep.first->dependencies()) {
-                if (second_dep.first->outputs_allocated() && eng.is_the_same_buffer(mem_orig, second_dep.first->output_memory())) {
+                if (second_dep.first->outputs_allocated() && mem_orig && eng.is_the_same_buffer(*mem_orig, second_dep.first->output_memory())) {
                     chain.push_back(const_cast<primitive_inst*>(second_dep.first));
                 }
             }
@@ -510,7 +514,7 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
         const auto& user_ids = mdata_ptr->get_user_ids();
         for (const auto& id : user_ids) {
             auto usr_prim = get_primitive(id).get();
-            if (usr_prim->outputs_allocated() && eng.is_the_same_buffer(mem_orig, usr_prim->output_memory())) {
+            if (usr_prim->outputs_allocated() && mem_orig && eng.is_the_same_buffer(*mem_orig, usr_prim->output_memory())) {
                 chain.push_back(usr_prim);
             }
         }
@@ -529,7 +533,7 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
         candidates.pop();
         // Add cand inst to the chain when cand's output is not allocated yet.
         if (!p_inst->outputs_allocated()
-            || (cand->outputs_allocated() && eng.is_the_same_buffer(mem_orig, cand->output_memory()))) {
+            || (cand->outputs_allocated() && mem_orig && eng.is_the_same_buffer(*mem_orig, cand->output_memory()))) {
             auto nc_cand = const_cast<primitive_inst*>(cand);
             chain.push_back(nc_cand);
             add_mdata_chain(nc_cand);
@@ -543,7 +547,7 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
                     const auto& mem_dep = dep.first->output_memory();
                     // Add dep inst to the chain when dep's output is not allocated yet.
                     if (!p_inst->outputs_allocated()
-                        || eng.is_the_same_buffer(mem_orig, mem_dep)) {
+                        || (mem_orig && eng.is_the_same_buffer(*mem_orig, mem_dep))) {
                         auto nc_dep = const_cast<primitive_inst*>(dep.first);
                         chain.push_back(nc_dep);
                         add_mdata_chain(nc_dep);

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -486,11 +486,7 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
     auto& eng = get_engine();
 
     const auto& mem_orig = p_inst->output_memory_ptr();
-#ifdef GPU_DEBUG_CONFIG
-    if (!mem_orig) {
-        GPU_DEBUG_LOG << "output memory not allocated for " << p_inst->id() << " something may have gone wrong" << std::endl;
-    }
-#endif
+
     auto add_mdata_chain = [&](primitive_inst* p_inst) {
         auto mdata_ptr = dynamic_cast<mutable_data_inst*>(p_inst);
         if (!mdata_ptr)
@@ -533,7 +529,7 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
         candidates.pop();
         // Add cand inst to the chain when cand's output is not allocated yet.
         if (!p_inst->outputs_allocated()
-            || (cand->outputs_allocated() && mem_orig && eng.is_the_same_buffer(*mem_orig, cand->output_memory()))) {
+            || (cand->outputs_allocated() && eng.is_the_same_buffer(*mem_orig, cand->output_memory()))) {
             auto nc_cand = const_cast<primitive_inst*>(cand);
             chain.push_back(nc_cand);
             add_mdata_chain(nc_cand);
@@ -547,7 +543,7 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
                     const auto& mem_dep = dep.first->output_memory();
                     // Add dep inst to the chain when dep's output is not allocated yet.
                     if (!p_inst->outputs_allocated()
-                        || (mem_orig && eng.is_the_same_buffer(*mem_orig, mem_dep))) {
+                        || (eng.is_the_same_buffer(*mem_orig, mem_dep))) {
                         auto nc_dep = const_cast<primitive_inst*>(dep.first);
                         chain.push_back(nc_dep);
                         add_mdata_chain(nc_dep);

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -543,7 +543,7 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
                     const auto& mem_dep = dep.first->output_memory();
                     // Add dep inst to the chain when dep's output is not allocated yet.
                     if (!p_inst->outputs_allocated()
-                        || (eng.is_the_same_buffer(*mem_orig, mem_dep))) {
+                        || eng.is_the_same_buffer(*mem_orig, mem_dep)) {
                         auto nc_dep = const_cast<primitive_inst*>(dep.first);
                         chain.push_back(nc_dep);
                         add_mdata_chain(nc_dep);


### PR DESCRIPTION
### Details:
 -  when output has no upper bound it maybe no allocation, added check and used ptr instead reference to object, to not reference nullptr, found that problem exist for bunch networks e.g DeepSeek-R1-Distill-Qwen-7B-fp16 from ov huggingface

### Tickets:
 - found when debugging 186519 but it not solve this ticket

### AI Assistance:
 - *AI assistance used: no