### PR TITLE
Add a `v2` version to the C API variable parameter interface to solve the problem of incompatibility of variable parameters when using `ffi` in various languages.

### DIFF
--- a/src/bindings/c/include/openvino/c/ov_compiled_model.h
+++ b/src/bindings/c/include/openvino/c/ov_compiled_model.h
@@ -149,6 +149,16 @@ OPENVINO_C_API(ov_status_e)
 ov_compiled_model_set_property(const ov_compiled_model_t* compiled_model, ...);
 
 /**
+ * @brief Sets properties for a device, acceptable keys can be found in ov_property_key_xxx.
+ * @ingroup ov_compiled_model_c_api
+ * @param compiled_model A pointer to the ov_compiled_model_t.
+ * @param prop Supported property key please see ov_property.h.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_compiled_model_set_property_v2(const ov_compiled_model_t* compiled_model, const ov_property_t* property);
+
+/**
  * @brief Gets properties for current compiled model.
  * @ingroup ov_compiled_model_c_api
  * @param compiled_model A pointer to the ov_compiled_model_t.

--- a/src/bindings/c/include/openvino/c/ov_core.h
+++ b/src/bindings/c/include/openvino/c/ov_core.h
@@ -216,6 +216,25 @@ ov_core_compile_model(const ov_core_t* core,
                       ...);
 
 /**
+ * @brief Creates a compiled model from a source model object.
+ * Users can create as many compiled models as they need and use
+ * them simultaneously (up to the limitation of the hardware resources).
+ * @ingroup ov_core_c_api
+ * @param core A pointer to the ov_core_t instance.
+ * @param model Model object acquired from Core::read_model.
+ * @param device_name Name of a device to load a model to.
+ * @param property Supported property key please see ov_property.h.
+ * @param compiled_model A pointer to the newly created compiled_model.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_core_compile_model_v2(const ov_core_t* core,
+                         const ov_model_t* model,
+                         const char* device_name,
+                         const ov_property_t* property,
+                         ov_compiled_model_t** compiled_model);
+
+/**
  * @brief Reads a model and creates a compiled model from the IR/ONNX/PDPD file.
  * This can be more efficient than using the ov_core_read_model_from_XXX + ov_core_compile_model flow,
  * especially for cases when caching is enabled and a cached model is available.
@@ -236,6 +255,25 @@ ov_core_compile_model_from_file(const ov_core_t* core,
                                 const size_t property_args_size,
                                 ov_compiled_model_t** compiled_model,
                                 ...);
+
+/**
+ * @brief Reads a model and creates a compiled model from the IR/ONNX/PDPD file.
+ * This can be more efficient than using the ov_core_read_model_from_XXX + ov_core_compile_model flow,
+ * especially for cases when caching is enabled and a cached model is available.
+ * @ingroup ov_core_c_api
+ * @param core A pointer to the ov_core_t instance.
+ * @param model_path Path to a model.
+ * @param device_name Name of a device to load a model to.
+ * @param property Supported property key please see ov_property.h.
+ * @param compiled_model A pointer to the newly created compiled_model.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_core_compile_model_from_file_v2(const ov_core_t* core,
+                                   const char* model_path,
+                                   const char* device_name,
+                                   const ov_property_t* property,
+                                   ov_compiled_model_t** compiled_model);
 
 /**
  * @brief Adds an extension to the core.
@@ -270,6 +308,26 @@ ov_core_compile_model_from_file_unicode(const ov_core_t* core,
                                         ov_compiled_model_t** compiled_model,
                                         ...);
 
+/**
+ * @brief Reads a model and creates a compiled model from the IR/ONNX/PDPD file.
+ * This can be more efficient than using the ov_core_read_model_from_XXX + ov_core_compile_model flow,
+ * especially for cases when caching is enabled and a cached model is available.
+ * @ingroup ov_core_c_api
+ * @param core A pointer to the ov_core_t instance.
+ * @param model_path Path to a model.
+ * @param device_name Name of a device to load a model to.
+ * @param property_args_size How many properties args will be passed, each property contains 2 args: key and value.
+ * @param compiled_model A pointer to the newly created compiled_model.
+ * @param ... Optional pack of pairs: <char* property_key, char* property_value> relevant only
+ * for this load operation operation. Supported property key please see ov_property.h.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_core_compile_model_from_file_unicode_v2(const ov_core_t* core,
+                                           const wchar_t* model_path,
+                                           const char* device_name,
+                                           const ov_property_t* property,
+                                           ov_compiled_model_t** compiled_model);
 #endif
 
 /**
@@ -283,6 +341,17 @@ ov_core_compile_model_from_file_unicode(const ov_core_t* core,
  */
 OPENVINO_C_API(ov_status_e)
 ov_core_set_property(const ov_core_t* core, const char* device_name, ...);
