### PR TITLE
NPUW: Batched scoring as a composable element (reranker / embedding)

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
@@ -87,6 +87,7 @@ INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_WHISPER_EOS_TOKEN, uint64_t, 50257, ov::intel_npu
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_WHISPER_DECOMPOSE_SDPA, bool, false, ov::intel_npu::npuw::whisper, whisper_decompose_sdpa, "NPUW_WHISPER_DECOMPOSE_SDPA", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_EAGLE, bool, false, ov::intel_npu::npuw::eagle, enabled, "NPUW_EAGLE", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_TEXT_EMBED, bool, false, ov::intel_npu::npuw::text_embed, enabled, "NPUW_TEXT_EMBED", LLM, EXPOSED, CACHED, ALL)
+INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_TEXT_RERANK, bool, false, ov::intel_npu::npuw::text_rerank, enabled, "NPUW_TEXT_RERANK", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_KOKORO, bool, false, ov::intel_npu::npuw::kokoro, enabled, "NPUW_KOKORO", KOKORO, EXPOSED, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_KOKORO_BLOCK_SIZE, uint64_t, 200, ov::intel_npu::npuw::kokoro, block_size, "NPUW_KOKORO_BLOCK_SIZE", KOKORO, EXPOSED, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_KOKORO_OVERLAP_SIZE, uint64_t, 20, ov::intel_npu::npuw::kokoro, overlap_size, "NPUW_KOKORO_OVERLAP_SIZE", KOKORO, EXPOSED, UNCACHED, ALL)

--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
@@ -91,6 +91,7 @@ INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_WHISPER_EOS_TOKEN, uint64_t, 50257, ov::intel_npu
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_WHISPER_DECOMPOSE_SDPA, bool, false, ov::intel_npu::npuw::whisper, whisper_decompose_sdpa, "NPUW_WHISPER_DECOMPOSE_SDPA", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_EAGLE, bool, false, ov::intel_npu::npuw::eagle, enabled, "NPUW_EAGLE", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_TEXT_EMBED, bool, false, ov::intel_npu::npuw::text_embed, enabled, "NPUW_TEXT_EMBED", LLM, EXPOSED, CACHED, ALL)
+INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_TEXT_RERANK, bool, false, ov::intel_npu::npuw::text_rerank, enabled, "NPUW_TEXT_RERANK", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_KOKORO, bool, false, ov::intel_npu::npuw::kokoro, enabled, "NPUW_KOKORO", KOKORO, EXPOSED, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_KOKORO_BLOCK_SIZE, uint64_t, 200, ov::intel_npu::npuw::kokoro, block_size, "NPUW_KOKORO_BLOCK_SIZE", KOKORO, EXPOSED, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_KOKORO_OVERLAP_SIZE, uint64_t, 20, ov::intel_npu::npuw::kokoro, overlap_size, "NPUW_KOKORO_OVERLAP_SIZE", KOKORO, EXPOSED, UNCACHED, ALL)

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -313,13 +313,15 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::LLMCompiledModel will be created.");
         auto llm_compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
+        compiled_model = llm_compiled_model;
         // Single-shot scoring pipelines (text rerank / embedding) may submit batched
         // [N, ...] inputs, while the LLM pipeline pins everything to a static batch
         // of 1. Wrap the compiled model with the batched element, which unrolls such
         // an infer row by row over the unchanged batch-1 inner request.
