### PR TITLE
[GPU] ISTFT kernel fix for PTL

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/istft_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/istft_ref.cl
@@ -2,43 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// Enable atomic operations for float and half types
-#pragma OPENCL EXTENSION cl_ext_float_atomics : enable
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-
-#define atomicAdd(TYPE, a, b)  _atomicAdd(TYPE, a, b)
-#define _atomicAdd(TYPE, a, b) atomicAdd_##TYPE(a, b)
-#define atomicAdd_float(a, b)  FUNC_CALL(_atomicAdd_float)((volatile global atomic_float*)(a), (b))
-#define atomicAdd_half(a, b)   FUNC_CALL(_atomicAdd_half)((volatile global atomic_half*)(a), (b))
-
-// WARNING: It is not possible to use check if atomic_fetch_add for half is available.
-// Clang compiler always define __opencl_c_ext_fp16_global_atomic_load_store if cl_khr_fp16
-// is enabled. This is a workaround solution.
-inline half FUNC(_atomicAdd_half)(volatile atomic_half* address, half value) {
-#ifndef __opencl_c_ext_fp16_global_atomic_load_store
-#    error "ISTFT requires __opencl_c_ext_fp16_global_atomic_load_store extension"
-#endif
-    half old = value;
-    half orig;
-    while ((old = atomic_exchange(address, (orig = atomic_exchange(address, 0)) + old)) != 0)
-        ;
-    return orig;
-}
-
-#ifdef __opencl_c_ext_fp32_local_atomic_add
-inline float FUNC(_atomicAdd_float)(volatile atomic_float* address, float value) {
-    return atomic_fetch_add(address, value);
-}
-#else
-inline float FUNC(_atomicAdd_float)(volatile atomic_float* address, float value) {
-    float old = value;
-    float orig;
-    while ((old = atomic_exchange(address, (orig = atomic_exchange(address, 0.0f)) + old)) != 0.0f)
-        ;
-    return orig;
-}
-#endif
-// ------------------------------------------------------------------------------
 
 // Calculates how many values from different frames correspond to the given global output index.
 inline int FUNC(calcBinSize)(int globalIdx, int frameSize, int frameStep, int bufferSize) {
@@ -86,11 +50,10 @@ KERNEL(istft_ref)(OPTIONAL_SHAPE_INFO_ARG const __global INPUT0_TYPE* restrict s
 #if LENGTH_BUFFER
                   const __global INPUT4_TYPE* restrict lengthBuff,
 #endif
-                  volatile __global OUTPUT_TYPE* restrict output) {
+                  __global OUTPUT_TYPE* restrict output) {
 
     const int batch = get_global_id(0);
-    const int frameID = get_global_id(1);
-    const int windowIdx = get_global_id(2);
+    const int finalOutputIdxWithinBatch = get_global_id(1);
     const int frameSize = (int)frameSizeBuff[0];
     const int frameStep = (int)frameStepBuff[0];
     const int windowSize = INPUT1_SIZE_X;
@@ -98,20 +61,23 @@ KERNEL(istft_ref)(OPTIONAL_SHAPE_INFO_ARG const __global INPUT0_TYPE* restrict s
     const int DEFAULT_OUTPUT_SIZE = (INPUT0_SIZE_Y - 1) * frameStep + frameSize;
 
     const int windowPadLeft = (frameSize - windowSize) / 2;
-    const int globalWindowIdx = windowIdx + windowPadLeft;
 
 #if LENGTH_BUFFER
     const int wantedLength = (int)lengthBuff[0];
+    if (finalOutputIdxWithinBatch >= wantedLength) {
+        return;
+    }
 #endif
 
-    const float windowVal = FUNC_CALL(getWindowVal)(windowBuff, globalWindowIdx, windowSize, frameSize);
-    const int frameIdxStartWithinBatch = frameID * frameStep;
+    int outputIdxWithinBatch = finalOutputIdxWithinBatch;
 
-    // Gather normalization sum for current outputIdxWithinBatch.
-    const int outputIdxWithinBatch = globalWindowIdx + frameIdxStartWithinBatch;
+#if CENTER
+    outputIdxWithinBatch += frameSize / 2;
+#endif
+
     float normalizationSum = 0.0f;
     const int binSize = FUNC_CALL(calcBinSize)(outputIdxWithinBatch, frameSize, frameStep, DEFAULT_OUTPUT_SIZE);
-    int startIdx = globalWindowIdx % frameStep;
+    int startIdx = outputIdxWithinBatch % frameStep;
     while ((outputIdxWithinBatch + (frameSize - startIdx - 1)) >= DEFAULT_OUTPUT_SIZE)
         startIdx += frameStep;
 
@@ -121,73 +87,66 @@ KERNEL(istft_ref)(OPTIONAL_SHAPE_INFO_ARG const __global INPUT0_TYPE* restrict s
         normalizationSum += val * val;
     }
 
-    // Calculate the IRDFT value for the current globalWindowIdx.
-    // idftPower = 2*PI*(n/N) from idft def.
-    const float idftPower = 2.0f * M_PI_F * (float)globalWindowIdx / (float)frameSize;
-
     const bool frameSize_even = frameSize % 2 == 0;
     const int freqsHandledInLoop = frameSize_even ? freqs - 1 : freqs;
+    float outputVal = 0.0f;
 
-    float result = signal[INPUT0_GET_INDEX(batch, 0, frameID, 0)];
-    // NOTE: since this is real IDFT, we can skip the imaginary part of the first frequency
-    for (int freqID = 1; freqID < freqsHandledInLoop; ++freqID) {
-        cfloat freqVal_i;
-        real(freqVal_i) = signal[INPUT0_GET_INDEX(batch, freqID, frameID, 0)];
-        imag(freqVal_i) = signal[INPUT0_GET_INDEX(batch, freqID, frameID, 1)];
+    const int firstFrameID = max(0, (outputIdxWithinBatch - frameSize + 1 + frameStep - 1) / frameStep);
+    const int lastFrameID = min(INPUT0_SIZE_Y - 1, outputIdxWithinBatch / frameStep);
 
-        const cfloat e_i = expi(idftPower * (float)(freqID));
-        const float val_i = crmult(freqVal_i, e_i);
-        result += val_i;
+    for (int frameID = firstFrameID; frameID <= lastFrameID; ++frameID) {
+        const int frameIdxStartWithinBatch = frameID * frameStep;
+        const int globalWindowIdx = outputIdxWithinBatch - frameIdxStartWithinBatch;
+        const float windowVal = FUNC_CALL(getWindowVal)(windowBuff, globalWindowIdx, windowSize, frameSize);
 
-        const cfloat e_i_n = expi(idftPower * (float)(frameSize - freqID));
-        const float val_i_n = crmult(conj(freqVal_i), e_i_n);
-        result += val_i_n;
-    }
+        if (windowVal == 0.0f) {
+            continue;
+        }
 
-    if (frameSize_even) {
-        cfloat lastFreq;
-        real(lastFreq) = signal[INPUT0_GET_INDEX(batch, freqs - 1, frameID, 0)];
-        imag(lastFreq) = signal[INPUT0_GET_INDEX(batch, freqs - 1, frameID, 1)];
+        // idftPower = 2*PI*(n/N) from idft def.
+        const float idftPower = 2.0f * M_PI_F * (float)globalWindowIdx / (float)frameSize;
 
-        const cfloat e_i = expi(idftPower * (float)(freqs - 1));
-        const float val_i = crmult(lastFreq, e_i);
-        result += val_i;
-    }
+        float result = signal[INPUT0_GET_INDEX(batch, 0, frameID, 0)];
+        // NOTE: since this is real IDFT, we can skip the imaginary part of the first frequency
+        for (int freqID = 1; freqID < freqsHandledInLoop; ++freqID) {
+            cfloat freqVal_i;
+            real(freqVal_i) = signal[INPUT0_GET_INDEX(batch, freqID, frameID, 0)];
+            imag(freqVal_i) = signal[INPUT0_GET_INDEX(batch, freqID, frameID, 1)];
 
-    const float finalIRDFTVal = result / frameSize;
+            const cfloat e_i = expi(idftPower * (float)(freqID));
+            const float val_i = crmult(freqVal_i, e_i);
+            result += val_i;
 
-    // IRDFT calculation is done.
-    // Apply any normalization.
+            const cfloat e_i_n = expi(idftPower * (float)(frameSize - freqID));
+            const float val_i_n = crmult(conj(freqVal_i), e_i_n);
+            result += val_i_n;
+        }
+
+        if (frameSize_even) {
+            cfloat lastFreq;
+            real(lastFreq) = signal[INPUT0_GET_INDEX(batch, freqs - 1, frameID, 0)];
+            imag(lastFreq) = signal[INPUT0_GET_INDEX(batch, freqs - 1, frameID, 1)];
+
+            const cfloat e_i = expi(idftPower * (float)(freqs - 1));
+            const float val_i = crmult(lastFreq, e_i);
+            result += val_i;
+        }
+
+        const float finalIRDFTVal = result / frameSize;
+
+        // IRDFT calculation is done.
+        // Apply any normalization.
 #if NORMALIZED
-    const float scale = sqrt((float)frameSize);
+        const float scale = sqrt((float)frameSize);
 #else
-    const float scale = 1.0f;
+        const float scale = 1.0f;
 #endif
 
-    const float finalVAl = (finalIRDFTVal * windowVal * scale) / (normalizationSum);
-    const OUTPUT_TYPE finalVal = (OUTPUT_TYPE)(finalVAl);
-
-    // Write the result to the output buffer.
-    int finalOutputIdxWithinBatch = outputIdxWithinBatch;
-
-#if CENTER
-    const int margin = frameSize / 2;
-    const int lastIdx = LENGTH_BUFFER ? DEFAULT_OUTPUT_SIZE : DEFAULT_OUTPUT_SIZE - margin;
-    if (!FUNC_CALL(isBetween)(finalOutputIdxWithinBatch, margin, lastIdx))
-        return;
-    finalOutputIdxWithinBatch -= margin;
-#endif
-
-#if LENGTH_BUFFER
-    if (finalOutputIdxWithinBatch >= wantedLength) {
-        return;
+        outputVal += (finalIRDFTVal * windowVal * scale) / normalizationSum;
     }
-#endif
 
     const int globalOutputIdx = OUTPUT_GET_INDEX(0, 0, batch, finalOutputIdxWithinBatch);
-
-    // Perform last reduction atomically.
-    atomicAdd(OUTPUT_TYPE, output + globalOutputIdx, finalVal);
+    output[globalOutputIdx] = (OUTPUT_TYPE)outputVal;
 }
 
 #undef real
@@ -195,7 +154,3 @@ KERNEL(istft_ref)(OPTIONAL_SHAPE_INFO_ARG const __global INPUT0_TYPE* restrict s
 #undef crmult
 #undef expi
 #undef conj
-#undef atomicAdd
-#undef _atomicAdd
-#undef atomicAdd_float
-#undef atomicAdd_half

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/istft/istft_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/istft/istft_kernel_base.cpp
@@ -34,15 +34,14 @@ ISTFTKernelBase::DispatchData ISTFTKernelBase::SetDefault(const ISTFT_params& pa
     CommonDispatchData dispatchData;
     const auto inLayout = params.inputs.front().GetLayout();
     const auto input0 = params.inputs.front();
-    const auto input1 = params.inputs[1];
     const auto& output = params.outputs.front();
     const auto outLayout = output.GetLayout();
 
     OPENVINO_ASSERT(output.Dimentions() == 4);
 
     std::vector<std::vector<Tensor::DataChannelName>> dimsByGws;
-    dispatchData.gws = {input0.Batch().v, input0.Y().v, input1.X().v};
-    dimsByGws = {{Tensor::DataChannelName::BATCH}, {Tensor::DataChannelName::Y}, {Tensor::DataChannelName::X}};
+    dispatchData.gws = {input0.Batch().v, output.X().v, 1};
+    dimsByGws = {{Tensor::DataChannelName::BATCH}, {Tensor::DataChannelName::X}, {Tensor::DataChannelName::X}};
 
     dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo, inLayout, outLayout, dimsByGws);
 


### PR DESCRIPTION
### Details:
 - *The ISTFT kernel depended on global floating-point atomics in a way that is not robust across GPU generations, and Xe3 exposes that weakness while Alder Lake happens not to.
   GPU threads were racing to add `float` or `half` values into the same global output element. Atomics make the write itself safe from being torn, but they do not make floating-point reduction deterministic. The order of additions can vary, and floating-point addition is not associative.
   Alder Lake passing does not prove the kernel was correct; it only means that its atomic reduction happened to produce acceptable results there. Xe3 likely made the nondeterminism or unsupported/fragile atomic path visible.*

### Tickets:
 - *CVS-189145*

### AI Assistance:
 - *AI assistance used: yes*
