### PR TITLE
[GHA] Temporarily disable sporadic async test cases

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_async_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_async_infer_request.py
@@ -27,6 +27,7 @@ from tests.utils.helpers import (
 )
 
 
+@pytest.mark.skip(reason="CVS-189144")
 @pytest.mark.parametrize("share_inputs", [True, False])
 def test_infer_queue(device, share_inputs):
     jobs = 8

--- a/tests/samples_tests/smoke_tests/test_classification_sample_async.py
+++ b/tests/samples_tests/smoke_tests/test_classification_sample_async.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """
  Copyright (C) 2018-2026 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/samples_tests/smoke_tests/test_classification_sample_async.py
+++ b/tests/samples_tests/smoke_tests/test_classification_sample_async.py
@@ -35,10 +35,12 @@ test_data_fp16 = get_tests({
 class TestClassification(SamplesCommonTestClass):
     sample_name = 'classification_sample_async'
 
+    @pytest.mark.skip(reason="CVS-188974")
     @pytest.mark.parametrize("param", test_data_fp32)
     def test_classification_sample_async_fp32(self, param, cache):
         _check_output(self, param, '215', cache)
 
+    @pytest.mark.skip(reason="CVS-188974")
     @pytest.mark.parametrize("param", test_data_fp16)
     def test_classification_sample_async_fp16(self, param, cache):
         _check_output(self, param, '215', cache)


### PR DESCRIPTION
### Details:
 - Sporadic timeouts in pre-commits on different OSes, both in fp32 and fp16 case

### Tickets:
 - CVS-188974
 - CVS-189144