+
+/**
+ * @brief Sets properties for a device, acceptable keys can be found in ov_property_key_xxx.
+ * @ingroup ov_core_c_api
+ * @param core A pointer to the ov_core_t instance.
+ * @param device_name Name of a device.
+ * @param property Supported property key please see ov_property.h.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_core_set_property_v2(const ov_core_t* core, const char* device_name, const ov_property_t* property);
 
 /**
  * @brief Gets properties related to device behaviour.
@@ -374,6 +443,22 @@ ov_core_create_context(const ov_core_t* core,
                        ...);
 
 /**
+ * @brief Creates a new remote shared context object on the specified accelerator device
+ * using specified plugin-specific low-level device API parameters (device handle, pointer, context, etc.).
+ * @ingroup ov_core_c_api
+ * @param core A pointer to the ov_core_t instance.
+ * @param device_name Device name to identify a plugin.
+ * @param property In fact, the following attribute parameters are used for remote context.
+ * @param context A pointer to the newly created remote context.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_core_create_context_v2(const ov_core_t* core,
+                          const char* device_name,
+                          const ov_property_t* property,
+                          ov_remote_context_t** context);
+
+/**
  * @brief Creates a compiled model from a source model within a specified remote context.
  * @ingroup ov_core_c_api
  * @param core A pointer to the ov_core_t instance.
@@ -391,6 +476,23 @@ ov_core_compile_model_with_context(const ov_core_t* core,
                                    const size_t property_args_size,
                                    ov_compiled_model_t** compiled_model,
                                    ...);
+
+/**
+ * @brief Creates a compiled model from a source model within a specified remote context.
+ * @ingroup ov_core_c_api
+ * @param core A pointer to the ov_core_t instance.
+ * @param model Model object acquired from ov_core_read_model.
+ * @param context A pointer to the newly created remote context.
+ * @param property In fact, the following attribute parameters are used for remote context.
+ * @param compiled_model A pointer to the newly created compiled_model.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_core_compile_model_with_context_v2(const ov_core_t* core,
+                                      const ov_model_t* model,
+                                      const ov_remote_context_t* context,
+                                      const ov_property_t* property,
+                                      ov_compiled_model_t** compiled_model);
 
 /**
  * @brief Gets a pointer to default (plugin-supplied) shared context object for the specified accelerator device.

--- a/src/bindings/c/include/openvino/c/ov_prepostprocess.h
+++ b/src/bindings/c/include/openvino/c/ov_prepostprocess.h
@@ -342,6 +342,22 @@ ov_preprocess_input_tensor_info_set_color_format_with_subname(
     ...);
 
 /**
+ * @brief Set ov_preprocess_input_tensor_info_t color format with subname.
+ * @ingroup ov_prepostprocess_c_api
+ * @param preprocess_input_tensor_info A pointer to the ov_preprocess_input_tensor_info_t.
+ * @param colorFormat The enumerate of colorFormat
+ * @param sub_names_size The size of sub_names
+ * @param sub_names Optional list of sub-names assigned for each plane (e.g. "Y", "UV").
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_preprocess_input_tensor_info_set_color_format_with_subname_v2(
+    ov_preprocess_input_tensor_info_t* preprocess_input_tensor_info,
+    const ov_color_format_e colorFormat,
+    const size_t sub_names_size,
+    const char** sub_names);
+
+/**
  * @brief Set ov_preprocess_input_tensor_info_t spatial_static_shape.
  * @ingroup ov_prepostprocess_c_api
  * @param preprocess_input_tensor_info A pointer to the ov_preprocess_input_tensor_info_t.

--- a/src/bindings/c/include/openvino/c/ov_property.h
+++ b/src/bindings/c/include/openvino/c/ov_property.h
@@ -246,3 +246,57 @@ ov_property_key_auto_batch_timeout;
  */
 OPENVINO_C_VAR(const char*)
 ov_property_key_intel_gpu_config_file;