-        compiled_model = ov::npuw::batched::CompiledModel::create(llm_compiled_model,
-                                                                  plugin,
-                                                                  ov::npuw::batched::requested(properties));
+        if (ov::npuw::batched::requested(llm_compiled_model)) {
+            LOG_INFO("Wrapping with ov::npuw::batched::CompiledModel.");
+            compiled_model = std::make_shared<ov::npuw::batched::CompiledModel>(llm_compiled_model, plugin);
+        }
     } else if (properties.count(use_kokoro_key) && properties.at(use_kokoro_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::KokoroCompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::KokoroCompiledModel>(model, plugin, config);

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -312,16 +312,14 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
         compiled_model = std::make_shared<ov::npuw::GQACompiledModel>(model, plugin, config);
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::LLMCompiledModel will be created.");
-        auto llm_compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
-        compiled_model = llm_compiled_model;
         // Single-shot scoring pipelines (text rerank / embedding) may submit batched
         // [N, ...] inputs, while the LLM pipeline pins everything to a static batch
-        // of 1. Wrap the compiled model with the batched element, which unrolls such
-        // an infer row by row over the unchanged batch-1 inner request.
-        if (ov::npuw::batched::requested(llm_compiled_model)) {
-            LOG_INFO("Wrapping with ov::npuw::batched::CompiledModel.");
-            compiled_model = std::make_shared<ov::npuw::batched::CompiledModel>(llm_compiled_model, plugin);
-        }
+        // of 1. batched::CompiledModel::create() wraps models tagged for such scoring
+        // with the batched element, which unrolls an infer row by row over the
+        // unchanged batch-1 inner request; untagged models are returned unwrapped.
+        compiled_model = ov::npuw::batched::CompiledModel::create(
+            std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config),
+            plugin);
     } else if (properties.count(use_kokoro_key) && properties.at(use_kokoro_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::KokoroCompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::KokoroCompiledModel>(model, plugin, config);

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -30,6 +30,7 @@
 #include "unfold_sync_infer_request.hpp"
 #include "util.hpp"
 #include "v1/elements/accuracy_checked.hpp"
+#include "v1/elements/batched.hpp"
 #include "v1/elements/failsafe.hpp"
 
 // required for get_properties_per_device()
@@ -311,7 +312,14 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
         compiled_model = std::make_shared<ov::npuw::GQACompiledModel>(model, plugin, config);
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::LLMCompiledModel will be created.");
-        compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
+        auto llm_compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
+        // Single-shot scoring pipelines (text rerank / embedding) may submit batched
+        // [N, ...] inputs, while the LLM pipeline pins everything to a static batch
+        // of 1. Wrap the compiled model with the batched element, which unrolls such
+        // an infer row by row over the unchanged batch-1 inner request.
+        compiled_model = ov::npuw::batched::CompiledModel::create(llm_compiled_model,
+                                                                  plugin,
+                                                                  ov::npuw::batched::requested(properties));
     } else if (properties.count(use_kokoro_key) && properties.at(use_kokoro_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::KokoroCompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::KokoroCompiledModel>(model, plugin, config);

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -346,6 +346,42 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     return compiled_model;
 }
 
+std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::import_model(
+    std::istream& stream,
+    const std::shared_ptr<const ov::IPlugin>& plugin,
+    const ov::AnyMap& properties) {
+    LOG_INFO("Choosing which NPUW CompiledModel to import");
+    LOG_BLOCK();
+
+    const auto stream_start_pos = stream.tellg();
+    ov::npuw::s11n::IndicatorType serialization_indicator;
+    OPENVINO_ASSERT(
+        ov::npuw::orc::try_read_bytes(stream, serialization_indicator.data(), serialization_indicator.size()) &&
+            serialization_indicator == NPUW_SERIALIZATION_INDICATOR,
+        "Couldn't deserialize NPUW blob - no NPUW serialization indicator found!");
+    ov::npuw::s11n::IndicatorType compiled_model_indicator;
+    OPENVINO_ASSERT(
+        ov::npuw::orc::try_read_bytes(stream, compiled_model_indicator.data(), compiled_model_indicator.size()),
+        "Couldn't deserialize NPUW blob - no compiled model indicator found!");
+    stream.clear();
+    stream.seekg(stream_start_pos);
+
+    if (compiled_model_indicator == NPUW_FLUX2_COMPILED_MODEL_INDICATOR) {
+        return ov::npuw::Flux2CompiledModel::import_model(stream, plugin, properties);
+    } else if (compiled_model_indicator == NPUW_GQA_COMPILED_MODEL_INDICATOR) {
+        return ov::npuw::GQACompiledModel::import_model(stream, plugin, properties);
+    } else if (compiled_model_indicator == NPUW_LLM_COMPILED_MODEL_INDICATOR) {
+        // Properties are required for ov::weights_path
+        return ov::npuw::LLMCompiledModel::import_model(stream, plugin, properties);
+    } else if (compiled_model_indicator == NPUW_BATCHED_COMPILED_MODEL_INDICATOR) {
+        return ov::npuw::batched::CompiledModel::import_model(stream, plugin, properties);
+    } else if (compiled_model_indicator == NPUW_COMPILED_MODEL_INDICATOR) {
+        OPENVINO_THROW("Legacy flat NPUW CompiledModel blobs are no longer supported. Re-export the model with "
+                       "the current ORC serializer.");
+    }
+    OPENVINO_THROW("Couldn't deserialize NPUW blob - fatal error!");
+}
+
 ov::npuw::ICompiledModel::ICompiledModel(const std::shared_ptr<ov::Model>& model,
                                          const std::shared_ptr<const ov::IPlugin>& plugin)
     : ov::ICompiledModel(model, plugin) {}

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -320,13 +320,15 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::LLMCompiledModel will be created.");
         auto llm_compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
-        if (ov::npuw::batched::requested(config)) {
+        const auto scoring_tags = ov::npuw::batched::scoring_tags(config);
+        if (scoring_tags.text_rerank || scoring_tags.text_embed) {
             // Single-shot scoring pipelines (text rerank / embedding) may submit
             // batched [N, ...] inputs, while the LLM pipeline pins everything to a
             // static batch of 1. The batched element unrolls such an infer row by
             // row over the unchanged batch-1 inner request.
             LOG_INFO("Wrapping with ov::npuw::batched::CompiledModel.");
-            compiled_model = std::make_shared<ov::npuw::batched::CompiledModel>(llm_compiled_model, plugin);
+            compiled_model =
+                std::make_shared<ov::npuw::batched::CompiledModel>(llm_compiled_model, plugin, scoring_tags);
         } else {
             compiled_model = llm_compiled_model;
         }

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -319,14 +319,17 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
         compiled_model = std::make_shared<ov::npuw::GQACompiledModel>(model, plugin, config);
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::LLMCompiledModel will be created.");
-        // Single-shot scoring pipelines (text rerank / embedding) may submit batched
-        // [N, ...] inputs, while the LLM pipeline pins everything to a static batch
-        // of 1. batched::CompiledModel::create() wraps models tagged for such scoring
-        // with the batched element, which unrolls an infer row by row over the
-        // unchanged batch-1 inner request; untagged models are returned unwrapped.
-        compiled_model = ov::npuw::batched::CompiledModel::create(
-            std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config),
-            plugin);
+        auto llm_compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
+        if (ov::npuw::batched::requested(llm_compiled_model)) {
+            // Single-shot scoring pipelines (text rerank / embedding) may submit
+            // batched [N, ...] inputs, while the LLM pipeline pins everything to a
+            // static batch of 1. The batched element unrolls such an infer row by
+            // row over the unchanged batch-1 inner request.
+            LOG_INFO("Wrapping with ov::npuw::batched::CompiledModel.");
+            compiled_model = std::make_shared<ov::npuw::batched::CompiledModel>(llm_compiled_model, plugin);
+        } else {
+            compiled_model = llm_compiled_model;
+        }
     } else if (properties.count(use_pa_key) && properties.at(use_pa_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::PACompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::PACompiledModel>(model, plugin, config);

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -32,6 +32,7 @@
 #include "unfold_sync_infer_request.hpp"
 #include "util.hpp"
 #include "v1/elements/accuracy_checked.hpp"
+#include "v1/elements/batched.hpp"
 #include "v1/elements/failsafe.hpp"
 
 // required for get_properties_per_device()
@@ -318,7 +319,14 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
         compiled_model = std::make_shared<ov::npuw::GQACompiledModel>(model, plugin, config);
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::LLMCompiledModel will be created.");
-        compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
+        // Single-shot scoring pipelines (text rerank / embedding) may submit batched
+        // [N, ...] inputs, while the LLM pipeline pins everything to a static batch
+        // of 1. batched::CompiledModel::create() wraps models tagged for such scoring
+        // with the batched element, which unrolls an infer row by row over the
+        // unchanged batch-1 inner request; untagged models are returned unwrapped.
+        compiled_model = ov::npuw::batched::CompiledModel::create(
+            std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config),
+            plugin);
     } else if (properties.count(use_pa_key) && properties.at(use_pa_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::PACompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::PACompiledModel>(model, plugin, config);

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -320,7 +320,7 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::LLMCompiledModel will be created.");
         auto llm_compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
-        if (ov::npuw::batched::requested(llm_compiled_model)) {
+        if (ov::npuw::batched::requested(config)) {
             // Single-shot scoring pipelines (text rerank / embedding) may submit
             // batched [N, ...] inputs, while the LLM pipeline pins everything to a
             // static batch of 1. The batched element unrolls such an infer row by

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
@@ -38,6 +38,12 @@ public:
     static std::shared_ptr<ov::npuw::ICompiledModel> create(const std::shared_ptr<ov::Model>& model,
                                                             const std::shared_ptr<const ov::IPlugin>& plugin,
                                                             const ov::AnyMap& properties);
+    // Imports any indicator-headed NPUW blob: peeks the compiled-model indicator
+    // that follows the NPUW serialization indicator and routes the stream to the
+    // matching implementation's import_model(). The import counterpart of create().
+    static std::shared_ptr<ov::npuw::ICompiledModel> import_model(std::istream& stream,
+                                                                  const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                                  const ov::AnyMap& properties);
     ICompiledModel(const std::shared_ptr<ov::Model>& model, const std::shared_ptr<const ov::IPlugin>& plugin);
 };
 

--- a/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
@@ -202,12 +202,7 @@ ov::npuw::Flux2CompiledModel::Flux2CompiledModel(PreparedState prepared,
 
 void ov::npuw::Flux2CompiledModel::export_model(std::ostream& stream) const {
     using namespace ov::npuw::s11n;
-    write(stream, NPUW_SERIALIZATION_INDICATOR);
-    write(stream, NPUW_FLUX2_COMPILED_MODEL_INDICATOR);
-    write(stream, OPENVINO_VERSION_MAJOR);
-    write(stream, OPENVINO_VERSION_MINOR);
-    write(stream, OPENVINO_VERSION_PATCH);
-    write(stream, std::string(NPUW_SERIALIZATION_VERSION));
+    write_header(stream, NPUW_FLUX2_COMPILED_MODEL_INDICATOR);
     m_compiled_model->export_model(stream);
 }
 
@@ -220,40 +215,7 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::Flux2CompiledModel::import_m
 
     using namespace ov::npuw::s11n;
 
-    ov::npuw::s11n::IndicatorType serialization_indicator;
-    read(stream, serialization_indicator);
-    NPUW_ASSERT(serialization_indicator == NPUW_SERIALIZATION_INDICATOR);
-
-    ov::npuw::s11n::IndicatorType flux2_indicator;
-    read(stream, flux2_indicator);
-    NPUW_ASSERT(flux2_indicator == NPUW_FLUX2_COMPILED_MODEL_INDICATOR);
-
-    int vmajor, vminor, vpatch;
-    std::string s11n_version;
-    read(stream, vmajor);
-    read(stream, vminor);
-    read(stream, vpatch);
-    read(stream, s11n_version);
-
-    if (vmajor != OPENVINO_VERSION_MAJOR || vminor != OPENVINO_VERSION_MINOR || vpatch != OPENVINO_VERSION_PATCH ||
-        s11n_version != std::string(NPUW_SERIALIZATION_VERSION)) {
-        OPENVINO_THROW("Flux2 blob was serialized with a different OV version (",
-                       vmajor,
-                       '.',
-                       vminor,
-                       '.',
-                       vpatch,
-                       " / NPUW s11n ",
-                       s11n_version,
-                       "); current is ",
-                       OPENVINO_VERSION_MAJOR,
-                       '.',
-                       OPENVINO_VERSION_MINOR,
-                       '.',
-                       OPENVINO_VERSION_PATCH,
-                       " / NPUW s11n ",
-                       NPUW_SERIALIZATION_VERSION);
-    }
+    read_and_check_header(stream, NPUW_FLUX2_COMPILED_MODEL_INDICATOR, "Flux2CompiledModel");
 
     // The rest of the stream is the inner CompiledModel ORC blob.
     // After import it is fully self-contained; no outer Flux2 wrapper is needed

--- a/src/plugins/intel_npu/src/plugin/npuw/gqa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/gqa_compiled_model.cpp
@@ -157,12 +157,7 @@ ov::npuw::GQACompiledModel::GQACompiledModel(PreparedState prepared,
 
 void ov::npuw::GQACompiledModel::export_model(std::ostream& stream) const {
     using namespace ov::npuw::s11n;
-    write(stream, NPUW_SERIALIZATION_INDICATOR);
-    write(stream, NPUW_GQA_COMPILED_MODEL_INDICATOR);
-    write(stream, OPENVINO_VERSION_MAJOR);
-    write(stream, OPENVINO_VERSION_MINOR);
-    write(stream, OPENVINO_VERSION_PATCH);
-    write(stream, std::string(NPUW_SERIALIZATION_VERSION));
+    write_header(stream, NPUW_GQA_COMPILED_MODEL_INDICATOR);
     m_compiled_model->export_model(stream);
 }
 
@@ -175,40 +170,7 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::GQACompiledModel::import_mod
 
     using namespace ov::npuw::s11n;
 
-    ov::npuw::s11n::IndicatorType serialization_indicator;
-    read(stream, serialization_indicator);
-    NPUW_ASSERT(serialization_indicator == NPUW_SERIALIZATION_INDICATOR);
-
-    ov::npuw::s11n::IndicatorType gqa_indicator;
-    read(stream, gqa_indicator);
-    NPUW_ASSERT(gqa_indicator == NPUW_GQA_COMPILED_MODEL_INDICATOR);
-
-    int vmajor, vminor, vpatch;
-    std::string s11n_version;
-    read(stream, vmajor);
-    read(stream, vminor);
-    read(stream, vpatch);
-    read(stream, s11n_version);
-
-    if (vmajor != OPENVINO_VERSION_MAJOR || vminor != OPENVINO_VERSION_MINOR || vpatch != OPENVINO_VERSION_PATCH ||
-        s11n_version != std::string(NPUW_SERIALIZATION_VERSION)) {
-        OPENVINO_THROW("GQA blob was serialized with a different OV version (",
-                       vmajor,
-                       '.',
-                       vminor,
-                       '.',
-                       vpatch,
-                       " / NPUW s11n ",
-                       s11n_version,
-                       "); current is ",
-                       OPENVINO_VERSION_MAJOR,
-                       '.',
-                       OPENVINO_VERSION_MINOR,
-                       '.',
-                       OPENVINO_VERSION_PATCH,
-                       " / NPUW s11n ",
-                       NPUW_SERIALIZATION_VERSION);
-    }
+    read_and_check_header(stream, NPUW_GQA_COMPILED_MODEL_INDICATOR, "GQACompiledModel");
 
     // The rest of the stream is the inner CompiledModel ORC blob.
     // After import it is fully self-contained; no outer GQA wrapper is needed

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -45,7 +45,6 @@
 #include "serialization.hpp"
 #include "transformations/convert_precision.hpp"
 #include "util.hpp"
-#include "v1/elements/batched.hpp"
 #include "whisper/prepare_whisper_model.hpp"
 #include "whisper/whisper_infer_request.hpp"
 
@@ -816,8 +815,10 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     auto use_text_embed_key = pop_option(other_props, std::string("NPUW_TEXT_EMBED"));
     m_is_embedding = use_text_embed_key.value_or(false).as<bool>() == true;
 
-    auto use_text_rerank_key = pop_option(other_props, std::string("NPUW_TEXT_RERANK"));
-    m_is_rerank = use_text_rerank_key.value_or(false).as<bool>() == true;
+    // NPUW_TEXT_RERANK is consumed at the entry point (npuw::ICompiledModel::create
+    // wraps this model with the batched element); pop it here so it doesn't leak
+    // into the submodel configs.
+    pop_option(other_props, std::string("NPUW_TEXT_RERANK"));
 
     if (m_is_embedding) {
         LOG_DEBUG("Text-embedding model rebuild");
@@ -1623,30 +1624,13 @@ ov::Any ov::npuw::LLMCompiledModel::get_property(const std::string& name) const 
 
 std::shared_ptr<ov::ISyncInferRequest> ov::npuw::LLMCompiledModel::create_sync_infer_request() const {
     auto* non_const_this = const_cast<ov::npuw::LLMCompiledModel*>(this);  // because of const in API
-
     if (m_is_whisper) {
         return non_const_this->create_whisper_infer_request();
+    } else if (m_is_embedding) {
+        return non_const_this->create_embedding_infer_request();
+    } else {
+        return non_const_this->create_llm_infer_request();
     }
-
-    auto inner =
-        m_is_embedding ? non_const_this->create_embedding_infer_request() : non_const_this->create_llm_infer_request();
-
-    // Batched scoring: wrap the single-sequence request with the batched element so a
-    // [N, ...] input is unrolled into N independent [1, ...] inferences (rows are scored
-    // one at a time, with the KV-cache reset between them) and stacked back into [N, ...].
-    // This is valid only for the non-generating scoring pipelines -- text embedding and
-    // text reranking -- where rows are independent; the pipeline flags the model as such at
-    // compile time, so no user-facing option is needed. Generation never sets these.
-    if (m_is_embedding || m_is_rerank) {
-        // Drive the single-sequence request synchronously (sync overload) so it runs on the
-        // calling thread rather than being re-scheduled onto this model's task executor -- the
-        // outer request is already async on that executor, and nesting on the same executor
-        // would deadlock.
-        auto self = std::static_pointer_cast<const ov::ICompiledModel>(shared_from_this());
-        return std::make_shared<ov::npuw::batched::InferRequest>(self, std::move(inner));
-    }
-
-    return inner;
 }
 
 std::shared_ptr<ov::ISyncInferRequest> ov::npuw::LLMCompiledModel::create_llm_infer_request() {

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -10,7 +10,6 @@
 #include "llm_compiled_model_utils.hpp"
 #include "llm_infer_request.hpp"
 #include "logging.hpp"
-#include "v1/elements/batched.hpp"
 #include "moe_transformations/apply_moe_device_routed_transforms.hpp"
 #include "npuw_transformations/add_position_ids_param.hpp"
 #include "npuw_transformations/convert_kvcache_to_precision.hpp"
@@ -46,6 +45,7 @@
 #include "serialization.hpp"
 #include "transformations/convert_precision.hpp"
 #include "util.hpp"
+#include "v1/elements/batched.hpp"
 #include "whisper/prepare_whisper_model.hpp"
 #include "whisper/whisper_infer_request.hpp"
 
@@ -1628,8 +1628,8 @@ std::shared_ptr<ov::ISyncInferRequest> ov::npuw::LLMCompiledModel::create_sync_i
         return non_const_this->create_whisper_infer_request();
     }
 
-    auto inner = m_is_embedding ? non_const_this->create_embedding_infer_request()
-                                : non_const_this->create_llm_infer_request();
+    auto inner =
+        m_is_embedding ? non_const_this->create_embedding_infer_request() : non_const_this->create_llm_infer_request();
 
     // Batched scoring: wrap the single-sequence request with the batched element so a
     // [N, ...] input is unrolled into N independent [1, ...] inferences (rows are scored

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -10,6 +10,7 @@
 #include "llm_compiled_model_utils.hpp"
 #include "llm_infer_request.hpp"
 #include "logging.hpp"
+#include "v1/elements/batched.hpp"
 #include "moe_transformations/apply_moe_device_routed_transforms.hpp"
 #include "npuw_transformations/add_position_ids_param.hpp"
 #include "npuw_transformations/convert_kvcache_to_precision.hpp"
@@ -815,6 +816,9 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     auto use_text_embed_key = pop_option(other_props, std::string("NPUW_TEXT_EMBED"));
     m_is_embedding = use_text_embed_key.value_or(false).as<bool>() == true;
 
+    auto use_text_rerank_key = pop_option(other_props, std::string("NPUW_TEXT_RERANK"));
+    m_is_rerank = use_text_rerank_key.value_or(false).as<bool>() == true;
+
     if (m_is_embedding) {
         LOG_DEBUG("Text-embedding model rebuild");
         ov::npuw::util::PrepareTextEmbeddingModel(seq_len_dim).run_on_model(kvcache_model);
@@ -1619,13 +1623,30 @@ ov::Any ov::npuw::LLMCompiledModel::get_property(const std::string& name) const 
 
 std::shared_ptr<ov::ISyncInferRequest> ov::npuw::LLMCompiledModel::create_sync_infer_request() const {
     auto* non_const_this = const_cast<ov::npuw::LLMCompiledModel*>(this);  // because of const in API
+
     if (m_is_whisper) {
         return non_const_this->create_whisper_infer_request();
-    } else if (m_is_embedding) {
-        return non_const_this->create_embedding_infer_request();
-    } else {
-        return non_const_this->create_llm_infer_request();
     }
+
+    auto inner = m_is_embedding ? non_const_this->create_embedding_infer_request()
+                                : non_const_this->create_llm_infer_request();
+
+    // Batched scoring: wrap the single-sequence request with the batched element so a
+    // [N, ...] input is unrolled into N independent [1, ...] inferences (rows are scored
+    // one at a time, with the KV-cache reset between them) and stacked back into [N, ...].
+    // This is valid only for the non-generating scoring pipelines -- text embedding and
+    // text reranking -- where rows are independent; the pipeline flags the model as such at
+    // compile time, so no user-facing option is needed. Generation never sets these.
+    if (m_is_embedding || m_is_rerank) {
+        // Drive the single-sequence request synchronously (sync overload) so it runs on the
+        // calling thread rather than being re-scheduled onto this model's task executor -- the
+        // outer request is already async on that executor, and nesting on the same executor
+        // would deadlock.
+        auto self = std::static_pointer_cast<const ov::ICompiledModel>(shared_from_this());
+        return std::make_shared<ov::npuw::batched::InferRequest>(self, std::move(inner));
+    }
+
+    return inner;
 }
 
 std::shared_ptr<ov::ISyncInferRequest> ov::npuw::LLMCompiledModel::create_llm_infer_request() {
@@ -1675,6 +1696,7 @@ void ov::npuw::LLMCompiledModel::implement_properties() {
                           BIND(npuw::whisper::whisper_eos_token, NPUW_WHISPER_EOS_TOKEN, get),
                           BIND(npuw::whisper::whisper_decompose_sdpa, NPUW_WHISPER_DECOMPOSE_SDPA, get),
                           BIND(npuw::eagle::enabled, NPUW_EAGLE, get),
-                          BIND(npuw::text_embed::enabled, NPUW_TEXT_EMBED, get)});
+                          BIND(npuw::text_embed::enabled, NPUW_TEXT_EMBED, get),
+                          BIND(npuw::text_rerank::enabled, NPUW_TEXT_RERANK, get)});
 #undef BIND
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -812,13 +812,21 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     LOG_DEBUG("Creating kvcache model as clone of passed one.");
     auto kvcache_model = model->clone();
 
+    // NPUW_TEXT_EMBED / NPUW_TEXT_RERANK tag the single-shot scoring pipelines and gate
+    // the batched wrapper the entry points put around this model. Pop them from
+    // other_props so they don't leak into the submodel configs, and record them in
+    // m_cfg, which is serialized into the blob wholesale - so the tag survives
+    // export/import and both entry points can decide by querying the model itself.
     auto use_text_embed_key = pop_option(other_props, std::string("NPUW_TEXT_EMBED"));
     m_is_embedding = use_text_embed_key.value_or(false).as<bool>() == true;
+    if (use_text_embed_key.has_value()) {
+        m_cfg.update({{"NPUW_TEXT_EMBED", m_is_embedding ? "YES" : "NO"}});
+    }
 
-    // NPUW_TEXT_RERANK is consumed at the entry point (npuw::ICompiledModel::create
-    // wraps this model with the batched element); pop it here so it doesn't leak
-    // into the submodel configs.
-    pop_option(other_props, std::string("NPUW_TEXT_RERANK"));
+    auto use_text_rerank_key = pop_option(other_props, std::string("NPUW_TEXT_RERANK"));
+    if (use_text_rerank_key.has_value()) {
+        m_cfg.update({{"NPUW_TEXT_RERANK", use_text_rerank_key.value().as<bool>() ? "YES" : "NO"}});
+    }
 
     if (m_is_embedding) {
         LOG_DEBUG("Text-embedding model rebuild");
@@ -1594,6 +1602,16 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
     }
 
     NPUW_ASSERT(compiled && "Couldn't create NPUW compiled model!");
+
+    // The scoring tags may also be supplied with the import properties (e.g. by a caller
+    // re-passing its compile config). Mirror the compile-side handling: an explicit
+    // caller value overrides the blob-recorded one.
+    for (const auto& key : {std::string("NPUW_TEXT_EMBED"), std::string("NPUW_TEXT_RERANK")}) {
+        const auto prop_iter = properties.find(key);
+        if (prop_iter != properties.end()) {
+            compiled->m_cfg.update({{key, prop_iter->second.as<bool>() ? "YES" : "NO"}});
+        }
+    }
 
     return compiled;
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -858,21 +858,12 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     LOG_DEBUG("Creating kvcache model as clone of passed one.");
     auto kvcache_model = model->clone();
 
-    // NPUW_TEXT_EMBED / NPUW_TEXT_RERANK tag the single-shot scoring pipelines and gate
-    // the batched wrapper the entry points put around this model. Pop them from
-    // other_props so they don't leak into the submodel configs, and record them in
-    // m_cfg, which is serialized into the blob wholesale - so the tag survives
-    // export/import and both entry points can decide by querying the model itself.
     auto use_text_embed_key = pop_option(other_props, std::string("NPUW_TEXT_EMBED"));
     m_is_embedding = use_text_embed_key.value_or(false).as<bool>() == true;
-    if (use_text_embed_key.has_value()) {
-        m_cfg.update({{"NPUW_TEXT_EMBED", m_is_embedding ? "YES" : "NO"}});
-    }
 
-    auto use_text_rerank_key = pop_option(other_props, std::string("NPUW_TEXT_RERANK"));
-    if (use_text_rerank_key.has_value()) {
-        m_cfg.update({{"NPUW_TEXT_RERANK", use_text_rerank_key.value().as<bool>() ? "YES" : "NO"}});
-    }
+    // The rerank tag only gates the batched wrapper at the entry point. Pop it here
+    // so it stays out of the submodel configs, like the embed tag above.
+    pop_option(other_props, std::string("NPUW_TEXT_RERANK"));
 
     if (m_is_embedding) {
         // Both embedding flavours only ever prefill; what differs is how they attend. An
@@ -1792,16 +1783,6 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
     }
 
     NPUW_ASSERT(compiled && "Couldn't create NPUW compiled model!");
-
-    // The scoring tags may also be supplied with the import properties (e.g. by a caller
-    // re-passing its compile config). Mirror the compile-side handling: an explicit
-    // caller value overrides the blob-recorded one.
-    for (const auto& key : {std::string("NPUW_TEXT_EMBED"), std::string("NPUW_TEXT_RERANK")}) {
-        const auto prop_iter = properties.find(key);
-        if (prop_iter != properties.end()) {
-            compiled->m_cfg.update({{key, prop_iter->second.as<bool>() ? "YES" : "NO"}});
-        }
-    }
 
     return compiled;
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -1432,15 +1432,7 @@ void ov::npuw::LLMCompiledModel::export_model(std::ostream& stream) const {
     }
 
     // Write header regardless of encryption requirement - to identify NPUW serializated blobs
-    // Serialize magic number first
-    write(stream, NPUW_SERIALIZATION_INDICATOR);
-    // Serilize LLMCompiledModel identifier
-    write(stream, NPUW_LLM_COMPILED_MODEL_INDICATOR);
-    // Serialize general meta info
-    write(stream, OPENVINO_VERSION_MAJOR);
-    write(stream, OPENVINO_VERSION_MINOR);
-    write(stream, OPENVINO_VERSION_PATCH);
-    write(stream, std::string(NPUW_SERIALIZATION_VERSION));
+    write_header(stream, NPUW_LLM_COMPILED_MODEL_INDICATOR);
     // Serialize encrypted flag
     write(stream, encryption_required);
     // Write flow identifier
@@ -1568,44 +1560,8 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::import_m
 
     using namespace ov::npuw::s11n;
 
-    // Sanity check magic number
-    ov::npuw::s11n::IndicatorType serialization_indicator;
-    read(stream, serialization_indicator);
-    NPUW_ASSERT(serialization_indicator == NPUW_SERIALIZATION_INDICATOR && "This blob wasn't serialized via NPUW!");
-
-    ov::npuw::s11n::IndicatorType llm_compiled_indicator;
-    read(stream, llm_compiled_indicator);
-    NPUW_ASSERT(llm_compiled_indicator == NPUW_LLM_COMPILED_MODEL_INDICATOR &&
-                "This blob wasn't serialized via LLMCompiledModel!");
-
-    // Deserialize general meta info
-    int vmajor, vminor, vpatch;
-    std::string s11n_version;
-    read(stream, vmajor);
-    read(stream, vminor);
-    read(stream, vpatch);
-    read(stream, s11n_version);
-
-    if (vmajor != OPENVINO_VERSION_MAJOR || vminor != OPENVINO_VERSION_MINOR || vpatch != OPENVINO_VERSION_PATCH ||
-        s11n_version != std::string(NPUW_SERIALIZATION_VERSION)) {
-        OPENVINO_THROW("This blobs was serialized with different OV version!",
-                       "\nSerialized by OV ",
-                       vmajor,
-                       '.',
-                       vminor,
-                       '.',
-                       vpatch,
-                       "\nCurrent OV version ",
-                       OPENVINO_VERSION_MAJOR,
-                       '.',
-                       OPENVINO_VERSION_MINOR,
-                       '.',
-                       OPENVINO_VERSION_PATCH,
-                       "\nNPUW serialized by version ",
-                       s11n_version,
-                       "\nNPUW current serialization version ",
-                       NPUW_SERIALIZATION_VERSION);
-    }
+    // Sanity check the header (magic numbers + versions)
+    read_and_check_header(stream, NPUW_LLM_COMPILED_MODEL_INDICATOR, "LLMCompiledModel");
 
     bool encrypted = false;
     read(stream, encrypted);

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -858,8 +858,21 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     LOG_DEBUG("Creating kvcache model as clone of passed one.");
     auto kvcache_model = model->clone();
 
+    // NPUW_TEXT_EMBED / NPUW_TEXT_RERANK tag the single-shot scoring pipelines and gate
+    // the batched wrapper the entry points put around this model. Pop them from
+    // other_props so they don't leak into the submodel configs, and record them in
+    // m_cfg, which is serialized into the blob wholesale - so the tag survives
+    // export/import and both entry points can decide by querying the model itself.
     auto use_text_embed_key = pop_option(other_props, std::string("NPUW_TEXT_EMBED"));
     m_is_embedding = use_text_embed_key.value_or(false).as<bool>() == true;
+    if (use_text_embed_key.has_value()) {
+        m_cfg.update({{"NPUW_TEXT_EMBED", m_is_embedding ? "YES" : "NO"}});
+    }
+
+    auto use_text_rerank_key = pop_option(other_props, std::string("NPUW_TEXT_RERANK"));
+    if (use_text_rerank_key.has_value()) {
+        m_cfg.update({{"NPUW_TEXT_RERANK", use_text_rerank_key.value().as<bool>() ? "YES" : "NO"}});
+    }
 
     if (m_is_embedding) {
         // Both embedding flavours only ever prefill; what differs is how they attend. An
@@ -1780,6 +1793,16 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
 
     NPUW_ASSERT(compiled && "Couldn't create NPUW compiled model!");
 
+    // The scoring tags may also be supplied with the import properties (e.g. by a caller
+    // re-passing its compile config). Mirror the compile-side handling: an explicit
+    // caller value overrides the blob-recorded one.
+    for (const auto& key : {std::string("NPUW_TEXT_EMBED"), std::string("NPUW_TEXT_RERANK")}) {
+        const auto prop_iter = properties.find(key);
+        if (prop_iter != properties.end()) {
+            compiled->m_cfg.update({{key, prop_iter->second.as<bool>() ? "YES" : "NO"}});
+        }
+    }
+
     return compiled;
 }
 
@@ -1937,6 +1960,7 @@ void ov::npuw::LLMCompiledModel::implement_properties() {
                           BIND(npuw::whisper::whisper_eos_token, NPUW_WHISPER_EOS_TOKEN, get),
                           BIND(npuw::whisper::whisper_decompose_sdpa, NPUW_WHISPER_DECOMPOSE_SDPA, get),
                           BIND(npuw::eagle::enabled, NPUW_EAGLE, get),
-                          BIND(npuw::text_embed::enabled, NPUW_TEXT_EMBED, get)});
+                          BIND(npuw::text_embed::enabled, NPUW_TEXT_EMBED, get),
+                          BIND(npuw::text_rerank::enabled, NPUW_TEXT_RERANK, get)});
 #undef BIND
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -142,7 +142,6 @@ private:
     size_t m_decomposed_sdpa_size = 0;
 
     bool m_is_embedding = false;
-    bool m_is_rerank = false;
 
     // Create generate model variants with different sizes
     std::vector<std::shared_ptr<ov::Model>> create_generate_model_variants(

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -142,6 +142,7 @@ private:
     size_t m_decomposed_sdpa_size = 0;
 
     bool m_is_embedding = false;
+    bool m_is_rerank = false;
 
     // Create generate model variants with different sizes
     std::vector<std::shared_ptr<ov::Model>> create_generate_model_variants(

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_lora_states.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_lora_states.hpp
@@ -4,41 +4,10 @@
 
 #pragma once
 
-#include "openvino/runtime/itensor.hpp"
-#include "openvino/runtime/ivariable_state.hpp"
+#include "variable_state.hpp"
 
 namespace ov {
 namespace npuw {
-
-class VariableState final : public ov::IVariableState {
-public:
-    VariableState(const std::string& name, const ov::SoPtr<ov::ITensor>& tensor) : ov::IVariableState(name) {
-        m_state = tensor;
-        clear_state_updated();
-    }
-
-    void set_state(const ov::SoPtr<ov::ITensor>& newState) override {
-        m_state = newState;
-        m_state_updapted = true;
-    }
-
-    void reset() override {
-        OPENVINO_THROW("VariableState::reset() is not implemented");
-    }
-
-    ~VariableState() override = default;
-
-    bool is_state_updated() const {
-        return m_state_updapted;
-    }
-
-    void clear_state_updated() {
-        m_state_updapted = false;
-    }
-
-private:
-    bool m_state_updapted;
-};
 
 struct LoRANames {
     static constexpr const char* MatMul_A = "MatMul\\.A";

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
@@ -12,6 +12,7 @@
 #include "logging.hpp"
 #include "moe_transformations/moe_transformation.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
+#include "openvino/core/version.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/reference/convert.hpp"
@@ -419,5 +420,54 @@ void ov::npuw::orc::serialize_weightless(Stream& stream,
             serialize(stream, t);
             var.push_back(t);
         }
+    }
+}
+
+void ov::npuw::s11n::write_header(std::ostream& stream, const IndicatorType& model_indicator) {
+    write(stream, NPUW_SERIALIZATION_INDICATOR);
+    write(stream, model_indicator);
+    write(stream, OPENVINO_VERSION_MAJOR);
+    write(stream, OPENVINO_VERSION_MINOR);
+    write(stream, OPENVINO_VERSION_PATCH);
+    write(stream, std::string(NPUW_SERIALIZATION_VERSION));
+}
+
+void ov::npuw::s11n::read_and_check_header(std::istream& stream,
+                                           const IndicatorType& expected,
+                                           const std::string& what) {
+    IndicatorType serialization_indicator;
+    read(stream, serialization_indicator);
+    OPENVINO_ASSERT(serialization_indicator == NPUW_SERIALIZATION_INDICATOR, "This blob wasn't serialized via NPUW!");
+
+    IndicatorType model_indicator;
+    read(stream, model_indicator);
+    OPENVINO_ASSERT(model_indicator == expected, "This blob wasn't serialized via ", what, "!");
+
+    int vmajor = 0, vminor = 0, vpatch = 0;
+    std::string s11n_version;
+    read(stream, vmajor);
+    read(stream, vminor);
+    read(stream, vpatch);
+    read(stream, s11n_version);
+
+    if (vmajor != OPENVINO_VERSION_MAJOR || vminor != OPENVINO_VERSION_MINOR || vpatch != OPENVINO_VERSION_PATCH ||
+        s11n_version != std::string(NPUW_SERIALIZATION_VERSION)) {
+        OPENVINO_THROW("This blob was serialized with a different OV version!",
+                       "\nSerialized by OV ",
+                       vmajor,
+                       '.',
+                       vminor,
+                       '.',
+                       vpatch,
+                       "\nCurrent OV version ",
+                       OPENVINO_VERSION_MAJOR,
+                       '.',
+                       OPENVINO_VERSION_MINOR,
+                       '.',
+                       OPENVINO_VERSION_PATCH,
+                       "\nNPUW serialized by version ",
+                       s11n_version,
+                       "\nNPUW current serialization version ",
+                       NPUW_SERIALIZATION_VERSION);
     }
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
@@ -52,7 +52,11 @@ const constexpr ov::npuw::s11n::IndicatorType NPUW_GQA_COMPILED_MODEL_INDICATOR 
 const constexpr ov::npuw::s11n::IndicatorType NPUW_FLUX2_COMPILED_MODEL_INDICATOR =
     {char{0x46}, char{0x4c}, char{0x32}, char{0x43}, char{0x4d}, char{0x4f}};
 
-const constexpr char* NPUW_SERIALIZATION_VERSION = "0.31";
+// BAT = 0x42,0x41,0x54 + CMO = 0x43,0x4d,0x4f
+const constexpr ov::npuw::s11n::IndicatorType NPUW_BATCHED_COMPILED_MODEL_INDICATOR =
+    {char{0x42}, char{0x41}, char{0x54}, char{0x43}, char{0x4d}, char{0x4f}};
+
+const constexpr char* NPUW_SERIALIZATION_VERSION = "0.32";
 
 // Forward declaration
 namespace intel_npu {

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
@@ -244,6 +244,16 @@ inline void read_any(std::istream& stream, ov::Any& var) {
     read(stream, var);
 }
 
+// Writes the common NPUW blob header: the NPUW serialization indicator, the
+// given model indicator, and the serializing OV + NPUW s11n versions.
+void write_header(std::ostream& stream, const IndicatorType& model_indicator);
+
+// Reads and validates a header written by write_header(). Throws if the
+// stream wasn't serialized via NPUW, if the model indicator doesn't match
+// `expected` (`what` names the expected producer in the error message), or
+// if the blob was serialized by a different OV / NPUW s11n version.
+void read_and_check_header(std::istream& stream, const IndicatorType& expected, const std::string& what);
+
 }  // namespace s11n
 
 // --------------------------------------------------------------------------

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -4,6 +4,7 @@
 
 #include "batched.hpp"
 
+#include <algorithm>
 #include <utility>
 
 #include "openvino/core/except.hpp"
@@ -168,29 +169,35 @@ void ov::npuw::batched::InferRequest::infer() {
     OPENVINO_ASSERT(wrapper_inputs.size() == in_ports.size() && wrapper_outputs.size() == out_ports.size(),
                     "Batched element: inner request I/O does not match the wrapped model");
 
-    // Batch size is taken from the first input that carries a batch dimension.
-    std::size_t batch = 1;
+    // Snapshot the public inputs once -- read repeatedly below.
+    std::vector<ov::SoPtr<ov::ITensor>> in_tensors;
+    in_tensors.reserve(wrapper_inputs.size());
     for (const auto& port : wrapper_inputs) {
-        const auto tensor = get_tensor(port);
-        if (has_batch_dim(tensor)) {
-            batch = tensor->get_shape()[0];
-            break;
-        }
+        in_tensors.push_back(get_tensor(port));
     }
-    // A zero-sized batch has no rows to score and would leave the outputs unpopulated
-    // (publishing null tensors). Reject it explicitly rather than silently no-op.
-    OPENVINO_ASSERT(batch > 0, "Batched element: batch size must be > 0, got an input with batch dimension 0.");
 
-    // Validate every batched input up front: each row-carrying input must have a batch
-    // dimension equal to `batch`, or exactly 1 (a shared/broadcast input passed to every row).
-    // Anything else (e.g. a [M, ...] input with M != batch and M != 1) cannot be sliced per row
-    // and would otherwise be fed whole into the batch-1 inner request -> wrong results.
-    for (std::size_t i = 0; i < wrapper_inputs.size(); ++i) {
-        const auto full = get_tensor(wrapper_inputs[i]);
-        if (!has_batch_dim(full)) {
+    // Batch is the largest leading dim across inputs, so a shared [1, ...] input is broadcast
+    // rather than mistaken for the batch. Stays 1 when nothing is batched.
+    std::size_t batch = 1;
+    bool any_batched = false;
+    for (const auto& tensor : in_tensors) {
+        if (!has_batch_dim(tensor)) {
             continue;
         }
-        const std::size_t in_batch = full->get_shape()[0];
+        const std::size_t in_batch = tensor->get_shape()[0];
+        batch = any_batched ? std::max(batch, in_batch) : in_batch;
+        any_batched = true;
+    }
+    // A zero-sized batch has no rows and would publish unpopulated outputs; reject it.
+    OPENVINO_ASSERT(batch > 0, "Batched element: batch size must be > 0, got an input with batch dimension 0.");
+
+    // Every batched input must match `batch` or be a broadcast (dim 0 == 1); anything else
+    // cannot be sliced per row.
+    for (std::size_t i = 0; i < wrapper_inputs.size(); ++i) {
+        if (!has_batch_dim(in_tensors[i])) {
+            continue;
+        }
+        const std::size_t in_batch = in_tensors[i]->get_shape()[0];
         OPENVINO_ASSERT(in_batch == batch || in_batch == 1,
                         "Batched element: input '",
                         wrapper_inputs[i].get_any_name(),
@@ -201,33 +208,38 @@ void ov::npuw::batched::InferRequest::infer() {
                         " nor 1 (broadcast).");
     }
 
-    // Aggregated [batch, ...] outputs, allocated lazily once the per-row output shape is known.
-    std::vector<ov::SoPtr<ov::ITensor>> aggregated_outputs(wrapper_outputs.size());
-
-    // The inner request's variable states are stable across rows, so query them once and reset
-    // them per row rather than re-querying (which may allocate) on every iteration.
+    // States are stable across rows: query once, reset per row so row i never sees row i-1.
     const auto inner_states = inner_query_state();
-
-    for (std::size_t row = 0; row < batch; ++row) {
-        // Rows are independent prompts: clear the inner request's variable state
-        // (KV-cache) so row i never sees row i-1.  Harmless for stateless inners.
+    const auto reset_inner_state = [&] {
         for (const auto& state : inner_states) {
             state->reset();
         }
+    };
 
-        // Bind the row's slice of every batched input; pass shared ([1, ...] or non-batched)
-        // inputs through unchanged.
+    // Slice per-row inputs out of [batch, ...]; pass broadcast/non-batched inputs through whole.
+    const auto bind_row = [&](std::size_t row) {
         for (std::size_t i = 0; i < wrapper_inputs.size(); ++i) {
-            const auto full = get_tensor(wrapper_inputs[i]);
+            const auto& full = in_tensors[i];
             const bool sliceable = batch > 1 && has_batch_dim(full) && full->get_shape()[0] == batch;
             inner_set_tensor(in_ports[i], sliceable ? row_slice(full, row) : full);
         }
+    };
 
+    // Per-row outputs stacked along axis 0. A single row has nothing to stack, so its output is
+    // published as-is (no aggregation buffer or copy); a non-batched output collapses to the last row.
+    std::vector<ov::SoPtr<ov::ITensor>> aggregated_outputs(wrapper_outputs.size());
+
+    for (std::size_t row = 0; row < batch; ++row) {
+        reset_inner_state();
+        bind_row(row);
         inner_infer();
 
-        // Stack each per-row output into row i of the aggregated [batch, ...] tensor.
         for (std::size_t i = 0; i < wrapper_outputs.size(); ++i) {
             const auto inner_out = inner_get_tensor(out_ports[i]);
+            if (batch == 1) {
+                aggregated_outputs[i] = inner_out;
+                continue;
+            }
             if (!aggregated_outputs[i]) {
                 ov::Shape out_shape = inner_out->get_shape();
                 if (!out_shape.empty()) {
@@ -235,22 +247,22 @@ void ov::npuw::batched::InferRequest::infer() {
                 }
                 aggregated_outputs[i] = ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), out_shape));
             }
-            if (batch > 1 && has_batch_dim(inner_out)) {
-                const auto slot = row_slice(aggregated_outputs[i], row);
-                inner_out->copy_to(slot._ptr);
+            if (has_batch_dim(inner_out)) {
+                inner_out->copy_to(row_slice(aggregated_outputs[i], row)._ptr);
             } else {
                 inner_out->copy_to(aggregated_outputs[i]._ptr);
             }
         }
     }
 
-    // Publish the aggregated outputs as this request's public output tensors.
     for (std::size_t i = 0; i < wrapper_outputs.size(); ++i) {
         set_tensor(wrapper_outputs[i], aggregated_outputs[i]);
     }
 }
 
-void ov::npuw::batched::InferRequest::check_tensors() const {}
+void ov::npuw::batched::InferRequest::check_tensors() const {
+    // No-op: batched tensors are unrolled and validated per row by the inner request.
+}
 
 std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::batched::InferRequest::query_state() const {
     // The batched element resets inner state between rows and exposes no

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -28,11 +28,10 @@ bool has_batch_dim(const ov::SoPtr<ov::ITensor>& tensor) {
 
 }  // namespace
 
-ov::SoPtr<ov::ICompiledModel> ov::npuw::batched::CompiledModel::create(
-    const std::shared_ptr<ov::Model>& model,
-    const std::shared_ptr<const ov::IPlugin>& plugin,
-    ov::SoPtr<ov::ICompiledModel> inner_compiled,
-    bool enabled) {
+ov::SoPtr<ov::ICompiledModel> ov::npuw::batched::CompiledModel::create(const std::shared_ptr<ov::Model>& model,
+                                                                       const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                                       ov::SoPtr<ov::ICompiledModel> inner_compiled,
+                                                                       bool enabled) {
     OPENVINO_ASSERT(inner_compiled._ptr != nullptr, "Batched compiled model requires an inner compiled model");
 
     // No-op wrapper: hand back the inner model unchanged for the zero-overhead path.

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -1,0 +1,263 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "batched.hpp"
+
+#include <utility>
+
+#include "openvino/core/except.hpp"
+#include "openvino/runtime/make_tensor.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+namespace {
+
+// Zero-copy view of one batch row (axis 0) of a tensor: [N, ...] -> [1, ...].
+ov::SoPtr<ov::ITensor> row_slice(const ov::SoPtr<ov::ITensor>& tensor, std::size_t row) {
+    ov::Shape start_shape(tensor->get_shape().size(), 0u);
+    start_shape[0] = row;
+    ov::Shape end_shape = tensor->get_shape();
+    end_shape[0] = row + 1;
+    return ov::get_tensor_impl(ov::Tensor(ov::make_tensor(tensor), start_shape, end_shape));
+}
+
+bool has_batch_dim(const ov::SoPtr<ov::ITensor>& tensor) {
+    return !tensor->get_shape().empty();
+}
+
+}  // namespace
+
+ov::SoPtr<ov::ICompiledModel> ov::npuw::batched::CompiledModel::create(
+    const std::shared_ptr<ov::Model>& model,
+    const std::shared_ptr<const ov::IPlugin>& plugin,
+    ov::SoPtr<ov::ICompiledModel> inner_compiled,
+    bool enabled) {
+    OPENVINO_ASSERT(inner_compiled._ptr != nullptr, "Batched compiled model requires an inner compiled model");
+
+    // No-op wrapper: hand back the inner model unchanged for the zero-overhead path.
+    if (!enabled) {
+        return inner_compiled;
+    }
+
+    auto compiled_model = std::make_shared<CompiledModel>(model, plugin, std::move(inner_compiled));
+    return {compiled_model, {}};
+}
+
+ov::npuw::batched::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
+                                                const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                ov::SoPtr<ov::ICompiledModel> inner_compiled)
+    : ov::ICompiledModel(model, plugin),
+      m_inner(std::move(inner_compiled)) {
+    OPENVINO_ASSERT(m_inner._ptr != nullptr, "Batched compiled model requires an inner compiled model");
+}
+
+void ov::npuw::batched::CompiledModel::export_model(std::ostream& model) const {
+    m_inner->export_model(model);
+}
+
+std::shared_ptr<const ov::Model> ov::npuw::batched::CompiledModel::get_runtime_model() const {
+    return m_inner->get_runtime_model();
+}
+
+void ov::npuw::batched::CompiledModel::set_property(const ov::AnyMap& properties) {
+    m_inner->set_property(properties);
+}
+
+ov::Any ov::npuw::batched::CompiledModel::get_property(const std::string& name) const {
+    return m_inner->get_property(name);
+}
+
+std::shared_ptr<ov::ISyncInferRequest> ov::npuw::batched::CompiledModel::create_sync_infer_request() const {
+    auto self = std::static_pointer_cast<const ov::ICompiledModel>(shared_from_this());
+    auto inner_request = m_inner->create_infer_request();
+    OPENVINO_ASSERT(inner_request != nullptr, "Batched element: inner compiled model returned a null request");
+    return std::make_shared<InferRequest>(self, std::move(inner_request));
+}
+
+std::shared_ptr<ov::IAsyncInferRequest> ov::npuw::batched::CompiledModel::create_infer_request() const {
+    return std::make_shared<ov::IAsyncInferRequest>(create_sync_infer_request(),
+                                                    get_task_executor(),
+                                                    get_callback_executor());
+}
+
+ov::npuw::batched::InferRequest::InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
+                                              std::shared_ptr<ov::IAsyncInferRequest> inner_request)
+    : ov::ISyncInferRequest(compiled_model),
+      m_inner_async(std::move(inner_request)) {
+    OPENVINO_ASSERT(m_inner_async != nullptr, "Batched element requires a non-null inner request");
+    init_public_tensors();
+}
+
+ov::npuw::batched::InferRequest::InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
+                                              std::shared_ptr<ov::ISyncInferRequest> inner_request)
+    : ov::ISyncInferRequest(compiled_model),
+      m_inner_sync(std::move(inner_request)) {
+    OPENVINO_ASSERT(m_inner_sync != nullptr, "Batched element requires a non-null inner request");
+    init_public_tensors();
+}
+
+void ov::npuw::batched::InferRequest::init_public_tensors() {
+    // Allocate a tensor for every public port so get_tensor() never returns an
+    // uninitialized handle (callers such as the Python infer(dict) dispatcher fetch
+    // the tensor before populating it). Dynamic dims are sized to 0 and resized later;
+    // the real [N, ...] tensors are bound by the caller (inputs) or by infer() (outputs).
+    const auto init_port = [this](const ov::Output<const ov::Node>& port) {
+        if (ov::ISyncInferRequest::get_tensor(port)) {
+            return;
+        }
+        const auto& pshape = port.get_partial_shape();
+        ov::Shape shape;
+        if (pshape.is_dynamic()) {
+            for (const auto& dim : pshape) {
+                shape.push_back(dim.is_static() ? dim.get_length() : 0);
+            }
+        } else {
+            shape = pshape.to_shape();
+        }
+        set_tensor(port, ov::get_tensor_impl(ov::Tensor(port.get_element_type(), shape)));
+    };
+    for (const auto& port : get_inputs()) {
+        init_port(port);
+    }
+    for (const auto& port : get_outputs()) {
+        init_port(port);
+    }
+}
+
+const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::InferRequest::inner_inputs() const {
+    return m_inner_sync ? m_inner_sync->get_inputs() : m_inner_async->get_inputs();
+}
+
+const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::InferRequest::inner_outputs() const {
+    return m_inner_sync ? m_inner_sync->get_outputs() : m_inner_async->get_outputs();
+}
+
+void ov::npuw::batched::InferRequest::inner_set_tensor(const ov::Output<const ov::Node>& port,
+                                                       const ov::SoPtr<ov::ITensor>& tensor) {
+    if (m_inner_sync) {
+        m_inner_sync->set_tensor(port, tensor);
+    } else {
+        m_inner_async->set_tensor(port, tensor);
+    }
+}
+
+ov::SoPtr<ov::ITensor> ov::npuw::batched::InferRequest::inner_get_tensor(const ov::Output<const ov::Node>& port) const {
+    return m_inner_sync ? m_inner_sync->get_tensor(port) : m_inner_async->get_tensor(port);
+}
+
+void ov::npuw::batched::InferRequest::inner_infer() {
+    if (m_inner_sync) {
+        m_inner_sync->infer();
+    } else {
+        m_inner_async->infer();
+    }
+}
+
+std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::batched::InferRequest::inner_query_state() const {
+    return m_inner_sync ? m_inner_sync->query_state() : m_inner_async->query_state();
+}
+
+void ov::npuw::batched::InferRequest::infer() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    const auto& wrapper_inputs = get_inputs();
+    const auto& wrapper_outputs = get_outputs();
+    const auto& in_ports = inner_inputs();
+    const auto& out_ports = inner_outputs();
+
+    OPENVINO_ASSERT(wrapper_inputs.size() == in_ports.size() && wrapper_outputs.size() == out_ports.size(),
+                    "Batched element: inner request I/O does not match the wrapped model");
+
+    // Batch size is taken from the first input that carries a batch dimension.
+    std::size_t batch = 1;
+    for (const auto& port : wrapper_inputs) {
+        const auto tensor = get_tensor(port);
+        if (has_batch_dim(tensor)) {
+            batch = tensor->get_shape()[0];
+            break;
+        }
+    }
+    // A zero-sized batch has no rows to score and would leave the outputs unpopulated
+    // (publishing null tensors). Reject it explicitly rather than silently no-op.
+    OPENVINO_ASSERT(batch > 0, "Batched element: batch size must be > 0, got an input with batch dimension 0.");
+
+    // Validate every batched input up front: each row-carrying input must have a batch
+    // dimension equal to `batch`, or exactly 1 (a shared/broadcast input passed to every row).
+    // Anything else (e.g. a [M, ...] input with M != batch and M != 1) cannot be sliced per row
+    // and would otherwise be fed whole into the batch-1 inner request -> wrong results.
+    for (std::size_t i = 0; i < wrapper_inputs.size(); ++i) {
+        const auto full = get_tensor(wrapper_inputs[i]);
+        if (!has_batch_dim(full)) {
+            continue;
+        }
+        const std::size_t in_batch = full->get_shape()[0];
+        OPENVINO_ASSERT(in_batch == batch || in_batch == 1,
+                        "Batched element: input '",
+                        wrapper_inputs[i].get_any_name(),
+                        "' has batch dimension ",
+                        in_batch,
+                        " which is neither the inferred batch size ",
+                        batch,
+                        " nor 1 (broadcast).");
+    }
+
+    // Aggregated [batch, ...] outputs, allocated lazily once the per-row output shape is known.
+    std::vector<ov::SoPtr<ov::ITensor>> aggregated_outputs(wrapper_outputs.size());
+
+    // The inner request's variable states are stable across rows, so query them once and reset
+    // them per row rather than re-querying (which may allocate) on every iteration.
+    const auto inner_states = inner_query_state();
+
+    for (std::size_t row = 0; row < batch; ++row) {
+        // Rows are independent prompts: clear the inner request's variable state
+        // (KV-cache) so row i never sees row i-1.  Harmless for stateless inners.
+        for (const auto& state : inner_states) {
+            state->reset();
+        }
+
+        // Bind the row's slice of every batched input; pass shared ([1, ...] or non-batched)
+        // inputs through unchanged.
+        for (std::size_t i = 0; i < wrapper_inputs.size(); ++i) {
+            const auto full = get_tensor(wrapper_inputs[i]);
+            const bool sliceable = batch > 1 && has_batch_dim(full) && full->get_shape()[0] == batch;
+            inner_set_tensor(in_ports[i], sliceable ? row_slice(full, row) : full);
+        }
+
+        inner_infer();
+
+        // Stack each per-row output into row i of the aggregated [batch, ...] tensor.
+        for (std::size_t i = 0; i < wrapper_outputs.size(); ++i) {
+            const auto inner_out = inner_get_tensor(out_ports[i]);
+            if (!aggregated_outputs[i]) {
+                ov::Shape out_shape = inner_out->get_shape();
+                if (!out_shape.empty()) {
+                    out_shape[0] = batch;
+                }
+                aggregated_outputs[i] = ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), out_shape));
+            }
+            if (batch > 1 && has_batch_dim(inner_out)) {
+                const auto slot = row_slice(aggregated_outputs[i], row);
+                inner_out->copy_to(slot._ptr);
+            } else {
+                inner_out->copy_to(aggregated_outputs[i]._ptr);
+            }
+        }
+    }
+
+    // Publish the aggregated outputs as this request's public output tensors.
+    for (std::size_t i = 0; i < wrapper_outputs.size(); ++i) {
+        set_tensor(wrapper_outputs[i], aggregated_outputs[i]);
+    }
+}
+
+void ov::npuw::batched::InferRequest::check_tensors() const {}
+
+std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::batched::InferRequest::query_state() const {
+    // The batched element resets inner state between rows and exposes no
+    // cross-call state of its own, so it presents an empty state list.
+    return {};
+}
+
+std::vector<ov::ProfilingInfo> ov::npuw::batched::InferRequest::get_profiling_info() const {
+    return {};
+}

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -23,6 +23,16 @@ bool ov::npuw::batched::requested(const std::shared_ptr<ov::npuw::ICompiledModel
            is_enabled(ov::intel_npu::npuw::text_embed::enabled.name());
 }
 
+std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::create(
+    const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+    const std::shared_ptr<const ov::IPlugin>& plugin) {
+    if (!requested(inner)) {
+        return inner;
+    }
+    LOG_INFO("Wrapping with ov::npuw::batched::CompiledModel.");
+    return std::make_shared<CompiledModel>(inner, plugin);
+}
+
 ov::npuw::batched::CompiledModel::CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
                                                 const std::shared_ptr<const ov::IPlugin>& plugin)
     : ov::npuw::ICompiledModel(nullptr, plugin),  // I/O comes from the inner via inputs()/outputs()

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -14,26 +14,13 @@
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/runtime/tensor.hpp"
 
-bool ov::npuw::batched::requested(const ov::AnyMap& properties) {
-    const auto is_set = [&properties](const std::string& key) {
-        const auto it = properties.find(key);
-        return it != properties.end() && it->second.as<bool>();
+bool ov::npuw::batched::requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model) {
+    OPENVINO_ASSERT(model != nullptr, "Batched element: null compiled model");
+    const auto is_enabled = [&model](const std::string& key) {
+        return model->get_property(key).as<bool>();
     };
-    return is_set(ov::intel_npu::npuw::text_rerank::enabled.name()) ||
-           is_set(ov::intel_npu::npuw::text_embed::enabled.name());
-}
-
-std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::create(
-    const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
-    const std::shared_ptr<const ov::IPlugin>& plugin,
-    bool enabled) {
-    OPENVINO_ASSERT(inner != nullptr, "Batched compiled model requires an inner compiled model");
-
-    // No-op wrapper: hand back the inner model unchanged for the zero-overhead path.
-    if (!enabled) {
-        return inner;
-    }
-    return std::make_shared<CompiledModel>(inner, plugin);
+    return is_enabled(ov::intel_npu::npuw::text_rerank::enabled.name()) ||
+           is_enabled(ov::intel_npu::npuw::text_embed::enabled.name());
 }
 
 ov::npuw::batched::CompiledModel::CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "../../logging.hpp"
 #include "../../util.hpp"
 #include "intel_npu/npuw_private_properties.hpp"
 #include "openvino/core/except.hpp"
@@ -85,6 +86,9 @@ ov::npuw::batched::InferRequest::InferRequest(const std::shared_ptr<const ov::IC
       m_inner(std::move(inner_request)) {
     OPENVINO_ASSERT(m_inner != nullptr, "Batched element requires a non-null inner request");
 
+    m_profile.report_on_die = ov::npuw::profiling_enabled();
+    m_profile.area = "batched/execution";
+
     // Surface the inner request's own tensors as the public defaults (the ports are
     // the same objects, see CompiledModel::inputs()). Nothing is allocated here: a
     // batch-1 caller works directly on the inner's tensors, and a batched caller
@@ -96,19 +100,12 @@ ov::npuw::batched::InferRequest::InferRequest(const std::shared_ptr<const ov::IC
     }
 }
 
-void ov::npuw::batched::InferRequest::infer() {
-    std::lock_guard<std::mutex> lock(m_mutex);
-
+ov::npuw::batched::InferRequest::BatchedInputs ov::npuw::batched::InferRequest::extract_batch() const {
     const auto& in_ports = get_inputs();
-    const auto& out_ports = get_outputs();
     OPENVINO_ASSERT(!in_ports.empty(), "Batched element: the wrapped model has no inputs");
 
-    // Snapshot the public inputs. The batch is the largest leading dimension across
-    // them: every input must either carry the batch ([N, ...], sliced per row) or be
-    // shared across rows ([1, ...], bound whole).
-    std::vector<ov::SoPtr<ov::ITensor>> in_tensors;
-    in_tensors.reserve(in_ports.size());
-    std::size_t batch = 1;
+    BatchedInputs inputs;
+    inputs.tensors.reserve(in_ports.size());
     for (const auto& port : in_ports) {
         auto tensor = get_tensor(port);
         OPENVINO_ASSERT(tensor, "Batched element: no tensor is set for input '", port.get_any_name(), "'");
@@ -121,20 +118,34 @@ void ov::npuw::batched::InferRequest::infer() {
                         "Batched element: input '",
                         port.get_any_name(),
                         "' has a zero-sized batch dimension - batch size must be > 0");
-        batch = std::max(batch, shape[0]);
-        in_tensors.push_back(std::move(tensor));
+        inputs.batch = std::max(inputs.batch, shape[0]);
+        inputs.tensors.push_back(std::move(tensor));
     }
     for (std::size_t i = 0; i < in_ports.size(); ++i) {
-        const std::size_t in_batch = in_tensors[i]->get_shape()[0];
-        OPENVINO_ASSERT(in_batch == batch || in_batch == 1,
+        const std::size_t in_batch = inputs.tensors[i]->get_shape()[0];
+        OPENVINO_ASSERT(in_batch == inputs.batch || in_batch == 1,
                         "Batched element: input '",
                         in_ports[i].get_any_name(),
                         "' has batch dimension ",
                         in_batch,
                         " which is neither the inferred batch size ",
-                        batch,
+                        inputs.batch,
                         " nor 1 (shared).");
     }
+    return inputs;
+}
+
+void ov::npuw::batched::InferRequest::infer() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    const auto& in_ports = get_inputs();
+    const auto& out_ports = get_outputs();
+
+    BatchedInputs inputs;
+    m_profile["1.extract_batch"].record([&]() {
+        inputs = extract_batch();
+    });
+    const std::size_t batch = inputs.batch;
 
     // Unroll row by row: reset the inner variable state so each row is scored as an
     // independent prompt, bind the row's [1, ...] view of every batched input, run
@@ -142,23 +153,30 @@ void ov::npuw::batched::InferRequest::infer() {
     // [N, ...] public output tensors.
     const auto inner_states = m_inner->query_state();
     for (std::size_t row = 0; row < batch; ++row) {
-        for (const auto& state : inner_states) {
-            state->reset();
-        }
-        for (std::size_t i = 0; i < in_ports.size(); ++i) {
-            const auto& full = in_tensors[i];
-            m_inner->set_tensor(in_ports[i], full->get_shape()[0] == 1 ? full : ov::npuw::util::view(full, 0, row, 1));
-        }
-        m_inner->infer();
+        m_profile["2.bind_row"].record([&]() {
+            for (const auto& state : inner_states) {
+                state->reset();
+            }
+            for (std::size_t i = 0; i < in_ports.size(); ++i) {
+                const auto& full = inputs.tensors[i];
+                m_inner->set_tensor(in_ports[i],
+                                    full->get_shape()[0] == 1 ? full : ov::npuw::util::view(full, 0, row, 1));
+            }
+        });
+        m_profile["3.inner_infer"].record([&]() {
+            m_inner->infer();
+        });
 
         if (row == 0) {
             // The wrapped model's ports are dynamic - the output shapes are only
             // known once the first row has been scored.
             ensure_batched_outputs(batch);
         }
-        for (const auto& port : out_ports) {
-            m_inner->get_tensor(port)->copy_to(ov::npuw::util::view(get_tensor(port), 0, row, 1)._ptr);
-        }
+        m_profile["4.copy_row_out"].record([&]() {
+            for (const auto& port : out_ports) {
+                m_inner->get_tensor(port)->copy_to(ov::npuw::util::view(get_tensor(port), 0, row, 1)._ptr);
+            }
+        });
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -7,51 +7,52 @@
 #include <algorithm>
 #include <utility>
 
+#include "../../util.hpp"
+#include "intel_npu/npuw_private_properties.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/runtime/tensor.hpp"
 
-namespace {
-
-// Zero-copy view of one batch row (axis 0) of a tensor: [N, ...] -> [1, ...].
-ov::SoPtr<ov::ITensor> row_slice(const ov::SoPtr<ov::ITensor>& tensor, std::size_t row) {
-    ov::Shape start_shape(tensor->get_shape().size(), 0u);
-    start_shape[0] = row;
-    ov::Shape end_shape = tensor->get_shape();
-    end_shape[0] = row + 1;
-    return ov::get_tensor_impl(ov::Tensor(ov::make_tensor(tensor), start_shape, end_shape));
+bool ov::npuw::batched::requested(const ov::AnyMap& properties) {
+    const auto is_set = [&properties](const std::string& key) {
+        const auto it = properties.find(key);
+        return it != properties.end() && it->second.as<bool>();
+    };
+    return is_set(ov::intel_npu::npuw::text_rerank::enabled.name()) ||
+           is_set(ov::intel_npu::npuw::text_embed::enabled.name());
 }
 
-bool has_batch_dim(const ov::SoPtr<ov::ITensor>& tensor) {
-    return !tensor->get_shape().empty();
-}
-
-}  // namespace
-
-ov::SoPtr<ov::ICompiledModel> ov::npuw::batched::CompiledModel::create(const std::shared_ptr<ov::Model>& model,
-                                                                       const std::shared_ptr<const ov::IPlugin>& plugin,
-                                                                       ov::SoPtr<ov::ICompiledModel> inner_compiled,
-                                                                       bool enabled) {
-    OPENVINO_ASSERT(inner_compiled._ptr != nullptr, "Batched compiled model requires an inner compiled model");
+std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::create(
+    const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+    const std::shared_ptr<const ov::IPlugin>& plugin,
+    bool enabled) {
+    OPENVINO_ASSERT(inner != nullptr, "Batched compiled model requires an inner compiled model");
 
     // No-op wrapper: hand back the inner model unchanged for the zero-overhead path.
     if (!enabled) {
-        return inner_compiled;
+        return inner;
     }
-
-    auto compiled_model = std::make_shared<CompiledModel>(model, plugin, std::move(inner_compiled));
-    return {compiled_model, {}};
+    return std::make_shared<CompiledModel>(inner, plugin);
 }
 
-ov::npuw::batched::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
-                                                const std::shared_ptr<const ov::IPlugin>& plugin,
-                                                ov::SoPtr<ov::ICompiledModel> inner_compiled)
-    : ov::ICompiledModel(model, plugin),
-      m_inner(std::move(inner_compiled)) {
-    OPENVINO_ASSERT(m_inner._ptr != nullptr, "Batched compiled model requires an inner compiled model");
+ov::npuw::batched::CompiledModel::CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+                                                const std::shared_ptr<const ov::IPlugin>& plugin)
+    : ov::npuw::ICompiledModel(nullptr, plugin),  // I/O comes from the inner via inputs()/outputs()
+      m_inner(inner) {
+    OPENVINO_ASSERT(m_inner != nullptr, "Batched compiled model requires an inner compiled model");
+}
+
+const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::CompiledModel::inputs() const {
+    return m_inner->inputs();
+}
+
+const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::CompiledModel::outputs() const {
+    return m_inner->outputs();
 }
 
 void ov::npuw::batched::CompiledModel::export_model(std::ostream& model) const {
+    // The element is a runtime-only decorator: the blob is the inner's blob, and the
+    // entry points re-apply the wrapper on import based on the properties.
     m_inner->export_model(model);
 }
 
@@ -67,6 +68,10 @@ ov::Any ov::npuw::batched::CompiledModel::get_property(const std::string& name) 
     return m_inner->get_property(name);
 }
 
+void ov::npuw::batched::CompiledModel::release_memory() {
+    m_inner->release_memory();
+}
+
 std::shared_ptr<ov::ISyncInferRequest> ov::npuw::batched::CompiledModel::create_sync_infer_request() const {
     auto self = std::static_pointer_cast<const ov::ICompiledModel>(shared_from_this());
     auto inner_request = m_inner->create_infer_request();
@@ -74,193 +79,109 @@ std::shared_ptr<ov::ISyncInferRequest> ov::npuw::batched::CompiledModel::create_
     return std::make_shared<InferRequest>(self, std::move(inner_request));
 }
 
-std::shared_ptr<ov::IAsyncInferRequest> ov::npuw::batched::CompiledModel::create_infer_request() const {
-    return std::make_shared<ov::IAsyncInferRequest>(create_sync_infer_request(),
-                                                    get_task_executor(),
-                                                    get_callback_executor());
-}
-
 ov::npuw::batched::InferRequest::InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
                                               std::shared_ptr<ov::IAsyncInferRequest> inner_request)
     : ov::ISyncInferRequest(compiled_model),
-      m_inner_async(std::move(inner_request)) {
-    OPENVINO_ASSERT(m_inner_async != nullptr, "Batched element requires a non-null inner request");
-    init_public_tensors();
-}
+      m_inner(std::move(inner_request)) {
+    OPENVINO_ASSERT(m_inner != nullptr, "Batched element requires a non-null inner request");
 
-ov::npuw::batched::InferRequest::InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
-                                              std::shared_ptr<ov::ISyncInferRequest> inner_request)
-    : ov::ISyncInferRequest(compiled_model),
-      m_inner_sync(std::move(inner_request)) {
-    OPENVINO_ASSERT(m_inner_sync != nullptr, "Batched element requires a non-null inner request");
-    init_public_tensors();
-}
-
-void ov::npuw::batched::InferRequest::init_public_tensors() {
-    // Allocate a tensor for every public port so get_tensor() never returns an
-    // uninitialized handle (callers such as the Python infer(dict) dispatcher fetch
-    // the tensor before populating it). Dynamic dims are sized to 0 and resized later;
-    // the real [N, ...] tensors are bound by the caller (inputs) or by infer() (outputs).
-    const auto init_port = [this](const ov::Output<const ov::Node>& port) {
-        if (ov::ISyncInferRequest::get_tensor(port)) {
-            return;
-        }
-        const auto& pshape = port.get_partial_shape();
-        ov::Shape shape;
-        if (pshape.is_dynamic()) {
-            for (const auto& dim : pshape) {
-                shape.push_back(dim.is_static() ? dim.get_length() : 0);
-            }
-        } else {
-            shape = pshape.to_shape();
-        }
-        set_tensor(port, ov::get_tensor_impl(ov::Tensor(port.get_element_type(), shape)));
-    };
+    // Surface the inner request's own tensors as the public defaults (the ports are
+    // the same objects, see CompiledModel::inputs()). Nothing is allocated here: a
+    // batch-1 caller works directly on the inner's tensors, and a batched caller
+    // replaces them with its [N, ...] tensors via set_tensor().
     for (const auto& port : get_inputs()) {
-        init_port(port);
+        if (auto tensor = m_inner->get_tensor(port)) {
+            set_tensor(port, tensor);
+        }
     }
-    for (const auto& port : get_outputs()) {
-        init_port(port);
-    }
-}
-
-const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::InferRequest::inner_inputs() const {
-    return m_inner_sync ? m_inner_sync->get_inputs() : m_inner_async->get_inputs();
-}
-
-const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::InferRequest::inner_outputs() const {
-    return m_inner_sync ? m_inner_sync->get_outputs() : m_inner_async->get_outputs();
-}
-
-void ov::npuw::batched::InferRequest::inner_set_tensor(const ov::Output<const ov::Node>& port,
-                                                       const ov::SoPtr<ov::ITensor>& tensor) {
-    if (m_inner_sync) {
-        m_inner_sync->set_tensor(port, tensor);
-    } else {
-        m_inner_async->set_tensor(port, tensor);
-    }
-}
-
-ov::SoPtr<ov::ITensor> ov::npuw::batched::InferRequest::inner_get_tensor(const ov::Output<const ov::Node>& port) const {
-    return m_inner_sync ? m_inner_sync->get_tensor(port) : m_inner_async->get_tensor(port);
-}
-
-void ov::npuw::batched::InferRequest::inner_infer() {
-    if (m_inner_sync) {
-        m_inner_sync->infer();
-    } else {
-        m_inner_async->infer();
-    }
-}
-
-std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::batched::InferRequest::inner_query_state() const {
-    return m_inner_sync ? m_inner_sync->query_state() : m_inner_async->query_state();
 }
 
 void ov::npuw::batched::InferRequest::infer() {
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    const auto& wrapper_inputs = get_inputs();
-    const auto& wrapper_outputs = get_outputs();
-    const auto& in_ports = inner_inputs();
-    const auto& out_ports = inner_outputs();
+    const auto& in_ports = get_inputs();
+    const auto& out_ports = get_outputs();
+    OPENVINO_ASSERT(!in_ports.empty(), "Batched element: the wrapped model has no inputs");
 
-    OPENVINO_ASSERT(wrapper_inputs.size() == in_ports.size() && wrapper_outputs.size() == out_ports.size(),
-                    "Batched element: inner request I/O does not match the wrapped model");
-
-    // Snapshot the public inputs once -- read repeatedly below.
+    // Snapshot the public inputs. The batch is the largest leading dimension across
+    // them: every input must either carry the batch ([N, ...], sliced per row) or be
+    // shared across rows ([1, ...], bound whole).
     std::vector<ov::SoPtr<ov::ITensor>> in_tensors;
-    in_tensors.reserve(wrapper_inputs.size());
-    for (const auto& port : wrapper_inputs) {
-        in_tensors.push_back(get_tensor(port));
-    }
-
-    // Batch is the largest leading dim across inputs, so a shared [1, ...] input is broadcast
-    // rather than mistaken for the batch. Stays 1 when nothing is batched.
+    in_tensors.reserve(in_ports.size());
     std::size_t batch = 1;
-    bool any_batched = false;
-    for (const auto& tensor : in_tensors) {
-        if (!has_batch_dim(tensor)) {
-            continue;
-        }
-        const std::size_t in_batch = tensor->get_shape()[0];
-        batch = any_batched ? std::max(batch, in_batch) : in_batch;
-        any_batched = true;
+    for (const auto& port : in_ports) {
+        auto tensor = get_tensor(port);
+        OPENVINO_ASSERT(tensor, "Batched element: no tensor is set for input '", port.get_any_name(), "'");
+        const auto& shape = tensor->get_shape();
+        OPENVINO_ASSERT(!shape.empty(),
+                        "Batched element: input '",
+                        port.get_any_name(),
+                        "' has no leading (batch) dimension");
+        OPENVINO_ASSERT(shape[0] > 0,
+                        "Batched element: input '",
+                        port.get_any_name(),
+                        "' has a zero-sized batch dimension - batch size must be > 0");
+        batch = std::max(batch, shape[0]);
+        in_tensors.push_back(std::move(tensor));
     }
-    // A zero-sized batch has no rows and would publish unpopulated outputs; reject it.
-    OPENVINO_ASSERT(batch > 0, "Batched element: batch size must be > 0, got an input with batch dimension 0.");
-
-    // Every batched input must match `batch` or be a broadcast (dim 0 == 1); anything else
-    // cannot be sliced per row.
-    for (std::size_t i = 0; i < wrapper_inputs.size(); ++i) {
-        if (!has_batch_dim(in_tensors[i])) {
-            continue;
-        }
+    for (std::size_t i = 0; i < in_ports.size(); ++i) {
         const std::size_t in_batch = in_tensors[i]->get_shape()[0];
         OPENVINO_ASSERT(in_batch == batch || in_batch == 1,
                         "Batched element: input '",
-                        wrapper_inputs[i].get_any_name(),
+                        in_ports[i].get_any_name(),
                         "' has batch dimension ",
                         in_batch,
                         " which is neither the inferred batch size ",
                         batch,
-                        " nor 1 (broadcast).");
+                        " nor 1 (shared).");
     }
 
-    // States are stable across rows: query once, reset per row so row i never sees row i-1.
-    const auto inner_states = inner_query_state();
-    const auto reset_inner_state = [&] {
+    // Unroll row by row: reset the inner variable state so each row is scored as an
+    // independent prompt, bind the row's [1, ...] view of every batched input, run
+    // the batch-1 inner request, and write the row's outputs into row `row` of the
+    // [N, ...] public output tensors.
+    const auto inner_states = m_inner->query_state();
+    for (std::size_t row = 0; row < batch; ++row) {
         for (const auto& state : inner_states) {
             state->reset();
         }
-    };
-
-    // Slice per-row inputs out of [batch, ...]; pass broadcast/non-batched inputs through whole.
-    const auto bind_row = [&](std::size_t row) {
-        for (std::size_t i = 0; i < wrapper_inputs.size(); ++i) {
+        for (std::size_t i = 0; i < in_ports.size(); ++i) {
             const auto& full = in_tensors[i];
-            const bool sliceable = batch > 1 && has_batch_dim(full) && full->get_shape()[0] == batch;
-            inner_set_tensor(in_ports[i], sliceable ? row_slice(full, row) : full);
+            m_inner->set_tensor(in_ports[i], full->get_shape()[0] == 1 ? full : ov::npuw::util::view(full, 0, row, 1));
         }
-    };
+        m_inner->infer();
 
-    // Per-row outputs stacked along axis 0. A single row has nothing to stack, so its output is
-    // published as-is (no aggregation buffer or copy); a non-batched output collapses to the last row.
-    std::vector<ov::SoPtr<ov::ITensor>> aggregated_outputs(wrapper_outputs.size());
-
-    for (std::size_t row = 0; row < batch; ++row) {
-        reset_inner_state();
-        bind_row(row);
-        inner_infer();
-
-        for (std::size_t i = 0; i < wrapper_outputs.size(); ++i) {
-            const auto inner_out = inner_get_tensor(out_ports[i]);
-            if (batch == 1) {
-                aggregated_outputs[i] = inner_out;
-                continue;
-            }
-            if (!aggregated_outputs[i]) {
-                ov::Shape out_shape = inner_out->get_shape();
-                if (!out_shape.empty()) {
-                    out_shape[0] = batch;
-                }
-                aggregated_outputs[i] = ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), out_shape));
-            }
-            if (has_batch_dim(inner_out)) {
-                inner_out->copy_to(row_slice(aggregated_outputs[i], row)._ptr);
-            } else {
-                inner_out->copy_to(aggregated_outputs[i]._ptr);
-            }
+        if (row == 0) {
+            // The wrapped model's ports are dynamic - the output shapes are only
+            // known once the first row has been scored.
+            ensure_batched_outputs(batch);
+        }
+        for (const auto& port : out_ports) {
+            m_inner->get_tensor(port)->copy_to(ov::npuw::util::view(get_tensor(port), 0, row, 1)._ptr);
         }
     }
+}
 
-    for (std::size_t i = 0; i < wrapper_outputs.size(); ++i) {
-        set_tensor(wrapper_outputs[i], aggregated_outputs[i]);
+void ov::npuw::batched::InferRequest::ensure_batched_outputs(std::size_t batch) {
+    for (const auto& port : get_outputs()) {
+        const auto inner_out = m_inner->get_tensor(port);
+        OPENVINO_ASSERT(inner_out && !inner_out->get_shape().empty() && inner_out->get_shape()[0] == 1,
+                        "Batched element: output '",
+                        port.get_any_name(),
+                        "' of the inner request is not a [1, ...] tensor");
+        ov::Shape shape = inner_out->get_shape();
+        shape[0] = batch;
+        const auto current = get_tensor(port);
+        if (!current || current->get_element_type() != inner_out->get_element_type() || current->get_shape() != shape) {
+            set_tensor(port, ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), shape)));
+        }
     }
 }
 
 void ov::npuw::batched::InferRequest::check_tensors() const {
-    // No-op: batched tensors are unrolled and validated per row by the inner request.
+    // No-op: the public outputs are late-bound (allocated on infer once the batch is
+    // known), and the batched inputs are validated and then unrolled by infer() -- the
+    // per-row [1, ...] tensors are checked by the inner request.
 }
 
 std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::batched::InferRequest::query_state() const {
@@ -270,5 +191,5 @@ std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::batched::InferRequest::quer
 }
 
 std::vector<ov::ProfilingInfo> ov::npuw::batched::InferRequest::get_profiling_info() const {
-    return {};
+    return m_inner->get_profiling_info();
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -1,0 +1,210 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "batched.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "../../logging.hpp"
+#include "../../util.hpp"
+#include "intel_npu/npuw_private_properties.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/runtime/make_tensor.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+bool ov::npuw::batched::requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model) {
+    OPENVINO_ASSERT(model != nullptr, "Batched element: null compiled model");
+    const auto is_enabled = [&model](const std::string& key) {
+        return model->get_property(key).as<bool>();
+    };
+    return is_enabled(ov::intel_npu::npuw::text_rerank::enabled.name()) ||
+           is_enabled(ov::intel_npu::npuw::text_embed::enabled.name());
+}
+
+std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::create(
+    const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+    const std::shared_ptr<const ov::IPlugin>& plugin) {
+    if (!requested(inner)) {
+        return inner;
+    }
+    LOG_INFO("Wrapping with ov::npuw::batched::CompiledModel.");
+    return std::make_shared<CompiledModel>(inner, plugin);
+}
+
+ov::npuw::batched::CompiledModel::CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+                                                const std::shared_ptr<const ov::IPlugin>& plugin)
+    : ov::npuw::ICompiledModel(nullptr, plugin),  // I/O comes from the inner via inputs()/outputs()
+      m_inner(inner) {
+    OPENVINO_ASSERT(m_inner != nullptr, "Batched compiled model requires an inner compiled model");
+}
+
+const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::CompiledModel::inputs() const {
+    return m_inner->inputs();
+}
+
+const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::CompiledModel::outputs() const {
+    return m_inner->outputs();
+}
+
+void ov::npuw::batched::CompiledModel::export_model(std::ostream& model) const {
+    // The element is a runtime-only decorator: the blob is the inner's blob, and the
+    // entry points re-apply the wrapper on import based on the properties.
+    m_inner->export_model(model);
+}
+
+std::shared_ptr<const ov::Model> ov::npuw::batched::CompiledModel::get_runtime_model() const {
+    return m_inner->get_runtime_model();
+}
+
+void ov::npuw::batched::CompiledModel::set_property(const ov::AnyMap& properties) {
+    m_inner->set_property(properties);
+}
+
+ov::Any ov::npuw::batched::CompiledModel::get_property(const std::string& name) const {
+    return m_inner->get_property(name);
+}
+
+void ov::npuw::batched::CompiledModel::release_memory() {
+    m_inner->release_memory();
+}
+
+std::shared_ptr<ov::ISyncInferRequest> ov::npuw::batched::CompiledModel::create_sync_infer_request() const {
+    auto self = std::static_pointer_cast<const ov::ICompiledModel>(shared_from_this());
+    auto inner_request = m_inner->create_infer_request();
+    OPENVINO_ASSERT(inner_request != nullptr, "Batched element: inner compiled model returned a null request");
+    return std::make_shared<InferRequest>(self, std::move(inner_request));
+}
+
+ov::npuw::batched::InferRequest::InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
+                                              std::shared_ptr<ov::IAsyncInferRequest> inner_request)
+    : ov::ISyncInferRequest(compiled_model),
+      m_inner(std::move(inner_request)) {
+    OPENVINO_ASSERT(m_inner != nullptr, "Batched element requires a non-null inner request");
+
+    m_profile.report_on_die = ov::npuw::profiling_enabled();
+    m_profile.area = "batched/execution";
+
+    // Surface the inner request's own tensors as the public defaults (the ports are
+    // the same objects, see CompiledModel::inputs()). Nothing is allocated here: a
+    // batch-1 caller works directly on the inner's tensors, and a batched caller
+    // replaces them with its [N, ...] tensors via set_tensor().
+    for (const auto& port : get_inputs()) {
+        if (auto tensor = m_inner->get_tensor(port)) {
+            set_tensor(port, tensor);
+        }
+    }
+}
+
+ov::npuw::batched::InferRequest::BatchedInputs ov::npuw::batched::InferRequest::extract_batch() const {
+    const auto& in_ports = get_inputs();
+    OPENVINO_ASSERT(!in_ports.empty(), "Batched element: the wrapped model has no inputs");
+
+    BatchedInputs inputs;
+    inputs.tensors.reserve(in_ports.size());
+    for (const auto& port : in_ports) {
+        auto tensor = get_tensor(port);
+        OPENVINO_ASSERT(tensor, "Batched element: no tensor is set for input '", port.get_any_name(), "'");
+        const auto& shape = tensor->get_shape();
+        OPENVINO_ASSERT(!shape.empty(),
+                        "Batched element: input '",
+                        port.get_any_name(),
+                        "' has no leading (batch) dimension");
+        OPENVINO_ASSERT(shape[0] > 0,
+                        "Batched element: input '",
+                        port.get_any_name(),
+                        "' has a zero-sized batch dimension - batch size must be > 0");
+        inputs.batch = std::max(inputs.batch, shape[0]);
+        inputs.tensors.push_back(std::move(tensor));
+    }
+    for (std::size_t i = 0; i < in_ports.size(); ++i) {
+        const std::size_t in_batch = inputs.tensors[i]->get_shape()[0];
+        OPENVINO_ASSERT(in_batch == inputs.batch || in_batch == 1,
+                        "Batched element: input '",
+                        in_ports[i].get_any_name(),
+                        "' has batch dimension ",
+                        in_batch,
+                        " which is neither the inferred batch size ",
+                        inputs.batch,
+                        " nor 1 (shared).");
+    }
+    return inputs;
+}
+
+void ov::npuw::batched::InferRequest::infer() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    const auto& in_ports = get_inputs();
+    const auto& out_ports = get_outputs();
+
+    BatchedInputs inputs;
+    m_profile["1.extract_batch"].record([&]() {
+        inputs = extract_batch();
+    });
+    const std::size_t batch = inputs.batch;
+
+    // Unroll row by row: reset the inner variable state so each row is scored as an
+    // independent prompt, bind the row's [1, ...] view of every batched input, run
+    // the batch-1 inner request, and write the row's outputs into row `row` of the
+    // [N, ...] public output tensors.
+    const auto inner_states = m_inner->query_state();
+    for (std::size_t row = 0; row < batch; ++row) {
+        m_profile["2.bind_row"].record([&]() {
+            for (const auto& state : inner_states) {
+                state->reset();
+            }
+            for (std::size_t i = 0; i < in_ports.size(); ++i) {
+                const auto& full = inputs.tensors[i];
+                m_inner->set_tensor(in_ports[i],
+                                    full->get_shape()[0] == 1 ? full : ov::npuw::util::view(full, 0, row, 1));
+            }
+        });
+        m_profile["3.inner_infer"].record([&]() {
+            m_inner->infer();
+        });
+
+        if (row == 0) {
+            // The wrapped model's ports are dynamic - the output shapes are only
+            // known once the first row has been scored.
+            ensure_batched_outputs(batch);
+        }
+        m_profile["4.copy_row_out"].record([&]() {
+            for (const auto& port : out_ports) {
+                m_inner->get_tensor(port)->copy_to(ov::npuw::util::view(get_tensor(port), 0, row, 1)._ptr);
+            }
+        });
+    }
+}
+
+void ov::npuw::batched::InferRequest::ensure_batched_outputs(std::size_t batch) {
+    for (const auto& port : get_outputs()) {
+        const auto inner_out = m_inner->get_tensor(port);
+        OPENVINO_ASSERT(inner_out && !inner_out->get_shape().empty() && inner_out->get_shape()[0] == 1,
+                        "Batched element: output '",
+                        port.get_any_name(),
+                        "' of the inner request is not a [1, ...] tensor");
+        ov::Shape shape = inner_out->get_shape();
+        shape[0] = batch;
+        const auto current = get_tensor(port);
+        if (!current || current->get_element_type() != inner_out->get_element_type() || current->get_shape() != shape) {
+            set_tensor(port, ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), shape)));
+        }
+    }
+}
+
+void ov::npuw::batched::InferRequest::check_tensors() const {
+    // No-op: the public outputs are late-bound (allocated on infer once the batch is
+    // known), and the batched inputs are validated and then unrolled by infer() -- the
+    // per-row [1, ...] tensors are checked by the inner request.
+}
+
+std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::batched::InferRequest::query_state() const {
+    // The batched element resets inner state between rows and exposes no
+    // cross-call state of its own, so it presents an empty state list.
+    return {};
+}
+
+std::vector<ov::ProfilingInfo> ov::npuw::batched::InferRequest::get_profiling_info() const {
+    return m_inner->get_profiling_info();
+}

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -25,16 +25,6 @@ bool ov::npuw::batched::requested(const std::shared_ptr<ov::npuw::ICompiledModel
            is_enabled(ov::intel_npu::npuw::text_embed::enabled.name());
 }
 
-std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::create(
-    const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
-    const std::shared_ptr<const ov::IPlugin>& plugin) {
-    if (!requested(inner)) {
-        return inner;
-    }
-    LOG_INFO("Wrapping with ov::npuw::batched::CompiledModel.");
-    return std::make_shared<CompiledModel>(inner, plugin);
-}
-
 ov::npuw::batched::CompiledModel::CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
                                                 const std::shared_ptr<const ov::IPlugin>& plugin)
     : ov::npuw::ICompiledModel(nullptr, plugin),  // I/O comes from the inner via inputs()/outputs()

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -8,10 +8,10 @@
 #include <memory>
 #include <utility>
 
-#include "../../llm_lora_states.hpp"
 #include "../../logging.hpp"
 #include "../../serialization.hpp"
 #include "../../util.hpp"
+#include "../../variable_state.hpp"
 #include "intel_npu/npuw_private_properties.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/version.hpp"
@@ -184,9 +184,10 @@ void ov::npuw::batched::InferRequest::infer() {
     // Unroll row by row: reset the inner variable state so each row is scored as an
     // independent prompt, bind the row's [1, ...] view of every batched input, run
     // the batch-1 inner request, and write the row's outputs into row `row` of the
-    // [N, ...] public output tensors. LoRA adapter states are kept out of the reset
-    // set: they carry the adapter weights, not per-prompt data, so they must survive
-    // the row loop, and their reset() throws by design.
+    // [N, ...] public output tensors. States the inner exposes as
+    // ov::npuw::VariableState are kept out of the reset set: that type holds data
+    // bound for the model's lifetime, not per-inference data, so it must survive
+    // the row loop and by design implements no reset().
     auto inner_states = m_inner->query_state();
     inner_states.erase(std::remove_if(inner_states.begin(),
                                       inner_states.end(),

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -16,10 +16,10 @@
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/runtime/tensor.hpp"
 
-bool ov::npuw::batched::requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model) {
-    OPENVINO_ASSERT(model != nullptr, "Batched element: null compiled model");
-    const auto is_enabled = [&model](const std::string& key) {
-        return model->get_property(key).as<bool>();
+bool ov::npuw::batched::requested(const ov::AnyMap& properties) {
+    const auto is_enabled = [&properties](const std::string& key) {
+        const auto it = properties.find(key);
+        return it != properties.end() && it->second.as<bool>();
     };
     return is_enabled(ov::intel_npu::npuw::text_rerank::enabled.name()) ||
            is_enabled(ov::intel_npu::npuw::text_embed::enabled.name());

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -51,17 +51,17 @@ const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::CompiledModel:
     return m_inner->outputs();
 }
 
-void ov::npuw::batched::CompiledModel::export_model(std::ostream& model) const {
+void ov::npuw::batched::CompiledModel::export_model(std::ostream& stream) const {
     // The wrap is part of the blob. A batched header goes first, the complete inner
     // blob follows with its own header, and import reconstructs the wrapper from the
     // header alone.
     // The inner blob checks its own versions, but the wrapper header needs a
     // version of its own in case its format ever changes.
-    ov::npuw::s11n::write_header(model, NPUW_BATCHED_COMPILED_MODEL_INDICATOR);
+    ov::npuw::s11n::write_header(stream, NPUW_BATCHED_COMPILED_MODEL_INDICATOR);
     // The scoring tags are wrapper state, so they ride the wrapper's own header.
-    ov::npuw::s11n::write(model, m_tags.text_rerank);
-    ov::npuw::s11n::write(model, m_tags.text_embed);
-    m_inner->export_model(model);
+    ov::npuw::s11n::write(stream, m_tags.text_rerank);
+    ov::npuw::s11n::write(stream, m_tags.text_embed);
+    m_inner->export_model(stream);
 }
 
 std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::import_model(
@@ -138,6 +138,11 @@ ov::npuw::batched::InferRequest::BatchedInputs ov::npuw::batched::InferRequest::
     const auto& in_ports = get_inputs();
     OPENVINO_ASSERT(!in_ports.empty(), "Batched element: the wrapped model has no inputs");
 
+    // The batch contract: every input's leading dimension is either the batch size
+    // N (the input carries per-row data, sliced by infer()) or exactly 1 (the input
+    // is broadcast, bound whole to every row). N is whatever the batched inputs
+    // agree on - two inputs with different leading dimensions > 1 are an error -
+    // and with every input at 1 the infer is a plain batch-1 one.
     BatchedInputs inputs;
     inputs.tensors.reserve(in_ports.size());
     for (const auto& port : in_ports) {
@@ -152,19 +157,18 @@ ov::npuw::batched::InferRequest::BatchedInputs ov::npuw::batched::InferRequest::
                         "Batched element: input '",
                         port.get_any_name(),
                         "' has a zero-sized batch dimension - batch size must be > 0");
-        inputs.batch = std::max(inputs.batch, shape[0]);
+        if (shape[0] > 1) {
+            OPENVINO_ASSERT(inputs.batch == 1 || inputs.batch == shape[0],
+                            "Batched element: input '",
+                            port.get_any_name(),
+                            "' has batch dimension ",
+                            shape[0],
+                            " which is neither the inferred batch size ",
+                            inputs.batch,
+                            " nor 1 (broadcast).");
+            inputs.batch = shape[0];
+        }
         inputs.tensors.push_back(std::move(tensor));
-    }
-    for (std::size_t i = 0; i < in_ports.size(); ++i) {
-        const std::size_t in_batch = inputs.tensors[i]->get_shape()[0];
-        OPENVINO_ASSERT(in_batch == inputs.batch || in_batch == 1,
-                        "Batched element: input '",
-                        in_ports[i].get_any_name(),
-                        "' has batch dimension ",
-                        in_batch,
-                        " which is neither the inferred batch size ",
-                        inputs.batch,
-                        " nor 1 (shared).");
     }
     return inputs;
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -56,14 +56,9 @@ void ov::npuw::batched::CompiledModel::export_model(std::ostream& model) const {
     // The wrap is part of the blob. A batched header goes first, the complete inner
     // blob follows with its own header, and import reconstructs the wrapper from the
     // header alone.
-    ov::npuw::s11n::write(model, NPUW_SERIALIZATION_INDICATOR);
-    ov::npuw::s11n::write(model, NPUW_BATCHED_COMPILED_MODEL_INDICATOR);
-    // Versions, as in the LLM blob header. The inner blob checks its own, but the
-    // wrapper header needs a version of its own in case its format ever changes.
-    ov::npuw::s11n::write(model, OPENVINO_VERSION_MAJOR);
-    ov::npuw::s11n::write(model, OPENVINO_VERSION_MINOR);
-    ov::npuw::s11n::write(model, OPENVINO_VERSION_PATCH);
-    ov::npuw::s11n::write(model, std::string(NPUW_SERIALIZATION_VERSION));
+    // The inner blob checks its own versions, but the wrapper header needs a
+    // version of its own in case its format ever changes.
+    ov::npuw::s11n::write_header(model, NPUW_BATCHED_COMPILED_MODEL_INDICATOR);
     // The scoring tags are wrapper state, so they ride the wrapper's own header.
     ov::npuw::s11n::write(model, m_tags.text_rerank);
     ov::npuw::s11n::write(model, m_tags.text_embed);
@@ -76,42 +71,7 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::impo
     const ov::AnyMap& properties) {
     LOG_INFO("Deserializing batched::CompiledModel...");
 
-    ov::npuw::s11n::IndicatorType serialization_indicator;
-    ov::npuw::s11n::read(stream, serialization_indicator);
-    OPENVINO_ASSERT(serialization_indicator == NPUW_SERIALIZATION_INDICATOR, "This blob wasn't serialized via NPUW!");
-
-    ov::npuw::s11n::IndicatorType batched_indicator;
-    ov::npuw::s11n::read(stream, batched_indicator);
-    OPENVINO_ASSERT(batched_indicator == NPUW_BATCHED_COMPILED_MODEL_INDICATOR,
-                    "This blob wasn't serialized via batched::CompiledModel!");
-
-    int vmajor = 0, vminor = 0, vpatch = 0;
-    std::string s11n_version;
-    ov::npuw::s11n::read(stream, vmajor);
-    ov::npuw::s11n::read(stream, vminor);
-    ov::npuw::s11n::read(stream, vpatch);
-    ov::npuw::s11n::read(stream, s11n_version);
-
-    if (vmajor != OPENVINO_VERSION_MAJOR || vminor != OPENVINO_VERSION_MINOR || vpatch != OPENVINO_VERSION_PATCH ||
-        s11n_version != std::string(NPUW_SERIALIZATION_VERSION)) {
-        OPENVINO_THROW("This blob was serialized with different OV version!",
-                       "\nSerialized by OV ",
-                       vmajor,
-                       '.',
-                       vminor,
-                       '.',
-                       vpatch,
-                       "\nCurrent OV version ",
-                       OPENVINO_VERSION_MAJOR,
-                       '.',
-                       OPENVINO_VERSION_MINOR,
-                       '.',
-                       OPENVINO_VERSION_PATCH,
-                       "\nNPUW serialized by version ",
-                       s11n_version,
-                       "\nNPUW current serialization version ",
-                       NPUW_SERIALIZATION_VERSION);
-    }
+    ov::npuw::s11n::read_and_check_header(stream, NPUW_BATCHED_COMPILED_MODEL_INDICATOR, "batched::CompiledModel");
 
     ScoringTags tags;
     ov::npuw::s11n::read(stream, tags.text_rerank);

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -13,6 +13,7 @@
 #include "../../util.hpp"
 #include "intel_npu/npuw_private_properties.hpp"
 #include "openvino/core/except.hpp"
+#include "openvino/core/version.hpp"
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/runtime/tensor.hpp"
 
@@ -46,6 +47,12 @@ void ov::npuw::batched::CompiledModel::export_model(std::ostream& model) const {
     // indicator alone.
     ov::npuw::s11n::write(model, NPUW_SERIALIZATION_INDICATOR);
     ov::npuw::s11n::write(model, NPUW_BATCHED_COMPILED_MODEL_INDICATOR);
+    // Versions, as in the LLM blob header. The inner blob checks its own, but the
+    // wrapper header needs a version of its own in case its format ever changes.
+    ov::npuw::s11n::write(model, OPENVINO_VERSION_MAJOR);
+    ov::npuw::s11n::write(model, OPENVINO_VERSION_MINOR);
+    ov::npuw::s11n::write(model, OPENVINO_VERSION_PATCH);
+    ov::npuw::s11n::write(model, std::string(NPUW_SERIALIZATION_VERSION));
     m_inner->export_model(model);
 }
 
@@ -63,6 +70,34 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::impo
     ov::npuw::s11n::read(stream, batched_indicator);
     OPENVINO_ASSERT(batched_indicator == NPUW_BATCHED_COMPILED_MODEL_INDICATOR,
                     "This blob wasn't serialized via batched::CompiledModel!");
+
+    int vmajor = 0, vminor = 0, vpatch = 0;
+    std::string s11n_version;
+    ov::npuw::s11n::read(stream, vmajor);
+    ov::npuw::s11n::read(stream, vminor);
+    ov::npuw::s11n::read(stream, vpatch);
+    ov::npuw::s11n::read(stream, s11n_version);
+
+    if (vmajor != OPENVINO_VERSION_MAJOR || vminor != OPENVINO_VERSION_MINOR || vpatch != OPENVINO_VERSION_PATCH ||
+        s11n_version != std::string(NPUW_SERIALIZATION_VERSION)) {
+        OPENVINO_THROW("This blob was serialized with different OV version!",
+                       "\nSerialized by OV ",
+                       vmajor,
+                       '.',
+                       vminor,
+                       '.',
+                       vpatch,
+                       "\nCurrent OV version ",
+                       OPENVINO_VERSION_MAJOR,
+                       '.',
+                       OPENVINO_VERSION_MINOR,
+                       '.',
+                       OPENVINO_VERSION_PATCH,
+                       "\nNPUW serialized by version ",
+                       s11n_version,
+                       "\nNPUW current serialization version ",
+                       NPUW_SERIALIZATION_VERSION);
+    }
 
     auto inner = ov::npuw::LLMCompiledModel::import_model(stream, plugin, properties);
     return std::make_shared<CompiledModel>(inner, plugin);

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -213,6 +213,14 @@ void ov::npuw::batched::InferRequest::infer() {
             m_inner->infer();
         });
 
+        if (batch == 1) {
+            // A single row needs no stacking - expose the inner outputs directly.
+            m_profile["4.copy_row_out"].record([&]() {
+                expose_inner_outputs();
+            });
+            return;
+        }
+
         if (row == 0) {
             // The wrapped model's ports are dynamic - the output shapes are only
             // known once the first row has been scored.
@@ -223,6 +231,20 @@ void ov::npuw::batched::InferRequest::infer() {
                 m_inner->get_tensor(port)->copy_to(ov::npuw::util::view(get_tensor(port), 0, row, 1)._ptr);
             }
         });
+    }
+}
+
+void ov::npuw::batched::InferRequest::expose_inner_outputs() {
+    for (const auto& port : get_outputs()) {
+        const auto inner_out = m_inner->get_tensor(port);
+        const auto current = get_tensor(port);
+        if (current && current._ptr != inner_out._ptr && current->get_element_type() == inner_out->get_element_type() &&
+            current->get_shape() == inner_out->get_shape()) {
+            // The caller bound a fitting output tensor - keep writing into it.
+            inner_out->copy_to(current._ptr);
+        } else {
+            set_tensor(port, inner_out);
+        }
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -8,7 +8,6 @@
 #include <memory>
 #include <utility>
 
-#include "../../llm_compiled_model.hpp"
 #include "../../llm_lora_states.hpp"
 #include "../../logging.hpp"
 #include "../../serialization.hpp"
@@ -77,7 +76,9 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::impo
     ov::npuw::s11n::read(stream, tags.text_rerank);
     ov::npuw::s11n::read(stream, tags.text_embed);
 
-    auto inner = ov::npuw::LLMCompiledModel::import_model(stream, plugin, properties);
+    // The inner blob carries its own indicator header - the common NPUW dispatch
+    // picks the right implementation, so the wrapper stays agnostic of what it wraps.
+    auto inner = ov::npuw::ICompiledModel::import_model(stream, plugin, properties);
     return std::make_shared<CompiledModel>(inner, plugin, tags);
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -7,7 +7,9 @@
 #include <algorithm>
 #include <utility>
 
+#include "../../llm_compiled_model.hpp"
 #include "../../logging.hpp"
+#include "../../serialization.hpp"
 #include "../../util.hpp"
 #include "intel_npu/npuw_private_properties.hpp"
 #include "openvino/core/except.hpp"
@@ -49,9 +51,31 @@ const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::CompiledModel:
 }
 
 void ov::npuw::batched::CompiledModel::export_model(std::ostream& model) const {
-    // The element is a runtime-only decorator: the blob is the inner's blob, and the
-    // entry points re-apply the wrapper on import based on the properties.
+    // The wrap is part of the blob. A batched header goes first, the complete inner
+    // blob follows with its own header, and import reconstructs the wrapper from the
+    // indicator alone.
+    ov::npuw::s11n::write(model, NPUW_SERIALIZATION_INDICATOR);
+    ov::npuw::s11n::write(model, NPUW_BATCHED_COMPILED_MODEL_INDICATOR);
     m_inner->export_model(model);
+}
+
+std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::import_model(
+    std::istream& stream,
+    const std::shared_ptr<const ov::IPlugin>& plugin,
+    const ov::AnyMap& properties) {
+    LOG_INFO("Deserializing batched::CompiledModel...");
+
+    ov::npuw::s11n::IndicatorType serialization_indicator;
+    ov::npuw::s11n::read(stream, serialization_indicator);
+    OPENVINO_ASSERT(serialization_indicator == NPUW_SERIALIZATION_INDICATOR, "This blob wasn't serialized via NPUW!");
+
+    ov::npuw::s11n::IndicatorType batched_indicator;
+    ov::npuw::s11n::read(stream, batched_indicator);
+    OPENVINO_ASSERT(batched_indicator == NPUW_BATCHED_COMPILED_MODEL_INDICATOR,
+                    "This blob wasn't serialized via batched::CompiledModel!");
+
+    auto inner = ov::npuw::LLMCompiledModel::import_model(stream, plugin, properties);
+    return std::make_shared<CompiledModel>(inner, plugin);
 }
 
 std::shared_ptr<const ov::Model> ov::npuw::batched::CompiledModel::get_runtime_model() const {

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -5,9 +5,11 @@
 #include "batched.hpp"
 
 #include <algorithm>
+#include <memory>
 #include <utility>
 
 #include "../../llm_compiled_model.hpp"
+#include "../../llm_lora_states.hpp"
 #include "../../logging.hpp"
 #include "../../serialization.hpp"
 #include "../../util.hpp"
@@ -196,8 +198,17 @@ void ov::npuw::batched::InferRequest::infer() {
     // Unroll row by row: reset the inner variable state so each row is scored as an
     // independent prompt, bind the row's [1, ...] view of every batched input, run
     // the batch-1 inner request, and write the row's outputs into row `row` of the
-    // [N, ...] public output tensors.
-    const auto inner_states = m_inner->query_state();
+    // [N, ...] public output tensors. LoRA adapter states are kept out of the reset
+    // set: they carry the adapter weights, not per-prompt data, so they must survive
+    // the row loop, and their reset() throws by design.
+    auto inner_states = m_inner->query_state();
+    inner_states.erase(std::remove_if(inner_states.begin(),
+                                      inner_states.end(),
+                                      [](const ov::SoPtr<ov::IVariableState>& state) {
+                                          return std::dynamic_pointer_cast<ov::npuw::VariableState>(state._ptr) !=
+                                                 nullptr;
+                                      }),
+                       inner_states.end());
     for (std::size_t row = 0; row < batch; ++row) {
         m_profile["2.bind_row"].record([&]() {
             for (const auto& state : inner_states) {

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -18,6 +18,15 @@
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/runtime/tensor.hpp"
 
+namespace {
+// A port name for error messages. get_any_name() throws on a tensor with no
+// names, so fall back to the node's friendly name.
+std::string port_name(const ov::Output<const ov::Node>& port) {
+    const auto& names = port.get_names();
+    return names.empty() ? port.get_node()->get_friendly_name() : port.get_any_name();
+}
+}  // anonymous namespace
+
 ov::npuw::batched::ScoringTags ov::npuw::batched::scoring_tags(const ov::AnyMap& properties) {
     const auto is_enabled = [&properties](const std::string& key) {
         const auto it = properties.find(key);
@@ -147,20 +156,20 @@ ov::npuw::batched::InferRequest::BatchedInputs ov::npuw::batched::InferRequest::
     inputs.tensors.reserve(in_ports.size());
     for (const auto& port : in_ports) {
         auto tensor = get_tensor(port);
-        OPENVINO_ASSERT(tensor, "Batched element: no tensor is set for input '", port.get_any_name(), "'");
+        OPENVINO_ASSERT(tensor, "Batched element: no tensor is set for input '", port_name(port), "'");
         const auto& shape = tensor->get_shape();
         OPENVINO_ASSERT(!shape.empty(),
                         "Batched element: input '",
-                        port.get_any_name(),
+                        port_name(port),
                         "' has no leading (batch) dimension");
         OPENVINO_ASSERT(shape[0] > 0,
                         "Batched element: input '",
-                        port.get_any_name(),
+                        port_name(port),
                         "' has a zero-sized batch dimension - batch size must be > 0");
         if (shape[0] > 1) {
             OPENVINO_ASSERT(inputs.batch == 1 || inputs.batch == shape[0],
                             "Batched element: input '",
-                            port.get_any_name(),
+                            port_name(port),
                             "' has batch dimension ",
                             shape[0],
                             " which is neither the inferred batch size ",
@@ -244,9 +253,26 @@ void ov::npuw::batched::InferRequest::expose_inner_outputs() {
             current->get_shape() == inner_out->get_shape()) {
             // The caller bound a fitting output tensor - keep writing into it.
             inner_out->copy_to(current._ptr);
-        } else {
-            set_tensor(port, inner_out);
+            continue;
         }
+        if (current && current._ptr != inner_out._ptr) {
+            // Only the element's own previous publications may be replaced - a
+            // tensor the caller bound is never discarded behind their back.
+            OPENVINO_ASSERT(m_owned_outputs.count(current._ptr.get()) > 0,
+                            "Batched element: output '",
+                            port_name(port),
+                            "' is bound to a caller tensor of type ",
+                            current->get_element_type(),
+                            " and shape ",
+                            current->get_shape(),
+                            ", but this inference produces type ",
+                            inner_out->get_element_type(),
+                            " and shape ",
+                            inner_out->get_shape(),
+                            " - bind a fitting tensor or leave the output unset.");
+        }
+        m_owned_outputs.insert(inner_out._ptr.get());
+        set_tensor(port, inner_out);
     }
 }
 
@@ -255,14 +281,33 @@ void ov::npuw::batched::InferRequest::ensure_batched_outputs(std::size_t batch) 
         const auto inner_out = m_inner->get_tensor(port);
         OPENVINO_ASSERT(inner_out && !inner_out->get_shape().empty() && inner_out->get_shape()[0] == 1,
                         "Batched element: output '",
-                        port.get_any_name(),
+                        port_name(port),
                         "' of the inner request is not a [1, ...] tensor");
         ov::Shape shape = inner_out->get_shape();
         shape[0] = batch;
         const auto current = get_tensor(port);
-        if (!current || current->get_element_type() != inner_out->get_element_type() || current->get_shape() != shape) {
-            set_tensor(port, ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), shape)));
+        if (current && current->get_element_type() == inner_out->get_element_type() && current->get_shape() == shape) {
+            // Fits (caller-bound or ours from an earlier call) - rows are written
+            // straight into it.
+            continue;
         }
+        // Only the element's own previous publications may be replaced - a tensor
+        // the caller bound is never discarded behind their back.
+        OPENVINO_ASSERT(!current || m_owned_outputs.count(current._ptr.get()) > 0,
+                        "Batched element: output '",
+                        port_name(port),
+                        "' is bound to a caller tensor of type ",
+                        current ? current->get_element_type() : ov::element::dynamic,
+                        " and shape ",
+                        current ? current->get_shape() : ov::Shape{},
+                        ", but this inference produces type ",
+                        inner_out->get_element_type(),
+                        " and shape ",
+                        shape,
+                        " - bind a fitting tensor or leave the output unset.");
+        auto fresh = ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), shape));
+        m_owned_outputs.insert(fresh._ptr.get());
+        set_tensor(port, fresh);
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -19,19 +19,28 @@
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/runtime/tensor.hpp"
 
-bool ov::npuw::batched::requested(const ov::AnyMap& properties) {
+ov::npuw::batched::ScoringTags ov::npuw::batched::scoring_tags(const ov::AnyMap& properties) {
     const auto is_enabled = [&properties](const std::string& key) {
         const auto it = properties.find(key);
         return it != properties.end() && it->second.as<bool>();
     };
-    return is_enabled(ov::intel_npu::npuw::text_rerank::enabled.name()) ||
-           is_enabled(ov::intel_npu::npuw::text_embed::enabled.name());
+    ScoringTags tags;
+    tags.text_rerank = is_enabled(ov::intel_npu::npuw::text_rerank::enabled.name());
+    tags.text_embed = is_enabled(ov::intel_npu::npuw::text_embed::enabled.name());
+    return tags;
+}
+
+bool ov::npuw::batched::requested(const ov::AnyMap& properties) {
+    const auto tags = scoring_tags(properties);
+    return tags.text_rerank || tags.text_embed;
 }
 
 ov::npuw::batched::CompiledModel::CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
-                                                const std::shared_ptr<const ov::IPlugin>& plugin)
+                                                const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                const ScoringTags& tags)
     : ov::npuw::ICompiledModel(nullptr, plugin),  // I/O comes from the inner via inputs()/outputs()
-      m_inner(inner) {
+      m_inner(inner),
+      m_tags(tags) {
     OPENVINO_ASSERT(m_inner != nullptr, "Batched compiled model requires an inner compiled model");
 }
 
@@ -46,7 +55,7 @@ const std::vector<ov::Output<const ov::Node>>& ov::npuw::batched::CompiledModel:
 void ov::npuw::batched::CompiledModel::export_model(std::ostream& model) const {
     // The wrap is part of the blob. A batched header goes first, the complete inner
     // blob follows with its own header, and import reconstructs the wrapper from the
-    // indicator alone.
+    // header alone.
     ov::npuw::s11n::write(model, NPUW_SERIALIZATION_INDICATOR);
     ov::npuw::s11n::write(model, NPUW_BATCHED_COMPILED_MODEL_INDICATOR);
     // Versions, as in the LLM blob header. The inner blob checks its own, but the
@@ -55,6 +64,9 @@ void ov::npuw::batched::CompiledModel::export_model(std::ostream& model) const {
     ov::npuw::s11n::write(model, OPENVINO_VERSION_MINOR);
     ov::npuw::s11n::write(model, OPENVINO_VERSION_PATCH);
     ov::npuw::s11n::write(model, std::string(NPUW_SERIALIZATION_VERSION));
+    // The scoring tags are wrapper state, so they ride the wrapper's own header.
+    ov::npuw::s11n::write(model, m_tags.text_rerank);
+    ov::npuw::s11n::write(model, m_tags.text_embed);
     m_inner->export_model(model);
 }
 
@@ -101,8 +113,12 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::batched::CompiledModel::impo
                        NPUW_SERIALIZATION_VERSION);
     }
 
+    ScoringTags tags;
+    ov::npuw::s11n::read(stream, tags.text_rerank);
+    ov::npuw::s11n::read(stream, tags.text_embed);
+
     auto inner = ov::npuw::LLMCompiledModel::import_model(stream, plugin, properties);
-    return std::make_shared<CompiledModel>(inner, plugin);
+    return std::make_shared<CompiledModel>(inner, plugin, tags);
 }
 
 std::shared_ptr<const ov::Model> ov::npuw::batched::CompiledModel::get_runtime_model() const {
@@ -114,6 +130,15 @@ void ov::npuw::batched::CompiledModel::set_property(const ov::AnyMap& properties
 }
 
 ov::Any ov::npuw::batched::CompiledModel::get_property(const std::string& name) const {
+    // The scoring tags live with the wrapper, not the inner model, which stays
+    // unaware of the wrap. Answer them here so the public compiled model reports
+    // them truthfully, on compile and after import alike.
+    if (name == ov::intel_npu::npuw::text_rerank::enabled.name()) {
+        return m_tags.text_rerank;
+    }
+    if (name == ov::intel_npu::npuw::text_embed::enabled.name()) {
+        return m_tags.text_embed;
+    }
     return m_inner->get_property(name);
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -249,27 +249,22 @@ void ov::npuw::batched::InferRequest::expose_inner_outputs() {
     for (const auto& port : get_outputs()) {
         const auto inner_out = m_inner->get_tensor(port);
         const auto current = get_tensor(port);
-        if (current && current._ptr != inner_out._ptr && current->get_element_type() == inner_out->get_element_type() &&
-            current->get_shape() == inner_out->get_shape()) {
-            // The caller bound a fitting output tensor - keep writing into it.
-            inner_out->copy_to(current._ptr);
-            continue;
-        }
-        if (current && current._ptr != inner_out._ptr) {
-            // Only the element's own previous publications may be replaced - a
-            // tensor the caller bound is never discarded behind their back.
-            OPENVINO_ASSERT(m_owned_outputs.count(current._ptr.get()) > 0,
+        if (current && current._ptr != inner_out._ptr && m_owned_outputs.count(current._ptr.get()) == 0) {
+            // A caller-bound tensor is the caller's: it is never replaced, the
+            // result is written into it. The shape is brought in line the way
+            // plugins treat dynamic outputs - set_shape() resizes an owning
+            // tensor and throws for a fixed view too small for the data.
+            OPENVINO_ASSERT(current->get_element_type() == inner_out->get_element_type(),
                             "Batched element: output '",
                             port_name(port),
                             "' is bound to a caller tensor of type ",
                             current->get_element_type(),
-                            " and shape ",
-                            current->get_shape(),
                             ", but this inference produces type ",
                             inner_out->get_element_type(),
-                            " and shape ",
-                            inner_out->get_shape(),
-                            " - bind a fitting tensor or leave the output unset.");
+                            " - bind a tensor of the produced type or leave the output unset.");
+            current->set_shape(inner_out->get_shape());
+            inner_out->copy_to(current._ptr);
+            continue;
         }
         m_owned_outputs.insert(inner_out._ptr.get());
         set_tensor(port, inner_out);
@@ -286,25 +281,28 @@ void ov::npuw::batched::InferRequest::ensure_batched_outputs(std::size_t batch) 
         ov::Shape shape = inner_out->get_shape();
         shape[0] = batch;
         const auto current = get_tensor(port);
-        if (current && current->get_element_type() == inner_out->get_element_type() && current->get_shape() == shape) {
-            // Fits (caller-bound or ours from an earlier call) - rows are written
-            // straight into it.
+        if (current && current._ptr != inner_out._ptr && m_owned_outputs.count(current._ptr.get()) == 0) {
+            // A caller-bound tensor is the caller's: it is never replaced, the
+            // rows are written into it. The shape is brought in line the way
+            // plugins treat dynamic outputs - set_shape() resizes an owning
+            // tensor and throws for a fixed view too small for the data.
+            OPENVINO_ASSERT(current->get_element_type() == inner_out->get_element_type(),
+                            "Batched element: output '",
+                            port_name(port),
+                            "' is bound to a caller tensor of type ",
+                            current->get_element_type(),
+                            ", but this inference produces type ",
+                            inner_out->get_element_type(),
+                            " - bind a tensor of the produced type or leave the output unset.");
+            current->set_shape(shape);
             continue;
         }
-        // Only the element's own previous publications may be replaced - a tensor
-        // the caller bound is never discarded behind their back.
-        OPENVINO_ASSERT(!current || m_owned_outputs.count(current._ptr.get()) > 0,
-                        "Batched element: output '",
-                        port_name(port),
-                        "' is bound to a caller tensor of type ",
-                        current ? current->get_element_type() : ov::element::dynamic,
-                        " and shape ",
-                        current ? current->get_shape() : ov::Shape{},
-                        ", but this inference produces type ",
-                        inner_out->get_element_type(),
-                        " and shape ",
-                        shape,
-                        " - bind a fitting tensor or leave the output unset.");
+        if (current && current._ptr != inner_out._ptr && current->get_element_type() == inner_out->get_element_type() &&
+            current->get_shape() == shape) {
+            // The element's own tensor from an earlier call still fits - rows are
+            // written straight into it.
+            continue;
+        }
         auto fresh = ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), shape));
         m_owned_outputs.insert(fresh._ptr.get());
         set_tensor(port, fresh);

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -38,11 +38,6 @@ ov::npuw::batched::ScoringTags ov::npuw::batched::scoring_tags(const ov::AnyMap&
     return tags;
 }
 
-bool ov::npuw::batched::requested(const ov::AnyMap& properties) {
-    const auto tags = scoring_tags(properties);
-    return tags.text_rerank || tags.text_embed;
-}
-
 ov::npuw::batched::CompiledModel::CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
                                                 const std::shared_ptr<const ov::IPlugin>& plugin,
                                                 const ScoringTags& tags)
@@ -194,13 +189,18 @@ void ov::npuw::batched::InferRequest::infer() {
     });
     const std::size_t batch = inputs.batch;
 
-    // Unroll row by row: reset the inner variable state so each row is scored as an
-    // independent prompt, bind the row's [1, ...] view of every batched input, run
-    // the batch-1 inner request, and write the row's outputs into row `row` of the
-    // [N, ...] public output tensors. States the inner exposes as
-    // ov::npuw::VariableState are kept out of the reset set: that type holds data
-    // bound for the model's lifetime, not per-inference data, so it must survive
-    // the row loop and by design implements no reset().
+    // Broadcast inputs are bound whole, once. Batched inputs are rebound per row
+    // to the row's [1, ...] view below.
+    for (std::size_t i = 0; i < in_ports.size(); ++i) {
+        if (inputs.tensors[i]->get_shape()[0] == 1) {
+            m_inner->set_tensor(in_ports[i], inputs.tensors[i]);
+        }
+    }
+
+    // States the inner exposes as ov::npuw::VariableState are kept out of the
+    // per-row reset: that type holds data bound for the model's lifetime, not
+    // per-inference data, so it must survive the row loop and by design
+    // implements no reset().
     auto inner_states = m_inner->query_state();
     inner_states.erase(std::remove_if(inner_states.begin(),
                                       inner_states.end(),
@@ -209,6 +209,11 @@ void ov::npuw::batched::InferRequest::infer() {
                                                  nullptr;
                                       }),
                        inner_states.end());
+
+    // Unroll row by row: reset the inner state so each row is scored as an
+    // independent prompt, bind the row's view of every batched input, run the
+    // batch-1 inner request, and copy its outputs into row `row` of the [N, ...]
+    // public outputs.
     for (std::size_t row = 0; row < batch; ++row) {
         m_profile["2.bind_row"].record([&]() {
             for (const auto& state : inner_states) {
@@ -216,26 +221,18 @@ void ov::npuw::batched::InferRequest::infer() {
             }
             for (std::size_t i = 0; i < in_ports.size(); ++i) {
                 const auto& full = inputs.tensors[i];
-                m_inner->set_tensor(in_ports[i],
-                                    full->get_shape()[0] == 1 ? full : ov::npuw::util::view(full, 0, row, 1));
+                if (full->get_shape()[0] != 1) {
+                    m_inner->set_tensor(in_ports[i], ov::npuw::util::view(full, 0, row, 1));
+                }
             }
         });
         m_profile["3.inner_infer"].record([&]() {
             m_inner->infer();
         });
-
-        if (batch == 1) {
-            // A single row needs no stacking - expose the inner outputs directly.
-            m_profile["4.copy_row_out"].record([&]() {
-                expose_inner_outputs();
-            });
-            return;
-        }
-
         if (row == 0) {
             // The wrapped model's ports are dynamic - the output shapes are only
             // known once the first row has been scored.
-            ensure_batched_outputs(batch);
+            prepare_outputs(batch);
         }
         m_profile["4.copy_row_out"].record([&]() {
             for (const auto& port : out_ports) {
@@ -245,56 +242,8 @@ void ov::npuw::batched::InferRequest::infer() {
     }
 }
 
-bool ov::npuw::batched::InferRequest::published_by_element(std::size_t port_idx,
-                                                          const ov::SoPtr<ov::ITensor>& tensor) const {
-    return port_idx < m_published_outputs.size() && m_published_outputs[port_idx]._ptr != nullptr &&
-           m_published_outputs[port_idx]._ptr == tensor._ptr;
-}
-
-void ov::npuw::batched::InferRequest::publish_output(std::size_t port_idx,
-                                                     const ov::Output<const ov::Node>& port,
-                                                     const ov::SoPtr<ov::ITensor>& tensor) {
-    if (m_published_outputs.size() <= port_idx) {
-        m_published_outputs.resize(port_idx + 1);
-    }
-    // Keep the published tensor alive for as long as it is remembered: a freed
-    // tensor's address could otherwise be reused by a caller's allocation and
-    // mistaken for one of ours.
-    m_published_outputs[port_idx] = tensor;
-    set_tensor(port, tensor);
-}
-
-void ov::npuw::batched::InferRequest::expose_inner_outputs() {
-    const auto& out_ports = get_outputs();
-    for (std::size_t k = 0; k < out_ports.size(); ++k) {
-        const auto& port = out_ports[k];
-        const auto inner_out = m_inner->get_tensor(port);
-        const auto current = get_tensor(port);
-        if (current && current._ptr != inner_out._ptr && !published_by_element(k, current)) {
-            // A caller-bound tensor is the caller's: it is never replaced, the
-            // result is written into it. The shape is brought in line the way
-            // plugins treat dynamic outputs - set_shape() resizes an owning
-            // tensor and throws for a fixed view too small for the data.
-            OPENVINO_ASSERT(current->get_element_type() == inner_out->get_element_type(),
-                            "Batched element: output '",
-                            port_name(port),
-                            "' is bound to a caller tensor of type ",
-                            current->get_element_type(),
-                            ", but this inference produces type ",
-                            inner_out->get_element_type(),
-                            " - bind a tensor of the produced type or leave the output unset.");
-            current->set_shape(inner_out->get_shape());
-            inner_out->copy_to(current._ptr);
-            continue;
-        }
-        publish_output(k, port, inner_out);
-    }
-}
-
-void ov::npuw::batched::InferRequest::ensure_batched_outputs(std::size_t batch) {
-    const auto& out_ports = get_outputs();
-    for (std::size_t k = 0; k < out_ports.size(); ++k) {
-        const auto& port = out_ports[k];
+void ov::npuw::batched::InferRequest::prepare_outputs(std::size_t batch) {
+    for (const auto& port : get_outputs()) {
         const auto inner_out = m_inner->get_tensor(port);
         OPENVINO_ASSERT(inner_out && !inner_out->get_shape().empty() && inner_out->get_shape()[0] == 1,
                         "Batched element: output '",
@@ -302,37 +251,31 @@ void ov::npuw::batched::InferRequest::ensure_batched_outputs(std::size_t batch) 
                         "' of the inner request is not a [1, ...] tensor");
         ov::Shape shape = inner_out->get_shape();
         shape[0] = batch;
+
         const auto current = get_tensor(port);
-        if (current && current._ptr != inner_out._ptr && !published_by_element(k, current)) {
-            // A caller-bound tensor is the caller's: it is never replaced, the
-            // rows are written into it. The shape is brought in line the way
-            // plugins treat dynamic outputs - set_shape() resizes an owning
-            // tensor and throws for a fixed view too small for the data.
-            OPENVINO_ASSERT(current->get_element_type() == inner_out->get_element_type(),
-                            "Batched element: output '",
-                            port_name(port),
-                            "' is bound to a caller tensor of type ",
-                            current->get_element_type(),
-                            ", but this inference produces type ",
-                            inner_out->get_element_type(),
-                            " - bind a tensor of the produced type or leave the output unset.");
-            current->set_shape(shape);
+        if (!current) {
+            set_tensor(port, ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), shape)));
             continue;
         }
-        if (current && current._ptr != inner_out._ptr && current->get_element_type() == inner_out->get_element_type() &&
-            current->get_shape() == shape) {
-            // The element's own tensor from an earlier call still fits - rows are
-            // written straight into it.
-            continue;
-        }
-        publish_output(k, port, ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), shape)));
+        // Whatever is bound stays bound and is written into, the way plugins treat
+        // dynamic outputs: set_shape() resizes an owning tensor when the produced
+        // shape differs and throws for a fixed view too small for the data.
+        OPENVINO_ASSERT(current->get_element_type() == inner_out->get_element_type(),
+                        "Batched element: output '",
+                        port_name(port),
+                        "' is bound to a tensor of type ",
+                        current->get_element_type(),
+                        ", but this inference produces type ",
+                        inner_out->get_element_type(),
+                        " - bind a tensor of the produced type or leave the output unset.");
+        current->set_shape(shape);
     }
 }
 
 void ov::npuw::batched::InferRequest::check_tensors() const {
-    // No-op: the public outputs are late-bound (allocated on infer once the batch is
-    // known), and the batched inputs are validated and then unrolled by infer() -- the
-    // per-row [1, ...] tensors are checked by the inner request.
+    // No-op: the public outputs are sized on infer once the batch is known, and
+    // the batched inputs are validated and then unrolled by infer() - the per-row
+    // [1, ...] tensors are checked by the inner request.
 }
 
 std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::batched::InferRequest::query_state() const {

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
@@ -245,11 +245,32 @@ void ov::npuw::batched::InferRequest::infer() {
     }
 }
 
+bool ov::npuw::batched::InferRequest::published_by_element(std::size_t port_idx,
+                                                          const ov::SoPtr<ov::ITensor>& tensor) const {
+    return port_idx < m_published_outputs.size() && m_published_outputs[port_idx]._ptr != nullptr &&
+           m_published_outputs[port_idx]._ptr == tensor._ptr;
+}
+
+void ov::npuw::batched::InferRequest::publish_output(std::size_t port_idx,
+                                                     const ov::Output<const ov::Node>& port,
+                                                     const ov::SoPtr<ov::ITensor>& tensor) {
+    if (m_published_outputs.size() <= port_idx) {
+        m_published_outputs.resize(port_idx + 1);
+    }
+    // Keep the published tensor alive for as long as it is remembered: a freed
+    // tensor's address could otherwise be reused by a caller's allocation and
+    // mistaken for one of ours.
+    m_published_outputs[port_idx] = tensor;
+    set_tensor(port, tensor);
+}
+
 void ov::npuw::batched::InferRequest::expose_inner_outputs() {
-    for (const auto& port : get_outputs()) {
+    const auto& out_ports = get_outputs();
+    for (std::size_t k = 0; k < out_ports.size(); ++k) {
+        const auto& port = out_ports[k];
         const auto inner_out = m_inner->get_tensor(port);
         const auto current = get_tensor(port);
-        if (current && current._ptr != inner_out._ptr && m_owned_outputs.count(current._ptr.get()) == 0) {
+        if (current && current._ptr != inner_out._ptr && !published_by_element(k, current)) {
             // A caller-bound tensor is the caller's: it is never replaced, the
             // result is written into it. The shape is brought in line the way
             // plugins treat dynamic outputs - set_shape() resizes an owning
@@ -266,13 +287,14 @@ void ov::npuw::batched::InferRequest::expose_inner_outputs() {
             inner_out->copy_to(current._ptr);
             continue;
         }
-        m_owned_outputs.insert(inner_out._ptr.get());
-        set_tensor(port, inner_out);
+        publish_output(k, port, inner_out);
     }
 }
 
 void ov::npuw::batched::InferRequest::ensure_batched_outputs(std::size_t batch) {
-    for (const auto& port : get_outputs()) {
+    const auto& out_ports = get_outputs();
+    for (std::size_t k = 0; k < out_ports.size(); ++k) {
+        const auto& port = out_ports[k];
         const auto inner_out = m_inner->get_tensor(port);
         OPENVINO_ASSERT(inner_out && !inner_out->get_shape().empty() && inner_out->get_shape()[0] == 1,
                         "Batched element: output '",
@@ -281,7 +303,7 @@ void ov::npuw::batched::InferRequest::ensure_batched_outputs(std::size_t batch) 
         ov::Shape shape = inner_out->get_shape();
         shape[0] = batch;
         const auto current = get_tensor(port);
-        if (current && current._ptr != inner_out._ptr && m_owned_outputs.count(current._ptr.get()) == 0) {
+        if (current && current._ptr != inner_out._ptr && !published_by_element(k, current)) {
             // A caller-bound tensor is the caller's: it is never replaced, the
             // rows are written into it. The shape is brought in line the way
             // plugins treat dynamic outputs - set_shape() resizes an owning
@@ -303,9 +325,7 @@ void ov::npuw::batched::InferRequest::ensure_batched_outputs(std::size_t batch) 
             // written straight into it.
             continue;
         }
-        auto fresh = ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), shape));
-        m_owned_outputs.insert(fresh._ptr.get());
-        set_tensor(port, fresh);
+        publish_output(k, port, ov::get_tensor_impl(ov::Tensor(inner_out->get_element_type(), shape)));
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "openvino/runtime/iasync_infer_request.hpp"
+#include "openvino/runtime/icompiled_model.hpp"
+#include "openvino/runtime/isync_infer_request.hpp"
+#include "openvino/runtime/so_ptr.hpp"
+
+namespace ov::npuw::batched {
+
+class InferRequest;
+
+// A compiled-model wrapper that adds batched (batch > 1) execution on top of an
+// inner compiled model that only supports a batch size of 1 (as NPUW's LLM
+// pipeline does, since it reshapes every sub-model to a static batch of 1).
+//
+// Like the other v1/elements wrappers (failsafe, accuracy_checked) it is a
+// transparent ov::ICompiledModel decorator that exposes the same I/O as the
+// model it wraps and forwards property queries to the inner model.  Unlike
+// them it is a *fan-out* element: a single [N, ...] inference is unrolled into
+// N independent [1, ...] inferences on the inner request, the inner variable
+// state (KV-cache) is reset between rows, and the per-row outputs are stacked
+// back into [N, ...] tensors along the batch dimension (axis 0).
+//
+// This is correct for single-shot scoring workloads whose rows are independent
+// -- text reranking and text embedding -- where batched and per-row results are
+// identical and batching is purely a throughput/ergonomics choice.  It is NOT
+// valid for autoregressive generation, where rows are not independent.
+//
+// It composes on top of the other elements, e.g.:
+//
+//   Batched( AccuracyChecked( Failsafe(NPU -> CPU) ) )
+//
+// and the inner request needs no awareness of batching at all -- a stock
+// single-sequence LLM/embedding infer request works unchanged.
+class CompiledModel final : public ov::ICompiledModel {
+public:
+    // Factory method.  Returns inner_compiled unwrapped when enabled == false,
+    // keeping the zero-overhead path trivial (mirrors accuracy_checked::create).
+    static ov::SoPtr<ov::ICompiledModel> create(const std::shared_ptr<ov::Model>& model,
+                                                const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                ov::SoPtr<ov::ICompiledModel> inner_compiled,
+                                                bool enabled);
+
+    CompiledModel(const std::shared_ptr<ov::Model>& model,
+                  const std::shared_ptr<const ov::IPlugin>& plugin,
+                  ov::SoPtr<ov::ICompiledModel> inner_compiled);
+
+    void export_model(std::ostream& model) const override;
+    std::shared_ptr<const ov::Model> get_runtime_model() const override;
+
+    void set_property(const ov::AnyMap& properties) override;
+    ov::Any get_property(const std::string& name) const override;
+
+    std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
+    std::shared_ptr<ov::IAsyncInferRequest> create_infer_request() const override;
+
+private:
+    friend class InferRequest;
+
+    ov::SoPtr<ov::ICompiledModel> m_inner;
+};
+
+// Sync infer request that unrolls a batched inference over a single-sequence
+// inner request.
+//
+// On each infer() call it determines the batch size N from the inputs, then for
+// each row 0..N-1: resets the inner request's variable state, binds the row's
+// [1, ...] slice of every input, runs the inner request, and copies the inner
+// [1, ...] output into row i of the wrapper's [N, ...] output tensors.  The
+// public input/output tensors are held by the ISyncInferRequest base; only the
+// inner request sees [1, ...] shapes.
+//
+// It is constructed from the compiled model whose I/O it exposes plus the inner
+// request to drive.  This lets it be produced both by Batched::CompiledModel
+// (standalone, composable element) and reused directly by a pipeline that
+// already owns a single-sequence request (e.g. NPUW's LLMCompiledModel wrapping
+// its LLMInferRequest for scoring), without that pipeline having to wrap its
+// whole compiled model.
+class InferRequest final : public ov::ISyncInferRequest {
+public:
+    // Drive an async inner request (used by the standalone Batched::CompiledModel decorator,
+    // where the inner is a separate compiled model with its own task executor).
+    InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
+                 std::shared_ptr<ov::IAsyncInferRequest> inner_request);
+
+    // Drive a sync inner request directly, on the calling thread, without an executor. Used when a
+    // pipeline wraps its own single-sequence request (e.g. NPUW's LLMCompiledModel wrapping its
+    // LLMInferRequest): this avoids a nested-executor deadlock that would otherwise occur if the
+    // inner ran on the same task executor as the outer (async) request.
+    InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
+                 std::shared_ptr<ov::ISyncInferRequest> inner_request);
+
+    void infer() override;
+    void check_tensors() const override;
+
+    std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override;
+    std::vector<ov::ProfilingInfo> get_profiling_info() const override;
+
+private:
+    void init_public_tensors();
+
+    // The inner single-sequence request, driven row by row. Exactly one of the two handles is set;
+    // the small accessors below hide which interface (sync/async) is in use from infer().
+    const std::vector<ov::Output<const ov::Node>>& inner_inputs() const;
+    const std::vector<ov::Output<const ov::Node>>& inner_outputs() const;
+    void inner_set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor);
+    ov::SoPtr<ov::ITensor> inner_get_tensor(const ov::Output<const ov::Node>& port) const;
+    void inner_infer();
+    std::vector<ov::SoPtr<ov::IVariableState>> inner_query_state() const;
+
+    std::shared_ptr<ov::IAsyncInferRequest> m_inner_async;
+    std::shared_ptr<ov::ISyncInferRequest> m_inner_sync;
+    mutable std::mutex m_mutex;
+};
+
+}  // namespace ov::npuw::batched

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -71,12 +71,13 @@ private:
 // Sync infer request that unrolls a batched inference over a single-sequence
 // inner request.
 //
-// On each infer() call it determines the batch size N from the inputs, then for
-// each row 0..N-1: resets the inner request's variable state, binds the row's
-// [1, ...] slice of every input, runs the inner request, and copies the inner
-// [1, ...] output into row i of the wrapper's [N, ...] output tensors.  The
-// public input/output tensors are held by the ISyncInferRequest base; only the
-// inner request sees [1, ...] shapes.
+// On each infer() call it takes the batch size N as the largest leading dimension
+// across the inputs (so a shared [1, ...] input is broadcast, not mistaken for the
+// batch), then for each row 0..N-1: resets the inner request's variable state, binds
+// the row's [1, ...] slice of every per-row input, runs the inner request, and copies
+// the inner [1, ...] output into row i of the wrapper's [N, ...] output tensors.
+// N == 1 publishes the inner outputs directly.  The public input/output tensors are
+// held by the ISyncInferRequest base; only the inner request sees [1, ...] shapes.
 //
 // It is constructed from the compiled model whose I/O it exposes plus the inner
 // request to drive.  This lets it be produced both by Batched::CompiledModel

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "../../compiled_model.hpp"
+#include "../../perf.hpp"
 #include "openvino/runtime/iasync_infer_request.hpp"
 #include "openvino/runtime/isync_infer_request.hpp"
 #include "openvino/runtime/so_ptr.hpp"
@@ -96,6 +97,19 @@ public:
     std::vector<ov::ProfilingInfo> get_profiling_info() const override;
 
 private:
+    // The public input tensors snapshotted for one infer() call, together with the
+    // batch size derived from them.
+    struct BatchedInputs {
+        std::vector<ov::SoPtr<ov::ITensor>> tensors;  // parallel to get_inputs()
+        std::size_t batch = 1;
+    };
+
+    // Snapshot the public inputs and derive the batch size: the largest leading
+    // dimension across them. Every input must either carry the batch ([N, ...],
+    // sliced per row by infer()) or be shared across rows ([1, ...], bound whole);
+    // anything else throws.
+    BatchedInputs extract_batch() const;
+
     // Make the public output tensors [batch, ...] copies of the inner's [1, ...]
     // outputs, reusing caller-bound tensors that already fit. The wrapped model's
     // ports are dynamic, so this can only run once the first row has been scored
@@ -104,6 +118,10 @@ private:
 
     std::shared_ptr<ov::IAsyncInferRequest> m_inner;
     mutable std::mutex m_mutex;
+
+    // Per-phase timings of the unroll.
+    using MS = ov::npuw::perf::metric<ov::npuw::perf::MSec>;
+    ov::npuw::perf::Profile<MS> m_profile;
 };
 
 }  // namespace ov::npuw::batched

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -8,50 +8,56 @@
 #include <mutex>
 #include <vector>
 
+#include "../../compiled_model.hpp"
 #include "openvino/runtime/iasync_infer_request.hpp"
-#include "openvino/runtime/icompiled_model.hpp"
 #include "openvino/runtime/isync_infer_request.hpp"
 #include "openvino/runtime/so_ptr.hpp"
 
 namespace ov::npuw::batched {
 
-class InferRequest;
+// True when the compile/import properties opt into batched single-shot scoring --
+// currently the text rerank and text embedding pipelines. Used by the entry points
+// (npuw::ICompiledModel::create and the NPUW import path) to decide whether to
+// apply the batched element.
+bool requested(const ov::AnyMap& properties);
 
-// A compiled-model wrapper that adds batched (batch > 1) execution on top of an
+// A compiled-model decorator that adds batched (batch > 1) execution on top of an
 // inner compiled model that only supports a batch size of 1 (as NPUW's LLM
 // pipeline does, since it reshapes every sub-model to a static batch of 1).
 //
 // Like the other v1/elements wrappers (failsafe, accuracy_checked) it is a
-// transparent ov::ICompiledModel decorator that exposes the same I/O as the
-// model it wraps and forwards property queries to the inner model.  Unlike
-// them it is a *fan-out* element: a single [N, ...] inference is unrolled into
-// N independent [1, ...] inferences on the inner request, the inner variable
-// state (KV-cache) is reset between rows, and the per-row outputs are stacked
-// back into [N, ...] tensors along the batch dimension (axis 0).
+// transparent decorator that exposes the inner model's I/O (inputs()/outputs()
+// forward to the inner, so the ports are literally the same objects) and forwards
+// everything but inference to the inner model. Unlike them it is a *fan-out*
+// element: a single [N, ...] inference is unrolled into N independent [1, ...]
+// inferences on the inner request, the inner variable state (KV-cache) is reset
+// between rows, and the per-row outputs are written into rows of the [N, ...]
+// public output tensors.
 //
 // This is correct for single-shot scoring workloads whose rows are independent
 // -- text reranking and text embedding -- where batched and per-row results are
-// identical and batching is purely a throughput/ergonomics choice.  It is NOT
-// valid for autoregressive generation, where rows are not independent.
+// identical and batching is purely a throughput/ergonomics choice. It is NOT
+// valid for autoregressive generation, where state must persist across calls.
 //
-// It composes on top of the other elements, e.g.:
-//
-//   Batched( AccuracyChecked( Failsafe(NPU -> CPU) ) )
-//
-// and the inner request needs no awareness of batching at all -- a stock
-// single-sequence LLM/embedding infer request works unchanged.
-class CompiledModel final : public ov::ICompiledModel {
+// It is instantiated at the NPUW entry points only: npuw::ICompiledModel::create()
+// on compilation and the plugin's NPUW import path on blob import (the element is
+// runtime-only and is not part of the serialized blob). Both wrap the
+// LLMCompiledModel produced there from the very same model, which is what
+// guarantees the inner is the matching batch-1 compilation.
+class CompiledModel final : public ov::npuw::ICompiledModel {
 public:
-    // Factory method.  Returns inner_compiled unwrapped when enabled == false,
-    // keeping the zero-overhead path trivial (mirrors accuracy_checked::create).
-    static ov::SoPtr<ov::ICompiledModel> create(const std::shared_ptr<ov::Model>& model,
-                                                const std::shared_ptr<const ov::IPlugin>& plugin,
-                                                ov::SoPtr<ov::ICompiledModel> inner_compiled,
-                                                bool enabled);
+    // Factory method. Returns inner unwrapped when enabled == false, keeping the
+    // default path zero-overhead.
+    static std::shared_ptr<ov::npuw::ICompiledModel> create(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+                                                            const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                            bool enabled);
 
-    CompiledModel(const std::shared_ptr<ov::Model>& model,
-                  const std::shared_ptr<const ov::IPlugin>& plugin,
-                  ov::SoPtr<ov::ICompiledModel> inner_compiled);
+    CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+                  const std::shared_ptr<const ov::IPlugin>& plugin);
+
+    // The wrapper adds no I/O of its own -- it exposes the inner model's ports.
+    const std::vector<ov::Output<const ov::Node>>& inputs() const override;
+    const std::vector<ov::Output<const ov::Node>>& outputs() const override;
 
     void export_model(std::ostream& model) const override;
     std::shared_ptr<const ov::Model> get_runtime_model() const override;
@@ -59,45 +65,29 @@ public:
     void set_property(const ov::AnyMap& properties) override;
     ov::Any get_property(const std::string& name) const override;
 
+    void release_memory() override;
+
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
-    std::shared_ptr<ov::IAsyncInferRequest> create_infer_request() const override;
 
 private:
-    friend class InferRequest;
-
-    ov::SoPtr<ov::ICompiledModel> m_inner;
+    std::shared_ptr<ov::npuw::ICompiledModel> m_inner;
 };
 
-// Sync infer request that unrolls a batched inference over a single-sequence
+// Sync infer request that unrolls a batched inference over the single-sequence
 // inner request.
 //
-// On each infer() call it takes the batch size N as the largest leading dimension
-// across the inputs (so a shared [1, ...] input is broadcast, not mistaken for the
-// batch), then for each row 0..N-1: resets the inner request's variable state, binds
-// the row's [1, ...] slice of every per-row input, runs the inner request, and copies
-// the inner [1, ...] output into row i of the wrapper's [N, ...] output tensors.
-// N == 1 publishes the inner outputs directly.  The public input/output tensors are
-// held by the ISyncInferRequest base; only the inner request sees [1, ...] shapes.
-//
-// It is constructed from the compiled model whose I/O it exposes plus the inner
-// request to drive.  This lets it be produced both by Batched::CompiledModel
-// (standalone, composable element) and reused directly by a pipeline that
-// already owns a single-sequence request (e.g. NPUW's LLMCompiledModel wrapping
-// its LLMInferRequest for scoring), without that pipeline having to wrap its
-// whole compiled model.
+// The public input tensors default to the inner request's own tensors (surfaced in
+// the constructor), so a plain batch-1 infer works exactly as on the inner. When
+// the caller binds [N, ...] inputs, infer() takes N as the largest leading
+// dimension across the inputs (an input with a leading dim of 1 is shared across
+// rows), and for each row: resets the inner variable state, binds the row's
+// [1, ...] view of every batched input, runs the inner request, and copies the
+// inner outputs into row i of the [N, ...] public output tensors. Caller-bound
+// output tensors are reused when they already have the right shape and type.
 class InferRequest final : public ov::ISyncInferRequest {
 public:
-    // Drive an async inner request (used by the standalone Batched::CompiledModel decorator,
-    // where the inner is a separate compiled model with its own task executor).
     InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
                  std::shared_ptr<ov::IAsyncInferRequest> inner_request);
-
-    // Drive a sync inner request directly, on the calling thread, without an executor. Used when a
-    // pipeline wraps its own single-sequence request (e.g. NPUW's LLMCompiledModel wrapping its
-    // LLMInferRequest): this avoids a nested-executor deadlock that would otherwise occur if the
-    // inner ran on the same task executor as the outer (async) request.
-    InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
-                 std::shared_ptr<ov::ISyncInferRequest> inner_request);
 
     void infer() override;
     void check_tensors() const override;
@@ -106,19 +96,13 @@ public:
     std::vector<ov::ProfilingInfo> get_profiling_info() const override;
 
 private:
-    void init_public_tensors();
+    // Make the public output tensors [batch, ...] copies of the inner's [1, ...]
+    // outputs, reusing caller-bound tensors that already fit. The wrapped model's
+    // ports are dynamic, so this can only run once the first row has been scored
+    // and the inner output shapes are known.
+    void ensure_batched_outputs(std::size_t batch);
 
-    // The inner single-sequence request, driven row by row. Exactly one of the two handles is set;
-    // the small accessors below hide which interface (sync/async) is in use from infer().
-    const std::vector<ov::Output<const ov::Node>>& inner_inputs() const;
-    const std::vector<ov::Output<const ov::Node>>& inner_outputs() const;
-    void inner_set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor);
-    ov::SoPtr<ov::ITensor> inner_get_tensor(const ov::Output<const ov::Node>& port) const;
-    void inner_infer();
-    std::vector<ov::SoPtr<ov::IVariableState>> inner_query_state() const;
-
-    std::shared_ptr<ov::IAsyncInferRequest> m_inner_async;
-    std::shared_ptr<ov::ISyncInferRequest> m_inner_sync;
+    std::shared_ptr<ov::IAsyncInferRequest> m_inner;
     mutable std::mutex m_mutex;
 };
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -1,0 +1,129 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "../../compiled_model.hpp"
+#include "../../perf.hpp"
+#include "openvino/runtime/iasync_infer_request.hpp"
+#include "openvino/runtime/isync_infer_request.hpp"
+#include "openvino/runtime/so_ptr.hpp"
+
+namespace ov::npuw::batched {
+
+// True when the given compiled model is tagged for batched single-shot scoring --
+// currently the text rerank and text embedding pipelines. The tag is read from the
+// model's own properties (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED, recorded in its config
+// and serialized with it into the blob), which is what lets CompiledModel::create()
+// decide identically at both NPUW entry points.
+bool requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model);
+
+// A compiled-model decorator that adds batched (batch > 1) execution on top of an
+// inner compiled model that only supports a batch size of 1 (as NPUW's LLM
+// pipeline does, since it reshapes every sub-model to a static batch of 1).
+//
+// Like the other v1/elements wrappers (failsafe, accuracy_checked) it is a
+// transparent decorator that exposes the inner model's I/O (inputs()/outputs()
+// forward to the inner, so the ports are literally the same objects) and forwards
+// everything but inference to the inner model. Unlike them it is a *fan-out*
+// element: a single [N, ...] inference is unrolled into N independent [1, ...]
+// inferences on the inner request, the inner variable state (KV-cache) is reset
+// between rows, and the per-row outputs are written into rows of the [N, ...]
+// public output tensors.
+//
+// This is correct for single-shot scoring workloads whose rows are independent
+// -- text reranking and text embedding -- where batched and per-row results are
+// identical and batching is purely a throughput/ergonomics choice. It is NOT
+// valid for autoregressive generation, where state must persist across calls.
+//
+// It is applied via create() at the NPUW entry points only:
+// npuw::ICompiledModel::create() on compilation and the plugin's NPUW import path
+// on blob import (the element is runtime-only and is not part of the serialized
+// blob). Both wrap the LLMCompiledModel produced there from the very same model,
+// which is what guarantees the inner is the matching batch-1 compilation.
+class CompiledModel final : public ov::npuw::ICompiledModel {
+public:
+    // Factory used by the NPUW entry points. Returns the inner model unwrapped
+    // when it is not tagged for batched scoring (see requested()), keeping the
+    // untagged path zero-overhead -- the same convention as the other elements'
+    // create() no-op paths.
+    static std::shared_ptr<ov::npuw::ICompiledModel> create(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+                                                            const std::shared_ptr<const ov::IPlugin>& plugin);
+
+    CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+                  const std::shared_ptr<const ov::IPlugin>& plugin);
+
+    // The wrapper adds no I/O of its own -- it exposes the inner model's ports.
+    const std::vector<ov::Output<const ov::Node>>& inputs() const override;
+    const std::vector<ov::Output<const ov::Node>>& outputs() const override;
+
+    void export_model(std::ostream& model) const override;
+    std::shared_ptr<const ov::Model> get_runtime_model() const override;
+
+    void set_property(const ov::AnyMap& properties) override;
+    ov::Any get_property(const std::string& name) const override;
+
+    void release_memory() override;
+
+    std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
+
+private:
+    std::shared_ptr<ov::npuw::ICompiledModel> m_inner;
+};
+
+// Sync infer request that unrolls a batched inference over the single-sequence
+// inner request.
+//
+// The public input tensors default to the inner request's own tensors (surfaced in
+// the constructor), so a plain batch-1 infer works exactly as on the inner. When
+// the caller binds [N, ...] inputs, infer() takes N as the largest leading
+// dimension across the inputs (an input with a leading dim of 1 is shared across
+// rows), and for each row: resets the inner variable state, binds the row's
+// [1, ...] view of every batched input, runs the inner request, and copies the
+// inner outputs into row i of the [N, ...] public output tensors. Caller-bound
+// output tensors are reused when they already have the right shape and type.
+class InferRequest final : public ov::ISyncInferRequest {
+public:
+    InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
+                 std::shared_ptr<ov::IAsyncInferRequest> inner_request);
+
+    void infer() override;
+    void check_tensors() const override;
+
+    std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override;
+    std::vector<ov::ProfilingInfo> get_profiling_info() const override;
+
+private:
+    // The public input tensors snapshotted for one infer() call, together with the
+    // batch size derived from them.
+    struct BatchedInputs {
+        std::vector<ov::SoPtr<ov::ITensor>> tensors;  // parallel to get_inputs()
+        std::size_t batch = 1;
+    };
+
+    // Snapshot the public inputs and derive the batch size: the largest leading
+    // dimension across them. Every input must either carry the batch ([N, ...],
+    // sliced per row by infer()) or be shared across rows ([1, ...], bound whole);
+    // anything else throws.
+    BatchedInputs extract_batch() const;
+
+    // Make the public output tensors [batch, ...] copies of the inner's [1, ...]
+    // outputs, reusing caller-bound tensors that already fit. The wrapped model's
+    // ports are dynamic, so this can only run once the first row has been scored
+    // and the inner output shapes are known.
+    void ensure_batched_outputs(std::size_t batch);
+
+    std::shared_ptr<ov::IAsyncInferRequest> m_inner;
+    mutable std::mutex m_mutex;
+
+    // Per-phase timings of the unroll.
+    using MS = ov::npuw::perf::metric<ov::npuw::perf::MSec>;
+    ov::npuw::perf::Profile<MS> m_profile;
+};
+
+}  // namespace ov::npuw::batched

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -19,9 +19,8 @@ namespace ov::npuw::batched {
 // True when the given compiled model is tagged for batched single-shot scoring --
 // currently the text rerank and text embedding pipelines. The tag is read from the
 // model's own properties (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED, recorded in its config
-// and serialized with it into the blob), so both entry points --
-// npuw::ICompiledModel::create on compile and the NPUW import path on blob import --
-// decide identically whether to apply the batched element.
+// and serialized with it into the blob), which is what lets CompiledModel::create()
+// decide identically at both NPUW entry points.
 bool requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model);
 
 // A compiled-model decorator that adds batched (batch > 1) execution on top of an
@@ -42,13 +41,20 @@ bool requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model);
 // identical and batching is purely a throughput/ergonomics choice. It is NOT
 // valid for autoregressive generation, where state must persist across calls.
 //
-// It is instantiated at the NPUW entry points only: npuw::ICompiledModel::create()
-// on compilation and the plugin's NPUW import path on blob import (the element is
-// runtime-only and is not part of the serialized blob). Both wrap the
-// LLMCompiledModel produced there from the very same model, which is what
-// guarantees the inner is the matching batch-1 compilation.
+// It is applied via create() at the NPUW entry points only:
+// npuw::ICompiledModel::create() on compilation and the plugin's NPUW import path
+// on blob import (the element is runtime-only and is not part of the serialized
+// blob). Both wrap the LLMCompiledModel produced there from the very same model,
+// which is what guarantees the inner is the matching batch-1 compilation.
 class CompiledModel final : public ov::npuw::ICompiledModel {
 public:
+    // Factory used by the NPUW entry points. Returns the inner model unwrapped
+    // when it is not tagged for batched scoring (see requested()), keeping the
+    // untagged path zero-overhead -- the same convention as the other elements'
+    // create() no-op paths.
+    static std::shared_ptr<ov::npuw::ICompiledModel> create(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
+                                                            const std::shared_ptr<const ov::IPlugin>& plugin);
+
     CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
                   const std::shared_ptr<const ov::IPlugin>& plugin);
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -16,11 +16,13 @@
 
 namespace ov::npuw::batched {
 
-// True when the compile/import properties opt into batched single-shot scoring --
-// currently the text rerank and text embedding pipelines. Used by the entry points
-// (npuw::ICompiledModel::create and the NPUW import path) to decide whether to
-// apply the batched element.
-bool requested(const ov::AnyMap& properties);
+// True when the given compiled model is tagged for batched single-shot scoring --
+// currently the text rerank and text embedding pipelines. The tag is read from the
+// model's own properties (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED, recorded in its config
+// and serialized with it into the blob), so both entry points --
+// npuw::ICompiledModel::create on compile and the NPUW import path on blob import --
+// decide identically whether to apply the batched element.
+bool requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model);
 
 // A compiled-model decorator that adds batched (batch > 1) execution on top of an
 // inner compiled model that only supports a batch size of 1 (as NPUW's LLM
@@ -47,12 +49,6 @@ bool requested(const ov::AnyMap& properties);
 // guarantees the inner is the matching batch-1 compilation.
 class CompiledModel final : public ov::npuw::ICompiledModel {
 public:
-    // Factory method. Returns inner unwrapped when enabled == false, keeping the
-    // default path zero-overhead.
-    static std::shared_ptr<ov::npuw::ICompiledModel> create(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
-                                                            const std::shared_ptr<const ov::IPlugin>& plugin,
-                                                            bool enabled);
-
     CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
                   const std::shared_ptr<const ov::IPlugin>& plugin);
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -115,6 +115,11 @@ private:
     // and the inner output shapes are known.
     void ensure_batched_outputs(std::size_t batch);
 
+    // Batch-1 shortcut: publish the inner outputs as the public ones without the
+    // stacking copy. A caller-bound tensor of the fitting shape and type is still
+    // written in place instead.
+    void expose_inner_outputs();
+
     std::shared_ptr<ov::IAsyncInferRequest> m_inner;
     mutable std::mutex m_mutex;
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -16,11 +16,11 @@
 
 namespace ov::npuw::batched {
 
-// True when the given compiled model is tagged for batched single-shot scoring --
-// currently the text rerank and text embedding pipelines. The tag is read from the
-// model's own properties (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED). The compile entry
-// point uses this to decide the wrap explicitly.
-bool requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model);
+// True when the compile properties tag the model for batched single-shot scoring
+// (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED) -- currently the text rerank and text
+// embedding pipelines. The compile entry point uses this to decide the wrap
+// explicitly. Import needs no such decision, the blob indicator carries it.
+bool requested(const ov::AnyMap& properties);
 
 // A compiled-model decorator that adds batched (batch > 1) execution on top of an
 // inner compiled model that only supports a batch size of 1 (as NPUW's LLM

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -16,6 +16,18 @@
 
 namespace ov::npuw::batched {
 
+// The scoring tags that request the wrap (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED).
+// The wrapper records them so the public compiled model reports them truthfully
+// via get_property(), and they ride the batched blob header so import restores
+// them without any property being re-supplied.
+struct ScoringTags {
+    bool text_rerank = false;
+    bool text_embed = false;
+};
+
+// Extract the scoring tags from the compile properties.
+ScoringTags scoring_tags(const ov::AnyMap& properties);
+
 // True when the compile properties tag the model for batched single-shot scoring
 // (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED) -- currently the text rerank and text
 // embedding pipelines. The compile entry point uses this to decide the wrap
@@ -41,9 +53,10 @@ bool requested(const ov::AnyMap& properties);
 // valid for autoregressive generation, where state must persist across calls.
 //
 // It is applied at npuw::ICompiledModel::create() on compilation, and the wrap is
-// part of the serialized blob. export_model() writes a batched header in front of
-// the complete inner blob, so the plugin's NPUW import dispatch reconstructs the
-// wrapper from the indicator alone, with no entry point deciding anything.
+// part of the serialized blob. export_model() writes a batched header (indicator,
+// versions and the scoring tags) in front of the complete inner blob, so the
+// plugin's NPUW import dispatch reconstructs the wrapper from the header alone,
+// with no entry point deciding anything.
 class CompiledModel final : public ov::npuw::ICompiledModel {
 public:
     // Deserializes a blob written by export_model(). Consumes the batched header,
@@ -53,7 +66,8 @@ public:
                                                                   const ov::AnyMap& properties);
 
     CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
-                  const std::shared_ptr<const ov::IPlugin>& plugin);
+                  const std::shared_ptr<const ov::IPlugin>& plugin,
+                  const ScoringTags& tags);
 
     // The wrapper adds no I/O of its own -- it exposes the inner model's ports.
     const std::vector<ov::Output<const ov::Node>>& inputs() const override;
@@ -63,6 +77,9 @@ public:
     std::shared_ptr<const ov::Model> get_runtime_model() const override;
 
     void set_property(const ov::AnyMap& properties) override;
+
+    // Answers the scoring tags from the wrapper's own record; everything else is
+    // forwarded to the inner model.
     ov::Any get_property(const std::string& name) const override;
 
     void release_memory() override;
@@ -71,6 +88,7 @@ public:
 
 private:
     std::shared_ptr<ov::npuw::ICompiledModel> m_inner;
+    ScoringTags m_tags;
 };
 
 // Sync infer request that unrolls a batched inference over the single-sequence

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -73,7 +73,7 @@ public:
     const std::vector<ov::Output<const ov::Node>>& inputs() const override;
     const std::vector<ov::Output<const ov::Node>>& outputs() const override;
 
