### PR TITLE
[GPU] Fix CM kernels not compiled in default build

### DIFF
--- a/src/plugins/intel_gpu/src/graph/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/CMakeLists.txt
@@ -4,6 +4,10 @@
 
 set(TARGET_NAME "openvino_intel_gpu_graph")
 
+if(ENABLE_CM_FOR_GPU)
+    add_compile_definitions(ENABLE_CM_FOR_GPU)
+endif()
+
 file(GLOB SUBDIRS "${CMAKE_CURRENT_SOURCE_DIR}/impls/*")
 
 find_host_package(Python3 REQUIRED COMPONENTS Interpreter)
@@ -107,10 +111,6 @@ add_custom_target(run_codegen_test
 add_test(NAME TestOCLCodePreprocessing
          COMMAND ${Python3_EXECUTABLE} -B ${CODEGEN_TEST_SCRIPT}
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-
-if(ENABLE_CM_FOR_GPU)
-    add_compile_definitions(ENABLE_CM_FOR_GPU)
-endif()
 
 foreach(IMPL_TYPE IN LISTS AVAILABLE_IMPL_TYPES)
     if(IMPL_TYPE STREQUAL "cm" AND NOT ENABLE_CM_FOR_GPU)

--- a/src/plugins/intel_gpu/src/graph/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/CMakeLists.txt
@@ -108,6 +108,10 @@ add_test(NAME TestOCLCodePreprocessing
          COMMAND ${Python3_EXECUTABLE} -B ${CODEGEN_TEST_SCRIPT}
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+if(ENABLE_CM_FOR_GPU)
+    add_compile_definitions(ENABLE_CM_FOR_GPU)
+endif()
+
 foreach(IMPL_TYPE IN LISTS AVAILABLE_IMPL_TYPES)
     if(IMPL_TYPE STREQUAL "cm" AND NOT ENABLE_CM_FOR_GPU)
         continue()

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/CMakeLists.txt
@@ -8,10 +8,6 @@ ov_gpu_add_backend_target(
     NAME ${TARGET_NAME}
 )
 
-if(ENABLE_CM_FOR_GPU)
-    target_compile_definitions(${TARGET_NAME} PRIVATE ENABLE_CM_FOR_GPU)
-endif()
-
 ov_build_target_faster(${TARGET_NAME} PCH)
 
 if(GPU_RT_TYPE STREQUAL "SYCL")


### PR DESCRIPTION
### Details:
 - https://github.com/openvinotoolkit/openvino/pull/36431 made `OV_GPU_WITH_CM` depend on the `ENABLE_CM_FOR_GPU` macro being defined at compile time, but added that compile definition only to the `openvino_intel_gpu_ocl_obj` target. The registry sources (registry/*_impls.cpp) compile into the main `openvino_intel_gpu_graph` target, which never received the definition
 - Define `ENABLE_CM_FOR_GPU` at the graph module directory scope (`src/graph/CMakeLists.txt`) via `add_compile_definitions`, so it reaches both the backend obj targets and the main graph target uniformly