### PR TITLE
[TEMPLATE] Don't register Template plugin if enabled registration in cmake

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_integration.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/core_integration.hpp
@@ -114,19 +114,19 @@ using OVClassNetworkTestPNPU = OVClassBaseTestPNPU;
 using OVClassLoadNetworkTestNPU = OVClassBaseTestPNPU;
 
 TEST_P(OVClassNetworkTestPNPU, LoadNetworkActualNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
+    ov::Core ie = ov::test::utils::create_core();
     OV_ASSERT_NO_THROW(ie.compile_model(actualNetwork, target_device, configuration));
 }
 
 TEST_P(OVClassNetworkTestPNPU, LoadNetworkActualHeteroDeviceNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
+    ov::Core ie = ov::test::utils::create_core();
     OV_ASSERT_NO_THROW(ie.compile_model(actualNetwork,
                                         ov::test::utils::DEVICE_HETERO + std::string(":") + target_device,
                                         configuration));
 }
 
 TEST_P(OVClassNetworkTestPNPU, LoadNetworkActualHeteroDevice2NoThrow) {
-    ov::Core ie = createCoreWithTemplate();
+    ov::Core ie = ov::test::utils::create_core();
 
     OV_ASSERT_NO_THROW(ie.compile_model(actualNetwork,
                                         ov::test::utils::DEVICE_HETERO,
@@ -135,7 +135,7 @@ TEST_P(OVClassNetworkTestPNPU, LoadNetworkActualHeteroDevice2NoThrow) {
 }
 
 TEST_P(OVClassNetworkTestPNPU, LoadNetworkActualHeteroDeviceUsingDevicePropertiesNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
+    ov::Core ie = ov::test::utils::create_core();
     configuration.emplace(ov::enable_profiling(true));
 
     OV_ASSERT_NO_THROW(ie.compile_model(actualNetwork,
@@ -145,7 +145,7 @@ TEST_P(OVClassNetworkTestPNPU, LoadNetworkActualHeteroDeviceUsingDevicePropertie
 }
 
 TEST_P(OVClassLoadNetworkTestNPU, LoadNetworkHETEROWithDeviceIDNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
+    ov::Core ie = ov::test::utils::create_core();
 
     auto supported_properties = ie.get_property(target_device, ov::supported_properties);
 
@@ -455,7 +455,7 @@ TEST_P(OVClassCompileModel, CompileModelWithDifferentThreadNumbers) {
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 
 TEST_P(OVClassBasicTestPNPU, smoke_registerPluginsLibrariesUnicodePath) {
-    ov::Core core = createCoreWithTemplate();
+    ov::Core core = ov::test::utils::create_core();
 
     const std::vector<std::string> libs = {pluginName};
 

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/life_time.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/life_time.hpp
@@ -73,7 +73,7 @@ static void release_order_test(std::vector<std::size_t> order,
                                ov::AnyMap configuration) {
     ov::AnyVector objects;
     {
-        ov::Core core = createCoreWithTemplate();
+        ov::Core core = ov::test::utils::create_core();
         auto compiled_model = core.compile_model(function, deviceName, configuration);
         auto request = compiled_model.create_infer_request();
 
@@ -105,7 +105,7 @@ TEST_P(OVHoldersTestNPU, Orders) {
 TEST_P(OVHoldersTestNPU, LoadedState) {
     std::vector<ov::VariableState> states;
     {
-        ov::Core core = createCoreWithTemplate();
+        ov::Core core = ov::test::utils::create_core();
         auto compiled_model = core.compile_model(function, target_device, configuration);
         auto request = compiled_model.create_infer_request();
         try {
@@ -118,7 +118,7 @@ TEST_P(OVHoldersTestNPU, LoadedState) {
 TEST_P(OVHoldersTestNPU, LoadedInferRequest) {
     ov::InferRequest inferRequest;
     {
-        ov::Core core = createCoreWithTemplate();
+        ov::Core core = ov::test::utils::create_core();
         auto compiled_model = core.compile_model(function, target_device, configuration);
         inferRequest = compiled_model.create_infer_request();
     }
@@ -127,7 +127,7 @@ TEST_P(OVHoldersTestNPU, LoadedInferRequest) {
 TEST_P(OVHoldersTestNPU, LoadedTensor) {
     ov::Tensor tensor;
     {
-        ov::Core core = createCoreWithTemplate();
+        ov::Core core = ov::test::utils::create_core();
         auto compiled_model = core.compile_model(function, target_device, configuration);
         auto request = compiled_model.create_infer_request();
         tensor = request.get_input_tensor();
@@ -137,7 +137,7 @@ TEST_P(OVHoldersTestNPU, LoadedTensor) {
 TEST_P(OVHoldersTestNPU, LoadedAny) {
     ov::Any any;
     {
-        ov::Core core = createCoreWithTemplate();
+        ov::Core core = ov::test::utils::create_core();
         auto compiled_model = core.compile_model(function, target_device, configuration);
         any = compiled_model.get_property(ov::supported_properties.name());
     }
@@ -148,7 +148,7 @@ TEST_P(OVHoldersTestNPU, LoadedRemoteContext) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     ov::RemoteContext ctx;
     {
-        ov::Core core = createCoreWithTemplate();
+        ov::Core core = ov::test::utils::create_core();
         auto compiled_model = core.compile_model(function, target_device, configuration);
         try {
             ctx = compiled_model.get_context();
@@ -163,7 +163,7 @@ TEST_P(OVHoldersTestNPU, CompileModelWithEncryptionWorksAfterConfigDeallocate) {
         ov::AnyMap copy_configuration = configuration;
         copy_configuration.insert(
             ov::cache_encryption_callbacks(ov::EncryptionCallbacks{ov::util::codec_xor, nullptr}));
-        ov::Core core = createCoreWithTemplate();
+        ov::Core core = ov::test::utils::create_core();
         compiled_model = core.compile_model(function, target_device, copy_configuration);
     }
     std::stringstream str;
@@ -218,7 +218,7 @@ public:
 };
 
 TEST_P(OVHoldersTestOnImportedNetworkNPU, LoadedTensor) {
-    ov::Core core = createCoreWithTemplate();
+    ov::Core core = ov::test::utils::create_core();
     std::stringstream stream;
     {
         auto compiled_model = core.compile_model(function, target_device, configuration);
@@ -230,7 +230,7 @@ TEST_P(OVHoldersTestOnImportedNetworkNPU, LoadedTensor) {
 }
 
 TEST_P(OVHoldersTestOnImportedNetworkNPU, CreateRequestWithCoreRemoved) {
-    ov::Core core = createCoreWithTemplate();
+    ov::Core core = ov::test::utils::create_core();
     std::stringstream stream;
     {
         auto compiled_model = core.compile_model(function, target_device, configuration);
@@ -242,7 +242,7 @@ TEST_P(OVHoldersTestOnImportedNetworkNPU, CreateRequestWithCoreRemoved) {
 }
 
 TEST_P(OVHoldersTestOnImportedNetworkNPU, CanInferAfterTensorIsDestroyed) {
-    ov::Core core = createCoreWithTemplate();
+    ov::Core core = ov::test::utils::create_core();
 
     for (size_t i = 0; i < 2; ++i) {
         ov::CompiledModel compiled_model;

--- a/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_behavior_test_utils.hpp
+++ b/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_behavior_test_utils.hpp
@@ -182,10 +182,7 @@ inline ov::Core createCoreWithTemplate() {
     ov::test::utils::PluginCache::get().reset();
     ov::Core core;
 #ifndef OPENVINO_STATIC_LIBRARY
-    std::string pluginName = "openvino_template_plugin";
-    pluginName += OV_BUILD_POSTFIX;
-    core.register_plugin(ov::util::make_plugin_library_name(ov::test::utils::getExecutableDirectory(), pluginName),
-        ov::test::utils::DEVICE_TEMPLATE);
+    ov::test::utils::register_template_plugin(core);
 #endif // !OPENVINO_STATIC_LIBRARY
     return core;
 }

--- a/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_behavior_test_utils.hpp
+++ b/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_behavior_test_utils.hpp
@@ -176,15 +176,9 @@ protected:
 };
 
 // DEPRECATED
-// Replace the usage by `ov::test::utils::create_core()`
-// in NVIDIA and NPU plugin
+// Replace the usage by `ov::test::utils::create_core()` in NVIDIA
 inline ov::Core createCoreWithTemplate() {
-    ov::test::utils::PluginCache::get().reset();
-    ov::Core core;
-#ifndef OPENVINO_STATIC_LIBRARY
-    ov::test::utils::register_template_plugin(core);
-#endif // !OPENVINO_STATIC_LIBRARY
-    return core;
+    return ov::test::utils::create_core();
 }
 
 class OVClassNetworkTest {

--- a/src/tests/functional/base_func_tests/src/behavior/compiled_model/import_export.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/compiled_model/import_export.cpp
@@ -298,7 +298,7 @@ TEST_P(OVClassCompiledModelImportExportTestP, smoke_ImportNetworkNoThrowWithDevi
 
 TEST_P(OVClassCompiledModelImportExportTestP, smoke_ImportNetworkThrowWithDeviceName) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    ov::Core ie = createCoreWithTemplate();
+    ov::Core ie = ov::test::utils::create_core();
     std::stringstream wrongStm;
     // Import model with wrong format throws exception
     OV_EXPECT_THROW((ie.import_model(wrongStm, target_device)),

--- a/src/tests/test_utils/common_test_utils/CMakeLists.txt
+++ b/src/tests/test_utils/common_test_utils/CMakeLists.txt
@@ -67,7 +67,11 @@ function(add_common_utils ADD_TARGET_NAME)
             $<TARGET_PROPERTY:openvino::runtime::dev,INTERFACE_INCLUDE_DIRECTORIES>)
     target_include_directories(${ADD_TARGET_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${OV_TESTS_ROOT}/test_utils>")
 
-    target_compile_definitions(${ADD_TARGET_NAME} PUBLIC ${ARGN})
+    target_compile_definitions(${ADD_TARGET_NAME} 
+        PUBLIC
+            ${ARGN}
+        PRIVATE
+            $<$<BOOL:${ENABLE_TEMPLATE_REGISTRATION}>:ENABLE_TEMPLATE_REGISTRATION>)
 endfunction()
 
 # Keep old name so that library can be used from NPU repo

--- a/src/tests/test_utils/common_test_utils/src/ov_plugin_cache.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_plugin_cache.cpp
@@ -27,7 +27,8 @@ void register_plugin(ov::Core& ov_core) noexcept {
     }
 }
 
-void register_template_plugin(ov::Core& ov_core) noexcept {
+void register_template_plugin([[maybe_unused]] ov::Core& ov_core) noexcept {
+#if !defined(ENABLE_TEMPLATE_REGISTRATION)
     auto plugin_path =
         ov::util::make_plugin_library_name(ov::test::utils::getExecutableDirectory(),
                                            std::string(ov::test::utils::TEMPLATE_LIB) + OV_BUILD_POSTFIX);
@@ -35,6 +36,7 @@ void register_template_plugin(ov::Core& ov_core) noexcept {
         OPENVINO_THROW("Plugin: " + plugin_path + " does not exists!");
     }
     ov_core.register_plugin(plugin_path, ov::test::utils::DEVICE_TEMPLATE);
+#endif
 }
 
 ov::Core create_core(const std::string& in_target_device) {


### PR DESCRIPTION
### Details:
 - Don't register Template plugin if registered by compilation option `ENABLE_TEMPLATE_REGISTRATION`, which remove test error when option enabled and plugin installed.
 - Remove usage of deprecated test utils function in project

### Tickets:
 - CVS-152394

### AI Assistance:
 - *AI assistance used: no*
