### PR TITLE
[GPU] Fix f32 scatter_elements_update overflow in reduction mode by using bit-reinterpret CAS

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_ref.cl
@@ -64,17 +64,21 @@
     #define MIN_MODE 3
     #define MAX_MODE 4
     #define MEAN_MODE 5
-    #if INPUT2_IS_FP == 1 &&  INPUT2_TYPE_SIZE == 4
-        #define FP_SCALE 65536.0f
-    #elif INPUT2_IS_FP == 1 && INPUT2_TYPE_SIZE == 2
-        #define FP_SCALE 65504.0f
+    #if INPUT2_IS_FP == 1 && INPUT2_TYPE_SIZE == 4   // f32
+        #define FP_INT_MAX  MAXFLOAT
+        #define FP_INT_MIN  (-MAXFLOAT)
+    #elif INPUT2_IS_FP == 1                           // fp16
+        #define FP_SCALE     65504.0f
+        #define FP_SCALE_MAX 2147483648.0f
+        #define FP_SCALE_MIN -FP_SCALE_MAX
+        #define FP_INT_MAX  32767
+        #define FP_INT_MIN  (-32767)
+    #else                                             // int
+        #define FP_INT_MAX  32767
+        #define FP_INT_MIN  (-32767)
     #endif
-    #define FP_SCALE_MAX 2147483648.0f
-    #define FP_SCALE_MIN -FP_SCALE_MAX
-    #define FP_INT_MAX 32767
-    #define FP_INT_MIN -FP_INT_MAX
     #define FP_INT_ZERO 0
-    #define FP_INT_ONE 1
+    #define FP_INT_ONE  1
 
     #if REDUCE_MODE == SUM_MODE
         #define REDUCTION_NEUTRAL_VALUE FP_INT_ZERO
@@ -90,87 +94,78 @@
         #error "Invalid REDUCE_MODE value"
     #endif
 
+    // Generic CAS loop. Pass the full desired_value expression as expr.
+    // For f32 modes: wrap float result with as_int(), e.g. as_int(as_float(expected_value) + as_float(val)).
+    // For int/fp16 modes: pass integer expression directly, e.g. expected_value * val.
+    #define CAS_OP(addr, val, expr) { \
+        int expected_value; \
+        int desired_value; \
+        bool success; \
+        do { \
+            expected_value = atomic_load_explicit(addr, memory_order_acquire, memory_scope_work_group); \
+            desired_value  = (expr); \
+            success = atomic_compare_exchange_weak_explicit(addr, &expected_value, desired_value, \
+                          memory_order_acq_rel, memory_order_acquire, memory_scope_work_group); \
+        } while (!success); \
+    }
+
     inline int FUNC(to_fixed_point)(INPUT2_TYPE data_in)
     {
         #if INPUT2_IS_FP
-            float scaled = data_in;
-            #if INPUT2_TYPE_SIZE == 2
-                scaled = convert_float(scaled) * FP_SCALE;
+            #if INPUT2_TYPE_SIZE == 4
+                // f32: store IEEE 754 bits directly — as_float() reverses this.
+                return as_int((float)data_in);
+            #else
+                // fp16: fixed-point scale; fp16 range fits within int32.
+                float scaled = convert_float((half)data_in) * FP_SCALE;
                 scaled = clamp(scaled, FP_SCALE_MIN, FP_SCALE_MAX);
-            #elif INPUT2_TYPE_SIZE == 4
-                scaled = scaled * FP_SCALE;
-                scaled = clamp(scaled, FP_SCALE_MIN, FP_SCALE_MAX);
+                return convert_int_rte(scaled);
             #endif
-            return convert_int_rte(scaled);
         #else
             return data_in;
         #endif
     }
 
-
     #if REDUCE_MODE < 1 && REDUCE_MODE > 5
         #error "Invalid REDUCE_MODE value"
     #endif
 
