### PR TITLE
[GPU] Fix BY_CHANNEL requantize offset when head_dim >=512.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/pa_kv_cache_update_ref.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/pa_kv_cache_update_ref.cl
@@ -126,8 +126,8 @@ inline void FUNC(quantize_and_save_by_channel_block_with_requantize)(__global co
                                     const uint new_tokens_num,
                                     const uint sglid,
                                     const uint is_prefill_stage) {
-    int head_size_offset = SUBGROUP_SIZE * get_group_id(2);
     int num_head_size_groups = is_prefill_stage ? NUM_HEAD_SIZE_GROUPS : NUM_HEAD_SIZE_GROUPS / NUM_K_HEAD_SIZE_PARTITIONS;
+    int head_size_offset = SUBGROUP_SIZE * get_group_id(2) * num_head_size_groups;
     for (int h_sub = 0; h_sub < num_head_size_groups; h_sub++) {
         const int hidden_idx = head_size_offset + h_sub * SUBGROUP_SIZE + sglid;
         const uint out_offset_per_wi = out_data_offset + hidden_idx * out_data_pitch;
@@ -204,13 +204,13 @@ inline void FUNC(quantize_and_save_by_channel_block_with_requantize_int4)(__glob
     // Column layout: [packed_tokens (8 bytes)] [scale (f16)] [zp (f16)] = 12 bytes
     // Byte t/2 in column h: lo nibble = token t, hi nibble = token t+1
     // Each lane (sglid) processes one head dim per iteration.
-    int head_size_offset = SUBGROUP_SIZE * get_group_id(2);
     int num_head_size_groups;
     if (is_prefill_stage) {
         num_head_size_groups = NUM_HEAD_SIZE_GROUPS;
     } else {
         num_head_size_groups = NUM_HEAD_SIZE_GROUPS / NUM_K_HEAD_SIZE_PARTITIONS;
     }
+    int head_size_offset = SUBGROUP_SIZE * get_group_id(2) * num_head_size_groups;
 
     for (int h_sub = 0; h_sub < num_head_size_groups; h_sub++) {
         const int hidden_idx = head_size_offset + h_sub * SUBGROUP_SIZE + sglid;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -901,3 +901,70 @@ INSTANTIATE_TEST_SUITE_P(smoke_shared_kv_cache_cm, shared_kv_cache_test, ::testi
     paged_attention_test_params{ {{1, 32}, {1, 64}}, 4, 2, 64, 64, 256, 0, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, true, std::vector<float>{100.0f, 100.0f}, std::vector<int>{128, 128} },
 }));
 
+// Test to verify BY_CHANNEL requantize offset correctness for large head_dim (>=256).
+// When head_dim > SUBGROUP_SIZE (16), the KV cache update kernel partitions the head dimension
+// across work-groups. A bug in the head_size_offset calculation caused overlapping/missing channel
+// writes for channels >= SUBGROUP_SIZE * NUM_K_HEAD_SIZE_PARTITIONS (e.g., 272-511 for head_dim=512),
+// resulting in non-deterministic cache content.
+// This test writes to the KV cache via PA, reads back the quantized cache, dequantizes, and
+// verifies against the original input key data.
+class kv_cache_by_channel_large_head_test : public PagedAttentionTest<paged_attention_test_params> {};
+TEST_P(kv_cache_by_channel_large_head_test, verify_kv_cache_content) {
+    auto p = GetParam();
+
+    ASSERT_TRUE(this->pam.has_value());
+    auto& pam_ref = *this->pam;
+
+    auto result = run_gpu_inference(pam_ref, p);
+
+    PagedAttentionReference ref(pam_ref);
+
+    for (size_t seq_idx = 0; seq_idx < p.subsequences.size(); seq_idx++) {
+        const auto& sd = p.subsequences[seq_idx];
+        const int total_tokens = sd.num_tokens + sd.past_len;
+
+        auto cached_key = ref.read_key_from_cache(result.key_cache_mem, seq_idx, total_tokens);
+
+        // Compare newly written tokens (positions past_len .. total_tokens-1) against original input
+        for (int token_idx = sd.past_len; token_idx < total_tokens; token_idx++) {
+            for (int head_idx = 0; head_idx < p.num_kv_heads; head_idx++) {
+                for (int dim = 0; dim < p.k_head_size; dim++) {
+                    size_t cache_offset = static_cast<size_t>(head_idx) * total_tokens * p.k_head_size +
+                                          static_cast<size_t>(token_idx) * p.k_head_size + dim;
+                    size_t input_offset = static_cast<size_t>(token_idx) * p.num_kv_heads * p.k_head_size +
+                                          static_cast<size_t>(head_idx) * p.k_head_size + dim;
+
+                    float cached_val = static_cast<float>(cached_key[cache_offset]);
+                    float original_val = static_cast<float>(pam_ref.key_data[seq_idx][input_offset]);
+
+                    // BY_CHANNEL i8 quantization tolerance: scale=(max-min)/255 per sub-block per channel
+                    ASSERT_NEAR(cached_val, original_val, 25e-3f)
+                        << " seq=" << seq_idx << " token=" << token_idx
+                        << " head=" << head_idx << " dim=" << dim;
+                }
+            }
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_kv_cache_by_channel_large_head, kv_cache_by_channel_large_head_test, ::testing::ValuesIn(std::vector<paged_attention_test_params>{
+    // head_dim=256, BY_CHANNEL i8: NUM_HEAD_SIZE_GROUPS=16, multiple partitions in generate
+    paged_attention_test_params{ {{1, 10}}, 2, 2, 256, 256, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2 },
+    // head_dim=512, BY_CHANNEL i8: reproduces the original Gemma-4 VLM bug
+    paged_attention_test_params{ {{1, 10}}, 2, 2, 512, 512, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2 },
+    // head_dim=512, BY_CHANNEL i8: prefill (multi-token write)
+    paged_attention_test_params{ {{10, 0}}, 2, 2, 512, 512, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2 },
+    // head_dim=512, BY_CHANNEL i8: mixed (prefix-cached + new tokens)
+    paged_attention_test_params{ {{4, 8}}, 2, 2, 512, 512, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2 },
+    // head_dim=512, BY_CHANNEL u4: INT4 variant
+    paged_attention_test_params{ {{1, 10}}, 2, 2, 512, 512, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, std::nullopt, std::nullopt, ov::element::u4 },
+    // head_dim=512, BY_CHANNEL u4: prefill
+    paged_attention_test_params{ {{10, 0}}, 2, 2, 512, 512, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, std::nullopt, std::nullopt, ov::element::u4 },
+    // head_dim=256, BY_CHANNEL i8: GQA (8 heads, 2 KV heads)
+    paged_attention_test_params{ {{1, 10}}, 8, 2, 256, 256, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2 },
+    // head_dim=512, BY_CHANNEL i8: GQA (8 heads, 2 KV heads)
+    paged_attention_test_params{ {{1, 10}}, 8, 2, 512, 512, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2 },
+    // head_dim=512, BY_CHANNEL i8: multi-sequence generate
+    paged_attention_test_params{ {{1, 10}, {1, 14}}, 2, 2, 512, 512, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2 },
+}));
+

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.h
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.h
@@ -1523,6 +1523,7 @@ private:
         }
     }
 
+public:
     std::vector<ov::float16> read_key_from_cache(cldnn::memory::ptr key_cache_mem, size_t seq_idx, int total_tokens) {
         // Read key vectors from key_cache memory
         // key_cache layout: [num_blocks, num_kv_heads, head_size, block_size]
@@ -1727,6 +1728,7 @@ private:
         return key_data;
     }
 
+private:
     std::vector<ov::float16> compute_diversity_reference(cldnn::memory::ptr key_cache_mem) {
         std::vector<ov::float16> diversity_output;
 


### PR DESCRIPTION
Fix BY_CHANNEL requantize offset for head_dim >= 512 in KV cache update kernel. 

When num_head_size_groups > 1, work-groups must stride by SUBGROUP_SIZE * num_head_size_groups to avoid overlapping channel writes. Without this fix, channels 272–511 are either duplicated or unwritten, causing non-deterministic inference on models like Gemma-4 VLM (u4/i8 BY_CHANNEL, head_dim=512).

### Tickets:
 - *CVS-189002*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
