### PR TITLE
[EXPERIMENT][WIP] Support 5D (volumetric) GridSample

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/image/grid-sample-9.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/image/grid-sample-9.rst
@@ -14,6 +14,8 @@ GridSample
 
 **Detailed description:** *GridSample* operates on a 4D input tensor representing an image. It calculates the output by selecting a location in the input image based on the values of the ``grid`` input. The latter contains a pair of float numbers for each output element that the operator is supposed to produce. Conceptually the operator behaves like *Gather* or *GatherND* but the difference is that the pixels to be selected are denoted by pairs of floats which belong to the range ``[-1, 1]``. Those values have to be denormalized first (mapped to the integer coordinates of the input tensor) and then the output value is calculated according to the interpolation ``mode``.
 
+*GridSample* also supports 5D (volumetric) input. In that case the ``data`` tensor has the ``[N, C, D, H, W]`` layout and the ``grid`` tensor has the shape ``[N, D_out, H_out, W_out, 3]``, where the last dimension stores ``(x, y, z)`` triplets (``x`` maps to ``W``, ``y`` to ``H`` and ``z`` to ``D``). The ``bilinear`` mode performs trilinear interpolation over the 8 surrounding voxels and ``nearest`` selects the closest voxel. The ``bicubic`` mode is only defined for 4D input and is rejected for 5D. The number of spatial dimensions of ``data`` and the last dimension of ``grid`` must be consistent (``2`` for 4D, ``3`` for 5D).
+
 **Attributes**
 
 * *align_corners*
@@ -52,13 +54,17 @@ GridSample
 **Inputs**
 
 * **1**: ``data`` - Input tensor of type ``T`` with data to be sampled. This input is expected to
-  be a 4-dimensional tensor with NCHW layout. **Required.**
-* **2**: ``grid`` - A 4-dimensional tensor containing normalized sampling coordinates(pairs of floats).
-  The shape of this tensor is ``[N, H_out, W_out, 2]`` and the data type is ``T1``. **Required.**
+  be a 4-dimensional tensor with NCHW layout, or a 5-dimensional tensor with NCDHW layout for
+  volumetric sampling. **Required.**
+* **2**: ``grid`` - A tensor containing normalized sampling coordinates. For 4D ``data`` it is a
+  4-dimensional tensor of shape ``[N, H_out, W_out, 2]`` holding ``(x, y)`` pairs; for 5D ``data`` it
+  is a 5-dimensional tensor of shape ``[N, D_out, H_out, W_out, 3]`` holding ``(x, y, z)`` triplets.
+  The data type is ``T1``. **Required.**
 
 **Outputs**
 
-* **1**: A 4-dimensional tensor of type ``T`` with ``[N, C, H_out, W_out]`` shape.
+* **1**: A tensor of type ``T`` with ``[N, C, H_out, W_out]`` shape for 4D input, or
+  ``[N, C, D_out, H_out, W_out]`` for 5D input.
   It contains the interpolated values calculated by this operator.
 
 **Types**