-    #if REDUCE_MODE == SUM_MODE
-        #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_add(addr, val)
-    #elif REDUCE_MODE == MIN_MODE
-        #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_min(addr, val)
-    #elif REDUCE_MODE == MAX_MODE
-        #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_max(addr, val)
-    #elif REDUCE_MODE == MEAN_MODE
-        #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_add(addr, val)
-    #elif REDUCE_MODE == PROD_MODE && INPUT2_IS_FP == 1
-        #define ATOMIC_REDUCE_OP(addr, val)  { \
-            int expected_value; \
-            int desired_value; \
-            bool success; \
-            do {  \
-                expected_value = atomic_load_explicit ( \
-                    addr, \
-                    memory_order_acquire, \
-                    memory_scope_work_group \
-                ); \
-
-                float expected_f32 = convert_float(expected_value) / FP_SCALE; \
-                float val_f32 = convert_float(val) / FP_SCALE; \
-                float desired_f32 = expected_f32 * val_f32; \
-                desired_value = FUNC_CALL(to_fixed_point)(desired_f32); \
-
-                success = atomic_compare_exchange_weak_explicit ( \
-                    addr, \
-                    &expected_value,\
-                    desired_value, \
-                    memory_order_acq_rel, \
-                    memory_order_acquire, \
-                    memory_scope_work_group \
-                ); \
-            } while (!success); \
-         }
-    #elif REDUCE_MODE == PROD_MODE && INPUT2_IS_FP == 0
-        #define ATOMIC_REDUCE_OP(addr, val)  { \
-            int expected_value; \
-            int desired_value; \
-            bool success; \
-            do {  \
-                expected_value = atomic_load_explicit ( \
-                    addr, \
-                    memory_order_acquire, \
-                    memory_scope_work_group \
-                ); \
-
-                desired_value = expected_value * val; \
-
-                success = atomic_compare_exchange_weak_explicit ( \
-                    addr, \
-                    &expected_value,\
-                    desired_value, \
-                    memory_order_acq_rel, \
-                    memory_order_acquire, \
-                    memory_scope_work_group \
-                ); \
-            } while (!success); \
-         }
+    // f32: native float atomics unavailable in OpenCL — use bit-reinterpret CAS for all modes.
+    // fp16 / int: native atomic ops suffice for SUM/MIN/MAX/MEAN (fixed-point representation
+    //             preserves ordering); only PROD requires a CAS loop.
+    // f32: native float atomics unavailable in OpenCL — use bit-reinterpret CAS for all modes.
+    // fp16 / int: native atomic ops suffice for SUM/MIN/MAX/MEAN (fixed-point representation
+    //             preserves ordering); only PROD requires a CAS loop.
+    #if INPUT2_IS_FP == 1 && INPUT2_TYPE_SIZE == 4
+        #if REDUCE_MODE == SUM_MODE || REDUCE_MODE == MEAN_MODE
+            #define ATOMIC_REDUCE_OP(addr, val) \
+                CAS_OP(addr, val, as_int(as_float(expected_value) + as_float(val)))
+        #elif REDUCE_MODE == MIN_MODE
+            #define ATOMIC_REDUCE_OP(addr, val) \
+                CAS_OP(addr, val, as_int(fmin(as_float(expected_value), as_float(val))))
+        #elif REDUCE_MODE == MAX_MODE
+            #define ATOMIC_REDUCE_OP(addr, val) \
+                CAS_OP(addr, val, as_int(fmax(as_float(expected_value), as_float(val))))
+        #elif REDUCE_MODE == PROD_MODE
+            #define ATOMIC_REDUCE_OP(addr, val) \
+                CAS_OP(addr, val, as_int(as_float(expected_value) * as_float(val)))
+        #endif
+    #else
+        #if REDUCE_MODE == SUM_MODE || REDUCE_MODE == MEAN_MODE
+            #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_add(addr, val)
+        #elif REDUCE_MODE == MIN_MODE
+            #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_min(addr, val)
+        #elif REDUCE_MODE == MAX_MODE
+            #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_max(addr, val)
+        #elif REDUCE_MODE == PROD_MODE && INPUT2_IS_FP == 1
+            // fp16 PROD: decode fixed-point, multiply as float, re-encode.
+            #define ATOMIC_REDUCE_OP(addr, val) \
+                CAS_OP(addr, val, FUNC_CALL(to_fixed_point)( \
+                    (convert_float(expected_value) / FP_SCALE) * (convert_float(val) / FP_SCALE)))
+        #elif REDUCE_MODE == PROD_MODE
+            #define ATOMIC_REDUCE_OP(addr, val) \
+                CAS_OP(addr, val, expected_value * val)
+        #endif
     #endif
 
     #define DEFINE_ATOMIC_REDUCE(STORAGE_QUALIFIER, SUFFIX) \
