### PR TITLE
[PT FE] Fix var/std correction other than 1 failing to convert on the export path

### DIFF
--- a/src/frontends/pytorch/src/op/var_mean.cpp
+++ b/src/frontends/pytorch/src/op/var_mean.cpp
@@ -47,16 +47,19 @@ OutputVector translate_var_mean_common(const NodeContext& context,
     auto sub_v = context.mark_node(std::make_shared<v1::Subtract>(data, t_mean));
     auto sqr_sub = context.mark_node(std::make_shared<v1::Multiply>(sub_v, sub_v));
     auto var = context.mark_node(std::make_shared<v1::ReduceMean>(sqr_sub, _axes, keepdims));
-    // if unbiased=true Bessel’s correction will be used
-    // Correct bias in calculating variance, by dividing it over (N - 1) instead on N
+    // Apply the requested correction by dividing the sum of squared deviations
+    // over (N - correction) instead of N. correction=0 keeps the biased estimator
+    // (already produced by ReduceMean), correction=1 is Bessel's correction, and
+    // PyTorch also accepts other non-negative integer corrections.
     if (correction) {
-        PYTORCH_OP_CONVERSION_CHECK(correction == 1, "Unexpected value of correction.");
+        PYTORCH_OP_CONVERSION_CHECK(correction >= 0, "Unexpected value of correction.");
         num_elements = context.mark_node(std::make_shared<v1::ConvertLike>(num_elements, data));
-        auto one = context.mark_node(v0::Constant::create(element::f32, Shape{}, {1}));
-        one = context.mark_node(std::make_shared<v1::ConvertLike>(one, data));
+        auto correction_c =
+            context.mark_node(v0::Constant::create(element::f32, Shape{}, {static_cast<float>(correction)}));
+        correction_c = context.mark_node(std::make_shared<v1::ConvertLike>(correction_c, data));
         auto mul = context.mark_node(std::make_shared<v1::Multiply>(var, num_elements));
-        auto n_minus_one = context.mark_node(std::make_shared<v1::Subtract>(num_elements, one));
-        var = context.mark_node(std::make_shared<v1::Divide>(mul, n_minus_one));
+        auto n_minus_correction = context.mark_node(std::make_shared<v1::Subtract>(num_elements, correction_c));
+        var = context.mark_node(std::make_shared<v1::Divide>(mul, n_minus_correction));
     }
     return {var, mean};
 };

--- a/tests/layer_tests/pytorch_tests/test_var_mean.py
+++ b/tests/layer_tests/pytorch_tests/test_var_mean.py
@@ -73,3 +73,49 @@ class TestVarMean(PytorchLayerTest):
     def test_op(self, unbiased, dim, keepdim, op_type, ie_device, precision, ir_version):
         self._test(*self.create_model(unbiased, dim, keepdim, two_args_case=False, op_type=op_type), ie_device, precision, ir_version,
                    trace_model=True)
+
+
+class TestVarMeanCorrection(PytorchLayerTest):
+    def _prepare_input(self):
+        return (self.random.randn(8, 8, 8),)
+
+    def create_model(self, correction, dim, keepdim, op_type):
+        import torch
+
+        ops = {
+            "var": torch.var,
+            "var_mean": torch.var_mean,
+            "std": torch.std,
+            "std_mean": torch.std_mean
+        }
+
+        op = ops[op_type]
+
+        class aten_var_correction(torch.nn.Module):
+            def __init__(self, dim, correction, keepdim, op):
+                super().__init__()
+                self.correction = correction
+                self.dim = dim
+                self.keepdim = keepdim
+                self.op = op
+
+            def forward(self, x):
+                return self.op(x, self.dim, correction=self.correction, keepdim=self.keepdim)
+
+        return aten_var_correction(dim, correction, keepdim, op), f"aten::{op_type}"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_torch_export
+    @pytest.mark.precommit_fx_backend
+    @pytest.mark.parametrize("correction", [0, 1, 2, 3])
+    @pytest.mark.parametrize("dim", [0, 1, -1, (0, 1), (-1, -2)])
+    @pytest.mark.parametrize("keepdim", [True, False])
+    # Input is 8x8x8 so the reduction factor (>= 8) stays strictly greater than
+    # the largest correction, keeping the unbiased estimator well-defined.
+    @pytest.mark.parametrize("op_type", ["var", "var_mean", "std", "std_mean"])
+    @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
+                       reason='Ticket - 122715')
+    def test_correction(self, correction, dim, keepdim, op_type, ie_device, precision, ir_version):
+        self._test(*self.create_model(correction, dim, keepdim, op_type=op_type), ie_device, precision, ir_version,
+                   trace_model=True)


### PR DESCRIPTION
### Details:
 - `translate_var_mean_common` asserts `correction == 1` and always divides the
   sum of squared deviations by `(N - 1)`, but PyTorch divides by
   `(N - correction)`. The integer `correction` only reaches this translator on
   the `torch.export`/FX path, so a `var`/`std` call with a `correction` other
   than `0`/`1` **fails to convert** there with
   `OpConversionFailure: Check '(correction == 1)' failed`.
 - Fix: divide by `(N - correction)` and relax the assertion to `correction >= 0`.
   `correction=0`/`1` are unchanged; after the fix `correction=0..3` models convert
   and match eager PyTorch (~2e-7, FP32). The plain TorchScript trace path is
   unaffected — PyTorch's JIT collapses `correction` to the `unbiased` bool before
   it reaches OpenVINO.
 - Added `TestVarMeanCorrection` (var/std/var_mean/std_mean, corrections `0..3`);
   on the `torch.export` lane the `correction=2`/`3` cases fail to convert before
   the change and pass after.

### Tickets:
 - Fixes #36417

### AI Assistance:
 - AI assistance used: yes
 - If yes: AI helped locate the affected code path and draft wording; the
   root-cause analysis, the `(N - correction)` fix, and the regression test are mine.
 - Human validation performed: built OpenVINO from source and ran the PyTorch
   frontend layer tests — reproduced the `OpConversionFailure` on the unpatched
   frontend through `torch.export`, and confirmed the patched frontend converts
   and matches eager PyTorch for `correction=0..3` with existing trace-mode tests
   still passing. I understand and take responsibility for this change.