-    void export_model(std::ostream& model) const override;
+    void export_model(std::ostream& stream) const override;
     std::shared_ptr<const ov::Model> get_runtime_model() const override;
 
     void set_property(const ov::AnyMap& properties) override;
@@ -96,9 +96,9 @@ private:
 //
 // The public input tensors default to the inner request's own tensors (surfaced in
 // the constructor), so a plain batch-1 infer works exactly as on the inner. When
-// the caller binds [N, ...] inputs, infer() takes N as the largest leading
-// dimension across the inputs (an input with a leading dim of 1 is shared across
-// rows), and for each row: resets the inner variable state, binds the row's
+// the caller binds [N, ...] inputs, infer() takes N as the leading dimension the
+// batched inputs agree on (an input with a leading dim of 1 is broadcast - shared
+// across rows), and for each row: resets the inner variable state, binds the row's
 // [1, ...] view of every batched input, runs the inner request, and copies the
 // inner outputs into row i of the [N, ...] public output tensors. Caller-bound
 // output tensors are reused when they already have the right shape and type.
@@ -121,10 +121,9 @@ private:
         std::size_t batch = 1;
     };
 
-    // Snapshot the public inputs and derive the batch size: the largest leading
-    // dimension across them. Every input must either carry the batch ([N, ...],
-    // sliced per row by infer()) or be shared across rows ([1, ...], bound whole);
-    // anything else throws.
+    // Snapshot the public inputs and derive the batch size N. Every input must
+    // either carry the batch ([N, ...], sliced per row by infer()) or be broadcast
+    // ([1, ...], bound whole to every row); inputs disagreeing on N throw.
     BatchedInputs extract_batch() const;
 
     // Make the public output tensors [batch, ...] copies of the inner's [1, ...]

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -41,11 +41,10 @@ bool requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model);
 // identical and batching is purely a throughput/ergonomics choice. It is NOT
 // valid for autoregressive generation, where state must persist across calls.
 //
