### PR TITLE
[Transformations] Restore baked batch dimension in window-reverse reshapes via SmartReshape

### DIFF
--- a/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
+++ b/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
@@ -1,0 +1,110 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/pass.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov {
+namespace pass {
+
+/// \ingroup ov_transformation_common_api
+/// \brief Restores a dynamic batch dimension that framework tracing froze into a window-reverse view
+/// shape, so the model can be reshaped along batch.
+///
+/// When a model is traced with a fixed batch, a window-reverse style view such as `x.view(B, H, W, -1)`
+/// bakes `B` as a literal `Constant` in the leading position of the Reshape's shape `Concat`, while the
+/// channel dimension is the single trailing `-1` (infer) slot. After the model batch is changed (e.g.
+/// `model.reshape({input:[2,...]})`) the leading constant cannot propagate the new batch, so the `-1`
+/// channel silently absorbs it and the data is mis-partitioned.
+///
+/// The pass rewrites the shape `Concat` that feeds the Reshape: the leading baked-batch `Constant`
+/// becomes `Constant(-1)` (the batch is inferred from the real element count) and the trailing `-1`
+/// (infer) slot becomes `Constant(channel)` (the batch-independent channel recovered statically). The
+/// interior dimensions are kept.
+///
+/// Before:
+///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
+///   │  Constant(B)  │ │   <interior> │ │   <interior> │ │ Constant(-1) │  │ data │
+///   │ leading batch │ │   (dynamic)  │ │   (dynamic)  │ │   channel    │  └──┬───┘
+///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
+///           └────────────────┴───────┬────────┴────────────────┘             │
+///                              ┌──────▼──────┐                                │
+///                              │   Concat    │ axis = 0                       │
+///                              │ (view shape)│                                │
+///                              └──────┬──────┘                                │
+///                                     └─────────────────┬─────────────────────┘
+///                                                ┌──────▼──────┐
+///                                                │   Reshape   │ special_zero = false
+///                                                └──────┬──────┘
+///                                                       ▼
+///
+/// After:
+///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
+///   │ Constant(-1)  │ │   <interior> │ │   <interior> │ │Constant(chan)│  │ data │
+///   │ leading batch │ │   (dynamic,  │ │   (dynamic,  │ │   channel    │  └──┬───┘
+///   │   (inferred)  │ │  unchanged)  │ │  unchanged)  │ │  (static)    │     │
+///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
+///           └────────────────┴───────┬────────┴────────────────┘             │
+///                              ┌──────▼──────┐                                │
+///                              │   Concat    │ axis = 0                       │
+///                              │ (view shape)│                                │
+///                              └──────┬──────┘                                │
+///                                     └─────────────────┬─────────────────────┘
+///                                                ┌──────▼──────┐
+///                                                │   Reshape   │ special_zero = false
+///                                                └──────┬──────┘
+///                                                       ▼
+///
+/// The rewrite is value-preserving ONLY for window-reverse views, where the restored channel provably
+/// equals the data tensor's channel dimension. The pass fires only when the shape `Concat` has a leading
+/// positive-int constant, exactly one trailing `-1`, at least one dynamic interior dimension, AND the
+/// channel can be recovered statically. Two value-preservation guards keep it from corrupting ordinary
+/// reshapes that share the structural signature (spatial flatten `view(1, C, -1)`, attention head-merge
+/// `view(1, N, -1)`, merge/split reshapes whose `-1` spans more than the data's last dim):
+///   1. If the reshape's output last dim is statically known, it must equal the recovered channel.
+///   2. (Direct path only — the channel was recovered from the data's OWN static last dim.) When the
+///      output last dim is dynamic, guard 1 is vacuous; guard 2 requires the rewrite to merely
+///      re-partition data's leading dimension and keep data's entire trailing block, which is exactly
+///      the window-reverse semantics and rejects merge/split reshapes.
+///
+/// This lives in SmartReshape because it is a reshapeability concern (it runs inside `Model::reshape`),
+/// not a framework-import concern: it operates on the already-built `ov::Model` and is framework-agnostic.
+///
+/// It is a ModelPass (not a MatcherPass) because window-reverse uses two chained views: the second view's
+/// data is the permuted output of the first, whose channel OV shape inference does NOT propagate through
+/// the permute (the spatial value-bounds collapse the permuted output to fully dynamic). The pass recovers
+/// the channel itself with a deterministic two-phase walk-back: COLLECT iterates the ops in topological
+/// order and, for each structurally matching reshape, recovers the channel by walking back from its data;
+/// REWRITE then replays the recorded rewrites.
+///
+/// Channel recovery walk-back (the two chained window-reverse views):
+///
+///        data [?,8,8,180]                          (static last dim = 180)
+///              │
+///        ┌─────▼──────┐  Reshape_1 (1st view)   ── channel resolved DIRECTLY from data's
+///        │  Reshape   │  out [?,?,?,8,8,180]        static last dim ──────────────► 180
+///        └─────┬──────┘                                                              │
+///              │  out last dim 180 still static                                      │
+///        ┌─────▼──────┐  Transpose(order=[0,1,3,2,4,5])   last axis kept last        │
+///        │ Transpose  │  out [?,?,?,?,?,?] (fully dynamic — bounds collapse)         │
+///        └─────┬──────┘                                                              │
+///              │  data last dim now DYNAMIC                                          │
+///        ┌─────▼──────┐  Reshape_2 (2nd view)   ── channel resolved by WALK-BACK:    │
+///        │  Reshape   │  out [?,H,W,-1]            Transpose (last-axis-preserving)   │
+///        └─────┬──────┘                            then Reshape_1's recorded channel ┘
+///              ▼
+///
+/// Reshape_1 takes the DIRECT path (its own data last dim is static) and the trailing-block guard
+/// applies; Reshape_2 takes the WALK-BACK path (its data last dim is dynamic, recovered structurally
+/// through the permute) and is exempt from the trailing-block guard.
+class TRANSFORMATIONS_API RestoreReshapeBakedBatch : public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("RestoreReshapeBakedBatch");
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+};
+
+}  // namespace pass
+}  // namespace ov

