### PR TITLE
Fix pr 4271 stateful doc link

### DIFF
--- a/docs/articles_en/openvino-workflow/running-inference/inference-request/stateful-models.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-request/stateful-models.rst
@@ -140,6 +140,4 @@ sequences.
 You can find more examples demonstrating how to work with states in other articles:
 
 * `LLaVA-NeXT Multimodal Chatbot notebook <https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/llava-next-multimodal-chatbot>`__
-* :doc:`Serving Stateful Models with OpenVINO Model Server <../../../../model-server/ovms_docs_stateful_models>`
-
 


### PR DESCRIPTION
Summary
Fixes documentation build failure caused by a broken internal link
after removal of the stateful models documentation page.
Changes

Removed invalid :doc: link referencing the deleted stateful-models page
Updated the OpenVINO stateful models guide to eliminate the broken Model Server link

Note that this PR also includes inherited submodule pointer updates from the master base commit de95f5c92, which updates CPU plugin third-party dependencies (ComputeLibrary and onednn). These changes were already present on the branch base and are unrelated to the documentation fix, but I got them when I was updating my local fork from the master.

Motivation
After merging [PR #4271 ("Remove stateful model feature support")](https://github.com/openvinotoolkit/model_server/pull/4271),
builds from the master branch began failing due to a documentation error.
The root cause was an internal Sphinx :doc: reference pointing to a page
that had been removed, which resulted in a build-breaking error.
This change resolves the issue by removing the stale reference.
Implementation Notes

Fix ensures that all internal documentation links point to valid pages
Prevents Sphinx build failures caused by missing targets
Keeps documentation consistent with previously removed content

Testing

Reproduced the issue locally
Verified the fix with a local Sphinx build
Validated the fix using Jenkins, build completed successfully

Checklist

 Fix is minimal and focused
 Root cause identified and addressed
 Documentation builds successfully (local + Jenkins)
 No unrelated changes included