### PR TITLE
[GHA] Add push trigger to L0 workflows

### DIFF
--- a/.github/workflows/dev_gpu_linux_level_zero.yml
+++ b/.github/workflows/dev_gpu_linux_level_zero.yml
@@ -13,6 +13,10 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  push:
+    branches:
+      - master
+      - 'releases/**'
 
 concurrency:
   group: ${{ github.event_name == 'push' && github.run_id || github.ref }}-linux-gpu-level-zero-dev

--- a/.github/workflows/windows_level_zero_build.yml
+++ b/.github/workflows/windows_level_zero_build.yml
@@ -12,6 +12,10 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  push:
+    branches:
+      - master
+      - 'releases/**'
 
 concurrency:
   # github.ref is not unique in post-commit


### PR DESCRIPTION
### Details:
 - Push trigger is required for build cache generation
