### PR TITLE
[Transformations] Fix `TransposeFQ` to only fire when FQ consumer is a Transpose

### DIFF
--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -156,6 +156,8 @@ TRANSFORMATIONS_API bool get_single_value(const std::shared_ptr<ov::op::v0::Cons
                                           float& value,
                                           bool check_value_range = true);
 
+TRANSFORMATIONS_API bool fq_ranges_are_equal(const std::shared_ptr<const ov::Node>& fq);
+
 TRANSFORMATIONS_API std::shared_ptr<Node> normalize_constant(const std::shared_ptr<ov::op::v0::Constant>& constant,
                                                              const PartialShape& shape);
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -100,6 +100,14 @@ ov::pass::TransposeFQ::TransposeFQ() {
         if (!transpose_order || !fq)
             return false;
 
+        // Only sink when FQ's sole consumer is another Transpose; the purpose of
+        // this pass is to create a Transpose-FQ-Transpose pattern so TransposeFuse
+        // can eliminate the pair
+        const auto& fq_target_inputs = fq->get_output_target_inputs(0);
+        if (fq_target_inputs.size() != 1 ||
+            !ov::is_type<v1::Transpose>(fq_target_inputs.begin()->get_node()))
+            return false;
+
         ov::NodeVector new_ops;
 
         const auto& reverse_order_constant = get_reversed_order_constant(transpose_order);

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -101,7 +101,7 @@ ov::pass::TransposeFQ::TransposeFQ() {
             return false;
 
         // Sink only when the FakeQuantize represents both quantize and dequantize:
-	// input_low == output_low and input_high == output_high
+        // input_low == output_low and input_high == output_high
         if (!op_util::fq_ranges_are_equal(fq))
             return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -89,9 +89,6 @@ ov::pass::TransposeFQ::TransposeFQ() {
                                                  any_input(ov::pass::pattern::has_static_rank()),
                                                  any_input(ov::pass::pattern::has_static_rank())},
                                                 consumers_count(1));
-    // The downstream Transpose is part of the pattern: TransposeFQ only makes sense
-    // when FQ is between two Transposes so TransposeFuse can later eliminate the pair
-    auto transpose_after_label = wrap_type<v1::Transpose>({fq_label, any_input()});
 
     matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
@@ -103,23 +100,10 @@ ov::pass::TransposeFQ::TransposeFQ() {
         if (!transpose_order || !fq)
             return false;
 
-        // Skip FQ nodes that represent the Quantize half of a QDQ pair (e.g. QuantizeLinear from ONNX)
-        // Such FQs have input_low == output_low and input_high == output_high
-        // ConvertQuantizeDequantize will fold them with the downstream DequantizeLinear
-        // moving them before a Transpose would break that adjacency.
-        const auto i_low_const = ov::as_type_ptr<v0::Constant>(fq->get_input_node_shared_ptr(1));
-        const auto i_high_const = ov::as_type_ptr<v0::Constant>(fq->get_input_node_shared_ptr(2));
-        const auto o_low_const = ov::as_type_ptr<v0::Constant>(fq->get_input_node_shared_ptr(3));
-        const auto o_high_const = ov::as_type_ptr<v0::Constant>(fq->get_input_node_shared_ptr(4));
-        if (i_low_const && i_high_const && o_low_const && o_high_const) {
-            float i_low_val, i_high_val, o_low_val, o_high_val;
-            if (op_util::get_single_value(i_low_const, i_low_val) &&
-                op_util::get_single_value(i_high_const, i_high_val) &&
-                op_util::get_single_value(o_low_const, o_low_val) &&
-                op_util::get_single_value(o_high_const, o_high_val) &&
-                i_low_val == o_low_val && i_high_val == o_high_val)
-                return false;
-        }
+        // Sink only when the FakeQuantize represents both quantize and dequantize:
+	// input_low == output_low and input_high == output_high
+        if (!op_util::fq_ranges_are_equal(fq))
+            return false;
 
         ov::NodeVector new_ops;
 
@@ -163,12 +147,10 @@ ov::pass::TransposeFQ::TransposeFQ() {
 
         ov::copy_runtime_info({fq, transpose}, new_ops);
         ov::replace_node(fq, new_transpose);
-        // Re-enqueue the downstream Transpose (match root) so TransposeFuse can fire on the new_transpose
-        register_new_node(m.get_match_root());
         return true;
     };
 
-    auto m = std::make_shared<Matcher>(transpose_after_label, matcher_name);
+    auto m = std::make_shared<Matcher>(fq_label, matcher_name);
     register_matcher(m, matcher_pass_callback);
 }
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -145,6 +145,8 @@ ov::pass::TransposeFQ::TransposeFQ() {
 
         ov::copy_runtime_info({fq, transpose}, new_ops);
         ov::replace_node(fq, new_transpose);
+        // Re-enqueue the downstream Transpose (match root) so TransposeFuse can fire on the new_transpose
+        register_new_node(m.get_match_root());
         return true;
     };
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -83,20 +83,15 @@ ov::pass::TransposeFQ::TransposeFQ() {
 
     auto transpose_order_m = wrap_type<v0::Constant>();
     auto transpose_label = wrap_type<v1::Transpose>({any_input(pattern::has_static_rank()), transpose_order_m});
-    // Only sink when FQ's sole consumer is another Transpose; the purpose of this
-    // pass is to create a Transpose-FQ-Transpose pattern so TransposeFuse can
-    // eliminate the pair
-    auto fq_consumer_is_transpose = [](const Output<Node>& output) {
-        const auto& target_inputs = output.get_target_inputs();
-        return target_inputs.size() == 1 &&
-               ov::is_type<v1::Transpose>(target_inputs.begin()->get_node());
-    };
     auto fq_label = wrap_type<v0::FakeQuantize>({transpose_label,
                                                  any_input(ov::pass::pattern::has_static_rank()),
                                                  any_input(ov::pass::pattern::has_static_rank()),
                                                  any_input(ov::pass::pattern::has_static_rank()),
                                                  any_input(ov::pass::pattern::has_static_rank())},
-                                                fq_consumer_is_transpose);
+                                                consumers_count(1));
+    // The downstream Transpose is part of the pattern: TransposeFQ only makes sense
+    // when FQ is between two Transposes so TransposeFuse can later eliminate the pair
+    auto transpose_after_label = wrap_type<v1::Transpose>({fq_label, any_input()});
 
     matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
@@ -153,7 +148,7 @@ ov::pass::TransposeFQ::TransposeFQ() {
         return true;
     };
 
-    auto m = std::make_shared<Matcher>(fq_label, matcher_name);
+    auto m = std::make_shared<Matcher>(transpose_after_label, matcher_name);
     register_matcher(m, matcher_pass_callback);
 }
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -83,12 +83,20 @@ ov::pass::TransposeFQ::TransposeFQ() {
 
     auto transpose_order_m = wrap_type<v0::Constant>();
     auto transpose_label = wrap_type<v1::Transpose>({any_input(pattern::has_static_rank()), transpose_order_m});
+    // Only sink when FQ's sole consumer is another Transpose; the purpose of this
+    // pass is to create a Transpose-FQ-Transpose pattern so TransposeFuse can
+    // eliminate the pair
+    auto fq_consumer_is_transpose = [](const Output<Node>& output) {
+        const auto& target_inputs = output.get_target_inputs();
+        return target_inputs.size() == 1 &&
+               ov::is_type<v1::Transpose>(target_inputs.begin()->get_node());
+    };
     auto fq_label = wrap_type<v0::FakeQuantize>({transpose_label,
                                                  any_input(ov::pass::pattern::has_static_rank()),
                                                  any_input(ov::pass::pattern::has_static_rank()),
                                                  any_input(ov::pass::pattern::has_static_rank()),
                                                  any_input(ov::pass::pattern::has_static_rank())},
-                                                consumers_count(1));
+                                                fq_consumer_is_transpose);
 
     matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