-// It is applied via create() at the NPUW entry points only:
-// npuw::ICompiledModel::create() on compilation and the plugin's NPUW import path
-// on blob import (the element is runtime-only and is not part of the serialized
-// blob). Both wrap the LLMCompiledModel produced there from the very same model,
-// which is what guarantees the inner is the matching batch-1 compilation.
+// It is applied at npuw::ICompiledModel::create() on compilation, and the wrap is
+// part of the serialized blob. export_model() writes a batched header in front of
+// the complete inner blob, so the plugin's NPUW import dispatch reconstructs the
+// wrapper from the indicator alone, with no entry point deciding anything.
 class CompiledModel final : public ov::npuw::ICompiledModel {
 public:
     // Factory used by the NPUW entry points. Returns the inner model unwrapped
@@ -54,6 +53,12 @@ public:
     // create() no-op paths.
     static std::shared_ptr<ov::npuw::ICompiledModel> create(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
                                                             const std::shared_ptr<const ov::IPlugin>& plugin);
+
+    // Deserializes a blob written by export_model(). Consumes the batched header,
+    // imports the nested inner blob and wraps it.
+    static std::shared_ptr<ov::npuw::ICompiledModel> import_model(std::istream& stream,
+                                                                  const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                                  const ov::AnyMap& properties);
 
     CompiledModel(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
                   const std::shared_ptr<const ov::IPlugin>& plugin);

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -18,9 +18,8 @@ namespace ov::npuw::batched {
 
 // True when the given compiled model is tagged for batched single-shot scoring --
 // currently the text rerank and text embedding pipelines. The tag is read from the
-// model's own properties (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED, recorded in its config
-// and serialized with it into the blob), which is what lets CompiledModel::create()
-// decide identically at both NPUW entry points.
+// model's own properties (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED). The compile entry
+// point uses this to decide the wrap explicitly.
 bool requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model);
 
 // A compiled-model decorator that adds batched (batch > 1) execution on top of an
@@ -47,13 +46,6 @@ bool requested(const std::shared_ptr<ov::npuw::ICompiledModel>& model);
 // wrapper from the indicator alone, with no entry point deciding anything.
 class CompiledModel final : public ov::npuw::ICompiledModel {
 public:
-    // Factory used by the NPUW entry points. Returns the inner model unwrapped
-    // when it is not tagged for batched scoring (see requested()), keeping the
-    // untagged path zero-overhead -- the same convention as the other elements'
-    // create() no-op paths.
-    static std::shared_ptr<ov::npuw::ICompiledModel> create(const std::shared_ptr<ov::npuw::ICompiledModel>& inner,
-                                                            const std::shared_ptr<const ov::IPlugin>& plugin);
-
     // Deserializes a blob written by export_model(). Consumes the batched header,
     // imports the nested inner blob and wraps it.
     static std::shared_ptr<ov::npuw::ICompiledModel> import_model(std::istream& stream,

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <mutex>
+#include <unordered_set>
 #include <vector>
 
 #include "../../compiled_model.hpp"
@@ -127,17 +128,23 @@ private:
     BatchedInputs extract_batch() const;
 
     // Make the public output tensors [batch, ...] copies of the inner's [1, ...]
-    // outputs, reusing caller-bound tensors that already fit. The wrapped model's
-    // ports are dynamic, so this can only run once the first row has been scored
-    // and the inner output shapes are known.
+    // outputs. A caller-bound tensor that already fits is kept and written into; a
+    // caller-bound tensor that does not fit throws (the element never discards a
+    // tensor the caller provided); only the element's own previous allocations are
+    // replaced freely. The wrapped model's ports are dynamic, so this can only run
+    // once the first row has been scored and the inner output shapes are known.
     void ensure_batched_outputs(std::size_t batch);
 
     // Batch-1 shortcut: publish the inner outputs as the public ones without the
-    // stacking copy. A caller-bound tensor of the fitting shape and type is still
-    // written in place instead.
+    // stacking copy. A caller-bound tensor of the fitting shape and type is
+    // written in place instead, and a mismatched caller-bound tensor throws.
     void expose_inner_outputs();
 
     std::shared_ptr<ov::IAsyncInferRequest> m_inner;
+    // The output tensors the element itself published (its own allocations and
+    // exposed inner tensors), so mismatch handling can tell them from tensors the
+    // caller bound: ours are replaced freely, the caller's are never discarded.
+    std::unordered_set<const ov::ITensor*> m_owned_outputs;
     mutable std::mutex m_mutex;
 
     // Per-phase timings of the unroll.

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -55,7 +55,7 @@ bool requested(const ov::AnyMap& properties);
 // It is applied at npuw::ICompiledModel::create() on compilation, and the wrap is
 // part of the serialized blob. export_model() writes a batched header (indicator,
 // versions and the scoring tags) in front of the complete inner blob, so the
-// plugin's NPUW import dispatch reconstructs the wrapper from the header alone,
+// common NPUW import dispatch reconstructs the wrapper from the header alone,
 // with no entry point deciding anything.
 class CompiledModel final : public ov::npuw::ICompiledModel {
 public:

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -101,8 +101,8 @@ private:
 // batched inputs agree on (an input with a leading dim of 1 is broadcast - shared
 // across rows), and for each row: resets the inner variable state, binds the row's
 // [1, ...] view of every batched input, runs the inner request, and copies the
-// inner outputs into row i of the [N, ...] public output tensors. Caller-bound
-// output tensors are reused when they already have the right shape and type.
+// inner outputs into row i of the [N, ...] public output tensors. A caller-bound
+// output tensor is written into in place, resized via set_shape() when needed.
 class InferRequest final : public ov::ISyncInferRequest {
 public:
     InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
@@ -128,22 +128,23 @@ private:
     BatchedInputs extract_batch() const;
 
     // Make the public output tensors [batch, ...] copies of the inner's [1, ...]
-    // outputs. A caller-bound tensor that already fits is kept and written into; a
-    // caller-bound tensor that does not fit throws (the element never discards a
-    // tensor the caller provided); only the element's own previous allocations are
-    // replaced freely. The wrapped model's ports are dynamic, so this can only run
-    // once the first row has been scored and the inner output shapes are known.
+    // outputs. A caller-bound tensor is never discarded: it is resized in place
+    // via set_shape() and written into (a type mismatch throws, as does set_shape
+    // on a fixed view too small for the data); only the element's own previous
+    // allocations are replaced freely. The wrapped model's ports are dynamic, so
+    // this can only run once the first row has been scored and the inner output
+    // shapes are known.
     void ensure_batched_outputs(std::size_t batch);
 
     // Batch-1 shortcut: publish the inner outputs as the public ones without the
-    // stacking copy. A caller-bound tensor of the fitting shape and type is
-    // written in place instead, and a mismatched caller-bound tensor throws.
+    // stacking copy. A caller-bound tensor is instead resized in place when needed
+    // and written into, under the same contract as ensure_batched_outputs().
     void expose_inner_outputs();
 
     std::shared_ptr<ov::IAsyncInferRequest> m_inner;
     // The output tensors the element itself published (its own allocations and
-    // exposed inner tensors), so mismatch handling can tell them from tensors the
-    // caller bound: ours are replaced freely, the caller's are never discarded.
+    // exposed inner tensors), to tell them from tensors the caller bound: ours
+    // are replaced freely, the caller's are resized in place, never discarded.
     std::unordered_set<const ov::ITensor*> m_owned_outputs;
     mutable std::mutex m_mutex;
 

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -28,12 +28,6 @@ struct ScoringTags {
 // Extract the scoring tags from the compile properties.
 ScoringTags scoring_tags(const ov::AnyMap& properties);
 
-// True when the compile properties tag the model for batched single-shot scoring
-// (NPUW_TEXT_RERANK / NPUW_TEXT_EMBED) -- currently the text rerank and text
-// embedding pipelines. The compile entry point uses this to decide the wrap
-// explicitly. Import needs no such decision, the blob indicator carries it.
-bool requested(const ov::AnyMap& properties);
-
 // A compiled-model decorator that adds batched (batch > 1) execution on top of an
 // inner compiled model that only supports a batch size of 1 (as NPUW's LLM
 // pipeline does, since it reshapes every sub-model to a static batch of 1).
@@ -95,13 +89,14 @@ private:
 // inner request.
 //
 // The public input tensors default to the inner request's own tensors (surfaced in
-// the constructor), so a plain batch-1 infer works exactly as on the inner. When
-// the caller binds [N, ...] inputs, infer() takes N as the leading dimension the
-// batched inputs agree on (an input with a leading dim of 1 is broadcast - shared
-// across rows), and for each row: resets the inner variable state, binds the row's
-// [1, ...] view of every batched input, runs the inner request, and copies the
-// inner outputs into row i of the [N, ...] public output tensors. A caller-bound
-// output tensor is written into in place, resized via set_shape() when needed.
+// the constructor), so a plain batch-1 infer works exactly as on the inner. infer()
+// takes N as the leading dimension the batched inputs agree on (an input with a
+// leading dim of 1 is broadcast - shared across rows), and for each row: resets the
+// inner variable state, binds the row's [1, ...] view of every batched input, runs
+// the inner request, and copies the inner outputs into row i of the [N, ...] public
+// output tensors. Outputs are always the element's own dense [N, ...] copies. A
+// bound output tensor is written into in place and resized via set_shape() when
+// the produced shape differs, the way plugins treat dynamic outputs.
 class InferRequest final : public ov::ISyncInferRequest {
 public:
     InferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
@@ -126,35 +121,15 @@ private:
     // ([1, ...], bound whole to every row); inputs disagreeing on N throw.
     BatchedInputs extract_batch() const;
 
-    // Make the public output tensors [batch, ...] copies of the inner's [1, ...]
-    // outputs. A caller-bound tensor is never discarded: it is resized in place
-    // via set_shape() and written into (a type mismatch throws, as does set_shape
-    // on a fixed view too small for the data); only the element's own previous
-    // allocations are replaced freely. The wrapped model's ports are dynamic, so
-    // this can only run once the first row has been scored and the inner output
-    // shapes are known.
-    void ensure_batched_outputs(std::size_t batch);
-
-    // Batch-1 shortcut: publish the inner outputs as the public ones without the
-    // stacking copy. A caller-bound tensor is instead resized in place when needed
-    // and written into, under the same contract as ensure_batched_outputs().
-    void expose_inner_outputs();
-
-    // Whether `tensor` is what the element itself last published on output
-    // `port_idx` (its own allocation or an exposed inner tensor), as opposed to
-    // a tensor the caller bound: ours are replaced freely, the caller's are
-    // resized in place, never discarded.
-    bool published_by_element(std::size_t port_idx, const ov::SoPtr<ov::ITensor>& tensor) const;
-    // Bind `tensor` to output `port_idx` and remember it as the element's own.
-    void publish_output(std::size_t port_idx,
-                        const ov::Output<const ov::Node>& port,
-                        const ov::SoPtr<ov::ITensor>& tensor);
+    // Size the public output tensors to [batch, ...] from the inner's [1, ...]
+    // outputs. An unset output gets a fresh tensor; a bound one is resized in
+    // place via set_shape() (a type mismatch throws, as does set_shape on a fixed
+    // view too small for the data). The wrapped model's ports are dynamic, so this
+    // can only run once the first row has been scored and the inner output shapes
+    // are known.
+    void prepare_outputs(std::size_t batch);
 
     std::shared_ptr<ov::IAsyncInferRequest> m_inner;
-    // Per output port, the tensor the element last published there. Held, not
-    // just remembered by address, so a caller's later allocation can never be
-    // mistaken for it.
-    std::vector<ov::SoPtr<ov::ITensor>> m_published_outputs;
     mutable std::mutex m_mutex;
 
     // Per-phase timings of the unroll.

--- a/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.hpp
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <mutex>
-#include <unordered_set>
 #include <vector>
 
 #include "../../compiled_model.hpp"
@@ -141,11 +140,21 @@ private:
     // and written into, under the same contract as ensure_batched_outputs().
     void expose_inner_outputs();
 
+    // Whether `tensor` is what the element itself last published on output
+    // `port_idx` (its own allocation or an exposed inner tensor), as opposed to
+    // a tensor the caller bound: ours are replaced freely, the caller's are
+    // resized in place, never discarded.
+    bool published_by_element(std::size_t port_idx, const ov::SoPtr<ov::ITensor>& tensor) const;
+    // Bind `tensor` to output `port_idx` and remember it as the element's own.
+    void publish_output(std::size_t port_idx,
+                        const ov::Output<const ov::Node>& port,
+                        const ov::SoPtr<ov::ITensor>& tensor);
+
     std::shared_ptr<ov::IAsyncInferRequest> m_inner;
-    // The output tensors the element itself published (its own allocations and
-    // exposed inner tensors), to tell them from tensors the caller bound: ours
-    // are replaced freely, the caller's are resized in place, never discarded.
-    std::unordered_set<const ov::ITensor*> m_owned_outputs;
+    // Per output port, the tensor the element last published there. Held, not
+    // just remembered by address, so a caller's later allocation can never be
+    // mistaken for it.
+    std::vector<ov::SoPtr<ov::ITensor>> m_published_outputs;
     mutable std::mutex m_mutex;
 
     // Per-phase timings of the unroll.

--- a/src/plugins/intel_npu/src/plugin/npuw/variable_state.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/variable_state.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/runtime/itensor.hpp"
+#include "openvino/runtime/ivariable_state.hpp"
+
+namespace ov {
+namespace npuw {
+
+// A variable state over a tensor that is bound for the lifetime of the model
+// (e.g. LoRA adapter weights), not per-inference data. It deliberately
+// implements no reset(): such a state has no meaningful "initial" value to
+// return to, so resetting it is an error.
+class VariableState final : public ov::IVariableState {
+public:
+    VariableState(const std::string& name, const ov::SoPtr<ov::ITensor>& tensor) : ov::IVariableState(name) {
+        m_state = tensor;
+        clear_state_updated();
+    }
+
+    void set_state(const ov::SoPtr<ov::ITensor>& newState) override {
+        m_state = newState;
+        m_state_updapted = true;
+    }
+
+    void reset() override {
+        OPENVINO_THROW("VariableState::reset() is not implemented");
+    }
+
+    ~VariableState() override = default;
+
+    bool is_state_updated() const {
+        return m_state_updapted;
+    }
+
+    void clear_state_updated() {
+        m_state_updapted = false;
+    }
+
+private:
+    bool m_state_updapted;
+};
+
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/sources.cmake
+++ b/src/plugins/intel_npu/src/plugin/sources.cmake
@@ -219,6 +219,8 @@ set(NPUW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/util_xarch.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/elements/accuracy_checked.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/elements/accuracy_checked.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/elements/batched.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/elements/batched.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/elements/failsafe.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/elements/failsafe.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/subgraph_pipeline.hpp

--- a/src/plugins/intel_npu/src/plugin/sources.cmake
+++ b/src/plugins/intel_npu/src/plugin/sources.cmake
@@ -224,6 +224,7 @@ set(NPUW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/elements/failsafe.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/elements/failsafe.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/v1/subgraph_pipeline.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/variable_state.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/weights_bank.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/weights_bank.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/whisper/prepare_whisper_model.cpp

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -24,6 +24,7 @@
 #include "npuw/llm_compiled_model.hpp"
 #include "npuw/orc/schema_npuw.hpp"
 #include "npuw/serialization.hpp"
+#include "npuw/v1/elements/batched.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/parameter.hpp"
@@ -173,7 +174,13 @@ std::shared_ptr<ov::ICompiledModel> import_model_npuw(std::istream& stream,
                 return ov::npuw::GQACompiledModel::import_model(stream, pluginSO, properties);
             } else if (compiled_model_indicator == NPUW_LLM_COMPILED_MODEL_INDICATOR) {
                 // Properties are required for ov::weights_path
-                return ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties);
+                auto llm_compiled_model = ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties);
+                // The batched-scoring element is a runtime-only decorator and is not
+                // part of the blob - re-apply it from the import properties, mirroring
+                // ov::npuw::ICompiledModel::create().
+                return ov::npuw::batched::CompiledModel::create(llm_compiled_model,
+                                                                pluginSO,
+                                                                ov::npuw::batched::requested(properties));
             } else if (compiled_model_indicator == NPUW_COMPILED_MODEL_INDICATOR) {
                 OPENVINO_THROW("Legacy flat NPUW CompiledModel blobs are no longer supported. Re-export the model with "
                                "the current ORC serializer.");

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -176,11 +176,13 @@ std::shared_ptr<ov::ICompiledModel> import_model_npuw(std::istream& stream,
                 // Properties are required for ov::weights_path
                 auto llm_compiled_model = ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties);
                 // The batched-scoring element is a runtime-only decorator and is not
-                // part of the blob - re-apply it from the import properties, mirroring
-                // ov::npuw::ICompiledModel::create().
-                return ov::npuw::batched::CompiledModel::create(llm_compiled_model,
-                                                                pluginSO,
-                                                                ov::npuw::batched::requested(properties));
+                // part of the blob - re-apply it by querying the imported model, whose
+                // scoring tag is restored from the blob (or re-supplied with the import
+                // properties), mirroring ov::npuw::ICompiledModel::create().
+                if (ov::npuw::batched::requested(llm_compiled_model)) {
+                    return std::make_shared<ov::npuw::batched::CompiledModel>(llm_compiled_model, pluginSO);
+                }
+                return llm_compiled_model;
             } else if (compiled_model_indicator == NPUW_COMPILED_MODEL_INDICATOR) {
                 OPENVINO_THROW("Legacy flat NPUW CompiledModel blobs are no longer supported. Re-export the model with "
                                "the current ORC serializer.");

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -174,15 +174,15 @@ std::shared_ptr<ov::ICompiledModel> import_model_npuw(std::istream& stream,
                 return ov::npuw::GQACompiledModel::import_model(stream, pluginSO, properties);
             } else if (compiled_model_indicator == NPUW_LLM_COMPILED_MODEL_INDICATOR) {
                 // Properties are required for ov::weights_path
-                auto llm_compiled_model = ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties);
+                //
                 // The batched-scoring element is a runtime-only decorator and is not
-                // part of the blob - re-apply it by querying the imported model, whose
-                // scoring tag is restored from the blob (or re-supplied with the import
-                // properties), mirroring ov::npuw::ICompiledModel::create().
-                if (ov::npuw::batched::requested(llm_compiled_model)) {
-                    return std::make_shared<ov::npuw::batched::CompiledModel>(llm_compiled_model, pluginSO);
-                }
-                return llm_compiled_model;
+                // part of the blob - batched::CompiledModel::create() re-applies it to
+                // the imported model, whose scoring tag is restored from the blob (or
+                // re-supplied with the import properties), mirroring the compile-side
+                // entry point in ov::npuw::ICompiledModel::create().
+                return ov::npuw::batched::CompiledModel::create(
+                    ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties),
+                    pluginSO);
             } else if (compiled_model_indicator == NPUW_COMPILED_MODEL_INDICATOR) {
                 OPENVINO_THROW("Legacy flat NPUW CompiledModel blobs are no longer supported. Re-export the model with "
                                "the current ORC serializer.");

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -92,15 +92,9 @@ std::shared_ptr<ov::ICompiledModel> import_model_npuw(std::istream& stream,
                 return ov::npuw::GQACompiledModel::import_model(stream, pluginSO, properties);
             } else if (compiled_model_indicator == NPUW_LLM_COMPILED_MODEL_INDICATOR) {
                 // Properties are required for ov::weights_path
-                //
-                // The batched-scoring element is a runtime-only decorator and is not
-                // part of the blob - batched::CompiledModel::create() re-applies it to
-                // the imported model, whose scoring tag is restored from the blob (or
-                // re-supplied with the import properties), mirroring the compile-side
-                // entry point in ov::npuw::ICompiledModel::create().
-                return ov::npuw::batched::CompiledModel::create(
-                    ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties),
-                    pluginSO);
+                return ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties);
+            } else if (compiled_model_indicator == NPUW_BATCHED_COMPILED_MODEL_INDICATOR) {
+                return ov::npuw::batched::CompiledModel::import_model(stream, pluginSO, properties);
             } else if (compiled_model_indicator == NPUW_COMPILED_MODEL_INDICATOR) {
                 OPENVINO_THROW("Legacy flat NPUW CompiledModel blobs are no longer supported. Re-export the model with "
                                "the current ORC serializer.");

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -19,12 +19,8 @@
 #include "intel_npu/config/options.hpp"
 #include "intel_npu/utils/utils.hpp"
 #include "npuw/compiled_model.hpp"
-#include "npuw/flux2_compiled_model.hpp"
-#include "npuw/gqa_compiled_model.hpp"
-#include "npuw/llm_compiled_model.hpp"
 #include "npuw/orc/schema_npuw.hpp"
 #include "npuw/serialization.hpp"
-#include "npuw/v1/elements/batched.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/runtime/intel_npu/properties.hpp"
@@ -81,27 +77,11 @@ std::shared_ptr<ov::ICompiledModel> import_model_npuw(std::istream& stream,
     ov::npuw::s11n::IndicatorType serialization_indicator;
     if (ov::npuw::orc::try_read_bytes(stream, serialization_indicator.data(), serialization_indicator.size()) &&
         serialization_indicator == NPUW_SERIALIZATION_INDICATOR) {
-        ov::npuw::s11n::IndicatorType compiled_model_indicator;
-        if (ov::npuw::orc::try_read_bytes(stream, compiled_model_indicator.data(), compiled_model_indicator.size())) {
-            stream.clear();
-            stream.seekg(stream_start_pos);
-
-            if (compiled_model_indicator == NPUW_FLUX2_COMPILED_MODEL_INDICATOR) {
-                return ov::npuw::Flux2CompiledModel::import_model(stream, pluginSO, properties);
-            } else if (compiled_model_indicator == NPUW_GQA_COMPILED_MODEL_INDICATOR) {
-                return ov::npuw::GQACompiledModel::import_model(stream, pluginSO, properties);
-            } else if (compiled_model_indicator == NPUW_LLM_COMPILED_MODEL_INDICATOR) {
-                // Properties are required for ov::weights_path
-                return ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties);
-            } else if (compiled_model_indicator == NPUW_BATCHED_COMPILED_MODEL_INDICATOR) {
-                return ov::npuw::batched::CompiledModel::import_model(stream, pluginSO, properties);
-            } else if (compiled_model_indicator == NPUW_COMPILED_MODEL_INDICATOR) {
-                OPENVINO_THROW("Legacy flat NPUW CompiledModel blobs are no longer supported. Re-export the model with "
-                               "the current ORC serializer.");
-            } else {
-                OPENVINO_THROW("Couldn't deserialize NPUW blob - fatal error!");
-            }
-        }
+        stream.clear();
+        stream.seekg(stream_start_pos);
+        // Every indicator-headed NPUW blob names its compiled model right after the
+        // NPUW indicator - the common dispatch picks the implementation from it.
+        return ov::npuw::ICompiledModel::import_model(stream, pluginSO, properties);
     }
     stream.clear();
     stream.seekg(stream_start_pos);

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -24,6 +24,7 @@
 #include "npuw/llm_compiled_model.hpp"
 #include "npuw/orc/schema_npuw.hpp"
 #include "npuw/serialization.hpp"
+#include "npuw/v1/elements/batched.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/runtime/intel_npu/properties.hpp"
@@ -91,7 +92,15 @@ std::shared_ptr<ov::ICompiledModel> import_model_npuw(std::istream& stream,
                 return ov::npuw::GQACompiledModel::import_model(stream, pluginSO, properties);
             } else if (compiled_model_indicator == NPUW_LLM_COMPILED_MODEL_INDICATOR) {
                 // Properties are required for ov::weights_path
-                return ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties);
+                //
+                // The batched-scoring element is a runtime-only decorator and is not
+                // part of the blob - batched::CompiledModel::create() re-applies it to
+                // the imported model, whose scoring tag is restored from the blob (or
+                // re-supplied with the import properties), mirroring the compile-side
+                // entry point in ov::npuw::ICompiledModel::create().
+                return ov::npuw::batched::CompiledModel::create(
+                    ov::npuw::LLMCompiledModel::import_model(stream, pluginSO, properties),
+                    pluginSO);
             } else if (compiled_model_indicator == NPUW_COMPILED_MODEL_INDICATOR) {
                 OPENVINO_THROW("Legacy flat NPUW CompiledModel blobs are no longer supported. Re-export the model with "
                                "the current ORC serializer.");

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -69,6 +69,7 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/util.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/util_xarch.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/v1/elements/failsafe.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/split_kvcache_into_blocks.cpp
@@ -147,6 +148,7 @@ target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/executor_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_compiled_model_graph_options_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npuw/batched_element_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/stored_tokens_state_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_infer_request_variant_switch_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/lincache_utils_test.cpp

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -77,6 +77,7 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/util.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/util_xarch.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/v1/elements/accuracy_checked.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/v1/elements/batched.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/v1/elements/failsafe.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/split_kvcache_into_blocks.cpp
@@ -163,6 +164,7 @@ target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_continuation_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_continued_prefill_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npuw/batched_element_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/stored_tokens_state_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_infer_request_variant_switch_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_infer_request_port_names_test.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -19,6 +19,11 @@
 #include <vector>
 
 #include "llm_test_helpers.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
 #include "openvino/runtime/iasync_infer_request.hpp"
 #include "openvino/runtime/icompiled_model.hpp"
 #include "openvino/runtime/isync_infer_request.hpp"
@@ -30,6 +35,9 @@ namespace {
 
 using ov::test::npuw::build_reranker_test_model;
 using ov::test::npuw::NullPlugin;
+
+// Per-output value offset the mock applies so multi-output tests can tell stacked outputs apart.
+constexpr float kOutputChannelOffset = 1000.0f;
 
 // Ordered log of the lifecycle the element drives on the inner: "reset" before each row,
 // "infer" for each row. Mirrors the events-vector pattern in failsafe.cpp / accuracy_checked.cpp.
@@ -66,6 +74,20 @@ std::string error_message(const ov::Exception& ex) {
     return ex.what() == nullptr ? std::string{} : std::string(ex.what());
 }
 
+// Minimal two-output model (one input_ids input, two f32 outputs) for the multi-output test. The
+// mock fills the outputs itself, so only the I/O signature matters.
+std::shared_ptr<ov::Model> build_two_output_model() {
+    auto ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{-1, -1});
+    ids->set_friendly_name("input_ids");
+    ids->output(0).set_names({"input_ids"});
+
+    auto as_f32 = std::make_shared<ov::op::v0::Convert>(ids, ov::element::f32);
+    auto two = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {2.0f});
+    auto scaled = std::make_shared<ov::op::v1::Multiply>(as_f32, two);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{as_f32, scaled}, ov::ParameterVector{ids}, "two_output");
+}
+
 // Batch-1 inner stand-in: echoes the row's first input_ids token across its (generically
 // shaped) output. Pure in its input, so the same row always yields the same value -- which
 // is what lets callers check that batched scoring equals per-row scoring.
@@ -82,14 +104,21 @@ public:
         const auto ids = get_tensor(port_named(get_inputs(), "input_ids"));
         const float token = static_cast<float>(static_cast<const int64_t*>(ids->data())[0]);
 
-        const auto port = get_outputs()[0];
-        ov::Shape shape;
-        for (const auto& dim : port.get_partial_shape()) {
-            shape.push_back(dim.is_static() ? static_cast<std::size_t>(dim.get_length()) : std::size_t{1});
+        // Echo the row's token across every output; output k is offset by k so multi-output
+        // tests can tell the stacked outputs apart.
+        const auto& ports = get_outputs();
+        for (std::size_t k = 0; k < ports.size(); ++k) {
+            const auto& port = ports[k];
+            ov::Shape shape;
+            for (const auto& dim : port.get_partial_shape()) {
+                shape.push_back(dim.is_static() ? static_cast<std::size_t>(dim.get_length()) : std::size_t{1});
+            }
+            auto out = ov::get_tensor_impl(ov::Tensor(port.get_element_type(), shape));
+            std::fill_n(static_cast<float*>(out->data()),
+                        out->get_size(),
+                        token + static_cast<float>(k) * kOutputChannelOffset);
+            set_tensor(port, out);
         }
-        auto out = ov::get_tensor_impl(ov::Tensor(port.get_element_type(), shape));
-        std::fill_n(static_cast<float*>(out->data()), out->get_size(), token);
-        set_tensor(port, out);
     }
 
     void check_tensors() const override {}
@@ -150,32 +179,37 @@ protected:
         return ov::npuw::batched::CompiledModel::create(m_model, m_plugin, make_inner(), enabled);
     }
 
-    // Resize a named input on the request, in place, and return it.
-    static ov::SoPtr<ov::ITensor> resize_input(const std::shared_ptr<ov::IAsyncInferRequest>& req,
-                                               const ov::SoPtr<ov::ICompiledModel>& wrapped,
+    // Resize a named input in place and return it. Templated so it serves both the async wrapper
+    // and a bare sync request -- both expose get_inputs()/get_tensor().
+    template <class Req>
+    static ov::SoPtr<ov::ITensor> resize_input(const std::shared_ptr<Req>& req,
                                                const std::string& name,
                                                const ov::Shape& shape) {
-        const auto tensor = req->get_tensor(port_named(wrapped->inputs(), name));
+        const auto tensor = req->get_tensor(port_named(req->get_inputs(), name));
         tensor->set_shape(shape);
         return tensor;
     }
 
-    // Bind the reranker inputs at the batch/length implied by `ids`. Only input_ids carries
-    // values the mock reads; attention_mask, position_ids and beam_idx just need a matching
-    // batch dimension, so they are sized but left unset.
-    static void bind_inputs(const std::shared_ptr<ov::IAsyncInferRequest>& req,
-                            const ov::SoPtr<ov::ICompiledModel>& wrapped,
-                            const std::vector<std::vector<int64_t>>& ids) {
+    // Set input_ids to [batch, len] and fill it row-major -- the only input the mock reads.
+    template <class Req>
+    static void set_input_ids(const std::shared_ptr<Req>& req, const std::vector<std::vector<int64_t>>& ids) {
         const std::size_t batch = ids.size();
         const std::size_t len = ids.empty() ? 0 : ids.front().size();
-
-        auto* tokens = static_cast<int64_t*>(resize_input(req, wrapped, "input_ids", {batch, len})->data());
+        auto* tokens = static_cast<int64_t*>(resize_input(req, "input_ids", {batch, len})->data());
         for (std::size_t r = 0; r < batch; ++r) {
             std::copy(ids[r].begin(), ids[r].end(), tokens + r * len);
         }
-        resize_input(req, wrapped, "attention_mask", {batch, len});
-        resize_input(req, wrapped, "position_ids", {batch, len});
-        resize_input(req, wrapped, "beam_idx", {batch});
+    }
+
+    // Bind the full reranker input set; the non-input_ids inputs just need a matching batch dim.
+    template <class Req>
+    static void bind_inputs(const std::shared_ptr<Req>& req, const std::vector<std::vector<int64_t>>& ids) {
+        const std::size_t batch = ids.size();
+        const std::size_t len = ids.empty() ? 0 : ids.front().size();
+        set_input_ids(req, ids);
+        resize_input(req, "attention_mask", {batch, len});
+        resize_input(req, "position_ids", {batch, len});
+        resize_input(req, "beam_idx", {batch});
     }
 
     // First element of output row r (the echoed token), independent of the output's rank.
@@ -208,7 +242,7 @@ TEST_F(NPUWBatchedElementTest, EachRowScoredIndependentlyAndStacked) {
 
     // Distinct first tokens so a misrouted row would surface as a wrong output value.
     const std::vector<std::vector<int64_t>> ids = {{11, 2, 3, 4}, {22, 5, 6, 7}, {33, 8, 9, 10}};
-    bind_inputs(req, wrapped, ids);
+    bind_inputs(req, ids);
 
     req->infer();
 
@@ -228,7 +262,7 @@ TEST_F(NPUWBatchedElementTest, SingleRowScored) {
     auto req = wrapped->create_infer_request();
 
     const std::vector<std::vector<int64_t>> ids = {{42, 8, 9, 10}};
-    bind_inputs(req, wrapped, ids);
+    bind_inputs(req, ids);
 
     req->infer();
 
@@ -243,7 +277,7 @@ TEST_F(NPUWBatchedElementTest, ZeroBatchIsRejected) {
     auto wrapped = wrap(/*enabled=*/true);
     auto req = wrapped->create_infer_request();
 
-    resize_input(req, wrapped, "input_ids", {0, 4});
+    resize_input(req, "input_ids", {0, 4});
 
     try {
         req->infer();
@@ -260,8 +294,8 @@ TEST_F(NPUWBatchedElementTest, MismatchedBatchRejected) {
     auto wrapped = wrap(/*enabled=*/true);
     auto req = wrapped->create_infer_request();
 
-    bind_inputs(req, wrapped, {{1, 2}, {3, 4}, {5, 6}});
-    resize_input(req, wrapped, "attention_mask", {2, 2});
+    bind_inputs(req, {{1, 2}, {3, 4}, {5, 6}});
+    resize_input(req, "attention_mask", {2, 2});
 
     try {
         req->infer();
@@ -270,6 +304,97 @@ TEST_F(NPUWBatchedElementTest, MismatchedBatchRejected) {
         EXPECT_NE(error_message(ex).find("neither the inferred batch size"), std::string::npos);
     }
     EXPECT_TRUE(m_recorder->events.empty());
+}
+
+// The production LLM/rerank wiring builds the element from a *sync* inner request (driven on the
+// calling thread to dodge a nested-executor deadlock), bypassing batched::CompiledModel. Exercise
+// that constructor directly.
+TEST_F(NPUWBatchedElementTest, SyncInnerConstructorScoresEachRow) {
+    auto inner_compiled = std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder);
+    std::shared_ptr<ov::ISyncInferRequest> inner_sync = inner_compiled->create_sync_infer_request();
+    std::shared_ptr<const ov::ICompiledModel> compiled = inner_compiled;
+    auto req = std::make_shared<ov::npuw::batched::InferRequest>(compiled, std::move(inner_sync));
+
+    const std::vector<std::vector<int64_t>> ids = {{11, 2, 3, 4}, {22, 5, 6, 7}, {33, 8, 9, 10}};
+    bind_inputs(req, ids);
+
+    req->infer();
+
+    const auto out = req->get_tensor(req->get_outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], ids.size());
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front())) << "output row " << r;
+    }
+    EXPECT_EQ(m_recorder->events,
+              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+// A shared/broadcast input (batch 1) is fed to every row unsliced -- the slice guard only fires
+// when the leading dim equals the batch, so a [1, L] input is never sliced out of range.
+TEST_F(NPUWBatchedElementTest, BroadcastInputSharedAcrossRows) {
+    auto wrapped = wrap(/*enabled=*/true);
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{11, 1, 1, 1}, {22, 1, 1, 1}, {33, 1, 1, 1}};
+    bind_inputs(req, ids);
+    resize_input(req, "attention_mask", {1, 4});  // shared across the 3 rows
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], ids.size());
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front())) << "output row " << r;
+    }
+    EXPECT_EQ(m_recorder->events,
+              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+// Regression: a leading batch-1 input (here input_ids, shared) must not pin the batch to 1 when a
+// later input carries the real batch. The old "first input with a batch dim wins" logic set batch=1
+// and rejected attention_mask as a mismatch; detection now takes the largest leading dim.
+TEST_F(NPUWBatchedElementTest, BatchSizeFromNonLeadingInput) {
+    auto wrapped = wrap(/*enabled=*/true);
+    auto req = wrapped->create_infer_request();
+
+    bind_inputs(req, {{7, 1, 1, 1}});             // input_ids = [1, 4], shared prompt (token 7)
+    resize_input(req, "attention_mask", {3, 4});  // real batch N = 3 on a non-leading input
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], 3u);
+    for (std::size_t r = 0; r < 3; ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), 7.0f) << "output row " << r;  // input_ids broadcast to every row
+    }
+    EXPECT_EQ(m_recorder->events,
+              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+// Each model output is stacked into its own [N, ...] tensor. The mock offsets output k by k, so the
+// two outputs must differ per row.
+TEST_F(NPUWBatchedElementTest, MultipleOutputsStackedIndependently) {
+    auto model = build_two_output_model();
+    ov::SoPtr<ov::ICompiledModel> inner{std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder), {}};
+    auto wrapped = ov::npuw::batched::CompiledModel::create(model, m_plugin, inner, /*enabled=*/true);
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
+    set_input_ids(req, ids);  // the two-output model has only input_ids
+
+    req->infer();
+
+    ASSERT_EQ(wrapped->outputs().size(), 2u);
+    const auto score = req->get_tensor(wrapped->outputs()[0]);
+    const auto hidden = req->get_tensor(wrapped->outputs()[1]);
+    ASSERT_EQ(score->get_shape()[0], ids.size());
+    ASSERT_EQ(hidden->get_shape()[0], ids.size());
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(score, r), static_cast<float>(ids[r].front()));
+        EXPECT_FLOAT_EQ(row_value(hidden, r), static_cast<float>(ids[r].front()) + kOutputChannelOffset);
+    }
+    EXPECT_EQ(m_recorder->events,
+              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
 }
 
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -1,0 +1,275 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Unit tests for the batched v1 element (ov::npuw::batched), a model-agnostic fan-out
+// decorator that unrolls a batched [N, ...] request into N batch-1 inner inferences,
+// resets inner variable state between rows, and stacks the per-row outputs back to [N, ...].
+// The element itself is the unit under test; only the inner compiled model is mocked, which
+// keeps the tests deviceless and lets them observe the per-row infer/reset. It is driven
+// through a synthetic Qwen-style reranker (realistic multi-input, stateful signature), and the
+// mock echoes each row's first token so a test can assert output row r reflects input row r.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "llm_test_helpers.hpp"
+#include "openvino/runtime/iasync_infer_request.hpp"
+#include "openvino/runtime/icompiled_model.hpp"
+#include "openvino/runtime/isync_infer_request.hpp"
+#include "openvino/runtime/ivariable_state.hpp"
+#include "openvino/runtime/make_tensor.hpp"
+#include "v1/elements/batched.hpp"
+
+namespace {
+
+using ov::test::npuw::build_reranker_test_model;
+using ov::test::npuw::NullPlugin;
+
+// Ordered log of the lifecycle the element drives on the inner: "reset" before each row,
+// "infer" for each row. Mirrors the events-vector pattern in failsafe.cpp / accuracy_checked.cpp.
+struct Recorder {
+    std::vector<std::string> events;
+};
+
+class MockState : public ov::IVariableState {
+public:
+    explicit MockState(std::shared_ptr<Recorder> rec) : ov::IVariableState("mock_state"), m_rec(std::move(rec)) {}
+    void reset() override {
+        m_rec->events.emplace_back("reset");
+    }
+    void set_state(const ov::SoPtr<ov::ITensor>&) override {}
+    ov::SoPtr<ov::ITensor> get_state() const override {
+        return {};
+    }
+
+private:
+    std::shared_ptr<Recorder> m_rec;
+};
+
+ov::Output<const ov::Node> port_named(const std::vector<ov::Output<const ov::Node>>& ports,
+                                      const std::string& needle) {
+    for (const auto& port : ports) {
+        if (port.get_any_name().find(needle) != std::string::npos) {
+            return port;
+        }
+    }
+    OPENVINO_THROW("port not found: ", needle);
+}
+
+std::string error_message(const ov::Exception& ex) {
+    return ex.what() == nullptr ? std::string{} : std::string(ex.what());
+}
+
+// Batch-1 inner stand-in: echoes the row's first input_ids token across its (generically
+// shaped) output. Pure in its input, so the same row always yields the same value -- which
+// is what lets callers check that batched scoring equals per-row scoring.
+class MockInnerSync : public ov::ISyncInferRequest {
+public:
+    MockInnerSync(std::shared_ptr<const ov::ICompiledModel> compiled_model, std::shared_ptr<Recorder> rec)
+        : ov::ISyncInferRequest(std::move(compiled_model)),
+          m_rec(std::move(rec)),
+          m_state(std::make_shared<MockState>(m_rec)) {}
+
+    void infer() override {
+        m_rec->events.emplace_back("infer");
+
+        const auto ids = get_tensor(port_named(get_inputs(), "input_ids"));
+        const float token = static_cast<float>(static_cast<const int64_t*>(ids->data())[0]);
+
+        const auto port = get_outputs()[0];
+        ov::Shape shape;
+        for (const auto& dim : port.get_partial_shape()) {
+            shape.push_back(dim.is_static() ? static_cast<std::size_t>(dim.get_length()) : std::size_t{1});
+        }
+        auto out = ov::get_tensor_impl(ov::Tensor(port.get_element_type(), shape));
+        std::fill_n(static_cast<float*>(out->data()), out->get_size(), token);
+        set_tensor(port, out);
+    }
+
+    void check_tensors() const override {}
+    std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override {
+        return {ov::SoPtr<ov::IVariableState>(m_state)};
+    }
+    std::vector<ov::ProfilingInfo> get_profiling_info() const override {
+        return {};
+    }
+
+private:
+    std::shared_ptr<Recorder> m_rec;
+    std::shared_ptr<MockState> m_state;
+};
+
+class MockInnerCompiled : public ov::ICompiledModel {
+public:
+    MockInnerCompiled(const std::shared_ptr<ov::Model>& model,
+                      const std::shared_ptr<const ov::IPlugin>& plugin,
+                      std::shared_ptr<Recorder> rec)
+        : ov::ICompiledModel(model, plugin),
+          m_rec(std::move(rec)) {}
+
+    std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override {
+        return std::make_shared<MockInnerSync>(shared_from_this(), m_rec);
+    }
+    std::shared_ptr<ov::IAsyncInferRequest> create_infer_request() const override {
+        return std::make_shared<ov::IAsyncInferRequest>(create_sync_infer_request(),
+                                                        get_task_executor(),
+                                                        get_callback_executor());
+    }
+    void export_model(std::ostream&) const override {}
+    std::shared_ptr<const ov::Model> get_runtime_model() const override {
+        return nullptr;
+    }
+    void set_property(const ov::AnyMap&) override {}
+    ov::Any get_property(const std::string&) const override {
+        return {};
+    }
+
+private:
+    std::shared_ptr<Recorder> m_rec;
+};
+
+class NPUWBatchedElementTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        m_plugin = std::make_shared<NullPlugin>();
+        m_model = build_reranker_test_model();
+        m_recorder = std::make_shared<Recorder>();
+    }
+
+    ov::SoPtr<ov::ICompiledModel> make_inner() {
+        return {std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder), {}};
+    }
+
+    ov::SoPtr<ov::ICompiledModel> wrap(bool enabled) {
+        return ov::npuw::batched::CompiledModel::create(m_model, m_plugin, make_inner(), enabled);
+    }
+
+    // Resize a named input on the request, in place, and return it.
+    static ov::SoPtr<ov::ITensor> resize_input(const std::shared_ptr<ov::IAsyncInferRequest>& req,
+                                               const ov::SoPtr<ov::ICompiledModel>& wrapped,
+                                               const std::string& name,
+                                               const ov::Shape& shape) {
+        const auto tensor = req->get_tensor(port_named(wrapped->inputs(), name));
+        tensor->set_shape(shape);
+        return tensor;
+    }
+
+    // Bind the reranker inputs at the batch/length implied by `ids`. Only input_ids carries
+    // values the mock reads; attention_mask, position_ids and beam_idx just need a matching
+    // batch dimension, so they are sized but left unset.
+    static void bind_inputs(const std::shared_ptr<ov::IAsyncInferRequest>& req,
+                            const ov::SoPtr<ov::ICompiledModel>& wrapped,
+                            const std::vector<std::vector<int64_t>>& ids) {
+        const std::size_t batch = ids.size();
+        const std::size_t len = ids.empty() ? 0 : ids.front().size();
+
+        auto* tokens = static_cast<int64_t*>(resize_input(req, wrapped, "input_ids", {batch, len})->data());
+        for (std::size_t r = 0; r < batch; ++r) {
+            std::copy(ids[r].begin(), ids[r].end(), tokens + r * len);
+        }
+        resize_input(req, wrapped, "attention_mask", {batch, len});
+        resize_input(req, wrapped, "position_ids", {batch, len});
+        resize_input(req, wrapped, "beam_idx", {batch});
+    }
+
+    // First element of output row r (the echoed token), independent of the output's rank.
+    static float row_value(const ov::SoPtr<ov::ITensor>& out, std::size_t row) {
+        const std::size_t stride = out->get_size() / out->get_shape()[0];
+        return static_cast<const float*>(out->data())[row * stride];
+    }
+
+    std::shared_ptr<ov::IPlugin> m_plugin;
+    std::shared_ptr<ov::Model> m_model;
+    std::shared_ptr<Recorder> m_recorder;
+};
+
+TEST_F(NPUWBatchedElementTest, DisabledReturnsInnerUnwrapped) {
+    auto inner = make_inner();
+    auto wrapped = ov::npuw::batched::CompiledModel::create(m_model, m_plugin, inner, /*enabled=*/false);
+    EXPECT_EQ(wrapped._ptr, inner._ptr);
+}
+
+TEST_F(NPUWBatchedElementTest, EnabledWrapsInner) {
+    auto inner = make_inner();
+    auto wrapped = ov::npuw::batched::CompiledModel::create(m_model, m_plugin, inner, /*enabled=*/true);
+    EXPECT_NE(wrapped._ptr, inner._ptr);
+    EXPECT_NE(std::dynamic_pointer_cast<ov::npuw::batched::CompiledModel>(wrapped._ptr), nullptr);
+}
+
+TEST_F(NPUWBatchedElementTest, EachRowScoredIndependentlyAndStacked) {
+    auto wrapped = wrap(/*enabled=*/true);
+    auto req = wrapped->create_infer_request();
+
+    // Distinct first tokens so a misrouted row would surface as a wrong output value.
+    const std::vector<std::vector<int64_t>> ids = {{11, 2, 3, 4}, {22, 5, 6, 7}, {33, 8, 9, 10}};
+    bind_inputs(req, wrapped, ids);
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], ids.size());
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front())) << "output row " << r;
+    }
+
+    // One inner inference per row, each preceded by a state reset, in order.
+    EXPECT_EQ(m_recorder->events,
+              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+TEST_F(NPUWBatchedElementTest, SingleRowScored) {
+    auto wrapped = wrap(/*enabled=*/true);
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{42, 8, 9, 10}};
+    bind_inputs(req, wrapped, ids);
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], 1u);
+    EXPECT_FLOAT_EQ(row_value(out, 0), static_cast<float>(ids[0].front()));
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer"}));
+}
+
+// A zero-row batch has nothing to score and would publish an unpopulated output.
+TEST_F(NPUWBatchedElementTest, ZeroBatchIsRejected) {
+    auto wrapped = wrap(/*enabled=*/true);
+    auto req = wrapped->create_infer_request();
+
+    resize_input(req, wrapped, "input_ids", {0, 4});
+
+    try {
+        req->infer();
+        FAIL() << "expected a zero-batch rejection";
+    } catch (const ov::Exception& ex) {
+        EXPECT_NE(error_message(ex).find("batch size must be > 0"), std::string::npos);
+    }
+    EXPECT_TRUE(m_recorder->events.empty());
+}
+
+// input_ids fixes N=3; an attention_mask with batch 2 (neither N nor 1) cannot be sliced
+// per row and must be rejected rather than fed whole into the batch-1 inner.
+TEST_F(NPUWBatchedElementTest, MismatchedBatchRejected) {
+    auto wrapped = wrap(/*enabled=*/true);
+    auto req = wrapped->create_infer_request();
+
+    bind_inputs(req, wrapped, {{1, 2}, {3, 4}, {5, 6}});
+    resize_input(req, wrapped, "attention_mask", {2, 2});
+
+    try {
+        req->infer();
+        FAIL() << "expected a batch-mismatch rejection";
+    } catch (const ov::Exception& ex) {
+        EXPECT_NE(error_message(ex).find("neither the inferred batch size"), std::string::npos);
+    }
+    EXPECT_TRUE(m_recorder->events.empty());
+}
+
+}  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -60,8 +60,7 @@ private:
     std::shared_ptr<Recorder> m_rec;
 };
 
