### PR TITLE
[CPU][ARM] Fix GridSample tests for integral data

### DIFF
--- a/src/core/src/op/grid_sample.cpp
+++ b/src/core/src/op/grid_sample.cpp
@@ -26,7 +26,7 @@ struct Evaluate : element::NoAction<bool> {
                              const GridSample::Attributes& attributes) {
         using namespace ov::element;
         return IF_TYPE_OF(eval_by_grid_type,
-                          OV_PP_ET_LIST(f32),
+                          OV_PP_ET_LIST(bf16, f16, f32, f64),
                           EvalByGridType,
                           grid.get_element_type(),
                           output.data<T>(),
@@ -104,7 +104,7 @@ bool GridSample::evaluate(TensorVector& outputs, const TensorVector& inputs) con
 
     using namespace ov::element;
     return IF_TYPE_OF(v9_GridSample_evaluate,
-                      OV_PP_ET_LIST(f32),
+                      OV_PP_ET_LIST(boolean, bf16, f16, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64),
                       Evaluate,
                       inputs[0].get_element_type(),
                       outputs[0],
@@ -116,7 +116,38 @@ bool GridSample::evaluate(TensorVector& outputs, const TensorVector& inputs) con
 }
 
 bool GridSample::has_evaluate() const {
-    return get_input_element_type(0) == element::f32 && get_input_element_type(1) == element::f32;
+    const auto is_supported_data_type = [](const element::Type& type) {
+        switch (type) {
+        case element::boolean:
+        case element::bf16:
+        case element::f16:
+        case element::f32:
+        case element::f64:
+        case element::i8:
+        case element::i16:
+        case element::i32:
+        case element::i64:
+        case element::u8:
+        case element::u16:
+        case element::u32:
+        case element::u64:
+            return true;
+        default:
+            return false;
+        }
+    };
+    const auto is_supported_grid_type = [](const element::Type& type) {
+        switch (type) {
+        case element::bf16:
+        case element::f16:
+        case element::f32:
+        case element::f64:
+            return true;
+        default:
+            return false;
+        }
+    };
+    return is_supported_data_type(get_input_element_type(0)) && is_supported_grid_type(get_input_element_type(1));
 }
 }  // namespace v9
 }  // namespace op

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/grid_sample_decomposition.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/grid_sample_decomposition.cpp
@@ -797,6 +797,9 @@ GridSampleDecomposition::GridSampleDecomposition() {
             return false;
         }
         const auto& attrs = grid_sample->get_attributes();
+        if (grid_sample->get_input_element_type(0).is_integral()) {
+            return false;
+        }
         const bool is_f32_data = grid_sample->get_input_element_type(0) == element::f32;
         const bool is_f32_grid = grid_sample->get_input_element_type(1) == element::f32;
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -82,13 +82,6 @@ const std::vector<std::regex>& disabled_test_patterns() {
             std::regex(R"(.*CompileModelCacheTestBase.*CompareWithRefImpl.*KSOFunction.*)"),
             std::regex(R"(.*CompileModelCacheTestBase.*CompareWithRefImpl.*NonMaxSuppression.*)"),
             std::regex(R"(.*CompileModelCacheTestBase.*CompareWithRefImpl.*Nms.*)"),
-            // 94982. FP32->I32 conversion issue in the reference implementation. There can be some garbage in the rest of
-            // float values like 0.333333745.
-            // The kernel does not have such garbage. The diff 0.000000745 is taken into account in calculations and affects
-            // further type conversion.
-            // Reorder->GridSample->Reorder also does not work here. Potential fix is to use nearest conversion instead of
-            // truncation.
-            std::regex(R"(.*GridSampleLayerTestCPU.*(BILINEAR|BICUBIC).*(i32|i8).*)"),
             std::regex(R"(.*smoke_static/GridSampleLayerTestCPU.CompareWithRefs/.*_TS=.*(1.7.5.3|2.6.3.10).*_interpMode=NEAREST_padMode=REFLECTION_alignCorners=False_dataPrc=(f32|i32)_gridPrc=f32_.*)"),
             std::regex(R"(.*smoke_static/GridSampleLayerTestCPU.CompareWithRefs/.*_TS=.*5.3.2.13.*_interpMode=BICUBIC_padMode=REFLECTION_alignCorners=True_dataPrc=f32_gridPrc=f32_.*)"),
             std::regex(R"(.*smoke_static/GridSampleLayerTestCPU.CompareWithRefs/.*_TS=.*2.1.6.16.*_interpMode=NEAREST_padMode=(BORDER|REFLECTION)_alignCorners=(True|False)_dataPrc=(f32|i32)_gridPrc=f32_.*)"),

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/grid_sample_decomposition.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/grid_sample_decomposition.cpp
@@ -576,7 +576,9 @@ static std::shared_ptr<ov::Model> create_expected_decomposed_pattern(const ov::P
                                    !attrs.align_corners;
 
     std::shared_ptr<ov::Node> out_node;
-    if (is_f32_data && is_f32_grid && (nearest_reflection_border_bad || nearest_zeros_bad || bicubic_zeros_bad)) {
+    if (data_type.is_integral()) {
+        out_node = std::make_shared<ov::op::v9::GridSample>(data, grid, attrs);
+    } else if (is_f32_data && is_f32_grid && (nearest_reflection_border_bad || nearest_zeros_bad || bicubic_zeros_bad)) {
         // Keep original GridSample
         out_node = std::make_shared<ov::op::v9::GridSample>(data, grid, attrs);
     } else if ((!is_f32_data || !is_f32_grid) && nearest_reflection_border_bad) {


### PR DESCRIPTION
### Details:
Keep ARM GridSample with integral input data on the reference path instead of decomposing it through floating-point arithmetic, since that changes rounding behavior for i32 outputs.

`ARM_smoke/GridSampleLayerTestCPU` tests are fixed

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: yes*
 - The implementation is agentically assisted, manually adjusted after that and checked using the func tests