+
+/**
+ * @struct ov_property
+ * @brief type define ov_property from ov_property_opaque
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+typedef struct ov_property_opaque ov_property;
+
+/**
+ * @brief Construct ov_property.
+ * @param prop A pointer to the newly created ov_property.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_C_API(ov_status_e) ov_property_create(ov_property** prop);
+
+/**
+ * @brief Release the memory allocated by ov_property* prop.
+ * @param model A pointer to the ov_property* prop to free memory.
+ */
+OPENVINO_C_API(ov_status_e) ov_property_free(ov_property* prop);
+
+/**
+ * @brief Put a string-type property key-value pair into ov_property.
+ * The property can later be used in ov_compiled_model_get_property or ov_core_set_property.
+ * @param prop A pointer to the ov_property.
+ * @param key A pointer to the property key string.
+ * @param val A string value to set for the property.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_C_API(ov_status_e) ov_property_put_str(ov_property* prop, const char* key, const char* val);
+
+/**
+ * @brief Put an integer-type property key-value pair into ov_property.
+ * The property can later be used in ov_compiled_model_get_property or ov_core_set_property.
+ * @param prop A pointer to the ov_property.
+ * @param key A pointer to the property key string.
+ * @param val An integer value to set for the property.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_C_API(ov_status_e) ov_property_put_int(ov_property* prop, const char* key, const int val);
+
+/**
+ * @brief Put encryption/decryption callbacks property into ov_property.
+ * This property is used to set custom encryption and decryption functions
+ * for model cache protection. The callbacks are applied when saving to
+ * and loading from the model cache.
+ * @param prop A pointer to the ov_property.
+ * @param key A pointer to the property key string.
+ * @param val A pointer to the ov_encryption_callbacks structure
+ * containing encrypt_func and decrypt_func.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_property_put_encryption_callbacks(ov_property* prop, const char* key, const ov_encryption_callbacks* val);

--- a/src/bindings/c/include/openvino/c/ov_property.h
+++ b/src/bindings/c/include/openvino/c/ov_property.h
@@ -252,20 +252,20 @@ ov_property_key_intel_gpu_config_file;
  * @brief type define ov_property from ov_property_opaque
  * @return ov_status_e A status code, return OK(0) if successful.
  */
-typedef struct ov_property_opaque ov_property;
+typedef struct ov_property ov_property_t;
 
 /**
  * @brief Construct ov_property.
  * @param prop A pointer to the newly created ov_property.
  * @return ov_status_e A status code, return OK(0) if successful.
  */
-OPENVINO_C_API(ov_status_e) ov_property_create(ov_property** prop);
+OPENVINO_C_API(ov_status_e) ov_property_create(ov_property_t** prop);
 
 /**
  * @brief Release the memory allocated by ov_property* prop.
  * @param model A pointer to the ov_property* prop to free memory.
  */
-OPENVINO_C_API(ov_status_e) ov_property_free(ov_property* prop);
+OPENVINO_C_API(ov_status_e) ov_property_free(ov_property_t* prop);
 
 /**
  * @brief Put a string-type property key-value pair into ov_property.
@@ -275,7 +275,7 @@ OPENVINO_C_API(ov_status_e) ov_property_free(ov_property* prop);
  * @param val A string value to set for the property.
  * @return ov_status_e A status code, return OK(0) if successful.
  */
-OPENVINO_C_API(ov_status_e) ov_property_put_str(ov_property* prop, const char* key, const char* val);
+OPENVINO_C_API(ov_status_e) ov_property_put_str(ov_property_t* prop, const char* key, const char* val);
 
 /**
  * @brief Put an integer-type property key-value pair into ov_property.
@@ -285,7 +285,7 @@ OPENVINO_C_API(ov_status_e) ov_property_put_str(ov_property* prop, const char* k
  * @param val An integer value to set for the property.
  * @return ov_status_e A status code, return OK(0) if successful.
  */
