### PR TITLE
[GPU] Fix non-deterministic weights-reorder padding (zero-fill) in propagate_constants

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2729,13 +2729,9 @@ memory::ptr primitive_inst::allocate_output(engine& _engine,
         if (node.can_be_optimized() || is_reorder_weights) {
             GPU_DEBUG_LOG << "[" << node.id() << ": output]" << std::endl;
             // Use usm_device memory for weights reordering when available.
-            // Skip memset (reset=false) regardless of the final allocation type —
-            // the weights reorder kernel writes every output element unconditionally.
-            if (is_internal && is_reorder_weights) {
-                if (_engine.supports_allocation(allocation_type::usm_device))
-                    alloc_type = allocation_type::usm_device;
-                reset = false;
-            }
+            if (is_internal && is_reorder_weights &&
+                _engine.supports_allocation(allocation_type::usm_device))
+                alloc_type = allocation_type::usm_device;
             return get_memory_from_pool(_engine,
                                         net_id,
                                         pool,


### PR DESCRIPTION
### Details:
Re-enable zero-fill (reset) of internal weights-reorder output buffers. PR #34859 set `reset = false` for these allocations on the assumption that "the weights reorder kernel writes every output element unconditionally" this is only true for the reorder_weights_opt kernel, not for the generic ReorderWeightsKernel.
This PR fixes `post_optimize_weights.weights_reorder_constant_folding_test` unit test for  Xe2+ HW

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: yes*
