### PR TITLE
[GPU] support Gather-based RoPE pattern for position ids in LTX-Video

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -305,57 +305,61 @@ IncreasePositionIdsPrecisionForQwen3VL::IncreasePositionIdsPrecisionForQwen3VL()
 
 IncreasePositionIdsPrecisionForLtxVideo::IncreasePositionIdsPrecisionForLtxVideo() {
     using namespace ov::pass::pattern;
+    using ov::pass::pattern::op::Or;
 
     // LTX-Video RoPE position encoding pattern (anchored on fused RoPE).
-    // Position encoding is computed once and shared across all 28 transformer blocks (56 RoPE nodes).
-    // A single match is sufficient — subsequent RoPE nodes reuse the precision-upgraded shared path.
+    // Handles two topology variants sharing the same upstream path.
     //
+    // model1 (original):
     //   Multiply → Add(Constant) → Transpose → Reshape
-    //                                              │
-    //                                     ┌────────┴────────┐
-    //                                     │                 │
-    //                                    Sin               Cos
-    //                                     │                 │
-    //                                  Transpose         Transpose
-    //                                     │                 │
-    //                                  Unsqueeze         Unsqueeze
-    //                                     │                 │
-    //                                  Broadcast         Broadcast
-    //                                     │                 │
-    //                                  GatherND          GatherND
-    //                                     │                 │
-    //                                  Transpose         Transpose
-    //                                     │                 │
-    //                                  Concat_sin        Concat_cos
-    //                                     │                 │
-    //                                     └────────┬────────┘
-    //                                              │
-    //                              RoPE(x, Concat_cos, Concat_sin)
+    //       → Sin → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat_sin
+    //       → Cos → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat_cos
+    //       → RoPE(x, Concat_cos, Concat_sin)
+    //
+    // model2 (new topology):
+    //   Multiply → Add(Constant) → Transpose → Reshape
+    //       → Sin → Gather(Sin, Const, Const) → Concat(Broadcast, Gather)  [sin_concat]
+    //       → Cos → Gather(Cos, Const, Const) → Concat(Broadcast, Gather)  [cos_concat]
+    //       → RoPE(x, Concat_cos, Concat_sin)
 
-    // Upstream: Multiply → Add(Constant) → Transpose → Reshape
+    // Upstream: Multiply → Add(Constant) → Transpose → Reshape (same for both models)
     auto mul = wrap_type<ov::op::v1::Multiply>({any_input(), any_input()});
     auto add_constant = wrap_type<ov::op::v0::Constant>();
     auto add = wrap_type<ov::op::v1::Add>({mul, add_constant});
     auto transpose_up = wrap_type<ov::op::v1::Transpose>({add, any_input()});
     auto reshape = wrap_type<ov::op::v1::Reshape>({transpose_up, any_input()});
 
-    // Sin path: Sin → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat
+    // Sin and Cos nodes (shared between both model variants)
     auto sin = wrap_type<ov::op::v0::Sin>({reshape});
+    auto cos = wrap_type<ov::op::v0::Cos>({reshape});
+
+    // model1 sin path: Sin → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat
     auto sin_transpose = wrap_type<ov::op::v1::Transpose>({sin, any_input()});
     auto sin_unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({sin_transpose, any_input()});
     auto sin_broadcast = wrap_type<ov::op::v3::Broadcast>({sin_unsqueeze, any_input()});
     auto sin_gathernd = wrap_type<ov::op::v8::GatherND>({sin_broadcast, any_input()});
     auto sin_transpose2 = wrap_type<ov::op::v1::Transpose>({sin_gathernd, any_input()});
-    auto sin_concat = wrap_type<ov::op::v0::Concat>({any_input(), sin_transpose2});
+    auto sin_concat_m1 = wrap_type<ov::op::v0::Concat>({any_input(), sin_transpose2});
 
-    // Cos path: Cos → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat
-    auto cos = wrap_type<ov::op::v0::Cos>({reshape});
+    // model2 sin path: Sin → Gather → Concat
+    auto sin_gather_m2 = wrap_type<ov::op::v8::Gather>({sin, any_input(), any_input()});
+    auto sin_concat_m2 = wrap_type<ov::op::v0::Concat>({any_input(), sin_gather_m2});
+
+    auto sin_concat = std::make_shared<Or>(OutputVector{sin_concat_m1, sin_concat_m2});
+
+    // model1 cos path: Cos → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat
     auto cos_transpose = wrap_type<ov::op::v1::Transpose>({cos, any_input()});
     auto cos_unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({cos_transpose, any_input()});
     auto cos_broadcast = wrap_type<ov::op::v3::Broadcast>({cos_unsqueeze, any_input()});
     auto cos_gathernd = wrap_type<ov::op::v8::GatherND>({cos_broadcast, any_input()});
     auto cos_transpose2 = wrap_type<ov::op::v1::Transpose>({cos_gathernd, any_input()});
-    auto cos_concat = wrap_type<ov::op::v0::Concat>({any_input(), cos_transpose2});
+    auto cos_concat_m1 = wrap_type<ov::op::v0::Concat>({any_input(), cos_transpose2});
+
+    // model2 cos path: Cos → Gather → Concat
+    auto cos_gather_m2 = wrap_type<ov::op::v8::Gather>({cos, any_input(), any_input()});
+    auto cos_concat_m2 = wrap_type<ov::op::v0::Concat>({any_input(), cos_gather_m2});
+
+    auto cos_concat = std::make_shared<Or>(OutputVector{cos_concat_m1, cos_concat_m2});
 
     // RoPE: input 0 = x, input 1 = cos_concat, input 2 = sin_concat
     auto rope = wrap_type<ov::op::internal::RoPE>({any_input(), cos_concat, sin_concat},

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
@@ -509,6 +509,104 @@ TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideo_F) {
     test_IncreasePositionIdsLTXVideo(model, model_ref, manager, comparator, false);
 }
 
+// model2 topology: Sin/Cos → Gather(repeat_interleave) → Concat
+// Replaces the GatherND→Transpose chain used in model1.
+static void test_IncreasePositionIdsLTXVideoGather(std::shared_ptr<ov::Model>& model,
+                                                   std::shared_ptr<ov::Model>& model_ref,
+                                                   ov::pass::Manager& manager,
+                                                   FunctionsComparator& comparator,
+                                                   bool is_ltx_video) {
+    {
+        auto param_mul_in = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 64});
+        auto param_x = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 64, 16});
+
+        // Upstream: Multiply → Add(Constant) → Transpose → Reshape
+        auto mul_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 1, 64}, {3.14f});
+        auto multiply = std::make_shared<ov::op::v1::Multiply>(param_mul_in, mul_const);
+        auto add_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 1, 64}, {1e-6f});
+        auto add = std::make_shared<ov::op::v1::Add>(multiply, add_const);
+        auto transpose_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto transpose_up = std::make_shared<ov::op::v1::Transpose>(add, transpose_order);
+        auto reshape_shape = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {1, 64, 3});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(transpose_up, reshape_shape, false);
+
+        // Sin path: Sin → Gather → Concat(Broadcast, Gather)
+        auto sin_node = std::make_shared<ov::op::v0::Sin>(reshape);
+        auto sin_gather_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{64}, {0});
+        auto sin_gather_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {-1});
+        auto sin_gather = std::make_shared<ov::op::v8::Gather>(sin_node, sin_gather_indices, sin_gather_axis);
+        auto sin_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {0.0f});
+        auto sin_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{sin_concat_other, sin_gather}, -1);
+
+        // Cos path: Cos → Gather → Concat(Broadcast, Gather)
+        auto cos_node = std::make_shared<ov::op::v0::Cos>(reshape);
+        auto cos_gather_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{64}, {0});
+        auto cos_gather_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {-1});
+        auto cos_gather = std::make_shared<ov::op::v8::Gather>(cos_node, cos_gather_indices, cos_gather_axis);
+        auto cos_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {1.0f});
+        auto cos_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{cos_concat_other, cos_gather}, -1);
+
+        ov::op::internal::RoPE::Config rope_config;
+        rope_config.is_ltx_video = is_ltx_video;
+        rope_config.rotary_ndims = 64;
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{param_x, cos_concat, sin_concat}, rope_config);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{param_mul_in, param_x});
+        manager.register_pass<IncreasePositionIdsPrecision>();
+    }
+    if (is_ltx_video) {
+        auto param_mul_in = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 64});
+        auto param_x = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 64, 16});
+
+        // Upstream with f32 converts inserted by the pass
+        auto convert_mul_in = std::make_shared<ov::op::v0::Convert>(param_mul_in, ov::element::f32);
+        auto mul_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 1, 64}, {3.14f});
+        auto convert_mul_const = std::make_shared<ov::op::v0::Convert>(mul_const, ov::element::f32);
+        auto multiply = std::make_shared<ov::op::v1::Multiply>(convert_mul_in, convert_mul_const);
+        auto add_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 1, 64}, {1e-6f});
+        auto convert_add_const = std::make_shared<ov::op::v0::Convert>(add_const, ov::element::f32);
+        auto add = std::make_shared<ov::op::v1::Add>(multiply, convert_add_const);
+        auto transpose_order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+        auto transpose_up = std::make_shared<ov::op::v1::Transpose>(add, transpose_order);
+        auto reshape_shape = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {1, 64, 3});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(transpose_up, reshape_shape, false);
+
+        // Sin path with Convert(f32→f16) after Sin
+        auto sin_node = std::make_shared<ov::op::v0::Sin>(reshape);
+        auto convert_sin = std::make_shared<ov::op::v0::Convert>(sin_node, ov::element::f16);
+        auto sin_gather_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{64}, {0});
+        auto sin_gather_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {-1});
+        auto sin_gather = std::make_shared<ov::op::v8::Gather>(convert_sin, sin_gather_indices, sin_gather_axis);
+        auto sin_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {0.0f});
+        auto sin_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{sin_concat_other, sin_gather}, -1);
+
+        // Cos path with Convert(f32→f16) after Cos
+        auto cos_node = std::make_shared<ov::op::v0::Cos>(reshape);
+        auto convert_cos = std::make_shared<ov::op::v0::Convert>(cos_node, ov::element::f16);
+        auto cos_gather_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{64}, {0});
+        auto cos_gather_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {-1});
+        auto cos_gather = std::make_shared<ov::op::v8::Gather>(convert_cos, cos_gather_indices, cos_gather_axis);
+        auto cos_concat_other = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, 64, 8}, {1.0f});
+        auto cos_concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{cos_concat_other, cos_gather}, -1);
+
+        ov::op::internal::RoPE::Config rope_config;
+        rope_config.is_ltx_video = true;
+        rope_config.rotary_ndims = 64;
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{param_x, cos_concat, sin_concat}, rope_config);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{param_mul_in, param_x});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideoGather_T) {
+    test_IncreasePositionIdsLTXVideoGather(model, model_ref, manager, comparator, true);
+}
+
+TEST_F(TransformationTestsF, IncreasePositionIdsLTXVideoGather_F) {
+    test_IncreasePositionIdsLTXVideoGather(model, model_ref, manager, comparator, false);
+}
+
 TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForQwen25VL) {
     {
         auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ 3, -1, -1 });