@@ -98,14 +106,6 @@ ov::pass::TransposeFQ::TransposeFQ() {
         auto transpose_order =
             ov::as_type_ptr<v0::Constant>(pattern_to_output.at(transpose_order_m).get_node_shared_ptr());
         if (!transpose_order || !fq)
-            return false;
-
-        // Only sink when FQ's sole consumer is another Transpose; the purpose of
-        // this pass is to create a Transpose-FQ-Transpose pattern so TransposeFuse
-        // can eliminate the pair
-        const auto& fq_target_inputs = fq->get_output_target_inputs(0);
-        if (fq_target_inputs.size() != 1 ||
-            !ov::is_type<v1::Transpose>(fq_target_inputs.begin()->get_node()))
             return false;
 
         ov::NodeVector new_ops;

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -103,6 +103,24 @@ ov::pass::TransposeFQ::TransposeFQ() {
         if (!transpose_order || !fq)
             return false;
 
+        // Skip FQ nodes that represent the Quantize half of a QDQ pair (e.g. QuantizeLinear from ONNX)
+        // Such FQs have input_low == output_low and input_high == output_high
+        // ConvertQuantizeDequantize will fold them with the downstream DequantizeLinear
+        // moving them before a Transpose would break that adjacency.
+        const auto i_low_const = ov::as_type_ptr<v0::Constant>(fq->get_input_node_shared_ptr(1));
+        const auto i_high_const = ov::as_type_ptr<v0::Constant>(fq->get_input_node_shared_ptr(2));
+        const auto o_low_const = ov::as_type_ptr<v0::Constant>(fq->get_input_node_shared_ptr(3));
+        const auto o_high_const = ov::as_type_ptr<v0::Constant>(fq->get_input_node_shared_ptr(4));
+        if (i_low_const && i_high_const && o_low_const && o_high_const) {
+            float i_low_val, i_high_val, o_low_val, o_high_val;
+            if (op_util::get_single_value(i_low_const, i_low_val) &&
+                op_util::get_single_value(i_high_const, i_high_val) &&
+                op_util::get_single_value(o_low_const, o_low_val) &&
+                op_util::get_single_value(o_high_const, o_high_val) &&
+                i_low_val == o_low_val && i_high_val == o_high_val)
+                return false;
+        }
+
         ov::NodeVector new_ops;
 
         const auto& reverse_order_constant = get_reversed_order_constant(transpose_order);

--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -12,13 +12,16 @@
 #include <vector>
 
 #include "openvino/core/validation_util.hpp"
+#include "openvino/op/abs.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/divide.hpp"
+#include "openvino/op/fake_quantize.hpp"
 #include "openvino/op/gather.hpp"
+#include "openvino/op/less.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/paged_attention.hpp"
 #include "openvino/op/parameter.hpp"
@@ -137,6 +140,27 @@ bool get_single_value(const std::shared_ptr<op::v0::Constant>& const_node, float
     default:
         OPENVINO_THROW("Unsupported precision for const operation: ", const_node->get_friendly_name());
     }
+}
+
+bool fq_ranges_are_equal(const std::shared_ptr<const ov::Node>& fq) {
+    if (!ov::is_type<op::v0::FakeQuantize>(fq))
+        return false;
+
+    auto equal_with_threshold = [](const ov::Output<ov::Node>& val1, const ov::Output<ov::Node>& val2) {
+        auto diff = std::make_shared<op::v1::Subtract>(val1, val2);
+        auto abs_diff = std::make_shared<op::v0::Abs>(diff);
+        auto eps = op::v0::Constant::create(val1.get_element_type(), {}, {1e-6f});
+        auto is_less = ov::util::get_constant_from_source(std::make_shared<op::v1::Less>(abs_diff, eps));
+        if (!is_less)
+            return false;
+        const auto v = is_less->get_vector<bool>();
+        return std::all_of(v.begin(), v.end(), [](bool b) {
+            return b;
+        });
+    };
+
+    return equal_with_threshold(fq->input_value(1), fq->input_value(3)) &&
+           equal_with_threshold(fq->input_value(2), fq->input_value(4));
 }
 
 std::shared_ptr<Node> normalize_constant(const std::shared_ptr<op::v0::Constant>& constant, const PartialShape& shape) {

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
@@ -25,6 +25,7 @@
 #include "openvino/op/reduce_min.hpp"
 #include "openvino/op/reduce_prod.hpp"
 #include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/relu.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/op/transpose.hpp"
@@ -232,6 +233,36 @@ INSTANTIATE_TEST_SUITE_P(TransposeSinkingCommon,
                                          TransposeFQTransposeFuseParams{{1, 3}, {1, 3, 1, 1}},
                                          TransposeFQTransposeFuseParams{{1, 1, 3}, {1, 3, 1, 1}},
                                          TransposeFQTransposeFuseParams{{1, 1, 1, 3}, {1, 3, 1, 1}}));
+
+// TransposeFQ must not fire when FQ's consumer is not a Transpose.
+TEST(TransposeFQNoSinkingTest, TransposeFQNotAppliedWhenFQConsumerIsNotTranspose) {
+    auto input = std::make_shared<opset6::Parameter>(element::f32, PartialShape{1, 3, 4, 5});
+
+    auto order = std::make_shared<opset6::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 3, 1});
+    auto transpose = std::make_shared<opset6::Transpose>(input, order);
+
+    auto i_low  = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
+    auto i_high = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{1.f});
+    auto o_low  = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
+    auto o_high = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{255.f});
+    auto fq = std::make_shared<opset6::FakeQuantize>(transpose, i_low, i_high, o_low, o_high, 256);
+
+    auto relu = std::make_shared<ov::op::v0::Relu>(fq);
+
+    auto model = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
+    auto model_ref = model->clone();
+
+    pass::Manager manager;
+    manager.register_pass<ov::pass::InitNodeInfo>();
+    manager.register_pass<ov::pass::TransposeFQ>();
+    manager.run_passes(model);
+
+    auto fc = FunctionsComparator::no_default()
+                  .enable(FunctionsComparator::NODES)
+                  .enable(FunctionsComparator::PRECISIONS);
+    auto res = fc.compare(model, model_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
 
 struct TransposeReduceParams {
     // given params

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
@@ -250,7 +250,6 @@ TEST(TransposeFQNoSinkingTest, TransposeFQNotAppliedWhenFQConsumerIsNotTranspose
     auto relu = std::make_shared<ov::op::v0::Relu>(fq);
 
     auto model = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
-    auto model_ref = model->clone();
 
     pass::Manager manager;
     manager.register_pass<ov::pass::InitNodeInfo>();

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
@@ -25,7 +25,6 @@
 #include "openvino/op/reduce_min.hpp"
 #include "openvino/op/reduce_prod.hpp"
 #include "openvino/op/reduce_sum.hpp"
-#include "openvino/op/relu.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/op/transpose.hpp"
@@ -234,22 +233,27 @@ INSTANTIATE_TEST_SUITE_P(TransposeSinkingCommon,
                                          TransposeFQTransposeFuseParams{{1, 1, 3}, {1, 3, 1, 1}},
                                          TransposeFQTransposeFuseParams{{1, 1, 1, 3}, {1, 3, 1, 1}}));
 
-// TransposeFQ must not fire when FQ's consumer is not a Transpose.
-TEST(TransposeFQNoSinkingTest, TransposeFQNotAppliedWhenFQConsumerIsNotTranspose) {
+// TransposeFQ must not fire when the FakeQuantize is the Quantize half of a QDQ pair
+TEST(TransposeFQNoSinkingTest, TransposeFQNotAppliedForQuantizeLinear) {
     auto input = std::make_shared<opset6::Parameter>(element::f32, PartialShape{1, 3, 4, 5});
 
     auto order = std::make_shared<opset6::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 3, 1});
     auto transpose = std::make_shared<opset6::Transpose>(input, order);
 
-    auto i_low = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
-    auto i_high = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{1.f});
+    auto i_low = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{-3.5f});
+    auto i_high = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{6.2f});
     auto o_low = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
     auto o_high = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{255.f});
     auto fq = std::make_shared<opset6::FakeQuantize>(transpose, i_low, i_high, o_low, o_high, 256);
 
