### PR TITLE
onnx/MatMulNBits: propagate B tensor name to casted_b [CVS-188759]

### DIFF
--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -175,6 +175,11 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
             FRONT_END_THROW("Unsupported bits count");
             break;
         }
+        // Propagate tensor names from the original B constant so weight-sharing
+        // infrastructure can identify this node by its ONNX initializer name.
+        ov::as_type_ptr<v0::Constant>(casted_b.get_node_shared_ptr())
+            ->get_output_tensor(0).set_names(b_const->get_output_tensor(0).get_names());
+
 
         ov::Output<ov::Node> converted_zero_points;
         if (!zero_points.get_node_shared_ptr()) {
@@ -216,9 +221,14 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                                  zp_shape);
 
                 ov::Shape casted_zp_shape = ov::Shape{static_cast<size_t>(N), static_cast<size_t>(n_blocks_per_col), 1};
-                converted_zero_points = std::make_shared<v0::Constant>(a.get_element_type(),
+                {
+                    auto zp_fp_const = std::make_shared<v0::Constant>(a.get_element_type(),
                                                                        casted_zp_shape,
                                                                        zero_points_const->get_data_ptr());
+                    zp_fp_const->get_output_tensor(0).set_names(
+                        zero_points_const->get_output_tensor(0).get_names());
+                    converted_zero_points = zp_fp_const;
+                }
             } else if (zero_points.get_element_type() == ov::element::u8) {
                 // for alignment, n_blocks_per_col might not aligned to num_per_byte
                 uint64_t num_per_byte = 8 / bits;
@@ -228,6 +238,8 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                     ov::Shape{static_cast<size_t>(N), static_cast<size_t>(num_elements_aligned), 1};
                 auto casted_zp_org =
                     std::make_shared<v0::Constant>(zp_element_type, casted_zp_shape, zero_points_const->get_data_ptr());
+                casted_zp_org->get_output_tensor(0).set_names(
+                    zero_points_const->get_output_tensor(0).get_names());
                 converted_zero_points = std::make_shared<v0::Convert>(casted_zp_org, a.get_element_type());
                 if (n_blocks_per_col != num_elements_aligned) {
                     // if not align

--- a/src/frontends/onnx/tests/onnx_tensor_names.cpp
+++ b/src/frontends/onnx/tests/onnx_tensor_names.cpp
@@ -8,6 +8,7 @@
 #include "gtest/gtest.h"
 #include "onnx_utils.hpp"
 #include "openvino/op/abs.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/identity.hpp"
 #include "openvino/op/matmul.hpp"
@@ -166,4 +167,23 @@ OPENVINO_TEST(onnx_tensor_names, subgraph_gemm_with_bias) {
     EXPECT_EQ(result1->input(0).get_source_output().get_names(), std::unordered_set<std::string>({"y"}));
 
     EXPECT_NE(nullptr, find_by_friendly_name<op::v0::MatMul>(ops, "y/WithoutBiases"));
+}
+
+OPENVINO_TEST(onnx_tensor_names, matmulnbits_b_tensor_name_propagation) {
+    // Verify that MatMulNBits preserves the B initializer tensor name on the casted constant
+    const auto model = convert_model("com.microsoft/matmulnbits_3x4.onnx");
+
+    const auto ops = model->get_ordered_ops();
+
+    // After decomposition, there must be a Constant whose output tensor carries the name "b_Q4"
+    // (the original ONNX initializer name).  Without the fix this name was lost.
+    const bool found = std::any_of(ops.begin(), ops.end(), [](const std::shared_ptr<ov::Node>& op) {
+        if (ov::as_type_ptr<ov::op::v0::Constant>(op)) {
+            const auto& names = op->get_output_tensor(0).get_names();
+            return names.count("b_Q4") > 0;
+        }
+        return false;
+    });
+
+    EXPECT_TRUE(found) << "No Constant node with tensor name 'b_Q4' found after MatMulNBits decomposition";
 }


### PR DESCRIPTION
### Details:
Without this fix, MatMulNBits loses the B initializer tensor name during type-cast, breaking NPUW weight-sharing name matching. Also adds a unit test in onnx_tensor_names.cpp verifying the name survives decomposition.

### Tickets:
 - [CVS-188759]

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