### PR DESCRIPTION
## Details

**Problem:** LTX-Video model produces corrupted output on GPU due to FP16 precision loss in position_ids.

**Root cause:** The `IncreasePositionIdsPrecisionForLtxVideo` nGraph pass pattern became stale after model updates and the RoPE-for-LTX-Video integration. The old pattern matched only the `GatherND → Transpose → Concat` downstream path from Sin/Cos, but newer models exported with diffusers ≥0.37.1 / optimum ≥2.2.0 use a simpler `Gather → Concat` path (aten::repeat_interleave pattern). As a result, position_ids remained in FP16, causing SDPA computation errors that accumulated through FFN layers across all 28 transformer blocks.

**Fix:** Extended the pass to match both downstream topologies using `ov::pass::pattern::op::Or`:
- Path 1 (existing): `Sin/Cos → Transpose → Unsqueeze → Broadcast → GatherND → Transpose → Concat`
- Path 2 (new): `Sin/Cos → Gather → Concat`

Updated unit tests to cover the new Gather-based pattern (`IncreasePositionIdsLTXVideoGather_T/F`).

## Tickets

- [CVS-185162](https://jira.devtools.intel.com/browse/CVS-185162)

## AI Assistance

- AI assistance used: yes
- GitHub Copilot was used for sublayer diff analysis, force-fp32 binary search automation, and debug log analysis. All code changes were manually reviewed and validated with FP16/INT4 accuracy tests.
