### PR TITLE
[GPU] Reduce redundant K/V work for causal attention in the SDPA micro-kernel

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
@@ -218,6 +218,31 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #else
     uint wg_j0 = get_group_id(0) * ugemm_kq_wg_tile_n;
 #endif
+
+    int causal_k = k;
+#if IS_CAUSAL
+    #if IS_PAGED_ATTENTION && !IS_PREFILL
+        #if !IS_GQA_SINGLE_TOKEN
+            causal_k = min(k, past_len + (int)wg_j0 + ugemm_kq_wg_tile_n);
+        #endif
+    #else
+        causal_k = min(k, (int)wg_j0 + ugemm_kq_wg_tile_n);
+    #endif
+#endif
+
+    int window_k_begin = 0;
+    int window_k0_begin = 0;
+#if IS_CAUSAL && SLIDING_WINDOW_SIZE
+    #if IS_GQA_SINGLE_TOKEN
+        window_k_begin = MAX(0, k - SLIDING_WINDOW_SIZE);
+    #elif IS_PAGED_ATTENTION && !IS_PREFILL
+        window_k_begin = MAX(0, past_len + (int)wg_j0 - SLIDING_WINDOW_SIZE + 1);
+    #else
+        window_k_begin = MAX(0, (int)wg_j0 - SLIDING_WINDOW_SIZE + 1);
+    #endif
+    window_k0_begin = (window_k_begin / ugemm_kq_wg_tile_m) * ugemm_kq_wg_tile_m;
+#endif
+
     /* Leading dimension for matrices */
 #if IS_PAGED_ATTENTION
     #if IS_GQA_SINGLE_TOKEN
@@ -368,6 +393,18 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     __builtin_assume_aligned(V, V_ALIGN);
     __builtin_assume_aligned(A, A_ALIGN);
 
+#if SLIDING_WINDOW_SIZE && !(IS_PAGED_ATTENTION && !IS_PREFILL)
+    if (window_k0_begin > 0) {
+        V += (size_t)ldv * window_k0_begin / VAL_ELEMENTS_PER_BYTE;
+    #if VAL_SCALES == QUANTIZE_2D
+        V_scales += (size_t)ldvq * window_k0_begin;
+    #endif
+    #if VAL_ZERO_POINTS == QUANTIZE_2D
+        V_zp += (size_t)ldvq * window_k0_begin / VAL_ZP_ELEMENTS_PER_BYTE;
+    #endif
+    }
+#endif
+
     /* Load Q tile, destined for SLM */
     q_tile_type Q_tile;
     uint q0_copy = q_tile_sg_n * sg_ij;
@@ -429,10 +466,15 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 
 #ifdef PREFETCH_K0
     /* Prefetch first K tile. */