-    auto relu = std::make_shared<ov::op::v0::Relu>(fq);
+    auto convert_to_u8 = std::make_shared<opset6::Convert>(fq, element::u8);
+    auto convert_to_f32 = std::make_shared<opset6::Convert>(convert_to_u8, element::f32);
+    auto zero_point = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{92.f});
+    auto subtract = std::make_shared<opset6::Subtract>(convert_to_f32, zero_point);
+    auto scale = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{0.038f});
+    auto multiply = std::make_shared<opset6::Multiply>(subtract, scale);
 
-    auto model = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
+    auto model = std::make_shared<ov::Model>(OutputVector{multiply}, ParameterVector{input});
     auto model_ref = model->clone();
 
     pass::Manager manager;

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
@@ -250,6 +250,7 @@ TEST(TransposeFQNoSinkingTest, TransposeFQNotAppliedWhenFQConsumerIsNotTranspose
     auto relu = std::make_shared<ov::op::v0::Relu>(fq);
 
     auto model = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
+    auto model_ref = model->clone();
 
     pass::Manager manager;
     manager.register_pass<ov::pass::InitNodeInfo>();

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
@@ -241,9 +241,9 @@ TEST(TransposeFQNoSinkingTest, TransposeFQNotAppliedWhenFQConsumerIsNotTranspose
     auto order = std::make_shared<opset6::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 2, 3, 1});
     auto transpose = std::make_shared<opset6::Transpose>(input, order);
 
