### PR TITLE
[CPU][ARM] Guard ARM SVE kernel entry points

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.cpp
@@ -17,6 +17,7 @@
 #include "cpu_memory.h"
 #include "nodes/executors/memory_arguments.hpp"
 #include "utils/debug_capabilities.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -75,6 +76,15 @@ ACLCommonExecutor::ACLCommonExecutor() {
 }
 
 bool ACLCommonExecutor::update(const MemoryArgs& memory) {
+    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD). Declare the required ISA once
+    // here, in the common base of every ACL executor, so that on a core lacking it the
+    // executor declines and the framework falls back to a baseline implementation instead
+    // of running an unsupported instruction. ASIMD is always present on AArch64, so this
+    // never over-restricts; it is the single hoisted gate for all ACLCommonExecutor children.
+    if (!hasArmISASupport(ArmISA::ASIMD)) {
+        return false;
+    }
+
     // Initialize ACL tensors params
     ACLShapes aclMemoryShapes;
     ACLTypes aclDataType{};

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.cpp
@@ -17,7 +17,6 @@
 #include "cpu_memory.h"
 #include "nodes/executors/memory_arguments.hpp"
 #include "utils/debug_capabilities.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -76,15 +75,6 @@ ACLCommonExecutor::ACLCommonExecutor() {
 }
 
 bool ACLCommonExecutor::update(const MemoryArgs& memory) {
-    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD). Declare the required ISA once
-    // here, in the common base of every ACL executor, so that on a core lacking it the
-    // executor declines and the framework falls back to a baseline implementation instead
-    // of running an unsupported instruction. ASIMD is always present on AArch64, so this
-    // never over-restricts; it is the single hoisted gate for all ACLCommonExecutor children.
-    if (!hasArmISASupport(ArmISA::ASIMD)) {
-        return false;
-    }
-
     // Initialize ACL tensors params
     ACLShapes aclMemoryShapes;
     ACLTypes aclDataType{};

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -26,13 +26,13 @@
 #include "nodes/executors/common/common_utils.hpp"
 #include "nodes/executors/convolution_config.hpp"
 #include "nodes/executors/debug_messages.hpp"
-#include "utils/precision_support.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/memory_arguments.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -32,7 +32,6 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -118,7 +117,7 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
 }
 
 bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
     VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
 
     const auto& srcDesc = config.descs.at(ARG_SRC);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -117,12 +117,12 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
 }
 
 bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
