### PR TITLE
[GPU] Fix gha ci dgpu test failures

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
@@ -68,10 +68,6 @@ struct dynamic_quantize_impl : typed_primitive_impl_ocl<dynamic_quantize> {
             return;
         }
 
-        OPENVINO_ASSERT(_kernel_data.update_dispatch_data_func,
-                        "[GPU] Missing update_dispatch_data_func for dynamic_quantize kernel: ",
-                        _kernel_data.kernelName);
-
         auto kernel_params = get_kernel_params(impl_param, true);
         (_kernel_data.update_dispatch_data_func)(kernel_params, _kernel_data);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
@@ -64,6 +64,14 @@ struct dynamic_quantize_impl : typed_primitive_impl_ocl<dynamic_quantize> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
+        if (impl_param.can_be_optimized()) {
+            return;
+        }
+
+        OPENVINO_ASSERT(_kernel_data.update_dispatch_data_func,
+                        "[GPU] Missing update_dispatch_data_func for dynamic_quantize kernel: ",
+                        _kernel_data.kernelName);
+
         auto kernel_params = get_kernel_params(impl_param, true);
         (_kernel_data.update_dispatch_data_func)(kernel_params, _kernel_data);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -1154,6 +1154,19 @@ inline SEQ_RANGE FUNC(calc_sliding_window_seq_range)(const SEQ_RANGE default_seq
         int found_block_range_end = default_block_range_end;
         int found_block_range_begin = default_block_range_begin;
 
+        // Bounds guard with full-range fallback.
+        // When any token_type_ids index would exceed seq_len, bypass token-type filtering
+        // for this work item and fall back to the full valid source range.
+        // Note: range.max is an inclusive bound, while subgroup_max is exclusive.
+        if (default_seq_range.max >= seq_len || default_block_range_end <= 0 || default_block_range_begin >= seq_len) {
+            // Return full valid source range: [0, seq_len - 1].
+            SEQ_RANGE range;
+            range.min = 0;
+            range.max = seq_len > 0 ? seq_len - 1 : 0;
+            range.subgroup_max = min(default_block_range_end, seq_len);
+            return range;
+        }
+
         // block cooperative search for token group end
         if (token_type_ids[default_block_range_end - 1] == 1) {
             found_block_range_end = FUNC_CALL(find_first_zero_to_the_right_wg)(token_type_ids, reduction_buffer, default_block_range_end, seq_len);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -1154,17 +1154,17 @@ inline SEQ_RANGE FUNC(calc_sliding_window_seq_range)(const SEQ_RANGE default_seq
         int found_block_range_end = default_block_range_end;
         int found_block_range_begin = default_block_range_begin;
 
-        // Bounds guard with full-range fallback.
-        // When any token_type_ids index would exceed seq_len, bypass token-type filtering
-        // for this work item and fall back to the full valid source range.
-        // Note: range.max is an inclusive bound, while subgroup_max is exclusive.
-        if (default_seq_range.max >= seq_len || default_block_range_end <= 0 || default_block_range_begin >= seq_len) {
-            // Return full valid source range: [0, seq_len - 1].
-            SEQ_RANGE range;
-            range.min = 0;
-            range.max = seq_len > 0 ? seq_len - 1 : 0;
-            range.subgroup_max = min(default_block_range_end, seq_len);
-            return range;
+        // Full-range fallback for lanes that do not correspond to a real target row.
+        // Do not return on lane-local conditions before the cooperative searches below,
+        // because the helpers use work-group barriers.
+        SEQ_RANGE fallback_range;
+        fallback_range.min = 0;
+        fallback_range.max = seq_len > 0 ? seq_len - 1 : 0;
+        fallback_range.subgroup_max = min(default_block_range_end, seq_len);
+
+        // These conditions are block-uniform and protect the barrier-free reads below.
+        if (default_block_range_end <= 0 || default_block_range_end > seq_len || default_block_range_begin >= seq_len) {
+            return fallback_range;
         }
 
         // block cooperative search for token group end
@@ -1179,6 +1179,11 @@ inline SEQ_RANGE FUNC(calc_sliding_window_seq_range)(const SEQ_RANGE default_seq
 
         int token_group_end = default_seq_range.max;
         int token_group_begin = default_seq_range.max;
+
+        // Lane-local fallback is only safe after all cooperative searches complete.
+        if (token_group_end >= seq_len) {
+            return fallback_range;
+        }
 
         // Special case: image group is less than subgroup size.
         if (token_type_ids[token_group_end] == 1) {


### PR DESCRIPTION
### Details:
fixed  two independent dGPU GHA CI failures in the Intel GPU plugin, including `bad_function_call` in dynamic quantize dispatch update, and out of bound access of token_type_ids in sdpa_opt kernel.

### Description of the issue
#### Symptom
`smoke_MatMulCompressedWeights_dyn_quan_no_slm/MatmulWeightsDecompression.Inference` & `smoke_PagedAttentionTokenType/PagedAttentionTokenTypeTest.CompareWithPytorch` testcases failed in dGPU GHA CI tests.

#### Root cause
- `bad_function_call` in dynamic quantize dispatch update 
In the dynamic quantize path, `update_dispatch_data()` could still be called for a primitive that is optimized away. In that case, the kernel-specific update callback is not expected to be used, but the code still dereferenced it and could hit `bad_function_call`.
- Intermittent `CL_OUT_OF_RESOURCES` in paged attention with `token_type_ids` `smoke_PagedAttentionTokenType/PagedAttentionTokenTypeTest.CompareWithPytorch` had a random dGPU failure caused by out-of-bounds access in the SDPA OpenCL kernel. The issue could happen in the last partial target block, where some lanes correspond to padding rather than real target rows.
   - lane-local target indices could point past `seq_len`
   - the old logic could fall into token-group probing on those invalid lanes
   - the fix also keeps the control flow safe with respect to barrier-based cooperative searches by avoiding lane-local early return before those helpers complete

#### How to fix it
- bad_function_call: skip `update_dispatch_data()` when `impl_param.can_be_optimized()` is true.
- CL_OUT_OF_RESOURCES: 
   - add a full-range fallback for lanes that do not correspond to a valid target row
   - keep only block-uniform guards before cooperative helper calls
   - move lane-local fallback until after all barrier-based cooperative searches are finished

#### Reproduction step and snapshot


- smoke_MatMulCompressedWeights_dyn_quan_no_slm/MatmulWeightsDecompression.Inference

./ov_gpu_func_tests --device_suffix=1 --gtest_filter='smoke_MatMulCompressedWeights_dyn_quan_no_slm/MatmulWeightsDecompression.Inference/data_shape=[?.?.1024]_[2.1.1024]_[1.1.1024]_[2.1.1024]__weights_shape=[1024,1]_group_size=128_weights_precision=u8_activations_precision=f16_transpose_weights=0_decompression_subtract=0_reshape_on_decompression=1_extra_multiply=0_per_tensor_zp=1_param_weights=0_dyn_quan_group_size=9223372036854775807'

- smoke_PagedAttentionTokenType/PagedAttentionTokenTypeTest.CompareWithPytorch

./ov_gpu_func_tests --device_suffix=1 --gtest_filter='smoke_PagedAttentionTokenType/PagedAttentionTokenTypeTest.CompareWithPytorch/Prc=f32_HS=32_HN=4_SW=0_BS=1_SQ=500_Device=GPU*'

### Tickets:
 - *CVS-182520*

### AI Assistance:
 - *AI assistance used: yes*
 - *Used for root-cause analysis*