-    auto i_low  = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
+    auto i_low = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
     auto i_high = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{1.f});
-    auto o_low  = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
+    auto o_low = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
     auto o_high = std::make_shared<opset6::Constant>(element::f32, Shape{}, std::vector<float>{255.f});
     auto fq = std::make_shared<opset6::FakeQuantize>(transpose, i_low, i_high, o_low, o_high, 256);
 
@@ -257,9 +257,8 @@ TEST(TransposeFQNoSinkingTest, TransposeFQNotAppliedWhenFQConsumerIsNotTranspose
     manager.register_pass<ov::pass::TransposeFQ>();
     manager.run_passes(model);
 
-    auto fc = FunctionsComparator::no_default()
-                  .enable(FunctionsComparator::NODES)
-                  .enable(FunctionsComparator::PRECISIONS);
+    auto fc =
+        FunctionsComparator::no_default().enable(FunctionsComparator::NODES).enable(FunctionsComparator::PRECISIONS);
     auto res = fc.compare(model, model_ref);
     ASSERT_TRUE(res.valid) << res.message;
 }

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
@@ -16,6 +16,7 @@
 #include "openvino/op/add.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/multiply.hpp"
 #include "openvino/op/reduce_l1.hpp"
 #include "openvino/op/reduce_l2.hpp"
 #include "openvino/op/reduce_logical_and.hpp"