-    VERIFY(aclCommonExecutorSupported(config.descs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
-    VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
-
     const auto& srcDesc = config.descs.at(ARG_SRC);
     const auto& weiDesc = config.descs.at(ARG_WEI);
     const auto& dstDesc = config.descs.at(ARG_DST);
+
+    VERIFY(aclCommonExecutorSupported({srcDesc, weiDesc, dstDesc}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
 
     // ACL GemmConv2d supports 4D activations and 4D weight only
     VERIFY(srcDesc->getShape().getRank() == 4 && weiDesc->getShape().getRank() == 4, UNSUPPORTED_BY_EXECUTOR);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -117,7 +117,7 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
 }
 
 bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
 
     const auto& srcDesc = config.descs.at(ARG_SRC);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -32,7 +32,6 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -118,9 +117,6 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
 }
 
 bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
-    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly
-    // so the executor is selected only on a core that provides the required ISA.
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
 
     const auto& srcDesc = config.descs.at(ARG_SRC);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -26,6 +26,7 @@
 #include "nodes/executors/common/common_utils.hpp"
 #include "nodes/executors/convolution_config.hpp"
 #include "nodes/executors/debug_messages.hpp"
+#include "utils/precision_support.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/memory_arguments.hpp"
 #include "openvino/core/except.hpp"
@@ -117,6 +118,9 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
 }
 
 bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
+    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly
+    // so the executor is selected only on a core that provides the required ISA.
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
 
     const auto& srcDesc = config.descs.at(ARG_SRC);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -117,7 +117,7 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
 }
 
 bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported(config.descs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
 
     const auto& srcDesc = config.descs.at(ARG_SRC);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -121,7 +121,7 @@ bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
     const auto& weiDesc = config.descs.at(ARG_WEI);
     const auto& dstDesc = config.descs.at(ARG_DST);
 
-    VERIFY(aclCommonExecutorSupported({srcDesc, weiDesc, dstDesc}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclSupported({srcDesc, weiDesc, dstDesc}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
 
     // ACL GemmConv2d supports 4D activations and 4D weight only

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -32,6 +32,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -117,6 +118,7 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
 }
 
 bool ACLConvolutionExecutor::supports(const ConvConfig& config) {
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     VERIFY(config.attrs.postOps.size() <= 1U, UNSUPPORTED_BY_EXECUTOR);
 
     const auto& srcDesc = config.descs.at(ARG_SRC);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
@@ -101,7 +101,7 @@ void ACLConvertExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vec
 bool ACLConvertExecutorBuilder::isSupported(const ConvertParams& convertParams,
                                             const MemoryDescPtr& srcDesc,
                                             const MemoryDescPtr& dstDesc) const {
-    VERIFY(aclCommonExecutorSupported({srcDesc, dstDesc}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclSupported({srcDesc, dstDesc}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (convertParams.srcPrc != convertParams.dstPrc) {
         if (none_of(convertParams.srcPrc,
                     ov::element::i8,

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
@@ -20,9 +20,11 @@
 #include "cpu_memory.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "nodes/executors/convert.hpp"
+#include "nodes/executors/debug_messages.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -100,6 +102,7 @@ void ACLConvertExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vec
 bool ACLConvertExecutorBuilder::isSupported(const ConvertParams& convertParams,
                                             [[maybe_unused]] const MemoryDescPtr& srcDesc,
                                             [[maybe_unused]] const MemoryDescPtr& dstDesc) const {
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     if (convertParams.srcPrc != convertParams.dstPrc) {
         if (none_of(convertParams.srcPrc,
                     ov::element::i8,

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
@@ -24,7 +24,6 @@
 #include "openvino/core/type/element_type.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -102,7 +101,7 @@ void ACLConvertExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vec
 bool ACLConvertExecutorBuilder::isSupported(const ConvertParams& convertParams,
                                             [[maybe_unused]] const MemoryDescPtr& srcDesc,
                                             [[maybe_unused]] const MemoryDescPtr& dstDesc) const {
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
     if (convertParams.srcPrc != convertParams.dstPrc) {
         if (none_of(convertParams.srcPrc,
                     ov::element::i8,

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
@@ -12,7 +12,6 @@
 #include <arm_compute/runtime/NEON/functions/NECopy.h>
 
 #include <cassert>
-#include <initializer_list>
 #include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <vector>
@@ -102,8 +101,7 @@ void ACLConvertExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vec
 bool ACLConvertExecutorBuilder::isSupported(const ConvertParams& convertParams,
                                             const MemoryDescPtr& srcDesc,
                                             const MemoryDescPtr& dstDesc) const {
-    VERIFY(aclCommonExecutorSupported(std::initializer_list<MemoryDescPtr>{srcDesc, dstDesc}),
-           UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported({srcDesc, dstDesc}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (convertParams.srcPrc != convertParams.dstPrc) {
         if (none_of(convertParams.srcPrc,
                     ov::element::i8,

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
@@ -101,7 +101,7 @@ void ACLConvertExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vec
 bool ACLConvertExecutorBuilder::isSupported(const ConvertParams& convertParams,
                                             [[maybe_unused]] const MemoryDescPtr& srcDesc,
                                             [[maybe_unused]] const MemoryDescPtr& dstDesc) const {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (convertParams.srcPrc != convertParams.dstPrc) {
         if (none_of(convertParams.srcPrc,
                     ov::element::i8,

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
@@ -12,6 +12,7 @@
 #include <arm_compute/runtime/NEON/functions/NECopy.h>
 
 #include <cassert>
+#include <initializer_list>
 #include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <vector>
@@ -99,9 +100,10 @@ void ACLConvertExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vec
 }
 
 bool ACLConvertExecutorBuilder::isSupported(const ConvertParams& convertParams,
-                                            [[maybe_unused]] const MemoryDescPtr& srcDesc,
-                                            [[maybe_unused]] const MemoryDescPtr& dstDesc) const {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+                                            const MemoryDescPtr& srcDesc,
+                                            const MemoryDescPtr& dstDesc) const {
+    VERIFY(aclCommonExecutorSupported(std::initializer_list<MemoryDescPtr>{srcDesc, dstDesc}),
+           UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (convertParams.srcPrc != convertParams.dstPrc) {
         if (none_of(convertParams.srcPrc,
                     ov::element::i8,

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
@@ -235,7 +235,7 @@ void AclDeconvExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclDeconvExecutorBuilder::customIsSupported(const DeconvAttrs& deconvAttrs,
                                                  const std::vector<MemoryDescPtr>& srcDescs,
                                                  const std::vector<MemoryDescPtr>& dstDescs) {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (srcDescs[0]->getShape().getDims().size() != 4 || dstDescs[0]->getShape().getDims().size() != 4 ||
         srcDescs[1]->getShape().getDims().size() != 4) {
         DEBUG_LOG("AclDeconvExecutor only supports 4D tensors:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
@@ -235,7 +235,7 @@ void AclDeconvExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclDeconvExecutorBuilder::customIsSupported(const DeconvAttrs& deconvAttrs,
                                                  const std::vector<MemoryDescPtr>& srcDescs,
                                                  const std::vector<MemoryDescPtr>& dstDescs) {
-    VERIFY(aclCommonExecutorSupported(srcDescs, dstDescs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported({srcDescs[0], dstDescs[0]}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (srcDescs[0]->getShape().getDims().size() != 4 || dstDescs[0]->getShape().getDims().size() != 4 ||
         srcDescs[1]->getShape().getDims().size() != 4) {
         DEBUG_LOG("AclDeconvExecutor only supports 4D tensors:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
@@ -235,7 +235,7 @@ void AclDeconvExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclDeconvExecutorBuilder::customIsSupported(const DeconvAttrs& deconvAttrs,
                                                  const std::vector<MemoryDescPtr>& srcDescs,
                                                  const std::vector<MemoryDescPtr>& dstDescs) {
-    VERIFY(aclCommonExecutorSupported({srcDescs[0], dstDescs[0]}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclSupported({srcDescs[0], dstDescs[0]}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (srcDescs[0]->getShape().getDims().size() != 4 || dstDescs[0]->getShape().getDims().size() != 4 ||
         srcDescs[1]->getShape().getDims().size() != 4) {
         DEBUG_LOG("AclDeconvExecutor only supports 4D tensors:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
@@ -29,7 +29,6 @@
 #include "openvino/core/type/float16.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -236,7 +235,7 @@ void AclDeconvExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclDeconvExecutorBuilder::customIsSupported(const DeconvAttrs& deconvAttrs,
                                                  const std::vector<MemoryDescPtr>& srcDescs,
                                                  const std::vector<MemoryDescPtr>& dstDescs) {
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
     if (srcDescs[0]->getShape().getDims().size() != 4 || dstDescs[0]->getShape().getDims().size() != 4 ||
         srcDescs[1]->getShape().getDims().size() != 4) {
         DEBUG_LOG("AclDeconvExecutor only supports 4D tensors:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
@@ -21,6 +21,7 @@
 #include "cpu_memory.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "nodes/executors/acl/acl_utils.hpp"
+#include "nodes/executors/debug_messages.hpp"
 #include "nodes/executors/deconv.hpp"
 #include "nodes/executors/executor.hpp"
 #include "openvino/core/parallel.hpp"
@@ -28,6 +29,7 @@
 #include "openvino/core/type/float16.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -234,6 +236,7 @@ void AclDeconvExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclDeconvExecutorBuilder::customIsSupported(const DeconvAttrs& deconvAttrs,
                                                  const std::vector<MemoryDescPtr>& srcDescs,
                                                  const std::vector<MemoryDescPtr>& dstDescs) {
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     if (srcDescs[0]->getShape().getDims().size() != 4 || dstDescs[0]->getShape().getDims().size() != 4 ||
         srcDescs[1]->getShape().getDims().size() != 4) {
         DEBUG_LOG("AclDeconvExecutor only supports 4D tensors:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
@@ -235,7 +235,7 @@ void AclDeconvExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclDeconvExecutorBuilder::customIsSupported(const DeconvAttrs& deconvAttrs,
                                                  const std::vector<MemoryDescPtr>& srcDescs,
                                                  const std::vector<MemoryDescPtr>& dstDescs) {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported(srcDescs, dstDescs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (srcDescs[0]->getShape().getDims().size() != 4 || dstDescs[0]->getShape().getDims().size() != 4 ||
         srcDescs[1]->getShape().getDims().size() != 4) {
         DEBUG_LOG("AclDeconvExecutor only supports 4D tensors:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
@@ -76,9 +76,8 @@ inline void log_unsupported_prec(const std::vector<MemoryDescPtr>& srcDescs,
 }
 
 bool AclEltwiseExecutor::supports(const EltwiseConfig& config) {
-    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly
-    // so the executor is selected only on a core that provides the required ISA.
     if (!aclCommonExecutorSupported()) {
+        DEBUG_LOG("ACL common preconditions not met");
         return false;
     }
     std::vector<MemoryDescPtr> srcDescs(config.descs.size() - 1);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
@@ -31,6 +31,7 @@
 #include "cpu_types.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "nodes/executors/eltwise_config.hpp"
+#include "utils/precision_support.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/memory_arguments.hpp"
 #include "openvino/core/except.hpp"
@@ -76,6 +77,11 @@ inline void log_unsupported_prec(const std::vector<MemoryDescPtr>& srcDescs,
 }
 
 bool AclEltwiseExecutor::supports(const EltwiseConfig& config) {
+    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly
+    // so the executor is selected only on a core that provides the required ISA.
+    if (!hasArmISASupport(ArmISA::ASIMD)) {
+        return false;
+    }
     std::vector<MemoryDescPtr> srcDescs(config.descs.size() - 1);
     std::vector<MemoryDescPtr> dstDescs{config.descs.at(ARG_DST)};
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
@@ -87,7 +87,7 @@ bool AclEltwiseExecutor::supports(const EltwiseConfig& config) {
         srcDescs[argId - ARG_SRC] = desc;
     }
 
-    if (!aclCommonExecutorSupported(srcDescs, dstDescs)) {
+    if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) {
         DEBUG_LOG("ACL common preconditions not met");
         return false;
     }

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
@@ -87,8 +87,8 @@ bool AclEltwiseExecutor::supports(const EltwiseConfig& config) {
         srcDescs[argId - ARG_SRC] = desc;
     }
 
-    if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) {
-        DEBUG_LOG("ACL common preconditions not met");
+    if (!aclSupported({srcDescs[0], dstDescs[0]})) {
+        DEBUG_LOG("ACL common preconditions are not met");
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
@@ -36,7 +36,6 @@
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "utils/debug_capabilities.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -79,7 +78,7 @@ inline void log_unsupported_prec(const std::vector<MemoryDescPtr>& srcDescs,
 bool AclEltwiseExecutor::supports(const EltwiseConfig& config) {
     // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly
     // so the executor is selected only on a core that provides the required ISA.
-    if (!hasArmISASupport(ArmISA::ASIMD)) {
+    if (!aclCommonExecutorSupported()) {
         return false;
     }
     std::vector<MemoryDescPtr> srcDescs(config.descs.size() - 1);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
@@ -76,10 +76,6 @@ inline void log_unsupported_prec(const std::vector<MemoryDescPtr>& srcDescs,
 }
 
 bool AclEltwiseExecutor::supports(const EltwiseConfig& config) {
-    if (!aclCommonExecutorSupported()) {
-        DEBUG_LOG("ACL common preconditions not met");
-        return false;
-    }
     std::vector<MemoryDescPtr> srcDescs(config.descs.size() - 1);
     std::vector<MemoryDescPtr> dstDescs{config.descs.at(ARG_DST)};
 
@@ -89,6 +85,11 @@ bool AclEltwiseExecutor::supports(const EltwiseConfig& config) {
         }
 
         srcDescs[argId - ARG_SRC] = desc;
+    }
+
+    if (!aclCommonExecutorSupported(srcDescs, dstDescs)) {
+        DEBUG_LOG("ACL common preconditions not met");
+        return false;
     }
 
     auto checkPrecision = [&srcDescs, &dstDescs](std::vector<ov::element::Type> srcVecPrc,

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
@@ -31,12 +31,12 @@
 #include "cpu_types.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "nodes/executors/eltwise_config.hpp"
-#include "utils/precision_support.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/memory_arguments.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "utils/debug_capabilities.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -75,7 +75,7 @@ ACLFullyConnectedExecutor::ACLFullyConnectedExecutor(const FCAttrs& attrs,
 }
 
 bool ACLFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported(config.descs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(any_of(weiType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(postOpsNumbers(config) < 2, UNSUPPORTED_NUMBER_OF_POSTOPS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -24,6 +24,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -75,6 +76,7 @@ ACLFullyConnectedExecutor::ACLFullyConnectedExecutor(const FCAttrs& attrs,
 }
 
 bool ACLFullyConnectedExecutor::supports(const FCConfig& config) {
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     VERIFY(any_of(srcType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(any_of(weiType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(postOpsNumbers(config) < 2, UNSUPPORTED_NUMBER_OF_POSTOPS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -75,7 +75,7 @@ ACLFullyConnectedExecutor::ACLFullyConnectedExecutor(const FCAttrs& attrs,
 }
 
 bool ACLFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(any_of(weiType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(postOpsNumbers(config) < 2, UNSUPPORTED_NUMBER_OF_POSTOPS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -17,6 +17,7 @@
 #include "nodes/executors/acl/acl_common_executor.hpp"
 #include "nodes/executors/acl/acl_fullyconnected_utils.hpp"
 #include "nodes/executors/debug_messages.hpp"
+#include "utils/precision_support.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/fullyconnected_config.hpp"
 #include "nodes/executors/implementation_utils.hpp"
@@ -75,6 +76,9 @@ ACLFullyConnectedExecutor::ACLFullyConnectedExecutor(const FCAttrs& attrs,
 }
 
 bool ACLFullyConnectedExecutor::supports(const FCConfig& config) {
+    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly
+    // so the executor is selected only on a core that provides the required ISA.
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     VERIFY(any_of(srcType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(any_of(weiType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(postOpsNumbers(config) < 2, UNSUPPORTED_NUMBER_OF_POSTOPS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -75,7 +75,8 @@ ACLFullyConnectedExecutor::ACLFullyConnectedExecutor(const FCAttrs& attrs,
 }
 
 bool ACLFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(aclCommonExecutorSupported(config.descs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported({config.descs.at(ARG_SRC), config.descs.at(ARG_WEI), config.descs.at(ARG_DST)}),
+           UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(any_of(weiType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(postOpsNumbers(config) < 2, UNSUPPORTED_NUMBER_OF_POSTOPS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -24,7 +24,6 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -76,9 +75,6 @@ ACLFullyConnectedExecutor::ACLFullyConnectedExecutor(const FCAttrs& attrs,
 }
 
 bool ACLFullyConnectedExecutor::supports(const FCConfig& config) {
-    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly
-    // so the executor is selected only on a core that provides the required ISA.
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     VERIFY(any_of(srcType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(any_of(weiType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(postOpsNumbers(config) < 2, UNSUPPORTED_NUMBER_OF_POSTOPS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -17,7 +17,6 @@
 #include "nodes/executors/acl/acl_common_executor.hpp"
 #include "nodes/executors/acl/acl_fullyconnected_utils.hpp"
 #include "nodes/executors/debug_messages.hpp"
-#include "utils/precision_support.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/fullyconnected_config.hpp"
 #include "nodes/executors/implementation_utils.hpp"
@@ -25,6 +24,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -75,7 +75,7 @@ ACLFullyConnectedExecutor::ACLFullyConnectedExecutor(const FCAttrs& attrs,
 }
 
 bool ACLFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(aclCommonExecutorSupported({config.descs.at(ARG_SRC), config.descs.at(ARG_WEI), config.descs.at(ARG_DST)}),
+    VERIFY(aclSupported({config.descs.at(ARG_SRC), config.descs.at(ARG_WEI), config.descs.at(ARG_DST)}),
            UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(any_of(weiType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_WEI_PRECISIONS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.cpp
@@ -24,7 +24,6 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -76,7 +75,7 @@ ACLFullyConnectedExecutor::ACLFullyConnectedExecutor(const FCAttrs& attrs,
 }
 
 bool ACLFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
     VERIFY(any_of(srcType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(any_of(weiType(config), ov::element::f16, ov::element::f32), UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(postOpsNumbers(config) < 2, UNSUPPORTED_NUMBER_OF_POSTOPS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
@@ -198,7 +198,7 @@ bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupportedConfiguration(
 bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupported(const ov::intel_cpu::InterpolateAttrs& interpolateAttrs,
                                                                const std::vector<MemoryDescPtr>& srcDescs,
                                                                const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (srcDescs[0]->getShape().getDims().size() != 4U) {
         DEBUG_LOG("ACL Interpolate does not support src shape rank: ", srcDescs[0]->getShape().getDims().size());
         return false;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
@@ -18,10 +18,12 @@
 #include "acl_utils.hpp"
 #include "cpu_memory.h"
 #include "memory_desc/cpu_memory_desc.h"
+#include "nodes/executors/debug_messages.hpp"
 #include "nodes/executors/interpolate.hpp"
 #include "openvino/core/except.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
+#include "utils/precision_support.h"
 
 bool ov::intel_cpu::ACLInterpolateExecutor::init(const InterpolateAttrs& interpolateAttrs,
                                                  const std::vector<MemoryDescPtr>& srcDescs,
@@ -197,6 +199,7 @@ bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupportedConfiguration(
 bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupported(const ov::intel_cpu::InterpolateAttrs& interpolateAttrs,
                                                                const std::vector<MemoryDescPtr>& srcDescs,
                                                                const std::vector<MemoryDescPtr>& dstDescs) const {
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     if (srcDescs[0]->getShape().getDims().size() != 4U) {
         DEBUG_LOG("ACL Interpolate does not support src shape rank: ", srcDescs[0]->getShape().getDims().size());
         return false;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
@@ -198,7 +198,7 @@ bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupportedConfiguration(
 bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupported(const ov::intel_cpu::InterpolateAttrs& interpolateAttrs,
                                                                const std::vector<MemoryDescPtr>& srcDescs,
                                                                const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported(srcDescs, dstDescs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (srcDescs[0]->getShape().getDims().size() != 4U) {
         DEBUG_LOG("ACL Interpolate does not support src shape rank: ", srcDescs[0]->getShape().getDims().size());
         return false;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
@@ -198,7 +198,7 @@ bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupportedConfiguration(
 bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupported(const ov::intel_cpu::InterpolateAttrs& interpolateAttrs,
                                                                const std::vector<MemoryDescPtr>& srcDescs,
                                                                const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(aclCommonExecutorSupported({srcDescs[0], dstDescs[0]}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclSupported({srcDescs[0], dstDescs[0]}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (srcDescs[0]->getShape().getDims().size() != 4U) {
         DEBUG_LOG("ACL Interpolate does not support src shape rank: ", srcDescs[0]->getShape().getDims().size());
         return false;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
@@ -23,7 +23,6 @@
 #include "openvino/core/except.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
 
 bool ov::intel_cpu::ACLInterpolateExecutor::init(const InterpolateAttrs& interpolateAttrs,
                                                  const std::vector<MemoryDescPtr>& srcDescs,
@@ -199,7 +198,7 @@ bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupportedConfiguration(
 bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupported(const ov::intel_cpu::InterpolateAttrs& interpolateAttrs,
                                                                const std::vector<MemoryDescPtr>& srcDescs,
                                                                const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
     if (srcDescs[0]->getShape().getDims().size() != 4U) {
         DEBUG_LOG("ACL Interpolate does not support src shape rank: ", srcDescs[0]->getShape().getDims().size());
         return false;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
@@ -198,7 +198,7 @@ bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupportedConfiguration(
 bool ov::intel_cpu::ACLInterpolateExecutorBuilder::isSupported(const ov::intel_cpu::InterpolateAttrs& interpolateAttrs,
                                                                const std::vector<MemoryDescPtr>& srcDescs,
                                                                const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(aclCommonExecutorSupported(srcDescs, dstDescs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported({srcDescs[0], dstDescs[0]}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if (srcDescs[0]->getShape().getDims().size() != 4U) {
         DEBUG_LOG("ACL Interpolate does not support src shape rank: ", srcDescs[0]->getShape().getDims().size());
         return false;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -78,7 +78,7 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
 }
 
 bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(dstType(config) == ov::element::f32, UNSUPPORTED_DST_PRECISIONS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -78,7 +78,8 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
 }
 
 bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(aclCommonExecutorSupported(config.descs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported({config.descs.at(ARG_SRC), config.descs.at(ARG_WEI), config.descs.at(ARG_DST)}),
+           UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(dstType(config) == ov::element::f32, UNSUPPORTED_DST_PRECISIONS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -78,7 +78,7 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
 }
 
 bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(aclCommonExecutorSupported({config.descs.at(ARG_SRC), config.descs.at(ARG_WEI), config.descs.at(ARG_DST)}),
+    VERIFY(aclSupported({config.descs.at(ARG_SRC), config.descs.at(ARG_WEI), config.descs.at(ARG_DST)}),
            UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -28,6 +28,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -78,6 +79,7 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
 }
 
 bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(dstType(config) == ov::element::f32, UNSUPPORTED_DST_PRECISIONS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -28,7 +28,6 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -79,9 +78,6 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
 }
 
 bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
-    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly
-    // so the executor is selected only on a core that provides the required ISA.
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(dstType(config) == ov::element::f32, UNSUPPORTED_DST_PRECISIONS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -78,7 +78,7 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
 }
 
 bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported(config.descs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(dstType(config) == ov::element::f32, UNSUPPORTED_DST_PRECISIONS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -21,7 +21,6 @@
 #include "nodes/executors/acl/acl_utils.hpp"
 #include "nodes/executors/common/common_utils.hpp"
 #include "nodes/executors/debug_messages.hpp"
-#include "utils/precision_support.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/fullyconnected_config.hpp"
 #include "nodes/executors/implementation_utils.hpp"
@@ -29,6 +28,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -28,7 +28,6 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -79,7 +78,7 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
 }
 
 bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(dstType(config) == ov::element::f32, UNSUPPORTED_DST_PRECISIONS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -21,6 +21,7 @@
 #include "nodes/executors/acl/acl_utils.hpp"
 #include "nodes/executors/common/common_utils.hpp"
 #include "nodes/executors/debug_messages.hpp"
+#include "utils/precision_support.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/fullyconnected_config.hpp"
 #include "nodes/executors/implementation_utils.hpp"
@@ -78,6 +79,9 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
 }
 
 bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
+    // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly
+    // so the executor is selected only on a core that provides the required ISA.
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);
     VERIFY(dstType(config) == ov::element::f32, UNSUPPORTED_DST_PRECISIONS);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
@@ -102,7 +102,7 @@ void AclMVNExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclMVNExecutorBuilder::isSupported(const MVNAttrs& mvnAttrs,
                                         const std::vector<MemoryDescPtr>& srcDescs,
                                         const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if ((srcDescs[0]->getPrecision() != ov::element::f32 && srcDescs[0]->getPrecision() != ov::element::f16) ||
         srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision()) {
         DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support precisions:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
@@ -102,7 +102,7 @@ void AclMVNExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclMVNExecutorBuilder::isSupported(const MVNAttrs& mvnAttrs,
                                         const std::vector<MemoryDescPtr>& srcDescs,
                                         const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(aclCommonExecutorSupported({srcDescs[0], dstDescs[0]}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclSupported({srcDescs[0], dstDescs[0]}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if ((srcDescs[0]->getPrecision() != ov::element::f32 && srcDescs[0]->getPrecision() != ov::element::f16) ||
         srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision()) {
         DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support precisions:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
@@ -102,7 +102,7 @@ void AclMVNExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclMVNExecutorBuilder::isSupported(const MVNAttrs& mvnAttrs,
                                         const std::vector<MemoryDescPtr>& srcDescs,
                                         const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported(srcDescs, dstDescs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if ((srcDescs[0]->getPrecision() != ov::element::f32 && srcDescs[0]->getPrecision() != ov::element::f16) ||
         srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision()) {
         DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support precisions:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
@@ -102,7 +102,7 @@ void AclMVNExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclMVNExecutorBuilder::isSupported(const MVNAttrs& mvnAttrs,
                                         const std::vector<MemoryDescPtr>& srcDescs,
                                         const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(aclCommonExecutorSupported(srcDescs, dstDescs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+    VERIFY(aclCommonExecutorSupported({srcDescs[0], dstDescs[0]}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
     if ((srcDescs[0]->getPrecision() != ov::element::f32 && srcDescs[0]->getPrecision() != ov::element::f16) ||
         srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision()) {
         DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support precisions:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
@@ -21,7 +21,6 @@
 #include "nodes/executors/mvn.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "utils/debug_capabilities.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -103,7 +102,7 @@ void AclMVNExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclMVNExecutorBuilder::isSupported(const MVNAttrs& mvnAttrs,
                                         const std::vector<MemoryDescPtr>& srcDescs,
                                         const std::vector<MemoryDescPtr>& dstDescs) const {
-    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
+    VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);
     if ((srcDescs[0]->getPrecision() != ov::element::f32 && srcDescs[0]->getPrecision() != ov::element::f16) ||
         srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision()) {
         DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support precisions:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
@@ -16,10 +16,12 @@
 #include "cpu_memory.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "nodes/executors/acl/acl_utils.hpp"
+#include "nodes/executors/debug_messages.hpp"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/mvn.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "utils/debug_capabilities.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -101,6 +103,7 @@ void AclMVNExecutor::exec(const std::vector<MemoryCPtr>& src,
 bool AclMVNExecutorBuilder::isSupported(const MVNAttrs& mvnAttrs,
                                         const std::vector<MemoryDescPtr>& srcDescs,
                                         const std::vector<MemoryDescPtr>& dstDescs) const {
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     if ((srcDescs[0]->getPrecision() != ov::element::f32 && srcDescs[0]->getPrecision() != ov::element::f16) ||
         srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision()) {
         DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support precisions:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
@@ -54,7 +54,7 @@ public:
     [[nodiscard]] bool isSupported(const PoolingAttrs& poolingAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if (!aclCommonExecutorSupported(srcDescs, dstDescs)) {
+        if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) {
             DEBUG_LOG("ACL common preconditions not met");
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include "acl_utils.hpp"
 #include "arm_compute/runtime/NEON/NEFunctions.h"
 #include "nodes/executors/pooling.hpp"
 #include "utils/debug_capabilities.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -55,7 +55,7 @@ public:
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
         // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly.
-        if (!hasArmISASupport(ArmISA::ASIMD)) {
+        if (!aclCommonExecutorSupported()) {
             return false;
         }
         auto isSupportedPrecision = [](const ov::element::Type precision) {

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
@@ -54,7 +54,7 @@ public:
     [[nodiscard]] bool isSupported(const PoolingAttrs& poolingAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if (!aclCommonExecutorSupported()) {
+        if (!aclCommonExecutorSupported(srcDescs, dstDescs)) {
             DEBUG_LOG("ACL common preconditions not met");
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
@@ -54,8 +54,8 @@ public:
     [[nodiscard]] bool isSupported(const PoolingAttrs& poolingAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly.
         if (!aclCommonExecutorSupported()) {
+            DEBUG_LOG("ACL common preconditions not met");
             return false;
         }
         auto isSupportedPrecision = [](const ov::element::Type precision) {

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
@@ -54,8 +54,8 @@ public:
     [[nodiscard]] bool isSupported(const PoolingAttrs& poolingAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) {
-            DEBUG_LOG("ACL common preconditions not met");
+        if (!aclSupported({srcDescs[0], dstDescs[0]})) {
+            DEBUG_LOG("ACL common preconditions are not met");
             return false;
         }
         auto isSupportedPrecision = [](const ov::element::Type precision) {

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
@@ -7,6 +7,7 @@
 #include "arm_compute/runtime/NEON/NEFunctions.h"
 #include "nodes/executors/pooling.hpp"
 #include "utils/debug_capabilities.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -53,6 +54,10 @@ public:
     [[nodiscard]] bool isSupported(const PoolingAttrs& poolingAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
+        // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly.
+        if (!hasArmISASupport(ArmISA::ASIMD)) {
+            return false;
+        }
         auto isSupportedPrecision = [](const ov::element::Type precision) {
             return any_of(precision, ov::element::f32, ov::element::f16, ov::element::u8, ov::element::i8);
         };

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
@@ -8,6 +8,7 @@
 #include "arm_compute/runtime/NEON/NEFunctions.h"
 #include "nodes/executors/reduce.hpp"
 #include "utils/debug_capabilities.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -42,6 +43,10 @@ public:
     [[nodiscard]] bool isSupported(const ReduceAttrs& reduceAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
+        // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly.
+        if (!hasArmISASupport(ArmISA::ASIMD)) {
+            return false;
+        }
         if (reduceAttrs.operation == Algorithm::ReduceMean) {
             if (srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision() ||
                 (srcDescs[0]->getPrecision() != ov::element::f32 && srcDescs[0]->getPrecision() != ov::element::f16)) {

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
@@ -42,7 +42,7 @@ public:
     [[nodiscard]] bool isSupported(const ReduceAttrs& reduceAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if (!aclCommonExecutorSupported()) {
+        if (!aclCommonExecutorSupported(srcDescs, dstDescs)) {
             DEBUG_LOG("ACL common preconditions not met");
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
@@ -42,8 +42,8 @@ public:
     [[nodiscard]] bool isSupported(const ReduceAttrs& reduceAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly.
         if (!aclCommonExecutorSupported()) {
+            DEBUG_LOG("ACL common preconditions not met");
             return false;
         }
         if (reduceAttrs.operation == Algorithm::ReduceMean) {

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
@@ -42,7 +42,7 @@ public:
     [[nodiscard]] bool isSupported(const ReduceAttrs& reduceAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if (!aclCommonExecutorSupported(srcDescs, dstDescs)) {
+        if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) {
             DEBUG_LOG("ACL common preconditions not met");
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
@@ -8,7 +8,6 @@
 #include "arm_compute/runtime/NEON/NEFunctions.h"
 #include "nodes/executors/reduce.hpp"
 #include "utils/debug_capabilities.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -44,7 +43,7 @@ public:
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
         // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly.
-        if (!hasArmISASupport(ArmISA::ASIMD)) {
+        if (!aclCommonExecutorSupported()) {
             return false;
         }
         if (reduceAttrs.operation == Algorithm::ReduceMean) {

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
@@ -42,8 +42,8 @@ public:
     [[nodiscard]] bool isSupported(const ReduceAttrs& reduceAttrs,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) {
-            DEBUG_LOG("ACL common preconditions not met");
+        if (!aclSupported({srcDescs[0], dstDescs[0]})) {
+            DEBUG_LOG("ACL common preconditions are not met");
             return false;
         }
         if (reduceAttrs.operation == Algorithm::ReduceMean) {

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
@@ -35,8 +35,8 @@ public:
     [[nodiscard]] bool isSupported([[maybe_unused]] const TransposeParams& transposeParams,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) {
-            DEBUG_LOG("ACL common preconditions not met");
+        if (!aclSupported({srcDescs[0], dstDescs[0]})) {
+            DEBUG_LOG("ACL common preconditions are not met");
             return false;
         }
         if ((srcDescs[0]->hasLayoutType(LayoutType::ncsp) || dstDescs[0]->hasLayoutType(LayoutType::ncsp)) &&

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
@@ -35,7 +35,7 @@ public:
     [[nodiscard]] bool isSupported([[maybe_unused]] const TransposeParams& transposeParams,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if (!aclCommonExecutorSupported(srcDescs, dstDescs)) {
+        if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) {
             DEBUG_LOG("ACL common preconditions not met");
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
@@ -4,11 +4,11 @@
 
 #pragma once
 
+#include "acl_utils.hpp"
 #include "arm_compute/runtime/NEON/functions/NEPermute.h"
 #include "arm_compute/runtime/Tensor.h"
 #include "nodes/executors/transpose.hpp"
 #include "utils/debug_capabilities.h"
-#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -36,7 +36,7 @@ public:
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
         // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly.
-        if (!hasArmISASupport(ArmISA::ASIMD)) {
+        if (!aclCommonExecutorSupported()) {
             return false;
         }
         if ((srcDescs[0]->hasLayoutType(LayoutType::ncsp) || dstDescs[0]->hasLayoutType(LayoutType::ncsp)) &&

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
@@ -35,7 +35,7 @@ public:
     [[nodiscard]] bool isSupported([[maybe_unused]] const TransposeParams& transposeParams,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if (!aclCommonExecutorSupported()) {
+        if (!aclCommonExecutorSupported(srcDescs, dstDescs)) {
             DEBUG_LOG("ACL common preconditions not met");
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
@@ -35,8 +35,8 @@ public:
     [[nodiscard]] bool isSupported([[maybe_unused]] const TransposeParams& transposeParams,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
-        // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly.
         if (!aclCommonExecutorSupported()) {
+            DEBUG_LOG("ACL common preconditions not met");
             return false;
         }
         if ((srcDescs[0]->hasLayoutType(LayoutType::ncsp) || dstDescs[0]->hasLayoutType(LayoutType::ncsp)) &&

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
@@ -8,6 +8,7 @@
 #include "arm_compute/runtime/Tensor.h"
 #include "nodes/executors/transpose.hpp"
 #include "utils/debug_capabilities.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -34,6 +35,10 @@ public:
     [[nodiscard]] bool isSupported([[maybe_unused]] const TransposeParams& transposeParams,
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override {
+        // ACL kernels run on the ARMv8-A NEON baseline (ASIMD); declare it explicitly.
+        if (!hasArmISASupport(ArmISA::ASIMD)) {
+            return false;
+        }
         if ((srcDescs[0]->hasLayoutType(LayoutType::ncsp) || dstDescs[0]->hasLayoutType(LayoutType::ncsp)) &&
             (srcDescs[0]->hasLayoutType(LayoutType::nspc) || dstDescs[0]->hasLayoutType(LayoutType::nspc))) {
             DEBUG_LOG("NEPermute does not support layout:",

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
@@ -18,9 +18,9 @@ namespace ov::intel_cpu {
  * ACL kernels run on the ARMv8-A NEON baseline (ASIMD), so an executor must not be selected on a
  * core that lacks it. Op-specific checks (precisions, ranks, post ops, ...) stay in each executor's
  * own supports()/isSupported(). Use it with the predicate's own idiom, e.g.
- *   VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);   // VERIFY-based predicates
- *   if (!aclCommonExecutorSupported()) { return false; }     // if/return predicates
- * @return whether the current core can run ACL executors
+ *   VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);  // VERIFY-based predicates
+ *   if (!aclCommonExecutorSupported()) { return false; }                        // if/return predicates
+ * @return whether the current core meets the common preconditions to run ACL executors
  */
 inline bool aclCommonExecutorSupported() {
     return hasArmISASupport(ArmISA::ASIMD);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
@@ -9,8 +9,22 @@
 #include "arm_compute/core/Types.h"
 #include "cpu_types.h"
 #include "memory_desc/cpu_memory_desc.h"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
+
+/**
+ * @brief Common precondition shared by every ACL executor, independent of the op/config type.
+ * ACL kernels run on the ARMv8-A NEON baseline (ASIMD), so an executor must not be selected on a
+ * core that lacks it. Op-specific checks (precisions, ranks, post ops, ...) stay in each executor's
+ * own supports()/isSupported(). Use it with the predicate's own idiom, e.g.
+ *   VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ISA);   // VERIFY-based predicates
+ *   if (!aclCommonExecutorSupported()) { return false; }     // if/return predicates
+ * @return whether the current core can run ACL executors
+ */
+inline bool aclCommonExecutorSupported() {
+    return hasArmISASupport(ArmISA::ASIMD);
+}
 
 /**
  * @brief Convert ACL DataType to quantized variant for U8/S8 tensors.

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
@@ -10,7 +10,7 @@
 #include "arm_compute/core/Types.h"
 #include "cpu_types.h"
 #include "memory_desc/cpu_memory_desc.h"
-#include "utils/precision_support.h"
+#include "utils/arm_isa_support.h"
 
 namespace ov::intel_cpu {
 
@@ -178,11 +178,11 @@ inline arm_compute::DataType precisionToAclDataType(ov::element::Type precision)
  * executor must not be selected when either is unmet. Op-specific checks (exact precisions, ranks,
  * post ops, layouts, ...) stay in each executor's own supports()/isSupported(). Pass the executor's
  * tensor descriptors; empty ones (e.g. an absent optional bias) are ignored. Usage:
- *   VERIFY(aclCommonExecutorSupported({srcDesc, weiDesc, dstDesc}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
- *   if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) { return false; }
+ *   VERIFY(aclSupported({srcDesc, weiDesc, dstDesc}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+ *   if (!aclSupported({srcDescs[0], dstDescs[0]})) { return false; }
  * @return whether the current core and the tensor precisions meet the common ACL preconditions
  */
-inline bool aclCommonExecutorSupported(const std::vector<MemoryDescPtr>& descs) {
+inline bool aclSupported(const std::vector<MemoryDescPtr>& descs) {
     return hasArmISASupport(ArmISA::ASIMD) && std::all_of(descs.begin(), descs.end(), [](const MemoryDescPtr& desc) {
                return desc->empty() || precisionToAclDataType(desc->getPrecision()) != arm_compute::DataType::UNKNOWN;
            });

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
@@ -4,14 +4,12 @@
 #pragma once
 
 #include <algorithm>
-#include <initializer_list>
 #include <vector>
 
 #include "arm_compute/core/QuantizationInfo.h"
 #include "arm_compute/core/Types.h"
 #include "cpu_types.h"
 #include "memory_desc/cpu_memory_desc.h"
-#include "nodes/executors/memory_arguments.hpp"
 #include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
@@ -174,52 +172,20 @@ inline arm_compute::DataType precisionToAclDataType(ov::element::Type precision)
 }
 
 /**
- * @brief Whether ACL can represent this descriptor's precision (precisionToAclDataType maps it to a
- * concrete DataType, not UNKNOWN). A type ACL cannot represent (e.g. u4/i4/nf4/string) must never
- * reach an ACL kernel.
- */
-inline bool aclSupportedPrecision(const MemoryDescPtr& desc) {
-    return precisionToAclDataType(desc->getPrecision()) != arm_compute::DataType::UNKNOWN;
-}
-
-/**
- * @brief Collect the ACL precision-representable check across descriptors given in any of the forms
- * an executor's predicate has them. These overloads exist so each executor passes its own tensor
- * descriptors directly (a vector, a MemoryDescArgs map keyed by ARG_*, or individual descriptors)
- * without hand-rolling a vector at the call site.
- */
-inline bool aclSupportedPrecisions(const std::vector<MemoryDescPtr>& descs) {
-    return std::all_of(descs.begin(), descs.end(), aclSupportedPrecision);
-}
-inline bool aclSupportedPrecisions(const MemoryDescArgs& descs) {
-    return std::all_of(descs.begin(), descs.end(), [](const auto& argDesc) {
-        // Empty descriptors (e.g. an absent optional bias) carry no real tensor and never reach an
-        // ACL kernel, so they must not be precision-checked (their precision is dynamic == UNKNOWN).
-        return argDesc.second->empty() || aclSupportedPrecision(argDesc.second);
-    });
-}
-inline bool aclSupportedPrecisions(std::initializer_list<MemoryDescPtr> descs) {
-    return std::all_of(descs.begin(), descs.end(), aclSupportedPrecision);
-}
-
-/**
  * @brief Preconditions common to every ACL executor, independent of the op/config type. ACL kernels
- * run on the ARMv8-A NEON baseline (ASIMD) and can only operate on ACL-representable precisions, so
- * an executor must not be selected when either is unmet. Op-specific checks (exact precisions, ranks,
- * post ops, layouts, ...) stay in each executor's own supports()/isSupported(). The descriptor
- * argument accepts any of the forms a predicate has (vector, MemoryDescArgs map, or an initializer
- * list of individual descriptors), e.g.
- *   VERIFY(aclCommonExecutorSupported(config.descs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
- *   if (!aclCommonExecutorSupported(srcDescs, dstDescs)) { return false; }
+ * run on the ARMv8-A NEON baseline (ASIMD) and can only operate on ACL-representable precisions
+ * (precisionToAclDataType != UNKNOWN; e.g. u4/i4/nf4/string must never reach an ACL kernel), so an
+ * executor must not be selected when either is unmet. Op-specific checks (exact precisions, ranks,
+ * post ops, layouts, ...) stay in each executor's own supports()/isSupported(). Pass the executor's
+ * tensor descriptors; empty ones (e.g. an absent optional bias) are ignored. Usage:
+ *   VERIFY(aclCommonExecutorSupported({srcDesc, weiDesc, dstDesc}), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+ *   if (!aclCommonExecutorSupported({srcDescs[0], dstDescs[0]})) { return false; }
  * @return whether the current core and the tensor precisions meet the common ACL preconditions
  */
-template <typename Descs>
-bool aclCommonExecutorSupported(const Descs& descs) {
-    return hasArmISASupport(ArmISA::ASIMD) && aclSupportedPrecisions(descs);
-}
-inline bool aclCommonExecutorSupported(const std::vector<MemoryDescPtr>& srcDescs,
-                                       const std::vector<MemoryDescPtr>& dstDescs) {
-    return hasArmISASupport(ArmISA::ASIMD) && aclSupportedPrecisions(srcDescs) && aclSupportedPrecisions(dstDescs);
+inline bool aclCommonExecutorSupported(const std::vector<MemoryDescPtr>& descs) {
+    return hasArmISASupport(ArmISA::ASIMD) && std::all_of(descs.begin(), descs.end(), [](const MemoryDescPtr& desc) {
+               return desc->empty() || precisionToAclDataType(desc->getPrecision()) != arm_compute::DataType::UNKNOWN;
+           });
 }
 
 /**

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
@@ -3,28 +3,18 @@
 //
 #pragma once
 
+#include <algorithm>
+#include <initializer_list>
 #include <vector>
 
 #include "arm_compute/core/QuantizationInfo.h"
 #include "arm_compute/core/Types.h"
 #include "cpu_types.h"
 #include "memory_desc/cpu_memory_desc.h"
+#include "nodes/executors/memory_arguments.hpp"
 #include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
-
-/**
- * @brief Common precondition shared by every ACL executor, independent of the op/config type.
- * ACL kernels run on the ARMv8-A NEON baseline (ASIMD), so an executor must not be selected on a
- * core that lacks it. Op-specific checks (precisions, ranks, post ops, ...) stay in each executor's
- * own supports()/isSupported(). Use it with the predicate's own idiom, e.g.
- *   VERIFY(aclCommonExecutorSupported(), UNSUPPORTED_ACL_COMMON_PRECONDITION);  // VERIFY-based predicates
- *   if (!aclCommonExecutorSupported()) { return false; }                        // if/return predicates
- * @return whether the current core meets the common preconditions to run ACL executors
- */
-inline bool aclCommonExecutorSupported() {
-    return hasArmISASupport(ArmISA::ASIMD);
-}
 
 /**
  * @brief Convert ACL DataType to quantized variant for U8/S8 tensors.
@@ -181,6 +171,55 @@ inline arm_compute::DataType precisionToAclDataType(ov::element::Type precision)
     default:
         return arm_compute::DataType::UNKNOWN;
     }
+}
+
+/**
+ * @brief Whether ACL can represent this descriptor's precision (precisionToAclDataType maps it to a
+ * concrete DataType, not UNKNOWN). A type ACL cannot represent (e.g. u4/i4/nf4/string) must never
+ * reach an ACL kernel.
+ */
+inline bool aclSupportedPrecision(const MemoryDescPtr& desc) {
+    return precisionToAclDataType(desc->getPrecision()) != arm_compute::DataType::UNKNOWN;
+}
+
+/**
+ * @brief Collect the ACL precision-representable check across descriptors given in any of the forms
+ * an executor's predicate has them. These overloads exist so each executor passes its own tensor
+ * descriptors directly (a vector, a MemoryDescArgs map keyed by ARG_*, or individual descriptors)
+ * without hand-rolling a vector at the call site.
+ */
+inline bool aclSupportedPrecisions(const std::vector<MemoryDescPtr>& descs) {
+    return std::all_of(descs.begin(), descs.end(), aclSupportedPrecision);
+}
+inline bool aclSupportedPrecisions(const MemoryDescArgs& descs) {
+    return std::all_of(descs.begin(), descs.end(), [](const auto& argDesc) {
+        // Empty descriptors (e.g. an absent optional bias) carry no real tensor and never reach an
+        // ACL kernel, so they must not be precision-checked (their precision is dynamic == UNKNOWN).
+        return argDesc.second->empty() || aclSupportedPrecision(argDesc.second);
+    });
+}
+inline bool aclSupportedPrecisions(std::initializer_list<MemoryDescPtr> descs) {
+    return std::all_of(descs.begin(), descs.end(), aclSupportedPrecision);
+}
+
+/**
+ * @brief Preconditions common to every ACL executor, independent of the op/config type. ACL kernels
+ * run on the ARMv8-A NEON baseline (ASIMD) and can only operate on ACL-representable precisions, so
+ * an executor must not be selected when either is unmet. Op-specific checks (exact precisions, ranks,
+ * post ops, layouts, ...) stay in each executor's own supports()/isSupported(). The descriptor
+ * argument accepts any of the forms a predicate has (vector, MemoryDescArgs map, or an initializer
+ * list of individual descriptors), e.g.
+ *   VERIFY(aclCommonExecutorSupported(config.descs), UNSUPPORTED_ACL_COMMON_PRECONDITION);
+ *   if (!aclCommonExecutorSupported(srcDescs, dstDescs)) { return false; }
+ * @return whether the current core and the tensor precisions meet the common ACL preconditions
+ */
+template <typename Descs>
+bool aclCommonExecutorSupported(const Descs& descs) {
+    return hasArmISASupport(ArmISA::ASIMD) && aclSupportedPrecisions(descs);
+}
+inline bool aclCommonExecutorSupported(const std::vector<MemoryDescPtr>& srcDescs,
+                                       const std::vector<MemoryDescPtr>& dstDescs) {
+    return hasArmISASupport(ArmISA::ASIMD) && aclSupportedPrecisions(srcDescs) && aclSupportedPrecisions(dstDescs);
 }
 
 /**

--- a/src/plugins/intel_cpu/src/nodes/executors/debug_messages.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/debug_messages.hpp
@@ -21,6 +21,7 @@
 #define UNSUPPORTED_DST_STRIDES              " unsupported dst strides"
 #define UNSUPPORTED_PER_CHANNEL_QUANTIZATION " unsupported per-channel quantization"
 #define UNSUPPORTED_BY_EXECUTOR              " unsupported by executor"
+#define UNSUPPORTED_ACL_COMMON_PRECONDITION  " ACL common preconditions not met"
 #define HEURISTICS_MISMATCH                  " heuristics mismatch"
 #define MEMORY_FORMAT_MISMATCH               " memory format mismatch"
 

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_gathermatmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_gathermatmul.cpp
@@ -28,7 +28,7 @@
 namespace ov::intel_cpu {
 
 static bool useDynamicQuantizationImpl(const MemoryDescPtr& weightDesc) {
-    if (!hasIntDotProductSupport() && !hasInt8MMSupport()) {
+    if (!hasArmISASupport(ArmISA::DOTPROD) && !hasArmISASupport(ArmISA::I8MM)) {
         return false;
     }
     return weightDesc->getPrecision() == element::i8 || weightDesc->getPrecision() == element::i4;

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_gathermatmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_gathermatmul.cpp
@@ -23,7 +23,7 @@
 #include "nodes/executors/memory_arguments.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
-#include "utils/precision_support.h"
+#include "utils/arm_isa_support.h"
 
 namespace ov::intel_cpu {
 

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
@@ -28,6 +28,7 @@
 #include "nodes/common/blocked_desc_creator.h"
 #include "nodes/executors/acl/acl_fullyconnected_utils.hpp"
 #include "nodes/executors/common/offset_helper.hpp"
+#include "nodes/executors/debug_messages.hpp"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/fullyconnected_config.hpp"
 #include "nodes/executors/memory_arguments.hpp"
@@ -66,6 +67,7 @@ static bool useDynamicQuantizationImpl(const FCAttrs& attrs, const MemoryDescPtr
 }
 
 bool MatMulKleidiAIExecutor::supports(const FCConfig& config) {
+    VERIFY(hasArmASIMDSupport(), UNSUPPORTED_ISA);
     return config.descs.at(ARG_WEI)->getPrecision() == element::f32 ||
            useDynamicQuantizationImpl(config.attrs, config.descs.at(ARG_WEI));
 }

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
@@ -38,7 +38,7 @@
 #include "utils/cpu_utils.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
-#include "utils/precision_support.h"
+#include "utils/arm_isa_support.h"
 
 #define FLOAT_MAX 3.4028235e38f
 #define FLOAT_MIN (-3.4028235e38f)

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
@@ -59,7 +59,7 @@ static bool useDynamicQuantizationImpl(const FCAttrs& attrs, const MemoryDescPtr
         return false;
     }
 
-    if (!hasIntDotProductSupport() && !hasInt8MMSupport()) {
+    if (!hasArmISASupport(ArmISA::DOTPROD) && !hasArmISASupport(ArmISA::I8MM)) {
         return false;
     }
 
@@ -144,7 +144,7 @@ MatMulKleidiAIExecutor::MatMulKleidiAIExecutor(const FCAttrs& attrs,
         MemoryPtr weightsMemory = memory.at(ARG_WEI);
         INT4_IMPL = weightsMemory->getDescPtr()->getPrecision() == element::i4;
         if (INT4_IMPL) {
-            ukernel_i4 = hasInt8MMSupport() ? &ukernel_i4_imm : &ukernel_i4_dotprod;
+            ukernel_i4 = hasArmISASupport(ArmISA::I8MM) ? &ukernel_i4_imm : &ukernel_i4_dotprod;
             BLOCK_SIZE_M_LOWP = ukernel_i4->get_m_step();
 
             mr = ukernel_i4->get_mr();
@@ -194,7 +194,7 @@ MatMulKleidiAIExecutor::MatMulKleidiAIExecutor(const FCAttrs& attrs,
             }
 
         } else {
-            ukernel_i8 = hasInt8MMSupport() ? &ukernel_i8_imm : &ukernel_i8_dotprod;
+            ukernel_i8 = hasArmISASupport(ArmISA::I8MM) ? &ukernel_i8_imm : &ukernel_i8_dotprod;
             BLOCK_SIZE_M_LOWP = 16;
             if (!attrs.weightsNonTransposed) {
                 auto dnnlSrcDesc = MemoryDescUtils::convertToDnnlMemoryDesc(originalWeightsDesc);

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
@@ -35,10 +35,10 @@
 #include "openvino/core/except.hpp"
 #include "openvino/core/parallel.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "utils/arm_isa_support.h"
 #include "utils/cpu_utils.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
-#include "utils/arm_isa_support.h"
 
 #define FLOAT_MAX 3.4028235e38f
 #define FLOAT_MIN (-3.4028235e38f)

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
@@ -67,7 +67,7 @@ static bool useDynamicQuantizationImpl(const FCAttrs& attrs, const MemoryDescPtr
 }
 
 bool MatMulKleidiAIExecutor::supports(const FCConfig& config) {
-    VERIFY(hasArmASIMDSupport(), UNSUPPORTED_ISA);
+    VERIFY(hasArmISASupport(ArmISA::ASIMD), UNSUPPORTED_ISA);
     return config.descs.at(ARG_WEI)->getPrecision() == element::f32 ||
            useDynamicQuantizationImpl(config.attrs, config.descs.at(ARG_WEI));
 }

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -189,7 +189,7 @@ bool FullyConnected::isSupportedCompressedOperation([[maybe_unused]] const std::
         if (!isSupportedOperation(op, errorMessage)) {
             return false;
         }
-        if (!hasIntDotProductSupport()) {
+        if (!hasArmISASupport(ArmISA::DOTPROD)) {
             return false;
         }
         if (config.fcDynamicQuantizationGroupSize != UINT64_MAX) {

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -53,7 +53,7 @@
 #include "utils/general_utils.h"
 #if defined(OV_CPU_WITH_KLEIDIAI)
 #    include "openvino/core/shape.hpp"
-#    include "utils/precision_support.h"
+#    include "utils/arm_isa_support.h"
 #endif
 
 using namespace dnnl;

--- a/src/plugins/intel_cpu/src/nodes/gathermatmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gathermatmul.cpp
@@ -20,7 +20,7 @@
 #    include <cstdint>
 #    include <limits>
 
-#    include "utils/precision_support.h"
+#    include "utils/arm_isa_support.h"
 #endif
 #include "graph_context.h"
 #include "memory_desc/cpu_memory_desc.h"

--- a/src/plugins/intel_cpu/src/nodes/gathermatmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gathermatmul.cpp
@@ -142,7 +142,7 @@ bool GatherMatmul::isSupportedCompressedOperation([[maybe_unused]] const std::sh
         if (!isSupportedOperation(op, errorMessage)) {
             return false;
         }
-        if (!hasIntDotProductSupport() && !hasInt8MMSupport()) {
+        if (!hasArmISASupport(ArmISA::DOTPROD) && !hasArmISASupport(ArmISA::I8MM)) {
             return false;
         }
         if (config.fcDynamicQuantizationGroupSize != std::numeric_limits<uint64_t>::max()) {

--- a/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
@@ -35,32 +35,22 @@ using namespace dnnl::impl::cpu::aarch64::matmul;
 
 namespace ov::intel_cpu {
 
-// Highest SVE ISA the current core supports, for the main brgemm kernel which has
-// sve_512/sve_256/sve_128 implementations. Returns isa_undef on a core without SVE
-// so callers can decline instead of emitting SVE instructions that would be illegal.
-static cpu_isa_t getSupportedSveIsa() {
+// Highest SVE ISA the current core supports, not below `min_isa`. Returns isa_undef
+// when no supported SVE level reaches `min_isa`, so callers decline instead of
+// emitting SVE instructions that would be illegal on a core without (enough) SVE.
+// The main brgemm kernel has sve_512/sve_256/sve_128 implementations, so it uses the
+// default sve_128 floor; the copy_a/copy_b kernels only have sve_512/sve_256 in oneDNN
+// (create_brgemm_matmul_copy_* asserts the isa is a superset of sve_256), so they
+// pass sve_256.
+static cpu_isa_t getSupportedSveIsa(cpu_isa_t min_isa = cpu_isa_t::sve_128) {
     if (mayiuse(sve_512)) {
         return cpu_isa_t::sve_512;
     }
     if (mayiuse(sve_256)) {
         return cpu_isa_t::sve_256;
     }
-    if (mayiuse(sve_128)) {
+    if (min_isa == cpu_isa_t::sve_128 && mayiuse(sve_128)) {
         return cpu_isa_t::sve_128;
-    }
-    return cpu_isa_t::isa_undef;
-}
-
-// Same, but for the brgemm copy_a/copy_b kernels: oneDNN only provides sve_512 and
-// sve_256 implementations for them (create_brgemm_matmul_copy_* asserts the isa is a
-// superset of sve_256), so sve_128 is not a valid choice here. Returns isa_undef
-// below sve_256 so callers decline rather than passing an unsupported isa.
-static cpu_isa_t getSupportedSve256Isa() {
-    if (mayiuse(sve_512)) {
-        return cpu_isa_t::sve_512;
-    }
-    if (mayiuse(sve_256)) {
-        return cpu_isa_t::sve_256;
     }
     return cpu_isa_t::isa_undef;
 }
@@ -245,7 +235,7 @@ void BrgemmKernel::init_brgemm_copy_a(
     // copied A has the same precision of original
     brgCopyKernelConf.tr_a_dt_sz = DnnlExtensionUtils::sizeOfDataType(static_cast<dnnl::memory::data_type>(dt_in0));
     brgCopyKernelConf.transposed_A = transpose;
-    brgCopyKernelConf.isa = getSupportedSve256Isa();
+    brgCopyKernelConf.isa = getSupportedSveIsa(cpu_isa_t::sve_256);
     if (brgCopyKernelConf.isa == cpu_isa_t::isa_undef) {
         THROW_ERROR("copy A kernel requires ARM SVE256 support");
     }
@@ -285,7 +275,7 @@ void BrgemmKernel::init_brgemm_copy_b(
     brgCopyKernelConf.tr_b_dt_sz =
         DnnlExtensionUtils::sizeOfDataType(static_cast<dnnl::memory::data_type>(brgCopyKernelConf.src_dt));
     brgCopyKernelConf.req_wei_vnni_downconvert = false;
-    brgCopyKernelConf.isa = getSupportedSve256Isa();
+    brgCopyKernelConf.isa = getSupportedSveIsa(cpu_isa_t::sve_256);
     if (brgCopyKernelConf.isa == cpu_isa_t::isa_undef) {
         THROW_ERROR("copy B kernel requires ARM SVE256 support");
     }

--- a/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
@@ -35,6 +35,9 @@ using namespace dnnl::impl::cpu::aarch64::matmul;
 
 namespace ov::intel_cpu {
 
+// Highest SVE ISA the current core supports, for the main brgemm kernel which has
+// sve_512/sve_256/sve_128 implementations. Returns isa_undef on a core without SVE
+// so callers can decline instead of emitting SVE instructions that would be illegal.
 static cpu_isa_t getSupportedSveIsa() {
     if (mayiuse(sve_512)) {
         return cpu_isa_t::sve_512;
@@ -48,6 +51,10 @@ static cpu_isa_t getSupportedSveIsa() {
     return cpu_isa_t::isa_undef;
 }
 
+// Same, but for the brgemm copy_a/copy_b kernels: oneDNN only provides sve_512 and
+// sve_256 implementations for them (create_brgemm_matmul_copy_* asserts the isa is a
+// superset of sve_256), so sve_128 is not a valid choice here. Returns isa_undef
+// below sve_256 so callers decline rather than passing an unsupported isa.
 static cpu_isa_t getSupportedSve256Isa() {
     if (mayiuse(sve_512)) {
         return cpu_isa_t::sve_512;

--- a/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2026 Intel Corporation
+// Copyright (C) 2024 FUJITSU LIMITED
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright (C) 2024 FUJITSU LIMITED
 
 #include "brgemm_kernel.hpp"
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
@@ -35,13 +35,10 @@ using namespace dnnl::impl::cpu::aarch64::matmul;
 
 namespace ov::intel_cpu {
 
-// Highest SVE ISA the current core supports, not below `min_isa`. Returns isa_undef
-// when no supported SVE level reaches `min_isa`, so callers decline instead of
-// emitting SVE instructions that would be illegal on a core without (enough) SVE.
-// The main brgemm kernel has sve_512/sve_256/sve_128 implementations, so it uses the
-// default sve_128 floor; the copy_a/copy_b kernels only have sve_512/sve_256 in oneDNN
-// (create_brgemm_matmul_copy_* asserts the isa is a superset of sve_256), so they
-// pass sve_256.
+// Highest supported SVE ISA at or above `min_isa`, or isa_undef if none (caller then
+// declines instead of emitting illegal SVE). Default floor sve_128 fits the main brgemm
+// kernel; copy_a/copy_b pass sve_256 since oneDNN only provides sve_256/sve_512 for them
+// (create_brgemm_matmul_copy_* asserts the isa is a superset of sve_256).
 static cpu_isa_t getSupportedSveIsa(cpu_isa_t min_isa = cpu_isa_t::sve_128) {
     if (mayiuse(sve_512)) {
         return cpu_isa_t::sve_512;

--- a/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2026 Intel Corporation
-// Copyright (C) 2024 FUJITSU LIMITED
 // SPDX-License-Identifier: Apache-2.0
 //
+// Copyright (C) 2024 FUJITSU LIMITED
 
 #include "brgemm_kernel.hpp"
 
@@ -35,14 +35,41 @@ using namespace dnnl::impl::cpu::aarch64::matmul;
 
 namespace ov::intel_cpu {
 
-static size_t getVlen() {
+static cpu_isa_t getSupportedSveIsa() {
     if (mayiuse(sve_512)) {
-        return cpu_isa_traits<sve_512>::vlen;
+        return cpu_isa_t::sve_512;
     }
     if (mayiuse(sve_256)) {
+        return cpu_isa_t::sve_256;
+    }
+    if (mayiuse(sve_128)) {
+        return cpu_isa_t::sve_128;
+    }
+    return cpu_isa_t::isa_undef;
+}
+
+static cpu_isa_t getSupportedSve256Isa() {
+    if (mayiuse(sve_512)) {
+        return cpu_isa_t::sve_512;
+    }
+    if (mayiuse(sve_256)) {
+        return cpu_isa_t::sve_256;
+    }
+    return cpu_isa_t::isa_undef;
+}
+
+static size_t getVlen() {
+    const auto isa = getSupportedSveIsa();
+    if (isa == cpu_isa_t::sve_512) {
+        return cpu_isa_traits<sve_512>::vlen;
+    }
+    if (isa == cpu_isa_t::sve_256) {
         return cpu_isa_traits<sve_256>::vlen;
     }
-    return cpu_isa_traits<sve_128>::vlen;
+    if (isa == cpu_isa_t::sve_128) {
+        return cpu_isa_traits<sve_128>::vlen;
+    }
+    THROW_ERROR("requires ARM SVE support");
 }
 
 BrgemmKernel::BrgemmKernel(size_t M,
@@ -152,15 +179,10 @@ size_t BrgemmKernel::get_scratch_b_size() const {
 
 void BrgemmKernel::init_brgemm(brgemmCtx& ctx, std::unique_ptr<dnnl::impl::cpu::aarch64::brgemm_kernel_t>& brgKernel) {
     brgemm_t brgDesc;
-    cpu_isa_t isa = [&]() {
-        if (mayiuse(sve_512)) {
-            return cpu_isa_t::sve_512;
-        }
-        if (mayiuse(sve_256)) {
-            return cpu_isa_t::sve_256;
-        }
-        return cpu_isa_t::sve_128;
-    }();
+    const cpu_isa_t isa = getSupportedSveIsa();
+    if (isa == cpu_isa_t::isa_undef) {
+        THROW_ERROR("requires ARM SVE support");
+    }
     auto status = brgemm_desc_init(&brgDesc,
                                    isa,
                                    brgemm_addr,
@@ -216,15 +238,10 @@ void BrgemmKernel::init_brgemm_copy_a(
     // copied A has the same precision of original
     brgCopyKernelConf.tr_a_dt_sz = DnnlExtensionUtils::sizeOfDataType(static_cast<dnnl::memory::data_type>(dt_in0));
     brgCopyKernelConf.transposed_A = transpose;
-    brgCopyKernelConf.isa = [&]() {
-        if (mayiuse(sve_512)) {
-            return cpu_isa_t::sve_512;
-        }
-        if (mayiuse(sve_256)) {
-            return cpu_isa_t::sve_256;
-        }
-        return cpu_isa_t::sve_128;
-    }();
+    brgCopyKernelConf.isa = getSupportedSve256Isa();
+    if (brgCopyKernelConf.isa == cpu_isa_t::isa_undef) {
+        THROW_ERROR("copy A kernel requires ARM SVE256 support");
+    }
 
     create_brgemm_matmul_copy_a(brgCopyKernel, &brgCopyKernelConf);
 }
@@ -261,15 +278,10 @@ void BrgemmKernel::init_brgemm_copy_b(
     brgCopyKernelConf.tr_b_dt_sz =
         DnnlExtensionUtils::sizeOfDataType(static_cast<dnnl::memory::data_type>(brgCopyKernelConf.src_dt));
     brgCopyKernelConf.req_wei_vnni_downconvert = false;
-    brgCopyKernelConf.isa = []() {
-        if (mayiuse(sve_512)) {
-            return cpu_isa_t::sve_512;
-        }
-        if (mayiuse(sve_256)) {
-            return cpu_isa_t::sve_256;
-        }
-        return cpu_isa_t::sve_128;
-    }();
+    brgCopyKernelConf.isa = getSupportedSve256Isa();
+    if (brgCopyKernelConf.isa == cpu_isa_t::isa_undef) {
+        THROW_ERROR("copy B kernel requires ARM SVE256 support");
+    }
 
     brgCopyKernelConf.has_zero_point_a = false;
     brgCopyKernelConf.has_zero_point_b = false;

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -48,7 +48,6 @@
 #    include "nodes/kernels/aarch64/brgemm_kernel.hpp"
 #    include "nodes/kernels/aarch64/sve_utils.hpp"
 #    include "nodes/kernels/kai/kleidi_kernel.hpp"
-#    include "utils/precision_support.h"
 #endif
 
 namespace ov::Extensions::Cpu::XARCH {
@@ -2927,12 +2926,6 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
         OPENVINO_THROW("make_pa_executor: unsupported precision: ", data_type);
     }
 #elif (defined(OPENVINO_ARCH_ARM64) && defined(HAVE_SVE))
-    // Decline before constructing the executor on a core without SVE: this code is in the SVE
-    // clone and AttentionExecutor::init has SVE-autovectorized helpers that would run (and trap)
-    // before any kernel-level check. Runtime SVE query, no extra build-time define.
-    if (!ov::intel_cpu::hasArmISASupport(ov::intel_cpu::ArmISA::SVE)) {
-        OPENVINO_THROW("make_pa_executor: ARM implementation requires SVE support");
-    }
     if (data_type == ov::element::f32) {
         if (key_cache_type == ov::element::u8 && value_cache_type == ov::element::u8) {
             executor =

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -48,6 +48,7 @@
 #    include "nodes/kernels/aarch64/brgemm_kernel.hpp"
 #    include "nodes/kernels/aarch64/sve_utils.hpp"
 #    include "nodes/kernels/kai/kleidi_kernel.hpp"
+#    include "utils/precision_support.h"
 #endif
 
 namespace ov::Extensions::Cpu::XARCH {
@@ -2926,6 +2927,14 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
         OPENVINO_THROW("make_pa_executor: unsupported precision: ", data_type);
     }
 #elif (defined(OPENVINO_ARCH_ARM64) && defined(HAVE_SVE))
+    // The ARM PagedAttention path is built into the SVE runtime clone; its kernels (and the
+    // generic helpers GCC may auto-vectorize with SVE) require SVE at runtime. On a core
+    // without SVE, decline here so the executor is never constructed and no SVE instruction
+    // is reached. This is a runtime check (no extra build-time define): hasArmISASupport
+    // queries the same SVE detector the dispatcher uses.
+    if (!ov::intel_cpu::hasArmISASupport(ov::intel_cpu::ArmISA::SVE)) {
+        OPENVINO_THROW("make_pa_executor: ARM implementation requires SVE support");
+    }
     if (data_type == ov::element::f32) {
         if (key_cache_type == ov::element::u8 && value_cache_type == ov::element::u8) {
             executor =

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -2927,11 +2927,9 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
         OPENVINO_THROW("make_pa_executor: unsupported precision: ", data_type);
     }
 #elif (defined(OPENVINO_ARCH_ARM64) && defined(HAVE_SVE))
-    // The ARM PagedAttention path is built into the SVE runtime clone; its kernels (and the
-    // generic helpers GCC may auto-vectorize with SVE) require SVE at runtime. On a core
-    // without SVE, decline here so the executor is never constructed and no SVE instruction
-    // is reached. This is a runtime check (no extra build-time define): hasArmISASupport
-    // queries the same SVE detector the dispatcher uses.
+    // Decline before constructing the executor on a core without SVE: this code is in the SVE
+    // clone and AttentionExecutor::init has SVE-autovectorized helpers that would run (and trap)
+    // before any kernel-level check. Runtime SVE query, no extra build-time define.
     if (!ov::intel_cpu::hasArmISASupport(ov::intel_cpu::ArmISA::SVE)) {
         OPENVINO_THROW("make_pa_executor: ARM implementation requires SVE support");
     }

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -40,7 +40,6 @@
 #include "transpose_kernel.hpp"
 #include "utils/general_utils.h"
 #include "utils/plain_tensor.hpp"
-#include "utils/precision_support.h"
 #include "xattention.hpp"
 #if defined(OPENVINO_ARCH_X86_64)
 #    include "nodes/kernels/x64/brgemm_kernel.hpp"
@@ -2927,9 +2926,6 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
         OPENVINO_THROW("make_pa_executor: unsupported precision: ", data_type);
     }
 #elif (defined(OPENVINO_ARCH_ARM64) && defined(HAVE_SVE))
-    if (!ov::intel_cpu::hasArmSVESupport()) {
-        OPENVINO_THROW("make_pa_executor: ARM implementation requires SVE support");
-    }
     if (data_type == ov::element::f32) {
         if (key_cache_type == ov::element::u8 && value_cache_type == ov::element::u8) {
             executor =
@@ -2937,15 +2933,14 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
         } else {
             OPENVINO_THROW("make_pa_executor: key_cache_type and value_cache_type of u8 is only support");
         }
-    } else if (data_type == ov::element::f16) {
+    }
+    if (data_type == ov::element::f16) {
         if (key_cache_type == ov::element::u8 && value_cache_type == ov::element::u8) {
             executor = std::make_shared<AttentionExecutor<ov::float16, ov::element::u8, ov::element::u8>>(params,
                                                                                                           cpu_parallel);
         } else {
             OPENVINO_THROW("make_pa_executor: key_cache_type and value_cache_type of u8 is only support");
         }
-    } else {
-        OPENVINO_THROW("make_pa_executor: unsupported precision: ", data_type);
     }
 
 #else

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -40,6 +40,7 @@
 #include "transpose_kernel.hpp"
 #include "utils/general_utils.h"
 #include "utils/plain_tensor.hpp"
+#include "utils/precision_support.h"
 #include "xattention.hpp"
 #if defined(OPENVINO_ARCH_X86_64)
 #    include "nodes/kernels/x64/brgemm_kernel.hpp"
@@ -2926,6 +2927,9 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
         OPENVINO_THROW("make_pa_executor: unsupported precision: ", data_type);
     }
 #elif (defined(OPENVINO_ARCH_ARM64) && defined(HAVE_SVE))
+    if (!ov::intel_cpu::hasArmSVESupport()) {
+        OPENVINO_THROW("make_pa_executor: ARM implementation requires SVE support");
+    }
     if (data_type == ov::element::f32) {
         if (key_cache_type == ov::element::u8 && value_cache_type == ov::element::u8) {
             executor =
@@ -2933,14 +2937,15 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
         } else {
             OPENVINO_THROW("make_pa_executor: key_cache_type and value_cache_type of u8 is only support");
         }
-    }
-    if (data_type == ov::element::f16) {
+    } else if (data_type == ov::element::f16) {
         if (key_cache_type == ov::element::u8 && value_cache_type == ov::element::u8) {
             executor = std::make_shared<AttentionExecutor<ov::float16, ov::element::u8, ov::element::u8>>(params,
                                                                                                           cpu_parallel);
         } else {
             OPENVINO_THROW("make_pa_executor: key_cache_type and value_cache_type of u8 is only support");
         }
+    } else {
+        OPENVINO_THROW("make_pa_executor: unsupported precision: ", data_type);
     }
 
 #else

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
@@ -35,6 +35,7 @@
 
 #if defined(OPENVINO_ARCH_ARM64)
 #    include "openvino/core/shape.hpp"
+#    include "utils/precision_support.h"
 #endif
 
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64) || defined(OPENVINO_ARCH_ARM64)
@@ -293,6 +294,13 @@ void PagedAttention::createPrimitive() {
 
     auto builder = [&]([[maybe_unused]] const PagedAttentionKey& key) -> std::shared_ptr<PagedAttentionExecutor> {
 #if defined(OPENVINO_ARCH_X86_64) || (defined(OPENVINO_ARCH_ARM64))
+#    if defined(OPENVINO_ARCH_ARM64)
+        // The ARM PagedAttention kernels exist only in the SVE clone; decline on a core
+        // without SVE so make_pa_executor's SVE-autovectorized init is never reached.
+        if (!hasArmISASupport(ArmISA::SVE)) {
+            return nullptr;
+        }
+#    endif
         PagedAttnQuantParams params{cpuConfig.keyCacheGroupSize,
                                     cpuConfig.valueCacheGroupSize,
                                     quantKeybyChannel,

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
@@ -35,7 +35,7 @@
 
 #if defined(OPENVINO_ARCH_ARM64)
 #    include "openvino/core/shape.hpp"
-#    include "utils/precision_support.h"
+#    include "utils/arm_isa_support.h"
 #endif
 
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64) || defined(OPENVINO_ARCH_ARM64)

--- a/src/plugins/intel_cpu/src/utils/arm_isa_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/arm_isa_support.cpp
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "arm_isa_support.h"
-
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+#    include "arm_isa_support.h"
+
 #    include "openvino/core/except.hpp"
 #    include "openvino/runtime/system_conf.hpp"
 

--- a/src/plugins/intel_cpu/src/utils/arm_isa_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/arm_isa_support.cpp
@@ -6,7 +6,6 @@
 
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 #    include "arm_isa_support.h"
-
 #    include "openvino/core/except.hpp"
 #    include "openvino/runtime/system_conf.hpp"
 

--- a/src/plugins/intel_cpu/src/utils/arm_isa_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/arm_isa_support.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "arm_isa_support.h"
+
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+#    include "openvino/core/except.hpp"
+#    include "openvino/runtime/system_conf.hpp"
+
+namespace ov::intel_cpu {
+
+bool hasArmISASupport(ArmISA isa) {
+    switch (isa) {
+    case ArmISA::ASIMD:
+        return true;  // ARMv8-A baseline, always present
+    case ArmISA::SVE:
+        return with_cpu_sve();  // any SVE vector length
+    case ArmISA::DOTPROD:
+        return with_cpu_arm_dotprod();
+    case ArmISA::I8MM:
+        return with_cpu_arm_i8mm();
+    }
+    // An unhandled ArmISA must never be silently reported as supported: that could let an
+    // executor emit instructions the core lacks. Fail loudly so a newly added ISA is wired up.
+    OPENVINO_THROW("hasArmISASupport: unhandled ArmISA value");
+}
+
+}  // namespace ov::intel_cpu
+
+#endif  // OPENVINO_ARCH_ARM || OPENVINO_ARCH_ARM64

--- a/src/plugins/intel_cpu/src/utils/arm_isa_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/arm_isa_support.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/core/visibility.hpp"  // OPENVINO_ARCH_* macros used by the guard below
+
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 #    include "arm_isa_support.h"
 

--- a/src/plugins/intel_cpu/src/utils/arm_isa_support.h
+++ b/src/plugins/intel_cpu/src/utils/arm_isa_support.h
@@ -1,0 +1,24 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+
+#include "openvino/core/visibility.hpp"
+
+namespace ov::intel_cpu {
+
+// ARM-only: referenced solely by the ARM executors (ACL / KleidiAI). Not defined on x86_64 / RISC-V.
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+
+// ISA an ARM executor requires in its supports() predicate. ASIMD is the baseline (declare
+// nothing); requiring a higher ISA (e.g. SVE) makes the executor decline on incapable cores.
+enum class ArmISA : uint8_t { ASIMD, SVE, DOTPROD, I8MM };
+
+bool hasArmISASupport(ArmISA isa);
+
+#endif  // OPENVINO_ARCH_ARM || OPENVINO_ARCH_ARM64
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -8,7 +8,6 @@
 #    include "cpu/x64/cpu_isa_traits.hpp"
 #endif
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
-#    include "openvino/core/except.hpp"
 #    include "openvino/runtime/system_conf.hpp"
 #endif
 #include "openvino/core/type/element_type.hpp"
@@ -57,21 +56,4 @@ ov::element::Type defaultFloatPrecision() {
     return ov::element::f32;
 }
 
-#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
-bool hasArmISASupport(ArmISA isa) {
-    switch (isa) {
-    case ArmISA::ASIMD:
-        return true;  // ARMv8-A baseline, always present
-    case ArmISA::SVE:
-        return with_cpu_sve();  // any SVE vector length
-    case ArmISA::DOTPROD:
-        return with_cpu_arm_dotprod();
-    case ArmISA::I8MM:
-        return with_cpu_arm_i8mm();
-    }
-    // An unhandled ArmISA must never be silently reported as supported: that could let an
-    // executor emit instructions the core lacks. Fail loudly so a newly added ISA is wired up.
-    OPENVINO_THROW("hasArmISASupport: unhandled ArmISA value");
-}
-#endif
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -8,9 +8,9 @@
 #    include "cpu/x64/cpu_isa_traits.hpp"
 #endif
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+#    include "openvino/core/except.hpp"
 #    include "openvino/runtime/system_conf.hpp"
 #endif
-#include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/visibility.hpp"
 

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -60,10 +60,9 @@ ov::element::Type defaultFloatPrecision() {
 bool hasArmISASupport(ArmISA isa) {
     switch (isa) {
     case ArmISA::ASIMD:
-        // NEON/ASIMD is the ARM baseline, present on every supported ARM core.
-        return true;
+        return true;  // ARMv8-A baseline, always present
     case ArmISA::SVE:
-        return with_cpu_sve();
+        return with_cpu_sve();  // any SVE vector length
     case ArmISA::DOTPROD:
         return with_cpu_arm_dotprod();
     case ArmISA::I8MM:

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -65,24 +65,21 @@ bool hasInt8MMSupport() {
     return with_cpu_arm_i8mm();
 }
 
+// aarch64::mayiuse exists only on AArch64, so the ISA queries live in the ARM64 branch;
+// 32-bit ARM has no SVE and NEON as its baseline, so its gate is permissive.
 #if defined(OPENVINO_ARCH_ARM64)
 static bool hasArmASIMDSupport() {
     return dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::asimd);
 }
 
-// "Baseline" SVE = the lowest SVE tier (sve_128). oneDNN models SVE vector width as
-// distinct ISA levels (sve_128/sve_256/sve_512); sve_128 is the minimum, so
-// mayiuse(sve_128) answers "does this core have SVE at all". We additionally require
-// with_cpu_sve() because the two detect SVE through different paths (OpenVINO's HWCAP
-// view vs. oneDNN's), and an executor's kernels are dispatched through oneDNN.
+// sve_128 is the lowest SVE level in oneDNN's ISA hierarchy, so mayiuse(sve_128) tests
+// for SVE presence; with_cpu_sve() is the OpenVINO-side HWCAP check. Both are required
+// because executor kernels are dispatched through oneDNN.
 static bool hasArmBaselineSVESupport() {
     return with_cpu_sve() && dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::sve_128);
 }
-#endif
 
-#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 bool hasArmISASupport(ArmISA isa) {
-#    if defined(OPENVINO_ARCH_ARM64)
     switch (isa) {
     case ArmISA::ASIMD:
         return hasArmASIMDSupport();
@@ -94,12 +91,10 @@ bool hasArmISASupport(ArmISA isa) {
         return hasInt8MMSupport();
     }
     return true;
-#    else
-    // 32-bit ARM: NEON is the baseline and there is no SVE; keep the gate permissive
-    // so the ARM executors that only require ASIMD are never declined.
-    (void)isa;
+}
+#elif defined(OPENVINO_ARCH_ARM)
+bool hasArmISASupport(ArmISA /*isa*/) {
     return true;
-#    endif
 }
 #endif
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -7,9 +7,6 @@
 #if defined(OPENVINO_ARCH_X86_64)
 #    include "cpu/x64/cpu_isa_traits.hpp"
 #endif
-#if defined(OPENVINO_ARCH_ARM64)
-#    include "cpu/aarch64/cpu_isa_traits.hpp"
-#endif
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/visibility.hpp"
 #include "openvino/runtime/system_conf.hpp"
@@ -65,35 +62,19 @@ bool hasInt8MMSupport() {
     return with_cpu_arm_i8mm();
 }
 
-// aarch64::mayiuse exists only on AArch64, so the ISA queries live in the ARM64 branch;
-// 32-bit ARM has no SVE and NEON as its baseline, so its gate is permissive.
-#if defined(OPENVINO_ARCH_ARM64)
-static bool hasArmASIMDSupport() {
-    return dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::asimd);
-}
-
-// sve_128 is the lowest SVE level in oneDNN's ISA hierarchy, so mayiuse(sve_128) tests
-// for SVE presence; with_cpu_sve() is the OpenVINO-side HWCAP check. Both are required
-// because executor kernels are dispatched through oneDNN.
-static bool hasArmBaselineSVESupport() {
-    return with_cpu_sve() && dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::sve_128);
-}
-
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 bool hasArmISASupport(ArmISA isa) {
     switch (isa) {
     case ArmISA::ASIMD:
-        return hasArmASIMDSupport();
+        // NEON/ASIMD is the ARM baseline, present on every supported ARM core.
+        return true;
     case ArmISA::SVE:
-        return hasArmBaselineSVESupport();
+        return with_cpu_sve();
     case ArmISA::DOTPROD:
-        return hasIntDotProductSupport();
+        return with_cpu_arm_dotprod();
     case ArmISA::I8MM:
-        return hasInt8MMSupport();
+        return with_cpu_arm_i8mm();
     }
-    return true;
-}
-#elif defined(OPENVINO_ARCH_ARM)
-bool hasArmISASupport(ArmISA /*isa*/) {
     return true;
 }
 #endif

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -54,7 +54,6 @@ ov::element::Type defaultFloatPrecision() {
     return ov::element::f32;
 }
 
-#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 bool hasArmISASupport(ArmISA isa) {
     switch (isa) {
     case ArmISA::ASIMD:
@@ -69,5 +68,4 @@ bool hasArmISASupport(ArmISA isa) {
     }
     return true;
 }
-#endif
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -7,6 +7,9 @@
 #if defined(OPENVINO_ARCH_X86_64)
 #    include "cpu/x64/cpu_isa_traits.hpp"
 #endif
+#if defined(OPENVINO_ARCH_ARM64)
+#    include "cpu/aarch64/cpu_isa_traits.hpp"
+#endif
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/visibility.hpp"
 #include "openvino/runtime/system_conf.hpp"
@@ -54,11 +57,46 @@ ov::element::Type defaultFloatPrecision() {
     return ov::element::f32;
 }
 
+bool hasArmASIMDSupport() {
+#if defined(OPENVINO_ARCH_ARM64)
+    return dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::asimd);
+#else
+    return false;
+#endif
+}
+
+bool hasArmSVESupport() {
+#if defined(OPENVINO_ARCH_ARM64)
+    return with_cpu_sve() && dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::sve_128);
+#else
+    return false;
+#endif
+}
+
 bool hasIntDotProductSupport() {
     return with_cpu_arm_dotprod();
 }
 
 bool hasInt8MMSupport() {
     return with_cpu_arm_i8mm();
+}
+
+bool hasArmISASupport(ArmISA isa) {
+#if defined(OPENVINO_ARCH_ARM64)
+    switch (isa) {
+    case ArmISA::ASIMD:
+        return hasArmASIMDSupport();
+    case ArmISA::SVE:
+        return hasArmSVESupport();
+    case ArmISA::DOTPROD:
+        return hasIntDotProductSupport();
+    case ArmISA::I8MM:
+        return hasInt8MMSupport();
+    }
+    return true;
+#else
+    (void)isa;
+    return true;
+#endif
 }
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -57,22 +57,6 @@ ov::element::Type defaultFloatPrecision() {
     return ov::element::f32;
 }
 
-bool hasArmASIMDSupport() {
-#if defined(OPENVINO_ARCH_ARM64)
-    return dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::asimd);
-#else
-    return false;
-#endif
-}
-
-bool hasArmSVESupport() {
-#if defined(OPENVINO_ARCH_ARM64)
-    return with_cpu_sve() && dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::sve_128);
-#else
-    return false;
-#endif
-}
-
 bool hasIntDotProductSupport() {
     return with_cpu_arm_dotprod();
 }
@@ -81,22 +65,41 @@ bool hasInt8MMSupport() {
     return with_cpu_arm_i8mm();
 }
 
-bool hasArmISASupport(ArmISA isa) {
 #if defined(OPENVINO_ARCH_ARM64)
+static bool hasArmASIMDSupport() {
+    return dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::asimd);
+}
+
+// "Baseline" SVE = the lowest SVE tier (sve_128). oneDNN models SVE vector width as
+// distinct ISA levels (sve_128/sve_256/sve_512); sve_128 is the minimum, so
+// mayiuse(sve_128) answers "does this core have SVE at all". We additionally require
+// with_cpu_sve() because the two detect SVE through different paths (OpenVINO's HWCAP
+// view vs. oneDNN's), and an executor's kernels are dispatched through oneDNN.
+static bool hasArmBaselineSVESupport() {
+    return with_cpu_sve() && dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::sve_128);
+}
+#endif
+
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+bool hasArmISASupport(ArmISA isa) {
+#    if defined(OPENVINO_ARCH_ARM64)
     switch (isa) {
     case ArmISA::ASIMD:
         return hasArmASIMDSupport();
     case ArmISA::SVE:
-        return hasArmSVESupport();
+        return hasArmBaselineSVESupport();
     case ArmISA::DOTPROD:
         return hasIntDotProductSupport();
     case ArmISA::I8MM:
         return hasInt8MMSupport();
     }
     return true;
-#else
+#    else
+    // 32-bit ARM: NEON is the baseline and there is no SVE; keep the gate permissive
+    // so the ARM executors that only require ASIMD are never declined.
     (void)isa;
     return true;
-#endif
+#    endif
 }
+#endif
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -54,14 +54,6 @@ ov::element::Type defaultFloatPrecision() {
     return ov::element::f32;
 }
 
-bool hasIntDotProductSupport() {
-    return with_cpu_arm_dotprod();
-}
-
-bool hasInt8MMSupport() {
-    return with_cpu_arm_i8mm();
-}
-
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 bool hasArmISASupport(ArmISA isa) {
     switch (isa) {

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -10,6 +10,7 @@
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 #    include "openvino/runtime/system_conf.hpp"
 #endif
+#include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/visibility.hpp"
 
@@ -68,7 +69,9 @@ bool hasArmISASupport(ArmISA isa) {
     case ArmISA::I8MM:
         return with_cpu_arm_i8mm();
     }
-    return true;
+    // An unhandled ArmISA must never be silently reported as supported: that could let an
+    // executor emit instructions the core lacks. Fail loudly so a newly added ISA is wired up.
+    OPENVINO_THROW("hasArmISASupport: unhandled ArmISA value");
 }
 #endif
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -7,9 +7,11 @@
 #if defined(OPENVINO_ARCH_X86_64)
 #    include "cpu/x64/cpu_isa_traits.hpp"
 #endif
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+#    include "openvino/runtime/system_conf.hpp"
+#endif
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/visibility.hpp"
-#include "openvino/runtime/system_conf.hpp"
 
 namespace ov::intel_cpu {
 
@@ -54,6 +56,7 @@ ov::element::Type defaultFloatPrecision() {
     return ov::element::f32;
 }
 
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 bool hasArmISASupport(ArmISA isa) {
     switch (isa) {
     case ArmISA::ASIMD:
@@ -68,4 +71,5 @@ bool hasArmISASupport(ArmISA isa) {
     }
     return true;
 }
+#endif
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -13,8 +13,6 @@ namespace ov::intel_cpu {
 
 bool hasHardwareSupport(const ov::element::Type& precision);
 ov::element::Type defaultFloatPrecision();
-bool hasIntDotProductSupport();
-bool hasInt8MMSupport();
 
 // Declared for ARM only: the gate is referenced solely by the ARM executors
 // (ACL / KleidiAI), which are compiled only on ARM.

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -16,24 +16,17 @@ ov::element::Type defaultFloatPrecision();
 bool hasIntDotProductSupport();
 bool hasInt8MMSupport();
 
-// The ARM ISA gate below is only referenced by the ARM executors (ACL / KleidiAI),
-// which are compiled exclusively on ARM, so it is declared for ARM targets only.
+// Declared for ARM only: the gate is referenced solely by the ARM executors
+// (ACL / KleidiAI), which are compiled only on ARM.
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 
-// Minimum ARM ISA an executor's kernels require, to be declared in its supports()
-// predicate. ASIMD is the ARMv8-A baseline (present on every AArch64 core), so it
-// is the implicit default: an executor that needs only baseline NEON declares
-// nothing and is never gated. Only executors whose kernels emit above-baseline
-// instructions (e.g. SVE) should require the corresponding ISA, so that on a core
-// lacking it the executor declines cleanly and the framework falls back to a
-// baseline implementation instead of executing an illegal instruction.
-//
-// Usage in an executor's supports() predicate:
-//     VERIFY(hasArmISASupport(ArmISA::SVE), UNSUPPORTED_ISA);
+// ARM ISA an executor's kernels require, declared in its supports() predicate.
+// ASIMD is the ARMv8-A baseline; an executor needing only NEON declares nothing.
+// An executor whose kernels use a higher ISA (e.g. SVE) requires it so that a core
+// without it declines and the framework falls back to a baseline implementation.
 enum class ArmISA : uint8_t { ASIMD, SVE, DOTPROD, I8MM };
 
-// Returns whether the current core supports `isa`. ASIMD is always available on
-// AArch64; on 32-bit ARM the gate is permissive (NEON is the baseline there too).
+// Whether the current core supports `isa`. Permissive on 32-bit ARM (NEON baseline).
 bool hasArmISASupport(ArmISA isa);
 
 #endif  // OPENVINO_ARCH_ARM || OPENVINO_ARCH_ARM64

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -4,13 +4,34 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "openvino/core/type/element_type.hpp"
 
 namespace ov::intel_cpu {
 
 bool hasHardwareSupport(const ov::element::Type& precision);
 ov::element::Type defaultFloatPrecision();
+bool hasArmASIMDSupport();
+bool hasArmSVESupport();
 bool hasIntDotProductSupport();
 bool hasInt8MMSupport();
+
+// Minimum ARM ISA an executor's kernels require, to be declared in its supports()
+// predicate. ASIMD is the ARMv8-A baseline (present on every AArch64 core), so it
+// is the implicit default: an executor that needs only baseline NEON declares
+// nothing and is never gated. Only executors whose kernels emit above-baseline
+// instructions (e.g. SVE) should require the corresponding ISA, so that on a core
+// lacking it the executor declines cleanly and the framework falls back to a
+// baseline implementation instead of executing an illegal instruction.
+//
+// Usage in an executor's supports() predicate:
+//     VERIFY(hasArmISASupport(ArmISA::SVE), UNSUPPORTED_ISA);
+enum class ArmISA : uint8_t { ASIMD, SVE, DOTPROD, I8MM };
+
+// Returns whether the current core supports `isa`. ASIMD is always available on
+// AArch64. On non-ARM targets returns true (no ARM ISA restriction), so x64/RISC-V
+// registrations are unaffected.
+bool hasArmISASupport(ArmISA isa);
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -7,15 +7,18 @@
 #include <cstdint>
 
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/visibility.hpp"
 
 namespace ov::intel_cpu {
 
 bool hasHardwareSupport(const ov::element::Type& precision);
 ov::element::Type defaultFloatPrecision();
-bool hasArmASIMDSupport();
-bool hasArmSVESupport();
 bool hasIntDotProductSupport();
 bool hasInt8MMSupport();
+
+// The ARM ISA gate below is only referenced by the ARM executors (ACL / KleidiAI),
+// which are compiled exclusively on ARM, so it is declared for ARM targets only.
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 
 // Minimum ARM ISA an executor's kernels require, to be declared in its supports()
 // predicate. ASIMD is the ARMv8-A baseline (present on every AArch64 core), so it
@@ -30,8 +33,9 @@ bool hasInt8MMSupport();
 enum class ArmISA : uint8_t { ASIMD, SVE, DOTPROD, I8MM };
 
 // Returns whether the current core supports `isa`. ASIMD is always available on
-// AArch64. On non-ARM targets returns true (no ARM ISA restriction), so x64/RISC-V
-// registrations are unaffected.
+// AArch64; on 32-bit ARM the gate is permissive (NEON is the baseline there too).
 bool hasArmISASupport(ArmISA isa);
+
+#endif  // OPENVINO_ARCH_ARM || OPENVINO_ARCH_ARM64
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -4,25 +4,11 @@
 
 #pragma once
 
-#include <cstdint>
-
 #include "openvino/core/type/element_type.hpp"
-#include "openvino/core/visibility.hpp"
 
 namespace ov::intel_cpu {
 
 bool hasHardwareSupport(const ov::element::Type& precision);
 ov::element::Type defaultFloatPrecision();
-
-// ARM-only: referenced solely by the ARM executors (ACL / KleidiAI). Not defined on x86_64 / RISC-V.
-#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
-
-// ISA an ARM executor requires in its supports() predicate. ASIMD is the baseline (declare
-// nothing); requiring a higher ISA (e.g. SVE) makes the executor decline on incapable cores.
-enum class ArmISA : uint8_t { ASIMD, SVE, DOTPROD, I8MM };
-
-bool hasArmISASupport(ArmISA isa);
-
-#endif  // OPENVINO_ARCH_ARM || OPENVINO_ARCH_ARM64
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -7,11 +7,17 @@
 #include <cstdint>
 
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/visibility.hpp"
 
 namespace ov::intel_cpu {
 
 bool hasHardwareSupport(const ov::element::Type& precision);
 ov::element::Type defaultFloatPrecision();
+
+// The ARM ISA gate below is referenced only by the ARM executors (ACL / KleidiAI),
+// which are compiled exclusively on ARM, so it is declared for ARM targets only and
+// does not exist on x86_64 / RISC-V builds.
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 
 // ARM ISA an executor's kernels require, declared in its supports() predicate.
 // ASIMD is the ARM baseline; an executor needing only NEON declares nothing.
@@ -21,5 +27,7 @@ enum class ArmISA : uint8_t { ASIMD, SVE, DOTPROD, I8MM };
 
 // Whether the current core supports `isa`.
 bool hasArmISASupport(ArmISA isa);
+
+#endif  // OPENVINO_ARCH_ARM || OPENVINO_ARCH_ARM64
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -21,12 +21,12 @@ bool hasInt8MMSupport();
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 
 // ARM ISA an executor's kernels require, declared in its supports() predicate.
-// ASIMD is the ARMv8-A baseline; an executor needing only NEON declares nothing.
+// ASIMD is the ARM baseline; an executor needing only NEON declares nothing.
 // An executor whose kernels use a higher ISA (e.g. SVE) requires it so that a core
 // without it declines and the framework falls back to a baseline implementation.
 enum class ArmISA : uint8_t { ASIMD, SVE, DOTPROD, I8MM };
 
-// Whether the current core supports `isa`. Permissive on 32-bit ARM (NEON baseline).
+// Whether the current core supports `isa`.
 bool hasArmISASupport(ArmISA isa);
 
 #endif  // OPENVINO_ARCH_ARM || OPENVINO_ARCH_ARM64

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -14,18 +14,13 @@ namespace ov::intel_cpu {
 bool hasHardwareSupport(const ov::element::Type& precision);
 ov::element::Type defaultFloatPrecision();
 
-// The ARM ISA gate below is referenced only by the ARM executors (ACL / KleidiAI),
-// which are compiled exclusively on ARM, so it is declared for ARM targets only and
-// does not exist on x86_64 / RISC-V builds.
+// ARM-only: referenced solely by the ARM executors (ACL / KleidiAI). Not defined on x86_64 / RISC-V.
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 
-// ARM ISA an executor's kernels require, declared in its supports() predicate.
-// ASIMD is the ARM baseline; an executor needing only NEON declares nothing.
-// An executor whose kernels use a higher ISA (e.g. SVE) requires it so that a core
-// without it declines and the framework falls back to a baseline implementation.
+// ISA an ARM executor requires in its supports() predicate. ASIMD is the baseline (declare
+// nothing); requiring a higher ISA (e.g. SVE) makes the executor decline on incapable cores.
 enum class ArmISA : uint8_t { ASIMD, SVE, DOTPROD, I8MM };
 
-// Whether the current core supports `isa`.
 bool hasArmISASupport(ArmISA isa);
 
 #endif  // OPENVINO_ARCH_ARM || OPENVINO_ARCH_ARM64

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -7,16 +7,11 @@
 #include <cstdint>
 
 #include "openvino/core/type/element_type.hpp"
-#include "openvino/core/visibility.hpp"
 
 namespace ov::intel_cpu {
 
 bool hasHardwareSupport(const ov::element::Type& precision);
 ov::element::Type defaultFloatPrecision();
-
-// Declared for ARM only: the gate is referenced solely by the ARM executors
-// (ACL / KleidiAI), which are compiled only on ARM.
-#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 
 // ARM ISA an executor's kernels require, declared in its supports() predicate.
 // ASIMD is the ARM baseline; an executor needing only NEON declares nothing.
@@ -26,7 +21,5 @@ enum class ArmISA : uint8_t { ASIMD, SVE, DOTPROD, I8MM };
 
 // Whether the current core supports `isa`.
 bool hasArmISASupport(ArmISA isa);
-
-#endif  // OPENVINO_ARCH_ARM || OPENVINO_ARCH_ARM64
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(cpuUtils STATIC
     $<TARGET_PROPERTY:openvino_intel_cpu_plugin,SOURCE_DIR>/src/utils/rt_info/memory_formats_attribute.cpp
     $<TARGET_PROPERTY:openvino_intel_cpu_plugin,SOURCE_DIR>/src/utils/precision_support.h
     $<TARGET_PROPERTY:openvino_intel_cpu_plugin,SOURCE_DIR>/src/utils/precision_support.cpp
+    $<TARGET_PROPERTY:openvino_intel_cpu_plugin,SOURCE_DIR>/src/utils/arm_isa_support.h
+    $<TARGET_PROPERTY:openvino_intel_cpu_plugin,SOURCE_DIR>/src/utils/arm_isa_support.cpp
     ${CPU_ISA_TRAITS_RV64})
 set(CPU_UTILS_LINK_LIBRARIES openvino::runtime::dev)
 set(CPU_UTILS_INCLUDE_PATHS)

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "openvino/core/visibility.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
+
+#include "openvino/core/visibility.hpp"
 #include "openvino/runtime/system_conf.hpp"
+#include "snippets/utils.hpp"
 #include "utils/arm_isa_support.h"
 #include "utils/precision_support.h"
-#include "snippets/utils.hpp"
 #if defined(OPENVINO_ARCH_RISCV64)
-#   include "nodes/kernels/riscv64/cpu_isa_traits.hpp"
+#    include "nodes/kernels/riscv64/cpu_isa_traits.hpp"
 #endif
 #include <string>
 #include <vector>

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -5,6 +5,7 @@
 #include "openvino/core/visibility.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
 #include "openvino/runtime/system_conf.hpp"
+#include "utils/arm_isa_support.h"
 #include "utils/precision_support.h"
 #include "snippets/utils.hpp"
 #if defined(OPENVINO_ARCH_RISCV64)

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -668,7 +668,7 @@ const std::vector<std::regex>& disabled_test_patterns() {
             patterns.emplace_back(std::regex(R"(.*ConvertCPULayerTest.*f16.*)"));
         }
 #elif defined(OPENVINO_ARCH_ARM64) || defined(OPENVINO_ARCH_ARM)
-        if (!ov::intel_cpu::hasIntDotProductSupport()) {
+        if (!ov::intel_cpu::hasArmISASupport(ov::intel_cpu::ArmISA::DOTPROD)) {
             patterns.emplace_back(std::regex(R"(.*smoke_MatMulCompressedWeights_Kleidiai.*)"));
         }
         if (!ov::intel_cpu::hasHardwareSupport(ov::element::f16)) {


### PR DESCRIPTION
## Cause
- On AArch64 with GCC (cross-compile, gcc-10) + LTO, `-march=armv8-a+sve` target attributes from runtime-dispatched SVE clones leak into generic ARMv8-A baseline code.
- GCC auto-vectorizes generic helpers (e.g. `std::vector<...>` resize in the SVE PagedAttention `AttentionExecutor::init`) with SVE instructions (`mov z0.b, #0` / `whilelo` / `st1d`).
- On cores without SVE (e.g. Cortex-A72) these are illegal instructions → SIGILL at runtime (reached on a TBB worker thread).
- `brgemm_kernel.cpp` ISA selection unconditionally fell back to `sve_128` without checking `mayiuse(...)`, so it built oneDNN kernels that emit SVE on cores without SVE.

## Solution
- `precision_support`: add a single ARM ISA gate — `enum class ArmISA { ASIMD, SVE, DOTPROD, I8MM }` and `bool hasArmISASupport(ArmISA)` (ASIMD → always true baseline, SVE → `with_cpu_sve()`, DOTPROD/I8MM → `with_cpu_arm_*`). It consolidates the former `hasIntDotProductSupport()` / `hasInt8MMSupport()` helpers. Declared/defined for ARM targets only, so x86_64 / RISC-V are unaffected.
- ACL executors: encapsulate the precondition common to every ACL executor in `aclCommonExecutorSupported()` (in `acl_utils.hpp`; today the ARMv8-A NEON/ASIMD baseline, extensible). Each ACL executor calls it in its `supports()` / `isSupported()` predicate (`VERIFY(..., UNSUPPORTED_ACL_COMMON_PRECONDITION)` or `if/return` + `DEBUG_LOG`), keeping its op-specific checks. ASIMD is always present on AArch64, so this never over-restricts.
- `kleidiai_mm` / `fullyconnected` (KleidiAI path): query `hasArmISASupport` directly (ASIMD, plus DOTPROD/I8MM for ukernel selection).
- `brgemm_kernel.cpp`: `getSupportedSveIsa(min_isa = sve_128)` returns the highest supported SVE ISA at or above `min_isa`, or `isa_undef` (then the caller throws) instead of the unconditional `sve_128` fallback. The main brgemm kernel uses the default `sve_128` floor; the `copy_a` / `copy_b` kernels pass `sve_256` (oneDNN only provides `sve_256`/`sve_512` for them — `create_brgemm_matmul_copy_*` asserts a superset of `sve_256`).
- `paged_attn.cpp`: decline the ARM PagedAttention executor when the core has no SVE (`hasArmISASupport(ArmISA::SVE)`), in the baseline caller before `make_pa_executor` dispatches to the SVE clone, so the SVE-autovectorized `AttentionExecutor::init` is never reached. The node throws cleanly instead.
- SVE codegen is unchanged: SVE-capable cores keep SVE paths; non-SVE cores decline them and fall back to ANY/NEON.

## Tickets
- CVS-179098
