### PR TITLE
[GPU] Fix PagedAttention intermediate buffer crash with token_type_ids

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1376,6 +1376,10 @@ public:
             return false;
         }
 
+        if (desc->has_token_type_ids) {
+            return false;
+        }
+
         if (desc->has_scores_output() || desc->has_score_aggregation) {
             return false;
         }


### PR DESCRIPTION
### Description
In VLM pipelines (e.g., Gemma-3), the Paged Attention descriptor can have `has_token_type_ids = true`. During the memory allocation phase (`get_internal_buffer_descs`), the allocator relies on `supports_micro_sdpa()` to determine which buffers to reserve. 

Previously, for hardware supporting `immad` (like A770/DG2), `supports_micro_sdpa()` skipped checking `has_token_type_ids` and incorrectly returned `true`. This caused the allocator to skip allocating several intermediate buffers (such as `sequential_gws_subseq_mapping`, `exp_sums`, `max_logits`).

During kernel execution (`update_rt_params`), a stricter runtime check correctly evaluates `desc->has_token_type_ids == false` and falls back to the standard fallback PA kernel (Mixed mode). The fallback kernel then attempts to access these unallocated buffers, resulting in an `Unexpected number of intermediates buffers` assertion failure and a segmentation fault.

This PR adds the missing `has_token_type_ids` check to `supports_micro_sdpa()` to ensure the allocator reserves all necessary buffers for the fallback kernel.