+#if TRANSPOSE_K
+    const uint stride_k0 = ldk;
+#else
+    const uint stride_k0 = 1;
+#endif
     cooperative_prefetch_2d_k(
-            /* ptr */ K,
-            /* r */ d,
-            /* c */ k,
+            /* ptr */ K + window_k_begin * stride_k0,
+            /* r */ causal_k - window_k_begin,
+            /* c */ d,
             /* rmax */ ugemm_kq_wg_tile_m,
             /* cmax */ PREFETCH_D_MAX,
             /* ld */ ldk,
@@ -443,8 +485,8 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 
 #if KEY_SCALES == QUANTIZE_2D
     cooperative_prefetch_2d_maybe_rem(
-            /* ptr */ K_scales,
-            /* r */ k,
+            /* ptr */ K_scales + window_k_begin,
+            /* r */ causal_k - window_k_begin,
             /* c */ num_key_groups,
             /* rmax */ ugemm_kq_wg_tile_m,
             /* cmax */ D_MAX / KEY_GROUP_SIZE,
@@ -456,8 +498,8 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 #if KEY_ZERO_POINTS == QUANTIZE_2D
     cooperative_prefetch_2d_maybe_rem(
-            /* ptr */ K_zp,
-            /* r */ k,
+            /* ptr */ K_zp + window_k_begin,
+            /* r */ causal_k - window_k_begin,
             /* c */ num_key_groups,
             /* rmax */ ugemm_kq_wg_tile_m,
             /* cmax */ D_MAX / KEY_GROUP_SIZE,
@@ -497,14 +539,14 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     barrier(CLK_LOCAL_MEM_FENCE);
 
     /* Main loop over k blocks */
-    for (int k0 = 0; k0 < k; k0 += ugemm_kq_wg_tile_m) {
-        bool first = (k0 == 0);
-        bool last = (k0 + ugemm_kq_wg_tile_m >= k);
+    for (int k0 = window_k0_begin; k0 < causal_k; k0 += ugemm_kq_wg_tile_m) {
+        bool first = (k0 == window_k0_begin);
+        bool last = (k0 + ugemm_kq_wg_tile_m >= causal_k);
 
         uint sg_i0_kq = sg_i_kq * ugemm_kq_sg_tile_m;
         uint sg_j0_kq = sg_j_kq * ugemm_kq_sg_tile_n;
 
-        int k_chunk = min(k - k0, ugemm_kq_wg_tile_m);
+        int k_chunk = min(causal_k - k0, ugemm_kq_wg_tile_m);
 
 #if WITH_ATTN_MASK
         /* Load mask. No remainder handling needed assuming k block size is a power of 2. */
@@ -526,7 +568,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         for (int ii = 0; ii < ugemm_kq_sg_tile_m / SUBGROUP_SIZE; ii++)
             k_mask.x[0][ii] = (k0 + sg_i0_kq + ii * SUBGROUP_SIZE
                                               + get_sub_group_local_id()
-                                      < k)
+                                      < causal_k)
                     ? nan(0u)
                     : -INFINITY;
 #endif
@@ -581,7 +623,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         }
 
         for (; k0 >= past_lens[gws_mapping];) {
-            s_tile_type S_tile1 = ugemm_kcq(Kc, ldkc, Q_slm, D_MAX, (k - past_lens[gws_mapping]), ugemm_kq_wg_tile_n, d, (k0 - past_lens[gws_mapping]),
+            s_tile_type S_tile1 = ugemm_kcq(Kc, ldkc, Q_slm, D_MAX, (causal_k - past_lens[gws_mapping]), ugemm_kq_wg_tile_n, d, (k0 - past_lens[gws_mapping]),
                         0, 0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm);
             tile_binary(S_tile, S_tile1, binary_add);
             break;
@@ -589,7 +631,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     #endif
 #else
         s_tile_type S_tile
-                = ugemm_kq(K, ldk, Q_slm, D_MAX, k, ugemm_kq_wg_tile_n, d, k0,
+                = ugemm_kq(K, ldk, Q_slm, D_MAX, causal_k, ugemm_kq_wg_tile_n, d, k0,
                         0, 0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm
         #if KEY_SCALES == QUANTIZE_2D
                         ,
@@ -642,21 +684,42 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     #else
         #define greater_than(offset_k, offset_q) (offset_k > offset_q)
     #endif
-                             
+
         int col_offset = wg_j0 + sg_j0_kq;
+        int causal_q_begin = col_offset;
     #if IS_PAGED_ATTENTION && !IS_PREFILL
         #if IS_GQA_SINGLE_TOKEN
             col_offset += k - 1 - get_sub_group_local_id();
+            causal_q_begin += k - 1;
         #else
             col_offset += k - q;
+            causal_q_begin += k - q;
         #endif
     #endif
 
         /* Apply causal mask */
-        tile_predicated_assignment_t(S_tile, k0 + sg_i0_kq, col_offset,
-                greater_than, -FLT_MAX, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
-                ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
-                ugemm_kq_c_type_nblock1);
+        const int causal_k_begin = k0 + sg_i0_kq;
+        const int causal_k_end = causal_k_begin
+                + ugemm_kq_c_type_block1 * ugemm_kq_c_type_nblock1;
+    #if SLIDING_WINDOW_SIZE
+        const int causal_q_end = causal_q_begin
+                + ugemm_kq_c_type_block0 * ugemm_kq_c_type_nblock0 - 1;
+        const bool causal_block_fully_valid =
+                (causal_k_begin > causal_q_end - SLIDING_WINDOW_SIZE)
+                && (causal_k_end <= causal_q_begin);
+        if (!causal_block_fully_valid) {
+    #else
+        if (causal_k_end > causal_q_begin) {
+    #endif
+            tile_predicated_assignment_t(S_tile, k0 + sg_i0_kq, col_offset,
+                    greater_than, -FLT_MAX, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
+                    ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
+                    ugemm_kq_c_type_nblock1);
+    #if SLIDING_WINDOW_SIZE
+        }
+    #else
+        }
+    #endif
 #endif
 
 #if HAS_QQ_BIAS && IS_PAGED_ATTENTION && (IS_PREFILL == 0)
@@ -698,7 +761,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         intel_work_group_barrier_arrive(CLK_LOCAL_MEM_FENCE);
 
         #ifdef HAS_SINK_INPUT
-        const int cur_k = k - k0 - 1;
+        const int cur_k = causal_k - k0 - 1;
         const bool is_last_m_sg = last && (sg_i_kq == cur_k / ugemm_kq_sg_tile_m);
         if (is_last_m_sg) {
         #if MULTI_TOKENS_PER_WI
@@ -715,12 +778,17 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 
 #ifdef PREFETCH_V
         /* Prefetch V tile. */
+#if SLIDING_WINDOW_SIZE && !(IS_PAGED_ATTENTION && !IS_PREFILL)
+    const int window_v_pf_begin = first ? (window_k_begin - k0) : 0;
+#else
+    const int window_v_pf_begin = 0;
+#endif
         cooperative_prefetch_2d_maybe_rem(
-                /* ptr */ V,
+                /* ptr */ V + (size_t)ldv * window_v_pf_begin / VAL_ELEMENTS_PER_BYTE,
                 /* r */ d,
-                /* c */ k - k0,
+                /* c */ causal_k - k0 - window_v_pf_begin,
                 /* rmax */ PREFETCH_D_MAX,
-                /* cmax */ ugemm_kq_wg_tile_m,
+                /* cmax */ ugemm_kq_wg_tile_m - window_v_pf_begin,
                 /* ld */ ldv,
                 /* sg_id */ sg_ij,
                 /* n_sg */ sg_per_wg,
@@ -730,11 +798,11 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #if VAL_SCALES == QUANTIZE_2D
         /* Prefetch V scales. */
         cooperative_prefetch_2d_maybe_rem(
-                /* ptr */ V_scales,
+                /* ptr */ V_scales + (size_t)ldvq * window_v_pf_begin,
                 /* r */ num_val_groups,
-                /* c */ k - k0,
+                /* c */ causal_k - k0 - window_v_pf_begin,
                 /* rmax */ PREFETCH_D_MAX / VAL_GROUP_SIZE,
-                /* cmax */ k_chunk,
+                /* cmax */ k_chunk - window_v_pf_begin,
                 /* ld */ ldvq,
                 /* sg_id */ sg_ij,
                 /* n_sg */ sg_per_wg,
@@ -744,11 +812,11 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #if VAL_ZERO_POINTS == QUANTIZE_2D
         /* Prefetch V zero points. */
         cooperative_prefetch_2d_maybe_rem(
-                /* ptr */ V_zp,
+                /* ptr */ V_zp + (size_t)ldvq * window_v_pf_begin / VAL_ZP_ELEMENTS_PER_BYTE,
                 /* r */ num_val_groups,
-                /* c */ k - k0,
+                /* c */ causal_k - k0 - window_v_pf_begin,
                 /* rmax */ PREFETCH_D_MAX / VAL_GROUP_SIZE,
-                /* cmax */ k_chunk,
+                /* cmax */ k_chunk - window_v_pf_begin,
                 /* ld */ ldvq,
                 /* sg_id */ sg_ij,
                 /* n_sg */ sg_per_wg,
@@ -858,7 +926,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 
             cooperative_prefetch_2d_k(
                     /* ptr */ K + (k0 + ugemm_kq_wg_tile_m) * stride_k,
-                    /* r */ k - k0 - ugemm_kq_wg_tile_m,
+                    /* r */ causal_k - k0 - ugemm_kq_wg_tile_m,
                     /* c */ d,
                     /* rmax */ ugemm_kq_wg_tile_m,
                     /* cmax */ D_MAX,
@@ -870,7 +938,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #if KEY_SCALES == QUANTIZE_2D
             cooperative_prefetch_2d_maybe_rem(
                     /* ptr */ K_scales + (k0 + ugemm_kq_wg_tile_m),
-                    /* r */ k - k0 - ugemm_kq_wg_tile_m,
+                    /* r */ causal_k - k0 - ugemm_kq_wg_tile_m,
                     /* c */ num_key_groups,
                     /* rmax */ ugemm_kq_wg_tile_m,
                     /* cmax */ D_MAX / KEY_GROUP_SIZE,
@@ -883,7 +951,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #if KEY_ZERO_POINTS == QUANTIZE_2D
             cooperative_prefetch_2d_maybe_rem(
                     /* ptr */ K_zp + (k0 + ugemm_kq_wg_tile_m),
-                    /* r */ k - k0 - ugemm_kq_wg_tile_m,
+                    /* r */ causal_k - k0 - ugemm_kq_wg_tile_m,
                     /* c */ num_key_groups,
                     /* rmax */ ugemm_kq_wg_tile_m,
                     /* cmax */ D_MAX / KEY_GROUP_SIZE,
@@ -900,7 +968,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         if (!last) {
             cooperative_prefetch_2d_maybe_rem(
                     /* ptr */ msk + k0 + ugemm_kq_sg_tile_m + (wg_j0)*ldmsk,
-                    /* r */ k - k0 - ugemm_kq_wg_tile_m,
+                    /* r */ causal_k - k0 - ugemm_kq_wg_tile_m,
                     /* c */ q - wg_j0,
                     /* rmax */ ugemm_kq_wg_tile_m,
                     /* cmax */ (ugemm_kq_wg_tile_n * PREFETCH_D_MAX) / D_MAX,
@@ -932,7 +1000,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
             local half *Sb0 = S_slm + s_block_num * ugemm_kq_sg_tile_m * ugemm_kq_sg_tile_n;
             uint v_block_num = (k0 + kb0) / PAGED_ATTENTION_BLOCK_SIZE;
             global VAL_DATA_T *Vb0 = V + KV_HEADS_NUM * ADJUSTED_V_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE * block_indices[base_block_index + v_block_num];
-            int kb_chunk = min(k - k0 - kb0, PAGED_ATTENTION_BLOCK_SIZE);
+            int kb_chunk = min(k_chunk - kb0, PAGED_ATTENTION_BLOCK_SIZE);
             #if IS_KV_COMPRESSED_PA
                 #if IS_INT4_KV_CACHE
                 // INT4: scales embedded at HEAD_SIZE/2 offset within each token row


### PR DESCRIPTION
### Summary

This change tightens the effective K range processed by the SDPA micro-kernel for causal attention.

For causal attention in general, it introduces a per-query-tile upper bound, `causal_k`, and uses it in loop bounds, chunk sizing, tail handling, causal mask gating, prefetch sizing, and paged-attention VS chunk sizing. For sliding-window causal attention, it additionally computes the semantic lower bound, `window_k_begin`, and the aligned block start, `window_k0_begin`, and uses them to shift the loop start and trim first-block K/V prefetches.

This reduces redundant K/V work while preserving the existing ugemm KQ to SLM to VS flow.

### Details

The causal path now:
- uses `causal_k` instead of the full K extent for loop termination
- derives `k_chunk` and K-tail handling from `causal_k`
- uses `causal_k` in `ugemm_kcq` sizing, later prefetch remainder sizing, sink-related last-block handling, and paged-attention VS chunk sizing
- skips per-element causal mask assignment for blocks that are already fully valid

When sliding-window causal attention is enabled, the kernel also:
- computes `window_k_begin` as the semantic lower bound of the valid K range
- computes `window_k0_begin` as the aligned block start required by the ugemm pipeline
- starts the main K loop from `window_k0_begin`
- shifts the non-paged linear V path to the same aligned start
- starts the first K prefetch from `window_k_begin`, with the same adjustment applied to K scales and zero points
- aligns the first K prefetch shape with the later K prefetch path by using remaining K by `d`
- trims the first V prefetch so that it skips the invalid left prefix within the first aligned block, with the same adjustment applied to V scales and zero points

### Note

This implementation and the accompanying PR description were prepared with the assistance of GPT 5.4 in Copilot and reviewed by the author.