### PR TITLE
 [GPU] Keep SDPA fused when head_size is dynamic on K/V but static on a sibling

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
@@ -325,6 +325,15 @@ JitConstants SDPABase::get_jit_constants(const kernel_impl_params& params) const
             }
         }
 
+        // General head_size recovery: K/V head_size equals Q head_size (the QK^T
+        // contraction dim) by SDPA shape inference. When K/V carry it dynamically
+        // (get_head_size returns -1) recover from Q so the kernel is jitted with a
+        // valid compile-time constant rather than -1.
+        if (k_head_size < 0)
+            k_head_size = q_head_size;
+        if (v_head_size < 0)
+            v_head_size = q_head_size;
+
         jit.make("HEAD_SIZE", q_head_size);
         jit.make("NUM_HEADS", q_num_head);
         jit.make("K_HEAD_SIZE", k_head_size);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
@@ -75,6 +75,20 @@ JitConstants SDPAOptGeneratorBase::get_jit_constants_base(const kernel_impl_para
             }
         }
 
+        // General head_size recovery: head_size is the QK^T contraction dim, equal
+        // across Q/K/V by SDPA shape inference. When K/V carry it dynamically (-1) but
+        // Q has it statically, recover from Q so the kernel still gets a compile-time
+        // constant instead of falling back to the ref kernel. (validate_impl applies
+        // the same recovery to admit this case.)
+        {
+            auto extended_input_q_transpose_order = extend_order_in_num_heads_dim(desc->input_q_transpose_order);
+            auto q_head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
+            if (k_head_size < 0)
+                k_head_size = (v_head_size >= 0) ? v_head_size : q_head_size;
+            if (v_head_size < 0)
+                v_head_size = (k_head_size >= 0) ? k_head_size : q_head_size;
+        }
+
         GPU_DEBUG_TRACE_DETAIL << "k_head_size = " << k_head_size << ", v_head_size = " << v_head_size << "\n";
 
         size_t data_inputs_num = get_data_inputs_num(*desc);