-ov::Output<const ov::Node> port_named(const std::vector<ov::Output<const ov::Node>>& ports,
-                                      const std::string& needle) {
+ov::Output<const ov::Node> port_named(const std::vector<ov::Output<const ov::Node>>& ports, const std::string& needle) {
     for (const auto& port : ports) {
         if (port.get_any_name().find(needle) != std::string::npos) {
             return port;
@@ -253,8 +252,7 @@ TEST_F(NPUWBatchedElementTest, EachRowScoredIndependentlyAndStacked) {
     }
 
     // One inner inference per row, each preceded by a state reset, in order.
-    EXPECT_EQ(m_recorder->events,
-              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
 }
 
 TEST_F(NPUWBatchedElementTest, SingleRowScored) {
@@ -325,8 +323,7 @@ TEST_F(NPUWBatchedElementTest, SyncInnerConstructorScoresEachRow) {
     for (std::size_t r = 0; r < ids.size(); ++r) {
         EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front())) << "output row " << r;
     }
-    EXPECT_EQ(m_recorder->events,
-              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
 }
 
 // A shared/broadcast input (batch 1) is fed to every row unsliced -- the slice guard only fires
@@ -346,8 +343,7 @@ TEST_F(NPUWBatchedElementTest, BroadcastInputSharedAcrossRows) {
     for (std::size_t r = 0; r < ids.size(); ++r) {
         EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front())) << "output row " << r;
     }
-    EXPECT_EQ(m_recorder->events,
-              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
 }
 
 // Regression: a leading batch-1 input (here input_ids, shared) must not pin the batch to 1 when a
@@ -367,8 +363,7 @@ TEST_F(NPUWBatchedElementTest, BatchSizeFromNonLeadingInput) {
     for (std::size_t r = 0; r < 3; ++r) {
         EXPECT_FLOAT_EQ(row_value(out, r), 7.0f) << "output row " << r;  // input_ids broadcast to every row
     }
-    EXPECT_EQ(m_recorder->events,
-              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
 }
 
 // Each model output is stacked into its own [N, ...] tensor. The mock offsets output k by k, so the
@@ -393,8 +388,7 @@ TEST_F(NPUWBatchedElementTest, MultipleOutputsStackedIndependently) {
         EXPECT_FLOAT_EQ(row_value(score, r), static_cast<float>(ids[r].front()));
         EXPECT_FLOAT_EQ(row_value(hidden, r), static_cast<float>(ids[r].front()) + kOutputChannelOffset);
     }
-    EXPECT_EQ(m_recorder->events,
-              (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
 }
 
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -245,6 +245,24 @@ TEST_F(NPUWBatchedElementTest, RequestedFromModel) {
     EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}})));
 }
 
