### PR TITLE
Fix build-time race condition for NPU VM target

### DIFF
--- a/src/plugins/intel_npu/src/utils/src/vm/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/utils/src/vm/CMakeLists.txt
@@ -28,3 +28,10 @@ target_include_directories(${TARGET_NAME}
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(${TARGET_NAME} PRIVATE OPENVINO_STATIC_LIBRARY)
 endif()
+
+# The include directories above use TARGET_PROPERTY expressions instead of
+# target_link_libraries, so CMake creates no build-order edge. Level Zero
+# headers are copied into the build directory by prepare_ze_headers; without
+# this explicit dependency a parallel build may compile ${TARGET_NAME} before
+# the headers are copied, causing a missing-header error
+add_dependencies(${TARGET_NAME} prepare_ze_headers)


### PR DESCRIPTION
### Details:

openvino_npu_vm_utils may be compiled before Level Zero headers are copied into the build directory, causing a missing-header error on parallel builds. Add an explicit dependency on prepare_ze_headers to ensure correct build ordering.

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-188745

### AI Assistance:
 - *AI assistance used: yes*
 - AI was asked to find the reason for build issue (missing header during VPUx build), check if there're other related issues with the same CMake target and propose a fix. Also AI was asked to propose a reproducer to make issue visible locally on Ubuntu (originally build failed only on Windows pre-commit of VPUx). I manually tested the build locally on Ubuntu, checked with reproducer (manually remove copied headers and try again) that issue now disappears and tested in Windows VPUx pre-commit, where issue were originally reproduced to see if it was solved