--- a/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
+++ b/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
@@ -82,19 +82,19 @@ namespace pass {
 ///
 /// Channel recovery walk-back (the two chained window-reverse views):
 ///
-///        data [?,8,8,180]                          (static last dim = 180)
+///        data [?,8,8,180]   (static last dim = 180)
 ///              │
-///        ┌─────▼──────┐  Reshape_1 (1st view)   ── channel resolved DIRECTLY from data's
-///        │  Reshape   │  out [?,?,?,8,8,180]        static last dim ──────────────► 180
-///        └─────┬──────┘                                                              │
-///              │  out last dim 180 still static                                      │
-///        ┌─────▼──────┐  Transpose(order=[0,1,3,2,4,5])   last axis kept last        │
-///        │ Transpose  │  out [?,?,?,?,?,?] (fully dynamic — bounds collapse)         │
-///        └─────┬──────┘                                                              │
-///              │  data last dim now DYNAMIC                                          │
-///        ┌─────▼──────┐  Reshape_2 (2nd view)   ── channel resolved by WALK-BACK:    │
-///        │  Reshape   │  out [?,H,W,-1]            Transpose (last-axis-preserving)   │
-///        └─────┬──────┘                            then Reshape_1's recorded channel ┘
+///        ┌─────▼──────┐  Reshape_1 (1st view): channel resolved DIRECTLY from its data's
+///        │  Reshape   │  static last dim 180. Its OWN output last dim is DYNAMIC
+///        └─────┬──────┘  (out [?,?,?,8,8,?]) -- 180 is RECORDED, not read off this output.
+///              │
+///        ┌─────▼──────┐  Transpose(order=[0,1,3,2,4,5]): last axis kept last
+///        │ Transpose  │  out [?,?,?,?,?,?] (fully dynamic -- bounds collapse)
+///        └─────┬──────┘
+///              │  data last dim is now DYNAMIC
+///        ┌─────▼──────┐  Reshape_2 (2nd view): channel resolved by WALK-BACK through the
+///        │  Reshape   │  last-axis-preserving Transpose to Reshape_1's RECORDED channel 180
+///        └─────┬──────┘  (out [?,H,W,-1]).
 ///              ▼
 ///
 /// Reshape_1 takes the DIRECT path (its own data last dim is static) and the trailing-block guard

--- a/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
+++ b/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
@@ -73,12 +73,11 @@ namespace pass {
 /// This lives in SmartReshape because it is a reshapeability concern (it runs inside `Model::reshape`),
 /// not a framework-import concern: it operates on the already-built `ov::Model` and is framework-agnostic.
 ///
-/// It is a ModelPass (not a MatcherPass) because window-reverse uses two chained views: the second view's
-/// data is the permuted output of the first, whose channel OV shape inference does NOT propagate through
-/// the permute (the spatial value-bounds collapse the permuted output to fully dynamic). The pass recovers
-/// the channel itself with a deterministic two-phase walk-back: COLLECT iterates the ops in topological
-/// order and, for each structurally matching reshape, recovers the channel by walking back from its data;
-/// REWRITE then replays the recorded rewrites.
+/// Window-reverse uses two chained views: the second view's data is the permuted output of the first, and
+/// OV shape inference does NOT propagate the channel through the permute (the spatial value-bounds collapse
+/// the permuted output to fully dynamic). The pass therefore recovers the channel itself, walking the whole
+/// model in two phases: COLLECT iterates the ops in topological order and, for each structurally matching
+/// reshape, recovers the channel by walking back from its data; REWRITE then replays the recorded rewrites.
 ///
 /// Channel recovery walk-back (the two chained window-reverse views):
 ///

--- a/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
@@ -1,0 +1,239 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/smart_reshape/restore_reshape_baked_batch.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/pass/node_registry.hpp"
+#include "transformations/utils/utils.hpp"
+
+using namespace ov;
+using namespace ov::op;
+
+namespace {
+
+// True if `out` is a Constant holding a single element equal to `value`.
+bool is_scalar_constant_with_value(const Output<Node>& out, int64_t value) {
+    return ov::op::util::has_constant_value<int64_t>(out.get_node_shared_ptr(), value);
+}
+
+// True if `out` is a Constant holding a single positive integer.
+bool is_scalar_positive_constant(const Output<Node>& out) {
+    int64_t value = 0;
+    return ov::op::util::get_constant_value<int64_t>(out.get_node_shared_ptr(), value) && value > 0;
+}
+
+// The statically-known last dimension of `ps`, or nullopt when the rank is dynamic, the shape is a
+// scalar, or the last dimension itself is dynamic.
+std::optional<int64_t> static_last_dim(const PartialShape& ps) {
+    if (ps.rank().is_dynamic() || ps.size() == 0)
+        return std::nullopt;
+    const auto& last = ps[static_cast<std::ptrdiff_t>(ps.size()) - 1];
+    if (last.is_static())
+        return last.get_length();
+    return std::nullopt;
+}
+
+// Structural signature of a window-reverse style view whose leading batch was frozen by tracing.
+bool passes_structural_gates(const std::shared_ptr<v1::Reshape>& reshape, const std::shared_ptr<v0::Concat>& concat) {
+    if (reshape->get_special_zero())
+        return false;
+    if (concat->get_axis() != 0)
+        return false;
+
+    const auto& shape_inputs = concat->input_values();
+    if (shape_inputs.size() < 3)
+        return false;
+
+    if (!is_scalar_positive_constant(shape_inputs.front()))
+        return false;
+
+    const size_t channel_idx = shape_inputs.size() - 1;
+    if (!is_scalar_constant_with_value(shape_inputs.back(), -1))
+        return false;
+    for (size_t i = 0; i + 1 < shape_inputs.size(); ++i) {
+        if (is_scalar_constant_with_value(shape_inputs[i], -1))
+            return false;  // more than one -1 -> ambiguous, not our pattern
+    }
+
+    for (size_t i = 1; i < channel_idx; ++i) {
+        if (!ov::as_type_ptr<v0::Constant>(shape_inputs[i].get_node_shared_ptr()))
+            return true;
+    }
+    return false;
+}
+
+// Recover the statically-known last (channel) dimension of `data` by walking the graph deterministically.
+std::optional<int64_t> resolve_static_last_dim(const Output<Node>& data,
+                                               const std::unordered_map<const Node*, int64_t>& pending_channel,
+                                               std::unordered_set<const Node*>& visited) {
+    const Node* producer = data.get_node();
+    if (producer && !visited.insert(producer).second)
+        return std::nullopt;
+
+    if (const auto last = static_last_dim(data.get_partial_shape()))
+        return last;
+
+    if (auto transpose = ov::as_type_ptr<v1::Transpose>(data.get_node_shared_ptr())) {
+        auto order = ov::as_type_ptr<v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
+        const auto& in_ps = transpose->input_value(0).get_partial_shape();
+        if (order && in_ps.rank().is_static()) {
+            const auto perm = order->cast_vector<int64_t>();
+            const int64_t rank = in_ps.rank().get_length();
+            if (static_cast<int64_t>(perm.size()) == rank && !perm.empty() && perm.back() == rank - 1)
+                return resolve_static_last_dim(transpose->input_value(0), pending_channel, visited);
+        }
+        return std::nullopt;
+    }
+
+    if (auto rs = ov::as_type_ptr<v1::Reshape>(data.get_node_shared_ptr())) {
+        const auto it = pending_channel.find(rs.get());
+        if (it != pending_channel.end())
+            return it->second;
+    }
+
+    return std::nullopt;
+}
+
+// Value-preservation guard for the DIRECT path (channel recovered from the reshape's own static data
+// last dim). The rewrite must merely re-partition data's leading dimension and keep data's entire
+// trailing block intact — exactly the window-reverse semantics.
+bool keeps_data_trailing_block(const std::shared_ptr<v1::Reshape>& reshape,
+                               const std::shared_ptr<v0::Concat>& concat,
+                               int64_t channel) {
+    const auto& data_ps = reshape->input_value(0).get_partial_shape();
+    if (data_ps.rank().is_dynamic())
+        return false;
+    const int64_t rank = data_ps.rank().get_length();
+    if (rank < 2)
+        return false;
+
+    const auto& shape_inputs = concat->input_values();
+    const auto m = static_cast<int64_t>(shape_inputs.size());
+    if (m < rank)
+        return false;
+
+    for (int64_t j = 1; j < rank; ++j) {
+        const auto& data_dim = data_ps[static_cast<std::ptrdiff_t>(j)];
+        if (data_dim.is_dynamic())
+            return false;
+        const auto& shape_elem = shape_inputs[static_cast<size_t>(m - rank + j)];
+        if (j == rank - 1) {
+            if (channel != data_dim.get_length())
+                return false;
+        } else if (!is_scalar_constant_with_value(shape_elem, data_dim.get_length())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Rebuild the shape vector for THIS reshape's own data (the concat may be shared between blocks, so we
+// must not edit it in place): leading batch -> -1; channel (-1) -> Constant(channel).
+void rewrite_reshape(const std::shared_ptr<v1::Reshape>& reshape,
+                     const std::shared_ptr<v0::Concat>& concat,
+                     int64_t channel) {
+    const auto& shape_inputs = concat->input_values();
+    const size_t channel_idx = shape_inputs.size() - 1;
+
+    ov::pass::NodeRegistry rg;
+
+    const auto& channel_et = concat->input_value(channel_idx).get_element_type();
+    const auto channel_out = rg.make<v0::Constant>(channel_et.is_static() ? channel_et : element::i64,
+                                                   Shape{1},
+                                                   std::vector<int64_t>{channel});
+
+    const auto& batch_et = shape_inputs.front().get_element_type();
+    const auto minus_one =
+        rg.make<v0::Constant>(batch_et.is_static() ? batch_et : element::i64, Shape{1}, std::vector<int64_t>{-1});
+
+    OutputVector new_shape_inputs;
+    new_shape_inputs.reserve(shape_inputs.size());
+    new_shape_inputs.push_back(minus_one);
+    for (size_t i = 1; i < channel_idx; ++i)
+        new_shape_inputs.push_back(shape_inputs[i]);
+    new_shape_inputs.push_back(channel_out);
+
+    const auto new_concat = rg.make<v0::Concat>(new_shape_inputs, 0);
+    reshape->input(1).replace_source_output(new_concat);
+    copy_runtime_info(concat, rg.get());
+}
+
+}  // namespace
+
+bool ov::pass::RestoreReshapeBakedBatch::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    RUN_ON_MODEL_SCOPE(RestoreReshapeBakedBatch);
+
+    // Cheap structural pre-scan: the structural gates inspect only the shape Concat's axis and constant
+    // elements — never an inferred PartialShape — so they need no shape inference. If no reshape carries
+    // the window-reverse signature (the common case) we return immediately.
+    const auto matches_signature = [](const std::shared_ptr<Node>& op) {
+        auto reshape = ov::as_type_ptr<v1::Reshape>(op);
+        if (!reshape)
+            return false;
+        auto concat = ov::as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
+        return concat && passes_structural_gates(reshape, concat);
+    };
+    const auto& ordered_ops = model->get_ordered_ops();
+    if (std::none_of(ordered_ops.begin(), ordered_ops.end(), matches_signature))
+        return false;
+
+    // A candidate exists: make sure the shapes the walk-back keys on are materialized before resolving.
+    model->validate_nodes_and_infer_types();
+
+    struct PendingRewrite {
+        std::shared_ptr<v1::Reshape> reshape;
+        std::shared_ptr<v0::Concat> concat;
+        int64_t channel;
+    };
+    std::vector<PendingRewrite> pending;
+    std::unordered_map<const Node*, int64_t> pending_channel;
+
+    // PHASE 1 — COLLECT (topological order: producers before consumers).
+    for (const auto& op : ordered_ops) {
+        auto reshape = ov::as_type_ptr<v1::Reshape>(op);
+        if (!reshape)
+            continue;
+        auto concat = ov::as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
+        if (!concat)
+            continue;
+        if (!passes_structural_gates(reshape, concat))
+            continue;
+
+        std::unordered_set<const Node*> visited;
+        const auto channel = resolve_static_last_dim(reshape->input_value(0), pending_channel, visited);
+        if (!channel)
+            continue;
+
+        const auto out_last = static_last_dim(reshape->get_output_partial_shape(0));
+        if (out_last && *out_last != *channel)
+            continue;
+
+        const bool direct_path = static_last_dim(reshape->input_value(0).get_partial_shape()).has_value();
+        if (direct_path && !keeps_data_trailing_block(reshape, concat, *channel))
+            continue;
+
+        pending.push_back({reshape, concat, *channel});
+        pending_channel.emplace(reshape.get(), *channel);
+    }
+
+    // PHASE 2 — REWRITE.
+    for (const auto& entry : pending)
+        rewrite_reshape(entry.reshape, entry.concat, entry.channel);
+
+    return !pending.empty();
+}

--- a/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
@@ -20,25 +20,25 @@
 #include "openvino/pass/node_registry.hpp"
 #include "transformations/utils/utils.hpp"
 
-using namespace ov;
-using namespace ov::op;
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
 
 namespace {
 
 // True if `out` is a Constant holding a single element equal to `value`.
-bool is_scalar_constant_with_value(const Output<Node>& out, int64_t value) {
+bool is_scalar_constant_with_value(const ov::Output<ov::Node>& out, int64_t value) {
     return ov::op::util::has_constant_value<int64_t>(out.get_node_shared_ptr(), value);
 }
 
 // True if `out` is a Constant holding a single positive integer.
-bool is_scalar_positive_constant(const Output<Node>& out) {
+bool is_scalar_positive_constant(const ov::Output<ov::Node>& out) {
     int64_t value = 0;
     return ov::op::util::get_constant_value<int64_t>(out.get_node_shared_ptr(), value) && value > 0;
 }
 
 // The statically-known last dimension of `ps`, or nullopt when the rank is dynamic, the shape is a
 // scalar, or the last dimension itself is dynamic.
-std::optional<int64_t> static_last_dim(const PartialShape& ps) {
+std::optional<int64_t> static_last_dim(const ov::PartialShape& ps) {
     if (ps.rank().is_dynamic() || ps.size() == 0)
         return std::nullopt;
     const auto& last = ps[static_cast<std::ptrdiff_t>(ps.size()) - 1];
@@ -77,10 +77,10 @@ bool passes_structural_gates(const std::shared_ptr<v1::Reshape>& reshape, const 
 }
 
 // Recover the statically-known last (channel) dimension of `data` by walking the graph deterministically.
-std::optional<int64_t> resolve_static_last_dim(const Output<Node>& data,
-                                               const std::unordered_map<const Node*, int64_t>& pending_channel,
-                                               std::unordered_set<const Node*>& visited) {
-    const Node* producer = data.get_node();
+std::optional<int64_t> resolve_static_last_dim(const ov::Output<ov::Node>& data,
+                                               const std::unordered_map<const ov::Node*, int64_t>& pending_channel,
+                                               std::unordered_set<const ov::Node*>& visited) {
+    const ov::Node* producer = data.get_node();
     if (producer && !visited.insert(producer).second)
         return std::nullopt;
 
@@ -152,15 +152,16 @@ void rewrite_reshape(const std::shared_ptr<v1::Reshape>& reshape,
     ov::pass::NodeRegistry rg;
 
     const auto& channel_et = concat->input_value(channel_idx).get_element_type();
-    const auto channel_out = rg.make<v0::Constant>(channel_et.is_static() ? channel_et : element::i64,
-                                                   Shape{1},
+    const auto channel_out = rg.make<v0::Constant>(channel_et.is_static() ? channel_et : ov::element::i64,
+                                                   ov::Shape{1},
                                                    std::vector<int64_t>{channel});
 
     const auto& batch_et = shape_inputs.front().get_element_type();
-    const auto minus_one =
-        rg.make<v0::Constant>(batch_et.is_static() ? batch_et : element::i64, Shape{1}, std::vector<int64_t>{-1});
+    const auto minus_one = rg.make<v0::Constant>(batch_et.is_static() ? batch_et : ov::element::i64,
+                                                 ov::Shape{1},
+                                                 std::vector<int64_t>{-1});
 
-    OutputVector new_shape_inputs;
+    ov::OutputVector new_shape_inputs;
     new_shape_inputs.reserve(shape_inputs.size());
     new_shape_inputs.push_back(minus_one);
     for (size_t i = 1; i < channel_idx; ++i)
@@ -169,7 +170,7 @@ void rewrite_reshape(const std::shared_ptr<v1::Reshape>& reshape,
 
     const auto new_concat = rg.make<v0::Concat>(new_shape_inputs, 0);
     reshape->input(1).replace_source_output(new_concat);
-    copy_runtime_info(concat, rg.get());
+    ov::copy_runtime_info(concat, rg.get());
 }
 
 }  // namespace
@@ -202,8 +203,12 @@ bool ov::pass::RestoreReshapeBakedBatch::run_on_model(const std::shared_ptr<ov::
     if (candidates.empty())
         return false;
 
-    // A candidate exists: materialize the shapes the walk-back keys on. validate_nodes_and_infer_types()
-    // only re-infers types/shapes — it adds/removes no nodes — so the captured pointers stay valid and the
+    // A candidate exists: materialize the shapes the walk-back keys on. This runs only on the rare model
+    // that actually carries the window-reverse signature (guarded by the early return above), so it adds no
+    // cost to ordinary models. Validating here keeps the pass self-contained — its channel recovery reads
+    // PartialShapes directly and must not depend on the caller's per-pass-validation policy (the sibling
+    // dynamic_manager in smart_reshape.cpp turns validation off). validate_nodes_and_infer_types() only
+    // re-infers types/shapes — it adds/removes no nodes — so the captured pointers stay valid and the
     // candidate vector stays in topological order.
     model->validate_nodes_and_infer_types();
 
@@ -213,14 +218,14 @@ bool ov::pass::RestoreReshapeBakedBatch::run_on_model(const std::shared_ptr<ov::
         int64_t channel;
     };
     std::vector<PendingRewrite> pending;
-    std::unordered_map<const Node*, int64_t> pending_channel;
+    std::unordered_map<const ov::Node*, int64_t> pending_channel;
 
     // PHASE 1 — COLLECT (topological order: producers before consumers).
     for (const auto& candidate : candidates) {
         const auto& reshape = candidate.reshape;
         const auto& concat = candidate.concat;
 
-        std::unordered_set<const Node*> visited;
+        std::unordered_set<const ov::Node*> visited;
         const auto channel = resolve_static_last_dim(reshape->input_value(0), pending_channel, visited);
         if (!channel)
             continue;

--- a/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
@@ -4,7 +4,6 @@
 
 #include "transformations/smart_reshape/restore_reshape_baked_batch.hpp"
 
-#include <algorithm>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -178,21 +177,34 @@ void rewrite_reshape(const std::shared_ptr<v1::Reshape>& reshape,
 bool ov::pass::RestoreReshapeBakedBatch::run_on_model(const std::shared_ptr<ov::Model>& model) {
     RUN_ON_MODEL_SCOPE(RestoreReshapeBakedBatch);
 
-    // Cheap structural pre-scan: the structural gates inspect only the shape Concat's axis and constant
-    // elements — never an inferred PartialShape — so they need no shape inference. If no reshape carries
-    // the window-reverse signature (the common case) we return immediately.
-    const auto matches_signature = [](const std::shared_ptr<Node>& op) {
+    struct Candidate {
+        std::shared_ptr<v1::Reshape> reshape;
+        std::shared_ptr<v0::Concat> concat;
+    };
+
+    // Cheap structural scan (NO shape inference): the structural gates inspect only the shape Concat's
+    // axis and constant elements — never an inferred PartialShape — so they yield the same verdict before
+    // and after inference. We collect the candidates ONCE, here, in get_ordered_ops() topological order
+    // (producers before consumers — the walk-back below relies on it).
+    std::vector<Candidate> candidates;
+    for (const auto& op : model->get_ordered_ops()) {
         auto reshape = ov::as_type_ptr<v1::Reshape>(op);
         if (!reshape)
-            return false;
+            continue;
         auto concat = ov::as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
-        return concat && passes_structural_gates(reshape, concat);
-    };
-    const auto& ordered_ops = model->get_ordered_ops();
-    if (std::none_of(ordered_ops.begin(), ordered_ops.end(), matches_signature))
+        if (!concat)
+            continue;
+        if (passes_structural_gates(reshape, concat))
+            candidates.push_back({reshape, concat});
+    }
+
+    // No reshape carries the window-reverse signature (the common case): return without re-inferring shapes.
+    if (candidates.empty())
         return false;
 
-    // A candidate exists: make sure the shapes the walk-back keys on are materialized before resolving.
+    // A candidate exists: materialize the shapes the walk-back keys on. validate_nodes_and_infer_types()
+    // only re-infers types/shapes — it adds/removes no nodes — so the captured pointers stay valid and the
+    // candidate vector stays in topological order.
     model->validate_nodes_and_infer_types();
 
     struct PendingRewrite {
@@ -204,15 +216,9 @@ bool ov::pass::RestoreReshapeBakedBatch::run_on_model(const std::shared_ptr<ov::
     std::unordered_map<const Node*, int64_t> pending_channel;
 
     // PHASE 1 — COLLECT (topological order: producers before consumers).
-    for (const auto& op : ordered_ops) {
-        auto reshape = ov::as_type_ptr<v1::Reshape>(op);
-        if (!reshape)
-            continue;
-        auto concat = ov::as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
-        if (!concat)
-            continue;
-        if (!passes_structural_gates(reshape, concat))
-            continue;
+    for (const auto& candidate : candidates) {
+        const auto& reshape = candidate.reshape;
+        const auto& concat = candidate.concat;
 
         std::unordered_set<const Node*> visited;
         const auto channel = resolve_static_last_dim(reshape->input_value(0), pending_channel, visited);

--- a/src/common/transformations/src/transformations/smart_reshape/smart_reshape.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/smart_reshape.cpp
@@ -16,6 +16,7 @@
 #include "transformations/smart_reshape/proposal_scales_stridedslice.hpp"
 #include "transformations/smart_reshape/reshape_sinking.hpp"
 #include "transformations/smart_reshape/reshape_to_1D.hpp"
+#include "transformations/smart_reshape/restore_reshape_baked_batch.hpp"
 #include "transformations/smart_reshape/shape_of_const_folding.hpp"
 #include "transformations/smart_reshape/strided_slice_squeeze.hpp"
 
@@ -35,6 +36,7 @@ bool ov::pass::SmartReshape::run_on_model(const std::shared_ptr<ov::Model>& f) {
     static_manager.register_pass<ov::pass::BroadcastConstRangeReplacement>();
     static_manager.register_pass<ov::pass::LSTMStatesBroadcast>();
     static_manager.register_pass<ov::pass::ReshapeSinkingMatMul>();
+    static_manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
     static_manager.run_passes(f);
 
     ov::pass::Manager dynamic_manager("SmartReshape:dynamic");

--- a/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
@@ -1,0 +1,164 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/smart_reshape/restore_reshape_baked_batch.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reshape.hpp"
+
+using namespace ov;
+using namespace ov::op;
+
+namespace {
+
+// Build a 1-element i64 Constant (a shape-vector element).
+std::shared_ptr<v0::Constant> dim_const(int64_t value) {
+    return v0::Constant::create(element::i64, Shape{1}, {value});
+}
+
+}  // namespace
+
+// Positive, DIRECT path. A window-reverse R8-style view: the windows tensor [num_win*B, ws, ws, C]
+// is split into [B, H//ws, W//ws, ws, ws, C]. Tracing froze the leading batch into Constant(1) and
+// left the channel as the trailing -1; the spatial split (H//ws, W//ws) stays dynamic. The pass must
+// rewrite the shape Concat so the leading Constant becomes -1 (batch inferred) and the trailing -1
+// becomes Constant(C) (channel recovered from data's static last dim), keeping the interior intact.
+TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_direct_positive) {
+    constexpr int64_t WS = 8, C = 16;
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32,
+                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        // Dynamic spatial split (H//ws, W//ws) -- non-constant shape elements.
+        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto shape = std::make_shared<v0::Concat>(
+            OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+        auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
+
+        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
+        // The rewrite only flips two scalar Constants (1 -> -1, -1 -> C); the default comparator does
+        // not inspect Constant values, so enable that explicitly to actually assert the rewrite.
+        comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    }
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32,
+                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto shape = std::make_shared<v0::Concat>(
+            OutputVector{dim_const(-1), h, w, dim_const(WS), dim_const(WS), dim_const(C)}, 0);
+        auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
+    }
+}
+
+// End-to-end: SmartReshape runs inside Model::reshape, so re-batching the windows tensor must drive
+// the pass over the whole model. We assert the rewrite happened through that full path: the shape
+// Concat's leading baked-batch Constant is relaxed to -1 (batch inferred) and the trailing -1 channel
+// is pinned to Constant(C). (The Reshape's inferred partial shape stays dynamic here because the
+// interior spatial dims are dynamic Parameters and the leading -1 cannot be folded -- the rewrite is
+// nonetheless value-correct, which the real-model A/B verifies; here we pin the graph-level effect.)
+TEST(SmartReshapeTests, RestoreReshapeBakedBatch_reshape) {
+    constexpr int64_t WS = 2, C = 16;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{4, WS, WS, C});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape = std::make_shared<v0::Concat>(
+        OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    auto model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
+
+    // RestoreReshapeBakedBatch is called as a part of SmartReshape.
+    OV_ASSERT_NO_THROW(model->reshape({{data->output(0), PartialShape{8, WS, WS, C}}}));
+
+    auto concat = ov::as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
+    ASSERT_NE(concat, nullptr);
+    const auto& elems = concat->input_values();
+    ASSERT_EQ(elems.size(), 6u);
+
+    auto leading = ov::as_type_ptr<v0::Constant>(elems.front().get_node_shared_ptr());
+    ASSERT_NE(leading, nullptr) << "leading element must be the inferred -1 Constant";
+    EXPECT_EQ(leading->cast_vector<int64_t>().at(0), -1) << "baked batch not relaxed to -1";
+
+    auto channel = ov::as_type_ptr<v0::Constant>(elems.back().get_node_shared_ptr());
+    ASSERT_NE(channel, nullptr) << "channel must be pinned to a static Constant";
+    EXPECT_EQ(channel->cast_vector<int64_t>().at(0), C) << "channel not pinned to data's last dim";
+}
+
+// Negative: special_zero == true is a different reshape semantics and must never match.
+TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_special_zero) {
+    constexpr int64_t WS = 8, C = 16;
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32,
+                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto shape = std::make_shared<v0::Concat>(
+            OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+        auto reshape = std::make_shared<v1::Reshape>(data, shape, /*special_zero=*/true);
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
+
+        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
+    }
+}
+
+// Negative: a non-constant (already-symbolic) leading element means the batch already propagates --
+// there is nothing baked to relax, so the pass must not fire.
+TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_dynamic_leading) {
+    constexpr int64_t WS = 8, C = 16;
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32,
+                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto batch = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic leading
+        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto shape = std::make_shared<v0::Concat>(
+            OutputVector{batch, h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+        auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, batch, h, w});
+
+        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
+    }
+}
+
+// Negative: a fully baked shape (no dynamic interior) is an ordinary fixed reshape, not the
+// window-reverse signature -- the pass must not fire.
+TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_no_dynamic_interior) {
+    constexpr int64_t WS = 8, C = 16;
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32,
+                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto shape = std::make_shared<v0::Concat>(
+            OutputVector{dim_const(1), dim_const(2), dim_const(2), dim_const(WS), dim_const(WS), dim_const(-1)},
+            0);
+        auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
+
+        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
+    }
+}
+
+// Negative: spatial flatten view(1, C, -1). The shape vector is shorter than the data rank, so the
+// trailing-block guard rejects it (the -1 would span more than data's last dim -- here H*W, not W).
+TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_spatial_flatten) {
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{2, 3, 4, 5});  // last dim 5
+        auto c = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});               // dynamic C slot
+        auto shape = std::make_shared<v0::Concat>(OutputVector{dim_const(1), c, dim_const(-1)}, 0);
+        auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, c});
+
+        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
+    }
+}

--- a/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
@@ -210,7 +210,8 @@ std::shared_ptr<Model> build_neg_spatial_flatten() {
 // dynamic, so the rewrite cannot be proven to keep data's trailing block).
 std::shared_ptr<Model> build_neg_head_merge() {
     constexpr int64_t D = 8;
-    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), Dimension::dynamic(), D});
+    auto data =
+        std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), Dimension::dynamic(), D});
     auto t = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic T//2
     auto shape = std::make_shared<v0::Concat>(OutputVector{dim_const(1), t, dim_const(-1)}, 0);
     auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
@@ -235,8 +236,7 @@ std::shared_ptr<Model> build_neg_head_split() {
 std::shared_ptr<Model> build_neg_dyn_channel() {
     constexpr int64_t WS = 8;
     auto data =
-        std::make_shared<v0::Parameter>(element::f32,
-                                        PartialShape{Dimension::dynamic(), WS, WS, Dimension::dynamic()});
+        std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, Dimension::dynamic()});
     auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
     auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
     auto shape =
@@ -276,19 +276,18 @@ TEST_P(RestoreReshapeBakedBatchNeg, PassDoesNotFire) {
     // so the test asserts the pass made no change.
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    SmartReshapeTests,
-    RestoreReshapeBakedBatchNeg,
-    testing::ValuesIn(std::vector<NegParams>{
-        {"special_zero", build_neg_special_zero},
-        {"dynamic_leading", build_neg_dynamic_leading},
-        {"no_dynamic_interior", build_neg_no_dynamic_interior},
-        {"spatial_flatten", build_neg_spatial_flatten},
-        {"head_merge", build_neg_head_merge},
-        {"head_split", build_neg_head_split},
-        {"dyn_channel", build_neg_dyn_channel},
-        {"already_rewritten", build_neg_already_rewritten},
-    }),
-    [](const testing::TestParamInfo<NegParams>& info) {
-        return info.param.name;
-    });
+INSTANTIATE_TEST_SUITE_P(SmartReshapeTests,
+                         RestoreReshapeBakedBatchNeg,
+                         testing::ValuesIn(std::vector<NegParams>{
+                             {"special_zero", build_neg_special_zero},
+                             {"dynamic_leading", build_neg_dynamic_leading},
+                             {"no_dynamic_interior", build_neg_no_dynamic_interior},
+                             {"spatial_flatten", build_neg_spatial_flatten},
+                             {"head_merge", build_neg_head_merge},
+                             {"head_split", build_neg_head_split},
+                             {"dyn_channel", build_neg_dyn_channel},
+                             {"already_rewritten", build_neg_already_rewritten},
+                         }),
+                         [](const testing::TestParamInfo<NegParams>& info) {
+                             return info.param.name;
+                         });

--- a/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
@@ -6,7 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "common_test_utils/ov_test_utils.hpp"
@@ -15,6 +17,7 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/reshape.hpp"
+#include "openvino/op/transpose.hpp"
 
 using namespace ov;
 using namespace ov::op;
@@ -63,6 +66,54 @@ TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_direct_positive) {
     }
 }
 