+// create() is the single gating point used by both NPUW entry points (compile and
+// blob import): tagged models come back wrapped, untagged ones pass through as-is.
+TEST_F(NPUWBatchedElementTest, CreateWrapsOnlyWhenRequested) {
+    const auto model_with = [&](ov::AnyMap props) -> std::shared_ptr<ov::npuw::ICompiledModel> {
+        return std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder, std::move(props));
+    };
+
+    const auto plain = model_with({});
+    EXPECT_EQ(ov::npuw::batched::CompiledModel::create(plain, m_plugin), plain);
+
+    const auto tagged = model_with({{"NPUW_TEXT_RERANK", true}});
+    const auto wrapped = ov::npuw::batched::CompiledModel::create(tagged, m_plugin);
+    ASSERT_NE(wrapped, nullptr);
+    ASSERT_NE(wrapped, tagged);
+    EXPECT_NE(std::dynamic_pointer_cast<ov::npuw::batched::CompiledModel>(wrapped), nullptr);
+    EXPECT_EQ(&wrapped->inputs(), &tagged->inputs());
+}
+
 TEST_F(NPUWBatchedElementTest, ForwardsInnerIO) {
     auto inner = make_inner();
     auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -139,9 +139,11 @@ class MockInnerCompiled : public ov::npuw::ICompiledModel {
 public:
     MockInnerCompiled(const std::shared_ptr<ov::Model>& model,
                       const std::shared_ptr<const ov::IPlugin>& plugin,
-                      std::shared_ptr<Recorder> rec)
+                      std::shared_ptr<Recorder> rec,
+                      ov::AnyMap props = {})
         : ov::npuw::ICompiledModel(model, plugin),
-          m_rec(std::move(rec)) {}
+          m_rec(std::move(rec)),
+          m_props(std::move(props)) {}
 
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override {
         return std::make_shared<MockInnerSync>(shared_from_this(), m_rec);
@@ -151,12 +153,22 @@ public:
         return nullptr;
     }
     void set_property(const ov::AnyMap&) override {}
-    ov::Any get_property(const std::string&) const override {
+    ov::Any get_property(const std::string& name) const override {
+        const auto it = m_props.find(name);
+        if (it != m_props.end()) {
+            return it->second;
+        }
+        // The batched element queries these scoring flags; default them to disabled so
+        // get_property(...).as<bool>() is always well-formed.
+        if (name == "NPUW_TEXT_RERANK" || name == "NPUW_TEXT_EMBED") {
+            return false;
+        }
         return {};
     }
 
 private:
     std::shared_ptr<Recorder> m_rec;
+    ov::AnyMap m_props;
 };
 
 class NPUWBatchedElementTest : public ::testing::Test {
@@ -171,8 +183,8 @@ protected:
         return std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder);
     }
 
-    std::shared_ptr<ov::npuw::ICompiledModel> wrap(bool enabled) {
-        return ov::npuw::batched::CompiledModel::create(make_inner(), m_plugin, enabled);
+    std::shared_ptr<ov::npuw::ICompiledModel> wrap() {
+        return std::make_shared<ov::npuw::batched::CompiledModel>(make_inner(), m_plugin);
     }
 
     // Bind a fresh zero-filled tensor of the port's element type to a named input.
@@ -222,32 +234,27 @@ protected:
     std::shared_ptr<Recorder> m_recorder;
 };
 
-TEST_F(NPUWBatchedElementTest, RequestedFromProperties) {
-    EXPECT_FALSE(ov::npuw::batched::requested({}));
-    EXPECT_FALSE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", false}}));
-    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", true}}));
-    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_EMBED", true}}));
-    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}}));
+TEST_F(NPUWBatchedElementTest, RequestedFromModel) {
+    const auto model_with = [&](ov::AnyMap props) -> std::shared_ptr<ov::npuw::ICompiledModel> {
+        return std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder, std::move(props));
+    };
+    EXPECT_FALSE(ov::npuw::batched::requested(model_with({})));
+    EXPECT_FALSE(ov::npuw::batched::requested(model_with({{"NPUW_TEXT_RERANK", false}})));
+    EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_TEXT_RERANK", true}})));
+    EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_TEXT_EMBED", true}})));
+    EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}})));
 }
 
