### PR TITLE
Fix SKILL.md to fix yaml formatter

### DIFF
--- a/.claude/skills/ov-update-pytorch-version/SKILL.md
+++ b/.claude/skills/ov-update-pytorch-version/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ov-update-pytorch-version
-description: Upgrade the PyTorch version used by OpenVINO tests (torch / torchvision / torchaudio) and resolve fallout — missing operator translators, new functionalized `*_copy` aten ops, decomposition changes, FX-only tests failing in TorchScript mode, and accuracy regressions caused by stricter typing. Use when the user asks to "bump torch", "update pytorch to X.Y", "upgrade torch tests", or when pytorch_tests / model_hub pytorch tests fail after a torch version change. Do not use for: enabling a single new PyTorch operator unrelated to a version bump, GenAI / Optimum upgrades, or plugin-level numerical bugs unrelated to the frontend.
+description: Upgrade the PyTorch version used by OpenVINO tests (torch / torchvision / torchaudio) and resolve fallout — missing operator translators, new functionalized `*_copy` aten ops, decomposition changes, FX-only tests failing in TorchScript mode, and accuracy regressions caused by stricter typing. Use when the user asks to "bump torch", "update pytorch to X.Y", "upgrade torch tests", or when pytorch_tests / model_hub pytorch tests fail after a torch version change. Do not use for enabling a single new PyTorch operator unrelated to a version bump, GenAI / Optimum upgrades, or plugin-level numerical bugs unrelated to the frontend.
 ---
 
 # Update PyTorch Version in OpenVINO


### PR DESCRIPTION
yaml formatter can result in parsing error if skill description or name contains `:`, so I removed and fixed the error

**Before**
<img width="1150" height="264" alt="image" src="https://github.com/user-attachments/assets/ca719a87-2c5f-413f-b7df-2d29b795de2f" />

**After the FIX**
<img width="1161" height="262" alt="image" src="https://github.com/user-attachments/assets/dbf6bc0d-804f-43de-bf58-d81ed09ad428" />



### Details:
fixed yaml formatter error

### Tickets:
N/A

### AI Assistance:
 - *AI assistance used: no*
