### PR TITLE
[GPU] Keep SDPA fused when head_size is dynamic on K/V but static on a sibling

### DIFF
--- a/src/plugins/intel_gpu/src/graph/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/strided_slice.cpp
@@ -87,12 +87,16 @@ std::vector<layout> strided_slice_inst::calc_output_layouts(strided_slice_node c
                     continue;
                 }
 
+                // Each output dim depends only on the corresponding input dim, so a
+                // dynamic input dim only makes its own output dim dynamic. Keep
+                // propagating instead of breaking at the first dynamic dim, so static
+                // dims that follow it are preserved.
                 if (input0_pshape[input_idx].is_static()) {
                     output_shape[output_idx++] = input0_pshape[input_idx];
-                    input_idx++;
                 } else {
-                    break;
+                    output_shape[output_idx++] = ov::Dimension::dynamic();
                 }
+                input_idx++;
             }
         }
 

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/sdpa.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/sdpa.cpp
@@ -19,6 +19,10 @@
 #include "openvino/op/result.hpp"
 #include "openvino/op/softmax.hpp"
 #include "openvino/op/split.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/gather.hpp"
+#include <cmath>
 #include "openvino/opsets/opset13_decl.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/runtime/exec_model_info.hpp"
@@ -277,6 +281,105 @@ protected:
 
 TEST_F(SDPA, smoke_Inference) {
     run();
+}
+
+// head_size is the QK^T contraction dim and the softmax@V inner dim. A stateless graph
+// feeds the SDPA K/V from a KV-cache that is sliced on the sequence axis with a runtime
+// bound. The source model keeps head_size static the whole way to the SDPA, but the GPU
+// plugin's StridedSlice shape inference used to drop every static dim after the first
+// dynamic (sequence) dim, so K/V reached the SDPA as [1,?,?,?] -- which decomposed the
+// SDPA or fell back to the slow sdpa_ref kernel. This test reproduces that exact chain
+// (Parameter with static head_size -> Slice on the seq axis with a runtime bound -> SDPA)
+// and asserts the executed graph keeps a single fused SDPA running an "opt" kernel.
+class SDPADynamicHeadSize : virtual public ov::test::SubgraphBaseTest {
+protected:
+    static constexpr int64_t num_heads = 32;
+    static constexpr int64_t head_size = 64;
+
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+        inType = ov::element::f16;
+
+        const size_t seq_full = 256;  // allocated KV length
+        const size_t seq_kv = 128;    // active (sliced) KV length
+        // Q: [1, num_heads, -1, head_size]. K/V come from a cache [1, num_heads, -1,
+        // head_size] sliced on the sequence axis (dim 2) with a runtime end bound taken
+        // from the mask's KV length (ShapeOf(mask)[3]), so all graph inputs are f16 and
+        // the slice bound is a genuine runtime value. head_size stays static throughout.
+        init_input_shapes({
+            {{1, num_heads, -1, head_size}, {{1, num_heads, 1, head_size}}},
+            {{1, num_heads, -1, head_size}, {{1, num_heads, seq_full, head_size}}},
+            {{1, num_heads, -1, head_size}, {{1, num_heads, seq_full, head_size}}},
+            {{1, 1, -1, -1}, {{1, 1, 1, seq_kv}}},
+        });
+
+        auto q = std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[0]);
+        auto k_cache = std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[1]);
+        auto v_cache = std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[2]);
+        auto mask = std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[3]);
+        q->set_friendly_name("q");
+        k_cache->set_friendly_name("k");
+        v_cache->set_friendly_name("v");
+        mask->set_friendly_name("mask");
+
+        // Runtime slice end bound = mask KV length (dim 3). ShapeOf keeps it a runtime
+        // value (not constant-foldable), exercising the dynamic-bounds shape inference.
+        auto mask_shape = std::make_shared<ov::op::v3::ShapeOf>(mask, ov::element::i64);
+        auto kv_len = std::make_shared<ov::op::v8::Gather>(
+            mask_shape,
+            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {3}),
+            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0}));
+
+        // Slice K/V on the sequence axis (dim 2) with that runtime end bound -- this is
+        // the op whose GPU shape inference must keep head_size (dim 3) static.
+        auto start = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+        auto step = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+        auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+        auto k = std::make_shared<ov::op::v8::Slice>(k_cache, start, kv_len, step, axes);
+        auto v = std::make_shared<ov::op::v8::Slice>(v_cache, start, kv_len, step, axes);
+
+        auto scale = ov::op::v0::Constant::create(
+            inType, ov::Shape{}, std::vector<float>{1.0f / std::sqrt(static_cast<float>(head_size))});
+        auto sdpa = std::make_shared<ov::opset13::ScaledDotProductAttention>(q, k, v, mask, scale, false);
+        sdpa->set_friendly_name("sdpa");
+        auto result = std::make_shared<ov::op::v0::Result>(sdpa->output(0));
+        function = std::make_shared<ov::Model>(ov::OutputVector{result},
+                                               ov::ParameterVector{q, k_cache, v_cache, mask},
+                                               "sdpa_dynamic_head_size");
+
+        abs_threshold = 0.02;
+        rel_threshold = 0.02;
+
+        functionRefs = function->clone();
+        ov::pass::Manager manager;
+        manager.register_pass<ov::pass::ScaledDotProductAttentionDecomposition>();
+        manager.run_passes(functionRefs);
+    }
+
+    void check_results() {
+        auto exec_model = compiledModel.get_runtime_model();
+        int sdpa_found = 0;
+        std::string sdpa_impl;
+        for (const auto& n : exec_model->get_ordered_ops()) {
+            const auto& rt = n->get_rt_info();
+            if (rt.at(ov::exec_model_info::LAYER_TYPE).as<std::string>() == "scaled_dot_product_attention") {
+                sdpa_found++;
+                sdpa_impl = rt.at(ov::exec_model_info::IMPL_TYPE).as<std::string>();
+            }
+        }
+        // SDPA stays fused (not decomposed into Gemm/Softmax) ...
+        ASSERT_EQ(sdpa_found, 1) << "SDPA was decomposed instead of kept as a fused op";
+        // ... and runs an optimized kernel rather than the reference fallback.
+        EXPECT_NE(sdpa_impl.find("opt"), std::string::npos)
+            << "expected an optimized SDPA kernel for dynamic K/V head_size, got: " << sdpa_impl;
+        EXPECT_EQ(sdpa_impl.find("ref"), std::string::npos)
+            << "SDPA fell back to the ref kernel for dynamic K/V head_size: " << sdpa_impl;
+    }
+};
+
+TEST_F(SDPADynamicHeadSize, smoke_Inference) {
+    run();
+    check_results();
 }
 
 TEST_P(SDPAFusion, Inference) {

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/strided_slice_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/strided_slice_si_test.cpp
@@ -156,4 +156,64 @@ INSTANTIATE_TEST_SUITE_P(smoke, strided_slice_test_four_inputs,
         },
     }));
 