@@ -399,7 +394,10 @@ KERNEL(scatter_elements_update_ref)(OPTIONAL_SHAPE_INFO_ARG
     const uint input_idx = GET_INPUT_INDEX(ORDER);
     const uint output_idx = GET_OUTPUT_INDEX(ORDER);
 
-    #if INPUT2_IS_FP == 1
+    #if INPUT2_IS_FP == 1 && INPUT2_TYPE_SIZE == 4
+        float val_f32 = as_float(output_fp[input_idx]);
+        INPUT2_TYPE val = TO_OUTPUT_TYPE(val_f32);
+    #elif INPUT2_IS_FP == 1
         float val_f32 = convert_float(output_fp[input_idx]) / FP_SCALE;
         INPUT2_TYPE val = TO_OUTPUT_TYPE(val_f32);
     #else
@@ -436,9 +434,12 @@ KERNEL(scatter_elements_update_ref)(OPTIONAL_SHAPE_INFO_ARG
     #undef REDUCTION_NEUTRAL_VALUE
     #undef ATOMIC_REDUCE_OP
     #undef DEFINE_ATOMIC_REDUCE
-    #undef FP_SCALE
-    #undef FP_SCALE_MAX
-    #undef FP_SCALE_MIN
+    #undef CAS_OP
+    #if INPUT2_IS_FP == 1 && INPUT2_TYPE_SIZE != 4
+        #undef FP_SCALE
+        #undef FP_SCALE_MAX
+        #undef FP_SCALE_MIN
+    #endif
     #undef FP_INT_MAX
     #undef FP_INT_MIN
     #undef FP_INT_ZERO

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_ref.cl
@@ -94,29 +94,32 @@
         #error "Invalid REDUCE_MODE value"
     #endif
 
-    // Generic CAS loop. Pass the full desired_value expression as expr.
-    // For f32 modes: wrap float result with as_int(), e.g. as_int(as_float(expected_value) + as_float(val)).
-    // For int/fp16 modes: pass integer expression directly, e.g. expected_value * val.
-    #define CAS_OP(addr, val, expr) { \
+    // Generic CAS loop. scope must match the storage qualifier of addr:
+    //   memory_scope_work_group for __local,  memory_scope_device for __global.
+    #define CAS_OP(addr, val, scope, expr) { \
         int expected_value; \
         int desired_value; \
         bool success; \
         do { \
-            expected_value = atomic_load_explicit(addr, memory_order_acquire, memory_scope_work_group); \
+            expected_value = atomic_load_explicit(addr, memory_order_acquire, scope); \
             desired_value  = (expr); \
             success = atomic_compare_exchange_weak_explicit(addr, &expected_value, desired_value, \
-                          memory_order_acq_rel, memory_order_acquire, memory_scope_work_group); \
+                          memory_order_acq_rel, memory_order_acquire, scope); \
         } while (!success); \
     }
 
-    inline int FUNC(to_fixed_point)(INPUT2_TYPE data_in)
+    // to_int: encode INPUT2_TYPE value into int32 accumulator representation.
+    // from_int: decode int32 accumulator back to float for output writeback.
+    //
+    // f32:  bit-reinterpret (as_int/as_float) — no scale, full f32 range.
+    // fp16: fixed-point scale (FP_SCALE) — fp16 range fits within int32.
+    // int:  identity — value is already an integer.
+    inline int FUNC(to_int)(INPUT2_TYPE data_in)
     {
         #if INPUT2_IS_FP
             #if INPUT2_TYPE_SIZE == 4
-                // f32: store IEEE 754 bits directly — as_float() reverses this.
                 return as_int((float)data_in);
             #else
-                // fp16: fixed-point scale; fp16 range fits within int32.
                 float scaled = convert_float((half)data_in) * FP_SCALE;
                 scaled = clamp(scaled, FP_SCALE_MIN, FP_SCALE_MAX);
                 return convert_int_rte(scaled);
@@ -126,57 +129,65 @@
         #endif
     }
 