--- a/src/core/reference/include/openvino/reference/grid_sample.hpp
+++ b/src/core/reference/include/openvino/reference/grid_sample.hpp
@@ -19,12 +19,17 @@ namespace reference {
 namespace {
 
 using index_4D_t = typename std::array<size_t, 4>;
+using index_5D_t = typename std::array<size_t, 5>;
 
 template <typename GRID_ET>
 using denormalize_fn_t = GRID_ET (*)(GRID_ET, size_t);
 
 template <typename DATA_ET>
 using get_padded_fn_t = DATA_ET (*)(const DATA_ET*, const Shape&, size_t, size_t, long, long);
+
+// 3D-spatial (volumetric) variant of the padded-access function: takes (z, y, x) integer coordinates.
+template <typename DATA_ET>
+using get_padded_3d_fn_t = DATA_ET (*)(const DATA_ET*, const Shape&, size_t, size_t, long, long, long);
 
 template <typename DATA_ET, typename GRID_ET>
 using interpolate_fn_t = DATA_ET (*)(const DATA_ET* data,
@@ -36,8 +41,8 @@ using interpolate_fn_t = DATA_ET (*)(const DATA_ET* data,
                                      const get_padded_fn_t<DATA_ET>&,
                                      const denormalize_fn_t<GRID_ET>&);
 
-template <typename T>
-T& get_single_value(T* buffer, const Shape& shape, const index_4D_t& index) {
+template <typename T, std::size_t N>
+T& get_single_value(T* buffer, const Shape& shape, const std::array<size_t, N>& index) {
     // In this context below assertion is guaranteed by grid_sample(..) function.
     // assert(shape.size() == index.size());
     auto sx = shape.back();
@@ -231,27 +236,184 @@ DATA_ET bicubic(const DATA_ET* data,
     });
     return std::inner_product(cy.begin(), cy.end(), p.begin(), static_cast<DATA_ET>(0));
 }
+
+// ---------------------------------------------------------------------------
+// 5D (volumetric) GridSample helpers.
+//
+// Data layout is [N, C, D, H, W]; the spatial axes are data_shape[2] (D),
+// data_shape[3] (H) and data_shape[4] (W). The grid stores (x, y, z) triplets
+// where x maps to W, y maps to H and z maps to D - mirroring the (x, y) order of
+// the 4D path. Only `bilinear` (trilinear) and `nearest` are defined for 5D in
+// both PyTorch and ONNX; `bicubic` is rejected by the operator validation and is
+// therefore never dispatched here.
+// ---------------------------------------------------------------------------
+
+template <typename DATA_ET, typename GRID_ET>
+using interpolate_3d_fn_t = DATA_ET (*)(const DATA_ET* data,
+                                        const Shape&,
+                                        const size_t n,
+                                        const size_t c,
+                                        const GRID_ET,
+                                        const GRID_ET,
+                                        const GRID_ET,
+                                        const get_padded_3d_fn_t<DATA_ET>&,
+                                        const denormalize_fn_t<GRID_ET>&);
+
+template <typename DATA_ET>
+DATA_ET zeros_padding_3d(const DATA_ET* data,
+                         const Shape& data_shape,
+                         const size_t n,
+                         const size_t c,
+                         const long z_d,
+                         const long y_d,
+                         const long x_d) {
+    const auto D = static_cast<long>(data_shape[2]);
+    const auto H = static_cast<long>(data_shape[3]);
+    const auto W = static_cast<long>(data_shape[4]);
+    if (z_d < 0 || y_d < 0 || x_d < 0 || z_d >= D || y_d >= H || x_d >= W) {
+        return 0;
+    } else {
+        return get_single_value(data,
+                                data_shape,
+                                index_5D_t{n, c, static_cast<size_t>(z_d), static_cast<size_t>(y_d),
+                                           static_cast<size_t>(x_d)});
+    }
+}
+
+template <typename DATA_ET>
+DATA_ET border_padding_3d(const DATA_ET* data,
+                          const Shape& data_shape,
+                          const size_t n,
+                          const size_t c,
+                          const long z_d,
+                          const long y_d,
+                          const long x_d) {
+    const auto D = static_cast<long>(data_shape[2]);
+    const auto H = static_cast<long>(data_shape[3]);
+    const auto W = static_cast<long>(data_shape[4]);
+    const auto z = static_cast<size_t>(std::min(std::max(z_d, 0l), D - 1));
+    const auto y = static_cast<size_t>(std::min(std::max(y_d, 0l), H - 1));
+    const auto x = static_cast<size_t>(std::min(std::max(x_d, 0l), W - 1));
+    return get_single_value(data, data_shape, index_5D_t{n, c, z, y, x});
+}
+
+// Reflects a single axis coordinate using the same arithmetic as the 4D path.
+inline long reflect_index_no_align(long coord, const long size) {
+    const auto size_2 = size * 2l;
+    coord = (coord % size_2 + size_2) % size_2;
+    return coord >= size ? size_2 - 1 - coord : coord;
+}
+
+inline long reflect_index_with_align(long coord, const long size) {
+    const auto span = size == 1 ? 1 : 2 * (size - 1);
+    coord = std::abs(coord) % span;
+    return coord >= size ? span - coord : coord;
+}
+
+template <typename DATA_ET>
+DATA_ET reflection_data_no_align_3d(const DATA_ET* data,
+                                    const Shape& data_shape,
+                                    const size_t n,
+                                    const size_t c,
+                                    long z_d,
+                                    long y_d,
+                                    long x_d) {
+    const auto z = static_cast<size_t>(reflect_index_no_align(z_d, static_cast<long>(data_shape[2])));
+    const auto y = static_cast<size_t>(reflect_index_no_align(y_d, static_cast<long>(data_shape[3])));
+    const auto x = static_cast<size_t>(reflect_index_no_align(x_d, static_cast<long>(data_shape[4])));
+    return get_single_value(data, data_shape, index_5D_t{n, c, z, y, x});
+}
+
+template <typename DATA_ET>
+DATA_ET reflection_data_with_align_3d(const DATA_ET* data,
+                                      const Shape& data_shape,
+                                      const size_t n,
+                                      const size_t c,
+                                      long z_d,
+                                      long y_d,
+                                      long x_d) {
+    const auto z = static_cast<size_t>(reflect_index_with_align(z_d, static_cast<long>(data_shape[2])));
+    const auto y = static_cast<size_t>(reflect_index_with_align(y_d, static_cast<long>(data_shape[3])));
+    const auto x = static_cast<size_t>(reflect_index_with_align(x_d, static_cast<long>(data_shape[4])));
+    return get_single_value(data, data_shape, index_5D_t{n, c, z, y, x});
+}
+
+template <typename DATA_ET, typename GRID_ET>
+DATA_ET trilinear(const DATA_ET* data,
+                  const Shape& data_shape,
+                  const size_t n,
+                  const size_t c,
+                  const GRID_ET z_n,
+                  const GRID_ET y_n,
+                  const GRID_ET x_n,
+                  const get_padded_3d_fn_t<DATA_ET>& get_padded,
+                  const denormalize_fn_t<GRID_ET>& denormalize) {
+    const auto z_d = denormalize(z_n, data_shape[2]);
+    const auto y_d = denormalize(y_n, data_shape[3]);
+    const auto x_d = denormalize(x_n, data_shape[4]);
+    const auto z_topleft = std::floor(z_d);
+    const auto y_topleft = std::floor(y_d);
+    const auto x_topleft = std::floor(x_d);
+    const auto dz = static_cast<DATA_ET>(z_d - z_topleft);
+    const auto dy = static_cast<DATA_ET>(y_d - y_topleft);
+    const auto dx = static_cast<DATA_ET>(x_d - x_topleft);
+
+    const auto z0 = static_cast<long>(z_topleft);
+    const auto y0 = static_cast<long>(y_topleft);
+    const auto x0 = static_cast<long>(x_topleft);
+
+    const auto v000 = get_padded(data, data_shape, n, c, z0, y0, x0);
+    const auto v001 = get_padded(data, data_shape, n, c, z0, y0, x0 + 1);
+    const auto v010 = get_padded(data, data_shape, n, c, z0, y0 + 1, x0);
+    const auto v011 = get_padded(data, data_shape, n, c, z0, y0 + 1, x0 + 1);
+    const auto v100 = get_padded(data, data_shape, n, c, z0 + 1, y0, x0);
+    const auto v101 = get_padded(data, data_shape, n, c, z0 + 1, y0, x0 + 1);
+    const auto v110 = get_padded(data, data_shape, n, c, z0 + 1, y0 + 1, x0);
+    const auto v111 = get_padded(data, data_shape, n, c, z0 + 1, y0 + 1, x0 + 1);
+
+    // Interpolate along x, then y, then z.
+    const auto c00 = (1 - dx) * v000 + dx * v001;
+    const auto c01 = (1 - dx) * v010 + dx * v011;
+    const auto c10 = (1 - dx) * v100 + dx * v101;
+    const auto c11 = (1 - dx) * v110 + dx * v111;
+
+    const auto c0 = (1 - dy) * c00 + dy * c01;
+    const auto c1 = (1 - dy) * c10 + dy * c11;
+
+    return (1 - dz) * c0 + dz * c1;
+}
+
+template <typename DATA_ET, typename GRID_ET>
+DATA_ET nearest_3d(const DATA_ET* data,
+                   const Shape& data_shape,
+                   const size_t n,
+                   const size_t c,
+                   const GRID_ET z_n,
+                   const GRID_ET y_n,
+                   const GRID_ET x_n,
+                   const get_padded_3d_fn_t<DATA_ET>& get_padded,
+                   const denormalize_fn_t<GRID_ET>& denormalize) {
+    const auto z_nearest = std::lrint(denormalize(z_n, data_shape[2]));
+    const auto y_nearest = std::lrint(denormalize(y_n, data_shape[3]));
+    const auto x_nearest = std::lrint(denormalize(x_n, data_shape[4]));
+    return get_padded(data, data_shape, n, c, z_nearest, y_nearest, x_nearest);
+}
 }  // namespace
 
 template <typename DATA_ET, typename GRID_ET>
-void grid_sample(DATA_ET* output,
-                 const DATA_ET* data,
-                 const GRID_ET* grid,
-                 const Shape& data_shape,
-                 const Shape& grid_shape,
-                 const bool align_corners,
-                 const ov::op::v9::GridSample::InterpolationMode interpolation_mode,
-                 const ov::op::v9::GridSample::PaddingMode padding_mode) {
-    assert(data_shape.size() == 4 && grid_shape.size() == 4);
-    assert(data_shape[0] == grid_shape[0] && grid_shape[3] == 2);
-
+void grid_sample_2d_spatial(DATA_ET* output,
+                            const DATA_ET* data,
+                            const GRID_ET* grid,
+                            const Shape& data_shape,
+                            const Shape& grid_shape,
+                            const bool align_corners,
+                            const ov::op::v9::GridSample::InterpolationMode interpolation_mode,
+                            const ov::op::v9::GridSample::PaddingMode padding_mode) {
     const auto N = data_shape[0];
     const auto C = data_shape[1];
     const auto H_out = grid_shape[1];
     const auto W_out = grid_shape[2];
     const Shape output_shape{N, C, H_out, W_out};
-
-    const RoundingGuard rounding_guard{FE_TONEAREST};
 
     get_padded_fn_t<DATA_ET> get_padded_fn;
     switch (padding_mode) {
@@ -295,6 +457,106 @@ void grid_sample(DATA_ET* output,
                 }
             }
         }
+    }
+}
+
+template <typename DATA_ET, typename GRID_ET>
+void grid_sample_3d_spatial(DATA_ET* output,
+                            const DATA_ET* data,
+                            const GRID_ET* grid,
+                            const Shape& data_shape,
+                            const Shape& grid_shape,
+                            const bool align_corners,
+                            const ov::op::v9::GridSample::InterpolationMode interpolation_mode,
+                            const ov::op::v9::GridSample::PaddingMode padding_mode) {
+    const auto N = data_shape[0];
+    const auto C = data_shape[1];
+    const auto D_out = grid_shape[1];
+    const auto H_out = grid_shape[2];
+    const auto W_out = grid_shape[3];
+    const Shape output_shape{N, C, D_out, H_out, W_out};
+
+    get_padded_3d_fn_t<DATA_ET> get_padded_fn;
+    switch (padding_mode) {
+    default:
+    case ov::op::v9::GridSample::PaddingMode::ZEROS:
+        get_padded_fn = zeros_padding_3d<DATA_ET>;
+        break;
+    case ov::op::v9::GridSample::PaddingMode::BORDER:
+        get_padded_fn = border_padding_3d<DATA_ET>;
+        break;
+    case ov::op::v9::GridSample::PaddingMode::REFLECTION:
+        get_padded_fn = align_corners ? reflection_data_with_align_3d<DATA_ET> : reflection_data_no_align_3d<DATA_ET>;
+        break;
+    }
+
+    const auto denormalize_fn = align_corners ? rescale_align<GRID_ET> : rescale_noalign<GRID_ET>;
+
+    // `bicubic` is undefined for volumetric input and is rejected by the operator validation,
+    // so only `bilinear` (trilinear) and `nearest` reach this point.
+    interpolate_3d_fn_t<DATA_ET, GRID_ET> interpolate_fn;
+    switch (interpolation_mode) {
+    default:
+    case ov::op::v9::GridSample::InterpolationMode::BILINEAR:
+        interpolate_fn = trilinear<DATA_ET, GRID_ET>;
+        break;
+    case ov::op::v9::GridSample::InterpolationMode::NEAREST:
+        interpolate_fn = nearest_3d<DATA_ET, GRID_ET>;
+        break;
+    }
+
+    for (size_t n = 0; n < N; ++n) {
+        for (size_t c = 0; c < C; ++c) {
+            for (size_t z = 0; z < D_out; ++z) {
+                for (size_t y = 0; y < H_out; ++y) {
+                    for (size_t x = 0; x < W_out; ++x) {
+                        const auto x_n = get_single_value(grid, grid_shape, index_5D_t{n, z, y, x, 0});
+                        const auto y_n = get_single_value(grid, grid_shape, index_5D_t{n, z, y, x, 1});
+                        const auto z_n = get_single_value(grid, grid_shape, index_5D_t{n, z, y, x, 2});
+
+                        auto& out = get_single_value(output, output_shape, index_5D_t{n, c, z, y, x});
+                        out = interpolate_fn(data, data_shape, n, c, z_n, y_n, x_n, get_padded_fn, denormalize_fn);
+                    }
+                }
+            }
+        }
+    }
+}
+
+template <typename DATA_ET, typename GRID_ET>
+void grid_sample(DATA_ET* output,
+                 const DATA_ET* data,
+                 const GRID_ET* grid,
+                 const Shape& data_shape,
+                 const Shape& grid_shape,
+                 const bool align_corners,
+                 const ov::op::v9::GridSample::InterpolationMode interpolation_mode,
+                 const ov::op::v9::GridSample::PaddingMode padding_mode) {
+    assert(data_shape.size() == grid_shape.size());
+    assert(data_shape[0] == grid_shape[0]);
+
+    const RoundingGuard rounding_guard{FE_TONEAREST};
+
+    if (data_shape.size() == 5) {
+        assert(grid_shape[4] == 3);
+        grid_sample_3d_spatial(output,
+                               data,
+                               grid,
+                               data_shape,
+                               grid_shape,
+                               align_corners,
+                               interpolation_mode,
+                               padding_mode);
+    } else {
+        assert(data_shape.size() == 4 && grid_shape[3] == 2);
+        grid_sample_2d_spatial(output,
+                               data,
+                               grid,
+                               data_shape,
+                               grid_shape,
+                               align_corners,
+                               interpolation_mode,
+                               padding_mode);
     }
 }
 }  // namespace reference

