### PR TITLE
CVS-188759 : [ONNX FE] MatMulNBits name packed B constant for weight sharing

### DIFF
--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -176,6 +176,18 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
             break;
         }
 
+        // Propagate the ONNX B initializer identity onto the PACKED low-bit weight constant so that
+        // weight-sharing infrastructure (e.g. the OpenVINO EP plugin weights-as-input pass) can
+        // identify this node by its ONNX initializer name and promote it to a graph input without
+        // const-folding it to full precision. The name is set on BOTH the friendly_name and the
+        // output tensor names because consumers may match on either. Only the WEIGHT (B) is named;
+        // the scale and zero-point dequantization parameters are intentionally left unnamed so that
+        // weight-sharing never promotes them (they must stay Constants for correct/NPU-safe dequant).
+        if (const auto casted_b_const = ov::as_type_ptr<v0::Constant>(casted_b.get_node_shared_ptr())) {
+            casted_b_const->set_friendly_name(b_const->get_friendly_name());
+            casted_b_const->get_output_tensor(0).set_names(b_const->get_output_tensor(0).get_names());
+        }
+
         ov::Output<ov::Node> converted_zero_points;
         if (!zero_points.get_node_shared_ptr()) {
             converted_zero_points = std::make_shared<v0::Convert>(default_zp, a.get_element_type());

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -176,13 +176,8 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
             break;
         }
 
