### PR TITLE
[DOCS] Add "Explore on GitHub" button and reusable theme component

### DIFF
--- a/docs/articles_en/physical-ai.md
+++ b/docs/articles_en/physical-ai.md
@@ -1,3 +1,7 @@
+---
+explore_github_url: https://github.com/openvinotoolkit/physicalai
+---
+
 # OpenVINO™ Physical AI
 
 ```{toctree}

--- a/docs/openvino_sphinx_theme/openvino_sphinx_theme/templates/edit-this-page.html
+++ b/docs/openvino_sphinx_theme/openvino_sphinx_theme/templates/edit-this-page.html
@@ -1,4 +1,14 @@
 </br>
+{% if meta is defined and meta is not none and meta.get("explore_github_url") %}
+<div class="editthispage">
+    <a class="button button-size-m"
+       href="{{ meta.get('explore_github_url') | e }}"
+       target="_blank"
+       rel="noopener noreferrer">
+        {{ _("Explore on GitHub") }}
+    </a>
+</div>
+{% endif %}
 {% if sourcename is defined and theme_use_edit_page_button==true and page_source_suffix and has_github_page %}
 {% set src = sourcename.split('.') %}
 <div class="editthispage">


### PR DESCRIPTION
## Summary

Adds a reusable "Explore on GitHub" button to documentation pages  
and enables it for the Physical AI article.

## Changes

* Added a new **"Explore on GitHub"** button to `docs/articles_en/physical-ai.md`
  * Displays in the right-hand sidebar
  * Links to the Physical AI GitHub repository

* Extended Sphinx theme template:  
  `docs/openvino_sphinx_theme/openvino_sphinx_theme/templates/edit-this-page.html`
  * Introduced a reusable HTML component that conditionally renders the  
    "Explore on GitHub" button when `explore_github_url` is defined in page metadata
  * Preserved existing functionality by keeping the  
    **"Edit on GitHub"** button rendered after the new component

## Implementation Notes

* The new component checks:
  ```jinja2
  meta.get("explore_github_url")
  ```
  and renders the button only when the metadata field is present

* The component is designed to be **reusable across documentation pages**,  
  enabling easy linkage to corresponding GitHub repositories

* Existing behavior remains unchanged when the metadata field is not provided

## Motivation

This change improves discoverability of related GitHub repositories directly  
from documentation pages and introduces a reusable pattern that can be applied  
consistently across OpenVINO documentation.

## Testing

* Verified rendering locally in Sphinx build
* Confirmed:
  * button appears only when metadata is defined
  * correct placement in sidebar
  * existing "Edit on GitHub" button remains functional

## Checklist

* [x] Changes are focused and scoped to documentation/theme
* [x] Existing functionality preserved
* [x] Reusable solution implemented
* [x] Verified locally