### PR TITLE
[core] Fix xml read offset is outside file don't search xml line

### DIFF
--- a/src/common/util/include/openvino/util/xml_parse_utils.hpp
+++ b/src/common/util/include/openvino/util/xml_parse_utils.hpp
@@ -225,14 +225,18 @@ inline ParseResult parse_xml(const std::filesystem::path& file_path) {
             const auto file =
                 std::string(std::istreambuf_iterator<char>{file_stream}, std::istreambuf_iterator<char>{});
 
-            const auto error_offset = std::next(file.rbegin(), file.size() - load_result.offset);
-            const auto line_begin = std::find(error_offset, file.rend(), '\n');
-            const auto line = 1 + std::count(line_begin, file.rend(), '\n');
-            const auto pos = std::distance(error_offset, line_begin);
-
             std::stringstream ss;
-            ss << "Error loading XML file: " << file_path << ":" << line << ":" << pos << ": "
-               << load_result.description();
+            ss << "Error loading XML file: " << file_path;
+            if (static_cast<std::size_t>(load_result.offset) > file.size()) {
+                ss << ": " << load_result.description();
+            } else {
+                const auto error_offset = std::next(file.rbegin(), file.size() - load_result.offset);
+                const auto line_begin = std::find(error_offset, file.rend(), '\n');
+                const auto line = 1 + std::count(line_begin, file.rend(), '\n');
+                const auto pos = std::distance(error_offset, line_begin);
+
+                ss << ":" << line << ":" << pos << ": " << load_result.description();
+            }
             return ss.str();
         }();
 

--- a/src/common/util/include/openvino/util/xml_parse_utils.hpp
+++ b/src/common/util/include/openvino/util/xml_parse_utils.hpp
@@ -241,7 +241,7 @@ inline ParseResult parse_xml(const std::filesystem::path& file_path) {
         }();
 
         return {std::move(xml), std::move(error_msg)};
-    } catch (std::exception& e) {
+    } catch (const std::exception& e) {
         return {std::move(nullptr), std::string("Error loading XML file: ") + e.what()};
     }
 }

--- a/src/core/tests/xml_util/xml_parse_utils_test.cpp
+++ b/src/core/tests/xml_util/xml_parse_utils_test.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/util/xml_parse_utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <pugixml.hpp>
+#include <string>
+
+#include "common_test_utils/file_utils.hpp"
+
+namespace ov::test {
+
+class ParseXmlTest : public testing::Test {
+protected:
+    std::filesystem::path m_xml_path;
+
+    void SetUp() override {
+        m_xml_path = ov::test::utils::generateTestFilePrefix() + "_gh34337.xml";
+    }
+
+    void TearDown() override {
+        if (std::filesystem::exists(m_xml_path)) {
+            std::filesystem::remove(m_xml_path);
+        }
+    }
+};
+
+TEST_F(ParseXmlTest, utf16_cjk_expanded_buffer) {
+    // Build the UTF-16 LE test file, which matches the UTF-16 LE format that pugixml recognise via the U+FEFF BOM.
+    // The file contains:
+    //   u"\uFEFF"   -> FF FE on disk (BOM, tells pugixml this is UTF-16 LE)
+    //   u"<a>"      -> 3C 00  61 00  3E 00 (opening tag)
+    //   u'\u4E00'   -> 00 4E per char (CJK '一': 2 bytes UTF-16, 3 bytes UTF-8)
+    // File is truncated (no closing </a>), so pugixml returns a parse error whose offset
+    // is into the expanded UTF-8 decoded buffer (~305 bytes), which exceeds the 208 raw bytes on disk.
+    const std::u16string content = u"\uFEFF<a>" + std::u16string(100, u'\u4E00');
+    const auto raw_file_size = content.size() * sizeof(char16_t);  // 208 bytes
+    {
+        std::ofstream out(m_xml_path, std::ios::binary);
+        ASSERT_TRUE(out.is_open());
+        out.write(reinterpret_cast<const char*>(content.data()), static_cast<std::streamsize>(raw_file_size));
+    }
+
+    // trigger condition (offset > file.size())
+    pugi::xml_document doc;
+    const auto pugi_result = doc.load_file(m_xml_path.c_str());
+    ASSERT_NE(pugi_result.status, pugi::status_ok);
+
+    std::ifstream fs(m_xml_path);
+    const std::string raw(std::istreambuf_iterator<char>{fs}, std::istreambuf_iterator<char>{});
+    // the crafted file triggers offset > file.size().
+    ASSERT_GT(static_cast<std::size_t>(pugi_result.offset), raw.size());
+
+    const auto result = ov::util::pugixml::parse_xml(m_xml_path);
+    // The file is genuinely malformed – parse_xml must always report an error.
+    ASSERT_FALSE(result.error_msg.empty());
+}
+
+}  // namespace ov::test

--- a/src/core/tests/xml_util/xml_parse_utils_test.cpp
+++ b/src/core/tests/xml_util/xml_parse_utils_test.cpp
@@ -21,7 +21,7 @@ protected:
     std::filesystem::path m_xml_path;
 
     void SetUp() override {
-        m_xml_path = ov::test::utils::generateTestFilePrefix() + "_gh34337.xml";
+        m_xml_path = ov::test::utils::generateTestFilePrefix() + "_test.xml";
     }
 
     void TearDown() override {
@@ -39,12 +39,12 @@ TEST_F(ParseXmlTest, utf16_cjk_expanded_buffer) {
     //   u'\u4E00'   -> 00 4E per char (CJK '一': 2 bytes UTF-16, 3 bytes UTF-8)
     // File is truncated (no closing </a>), so pugixml returns a parse error whose offset
     // is into the expanded UTF-8 decoded buffer (~305 bytes), which exceeds the 208 raw bytes on disk.
-    const std::u16string content = u"\uFEFF<a>" + std::u16string(100, u'\u4E00');
-    const auto raw_file_size = content.size() * sizeof(char16_t);  // 208 bytes
     {
+        const std::u16string content = u"\uFEFF<a>" + std::u16string(100, u'\u4E00');
+        const std::streamsize raw_file_size = content.size() * sizeof(char16_t);
         std::ofstream out(m_xml_path, std::ios::binary);
         ASSERT_TRUE(out.is_open());
-        out.write(reinterpret_cast<const char*>(content.data()), static_cast<std::streamsize>(raw_file_size));
+        out.write(reinterpret_cast<const char*>(content.data()), raw_file_size);
     }
 
     // trigger condition (offset > file.size())
@@ -55,7 +55,7 @@ TEST_F(ParseXmlTest, utf16_cjk_expanded_buffer) {
     std::ifstream fs(m_xml_path);
     const std::string raw(std::istreambuf_iterator<char>{fs}, std::istreambuf_iterator<char>{});
     // the crafted file triggers offset > file.size().
-    ASSERT_GT(static_cast<std::size_t>(pugi_result.offset), raw.size());
+    ASSERT_GT(static_cast<size_t>(pugi_result.offset), raw.size());
 
     const auto result = ov::util::pugixml::parse_xml(m_xml_path);
     // The file is genuinely malformed – parse_xml must always report an error.


### PR DESCRIPTION
### Details:
 - Fix access violation when malformed xml parsed. Don't decode xml line if this is not possible to calculate.

### Tickets:
 - CVS-181937

### AI Assistance:
 - *AI assistance used: yes*
 - *Debug*
