### PR TITLE
[GPU] distil-large-v2 INT8-CW regression

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -149,7 +149,7 @@ add_fusing_type onednn_add_fusing_helpers::get_add_fusing_type(
             && !dep_node.is_constant()
             && !p_node.is_type<pooling>()
             && !p_node.is_output()
-            && !(dep_node.is_type<input_layout>())) {
+            && !(dep_node.is_type<input_layout>() && dep_node.get_users().size() > 1)) {
             return add_fusing_type::sum;
         } else if (p_layout.get_tensor() == d_layout.get_tensor()) {
             return add_fusing_type::binary_per_tensor;

--- a/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
@@ -101,7 +101,7 @@ TEST(add_onednn_optimization_attributes, sum_post_op_for_residual_connection) {
 }
 
 
-TEST(add_onednn_optimization_attributes, fc_sum_u8_uses_binary_per_tensor) {
+TEST(add_onednn_optimization_attributes, fc_sum_u8_single_user_input_uses_sum) {
     auto& engine = get_test_engine();
 
     if (!engine.get_device_info().supports_immad)
@@ -133,6 +133,43 @@ TEST(add_onednn_optimization_attributes, fc_sum_u8_uses_binary_per_tensor) {
     program_wrapper::apply_opt_pass<add_onednn_optimization_attributes>(*prog);
 
     // eltwise should be fused into fc as a post-op
+    auto& fc_node = prog->get_node("fc");
+    auto& fused = fc_node.get_fused_primitives();
+    ASSERT_EQ(fused.size(), 1);
+
+    auto fusing_type = onednn_add_fusing_helpers::get_add_fusing_type(fc_node, fused[0]);
+    ASSERT_EQ(fusing_type, add_fusing_type::sum);
+}
+
+TEST(add_onednn_optimization_attributes, fc_sum_u8_residual_input_uses_binary) {
+    auto& engine = get_test_engine();
+
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    auto in_layout = layout{ ov::PartialShape({8, 16}), data_types::u8, format::bfyx };
+    auto weights_mem = engine.allocate_memory({ ov::PartialShape({16, 16}), data_types::u8, format::bfyx });
+
+    topology topology;
+    topology.add(data("weights", weights_mem));
+    topology.add(input_layout("input", in_layout));
+
+    topology.add(fully_connected("fc", input_info("input"), { "weights" }, "", data_types::u8));
+    topology.add(eltwise("sum", { input_info("fc"), input_info("input") }, eltwise_mode::sum));
+    topology.add(reorder("out", input_info("sum"), format::bfyx, data_types::u8));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    auto prog = program::build_program(engine, topology, config, false, true);
+    ASSERT_NE(prog, nullptr);
+
+    prog->get_layout_optimizer().add_all_onednn_impls_optimization_attribute();
+
+    program_wrapper::apply_opt_pass<prepare_primitive_fusing>(*prog);
+    program_wrapper::apply_opt_pass<add_onednn_optimization_attributes>(*prog);
+
     auto& fc_node = prog->get_node("fc");
     auto& fused = fc_node.get_fused_primitives();
     ASSERT_EQ(fused.size(), 1);

--- a/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
@@ -147,15 +147,18 @@ TEST(add_onednn_optimization_attributes, fc_sum_u8_residual_input_uses_binary) {
     if (!engine.get_device_info().supports_immad)
         return;
 
-    auto in_layout = layout{ ov::PartialShape({8, 16}), data_types::u8, format::bfyx };
-    auto weights_mem = engine.allocate_memory({ ov::PartialShape({16, 16}), data_types::u8, format::bfyx });
+    auto in_layout = layout{ ov::PartialShape({32, 16}), data_types::u8, format::bfyx };
+    auto weights1_mem = engine.allocate_memory({ ov::PartialShape({16, 16}), data_types::u8, format::bfyx });
+    auto weights2_mem = engine.allocate_memory({ ov::PartialShape({16, 16}), data_types::u8, format::bfyx });
 
     topology topology;
-    topology.add(data("weights", weights_mem));
+    topology.add(data("weights1", weights1_mem));
+    topology.add(data("weights2", weights2_mem));
     topology.add(input_layout("input", in_layout));
 
-    topology.add(fully_connected("fc", input_info("input"), { "weights" }, "", data_types::u8));
-    topology.add(eltwise("sum", { input_info("fc"), input_info("input") }, eltwise_mode::sum));
+    topology.add(fully_connected("fc1", input_info("input"), { "weights1" }, "", data_types::u8));
+    topology.add(fully_connected("fc2", input_info("fc1"), { "weights2" }, "", data_types::u8));
+    topology.add(eltwise("sum", { input_info("fc2"), input_info("input") }, eltwise_mode::sum));
     topology.add(reorder("out", input_info("sum"), format::bfyx, data_types::u8));
 
     ExecutionConfig config = get_test_default_config(engine);
@@ -170,7 +173,7 @@ TEST(add_onednn_optimization_attributes, fc_sum_u8_residual_input_uses_binary) {
     program_wrapper::apply_opt_pass<prepare_primitive_fusing>(*prog);
     program_wrapper::apply_opt_pass<add_onednn_optimization_attributes>(*prog);
 
-    auto& fc_node = prog->get_node("fc");
+    auto& fc_node = prog->get_node("fc2");
     auto& fused = fc_node.get_fused_primitives();
     ASSERT_EQ(fused.size(), 1);
 


### PR DESCRIPTION
### Details:
PR #35720 fixed a Phi accuracy bug (garbage output) by disabling the onednn `sum` post-op for any fused eltwise add whose addend is an `input_layout` node:
```
  && !(dep_node.is_type<input_layout>())
```
This was over-broad. The onednn `sum` post-op aliases the addend buffer in-place as the node's output (see `get_reused_eltwmem_idx` → `primitive_inst.cpp`), so the primitive overwrites the addend. That is only unsafe when the `input_layout` addend has another live consumer - which is exactly the Phi `input_hidden_states` residual case: the network input feeds both the FullyConnected (reaching `sum` via `is_direct_ancestor`) and downstream blocks (`users > 1`), so the in-place write corrupts the value the residual still needs.

When the `input_layout` addend has a single user, there is no surviving reader of the original buffer, so the in-place `sum` is safe. Blanket-disabling it forced these cases onto a slower `binary_add` post-op (extra addend read, lost buffer reuse, possible extra reorder), which regressed per-token decode latency.

This caused a 2nd-token (decode) latency regression for distil-large-v2 INT8-CW on GPU (b_fs_yx_fsv16/compressed-FC path). Measured on a Battlemage dGPU (arls): INT8-CW 2nd-token went from ~2.54 ms to ~2.96 ms (+16.6%), with 1st-token unaffected. FP16/INT4 were unaffected because they dispatch through a different FC path.

### Fix:
Narrow the guard so sum is only disabled for the unsafe multi-consumer case:
```
  && !(dep_node.is_type<input_layout>() && dep_node.get_users().size() > 1)
```
  - Multi-user input_layout addend (Phi residual): users > 1 → falls back to binary add → accuracy preserved.
  - Single-user input_layout addend (distil-large-v2 INT8-CW FC): keeps the in-place sum → regression fixed.

The new clause is only reachable in the multi-user case through the existing is_direct_ancestor branch (a single-user dependency already satisfies get_users().size() == 1 on the preceding line), so single-user behavior is unchanged everywhere else. fuse_nodes() appends the fused addend edge to the dependency's user list without dedup, so a residual addend reliably has users > 1 after fusing.

### Tickets:
 - CVS-170687