### PR TITLE
Support intel_npu::FlashAttentionTile for compile-tool

### DIFF
--- a/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
@@ -25,7 +25,8 @@ ov_add_target(TYPE EXECUTABLE
               ROOT ${CMAKE_CURRENT_SOURCE_DIR}
               LINK_LIBRARIES
                   PRIVATE
-                      openvino::runtime
+                      openvino::runtime::dev
+                      openvino::npu_ops
                       gflags
                       Threads::Threads
                       npu_tools_utils)

--- a/src/plugins/intel_npu/tools/compile_tool/main.cpp
+++ b/src/plugins/intel_npu/tools/compile_tool/main.cpp
@@ -16,6 +16,12 @@
 #include <unordered_map>
 #include <vector>
 
+#include <openvino/core/op_extension.hpp>
+#include <openvino/op/group_query_attention.hpp>
+#include <ov_ops/rms.hpp>
+#include <ov_ops/rotary_positional_embeddings.hpp>
+
+#include "intel_npu/ops/flash_attention_tile.hpp"
 #include "tools_helpers.hpp"
 
 static constexpr char help_message[] = "Optional. Print the usage message.";
@@ -461,6 +467,15 @@ int main(int argc, char* argv[]) {
             std::stringstream{FLAGS_log_level} >> level;
             core.set_property(FLAGS_d, ov::log::level(level));
         }
+
+        // Register custom op extensions so the IR reader can deserialize NPU-specific ops
+        // (e.g. FlashAttentionTile in the "intel_npu" opset). Mirrors the compiler-side
+        // deserialization path in vpux_compiler/src/frontend/model_preprocessor.cpp.
+        core.add_extension(std::vector<ov::Extension::Ptr>{
+            std::make_shared<ov::OpExtension<ov::op::internal::RMS>>(),
+            std::make_shared<ov::OpExtension<ov::op::internal::RoPE>>(),
+            std::make_shared<ov::OpExtension<ov::op::internal::GroupQueryAttention>>(),
+            std::make_shared<ov::OpExtension<ov::intel_npu::op::FlashAttentionTile>>()});
 
         std::cout << "Reading model" << std::endl;
         auto model = core.read_model(FLAGS_m);


### PR DESCRIPTION
### Details:
intel_npu::FlashAttention can't be supported for compile-tool, the changes support intel_npu::FlashAttentionTile and other internal ops like internal::RMS, internal::RoPE, internal::GroupQueryAttention for compile-tool on NPU.

### Tickets:
 - [EISW-222351](https://jira.devtools.intel.com/browse/EISW-222351)

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