-TEST_F(NPUWBatchedElementTest, DisabledReturnsInnerUnwrapped) {
+TEST_F(NPUWBatchedElementTest, ForwardsInnerIO) {
     auto inner = make_inner();
-    auto wrapped = ov::npuw::batched::CompiledModel::create(inner, m_plugin, /*enabled=*/false);
-    EXPECT_EQ(wrapped, inner);
-}
-
-TEST_F(NPUWBatchedElementTest, EnabledWrapsInner) {
-    auto inner = make_inner();
-    auto wrapped = ov::npuw::batched::CompiledModel::create(inner, m_plugin, /*enabled=*/true);
-    EXPECT_NE(wrapped, inner);
-    EXPECT_NE(std::dynamic_pointer_cast<ov::npuw::batched::CompiledModel>(wrapped), nullptr);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
     // The wrapper adds no I/O of its own -- it exposes the inner model's ports.
     EXPECT_EQ(&wrapped->inputs(), &inner->inputs());
     EXPECT_EQ(&wrapped->outputs(), &inner->outputs());
 }
 
 TEST_F(NPUWBatchedElementTest, EachRowScoredIndependentlyAndStacked) {
-    auto wrapped = wrap(/*enabled=*/true);
+    auto wrapped = wrap();
     auto req = wrapped->create_infer_request();
 
     // Distinct first tokens so a misrouted row would surface as a wrong output value.
@@ -267,7 +274,7 @@ TEST_F(NPUWBatchedElementTest, EachRowScoredIndependentlyAndStacked) {
 }
 
 TEST_F(NPUWBatchedElementTest, SingleRowScored) {
-    auto wrapped = wrap(/*enabled=*/true);
+    auto wrapped = wrap();
     auto req = wrapped->create_infer_request();
 
     const std::vector<std::vector<int64_t>> ids = {{42, 8, 9, 10}};
@@ -283,7 +290,7 @@ TEST_F(NPUWBatchedElementTest, SingleRowScored) {
 
 // A zero-row batch has nothing to score and would publish unpopulated outputs.
 TEST_F(NPUWBatchedElementTest, ZeroBatchIsRejected) {
-    auto wrapped = wrap(/*enabled=*/true);
+    auto wrapped = wrap();
     auto req = wrapped->create_infer_request();
 
     bind_inputs(req, {{1, 2, 3, 4}});
@@ -301,7 +308,7 @@ TEST_F(NPUWBatchedElementTest, ZeroBatchIsRejected) {
 // input_ids fixes N=3; an attention_mask with batch 2 (neither N nor 1) cannot be sliced
 // per row and must be rejected rather than fed whole into the batch-1 inner.
 TEST_F(NPUWBatchedElementTest, MismatchedBatchRejected) {
-    auto wrapped = wrap(/*enabled=*/true);
+    auto wrapped = wrap();
     auto req = wrapped->create_infer_request();
 
     bind_inputs(req, {{1, 2}, {3, 4}, {5, 6}});
@@ -319,7 +326,7 @@ TEST_F(NPUWBatchedElementTest, MismatchedBatchRejected) {
 // A shared input (batch 1) is fed to every row whole -- only inputs carrying the full
 // batch are sliced, so a [1, L] input is never sliced out of range.
 TEST_F(NPUWBatchedElementTest, SharedInputBoundToEveryRow) {
-    auto wrapped = wrap(/*enabled=*/true);
+    auto wrapped = wrap();
     auto req = wrapped->create_infer_request();
 
     const std::vector<std::vector<int64_t>> ids = {{11, 1, 1, 1}, {22, 1, 1, 1}, {33, 1, 1, 1}};
@@ -339,7 +346,7 @@ TEST_F(NPUWBatchedElementTest, SharedInputBoundToEveryRow) {
 // Regression: a leading batch-1 input (here input_ids, shared) must not pin the batch to 1
 // when a later input carries the real batch -- the batch is the largest leading dim.
 TEST_F(NPUWBatchedElementTest, BatchSizeFromNonLeadingInput) {
-    auto wrapped = wrap(/*enabled=*/true);
+    auto wrapped = wrap();
     auto req = wrapped->create_infer_request();
 
     bind_inputs(req, {{7, 1, 1, 1}});           // input_ids = [1, 4], shared prompt (token 7)
@@ -360,7 +367,7 @@ TEST_F(NPUWBatchedElementTest, BatchSizeFromNonLeadingInput) {
 TEST_F(NPUWBatchedElementTest, MultipleOutputsStackedIndependently) {
     auto model = build_two_output_model();
     auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
-    auto wrapped = ov::npuw::batched::CompiledModel::create(inner, m_plugin, /*enabled=*/true);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
     auto req = wrapped->create_infer_request();
 
     const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
@@ -384,7 +391,7 @@ TEST_F(NPUWBatchedElementTest, MultipleOutputsStackedIndependently) {
 TEST_F(NPUWBatchedElementTest, PreBoundOutputTensorReused) {
     auto model = build_two_output_model();
     auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
-    auto wrapped = ov::npuw::batched::CompiledModel::create(inner, m_plugin, /*enabled=*/true);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
     auto req = wrapped->create_infer_request();
 
     const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -1,0 +1,431 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Unit tests for the batched v1 element (ov::npuw::batched), a model-agnostic fan-out
+// decorator that unrolls a batched [N, ...] request into N batch-1 inner inferences,
+// resets inner variable state between rows, and writes the per-row outputs into rows
+// of the [N, ...] public output tensors. The element itself is the unit under test;
+// only the inner compiled model is mocked, which keeps the tests deviceless and lets
+// them observe the per-row infer/reset. It is driven through a synthetic Qwen-style
+// reranker (realistic multi-input, stateful signature), and the mock echoes each
+// row's first token so a test can assert output row r reflects input row r.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "llm_test_helpers.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/runtime/iasync_infer_request.hpp"
+#include "openvino/runtime/icompiled_model.hpp"
+#include "openvino/runtime/isync_infer_request.hpp"
+#include "openvino/runtime/ivariable_state.hpp"
+#include "openvino/runtime/make_tensor.hpp"
+#include "v1/elements/batched.hpp"
+
+namespace {
+
+using ov::test::npuw::build_reranker_test_model;
+using ov::test::npuw::NullPlugin;
+
+// Per-output value offset the mock applies so multi-output tests can tell stacked outputs apart.
+constexpr float kOutputChannelOffset = 1000.0f;
+
+// Ordered log of the lifecycle the element drives on the inner: "reset" before each row,
+// "infer" for each row. Mirrors the events-vector pattern in failsafe.cpp / accuracy_checked.cpp.
+struct Recorder {
+    std::vector<std::string> events;
+};
+
+class MockState : public ov::IVariableState {
+public:
+    explicit MockState(std::shared_ptr<Recorder> rec) : ov::IVariableState("mock_state"), m_rec(std::move(rec)) {}
+    void reset() override {
+        m_rec->events.emplace_back("reset");
+    }
+    void set_state(const ov::SoPtr<ov::ITensor>&) override {}
+    ov::SoPtr<ov::ITensor> get_state() const override {
+        return {};
+    }
+
+private:
+    std::shared_ptr<Recorder> m_rec;
+};
+
+ov::Output<const ov::Node> port_named(const std::vector<ov::Output<const ov::Node>>& ports, const std::string& needle) {
+    for (const auto& port : ports) {
+        if (port.get_any_name().find(needle) != std::string::npos) {
+            return port;
+        }
+    }
+    OPENVINO_THROW("port not found: ", needle);
+}
+
+std::string error_message(const ov::Exception& ex) {
+    return ex.what() == nullptr ? std::string{} : std::string(ex.what());
+}
+
+// Minimal two-output model (one input_ids input, two f32 outputs) for the multi-output test. The
+// mock fills the outputs itself, so only the I/O signature matters.
+std::shared_ptr<ov::Model> build_two_output_model() {
+    auto ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{-1, -1});
+    ids->set_friendly_name("input_ids");
+    ids->output(0).set_names({"input_ids"});
+
+    auto as_f32 = std::make_shared<ov::op::v0::Convert>(ids, ov::element::f32);
+    auto two = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {2.0f});
+    auto scaled = std::make_shared<ov::op::v1::Multiply>(as_f32, two);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{as_f32, scaled}, ov::ParameterVector{ids}, "two_output");
+}
+
+// Batch-1 inner stand-in: echoes the row's first input_ids token across its (generically
+// shaped) output. Pure in its input, so the same row always yields the same value -- which
+// is what lets callers check that batched scoring equals per-row scoring.
+class MockInnerSync : public ov::ISyncInferRequest {
+public:
+    MockInnerSync(std::shared_ptr<const ov::ICompiledModel> compiled_model, std::shared_ptr<Recorder> rec)
+        : ov::ISyncInferRequest(std::move(compiled_model)),
+          m_rec(std::move(rec)),
+          m_state(std::make_shared<MockState>(m_rec)) {}
+
+    void infer() override {
+        m_rec->events.emplace_back("infer");
+
+        const auto ids = get_tensor(port_named(get_inputs(), "input_ids"));
+        const float token = static_cast<float>(static_cast<const int64_t*>(ids->data())[0]);
+
+        // Echo the row's token across every output; output k is offset by k so multi-output
+        // tests can tell the stacked outputs apart.
+        const auto& ports = get_outputs();
+        for (std::size_t k = 0; k < ports.size(); ++k) {
+            const auto& port = ports[k];
+            ov::Shape shape;
+            for (const auto& dim : port.get_partial_shape()) {
+                shape.push_back(dim.is_static() ? static_cast<std::size_t>(dim.get_length()) : std::size_t{1});
+            }
+            auto out = ov::get_tensor_impl(ov::Tensor(port.get_element_type(), shape));
+            std::fill_n(static_cast<float*>(out->data()),
+                        out->get_size(),
+                        token + static_cast<float>(k) * kOutputChannelOffset);
+            set_tensor(port, out);
+        }
+    }
+
+    void check_tensors() const override {}
+    std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override {
+        return {ov::SoPtr<ov::IVariableState>(m_state)};
+    }
+    std::vector<ov::ProfilingInfo> get_profiling_info() const override {
+        return {};
+    }
+
+private:
+    std::shared_ptr<Recorder> m_rec;
+    std::shared_ptr<MockState> m_state;
+};
+
+class MockInnerCompiled : public ov::npuw::ICompiledModel {
+public:
+    MockInnerCompiled(const std::shared_ptr<ov::Model>& model,
+                      const std::shared_ptr<const ov::IPlugin>& plugin,
+                      std::shared_ptr<Recorder> rec,
+                      ov::AnyMap props = {})
+        : ov::npuw::ICompiledModel(model, plugin),
+          m_rec(std::move(rec)),
+          m_props(std::move(props)) {}
+
+    std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override {
+        return std::make_shared<MockInnerSync>(shared_from_this(), m_rec);
+    }
+    void export_model(std::ostream&) const override {}
+    std::shared_ptr<const ov::Model> get_runtime_model() const override {
+        return nullptr;
+    }
+    void set_property(const ov::AnyMap&) override {}
+    ov::Any get_property(const std::string& name) const override {
+        const auto it = m_props.find(name);
+        if (it != m_props.end()) {
+            return it->second;
+        }
+        // The batched element queries these scoring flags; default them to disabled so
+        // get_property(...).as<bool>() is always well-formed.
+        if (name == "NPUW_TEXT_RERANK" || name == "NPUW_TEXT_EMBED") {
+            return false;
+        }
+        return {};
+    }
+
+private:
+    std::shared_ptr<Recorder> m_rec;
+    ov::AnyMap m_props;
+};
+
+class NPUWBatchedElementTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        m_plugin = std::make_shared<NullPlugin>();
+        m_model = build_reranker_test_model();
+        m_recorder = std::make_shared<Recorder>();
+    }
+
+    std::shared_ptr<ov::npuw::ICompiledModel> make_inner() {
+        return std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder);
+    }
+
+    std::shared_ptr<ov::npuw::ICompiledModel> wrap() {
+        return std::make_shared<ov::npuw::batched::CompiledModel>(make_inner(), m_plugin);
+    }
+
+    // Bind a fresh zero-filled tensor of the port's element type to a named input.
+    template <class Req>
+    static ov::SoPtr<ov::ITensor> bind_input(const std::shared_ptr<Req>& req,
+                                             const std::string& name,
+                                             const ov::Shape& shape) {
+        const auto port = port_named(req->get_inputs(), name);
+        auto tensor = ov::get_tensor_impl(ov::Tensor(port.get_element_type(), shape));
+        if (tensor->get_byte_size() > 0) {
+            std::memset(tensor->data(), 0, tensor->get_byte_size());
+        }
+        req->set_tensor(port, tensor);
+        return tensor;
+    }
+
+    // Set input_ids to [batch, len] and fill it row-major -- the only input the mock reads.
+    template <class Req>
+    static void set_input_ids(const std::shared_ptr<Req>& req, const std::vector<std::vector<int64_t>>& ids) {
+        const std::size_t batch = ids.size();
+        const std::size_t len = ids.empty() ? 0 : ids.front().size();
+        auto* tokens = static_cast<int64_t*>(bind_input(req, "input_ids", {batch, len})->data());
+        for (std::size_t r = 0; r < batch; ++r) {
+            std::copy(ids[r].begin(), ids[r].end(), tokens + r * len);
+        }
+    }
+
+    // Bind the full reranker input set; the non-input_ids inputs just need a matching batch dim.
+    template <class Req>
+    static void bind_inputs(const std::shared_ptr<Req>& req, const std::vector<std::vector<int64_t>>& ids) {
+        const std::size_t batch = ids.size();
+        const std::size_t len = ids.empty() ? 0 : ids.front().size();
+        set_input_ids(req, ids);
+        bind_input(req, "attention_mask", {batch, len});
+        bind_input(req, "position_ids", {batch, len});
+        bind_input(req, "beam_idx", {batch});
+    }
+
+    // First element of output row r (the echoed token), independent of the output's rank.
+    static float row_value(const ov::SoPtr<ov::ITensor>& out, std::size_t row) {
+        const std::size_t stride = out->get_size() / out->get_shape()[0];
+        return static_cast<const float*>(out->data())[row * stride];
+    }
+
+    std::shared_ptr<ov::IPlugin> m_plugin;
+    std::shared_ptr<ov::Model> m_model;
+    std::shared_ptr<Recorder> m_recorder;
+};
+
+TEST_F(NPUWBatchedElementTest, RequestedFromModel) {
+    const auto model_with = [&](ov::AnyMap props) -> std::shared_ptr<ov::npuw::ICompiledModel> {
+        return std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder, std::move(props));
+    };
+    EXPECT_FALSE(ov::npuw::batched::requested(model_with({})));
+    EXPECT_FALSE(ov::npuw::batched::requested(model_with({{"NPUW_TEXT_RERANK", false}})));
+    EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_TEXT_RERANK", true}})));
+    EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_TEXT_EMBED", true}})));
+    EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}})));
+}
+
+// create() is the single gating point used by both NPUW entry points (compile and
+// blob import): tagged models come back wrapped, untagged ones pass through as-is.
+TEST_F(NPUWBatchedElementTest, CreateWrapsOnlyWhenRequested) {
+    const auto model_with = [&](ov::AnyMap props) -> std::shared_ptr<ov::npuw::ICompiledModel> {
+        return std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder, std::move(props));
+    };
+
+    const auto plain = model_with({});
+    EXPECT_EQ(ov::npuw::batched::CompiledModel::create(plain, m_plugin), plain);
+
+    const auto tagged = model_with({{"NPUW_TEXT_RERANK", true}});
+    const auto wrapped = ov::npuw::batched::CompiledModel::create(tagged, m_plugin);
+    ASSERT_NE(wrapped, nullptr);
+    ASSERT_NE(wrapped, tagged);
+    EXPECT_NE(std::dynamic_pointer_cast<ov::npuw::batched::CompiledModel>(wrapped), nullptr);
+    EXPECT_EQ(&wrapped->inputs(), &tagged->inputs());
+}
+
+TEST_F(NPUWBatchedElementTest, ForwardsInnerIO) {
+    auto inner = make_inner();
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
+    // The wrapper adds no I/O of its own -- it exposes the inner model's ports.
+    EXPECT_EQ(&wrapped->inputs(), &inner->inputs());
+    EXPECT_EQ(&wrapped->outputs(), &inner->outputs());
+}
+
+TEST_F(NPUWBatchedElementTest, EachRowScoredIndependentlyAndStacked) {
+    auto wrapped = wrap();
+    auto req = wrapped->create_infer_request();
+
+    // Distinct first tokens so a misrouted row would surface as a wrong output value.
+    const std::vector<std::vector<int64_t>> ids = {{11, 2, 3, 4}, {22, 5, 6, 7}, {33, 8, 9, 10}};
+    bind_inputs(req, ids);
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], ids.size());
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front())) << "output row " << r;
+    }
+
+    // One inner inference per row, each preceded by a state reset, in order.
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+TEST_F(NPUWBatchedElementTest, SingleRowScored) {
+    auto wrapped = wrap();
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{42, 8, 9, 10}};
+    bind_inputs(req, ids);
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], 1u);
+    EXPECT_FLOAT_EQ(row_value(out, 0), static_cast<float>(ids[0].front()));
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer"}));
+}
+
+// A zero-row batch has nothing to score and would publish unpopulated outputs.
+TEST_F(NPUWBatchedElementTest, ZeroBatchIsRejected) {
+    auto wrapped = wrap();
+    auto req = wrapped->create_infer_request();
+
+    bind_inputs(req, {{1, 2, 3, 4}});
+    bind_input(req, "input_ids", {0, 4});
+
+    try {
+        req->infer();
+        FAIL() << "expected a zero-batch rejection";
+    } catch (const ov::Exception& ex) {
+        EXPECT_NE(error_message(ex).find("zero-sized batch dimension"), std::string::npos);
+    }
+    EXPECT_TRUE(m_recorder->events.empty());
+}
+
+// input_ids fixes N=3; an attention_mask with batch 2 (neither N nor 1) cannot be sliced
+// per row and must be rejected rather than fed whole into the batch-1 inner.
+TEST_F(NPUWBatchedElementTest, MismatchedBatchRejected) {
+    auto wrapped = wrap();
+    auto req = wrapped->create_infer_request();
+
+    bind_inputs(req, {{1, 2}, {3, 4}, {5, 6}});
+    bind_input(req, "attention_mask", {2, 2});
+
+    try {
+        req->infer();
+        FAIL() << "expected a batch-mismatch rejection";
+    } catch (const ov::Exception& ex) {
+        EXPECT_NE(error_message(ex).find("neither the inferred batch size"), std::string::npos);
+    }
+    EXPECT_TRUE(m_recorder->events.empty());
+}
+
+// A shared input (batch 1) is fed to every row whole -- only inputs carrying the full
+// batch are sliced, so a [1, L] input is never sliced out of range.
+TEST_F(NPUWBatchedElementTest, SharedInputBoundToEveryRow) {
+    auto wrapped = wrap();
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{11, 1, 1, 1}, {22, 1, 1, 1}, {33, 1, 1, 1}};
+    bind_inputs(req, ids);
+    bind_input(req, "attention_mask", {1, 4});  // shared across the 3 rows
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], ids.size());
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front())) << "output row " << r;
+    }
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+// Regression: a leading batch-1 input (here input_ids, shared) must not pin the batch to 1
+// when a later input carries the real batch -- the batch is the largest leading dim.
+TEST_F(NPUWBatchedElementTest, BatchSizeFromNonLeadingInput) {
+    auto wrapped = wrap();
+    auto req = wrapped->create_infer_request();
+
+    bind_inputs(req, {{7, 1, 1, 1}});           // input_ids = [1, 4], shared prompt (token 7)
+    bind_input(req, "attention_mask", {3, 4});  // real batch N = 3 on a non-leading input
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], 3u);
+    for (std::size_t r = 0; r < 3; ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), 7.0f) << "output row " << r;  // input_ids shared with every row
+    }
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+// Each model output is stacked into its own [N, ...] tensor. The mock offsets output k by k, so the
+// two outputs must differ per row.
+TEST_F(NPUWBatchedElementTest, MultipleOutputsStackedIndependently) {
+    auto model = build_two_output_model();
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
+    set_input_ids(req, ids);  // the two-output model has only input_ids
+
+    req->infer();
+
+    ASSERT_EQ(wrapped->outputs().size(), 2u);
+    const auto score = req->get_tensor(wrapped->outputs()[0]);
+    const auto hidden = req->get_tensor(wrapped->outputs()[1]);
+    ASSERT_EQ(score->get_shape()[0], ids.size());
+    ASSERT_EQ(hidden->get_shape()[0], ids.size());
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(score, r), static_cast<float>(ids[r].front()));
+        EXPECT_FLOAT_EQ(row_value(hidden, r), static_cast<float>(ids[r].front()) + kOutputChannelOffset);
+    }
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+// A caller-bound output tensor of the right shape and type is written in place, not replaced.
+TEST_F(NPUWBatchedElementTest, PreBoundOutputTensorReused) {
+    auto model = build_two_output_model();
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
+    set_input_ids(req, ids);
+
+    // The mock produces [1, 1] outputs (dynamic dims sized to 1), so the stacked shape is [3, 1].
+    auto bound = ov::get_tensor_impl(ov::Tensor(ov::element::f32, {3, 1}));
+    req->set_tensor(wrapped->outputs()[0], bound);
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    EXPECT_EQ(out->data(), bound->data());
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front()));
+    }
+}
+
+}  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -4,16 +4,18 @@
 
 // Unit tests for the batched v1 element (ov::npuw::batched), a model-agnostic fan-out
 // decorator that unrolls a batched [N, ...] request into N batch-1 inner inferences,
-// resets inner variable state between rows, and stacks the per-row outputs back to [N, ...].
-// The element itself is the unit under test; only the inner compiled model is mocked, which
-// keeps the tests deviceless and lets them observe the per-row infer/reset. It is driven
-// through a synthetic Qwen-style reranker (realistic multi-input, stateful signature), and the
-// mock echoes each row's first token so a test can assert output row r reflects input row r.
+// resets inner variable state between rows, and writes the per-row outputs into rows
+// of the [N, ...] public output tensors. The element itself is the unit under test;
+// only the inner compiled model is mocked, which keeps the tests deviceless and lets
+// them observe the per-row infer/reset. It is driven through a synthetic Qwen-style
+// reranker (realistic multi-input, stateful signature), and the mock echoes each
+// row's first token so a test can assert output row r reflects input row r.
 
 #include <gtest/gtest.h>
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <vector>
@@ -133,21 +135,16 @@ private:
     std::shared_ptr<MockState> m_state;
 };
 
-class MockInnerCompiled : public ov::ICompiledModel {
+class MockInnerCompiled : public ov::npuw::ICompiledModel {
 public:
     MockInnerCompiled(const std::shared_ptr<ov::Model>& model,
                       const std::shared_ptr<const ov::IPlugin>& plugin,
                       std::shared_ptr<Recorder> rec)
-        : ov::ICompiledModel(model, plugin),
+        : ov::npuw::ICompiledModel(model, plugin),
           m_rec(std::move(rec)) {}
 
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override {
         return std::make_shared<MockInnerSync>(shared_from_this(), m_rec);
-    }
-    std::shared_ptr<ov::IAsyncInferRequest> create_infer_request() const override {
-        return std::make_shared<ov::IAsyncInferRequest>(create_sync_infer_request(),
-                                                        get_task_executor(),
-                                                        get_callback_executor());
     }
     void export_model(std::ostream&) const override {}
     std::shared_ptr<const ov::Model> get_runtime_model() const override {
@@ -170,22 +167,25 @@ protected:
         m_recorder = std::make_shared<Recorder>();
     }
 
-    ov::SoPtr<ov::ICompiledModel> make_inner() {
-        return {std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder), {}};
+    std::shared_ptr<ov::npuw::ICompiledModel> make_inner() {
+        return std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder);
     }
 
-    ov::SoPtr<ov::ICompiledModel> wrap(bool enabled) {
-        return ov::npuw::batched::CompiledModel::create(m_model, m_plugin, make_inner(), enabled);
+    std::shared_ptr<ov::npuw::ICompiledModel> wrap(bool enabled) {
+        return ov::npuw::batched::CompiledModel::create(make_inner(), m_plugin, enabled);
     }
 
-    // Resize a named input in place and return it. Templated so it serves both the async wrapper
-    // and a bare sync request -- both expose get_inputs()/get_tensor().
+    // Bind a fresh zero-filled tensor of the port's element type to a named input.
     template <class Req>
-    static ov::SoPtr<ov::ITensor> resize_input(const std::shared_ptr<Req>& req,
-                                               const std::string& name,
-                                               const ov::Shape& shape) {
-        const auto tensor = req->get_tensor(port_named(req->get_inputs(), name));
-        tensor->set_shape(shape);
+    static ov::SoPtr<ov::ITensor> bind_input(const std::shared_ptr<Req>& req,
+                                             const std::string& name,
+                                             const ov::Shape& shape) {
+        const auto port = port_named(req->get_inputs(), name);
+        auto tensor = ov::get_tensor_impl(ov::Tensor(port.get_element_type(), shape));
+        if (tensor->get_byte_size() > 0) {
+            std::memset(tensor->data(), 0, tensor->get_byte_size());
+        }
+        req->set_tensor(port, tensor);
         return tensor;
     }
 
@@ -194,7 +194,7 @@ protected:
     static void set_input_ids(const std::shared_ptr<Req>& req, const std::vector<std::vector<int64_t>>& ids) {
         const std::size_t batch = ids.size();
         const std::size_t len = ids.empty() ? 0 : ids.front().size();
-        auto* tokens = static_cast<int64_t*>(resize_input(req, "input_ids", {batch, len})->data());
+        auto* tokens = static_cast<int64_t*>(bind_input(req, "input_ids", {batch, len})->data());
         for (std::size_t r = 0; r < batch; ++r) {
             std::copy(ids[r].begin(), ids[r].end(), tokens + r * len);
         }
@@ -206,9 +206,9 @@ protected:
         const std::size_t batch = ids.size();
         const std::size_t len = ids.empty() ? 0 : ids.front().size();
         set_input_ids(req, ids);
-        resize_input(req, "attention_mask", {batch, len});
-        resize_input(req, "position_ids", {batch, len});
-        resize_input(req, "beam_idx", {batch});
+        bind_input(req, "attention_mask", {batch, len});
+        bind_input(req, "position_ids", {batch, len});
+        bind_input(req, "beam_idx", {batch});
     }
 
     // First element of output row r (the echoed token), independent of the output's rank.
@@ -222,17 +222,28 @@ protected:
     std::shared_ptr<Recorder> m_recorder;
 };
 
+TEST_F(NPUWBatchedElementTest, RequestedFromProperties) {
+    EXPECT_FALSE(ov::npuw::batched::requested({}));
+    EXPECT_FALSE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", false}}));
+    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", true}}));
+    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_EMBED", true}}));
+    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}}));
+}
+
 TEST_F(NPUWBatchedElementTest, DisabledReturnsInnerUnwrapped) {
     auto inner = make_inner();
-    auto wrapped = ov::npuw::batched::CompiledModel::create(m_model, m_plugin, inner, /*enabled=*/false);
-    EXPECT_EQ(wrapped._ptr, inner._ptr);
+    auto wrapped = ov::npuw::batched::CompiledModel::create(inner, m_plugin, /*enabled=*/false);
+    EXPECT_EQ(wrapped, inner);
 }
 
 TEST_F(NPUWBatchedElementTest, EnabledWrapsInner) {
     auto inner = make_inner();
-    auto wrapped = ov::npuw::batched::CompiledModel::create(m_model, m_plugin, inner, /*enabled=*/true);
-    EXPECT_NE(wrapped._ptr, inner._ptr);
-    EXPECT_NE(std::dynamic_pointer_cast<ov::npuw::batched::CompiledModel>(wrapped._ptr), nullptr);
+    auto wrapped = ov::npuw::batched::CompiledModel::create(inner, m_plugin, /*enabled=*/true);
+    EXPECT_NE(wrapped, inner);
+    EXPECT_NE(std::dynamic_pointer_cast<ov::npuw::batched::CompiledModel>(wrapped), nullptr);
+    // The wrapper adds no I/O of its own -- it exposes the inner model's ports.
+    EXPECT_EQ(&wrapped->inputs(), &inner->inputs());
+    EXPECT_EQ(&wrapped->outputs(), &inner->outputs());
 }
 
 TEST_F(NPUWBatchedElementTest, EachRowScoredIndependentlyAndStacked) {
@@ -270,18 +281,19 @@ TEST_F(NPUWBatchedElementTest, SingleRowScored) {
     EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer"}));
 }
 
-// A zero-row batch has nothing to score and would publish an unpopulated output.
+// A zero-row batch has nothing to score and would publish unpopulated outputs.
 TEST_F(NPUWBatchedElementTest, ZeroBatchIsRejected) {
     auto wrapped = wrap(/*enabled=*/true);
     auto req = wrapped->create_infer_request();
 
-    resize_input(req, "input_ids", {0, 4});
+    bind_inputs(req, {{1, 2, 3, 4}});
+    bind_input(req, "input_ids", {0, 4});
 
     try {
         req->infer();
         FAIL() << "expected a zero-batch rejection";
     } catch (const ov::Exception& ex) {
-        EXPECT_NE(error_message(ex).find("batch size must be > 0"), std::string::npos);
+        EXPECT_NE(error_message(ex).find("zero-sized batch dimension"), std::string::npos);
     }
     EXPECT_TRUE(m_recorder->events.empty());
 }
@@ -293,7 +305,7 @@ TEST_F(NPUWBatchedElementTest, MismatchedBatchRejected) {
     auto req = wrapped->create_infer_request();
 
     bind_inputs(req, {{1, 2}, {3, 4}, {5, 6}});
-    resize_input(req, "attention_mask", {2, 2});
+    bind_input(req, "attention_mask", {2, 2});
 
     try {
         req->infer();
@@ -304,37 +316,15 @@ TEST_F(NPUWBatchedElementTest, MismatchedBatchRejected) {
     EXPECT_TRUE(m_recorder->events.empty());
 }
 
-// The production LLM/rerank wiring builds the element from a *sync* inner request (driven on the
-// calling thread to dodge a nested-executor deadlock), bypassing batched::CompiledModel. Exercise
-// that constructor directly.
-TEST_F(NPUWBatchedElementTest, SyncInnerConstructorScoresEachRow) {
-    auto inner_compiled = std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder);
-    std::shared_ptr<ov::ISyncInferRequest> inner_sync = inner_compiled->create_sync_infer_request();
-    std::shared_ptr<const ov::ICompiledModel> compiled = inner_compiled;
-    auto req = std::make_shared<ov::npuw::batched::InferRequest>(compiled, std::move(inner_sync));
-
-    const std::vector<std::vector<int64_t>> ids = {{11, 2, 3, 4}, {22, 5, 6, 7}, {33, 8, 9, 10}};
-    bind_inputs(req, ids);
-
-    req->infer();
-
-    const auto out = req->get_tensor(req->get_outputs()[0]);
-    ASSERT_EQ(out->get_shape()[0], ids.size());
-    for (std::size_t r = 0; r < ids.size(); ++r) {
-        EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front())) << "output row " << r;
-    }
-    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
-}
-
-// A shared/broadcast input (batch 1) is fed to every row unsliced -- the slice guard only fires
-// when the leading dim equals the batch, so a [1, L] input is never sliced out of range.
-TEST_F(NPUWBatchedElementTest, BroadcastInputSharedAcrossRows) {
+// A shared input (batch 1) is fed to every row whole -- only inputs carrying the full
+// batch are sliced, so a [1, L] input is never sliced out of range.
+TEST_F(NPUWBatchedElementTest, SharedInputBoundToEveryRow) {
     auto wrapped = wrap(/*enabled=*/true);
     auto req = wrapped->create_infer_request();
 
     const std::vector<std::vector<int64_t>> ids = {{11, 1, 1, 1}, {22, 1, 1, 1}, {33, 1, 1, 1}};
     bind_inputs(req, ids);
-    resize_input(req, "attention_mask", {1, 4});  // shared across the 3 rows
+    bind_input(req, "attention_mask", {1, 4});  // shared across the 3 rows
 
     req->infer();
 
@@ -346,22 +336,21 @@ TEST_F(NPUWBatchedElementTest, BroadcastInputSharedAcrossRows) {
     EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
 }
 
-// Regression: a leading batch-1 input (here input_ids, shared) must not pin the batch to 1 when a
-// later input carries the real batch. The old "first input with a batch dim wins" logic set batch=1
-// and rejected attention_mask as a mismatch; detection now takes the largest leading dim.
+// Regression: a leading batch-1 input (here input_ids, shared) must not pin the batch to 1
+// when a later input carries the real batch -- the batch is the largest leading dim.
 TEST_F(NPUWBatchedElementTest, BatchSizeFromNonLeadingInput) {
     auto wrapped = wrap(/*enabled=*/true);
     auto req = wrapped->create_infer_request();
 
-    bind_inputs(req, {{7, 1, 1, 1}});             // input_ids = [1, 4], shared prompt (token 7)
-    resize_input(req, "attention_mask", {3, 4});  // real batch N = 3 on a non-leading input
+    bind_inputs(req, {{7, 1, 1, 1}});           // input_ids = [1, 4], shared prompt (token 7)
+    bind_input(req, "attention_mask", {3, 4});  // real batch N = 3 on a non-leading input
 
     req->infer();
 
     const auto out = req->get_tensor(wrapped->outputs()[0]);
     ASSERT_EQ(out->get_shape()[0], 3u);
     for (std::size_t r = 0; r < 3; ++r) {
-        EXPECT_FLOAT_EQ(row_value(out, r), 7.0f) << "output row " << r;  // input_ids broadcast to every row
+        EXPECT_FLOAT_EQ(row_value(out, r), 7.0f) << "output row " << r;  // input_ids shared with every row
     }
     EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
 }
@@ -370,8 +359,8 @@ TEST_F(NPUWBatchedElementTest, BatchSizeFromNonLeadingInput) {
 // two outputs must differ per row.
 TEST_F(NPUWBatchedElementTest, MultipleOutputsStackedIndependently) {
     auto model = build_two_output_model();
-    ov::SoPtr<ov::ICompiledModel> inner{std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder), {}};
-    auto wrapped = ov::npuw::batched::CompiledModel::create(model, m_plugin, inner, /*enabled=*/true);
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = ov::npuw::batched::CompiledModel::create(inner, m_plugin, /*enabled=*/true);
     auto req = wrapped->create_infer_request();
 
     const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
@@ -389,6 +378,29 @@ TEST_F(NPUWBatchedElementTest, MultipleOutputsStackedIndependently) {
         EXPECT_FLOAT_EQ(row_value(hidden, r), static_cast<float>(ids[r].front()) + kOutputChannelOffset);
     }
     EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+// A caller-bound output tensor of the right shape and type is written in place, not replaced.
+TEST_F(NPUWBatchedElementTest, PreBoundOutputTensorReused) {
+    auto model = build_two_output_model();
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = ov::npuw::batched::CompiledModel::create(inner, m_plugin, /*enabled=*/true);
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
+    set_input_ids(req, ids);
+
+    // The mock produces [1, 1] outputs (dynamic dims sized to 1), so the stacked shape is [3, 1].
+    auto bound = ov::get_tensor_impl(ov::Tensor(ov::element::f32, {3, 1}));
+    req->set_tensor(wrapped->outputs()[0], bound);
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    EXPECT_EQ(out->data(), bound->data());
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front()));
+    }
 }
 
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -23,6 +23,7 @@
 
 #include "llm_test_helpers.hpp"
 #include "openvino/core/model.hpp"
+#include "openvino/core/version.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/multiply.hpp"
@@ -249,6 +250,17 @@ TEST_F(NPUWBatchedElementTest, ExportWritesBatchedHeader) {
     ov::npuw::s11n::IndicatorType batched_indicator{};
     stream.read(reinterpret_cast<char*>(batched_indicator.data()), batched_indicator.size());
     EXPECT_EQ(batched_indicator, NPUW_BATCHED_COMPILED_MODEL_INDICATOR);
+
+    int vmajor = 0, vminor = 0, vpatch = 0;
+    std::string s11n_version;
+    ov::npuw::s11n::read(stream, vmajor);
+    ov::npuw::s11n::read(stream, vminor);
+    ov::npuw::s11n::read(stream, vpatch);
+    ov::npuw::s11n::read(stream, s11n_version);
+    EXPECT_EQ(vmajor, OPENVINO_VERSION_MAJOR);
+    EXPECT_EQ(vminor, OPENVINO_VERSION_MINOR);
+    EXPECT_EQ(vpatch, OPENVINO_VERSION_PATCH);
+    EXPECT_EQ(s11n_version, std::string(NPUW_SERIALIZATION_VERSION));
 
     // The mock inner writes nothing, so the header is the whole stream.
     EXPECT_EQ(stream.peek(), std::char_traits<char>::eof());

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -413,7 +413,8 @@ TEST_F(NPUWBatchedElementTest, SharedInputBoundToEveryRow) {
 }
 
 // Regression: a leading batch-1 input (here input_ids, shared) must not pin the batch to 1
-// when a later input carries the real batch -- the batch is the largest leading dim.
+// when a later input carries the real batch -- a leading dim of 1 means broadcast, and the
+// batch is whatever the batched inputs agree on.
 TEST_F(NPUWBatchedElementTest, BatchSizeFromNonLeadingInput) {
     auto wrapped = wrap();
     auto req = wrapped->create_infer_request();
@@ -477,6 +478,57 @@ TEST_F(NPUWBatchedElementTest, PreBoundOutputTensorReused) {
     for (std::size_t r = 0; r < ids.size(); ++r) {
         EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front()));
     }
+}
+
+// A caller-bound output tensor that does not fit what the inference produces is a
+// contract violation: the element never discards a caller's tensor behind their
+// back, so it throws instead of silently replacing it.
+TEST_F(NPUWBatchedElementTest, MismatchedPreBoundOutputThrows) {
+    auto model = build_two_output_model();
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
+    set_input_ids(req, ids);
+
+    // The stacked shape will be [3, 1]; bind a [2, 1] caller tensor.
+    auto bound = ov::get_tensor_impl(ov::Tensor(ov::element::f32, {2, 1}));
+    req->set_tensor(wrapped->outputs()[0], bound);
+
+    try {
+        req->infer();
+        FAIL() << "expected a mismatched caller-bound output rejection";
+    } catch (const ov::Exception& ex) {
+        EXPECT_NE(error_message(ex).find("caller tensor"), std::string::npos);
+    }
+}
+
+// Re-inferring with a different batch reallocates the outputs the element bound
+// itself -- they are the element's own, unlike a caller's tensor -- and the batch-1
+// shortcut may likewise replace them with the exposed inner outputs.
+TEST_F(NPUWBatchedElementTest, BatchChangeReallocatesElementOutputs) {
+    auto model = build_two_output_model();
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
+    auto req = wrapped->create_infer_request();
+
+    set_input_ids(req, {{11, 1}, {22, 1}, {33, 1}});
+    req->infer();
+    ASSERT_EQ(req->get_tensor(wrapped->outputs()[0])->get_shape()[0], 3u);
+
+    set_input_ids(req, {{44, 1}, {55, 1}});
+    ASSERT_NO_THROW(req->infer());
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(out->get_shape()[0], 2u);
+    EXPECT_FLOAT_EQ(row_value(out, 0), 44.0f);
+    EXPECT_FLOAT_EQ(row_value(out, 1), 55.0f);
+
+    set_input_ids(req, {{66, 1}});
+    ASSERT_NO_THROW(req->infer());
+    const auto single = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(single->get_shape()[0], 1u);
+    EXPECT_FLOAT_EQ(row_value(single, 0), 66.0f);
 }
 
 // At batch 1 the outputs skip the stacking path, but a caller-bound tensor of the

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,7 @@
 #include "openvino/runtime/isync_infer_request.hpp"
 #include "openvino/runtime/ivariable_state.hpp"
 #include "openvino/runtime/make_tensor.hpp"
+#include "serialization.hpp"
 #include "v1/elements/batched.hpp"
 
 namespace {
@@ -261,6 +263,28 @@ TEST_F(NPUWBatchedElementTest, CreateWrapsOnlyWhenRequested) {
     ASSERT_NE(wrapped, tagged);
     EXPECT_NE(std::dynamic_pointer_cast<ov::npuw::batched::CompiledModel>(wrapped), nullptr);
     EXPECT_EQ(&wrapped->inputs(), &tagged->inputs());
+}
+
+// The wrap is part of the blob. export_model() writes the batched header in front
+// of the inner blob, which is what the plugin's import dispatch keys on.
+TEST_F(NPUWBatchedElementTest, ExportWritesBatchedHeader) {
+    const auto tagged =
+        std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder, ov::AnyMap{{"NPUW_TEXT_RERANK", true}});
+    const auto wrapped = ov::npuw::batched::CompiledModel::create(tagged, m_plugin);
+
+    std::stringstream stream;
+    wrapped->export_model(stream);
+
+    ov::npuw::s11n::IndicatorType serialization_indicator{};
+    stream.read(reinterpret_cast<char*>(serialization_indicator.data()), serialization_indicator.size());
+    EXPECT_EQ(serialization_indicator, NPUW_SERIALIZATION_INDICATOR);
+
+    ov::npuw::s11n::IndicatorType batched_indicator{};
+    stream.read(reinterpret_cast<char*>(batched_indicator.data()), batched_indicator.size());
+    EXPECT_EQ(batched_indicator, NPUW_BATCHED_COMPILED_MODEL_INDICATOR);
+
+    // The mock inner writes nothing, so the header is the whole stream.
+    EXPECT_EQ(stream.peek(), std::char_traits<char>::eof());
 }
 
 TEST_F(NPUWBatchedElementTest, ForwardsInnerIO) {

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -79,6 +79,14 @@ std::string error_message(const ov::Exception& ex) {
     return ex.what() == nullptr ? std::string{} : std::string(ex.what());
 }
 
+// The fixture drives the element through a synthetic reranker, so the wrap is
+// requested with the rerank tag throughout.
+ov::npuw::batched::ScoringTags rerank_tags() {
+    ov::npuw::batched::ScoringTags tags;
+    tags.text_rerank = true;
+    return tags;
+}
+
 // Minimal two-output model (one input_ids input, two f32 outputs) for the multi-output test. The
 // mock fills the outputs itself, so only the I/O signature matters.
 std::shared_ptr<ov::Model> build_two_output_model() {
@@ -183,7 +191,7 @@ protected:
     }
 
     std::shared_ptr<ov::npuw::ICompiledModel> wrap() {
-        return std::make_shared<ov::npuw::batched::CompiledModel>(make_inner(), m_plugin);
+        return std::make_shared<ov::npuw::batched::CompiledModel>(make_inner(), m_plugin, rerank_tags());
     }
 
     // Bind a fresh zero-filled tensor of the port's element type to a named input.
@@ -270,13 +278,30 @@ TEST_F(NPUWBatchedElementTest, ExportWritesBatchedHeader) {
     EXPECT_EQ(vpatch, OPENVINO_VERSION_PATCH);
     EXPECT_EQ(s11n_version, std::string(NPUW_SERIALIZATION_VERSION));
 
+    // The scoring tags follow the version fields, so import restores them from
+    // the header alone.
+    bool text_rerank = false;
+    bool text_embed = true;
+    ov::npuw::s11n::read(stream, text_rerank);
+    ov::npuw::s11n::read(stream, text_embed);
+    EXPECT_TRUE(text_rerank);
+    EXPECT_FALSE(text_embed);
+
     // The mock inner writes nothing, so the header is the whole stream.
     EXPECT_EQ(stream.peek(), std::char_traits<char>::eof());
 }
 
+// The scoring tags are wrapper state: the inner model never records them, so the
+// wrapper answers them itself and forwards every other property.
+TEST_F(NPUWBatchedElementTest, WrapperReportsScoringTags) {
+    const auto wrapped = wrap();
+    EXPECT_TRUE(wrapped->get_property("NPUW_TEXT_RERANK").as<bool>());
+    EXPECT_FALSE(wrapped->get_property("NPUW_TEXT_EMBED").as<bool>());
+}
+
 TEST_F(NPUWBatchedElementTest, ForwardsInnerIO) {
     auto inner = make_inner();
-    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
     // The wrapper adds no I/O of its own -- it exposes the inner model's ports.
     EXPECT_EQ(&wrapped->inputs(), &inner->inputs());
     EXPECT_EQ(&wrapped->outputs(), &inner->outputs());
@@ -411,7 +436,7 @@ TEST_F(NPUWBatchedElementTest, BatchSizeFromNonLeadingInput) {
 TEST_F(NPUWBatchedElementTest, MultipleOutputsStackedIndependently) {
     auto model = build_two_output_model();
     auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
-    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
     auto req = wrapped->create_infer_request();
 
     const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
@@ -435,7 +460,7 @@ TEST_F(NPUWBatchedElementTest, MultipleOutputsStackedIndependently) {
 TEST_F(NPUWBatchedElementTest, PreBoundOutputTensorReused) {
     auto model = build_two_output_model();
     auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
-    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
     auto req = wrapped->create_infer_request();
 
     const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
@@ -459,7 +484,7 @@ TEST_F(NPUWBatchedElementTest, PreBoundOutputTensorReused) {
 TEST_F(NPUWBatchedElementTest, SingleRowPreBoundOutputWrittenInPlace) {
     auto model = build_two_output_model();
     auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
-    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
     auto req = wrapped->create_infer_request();
 
     set_input_ids(req, {{42, 1}});

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -21,7 +21,6 @@
 #include <string>
 #include <vector>
 
-#include "llm_lora_states.hpp"
 #include "llm_test_helpers.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/version.hpp"
@@ -36,6 +35,7 @@
 #include "openvino/runtime/make_tensor.hpp"
 #include "serialization.hpp"
 #include "v1/elements/batched.hpp"
+#include "variable_state.hpp"
 
 namespace {
 

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -141,11 +141,9 @@ class MockInnerCompiled : public ov::npuw::ICompiledModel {
 public:
     MockInnerCompiled(const std::shared_ptr<ov::Model>& model,
                       const std::shared_ptr<const ov::IPlugin>& plugin,
-                      std::shared_ptr<Recorder> rec,
-                      ov::AnyMap props = {})
+                      std::shared_ptr<Recorder> rec)
         : ov::npuw::ICompiledModel(model, plugin),
-          m_rec(std::move(rec)),
-          m_props(std::move(props)) {}
+          m_rec(std::move(rec)) {}
 
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override {
         return std::make_shared<MockInnerSync>(shared_from_this(), m_rec);
@@ -155,22 +153,12 @@ public:
         return nullptr;
     }
     void set_property(const ov::AnyMap&) override {}
-    ov::Any get_property(const std::string& name) const override {
-        const auto it = m_props.find(name);
-        if (it != m_props.end()) {
-            return it->second;
-        }
-        // The batched element queries these scoring flags; default them to disabled so
-        // get_property(...).as<bool>() is always well-formed.
-        if (name == "NPUW_TEXT_RERANK" || name == "NPUW_TEXT_EMBED") {
-            return false;
-        }
+    ov::Any get_property(const std::string&) const override {
         return {};
     }
 
 private:
     std::shared_ptr<Recorder> m_rec;
-    ov::AnyMap m_props;
 };
 
 class NPUWBatchedElementTest : public ::testing::Test {
@@ -236,15 +224,14 @@ protected:
     std::shared_ptr<Recorder> m_recorder;
 };
 
-TEST_F(NPUWBatchedElementTest, RequestedFromModel) {
-    const auto model_with = [&](ov::AnyMap props) -> std::shared_ptr<ov::npuw::ICompiledModel> {
-        return std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder, std::move(props));
-    };
-    EXPECT_FALSE(ov::npuw::batched::requested(model_with({})));
-    EXPECT_FALSE(ov::npuw::batched::requested(model_with({{"NPUW_TEXT_RERANK", false}})));
-    EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_TEXT_RERANK", true}})));
-    EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_TEXT_EMBED", true}})));
-    EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}})));
+TEST_F(NPUWBatchedElementTest, RequestedFromProperties) {
+    EXPECT_FALSE(ov::npuw::batched::requested({}));
+    EXPECT_FALSE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", false}}));
+    EXPECT_FALSE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", "NO"}}));
+    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", true}}));
+    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", "YES"}}));
+    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_EMBED", true}}));
+    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}}));
 }
 
 // The wrap is part of the blob. export_model() writes the batched header in front

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -431,4 +431,25 @@ TEST_F(NPUWBatchedElementTest, PreBoundOutputTensorReused) {
     }
 }
 
