### PR TITLE
[CPU][Tests] Skip InputNoReorderEltwiseBF16 on platforms without BF16 support

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/input_noreorder_eltwise_bf16.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/input_noreorder_eltwise_bf16.cpp
@@ -53,6 +53,10 @@ protected:
              Output[BF16]
 */
 TEST_F(InputNoReorderEltwiseBF16, smoke_CompareWithRefs) {
+    if (!ov::with_cpu_x86_bfloat16() && !ov::with_cpu_x86_avx512_core_amx_bf16()) {
+        GTEST_SKIP() << "Skipping test, platform doesn't support precision bf16";
+    }
+
     run();
 
     CheckNumberOfNodesWithType(compiledModel, "Reorder", 0);


### PR DESCRIPTION
### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: no*