-OPENVINO_C_API(ov_status_e) ov_property_put_int(ov_property* prop, const char* key, const int val);
+OPENVINO_C_API(ov_status_e) ov_property_put_int(ov_property_t* prop, const char* key, const int val);
 
 /**
  * @brief Put encryption/decryption callbacks property into ov_property.
@@ -299,4 +299,4 @@ OPENVINO_C_API(ov_status_e) ov_property_put_int(ov_property* prop, const char* k
  * @return ov_status_e A status code, return OK(0) if successful.
  */
 OPENVINO_C_API(ov_status_e)
-ov_property_put_encryption_callbacks(ov_property* prop, const char* key, const ov_encryption_callbacks* val);
+ov_property_put_encryption_callbacks(ov_property_t* prop, const char* key, const ov_encryption_callbacks* val);

--- a/src/bindings/c/include/openvino/c/ov_remote_context.h
+++ b/src/bindings/c/include/openvino/c/ov_remote_context.h
@@ -37,6 +37,25 @@ ov_remote_context_create_tensor(const ov_remote_context_t* context,
                                 ...);
 
 /**
+ * @brief Allocates memory tensor in device memory or wraps user-supplied memory handle
+ * using the specified tensor description and low-level device-specific parameters.
+ * Returns a pointer to the object that implements the RemoteTensor interface.
+ * @ingroup ov_remote_context_c_api
+ * @param context A pointer to the ov_remote_context_t instance.
+ * @param type Defines the element type of the tensor.
+ * @param shape Defines the shape of the tensor.
+ * @param property The low-level tensor object parameters.
+ * @param remote_tensor Pointer to returned ov_tensor_t that contains remote tensor instance.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_remote_context_create_tensor_v2(const ov_remote_context_t* context,
+                                   const ov_element_type_e type,
+                                   const ov_shape_t shape,
+                                   const ov_property_t* property,
+                                   ov_tensor_t** remote_tensor);
+
+/**
  * @brief Returns name of a device on which underlying object is allocated.
  * @ingroup ov_remote_context_c_api
  * @param context A pointer to the ov_remote_context_t instance.

--- a/src/bindings/c/include/openvino/c/ov_remote_context.h
+++ b/src/bindings/c/include/openvino/c/ov_remote_context.h
@@ -10,6 +10,7 @@
 #pragma once
 #include "openvino/c/gpu/gpu_plugin_properties.h"
 #include "openvino/c/ov_common.h"
+#include "openvino/c/ov_property.h"
 #include "openvino/c/ov_shape.h"
 #include "openvino/c/ov_tensor.h"
 

--- a/src/bindings/c/src/common.h
+++ b/src/bindings/c/src/common.h
@@ -90,10 +90,10 @@ struct ov_model {
 };
 
 /**
- * @struct ov_property_opaque
+ * @struct ov_property
  * @brief This is an interface of ov::AnyMap
  */
