### PR TITLE
Fix profiling exec_type reporting "undef" for dynamic-shape and custom ops

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
@@ -83,8 +83,9 @@ struct custom_gpu_primitive_impl : typed_primitive_impl<custom_gpu_primitive> {
     : _kernels() {}
 
     custom_gpu_primitive_impl(const custom_gpu_primitive_impl& other)
-    : cl_kernel(other.cl_kernel)
-    , _kernels({}) 
+    : parent(other.get_kernel_name())
+    , cl_kernel(other.cl_kernel)
+    , _kernels({})
     , size_expr_map(other.size_expr_map) {
         for (const auto& kernel : other._kernels) {
             _kernels.emplace_back(kernel->clone(other.can_share_kernels));
@@ -93,15 +94,17 @@ struct custom_gpu_primitive_impl : typed_primitive_impl<custom_gpu_primitive> {
 
     custom_gpu_primitive_impl(const custom_gpu_primitive_node& arg,
                              std::shared_ptr<kernel_selector::cl_kernel_data>& cl_kernel)
-        : cl_kernel(cl_kernel)
-        , _kernels() { }
+    : parent(cl_kernel->code.kernelString->entry_point)
+    , cl_kernel(cl_kernel)
+    , _kernels() { }
 
     custom_gpu_primitive_impl(const custom_gpu_primitive_node& arg,
-                             std::shared_ptr<kernel_selector::cl_kernel_data>& cl_kernel,
-                             const std::map<uint32_t, std::string>& size_expr_map)
-        : cl_kernel(cl_kernel)
-        , _kernels()
-        , size_expr_map(size_expr_map) { }
+                              std::shared_ptr<kernel_selector::cl_kernel_data>& cl_kernel,
+                              const std::map<uint32_t, std::string>& size_expr_map)
+    : parent(cl_kernel->code.kernelString->entry_point)
+    , cl_kernel(cl_kernel)
+    , _kernels()
+    , size_expr_map(size_expr_map) { }
 
     std::vector<std::shared_ptr<cldnn::kernel_string>> get_kernels_source() override {
         std::vector<std::shared_ptr<cldnn::kernel_string>> kernel_strings;

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -630,11 +630,18 @@ std::string network::get_implementation_info(const primitive_id& id) const {
             auto* impl = it->second->get_impl();
             auto kernel_name = impl ? impl->get_kernel_name() : "";
             if (!kernel_name.empty()) {
-                const auto& node = it->second->get_node();
-                return kernel_name + "__" + dt_to_str(_program->get_inference_precision(node));
+                if (_program != nullptr) {
+                    const auto& node = it->second->get_node();
+                    return kernel_name + "__" + dt_to_str(_program->get_inference_precision(node));
+                } else {
+                    return kernel_name;
+                }
             }
         }
     } catch (...) { }
+
+    if (_program == nullptr)
+        return "undef";
 
     return _program->get_implementation_info(id);
 }

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -37,6 +37,7 @@
 #include "kv_cache_inst.h"
 #include "program_helpers.h"
 #include "program_dump_graph.h"
+#include "to_string_utils.h"
 
 #include <algorithm>
 #include <string>
@@ -623,6 +624,18 @@ bool network::does_node_need_lockable_output(const primitive_id& id) const {
 }
 
 std::string network::get_implementation_info(const primitive_id& id) const {
+    try {
+        auto it = _primitives.find(id);
+        if (it != _primitives.end()) {
+            auto* impl = it->second->get_impl();
+            auto kernel_name = impl ? impl->get_kernel_name() : "";
+            if (!kernel_name.empty()) {
+                const auto& node = it->second->get_node();
+                return kernel_name + "__" + dt_to_str(_program->get_inference_precision(node));
+            }
+        }
+    } catch (...) { }
+
     return _program->get_implementation_info(id);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -771,6 +771,9 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
                     } else {
                         extPerfEntry.exec_type = pi.kernel_id;
                     }
+                    if (extPerfEntry.exec_type == "undef") {
+                        extPerfEntry.exec_type = get_network()->get_implementation_info(primId);
+                    }
 
                     extPerfEntry.node_type = getUpperCaseName(pi.type_id);
                     extPerfEntry.node_name = pi.original_id;


### PR DESCRIPTION
### Details:
Per-layer profiling printed "undef" as `exec_type` or not showing exact execution type several ops,
as well as for custom GPU primitives.

 - *`network::get_implementation_info` delegated straight to the program-level lookup, which reads the compile-time `program_node::get_selected_impl()`. For dynamic-shape nodes that impl is only a placeholder with an empty kernel name; the actually selected kernel lives in the runtime `primitive_inst::_impl` owned by network. Now query the runtime impl first and fall back to the program-level lookup.*
 - *`custom_gpu_primitive_impl` never initialized its base kernel name, so even its runtime impl returned empty. Initialize the base from the custom kernel entry point and preserve it across cloning.*

### Tickets:
 - *CVS-189223*

### AI Assistance:
 - *AI assistance used: yes*
 - *Used to understand ov code flow for getting `exec_type`, adding the improvement quickly followed by tests over existing model to print the exec_types with and without custom_ops. Manual checks are done for correctness and validation.*