+// When begin/end/strides are not available at shape-inference time (runtime bounds),
+// calc_output_layouts uses a fallback that previously stopped at the first dynamic
+// input dim, discarding every static dim after it. A slice that only touches the
+// sequence axis of an attention K/V tensor [1, -1(seq), num_heads, head_size] must
+// keep num_heads and head_size static. This guards that behavior.
+class strided_slice_test_dynamic_bounds : public testing::TestWithParam<strided_slice_test_params> { };
+
+TEST_P(strided_slice_test_dynamic_bounds, shape_infer) {
+    auto p = GetParam();
+    auto& engine = get_test_engine();
+
+    auto input_prim = std::make_shared<input_layout>("input", p.in_layout);
+    auto begin_prim = std::make_shared<input_layout>("begin", p.begin_layout);
+    auto end_prim = std::make_shared<input_layout>("end", p.end_layout);
+    auto strides_prim = std::make_shared<input_layout>("strides", p.strides_layout);
+    // Empty begin/end/strides data => bounds are runtime values (not foldable).
+    auto strided_slice_prim = std::make_shared<strided_slice>("output",
+                                                              input_info("input"),
+                                                              input_info("begin"),
+                                                              input_info("end"),
+                                                              input_info("strides"),
+                                                              p.begin_mask,
+                                                              p.end_mask,
+                                                              p.new_axis_mask,
+                                                              p.shrink_axis_mask,
+                                                              p.ellipsis_mask,
+                                                              ov::Shape{});
+
+    cldnn::program prog(engine);
+    auto& input_node = prog.get_or_create(input_prim);
+    auto& begin_node = prog.get_or_create(begin_prim);
+    auto& end_node = prog.get_or_create(end_prim);
+    auto& strides_node = prog.get_or_create(strides_prim);
+    auto& strided_slice_node = prog.get_or_create(strided_slice_prim);
+    program_wrapper::add_connection(prog, input_node, strided_slice_node);
+    program_wrapper::add_connection(prog, begin_node, strided_slice_node);
+    program_wrapper::add_connection(prog, end_node, strided_slice_node);
+    program_wrapper::add_connection(prog, strides_node, strided_slice_node);
+    auto params = strided_slice_node.get_kernel_impl_params();
+    // No memory_deps: bounds are unavailable, exercising the dynamic-bounds fallback.
+    auto res = strided_slice_inst::calc_output_layouts<ov::PartialShape>(strided_slice_node, *params);
+
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res[0], p.expected_layout);
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke, strided_slice_test_dynamic_bounds,
+    testing::ValuesIn(std::vector<strided_slice_test_params>{
+        // Attention K/V: slice the dynamic sequence axis (dim 1); num_heads (8) and
+        // head_size (64) after it must stay static.
+        {
+            layout{ov::PartialShape{1, ov::Dimension::dynamic(), 8, 64}, data_types::f16, format::bfyx},
+            layout{ov::PartialShape{4}, data_types::i64, format::bfyx}, {},
+            layout{ov::PartialShape{4}, data_types::i64, format::bfyx}, {},
+            layout{ov::PartialShape{4}, data_types::i64, format::bfyx}, {},
+            {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {},
+            layout{ov::PartialShape{1, ov::Dimension::dynamic(), 8, 64}, data_types::f16, format::bfyx}
+        },
+    }));
+
 }  // shape_infer_tests