--- a/src/core/shape_inference/include/grid_sample_shape_inference.hpp
+++ b/src/core/shape_inference/include/grid_sample_shape_inference.hpp
@@ -19,26 +19,50 @@ std::vector<TRShape> shape_infer(const GridSample* op, const std::vector<TShape>
                           input_shapes.size() == 2,
                           "Incorrect number of input shapes in GridSample's shape inference function");
     const auto& data_shape = input_shapes[0];
-    NODE_VALIDATION_CHECK(op, data_shape.rank().compatible(4), "The supported shape of the input data tensor is 4D.");
     const auto& grid_shape = input_shapes[1];
-    NODE_VALIDATION_CHECK(op, grid_shape.rank().compatible(4), "The supported shape of the grid tensor is 4D.");
+
+    // GridSample supports 4D (N, C, H, W) and 5D (N, C, D, H, W) data. The grid is expected to have
+    // matching rank: 4D grid (N, H_out, W_out, 2) or 5D grid (N, D_out, H_out, W_out, 3). The last grid
+    // dimension stores the per-output spatial coordinates and therefore equals the spatial rank (2 or 3).
+    NODE_VALIDATION_CHECK(op,
+                          data_shape.rank().compatible(4) || data_shape.rank().compatible(5),
+                          "The supported shape of the input data tensor is 4D or 5D.");
+    NODE_VALIDATION_CHECK(op,
+                          grid_shape.rank().compatible(4) || grid_shape.rank().compatible(5),
+                          "The supported shape of the grid tensor is 4D or 5D.");
+
+    if (data_shape.rank().is_static() && grid_shape.rank().is_static()) {
+        NODE_VALIDATION_CHECK(op,
+                              data_shape.size() == grid_shape.size(),
+                              "The rank of the data and grid input tensors must be equal.");
+    }
+
+    // Determine the output rank: prefer whichever input has a static rank.
+    size_t out_rank = 4;
+    if (data_shape.rank().is_static()) {
+        out_rank = data_shape.size();
+    } else if (grid_shape.rank().is_static()) {
+        out_rank = grid_shape.size();
+    }
+    const size_t spatial_rank = out_rank - 2;
 
     auto output_shapes = std::vector<TRShape>(1);
     auto& output_shape = output_shapes.front();
-    output_shape.resize(4);
+    output_shape.resize(out_rank);
 
     auto& batch_dim = output_shape[0];
     auto& channel_dim = output_shape[1];
