### PR TITLE
Enable HostCompile_Interpreter when compilation mode is not set for models with dynamic inputs and outputs

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -71,7 +71,9 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
     // auto-select HostCompile_Interpreter on its own. Perform the selection here, where we
     // know we are on the PLUGIN path and have access to the ov::Model.
     FilteredConfig effectiveConfig = config;
-    if (!config.has<COMPILATION_MODE>()) {
+    if (!config.has<COMPILATION_MODE>() &&
+        !(config.has<DYNAMIC_SHAPE_TO_STATIC>() && config.get<DYNAMIC_SHAPE_TO_STATIC>())) {
+         
         const auto isDynamic = [](const auto& port) {
             auto& shape = port.get_partial_shape();
             // HostCompile_Interpreter does not support dynamic batch for now

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -69,7 +69,24 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
     auto [tensor, compatibilityDescriptor] = _compiler->compile(model, config);
     _logger.debug("compile end");
 
-    if (config.get<COMPILATION_MODE>().find("HostCompile") == 0) {
+    auto isHostCompiledBlob = [&]() {
+        // when compilation mode is not set,
+        // vpux compiler may generate a blob for HostCompile mode when both input and output shapes are dynamic,
+        // we need to detect it and use the right runtime to get metadata
+        if (!config.has<COMPILATION_MODE>()) {
+            const size_t headerSize = std::min(tensor.get_byte_size(), size_t{20});
+            const std::string_view header(static_cast<const char*>(tensor.data()), headerSize);
+            if (header.find("llvm") != std::string_view::npos ||
+                header.find("NPUByte\x00") != std::string_view::npos) {
+                _logger.debug("HostCompile mode is detected based on blob header, use internal function to get metadata!");
+                return true;
+            }
+        }
+        return false;
+    };
+
+    if ((config.get<COMPILATION_MODE>().find("HostCompile") == 0) ||
+        isHostCompiledBlob()) {
         NPUVMRuntimeApi::initializeFromBlob(tensor.data(), tensor.get_byte_size());
 
         // metadata will be obtained in initialze() of DynamicGraph

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
     auto [tensor, compatibilityDescriptor] = _compiler->compile(model, config);
     _logger.debug("compile end");
 
-    auto isHostCompiledBlob = [&]() {
+    auto isHostCompiledBlob = [&](ov::Tensor& tensor) {
         // when compilation mode is not set,
         // vpux compiler may generate a blob for HostCompile mode when both input and output shapes are dynamic,
         // we need to detect it and use the right runtime to get metadata
@@ -85,7 +85,7 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
         return false;
     };
 
-    if ((config.get<COMPILATION_MODE>().find("HostCompile") == 0) || isHostCompiledBlob()) {
+    if ((config.get<COMPILATION_MODE>().find("HostCompile") == 0) || isHostCompiledBlob(tensor)) {
         NPUVMRuntimeApi::initializeFromBlob(tensor.data(), tensor.get_byte_size());
 
         // metadata will be obtained in initialze() of DynamicGraph

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -65,19 +65,14 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
                                                        const FilteredConfig& config) const {
     OV_ITT_TASK_CHAIN(COMPILE_BLOB, itt::domains::NPUPlugin, "PluginCompilerAdapter", "compile");
 
-    // NPU_COMPILER_TYPE is a plugin-level routing key with OptionMode::RunTime, so it is
-    // stripped by FilteredConfig::toStringForCompiler() before reaching VCL. The compiler
-    // library therefore cannot distinguish the PLUGIN path from the DRIVER path and cannot
-    // auto-select HostCompile_Interpreter on its own. Perform the selection here, where we
-    // know we are on the PLUGIN path and have access to the ov::Model.
+    // specify HostCompile_Interpreter mode for dynamic model (inputs and outputs both dynamic) if NPU_COMPILATION_MODE
+    // is not set
     FilteredConfig effectiveConfig = config;
     if (!config.has<COMPILATION_MODE>() &&
         !(config.has<DYNAMIC_SHAPE_TO_STATIC>() && config.get<DYNAMIC_SHAPE_TO_STATIC>())) {
         const auto isDynamic = [](const auto& port) {
             auto& shape = port.get_partial_shape();
-            // HostCompile_Interpreter does not support dynamic batch for now
-            // EISW-221309
-            return shape.is_dynamic() && (shape.rank().get_length() == 4);
+            return shape.is_dynamic() && (shape.rank().get_length() == 4) && shape[0].is_static();
         };
 
         if (model) {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -65,27 +65,41 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
                                                        const FilteredConfig& config) const {
     OV_ITT_TASK_CHAIN(COMPILE_BLOB, itt::domains::NPUPlugin, "PluginCompilerAdapter", "compile");
 
+    // NPU_COMPILER_TYPE is a plugin-level routing key with OptionMode::RunTime, so it is
+    // stripped by FilteredConfig::toStringForCompiler() before reaching VCL. The compiler
+    // library therefore cannot distinguish the PLUGIN path from the DRIVER path and cannot
+    // auto-select HostCompile_Interpreter on its own. Perform the selection here, where we
+    // know we are on the PLUGIN path and have access to the ov::Model.
+    FilteredConfig effectiveConfig = config;
+    if (!config.has<COMPILATION_MODE>()) {
+        const auto isDynamic = [](const auto& port) {
+            return port.get_partial_shape().is_dynamic();
+        };
+        const bool inputsDynamic = std::any_of(model->inputs().begin(), model->inputs().end(), isDynamic);
+        const bool outputsDynamic = std::any_of(model->outputs().begin(), model->outputs().end(), isDynamic);
+        if (inputsDynamic && outputsDynamic) {
+            _logger.info("NPU_COMPILATION_MODE not set; selecting 'HostCompile_Interpreter' "
+                         "for fully-dynamic model (inputs and outputs both dynamic)");
+            effectiveConfig.update({{ov::intel_npu::compilation_mode.name(), "HostCompile_Interpreter"}});
+        }
+    }
+
     _logger.debug("compile start");
-    auto [tensor, compatibilityDescriptor] = _compiler->compile(model, config);
+    auto [tensor, compatibilityDescriptor] = _compiler->compile(model, effectiveConfig);
     _logger.debug("compile end");
 
     auto isHostCompiledBlob = [&](ov::Tensor& tensor) {
-        // when compilation mode is not set,
-        // vpux compiler may generate a blob for HostCompile mode when both input and output shapes are dynamic,
-        // we need to detect it and use the right runtime to get metadata
-        if (!config.has<COMPILATION_MODE>()) {
-            const size_t headerSize = std::min(tensor.get_byte_size(), size_t{20});
-            const std::string_view header(static_cast<const char*>(tensor.data()), headerSize);
-            if (header.find("llvm") != std::string_view::npos || header.find("NPUByte\x00") != std::string_view::npos) {
-                _logger.debug(
-                    "HostCompile mode is detected based on blob header, use internal function to get metadata!");
-                return true;
-            }
+        const size_t headerSize = std::min(tensor.get_byte_size(), size_t{20});
+        const std::string_view header(static_cast<const char*>(tensor.data()), headerSize);
+        if (header.find("llvm") != std::string_view::npos || header.find("NPUByte\x00") != std::string_view::npos) {
+            _logger.debug(
+                "HostCompile mode is detected based on blob header, use internal function to get metadata!");
+            return true;
         }
         return false;
     };
 
-    if ((config.get<COMPILATION_MODE>().find("HostCompile") == 0) || isHostCompiledBlob(tensor)) {
+    if (isHostCompiledBlob(tensor)) {
         NPUVMRuntimeApi::initializeFromBlob(tensor.data(), tensor.get_byte_size());
 
         // metadata will be obtained in initialze() of DynamicGraph

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -73,14 +73,23 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
     FilteredConfig effectiveConfig = config;
     if (!config.has<COMPILATION_MODE>()) {
         const auto isDynamic = [](const auto& port) {
-            return port.get_partial_shape().is_dynamic();
+            auto& shape = port.get_partial_shape();
+            // HostCompile_Interpreter does not support dynamic batch for now
+            // EISW-221309
+            return shape.is_dynamic() && (shape.rank().get_length() == 4) &&
+                !shape[0].is_dynamic() && !shape[1].is_dynamic();
         };
-        const bool inputsDynamic = std::any_of(model->inputs().begin(), model->inputs().end(), isDynamic);
-        const bool outputsDynamic = std::any_of(model->outputs().begin(), model->outputs().end(), isDynamic);
-        if (inputsDynamic && outputsDynamic) {
-            _logger.info("NPU_COMPILATION_MODE not set; selecting 'HostCompile_Interpreter' "
-                         "for fully-dynamic model (inputs and outputs both dynamic)");
-            effectiveConfig.update({{ov::intel_npu::compilation_mode.name(), "HostCompile_Interpreter"}});
+
+        if (model) {
+            auto& inputs = model->inputs();
+            auto& outputs = model->outputs();
+            const bool inputsDynamic = std::any_of(inputs.begin(), inputs.end(), isDynamic);
+            const bool outputsDynamic = std::any_of(outputs.begin(), outputs.end(), isDynamic);
+            if (inputsDynamic && outputsDynamic) {
+                _logger.info("NPU_COMPILATION_MODE not set; selecting 'HostCompile_Interpreter' "
+                             "for fully-dynamic model (inputs and outputs both dynamic)");
+                effectiveConfig.update({{ov::intel_npu::compilation_mode.name(), "HostCompile_Interpreter"}});
+            }
         }
     }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -73,13 +73,11 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
     FilteredConfig effectiveConfig = config;
     if (!config.has<COMPILATION_MODE>() &&
         !(config.has<DYNAMIC_SHAPE_TO_STATIC>() && config.get<DYNAMIC_SHAPE_TO_STATIC>())) {
-         
         const auto isDynamic = [](const auto& port) {
             auto& shape = port.get_partial_shape();
             // HostCompile_Interpreter does not support dynamic batch for now
             // EISW-221309
-            return shape.is_dynamic() && (shape.rank().get_length() == 4) && !shape[0].is_dynamic() &&
-                   !shape[1].is_dynamic();
+            return shape.is_dynamic() && (shape.rank().get_length() == 4);
         };
 
         if (model) {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -78,8 +78,8 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
             auto& shape = port.get_partial_shape();
             // HostCompile_Interpreter does not support dynamic batch for now
             // EISW-221309
-            return shape.is_dynamic() && (shape.rank().get_length() == 4) &&
-                !shape[0].is_dynamic() && !shape[1].is_dynamic();
+            return shape.is_dynamic() && (shape.rank().get_length() == 4) && !shape[0].is_dynamic() &&
+                   !shape[1].is_dynamic();
         };
 
         if (model) {
@@ -103,8 +103,7 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
         const size_t headerSize = std::min(tensor.get_byte_size(), size_t{20});
         const std::string_view header(static_cast<const char*>(tensor.data()), headerSize);
         if (header.find("llvm") != std::string_view::npos || header.find("NPUByte\x00") != std::string_view::npos) {
-            _logger.debug(
-                "HostCompile mode is detected based on blob header, use internal function to get metadata!");
+            _logger.debug("HostCompile mode is detected based on blob header, use internal function to get metadata!");
             return true;
         }
         return false;

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -76,17 +76,16 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
         if (!config.has<COMPILATION_MODE>()) {
             const size_t headerSize = std::min(tensor.get_byte_size(), size_t{20});
             const std::string_view header(static_cast<const char*>(tensor.data()), headerSize);
-            if (header.find("llvm") != std::string_view::npos ||
-                header.find("NPUByte\x00") != std::string_view::npos) {
-                _logger.debug("HostCompile mode is detected based on blob header, use internal function to get metadata!");
+            if (header.find("llvm") != std::string_view::npos || header.find("NPUByte\x00") != std::string_view::npos) {
+                _logger.debug(
+                    "HostCompile mode is detected based on blob header, use internal function to get metadata!");
                 return true;
             }
         }
         return false;
     };
 
-    if ((config.get<COMPILATION_MODE>().find("HostCompile") == 0) ||
-        isHostCompiledBlob()) {
+    if ((config.get<COMPILATION_MODE>().find("HostCompile") == 0) || isHostCompiledBlob()) {
         NPUVMRuntimeApi::initializeFromBlob(tensor.data(), tensor.get_byte_size());
 
         // metadata will be obtained in initialze() of DynamicGraph

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -81,8 +81,8 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
         };
 
         if (model) {
-            auto& inputs = model->inputs();
-            auto& outputs = model->outputs();
+            const auto& inputs = model->inputs();
+            const auto& outputs = model->outputs();
             const bool inputsDynamic = std::any_of(inputs.begin(), inputs.end(), isDynamic);
             const bool outputsDynamic = std::any_of(outputs.begin(), outputs.end(), isDynamic);
             if (inputsDynamic && outputsDynamic) {

--- a/src/plugins/intel_npu/tests/functional/behavior/dynamic_host_pipeline/infer_with_host_compile.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/dynamic_host_pipeline/infer_with_host_compile.cpp
@@ -32,3 +32,18 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                                             ::testing::ValuesIn(configs),
                                             ::testing::ValuesIn(modelNames)),
                          ov::test::utils::appendPlatformTypeTestName<InferWithHostCompileTests>);
+
+const std::vector<ov::AnyMap> defaultHostCompileconfigs = {
+    {
+        {"NPU_COMPILER_TYPE", "PLUGIN"},
+        {"NPU_CREATE_EXECUTOR", "0"},
+    }
+};
+
+const std::vector<std::string> defaultHCModelNames = {"MaxPool_NCHW", "MaxPool_NCHW_DynBatch"};
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
+                         InferWithDefaultHostCompileTests,
+                         ::testing::Combine(::testing::ValuesIn(devices),
+                                            ::testing::ValuesIn(defaultHostCompileconfigs),
+                                            ::testing::ValuesIn(defaultHCModelNames)),
+                         ov::test::utils::appendPlatformTypeTestName<InferWithDefaultHostCompileTests>);

--- a/src/plugins/intel_npu/tests/functional/behavior/dynamic_host_pipeline/infer_with_host_compile.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/dynamic_host_pipeline/infer_with_host_compile.hpp
@@ -26,11 +26,20 @@ namespace ov {
 namespace test {
 namespace behavior {
 
-inline std::shared_ptr<ov::Model> createMaxPoolModel() {
-    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16,
+inline std::shared_ptr<ov::Model> createMaxPoolModel(bool dynamicBatch = false, bool nhwcLayout = true) {
+    std::shared_ptr<ov::op::v0::Parameter> input;
+    if (dynamicBatch) {
+        input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16,
+                                                         ov::PartialShape{ov::Dimension(1, 10), 16, 720, 1280});
+    } else {
+        input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16,
                                                          ov::PartialShape{1, 16, ov::Dimension(10, 720), ov::Dimension(10, 1280)});
-    input->set_friendly_name("input1");
+    }
 
+    std::string inputName = "input1";
+    input->set_friendly_name(inputName);
+    input->get_output_tensor(0).set_names({inputName});
+    if (!nhwcLayout) input->set_layout("NCHW");
     auto maxpool = std::make_shared<ov::op::v1::MaxPool>(input,
                                                          Strides{1, 1},
                                                          Shape{0, 0},
@@ -41,16 +50,23 @@ inline std::shared_ptr<ov::Model> createMaxPoolModel() {
     maxpool->set_friendly_name("MaxPool_2");
 
     auto result = std::make_shared<ov::op::v0::Result>(maxpool);
-    result->set_friendly_name("output");
-    auto model = std::make_shared<Model>(ResultVector{result}, ParameterVector{input}, "MaxPool");
-    // making input and output to be NHWC
-    auto preProc = ov::preprocess::PrePostProcessor(model);
-    preProc.input(0).tensor().set_layout("NHWC");
-    preProc.input(0).model().set_layout("NCHW");
-    preProc.output(0).tensor().set_layout("NHWC");
-    preProc.output(0).model().set_layout("NCHW");
+    std::string outputName = "output";
+    if (!nhwcLayout) result->set_layout("NCHW");
+    result->set_friendly_name(outputName);
+    result->get_output_tensor(0).set_names({outputName});
 
-    model = preProc.build();
+    auto model = std::make_shared<Model>(ResultVector{result}, ParameterVector{input}, "MaxPool");
+    
+    // making input and output to be NHWC
+    if (nhwcLayout) {
+        auto preProc = ov::preprocess::PrePostProcessor(model);
+        preProc.input(0).tensor().set_layout("NHWC");
+        preProc.input(0).model().set_layout("NCHW");
+        preProc.output(0).tensor().set_layout("NHWC");
+        preProc.output(0).model().set_layout("NCHW");
+
+        model = preProc.build();
+    }
 
     return model;
 }
@@ -320,6 +336,12 @@ std::shared_ptr<ov::Model> InferWithHostCompileTests::createModelByName(const st
     }
     if (modelName == "MaxPool") {
         return createMaxPoolModel();
+    }
+    if (modelName == "MaxPool_NCHW") {
+        return createMaxPoolModel(false, false);
+    }
+    if (modelName == "MaxPool_NCHW_DynBatch") {
+        return createMaxPoolModel(true, false);
     }
 
     OPENVINO_THROW("Unknown model name for InferWithHostCompileTests: ", modelName);
@@ -649,6 +671,64 @@ TEST_P(InferWithHostCompileTests, CompileAndInferWithZeroTensor) {
     ASSERT_TRUE(logContains(logCapture, "Reset command list to run with runtime"))
         << "Expected log to contain 'Reset command list to run with runtime' for sixth inference, but got: "
         << logCapture.str();
+}
+
+using InferWithDefaultHostCompileTests = InferWithHostCompileTests;
+
+inline bool isByteCodeBlob(const std::string& blob) {
+    const size_t headerSize = std::min(blob.size(), size_t{20});
+    const std::string_view header(blob.data(), headerSize);
+    return header.find("NPUByte\x00") != std::string_view::npos;
+};
+
+inline bool isElfBlob(const std::string& blob) {
+    const size_t headerSize = std::min(blob.size(), size_t{20});
+    const std::string_view header(blob.data(), headerSize);
+    return header.find("ELF\x00") != std::string_view::npos;
+};
+
+TEST_P(InferWithDefaultHostCompileTests, CompileDynamicModelWithNoHostCompileMode) {
+    // Skip test according to plugin specific disabledTestPatterns() (if any)
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    if (!isTargetDevice) {
+        GTEST_SKIP() << "Skip test for current device";
+    }
+
+    auto model = createModelByName(selectedModelName);
+
+    ov::CompiledModel compiledModel;
+    // Compilation shall pass since load of npu_mlir_runtime is deffered with NPU_CREATE_EXECUTOR=0
+    OV_ASSERT_NO_THROW(compiledModel = core->compile_model(model, target_device, configuration));
+
+    std::stringstream modelStream;
+    OV_ASSERT_NO_THROW(compiledModel.export_model(modelStream));
+
+    if (modelStream.str().empty()) {
+        FAIL() << "Exported model stream is empty";
+    }
+
+    if (selectedModelName == "MaxPool_NCHW_DynBatch") {
+        ASSERT_TRUE(isElfBlob(modelStream.str()))
+            << "Expected exported model to be an ELF blob";
+    }
+    else if (selectedModelName == "MaxPool_NCHW") {
+        ASSERT_TRUE(isByteCodeBlob(modelStream.str()))
+            << "Expected exported model to be a bytecode";
+    }
+
+    ov::InferRequest reqDynamic;
+    try {
+        ov::CompiledModel importedModel = core->import_model(modelStream, target_device);
+        reqDynamic = importedModel.create_infer_request();
+    } catch (const ov::Exception& e) {
+        if (std::string(e.what()).find("Cannot load library") == std::string::npos) {
+            FAIL() << "Expected exception message to contain 'Cannot load library', but got: " << e.what();
+        } else {
+            GTEST_SKIP() << "Cannot load library, skip test.";
+        }
+    }
+
+    OV_ASSERT_NO_THROW(reqDynamic.infer());
 }
 
 }  // namespace behavior

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
@@ -76,7 +76,6 @@ public:
         SKIP_IF_CURRENT_TEST_IS_DISABLED();
 
         std::tie(target_device, configuration) = this->GetParam();
-        configuration.insert({ov::intel_npu::compilation_mode.name(), ov::Any("DefaultHW")});
         OVPluginTestBase::SetUp();
         ov_model = getDefaultNGraphFunctionForTheDeviceNPU();  // FIXME: E#80555
     }
@@ -2581,7 +2580,14 @@ TEST_P(CpuVaTensorsTests, checkResultsAfterRunningWithSameRawMemoryMultipleTimes
     ::operator delete(output_data, std::align_val_t(4096));
 }
 
-using DynamicBoundsTests = InferRequestRunTests;
+class DynamicBoundsTests : public InferRequestRunTests
+{
+public:
+    void SetUp() override {
+        InferRequestRunTests::SetUp();
+        configuration.insert({ov::intel_npu::compilation_mode.name(), ov::Any("DefaultHW")});
+    }
+};
 
 TEST_P(DynamicBoundsTests, ChangeShapeAfterTensorIsSet) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.hpp
@@ -76,6 +76,7 @@ public:
         SKIP_IF_CURRENT_TEST_IS_DISABLED();
 
         std::tie(target_device, configuration) = this->GetParam();
+        configuration.insert({ov::intel_npu::compilation_mode.name(), ov::Any("DefaultHW")});
         OVPluginTestBase::SetUp();
         ov_model = getDefaultNGraphFunctionForTheDeviceNPU();  // FIXME: E#80555
     }


### PR DESCRIPTION
### Details:
VPUX compiler will compile a model in host compile mode when input and outputs are dynamic and compile mode is not explicitly set. 
This PR makes npu_plugin to check blob format when COMPILATION_MODE is not set

### Tickets:
 - *E#221288*

### AI Assistance:
 - *AI assistance used: no*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
