### PR TITLE
[core] Fix constant fold for Loop if body cannot be evaluated

### DIFF
--- a/src/core/src/op/loop.cpp
+++ b/src/core/src/op/loop.cpp
@@ -349,29 +349,32 @@ Output<Node> Loop::get_concatenated_slices(const Output<Node>& value,
 
 bool Loop::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v5_Loop_evaluate);
-    EvaluationContext evaluation_context;
-    reference::loop(m_bodies[0],
-                    m_output_descriptions[0],
-                    m_input_descriptions[0],
-                    m_special_body_ports,
-                    outputs,
-                    inputs,
-                    evaluation_context);
-    return true;
+    return evaluate(outputs, inputs, {});
 }
 
 bool Loop::evaluate(TensorVector& outputs,
                     const TensorVector& inputs,
                     const EvaluationContext& evaluation_context) const {
     OV_OP_SCOPE(v5_Loop_evaluate);
-    reference::loop(m_bodies[0],
-                    m_output_descriptions[0],
-                    m_input_descriptions[0],
-                    m_special_body_ports,
-                    outputs,
-                    inputs,
-                    evaluation_context);
-    return true;
+    const auto can_evaluate = [](const auto& ops) -> bool {
+        return std::all_of(ops.begin(), ops.end(), [](const auto& node) {
+            return is_type<op::v0::Parameter>(node) || node->has_evaluate();
+        });
+    };
+
+    if (auto body = get_function(); body && can_evaluate(body->get_ops())) {
+        reference::loop(body,
+                        m_output_descriptions[0],
+                        m_input_descriptions[0],
+                        m_special_body_ports,
+                        outputs,
+                        inputs,
+                        evaluation_context);
+        return true;
+    } else {
+        // Loop body has node with no evaluate, return false instead throw.
+        return false;
+    }
 }
 
 bool Loop::has_evaluate() const {

--- a/src/core/src/op/loop.cpp
+++ b/src/core/src/op/loop.cpp
@@ -372,7 +372,6 @@ bool Loop::evaluate(TensorVector& outputs,
                         evaluation_context);
         return true;
     } else {
-        // Loop body has node with no evaluate, return false instead throw.
         return false;
     }
 }

--- a/src/core/tests/pass/constant_folding.cpp
+++ b/src/core/tests/pass/constant_folding.cpp
@@ -10,6 +10,7 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include "common_test_utils/test_tools.hpp"
 #include "openvino/core/constant_fold_utils.hpp"
+#include "openvino/op/gather_nd.hpp"
 #include "openvino/op/ops.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include "transformations/common_optimizations/disable_shapeof_constant_folding.hpp"
@@ -4124,4 +4125,37 @@ INSTANTIATE_TEST_SUITE_P(constant_folding,
                          UnsupportedTypesTest,
                          testing::ValuesIn(ov::util::unsupported_types()),
                          unsupported_types_test_case_name);
+
+TEST(constant_folding, loop_with_node_which_has_no_evaluate) {
+    // body subgraph inputs
+    auto it_param = std::make_shared<op::v0::Parameter>(element::i64, Shape{});
+    auto c_param = std::make_shared<op::v0::Parameter>(element::boolean, Shape{});
+
+    // Loop body has node with no evaluate
+    auto d_const =
+        op::v0::Constant::create(element::f32, Shape{3, 4}, std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+    auto i_const = op::v0::Constant::create(element::i64, Shape{2, 2}, std::vector<int64_t>{0, 1, 2, 3});
+    auto gather_nd = std::make_shared<op::v8::GatherND>(d_const, i_const, 0);  // → f32[2]
+    ASSERT_FALSE(gather_nd->has_evaluate());
+    auto co_result = std::make_shared<op::v0::Result>(c_param);
+    auto g_result = std::make_shared<op::v0::Result>(gather_nd);
+    auto body = std::make_shared<Model>(ResultVector{co_result, g_result}, ParameterVector{it_param, c_param});
+
+    // --- outer loop ---
+    auto trip_count = op::v0::Constant::create(element::i64, Shape{}, {1});
+    auto exec_cond = op::v0::Constant::create(element::boolean, Shape{}, {true});
+
+    auto loop = std::make_shared<op::v5::Loop>(trip_count, exec_cond);
+    loop->set_function(body);
+    loop->set_special_body_ports({0, 0});
+    loop->set_merged_input(c_param, exec_cond, co_result);
+    // Scan output: g accumulated over iterations → Y[1, 2]
+    auto scan_out = loop->get_concatenated_slices(g_result, 0, 1, 1, -1, 0);
+
+    auto result = std::make_shared<op::v0::Result>(scan_out);
+    auto model = std::make_shared<Model>(ResultVector{result}, ParameterVector{});
+
+    EXPECT_NO_THROW(pass::ConstantFolding().run_on_model(model));
+    EXPECT_EQ(count_ops_of_type<op::v5::Loop>(model), 1);
+}
 }  // namespace ov::test


### PR DESCRIPTION
### Details:
 - Fix throw exception when apply constant fold on the Loop node, when body of Loop has note which has not evaluate implementation. Return false from evaluate in this case which mean constant fold will be not applied.
 - Add test

### Tickets:
 - CVS-186547

### AI Assistance:
 - *AI assistance used: yes*
 - *Debug and create reproducer*
