### PR TITLE
[Transformations] ov-transformation-tests skill and tests writing documentation

### DIFF
--- a/.claude/skills/ov-transformation-tests/SKILL.md
+++ b/.claude/skills/ov-transformation-tests/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: ov-transformation-tests
+description: >
+  Write unit tests for OpenVINO ov::Model graph transformations (passes).
+  Use when the user asks to write, add, or refactor tests for a transformation pass
+  (MatcherPass, ModelPass), or to modernize legacy transformation tests.
+---
+
+1. Read `src/common/transformations/docs/writing_tests.md` — it covers test location, build target, fixture setup, FunctionsComparator flags, node builders, model builder helpers, parametrized and negative test patterns, and what NOT to do.
+2. Write or modify the test file(s) following the patterns in that guide.
+3. Build and run the tests to ensure all tests pass.

--- a/src/common/transformations/docs/README.md
+++ b/src/common/transformations/docs/README.md
@@ -1,5 +1,9 @@
 # Transformations documentation
 
+## Writing tests
+
+ * [Writing transformation tests](./writing_tests.md)
+
 ## Debug capabilities
 
  * [Matcher logging README](./debug_capabilities/matcher_logging.md)

--- a/src/common/transformations/docs/writing_tests.md
+++ b/src/common/transformations/docs/writing_tests.md
@@ -1,0 +1,225 @@
+# Writing Tests for OpenVINO Transformations
+
+## Contents
+
+- [Test location and build target](#test-location-and-build-target)
+- [Quick checklist](#quick-checklist)
+- [Test class setup](#test-class-setup)
+- [FunctionsComparator flags](#functionscomparator-flags)
+- [Node builders](#node-builders)
+- [Model builder helpers](#model-builder-helpers)
+- [Parametrized tests](#parametrized-tests)
+- [Negative tests (transformation must NOT fire)](#negative-tests-transformation-must-not-fire)
+- [What NOT to do](#what-not-to-do)
+
+## Test location and build target
+
+Test files live in `src/common/transformations/tests/` with subdirectories by category (e.g., `common_optimizations/`, `utils/`). Build and run all transformation tests with:
+
+```bash
+cmake --build build --target ov_transformations_tests -j$(nproc)
+./bin/ov_transformations_tests
+```
+
+Or run a single test:
+```bash
+./bin/ov_transformations_tests --gtest_filter="YourTestName"
+```
+
+## Quick checklist
+
+1. Base class: `TransformationTestsF` (not `TransformationTests`)
+2. Enable only the `FunctionsComparator::CmpValues` flags relevant to the transformation
+3. Build models in helper functions to eliminate duplication
+4. Parametrize when multiple input shapes / configs exercise the same structural pattern
+5. Use `node_builders/` helpers instead of directly instantiating ops when a builder exists
+
+## Test class setup
+
+```cpp
+#include "common_test_utils/ov_test_utils.hpp"   // TransformationTestsF, FunctionsComparator
+
+// Minimal fixture — use TEST_F when no parameters are needed
+class MyTransformTests : public TransformationTestsF {
+public:
+    MyTransformTests() {
+        // Enable additional comparator flags if your transformation changes them (e.g. CONST_VALUES, ATTRIBUTES).
+        // Skip this constructor if the default flags suffice.
+        comparator.enable(FunctionsComparator::CONST_VALUES);
+    }
+
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        manager.register_pass<ov::pass::MyTransformation>();
+    }
+};
+
+TEST_F(MyTransformTests, MyTransformName_SomeVariant) {
+    {   // original model
+        auto data = std::make_shared<ov::opset10::Parameter>(ov::element::f32, ov::Shape{1, 3, 16, 16});
+        // ... build graph ...
+        model = std::make_shared<ov::Model>(output, ov::ParameterVector{data});
+    }
+    {   // reference model — what the transformation should produce
+        auto data = std::make_shared<ov::opset10::Parameter>(ov::element::f32, ov::Shape{1, 3, 16, 16});
+        // ...
+        model_ref = std::make_shared<ov::Model>(output_ref, ov::ParameterVector{data});
+    }
+}
+```
+
+`TransformationTestsF` automatically:
+- Runs `InitNodeInfo` before the registered pass
+- Runs `FunctionsComparator` comparison in `TearDown`
+
+**`manager.register_pass<*>()` shoud be moved to fixture's `SetUp()`** when multiple TEST_F tests in the same fixture use the same transformation — this avoids duplication and makes the transformation explicit per fixture rather than hidden in each test body.
+
+**Never** manually create a `pass::Manager`, call `check_rt_info`, or call `compare_functions` — those are handled by the fixture.
+
+## FunctionsComparator flags
+
+`TransformationTestsF` initialises the comparator with `no_default()` and then explicitly enables `NODES | PRECISIONS | RUNTIME_KEYS | SUBGRAPH_DESCRIPTORS`.
+
+Enable **additional** flags only when they matter for correctness of your test:
+
+| Flag | On by default in `TransformationTestsF`? | When to add |
+|------|------------------------------------------|-------------|
+| `NODES` | yes | (always on) op type and graph topology |
+| `PRECISIONS` | yes | (always on) element type of each tensor |
+| `RUNTIME_KEYS` | yes | (always on) `rt_info` key presence and values |
+| `SUBGRAPH_DESCRIPTORS` | yes | (always on) Loop/If body port descriptors |
+| `CONST_VALUES` | no | Transformation changes, inserts, or folds constant data |
+| `ATTRIBUTES` | no | Transformation sets or changes op attributes (broadcast mode, strides, group count, …) |
+| `NAMES` | no | Transformation must preserve specific friendly names |
+| `TENSOR_NAMES` | no | Transformation must preserve output tensor names |
+| `ACCURACY` | no | Runs Template plugin inference on the pre- and post-transformation models and checks outputs are within threshold (structural `model_ref` comparison still runs after). **Makes tests significantly slower** — only enable when there is a direct justification (e.g. the transformation does floating-point constant folding and plugin functional tests don't cover this path); plugin tests already verify accuracy for most transformations |
+| `CONSUMERS_COUNT` | no | Transformation changes the number of consumers on an output (e.g. constant deduplication, shared subgraph nodes) |
+
+Enable in the constructor or `SetUp`, or inline at the test level:
+
+```cpp
+// In a parametrized class constructor:
+comparator.enable(FunctionsComparator::ATTRIBUTES);
+
+// In an individual TEST_F (after both models are assigned):
+comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+```
+
+Do **not** explicitly enable flags already on by default in `TransformationTestsF` (`NODES`, `PRECISIONS`, `RUNTIME_KEYS`, `SUBGRAPH_DESCRIPTORS`).
+
+## Node builders
+
+Use `node_builders/` helpers instead of constructing ops directly when they exist.
+Headers live in `src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/`.
+
+To discover what builders are available:
+```bash
+ls src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/
+```
+
+Import example:
+```cpp
+#include "common_test_utils/node_builders/eltwise.hpp"
+// usage:
+auto add = ov::test::utils::make_eltwise(data, constant, ov::test::utils::EltwiseTypes::ADD);
+```
+
+## Model builder helpers
+
+Extract original and reference model construction into functions (or static methods) to avoid duplicating parameter/shape handling. Name them `getModel` and `getModelRef`.
+
+Use a **single combined builder** only when the two models are nearly identical — e.g., they differ only in a constant value or a single attribute — and the shared structure would be more confusing to duplicate than to branch:
+
+```cpp
+// Single builder only when divergence is minimal (e.g. one constant differs):
+std::shared_ptr<ov::Model> getModel(const ov::PartialShape& shape, float alpha, bool addBias) {
+    auto data = std::make_shared<ov::opset10::Parameter>(ov::element::f32, shape);
+    auto c    = ov::opset10::Constant::create(ov::element::f32, {1}, {alpha});
+    auto mul  = std::make_shared<ov::opset10::Multiply>(data, c);
+    if (addBias) {
+        auto bias = ov::opset10::Constant::create(ov::element::f32, {1}, {0.f});
+        return std::make_shared<ov::Model>(
+            std::make_shared<ov::opset10::Add>(mul, bias), ov::ParameterVector{data});
+    }
+    return std::make_shared<ov::Model>(mul, ov::ParameterVector{data});
+}
+model     = getModel(shape, 0.5f, /*addBias=*/true);
+model_ref = getModel(shape, 0.5f, /*addBias=*/false);
+```
+
+When the two models have **different op topologies**, use separate `getModel` / `getModelRef` functions — do not force them into one builder with a `bool reference` flag:
+
+```cpp
+std::shared_ptr<ov::Model> getModel(const ov::PartialShape& shape) {
+    auto data = std::make_shared<ov::opset10::Parameter>(ov::element::f32, shape);
+    auto a    = std::make_shared<ov::opset10::OpA>(data);
+    auto b    = std::make_shared<ov::opset10::OpB>(a);
+    return std::make_shared<ov::Model>(b, ov::ParameterVector{data});
+}
+
+std::shared_ptr<ov::Model> getModelRef(const ov::PartialShape& shape) {
+    auto data = std::make_shared<ov::opset10::Parameter>(ov::element::f32, shape);
+    auto op   = std::make_shared<ov::opset10::SomeOp>(data);
+    return std::make_shared<ov::Model>(op, ov::ParameterVector{data});
+}
+```
+
+## Parametrized tests
+
+Use `testing::WithParamInterface<ParamType>` + `INSTANTIATE_TEST_SUITE_P` when multiple shapes, precisions, op variants, or broadcast modes all exercise the same structural transform.
+
+```cpp
+using MyTestParams = std::tuple<ov::element::Type, ov::Shape, /*…*/>;
+
+class MyTransformTests : public testing::WithParamInterface<MyTestParams>,
+                         public TransformationTestsF {
+public:
+    MyTransformTests() : TransformationTestsF() {
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+    static std::string getTestCaseName(const testing::TestParamInfo<MyTestParams>& info) {
+        const auto& [prc, shape] = info.param;
+        std::ostringstream ss;
+        ss << "prc=" << prc << "_shape=" << shape;
+        return ss.str();
+    }
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        const auto& [prc, shape] = GetParam();
+        model     = getModel(prc, shape);
+        model_ref = getModelRef(prc, shape);
+        manager.register_pass<ov::pass::MyTransformation>();
+    }
+};
+
+TEST_P(MyTransformTests, Transform) {}
+
+INSTANTIATE_TEST_SUITE_P(MyTransformTests, MyTransformTests,
+    ::testing::Combine(
+        ::testing::Values(ov::element::f32, ov::element::f16),
+        ::testing::Values(ov::Shape{1,3,16,16}, ov::Shape{1,1,4,4})),
+    MyTransformTests::getTestCaseName);
+```
+
+Corner cases whose model structure significantly differs from the parametrized builder belong in standalone `TEST_F` tests.
+
+## Negative tests (transformation must NOT fire)
+
+When the transformation should leave the model unchanged, leave `model_ref` as `nullptr` — the TransformationTestsF class logic assigns a copy of `model` to `model_ref`. The cleanest pattern:
+
+```cpp
+TEST_F(TransformationTestsF, MyTransform_Negative_SomeCondition) {
+    model = buildOriginal(…);
+    manager.register_pass<ov::pass::MyTransformation>();
+    // model_ref intentionally omitted
+}
+```
+
+## What NOT to do
+
+- Do **not** inherit from plain `TransformationTests` / `ov::test::TestsCommon`
+- Do **not** manually instantiate `pass::Manager` or call `manager.run_passes(model)`
+- Do **not** call `check_rt_info(f)` or the deprecated `compare_functions(f, f_ref, …)`
+- Do **not** add flags already on by default in `TransformationTestsF` (`NODES`, `PRECISIONS`, `RUNTIME_KEYS`, `SUBGRAPH_DESCRIPTORS`)

--- a/src/common/transformations/docs/writing_tests.md
+++ b/src/common/transformations/docs/writing_tests.md
@@ -88,13 +88,13 @@ Enable **additional** flags only when they matter for correctness of your test:
 | `NODES` | yes | (always on) op type and graph topology |
 | `PRECISIONS` | yes | (always on) element type of each tensor |
 | `RUNTIME_KEYS` | yes | (always on) `rt_info` key presence and values |
-| `SUBGRAPH_DESCRIPTORS` | yes | (always on) Loop/If body port descriptors |
+| `SUBGRAPH_DESCRIPTORS` | yes | (always on) SubGraphOp bodies port descriptors |
 | `CONST_VALUES` | no | Transformation changes, inserts, or folds constant data |
-| `ATTRIBUTES` | no | Transformation sets or changes op attributes (broadcast mode, strides, group count, …) |
+| `ATTRIBUTES` | no | Transformation sets or changes op attributes (broadcast mode, strides, group count, …), or creates new nodes with some specific attributes |
 | `NAMES` | no | Transformation must preserve specific friendly names |
 | `TENSOR_NAMES` | no | Transformation must preserve output tensor names |
-| `ACCURACY` | no | Runs Template plugin inference on the pre- and post-transformation models and checks outputs are within threshold (structural `model_ref` comparison still runs after). **Makes tests significantly slower** — only enable when there is a direct justification (e.g. the transformation does floating-point constant folding and plugin functional tests don't cover this path); plugin tests already verify accuracy for most transformations |
-| `CONSUMERS_COUNT` | no | Transformation changes the number of consumers on an output (e.g. constant deduplication, shared subgraph nodes) |
+| `CONSUMERS_COUNT` | no | Transformation changes the number of consumers on an output (e.g. constant deduplication, shared subgraph nodes) or the transformation's logic depends on the consumers count |
+| `ACCURACY` | no | Runs Template plugin inference on the pre- and post-transformation models and checks outputs are within threshold (structural `model_ref` comparison still runs after). **Makes tests significantly slower** — only enable when there is a direct justification; plugin tests already verify accuracy for most transformations |
 
 Enable in the constructor or `SetUp`, or inline at the test level:
 
@@ -112,11 +112,6 @@ Do **not** explicitly enable flags already on by default in `TransformationTests
 
 Use `node_builders/` helpers instead of constructing ops directly when they exist.
 Headers live in `src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/`.
-
-To discover what builders are available:
-```bash
-ls src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/
-```
 
 Import example:
 ```cpp

--- a/src/common/transformations/docs/writing_tests.md
+++ b/src/common/transformations/docs/writing_tests.md
@@ -73,7 +73,7 @@ TEST_F(MyTransformTests, MyTransformName_SomeVariant) {
 - Runs `InitNodeInfo` before the registered pass
 - Runs `FunctionsComparator` comparison in `TearDown`
 
-**`manager.register_pass<*>()` shoud be moved to fixture's `SetUp()`** when multiple TEST_F tests in the same fixture use the same transformation — this avoids duplication and makes the transformation explicit per fixture rather than hidden in each test body.
+**`manager.register_pass<*>()` should be moved to fixture's `SetUp()`** when multiple TEST_F tests in the same fixture use the same transformation — this avoids duplication and makes the transformation explicit per fixture rather than hidden in each test body.
 
 **Never** manually create a `pass::Manager`, call `check_rt_info`, or call `compare_functions` — those are handled by the fixture.
 
@@ -103,7 +103,7 @@ Enable in the constructor or `SetUp`, or inline at the test level:
 comparator.enable(FunctionsComparator::ATTRIBUTES);
 
 // In an individual TEST_F (after both models are assigned):
-comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+comparator.enable(FunctionsComparator::CONST_VALUES);
 ```
 
 Do **not** explicitly enable flags already on by default in `TransformationTestsF` (`NODES`, `PRECISIONS`, `RUNTIME_KEYS`, `SUBGRAPH_DESCRIPTORS`).

--- a/src/common/transformations/docs/writing_tests.md
+++ b/src/common/transformations/docs/writing_tests.md
@@ -32,7 +32,8 @@ Or run a single test:
 2. Enable only the `FunctionsComparator::CmpValues` flags relevant to the transformation
 3. Build models in helper functions to eliminate duplication
 4. Parametrize when multiple input shapes / configs exercise the same structural pattern
-5. Use `node_builders/` helpers instead of directly instantiating ops when a builder exists
+5. Consider using `node_builders/` helpers instead of directly instantiating ops when a builder exists and improves test readability
+6. Avoid building `model_ref` when the transformation does not modify the `model`, since `model_ref` is initialized as a clone of `model` by default
 
 ## Test class setup
 
@@ -110,7 +111,7 @@ Do **not** explicitly enable flags already on by default in `TransformationTests
 
 ## Node builders
 
-Use `node_builders/` helpers instead of constructing ops directly when they exist.
+Use `node_builders/` helpers instead of constructing ops directly when a builder exists and improves test readability.
 Headers live in `src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/`.
 
 Import example:
@@ -202,7 +203,7 @@ Corner cases whose model structure significantly differs from the parametrized b
 
 ## Negative tests (transformation must NOT fire)
 
-When the transformation should leave the model unchanged, leave `model_ref` as `nullptr` — the TransformationTestsF class logic assigns a copy of `model` to `model_ref`. The cleanest pattern:
+When the transformation should leave the `model` unchanged, leave `model_ref` as `nullptr` — the TransformationTestsF class logic assigns a copy of `model` to `model_ref`. The cleanest pattern:
 
 ```cpp
 TEST_F(TransformationTestsF, MyTransform_Negative_SomeCondition) {

--- a/src/common/transformations/tests/common_optimizations/convert_convertlike.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_convertlike.cpp
@@ -5,103 +5,58 @@
 #include "transformations/op_conversions/convert_convertlike.hpp"
 
 #include <gtest/gtest.h>
-
 #include <memory>
-#include <queue>
-#include <string>
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/op/convert.hpp"
 #include "openvino/op/convert_like.hpp"
-#include "openvino/opsets/opset8_decl.hpp"
-#include "openvino/pass/manager.hpp"
-#include "transformations/init_node_info.hpp"
-#include "transformations/utils/utils.hpp"
+#include "openvino/opsets/opset8.hpp"
 
 using namespace ov;
-using namespace testing;
 
-TEST(TransformationTests, ConvertConvertLike) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+class ConvertConvertLikeTransformTests : public TransformationTestsF {
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        manager.register_pass<ov::pass::ConvertConvertLike>();
+    }
+};
+
+TEST_F(ConvertConvertLikeTransformTests, ConvertLikeWithConstant) {
     {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{3, 1, 2});
         auto like = opset8::Constant::create(element::i32, Shape{1}, {1});
         auto cvtlike = std::make_shared<opset8::ConvertLike>(data, like);
-
-        f = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data});
-
-        pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ov::pass::ConvertConvertLike>();
-        m.run_passes(f);
-        OV_ASSERT_NO_THROW(check_rt_info(f));
+        model = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data});
     }
-
     {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{3, 1, 2});
         auto cvt = std::make_shared<opset8::Convert>(data, element::i32);
-
-        f_ref = std::make_shared<ov::Model>(OutputVector{cvt}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{cvt}, ParameterVector{data});
     }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertConvertLike2) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+TEST_F(ConvertConvertLikeTransformTests, ConvertLikeWithNodeOutput) {
     {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{3, 1, 2});
         auto data2 = std::make_shared<opset8::Parameter>(element::i8, Shape{1});
         auto constant = opset8::Constant::create(element::i8, Shape{}, {1});
         auto like = std::make_shared<opset8::Add>(data2, constant);
         auto cvtlike = std::make_shared<opset8::ConvertLike>(data, like);
-
-        f = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data, data2});
-
-        pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ov::pass::ConvertConvertLike>();
-        m.run_passes(f);
-        OV_ASSERT_NO_THROW(check_rt_info(f));
+        model = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data, data2});
     }
-
     {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{3, 1, 2});
         auto cvt = std::make_shared<opset8::Convert>(data, element::i8);
-
-        f_ref = std::make_shared<ov::Model>(OutputVector{cvt}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{cvt}, ParameterVector{data});
     }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertConvertLike_Negative) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{3, 1, 2});
-        auto like = std::make_shared<opset8::Parameter>(element::dynamic, Shape{1});
-        auto cvtlike = std::make_shared<opset8::ConvertLike>(data, like);
-
-        f = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data, like});
-
-        pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ov::pass::ConvertConvertLike>();
-        m.run_passes(f);
-        OV_ASSERT_NO_THROW(check_rt_info(f));
-    }
-
-    {
-        auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{3, 1, 2});
-        auto like = std::make_shared<opset8::Parameter>(element::dynamic, Shape{1});
-        auto cvtlike = std::make_shared<opset8::ConvertLike>(data, like);
-
-        f_ref = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data, like});
-    }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+TEST_F(ConvertConvertLikeTransformTests, ConvertLikeWithDynamicType_Negative) {
+    auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{3, 1, 2});
+    auto like = std::make_shared<opset8::Parameter>(element::dynamic, Shape{1});
+    auto cvtlike = std::make_shared<opset8::ConvertLike>(data, like);
+    model = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data, like});
 }

--- a/src/common/transformations/tests/common_optimizations/convert_convertlike.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_convertlike.cpp
@@ -5,6 +5,7 @@
 #include "transformations/op_conversions/convert_convertlike.hpp"
 
 #include <gtest/gtest.h>
+
 #include <memory>
 
 #include "common_test_utils/ov_test_utils.hpp"

--- a/src/common/transformations/tests/common_optimizations/divide_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/divide_fusion.cpp
@@ -6,24 +6,28 @@
 
 #include <gtest/gtest.h>
 
-#include <memory>
-#include <queue>
-#include <string>
-
 #include "common_test_utils/ov_test_utils.hpp"
-#include "openvino/core/model.hpp"
 #include "openvino/op/divide.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/power.hpp"
 #include "openvino/opsets/opset1_decl.hpp"
-#include "openvino/pass/manager.hpp"
-#include "transformations/init_node_info.hpp"
-#include "transformations/utils/utils.hpp"
-using namespace ov;
-using namespace testing;
 
-TEST(TransformationTests, DivideFusion) {
-    std::shared_ptr<ov::Model> f, f_ref;
+using namespace ov;
+
+class DivideFusionTest : public TransformationTestsF {
+public:
+    DivideFusionTest() {
+        comparator.enable(FunctionsComparator::CONST_VALUES);
+    }
+
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        manager.register_pass<ov::pass::DivideFusion>();
+    }
+};
+
+TEST_F(DivideFusionTest, MultiplyByPowerNegativeOne) {
     {
         auto data1 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
         auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
@@ -31,61 +35,23 @@ TEST(TransformationTests, DivideFusion) {
         auto pow = std::make_shared<opset1::Power>(data2, pow_constant);
         auto mul = std::make_shared<opset1::Multiply>(data1, pow);
 
-        f = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data1, data2});
-
-        pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ov::pass::DivideFusion>();
-        m.run_passes(f);
-        OV_ASSERT_NO_THROW(check_rt_info(f));
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data1, data2});
     }
-
     {
         auto data1 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
         auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
         auto divide = std::make_shared<opset1::Divide>(data1, data2);
 
-        f_ref = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data1, data2});
+        model_ref = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data1, data2});
     }
-
-    const auto res = FunctionsComparator::with_default()
-                         .enable(FunctionsComparator::CONST_VALUES)
-                         .enable(FunctionsComparator::ATTRIBUTES)
-                         .compare(f, f_ref);
-    ASSERT_TRUE(res.valid) << res.message;
 }
 
-TEST(TransformationTests, DivideFusionNegative) {
-    std::shared_ptr<ov::Model> f, f_ref;
-    {
-        auto data1 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
-        auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
-        auto pow_constant = opset1::Constant::create(element::f32, Shape{1}, {-1.01});
-        auto pow = std::make_shared<opset1::Power>(data2, pow_constant);
-        auto mul = std::make_shared<opset1::Multiply>(data1, pow);
+TEST_F(DivideFusionTest, MultiplyByPowerNotNegativeOne) {
+    auto data1 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
+    auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
+    auto pow_constant = opset1::Constant::create(element::f32, Shape{1}, {-1.01});
+    auto pow = std::make_shared<opset1::Power>(data2, pow_constant);
+    auto mul = std::make_shared<opset1::Multiply>(data1, pow);
 
-        f = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data1, data2});
-
-        pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ov::pass::DivideFusion>();
-        m.run_passes(f);
-        OV_ASSERT_NO_THROW(check_rt_info(f));
-    }
-
-    {
-        auto data1 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
-        auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
-        auto pow_constant = opset1::Constant::create(element::f32, Shape{1}, {-1.01});
-        auto pow = std::make_shared<opset1::Power>(data2, pow_constant);
-        auto mul = std::make_shared<opset1::Multiply>(data1, pow);
-
-        f_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data1, data2});
-    }
-
-    const auto res = FunctionsComparator::with_default()
-                         .enable(FunctionsComparator::CONST_VALUES)
-                         .enable(FunctionsComparator::ATTRIBUTES)
-                         .compare(f, f_ref);
-    ASSERT_TRUE(res.valid) << res.message;
+    model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data1, data2});
 }

--- a/src/common/transformations/tests/common_optimizations/divide_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/divide_fusion.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/core/model.hpp"
 #include "openvino/op/divide.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/power.hpp"


### PR DESCRIPTION
### Details:
 - *Added documentation with best practices for transformation tests writing*
 - *Added a corresponding skill to ensure automatic LLM agent routing to the new documentation in transformation tests writing scenario*
 - *The new skill was applied to a few existing legacy tests files to check how it works. Prompt example: `/ov-transformation-tests refactor @src/common/transformations/tests/common_optimizations/convert_convertlike.cpp tests`. The skill has been confirmed to work on lightweight models as well (e.g. Haiku).*

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used to test the new skill and for the new documentation adjustments*