@@ -208,6 +222,10 @@ DispatchDataFunc SDPAOptGeneratorSingleToken::get_dispatch_data_func() const {
             if (desc->is_kv_compressed && SDPABase::is_int4_kv_cache(params)) {
                 head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
             }
+            // General recovery: V head_size == Q head_size by SDPA shape inference;
+            // recover from Q when V carries it dynamically.
+            if (head_size < 0)
+                head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
 
             const size_t sg_num_scale = get_sg_number_scale_factor(params.get_device_info(), head_size, SDPAStage::SINGLE_TOKEN);
             GPU_DEBUG_TRACE_DETAIL << "batch_size = " << batch_size << ", target_seq_len = " << target_seq_len << ", heads_num = " << heads_num << "\n";
@@ -254,6 +272,10 @@ DispatchDataFunc SDPAOptGeneratorMultiToken::get_dispatch_data_func() const {
             if (desc->is_kv_compressed && SDPABase::is_int4_kv_cache(params)) {
                 head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
             }
+            // General recovery: V head_size == Q head_size by SDPA shape inference;
+            // recover from Q when V carries it dynamically.
+            if (head_size < 0)
+                head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
 
             const size_t sg_num_scale = get_sg_number_scale_factor(params.get_device_info(), head_size, SDPAStage::MULTI_TOKENS);
 
@@ -304,6 +326,10 @@ DispatchDataFunc SDPAOptGeneratorFinalization::get_dispatch_data_func() const {
             if (desc->is_kv_compressed && SDPABase::is_int4_kv_cache(params)) {
                 head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
             }
+            // General recovery: V head_size == Q head_size by SDPA shape inference;
+            // recover from Q when V carries it dynamically.
+            if (head_size < 0)
+                head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
 
             GPU_DEBUG_TRACE_DETAIL << "batch_size = " << batch_size << ", target_seq_len = " << target_seq_len << ", heads_num = " << heads_num << "\n";
             GPU_DEBUG_TRACE_DETAIL << "head_size = " << head_size << ", num_of_partitions = " << num_of_partitions << "\n";

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.hpp
@@ -55,8 +55,20 @@ struct SDPAOpt : public ImplementationManager {
             return false;
         }
 
-        auto dim_size = desc->input_k_transpose_order.size();
-        auto k_head_size = k_layout.get_partial_shape()[desc->input_k_transpose_order[dim_size - 1]];
+        // The opt kernel needs head_size as a compile-time constant. It is the QK^T
+        // contraction dim, equal across Q/K/V by SDPA shape inference, so a dynamic K
+        // head_size is still known when Q (or V) carries it statically. Recover it
+        // from a sibling input instead of bailing to the ref kernel; only reject when
+        // head_size is dynamic on every input. (Mirrors the recovery the opt kernel's
+        // jit already does for int4 KV-cache layouts in sdpa_gen_opt.cpp.)
+        auto head_size_of = [](const cldnn::layout& l, const std::vector<int64_t>& order) -> ov::Dimension {
+            return l.get_partial_shape()[order[order.size() - 1]];
+        };
+        auto k_head_size = head_size_of(k_layout, desc->input_k_transpose_order);
+        if (k_head_size.is_dynamic())
+            k_head_size = head_size_of(q_layout, desc->input_q_transpose_order);
+        if (k_head_size.is_dynamic())
+            k_head_size = head_size_of(v_layout, desc->input_v_transpose_order);
         if (k_head_size.is_dynamic()) {
             return false;
         }

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -864,8 +864,22 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 !(value_ps.size() == 3 || value_ps.size() == 4))
                 return false;
 
-            // - The head size of all Q, K, and V inputs should be the same static value
-            if (query_ps[query_ps.size() - 1].is_dynamic() || key_ps[key_ps.size() - 1].is_dynamic() || value_ps[value_ps.size() - 1].is_dynamic()) {
+            // - The head size of Q, K, and V is the same value (the QK^T contraction
+            //   dim E and the softmax@V output dim, guaranteed equal across the three
+            //   inputs by SDPA shape inference). The opt/micro kernels need it as a
+            //   compile-time constant, but it only has to be static on ONE input to be
+            //   known for all. Recover it from whichever input carries it statically;
+            //   only bail (decompose) when it is dynamic on every input.
+            auto static_head_size = [](const ov::PartialShape& ps) -> int64_t {
+                const auto& d = ps[ps.size() - 1];
+                return d.is_static() ? d.get_length() : -1;
+            };
+            int64_t recovered_head_size = static_head_size(query_ps);
+            if (recovered_head_size < 0)
+                recovered_head_size = static_head_size(key_ps);
+            if (recovered_head_size < 0)
+                recovered_head_size = static_head_size(value_ps);
+            if (recovered_head_size < 0) {
                 return false;
             }
 
@@ -879,7 +893,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                  return false;
              }
 
-            const auto head_size = static_cast<uint64_t>(query_ps[query_ps.size() - 1].get_length());
+            const auto head_size = static_cast<uint64_t>(recovered_head_size);
             if (device_info.supports_immad && cldnn::query_microkernels_supported(m_context->get_engine(), config) && head_size <= 256)
                 return true;
 


### PR DESCRIPTION
# [GPU] Keep SDPA fused when head_size is dynamic on K/V but static on a sibling

## Summary

`ScaledDotProductAttention` has a single `head_size`: it is the `QK^T` contraction
dimension and the `softmax·V` inner dimension, so SDPA shape inference *merges* it
across Q, K and V (`scaled_dot_product_attention_shape_inference.hpp`). The three
inputs are therefore provably equal in head_size — if any one of them is static, they
all are.

The Intel GPU plugin does not exploit this. It treats `head_size` as known only when
**every** one of Q/K/V carries it statically. When an SDPA reaches the plugin with a
**static Q head_size but a dynamic K/V head_size**, the fast attention path is lost:

- the `ScaledDotProductAttentionDecomposition` gate decomposes the SDPA into a
  `Gemm → SoftMax → Gemm` chain (`transformations_pipeline.cpp`), or
- `SDPAOpt::validate_impl` rejects the optimized OCL kernel and falls back to
  `ocl::sdpa::ref` (`sdpa_opt.hpp`),

even though head_size is knowable from Q.

This PR recovers `head_size` from whichever Q/K/V input carries it statically, and
only decomposes / rejects when it is dynamic on **all** of them.

## Why this is a real gap, not a misuse — regular case vs. corner case

This is an unstated assumption about the K/V producer, not a property of attention.
The fusion's own unit tests (`unsqueeze_broadcast_reshape_sdpa_fusion_test.cpp`)
encode the **regular case**: in every test K/V come from either

- a stateful **`KVCache`** op whose `Variable` bakes in a static head_size
  (e.g. `{-1,-1,2,32}`, `{-1,8,-1,32}`), or
- a **`RoPE`** op (static head_size by construction).

So head_size is static on the producer and survives when the fusion reconnects raw
K/V into the SDPA. Two pieces of code depend on that and cannot recover otherwise:

1. **`ensure_4d`** (`unsqueeze_broadcast_reshape_sdpa_fusion.cpp`) returns an
   already-rank-4 reconnected input untouched — it trusts the producer's static shape.
2. **`gpu::SDPA` shape inference** (`transformations/op/sdpa.cpp`) broadcasts over
   `[0, rank-1)` — **excluding the head_size dim** — and only copies a dim from Q when
   K's dim is *already* static. It can pin batch/num_heads from Q but **never recovers
   head_size**.

The **corner case** is a *stateless* graph whose K/V producer is
`Transpose ← Slice(runtime bound) ← Reshape ← flattened cache` (this is how
llama.cpp's OpenVINO backend builds K/V). It matches the fusion's structural pattern,
so the fusion fires — but the producer's static head_size does **not** survive runtime
re-inference once the raw `Transpose` is reconnected into `gpu::SDPA`, and the plugin
cannot recover it from Q. The SDPA's K resolves to `[1,-1,-1,-1]`, the opt kernel is
rejected, and it collapses to `ocl::sdpa::ref`.

The fix removes the producer dependence: head_size is recovered from the static Q
sibling. Regular `KVCache`/`RoPE` graphs are unaffected; stateless slice-based graphs
now also get the optimized kernel.

## Changes (`src/plugins/intel_gpu/`)

| File | Change |
|---|---|
| `src/plugin/transformations_pipeline.cpp` | Decomposition gate: recover `head_size` from Q, else K, else V; decompose only if dynamic on all. Use the recovered value in the subsequent head_size check. |
| `src/graph/impls/ocl_v2/sdpa/sdpa_opt.hpp` | `validate_impl`: recover K head_size from Q/V before rejecting, so the opt kernel is admitted. |
| `src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp` | JIT `K_HEAD_SIZE`/`V_HEAD_SIZE`: fall back to Q head_size when K/V carry it dynamically. |
| `src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp` | JIT + the SINGLE_TOKEN / MULTI_TOKENS / FINALIZATION work-group-size sites: recover head_size from Q when K/V dynamic. |

The recovery mirrors what the opt kernel already does for int4 KV-cache layouts
(`is_int4_kv_cache → use Q head_size`), generalized to any dynamic-head case.

## Validation

Standalone OpenVINO reproducer (no external framework). It builds an
`SDPA(Q,K,V,mask)` decode graph whose **source head_size is static on every tensor**,
in two sub-cases — `control` (K/V fed directly) and `llama.cpp-faithful` (K/V via the
`Reshape → Slice(runtime bound) → Transpose → GQA broadcast` chain) — compiles on GPU,
and reads the selected kernel from `compiled_model.get_runtime_model()`.

Intel Lunar Lake iGPU, 32 q-heads, head_size 64, 1 query token vs 1024-token KV:

| case | sub-case | before (master) | after (this PR) |
|---|---|---|---|
| no-GQA | control | `ocl::sdpa::opt`, 0.70 ms | `ocl::sdpa::opt`, 0.67 ms |
| no-GQA | **llama.cpp-faithful** | **`ocl::sdpa::ref`, 14.75 ms** | **`ocl::sdpa::opt`, 0.73 ms (~20×)** |
| GQA 32/8 | control | `ocl::sdpa::opt`, 0.26 ms | `ocl::sdpa::opt`, 0.26 ms |
| GQA 32/8 | **llama.cpp-faithful** | collapsed (`ref` / decomposed) | **`ocl::sdpa::opt`, 0.36 ms** |

- Static-head_size / shape-pinning-producer paths (the `control` rows) are unchanged.
- Output matches the CPU device on the patched path (`max|GPU − CPU|` ≈ 1e-4, f16).
- End-to-end on llama.cpp's OpenVINO backend, the stateless GQA decode that previously
  collapsed to `ocl::sdpa::ref` (~15 t/s) runs `ocl::sdpa::opt` at ~57 t/s @ depth 1024.

## Open item before merge

This was validated with the standalone reproducer and end-to-end on llama.cpp; the
in-tree GPU unit-test suite (`ov_gpu_unit_tests`) was **not** run locally. A functional
test should be added that builds an SDPA with a dynamic K/V head_size and static Q and
asserts `ocl::sdpa::opt` selection (not `ocl::sdpa::ref` / not decomposed). Happy to
add it.