### PR TITLE
[GPU] Fix OOB read in gemm_tiled_opt input1 K-leftover

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -583,12 +583,17 @@ KERNEL(gemm_tiled_opt)(
                 {
                 b_ptr = b_ptr + (input1_offset * sglid);
                 #if B_VEC_SIZE == 1
-                b_tile = (N > b_raw_global_id) ? VLOAD(0, b_ptr) : 0;
+                    unroll_for (uint b_load_id = 0; b_load_id < SIMD_WIDTH; b_load_id++) {
+                        b_tile[b_load_id] = ((N > b_raw_global_id) && ((K_FULL_ITERATIONS * TILE_K + b_load_id) < K)) ? b_ptr[b_load_id] : 0;
+                    }
                 #else
-                const __global INPUT1_TYPE* b_ptr_tmp = b_ptr;
-                unroll_for (uint b_elem = 0; b_elem < B_VEC_SIZE; ++b_elem) {
-                    b_tile[b_elem] = (N > b_raw_global_id + SIMD_WIDTH * b_elem) ? VLOAD(0, b_ptr_tmp + input1_offset * SIMD_WIDTH * b_elem) : 0;
-                }
+                    const __global INPUT1_TYPE* b_ptr_tmp = b_ptr;
+                    unroll_for (uint b_elem = 0; b_elem < B_VEC_SIZE; ++b_elem) {
+                        unroll_for (uint b_load_id = 0; b_load_id < SIMD_WIDTH; b_load_id++) {
+                            b_tile[b_elem][b_load_id] = ((N > b_raw_global_id + SIMD_WIDTH * b_elem) && ((K_FULL_ITERATIONS * TILE_K + b_load_id) < K))
+                                                            ? b_ptr_tmp[input1_offset * SIMD_WIDTH * b_elem + b_load_id] : 0;
+                        }
+                    }
                 #endif
                 b_ptr = b_ptr + input1_offset1 - (input1_offset * sglid);
                 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -702,7 +702,15 @@ KERNEL(gemm_tiled_opt)(
             #endif
          {
              b_ptr = b_ptr + (input1_offset * sglid);
-             b_tile = (N > b_raw_global_id) ? VLOAD(0, b_ptr) : 0;
+             if (N > b_raw_global_id + 1) {
+                 b_tile = VLOAD(0, b_ptr);
+             } else if (N > b_raw_global_id) {
+                 unroll_for (uint b_load_id = 0; b_load_id < SIMD_WIDTH; b_load_id++) {
+                     b_tile[b_load_id] = ((K_FULL_ITERATIONS * TILE_K + b_load_id) < K) ? b_ptr[b_load_id] : 0;
+                 }
+             } else {
+                 b_tile = 0;
+             }
          }
         #endif // TRANSPOSE_INPUT1 == TRANSPOSE_Y_LAST
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -583,15 +583,27 @@ KERNEL(gemm_tiled_opt)(
                 {
                 b_ptr = b_ptr + (input1_offset * sglid);
                 #if B_VEC_SIZE == 1
-                    unroll_for (uint b_load_id = 0; b_load_id < SIMD_WIDTH; b_load_id++) {
-                        b_tile[b_load_id] = ((N > b_raw_global_id) && ((K_FULL_ITERATIONS * TILE_K + b_load_id) < K)) ? b_ptr[b_load_id] : 0;
+                    if (N > b_raw_global_id + 1) {
+                        b_tile = VLOAD(0, b_ptr);
+                    } else if (N > b_raw_global_id) {
+                        unroll_for (uint b_load_id = 0; b_load_id < SIMD_WIDTH; b_load_id++) {
+                            b_tile[b_load_id] = ((K_FULL_ITERATIONS * TILE_K + b_load_id) < K) ? b_ptr[b_load_id] : 0;
+                        }
+                    } else {
+                        b_tile = 0;
                     }
                 #else
                     const __global INPUT1_TYPE* b_ptr_tmp = b_ptr;
                     unroll_for (uint b_elem = 0; b_elem < B_VEC_SIZE; ++b_elem) {
-                        unroll_for (uint b_load_id = 0; b_load_id < SIMD_WIDTH; b_load_id++) {
-                            b_tile[b_elem][b_load_id] = ((N > b_raw_global_id + SIMD_WIDTH * b_elem) && ((K_FULL_ITERATIONS * TILE_K + b_load_id) < K))
-                                                            ? b_ptr_tmp[input1_offset * SIMD_WIDTH * b_elem + b_load_id] : 0;
+                        if (N > b_raw_global_id + SIMD_WIDTH * b_elem + 1) {
+                            b_tile[b_elem] = VLOAD(0, b_ptr_tmp + input1_offset * SIMD_WIDTH * b_elem);
+                        } else if (N > b_raw_global_id + SIMD_WIDTH * b_elem) {
+                            unroll_for (uint b_load_id = 0; b_load_id < SIMD_WIDTH; b_load_id++) {
+                                b_tile[b_elem][b_load_id] = ((K_FULL_ITERATIONS * TILE_K + b_load_id) < K)
+                                                                ? b_ptr_tmp[input1_offset * SIMD_WIDTH * b_elem + b_load_id] : 0;
+                            }
+                        } else {
+                            b_tile[b_elem] = 0;
                         }
                     }
                 #endif


### PR DESCRIPTION
## Issue
The SAM image-encoder model intermittently fails on GPU with `CL_OUT_OF_RESOURCES`, raised by `clFinish()` right after GEMM (`Q @ K^T`, kernel `gemm_tiled_opt`).

## Root cause
In `gemm_tiled_opt.cl`, the `IS_DYNAMIC K-leftover` path for input1 (matrix B) in TRANSPOSE_Y_LAST mode loads the B tile with an unconditional `vload16`, guarded only by N, with no K-boundary check:
```cpp
b_ptr = b_ptr + (input1_offset * sglid);
b_tile = (N > b_raw_global_id) ? VLOAD(0, b_ptr) : 0;   // reads 16 K elements unconditionally
```
- For this GEMM the contraction dim K is `head_dim = 56`, and `TILE_K = 16`, so `56 % 16 = 8` leftover elements remain. 
- `vload16` reads 16 K elements (k = 48..63) while only 8 are valid (k = 48..55), over-reading 8 elements (32 bytes) past the end of the K buffer.
- This over-read is always present, but only faults when the byte right after the buffer is on an unmapped page

## Solution
- Add the missing K-boundary guard to the `input1` K-leftover load in the dynamic `TRANSPOSE_Y_LAST` path, mirroring the existing matrix-A guard. 
- `vload16` is replaced by an element-wise read that zeroes lanes whose K index is out of range, so the kernel never touches memory beyond the buffer:
```cpp
unroll_for (uint b_load_id = 0; b_load_id < SIMD_WIDTH; b_load_id++) {
    b_tile[b_load_id] = ((N > b_raw_global_id) && ((K_FULL_ITERATIONS * TILE_K + b_load_id) < K))
                            ? b_ptr[b_load_id] : 0;
}
```

## Ticket
- CVS-187767