-    auto& H_out_dim = output_shape[2];
-    auto& W_out_dim = output_shape[3];
 
     if (grid_shape.rank().is_static()) {
         NODE_VALIDATION_CHECK(op,
-                              grid_shape[3].compatible(2),
-                              "The last dimension of grid tensor's shape has to be equal to 2.");
+                              grid_shape[spatial_rank + 1].compatible(static_cast<int64_t>(spatial_rank)),
+                              "The last dimension of the grid tensor's shape has to be equal to the number of "
+                              "spatial dimensions of the data tensor.");
         batch_dim = grid_shape[0];
-        H_out_dim = grid_shape[1];
-        W_out_dim = grid_shape[2];
+        // Copy the output spatial dimensions (grid[1 .. spatial_rank]) into output[2 .. out_rank).
+        for (size_t i = 0; i < spatial_rank; ++i) {
+            output_shape[2 + i] = grid_shape[1 + i];
+        }
 
         if (data_shape.rank().is_static()) {
             NODE_VALIDATION_CHECK(

--- a/src/core/src/op/grid_sample.cpp
+++ b/src/core/src/op/grid_sample.cpp
@@ -84,6 +84,16 @@ void GridSample::validate_and_infer_types() {
     }
 
     const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
+
+    // Bicubic interpolation is only defined for 4D (2D-spatial) input - both PyTorch and ONNX restrict
+    // `bicubic`/`cubic` to images. Reject it for volumetric (5D) input.
+    const auto& data_rank = input_shapes[0].rank();
+    if (data_rank.is_static() && data_rank.get_length() == 5) {
+        NODE_VALIDATION_CHECK(this,
+                              m_attributes.mode != InterpolationMode::BICUBIC,
+                              "GridSample does not support bicubic interpolation for 5D (volumetric) input.");
+    }
+
     const auto out_shapes = shape_infer(this, input_shapes);
     set_output_type(0, get_input_element_type(0), out_shapes[0]);
 }

--- a/src/core/tests/type_prop/grid_sample.cpp
+++ b/src/core/tests/type_prop/grid_sample.cpp
@@ -149,15 +149,67 @@ TEST(type_prop, grid_sample_dynamic_output_spatials) {
         << "The output shape of GridSample is incorrect";
 }
 
-TEST(type_prop, grid_sample_unsupported_grid_rank) {
+TEST(type_prop, grid_sample_5d_default_attributes) {
+    const auto data = make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 3, 8, 16, 16});
+    const auto grid = make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 4, 10, 10, 3});
+    const auto grid_sample = make_shared<op::v9::GridSample>(data, grid, op::v9::GridSample::Attributes{});
+
+    EXPECT_EQ(grid_sample->get_element_type(), data->get_element_type());
+    EXPECT_TRUE(grid_sample->get_output_partial_shape(0).same_scheme(PartialShape{1, 3, 4, 10, 10}))
+        << "The output shape of 5D GridSample is incorrect";
+}
+
+TEST(type_prop, grid_sample_5d_dynamic_spatials_and_symbols) {
+    auto data_pshape = PartialShape{{2, 4}, {1, 3}, 8, 16, 16};
+    auto data_symbols = set_shape_symbols(data_pshape);
+    const auto data = make_shared<op::v0::Parameter>(element::f32, data_pshape);
+
+    auto grid_pshape = PartialShape{{3, 8}, {4, 6}, {5, 7}, {2, 9}, 3};
+    auto grid_symbols = set_shape_symbols(grid_pshape);
+    const auto grid = make_shared<op::v0::Parameter>(element::f32, grid_pshape);
+
+    const auto grid_sample = make_shared<op::v9::GridSample>(data, grid, op::v9::GridSample::Attributes{});
+
+    const auto& out_shape = grid_sample->get_output_partial_shape(0);
+    EXPECT_EQ(out_shape, (PartialShape{{3, 4}, {1, 3}, {4, 6}, {5, 7}, {2, 9}}));
+    EXPECT_THAT(get_shape_symbols(out_shape),
+                ElementsAre(grid_symbols[0], data_symbols[1], grid_symbols[1], grid_symbols[2], grid_symbols[3]));
+}
+
+TEST(type_prop, grid_sample_5d_dynamic_grid_rank) {
+    const auto data = make_shared<op::v0::Parameter>(element::f32, PartialShape{2, 3, 8, 16, 16});
+    const auto grid = make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
+    const auto grid_sample = make_shared<op::v9::GridSample>(data, grid, op::v9::GridSample::Attributes{});
+
+    EXPECT_TRUE(grid_sample->get_output_partial_shape(0).same_scheme(
+        PartialShape{2, 3, Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic()}))
+        << "The output shape of 5D GridSample is incorrect";
+}
+
+TEST(type_prop, grid_sample_5d_bicubic_is_rejected) {
+    const auto data = make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 3, 8, 16, 16});
+    const auto grid = make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 4, 10, 10, 3});
+    const auto attrs = op::v9::GridSample::Attributes{false,
+                                                      op::v9::GridSample::InterpolationMode::BICUBIC,
+                                                      op::v9::GridSample::PaddingMode::ZEROS};
+    EXPECT_THROW(op::v9::GridSample(data, grid, attrs), ov::NodeValidationFailure);
+}
+
+TEST(type_prop, grid_sample_5d_incorrect_last_dim_in_grid) {
+    const auto data = make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 3, 8, 16, 16});
+    const auto grid = make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 4, 10, 10, 2});
+    EXPECT_THROW(op::v9::GridSample(data, grid, op::v9::GridSample::Attributes{}), ov::NodeValidationFailure);
+}
+
+TEST(type_prop, grid_sample_mismatched_data_grid_rank) {
     const auto data = make_shared<op::v0::Parameter>(element::i32, PartialShape{1, 3, 224, 224});
-    const auto grid = make_shared<op::v0::Parameter>(element::f64, PartialShape{1, 2, 3, 4, 5});
+    const auto grid = make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, 3, 4, 3});
     EXPECT_THROW(op::v9::GridSample(data, grid, op::v9::GridSample::Attributes{}), ov::NodeValidationFailure);
 }
 
 TEST(type_prop, grid_sample_unsupported_data_rank) {
-    const auto data = make_shared<op::v0::Parameter>(element::i32, PartialShape{1, 3, 224, 224, 224});
-    const auto grid = make_shared<op::v0::Parameter>(element::f64, PartialShape{1, 5, 5, 2});
+    const auto data = make_shared<op::v0::Parameter>(element::i32, PartialShape{1, 3, 16, 16, 16, 16});
+    const auto grid = make_shared<op::v0::Parameter>(element::f64, PartialShape{1, 5, 5, 5, 5, 3});
     EXPECT_THROW(op::v9::GridSample(data, grid, op::v9::GridSample::Attributes{}), ov::NodeValidationFailure);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
@@ -48,6 +48,14 @@ bool GridSample::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
             errorMessage = "Not supported CPU instructions set.";
             return false;
         }
