### PR TITLE
intel_cpu: Fix out-of-bounds evaluation and zero-initialize decompression parameters

### DIFF
--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -736,7 +736,8 @@ static MemoryPtr prepackDecompressionParams(const MemoryCPtr& paramsPtr,
                                             ov::element::Type dstPrc,
                                             const dnnl::engine& engine) {
     auto shape = paramsPtr->getShape().getStaticDims();
-    if (all_of(1U, shape.size(), shape[0])) {
+    // Use short-circuit && to safely guard shape[0] access: shape must be non-empty first
+    if (shape.size() == 1U && shape[0] == 1U) {
         shape.push_back(1);
     }
 
@@ -754,6 +755,7 @@ static MemoryPtr prepackDecompressionParams(const MemoryCPtr& paramsPtr,
                                         DnnlExtensionUtils::ElementTypeToDataType(dstPrc),
                                         dnnl::memory::format_tag::io);
     auto dstMem = std::make_shared<Memory>(engine, dstMemoryDesc);
+    dstMem->nullify();
     auto srcFormat = needTranspose ? dnnl::memory::format_tag::oi : dnnl::memory::format_tag::io;
 
     DnnlBlockedMemoryDesc srcMemoryDesc(


### PR DESCRIPTION
### Details:
 - **Out-of-Bounds evaluation guard**: Replaced the template helper `all_of(1U, shape.size(), shape[0])` in `prepackDecompressionParams` with short-circuiting logic `shape.size() == 1U && shape[0] == 1U` to avoid reading stack/heap garbage when `shape` is empty.
 - **Zero-initialize decompression parameters**: Added `dstMem->nullify()` immediately after allocating memory for `dstMem` in `prepackDecompressionParams`. This prevents aligned vector loads from reading uninitialized padding/alignment bytes within the scale and zero-point parameters, which was causing non-deterministic NaN propagation.
 - **submodule dependency**: This PR should be combined with the oneDNN PR which zero-initializes the JIT decompression scratchpad buffer.

### Tickets:
 - Closes #36328

### AI Assistance:
 - AI assistance used: yes
 - **Summary:** AI assistance was used to analyze the memory layout, locate the uninitialized scratchpad/repack buffers, and write the fixes. 
 - **Human Validation:** Compiled the Intel CPU plugin locally in Release mode with Visual Studio 2022. Verified that the reproduction script `reproduce.py` consistently returns `"equal": true` (zero non-determinism). Ran custom benchmarks showing clean execution (average latency of 0.045 ms, ~22,200 FPS).