+// Positive, WALK-BACK path -- the reason this pass is a ModelPass rather than a MatcherPass. Two chained
+// window-reverse views: Reshape_1 [?,ws,ws,C] -> [?,?,?,ws,ws,C] (its channel resolves DIRECTLY from
+// data's static last dim C), then a last-axis-preserving Transpose(order=[0,1,3,2,4,5]) whose output is
+// fully dynamic, then Reshape_2 [B,H,W,-1] whose data last dim is now DYNAMIC. Reshape_2's channel cannot
+// be read off its data; it is recovered by walking back through the Transpose to Reshape_1's recorded
+// channel. BOTH reshapes must end up with leading -1 (batch inferred) and trailing Constant(C).
+TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_walkback_positive) {
+    constexpr int64_t WS = 8, C = 16;
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+
+        auto shape1 =
+            std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)},
+                                         0);
+        auto reshape1 = std::make_shared<v1::Reshape>(data, shape1, false);
+        // Last-axis-preserving permute (order.back() == rank - 1): keeps the channel axis last.
+        auto order = v0::Constant::create(element::i64, Shape{6}, {0, 1, 3, 2, 4, 5});
+        auto transpose = std::make_shared<v1::Transpose>(reshape1, order);
+        auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+        auto reshape2 = std::make_shared<v1::Reshape>(transpose, shape2, false);
+        model = std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+
+        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
+        comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    }
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+
+        auto shape1 =
+            std::make_shared<v0::Concat>(OutputVector{dim_const(-1), h, w, dim_const(WS), dim_const(WS), dim_const(C)},
+                                         0);
+        auto reshape1 = std::make_shared<v1::Reshape>(data, shape1, false);
+        auto order = v0::Constant::create(element::i64, Shape{6}, {0, 1, 3, 2, 4, 5});
+        auto transpose = std::make_shared<v1::Transpose>(reshape1, order);
+        auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(-1), H, W, dim_const(C)}, 0);
+        auto reshape2 = std::make_shared<v1::Reshape>(transpose, shape2, false);
+        model_ref = std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+    }
+}
+
 // End-to-end: SmartReshape runs inside Model::reshape, so re-batching the windows tensor must drive
 // the pass over the whole model. We assert the rewrite happened through that full path: the shape
 // Concat's leading baked-batch Constant is relaxed to -1 (batch inferred) and the trailing -1 channel