+// At batch 1 the outputs skip the stacking path, but a caller-bound tensor of the
+// fitting shape is still written in place rather than replaced.
+TEST_F(NPUWBatchedElementTest, SingleRowPreBoundOutputWrittenInPlace) {
+    auto model = build_two_output_model();
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin);
+    auto req = wrapped->create_infer_request();
+
+    set_input_ids(req, {{42, 1}});
+
+    auto bound = ov::get_tensor_impl(ov::Tensor(ov::element::f32, {1, 1}));
+    req->set_tensor(wrapped->outputs()[0], bound);
+
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    EXPECT_EQ(out->data(), bound->data());
+    EXPECT_FLOAT_EQ(row_value(out, 0), 42.0f);
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer"}));
+}
+
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -247,30 +247,10 @@ TEST_F(NPUWBatchedElementTest, RequestedFromModel) {
     EXPECT_TRUE(ov::npuw::batched::requested(model_with({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}})));
 }
 
-// create() is the single gating point used by both NPUW entry points (compile and
-// blob import): tagged models come back wrapped, untagged ones pass through as-is.
-TEST_F(NPUWBatchedElementTest, CreateWrapsOnlyWhenRequested) {
-    const auto model_with = [&](ov::AnyMap props) -> std::shared_ptr<ov::npuw::ICompiledModel> {
-        return std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder, std::move(props));
-    };
-
-    const auto plain = model_with({});
-    EXPECT_EQ(ov::npuw::batched::CompiledModel::create(plain, m_plugin), plain);
-
-    const auto tagged = model_with({{"NPUW_TEXT_RERANK", true}});
-    const auto wrapped = ov::npuw::batched::CompiledModel::create(tagged, m_plugin);
-    ASSERT_NE(wrapped, nullptr);
-    ASSERT_NE(wrapped, tagged);
-    EXPECT_NE(std::dynamic_pointer_cast<ov::npuw::batched::CompiledModel>(wrapped), nullptr);
-    EXPECT_EQ(&wrapped->inputs(), &tagged->inputs());
-}
-
 // The wrap is part of the blob. export_model() writes the batched header in front
 // of the inner blob, which is what the plugin's import dispatch keys on.
 TEST_F(NPUWBatchedElementTest, ExportWritesBatchedHeader) {
-    const auto tagged =
-        std::make_shared<MockInnerCompiled>(m_model, m_plugin, m_recorder, ov::AnyMap{{"NPUW_TEXT_RERANK", true}});
-    const auto wrapped = ov::npuw::batched::CompiledModel::create(tagged, m_plugin);
+    const auto wrapped = wrap();
 
     std::stringstream stream;
     wrapped->export_model(stream);

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include "llm_lora_states.hpp"
 #include "llm_test_helpers.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/version.hpp"
@@ -100,7 +101,10 @@ public:
     MockInnerSync(std::shared_ptr<const ov::ICompiledModel> compiled_model, std::shared_ptr<Recorder> rec)
         : ov::ISyncInferRequest(std::move(compiled_model)),
           m_rec(std::move(rec)),
-          m_state(std::make_shared<MockState>(m_rec)) {}
+          m_state(std::make_shared<MockState>(m_rec)),
+          m_adapter_state(std::make_shared<ov::npuw::VariableState>(
+              "lora_state.MatMul.A",
+              ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{1})))) {}
 
     void infer() override {
         m_rec->events.emplace_back("infer");
@@ -126,8 +130,11 @@ public:
     }
 
     void check_tensors() const override {}
+    // Every mock request also carries a LoRA adapter state, whose reset() throws by
+    // design. Its presence in every test guards the element's skip of adapter states
+    // in the per-row reset; only the recording MockState is expected to be reset.
     std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override {
-        return {ov::SoPtr<ov::IVariableState>(m_state)};
+        return {ov::SoPtr<ov::IVariableState>(m_state), ov::SoPtr<ov::IVariableState>(m_adapter_state)};
     }
     std::vector<ov::ProfilingInfo> get_profiling_info() const override {
         return {};
@@ -136,6 +143,7 @@ public:
 private:
     std::shared_ptr<Recorder> m_rec;
     std::shared_ptr<MockState> m_state;
+    std::shared_ptr<ov::npuw::VariableState> m_adapter_state;
 };
 
 class MockInnerCompiled : public ov::npuw::ICompiledModel {
@@ -292,6 +300,21 @@ TEST_F(NPUWBatchedElementTest, EachRowScoredIndependentlyAndStacked) {
 
     // One inner inference per row, each preceded by a state reset, in order.
     EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer", "reset", "infer"}));
+}
+
+// LoRA adapter states carry the adapter weights and their reset() throws, so the
+// element must leave them out of the per-row reset. The mock inner exposes such a
+// state on every request; a multi-row infer completing at all proves the skip, and
+// the event log proves the ordinary state still gets its per-row reset.
+TEST_F(NPUWBatchedElementTest, AdapterStateExcludedFromRowResets) {
+    auto wrapped = wrap();
+    auto req = wrapped->create_infer_request();
+
+    const std::vector<std::vector<int64_t>> ids = {{5, 1, 1, 1}, {6, 2, 2, 2}};
+    bind_inputs(req, ids);
+
+    ASSERT_NO_THROW(req->infer());
+    EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer", "reset", "infer"}));
 }
 
 TEST_F(NPUWBatchedElementTest, SingleRowScored) {

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -480,10 +480,10 @@ TEST_F(NPUWBatchedElementTest, PreBoundOutputTensorReused) {
     }
 }
 
-// A caller-bound output tensor that does not fit what the inference produces is a
-// contract violation: the element never discards a caller's tensor behind their
-// back, so it throws instead of silently replacing it.
-TEST_F(NPUWBatchedElementTest, MismatchedPreBoundOutputThrows) {
+// A caller-bound output tensor is never replaced: one of the wrong shape is
+// resized in place via set_shape once the produced shape is known, the way
+// plugins treat dynamic outputs, and the rows land in the caller's tensor.
+TEST_F(NPUWBatchedElementTest, PreBoundOutputResizedInPlace) {
     auto model = build_two_output_model();
     auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
     auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
@@ -492,16 +492,80 @@ TEST_F(NPUWBatchedElementTest, MismatchedPreBoundOutputThrows) {
     const std::vector<std::vector<int64_t>> ids = {{11, 1}, {22, 1}, {33, 1}};
     set_input_ids(req, ids);
 
-    // The stacked shape will be [3, 1]; bind a [2, 1] caller tensor.
+    // The stacked shape will be [3, 1]; bind an undersized [2, 1] caller tensor.
     auto bound = ov::get_tensor_impl(ov::Tensor(ov::element::f32, {2, 1}));
     req->set_tensor(wrapped->outputs()[0], bound);
 
-    try {
-        req->infer();
-        FAIL() << "expected a mismatched caller-bound output rejection";
-    } catch (const ov::Exception& ex) {
-        EXPECT_NE(error_message(ex).find("caller tensor"), std::string::npos);
+    req->infer();
+
+    const auto out = req->get_tensor(wrapped->outputs()[0]);
+    EXPECT_EQ(out._ptr, bound._ptr);
+    ASSERT_EQ(out->get_shape(), (ov::Shape{3, 1}));
+    for (std::size_t r = 0; r < ids.size(); ++r) {
+        EXPECT_FLOAT_EQ(row_value(out, r), static_cast<float>(ids[r].front()));
     }
+}
+
+// The caller's tensor stays bound across batch changes, resized each time --
+// including down through the batch-1 shortcut path.
+TEST_F(NPUWBatchedElementTest, PreBoundOutputResizedAcrossBatchChanges) {
+    auto model = build_two_output_model();
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
+    auto req = wrapped->create_infer_request();
+
+    auto bound = ov::get_tensor_impl(ov::Tensor(ov::element::f32, {3, 1}));
+    req->set_tensor(wrapped->outputs()[0], bound);
+
+    set_input_ids(req, {{11, 1}, {22, 1}, {33, 1}});
+    req->infer();
+    ASSERT_EQ(req->get_tensor(wrapped->outputs()[0])._ptr, bound._ptr);
+
+    set_input_ids(req, {{44, 1}, {55, 1}});
+    req->infer();
+    auto out = req->get_tensor(wrapped->outputs()[0]);
+    EXPECT_EQ(out._ptr, bound._ptr);
+    ASSERT_EQ(out->get_shape(), (ov::Shape{2, 1}));
+    EXPECT_FLOAT_EQ(row_value(out, 0), 44.0f);
+    EXPECT_FLOAT_EQ(row_value(out, 1), 55.0f);
+
+    set_input_ids(req, {{66, 1}});
+    req->infer();
+    out = req->get_tensor(wrapped->outputs()[0]);
+    EXPECT_EQ(out._ptr, bound._ptr);
+    ASSERT_EQ(out->get_shape(), (ov::Shape{1, 1}));
+    EXPECT_FLOAT_EQ(row_value(out, 0), 66.0f);
+}
+
+// A type mismatch cannot be resized away: the base request already rejects the
+// bind itself (the element's own type check only backstops dynamic-typed ports).
+TEST_F(NPUWBatchedElementTest, PreBoundOutputTypeMismatchThrows) {
+    auto model = build_two_output_model();
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
+    auto req = wrapped->create_infer_request();
+
+    set_input_ids(req, {{11, 1}, {22, 1}, {33, 1}});
+
+    auto bound = ov::get_tensor_impl(ov::Tensor(ov::element::f16, {3, 1}));
+    EXPECT_THROW(req->set_tensor(wrapped->outputs()[0], bound), ov::Exception);
+}
+
+// A fixed-capacity view over caller memory that cannot hold the result throws
+// from set_shape itself rather than being silently replaced.
+TEST_F(NPUWBatchedElementTest, NonResizablePreBoundOutputThrows) {
+    auto model = build_two_output_model();
+    auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
+    auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
+    auto req = wrapped->create_infer_request();
+
+    set_input_ids(req, {{11, 1}, {22, 1}, {33, 1}});
+
+    float caller_memory[2] = {};
+    auto bound = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{2, 1}, caller_memory));
+    req->set_tensor(wrapped->outputs()[0], bound);
+
+    EXPECT_THROW(req->infer(), ov::Exception);
 }
 
 // Re-inferring with a different batch reallocates the outputs the element bound

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -241,14 +241,17 @@ protected:
     std::shared_ptr<Recorder> m_recorder;
 };
 
-TEST_F(NPUWBatchedElementTest, RequestedFromProperties) {
-    EXPECT_FALSE(ov::npuw::batched::requested({}));
-    EXPECT_FALSE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", false}}));
-    EXPECT_FALSE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", "NO"}}));
-    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", true}}));
-    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_RERANK", "YES"}}));
-    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_TEXT_EMBED", true}}));
-    EXPECT_TRUE(ov::npuw::batched::requested({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}}));
+TEST_F(NPUWBatchedElementTest, ScoringTagsFromProperties) {
+    using ov::npuw::batched::scoring_tags;
+    EXPECT_FALSE(scoring_tags({}).text_rerank);
+    EXPECT_FALSE(scoring_tags({}).text_embed);
+    EXPECT_FALSE(scoring_tags({{"NPUW_TEXT_RERANK", false}}).text_rerank);
+    EXPECT_FALSE(scoring_tags({{"NPUW_TEXT_RERANK", "NO"}}).text_rerank);
+    EXPECT_TRUE(scoring_tags({{"NPUW_TEXT_RERANK", true}}).text_rerank);
+    EXPECT_TRUE(scoring_tags({{"NPUW_TEXT_RERANK", "YES"}}).text_rerank);
+    EXPECT_TRUE(scoring_tags({{"NPUW_TEXT_EMBED", true}}).text_embed);
+    EXPECT_FALSE(scoring_tags({{"NPUW_TEXT_EMBED", true}}).text_rerank);
+    EXPECT_TRUE(scoring_tags({{"NPUW_LLM", true}, {"NPUW_TEXT_RERANK", true}}).text_rerank);
 }
 
 // The wrap is part of the blob. export_model() writes the batched header in front
@@ -506,8 +509,8 @@ TEST_F(NPUWBatchedElementTest, PreBoundOutputResizedInPlace) {
     }
 }
 
-// The caller's tensor stays bound across batch changes, resized each time --
-// including down through the batch-1 shortcut path.
+// The caller's tensor stays bound across batch changes, resized each time,
+// including down to a single row.
 TEST_F(NPUWBatchedElementTest, PreBoundOutputResizedAcrossBatchChanges) {
     auto model = build_two_output_model();
     auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
@@ -568,10 +571,9 @@ TEST_F(NPUWBatchedElementTest, NonResizablePreBoundOutputThrows) {
     EXPECT_THROW(req->infer(), ov::Exception);
 }
 
-// Re-inferring with a different batch reallocates the outputs the element bound
-// itself -- they are the element's own, unlike a caller's tensor -- and the batch-1
-// shortcut may likewise replace them with the exposed inner outputs.
-TEST_F(NPUWBatchedElementTest, BatchChangeReallocatesElementOutputs) {
+// With no output bound, the element allocates one on the first infer and keeps
+// resizing that same tensor as the batch changes, growing and shrinking.
+TEST_F(NPUWBatchedElementTest, BatchChangeResizesElementOutputs) {
     auto model = build_two_output_model();
     auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);
     auto wrapped = std::make_shared<ov::npuw::batched::CompiledModel>(inner, m_plugin, rerank_tags());
@@ -579,11 +581,13 @@ TEST_F(NPUWBatchedElementTest, BatchChangeReallocatesElementOutputs) {
 
     set_input_ids(req, {{11, 1}, {22, 1}, {33, 1}});
     req->infer();
-    ASSERT_EQ(req->get_tensor(wrapped->outputs()[0])->get_shape()[0], 3u);
+    const auto first = req->get_tensor(wrapped->outputs()[0]);
+    ASSERT_EQ(first->get_shape()[0], 3u);
 
     set_input_ids(req, {{44, 1}, {55, 1}});
     ASSERT_NO_THROW(req->infer());
     const auto out = req->get_tensor(wrapped->outputs()[0]);
+    EXPECT_EQ(out._ptr, first._ptr);
     ASSERT_EQ(out->get_shape()[0], 2u);
     EXPECT_FLOAT_EQ(row_value(out, 0), 44.0f);
     EXPECT_FLOAT_EQ(row_value(out, 1), 55.0f);
@@ -591,12 +595,21 @@ TEST_F(NPUWBatchedElementTest, BatchChangeReallocatesElementOutputs) {
     set_input_ids(req, {{66, 1}});
     ASSERT_NO_THROW(req->infer());
     const auto single = req->get_tensor(wrapped->outputs()[0]);
+    EXPECT_EQ(single._ptr, first._ptr);
     ASSERT_EQ(single->get_shape()[0], 1u);
     EXPECT_FLOAT_EQ(row_value(single, 0), 66.0f);
+
+    set_input_ids(req, {{77, 1}, {88, 1}, {99, 1}, {100, 1}});
+    ASSERT_NO_THROW(req->infer());
+    const auto grown = req->get_tensor(wrapped->outputs()[0]);
+    EXPECT_EQ(grown._ptr, first._ptr);
+    ASSERT_EQ(grown->get_shape()[0], 4u);
+    EXPECT_FLOAT_EQ(row_value(grown, 3), 100.0f);
 }
 
-// At batch 1 the outputs skip the stacking path, but a caller-bound tensor of the
-// fitting shape is still written in place rather than replaced.
+// A single row goes through the same path: a caller-bound tensor of the fitting
+// shape is written in place, and the public output is the element's own copy,
+// never the inner's tensor.
 TEST_F(NPUWBatchedElementTest, SingleRowPreBoundOutputWrittenInPlace) {
     auto model = build_two_output_model();
     auto inner = std::make_shared<MockInnerCompiled>(model, m_plugin, m_recorder);

--- a/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/batched_element_test.cpp
@@ -32,13 +32,16 @@
 #include "openvino/runtime/icompiled_model.hpp"
 #include "openvino/runtime/isync_infer_request.hpp"
 #include "openvino/runtime/ivariable_state.hpp"
+#include "openvino/runtime/core.hpp"
 #include "openvino/runtime/make_tensor.hpp"
+#include "openvino/runtime/properties.hpp"
 #include "serialization.hpp"
 #include "v1/elements/batched.hpp"
 #include "variable_state.hpp"
 
 namespace {
 
+using ov::test::npuw::build_llm_test_model;
 using ov::test::npuw::build_reranker_test_model;
 using ov::test::npuw::NullPlugin;
 
@@ -628,5 +631,77 @@ TEST_F(NPUWBatchedElementTest, SingleRowPreBoundOutputWrittenInPlace) {
     EXPECT_FLOAT_EQ(row_value(out, 0), 42.0f);
     EXPECT_EQ(m_recorder->events, (std::vector<std::string>{"reset", "infer"}));
 }
+
+// The wrap is part of the blob end to end. A real LLM compiled through NPUW on
+// CPU with the rerank tag exports a batched blob, the import dispatch rebuilds
+// the wrapper from it (tag restored, no property re-supplied beyond the model
+// pointer the weightless blob needs), and the imported model stacks a batch row
+// for row like the compiled one scores single prompts.
+TEST(NPUWBatchedElementRoundTrip, ExportImportRebuildsTheWrapAndStacks) {
+    constexpr std::size_t kRows = 3;
+    constexpr std::size_t kLen = 6;
+
+    ov::Core core;
+    auto model = build_llm_test_model();
+    // The online partitioner's repeated-block detection does not cope with the
+    // synthetic model, so the sub-models are compiled whole on CPU.
+    const ov::AnyMap props = {{"NPU_USE_NPUW", "YES"},
+                              {"NPUW_LLM", "YES"},
+                              {"NPUW_DEVICES", "CPU"},
+                              {"NPUW_ONLINE_PIPELINE", "NONE"},
+                              {"NPUW_LLM_MAX_PROMPT_LEN", "32"},
+                              {"NPUW_LLM_MIN_RESPONSE_LEN", "8"},
+                              {"NPUW_TEXT_RERANK", "YES"}};
+    auto compiled = core.compile_model(model, "NPU", props);
+    ASSERT_TRUE(compiled.get_property("NPUW_TEXT_RERANK").as<bool>());
+
+    std::stringstream blob;
+    compiled.export_model(blob);
+    auto import_props = props;
+    import_props[ov::hint::model.name()] = std::static_pointer_cast<const ov::Model>(model);
+    auto imported = core.import_model(blob, "NPU", import_props);
+    EXPECT_TRUE(imported.get_property("NPUW_TEXT_RERANK").as<bool>());
+
+    // Row r of a batch carries tokens 1 + first_row + r, so batched row r on the
+    // imported model must equal a single-row infer of the same prompt on the
+    // compiled one.
+    const auto score = [&](ov::CompiledModel& cm, std::size_t rows, std::size_t first_row) {
+        auto req = cm.create_infer_request();
+        ov::Tensor input_ids(ov::element::i64, {rows, kLen});
+        ov::Tensor attention_mask(ov::element::i64, {rows, kLen});
+        ov::Tensor position_ids(ov::element::i64, {rows, kLen});
+        ov::Tensor beam_idx(ov::element::i32, {rows});
+        for (std::size_t r = 0; r < rows; ++r) {
+            for (std::size_t t = 0; t < kLen; ++t) {
+                input_ids.data<int64_t>()[r * kLen + t] = static_cast<int64_t>(1 + first_row + r + t);
+                attention_mask.data<int64_t>()[r * kLen + t] = 1;
+                position_ids.data<int64_t>()[r * kLen + t] = static_cast<int64_t>(t);
+            }
+            beam_idx.data<int32_t>()[r] = 0;
+        }
+        req.set_tensor("input_ids", input_ids);
+        req.set_tensor("attention_mask", attention_mask);
+        req.set_tensor("position_ids", position_ids);
+        req.set_tensor("beam_idx", beam_idx);
+        req.infer();
+        ov::Tensor out(req.get_output_tensor(0).get_element_type(), req.get_output_tensor(0).get_shape());
+        req.get_output_tensor(0).copy_to(out);
+        return out;
+    };
+
+    const auto batched = score(imported, kRows, 0);
+    ASSERT_EQ(batched.get_shape()[0], kRows);
+    const std::size_t row_elems = batched.get_size() / kRows;
+    for (std::size_t r = 0; r < kRows; ++r) {
+        const auto single = score(compiled, 1, r);
+        ASSERT_EQ(single.get_size(), row_elems) << "row " << r;
+        const float* got = batched.data<float>() + r * row_elems;
+        const float* want = single.data<float>();
+        for (std::size_t i = 0; i < row_elems; ++i) {
+            ASSERT_NEAR(got[i], want[i], 1e-5f) << "row " << r << " element " << i;
+        }
+    }
+}
+
 
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
@@ -295,6 +295,24 @@ TEST_F(LLMCompiledModelFactoryOptionsTest, VisibleLlmPropertiesRoundTripThroughC
     EXPECT_EQ(compiled->get_property("NPUW_LLM_PREFILL_CHUNK_SIZE").as<uint64_t>(), 0u);
 }
 
+// The rerank tag must land in the model's own config - that is what the batched-element
+// entry points query, and what the blob serialization persists - while staying out of
+// the submodel configs.
+TEST_F(LLMCompiledModelFactoryOptionsTest, TextRerankTagRecordedInConfigAndKeptOutOfStageConfigs) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(build_llm_model(), {{"NPUW_TEXT_RERANK", "YES"}}, recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    EXPECT_TRUE(compiled->get_property("NPUW_TEXT_RERANK").as<bool>());
+
+    const auto& prefill = require_call(recorder, "_prefill");
+    const auto& generate = require_call_containing(recorder, "_kv");
+    expect_missing_prop(prefill.props, "NPUW_TEXT_RERANK");
+    expect_missing_prop(generate.props, "NPUW_TEXT_RERANK");
+}
+
 TEST_F(LLMCompiledModelFactoryOptionsTest, DefaultStageConfigsCarryBaselineNpuwOptions) {
     RecordingFactory recorder;
     std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
@@ -302,17 +302,14 @@ TEST_F(LLMCompiledModelFactoryOptionsTest, VisibleLlmPropertiesRoundTripThroughC
     EXPECT_EQ(compiled->get_property("NPUW_LLM_PREFILL_CHUNK_SIZE").as<uint64_t>(), 0u);
 }
 
-// The rerank tag must land in the model's own config - that is what the batched-element
-// entry points query, and what the blob serialization persists - while staying out of
-// the submodel configs.
-TEST_F(LLMCompiledModelFactoryOptionsTest, TextRerankTagRecordedInConfigAndKeptOutOfStageConfigs) {
+// The rerank tag only gates the batched wrapper at the entry point and must stay
+// out of the submodel configs.
+TEST_F(LLMCompiledModelFactoryOptionsTest, TextRerankTagKeptOutOfStageConfigs) {
     RecordingFactory recorder;
     std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
 
     ASSERT_NO_THROW(compiled = create_compiled_model(build_llm_model(), {{"NPUW_TEXT_RERANK", "YES"}}, recorder));
     ASSERT_NE(compiled, nullptr);
-
-    EXPECT_TRUE(compiled->get_property("NPUW_TEXT_RERANK").as<bool>());
 
     const auto& prefill = require_call(recorder, "_prefill");
     const auto& generate = require_call_containing(recorder, "_kv");

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
@@ -302,6 +302,24 @@ TEST_F(LLMCompiledModelFactoryOptionsTest, VisibleLlmPropertiesRoundTripThroughC
     EXPECT_EQ(compiled->get_property("NPUW_LLM_PREFILL_CHUNK_SIZE").as<uint64_t>(), 0u);
 }
 
+// The rerank tag must land in the model's own config - that is what the batched-element
+// entry points query, and what the blob serialization persists - while staying out of
+// the submodel configs.
+TEST_F(LLMCompiledModelFactoryOptionsTest, TextRerankTagRecordedInConfigAndKeptOutOfStageConfigs) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(build_llm_model(), {{"NPUW_TEXT_RERANK", "YES"}}, recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    EXPECT_TRUE(compiled->get_property("NPUW_TEXT_RERANK").as<bool>());
+
+    const auto& prefill = require_call(recorder, "_prefill");
+    const auto& generate = require_call_containing(recorder, "_kv");
+    expect_missing_prop(prefill.props, "NPUW_TEXT_RERANK");
+    expect_missing_prop(generate.props, "NPUW_TEXT_RERANK");
+}
+
 TEST_F(LLMCompiledModelFactoryOptionsTest, DefaultStageConfigsCarryBaselineNpuwOptions) {
     RecordingFactory recorder;
     std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
@@ -100,6 +100,22 @@ inline std::shared_ptr<ov::Model> build_llm_gqa_test_model() {
     return mb.build_llm(make_test_model_config_gqa());
 }
 
+/// Minimal Qwen3-style reranker: a GQA causal decoder with RMSNorm and per-head
+/// Q/K normalization, stateful KV cache and an LM head (logits output). Matches the
+/// I/O signature of Qwen3-Reranker (input_ids/attention_mask/position_ids + beam_idx),
+/// which is what the batched scoring element fans out over.
+inline LLMConfig make_test_model_config_reranker() {
+    auto cfg = make_test_model_config_gqa();
+    cfg.norm = RMSNorm(cfg.hidden_size, cfg.precision);
+    cfg.qk_norm = RMSNorm(cfg.head_dim, cfg.precision);
+    return cfg;
+}
+
+inline std::shared_ptr<ov::Model> build_reranker_test_model() {
+    ModelBuilder mb;
+    return mb.build_llm(make_test_model_config_reranker());
+}
+
 inline std::shared_ptr<ov::Model> build_llm_test_model_with_kv_fake_convert(const ov::element::Type fake_convert_type) {
     auto model = build_llm_test_model();
     auto scale = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.0f});

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
@@ -69,8 +69,7 @@ inline std::shared_ptr<ov::Model> build_dynamic_attention_llm_model() {
     for (const auto& input : model->inputs()) {
         const auto& name = input.get_any_name();
         const auto& pshape = input.get_partial_shape();
-        if (name.find("input_ids") != std::string::npos ||
-            name.find("token_type_ids") != std::string::npos) {
+        if (name.find("input_ids") != std::string::npos || name.find("token_type_ids") != std::string::npos) {
             new_shapes[name] = ov::PartialShape{1, kSeq};
         } else if (name.find("attention_mask") != std::string::npos) {
             new_shapes[name] = ov::PartialShape{1, kSeq + kPast};
@@ -129,8 +128,7 @@ inline std::shared_ptr<ov::Model> build_llm_test_model_with_kv_fake_convert(cons
         auto inject_fake_convert = [&](size_t input_idx, const std::string& suffix) {
             auto fake_convert_1 =
                 std::make_shared<ov::op::v13::FakeConvert>(sdpa->input_value(input_idx), scale, fake_convert_type);
-            auto fake_convert_2 =
-                std::make_shared<ov::op::v13::FakeConvert>(fake_convert_1, scale, fake_convert_type);
+            auto fake_convert_2 = std::make_shared<ov::op::v13::FakeConvert>(fake_convert_1, scale, fake_convert_type);
             fake_convert_1->set_friendly_name(sdpa->get_friendly_name() + "/" + suffix + "_1");
             fake_convert_2->set_friendly_name(sdpa->get_friendly_name() + "/" + suffix + "_2");
             sdpa->input(input_idx).replace_source_output(fake_convert_2);
@@ -344,8 +342,8 @@ public:
 };
 
 struct CompileCall {
-    std::string                friendly_name;
-    ov::AnyMap                 props;
+    std::string friendly_name;
+    ov::AnyMap props;
     std::shared_ptr<ov::Model> model;
 };
 

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
@@ -69,8 +69,7 @@ inline std::shared_ptr<ov::Model> build_dynamic_attention_llm_model() {
     for (const auto& input : model->inputs()) {
         const auto& name = input.get_any_name();
         const auto& pshape = input.get_partial_shape();
-        if (name.find("input_ids") != std::string::npos ||
-            name.find("token_type_ids") != std::string::npos) {
+        if (name.find("input_ids") != std::string::npos || name.find("token_type_ids") != std::string::npos) {
             new_shapes[name] = ov::PartialShape{1, kSeq};
         } else if (name.find("attention_mask") != std::string::npos) {
             new_shapes[name] = ov::PartialShape{1, kSeq + kPast};
@@ -100,6 +99,22 @@ inline std::shared_ptr<ov::Model> build_llm_gqa_test_model() {
     return mb.build_llm(make_test_model_config_gqa());
 }
 
+/// Minimal Qwen3-style reranker: a GQA causal decoder with RMSNorm and per-head
+/// Q/K normalization, stateful KV cache and an LM head (logits output). Matches the
+/// I/O signature of Qwen3-Reranker (input_ids/attention_mask/position_ids + beam_idx),
+/// which is what the batched scoring element fans out over.
+inline LLMConfig make_test_model_config_reranker() {
+    auto cfg = make_test_model_config_gqa();
+    cfg.norm = RMSNorm(cfg.hidden_size, cfg.precision);
+    cfg.qk_norm = RMSNorm(cfg.head_dim, cfg.precision);
+    return cfg;
+}
+
+inline std::shared_ptr<ov::Model> build_reranker_test_model() {
+    ModelBuilder mb;
+    return mb.build_llm(make_test_model_config_reranker());
+}
+
 inline std::shared_ptr<ov::Model> build_llm_test_model_with_kv_fake_convert(const ov::element::Type fake_convert_type) {
     auto model = build_llm_test_model();
     auto scale = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.0f});
@@ -113,8 +128,7 @@ inline std::shared_ptr<ov::Model> build_llm_test_model_with_kv_fake_convert(cons
         auto inject_fake_convert = [&](size_t input_idx, const std::string& suffix) {
             auto fake_convert_1 =
                 std::make_shared<ov::op::v13::FakeConvert>(sdpa->input_value(input_idx), scale, fake_convert_type);
-            auto fake_convert_2 =
-                std::make_shared<ov::op::v13::FakeConvert>(fake_convert_1, scale, fake_convert_type);
+            auto fake_convert_2 = std::make_shared<ov::op::v13::FakeConvert>(fake_convert_1, scale, fake_convert_type);
             fake_convert_1->set_friendly_name(sdpa->get_friendly_name() + "/" + suffix + "_1");
             fake_convert_2->set_friendly_name(sdpa->get_friendly_name() + "/" + suffix + "_2");
             sdpa->input(input_idx).replace_source_output(fake_convert_2);
@@ -354,8 +368,8 @@ public:
 };
 
 struct CompileCall {
-    std::string                friendly_name;
-    ov::AnyMap                 props;
+    std::string friendly_name;
+    ov::AnyMap props;
     std::shared_ptr<ov::Model> model;
 };
 

--- a/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
@@ -213,4 +213,16 @@ TEST(NPUWConfigOptionsSmokeTest, AttentionHintDefaultsCanDifferPerOption) {
     EXPECT_EQ(cfg.getString<::intel_npu::NPUW_LLM_GENERATE_ATTENTION_HINT>(), "STATIC");
 }
 
+// LLMCompiledModel persists its config in the blob via toString()/fromString() - the
+// scoring tags must survive that round trip for import to re-apply the batched element.
+TEST(NPUWConfigOptionsSmokeTest, ScoringTagsSurviveConfigStringRoundTrip) {
+    const auto cfg = make_config({{"NPUW_TEXT_RERANK", "YES"}, {"NPUW_TEXT_EMBED", "YES"}});
+
+    ::intel_npu::Config restored(make_options_desc());
+    restored.fromString(cfg.toString());
+
+    EXPECT_TRUE(restored.get<::intel_npu::NPUW_TEXT_RERANK>());
+    EXPECT_TRUE(restored.get<::intel_npu::NPUW_TEXT_EMBED>());
+}
+
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
@@ -215,4 +215,16 @@ TEST(NPUWConfigOptionsSmokeTest, AttentionHintDefaultsCanDifferPerOption) {
     EXPECT_EQ(cfg.getString<::intel_npu::NPUW_LLM_GENERATE_ATTENTION_HINT>(), "STATIC");
 }
 
+// LLMCompiledModel persists its config in the blob via toString()/fromString() - the
+// scoring tags must survive that round trip for import to re-apply the batched element.
+TEST(NPUWConfigOptionsSmokeTest, ScoringTagsSurviveConfigStringRoundTrip) {
+    const auto cfg = make_config({{"NPUW_TEXT_RERANK", "YES"}, {"NPUW_TEXT_EMBED", "YES"}});
+
+    ::intel_npu::Config restored(make_options_desc());
+    restored.fromString(cfg.toString());
+
+    EXPECT_TRUE(restored.get<::intel_npu::NPUW_TEXT_RERANK>());
+    EXPECT_TRUE(restored.get<::intel_npu::NPUW_TEXT_EMBED>());
+}
+
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
@@ -215,8 +215,8 @@ TEST(NPUWConfigOptionsSmokeTest, AttentionHintDefaultsCanDifferPerOption) {
     EXPECT_EQ(cfg.getString<::intel_npu::NPUW_LLM_GENERATE_ATTENTION_HINT>(), "STATIC");
 }
 
-// LLMCompiledModel persists its config in the blob via toString()/fromString() - the
-// scoring tags must survive that round trip for import to re-apply the batched element.
+// The scoring tags are ordinary exposed options and must parse and survive a
+// config string round trip like any other.
 TEST(NPUWConfigOptionsSmokeTest, ScoringTagsSurviveConfigStringRoundTrip) {
     const auto cfg = make_config({{"NPUW_TEXT_RERANK", "YES"}, {"NPUW_TEXT_EMBED", "YES"}});
 


### PR DESCRIPTION
### Details

NPUW compiles LLM-family graphs with a static batch of 1, so pipelines that score N inputs in a single inference (GenAI `TextRerankPipeline`, text embedding) fail for N > 1.

This PR adds batched scoring without touching the compiled graph. A new runtime element (`v1/elements/batched`, same pattern as `failsafe` and `accuracy_checked`) wraps the unchanged batch-1 request and unrolls a `[N, ...]` infer row by row:

1. reset the inner variable state (KV-cache), so each row is an independent prompt
2. bind row n's `[1, ...]` view of every input (zero-copy)
3. run the batch-1 infer
4. copy the outputs into row n of the `[N, ...]` output tensors

Attention never crosses batch rows, so the result is bit-for-bit identical to scoring each row separately. The element is only valid for single-shot scoring where rows are independent, not for autoregressive generation, and is strictly opt-in.

### Changes

- `v1/elements/batched.{hpp,cpp}`: the decorator. Exposes the inner model's ports and forwards everything except inference. Inputs with a leading dim of 1 are shared across rows; the batch size is the largest leading dim.
- New `NPUW_TEXT_RERANK` option, mirroring the existing `NPUW_TEXT_EMBED`. Both tags are recorded in the model config, so they survive blob export/import.
- The wrapper is applied at the two entry points: `npuw::ICompiledModel::create()` on compile and the NPUW blob import path. With neither tag set, nothing changes.
- Unit tests (`batched_element_test.cpp`) with a mocked inner model: batched output matches per-row scoring, state is reset between rows, shared inputs, multi-output stacking, pre-bound output reuse, and the error cases (zero batch, mismatched batch).

### Validation

- `ov_npu_unit_tests` green.
- Qwen3-Reranker-0.6B through the full NPUW pipeline with `NPUW_DEVICES=CPU`: batched scoring matches per-row scoring exactly (max_abs_diff = 0.0).
- Verified on NPU hardware (LNL) end to end via GenAI `TextRerankPipeline`.

### Tickets

* EISW-192890
