### PR TITLE
[GPU] Fix in-place crop padding leak with dynamic predecessor

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -509,11 +509,18 @@ bool crop_in_place_optimization::match(const program_node& node,
     if (node.is_output() || crop_params.has_fused_primitives() || node.is_in_shape_of_subgraph())
         return false;
 
+    // Treat crop as dynamic if its predecessor is dynamic, so that the
+    // dyn-only guards below match the runtime path. Skipped at runtime
+    // since the predecessor shape is already resolved there.
+    const bool dyn_aware = node.is_dynamic() ||
+                           (!is_runtime && !node.get_dependencies().empty() &&
+                            node.get_dependency(0).is_dynamic());
+
     const auto& crop_layout = crop_params.get_output_layout();
     for (auto user : node.get_users()) {
         // If the user node's output shape is already static, the padding
         // w/ dyn pad mask will not be propagated properly at runtime
-        if (node.is_dynamic() && !user->get_output_pshape().is_dynamic())
+        if (dyn_aware && !user->get_output_pshape().is_dynamic())
             return false;
         // do not optimize when next node is concatenation which is not output
         if (user->is_type<concatenation>() && !user->is_output())
@@ -528,15 +535,15 @@ bool crop_in_place_optimization::match(const program_node& node,
         // where the total size of tensor is not properly calculated and becomes 0
         // It causes issue for internal buffer allocation during runtime
         // TODO: Need to allow optimization for gemm user
-        if (node.is_dynamic() && (user->is_type<convolution>() || user->is_type<gemm>()))
+        if (dyn_aware && (user->is_type<convolution>() || user->is_type<gemm>()))
             return false;
         if (user->is_type<reshape>()) {
             // runtime buffer fusing is only handled when there is only one reshape user
-            if (node.is_dynamic() && node.get_users().size() != 1)
+            if (dyn_aware && node.get_users().size() != 1)
                 return false;
             auto& reshape_node = user->as<reshape>();
             if (can_reshape_be_optimized(reshape_node) &&
-                (!node.is_dynamic() || !reshape_node.is_runtime_propagatable_padding()))
+                (!dyn_aware || !reshape_node.is_runtime_propagatable_padding()))
                 return false;
         }
         if (user->is_type<experimental_detectron_roi_feature_extractor>() && user->get_dependency_index(node) == 0)
@@ -568,17 +575,17 @@ bool crop_in_place_optimization::match(const program_node& node,
         return false;
 
     if (node.get_users().size() > 0) {
-        GPU_DEBUG_IF(node.get_config().get_disable_runtime_buffer_fusing() && node.is_dynamic()) {
+        GPU_DEBUG_IF(node.get_config().get_disable_runtime_buffer_fusing() && dyn_aware) {
             return false;
         }
 
         // optimization is available for cropping across depth(features) or batch
         // if output padding has defined padding across features already it wouldn't
         // work because it expect to have zeros in the padded area.
-        if ((!node.is_dynamic() || is_runtime) &&
+        if ((!dyn_aware || is_runtime) &&
             !is_optimizable_padding_for_crop(node, crop_layout, input_layout, crop_params.input_offsets[0]))
             return false;
-        if (!(((!node.is_dynamic() || is_runtime) && can_crop_be_optimized_along_feature(crop_layout, input_layout))
+        if (!(((!dyn_aware || is_runtime) && can_crop_be_optimized_along_feature(crop_layout, input_layout))
             || can_crop_be_optimized_simple_data_format(crop_layout, input_layout)))
             return false;
     } else {

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -2301,3 +2301,86 @@ TEST(prepare_buffer_fusing, in_place_crop_dynamic_indivisible_padding_with_resha
             ASSERT_FLOAT_EQ(out2[f * crop2_last + y], input_data[f * total_last + offset2 + y])
                 << "output2 mismatch at f=" << f << " y=" << y;
 }
+
+// dyn-aware match() guard: crop with a static own layout but a dynamic predecessor
+// (reshape with concrete output_pattern fed by dynamic input). Without the guard,
+// build-time match took the static path and wrote padding that leaked into runtime.
+TEST(prepare_buffer_fusing, in_place_crop_static_output_with_dynamic_predecessor) {
+    auto& engine = get_test_engine();
+    tests::random_generator rg(GET_SUITE_NAME);
+
+    auto in_layout = layout{ov::PartialShape{-1, 128}, data_types::f32, format::bfyx};
+    auto input_mem = engine.allocate_memory({{1, 128}, data_types::f32, format::bfyx});
+    auto axis_mem = engine.allocate_memory({{}, data_types::i64, format::bfyx});
+    auto splits_length_mem = engine.allocate_memory({{2}, data_types::i64, format::bfyx});
+
+    const int64_t axis = 2;
+    auto input_data = rg.generate_random_1d<float>(input_mem->count(), -2.f, 2.f);
+    set_values(input_mem, input_data);
+    set_values<int64_t>(axis_mem, {axis});
+    set_values<int64_t>(splits_length_mem, {2, 2});
+
+    cldnn::crop_ngraph_op_mode op_mode = cldnn::crop_ngraph_op_mode::variadic_split;
+    auto offset_q = cldnn::tensor(0);
+    auto offset_k = cldnn::tensor(cldnn::batch(0), cldnn::feature(0), cldnn::spatial(0, 2));
+    topology topology(
+        input_layout("input", in_layout),
+        // Dynamic input collapses to fully static [1,4,4,8] via a concrete output_pattern.
+        reshape("reshape", input_info("input"), true,
+                std::vector<int64_t>{1, 4, 4, 8}, ov::PartialShape{1, 4, 4, 8},
+                cldnn::reshape::reshape_mode::base),
+        data("axis", axis_mem),
+        data("splits_length", splits_length_mem),
+        // Q branch: crop -> eltwise -> gemm(input0)
+        crop("crop_q", {input_info("reshape"), input_info("axis"), input_info("splits_length")},
+             cldnn::tensor(1), offset_q, op_mode, 0, axis),
+        eltwise("scale_q", input_info("crop_q"), input_info("crop_q"), eltwise_mode::prod),
+        // K branch: crop -> gemm(input1)
+        crop("crop_k", {input_info("reshape"), input_info("axis"), input_info("splits_length")},
+             cldnn::tensor(1), offset_k, op_mode, 1, axis),
+        gemm("attn", {input_info("scale_q"), input_info("crop_k")},
+             data_types::f32, false, true),
+        reorder("output", input_info("attn"), format::bfyx, data_types::f32,
+                std::vector<float>(), reorder_mean_mode::subtract, padding(), true)
+    );
+
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    network network(engine, topology, config);
+    network.set_input_data("input", input_mem);
+
+    auto outputs = network.execute();
+
+    // dyn-aware guards must reject in-place crop and leave no stale padding behind.
+    ASSERT_FALSE(network.get_primitive("crop_q")->can_be_optimized());
+    ASSERT_FALSE(network.get_primitive("crop_k")->can_be_optimized());
+    const auto& q_pad = network.get_primitive("crop_q")->get_impl_params()->get_output_layout().data_padding;
+    const auto& k_pad = network.get_primitive("crop_k")->get_impl_params()->get_output_layout().data_padding;
+    ASSERT_FALSE(static_cast<bool>(q_pad));
+    ASSERT_FALSE(static_cast<bool>(k_pad));
+
+    // End-to-end correctness: gemm output matches host reference.
+    const int64_t F = 4, Y = 4, X = 8;
+    auto host_gemm_output = std::vector<float>(F * 2 * 2);
+    for (int64_t f = 0; f < F; f++) {
+        for (int64_t qy = 0; qy < 2; qy++) {
+            for (int64_t ky = 0; ky < 2; ky++) {
+                float acc = 0.f;
+                for (int64_t x = 0; x < X; x++) {
+                    const float q = input_data[f * Y * X + qy * X + x];
+                    const float k = input_data[f * Y * X + (2 + ky) * X + x];
+                    acc += (q * q) * k;
+                }
+                host_gemm_output[f * 4 + qy * 2 + ky] = acc;
+            }
+        }
+    }
+
+    auto out_mem = outputs.at("output").get_memory();
+    cldnn::mem_lock<float> out(out_mem, get_test_stream());
+    ASSERT_EQ(out.size(), host_gemm_output.size());
+    for (size_t i = 0; i < host_gemm_output.size(); i++) {
+        ASSERT_NEAR(out[i], host_gemm_output[i], 1e-3f) << "mismatch at i=" << i;
+    }
+}


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - **Symptom**: YOLO11 GPU inference via model_api returned 0 bboxes (CPU returns 6). `OV_GPU_DISABLE_RUNTIME_BUFFER_FUSING=1` works around it.
 - **Root cause**: Build-time/runtime `crop_in_place_optimization::match()` asymmetry. `program_node::is_dynamic()` checks the dep's own output layouts (not transitively), so a crop with a static reshape predecessor reports `false` even when the chain starts from a dynamic input. Build-time took the static path and wrote actual padding into the crop layout; runtime then rejected in-place mode but the padding was never reset and leaked into downstream kernels with wrong strides.
 - **Resolution**: Use `dyn_aware = node.is_dynamic() || (!is_runtime && dep0.is_dynamic())` for the user-side guards inside `match()`. Build-time now rejects the crop and writes no padding; runtime path is unchanged.

#### The code and line that caused this issue (if it is not changed directly)
 - `src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp::crop_in_place_optimization::match` — `node.is_dynamic()` checks only saw the crop's own output and the dep's own output layouts (not the chain beyond).

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - `python main.py yolo11l.xml 000000000074.jpg GPU` — before: `detected bboxes: 0`, after: `detected bboxes: 6`
 - `OV_GPU_DISABLE_RUNTIME_BUFFER_FUSING=1 python main.py …` returns 6 bboxes both before and after the fix (confirms the in-place crop path is the source).
 - CPU baseline: `detected bboxes: 6` for both images.

#### Problematic graph
 - YOLO11 attention block at `__module.model.10.m.0.attn`:
   ```
   qkv.conv (output static via shape inference, dep dynamic)
       │
       ▼
   view/Reshape (output_pattern=[1,4,128,400], static output, dynamic dep)
       │
       ▼
   VariadicSplit axis=2, [32, 32, 64]   ← all three crops report node.is_dynamic()=false
       │            │              │
       ▼            ▼              ▼
       Q (out0)    K (out1)        V (out2)
       │            │              │  ┌─────────────┐
       │     Multiply_52375        │  │ reshape     │
       │     (scale, eltwise)      │  │   ↓         │
       │            │              │  │ pe.conv     │
       └─── MatMul──┘              │  │   ↓         │
            (Q·Kᵀ)                 │  │ proj.conv   │
              │                    │  └─────────────┘
              ▼                    │
           Softmax                 │
              │                    │
              ▼                    │
           transpose ──────► MatMul_1
                              (V output)
   ```
 - Build-time wrote y-axis padding `[lower=32, upper=64]` on `K (out1)` and propagated it to `Multiply_52375` (eltwise user). Runtime rejected the crop's in-place mode but left padding in `_impl_params`, so `Multiply_52375` and `MatMul` read with shifted strides into the parent reshape buffer, returning 0.

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?  
   - `prepare_buffer_fusing.in_place_crop_static_output_with_dynamic_predecessor`
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   -  None covered the static-crop-with-dynamic-predecessor pattern, so a new test was added rather than extending an existing one. All 40 existing `prepare_buffer_fusing.*` tests pass with the fix.

### Tickets:
 - [CVS-188346](https://jira.devtools.intel.com/browse/CVS-188346)