@@ -96,67 +147,148 @@ TEST(SmartReshapeTests, RestoreReshapeBakedBatch_reshape) {
     EXPECT_EQ(channel->cast_vector<int64_t>().at(0), C) << "channel not pinned to data's last dim";
 }
 
-// Negative: special_zero == true is a different reshape semantics and must never match.
-TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_special_zero) {
+// --------------------------------------------------------------------------------------------------
+// Negative cases. The pass runs inside every Model::reshape, so it must never fire on a reshape it
+// cannot prove value-preserving. Each builder produces a graph the pass must leave untouched; the
+// TEST_P body sets only `model` (no model_ref), so TransformationTestsF::TearDown clones `model`
+// BEFORE running the pass and compares against the clone -- an exact "did not fire" assertion.
+// --------------------------------------------------------------------------------------------------
+
+namespace {
+
+// special_zero == true is a different reshape semantics and must never match.
+std::shared_ptr<Model> build_neg_special_zero() {
     constexpr int64_t WS = 8, C = 16;
-    {
-        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto shape =
-            std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)},
-                                         0);
-        auto reshape = std::make_shared<v1::Reshape>(data, shape, /*special_zero=*/true);
-        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
-
-        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
-    }
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, /*special_zero=*/true);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
 }
 
-// Negative: a non-constant (already-symbolic) leading element means the batch already propagates --
-// there is nothing baked to relax, so the pass must not fire.
-TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_dynamic_leading) {
+// A non-constant (already symbolic) leading element means the batch already propagates -- there is
+// nothing baked to relax, so the pass must not fire.
+std::shared_ptr<Model> build_neg_dynamic_leading() {
     constexpr int64_t WS = 8, C = 16;
-    {
-        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-        auto batch = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic leading
-        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto shape =
-            std::make_shared<v0::Concat>(OutputVector{batch, h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
-        auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
-        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, batch, h, w});
-
-        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
-    }
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto batch = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic leading
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape =
+        std::make_shared<v0::Concat>(OutputVector{batch, h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, batch, h, w});
 }
 
-// Negative: a fully baked shape (no dynamic interior) is an ordinary fixed reshape, not the
-// window-reverse signature -- the pass must not fire.
-TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_no_dynamic_interior) {
+// A fully baked shape (no dynamic interior) is an ordinary fixed reshape, not the window-reverse
+// signature -- the pass must not fire.
+std::shared_ptr<Model> build_neg_no_dynamic_interior() {
     constexpr int64_t WS = 8, C = 16;
-    {
-        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-        auto shape = std::make_shared<v0::Concat>(
-            OutputVector{dim_const(1), dim_const(2), dim_const(2), dim_const(WS), dim_const(WS), dim_const(-1)},
-            0);
-        auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
-        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
-
-        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
-    }
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto shape = std::make_shared<v0::Concat>(
+        OutputVector{dim_const(1), dim_const(2), dim_const(2), dim_const(WS), dim_const(WS), dim_const(-1)},
+        0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 }
 
-// Negative: spatial flatten view(1, C, -1). The shape vector is shorter than the data rank, so the
-// trailing-block guard rejects it (the -1 would span more than data's last dim -- here H*W, not W).
-TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_spatial_flatten) {
-    {
-        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{2, 3, 4, 5});  // last dim 5
-        auto c = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});              // dynamic C slot
-        auto shape = std::make_shared<v0::Concat>(OutputVector{dim_const(1), c, dim_const(-1)}, 0);
-        auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
-        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, c});
-
-        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
-    }
+// Spatial flatten view(1, C, -1). The shape vector is shorter than the data rank, so the trailing-block
+// guard rejects it (the -1 would span more than data's last dim -- here H*W, not W).
+std::shared_ptr<Model> build_neg_spatial_flatten() {
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{2, 3, 4, 5});  // last dim 5
+    auto c = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});              // dynamic C slot
+    auto shape = std::make_shared<v0::Concat>(OutputVector{dim_const(1), c, dim_const(-1)}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, c});
 }