### PR DESCRIPTION
# [GPU] Keep SDPA fused when head_size is dynamic on K/V but static on a sibling

## Summary

`ScaledDotProductAttention` has a single `head_size`: it is the `QK^T` contraction
dimension and the `softmax·V` inner dimension, so SDPA shape inference *merges* it
across Q, K and V (`scaled_dot_product_attention_shape_inference.hpp`). The three
inputs are therefore provably equal in head_size — if any one of them is static, they
all are.

The Intel GPU plugin does not exploit this. It treats `head_size` as known only when
**every** one of Q/K/V carries it statically. When an SDPA reaches the plugin with a
**static Q head_size but a dynamic K/V head_size**, the fast attention path is lost:

- the `ScaledDotProductAttentionDecomposition` gate decomposes the SDPA into a
  `Gemm → SoftMax → Gemm` chain (`transformations_pipeline.cpp`), or
- `SDPAOpt::validate_impl` rejects the optimized OCL kernel and falls back to
  `ocl::sdpa::ref` (`sdpa_opt.hpp`),

even though head_size is knowable from Q.

This PR recovers `head_size` from whichever Q/K/V input carries it statically, and
only decomposes / rejects when it is dynamic on **all** of them.

## Why this is a real gap, not a misuse — regular case vs. corner case

This is an unstated assumption about the K/V producer, not a property of attention.
The fusion's own unit tests (`unsqueeze_broadcast_reshape_sdpa_fusion_test.cpp`)
encode the **regular case**: in every test K/V come from either

- a stateful **`KVCache`** op whose `Variable` bakes in a static head_size
  (e.g. `{-1,-1,2,32}`, `{-1,8,-1,32}`), or
- a **`RoPE`** op (static head_size by construction).

So head_size is static on the producer and survives when the fusion reconnects raw
K/V into the SDPA. Two pieces of code depend on that and cannot recover otherwise:

1. **`ensure_4d`** (`unsqueeze_broadcast_reshape_sdpa_fusion.cpp`) returns an
   already-rank-4 reconnected input untouched — it trusts the producer's static shape.
2. **`gpu::SDPA` shape inference** (`transformations/op/sdpa.cpp`) broadcasts over
   `[0, rank-1)` — **excluding the head_size dim** — and only copies a dim from Q when
   K's dim is *already* static. It can pin batch/num_heads from Q but **never recovers
   head_size**.

