### PR TITLE
[GPU] Add `ENABLE_CM_FOR_GPU` build option to disable CM kernel compilation

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -51,6 +51,7 @@ if (ENABLE_INTEL_GPU)
 endif()
 
 ov_dependent_option (ENABLE_ONEDNN_FOR_GPU "Enable oneDNN with GPU support" ${ENABLE_ONEDNN_FOR_GPU_DEFAULT} "ENABLE_INTEL_GPU" OFF)
+ov_dependent_option (ENABLE_CM_FOR_GPU "Enable C for Metal (CM) kernels at GPU runtime" ON "ENABLE_INTEL_GPU" OFF)
 
 ov_dependent_option (ENABLE_INTEL_NPU "NPU plugin for OpenVINO runtime" ON "X86_64;WIN32 OR LINUX OR ANDROID" OFF)
 ov_dependent_option (ENABLE_INTEL_NPU_INTERNAL "NPU plugin internal components for OpenVINO runtime" ON "ENABLE_INTEL_NPU" OFF)

--- a/src/plugins/intel_gpu/src/graph/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/CMakeLists.txt
@@ -109,6 +109,9 @@ add_test(NAME TestOCLCodePreprocessing
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 foreach(IMPL_TYPE IN LISTS AVAILABLE_IMPL_TYPES)
+    if(IMPL_TYPE STREQUAL "cm" AND NOT ENABLE_CM_FOR_GPU)
+        continue()
+    endif()
     add_subdirectory(impls/${IMPL_TYPE})
     if (TARGET openvino_intel_gpu_${IMPL_TYPE}_obj)
         list(APPEND OBJ_FILES $<TARGET_OBJECTS:openvino_intel_gpu_${IMPL_TYPE}_obj>)

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/CMakeLists.txt
@@ -8,6 +8,10 @@ ov_gpu_add_backend_target(
     NAME ${TARGET_NAME}
 )
 
+if(ENABLE_CM_FOR_GPU)
+    target_compile_definitions(${TARGET_NAME} PRIVATE ENABLE_CM_FOR_GPU)
+endif()
+
 ov_build_target_faster(${TARGET_NAME} PCH)
 
 if(GPU_RT_TYPE STREQUAL "SYCL")

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
@@ -5,7 +5,9 @@
 #include "kernels_cache.hpp"
 #include <regex>
 
+#ifdef ENABLE_CM_FOR_GPU
 #include "impls/cm/utils/kernels_db.hpp"
+#endif
 #include "impls/ocl_v2/utils/kernels_db.hpp"
 #include "intel_gpu/runtime/kernel_args.hpp"
 #include "openvino/util/pp.hpp"
@@ -209,9 +211,14 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
                     for (auto& header : new_headers) {
                         if (std::find(all_headers.begin(), all_headers.end(), header) == all_headers.end()) {
                             all_headers.push_front(header);
-                            std::string_view header_code = prog.language == kernel_language::OCLC_V2
+                            std::string_view header_code =
+#ifdef ENABLE_CM_FOR_GPU
+                                prog.language == kernel_language::OCLC_V2
                                 ? ov::intel_gpu::ocl::SourcesDB::get_kernel_header(header)
                                 : ov::intel_gpu::cm::SourcesDB::get_kernel_header(header);
+#else
+                                ov::intel_gpu::ocl::SourcesDB::get_kernel_header(header);
+#endif
                             sources_to_process.push_back(std::string(header_code) + "\n");
                         }
                     }

--- a/src/plugins/intel_gpu/src/graph/registry/registry.hpp
+++ b/src/plugins/intel_gpu/src/graph/registry/registry.hpp
@@ -25,7 +25,11 @@
 #endif
 #define OV_GPU_WITH_COMMON 1
 #define OV_GPU_WITH_CPU 1
-#define OV_GPU_WITH_CM 1
+#ifdef ENABLE_CM_FOR_GPU
+    #define OV_GPU_WITH_CM 1
+#else
+    #define OV_GPU_WITH_CM 0
+#endif
 
 #ifdef EXPAND
 #undef EXPAND


### PR DESCRIPTION
Introduces `ENABLE_CM_FOR_GPU` CMake option (default: `ON`, depends on `ENABLE_INTEL_GPU`) that allows building the GPU plugin without C for Metal (CM) kernels, reducing binary size.

Tickets: CVS-188834