-    #if REDUCE_MODE < 1 && REDUCE_MODE > 5
+    inline float FUNC(from_int)(int acc)
+    {
+        #if INPUT2_IS_FP && INPUT2_TYPE_SIZE == 4
+            return as_float(acc);
+        #elif INPUT2_IS_FP
+            return convert_float(acc) / FP_SCALE;
+        #else
+            return convert_float(acc);
+        #endif
+    }
+
+    #if REDUCE_MODE < 1 || REDUCE_MODE > 5
         #error "Invalid REDUCE_MODE value"
     #endif
 
     // f32: native float atomics unavailable in OpenCL — use bit-reinterpret CAS for all modes.
     // fp16 / int: native atomic ops suffice for SUM/MIN/MAX/MEAN (fixed-point representation
     //             preserves ordering); only PROD requires a CAS loop.
-    // f32: native float atomics unavailable in OpenCL — use bit-reinterpret CAS for all modes.
-    // fp16 / int: native atomic ops suffice for SUM/MIN/MAX/MEAN (fixed-point representation
-    //             preserves ordering); only PROD requires a CAS loop.
     #if INPUT2_IS_FP == 1 && INPUT2_TYPE_SIZE == 4
         #if REDUCE_MODE == SUM_MODE || REDUCE_MODE == MEAN_MODE
-            #define ATOMIC_REDUCE_OP(addr, val) \
-                CAS_OP(addr, val, as_int(as_float(expected_value) + as_float(val)))
+            #define ATOMIC_REDUCE_OP(addr, val, scope) \
+                CAS_OP(addr, val, scope, as_int(as_float(expected_value) + as_float(val)))
         #elif REDUCE_MODE == MIN_MODE
-            #define ATOMIC_REDUCE_OP(addr, val) \
-                CAS_OP(addr, val, as_int(fmin(as_float(expected_value), as_float(val))))
+            #define ATOMIC_REDUCE_OP(addr, val, scope) \
+                CAS_OP(addr, val, scope, as_int(fmin(as_float(expected_value), as_float(val))))
         #elif REDUCE_MODE == MAX_MODE
-            #define ATOMIC_REDUCE_OP(addr, val) \
-                CAS_OP(addr, val, as_int(fmax(as_float(expected_value), as_float(val))))
+            #define ATOMIC_REDUCE_OP(addr, val, scope) \
+                CAS_OP(addr, val, scope, as_int(fmax(as_float(expected_value), as_float(val))))
         #elif REDUCE_MODE == PROD_MODE
-            #define ATOMIC_REDUCE_OP(addr, val) \
-                CAS_OP(addr, val, as_int(as_float(expected_value) * as_float(val)))
+            #define ATOMIC_REDUCE_OP(addr, val, scope) \
+                CAS_OP(addr, val, scope, as_int(as_float(expected_value) * as_float(val)))
         #endif
     #else
         #if REDUCE_MODE == SUM_MODE || REDUCE_MODE == MEAN_MODE
-            #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_add(addr, val)
+            #define ATOMIC_REDUCE_OP(addr, val, scope) atomic_fetch_add(addr, val)
         #elif REDUCE_MODE == MIN_MODE
-            #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_min(addr, val)
+            #define ATOMIC_REDUCE_OP(addr, val, scope) atomic_fetch_min(addr, val)
         #elif REDUCE_MODE == MAX_MODE
-            #define ATOMIC_REDUCE_OP(addr, val) atomic_fetch_max(addr, val)
+            #define ATOMIC_REDUCE_OP(addr, val, scope) atomic_fetch_max(addr, val)
         #elif REDUCE_MODE == PROD_MODE && INPUT2_IS_FP == 1
             // fp16 PROD: decode fixed-point, multiply as float, re-encode.
