### PR TITLE
[CORE] gather support scalar indices

### DIFF
--- a/src/core/shape_inference/include/gather_shape_inference.hpp
+++ b/src/core/shape_inference/include/gather_shape_inference.hpp
@@ -72,7 +72,7 @@ std::vector<TRShape> shape_infer(const util::GatherBase* op,
     const TShape lifted_indices_pshape =
         (indices_rank.is_static() && indices_rank.get_length() == 0) ? TShape(std::vector<size_t>{1}) : indices_pshape;
     const auto lifted_indices_rank = lifted_indices_pshape.rank();
-    
+
     if (data_rank.is_static() && lifted_indices_rank.is_static()) {
         const auto out_rank = data_rank.get_length() + lifted_indices_rank.get_length() - 1 - batch_dims;       
         // scalar has one

--- a/src/core/shape_inference/include/gather_shape_inference.hpp
+++ b/src/core/shape_inference/include/gather_shape_inference.hpp
@@ -74,7 +74,7 @@ std::vector<TRShape> shape_infer(const util::GatherBase* op,
     const auto lifted_indices_rank = lifted_indices_pshape.rank();
 
     if (data_rank.is_static() && lifted_indices_rank.is_static()) {
-        const auto out_rank = data_rank.get_length() + lifted_indices_rank.get_length() - 1 - batch_dims;       
+        const auto out_rank = data_rank.get_length() + lifted_indices_rank.get_length() - 1 - batch_dims;
         // scalar has one
         output_pshape.resize(out_rank);
 

--- a/src/core/shape_inference/include/gather_shape_inference.hpp
+++ b/src/core/shape_inference/include/gather_shape_inference.hpp
@@ -69,8 +69,12 @@ std::vector<TRShape> shape_infer(const util::GatherBase* op,
                               indices_rank.get_length());
     }
 
-    if (data_rank.is_static() && indices_rank.is_static()) {
-        auto out_rank = data_rank.get_length() + indices_rank.get_length() - 1 - batch_dims;
+    const TShape lifted_indices_pshape =
+        (indices_rank.is_static() && indices_rank.get_length() == 0) ? TShape(std::vector<size_t>{1}) : indices_pshape;
+    const auto lifted_indices_rank = lifted_indices_pshape.rank();
+    
+    if (data_rank.is_static() && lifted_indices_rank.is_static()) {
+        const auto out_rank = data_rank.get_length() + lifted_indices_rank.get_length() - 1 - batch_dims;       
         // scalar has one
         output_pshape.resize(out_rank);
 
@@ -80,32 +84,32 @@ std::vector<TRShape> shape_infer(const util::GatherBase* op,
         int i = 0;
         for (; i < batch_dims; i++) {
             NODE_VALIDATION_CHECK(op,
-                                  data_pshape[i].compatible(indices_pshape[i]),
+                                  data_pshape[i].compatible(lifted_indices_pshape[i]),
                                   "Shapes ",
                                   data_pshape,
                                   " and ",
-                                  indices_pshape,
+                                  lifted_indices_pshape,
                                   " are not consistent. data and indices must have equal or "
                                   "intersecting sizes until batch_dims");
 
-            output_pshape[i] = data_pshape[i] & indices_pshape[i];
+            output_pshape[i] = data_pshape[i] & lifted_indices_pshape[i];
         }
 
         if (axis_is_set) {
             for (; i < axis; i++) {
                 output_pshape[i] = data_pshape[i];
             }
-            for (; i < axis + indices_rank.get_length() - batch_dims; i++) {
-                output_pshape[i] = indices_pshape[batch_dims - axis + i];
+            for (; i < axis + lifted_indices_rank.get_length() - batch_dims; i++) {
+                output_pshape[i] = lifted_indices_pshape[batch_dims - axis + i];
             }
             for (; i < out_rank; i++) {
-                output_pshape[i] = data_pshape[batch_dims + 1 - indices_rank.get_length() + i];
+                output_pshape[i] = data_pshape[batch_dims + 1 - lifted_indices_rank.get_length() + i];
             }
         }
     } else {
-        auto out_rank = data_rank + indices_rank - 1 - batch_dims;
+        auto out_rank = data_rank + lifted_indices_rank - 1 - batch_dims;
         if (batch_dims < 0)
-            out_rank = out_rank - indices_rank.get_max_length();
+            out_rank = out_rank - lifted_indices_rank.get_max_length();
         output_pshape = PartialShape::dynamic(std::move(out_rank));
     }
     return output_shapes;

--- a/src/core/tests/type_prop/gather.cpp
+++ b/src/core/tests/type_prop/gather.cpp
@@ -183,6 +183,21 @@ TEST(type_prop, gather_7_axis_1) {
     EXPECT_EQ(G->get_axis(), 1);
 }
 
+TEST(type_prop, gather_7_scalar_indices) {
+    PartialShape data_shape{2, 3};
+    PartialShape indices_shape{};
+    PartialShape out_shape{2, 1};
+    int64_t axis = 1;
+
+    auto D = make_shared<ov::op::v0::Parameter>(element::f32, data_shape);
+    auto I = make_shared<ov::op::v0::Parameter>(element::i32, indices_shape);
+    auto A = ov::op::v0::Constant::create(element::i64, Shape{}, {axis});
+    auto G = make_shared<op::v7::Gather>(D, I, A);
+
+    EXPECT_EQ(G->get_output_partial_shape(0), out_shape);
+    EXPECT_EQ(G->get_axis(), 1);
+}
+
 TEST(type_prop, gather_7_negative_axis) {
     PartialShape data_shape{5, 6, 7};
     PartialShape indices_shape{4};
@@ -483,6 +498,22 @@ TEST(type_prop, gather_v8_axis_1) {
     PartialShape data_shape{3, 3};
     PartialShape indices_shape{1, 2};
     PartialShape out_shape{3, 1, 2};
+    int64_t axis = 1;
+
+    auto D = make_shared<ov::op::v0::Parameter>(element::f32, data_shape);
+    auto I = make_shared<ov::op::v0::Parameter>(element::i32, indices_shape);
+    auto A = ov::op::v0::Constant::create(element::i64, Shape{}, {axis});
+    auto G = make_shared<op::v8::Gather>(D, I, A);
+
+    EXPECT_EQ(G->get_element_type(), element::f32);
+    EXPECT_EQ(G->get_output_partial_shape(0), out_shape);
+    EXPECT_EQ(G->get_axis(), 1);
+}
+
+TEST(type_prop, gather_v8_scalar_indices) {
+    PartialShape data_shape{3, 3};
+    PartialShape indices_shape{};
+    PartialShape out_shape{3, 1};
     int64_t axis = 1;
 
     auto D = make_shared<ov::op::v0::Parameter>(element::f32, data_shape);


### PR DESCRIPTION
### Details:
 - When unrolling tensor (ov::pass::UnrollTensorIterator in gpu transformations_pipeline.cpp) from Parameter 34  is created new constant(Constant 5192) with scalar shape which is used as Gather indices input. Creation place is at end of function ov::pass::UnrollTensorIterator::run_on_model (as on image below) 
<img width="1056" height="287" alt="image" src="https://github.com/user-attachments/assets/d9b1d8ed-9954-4cb1-88a7-6d630a5a1fb4" />
- before transform
<img width="497" height="196" alt="image" src="https://github.com/user-attachments/assets/32877cc5-925f-48c5-8963-12c6295de825" />

- after transform (already with PR because without it it not compiles)
<img width="650" height="255" alt="image" src="https://github.com/user-attachments/assets/0bac2b84-162b-466c-a68d-f210f68a6cfc" />


### Tickets:
 - 186471
