### PR TITLE
[GPU] Make variadic_split with dynamic split_length able to do inplace crop

### DIFF
--- a/src/plugins/intel_gpu/src/graph/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/crop.cpp
@@ -72,15 +72,20 @@ std::vector<layout> crop_inst::calc_output_layouts(const crop_node& /*node*/, co
             auto split_length_mem = impl_param.memory_deps.at(2);
             cldnn::mem_lock<uint8_t, mem_lock_type::read> split_length_mem_lock(split_length_mem, impl_param.get_stream());
             const_data.emplace(2, make_tensor(split_length_mem->get_layout(), split_length_mem_lock.data()));
+        }
 
-            ov::op::v1::VariadicSplit op;
-            op.set_friendly_name(desc->id);
-            output_shapes = shape_infer(&op, input_shapes, ov::make_tensor_accessor(const_data));
-        } else {
+        ov::op::v1::VariadicSplit op;
+        op.set_friendly_name(desc->id);
+        output_shapes = shape_infer(&op, input_shapes, ov::make_tensor_accessor(const_data));
+
+        if (output_shapes.empty()) {
+            // Don't even know number of output, simply return dynamic as output shape
+            GPU_DEBUG_TRACE_DETAIL << impl_param.desc->id << " shape_infer return empty: splits [" << impl_param.get_input_layout(2) << "]" << std::endl;
             auto input0_layout = impl_param.get_input_layout(0);
             auto out_shape = ov::PartialShape::dynamic(input0_layout.get_partial_shape().size());
             return { layout{out_shape, input0_layout.data_type, input0_layout.format } };
         }
+        OPENVINO_ASSERT(desc->output_idx < output_shapes.size(), "[GPU] Shape_infer returns less ouput shape than request index");
     } else if (desc->op_mode == cldnn::crop_ngraph_op_mode::split) {
         std::unordered_map<size_t, ov::Tensor> const_data;
 
@@ -124,11 +129,14 @@ std::vector<layout> crop_inst::calc_output_layouts(const crop_node& /*node*/, co
         return {layout{ref_in_sizes.get_partial_shape(in_layout.get_partial_shape().size(), in_layout.get_rank()), in_layout.data_type, in_layout.format}};
     }
 
-    bool is_output_static = false;
+    // ensure all output is static
+    bool is_output_static = input_shapes[0].is_static();
     std::vector<layout> output_layouts;
     for (size_t i = 0; i < output_shapes.size(); ++i) {
         output_layouts.push_back(layout({output_shapes[i], in_layout.data_type, in_layout.format}));
-        is_output_static = (output_shapes[i].is_static()) ? true : is_output_static;
+        if (i < desc->output_idx) {
+            is_output_static = is_output_static && output_shapes[i].is_static();
+        }
     }
 
     // update split offsets

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -566,13 +566,17 @@ bool crop_in_place_optimization::match(const program_node& node,
     if (node.is_constant())
         return false;
 
-    // do not optimize variadic_split crop when either input1 or input2 is not constant.
-    // VariadicSplit ngraph shape infer requires value of axis(input1) and split_lengths(input2).
-    // And non_constant input1/input2 makes risky execution of runtime buffer fusing.
+    // do not optimize variadic_split crop when input1 is not constant
+    // when input0 is static, input2 should be constant since do_runtime_in_place_crop won't be triggered
+    // when input0 is dynamic, allow input2 to be dynamic but static rank, and do_runtime_in_place_crop should give correct layout
+    // non_constant input1/input2 makes risky execution of runtime buffer fusing?
     auto& crop_node = node.as<crop>();
-    if ((crop_node.get_primitive()->op_mode == cldnn::crop_ngraph_op_mode::variadic_split) &&
-        (!crop_node.get_dependency(1).is_constant() || !crop_node.get_dependency(2).is_constant()))
-        return false;
+    if (crop_node.get_primitive()->op_mode == cldnn::crop_ngraph_op_mode::variadic_split) {
+        const auto is_input_dynamic = crop_node.get_dependency(0).is_dynamic();
+        if (!crop_node.get_dependency(1).is_constant() ||
+            !(is_input_dynamic ? crop_node.get_input_layout(2).is_static() : crop_node.get_dependency(2).is_constant()))
+            return false;
+    }
 
     if (node.get_users().size() > 0) {
         GPU_DEBUG_IF(node.get_config().get_disable_runtime_buffer_fusing() && dyn_aware) {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1913,6 +1913,10 @@ void primitive_inst::do_runtime_in_place_crop() {
     for (auto u : get_user_insts()) {
         if (u->get_node().is_type<crop>()) {
             if (u->get_node().can_be_optimized()) {
+                if (u->get_node().get_dependency_index(get_node()) == 2) {
+                    // this is crop's split lengths, at this moment it's not executed and crop's update_shape will try read output, so skip
+                    continue;
+                }
                 GPU_DEBUG_TRACE_DETAIL << "[In place crop] update shape for " << u->id() << std::endl;
                 u->update_shape();
                 u->_update_shape_done_by_other = true;

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -1121,7 +1121,87 @@ TEST(prepare_buffer_fusing, in_place_crop_dynamic_reshape_squeeze_crop_axis) {
         ASSERT_EQ(second_half[i], full_output[full_output.size() / 2 + i]) << i;
 }
 
-TEST(prepare_buffer_fusing, in_place_crop_dynamic_split_lengths) {
+
+TEST(prepare_buffer_fusing, in_place_crop_static_input_dynamic_split_lengths) {
+    auto& engine = get_test_engine();
+
+    auto in_layout = layout{ov::PartialShape{1, 2, 4}, data_types::f32, format::bfyx};
+    auto in2_layout = layout{ov::PartialShape{-1, -1}, data_types::f32, format::bfyx};
+    auto input_mem = engine.allocate_memory({{1, 2, 4}, data_types::f32, format::bfyx});
+    auto weights_mem = engine.allocate_memory({{8, 4}, data_types::u8, format::bfyx});
+    auto bias_mem = engine.allocate_memory({{1, 1, 8}, data_types::f32, format::bfyx});
+    auto scale_mem = engine.allocate_memory({{8, 1}, data_types::f32, format::bfyx});
+    auto zp_mem = engine.allocate_memory({{8, 1}, data_types::f32, format::bfyx});
+    auto axis_mem = engine.allocate_memory({{}, data_types::i64, format::bfyx});
+    auto shapeof_mem = engine.allocate_memory({{2, 6}, data_types::f32, format::bfyx});
+
+    int64_t axis = 2;
+    set_values(input_mem, {-0.5f, 2.0f, 0.5f, 1.0f, 0.5f, -2.0f, -0.5f, -1.0f});
+    set_values<int64_t>(axis_mem, {axis});
+    set_values(shapeof_mem, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f});
+    set_values<uint8_t>(weights_mem, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0});
+    set_values(bias_mem, {1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.0f, 7.0f, 2.0f});
+    set_values(scale_mem, {2.0f, 4.0f, -2.0f, -4.0f, 0.5f, -0.5f, 2.0f, 2.0f});
+    set_values(zp_mem, {1.0f, 2.0f, 2.0f, 1.0f, 4.0f, 1.0f, 6.0f, 2.0f});
+
+    std::vector<float> out1 = {13.f, 58.f, -11.f, -62.f};
+    std::vector<float> out2 = {-51.f, -108.f, 18.5f, -18.f, 1.f, -4.f, 57.f, 100.f, -8.5f, 6.f, 13.f, 8.f};
+    std::vector<float> out3 = {13.f, 58.f, -51.f, -108.f, 18.5f, -18.f, 1.f, -4.f, -11.f, -62.f, 57.f, 100.f, -8.5f, 6.f, 13.f, 8.f};
+
+    cldnn::crop_ngraph_op_mode op_mode = cldnn::crop_ngraph_op_mode::variadic_split;
+    topology topology(
+        input_layout("input", in_layout),
+        input_layout("input_shapeof", in2_layout),
+        data("axis", axis_mem),
+        data("weights", weights_mem),
+        data("bias", bias_mem),
+        data("scale", scale_mem),
+        data("zp", zp_mem),
+        fully_connected("fc", input_info("input"), "weights", "bias", "scale", "zp", data_types::f32, 3, 2),
+        shape_of("shapeof", input_info("input_shapeof"), cldnn::data_types::i64),
+        crop("crop1", {input_info("fc"), input_info("axis"), input_info("shapeof")}, cldnn::tensor(1), cldnn::tensor(0), op_mode, 0, axis),
+        reorder("output1", input_info("crop1"), format::bfyx, data_types::f32),
+        crop("crop2", {input_info("fc"), input_info("axis"), input_info("shapeof")}, cldnn::tensor(1), cldnn::tensor(0), op_mode, 1, axis),
+        reshape("reshape", input_info("crop2"), true, std::vector<int64_t>{0, 0, 3, 2}, ov::PartialShape{-1, -1, 3, 2}, cldnn::reshape::reshape_mode::base),
+        reorder("output2", input_info("reshape"), format::bfyx, data_types::f32, std::vector<float>(), reorder_mean_mode::subtract, padding(), true),
+        reorder("output3", input_info("fc"), format::bfyx, data_types::f32));
+
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    network network(engine, topology, config);
+
+    network.set_input_data("input", input_mem);
+    network.set_input_data("input_shapeof", shapeof_mem);
+
+    std::map<cldnn::primitive_id, cldnn::network_output> outputs;
+    EXPECT_NO_THROW(outputs = network.execute());
+
+    auto output = outputs.at("output1").get_memory();
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+
+    for (size_t i = 0; i < out1.size(); i++)
+        ASSERT_EQ(output_ptr[i], out1[i]);
+
+    auto output_2 = outputs.at("output2").get_memory();
+    cldnn::mem_lock<float> output_ptr_2(output_2, get_test_stream());
+
+    for (size_t i = 0; i < out2.size(); i++)
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
+
+    auto output_3 = outputs.at("output3").get_memory();
+    cldnn::mem_lock<float> output_ptr_3(output_3, get_test_stream());
+
+    for (size_t i = 0; i < out3.size(); i++)
+        ASSERT_EQ(output_ptr_3[i], out3[i]);
+
+    auto crop1_prim = network.get_primitive("crop1");
+    EXPECT_EQ(crop1_prim->can_be_optimized(), false);
+    auto crop2_prim = network.get_primitive("crop2");
+    EXPECT_EQ(crop2_prim->can_be_optimized(), false);
+}
+
+TEST(prepare_buffer_fusing, in_place_crop_dynamic_input_dynamic_split_lengths) {
     auto& engine = get_test_engine();
 
     auto in_layout = layout{ ov::PartialShape{-1, -1, -1}, data_types::f32, format::bfyx};
@@ -1204,6 +1284,11 @@ TEST(prepare_buffer_fusing, in_place_crop_dynamic_split_lengths) {
 
     for (size_t i = 0; i < out3.size(); i++)
         ASSERT_EQ(output_ptr_3[i], out3[i]);
+
+    auto crop1_prim = network.get_primitive("crop1");
+    EXPECT_EQ(crop1_prim->can_be_optimized(), true);
+    auto crop2_prim = network.get_primitive("crop2");
+    EXPECT_EQ(crop2_prim->can_be_optimized(), false); // crop2's user reshape is not inpalce, so will be rejected as inplace
 }
 
 TEST(prepare_buffer_fusing, in_place_crop_dynamic_mvn) {

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/crop_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/crop_si_test.cpp
@@ -45,12 +45,21 @@ TEST_P(crop_si_test, shape_infer) {
     }
 
     for (size_t i = 1; i < p.input_layouts.size(); i++) {
-        auto prim_id = "const::data"+std::to_string(i);
-        auto prim_mem = engine.allocate_memory(p.input_layouts[i]);
-        set_values(prim_mem, p.const_values[i-1]);
-        auto const_data_prim = std::make_shared<data>(prim_id, prim_mem);
-        input_prims.push_back(const_data_prim);
-        input_prim_ids.push_back(input_info(prim_id));
+        const bool is_const_input = i - 1 < p.const_values.size() && !p.const_values[i - 1].empty();
+
+        if (is_const_input) {
+            auto prim_id = "const::data"+std::to_string(i);
+            auto prim_mem = engine.allocate_memory(p.input_layouts[i]);
+            set_values(prim_mem, p.const_values[i-1]);
+            auto const_data_prim = std::make_shared<data>(prim_id, prim_mem);
+            input_prims.push_back(const_data_prim);
+            input_prim_ids.push_back(input_info(prim_id));
+        } else {
+            auto prim_id = "input" + std::to_string(i);
+            auto input_layout_prim = std::make_shared<input_layout>(prim_id, p.input_layouts[i]);
+            input_prims.push_back(input_layout_prim);
+            input_prim_ids.push_back(input_info(prim_id));
+        }
     }
 
     crop_ngraph_op_mode op_mode = crop_ngraph_op_mode::none;
@@ -127,6 +136,14 @@ INSTANTIATE_TEST_SUITE_P(smoke, crop_si_test,
             1,
             {{{4819,4,1,1,4},data_types::f32,format::bfzyx}, {{},data_types::i64,format::bfzyx}, {{4},data_types::i64,format::bfzyx}},
             {{{4819,1,1,1,4},data_types::f32,format::bfzyx}, {{4819,1,1,1,4},data_types::f32,format::bfzyx}, {{4819,1,1,1,4},data_types::f32,format::bfzyx}, {{4819,1,1,1,4},data_types::f32,format::bfzyx}}, 0
+        },
+        {
+            tensor({1,1,1,1,1,1,1}),
+            {tensor({0,0,0,0,1,1,1}), tensor({0,0,0,0,1,1,1})},
+            {{1}, {}},
+            1,
+            {{{7,4,1,1,4},data_types::f32,format::bfzyx}, {{},data_types::i64,format::bfzyx}, {{2},data_types::i64,format::bfzyx}},
+            {{{7,ov::Dimension::dynamic(),1,1,4},data_types::f32,format::bfzyx}, {{7,ov::Dimension::dynamic(),1,1,4},data_types::f32,format::bfzyx}}, 0
         },
         {
             tensor({4507,1,1,1,1,1,1}),


### PR DESCRIPTION
### Details:
- Current crop is simply returning dynamic as output layout when split_lengths is not constant, which is not consistent with variadic_split's shape_infer behavior.
- Currently inplace crop only happens during compilation and requires split_lengths to be constants
- When split_lengths is a known shape but dynamic content, should still allow perform inplace crop.
- When data is static, there's no runtime_inplace_crop, so has to dynamic split_lengths only works with dynamic data.

### Tickets:
 - *CVS-189222*

### AI Assistance:
 - *AI assistance used: no