-            #define ATOMIC_REDUCE_OP(addr, val) \
-                CAS_OP(addr, val, FUNC_CALL(to_fixed_point)( \
+            #define ATOMIC_REDUCE_OP(addr, val, scope) \
+                CAS_OP(addr, val, scope, FUNC_CALL(to_int)( \
                     (convert_float(expected_value) / FP_SCALE) * (convert_float(val) / FP_SCALE)))
         #elif REDUCE_MODE == PROD_MODE
-            #define ATOMIC_REDUCE_OP(addr, val) \
-                CAS_OP(addr, val, expected_value * val)
+            #define ATOMIC_REDUCE_OP(addr, val, scope) \
+                CAS_OP(addr, val, scope, expected_value * val)
         #endif
     #endif
 
-    #define DEFINE_ATOMIC_REDUCE(STORAGE_QUALIFIER, SUFFIX) \
+    #define DEFINE_ATOMIC_REDUCE(STORAGE_QUALIFIER, SUFFIX, SCOPE) \
     inline void FUNC(atomic_reduce##SUFFIX)(volatile STORAGE_QUALIFIER int *ptr, int val) \
     { \
         atomic_int *atomic_addr = (atomic_int *)ptr; \
-        ATOMIC_REDUCE_OP(atomic_addr, val); \
+        ATOMIC_REDUCE_OP(atomic_addr, val, SCOPE); \
     }
 
-    DEFINE_ATOMIC_REDUCE(__local, _local)
-    DEFINE_ATOMIC_REDUCE(__global, _global)
+    DEFINE_ATOMIC_REDUCE(__local,  _local,  memory_scope_work_group)
+    DEFINE_ATOMIC_REDUCE(__global, _global, memory_scope_device)
 
     #define DEFINE_ATOMIC_COUNT(STORAGE_QUALIFIER, SUFFIX) \
     inline INPUT1_TYPE FUNC(count_add##SUFFIX)(volatile STORAGE_QUALIFIER int *ptr, int val) \
@@ -251,9 +262,9 @@ KERNEL(scatter_elements_update_ref)(OPTIONAL_SHAPE_INFO_ARG
         #if REDUCE_MODE == MEAN_MODE && USE_INIT_VAL == 0
             // For MEAN with USE_INIT_VAL=0: init to neutral so only scattered updates
             // contribute to the sum. Non-scattered positions restored in ITER=2.
-            output_fp[output_idx] = FUNC_CALL(to_fixed_point)(REDUCTION_NEUTRAL_VALUE);
+            output_fp[output_idx] = FUNC_CALL(to_int)(REDUCTION_NEUTRAL_VALUE);
         #else
-            INPUT1_TYPE val_fp = FUNC_CALL(to_fixed_point)(val);
+            INPUT1_TYPE val_fp = FUNC_CALL(to_int)(val);
             output_fp[output_idx] = val_fp;
         #endif
         #if REDUCE_MODE == MEAN_MODE
@@ -294,18 +305,18 @@ KERNEL(scatter_elements_update_ref)(OPTIONAL_SHAPE_INFO_ARG
         #ifndef NO_LOCAL_MEMORY
             reduction_thread[output_idx] = 0;
         #endif
-        reduction_v[output_idx] = FUNC_CALL(to_fixed_point)(REDUCTION_NEUTRAL_VALUE);
+        reduction_v[output_idx] = FUNC_CALL(to_int)(REDUCTION_NEUTRAL_VALUE);
 
         barrier(CLK_LOCAL_MEM_FENCE);
 
-        int val_fixed = FUNC_CALL(to_fixed_point)(val);
+        int val_fixed = FUNC_CALL(to_int)(val);
 
         #ifndef NO_LOCAL_MEMORY
             INPUT1_TYPE write_thread = FUNC_CALL(count_add_local)(&reduction_thread[output_idx], 1);
             #if REDUCE_MODE != MEAN_MODE
                 if (write_thread == 0) {
                     #if USE_INIT_VAL == 0
-                        output_fp[output_idx] = FUNC_CALL(to_fixed_point)(REDUCTION_NEUTRAL_VALUE);
+                        output_fp[output_idx] = FUNC_CALL(to_int)(REDUCTION_NEUTRAL_VALUE);
                     #endif
                 }
             #endif
@@ -330,7 +341,7 @@ KERNEL(scatter_elements_update_ref)(OPTIONAL_SHAPE_INFO_ARG
             #endif
 
             #if REDUCE_MODE != MEAN_MODE && USE_INIT_VAL == 0
-                output_fp[output_idx] = FUNC_CALL(to_fixed_point)(REDUCTION_NEUTRAL_VALUE);
+                output_fp[output_idx] = FUNC_CALL(to_int)(REDUCTION_NEUTRAL_VALUE);
             #endif
 
             FUNC_CALL(atomic_reduce_global)(&output_fp[output_idx], val_fixed);
@@ -394,11 +405,8 @@ KERNEL(scatter_elements_update_ref)(OPTIONAL_SHAPE_INFO_ARG
     const uint input_idx = GET_INPUT_INDEX(ORDER);
     const uint output_idx = GET_OUTPUT_INDEX(ORDER);
 
-    #if INPUT2_IS_FP == 1 && INPUT2_TYPE_SIZE == 4
-        float val_f32 = as_float(output_fp[input_idx]);
-        INPUT2_TYPE val = TO_OUTPUT_TYPE(val_f32);
-    #elif INPUT2_IS_FP == 1
-        float val_f32 = convert_float(output_fp[input_idx]) / FP_SCALE;
+    #if INPUT2_IS_FP == 1
+        float val_f32 = FUNC_CALL(from_int)(output_fp[input_idx]);
         INPUT2_TYPE val = TO_OUTPUT_TYPE(val_f32);
     #else
         INPUT2_TYPE val = output_fp[input_idx];

--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
@@ -847,3 +847,38 @@ TEST(scatter_elements_update_gpu_fp32, smoke_sum_large_values_overflow_guard) {
 
     ASSERT_NEAR(output_ptr[0], 3e7f, 1.0f);  // must not be ~0 or inf
 }
+
+TEST(scatter_elements_update_gpu_fp32, smoke_sum_large_values_overflow_guard_dynamic) {
+    // Same overflow guard as above but with dynamic (shape-agnostic) shapes,
+    // which dispatch a different kernel path than static shapes.
+    auto& engine = get_test_engine();
+    auto input1 = engine.allocate_memory({ data_types::f32, format::bfyx, tensor{1, 1, 1, 1} });
+    auto input2 = engine.allocate_memory({ data_types::i32, format::bfyx, tensor{3, 1, 1, 1} });
+    auto input3 = engine.allocate_memory({ data_types::f32, format::bfyx, tensor{3, 1, 1, 1} });
+
+    set_values(input1, std::vector<float>{0.0f});
+    set_values(input2, std::vector<int32_t>{0, 0, 0});
+    set_values(input3, std::vector<float>{1e7f, 1e7f, 1e7f});
+
+    topology topology;
+    topology.add(input_layout("input",   { ov::PartialShape{ ov::Dimension(-1) }, data_types::f32, format::bfyx }));
+    topology.add(input_layout("indices", { ov::PartialShape{ ov::Dimension(-1) }, data_types::i32, format::bfyx }));
+    topology.add(input_layout("updates", { ov::PartialShape{ ov::Dimension(-1) }, data_types::f32, format::bfyx }));
+    topology.add(scatter_elements_update("scatter_elements_update",
+                                         input_info("input"),
+                                         input_info("indices"),
+                                         input_info("updates"),
+                                         0,
+                                         ScatterElementsUpdateOp::Reduction::SUM,
+                                         true));
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input",   input1);
+    network.set_input_data("indices", input2);
+    network.set_input_data("updates", input3);
+    auto outputs = network.execute();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(
+        outputs.at("scatter_elements_update").get_memory(), get_test_stream());
+
+    ASSERT_NEAR(output_ptr[0], 3e7f, 1.0f);
+}

--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
@@ -808,3 +808,42 @@ TEST(scatter_elements_update_gpu_fp32, smoke_multiple_indices_sum_big_1d_dynamic
         ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
+
+TEST(scatter_elements_update_gpu_fp32, smoke_sum_large_values_overflow_guard) {
+    // Verifies that f32 SUM with update values >> 32768 (= INT32_MAX / FP_SCALE)
+    // does not overflow the fixed-point accumulator.
+    // Before the CAS fix: val * 65536 > INT32_MAX → convert_int_rte() UB → result ~0.
+    auto& engine = get_test_engine();
+    const int32_t num = 1;
+    auto input1 = engine.allocate_memory({ data_types::f32, format::bfyx, tensor{num, 1, 1, 1} });
+    auto input2 = engine.allocate_memory({ data_types::i32, format::bfyx, tensor{3,  1, 1, 1} });
+    auto input3 = engine.allocate_memory({ data_types::f32, format::bfyx, tensor{3,  1, 1, 1} });
+
+    // Each update value is 1e7 (>> 32768), all scattered to index 0.
+    // Expected: output[0] = 0.0 (init) + 1e7 + 1e7 + 1e7 = 3e7
+    set_values(input1, std::vector<float>{0.0f});
+    set_values(input2, std::vector<int32_t>{0, 0, 0});
+    set_values(input3, std::vector<float>{1e7f, 1e7f, 1e7f});
+
+    topology topology;
+    topology.add(input_layout("input",   input1->get_layout()));
+    topology.add(input_layout("indices", input2->get_layout()));
+    topology.add(input_layout("updates", input3->get_layout()));
+    topology.add(scatter_elements_update("scatter_elements_update",
+                                         input_info("input"),
+                                         input_info("indices"),
+                                         input_info("updates"),
+                                         0,
+                                         ScatterElementsUpdateOp::Reduction::SUM,
+                                         true));
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input",   input1);
+    network.set_input_data("indices", input2);
+    network.set_input_data("updates", input3);
+    auto outputs = network.execute();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(
+        outputs.at("scatter_elements_update").get_memory(), get_test_stream());
+
+    ASSERT_NEAR(output_ptr[0], 3e7f, 1.0f);  // must not be ~0 or inf
+}


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)

- **Symptom**: `scatter_elements_update` with reduction mode `SUM`/`MEAN`/`MIN`/`MAX`/`PROD` and `f32` update tensor produces completely wrong results (`rel_err = 1.0`, output ≈ 0) when update values exceed ~32,767.

- **Root cause**: The kernel uses a fixed-point accumulator scheme to emulate float atomics. For `f32` updates, `FP_SCALE = 65536.0f` is applied in `to_fixed_point()`:
  - `INT32_MAX / FP_SCALE ≈ 32,767` — any `f32` update value above this overflows `int32`
  - `convert_int_rte(value * 65536.0f)` returns 0 or wraps when value > 32,767
  - The final readback `output_fp / FP_SCALE` then produces ~0

- **Resolution**: For `f32` update tensors (`INPUT2_TYPE_SIZE == 4`), replaced the FP_SCALE fixed-point approach with **IEEE 754 bit-reinterpret CAS**:
  - `to_fixed_point()`: `as_int((float)data_in)` — stores raw f32 bits in `int32`, no scale, no range limit
  - `ATOMIC_REDUCE_OP` (SUM/MEAN/MIN/MAX/PROD): CAS loop using `as_float(expected) OP as_float(val)`, result stored back via `as_int()`
  - ITER=2 readback: `as_float(output_fp[...])` — symmetric reverse of `to_fixed_point()`
  - Neutral values for MIN/MAX changed to `MAXFLOAT` / `-MAXFLOAT`
  - `fp16` path is **unchanged**

#### The code and line that caused this issue (if it is not changed directly)

- `intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_ref.cl`
  - `FUNC(to_fixed_point)` — f32 branch: `data_in * FP_SCALE` overflows `int32`
  - `ATOMIC_REDUCE_OP` for SUM/MEAN/MIN/MAX — `atomic_fetch_add/min/max` on fixed-point integer gives incorrect results for f32
  - ITER=2 readback: `convert_float(output_fp[...]) / FP_SCALE` — wrong inverse when accumulator holds f32 bit patterns

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)

- Model with `f32` `scatter_elements_update` (SUM reduction) where update values exceed 32,767
- Compile with `INFERENCE_PRECISION_HINT=f32` on GPU device

#### Problematic graph

- `f32` inputs → `gemm_tiled_opt` (f32, large output values) → `scatter_elements_update_ref` (SUM, f32) → wrong output
- Bug isolated by layer-wise comparison: matmul output is correct, scatter output is wrong

#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
  - Added `scatter_elements_update_gpu_fp32.smoke_sum_large_values_overflow_guard`: 3 updates of `1e7` scattered to same index, expected sum `3e7`
- [x] Did you review existing test that can be extended to cover this scenario?
  - `scatter_elements_update_gpu_reduction_test_f32_2d/3d/4d`: all pass — existing update values are below 32,767 so did not catch the overflow


### Tickets:
 - *188838*


