### PR TITLE
[GPU] Print program build log on cl::Error during kernel build

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
@@ -72,6 +72,20 @@ class ocl_kernel_builder : public kernel_builder{
                 GPU_DEBUG_INFO << "-------- End of Kernel build error" << std::endl;
                 OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
             } catch (const cl::Error& err) {
+                // cl::Program::build only throws cl::BuildError for CL_BUILD_PROGRAM_FAILURE.
+                // Other build-time failures (e.g. CL_OUT_OF_RESOURCES when the generated
+                // kernel exceeds device limits) arrive here as a plain cl::Error, so the
+                // program build log is otherwise lost. Surface it for diagnostics.
+                GPU_DEBUG_INFO << "-------- Kernel build error" << std::endl;
+                try {
+                    auto log = program.getBuildInfo<CL_PROGRAM_BUILD_LOG>();
+                    for (auto& e : log) {
+                        GPU_DEBUG_INFO << e.second;
+                    }
+                } catch (const cl::Error&) {
+                    GPU_DEBUG_INFO << "Failed to retrieve program build log" << std::endl;
+                }
+                GPU_DEBUG_INFO << "-------- End of Kernel build error" << std::endl;
                 OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
             } catch (...) {
                 // We should never hit this catch block


### PR DESCRIPTION
**Problem:** In `ocl_kernel_builder`, `cl::Program::build` only raises `cl::BuildError` for `CL_BUILD_PROGRAM_FAILURE`, and only that branch prints the OpenCL program build log. Other build-time failures — notably `CL_OUT_OF_RESOURCES`, raised when a generated kernel exceeds device limits (e.g. SLM/local memory on integrated GPUs) — propagate as a plain `cl::Error`, whose handler rethrows with just the error code and no build log. This leaves such kernel-build failures effectively undiagnosable without local source patching.

**Solution:** In the `catch (const cl::Error&)` branch of `ocl_kernel_builder::build` (`src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp`), fetch and log the program build log via `program.getBuildInfo<CL_PROGRAM_BUILD_LOG>()` before rethrowing, mirroring the existing `cl::BuildError` branch and using the same `GPU_DEBUG_INFO` channel. The log retrieval is wrapped so a secondary failure does not mask the original error. No behavior change in the success path; output is only produced under GPU verbose logging.