-struct ov_property_opaque {
+struct ov_property {
     ov::AnyMap object;
 };
 

--- a/src/bindings/c/src/common.h
+++ b/src/bindings/c/src/common.h
@@ -90,6 +90,14 @@ struct ov_model {
 };
 
 /**
+ * @struct ov_property_opaque
+ * @brief This is an interface of ov::AnyMap
+ */
+struct ov_property_opaque {
+    ov::AnyMap object;
+};
+
+/**
  * @struct ov_output_const_port
  * @brief This is an interface of ov::Output<const ov::Node>
  */

--- a/src/bindings/c/src/ov_compiled_model.cpp
+++ b/src/bindings/c/src/ov_compiled_model.cpp
@@ -195,6 +195,20 @@ ov_status_e ov_compiled_model_set_property(const ov_compiled_model_t* compiled_m
     return ov_status_e::OK;
 }
 
+ov_status_e ov_compiled_model_set_property_v2(const ov_compiled_model_t* compiled_model,
+                                              const ov_property_t* property) {
+    if (!compiled_model) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+
+    try {
+        compiled_model->object->set_property(property->object);
+    }
+    CATCH_OV_EXCEPTIONS
+
+    return ov_status_e::OK;
+}
+
 ov_status_e ov_compiled_model_get_property(const ov_compiled_model_t* compiled_model,
                                            const char* key,
                                            char** property_value) {

--- a/src/bindings/c/src/ov_core.cpp
+++ b/src/bindings/c/src/ov_core.cpp
@@ -168,6 +168,32 @@ ov_status_e ov_core_compile_model(const ov_core_t* core,
     return ov_status_e::OK;
 }
 
+ov_status_e ov_core_compile_model_v2(const ov_core_t* core,
+                                     const ov_model_t* model,
+                                     const char* device_name,
+                                     const ov_property_t* property,
+                                     ov_compiled_model_t** compiled_model) {
+    if (!core || !model || !compiled_model) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+
+    try {
+        std::string dev_name = "";
+        ov::CompiledModel object;
+        if (device_name) {
+            dev_name = device_name;
+            object = core->object->compile_model(model->object, dev_name, property->object);
+        } else {
+            object = core->object->compile_model(model->object, property->object);
+        }
+        std::unique_ptr<ov_compiled_model_t> _compiled_model(new ov_compiled_model_t);
+        _compiled_model->object = std::make_shared<ov::CompiledModel>(std::move(object));
+        *compiled_model = _compiled_model.release();
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
+
 ov_status_e ov_core_compile_model_from_file(const ov_core_t* core,
                                             const char* model_path,
                                             const char* device_name,
@@ -195,6 +221,32 @@ ov_status_e ov_core_compile_model_from_file(const ov_core_t* core,
             object = core->object->compile_model(model_path, dev_name, property);
         } else {
             object = core->object->compile_model(model_path, property);
+        }
+        std::unique_ptr<ov_compiled_model_t> _compiled_model(new ov_compiled_model_t);
+        _compiled_model->object = std::make_shared<ov::CompiledModel>(std::move(object));
+        *compiled_model = _compiled_model.release();
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_core_compile_model_from_file_v2(const ov_core_t* core,
+                                               const char* model_path,
+                                               const char* device_name,
+                                               const ov_property_t* property,
+                                               ov_compiled_model_t** compiled_model) {
+    if (!core || !model_path || !compiled_model) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+
+    try {
+        ov::CompiledModel object;
+        std::string dev_name = "";
+        if (device_name) {
+            dev_name = device_name;
+            object = core->object->compile_model(model_path, dev_name, property->object);
+        } else {
+            object = core->object->compile_model(model_path, property->object);
         }
         std::unique_ptr<ov_compiled_model_t> _compiled_model(new ov_compiled_model_t);
         _compiled_model->object = std::make_shared<ov::CompiledModel>(std::move(object));
@@ -235,6 +287,26 @@ ov_status_e ov_core_set_property(const ov_core_t* core, const char* device_name,
             core->object->set_property(device_name, property);
         } else {
             core->object->set_property(property);
+        }
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_core_set_property_v2(const ov_core_t* core, const char* device_name, const ov_property_t* property) {
+    if (!core) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+
+    try {
+        if (property->object.size() == 0) {
+            return ov_status_e::INVALID_C_PARAM;
+        }
+
+        if (device_name) {
+            core->object->set_property(device_name, property->object);
+        } else {
+            core->object->set_property(property->object);
         }
     }
     CATCH_OV_EXCEPTIONS
@@ -426,6 +498,32 @@ ov_status_e ov_core_compile_model_from_file_unicode(const ov_core_t* core,
     CATCH_OV_EXCEPTIONS
     return ov_status_e::OK;
 }
+
+ov_status_e ov_core_compile_model_from_file_unicode_v2(const ov_core_t* core,
+                                                       const wchar_t* model_path_ws,
+                                                       const char* device_name,
+                                                       const ov_property_t* property,
+                                                       ov_compiled_model_t** compiled_model) {
+    if (!core || !model_path_ws || !compiled_model) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+
+    try {
+        ov::CompiledModel object;
+        std::string dev_name = "";
+        if (device_name) {
+            dev_name = device_name;
+            object = core->object->compile_model(model_path_ws, dev_name, property->object);
+        } else {
+            object = core->object->compile_model(model_path_ws, property->object);
+        }
+        std::unique_ptr<ov_compiled_model_t> _compiled_model(new ov_compiled_model_t);
+        _compiled_model->object = std::make_shared<ov::CompiledModel>(std::move(object));
+        *compiled_model = _compiled_model.release();
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
 #endif
 
 ov_status_e ov_core_compile_model_with_context(const ov_core_t* core,
@@ -449,6 +547,25 @@ ov_status_e ov_core_compile_model_with_context(const ov_core_t* core,
         va_end(args_ptr);
 
         ov::CompiledModel object = core->object->compile_model(model->object, *context->object, property);
+        std::unique_ptr<ov_compiled_model_t> _compiled_model(new ov_compiled_model_t);
+        _compiled_model->object = std::make_shared<ov::CompiledModel>(std::move(object));
+        *compiled_model = _compiled_model.release();
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_core_compile_model_with_context_v2(const ov_core_t* core,
+                                                  const ov_model_t* model,
+                                                  const ov_remote_context_t* context,
+                                                  const ov_property_t* property,
+                                                  ov_compiled_model_t** compiled_model) {
+    if (!core || !model || !context || !compiled_model) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+
+    try {
+        ov::CompiledModel object = core->object->compile_model(model->object, *context->object, property->object);
         std::unique_ptr<ov_compiled_model_t> _compiled_model(new ov_compiled_model_t);
         _compiled_model->object = std::make_shared<ov::CompiledModel>(std::move(object));
         *compiled_model = _compiled_model.release();

--- a/src/bindings/c/src/ov_prepostprocess.cpp
+++ b/src/bindings/c/src/ov_prepostprocess.cpp
@@ -173,10 +173,10 @@ ov_status_e ov_preprocess_preprocess_steps_scale(ov_preprocess_preprocess_steps_
     return ov_status_e::OK;
 }
 
-OPENVINO_C_API(ov_status_e)
-ov_preprocess_preprocess_steps_scale_multi_channels(ov_preprocess_preprocess_steps_t* preprocess_input_process_steps,
-                                                    const float* values,
-                                                    const int32_t value_size) {
+ov_status_e ov_preprocess_preprocess_steps_scale_multi_channels(
+    ov_preprocess_preprocess_steps_t* preprocess_input_process_steps,
+    const float* values,
+    const int32_t value_size) {
     if (!preprocess_input_process_steps || !values || value_size <= 0) {
         return ov_status_e::INVALID_C_PARAM;
     }
@@ -202,10 +202,10 @@ ov_status_e ov_preprocess_preprocess_steps_mean(ov_preprocess_preprocess_steps_t
     return ov_status_e::OK;
 }
 
-OPENVINO_C_API(ov_status_e)
-ov_preprocess_preprocess_steps_mean_multi_channels(ov_preprocess_preprocess_steps_t* preprocess_input_process_steps,
-                                                   const float* values,
-                                                   const int32_t value_size) {
+ov_status_e ov_preprocess_preprocess_steps_mean_multi_channels(
+    ov_preprocess_preprocess_steps_t* preprocess_input_process_steps,
+    const float* values,
+    const int32_t value_size) {
     if (!preprocess_input_process_steps || !values || value_size <= 0) {
         return ov_status_e::INVALID_C_PARAM;
     }
@@ -321,6 +321,29 @@ ov_status_e ov_preprocess_input_tensor_info_set_color_format_with_subname(
                 names.emplace_back(_value);
             }
             va_end(args_ptr);
+        }
+
+        preprocess_input_tensor_info->object->set_color_format(GET_OV_COLOR_FARMAT(colorFormat), names);
+    }
+    CATCH_OV_EXCEPTIONS
+
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_preprocess_input_tensor_info_set_color_format_with_subname_v2(
+    ov_preprocess_input_tensor_info_t* preprocess_input_tensor_info,
+    const ov_color_format_e colorFormat,
+    const size_t sub_names_size,
+    const char** sub_names) {
+    if (!preprocess_input_tensor_info) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        std::vector<std::string> names = {};
+        if (sub_names_size > 0) {
+            for (size_t i = 0; i < sub_names_size; i++) {
+                names.emplace_back(sub_names[i]);
+            }
         }
 
         preprocess_input_tensor_info->object->set_color_format(GET_OV_COLOR_FARMAT(colorFormat), names);

--- a/src/bindings/c/src/ov_property.cpp
+++ b/src/bindings/c/src/ov_property.cpp
@@ -41,3 +41,93 @@ const char* ov_property_key_intel_gpu_config_file = "CONFIG_FILE";
 
 // Write-only property key
 const char* ov_property_key_cache_encryption_callbacks = "CACHE_ENCRYPTION_CALLBACKS";
+
+ov_status_e ov_property_create(ov_property** prop) {
+    if (!prop) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        std::unique_ptr<ov_property> _prop = std::make_unique<ov_property>();
+        _prop->object = {};
+        *prop = _prop.release();
+
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_property_free(ov_property* prop) {
+    if (prop) {
+        delete prop;
+    }
+}
+
+ov_status_e ov_property_put_str(ov_property* prop, const char* key, const char* val) {
+    if (!prop) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        prop->object[key] = val;
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_property_put_int(ov_property* prop, const char* key, const int val) {
+    if (!prop) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        (prop->object)[key] = val;
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_property_put_encryption_callbacks(ov_property* prop,
+                                                 const char* key,
+                                                 const ov_encryption_callbacks* val) {
+    if (!prop) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        auto encrypt_func = val->encrypt_func;
+        auto decrypt_func = val->decrypt_func;
+        std::function<std::string(const std::string&)> encrypt_value = [encrypt_func](const std::string& in) {
+            size_t out_size = 0;
+            std::string out_str;
+            encrypt_func(in.c_str(), in.length(), nullptr, &out_size);
+            if (out_size > 0) {
+                std::unique_ptr<char[]> output_ptr = std::make_unique<char[]>(out_size);
+                if (output_ptr) {
+                    char* output = output_ptr.get();
+                    encrypt_func(in.c_str(), in.length(), output, &out_size);
+                    out_str.assign(output, out_size);
+                }
+            }
+            return out_str;
+        };
+        std::function<std::string(const std::string&)> decrypt_value = [decrypt_func](const std::string& in) {
+            size_t out_size = 0;
+            std::string out_str;
+            decrypt_func(in.c_str(), in.length(), nullptr, &out_size);
+            if (out_size > 0) {
+                std::unique_ptr<char[]> output_ptr = std::make_unique<char[]>(out_size);
+                if (output_ptr) {
+                    char* output = output_ptr.get();
+                    decrypt_func(in.c_str(), in.length(), output, &out_size);
+                    out_str.assign(output, out_size);
+                }
+            }
+            return out_str;
+        };
+        ov::EncryptionCallbacks encryption_callbacks{std::move(encrypt_value), std::move(decrypt_value)};
+        prop->object[key] = encryption_callbacks;
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+    return ov_status_e::OK;
+}

--- a/src/bindings/c/src/ov_property.cpp
+++ b/src/bindings/c/src/ov_property.cpp
@@ -42,12 +42,12 @@ const char* ov_property_key_intel_gpu_config_file = "CONFIG_FILE";
 // Write-only property key
 const char* ov_property_key_cache_encryption_callbacks = "CACHE_ENCRYPTION_CALLBACKS";
 
-ov_status_e ov_property_create(ov_property** prop) {
+ov_status_e ov_property_create(ov_property_t** prop) {
     if (!prop) {
         return ov_status_e::INVALID_C_PARAM;
     }
     try {
-        std::unique_ptr<ov_property> _prop = std::make_unique<ov_property>();
+        std::unique_ptr<ov_property_t> _prop = std::make_unique<ov_property_t>();
         _prop->object = {};
         *prop = _prop.release();
 
@@ -57,13 +57,13 @@ ov_status_e ov_property_create(ov_property** prop) {
     return ov_status_e::OK;
 }
 
-ov_status_e ov_property_free(ov_property* prop) {
+ov_status_e ov_property_free(ov_property_t* prop) {
     if (prop) {
         delete prop;
     }
 }
 
-ov_status_e ov_property_put_str(ov_property* prop, const char* key, const char* val) {
+ov_status_e ov_property_put_str(ov_property_t* prop, const char* key, const char* val) {
     if (!prop) {
         return ov_status_e::INVALID_C_PARAM;
     }
@@ -75,7 +75,7 @@ ov_status_e ov_property_put_str(ov_property* prop, const char* key, const char* 
     return ov_status_e::OK;
 }
 
-ov_status_e ov_property_put_int(ov_property* prop, const char* key, const int val) {
+ov_status_e ov_property_put_int(ov_property_t* prop, const char* key, const int val) {
     if (!prop) {
         return ov_status_e::INVALID_C_PARAM;
     }
@@ -87,7 +87,7 @@ ov_status_e ov_property_put_int(ov_property* prop, const char* key, const int va
     return ov_status_e::OK;
 }
 
-ov_status_e ov_property_put_encryption_callbacks(ov_property* prop,
+ov_status_e ov_property_put_encryption_callbacks(ov_property_t* prop,
                                                  const char* key,
                                                  const ov_encryption_callbacks* val) {
     if (!prop) {

--- a/src/bindings/c/src/ov_remote_context.cpp
+++ b/src/bindings/c/src/ov_remote_context.cpp
@@ -75,6 +75,26 @@ ov_status_e ov_core_create_context(const ov_core_t* core,
     return ov_status_e::OK;
 }
 
+ov_status_e ov_core_create_context_v2(const ov_core_t* core,
+                                      const char* device_name,
+                                      const ov_property_t* property,
+                                      ov_remote_context_t** context) {
+    if (!core || !device_name || !context) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+
+    try {
+        std::string dev_name = device_name;
+        ov::RemoteContext object = core->object->create_context(dev_name, property->object);
+
+        std::unique_ptr<ov_remote_context> _context(new ov_remote_context);
+        _context->object = std::make_shared<ov::RemoteContext>(std::move(object));
+        *context = _context.release();
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
+
 ov_status_e ov_remote_context_create_tensor(const ov_remote_context_t* context,
                                             const ov_element_type_e type,
                                             const ov_shape_t shape,
@@ -97,6 +117,29 @@ ov_status_e ov_remote_context_create_tensor(const ov_remote_context_t* context,
         std::copy_n(shape.dims, shape.rank, std::back_inserter(tmp_shape));
         auto tmp_type = get_element_type(type);
         ov::RemoteTensor object = context->object->create_tensor(tmp_type, tmp_shape, property);
+
+        std::unique_ptr<ov_tensor> _remote_tensor(new ov_tensor);
+        _remote_tensor->object = std::make_shared<ov::RemoteTensor>(std::move(object));
+        *remote_tensor = _remote_tensor.release();
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_remote_context_create_tensor_v2(const ov_remote_context_t* context,
+                                               const ov_element_type_e type,
+                                               const ov_shape_t shape,
+                                               const ov_property_t* property,
+                                               ov_tensor_t** remote_tensor) {
+    if (!context || !shape.dims || !remote_tensor) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+
+    try {
+        ov::Shape tmp_shape;
+        std::copy_n(shape.dims, shape.rank, std::back_inserter(tmp_shape));
+        auto tmp_type = get_element_type(type);
+        ov::RemoteTensor object = context->object->create_tensor(tmp_type, tmp_shape, property->object);
 
         std::unique_ptr<ov_tensor> _remote_tensor(new ov_tensor);
         _remote_tensor->object = std::make_shared<ov::RemoteTensor>(std::move(object));


### PR DESCRIPTION
### Details:
 - *Add a `v2` version to the C API variable parameter interface to solve the problem of incompatibility of variable parameters when using `ffi` in various languages.*

### Tickets:
 - *#36391*

### AI Assistance:
 - *AI assistance used: no*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