-        // Propagate the ONNX B initializer identity onto the PACKED low-bit weight constant so that
-        // weight-sharing infrastructure (e.g. the OpenVINO EP plugin weights-as-input pass) can
-        // identify this node by its ONNX initializer name and promote it to a graph input without
-        // const-folding it to full precision. The name is set on BOTH the friendly_name and the
-        // output tensor names because consumers may match on either. Only the WEIGHT (B) is named;
-        // the scale and zero-point dequantization parameters are intentionally left unnamed so that
-        // weight-sharing never promotes them (they must stay Constants for correct/NPU-safe dequant).
+        // Preserve the original B initializer name on the repacked weight constant so it can still be
+        // identified by name downstream (e.g. for weight sharing). Only B is named.
         if (const auto casted_b_const = ov::as_type_ptr<v0::Constant>(casted_b.get_node_shared_ptr())) {
             casted_b_const->set_friendly_name(b_const->get_friendly_name());
             casted_b_const->get_output_tensor(0).set_names(b_const->get_output_tensor(0).get_names());

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_shared_b.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_shared_b.prototxt
@@ -1,0 +1,141 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+producer_version: ""
+model_version: 0
+graph {
+  name: "test_matmulnbits_shared_b"
+  node {
+    input: "a"
+    input: "b_Q4"
+    input: "b_scales"
+    output: "c1"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 3
+      type: INT
+    }
+    attribute {
+      name: "accuracy_level"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  node {
+    input: "a"
+    input: "b_Q4"
+    input: "b_scales"
+    output: "c2"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 3
+      type: INT
+    }
+    attribute {
+      name: "accuracy_level"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  initializer {
+    dims: 3
+    dims: 1
+    dims: 8
+    data_type: 2
+    name: "b_Q4"
+    raw_data: "&P\000\000\000\000\000\000\005b\000\000\000\000\000\000\004\204\000\000\000\000\000\000"
+  }
+  initializer {
+    dims: 3
+    data_type: 1
+    name: "b_scales"
+    raw_data: "\000\000 \277\000\000 \277\000\000@\277"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 7
+}
+opset_import {
+  version: 1
+}

--- a/src/frontends/onnx/tests/onnx_tensor_names.cpp
+++ b/src/frontends/onnx/tests/onnx_tensor_names.cpp
@@ -175,26 +175,24 @@ OPENVINO_TEST(onnx_tensor_names, matmulnbits_b_name_preserved) {
 
     const auto ops = model->get_ordered_ops();
 
-    // The repacked u4 weight carries "b_Q4" as friendly_name and tensor name.
-    std::shared_ptr<op::v0::Constant> packed_b;
-    for (const auto& op : ops) {
-        const auto c = ov::as_type_ptr<op::v0::Constant>(op);
-        if (c && c->get_element_type() == element::u4 && c->get_friendly_name() == "b_Q4") {
-            packed_b = c;
-        }
-    }
+    // Repacked weight keeps "b_Q4" as friendly_name and tensor name.
+    EXPECT_TRUE(matching_node_found_in_graph<op::v0::Constant>(ops, "b_Q4", {"b_Q4"}));
+
+    // It is the u4 repacked weight, not the original initializer.
+    const auto packed_b = find_by_friendly_name<op::v0::Constant>(ops, "b_Q4");
     ASSERT_NE(packed_b, nullptr);
-    EXPECT_EQ(packed_b->get_output_tensor(0).get_names(), std::unordered_set<std::string>({"b_Q4"}));
+    EXPECT_EQ(packed_b->get_element_type(), element::u4);
 }
 
 OPENVINO_TEST(onnx_tensor_names, matmulnbits_shared_b_name_collision_resolved) {
-    // One B initializer feeding two MatMulNBits mints two same-named Constants. ResolveNameCollisions
-    // (run during normalize) keeps "b_Q4" on one and suffixes the other - no manual postfix needed.
+    // One B feeding two MatMulNBits creates two same-named Constants; ResolveNameCollisions (in
+    // normalize) keeps "b_Q4" on one and suffixes the other - no manual postfix needed.
     const auto model = convert_model("com.microsoft/matmulnbits_shared_b.onnx");
 
     const auto ops = model->get_ordered_ops();
 
-    // Two named u4 weights; unnamed u4 zero-point constants are excluded by the name check.
+    // Collect the two named u4 weights directly: counting and uniqueness can't be expressed by the
+    // bool/first-match helpers. Unnamed u4 zero-point constants are excluded by the name check.
     std::vector<std::shared_ptr<op::v0::Constant>> packed_weights;
     for (const auto& op : ops) {
         const auto c = ov::as_type_ptr<op::v0::Constant>(op);
@@ -204,7 +202,7 @@ OPENVINO_TEST(onnx_tensor_names, matmulnbits_shared_b_name_collision_resolved) {
     }
     ASSERT_EQ(packed_weights.size(), 2u);
 
-    // Both friendly_names and tensor names are unique after normalization.
+    // Names are unique after normalization.
     std::unordered_set<std::string> friendly_names;
     std::unordered_set<std::string> tensor_names;
     for (const auto& c : packed_weights) {
@@ -215,7 +213,8 @@ OPENVINO_TEST(onnx_tensor_names, matmulnbits_shared_b_name_collision_resolved) {
     EXPECT_EQ(friendly_names.size(), 2u);
     EXPECT_EQ(tensor_names.size(), 2u);
 
-    // Exactly one keeps "b_Q4" so weight sharing still matches; the other is suffixed.
+    // Exactly one keeps "b_Q4" so weight sharing still matches.
+    EXPECT_TRUE(matching_node_found_in_graph<op::v0::Constant>(ops, "b_Q4", {"b_Q4"}));
     EXPECT_EQ(friendly_names.count("b_Q4"), 1u);
     EXPECT_EQ(tensor_names.count("b_Q4"), 1u);
 }

--- a/src/frontends/onnx/tests/onnx_tensor_names.cpp
+++ b/src/frontends/onnx/tests/onnx_tensor_names.cpp
@@ -8,6 +8,7 @@
 #include "gtest/gtest.h"
 #include "onnx_utils.hpp"
 #include "openvino/op/abs.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/identity.hpp"
 #include "openvino/op/matmul.hpp"
@@ -166,4 +167,55 @@ OPENVINO_TEST(onnx_tensor_names, subgraph_gemm_with_bias) {
     EXPECT_EQ(result1->input(0).get_source_output().get_names(), std::unordered_set<std::string>({"y"}));
 
     EXPECT_NE(nullptr, find_by_friendly_name<op::v0::MatMul>(ops, "y/WithoutBiases"));
+}
+
+OPENVINO_TEST(onnx_tensor_names, matmulnbits_b_name_preserved) {
+    // MatMulNBits repacks B into a low-bit Constant; it must keep the ONNX initializer name "b_Q4".
+    const auto model = convert_model("com.microsoft/matmulnbits_3x4.onnx");
+
+    const auto ops = model->get_ordered_ops();
+
+    // The repacked u4 weight carries "b_Q4" as friendly_name and tensor name.
+    std::shared_ptr<op::v0::Constant> packed_b;
+    for (const auto& op : ops) {
+        const auto c = ov::as_type_ptr<op::v0::Constant>(op);
+        if (c && c->get_element_type() == element::u4 && c->get_friendly_name() == "b_Q4") {
+            packed_b = c;
+        }
+    }
+    ASSERT_NE(packed_b, nullptr);
+    EXPECT_EQ(packed_b->get_output_tensor(0).get_names(), std::unordered_set<std::string>({"b_Q4"}));
+}
+
+OPENVINO_TEST(onnx_tensor_names, matmulnbits_shared_b_name_collision_resolved) {
+    // One B initializer feeding two MatMulNBits mints two same-named Constants. ResolveNameCollisions
+    // (run during normalize) keeps "b_Q4" on one and suffixes the other - no manual postfix needed.
+    const auto model = convert_model("com.microsoft/matmulnbits_shared_b.onnx");
+
+    const auto ops = model->get_ordered_ops();
+
+    // Two named u4 weights; unnamed u4 zero-point constants are excluded by the name check.
+    std::vector<std::shared_ptr<op::v0::Constant>> packed_weights;
+    for (const auto& op : ops) {
+        const auto c = ov::as_type_ptr<op::v0::Constant>(op);
+        if (c && c->get_element_type() == element::u4 && !c->get_output_tensor(0).get_names().empty()) {
+            packed_weights.push_back(c);
+        }
+    }
+    ASSERT_EQ(packed_weights.size(), 2u);
+
+    // Both friendly_names and tensor names are unique after normalization.
+    std::unordered_set<std::string> friendly_names;
+    std::unordered_set<std::string> tensor_names;
+    for (const auto& c : packed_weights) {
+        friendly_names.insert(c->get_friendly_name());
+        const auto& names = c->get_output_tensor(0).get_names();
+        tensor_names.insert(names.begin(), names.end());
+    }
+    EXPECT_EQ(friendly_names.size(), 2u);
+    EXPECT_EQ(tensor_names.size(), 2u);
+
+    // Exactly one keeps "b_Q4" so weight sharing still matches; the other is suffixed.
+    EXPECT_EQ(friendly_names.count("b_Q4"), 1u);
+    EXPECT_EQ(tensor_names.count("b_Q4"), 1u);
 }


### PR DESCRIPTION
## Summary
During `MatMulNBits` decomposition, input `B` is repacked into a new low-bit constant (`casted_b`, `u2`/`u4`/`u8`) that loses the original ONNX initializer name. This propagates the source `B` initializer's identity (`friendly_name` + output tensor names) onto `casted_b`. Only `B` is named — `scale` and `zero_point` are intentionally left unnamed.

## Motivation
Weight-sharing consumers (the OpenVINO EP plugin's *weights-as-input* pass) match shareable weights by ONNX initializer name. Without a name, the decomposed `B` couldn't be matched and stayed a constant — baked and expanded into the compiled blob. Naming it lets the consumer promote `B` to a graph input, keeping the packed low-bit weight out of the blob. `scale`/`zero_point` stay unnamed so they remain constants (required for correct, NPU-friendly dequantization).

## Impact
- **Names only** — no change to graph topology, element types, or numerics.
- **Safe to land independently** — a no-op without a weight-sharing consumer.

## Validation
Verified end-to-end with the OVEP weights-as-input consumer on a real 2-bit LLM: `B` promoted to a `u2` graph input across all 280 `MatMulNBits` layers, `scale`/`zero_point` remain constants, inference numerically unchanged.


### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-188759

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
