### PR TITLE
[Snippets][CPU] Unify GELU v0/v7 emitters across architectures

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_dnnl_ext_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_dnnl_ext_emitters.hpp
@@ -17,7 +17,6 @@
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/clamp.hpp"
 #include "openvino/op/elu.hpp"
-#include "openvino/op/gelu.hpp"
 #include "openvino/op/round.hpp"
 #include "transformations/cpu_opset/common/op/swish_cpu.hpp"
 #include "utils/general_utils.h"
@@ -117,12 +116,12 @@ public:
     }
 };
 
-class jit_gelu_v0_emitter : public jit_dnnl_emitter {
+class jit_gelu_erf_emitter : public jit_dnnl_emitter {
 public:
-    jit_gelu_v0_emitter(dnnl::impl::cpu::x64::jit_generator_t* host,
-                        dnnl::impl::cpu::x64::cpu_isa_t host_isa,
-                        const std::shared_ptr<ov::Node>& n,
-                        ov::element::Type exec_prc = ov::element::f32)
+    jit_gelu_erf_emitter(dnnl::impl::cpu::x64::jit_generator_t* host,
+                         dnnl::impl::cpu::x64::cpu_isa_t host_isa,
+                         const std::shared_ptr<ov::Node>& n,
+                         ov::element::Type exec_prc = ov::element::f32)
         : jit_dnnl_emitter(host, host_isa, n, exec_prc) {
         kind = dnnl_eltwise_gelu_erf;
 
@@ -130,24 +129,14 @@ public:
     }
 };
 
-class jit_gelu_v7_emitter : public jit_dnnl_emitter {
+class jit_gelu_tanh_emitter : public jit_dnnl_emitter {
 public:
-    jit_gelu_v7_emitter(dnnl::impl::cpu::x64::jit_generator_t* host,
-                        dnnl::impl::cpu::x64::cpu_isa_t host_isa,
-                        const std::shared_ptr<ov::Node>& n,
-                        ov::element::Type exec_prc = ov::element::f32)
+    jit_gelu_tanh_emitter(dnnl::impl::cpu::x64::jit_generator_t* host,
+                          dnnl::impl::cpu::x64::cpu_isa_t host_isa,
+                          const std::shared_ptr<ov::Node>& n,
+                          ov::element::Type exec_prc = ov::element::f32)
         : jit_dnnl_emitter(host, host_isa, n, exec_prc) {
-        auto gelu = getNgraphOpAs<ov::op::v7::Gelu>(n);
-        ov::op::GeluApproximationMode approximationMode = gelu->get_approximation_mode();
-        if (approximationMode == ov::op::GeluApproximationMode::ERF) {
-            kind = dnnl_eltwise_gelu_erf;
-        } else if (approximationMode == ov::op::GeluApproximationMode::TANH) {
-            kind = dnnl_eltwise_gelu_tanh;
-        } else {
-            OPENVINO_THROW_NOT_IMPLEMENTED(
-                "Subgraph node doesn't support ngraph operation Gelu with approximation mode: ",
-                approximationMode);
-        }
+        kind = dnnl_eltwise_gelu_tanh;
 
         set_injector();
     }

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -139,37 +139,6 @@ static bool is_segfault_detector_emitter(const intel_cpu::aarch64::jit_emitter* 
 
 #endif
 
-#define CREATE_GELU_V7_EMITTER(e_type_erf, e_type_tanh)                                           \
-    {[this](const snippets::lowered::ExpressionPtr& expr) -> std::shared_ptr<snippets::Emitter> { \
-         const auto& n = expr->get_node();                                                        \
-         const auto& gelu = ov::as_type_ptr<ov::op::v7::Gelu>(n);                                 \
-         if (gelu == nullptr) {                                                                   \
-             OPENVINO_THROW("Can't cast to ov::op::v7::Gelu");                                    \
-         }                                                                                        \
-         const auto approximationMode = gelu->get_approximation_mode();                           \
-         if (approximationMode == ov::op::GeluApproximationMode::ERF) {                           \
-             return std::make_shared<e_type_erf>(h.get(), isa, n);                                \
-         }                                                                                        \
-         if (approximationMode == ov::op::GeluApproximationMode::TANH) {                          \
-             return std::make_shared<e_type_tanh>(h.get(), isa, n);                               \
-         }                                                                                        \
-         OPENVINO_THROW("Unsupported Gelu approximation mode");                                   \
-     },                                                                                           \
-     [](const std::shared_ptr<ov::Node>& n) -> std::set<std::vector<element::Type>> {             \
-         const auto& gelu = ov::as_type_ptr<ov::op::v7::Gelu>(n);                                 \
-         if (gelu == nullptr) {                                                                   \
-             OPENVINO_THROW("Can't cast to ov::op::v7::Gelu");                                    \
-         }                                                                                        \
-         const auto approximationMode = gelu->get_approximation_mode();                           \
-         if (approximationMode == ov::op::GeluApproximationMode::ERF) {                           \
-             return e_type_erf::get_supported_precisions(n);                                      \
-         }                                                                                        \
-         if (approximationMode == ov::op::GeluApproximationMode::TANH) {                          \
-             return e_type_tanh::get_supported_precisions(n);                                     \
-         }                                                                                        \
-         OPENVINO_THROW("Unsupported Gelu approximation mode");                                   \
-     }}
-
 #define CREATE_ROUND_V5_EMITTER(e_type_from_zero, e_type_even)                                    \
     {[this](const snippets::lowered::ExpressionPtr& expr) -> std::shared_ptr<snippets::Emitter> { \
          const auto& n = expr->get_node();                                                        \

--- a/src/plugins/intel_cpu/src/emitters/snippets/common/emitter_factory.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/common/emitter_factory.hpp
@@ -11,8 +11,10 @@
 #include <vector>
 
 #include "cache/multi_cache.h"
+#include "openvino/core/except.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/op/gelu.hpp"
 #include "snippets/lowered/expression.hpp"
 #include "snippets/target_machine.hpp"
 
@@ -161,5 +163,36 @@ EmitterFactory(GetHost, Isa, Wrap) -> EmitterFactory<GetHost, Isa, Wrap, void>;
 template <typename GetHost, typename Isa, typename Wrap, typename GetKernelExecutorTable>
 EmitterFactory(GetHost, Isa, Wrap, GetKernelExecutorTable, MultiCacheWeakPtr)
     -> EmitterFactory<GetHost, Isa, Wrap, GetKernelExecutorTable>;
+
+#define CREATE_GELU_V7_EMITTER(e_type_erf, e_type_tanh)                                           \
+    {[this](const snippets::lowered::ExpressionPtr& expr) -> std::shared_ptr<snippets::Emitter> { \
+         const auto& n = expr->get_node();                                                        \
+         const auto& gelu = ov::as_type_ptr<ov::op::v7::Gelu>(n);                                 \
+         if (gelu == nullptr) {                                                                   \
+             OPENVINO_THROW("Can't cast to ov::op::v7::Gelu");                                    \
+         }                                                                                        \
+         const auto approximationMode = gelu->get_approximation_mode();                           \
+         if (approximationMode == ov::op::GeluApproximationMode::ERF) {                           \
+             return std::make_shared<e_type_erf>(h.get(), isa, n);                                \
+         }                                                                                        \
+         if (approximationMode == ov::op::GeluApproximationMode::TANH) {                          \
+             return std::make_shared<e_type_tanh>(h.get(), isa, n);                               \
+         }                                                                                        \
+         OPENVINO_THROW("Unsupported Gelu approximation mode");                                   \
+     },                                                                                           \
+     [](const std::shared_ptr<ov::Node>& n) -> std::set<std::vector<element::Type>> {             \
+         const auto& gelu = ov::as_type_ptr<ov::op::v7::Gelu>(n);                                 \
+         if (gelu == nullptr) {                                                                   \
+             OPENVINO_THROW("Can't cast to ov::op::v7::Gelu");                                    \
+         }                                                                                        \
+         const auto approximationMode = gelu->get_approximation_mode();                           \
+         if (approximationMode == ov::op::GeluApproximationMode::ERF) {                           \
+             return e_type_erf::get_supported_precisions(n);                                      \
+         }                                                                                        \
+         if (approximationMode == ov::op::GeluApproximationMode::TANH) {                          \
+             return e_type_tanh::get_supported_precisions(n);                                     \
+         }                                                                                        \
+         OPENVINO_THROW("Unsupported Gelu approximation mode");                                   \
+     }}
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/emitters/snippets/riscv64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/riscv64/cpu_generator.cpp
@@ -116,37 +116,6 @@
 #    include "snippets/op/perf_count.hpp"
 #endif
 
-#define CREATE_GELU_V7_EMITTER(e_type_erf, e_type_tanh)                                           \
-    {[this](const snippets::lowered::ExpressionPtr& expr) -> std::shared_ptr<snippets::Emitter> { \
-         const auto& n = expr->get_node();                                                        \
-         const auto& gelu = ov::as_type_ptr<ov::op::v7::Gelu>(n);                                 \
-         if (gelu == nullptr) {                                                                   \
-             OPENVINO_THROW("Can't cast to ov::op::v7::Gelu");                                    \
-         }                                                                                        \
-         const auto approximationMode = gelu->get_approximation_mode();                           \
-         if (approximationMode == ov::op::GeluApproximationMode::ERF) {                           \
-             return std::make_shared<e_type_erf>(h.get(), isa, n);                                \
-         }                                                                                        \
-         if (approximationMode == ov::op::GeluApproximationMode::TANH) {                          \
-             return std::make_shared<e_type_tanh>(h.get(), isa, n);                               \
-         }                                                                                        \
-         OPENVINO_THROW("Unsupported Gelu approximation mode");                                   \
-     },                                                                                           \
-     [](const std::shared_ptr<ov::Node>& n) -> std::set<std::vector<ov::element::Type>> {         \
-         const auto& gelu = ov::as_type_ptr<ov::op::v7::Gelu>(n);                                 \
-         if (gelu == nullptr) {                                                                   \
-             OPENVINO_THROW("Can't cast to ov::op::v7::Gelu");                                    \
-         }                                                                                        \
-         const auto approximationMode = gelu->get_approximation_mode();                           \
-         if (approximationMode == ov::op::GeluApproximationMode::ERF) {                           \
-             return e_type_erf::get_supported_precisions(n);                                      \
-         }                                                                                        \
-         if (approximationMode == ov::op::GeluApproximationMode::TANH) {                          \
-             return e_type_tanh::get_supported_precisions(n);                                     \
-         }                                                                                        \
-         OPENVINO_THROW("Unsupported Gelu approximation mode");                                   \
-     }}
-
 #define CREATE_ROUND_V5_EMITTER(e_type_from_zero, e_type_even)                                    \
     {[this](const snippets::lowered::ExpressionPtr& expr) -> std::shared_ptr<snippets::Emitter> { \
          const auto& n = expr->get_node();                                                        \

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
@@ -329,8 +329,9 @@ intel_cpu::CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t ho
     jitters[ov::intel_cpu::SwishNode::get_type_info_static()] =
         emitter_factory.from_node<ov::intel_cpu::jit_swish_emitter>();
     jitters[ov::op::v4::HSwish::get_type_info_static()] = emitter_factory.from_node<intel_cpu::jit_hswish_emitter>();
-    jitters[ov::op::v0::Gelu::get_type_info_static()] = emitter_factory.from_node<intel_cpu::jit_gelu_v0_emitter>();
-    jitters[ov::op::v7::Gelu::get_type_info_static()] = emitter_factory.from_node<intel_cpu::jit_gelu_v7_emitter>();
+    jitters[ov::op::v0::Gelu::get_type_info_static()] = emitter_factory.from_node<intel_cpu::jit_gelu_erf_emitter>();
+    jitters[ov::op::v7::Gelu::get_type_info_static()] =
+        CREATE_GELU_V7_EMITTER(intel_cpu::jit_gelu_erf_emitter, intel_cpu::jit_gelu_tanh_emitter);
     jitters[snippets::op::Fill::get_type_info_static()] = emitter_factory.from_expr<intel_cpu::jit_fill_emitter>();
 
     jitters[snippets::op::HorizonMax::get_type_info_static()] =


### PR DESCRIPTION
### Details:
Unify GELU v0/v7 emitters across all (x64/aarch64/riscv64) architectures and extract CREATE_GELU_V7_EMITTER to common header

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: no*