+        // The optimized JIT kernel only implements 4D (N, C, H, W) sampling. 5D (volumetric) input is
+        // delegated to the reference implementation via the generic Reference fallback node.
+        const auto& data_rank = op->get_input_partial_shape(0).rank();
+        if (data_rank.is_static() && data_rank.get_length() != 4) {
+            errorMessage = "CPU plug-in optimized GridSample kernel supports only 4D input; other ranks are executed "
+                           "by the reference implementation.";
+            return false;
+        }
 #else
         return false;
 #endif  // OPENVINO_ARCH_X86_64

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/grid_sample_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/grid_sample_shape_inference_test.cpp
@@ -37,3 +37,28 @@ TEST_F(GridSampleStaticShapeInferenceTest, GridSample_default_constructor) {
     output_shapes = shape_inference(op.get(), input_shapes);
     EXPECT_EQ(output_shapes[0], exp_shape);
 }
+
+TEST_F(GridSampleStaticShapeInferenceTest, GridSample_5d) {
+    const auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1, -1});
+    const auto grid = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1, -1});
+
+    op = make_op(data, grid, opset9::GridSample::Attributes{});
+
+    input_shapes = {StaticShape{2, 3, 4, 8, 8}, StaticShape{2, 5, 6, 7, 3}};
+    output_shapes = {StaticShape{}};
+    exp_shape = StaticShape{2, 3, 5, 6, 7};
+
+    output_shapes = shape_inference(op.get(), input_shapes);
+    EXPECT_EQ(output_shapes[0], exp_shape);
+}
+
+TEST_F(GridSampleStaticShapeInferenceTest, GridSample_5d_default_constructor) {
+    op = make_op();
+
+    input_shapes = {StaticShape{1, 2, 4, 8, 8}, StaticShape{1, 5, 6, 7, 3}};
+    output_shapes = {StaticShape{}};
+    exp_shape = StaticShape{1, 2, 5, 6, 7};
+
+    output_shapes = shape_inference(op.get(), input_shapes);
+    EXPECT_EQ(output_shapes[0], exp_shape);
+}

