### PR TITLE
[GPU] Fix buffer overflow in MoE get_expert_mask_from_gpu

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
@@ -1117,14 +1117,13 @@ public:
         }
     }
 
-    void get_expert_mask_from_gpu(const MOECompressed::Config& config, memory::ptr mem, stream& stream, expert_mask_cpu& expert_mask) {
+    void get_expert_mask_from_gpu(const MOECompressed::Config& config, memory::ptr mem, stream& stream, expert_mask_cpu& expert_mask, size_t actual_token_num) {
         // shape: [token_num, topk]
         auto layout = mem->get_layout();
-        const auto& shape = layout.get_shape();
 
         int max_expert_num = static_cast<int>(config.num_expert);
         int max_topk = static_cast<int>(config.top_k);
-        int max_tokens = static_cast<int>(shape[0]);
+        int max_tokens = static_cast<int>(actual_token_num);
 
         expert_mask.pred_flag.resize(max_expert_num, 0);
         expert_mask.batch.resize(max_expert_num, {});
@@ -1419,7 +1418,7 @@ public:
         } else {
             ret_event = events.empty() ? nullptr : events[0];
             expert_mask_cpu expert_mask_cpu;
-            get_expert_mask_from_gpu(config, batch_mem_ptr, stream, expert_mask_cpu);
+            get_expert_mask_from_gpu(config, batch_mem_ptr, stream, expert_mask_cpu, token_num);
 
             auto token_size = token_num;
             auto max_topk = static_cast<int>(cur_moe->_config.top_k);
@@ -1868,8 +1867,9 @@ public:
 
         // [batch, max_topk]
         auto topk_id_mem = scratch.topk_id;
+        auto token_num = get_seq_len(hidden_states_layout);
         expert_mask_cpu expert_mask;
-        get_expert_mask_from_gpu(config, topk_id_mem, stream, expert_mask);
+        get_expert_mask_from_gpu(config, topk_id_mem, stream, expert_mask, token_num);
 
         for (size_t expert_no = 0; expert_no < config.num_expert; expert_no++) {
             if (expert_no >= expert_mask.pred_flag.size()) {
@@ -1978,7 +1978,7 @@ public:
         // ----------------------------------------------------------------
         cldnn::event::ptr ret_event = events.empty() ? nullptr : events[0];
         expert_mask_cpu expert_mask;
-        get_expert_mask_from_gpu(config, batch_mem_ptr, stream, expert_mask);
+        get_expert_mask_from_gpu(config, batch_mem_ptr, stream, expert_mask, token_num);
 
         // Flat list of source token indices per expert – input for prefill_gather
         std::vector<int32_t> tokens_per_expert_cpu(static_cast<size_t>(token_num) * max_topk, -1);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
@@ -1512,3 +1512,62 @@ INSTANTIATE_TEST_SUITE_P(smoke,
                                            Moe3GemmTestParams{1, true, 128, 256, 4, 2, 64, true},
                                            Moe3GemmTestParams{1, false, 128, 256, 4, 2, 64, true},
                                            Moe3GemmTestParams{1, true, 256, 512, 4, 2, 64, true}));
+
+// ----- get_expert_mask_from_gpu buffer overflow regression test -----
+// Reproduces the bug where shape predictor flattens topk_id layout [N, top_k] → [N*top_k*1.1]
+// and shape[0] is incorrectly used as token count, causing N*top_k*1.1 * top_k read overflow.
+namespace {
+struct expert_mask_test_result {
+    std::vector<int8_t> pred_flag;
+    std::vector<std::vector<int>> batch;
+    std::vector<std::vector<int>> topk;
+};
+
+void build_expert_mask_cpu(const int32_t* topk_id_buf, int max_tokens, int max_topk, int max_expert_num,
+                           expert_mask_test_result& result) {
+    result.pred_flag.assign(max_expert_num, 0);
+    result.batch.assign(max_expert_num, {});
+    result.topk.assign(max_expert_num, {});
+    for (int b = 0; b < max_tokens; b++) {
+        auto* tok_p = &topk_id_buf[b * max_topk];
+        for (int t = 0; t < max_topk; t++) {
+            auto expert_no = tok_p[t];
+            OPENVINO_ASSERT(expert_no >= 0 && expert_no < max_expert_num);
+            result.batch[expert_no].push_back(b);
+            result.topk[expert_no].push_back(t + b * max_topk);
+            result.pred_flag[expert_no] = 1;
+        }
+    }
+}
+}  // namespace
+
+TEST(moe_3gemm_expert_mask, shape_predictor_overflow_regression) {
+    // Simulates Gemma4-26b MoE: 128 experts, top_k=8, 274 tokens in prefill
+    constexpr int num_experts = 128;
+    constexpr int top_k = 8;
+    constexpr int actual_tokens = 274;
+    // Shape predictor flattens [274,8]=2192 elements, applies ratio 1.1: 2411
+    constexpr int predictor_shape0 = static_cast<int>(274 * 8 * 1.1);  // 2411
+
+    // Buffer allocated by predictor: 2411 int32 elements (not 2411*8)
+    std::vector<int32_t> buffer(predictor_shape0, 0);
+    for (int i = 0; i < actual_tokens * top_k; i++) {
+        buffer[i] = (i * 7) % num_experts;
+    }
+
+    // BUG: using predictor_shape0 as token count: reads 2411*8=19288 > buffer size 2411
+    size_t buggy_read = static_cast<size_t>(predictor_shape0) * top_k;
+    ASSERT_GT(buggy_read, buffer.size());
+
+    // FIX: using actual_token_num from hidden_states: reads 274*8=2192 ≤ buffer size 2411
+    size_t correct_read = static_cast<size_t>(actual_tokens) * top_k;
+    ASSERT_LE(correct_read, buffer.size());
+
+    expert_mask_test_result result;
+    ASSERT_NO_THROW(build_expert_mask_cpu(buffer.data(), actual_tokens, top_k, num_experts, result));
+
+    int total = 0;
+    for (int e = 0; e < num_experts; e++)
+        total += static_cast<int>(result.batch[e].size());
+    ASSERT_EQ(total, actual_tokens * top_k);
+}


### PR DESCRIPTION
Token count was read from preallocated buffer layout instead of actual input shape.
It's causing segfault when shape predictor over-provisions. 
Fix to pass actual_token_num from hidden_states.

### Tickets:
 - *189074*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