### PR DESCRIPTION
  **Details**
`TransposeFQ` (introduced in #36192) sinks a `Transpose` through a `FakeQuantize` to enable the `Transpose–FQ–Transpose` pattern to be later fused by `TransposeFuse`.
However, the pattern predicate only required that FQ has a single consumer (`consumers_count(1)`), without checking that the consumer is actually a `Transpose`.

When the FQ consumer is something else - e.g., a `QuantizeLinear` node in an `ONNX-QDQ` model - the transformation fires unnecessarily and breaks an accuracy-critical GPU plugin fusion.
Specifically, the GPU plugin has an optimized `Permute` kernel that fuses `Transpose + QuantizeLinear` (or `DequantizeLinear`) into a single primitive. After `TransposeFQ` rewrites `Transpose` → `FQ` to `FQ` → `Transpose`, the `QuantizeLinear` is no longer adjacent to the `Transpose`, so the fusion doesn't trigger.
The `QuantizeLinear` ends up omitted from the `Permute` primitive, and the convolution receives incorrectly dequantized data.

**Fix:** add a guard in the `TransposeFQ` callback that returns false immediately if FQ's output is not consumed by a `Transpose`. This restricts the pass to its documented and intended use case.

**Root cause analysis**

_Original subgraph (WITHOUT transformation):_
```
input(NHWC) → Convert → Transpose[0,3,1,2] → FQ → QuantizeLinear → Convolution
```
GPU runtime graph fuses Transpose + QuantizeLinear → single Permute(u8) primitive, then routes to `convolution_gpu_mmad` (int8 kernel). Correct results.

_With TransposeFQ (broken):_
```
input(NHWC) → Convert → FQ → Transpose[0,3,1,2] → Convolution
```
`QuantizeLinear` is detached from `Transpose`. GPU `Permute` primitive loses the `QuantizeLinear` fusion. `convolution_gpu_bfyx_to_bfyx_f16` (fp16 path) is used instead, but with dequantization missing from the transpose primitive - producing systematically wrong output values.

_With the fix applied:_
```
input(NHWC) → Convert → Transpose[0,3,1,2] → FQ → QuantizeLinear → Convolution
```
Identical to the original. GPU fusions are preserved. Output tensors are bit-identical to the no-transformation baseline for all non-FQ consumer cases.