+
+// Head-merge view(1, T//2, -1): data has a STATIC last dim (D) but a DYNAMIC interior, so the trailing
+// -1 spans more than D. The cheap output-channel guard is vacuous (output last dim dynamic), so the
+// trailing-block guard must reject -- here at its data_dim.is_dynamic() branch (the kept interior dim is
+// dynamic, so the rewrite cannot be proven to keep data's trailing block).
+std::shared_ptr<Model> build_neg_head_merge() {
+    constexpr int64_t D = 8;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), Dimension::dynamic(), D});
+    auto t = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic T//2
+    auto shape = std::make_shared<v0::Concat>(OutputVector{dim_const(1), t, dim_const(-1)}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, t});
+}
+
+// Head-split view(1, T*2, -1): data has a STATIC last dim (D) AND a static interior dim, but the kept
+// interior shape element is dynamic (T*2) and cannot be proven equal to data's static interior dim, so
+// the trailing-block guard rejects -- here at its non-constant-interior branch (distinct from head_merge).
+std::shared_ptr<Model> build_neg_head_split() {
+    constexpr int64_t D = 8, T = 4;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), T, D});
+    auto t = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic T*2
+    auto shape = std::make_shared<v0::Concat>(OutputVector{dim_const(1), t, dim_const(-1)}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, t});
+}
+
+// Window-reverse with a DYNAMIC channel (no projection to a fixed width). The channel flows from the
+// input and stays dynamic, so resolve_static_last_dim cannot recover a static last dim and returns
+// nullopt -- the pass must not fire.
+std::shared_ptr<Model> build_neg_dyn_channel() {
+    constexpr int64_t WS = 8;
+    auto data =
+        std::make_shared<v0::Parameter>(element::f32,
+                                        PartialShape{Dimension::dynamic(), WS, WS, Dimension::dynamic()});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
+}
+
+// Idempotency: the already-rewritten shape (leading Constant(-1), trailing Constant(C)). Re-running the
+// pass must not re-fire -- a Constant(-1) leading element fails the positive-int leading gate, so the
+// rewrite is a fixed point.
+std::shared_ptr<Model> build_neg_already_rewritten() {
+    constexpr int64_t WS = 8, C = 16;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(-1), h, w, dim_const(WS), dim_const(WS), dim_const(C)}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
+}
+
+struct NegParams {
+    std::string name;
+    std::function<std::shared_ptr<Model>()> build;
+};
+
+}  // namespace
+
+class RestoreReshapeBakedBatchNeg : public testing::WithParamInterface<NegParams>, public TransformationTestsF {};
+
+TEST_P(RestoreReshapeBakedBatchNeg, PassDoesNotFire) {
+    const auto& p = GetParam();
+    model = p.build();
+    manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
+    // model_ref left null on purpose: TearDown clones `model` before running the pass and compares,
+    // so the test asserts the pass made no change.
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SmartReshapeTests,
+    RestoreReshapeBakedBatchNeg,
+    testing::ValuesIn(std::vector<NegParams>{
+        {"special_zero", build_neg_special_zero},
+        {"dynamic_leading", build_neg_dynamic_leading},
+        {"no_dynamic_interior", build_neg_no_dynamic_interior},
+        {"spatial_flatten", build_neg_spatial_flatten},
+        {"head_merge", build_neg_head_merge},
+        {"head_split", build_neg_head_split},
+        {"dyn_channel", build_neg_dyn_channel},
+        {"already_rewritten", build_neg_already_rewritten},
+    }),
+    [](const testing::TestParamInfo<NegParams>& info) {
+        return info.param.name;
+    });

