### PR TITLE
[NPU] Fix spurious import rejection for page-adjacent host allocations

### DIFF
--- a/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
@@ -48,11 +48,14 @@ ZeroMem::ZeroMem(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                 "Importing standard allocation is not supported if memory is not aligned to standard page size");
         }
 
-        // We need to check if the end of the current region is part of a previous imported region
-        // The other cases are handled by the driver
-        if (zeroUtils::get_l0_context_memory_allocation_id(
+        // Reject the import only when the region genuinely overlaps a previously imported
+        // allocation. Probe the last valid byte (data + _size - 1) so that a buffer whose end
+        // merely abuts an adjacent allocation is still importable. Other cases are handled by
+        // the driver.
+        if (_size > 0 &&
+            zeroUtils::get_l0_context_memory_allocation_id(
                 _init_structs->getContext(),
-                static_cast<void*>(static_cast<uint8_t*>(const_cast<void*>(data)) + _size)) > 0) {
+                static_cast<void*>(static_cast<uint8_t*>(const_cast<void*>(data)) + _size - 1)) > 0) {
             throw ZeroMemException("Can not import a memory which is part of an existing allocation");
         }
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
@@ -52,10 +52,9 @@ ZeroMem::ZeroMem(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
         // allocation. Probe the last valid byte (data + _size - 1) so that a buffer whose end
         // merely abuts an adjacent allocation is still importable. Other cases are handled by
         // the driver.
-        if (_size > 0 &&
-            zeroUtils::get_l0_context_memory_allocation_id(
-                _init_structs->getContext(),
-                static_cast<void*>(static_cast<uint8_t*>(const_cast<void*>(data)) + _size - 1)) > 0) {
+        if (_size > 0 && zeroUtils::get_l0_context_memory_allocation_id(
+                             _init_structs->getContext(),
+                             static_cast<void*>(static_cast<uint8_t*>(const_cast<void*>(data)) + _size - 1)) > 0) {
             throw ZeroMemException("Can not import a memory which is part of an existing allocation");
         }
 

--- a/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_mem_pool_tests.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_mem_pool_tests.hpp
@@ -368,6 +368,38 @@ TEST_P(ZeroMemPoolTests, MultiThreadingImportMemoryReUseAndDestroyItWithMultiple
     }
 }
 
+TEST_P(ZeroMemPoolTests, ImportMemoryAdjacentToAlreadyImportedAllocation) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    if (!init_struct->isExternalMemoryStandardAllocationSupported()) {
+        GTEST_SKIP() << "Test requires support for importing standard allocated memory as external memory, which is "
+                        "not available on this platform.";
+    }
+
+    // Allocate a single, contiguous two-page block so the two halves are guaranteed to be page-adjacent.
+    constexpr size_t page = 4096;
+    void* block = ::operator new(2 * page, std::align_val_t(page));
+    auto* lower = static_cast<uint8_t*>(block);
+    auto* upper = lower + page;
+
+    // Import the upper page first so that it is a registered allocation in the L0 context.
+    std::shared_ptr<::intel_npu::ZeroMem> upper_mem;
+    OV_ASSERT_NO_THROW(upper_mem = ::intel_npu::zero_mem::import_standard_allocation_memory(init_struct, upper, page));
+
+    // The lower page's exclusive end pointer (lower + page) aliases the base of the already-imported upper page.
+    // This must NOT be treated as an overlap: the regions merely abut, they do not overlap. Importing the lower
+    // page must succeed.
+    std::shared_ptr<::intel_npu::ZeroMem> lower_mem;
+    OV_ASSERT_NO_THROW(lower_mem = ::intel_npu::zero_mem::import_standard_allocation_memory(init_struct, lower, page));
+
+    ASSERT_TRUE(::intel_npu::zeroUtils::get_l0_context_memory_allocation_id(init_struct->getContext(), lower));
+    ASSERT_TRUE(::intel_npu::zeroUtils::get_l0_context_memory_allocation_id(init_struct->getContext(), upper));
+
+    lower_mem = {};
+    upper_mem = {};
+    ::operator delete(block, std::align_val_t(page));
+}
+
 TEST_P(ZeroMemPoolTests, DontDestroyZeroMemoryWhenZeroContextIsDestroyed) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 


### PR DESCRIPTION
When importing a user-provided host buffer as a standard allocation,
ZeroMem checked whether the region was part of an already-imported
allocation by probing the exclusive end pointer (data + size). That
address is one byte past the buffer and aliases the base of an
exactly-adjacent allocation, so importing a buffer whose end abuts a
previously imported but non-overlapping allocation was incorrectly
rejected with "Can not import a memory which is part of an existing
allocation".

This is easy to hit when consecutive host buffers are carved from a
page-contiguous arena and imported into the same Level Zero context:
the check intermittently fails depending on import/free ordering and
buffer placement.

Probe the last valid byte (data + size - 1) instead of the exclusive
end pointer, so only a genuine overlap triggers the rejection.
Page-contiguous but non-overlapping imports now succeed; truly
overlapping regions are still detected, and remaining cases continue
to be handled by the driver.

Add a regression test (ZeroMemPoolTests.ImportMemoryAdjacentToAlreadyImportedAllocation)
that imports two page-adjacent halves of a single contiguous block and
asserts the second import succeeds. It fails on the old exclusive-end
probe and passes with the fix.