### PR TITLE
[PyTorch FE] Restore dynamic batch in window-reverse view shapes

### DIFF
--- a/src/frontends/pytorch/src/frontend.cpp
+++ b/src/frontends/pytorch/src/frontend.cpp
@@ -35,6 +35,7 @@
 #include "transforms/prim_unpack_parameter_replacer.hpp"
 #include "transforms/quantized_node_remover.hpp"
 #include "transforms/remove_packing_ops.hpp"
+#include "transforms/reshape_batch_dim_resolver.hpp"
 #include "transforms/reverseprop_resolver.hpp"
 #include "transforms/sequence_mark_replacer.hpp"
 #include "transforms/softmax_reshape_elimination.hpp"
@@ -264,6 +265,7 @@ void FrontEnd::normalize(const std::shared_ptr<ov::Model>& model) const {
     manager.register_pass<ov::frontend::pytorch::pass::AtenIndexPutReplacer>();
     manager.register_pass<ov::frontend::pytorch::pass::IndexLoopGetitemReplacer>();
     manager.register_pass<ov::frontend::pytorch::pass::SequenceMarkReplacer>();
+    manager.register_pass<ov::frontend::pytorch::pass::ReshapeBatchDimResolver>();
 
     // Check if model is symmetrically quantized
     bool sym = false;

--- a/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.cpp
+++ b/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.cpp
@@ -5,16 +5,17 @@
 #include "reshape_batch_dim_resolver.hpp"
 
 #include <memory>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "openvino/core/graph_util.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
-#include "openvino/op/convert.hpp"
-#include "openvino/op/gather.hpp"
 #include "openvino/op/reshape.hpp"
-#include "openvino/op/shape_of.hpp"
-#include "openvino/pass/pattern/matcher.hpp"
-#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/pass/node_registry.hpp"
 #include "utils.hpp"
 
 namespace ov {
@@ -23,7 +24,6 @@ namespace pytorch {
 namespace pass {
 
 using namespace ov::op;
-using namespace ov::pass::pattern;
 
 namespace {
 // True if `out` is a Constant holding a single element equal to `value`.
@@ -47,102 +47,190 @@ bool is_scalar_positive_constant(const Output<Node>& out) {
     const auto values = constant->cast_vector<int64_t>();
     return values.size() == 1 && values[0] > 0;
 }
+
+// Structural signature of a window-reverse style view whose leading batch was frozen by tracing.
+// Independent of where the channel value comes from: special_zero false (a 0 already means "copy
+// dim", which this rewrite would conflict with); shape concat on axis 0; a leading baked positive-int
+// batch constant; exactly one `-1` and it sits in the LAST (channel) position; at least one dynamic
+// interior dimension (a genuine shape expression -- a fully-constant shape vector is never a
+// propagation bug and would have const-folded away before reaching this pass).
+bool passes_structural_gates(const std::shared_ptr<v1::Reshape>& reshape, const std::shared_ptr<v0::Concat>& concat) {
+    if (reshape->get_special_zero())
+        return false;
+    if (concat->get_axis() != 0)
+        return false;
+
+    const auto& shape_inputs = concat->input_values();
+    // Need a leading batch dim, at least one interior dim, and a trailing channel slot.
+    if (shape_inputs.size() < 3)
+        return false;
+
+    // Leading element must be a baked positive-int batch constant (e.g. the traced 1).
+    if (!is_scalar_positive_constant(shape_inputs.front()))
+        return false;
+
+    // The infer slot (-1) must be unique and sit in the LAST (channel) position. This is the
+    // window-reverse signature and excludes ordinary reshapes whose -1 is elsewhere/absent.
+    const size_t channel_idx = shape_inputs.size() - 1;
+    if (!is_scalar_constant_with_value(shape_inputs.back(), -1))
+        return false;
+    for (size_t i = 0; i + 1 < shape_inputs.size(); ++i) {
+        if (is_scalar_constant_with_value(shape_inputs[i], -1))
+            return false;  // more than one -1 -> ambiguous, not our pattern
+    }
+
+    // At least one interior dimension (between batch and channel) must be dynamic.
+    for (size_t i = 1; i < channel_idx; ++i) {
+        if (!ov::as_type_ptr<v0::Constant>(shape_inputs[i].get_node_shared_ptr()))
+            return true;
+    }
+    return false;
+}
+
+// Recover the statically-known last (channel) dimension of `data` by walking the graph deterministically,
+// WITHOUT relying on OV re-inferring/propagating shapes through the intervening permute (which does not
+// happen on the real model -- the spatial value-bounds collapse the permuted output to fully dynamic).
+//   1. If `data`'s last dimension is already static -> return it. This covers the first window-reverse
+//      view (data `[?,8,8,180]`) and any last-dim-preserving eltwise producer in between (e.g. `+ 0.0`),
+//      since those keep the static last dimension.
+//   2. If the producer is a Transpose whose order keeps the original last axis last (`order.back() ==
+//      rank-1`, e.g. `[0,1,3,2,4,5]`) -> recurse into the transposed data: the channel stays trailing.
+//   3. If the producer is a Reshape we have already selected for rewrite -> use its resolved channel
+//      (this is how the second view resolves through the permute back to the first view's baked channel).
+//   4. Otherwise the channel is not statically recoverable -> nullopt (so ordinary `view(1, C, -1)` /
+//      attention head-merge, whose data comes from a Parameter with a dynamic last dim, is skipped).
+// `visited` guards against re-entry; the graph is a DAG and each step moves strictly to a producer, so
+// the walk terminates, but the set keeps it robust to any malformed structure.
+std::optional<int64_t> resolve_static_last_dim(const Output<Node>& data,
+                                               const std::unordered_map<const Node*, int64_t>& pending_channel,
+                                               std::unordered_set<const Node*>& visited) {
+    const Node* producer = data.get_node();
+    if (producer && !visited.insert(producer).second)
+        return std::nullopt;
+
+    // Step 1: a statically-known last dimension on `data` itself.
+    const auto& ps = data.get_partial_shape();
+    if (ps.rank().is_static() && ps.size() > 0) {
+        const auto& last = ps[static_cast<std::ptrdiff_t>(ps.size()) - 1];
+        if (last.is_static())
+            return last.get_length();
+    }
+
+    // Step 2: a last-axis-preserving Transpose -> recurse into the transposed data.
+    if (auto transpose = ov::as_type_ptr<v1::Transpose>(data.get_node_shared_ptr())) {
+        auto order = ov::as_type_ptr<v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
+        const auto& in_ps = transpose->input_value(0).get_partial_shape();
+        if (order && in_ps.rank().is_static()) {
+            const auto perm = order->cast_vector<int64_t>();
+            const int64_t rank = in_ps.rank().get_length();
+            // The order must be a full permutation we can reason about, and its last element must keep
+            // the original last axis last so the channel remains the trailing dimension.
+            if (static_cast<int64_t>(perm.size()) == rank && !perm.empty() && perm.back() == rank - 1)
+                return resolve_static_last_dim(transpose->input_value(0), pending_channel, visited);
+        }
+        return std::nullopt;
+    }
+
+    // Step 3: a Reshape already selected for rewrite -> reuse its resolved channel.
+    if (auto rs = ov::as_type_ptr<v1::Reshape>(data.get_node_shared_ptr())) {
+        const auto it = pending_channel.find(rs.get());
+        if (it != pending_channel.end())
+            return it->second;
+    }
+
+    return std::nullopt;
+}
+
+// Rebuild the shape vector for THIS reshape's own data (the concat may be shared between blocks, so we
+// must not edit it in place):
+//   leading batch -> -1                       (inferred from the real element count)
+//   channel (-1)  -> Constant(channel)        (the baked channel recovered by the walk-back)
+// Pinning the channel to a static constant (not a runtime Gather) is correct because the channel is
+// batch-independent, and it keeps the rewritten reshape's output last dimension static.
+void rewrite_reshape(const std::shared_ptr<v1::Reshape>& reshape,
+                     const std::shared_ptr<v0::Concat>& concat,
+                     int64_t channel) {
+    const auto& shape_inputs = concat->input_values();
+    const size_t channel_idx = shape_inputs.size() - 1;
+
+    ov::pass::NodeRegistry rg;
+
+    // Keep the same integer element type the original shape elements used.
+    const auto& channel_et = concat->input_value(channel_idx).get_element_type();
+    const auto channel_out = rg.make<v0::Constant>(channel_et.is_static() ? channel_et : element::i64,
+                                                   Shape{1},
+                                                   std::vector<int64_t>{channel});
+
+    const auto& batch_et = shape_inputs.front().get_element_type();
+    const auto minus_one =
+        rg.make<v0::Constant>(batch_et.is_static() ? batch_et : element::i64, Shape{1}, std::vector<int64_t>{-1});
+
+    OutputVector new_shape_inputs;
+    new_shape_inputs.reserve(shape_inputs.size());
+    new_shape_inputs.push_back(minus_one);
+    for (size_t i = 1; i < channel_idx; ++i)
+        new_shape_inputs.push_back(shape_inputs[i]);
+    new_shape_inputs.push_back(channel_out);
+
+    const auto new_concat = rg.make<v0::Concat>(new_shape_inputs, 0);
+    reshape->input(1).replace_source_output(new_concat);
+    copy_runtime_info_and_name(concat, rg.get(), {reshape});
+}
 }  // namespace
 
-ReshapeBatchDimResolver::ReshapeBatchDimResolver() {
-    // Match `Reshape(data, Concat(...))`: the offending view-shape is always built as a Concat
-    // (see get_input_concat_if_list); a fully const-folded shape has no propagation problem.
-    const auto concat_pattern = wrap_type<v0::Concat>();
-    const auto reshape_pattern = wrap_type<v1::Reshape>({any_input(), concat_pattern});
+bool ReshapeBatchDimResolver::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    model->validate_nodes_and_infer_types();
 
-    ov::matcher_pass_callback callback = [=](Matcher& m) {
-        const auto& pattern_map = m.get_pattern_value_map();
-        auto reshape = ov::as_type_ptr<v1::Reshape>(pattern_map.at(reshape_pattern).get_node_shared_ptr());
-        auto concat = ov::as_type_ptr<v0::Concat>(pattern_map.at(concat_pattern).get_node_shared_ptr());
-        if (!reshape || !concat)
-            return false;
-
-        // Only the standard frozen-batch shape: special_zero must be false (a 0 already means
-        // "copy dim", which this rewrite would conflict with) and the shape concat is on axis 0.
-        if (reshape->get_special_zero())
-            return false;
-        if (concat->get_axis() != 0)
-            return false;
-
-        const auto& shape_inputs = concat->input_values();
-        // Need a leading batch dim, at least one interior dim, and a trailing channel slot.
-        if (shape_inputs.size() < 3)
-            return false;
-
-        // Leading element must be a baked positive-int batch constant (e.g. the traced 1).
-        if (!is_scalar_positive_constant(shape_inputs.front()))
-            return false;
-
-        // The infer slot (-1) must be unique and sit in the LAST (channel) position. This is the
-        // window-reverse signature and excludes ordinary reshapes whose -1 is elsewhere/absent.
-        const size_t channel_idx = shape_inputs.size() - 1;
-        if (!is_scalar_constant_with_value(shape_inputs.back(), -1))
-            return false;
-        for (size_t i = 0; i + 1 < shape_inputs.size(); ++i) {
-            if (is_scalar_constant_with_value(shape_inputs[i], -1))
-                return false;  // more than one -1 -> ambiguous, not our pattern
-        }
-
-        // At least one interior dimension (between batch and channel) must be dynamic, i.e. a
-        // genuine shape expression. A fully-constant shape vector is never a propagation bug.
-        bool has_dynamic_interior = false;
-        for (size_t i = 1; i < channel_idx; ++i) {
-            if (!ov::as_type_ptr<v0::Constant>(shape_inputs[i].get_node_shared_ptr())) {
-                has_dynamic_interior = true;
-                break;
-            }
-        }
-        if (!has_dynamic_interior)
-            return false;
-
-        // The batch must be dynamic for the frozen leading constant to be wrong. After
-        // conversion the PyTorch decoder makes parameter dims dynamic, so this holds for the
-        // traced model while excluding genuinely static reshapes.
-        const auto& data = reshape->input_value(0);
-        const auto& data_ps = data.get_partial_shape();
-        if (data_ps.rank().is_static() && data_ps[0].is_static())
-            return false;
-
-        // Rebuild the shape vector for THIS reshape's own data (the concat may be shared between
-        // blocks, so we must not edit it in place):
-        //   leading batch  -> -1          (inferred from the real element count)
-        //   channel (-1)    -> Gather(ShapeOf(data), last)  (data's last dim, == the channel)
-        ov::pass::NodeRegistry rg;
-        const auto shape_of = rg.make<v3::ShapeOf>(data, element::i32);
-        const auto last_index = v0::Constant::create(element::i32, Shape{1}, {-1});
-        const auto gather_axis = v0::Constant::create(element::i32, Shape{}, {0});
-        const auto channel_dim = rg.make<v8::Gather>(shape_of, last_index, gather_axis);
-
-        const auto& channel_et = concat->input_value(channel_idx).get_element_type();
-        Output<Node> channel_out = channel_dim;
-        if (channel_et.is_static() && channel_et != element::i32)
-            channel_out = rg.make<v0::Convert>(channel_dim, channel_et);
-
-        const auto& batch_et = shape_inputs.front().get_element_type();
-        const auto minus_one =
-            rg.make<v0::Constant>(batch_et.is_static() ? batch_et : element::i64, Shape{1}, std::vector<int64_t>{-1});
-
-        OutputVector new_shape_inputs;
-        new_shape_inputs.reserve(shape_inputs.size());
-        new_shape_inputs.push_back(minus_one);
-        for (size_t i = 1; i < channel_idx; ++i)
-            new_shape_inputs.push_back(shape_inputs[i]);
-        new_shape_inputs.push_back(channel_out);
-
-        const auto new_concat = rg.make<v0::Concat>(new_shape_inputs, 0);
-        reshape->input(1).replace_source_output(new_concat);
-        copy_runtime_info_and_name(concat, rg.get(), {reshape});
-        return true;
+    struct PendingRewrite {
+        std::shared_ptr<v1::Reshape> reshape;
+        std::shared_ptr<v0::Concat> concat;
+        int64_t channel;
     };
+    // Ordered list replayed in phase 2; the map gives the resolver O(1) lookup of an already-selected
+    // upstream Reshape's channel (so the second window-reverse view resolves through the permute).
+    std::vector<PendingRewrite> pending;
+    std::unordered_map<const Node*, int64_t> pending_channel;
 
-    auto m = std::make_shared<Matcher>(reshape_pattern, "ov::frontend::pytorch::pass::ReshapeBatchDimResolver");
-    this->register_matcher(m, callback);
-};
+    // PHASE 1 -- COLLECT. get_ordered_ops() is topological (producers before consumers), so the first
+    // window-reverse view is recorded before the second one is examined, letting the second resolve its
+    // channel through the recorded first.
+    for (const auto& op : model->get_ordered_ops()) {
+        auto reshape = ov::as_type_ptr<v1::Reshape>(op);
+        if (!reshape)
+            continue;
+        auto concat = ov::as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
+        if (!concat)
+            continue;
+        if (!passes_structural_gates(reshape, concat))
+            continue;
+
+        std::unordered_set<const Node*> visited;
+        const auto channel = resolve_static_last_dim(reshape->input_value(0), pending_channel, visited);
+        if (!channel)
+            continue;
+
+        // Value-preservation guard: if the reshape's inferred output channel is statically known it must
+        // equal the recovered channel (the value the rewrite pins `-1` to). If they differ the `-1`
+        // resolves to a different product and the rewrite would corrupt the result, so skip it. This is
+        // the safety net that closes adversarial cases where a last-axis-preserving walk-back reaches a
+        // statically-shaped tensor whose last dim is not the reshape's true `-1` product.
+        const auto& out_ps = reshape->get_output_partial_shape(0);
+        if (out_ps.rank().is_static() && out_ps.size() > 0) {
+            const auto& out_last = out_ps[static_cast<std::ptrdiff_t>(out_ps.size()) - 1];
+            if (out_last.is_static() && out_last.get_length() != *channel)
+                continue;
+        }
+
+        pending.push_back({reshape, concat, *channel});
+        pending_channel.emplace(reshape.get(), *channel);
+    }
+
+    // PHASE 2 -- REWRITE.
+    for (const auto& entry : pending)
+        rewrite_reshape(entry.reshape, entry.concat, entry.channel);
+
+    return !pending.empty();
+}
 
 }  // namespace pass
 }  // namespace pytorch

--- a/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.cpp
+++ b/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.cpp
@@ -1,0 +1,150 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "reshape_batch_dim_resolver.hpp"
+
+#include <memory>
+
+#include "openvino/core/graph_util.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace pass {
+
+using namespace ov::op;
+using namespace ov::pass::pattern;
+
+namespace {
+// True if `out` is a Constant holding a single element equal to `value`.
+bool is_scalar_constant_with_value(const Output<Node>& out, int64_t value) {
+    auto constant = ov::as_type_ptr<v0::Constant>(out.get_node_shared_ptr());
+    if (!constant)
+        return false;
+    if (shape_size(constant->get_shape()) != 1)
+        return false;
+    const auto values = constant->cast_vector<int64_t>();
+    return values.size() == 1 && values[0] == value;
+}
+
+// True if `out` is a Constant holding a single positive integer.
+bool is_scalar_positive_constant(const Output<Node>& out) {
+    auto constant = ov::as_type_ptr<v0::Constant>(out.get_node_shared_ptr());
+    if (!constant)
+        return false;
+    if (shape_size(constant->get_shape()) != 1)
+        return false;
+    const auto values = constant->cast_vector<int64_t>();
+    return values.size() == 1 && values[0] > 0;
+}
+}  // namespace
+
+ReshapeBatchDimResolver::ReshapeBatchDimResolver() {
+    // Match `Reshape(data, Concat(...))`: the offending view-shape is always built as a Concat
+    // (see get_input_concat_if_list); a fully const-folded shape has no propagation problem.
+    const auto concat_pattern = wrap_type<v0::Concat>();
+    const auto reshape_pattern = wrap_type<v1::Reshape>({any_input(), concat_pattern});
+
+    ov::matcher_pass_callback callback = [=](Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto reshape = ov::as_type_ptr<v1::Reshape>(pattern_map.at(reshape_pattern).get_node_shared_ptr());
+        auto concat = ov::as_type_ptr<v0::Concat>(pattern_map.at(concat_pattern).get_node_shared_ptr());
+        if (!reshape || !concat)
+            return false;
+
+        // Only the standard frozen-batch shape: special_zero must be false (a 0 already means
+        // "copy dim", which this rewrite would conflict with) and the shape concat is on axis 0.
+        if (reshape->get_special_zero())
+            return false;
+        if (concat->get_axis() != 0)
+            return false;
+
+        const auto& shape_inputs = concat->input_values();
+        // Need a leading batch dim, at least one interior dim, and a trailing channel slot.
+        if (shape_inputs.size() < 3)
+            return false;
+
+        // Leading element must be a baked positive-int batch constant (e.g. the traced 1).
+        if (!is_scalar_positive_constant(shape_inputs.front()))
+            return false;
+
+        // The infer slot (-1) must be unique and sit in the LAST (channel) position. This is the
+        // window-reverse signature and excludes ordinary reshapes whose -1 is elsewhere/absent.
+        const size_t channel_idx = shape_inputs.size() - 1;
+        if (!is_scalar_constant_with_value(shape_inputs.back(), -1))
+            return false;
+        for (size_t i = 0; i + 1 < shape_inputs.size(); ++i) {
+            if (is_scalar_constant_with_value(shape_inputs[i], -1))
+                return false;  // more than one -1 -> ambiguous, not our pattern
+        }
+
+        // At least one interior dimension (between batch and channel) must be dynamic, i.e. a
+        // genuine shape expression. A fully-constant shape vector is never a propagation bug.
+        bool has_dynamic_interior = false;
+        for (size_t i = 1; i < channel_idx; ++i) {
+            if (!ov::as_type_ptr<v0::Constant>(shape_inputs[i].get_node_shared_ptr())) {
+                has_dynamic_interior = true;
+                break;
+            }
+        }
+        if (!has_dynamic_interior)
+            return false;
+
+        // The batch must be dynamic for the frozen leading constant to be wrong. After
+        // conversion the PyTorch decoder makes parameter dims dynamic, so this holds for the
+        // traced model while excluding genuinely static reshapes.
+        const auto& data = reshape->input_value(0);
+        const auto& data_ps = data.get_partial_shape();
+        if (data_ps.rank().is_static() && data_ps[0].is_static())
+            return false;
+
+        // Rebuild the shape vector for THIS reshape's own data (the concat may be shared between
+        // blocks, so we must not edit it in place):
+        //   leading batch  -> -1          (inferred from the real element count)
+        //   channel (-1)    -> Gather(ShapeOf(data), last)  (data's last dim, == the channel)
+        ov::pass::NodeRegistry rg;
+        const auto shape_of = rg.make<v3::ShapeOf>(data, element::i32);
+        const auto last_index = v0::Constant::create(element::i32, Shape{1}, {-1});
+        const auto gather_axis = v0::Constant::create(element::i32, Shape{}, {0});
+        const auto channel_dim = rg.make<v8::Gather>(shape_of, last_index, gather_axis);
+
+        const auto& channel_et = concat->input_value(channel_idx).get_element_type();
+        Output<Node> channel_out = channel_dim;
+        if (channel_et.is_static() && channel_et != element::i32)
+            channel_out = rg.make<v0::Convert>(channel_dim, channel_et);
+
+        const auto& batch_et = shape_inputs.front().get_element_type();
+        const auto minus_one =
+            rg.make<v0::Constant>(batch_et.is_static() ? batch_et : element::i64, Shape{1}, std::vector<int64_t>{-1});
+
+        OutputVector new_shape_inputs;
+        new_shape_inputs.reserve(shape_inputs.size());
+        new_shape_inputs.push_back(minus_one);
+        for (size_t i = 1; i < channel_idx; ++i)
+            new_shape_inputs.push_back(shape_inputs[i]);
+        new_shape_inputs.push_back(channel_out);
+
+        const auto new_concat = rg.make<v0::Concat>(new_shape_inputs, 0);
+        reshape->input(1).replace_source_output(new_concat);
+        copy_runtime_info_and_name(concat, rg.get(), {reshape});
+        return true;
+    };
+
+    auto m = std::make_shared<Matcher>(reshape_pattern, "ov::frontend::pytorch::pass::ReshapeBatchDimResolver");
+    this->register_matcher(m, callback);
+};
+
+}  // namespace pass
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.cpp
+++ b/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.cpp
@@ -17,6 +17,7 @@
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/pass/node_registry.hpp"
+#include "transformations/utils/utils.hpp"
 #include "utils.hpp"
 
 namespace ov {
@@ -29,24 +30,24 @@ using namespace ov::op;
 namespace {
 // True if `out` is a Constant holding a single element equal to `value`.
 bool is_scalar_constant_with_value(const Output<Node>& out, int64_t value) {
-    auto constant = ov::as_type_ptr<v0::Constant>(out.get_node_shared_ptr());
-    if (!constant)
-        return false;
-    if (shape_size(constant->get_shape()) != 1)
-        return false;
-    const auto values = constant->cast_vector<int64_t>();
-    return values.size() == 1 && values[0] == value;
+    return ov::op::util::has_constant_value<int64_t>(out.get_node_shared_ptr(), value);
 }
 
 // True if `out` is a Constant holding a single positive integer.
 bool is_scalar_positive_constant(const Output<Node>& out) {
-    auto constant = ov::as_type_ptr<v0::Constant>(out.get_node_shared_ptr());
-    if (!constant)
-        return false;
-    if (shape_size(constant->get_shape()) != 1)
-        return false;
-    const auto values = constant->cast_vector<int64_t>();
-    return values.size() == 1 && values[0] > 0;
+    int64_t value = 0;
+    return ov::op::util::get_constant_value<int64_t>(out.get_node_shared_ptr(), value) && value > 0;
+}
+
+// The statically-known last dimension of `ps`, or nullopt when the rank is dynamic, the shape is a
+// scalar, or the last dimension itself is dynamic.
+std::optional<int64_t> static_last_dim(const PartialShape& ps) {
+    if (ps.rank().is_dynamic() || ps.size() == 0)
+        return std::nullopt;
+    const auto& last = ps[static_cast<std::ptrdiff_t>(ps.size()) - 1];
+    if (last.is_static())
+        return last.get_length();
+    return std::nullopt;
 }
 
 // Structural signature of a window-reverse style view whose leading batch was frozen by tracing.
@@ -110,12 +111,8 @@ std::optional<int64_t> resolve_static_last_dim(const Output<Node>& data,
         return std::nullopt;
 
     // Step 1: a statically-known last dimension on `data` itself.
-    const auto& ps = data.get_partial_shape();
-    if (ps.rank().is_static() && ps.size() > 0) {
-        const auto& last = ps[static_cast<std::ptrdiff_t>(ps.size()) - 1];
-        if (last.is_static())
-            return last.get_length();
-    }
+    if (const auto last = static_last_dim(data.get_partial_shape()))
+        return last;
 
     // Step 2: a last-axis-preserving Transpose -> recurse into the transposed data.
     if (auto transpose = ov::as_type_ptr<v1::Transpose>(data.get_node_shared_ptr())) {
@@ -284,12 +281,9 @@ bool ReshapeBatchDimResolver::run_on_model(const std::shared_ptr<ov::Model>& mod
         // resolves to a different product and the rewrite would corrupt the result, so skip it. This is
         // the safety net that closes adversarial cases where a last-axis-preserving walk-back reaches a
         // statically-shaped tensor whose last dim is not the reshape's true `-1` product.
-        const auto& out_ps = reshape->get_output_partial_shape(0);
-        if (out_ps.rank().is_static() && out_ps.size() > 0) {
-            const auto& out_last = out_ps[static_cast<std::ptrdiff_t>(out_ps.size()) - 1];
-            if (out_last.is_static() && out_last.get_length() != *channel)
-                continue;
-        }
+        const auto out_last = static_last_dim(reshape->get_output_partial_shape(0));
+        if (out_last && *out_last != *channel)
+            continue;
 
         // Stronger guard for the DIRECT path (channel recovered from data's OWN static last dim). When the
         // output last dim is dynamic the cheap guard above is vacuous, so an ordinary reshape whose `-1`
@@ -298,9 +292,7 @@ bool ReshapeBatchDimResolver::run_on_model(const std::shared_ptr<ov::Model>& mod
         // re-partition data's leading dim and keep data's entire trailing block (the genuine window-reverse
         // semantics). The walk-back path (data last dim dynamic -- the second view) is exempt: its channel
         // is resolved structurally through the permute to an already-validated upstream view.
-        const auto& data_ps = reshape->input_value(0).get_partial_shape();
-        const bool direct_path = data_ps.rank().is_static() && data_ps.size() > 0 &&
-                                 data_ps[static_cast<std::ptrdiff_t>(data_ps.size()) - 1].is_static();
+        const bool direct_path = static_last_dim(reshape->input_value(0).get_partial_shape()).has_value();
         if (direct_path && !keeps_data_trailing_block(reshape, concat, *channel))
             continue;
 

--- a/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.cpp
+++ b/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.cpp
@@ -4,6 +4,7 @@
 
 #include "reshape_batch_dim_resolver.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -141,6 +142,55 @@ std::optional<int64_t> resolve_static_last_dim(const Output<Node>& data,
     return std::nullopt;
 }
 
+// Value-preservation guard for the DIRECT path (the channel was recovered from the reshape's own data
+// last dimension, i.e. data's last dim is static). Pinning the trailing `-1` to data's last dim and
+// freeing the leading dim to `-1` is value-preserving ONLY when the rewrite merely re-partitions data's
+// leading dimension and keeps data's entire trailing block intact -- exactly the first window-reverse view
+// (`data [?,8,8,180]` -> `[B, H//ws, W//ws, 8, 8, 180]`, whose output trailing dims `[8,8,180]` equal data's
+// trailing dims). It is NOT value-preserving for ordinary reshapes whose `-1` spans more than data's last
+// dim, e.g. a head-merge `Linear(D,D)` then `view(1, T//2, -1)` on data `[?,?,D]` (here `-1 == 2*D != D`):
+// those corrupt the result even at the traced batch. We require: data rank >= 2 and static; the shape
+// vector has at least one leading dim to absorb the freed batch (size >= data rank); and its trailing
+// (rank-1) elements statically equal data's dims [1 .. rank-1] (constant kept dims match data's static
+// dims; the trailing `-1` channel matches data's static last dim). When this cannot be proven the rewrite
+// is skipped. (The walk-back path -- the second window-reverse view, whose data is the fully dynamic
+// permuted output of the first view -- does not take this guard; its channel is resolved structurally
+// through a last-axis-preserving transpose to an already-validated upstream view.)
+bool keeps_data_trailing_block(const std::shared_ptr<v1::Reshape>& reshape,
+                               const std::shared_ptr<v0::Concat>& concat,
+                               int64_t channel) {
+    const auto& data_ps = reshape->input_value(0).get_partial_shape();
+    if (data_ps.rank().is_dynamic())
+        return false;
+    const int64_t rank = data_ps.rank().get_length();
+    if (rank < 2)
+        return false;
+
+    const auto& shape_inputs = concat->input_values();
+    const auto m = static_cast<int64_t>(shape_inputs.size());
+    // Need at least one leading dim (beyond the preserved trailing block) to absorb the freed batch.
+    if (m < rank)
+        return false;
+
+    // The last (rank-1) shape elements must map to data dims [1 .. rank-1]; element at index
+    // (m - rank + j) corresponds to data dim j.
+    for (int64_t j = 1; j < rank; ++j) {
+        const auto& data_dim = data_ps[static_cast<std::ptrdiff_t>(j)];
+        if (data_dim.is_dynamic())
+            return false;
+        const auto& shape_elem = shape_inputs[static_cast<size_t>(m - rank + j)];
+        if (j == rank - 1) {
+            // The trailing channel slot (the `-1`) is pinned to `channel`; it must equal data's last dim.
+            if (channel != data_dim.get_length())
+                return false;
+        } else if (!is_scalar_constant_with_value(shape_elem, data_dim.get_length())) {
+            // A kept interior dim must be a constant equal to data's corresponding (static) dim.
+            return false;
+        }
+    }
+    return true;
+}
+
 // Rebuild the shape vector for THIS reshape's own data (the concat may be shared between blocks, so we
 // must not edit it in place):
 //   leading batch -> -1                       (inferred from the real element count)
@@ -179,6 +229,25 @@ void rewrite_reshape(const std::shared_ptr<v1::Reshape>& reshape,
 }  // namespace
 
 bool ReshapeBatchDimResolver::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    // Cheap structural pre-scan: the structural gates inspect only the shape Concat's axis and constant
+    // elements -- never an inferred PartialShape -- so they need no shape inference. If no reshape carries
+    // the window-reverse signature (the common case for the vast majority of converted models) we return
+    // immediately, skipping the full-model validation below entirely.
+    const auto matches_signature = [](const std::shared_ptr<Node>& op) {
+        auto reshape = ov::as_type_ptr<v1::Reshape>(op);
+        if (!reshape)
+            return false;
+        auto concat = ov::as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
+        return concat && passes_structural_gates(reshape, concat);
+    };
+    const auto& ordered_ops = model->get_ordered_ops();
+    if (std::none_of(ordered_ops.begin(), ordered_ops.end(), matches_signature))
+        return false;
+
+    // A candidate exists: make sure the shapes the walk-back keys on (a statically-known data last
+    // dimension, e.g. [?,8,8,180]) are materialized before resolving. In the normalize() pipeline the
+    // preceding pass already triggers a Validate, but this keeps the pass self-contained and correct if it
+    // is ever run standalone or after a non-validating pass.
     model->validate_nodes_and_infer_types();
 
     struct PendingRewrite {
@@ -191,10 +260,11 @@ bool ReshapeBatchDimResolver::run_on_model(const std::shared_ptr<ov::Model>& mod
     std::vector<PendingRewrite> pending;
     std::unordered_map<const Node*, int64_t> pending_channel;
 
-    // PHASE 1 -- COLLECT. get_ordered_ops() is topological (producers before consumers), so the first
+    // PHASE 1 -- COLLECT. ordered_ops is topological (producers before consumers), so the first
     // window-reverse view is recorded before the second one is examined, letting the second resolve its
-    // channel through the recorded first.
-    for (const auto& op : model->get_ordered_ops()) {
+    // channel through the recorded first. validate_nodes_and_infer_types() above only re-inferred shapes
+    // on these same nodes; it did not change the node set, so the captured order is still valid.
+    for (const auto& op : ordered_ops) {
         auto reshape = ov::as_type_ptr<v1::Reshape>(op);
         if (!reshape)
             continue;
@@ -220,6 +290,19 @@ bool ReshapeBatchDimResolver::run_on_model(const std::shared_ptr<ov::Model>& mod
             if (out_last.is_static() && out_last.get_length() != *channel)
                 continue;
         }
+
+        // Stronger guard for the DIRECT path (channel recovered from data's OWN static last dim). When the
+        // output last dim is dynamic the cheap guard above is vacuous, so an ordinary reshape whose `-1`
+        // spans more than data's last dim (e.g. `Linear(D,D)` then `view(1, T//2, -1)`, `-1 == 2*D`) would
+        // slip through and corrupt the result even at the traced batch. Require the rewrite to merely
+        // re-partition data's leading dim and keep data's entire trailing block (the genuine window-reverse
+        // semantics). The walk-back path (data last dim dynamic -- the second view) is exempt: its channel
+        // is resolved structurally through the permute to an already-validated upstream view.
+        const auto& data_ps = reshape->input_value(0).get_partial_shape();
+        const bool direct_path = data_ps.rank().is_static() && data_ps.size() > 0 &&
+                                 data_ps[static_cast<std::ptrdiff_t>(data_ps.size()) - 1].is_static();
+        if (direct_path && !keeps_data_trailing_block(reshape, concat, *channel))
+            continue;
 
         pending.push_back({reshape, concat, *channel});
         pending_channel.emplace(reshape.get(), *channel);

--- a/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.hpp
+++ b/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.hpp
@@ -32,6 +32,17 @@ namespace pass {
 /// rewritten shape reproduces the original element count; after `model.reshape` it tracks the real
 /// batch.
 ///
+/// Two value-preservation guards keep the rewrite from corrupting ordinary reshapes that happen to
+/// share the structural signature:
+///   1. If the reshape's output last dim is statically known, it must equal the recovered channel.
+///   2. (Direct path only — the channel was recovered from the data's OWN static last dim.) When the
+///      output last dim is dynamic, guard 1 is vacuous, so a reshape whose `-1` spans more than data's
+///      last dim — e.g. `Linear(D, D)` then `view(1, T//2, -1)` (here `-1 == 2*D`, a head-merge over a
+///      static-`D` tensor with a dynamic interior) — would otherwise be rewritten and corrupt the result
+///      even at the traced batch. Guard 2 requires the rewrite to merely re-partition data's leading
+///      dimension and keep data's entire trailing block (output trailing `rank_data-1` dims equal data's
+///      trailing dims), which is exactly the window-reverse semantics and rejects merge/split reshapes.
+///
 /// This is a ModelPass rather than a MatcherPass because window-reverse uses two chained views:
 /// the second view (`view(B, H, W, -1)`) takes its data from the first view (`view(B, ..., -1)`)
 /// through a permute, so its data last dimension is dynamic at the time the pass runs and OV shape

--- a/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.hpp
+++ b/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "openvino/pass/graph_rewrite.hpp"
 #include "openvino/pass/pass.hpp"
 
 namespace ov {
@@ -12,24 +11,42 @@ namespace frontend {
 namespace pytorch {
 namespace pass {
 
-/// \brief Restores a dynamic batch dimension that tracing froze into a Reshape's shape vector.
+/// \brief Restores a dynamic batch dimension that tracing froze into a window-reverse view shape.
 ///
 /// When a model is traced with a fixed batch, a window-reverse style view such as
 /// `x.view(B, H, W, -1)` bakes `B` as a literal `Constant` in the leading position of the
-/// Reshape's shape `Concat`, while the channel dimension is the single `-1` (infer) slot.
-/// After the model batch is changed (e.g. `model.reshape({input:[2,...]})`) the leading
+/// Reshape's shape `Concat`, while the channel dimension is the single trailing `-1` (infer)
+/// slot. After the model batch is changed (e.g. `model.reshape({input:[2,...]})`) the leading
 /// constant cannot propagate the new batch, so the `-1` channel silently absorbs it and the
 /// data is mis-partitioned.
 ///
-/// This pass detects that shape `Concat` (leading positive-int constant, a single trailing
-/// `-1`, at least one dynamic interior dimension, dynamic data batch) and rebuilds it so the
-/// leading dimension becomes the `-1` (inferred from the real element count) and the former
-/// `-1` channel slot is pinned to the data tensor's last dimension via `Gather(ShapeOf(data),
-/// -1)`. The rewrite is a no-op at the traced batch and tracks the real batch afterwards.
-class ReshapeBatchDimResolver : public ov::pass::MatcherPass {
+/// The rewrite that repairs this — leading dimension becomes `-1` (inferred from the real
+/// element count) and the former `-1` channel is pinned to its (batch-independent) value as a
+/// `Constant` — is value-preserving ONLY for window-reverse views, where the restored channel
+/// provably equals the data tensor's channel dimension. The pass fires only when the matched
+/// shape `Concat` has a leading positive-int constant, exactly one trailing `-1`, at least one
+/// dynamic interior dimension, AND the channel can be recovered statically (see below). That last
+/// requirement excludes ordinary reshapes such as spatial flatten `view(1, C, -1)` or attention
+/// head-merge `view(1, N, -1)`, whose `-1` is a product of several dimensions and whose data
+/// (fed from a Parameter) has a dynamic last dim that cannot be recovered. At the traced batch the
+/// rewritten shape reproduces the original element count; after `model.reshape` it tracks the real
+/// batch.
+///
+/// This is a ModelPass rather than a MatcherPass because window-reverse uses two chained views:
+/// the second view (`view(B, H, W, -1)`) takes its data from the first view (`view(B, ..., -1)`)
+/// through a permute, so its data last dimension is dynamic at the time the pass runs and OV shape
+/// inference does NOT propagate the first view's static channel through that permute (the spatial
+/// value-bounds collapse the permuted output to fully dynamic). The pass therefore recovers the
+/// channel itself with a deterministic two-phase walk-back: COLLECT iterates the ops in topological
+/// order and, for each structurally matching reshape, recovers the channel by walking back from its
+/// data — directly if the data's last dim is static, through a last-axis-preserving `Transpose`
+/// (order ends in `rank-1`), or through a reshape already selected for rewrite — then REWRITE
+/// replays the recorded rewrites. A static-output-channel value-preservation guard rejects any case
+/// where the recovered channel disagrees with the reshape's statically inferred output channel.
+class ReshapeBatchDimResolver : public ov::pass::ModelPass {
 public:
-    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::ReshapeBatchDimResolver");
-    ReshapeBatchDimResolver();
+    OPENVINO_MODEL_PASS_RTTI("ov::frontend::pytorch::pass::ReshapeBatchDimResolver");
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
 };
 
 }  // namespace pass

--- a/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.hpp
+++ b/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.hpp
@@ -20,7 +20,45 @@ namespace pass {
 /// constant cannot propagate the new batch, so the `-1` channel silently absorbs it and the
 /// data is mis-partitioned.
 ///
-/// The rewrite that repairs this — leading dimension becomes `-1` (inferred from the real
+/// The pass rewrites the shape `Concat` that feeds the Reshape: the leading baked-batch
+/// `Constant` becomes `Constant(-1)` (so the batch is inferred from the real element count) and
+/// the trailing `-1` (infer) slot becomes `Constant(channel)` (the batch-independent channel that
+/// was baked into the data, recovered statically — see below). The interior dimensions are kept.
+///
+/// Before:
+///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
+///   │  Constant(B)  │ │   <interior> │ │   <interior> │ │ Constant(-1) │  │ data │
+///   │ leading batch │ │   (dynamic)  │ │   (dynamic)  │ │   channel    │  └──┬───┘
+///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
+///           └────────────────┴───────┬────────┴────────────────┘             │
+///                              ┌──────▼──────┐                                │
+///                              │   Concat    │ axis = 0                       │
+///                              │ (view shape)│                                │
+///                              └──────┬──────┘                                │
+///                                     └─────────────────┬─────────────────────┘
+///                                                ┌──────▼──────┐
+///                                                │   Reshape   │ special_zero = false
+///                                                └──────┬──────┘
+///                                                       ▼
+///
+/// After:
+///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
+///   │ Constant(-1)  │ │   <interior> │ │   <interior> │ │Constant(chan)│  │ data │
+///   │ leading batch │ │   (dynamic,  │ │   (dynamic,  │ │   channel    │  └──┬───┘
+///   │   (inferred)  │ │  unchanged)  │ │  unchanged)  │ │  (static)    │     │
+///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
+///           └────────────────┴───────┬────────┴────────────────┘             │
+///                              ┌──────▼──────┐                                │
+///                              │   Concat    │ axis = 0                       │
+///                              │ (view shape)│                                │
+///                              └──────┬──────┘                                │
+///                                     └─────────────────┬─────────────────────┘
+///                                                ┌──────▼──────┐
+///                                                │   Reshape   │ special_zero = false
+///                                                └──────┬──────┘
+///                                                       ▼
+///
+/// The rewrite — leading dimension becomes `-1` (inferred from the real
 /// element count) and the former `-1` channel is pinned to its (batch-independent) value as a
 /// `Constant` — is value-preserving ONLY for window-reverse views, where the restored channel
 /// provably equals the data tensor's channel dimension. The pass fires only when the matched
@@ -54,6 +92,27 @@ namespace pass {
 /// (order ends in `rank-1`), or through a reshape already selected for rewrite — then REWRITE
 /// replays the recorded rewrites. A static-output-channel value-preservation guard rejects any case
 /// where the recovered channel disagrees with the reshape's statically inferred output channel.
+///
+/// Channel recovery walk-back (the two chained window-reverse views):
+///
+///        data [?,8,8,180]                          (static last dim = 180)
+///              │
+///        ┌─────▼──────┐  Reshape_1 (1st view)   ── channel resolved DIRECTLY from data's
+///        │  Reshape   │  out [?,?,?,8,8,180]        static last dim ──────────────► 180
+///        └─────┬──────┘                                                              │
+///              │  out last dim 180 still static                                      │
+///        ┌─────▼──────┐  Transpose(order=[0,1,3,2,4,5])   last axis kept last        │
+///        │ Transpose  │  out [?,?,?,?,?,?] (fully dynamic — bounds collapse)         │
+///        └─────┬──────┘                                                              │
+///              │  data last dim now DYNAMIC                                          │
+///        ┌─────▼──────┐  Reshape_2 (2nd view)   ── channel resolved by WALK-BACK:    │
+///        │  Reshape   │  out [?,H,W,-1]            Transpose (last-axis-preserving)   │
+///        └─────┬──────┘                            then Reshape_1's recorded channel ┘
+///              ▼
+///
+/// Reshape_1 takes the DIRECT path (its own data last dim is static) and the trailing-block guard
+/// applies; Reshape_2 takes the WALK-BACK path (its data last dim is dynamic, recovered structurally
+/// through the permute) and is exempt from the trailing-block guard.
 class ReshapeBatchDimResolver : public ov::pass::ModelPass {
 public:
     OPENVINO_MODEL_PASS_RTTI("ov::frontend::pytorch::pass::ReshapeBatchDimResolver");

--- a/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.hpp
+++ b/src/frontends/pytorch/src/transforms/reshape_batch_dim_resolver.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/pass.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace pass {
+
+/// \brief Restores a dynamic batch dimension that tracing froze into a Reshape's shape vector.
+///
+/// When a model is traced with a fixed batch, a window-reverse style view such as
+/// `x.view(B, H, W, -1)` bakes `B` as a literal `Constant` in the leading position of the
+/// Reshape's shape `Concat`, while the channel dimension is the single `-1` (infer) slot.
+/// After the model batch is changed (e.g. `model.reshape({input:[2,...]})`) the leading
+/// constant cannot propagate the new batch, so the `-1` channel silently absorbs it and the
+/// data is mis-partitioned.
+///
+/// This pass detects that shape `Concat` (leading positive-int constant, a single trailing
+/// `-1`, at least one dynamic interior dimension, dynamic data batch) and rebuilds it so the
+/// leading dimension becomes the `-1` (inferred from the real element count) and the former
+/// `-1` channel slot is pinned to the data tensor's last dimension via `Gather(ShapeOf(data),
+/// -1)`. The rewrite is a no-op at the traced batch and tracks the real batch afterwards.
+class ReshapeBatchDimResolver : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::ReshapeBatchDimResolver");
+    ReshapeBatchDimResolver();
+};
+
+}  // namespace pass
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/tests/layer_tests/pytorch_tests/test_window_reverse.py
+++ b/tests/layer_tests/pytorch_tests/test_window_reverse.py
@@ -35,17 +35,25 @@ class WindowReverseModel(torch.nn.Module):
     H and W are read from the input tensor at runtime (as SwinIR does), so under tracing
     the spatial dims become dynamic `aten::size` expressions while the batch B collapses
     to a literal via `int(...)` -- reproducing the frozen-batch / dynamic-spatial Concat
-    that ReshapeBatchDimResolver must repair."""
+    that ReshapeBatchDimResolver must repair.
 
-    def __init__(self, window_size):
+    A `Linear(c_in, embed_dim)` projects to a fixed channel width before the window ops,
+    mirroring real SwinIR (which carries a static embed_dim=180 through the window blocks).
+    This makes the window_reverse channel STATIC -- the dimension the resolver recovers by
+    walking back from the view's data -- so the test exercises the same path as the model."""
+
+    def __init__(self, window_size, c_in, embed_dim):
         super().__init__()
         self.window_size = window_size
+        self.proj = torch.nn.Linear(c_in, embed_dim)
 
     def forward(self, x):
-        # x: (B, C, H, W) -> (B, H, W, C); H, W flow from the dynamic input shape.
+        # x: (B, C_in, H, W) -> (B, H, W, C_in); H, W flow from the dynamic input shape.
         H = x.shape[2]
         W = x.shape[3]
         x = x.permute(0, 2, 3, 1).contiguous()
+        # Project to a fixed embed_dim so the window channel is static, as in SwinIR.
+        x = self.proj(x)
         windows = window_partition(x, self.window_size)
         # touch the windows so the graph is non-trivial but still an identity overall
         windows = windows + 0.0
@@ -65,19 +73,19 @@ class TestWindowReverseBatchReshape:
     """
 
     @staticmethod
-    def _convert_batch1(window_size, H, W, C):
-        model = WindowReverseModel(window_size).eval()
+    def _convert_batch1(window_size, H, W, C, embed_dim):
+        model = WindowReverseModel(window_size, C, embed_dim).eval()
         example = torch.randn(1, C, H, W)
         with torch.no_grad():
             om = convert_model(model, example_input=example)
         return model, om
 
-    @pytest.mark.parametrize("window_size,H,W,C", [(8, 16, 16, 6), (4, 12, 8, 3)])
+    @pytest.mark.parametrize("window_size,H,W,C,embed_dim", [(8, 16, 16, 6, 12), (4, 12, 8, 3, 8)])
     @pytest.mark.parametrize("batch", [1, 2, 3])
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_window_reverse_rebatch(self, window_size, H, W, C, batch, ie_device, precision):
-        model, om = self._convert_batch1(window_size, H, W, C)
+    def test_window_reverse_rebatch(self, window_size, H, W, C, embed_dim, batch, ie_device, precision):
+        model, om = self._convert_batch1(window_size, H, W, C, embed_dim)
 
         # Reshape the converted (traced-at-batch-1) model to the target batch.
         om.reshape({om.input(0): PartialShape([batch, C, H, W])})
@@ -98,15 +106,15 @@ class TestWindowReverseBatchReshape:
         max_abs = float(np.abs(ov_out - ref).max())
         assert n_bad == 0, f"accuracy failed: {n_bad} mismatches, max_abs_diff={max_abs}"
 
-    @pytest.mark.parametrize("window_size,H,W,C", [(8, 16, 16, 6)])
+    @pytest.mark.parametrize("window_size,H,W,C,embed_dim", [(8, 16, 16, 6, 12)])
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_window_reverse_pass_fired(self, window_size, H, W, C, ie_device, precision):
+    def test_window_reverse_pass_fired(self, window_size, H, W, C, embed_dim, ie_device, precision):
         """Structural check: ReshapeBatchDimResolver must rebuild every window_reverse
         view shape so no Reshape keeps a frozen positive-int leading constant alongside a
         single trailing -1 (the baked-batch signature). Device/precision-independent
         (ie_device/precision are accepted only to satisfy the shared parametrization)."""
-        _, om = self._convert_batch1(window_size, H, W, C)
+        _, om = self._convert_batch1(window_size, H, W, C, embed_dim)
 
         offenders = []
         for node in om.get_ordered_ops():
@@ -163,4 +171,94 @@ class TestPlainReshapeNotAffected:
         compiled = Core().compile_model(om, ie_device, config)
         ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
         eps = 1e-4 if precision == "FP32" else 5e-2
+        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()
+
+
+def _has_rewritten_reshape(om):
+    """Return True if any Reshape in `om` was rewritten by ReshapeBatchDimResolver. The pass
+    turns the leading baked-batch Constant into a Constant(-1) and pins the former trailing -1
+    channel to a Constant holding data's (static) last dimension, i.e. a positive value. So the
+    fingerprint is a shape Concat whose leading element is Constant(-1) and whose last element is
+    a positive Constant -- the inverse of the offending baked pattern."""
+    for node in om.get_ordered_ops():
+        if node.get_type_info().name != "Reshape":
+            continue
+        shape_src = node.input_value(1).get_node()
+        if shape_src.get_type_info().name != "Concat":
+            continue
+        elems = [shape_src.input_value(i).get_node() for i in range(len(shape_src.inputs()))]
+        if len(elems) < 2:
+            continue
+
+        def const_scalar(n):
+            if n.get_type_info().name != "Constant":
+                return None
+            vals = n.data.flatten()
+            return int(vals[0]) if vals.size == 1 else None
+
+        lead = const_scalar(elems[0])
+        last = const_scalar(elems[-1])
+        if lead == -1 and last is not None and last > 0:
+            return True
+    return False
+
+
+class TestReshapeFalsePositiveNotFired:
+    """Negative tests for ReshapeBatchDimResolver over-matching.
+
+    These models contain the exact structural signature the pass keys on -- a literal leading
+    batch constant, a dynamic interior dim from the input shape, and a single trailing -1 built
+    as a Concat under TorchScript tracing. But the -1 here means "product of the remaining
+    dimensions" (H*W, or heads*head_dim), which is NOT the data tensor's last dimension. The
+    earlier (loose) pass rewrote the channel to Gather(ShapeOf(data), -1) and corrupted the output
+    even at the traced batch=1. The hardened predicate must leave these untouched: data's last
+    dimension is dynamic (it comes straight from a Parameter), so the static-last-dim gate excludes
+    them. We assert BOTH that the pass did not rewrite the Reshape (structural) and that batch=1
+    output matches torch (numeric -- catches the traced-batch corruption)."""
+
+    class SpatialFlatten(torch.nn.Module):
+        # x: (B, C, H, W); reshape(1, C, -1) -> -1 == H*W, NOT data's last dim (W).
+        def forward(self, x):
+            C = x.shape[1]
+            return x.reshape(1, C, -1)
+
+    class AttnHeadMerge(torch.nn.Module):
+        # x: (1, heads, N, head_dim); after transpose, reshape(1, N, -1) -> -1 == heads*head_dim,
+        # NOT data's last dim (head_dim). The classic attention output merge.
+        def forward(self, x):
+            N = x.shape[2]
+            x = x.transpose(1, 2)
+            return x.reshape(1, N, -1)
+
+    @pytest.mark.parametrize(
+        "model_cls,shape",
+        [
+            (SpatialFlatten, (1, 3, 4, 5)),
+            (AttnHeadMerge, (1, 4, 6, 8)),
+        ],
+    )
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_false_positive_not_fired(self, model_cls, shape, ie_device, precision):
+        model = model_cls().eval()
+        example = torch.randn(*shape)
+        with torch.no_grad():
+            om = convert_model(model, example_input=example)
+
+        # Structural: the pass must NOT have rewritten this ordinary reshape.
+        assert not _has_rewritten_reshape(om), (
+            f"{model_cls.__name__}: ReshapeBatchDimResolver fired on an ordinary reshape"
+        )
+
+        # Numeric at the traced batch: the loose pass corrupted the result even here.
+        np_in = np.random.randn(*shape).astype(np.float32)
+        with torch.no_grad():
+            ref = model(torch.from_numpy(np_in)).numpy()
+        config = {}
+        if precision == "FP32":
+            config[hints.inference_precision] = Type.f32
+        compiled = Core().compile_model(om, ie_device, config)
+        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
+        eps = 1e-4 if precision == "FP32" else 5e-2
+        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
         assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()

--- a/tests/layer_tests/pytorch_tests/test_window_reverse.py
+++ b/tests/layer_tests/pytorch_tests/test_window_reverse.py
@@ -262,3 +262,212 @@ class TestReshapeFalsePositiveNotFired:
         eps = 1e-4 if precision == "FP32" else 5e-2
         assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
         assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()
+
+
+class TestReshapeResolverBatch1Safety:
+    """The pass runs in normalize() on EVERY converted PyTorch model, so it must never
+    change the result at the traced batch. These models have the structural signature
+    the pass keys on -- a literal leading batch constant, a dynamic interior dim, a
+    single trailing -1 -- AND a STATIC data last dim (from a Linear), but the trailing
+    -1 spans MORE than data's last dimension, so pinning the channel to data's last dim
+    and freeing the batch would corrupt the output even at batch=1.
+
+    A `Linear(D, D)` gives a static last dim D; `reshape(1, T//2, -1)` makes -1 == 2*D
+    (a head-merge) and `reshape(1, T*2, -1)` makes -1 == D//2 (a head-split). The
+    earlier guard (output-channel-static) is vacuous here because the output last dim is
+    DYNAMIC, so without the trailing-block guard the pass fired and corrupted batch=1.
+    The hardened pass must NOT rewrite these and must match torch at the traced batch."""
+
+    class HeadMerge(torch.nn.Module):
+        def __init__(self, d):
+            super().__init__()
+            self.proj = torch.nn.Linear(d, d)
+
+        def forward(self, x):
+            # x: (B, T, D) with T even. -1 == 2*D, data last dim == D. interior T//2 dynamic.
+            x = self.proj(x)
+            T = x.shape[1]
+            return x.reshape(1, T // 2, -1)
+
+    class HeadSplit(torch.nn.Module):
+        def __init__(self, d):
+            super().__init__()
+            self.proj = torch.nn.Linear(d, d)
+
+        def forward(self, x):
+            # x: (B, T, D) with D even. -1 == D//2, data last dim == D. interior T*2 dynamic.
+            x = self.proj(x)
+            T = x.shape[1]
+            return x.reshape(1, T * 2, -1)
+
+    @pytest.mark.parametrize("model_cls,shape,d", [(HeadMerge, (1, 4, 8), 8), (HeadSplit, (1, 4, 8), 8)])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_traced_batch_not_corrupted(self, model_cls, shape, d, ie_device, precision):
+        model = model_cls(d).eval()
+        example = torch.randn(*shape)
+        with torch.no_grad():
+            om = convert_model(model, example_input=example)
+
+        # Structural: the trailing-block guard must reject these -- the pass must not fire.
+        assert not _has_rewritten_reshape(om), (
+            f"{model_cls.__name__}: ReshapeBatchDimResolver fired on an ordinary reshape"
+        )
+
+        np_in = np.random.randn(*shape).astype(np.float32)
+        with torch.no_grad():
+            ref = model(torch.from_numpy(np_in)).numpy()
+        config = {}
+        if precision == "FP32":
+            config[hints.inference_precision] = Type.f32
+        compiled = Core().compile_model(om, ie_device, config)
+        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
+        eps = 1e-4 if precision == "FP32" else 5e-2
+        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
+        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()
+
+
+class TestReshapeResolverIdempotent:
+    """The rewrite turns the leading baked-batch Constant into Constant(-1). Re-running
+    conversion (and thus the pass) must not re-fire or otherwise change the structure:
+    a Constant(-1) leading element fails the positive-int leading gate, so the pass is a
+    fixed point. Converting twice must yield the same rewrite fingerprint exactly once."""
+
+    @pytest.mark.parametrize("window_size,H,W,C,embed_dim", [(8, 16, 16, 6, 12)])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_idempotent(self, window_size, H, W, C, embed_dim, ie_device, precision):
+        def convert():
+            m = WindowReverseModel(window_size, C, embed_dim).eval()
+            example = torch.randn(1, C, H, W)
+            with torch.no_grad():
+                return convert_model(m, example_input=example)
+
+        om1 = convert()
+        om2 = convert()
+        # The fix fired on both conversions (the rewrite fingerprint is present)...
+        assert _has_rewritten_reshape(om1)
+        assert _has_rewritten_reshape(om2)
+        # ...and produced the SAME count of rewritten reshapes (no double-fire / drift).
+        def count_rewrites(om):
+            n = 0
+            for node in om.get_ordered_ops():
+                if node.get_type_info().name != "Reshape":
+                    continue
+                src = node.input_value(1).get_node()
+                if src.get_type_info().name != "Concat":
+                    continue
+                elems = [src.input_value(i).get_node() for i in range(len(src.inputs()))]
+                if len(elems) < 2:
+                    continue
+
+                def cs(n):
+                    if n.get_type_info().name != "Constant":
+                        return None
+                    v = n.data.flatten()
+                    return int(v[0]) if v.size == 1 else None
+
+                if cs(elems[0]) == -1 and (cs(elems[-1]) or 0) > 0:
+                    n += 1
+            return n
+
+        assert count_rewrites(om1) == count_rewrites(om2), "rewrite count differs across conversions"
+
+
+class TestWindowReverseDynamicChannel:
+    """Coverage-boundary test: when the window channel is DYNAMIC (no projection to a
+    fixed embed_dim -- the channel flows from the input), the resolver cannot recover
+    the channel by walking back to a static last dim, so the pass deliberately does NOT
+    fire. This documents the (intended) scope of the static-channel resolver: it fixes
+    the SwinIR case (static embed_dim) and leaves dynamic-channel reshapes untouched.
+    The traced batch=1 must still be correct (the pass is a no-op here)."""
+
+    class DynChannel(torch.nn.Module):
+        def __init__(self, window_size):
+            super().__init__()
+            self.window_size = window_size
+
+        def forward(self, x):
+            H = x.shape[2]
+            W = x.shape[3]
+            x = x.permute(0, 2, 3, 1).contiguous()  # (B,H,W,C), C dynamic from input
+            windows = window_partition(x, self.window_size)
+            windows = windows + 0.0
+            x = window_reverse(windows, self.window_size, H, W)
+            return x.permute(0, 3, 1, 2).contiguous()
+
+    @pytest.mark.parametrize("window_size,H,W,C", [(8, 16, 16, 6)])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_dynamic_channel_not_fired_and_b1_ok(self, window_size, H, W, C, ie_device, precision):
+        model = self.DynChannel(window_size).eval()
+        example = torch.randn(1, C, H, W)
+        with torch.no_grad():
+            om = convert_model(model, example_input=example)
+
+        # The resolver must not fire (channel is dynamic -> not statically recoverable).
+        assert not _has_rewritten_reshape(om), "resolver fired on a dynamic-channel window reverse"
+
+        np_in = np.random.randn(1, C, H, W).astype(np.float32)
+        with torch.no_grad():
+            ref = model(torch.from_numpy(np_in)).numpy()
+        config = {}
+        if precision == "FP32":
+            config[hints.inference_precision] = Type.f32
+        compiled = Core().compile_model(om, ie_device, config)
+        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
+        eps = 1e-4 if precision == "FP32" else 5e-2
+        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
+        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()
+
+
+class TestWindowReverseWalkBackFragility:
+    """The walk-back crosses exactly one last-axis-preserving Transpose. If an extra
+    last-axis-CHANGING permute sits between the two window_reverse views, the second
+    view's channel cannot be resolved through it. Whatever the pass does in that case,
+    it must remain correct at the traced batch=1 (it may legitimately skip the second
+    view). This pins the safety property: the pass never corrupts the traced batch even
+    when its structural assumption is perturbed."""
+
+    class Fragile(torch.nn.Module):
+        def __init__(self, window_size, c_in, embed_dim):
+            super().__init__()
+            self.window_size = window_size
+            self.proj = torch.nn.Linear(c_in, embed_dim)
+
+        def forward(self, x):
+            ws = self.window_size
+            H = x.shape[2]
+            W = x.shape[3]
+            x = x.permute(0, 2, 3, 1).contiguous()
+            x = self.proj(x)
+            windows = window_partition(x, ws)
+            windows = windows + 0.0
+            B = int(windows.shape[0] / (H * W / ws / ws))
+            v = windows.view(B, H // ws, W // ws, ws, ws, -1)
+            v = v.permute(0, 1, 3, 2, 4, 5).contiguous()
+            # extra last-axis-changing twist (transpose last two axes, then back):
+            v = v.transpose(-1, -2).contiguous().transpose(-1, -2).contiguous()
+            v = v.view(B, H, W, -1)
+            return v.permute(0, 3, 1, 2).contiguous()
+
+    @pytest.mark.parametrize("window_size,H,W,C,embed_dim", [(8, 16, 16, 6, 12)])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_fragile_walkback_b1_ok(self, window_size, H, W, C, embed_dim, ie_device, precision):
+        model = self.Fragile(window_size, C, embed_dim).eval()
+        example = torch.randn(1, C, H, W)
+        with torch.no_grad():
+            om = convert_model(model, example_input=example)
+
+        np_in = np.random.randn(1, C, H, W).astype(np.float32)
+        with torch.no_grad():
+            ref = model(torch.from_numpy(np_in)).numpy()
+        config = {}
+        if precision == "FP32":
+            config[hints.inference_precision] = Type.f32
+        compiled = Core().compile_model(om, ie_device, config)
+        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
+        eps = 1e-4 if precision == "FP32" else 5e-2
+        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
+        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()

--- a/tests/layer_tests/pytorch_tests/test_window_reverse.py
+++ b/tests/layer_tests/pytorch_tests/test_window_reverse.py
@@ -1,0 +1,166 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+
+from openvino import Core, PartialShape, convert_model
+import openvino.properties.hint as hints
+from openvino import Type
+
+
+def window_partition(x, window_size):
+    # x: (B, H, W, C) -> (num_windows*B, window_size, window_size, C)
+    B, H, W, C = x.shape
+    x = x.view(B, H // window_size, window_size, W // window_size, window_size, C)
+    windows = x.permute(0, 1, 3, 2, 4, 5).contiguous().view(-1, window_size, window_size, C)
+    return windows
+
+
+def window_reverse(windows, window_size, H, W):
+    # Mirrors SwinIR/Swin window_reverse: B is computed via int(...), which a tracer
+    # bakes into a literal constant in the view shape -- the source of the batch bug.
+    B = int(windows.shape[0] / (H * W / window_size / window_size))
+    x = windows.view(B, H // window_size, W // window_size, window_size, window_size, -1)
+    x = x.permute(0, 1, 3, 2, 4, 5).contiguous().view(B, H, W, -1)
+    return x
+
+
+class WindowReverseModel(torch.nn.Module):
+    """A round-trip through window_partition/window_reverse, exactly the structure that
+    produces the frozen-batch view shapes in SwinIR. The identity round-trip lets us
+    compare against a trivially-correct reference at any batch size.
+
+    H and W are read from the input tensor at runtime (as SwinIR does), so under tracing
+    the spatial dims become dynamic `aten::size` expressions while the batch B collapses
+    to a literal via `int(...)` -- reproducing the frozen-batch / dynamic-spatial Concat
+    that ReshapeBatchDimResolver must repair."""
+
+    def __init__(self, window_size):
+        super().__init__()
+        self.window_size = window_size
+
+    def forward(self, x):
+        # x: (B, C, H, W) -> (B, H, W, C); H, W flow from the dynamic input shape.
+        H = x.shape[2]
+        W = x.shape[3]
+        x = x.permute(0, 2, 3, 1).contiguous()
+        windows = window_partition(x, self.window_size)
+        # touch the windows so the graph is non-trivial but still an identity overall
+        windows = windows + 0.0
+        x = window_reverse(windows, self.window_size, H, W)
+        x = x.permute(0, 3, 1, 2).contiguous()
+        return x
+
+
+class TestWindowReverseBatchReshape:
+    """Regression for the PyTorch-FE baked-batch reshape bug.
+
+    A model traced at batch=1 must still produce correct results after the converted
+    model is reshaped to batch=2 (the SwinIR_Classical E2E failure). Before the
+    ReshapeBatchDimResolver pass the doubled batch was absorbed into the window_reverse
+    channel and the output was scrambled (max_abs_diff ~3.47); after the fix it tracks
+    the real batch.
+    """
+
+    @staticmethod
+    def _convert_batch1(window_size, H, W, C):
+        model = WindowReverseModel(window_size).eval()
+        example = torch.randn(1, C, H, W)
+        with torch.no_grad():
+            om = convert_model(model, example_input=example)
+        return model, om
+
+    @pytest.mark.parametrize("window_size,H,W,C", [(8, 16, 16, 6), (4, 12, 8, 3)])
+    @pytest.mark.parametrize("batch", [1, 2, 3])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_window_reverse_rebatch(self, window_size, H, W, C, batch, ie_device, precision):
+        model, om = self._convert_batch1(window_size, H, W, C)
+
+        # Reshape the converted (traced-at-batch-1) model to the target batch.
+        om.reshape({om.input(0): PartialShape([batch, C, H, W])})
+
+        np_in = np.random.randn(batch, C, H, W).astype(np.float32)
+        with torch.no_grad():
+            ref = model(torch.from_numpy(np_in)).numpy()
+
+        config = {}
+        if precision == "FP32":
+            config[hints.inference_precision] = Type.f32
+        compiled = Core().compile_model(om, ie_device, config)
+        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
+
+        eps = 1e-4 if precision == "FP32" else 5e-2
+        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
+        n_bad = int((~np.isclose(ov_out, ref, atol=eps, rtol=eps)).sum())
+        max_abs = float(np.abs(ov_out - ref).max())
+        assert n_bad == 0, f"accuracy failed: {n_bad} mismatches, max_abs_diff={max_abs}"
+
+    @pytest.mark.parametrize("window_size,H,W,C", [(8, 16, 16, 6)])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_window_reverse_pass_fired(self, window_size, H, W, C, ie_device, precision):
+        """Structural check: ReshapeBatchDimResolver must rebuild every window_reverse
+        view shape so no Reshape keeps a frozen positive-int leading constant alongside a
+        single trailing -1 (the baked-batch signature). Device/precision-independent
+        (ie_device/precision are accepted only to satisfy the shared parametrization)."""
+        _, om = self._convert_batch1(window_size, H, W, C)
+
+        offenders = []
+        for node in om.get_ordered_ops():
+            if node.get_type_info().name != "Reshape":
+                continue
+            shape_src = node.input_value(1).get_node()
+            if shape_src.get_type_info().name != "Concat":
+                continue
+            elems = [shape_src.input_value(i).get_node() for i in range(len(shape_src.inputs()))]
+
+            def const_scalar(n):
+                if n.get_type_info().name != "Constant":
+                    return None
+                vals = n.data.flatten()
+                return int(vals[0]) if vals.size == 1 else None
+
+            lead = const_scalar(elems[0])
+            neg1_positions = [i for i, e in enumerate(elems) if const_scalar(e) == -1]
+            # The offending pattern: positive-int leading constant + exactly one trailing -1.
+            if lead is not None and lead > 0 and neg1_positions == [len(elems) - 1]:
+                offenders.append(node.get_friendly_name())
+
+        assert not offenders, f"baked-batch reshapes not rewritten: {offenders}"
+
+
+class TestPlainReshapeNotAffected:
+    """Negative test: ordinary reshapes (no -1, or -1 not in the channel position, or a
+    fully-static shape vector) must be left untouched and stay correct after re-batching,
+    proving ReshapeBatchDimResolver does not fire on legitimate leading-constant reshapes."""
+
+    class PlainReshape(torch.nn.Module):
+        def forward(self, x):
+            # leading 1 is a genuine literal; shape is fully static, no -1 -> must NOT match.
+            b, c, h, w = x.shape
+            y = x.reshape(1, c * h * w)
+            return y.reshape(b, c, h, w)
+
+    @pytest.mark.parametrize("batch", [1, 2])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_plain_reshape_rebatch(self, batch, ie_device, precision):
+        model = self.PlainReshape().eval()
+        example = torch.randn(1, 3, 4, 5)
+        with torch.no_grad():
+            om = convert_model(model, example_input=example)
+        # This model is not batch-reshapeable (the middle reshape pins total size); just
+        # verify batch=1 stays correct and conversion is untouched by the pass.
+        np_in = np.random.randn(1, 3, 4, 5).astype(np.float32)
+        with torch.no_grad():
+            ref = model(torch.from_numpy(np_in)).numpy()
+        config = {}
+        if precision == "FP32":
+            config[hints.inference_precision] = Type.f32
+        compiled = Core().compile_model(om, ie_device, config)
+        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
+        eps = 1e-4 if precision == "FP32" else 5e-2
+        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()

--- a/tests/layer_tests/pytorch_tests/test_window_reverse.py
+++ b/tests/layer_tests/pytorch_tests/test_window_reverse.py
@@ -27,6 +27,65 @@ def window_reverse(windows, window_size, H, W):
     return x
 
 
+# --------------------------------------------------------------------------------------------------
+# Shared helpers (used by every test class below -- the structural walk and the compile/compare
+# boilerplate were previously copy-pasted into each class).
+# --------------------------------------------------------------------------------------------------
+
+def _const_scalar(node):
+    """Return the single int value of a Constant node, or None if it is not a 1-element Constant."""
+    if node.get_type_info().name != "Constant":
+        return None
+    vals = node.data.flatten()
+    return int(vals[0]) if vals.size == 1 else None
+
+
+def _count_rewritten_reshapes(om):
+    """Count Reshapes rewritten by ReshapeBatchDimResolver. The pass turns the leading baked-batch
+    Constant into Constant(-1) and pins the former trailing -1 channel to a positive Constant (data's
+    static last dim). So the fingerprint is a shape Concat whose leading element is Constant(-1) and
+    whose last element is a positive Constant -- the inverse of the offending baked pattern."""
+    n = 0
+    for node in om.get_ordered_ops():
+        if node.get_type_info().name != "Reshape":
+            continue
+        shape_src = node.input_value(1).get_node()
+        if shape_src.get_type_info().name != "Concat":
+            continue
+        elems = [shape_src.input_value(i).get_node() for i in range(len(shape_src.inputs()))]
+        if len(elems) < 2:
+            continue
+        lead = _const_scalar(elems[0])
+        last = _const_scalar(elems[-1])
+        if lead == -1 and last is not None and last > 0:
+            n += 1
+    return n
+
+
+def _has_rewritten_reshape(om):
+    """True if ReshapeBatchDimResolver rewrote any Reshape in `om` (see _count_rewritten_reshapes)."""
+    return _count_rewritten_reshapes(om) > 0
+
+
+def _compile_and_compare(om, model, np_in, ie_device, precision):
+    """Compile `om` on `ie_device`/`precision`, run it on `np_in`, and assert the output matches the
+    torch eager reference. Centralizes the precision-config + tolerance logic shared by all tests."""
+    config = {}
+    if precision == "FP32":
+        config[hints.inference_precision] = Type.f32
+    compiled = Core().compile_model(om, ie_device, config)
+    ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
+
+    with torch.no_grad():
+        ref = model(torch.from_numpy(np_in)).numpy()
+
+    eps = 1e-4 if precision == "FP32" else 5e-2
+    assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
+    n_bad = int((~np.isclose(ov_out, ref, atol=eps, rtol=eps)).sum())
+    max_abs = float(np.abs(ov_out - ref).max())
+    assert n_bad == 0, f"accuracy failed: {n_bad} mismatches, max_abs_diff={max_abs}"
+
+
 class WindowReverseModel(torch.nn.Module):
     """A round-trip through window_partition/window_reverse, exactly the structure that
     produces the frozen-batch view shapes in SwinIR. The identity round-trip lets us
@@ -91,20 +150,7 @@ class TestWindowReverseBatchReshape:
         om.reshape({om.input(0): PartialShape([batch, C, H, W])})
 
         np_in = np.random.randn(batch, C, H, W).astype(np.float32)
-        with torch.no_grad():
-            ref = model(torch.from_numpy(np_in)).numpy()
-
-        config = {}
-        if precision == "FP32":
-            config[hints.inference_precision] = Type.f32
-        compiled = Core().compile_model(om, ie_device, config)
-        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
-
-        eps = 1e-4 if precision == "FP32" else 5e-2
-        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
-        n_bad = int((~np.isclose(ov_out, ref, atol=eps, rtol=eps)).sum())
-        max_abs = float(np.abs(ov_out - ref).max())
-        assert n_bad == 0, f"accuracy failed: {n_bad} mismatches, max_abs_diff={max_abs}"
+        _compile_and_compare(om, model, np_in, ie_device, precision)
 
     @pytest.mark.parametrize("window_size,H,W,C,embed_dim", [(8, 16, 16, 6, 12)])
     @pytest.mark.nightly
@@ -125,14 +171,8 @@ class TestWindowReverseBatchReshape:
                 continue
             elems = [shape_src.input_value(i).get_node() for i in range(len(shape_src.inputs()))]
 
-            def const_scalar(n):
-                if n.get_type_info().name != "Constant":
-                    return None
-                vals = n.data.flatten()
-                return int(vals[0]) if vals.size == 1 else None
-
-            lead = const_scalar(elems[0])
-            neg1_positions = [i for i, e in enumerate(elems) if const_scalar(e) == -1]
+            lead = _const_scalar(elems[0])
+            neg1_positions = [i for i, e in enumerate(elems) if _const_scalar(e) == -1]
             # The offending pattern: positive-int leading constant + exactly one trailing -1.
             if lead is not None and lead > 0 and neg1_positions == [len(elems) - 1]:
                 offenders.append(node.get_friendly_name())
@@ -163,58 +203,27 @@ class TestPlainReshapeNotAffected:
         # This model is not batch-reshapeable (the middle reshape pins total size); just
         # verify batch=1 stays correct and conversion is untouched by the pass.
         np_in = np.random.randn(1, 3, 4, 5).astype(np.float32)
-        with torch.no_grad():
-            ref = model(torch.from_numpy(np_in)).numpy()
-        config = {}
-        if precision == "FP32":
-            config[hints.inference_precision] = Type.f32
-        compiled = Core().compile_model(om, ie_device, config)
-        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
-        eps = 1e-4 if precision == "FP32" else 5e-2
-        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()
+        _compile_and_compare(om, model, np_in, ie_device, precision)
 
 
-def _has_rewritten_reshape(om):
-    """Return True if any Reshape in `om` was rewritten by ReshapeBatchDimResolver. The pass
-    turns the leading baked-batch Constant into a Constant(-1) and pins the former trailing -1
-    channel to a Constant holding data's (static) last dimension, i.e. a positive value. So the
-    fingerprint is a shape Concat whose leading element is Constant(-1) and whose last element is
-    a positive Constant -- the inverse of the offending baked pattern."""
-    for node in om.get_ordered_ops():
-        if node.get_type_info().name != "Reshape":
-            continue
-        shape_src = node.input_value(1).get_node()
-        if shape_src.get_type_info().name != "Concat":
-            continue
-        elems = [shape_src.input_value(i).get_node() for i in range(len(shape_src.inputs()))]
-        if len(elems) < 2:
-            continue
+class TestResolverDoesNotFire:
+    """The pass runs in normalize() on EVERY converted PyTorch model, so it must never fire on a
+    reshape it cannot prove value-preserving, and must never change the result at the traced batch.
 
-        def const_scalar(n):
-            if n.get_type_info().name != "Constant":
-                return None
-            vals = n.data.flatten()
-            return int(vals[0]) if vals.size == 1 else None
+    Each model below carries the structural signature the pass keys on -- a literal leading batch
+    constant, a dynamic interior dim, and a single trailing -1 built as a Concat under TorchScript
+    tracing -- yet must be left untouched, for one of two reasons:
 
-        lead = const_scalar(elems[0])
-        last = const_scalar(elems[-1])
-        if lead == -1 and last is not None and last > 0:
-            return True
-    return False
+      * Dynamic data last dim (SpatialFlatten / AttnHeadMerge / DynChannel): the channel comes
+        straight from a Parameter, so the resolver cannot recover a static last dim by walking back.
+      * Static data last dim but the -1 spans MORE than it (HeadMerge / HeadSplit): a `Linear(D, D)`
+        gives a static last dim D, but `reshape(1, T//2, -1)` makes -1 == 2*D and `reshape(1, T*2, -1)`
+        makes -1 == D//2. The cheap output-channel guard is vacuous here (output last dim is dynamic),
+        so the trailing-block guard is what must reject them.
 
-
-class TestReshapeFalsePositiveNotFired:
-    """Negative tests for ReshapeBatchDimResolver over-matching.
-
-    These models contain the exact structural signature the pass keys on -- a literal leading
-    batch constant, a dynamic interior dim from the input shape, and a single trailing -1 built
-    as a Concat under TorchScript tracing. But the -1 here means "product of the remaining
-    dimensions" (H*W, or heads*head_dim), which is NOT the data tensor's last dimension. The
-    earlier (loose) pass rewrote the channel to Gather(ShapeOf(data), -1) and corrupted the output
-    even at the traced batch=1. The hardened predicate must leave these untouched: data's last
-    dimension is dynamic (it comes straight from a Parameter), so the static-last-dim gate excludes
-    them. We assert BOTH that the pass did not rewrite the Reshape (structural) and that batch=1
-    output matches torch (numeric -- catches the traced-batch corruption)."""
+    An earlier (loose) pass rewrote the channel to data's last dim and corrupted the output even at
+    the traced batch=1. We assert BOTH that the pass did not rewrite the Reshape (structural) and that
+    batch=1 output matches torch (numeric -- catches the traced-batch corruption)."""
 
     class SpatialFlatten(torch.nn.Module):
         # x: (B, C, H, W); reshape(1, C, -1) -> -1 == H*W, NOT data's last dim (W).
@@ -230,101 +239,73 @@ class TestReshapeFalsePositiveNotFired:
             x = x.transpose(1, 2)
             return x.reshape(1, N, -1)
 
-    @pytest.mark.parametrize(
-        "model_cls,shape",
-        [
-            (SpatialFlatten, (1, 3, 4, 5)),
-            (AttnHeadMerge, (1, 4, 6, 8)),
-        ],
-    )
-    @pytest.mark.nightly
-    @pytest.mark.precommit
-    def test_false_positive_not_fired(self, model_cls, shape, ie_device, precision):
-        model = model_cls().eval()
-        example = torch.randn(*shape)
-        with torch.no_grad():
-            om = convert_model(model, example_input=example)
-
-        # Structural: the pass must NOT have rewritten this ordinary reshape.
-        assert not _has_rewritten_reshape(om), (
-            f"{model_cls.__name__}: ReshapeBatchDimResolver fired on an ordinary reshape"
-        )
-
-        # Numeric at the traced batch: the loose pass corrupted the result even here.
-        np_in = np.random.randn(*shape).astype(np.float32)
-        with torch.no_grad():
-            ref = model(torch.from_numpy(np_in)).numpy()
-        config = {}
-        if precision == "FP32":
-            config[hints.inference_precision] = Type.f32
-        compiled = Core().compile_model(om, ie_device, config)
-        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
-        eps = 1e-4 if precision == "FP32" else 5e-2
-        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
-        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()
-
-
-class TestReshapeResolverBatch1Safety:
-    """The pass runs in normalize() on EVERY converted PyTorch model, so it must never
-    change the result at the traced batch. These models have the structural signature
-    the pass keys on -- a literal leading batch constant, a dynamic interior dim, a
-    single trailing -1 -- AND a STATIC data last dim (from a Linear), but the trailing
-    -1 spans MORE than data's last dimension, so pinning the channel to data's last dim
-    and freeing the batch would corrupt the output even at batch=1.
-
-    A `Linear(D, D)` gives a static last dim D; `reshape(1, T//2, -1)` makes -1 == 2*D
-    (a head-merge) and `reshape(1, T*2, -1)` makes -1 == D//2 (a head-split). The
-    earlier guard (output-channel-static) is vacuous here because the output last dim is
-    DYNAMIC, so without the trailing-block guard the pass fired and corrupted batch=1.
-    The hardened pass must NOT rewrite these and must match torch at the traced batch."""
-
     class HeadMerge(torch.nn.Module):
+        # x: (B, T, D) with T even, static last dim D from the Linear. -1 == 2*D, interior T//2 dynamic.
         def __init__(self, d):
             super().__init__()
             self.proj = torch.nn.Linear(d, d)
 
         def forward(self, x):
-            # x: (B, T, D) with T even. -1 == 2*D, data last dim == D. interior T//2 dynamic.
             x = self.proj(x)
             T = x.shape[1]
             return x.reshape(1, T // 2, -1)
 
     class HeadSplit(torch.nn.Module):
+        # x: (B, T, D) with D even, static last dim D from the Linear. -1 == D//2, interior T*2 dynamic.
         def __init__(self, d):
             super().__init__()
             self.proj = torch.nn.Linear(d, d)
 
         def forward(self, x):
-            # x: (B, T, D) with D even. -1 == D//2, data last dim == D. interior T*2 dynamic.
             x = self.proj(x)
             T = x.shape[1]
             return x.reshape(1, T * 2, -1)
 
-    @pytest.mark.parametrize("model_cls,shape,d", [(HeadMerge, (1, 4, 8), 8), (HeadSplit, (1, 4, 8), 8)])
+    class DynChannel(torch.nn.Module):
+        # window_reverse with NO projection: the window channel flows from the input and stays
+        # dynamic, so the resolver cannot walk back to a static last dim and must not fire.
+        def __init__(self, window_size):
+            super().__init__()
+            self.window_size = window_size
+
+        def forward(self, x):
+            H = x.shape[2]
+            W = x.shape[3]
+            x = x.permute(0, 2, 3, 1).contiguous()  # (B,H,W,C), C dynamic from input
+            windows = window_partition(x, self.window_size)
+            windows = windows + 0.0
+            x = window_reverse(windows, self.window_size, H, W)
+            return x.permute(0, 3, 1, 2).contiguous()
+
+    @pytest.mark.parametrize(
+        "make_model,shape",
+        [
+            pytest.param(lambda: TestResolverDoesNotFire.SpatialFlatten(), (1, 3, 4, 5),
+                         id="spatial_flatten_dyn_lastdim"),
+            pytest.param(lambda: TestResolverDoesNotFire.AttnHeadMerge(), (1, 4, 6, 8),
+                         id="attn_head_merge_dyn_lastdim"),
+            pytest.param(lambda: TestResolverDoesNotFire.HeadMerge(8), (1, 4, 8),
+                         id="head_merge_static_lastdim_minus1_2D"),
+            pytest.param(lambda: TestResolverDoesNotFire.HeadSplit(8), (1, 4, 8),
+                         id="head_split_static_lastdim_minus1_Dhalf"),
+            pytest.param(lambda: TestResolverDoesNotFire.DynChannel(8), (1, 6, 16, 16),
+                         id="window_reverse_dynamic_channel"),
+        ],
+    )
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_traced_batch_not_corrupted(self, model_cls, shape, d, ie_device, precision):
-        model = model_cls(d).eval()
+    def test_not_fired_and_b1_ok(self, make_model, shape, ie_device, precision):
+        model = make_model().eval()
         example = torch.randn(*shape)
         with torch.no_grad():
             om = convert_model(model, example_input=example)
 
-        # Structural: the trailing-block guard must reject these -- the pass must not fire.
-        assert not _has_rewritten_reshape(om), (
-            f"{model_cls.__name__}: ReshapeBatchDimResolver fired on an ordinary reshape"
-        )
+        # Structural: the pass must NOT have rewritten this ordinary reshape.
+        assert not _has_rewritten_reshape(om), "ReshapeBatchDimResolver fired on an ordinary reshape"
 
+        # Numeric at the traced batch: the loose pass corrupted the result even here.
         np_in = np.random.randn(*shape).astype(np.float32)
-        with torch.no_grad():
-            ref = model(torch.from_numpy(np_in)).numpy()
-        config = {}
-        if precision == "FP32":
-            config[hints.inference_precision] = Type.f32
-        compiled = Core().compile_model(om, ie_device, config)
-        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
-        eps = 1e-4 if precision == "FP32" else 5e-2
-        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
-        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()
+        _compile_and_compare(om, model, np_in, ie_device, precision)
 
 
 class TestReshapeResolverIdempotent:
@@ -349,76 +330,8 @@ class TestReshapeResolverIdempotent:
         assert _has_rewritten_reshape(om1)
         assert _has_rewritten_reshape(om2)
         # ...and produced the SAME count of rewritten reshapes (no double-fire / drift).
-        def count_rewrites(om):
-            n = 0
-            for node in om.get_ordered_ops():
-                if node.get_type_info().name != "Reshape":
-                    continue
-                src = node.input_value(1).get_node()
-                if src.get_type_info().name != "Concat":
-                    continue
-                elems = [src.input_value(i).get_node() for i in range(len(src.inputs()))]
-                if len(elems) < 2:
-                    continue
-
-                def cs(n):
-                    if n.get_type_info().name != "Constant":
-                        return None
-                    v = n.data.flatten()
-                    return int(v[0]) if v.size == 1 else None
-
-                if cs(elems[0]) == -1 and (cs(elems[-1]) or 0) > 0:
-                    n += 1
-            return n
-
-        assert count_rewrites(om1) == count_rewrites(om2), "rewrite count differs across conversions"
-
-
-class TestWindowReverseDynamicChannel:
-    """Coverage-boundary test: when the window channel is DYNAMIC (no projection to a
-    fixed embed_dim -- the channel flows from the input), the resolver cannot recover
-    the channel by walking back to a static last dim, so the pass deliberately does NOT
-    fire. This documents the (intended) scope of the static-channel resolver: it fixes
-    the SwinIR case (static embed_dim) and leaves dynamic-channel reshapes untouched.
-    The traced batch=1 must still be correct (the pass is a no-op here)."""
-
-    class DynChannel(torch.nn.Module):
-        def __init__(self, window_size):
-            super().__init__()
-            self.window_size = window_size
-
-        def forward(self, x):
-            H = x.shape[2]
-            W = x.shape[3]
-            x = x.permute(0, 2, 3, 1).contiguous()  # (B,H,W,C), C dynamic from input
-            windows = window_partition(x, self.window_size)
-            windows = windows + 0.0
-            x = window_reverse(windows, self.window_size, H, W)
-            return x.permute(0, 3, 1, 2).contiguous()
-
-    @pytest.mark.parametrize("window_size,H,W,C", [(8, 16, 16, 6)])
-    @pytest.mark.nightly
-    @pytest.mark.precommit
-    def test_dynamic_channel_not_fired_and_b1_ok(self, window_size, H, W, C, ie_device, precision):
-        model = self.DynChannel(window_size).eval()
-        example = torch.randn(1, C, H, W)
-        with torch.no_grad():
-            om = convert_model(model, example_input=example)
-
-        # The resolver must not fire (channel is dynamic -> not statically recoverable).
-        assert not _has_rewritten_reshape(om), "resolver fired on a dynamic-channel window reverse"
-
-        np_in = np.random.randn(1, C, H, W).astype(np.float32)
-        with torch.no_grad():
-            ref = model(torch.from_numpy(np_in)).numpy()
-        config = {}
-        if precision == "FP32":
-            config[hints.inference_precision] = Type.f32
-        compiled = Core().compile_model(om, ie_device, config)
-        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
-        eps = 1e-4 if precision == "FP32" else 5e-2
-        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
-        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()
+        assert _count_rewritten_reshapes(om1) == _count_rewritten_reshapes(om2), \
+            "rewrite count differs across conversions"
 
 
 class TestWindowReverseWalkBackFragility:
@@ -461,13 +374,4 @@ class TestWindowReverseWalkBackFragility:
             om = convert_model(model, example_input=example)
 
         np_in = np.random.randn(1, C, H, W).astype(np.float32)
-        with torch.no_grad():
-            ref = model(torch.from_numpy(np_in)).numpy()
-        config = {}
-        if precision == "FP32":
-            config[hints.inference_precision] = Type.f32
-        compiled = Core().compile_model(om, ie_device, config)
-        ov_out = np.asarray(compiled(np_in)[compiled.output(0)], dtype=np.float32)
-        eps = 1e-4 if precision == "FP32" else 5e-2
-        assert ov_out.shape == ref.shape, f"shape mismatch ov={ov_out.shape} ref={ref.shape}"
-        assert np.isclose(ov_out, ref, atol=eps, rtol=eps).all()
+        _compile_and_compare(om, model, np_in, ie_device, precision)


### PR DESCRIPTION
### Problem

SwinIR-style `window_reverse` computes the batch as plain Python arithmetic:

    B = int(windows.shape[0] / (H * W / ws / ws))
    x = windows.view(B, H // ws, W // ws, ws, ws, -1)

Under `torch.jit.trace` the `int(...)` collapses to a literal. In the IR the
view shape becomes a Concat where only the spatial dims stay live (`aten::size`),
the leading batch is a baked `Constant`, and the channel is the trailing `-1`:

    view(windows, [ B=Const(1), H//ws, W//ws, 8, 8, Const(-1) ])
                    baked        live   live              infer

At the traced batch=1 this is correct:

    windows = (361, 8, 8, 180),  total = 4_158_720
    H//ws = W//ws = 19  (live)
    known product = 1 * 19 * 19 * 8 * 8 = 23_104
    -1 = 4_158_720 / 23_104 = 180   -> channel 180, correct

After `model.reshape(batch=2)` the input becomes `(2, 3, 152, 152)`. The spatial
dims do not depend on batch, so the live `H//ws, W//ws` stay 19, 19, and the
leading `Const(1)` stays 1 (it is a literal with no input for reshape to rewrite):

    windows = (722, 8, 8, 180),  total = 8_317_440   (twice the elements)
    shape   = (1, 19, 19, 8, 8, -1)                  (leading still 1)
    known product = 1 * 19 * 19 * 8 * 8 = 23_104     (unchanged)
    -1 = 8_317_440 / 23_104 = 360                     (was 180)

The doubled element count divides by the same known product, so the only free
axis (`-1`) must absorb the extra factor of 2: the batch leaks into the channel,
180 -> 360, and the window grid is scrambled.

The corruption is silent because the final view rebuilds a correct shape -- its
batch is live and its channel is the literal `embed_dim`:

    Reshape_8: [1, 19, 19, 8, 8, 360]
    permute  : [1, 19, 8, 19, 8, 360]
    Reshape_9 = view(1, H, W, -1) -> [1, 152, 152, 360]
    final view(B, H*W, C) -> [2, 23104, 180]   shape correct, data wrong

Compilation, inference, and output shapes all pass; only the values are wrong
(max_abs_diff ~3.47 on the SwinIR_Classical models at batch=2).

### Fix

Add `ReshapeBatchDimResolver`, a PyTorch-FE `ModelPass` run in `normalize()`.
For a reshape carrying the window-reverse signature (leading positive-int
constant, exactly one trailing `-1`, at least one dynamic interior dim) it frees
the leading dim to `-1` and pins the channel to its batch-independent value as a
`Constant`, so the batch is inferred from the real element count and no longer
leaks into the channel.

The channel is recovered by a deterministic walk-back rather than OV shape
inference: window_reverse uses two chained views and the second takes its data
through a permute whose output stays dynamic. The pass walks back from the data
to a static last dim, through a last-axis-preserving `Transpose`, or to a view
already selected for rewrite.

Two guards keep it from touching ordinary reshapes that share the structure:
- if the output last dim is statically known, it must equal the recovered channel;
- on the direct path the rewrite must only re-partition the leading dim and keep
  the data's entire trailing block, which rejects merge/split reshapes such as
  `view(1, T//2, -1)` whose `-1` spans more than the data's last dim.

### Tickets:
 - 172206