The **corner case** is a *stateless* graph whose K/V producer is
`Transpose ← Slice(runtime bound) ← Reshape ← flattened cache` (this is how
llama.cpp's OpenVINO backend builds K/V). It matches the fusion's structural pattern,
so the fusion fires — but the producer's static head_size does **not** survive runtime
re-inference once the raw `Transpose` is reconnected into `gpu::SDPA`, and the plugin
cannot recover it from Q. The SDPA's K resolves to `[1,-1,-1,-1]`, the opt kernel is
rejected, and it collapses to `ocl::sdpa::ref`.

The fix removes the producer dependence: head_size is recovered from the static Q
sibling. Regular `KVCache`/`RoPE` graphs are unaffected; stateless slice-based graphs
now also get the optimized kernel.

## Changes (`src/plugins/intel_gpu/`)

| File | Change |
|---|---|
| `src/plugin/transformations_pipeline.cpp` | Decomposition gate: recover `head_size` from Q, else K, else V; decompose only if dynamic on all. Use the recovered value in the subsequent head_size check. |
| `src/graph/impls/ocl_v2/sdpa/sdpa_opt.hpp` | `validate_impl`: recover K head_size from Q/V before rejecting, so the opt kernel is admitted. |
| `src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp` | JIT `K_HEAD_SIZE`/`V_HEAD_SIZE`: fall back to Q head_size when K/V carry it dynamically. |
| `src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp` | JIT + the SINGLE_TOKEN / MULTI_TOKENS / FINALIZATION work-group-size sites: recover head_size from Q when K/V dynamic. |
| `tests/functional/subgraph_tests/sdpa.cpp` | New `SDPADynamicHeadSize` GPU functional test (see Validation). |

The recovery mirrors what the opt kernel already does for int4 KV-cache layouts
(`is_int4_kv_cache → use Q head_size`), generalized to any dynamic-head case.

## Validation

Standalone OpenVINO reproducer (no external framework). It builds an
`SDPA(Q,K,V,mask)` decode graph whose **source head_size is static on every tensor**,
in two sub-cases — `control` (K/V fed directly) and `llama.cpp-faithful` (K/V via the
`Reshape → Slice(runtime bound) → Transpose → GQA broadcast` chain) — compiles on GPU,
and reads the selected kernel from `compiled_model.get_runtime_model()`.

Intel Lunar Lake iGPU, 32 q-heads, head_size 64, 1 query token vs 1024-token KV:

| case | sub-case | before (master) | after (this PR) |
|---|---|---|---|
| no-GQA | control | `ocl::sdpa::opt`, 0.70 ms | `ocl::sdpa::opt`, 0.67 ms |
| no-GQA | **llama.cpp-faithful** | **`ocl::sdpa::ref`, 14.75 ms** | **`ocl::sdpa::opt`, 0.73 ms (~20×)** |
| GQA 32/8 | control | `ocl::sdpa::opt`, 0.26 ms | `ocl::sdpa::opt`, 0.26 ms |
| GQA 32/8 | **llama.cpp-faithful** | collapsed (`ref` / decomposed) | **`ocl::sdpa::opt`, 0.36 ms** |

- Static-head_size / shape-pinning-producer paths (the `control` rows) are unchanged.
- Output matches the CPU device on the patched path (`max|GPU − CPU|` ≈ 1e-4, f16).
- End-to-end on llama.cpp's OpenVINO backend, the stateless GQA decode that previously
  collapsed to `ocl::sdpa::ref` (~15 t/s) runs `ocl::sdpa::opt` at ~57 t/s @ depth 1024.

### Functional test (`SDPADynamicHeadSize`)

Added to `src/plugins/intel_gpu/tests/functional/subgraph_tests/sdpa.cpp`. It builds
an SDPA whose K/V reach the op with a **dynamic** head_size and whose Q head_size is
**static**, compiles it on the GPU, reads the executed graph from
`compiledModel.get_runtime_model()`, and asserts that:

- exactly one fused `scaled_dot_product_attention` op remains (it is **not** decomposed
  into Gemm/Softmax/Gemm), and
- its `primitiveType` is an `opt` kernel (**not** `ocl::sdpa::ref`).

Verified locally on an Intel Lunar Lake iGPU: the test **passes with this change** and
**fails without it** (without the fix the assertion reports "SDPA was decomposed
instead of kept as a fused op"). Existing SDPA tests are unaffected — the 13
`*SDPAFusion*`/`*TranposeSDPA*` transformation tests pass, and the `sdpa_gpu_test`
functional cases that run on this hardware behave identically to master (the few that
fail/crash do so identically with and without the patch — pre-existing, shape/resource
related, not introduced here).

Ticket: https://jira.devtools.intel.com/browse/CVS-189128