--- a/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
@@ -36,13 +36,13 @@ std::shared_ptr<v0::Constant> dim_const(int64_t value) {
 TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_direct_positive) {
     constexpr int64_t WS = 8, C = 16;
     {
-        auto data = std::make_shared<v0::Parameter>(element::f32,
-                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
         // Dynamic spatial split (H//ws, W//ws) -- non-constant shape elements.
         auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
         auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto shape = std::make_shared<v0::Concat>(
-            OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+        auto shape =
+            std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)},
+                                         0);
         auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
         model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
 
@@ -52,12 +52,12 @@ TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_direct_positive) {
         comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     }
     {
-        auto data = std::make_shared<v0::Parameter>(element::f32,
-                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
         auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
         auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto shape = std::make_shared<v0::Concat>(
-            OutputVector{dim_const(-1), h, w, dim_const(WS), dim_const(WS), dim_const(C)}, 0);
+        auto shape =
+            std::make_shared<v0::Concat>(OutputVector{dim_const(-1), h, w, dim_const(WS), dim_const(WS), dim_const(C)},
+                                         0);
         auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
         model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
     }
@@ -74,8 +74,8 @@ TEST(SmartReshapeTests, RestoreReshapeBakedBatch_reshape) {
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{4, WS, WS, C});
     auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
     auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto shape = std::make_shared<v0::Concat>(
-        OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto shape =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
     auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
     auto model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
 
@@ -100,12 +100,12 @@ TEST(SmartReshapeTests, RestoreReshapeBakedBatch_reshape) {
 TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_special_zero) {
     constexpr int64_t WS = 8, C = 16;
     {
-        auto data = std::make_shared<v0::Parameter>(element::f32,
-                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
         auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
         auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto shape = std::make_shared<v0::Concat>(
-            OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+        auto shape =
+            std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)},
+                                         0);
         auto reshape = std::make_shared<v1::Reshape>(data, shape, /*special_zero=*/true);
         model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
 
@@ -118,13 +118,12 @@ TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_special_zero) {
 TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_dynamic_leading) {
     constexpr int64_t WS = 8, C = 16;
     {
-        auto data = std::make_shared<v0::Parameter>(element::f32,
-                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
         auto batch = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic leading
         auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
         auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto shape = std::make_shared<v0::Concat>(
-            OutputVector{batch, h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+        auto shape =
+            std::make_shared<v0::Concat>(OutputVector{batch, h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
         auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
         model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, batch, h, w});
 
@@ -137,8 +136,7 @@ TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_dynamic_leading) {
 TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_no_dynamic_interior) {
     constexpr int64_t WS = 8, C = 16;
     {
-        auto data = std::make_shared<v0::Parameter>(element::f32,
-                                                    PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
         auto shape = std::make_shared<v0::Concat>(
             OutputVector{dim_const(1), dim_const(2), dim_const(2), dim_const(WS), dim_const(WS), dim_const(-1)},
             0);
@@ -154,7 +152,7 @@ TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_no_dynamic_interior) {
 TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_neg_spatial_flatten) {
     {
         auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{2, 3, 4, 5});  // last dim 5
-        auto c = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});               // dynamic C slot
+        auto c = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});              // dynamic C slot
         auto shape = std::make_shared<v0::Concat>(OutputVector{dim_const(1), c, dim_const(-1)}, 0);
         auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
         model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, c});


### PR DESCRIPTION
### Details:
A SwinIR-style window_reverse computes the batch as plain Python arithmetic:

    B = int(windows.shape[0] / (H * W / ws / ws))
    x = windows.view(B, H // ws, W // ws, ws, ws, -1)

Under torch.jit.trace the int(...) collapses to a literal. In the IR the view shape
becomes a Concat where only the spatial dims stay live (aten::size), the leading batch
is a baked Constant, and the channel is the trailing -1:

    view(windows, [ B=Const(1), H//ws, W//ws, 8, 8, Const(-1) ])
                    baked        live   live              infer

At the traced batch=1 this is correct:

    windows = (361, 8, 8, 180),  total = 4_158_720
    H//ws = W//ws = 19  (live)
    known product = 1 * 19 * 19 * 8 * 8 = 23_104
    -1 = 4_158_720 / 23_104 = 180   -> channel 180, correct

After model.reshape(batch=2) the input becomes (2, 3, 152, 152). The spatial dims do
not depend on batch, so the live H//ws, W//ws stay 19, 19, and the leading Const(1)
stays 1 (it is a literal with no input for reshape to rewrite):

    windows = (722, 8, 8, 180),  total = 8_317_440   (twice the elements)
    shape   = (1, 19, 19, 8, 8, -1)                  (leading still 1)
    known product = 1 * 19 * 19 * 8 * 8 = 23_104     (unchanged)
    -1 = 8_317_440 / 23_104 = 360                     (was 180)

The doubled element count divides by the same known product, so the only free axis (-1)
must absorb the extra factor of 2: the batch leaks into the channel, 180 -> 360, and the
window grid is scrambled.

The corruption is silent because the final view rebuilds a correct shape -- its batch is
live and its channel is the literal embed_dim:

    Reshape_8: [1, 19, 19, 8, 8, 360]
    permute  : [1, 19, 8, 19, 8, 360]
    Reshape_9 = view(1, H, W, -1) -> [1, 152, 152, 360]
    final view(B, H*W, C) -> [2, 23104, 180]   shape correct, data wrong

Compilation, inference, and output shapes all pass; only the values are wrong
(max_abs_diff ~3.47 on the SwinIR_Classical models at batch=2).

Fix

Add ov::pass::RestoreReshapeBakedBatch, a ModelPass registered in SmartReshape.
For a reshape carrying the window-reverse signature (leading positive-int constant,
exactly one trailing -1, at least one dynamic interior dim) it frees the leading dim to
-1 and pins the channel to its batch-independent value as a Constant, so the batch is
inferred from the real element count and no longer leaks into the channel.

The channel is recovered by a deterministic walk-back rather than OV shape inference:
window_reverse uses two chained views and the second takes its data through a permute
whose output stays dynamic. The pass walks back from the data to a static last dim,
through a last-axis-preserving Transpose, or to a view already selected for rewrite.

Two guards keep it from touching ordinary reshapes that share the structure:
- if the output last dim is statically known, it must equal the recovered channel;
- on the direct path the rewrite must only re-partition the leading dim and keep the
  data's entire trailing block, which rejects merge/split reshapes such as
  view(1, T//2, -1) whose -1 spans more than the data's last dim.

The pass lives in SmartReshape rather than the PyTorch frontend: it is a reshapeability
concern handled on the built ov::Model, so it runs both at convert time
(apply_moc_transformations with smart_reshape=True) and inside Model::reshape, for any
framework.



### Tickets:
 - 172206
