### PR TITLE
Add virtual inheritance for SubgraphBaseStaticTest due to errors in compiler tests

### DIFF
--- a/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_subgraph.hpp
@@ -177,7 +177,7 @@ inline void CheckNumberOfNodesWithType(std::shared_ptr<const ov::Model> function
     CheckNumberOfNodesWithTypes(function, {nodeType}, expectedCount);
 }
 
-class SubgraphBaseStaticTest : public ov::test::SubgraphBaseTest {
+class SubgraphBaseStaticTest : virtual public ov::test::SubgraphBaseTest {
 public:
     void run() override {
         std::vector<ov::Shape> input_shapes;


### PR DESCRIPTION
### Details:
This change is needed due to all warnings being treated as errors in compiler tests https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/26800:
```
15:55:55  /home/jenkins/agent/workspace/default-ws/NPU-Compiler/tests/functional/shared_tests_instances/single_layer_tests/prior_box.cpp:21:7: error: virtual base ���ov::test::SubgraphBaseTest��� inaccessible in ���ov::test::PriorBoxLayerTestCommon��� due to ambiguity [-Werror=inaccessible-base]
15:55:55     21 | class PriorBoxLayerTestCommon : public PriorBoxLayerTest, virtual public VpuOv2LayerTest {
15:55:55        |       ^~~~~~~~~~~~~~~~~~~~~~~
```

### Tickets:
 - [*EISW-222155*]

### AI Assistance:
 - *AI assistance used: no