--- a/src/plugins/intel_gpu/src/graph/grid_sample.cpp
+++ b/src/plugins/intel_gpu/src/graph/grid_sample.cpp
@@ -20,6 +20,15 @@ layout grid_sample_inst::calc_output_layout(const grid_sample_node& node, const 
 
     const auto grid_layout = impl_param.get_input_layout(1);
     const auto grid_sizes = grid_layout.get_dims();
+
+    // 5D (volumetric): data [N, C, D, H, W], grid [N, D_out, H_out, W_out, 3] -> out [N, C, D_out, H_out, W_out].
+    if (data_sizes.size() == 5) {
+        const auto& D_out = grid_sizes[1];
+        const auto& H_out = grid_sizes[2];
+        const auto& W_out = grid_sizes[3];
+        return {data_layout.data_type, data_layout.format, tensor(data_layout.format, {N, C, D_out, H_out, W_out})};
+    }
+
     const auto& H = grid_sizes[1];
     const auto& W = grid_sizes[2];
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grid_sample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grid_sample.cpp
@@ -73,6 +73,7 @@ attach_grid_sample_impl::attach_grid_sample_impl() {
     auto types = {data_types::u8, data_types::i8, data_types::f16, data_types::f32, data_types::i32, data_types::i64};
 
     auto formats = {format::bfyx,
+                    format::bfzyx,
                     format::b_fs_yx_fsv16,
                     format::b_fs_yx_fsv32,
                     format::bs_fs_yx_bsv16_fsv16,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_ref.cl
@@ -10,6 +10,229 @@ typedef INPUT0_TYPE data_et;
 typedef float grid_et;
 typedef OUTPUT_TYPE output_et;
 
+#ifdef VOLUMETRIC
+
+// ---------------------------------------------------------------------------
+// 5D (volumetric) GridSample. data: [N, C, D, H, W], grid: [N, D_out, H_out, W_out, 3]
+// where the last grid dimension stores (x, y, z) with x->W, y->H, z->D.
+// ---------------------------------------------------------------------------
+
+inline const data_et FUNC(get_data_single_value)(const data_t* buffer,
+                                                  const size_t n,
+                                                  const size_t c,
+                                                  const size_t z,
+                                                  const size_t y,
+                                                  const size_t x) {
+    const size_t idx = INPUT0_GET_INDEX(n, c, z, y, x);
+    return buffer[idx];
+}
+#define get_data_single_value FUNC_CALL(get_data_single_value)
+
+inline const grid_et FUNC(get_grid_single_value)(const grid_t* buffer,
+                                                  const size_t n,
+                                                  const size_t coord,
+                                                  const size_t z,
+                                                  const size_t y,
+                                                  const size_t x) {
+    const size_t idx = INPUT1_GET_INDEX(n, z, y, x, coord);
+    return buffer[idx];
+}
+#define get_grid_single_value FUNC_CALL(get_grid_single_value)
+
+inline void FUNC(set_output_single_value)(const output_et value,
+                                          output_t* buffer,
+                                          const size_t n,
+                                          const size_t c,
+                                          const size_t z,
+                                          const size_t y,
+                                          const size_t x) {
+    const size_t idx = OUTPUT_GET_INDEX(n, c, z, y, x);
+    buffer[idx] = value;
+}
+#define set_output_single_value FUNC_CALL(set_output_single_value)
+
+#if defined(ALIGN_CORNERS)
+#define rescale_align FUNC(denormalize)
+inline grid_et rescale_align(const grid_et value, const size_t range) {
+    return (value + 1) * ((grid_et)(range)-1) / 2;
+}
+#else
+#define rescale_noalign FUNC(denormalize)
+inline grid_et rescale_noalign(const grid_et value, const size_t range) {
+    return ((value + 1) * (grid_et)(range)-1) / 2;
+}
+#endif
+#define denormalize FUNC_CALL(denormalize)
+
+#if defined(PADDING_MODE_ZEROS)
+#define zeros_padding FUNC(get_padded)
+inline data_et zeros_padding(const data_t* data,
+                             const size_t n,
+                             const size_t c,
+                             const long z_d,
+                             const long y_d,
+                             const long x_d) {
+    const long D = convert_long(INPUT0_SIZE_Z);
+    const long H = convert_long(INPUT0_SIZE_Y);
+    const long W = convert_long(INPUT0_SIZE_X);
+    if (z_d < 0 || y_d < 0 || x_d < 0 || z_d >= D || y_d >= H || x_d >= W) {
+        return 0;
+    } else {
+        return get_data_single_value(data, n, c, (size_t)(z_d), (size_t)(y_d), (size_t)(x_d));
+    }
+}
+#undef zeros_padding
+
+#elif defined(PADDING_MODE_BORDER)
+#define border_padding FUNC(get_padded)
+inline data_et border_padding(const data_t* data,
+                              const size_t n,
+                              const size_t c,
+                              const long z_d,
+                              const long y_d,
+                              const long x_d) {
+    const long D = convert_long(INPUT0_SIZE_Z);
+    const long H = convert_long(INPUT0_SIZE_Y);
+    const long W = convert_long(INPUT0_SIZE_X);
+    const size_t z = (size_t)(clamp(z_d, 0l, D - 1));
+    const size_t y = (size_t)(clamp(y_d, 0l, H - 1));
+    const size_t x = (size_t)(clamp(x_d, 0l, W - 1));
+    return get_data_single_value(data, n, c, z, y, x);
+}
+#undef border_padding
+
+#elif defined(PADDING_MODE_REFLECTION)
+
+#if defined(ALIGN_CORNERS)
+inline long FUNC(reflect_axis)(long coord, const long size) {
+    const long span = size == 1 ? 1 : 2 * (size - 1);
+    coord = abs(coord) % span;
+    return coord >= size ? span - coord : coord;
+}
+#else
+inline long FUNC(reflect_axis)(long coord, const long size) {
+    const long span = size * 2l;
+    coord = (coord % span + span) % span;
+    return coord >= size ? span - 1 - coord : coord;
+}
+#endif
+#define reflect_axis FUNC_CALL(reflect_axis)
+
+#define reflection_padding FUNC(get_padded)
+inline data_et reflection_padding(const data_t* data,
+                                  const size_t n,
+                                  const size_t c,
+                                  long z_d,
+                                  long y_d,
+                                  long x_d) {
+    const size_t z = (size_t)reflect_axis(z_d, convert_long(INPUT0_SIZE_Z));
+    const size_t y = (size_t)reflect_axis(y_d, convert_long(INPUT0_SIZE_Y));
+    const size_t x = (size_t)reflect_axis(x_d, convert_long(INPUT0_SIZE_X));
+    return get_data_single_value(data, n, c, z, y, x);
+}
+#undef reflection_padding
+#else
+#error [clDNN grid_sample_ref.cl]: undefined padding mode
+#endif
+
+#define get_padded FUNC_CALL(get_padded)
+
+#if defined(INTERPOLATION_MODE_BILINEAR)
+#define trilinear FUNC(interpolate)
+inline data_et trilinear(const data_t* data,
+                         const size_t n,
+                         const size_t c,
+                         const grid_et z_n,
+                         const grid_et y_n,
+                         const grid_et x_n) {
+    const grid_et z_d = denormalize(z_n, INPUT0_SIZE_Z);
+    const grid_et y_d = denormalize(y_n, INPUT0_SIZE_Y);
+    const grid_et x_d = denormalize(x_n, INPUT0_SIZE_X);
+    const grid_et z0 = floor(z_d);
+    const grid_et y0 = floor(y_d);
+    const grid_et x0 = floor(x_d);
+    const grid_et dz = z_d - z0;
+    const grid_et dy = y_d - y0;
+    const grid_et dx = x_d - x0;
+
+    const data_et v000 = get_padded(data, n, c, z0, y0, x0);
+    const data_et v001 = get_padded(data, n, c, z0, y0, x0 + 1);
+    const data_et v010 = get_padded(data, n, c, z0, y0 + 1, x0);
+    const data_et v011 = get_padded(data, n, c, z0, y0 + 1, x0 + 1);
+    const data_et v100 = get_padded(data, n, c, z0 + 1, y0, x0);
+    const data_et v101 = get_padded(data, n, c, z0 + 1, y0, x0 + 1);
+    const data_et v110 = get_padded(data, n, c, z0 + 1, y0 + 1, x0);
+    const data_et v111 = get_padded(data, n, c, z0 + 1, y0 + 1, x0 + 1);
+
+    const data_et c00 = (1 - dx) * v000 + dx * v001;
+    const data_et c01 = (1 - dx) * v010 + dx * v011;
+    const data_et c10 = (1 - dx) * v100 + dx * v101;
+    const data_et c11 = (1 - dx) * v110 + dx * v111;
+
+    const data_et c0 = (1 - dy) * c00 + dy * c01;
+    const data_et c1 = (1 - dy) * c10 + dy * c11;
+
+    return (1 - dz) * c0 + dz * c1;
+}
+#undef trilinear
+
+#elif defined(INTERPOLATION_MODE_NEAREST)
+#define nearest3d FUNC(interpolate)
+inline data_et nearest3d(const data_t* data,
+                         const size_t n,
+                         const size_t c,
+                         const grid_et z_n,
+                         const grid_et y_n,
+                         const grid_et x_n) {
+    const grid_et z_nearest = rint(denormalize(z_n, INPUT0_SIZE_Z));
+    const grid_et y_nearest = rint(denormalize(y_n, INPUT0_SIZE_Y));
+    const grid_et x_nearest = rint(denormalize(x_n, INPUT0_SIZE_X));
+    return get_padded(data, n, c, z_nearest, y_nearest, x_nearest);
+}
+#undef nearest3d
+#else
+#error [clDNN grid_sample_ref.cl]: unsupported interpolation mode for volumetric GridSample
+#endif
+
+#define interpolate FUNC_CALL(interpolate)
+
+KERNEL(grid_sample_ref)(const data_t * data,
+                        const grid_t * grid,
+                        output_t * output
+                        #if HAS_FUSED_OPS_DECLS
+                        , FUSED_OPS_DECLS
+                        #endif
+                       ) {
+#if INPUT0_BATCH_NUM != INPUT1_BATCH_NUM
+#error [clDNN grid_sample_ref.cl]: the batch dimension in the input data tensor's shape doesn't match the batch dimension in the grid tensor's shape
+#endif
+
+#if INPUT1_SIZE_X != 3
+#error [clDNN grid_sample_ref.cl]: the last dimension of the grid tensor must be 3 for volumetric GridSample
+#endif
+
+    const uint nc = get_global_id(0);
+    const uint n = nc % OUTPUT_BATCH_NUM;
+    const uint c = nc / OUTPUT_BATCH_NUM;
+    const uint zy = get_global_id(1);
+    const uint z = zy / OUTPUT_SIZE_Y;
+    const uint y = zy % OUTPUT_SIZE_Y;
+    const uint x = get_global_id(2);
+
+    const grid_et x_n = get_grid_single_value(grid, n, 0, z, y, x);
+    const grid_et y_n = get_grid_single_value(grid, n, 1, z, y, x);
+    const grid_et z_n = get_grid_single_value(grid, n, 2, z, y, x);
+
+    const output_et out = interpolate(data, n, c, z_n, y_n, x_n);
+
+    set_output_single_value(out, output, n, c, z, y, x);
+}
+#undef interpolate
+#undef get_padded
+#undef denormalize
+
+#else  // !VOLUMETRIC  (original 4D path - unchanged)
+
 inline const data_et FUNC(
     get_data_single_value)(const data_t* buffer, const size_t n, const size_t c, const size_t h, const size_t w) {
     const size_t idx = INPUT0_GET_INDEX(n, c, h, w);
@@ -244,3 +467,5 @@ KERNEL(grid_sample_ref)(const data_t * data,
 #undef interpolate
 #undef get_padded
 #undef denormalize
+
+#endif  // VOLUMETRIC

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_base.cpp
@@ -51,6 +51,11 @@ JitConstants GridSampleKernelBase::GetJitConstants(const grid_sample_params& ker
         jit_constants.AddConstant(MakeJitConstant("ALIGN_CORNERS", true));
     }
 
+    // Volumetric (5D) sampling: data [N, C, D, H, W], grid [N, D_out, H_out, W_out, 3].
+    if (kernel_params.inputs[0].GetDims().size() == 5) {
+        jit_constants.AddConstant(MakeJitConstant("VOLUMETRIC", 1));
+    }
+
     return jit_constants;
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_ref.cpp
@@ -12,7 +12,12 @@ CommonDispatchData GridSampleKernelRef::CalcDispatch(const grid_sample_params& k
     CommonDispatchData dispatch_data;
     const auto& output = kernel_params.outputs.front();
 
-    dispatch_data.gws = {output.Batch().v * output.Feature().v, output.Y().v, output.X().v};
+    if (output.GetDims().size() == 5) {
+        // Volumetric output [N, C, D_out, H_out, W_out]: fold D_out into the second global dimension.
+        dispatch_data.gws = {output.Batch().v * output.Feature().v, output.Z().v * output.Y().v, output.X().v};
+    } else {
+        dispatch_data.gws = {output.Batch().v * output.Feature().v, output.Y().v, output.X().v};
+    }
     dispatch_data.lws = GetOptimalLocalWorkGroupSizes(dispatch_data.gws, kernel_params.engineInfo);
 
     return dispatch_data;
@@ -25,6 +30,8 @@ ParamsKey GridSampleKernelRef::GetSupportedKey() const {
     key.EnableDifferentTypes();
     key.EnableInputLayout(DataLayout::bfyx);
     key.EnableOutputLayout(DataLayout::bfyx);
+    key.EnableInputLayout(DataLayout::bfzyx);
+    key.EnableOutputLayout(DataLayout::bfzyx);
     key.EnableInputLayout(DataLayout::b_fs_yx_fsv32);
     key.EnableOutputLayout(DataLayout::b_fs_yx_fsv32);
     key.EnableInputLayout(DataLayout::b_fs_yx_fsv16);

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/grid_sample_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/grid_sample_si_test.cpp
@@ -76,6 +76,22 @@ INSTANTIATE_TEST_SUITE_P(smoke, grid_sample_test,
             GridSampleOp::PaddingMode::BORDER,
             layout{{1, 2, 5, 6}, data_types::f32, format::bfyx}
         },
+        {   // 5D volumetric: data [N,C,D,H,W], grid [N,Do,Ho,Wo,3] -> out [N,C,Do,Ho,Wo]
+            layout{{1, 2, 3, 4, 5}, data_types::f32, format::bfzyx},
+            layout{{1, 6, 7, 8, 3}, data_types::f32, format::bfzyx},
+            false,
+            GridSampleOp::InterpolationMode::BILINEAR,
+            GridSampleOp::PaddingMode::ZEROS,
+            layout{{1, 2, 6, 7, 8}, data_types::f32, format::bfzyx}
+        },
+        {   // 5D dynamic spatials
+            layout{{1, 2, -1, -1, -1}, data_types::f32, format::bfzyx},
+            layout{{1, -1, -1, -1, 3}, data_types::f32, format::bfzyx},
+            true,
+            GridSampleOp::InterpolationMode::NEAREST,
+            GridSampleOp::PaddingMode::BORDER,
+            layout{{1, 2, -1, -1, -1}, data_types::f32, format::bfzyx}
+        },
     }));
 
 }  // namespace shape_infer_tests

--- a/src/plugins/template/tests/functional/op_reference/grid_sample.cpp
+++ b/src/plugins/template/tests/functional/op_reference/grid_sample.cpp
@@ -572,6 +572,92 @@ std::vector<GridSampleParams> generateCornerCaseData1x1Params() {
     return params;
 }
 
+// 5D (volumetric) reference cases. Expected values produced with
+// torch.nn.functional.grid_sample (5D) which defines the GridSample volumetric semantics.
+template <ov::element::Type_t DATA_ET,
+          ov::element::Type_t GRID_ET,
+          class DT = ov::fundamental_type_for<DATA_ET>,
+          class GT = ov::fundamental_type_for<GRID_ET>>
+std::vector<GridSampleParams> generate5DParams() {
+    std::vector<GridSampleParams> params;
+    const auto types_str = param_types_str(DATA_ET, GRID_ET);
+
+    // Case 1: data [1, 1, 2, 3, 4] ramp, grid [1, 2, 2, 2, 3].
+    reference_tests::Tensor data1{{1, 1, 2, 3, 4}, DATA_ET, std::vector<DT>{1,  2,  3,  4,  5,  6,  7,  8,
+                                                                            9,  10, 11, 12, 13, 14, 15, 16,
+                                                                            17, 18, 19, 20, 21, 22, 23, 24}};
+    reference_tests::Tensor grid1{{1, 2, 2, 2, 3},
+                                  GRID_ET,
+                                  std::vector<GT>{-0.8, -0.8, -0.8, 0.7,  -0.6, -0.9, 0.1,  0.2,
+                                                  -0.3, -0.4, 0.5,  -0.6, -0.5, 0.9,  0.8,  0.3,
+                                                  -0.2, 0.4,  1.2,  -1.3, 0.5,  -1.1, 1.4,  -0.7}};
+    const Shape out1_shape{1, 1, 2, 2, 2};
+
+    params.emplace_back(
+        data1,
+        grid1,
+        op::v9::GridSample::Attributes{false, GS_BILINEAR, GS_ZEROS},
+        reference_tests::Tensor{out1_shape, DATA_ET, std::vector<DT>{0.504, 2.58, 10.3, 7.83, 9.782502, 16.7, 0.08, 0.0}},
+        "trilinear_zeros_noalign_5d" + types_str);
+    params.emplace_back(
+        data1,
+        grid1,
+        op::v9::GridSample::Attributes{true, GS_BILINEAR, GS_BORDER},
+        reference_tests::Tensor{out1_shape,
+                                DATA_ET,
+                                std::vector<DT>{3.3, 5.75, 11.65, 10.3, 20.15, 14.55, 13.0, 10.8}},
+        "trilinear_border_align_5d" + types_str);
+    params.emplace_back(
+        data1,
+        grid1,
+        op::v9::GridSample::Attributes{false, GS_BILINEAR, GS_REFLECTION},
+        reference_tests::Tensor{out1_shape, DATA_ET, std::vector<DT>{1.0, 4.3, 10.3, 8.7, 21.5, 16.7, 16.0, 8.6}},
+        "trilinear_reflection_noalign_5d" + types_str);
+    params.emplace_back(
+        data1,
+        grid1,
+        op::v9::GridSample::Attributes{true, GS_BILINEAR, GS_REFLECTION},
+        reference_tests::Tensor{out1_shape,
+                                DATA_ET,
+                                std::vector<DT>{3.3, 5.75, 11.65, 10.3, 20.15, 14.55, 13.9, 9.35}},
+        "trilinear_reflection_align_5d" + types_str);
+    params.emplace_back(
+        data1,
+        grid1,
+        op::v9::GridSample::Attributes{false, GS_NEAREST, GS_ZEROS},
+        reference_tests::Tensor{out1_shape, DATA_ET, std::vector<DT>{1.0, 4.0, 7.0, 10.0, 21.0, 19.0, 0.0, 0.0}},
+        "nearest_zeros_noalign_5d" + types_str);
+    params.emplace_back(
+        data1,
+        grid1,
+        op::v9::GridSample::Attributes{true, GS_NEAREST, GS_BORDER},
+        reference_tests::Tensor{out1_shape, DATA_ET, std::vector<DT>{1.0, 4.0, 7.0, 10.0, 22.0, 19.0, 16.0, 9.0}},
+        "nearest_border_align_5d" + types_str);
+
+    // Case 2: multi-channel data [1, 2, 2, 2, 2], grid [1, 1, 2, 2, 3] -> output [1, 2, 1, 2, 2].
+    reference_tests::Tensor data2{{1, 2, 2, 2, 2},
+                                  DATA_ET,
+                                  std::vector<DT>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}};
+    reference_tests::Tensor grid2{{1, 1, 2, 2, 3},
+                                  GRID_ET,
+                                  std::vector<GT>{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0}};
+    const Shape out2_shape{1, 2, 1, 2, 2};
+    params.emplace_back(
+        data2,
+        grid2,
+        op::v9::GridSample::Attributes{false, GS_BILINEAR, GS_ZEROS},
+        reference_tests::Tensor{out2_shape, DATA_ET, std::vector<DT>{1.0, 8.0, 4.5, 1.0, 9.0, 16.0, 12.5, 2.0}},
+        "trilinear_zeros_noalign_multichannel_5d" + types_str);
+    params.emplace_back(
+        data2,
+        grid2,
+        op::v9::GridSample::Attributes{false, GS_NEAREST, GS_ZEROS},
+        reference_tests::Tensor{out2_shape, DATA_ET, std::vector<DT>{1.0, 8.0, 1.0, 0.0, 9.0, 16.0, 9.0, 0.0}},
+        "nearest_zeros_noalign_multichannel_5d" + types_str);
+
+    return params;
+}
+
 std::vector<GridSampleParams> generateGridSampleParams() {
     using namespace ov::element;
     std::vector<std::vector<GridSampleParams>> combo_params{generateNearestParamsOddDimensionsInnerGrids<f32, f32>(),
@@ -604,7 +690,9 @@ std::vector<GridSampleParams> generateGridSampleParams() {
 
                                                             generateCornerCaseData1x1Params<f32, f32>(),
                                                             generateCornerCaseData1x1Params<f32, bf16>(),
-                                                            generateCornerCaseData1x1Params<f32, f16>()};
+                                                            generateCornerCaseData1x1Params<f32, f16>(),
+
+                                                            generate5DParams<f32, f32>()};
     std::vector<GridSampleParams> test_params;
     for (auto& params : combo_params)
         std::move(params.begin(), params.end(), std::back_inserter(test_params));


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Summary

Adds native **5D (volumetric) `GridSample`** support to OpenVINO. The existing
`v9::GridSample` is extended in place to accept **4D** `[N, C, H, W]` **or 5D**
`[N, C, D, H, W]` data with a matching-rank grid (`[N, H_out, W_out, 2]` or
`[N, D_out, H_out, W_out, 3]`). The 4D path is preserved byte-for-byte; 5D is a pure,
backward-compatible capability addition.

Motivation: talking-head avatar warping (ditto-talkinghead, LivePortrait, face-vid2vid),
NeRF rendering, 3D-aware GANs and video super-resolution all rely on volumetric
`grid_sample`. Previously these required an ONNX-graph-surgery workaround
(decomposition into ~16 ops per call). Ref: CVS-182840.

## Design decision

5D is added by **relaxing the rank constraint of `v9::GridSample`** rather than
introducing a new op version. Rationale: opset17 is still in development and a new
`v17::GridSample` would force new opset registration, ConvertOpset transforms and a
second op type across every frontend/plugin — a large ripple for a pure relaxation.
Extending `v9` keeps a single op identity that all plugins already recognize, preserves
all 4D behavior, and is the minimal, well-contained change. `bicubic` remains 4D-only
(undefined for 5D in both PyTorch and ONNX) and is rejected during validation.

Sampling for 5D is **trilinear** (8-voxel blend) / **nearest**, with per-axis
denormalization and `zeros`/`border`/`reflection` padding — matching
`torch.nn.functional.grid_sample` (5D) and ONNX `GridSample-20`.

## Changes by component

| Component | Change |
|-----------|--------|
| **Core shape inference** | Accept 4D or 5D; grid last-dim = spatial rank (2/3); equal-rank check; N-D output + symbol propagation |
| **Core reference** | `get_single_value` generalized to any rank; added 3D padding (zeros/border/reflection), trilinear, nearest3d; public `grid_sample` dispatches on rank (4D path unchanged) |
| **Core op** | Reject `bicubic` for 5D; `evaluate` works for 5D |
| **CPU plugin** | `isSupportedOperation` rejects non-4D → 5D routes to the generic Reference-fallback node (core `evaluate`); 4D JIT path untouched. ARM decomposition already guards rank → same fallback |
| **GPU plugin** | `grid_sample_ref.cl` gains a `VOLUMETRIC` path (trilinear, nearest3d, 3D padding); `bfzyx` layout registered; dispatch folds `D_out`; legacy output-layout handles 5D. Opt kernel stays 4D-only |
| **Docs** | `grid-sample-9.rst` documents the 5D extension |

## Tests written and executed

All built and run in-environment (gcc 13.3, Ninja, 24 cores; Intel Arc Pro B60 GPU):

- **`ov_core_unit_tests`** (type_prop + visitors): **23/23 PASS** — new 5D shape/symbol
  inference, dynamic-rank, grid-last-dim, bicubic-rejected, rank-mismatch cases.
- **`ov_template_func_tests`** (op_reference): **140/140 PASS** (132 pre-existing 4D —
  zero regression — + 8 new 5D). 5D expected values are **bit-accurate vs
  `torch.nn.functional.grid_sample`**.
- **`ov_cpu_unit_tests`** (shape inference): **4/4 PASS** (2 new 5D).
- **GPU shape-inference unit tests**: 5D static + dynamic cases added.
- **End-to-end inference vs PyTorch** (random input incl. out-of-bounds coords):
  - **CPU**: 7/7 cases PASS, max abs err **2.4e-7**.
  - **GPU (Arc, f32)**: 7/7 cases PASS, max abs err **3.4e-7**; default f16 within ~1e-3.
  - 4D regression on CPU (JIT) and GPU: PASS.
  - `bicubic`@5D correctly rejected.

## Notes

- Fully backward compatible: no existing valid 4D IR changes behavior.
- 5D on CPU uses the reference fallback (single source of numerical truth); the x64 JIT
  kernel is intentionally left 4D-only to avoid a large, bug-prone assembly rewrite for a
  rare, non-throughput-critical case.
### Tickets
- CVS-182840 · openvinotoolkit/omega#29 (based on #23)

### AI Assistance
- AI assistance used: yes (OMEGA / GitHub Copilot CLI). All tests were compiled and executed before this PR.
