### PR TITLE
[core] Align GQA present_kv datatype with past_kv

### DIFF
--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -53,8 +53,9 @@ void GroupQueryAttention::validate_and_infer_types() {
                           "GroupQueryAttention supports following element types: {f32, f16}");
 
     set_output_type(0, element_type, PartialShape{batch_size, sequence_len, head_size * m_num_heads});
+    const auto& kv_type = get_input_element_type(3);
     for (auto&& port : {1, 2}) {
-        set_output_type(port, element_type, kv_shape);
+        set_output_type(port, kv_type, kv_shape);
     }
 }
 


### PR DESCRIPTION
### Details:

According to [ONNX's GQA spec](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#outputs-1---4-1), present_k/v's datatype is `T_CACHE` not `T`, so it should use past_k/v 's datatype.

https://github.com/microsoft/onnxruntime/blob/1472c16ea521ae1ee8e564f16ca4fb3a202ade67/docs/ContribOperators.md?plain=1#L2655-L2658

### Tickets:

- *CVS-189221*

### AI Assistance:
 - *AI assistance used: no*
