### PR TITLE
[Core][CPU][PyTorch FE] Add ov::op::v17::Bincount operator

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs.rst
@@ -29,6 +29,7 @@ Operation Specifications
    BatchNormInference-5 <operation-specs/normalization/batch-norm-inference-5>
    BatchToSpace-2 <operation-specs/movement/batch-to-space-2>
    BinaryConvolution-1 <operation-specs/convolution/binary-convolution-1>
+   Bincount-17 <operation-specs/condition/bincount-17>
    BitwiseAnd-13 <operation-specs/bitwise/bitwise-and-13>
    BitwiseLeftShift-15 <operation-specs/bitwise/bitwise-left-shift-15>
    BitwiseNot-13 <operation-specs/bitwise/bitwise-not-13>

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/condition/bincount-17.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/condition/bincount-17.rst
@@ -1,0 +1,87 @@
+Bincount
+========
+
+
+.. meta::
+  :description: Learn about Bincount-17 - a condition operation that counts the
+                number of occurrences of each value in a 1-D integer tensor in OpenVINO.
+
+**Versioned name**: *Bincount-17*
+
+**Category**: *Condition*
+
+**Short description**: *Bincount* counts the number of occurrences of each non-negative integer value in a 1-D input tensor, producing a histogram-style output.
+
+**Detailed description**
+
+*Bincount* is equivalent to ``torch.bincount``. It counts the occurrences of each value in the 1-D ``data`` tensor and returns a 1-D output tensor where the element at index ``i`` equals the number of times the value ``i`` appears in ``data`` (or the sum of the corresponding ``weights`` when the optional ``weights`` input is provided).
+
+The output length is ``max(max(data) + 1, minlength)``. When ``data`` is empty, the output length equals ``minlength``.
+
+Because the output size depends on the maximum value in ``data``, the output shape is **data-dependent** and is not known statically in general. The static lower bound is ``minlength``.
+
+**Attributes**
+
+* *minlength*
+
+  * **Description**: minimum length of the output tensor.
+  * **Range of values**: a non-negative integer.
+  * **Type**: ``int64``
+  * **Default value**: 0
+  * **Required**: *no*
+
+**Inputs**
+
+* **1**: ``data`` - A 1-D tensor of type *T_DATA* containing non-negative integer values. **Required.**
+* **2**: ``weights`` - A 1-D tensor of type *T_WEIGHTS* with the same length as ``data``. When provided, each occurrence of ``data[i]`` contributes ``weights[i]`` to the output instead of 1. **Optional.**
+
+**Outputs**
+
+* **1**: A 1-D tensor of type *T_OUT*. When ``weights`` is absent the type is ``i64``; otherwise the type matches *T_WEIGHTS*. The shape is ``[max(max(data) + 1, minlength)]``.
+
+**Types**
+
+* *T_DATA*: ``i32``, ``i64``, ``u8``, ``u16``, ``u32``, or ``u64``.
+* *T_WEIGHTS*: ``f32``, ``f64``, ``i32``, or ``i64``.
+* *T_OUT*: ``i64`` when ``weights`` is absent; *T_WEIGHTS* otherwise.
+
+**Example 1: unweighted**
+
+.. code-block:: xml
+   :force:
+
+   <layer ... type="Bincount" version="opset17">
+       <data minlength="0"/>
+       <input>
+           <port id="0">
+               <dim>10</dim>
+           </port>
+       </input>
+       <output>
+           <port id="1" precision="I64">
+               <dim>-1</dim>
+           </port>
+       </output>
+   </layer>
+
+**Example 2: weighted with minlength**
+
+.. code-block:: xml
+   :force:
+
+   <layer ... type="Bincount" version="opset17">
+       <data minlength="5"/>
+       <input>
+           <port id="0">
+               <dim>10</dim>
+           </port>
+           <port id="1" precision="F32">
+               <dim>10</dim>
+           </port>
+       </input>
+       <output>
+           <port id="2" precision="F32">
+               <dim>-1</dim>
+           </port>
+       </output>
+   </layer>

--- a/src/bindings/python/src/openvino/opset17/__init__.py
+++ b/src/bindings/python/src/openvino/opset17/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # New operations added in Opset17
-from openvino.opset17.ops import erfinv
+from openvino.opset17.ops import bincount, erfinv
 
 # Operators from previous opsets
 # TODO (ticket: 179247): Add previous opset operators at the end of opset17 development

--- a/src/bindings/python/src/openvino/opset17/__init__.pyi
+++ b/src/bindings/python/src/openvino/opset17/__init__.pyi
@@ -1,5 +1,5 @@
 # type: ignore
 from . import ops
 from __future__ import annotations
-from openvino.opset17.ops import erfinv
-__all__: list[str] = ['erfinv', 'ops']
+from openvino.opset17.ops import bincount, erfinv
+__all__: list[str] = ['bincount', 'erfinv', 'ops']

--- a/src/bindings/python/src/openvino/opset17/ops.py
+++ b/src/bindings/python/src/openvino/opset17/ops.py
@@ -7,9 +7,9 @@ from functools import partial
 from typing import Optional
 
 from openvino import Node
-from openvino.utils.decorators import unary_op
+from openvino.utils.decorators import nameable_op, unary_op
 from openvino.utils.node_factory import _get_node_factory
-from openvino.utils.types import NodeInput
+from openvino.utils.types import NodeInput, as_nodes
 
 _get_node_factory_opset17 = partial(_get_node_factory, "opset17")
 
@@ -25,3 +25,24 @@ def erfinv(node: NodeInput, name: Optional[str] = None) -> Node:
     :return: The new node performing the element-wise ErfInv operation.
     """
     return _get_node_factory_opset17().create("ErfInv", [node])
+
+
+@nameable_op
+def bincount(
+    data: NodeInput,
+    weights: Optional[NodeInput] = None,
+    minlength: int = 0,
+    name: Optional[str] = None,
+) -> Node:
+    """Count occurrences of each value in a 1-D tensor of non-negative integers.
+
+    :param data: 1-D non-negative integer tensor.
+    :param weights: Optional 1-D float/integer tensor, same length as data.
+    :param minlength: Minimum length of the output tensor; defaults to 0.
+    :param name: The optional name for the new output node.
+    :return: The new Bincount node.
+    """
+    inputs = [data]
+    if weights is not None:
+        inputs.append(weights)
+    return _get_node_factory_opset17().create("Bincount", as_nodes(*inputs, name=name), {"minlength": minlength})

--- a/src/bindings/python/src/openvino/opset17/ops.pyi
+++ b/src/bindings/python/src/openvino/opset17/ops.pyi
@@ -10,15 +10,24 @@ import typing
 """
 Factory functions for ops added to openvino opset17.
 """
-__all__: list[str] = ['Node', 'NodeInput', 'erfinv', 'partial', 'unary_op']
+__all__: list[str] = ['Node', 'NodeInput', 'bincount', 'erfinv', 'partial', 'unary_op']
 def erfinv(input_value, *args, **kwargs) -> openvino._pyopenvino.Node:
     """
     Return node which calculates the inverse error function element-wise on the input tensor.
-    
+
         :param node: The node providing data for the operation. Must be of floating-point type.
         :param name: The optional name for the new output node.
         :return: The new node performing the element-wise ErfInv operation.
-        
+    """
+def bincount(data, weights=None, minlength=0, name=None) -> openvino._pyopenvino.Node:
+    """
+    Count occurrences of each value in a 1-D tensor of non-negative integers.
+
+        :param data: 1-D non-negative integer tensor.
+        :param weights: Optional 1-D float/integer tensor, same length as data.
+        :param minlength: Minimum length of the output tensor; defaults to 0.
+        :param name: The optional name for the new output node.
+        :return: The new Bincount node.
     """
 NodeInput: typing._UnionGenericAlias  # value = typing.Union[openvino._pyopenvino.Node, int, float, numpy.ndarray]
 _get_node_factory_opset17: functools.partial  # value = functools.partial(<function _get_node_factory at memory_address>, 'opset17')

--- a/src/core/dev_api/openvino/op/ops_decl.hpp
+++ b/src/core/dev_api/openvino/op/ops_decl.hpp
@@ -292,5 +292,6 @@ class SparseFillEmptyRows;
 }  // namespace ov::op::v16
 
 namespace ov::op::v17 {
+class Bincount;
 class ErfInv;
 }  // namespace ov::op::v17

--- a/src/core/include/openvino/op/bincount.hpp
+++ b/src/core/include/openvino/op/bincount.hpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "openvino/op/op.hpp"
+
+namespace ov {
+namespace op {
+namespace v17 {
+/// \brief Counts the number of occurrences of each value in a 1-D integer tensor.
+///
+/// \ingroup ov_ops_cpp_api
+class OPENVINO_API Bincount : public Op {
+public:
+    OPENVINO_OP("Bincount", "opset17", op::Op);
+
+    Bincount() = default;
+
+    /// \brief Constructs a Bincount operation without weights (result type is i64).
+    ///
+    /// \param data       1-D non-negative integer tensor
+    /// \param minlength  Minimum length of output; defaults to 0
+    Bincount(const Output<Node>& data, int64_t minlength = 0);
+
+    /// \brief Constructs a Bincount operation with weights.
+    ///
+    /// \param data       1-D non-negative integer tensor
+    /// \param weights    1-D float/integer tensor (same length as data)
+    /// \param minlength  Minimum length of output; defaults to 0
+    Bincount(const Output<Node>& data, const Output<Node>& weights, int64_t minlength = 0);
+
+    bool visit_attributes(AttributeVisitor& visitor) override;
+    void validate_and_infer_types() override;
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
+    bool has_evaluate() const override;
+
+    int64_t get_minlength() const {
+        return m_minlength;
+    }
+    void set_minlength(int64_t minlength) {
+        m_minlength = minlength;
+    }
+
+private:
+    int64_t m_minlength = 0;
+};
+}  // namespace v17
+}  // namespace op
+}  // namespace ov

--- a/src/core/include/openvino/op/ops.hpp
+++ b/src/core/include/openvino/op/ops.hpp
@@ -21,6 +21,7 @@
 #include "openvino/op/batch_norm.hpp"
 #include "openvino/op/batch_to_space.hpp"
 #include "openvino/op/binary_convolution.hpp"
+#include "openvino/op/bincount.hpp"
 #include "openvino/op/bitwise_and.hpp"
 #include "openvino/op/bitwise_left_shift.hpp"
 #include "openvino/op/bitwise_not.hpp"

--- a/src/core/include/openvino/opsets/opset17_tbl.hpp
+++ b/src/core/include/openvino/opsets/opset17_tbl.hpp
@@ -15,3 +15,4 @@ _OPENVINO_OP_REG(ShapeOf, ov::op::v3)
 
 // New operations added in opset17
 _OPENVINO_OP_REG(ErfInv, ov::op::v17)
+_OPENVINO_OP_REG(Bincount, ov::op::v17)

--- a/src/core/reference/include/openvino/reference/bincount.hpp
+++ b/src/core/reference/include/openvino/reference/bincount.hpp
@@ -1,0 +1,105 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include "openvino/core/except.hpp"
+
+namespace ov {
+namespace reference {
+namespace bincount_detail {
+
+template <typename TData>
+size_t normalize_value(const TData value) {
+    if constexpr (std::is_signed<TData>::value) {
+        OPENVINO_ASSERT(value >= 0, "Bincount input data must be non-negative.");
+    }
+
+    using plain_t = typename std::remove_cv<TData>::type;
+    using unsigned_t = typename std::make_unsigned<plain_t>::type;
+    const auto unsigned_value = static_cast<unsigned_t>(value);
+    const auto max_supported = static_cast<unsigned_t>(std::numeric_limits<int64_t>::max() - 1);
+    OPENVINO_ASSERT(unsigned_value <= max_supported, "Bincount input value is too large.");
+
+    return static_cast<size_t>(unsigned_value);
+}
+
+}  // namespace bincount_detail
+
+/// \brief Reference implementation of the Bincount operation (unweighted).
+///
+/// \param data       Pointer to input integer data.
+/// \param n          Number of elements in data.
+/// \param minlength  Minimum output length (unused in kernel, but kept for API symmetry).
+/// \param out        Output pointer (type int64_t). Must be a pre-allocated buffer of size out_size.
+/// \param out_size   Size of the output buffer.
+template <typename TData>
+void bincount(const TData* data, size_t n, int64_t /*minlength*/, int64_t* out, size_t out_size) {
+    for (size_t i = 0; i < out_size; ++i) {
+        out[i] = 0;
+    }
+    for (size_t i = 0; i < n; ++i) {
+        const auto val = bincount_detail::normalize_value(data[i]);
+        if (val < out_size) {
+            out[val]++;
+        }
+    }
+}
+
+/// \brief Reference implementation of the Bincount operation (weighted).
+///
+/// \param data       Pointer to input integer data.
+/// \param weights    Pointer to weights data.
+/// \param n          Number of elements in data (and weights).
+/// \param minlength  Minimum output length (unused in kernel, kept for API symmetry).
+/// \param out        Output pointer (type TWeight). Must be a pre-allocated buffer of size out_size.
+/// \param out_size   Size of the output buffer.
+template <typename TData, typename TWeight>
+void bincount_weighted(const TData* data,
+                       const TWeight* weights,
+                       size_t n,
+                       int64_t /*minlength*/,
+                       TWeight* out,
+                       size_t out_size) {
+    for (size_t i = 0; i < out_size; ++i) {
+        out[i] = TWeight{0};
+    }
+    for (size_t i = 0; i < n; ++i) {
+        const auto val = bincount_detail::normalize_value(data[i]);
+        if (val < out_size) {
+            out[val] += weights[i];
+        }
+    }
+}
+
+/// \brief Compute the output size for bincount.
+///
+/// \param data      Pointer to input integer data.
+/// \param n         Number of elements.
+/// \param minlength Minimum output length.
+/// \return          Output size = max(max(data) + 1, minlength)
+template <typename TData>
+size_t bincount_output_size(const TData* data, size_t n, int64_t minlength) {
+    size_t max_val = 0;
+    bool has_value = false;
+    for (size_t i = 0; i < n; ++i) {
+        const auto val = bincount_detail::normalize_value(data[i]);
+        if (!has_value || val > max_val) {
+            max_val = val;
+            has_value = true;
+        }
+    }
+
+    const size_t from_data = has_value ? max_val + 1 : 0;
+    return std::max(from_data, static_cast<size_t>(minlength));
+}
+
+}  // namespace reference
+}  // namespace ov

--- a/src/core/shape_inference/include/bincount_shape_inference.hpp
+++ b/src/core/shape_inference/include/bincount_shape_inference.hpp
@@ -1,0 +1,91 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+
+#include "dimension_util.hpp"
+#include "openvino/op/bincount.hpp"
+#include "openvino/reference/bincount.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace op {
+namespace v17 {
+
+template <class TShape, class TRShape = result_shape_t<TShape>>
+std::vector<TRShape> shape_infer(const Bincount* op,
+                                 const std::vector<TShape>& input_shapes,
+                                 const ITensorAccessor& ta = make_tensor_accessor()) {
+    NODE_VALIDATION_CHECK(op, input_shapes.size() == 1 || input_shapes.size() == 2);
+
+    const auto& data_shape = input_shapes[0];
+    NODE_VALIDATION_CHECK(op,
+                          data_shape.rank().compatible(1),
+                          "The 'data' input must be a 1-D tensor. Got rank: ",
+                          data_shape.rank());
+
+    if (input_shapes.size() == 2) {
+        const auto& weights_shape = input_shapes[1];
+        NODE_VALIDATION_CHECK(op,
+                              weights_shape.rank().compatible(1),
+                              "The 'weights' input must be a 1-D tensor. Got rank: ",
+                              weights_shape.rank());
+        if (data_shape.rank().is_static() && weights_shape.rank().is_static()) {
+            NODE_VALIDATION_CHECK(op,
+                                  data_shape[0].compatible(weights_shape[0]),
+                                  "The 'data' and 'weights' inputs must have the same length. Got: ",
+                                  data_shape[0],
+                                  " vs ",
+                                  weights_shape[0]);
+        }
+    }
+
+    if (const auto data_tensor = ta(0)) {
+        const auto data_et = data_tensor.get_element_type();
+        const auto n = data_tensor.get_size();
+        size_t out_size = 0;
+
+        switch (data_et) {
+        case element::i32:
+            out_size =
+                reference::bincount_output_size(data_tensor.data<const int32_t>(), n, op->get_minlength());
+            break;
+        case element::i64:
+            out_size =
+                reference::bincount_output_size(data_tensor.data<const int64_t>(), n, op->get_minlength());
+            break;
+        case element::u8:
+            out_size =
+                reference::bincount_output_size(data_tensor.data<const uint8_t>(), n, op->get_minlength());
+            break;
+        case element::u16:
+            out_size =
+                reference::bincount_output_size(data_tensor.data<const uint16_t>(), n, op->get_minlength());
+            break;
+        case element::u32:
+            out_size =
+                reference::bincount_output_size(data_tensor.data<const uint32_t>(), n, op->get_minlength());
+            break;
+        case element::u64:
+            out_size =
+                reference::bincount_output_size(data_tensor.data<const uint64_t>(), n, op->get_minlength());
+            break;
+        default:
+            break;
+        }
+
+        // We have constant data — return exact output size
+        return {TRShape{static_cast<typename TRShape::value_type>(out_size)}};
+    }
+
+    // Dynamic case: use minlength as lower bound
+    using TDim = typename TRShape::value_type;
+    return {TRShape{TDim(op->get_minlength(), ov::util::dim::inf_bound)}};
+}
+
+}  // namespace v17
+}  // namespace op
+}  // namespace ov

--- a/src/core/src/op/bincount.cpp
+++ b/src/core/src/op/bincount.cpp
@@ -1,0 +1,257 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/bincount.hpp"
+
+#include "bincount_shape_inference.hpp"
+#include "itt.hpp"
+#include "openvino/core/validation_util.hpp"
+#include "openvino/reference/bincount.hpp"
+
+namespace ov {
+namespace {
+
+template <typename TData>
+size_t bincount_compute_out_size(const Tensor& data, int64_t minlength) {
+    return reference::bincount_output_size(data.template data<const TData>(), data.get_size(), minlength);
+}
+
+template <typename TData>
+void bincount_eval_unweighted(const Tensor& data, Tensor& output, int64_t minlength, size_t out_size) {
+    output.set_shape(Shape{out_size});
+    reference::bincount(data.template data<const TData>(),
+                        data.get_size(),
+                        minlength,
+                        output.data<int64_t>(),
+                        out_size);
+}
+
+template <typename TData, typename TWeight>
+void bincount_eval_weighted(const Tensor& data,
+                            const Tensor& weights,
+                            Tensor& output,
+                            int64_t minlength,
+                            size_t out_size) {
+    output.set_shape(Shape{out_size});
+    reference::bincount_weighted(data.template data<const TData>(),
+                                 weights.template data<const TWeight>(),
+                                 data.get_size(),
+                                 minlength,
+                                 output.template data<TWeight>(),
+                                 out_size);
+}
+
+size_t bincount_get_out_size(const Tensor& data, int64_t minlength) {
+    switch (data.get_element_type()) {
+    case element::i32:
+        return bincount_compute_out_size<int32_t>(data, minlength);
+    case element::i64:
+        return bincount_compute_out_size<int64_t>(data, minlength);
+    case element::u8:
+        return bincount_compute_out_size<uint8_t>(data, minlength);
+    case element::u16:
+        return bincount_compute_out_size<uint16_t>(data, minlength);
+    case element::u32:
+        return bincount_compute_out_size<uint32_t>(data, minlength);
+    case element::u64:
+        return bincount_compute_out_size<uint64_t>(data, minlength);
+    default:
+        OPENVINO_THROW("Unsupported Bincount input element type: ", data.get_element_type());
+    }
+}
+
+bool bincount_dispatch_unweighted(const Tensor& data, Tensor& output, int64_t minlength, size_t out_size) {
+    switch (data.get_element_type()) {
+    case element::i32:
+        bincount_eval_unweighted<int32_t>(data, output, minlength, out_size);
+        return true;
+    case element::i64:
+        bincount_eval_unweighted<int64_t>(data, output, minlength, out_size);
+        return true;
+    case element::u8:
+        bincount_eval_unweighted<uint8_t>(data, output, minlength, out_size);
+        return true;
+    case element::u16:
+        bincount_eval_unweighted<uint16_t>(data, output, minlength, out_size);
+        return true;
+    case element::u32:
+        bincount_eval_unweighted<uint32_t>(data, output, minlength, out_size);
+        return true;
+    case element::u64:
+        bincount_eval_unweighted<uint64_t>(data, output, minlength, out_size);
+        return true;
+    default:
+        return false;
+    }
+}
+
+template <typename TData>
+bool bincount_dispatch_weight_type(const Tensor& data,
+                                   const Tensor& weights,
+                                   Tensor& output,
+                                   int64_t minlength,
+                                   size_t out_size,
+                                   const element::Type& weights_et) {
+    switch (weights_et) {
+    case element::f32:
+        bincount_eval_weighted<TData, float>(data, weights, output, minlength, out_size);
+        return true;
+    case element::f64:
+        bincount_eval_weighted<TData, double>(data, weights, output, minlength, out_size);
+        return true;
+    case element::i32:
+        bincount_eval_weighted<TData, int32_t>(data, weights, output, minlength, out_size);
+        return true;
+    case element::i64:
+        bincount_eval_weighted<TData, int64_t>(data, weights, output, minlength, out_size);
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool bincount_dispatch_weighted(const Tensor& data,
+                                const Tensor& weights,
+                                Tensor& output,
+                                int64_t minlength,
+                                size_t out_size) {
+    const auto& wt = weights.get_element_type();
+    switch (data.get_element_type()) {
+    case element::i32:
+        return bincount_dispatch_weight_type<int32_t>(data, weights, output, minlength, out_size, wt);
+    case element::i64:
+        return bincount_dispatch_weight_type<int64_t>(data, weights, output, minlength, out_size, wt);
+    case element::u8:
+        return bincount_dispatch_weight_type<uint8_t>(data, weights, output, minlength, out_size, wt);
+    case element::u16:
+        return bincount_dispatch_weight_type<uint16_t>(data, weights, output, minlength, out_size, wt);
+    case element::u32:
+        return bincount_dispatch_weight_type<uint32_t>(data, weights, output, minlength, out_size, wt);
+    case element::u64:
+        return bincount_dispatch_weight_type<uint64_t>(data, weights, output, minlength, out_size, wt);
+    default:
+        return false;
+    }
+}
+
+bool is_supported_data_type(const element::Type& et) {
+    return et == element::i32 || et == element::i64 || et == element::u8 || et == element::u16 ||
+           et == element::u32 || et == element::u64;
+}
+
+bool is_supported_weight_type(const element::Type& et) {
+    return et == element::f32 || et == element::f64 || et == element::i32 || et == element::i64;
+}
+
+}  // namespace
+
+namespace op {
+namespace v17 {
+
+Bincount::Bincount(const Output<Node>& data, int64_t minlength) : Op({data}), m_minlength(minlength) {
+    constructor_validate_and_infer_types();
+}
+
+Bincount::Bincount(const Output<Node>& data, const Output<Node>& weights, int64_t minlength)
+    : Op({data, weights}),
+      m_minlength(minlength) {
+    constructor_validate_and_infer_types();
+}
+
+bool Bincount::visit_attributes(AttributeVisitor& visitor) {
+    OV_OP_SCOPE(v17_Bincount_visit_attributes);
+    visitor.on_attribute("minlength", m_minlength);
+    return true;
+}
+
+void Bincount::validate_and_infer_types() {
+    OV_OP_SCOPE(v17_Bincount_validate_and_infer_types);
+
+    const auto& data_et = get_input_element_type(0);
+    NODE_VALIDATION_CHECK(this,
+                          data_et.is_dynamic() || is_supported_data_type(data_et),
+                          "The 'data' input must have one of the following element types: "
+                          "i32, i64, u8, u16, u32, u64. Got: ",
+                          data_et);
+
+    NODE_VALIDATION_CHECK(this, m_minlength >= 0, "minlength must be non-negative. Got: ", m_minlength);
+
+    element::Type output_et = element::i64;
+    if (get_input_size() == 2) {
+        const auto& weights_et = get_input_element_type(1);
+        NODE_VALIDATION_CHECK(this,
+                              weights_et.is_dynamic() || is_supported_weight_type(weights_et),
+                              "The 'weights' input must have one of the following element types: "
+                              "f32, f64, i32, i64. Got: ",
+                              weights_et);
+        output_et = weights_et;
+    }
+
+    set_input_is_relevant_to_shape(0);
+
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
+    const auto output_shapes = shape_infer(this, input_shapes);
+    set_output_type(0, output_et, output_shapes[0]);
+
+    const auto input_constant = ov::util::get_constant_from_source(input_value(0));
+    if (!input_constant) {
+        return;
+    }
+
+    TensorVector inputs{input_constant->get_tensor_view()};
+    if (get_input_size() == 2) {
+        const auto weights_constant = ov::util::get_constant_from_source(input_value(1));
+        if (!weights_constant) {
+            return;
+        }
+        inputs.push_back(weights_constant->get_tensor_view());
+    }
+
+    TensorVector outputs{{output_et, {}}};
+    if (!evaluate(outputs, inputs)) {
+        return;
+    }
+
+    const auto& out = outputs[0];
+    set_output_type(0, output_et, out.get_shape());
+    get_output_tensor(0).set_lower_value(out);
+    get_output_tensor(0).set_upper_value(out);
+}
+
+std::shared_ptr<Node> Bincount::clone_with_new_inputs(const OutputVector& new_args) const {
+    OV_OP_SCOPE(v17_Bincount_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    if (new_args.size() == 1) {
+        return std::make_shared<v17::Bincount>(new_args.at(0), m_minlength);
+    }
+    return std::make_shared<v17::Bincount>(new_args.at(0), new_args.at(1), m_minlength);
+}
+
+bool Bincount::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
+    OV_OP_SCOPE(v17_Bincount_evaluate);
+
+    OPENVINO_ASSERT(inputs.size() == 1 || inputs.size() == 2, "Bincount expects 1 or 2 inputs.");
+    if (inputs.size() == 2) {
+        OPENVINO_ASSERT(inputs[0].get_size() == inputs[1].get_size(),
+                        "Bincount 'data' and 'weights' inputs must have the same number of elements.");
+    }
+
+    const auto out_size = bincount_get_out_size(inputs[0], m_minlength);
+    if (inputs.size() == 1) {
+        return bincount_dispatch_unweighted(inputs[0], outputs[0], m_minlength, out_size);
+    }
+    return bincount_dispatch_weighted(inputs[0], inputs[1], outputs[0], m_minlength, out_size);
+}
+
+bool Bincount::has_evaluate() const {
+    OV_OP_SCOPE(v17_Bincount_has_evaluate);
+    if (!is_supported_data_type(get_input_element_type(0))) {
+        return false;
+    }
+    return get_input_size() == 1 || is_supported_weight_type(get_input_element_type(1));
+}
+
+}  // namespace v17
+}  // namespace op
+}  // namespace ov

--- a/src/core/tests/type_prop/bincount.cpp
+++ b/src/core/tests/type_prop/bincount.cpp
@@ -1,0 +1,129 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/bincount.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "common_test_utils/type_prop.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+
+using namespace ov;
+using ov::op::v0::Constant;
+using ov::op::v0::Parameter;
+using namespace testing;
+
+class TypePropBincountV17Test : public TypePropOpTest<op::v17::Bincount> {};
+
+TEST_F(TypePropBincountV17Test, default_ctor_unweighted) {
+    auto data = std::make_shared<Parameter>(element::i32, Shape{5});
+    auto bc = make_op(data);
+
+    EXPECT_EQ(bc->get_output_element_type(0), element::i64);
+    EXPECT_EQ(bc->get_input_size(), 1);
+    EXPECT_EQ(bc->get_output_size(), 1);
+}
+
+TEST_F(TypePropBincountV17Test, dynamic_output_shape_no_const) {
+    auto data = std::make_shared<Parameter>(element::i32, PartialShape{10});
+    auto bc = make_op(data, 0);
+
+    EXPECT_EQ(bc->get_output_element_type(0), element::i64);
+    EXPECT_TRUE(bc->get_output_partial_shape(0).rank().is_static());
+    EXPECT_EQ(bc->get_output_partial_shape(0).rank().get_length(), 1);
+}
+
+TEST_F(TypePropBincountV17Test, static_output_shape_from_constant) {
+    auto data = std::make_shared<Constant>(element::i32, Shape{5}, std::vector<int32_t>{0, 1, 2, 1, 3});
+    auto bc = make_op(data, 0);
+
+    EXPECT_EQ(bc->get_output_element_type(0), element::i64);
+    EXPECT_EQ(bc->get_output_partial_shape(0), PartialShape{4});
+}
+
+TEST_F(TypePropBincountV17Test, minlength_larger_than_data) {
+    auto data = std::make_shared<Constant>(element::i32, Shape{3}, std::vector<int32_t>{0, 1, 2});
+    auto bc = make_op(data, 10);
+
+    EXPECT_EQ(bc->get_output_partial_shape(0), PartialShape{10});
+}
+
+TEST_F(TypePropBincountV17Test, empty_data) {
+    auto data = std::make_shared<Constant>(element::i32, Shape{0}, std::vector<int32_t>{});
+    auto bc = make_op(data, 5);
+
+    EXPECT_EQ(bc->get_output_partial_shape(0), PartialShape{5});
+}
+
+TEST_F(TypePropBincountV17Test, weighted_output_type_f32) {
+    auto data = std::make_shared<Parameter>(element::i32, PartialShape{10});
+    auto weights = std::make_shared<Parameter>(element::f32, PartialShape{10});
+    auto bc = make_op(data, weights, 0);
+
+    EXPECT_EQ(bc->get_output_element_type(0), element::f32);
+}
+
+TEST_F(TypePropBincountV17Test, weighted_output_type_f64) {
+    auto data = std::make_shared<Parameter>(element::i64, PartialShape{10});
+    auto weights = std::make_shared<Parameter>(element::f64, PartialShape{10});
+    auto bc = make_op(data, weights, 0);
+
+    EXPECT_EQ(bc->get_output_element_type(0), element::f64);
+}
+
+TEST_F(TypePropBincountV17Test, i64_data) {
+    auto data = std::make_shared<Parameter>(element::i64, PartialShape{7});
+    auto bc = make_op(data, 3);
+
+    EXPECT_EQ(bc->get_output_element_type(0), element::i64);
+}
+
+TEST_F(TypePropBincountV17Test, dynamic_rank_data) {
+    auto data = std::make_shared<Parameter>(element::i32, PartialShape::dynamic());
+    auto bc = make_op(data);
+
+    EXPECT_EQ(bc->get_output_element_type(0), element::i64);
+}
+
+TEST_F(TypePropBincountV17Test, invalid_data_type) {
+    auto data = std::make_shared<Parameter>(element::f32, Shape{5});
+    OV_EXPECT_THROW(make_op(data), NodeValidationFailure, HasSubstr("element types: i32, i64, u8, u16, u32, u64"));
+}
+
+TEST_F(TypePropBincountV17Test, invalid_minlength_negative) {
+    auto data = std::make_shared<Parameter>(element::i32, Shape{5});
+    OV_EXPECT_THROW(make_op(data, -1), NodeValidationFailure, HasSubstr("minlength must be non-negative"));
+}
+
+TEST_F(TypePropBincountV17Test, invalid_data_rank_2d) {
+    auto data = std::make_shared<Parameter>(element::i32, Shape{2, 3});
+    OV_EXPECT_THROW(make_op(data), NodeValidationFailure, HasSubstr("1-D tensor"));
+}
+
+TEST_F(TypePropBincountV17Test, invalid_weights_rank_2d) {
+    auto data = std::make_shared<Parameter>(element::i32, Shape{5});
+    auto weights = std::make_shared<Parameter>(element::f32, Shape{1, 5});
+    OV_EXPECT_THROW(make_op(data, weights, 0), NodeValidationFailure, HasSubstr("'weights' input must be a 1-D tensor"));
+}
+
+TEST_F(TypePropBincountV17Test, invalid_weights_length) {
+    auto data = std::make_shared<Parameter>(element::i32, PartialShape{5});
+    auto weights = std::make_shared<Parameter>(element::f32, PartialShape{6});
+    OV_EXPECT_THROW(make_op(data, weights, 0), NodeValidationFailure, HasSubstr("must have the same length"));
+}
+
+TEST_F(TypePropBincountV17Test, invalid_negative_constant_data) {
+    auto data = std::make_shared<Constant>(element::i32, Shape{3}, std::vector<int32_t>{0, -1, 2});
+    OV_EXPECT_THROW(make_op(data, 0), ov::AssertFailure, HasSubstr("must be non-negative"));
+}
+
+TEST_F(TypePropBincountV17Test, minlength_attribute) {
+    auto data = std::make_shared<Parameter>(element::i32, Shape{5});
+    auto bc = make_op(data, 7);
+    EXPECT_EQ(bc->get_minlength(), 7);
+    bc->set_minlength(10);
+    EXPECT_EQ(bc->get_minlength(), 10);
+}

--- a/src/core/tests/visitors/op/bincount.cpp
+++ b/src/core/tests/visitors/op/bincount.cpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/bincount.hpp"
+
+#include <gtest/gtest.h>
+
+#include "openvino/op/parameter.hpp"
+#include "visitors/visitors.hpp"
+
+using namespace ov;
+using ov::test::NodeBuilder;
+
+TEST(attributes, bincount_v17_op_unweighted_defaults) {
+    NodeBuilder::opset().insert<ov::op::v17::Bincount>();
+    auto data = std::make_shared<ov::op::v0::Parameter>(element::i32, Shape{10});
+    auto bc = std::make_shared<ov::op::v17::Bincount>(data);
+    NodeBuilder builder(bc, {data});
+
+    auto g_bc = ov::as_type_ptr<ov::op::v17::Bincount>(builder.create());
+    EXPECT_EQ(g_bc->get_minlength(), bc->get_minlength());
+}
+
+TEST(attributes, bincount_v17_op_with_minlength) {
+    NodeBuilder::opset().insert<ov::op::v17::Bincount>();
+    auto data = std::make_shared<ov::op::v0::Parameter>(element::i64, Shape{10});
+    auto bc = std::make_shared<ov::op::v17::Bincount>(data, int64_t{5});
+    NodeBuilder builder(bc, {data});
+
+    auto g_bc = ov::as_type_ptr<ov::op::v17::Bincount>(builder.create());
+    EXPECT_EQ(g_bc->get_minlength(), 5);
+}
+
+TEST(attributes, bincount_v17_op_weighted) {
+    NodeBuilder::opset().insert<ov::op::v17::Bincount>();
+    auto data = std::make_shared<ov::op::v0::Parameter>(element::i32, Shape{10});
+    auto weights = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{10});
+    auto bc = std::make_shared<ov::op::v17::Bincount>(data, weights, int64_t{3});
+    NodeBuilder builder(bc, {data, weights});
+
+    auto g_bc = ov::as_type_ptr<ov::op::v17::Bincount>(builder.create());
+    EXPECT_EQ(g_bc->get_minlength(), bc->get_minlength());
+}

--- a/src/frontends/pytorch/src/op/bincount.cpp
+++ b/src/frontends/pytorch/src/op/bincount.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/bincount.hpp"
+#include "openvino/op/convert.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+OutputVector translate_bincount(const NodeContext& context) {
+    // aten::bincount(Tensor self, Tensor? weights=None, int minlength=0) -> Tensor
+    num_inputs_check(context, 1, 3);
+    auto data = context.get_input(0);
+
+    const auto data_et = data.get_element_type();
+    if (data_et != element::i32 && data_et != element::i64) {
+        data = context.mark_node(std::make_shared<v0::Convert>(data, element::i64));
+    }
+
+    int64_t minlength = 0;
+    if (context.get_input_size() > 2 && !context.input_is_none(2)) {
+        minlength = context.const_input<int64_t>(2);
+    }
+
+    if (context.get_input_size() == 1 || context.input_is_none(1)) {
+        return {context.mark_node(std::make_shared<v17::Bincount>(data, minlength))};
+    }
+
+    auto weights = context.get_input(1);
+    return {context.mark_node(std::make_shared<v17::Bincount>(data, weights, minlength))};
+}
+
+OutputVector translate_bincount_fx(const NodeContext& context) {
+    // aten.bincount.default — same signature and semantics as aten::bincount
+    return translate_bincount(context);
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -62,6 +62,7 @@ OP_CONVERTER(translate_bitwise_or);
 OP_CONVERTER(translate_bitwise_right_shift);
 OP_CONVERTER(translate_bitwise_xor);
 OP_CONVERTER(translate_bucketize);
+OP_CONVERTER(translate_bincount);
 OP_CONVERTER(translate_cat);
 OP_CONVERTER(translate_cdist);
 OP_CONVERTER(translate_celu);
@@ -312,6 +313,7 @@ OP_CONVERTER(translate_batch_norm_legit_no_training_fx);
 OP_CONVERTER(translate_batch_norm_legit_no_stats_fx);
 OP_CONVERTER(translate_cat_fx);
 OP_CONVERTER(translate_copy_fx);
+OP_CONVERTER(translate_bincount_fx);
 OP_CONVERTER(translate_cumsum_fx);
 OP_CONVERTER(translate_chunk_fx);
 OP_CONVERTER(translate_div_fx);
@@ -463,6 +465,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         // aten::broadcast_tensors - Supported in limited set of patterns
         {"aten::broadcast_to", op::translate_expand},
         {"aten::bucketize", op::translate_bucketize},
+        {"aten::bincount", op::translate_bincount},
         {"aten::cat", op::translate_cat},
         {"aten::cdist", op::translate_cdist},
         {"aten::ceil", op::optional_out<op::translate_1to1_match_1_inputs<opset10::Ceiling>, 1>},
@@ -920,6 +923,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.bitwise_xor.Tensor", op::translate_bitwise_xor},
         {"aten.bmm.default", op::translate_1to1_match_2_inputs_align_types<opset10::MatMul>},
         {"aten.bucketize.Tensor", op::translate_bucketize},
+        {"aten.bincount.default", op::translate_bincount_fx},
         {"aten.cat.default", op::translate_cat_fx},
         {"aten.ceil.default", op::translate_1to1_match_1_inputs<opset10::Ceiling>},
         {"aten.celu.default", op::translate_celu},

--- a/src/plugins/intel_cpu/src/cpu_types.cpp
+++ b/src/plugins/intel_cpu/src/cpu_types.cpp
@@ -186,6 +186,7 @@ static const TypeToNameMap& get_type_to_name_tbl() {
         {"RDFT", Type::RDFT},
         {"IRDFT", Type::RDFT},
         {"ISTFT", Type::ISTFT},
+        {"Bincount", Type::Bincount},
         {"STFT", Type::STFT},
         {"Abs", Type::Math},
         {"Acos", Type::Math},
@@ -358,6 +359,7 @@ std::string NameFromType(const Type type) {
         CASE(Math);
         CASE(CTCLoss);
         CASE(Bucketize);
+        CASE(Bincount);
         CASE(CTCGreedyDecoder);
         CASE(CTCGreedyDecoderSeqLen);
         CASE(CumSum);

--- a/src/plugins/intel_cpu/src/cpu_types.h
+++ b/src/plugins/intel_cpu/src/cpu_types.h
@@ -95,6 +95,7 @@ enum class Type : uint8_t {
     Math,
     CTCLoss,
     Bucketize,
+    Bincount,
     CTCGreedyDecoder,
     CTCGreedyDecoderSeqLen,
     CumSum,

--- a/src/plugins/intel_cpu/src/nodes/bincount.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bincount.cpp
@@ -1,0 +1,402 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "bincount.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <oneapi/dnnl/dnnl_common.hpp>
+#include <shape_inference/shape_inference_internal_dyn.hpp>
+#include <string>
+#include <vector>
+
+#include "cpu_types.h"
+#include "graph_context.h"
+#include "memory_desc/cpu_memory_desc.h"
+#include "node.h"
+#include "onednn/iml_type_mapper.h"
+#include "openvino/core/except.hpp"
+#include "openvino/core/node.hpp"
+#include "openvino/core/type.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/bincount.hpp"
+#include "openvino/reference/bincount.hpp"
+#include "utils/general_utils.h"
+
+namespace ov::intel_cpu::node {
+
+bool Bincount::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
+    try {
+        const auto bc = ov::as_type_ptr<const ov::op::v17::Bincount>(op);
+        if (!bc) {
+            errorMessage = "Only v17 Bincount operation is supported";
+            return false;
+        }
+    } catch (...) {
+        return false;
+    }
+    return true;
+}
+
+Bincount::Bincount(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
+    : Node(op, context, InternalDynShapeInferFactory()) {
+    std::string errorMessage;
+    if (!isSupportedOperation(op, errorMessage)) {
+        OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
+    }
+
+    const auto bc = ov::as_type_ptr<const ov::op::v17::Bincount>(op);
+    CPU_NODE_ASSERT(bc, "is not an instance of v17 Bincount.");
+    CPU_NODE_ASSERT(any_of(getOriginalInputsNumber(), 1U, 2U) && getOriginalOutputsNumber() == 1,
+                    "has incorrect number of input/output edges!");
+
+    m_minlength = bc->get_minlength();
+    m_has_weights = getOriginalInputsNumber() == 2;
+}
+
+void Bincount::initSupportedPrimitiveDescriptors() {
+    if (!supportedPrimitiveDescriptors.empty()) {
+        return;
+    }
+
+    m_data_precision = getOriginalInputPrecisionAtPort(INPUT_DATA_PORT);
+    CPU_NODE_ASSERT(any_of(m_data_precision,
+                           ov::element::i32,
+                           ov::element::i64,
+                           ov::element::u8,
+                           ov::element::u16,
+                           ov::element::u32,
+                           ov::element::u64),
+                    "has unsupported input precision: ",
+                    m_data_precision);
+
+    if (m_has_weights) {
+        m_weights_precision = getOriginalInputPrecisionAtPort(INPUT_WEIGHTS_PORT);
+        CPU_NODE_ASSERT(any_of(m_weights_precision, ov::element::f32, ov::element::f64, ov::element::i32, ov::element::i64),
+                        "has unsupported weights precision: ",
+                        m_weights_precision);
+        m_output_precision = m_weights_precision;
+        addSupportedPrimDesc({{LayoutType::ncsp, m_data_precision}, {LayoutType::ncsp, m_weights_precision}},
+                             {{LayoutType::ncsp, m_output_precision}},
+                             impl_desc_type::ref_any);
+    } else {
+        m_output_precision = ov::element::i64;
+        addSupportedPrimDesc({{LayoutType::ncsp, m_data_precision}},
+                             {{LayoutType::ncsp, m_output_precision}},
+                             impl_desc_type::ref_any);
+    }
+}
+
+void Bincount::prepareParams() {
+    CPU_NODE_ASSERT(getSrcMemoryAtPort(INPUT_DATA_PORT), "has null input data memory.");
+    CPU_NODE_ASSERT(getDstMemoryAtPort(OUTPUT_PORT), "has null output memory.");
+    if (m_has_weights) {
+        CPU_NODE_ASSERT(getSrcMemoryAtPort(INPUT_WEIGHTS_PORT), "has null weights memory.");
+    }
+}
+
+size_t Bincount::get_output_size() const {
+    const auto n = getSrcMemoryAtPort(INPUT_DATA_PORT)->getShape().getElementsCount();
+    switch (m_data_precision) {
+    case ov::element::i32:
+        return ov::reference::bincount_output_size(getSrcDataAtPortAs<const int32_t>(INPUT_DATA_PORT), n, m_minlength);
+    case ov::element::i64:
+        return ov::reference::bincount_output_size(getSrcDataAtPortAs<const int64_t>(INPUT_DATA_PORT), n, m_minlength);
+    case ov::element::u8:
+        return ov::reference::bincount_output_size(getSrcDataAtPortAs<const uint8_t>(INPUT_DATA_PORT), n, m_minlength);
+    case ov::element::u16:
+        return ov::reference::bincount_output_size(getSrcDataAtPortAs<const uint16_t>(INPUT_DATA_PORT), n, m_minlength);
+    case ov::element::u32:
+        return ov::reference::bincount_output_size(getSrcDataAtPortAs<const uint32_t>(INPUT_DATA_PORT), n, m_minlength);
+    case ov::element::u64:
+        return ov::reference::bincount_output_size(getSrcDataAtPortAs<const uint64_t>(INPUT_DATA_PORT), n, m_minlength);
+    default:
+        CPU_NODE_THROW("has unsupported data precision: ", m_data_precision);
+    }
+}
+
+void Bincount::execute([[maybe_unused]] const dnnl::stream& strm) {
+    const auto n = getSrcMemoryAtPort(INPUT_DATA_PORT)->getShape().getElementsCount();
+    const auto out_size = get_output_size();
+    redefineOutputMemory({VectorDims{out_size}});
+
+    if (!m_has_weights) {
+        auto* dst = getDstDataAtPortAs<int64_t>(OUTPUT_PORT);
+        switch (m_data_precision) {
+        case ov::element::i32:
+            ov::reference::bincount(getSrcDataAtPortAs<const int32_t>(INPUT_DATA_PORT), n, m_minlength, dst, out_size);
+            return;
+        case ov::element::i64:
+            ov::reference::bincount(getSrcDataAtPortAs<const int64_t>(INPUT_DATA_PORT), n, m_minlength, dst, out_size);
+            return;
+        case ov::element::u8:
+            ov::reference::bincount(getSrcDataAtPortAs<const uint8_t>(INPUT_DATA_PORT), n, m_minlength, dst, out_size);
+            return;
+        case ov::element::u16:
+            ov::reference::bincount(getSrcDataAtPortAs<const uint16_t>(INPUT_DATA_PORT), n, m_minlength, dst, out_size);
+            return;
+        case ov::element::u32:
+            ov::reference::bincount(getSrcDataAtPortAs<const uint32_t>(INPUT_DATA_PORT), n, m_minlength, dst, out_size);
+            return;
+        case ov::element::u64:
+            ov::reference::bincount(getSrcDataAtPortAs<const uint64_t>(INPUT_DATA_PORT), n, m_minlength, dst, out_size);
+            return;
+        default:
+            CPU_NODE_THROW("has unsupported data precision: ", m_data_precision);
+        }
+    }
+
+    CPU_NODE_ASSERT(n == getSrcMemoryAtPort(INPUT_WEIGHTS_PORT)->getShape().getElementsCount(),
+                    "requires data and weights to have the same number of elements.");
+
+    switch (m_data_precision) {
+    case ov::element::i32: {
+        const auto* data = getSrcDataAtPortAs<const int32_t>(INPUT_DATA_PORT);
+        switch (m_weights_precision) {
+        case ov::element::f32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const float>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<float>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::f64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const double>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<double>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int32_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int32_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int64_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int64_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        default:
+            CPU_NODE_THROW("has unsupported weights precision: ", m_weights_precision);
+        }
+    }
+    case ov::element::i64: {
+        const auto* data = getSrcDataAtPortAs<const int64_t>(INPUT_DATA_PORT);
+        switch (m_weights_precision) {
+        case ov::element::f32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const float>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<float>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::f64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const double>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<double>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int32_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int32_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int64_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int64_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        default:
+            CPU_NODE_THROW("has unsupported weights precision: ", m_weights_precision);
+        }
+    }
+    case ov::element::u8: {
+        const auto* data = getSrcDataAtPortAs<const uint8_t>(INPUT_DATA_PORT);
+        switch (m_weights_precision) {
+        case ov::element::f32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const float>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<float>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::f64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const double>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<double>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int32_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int32_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int64_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int64_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        default:
+            CPU_NODE_THROW("has unsupported weights precision: ", m_weights_precision);
+        }
+    }
+    case ov::element::u16: {
+        const auto* data = getSrcDataAtPortAs<const uint16_t>(INPUT_DATA_PORT);
+        switch (m_weights_precision) {
+        case ov::element::f32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const float>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<float>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::f64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const double>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<double>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int32_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int32_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int64_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int64_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        default:
+            CPU_NODE_THROW("has unsupported weights precision: ", m_weights_precision);
+        }
+    }
+    case ov::element::u32: {
+        const auto* data = getSrcDataAtPortAs<const uint32_t>(INPUT_DATA_PORT);
+        switch (m_weights_precision) {
+        case ov::element::f32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const float>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<float>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::f64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const double>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<double>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int32_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int32_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int64_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int64_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        default:
+            CPU_NODE_THROW("has unsupported weights precision: ", m_weights_precision);
+        }
+    }
+    case ov::element::u64: {
+        const auto* data = getSrcDataAtPortAs<const uint64_t>(INPUT_DATA_PORT);
+        switch (m_weights_precision) {
+        case ov::element::f32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const float>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<float>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::f64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const double>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<double>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i32:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int32_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int32_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        case ov::element::i64:
+            ov::reference::bincount_weighted(data,
+                                             getSrcDataAtPortAs<const int64_t>(INPUT_WEIGHTS_PORT),
+                                             n,
+                                             m_minlength,
+                                             getDstDataAtPortAs<int64_t>(OUTPUT_PORT),
+                                             out_size);
+            return;
+        default:
+            CPU_NODE_THROW("has unsupported weights precision: ", m_weights_precision);
+        }
+    }
+    default:
+        CPU_NODE_THROW("has unsupported data precision: ", m_data_precision);
+    }
+}
+
+void Bincount::executeDynamicImpl(const dnnl::stream& strm) {
+    execute(strm);
+}
+
+bool Bincount::created() const {
+    return getType() == Type::Bincount;
+}
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/bincount.h
+++ b/src/plugins/intel_cpu/src/nodes/bincount.h
@@ -1,0 +1,52 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <oneapi/dnnl/dnnl_common.hpp>
+#include <string>
+
+#include "graph_context.h"
+#include "node.h"
+#include "openvino/core/node.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+namespace ov::intel_cpu::node {
+
+class Bincount : public Node {
+public:
+    Bincount(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
+
+    void getSupportedDescriptors() override {};
+    void initSupportedPrimitiveDescriptors() override;
+    void execute(const dnnl::stream& strm) override;
+    [[nodiscard]] bool created() const override;
+    void executeDynamicImpl(const dnnl::stream& strm) override;
+
+    void prepareParams() override;
+
+    [[nodiscard]] bool needShapeInfer() const override {
+        return false;
+    }
+
+    static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
+
+private:
+    static constexpr size_t INPUT_DATA_PORT = 0;
+    static constexpr size_t INPUT_WEIGHTS_PORT = 1;
+    static constexpr size_t OUTPUT_PORT = 0;
+
+    size_t get_output_size() const;
+
+    int64_t m_minlength = 0;
+    bool m_has_weights = false;
+
+    ov::element::Type m_data_precision;
+    ov::element::Type m_weights_precision;
+    ov::element::Type m_output_precision;
+};
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes_factory.cpp
+++ b/src/plugins/intel_cpu/src/nodes_factory.cpp
@@ -9,6 +9,7 @@
 #include "nodes/bin_conv.h"
 #include "nodes/broadcast.h"
 #include "nodes/bucketize.h"
+#include "nodes/bincount.h"
 #include "nodes/causal_mask_preprocess.h"
 #include "nodes/col2im.h"
 #include "nodes/color_convert.h"
@@ -183,6 +184,7 @@ Node::NodesFactory::NodesFactory() : Factory("NodesFactory") {
     INTEL_CPU_NODE(GatherElements, Type::GatherElements);
     INTEL_CPU_NODE(CTCGreedyDecoderSeqLen, Type::CTCGreedyDecoderSeqLen);
     INTEL_CPU_NODE(Bucketize, Type::Bucketize);
+INTEL_CPU_NODE(Bincount, Type::Bincount);
     INTEL_CPU_NODE(ExperimentalDetectronROIFeatureExtractor, Type::ExperimentalDetectronROIFeatureExtractor);
     INTEL_CPU_NODE(Math, Type::Math);
     INTEL_CPU_NODE(MultiClassNms, Type::MulticlassNms);

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
@@ -25,6 +25,7 @@
 #include "avg_pool_shape_inference.hpp"
 #include "batch_to_space_shape_inference.hpp"
 #include "binary_convolution_shape_inference.hpp"
+#include "bincount_shape_inference.hpp"
 #include "broadcast_shape_inference.hpp"
 #include "bucketize_shape_inference.hpp"
 #include "col2im_shape_inference.hpp"
@@ -94,6 +95,7 @@
 #include "openvino/op/batch_norm.hpp"
 #include "openvino/op/batch_to_space.hpp"
 #include "openvino/op/binary_convolution.hpp"
+#include "openvino/op/bincount.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/bucketize.hpp"
 #include "openvino/op/col2im.hpp"
@@ -577,6 +579,8 @@ using IStaticShapeInferFactory =
 // To use other version of operators, explicitly specify operator with opset version namespace.
 template <>
 const IStaticShapeInferFactory::TRegistry IStaticShapeInferFactory::registry{
+    // opset17
+    OV_OP_SHAPE_INFER_MASK_REG(op::v17::Bincount, ShapeInferTA, util::bit::mask(0)),
     // opset16
     OV_OP_SHAPE_INFER_MASK_REG(op::v16::OneHot, ShapeInferTA, util::bit::mask(1)),
     OV_OP_SHAPE_INFER_MASK_REG(op::v16::AvgPool, ShapeInferPaddingTA, util::bit::mask()),

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/bincount_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/bincount_shape_inference_test.cpp
@@ -1,0 +1,107 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "bincount_shape_inference.hpp"
+#include "common_test_utils/test_assertions.hpp"
+#include "utils.hpp"
+
+using namespace ov;
+using namespace ov::intel_cpu;
+using namespace testing;
+
+using TensorMap = std::unordered_map<size_t, ov::Tensor>;
+
+class BincountV17StaticShapeInferenceTest : public OpStaticShapeInferenceTest<op::v17::Bincount> {
+    void SetUp() override {
+        output_shapes.resize(1);
+    }
+};
+
+TEST_F(BincountV17StaticShapeInferenceTest, unweighted_with_constant_data) {
+    const auto data = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    op = make_op(data, 0);
+
+    input_shapes = StaticShapeVector{{5}};
+    // data = [0, 1, 2, 3, 0] -> max is 3 -> output size = 4
+    const std::vector<int32_t> vals = {0, 1, 2, 3, 0};
+    auto data_tensor = ov::Tensor(element::i32, ov::Shape{5});
+    std::memcpy(data_tensor.data(), vals.data(), vals.size() * sizeof(int32_t));
+    TensorMap constant_data;
+    constant_data[0] = data_tensor;
+
+    output_shapes = shape_inference(op.get(), input_shapes, constant_data);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({4}));
+}
+
+TEST_F(BincountV17StaticShapeInferenceTest, minlength_larger_than_max_value) {
+    const auto data = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    op = make_op(data, 10);  // minlength = 10
+
+    input_shapes = StaticShapeVector{{3}};
+    // data = [0, 1, 2] -> max is 2 -> output size = max(3, 10) = 10
+    const std::vector<int32_t> vals = {0, 1, 2};
+    auto data_tensor = ov::Tensor(element::i32, ov::Shape{3});
+    std::memcpy(data_tensor.data(), vals.data(), vals.size() * sizeof(int32_t));
+    TensorMap constant_data;
+    constant_data[0] = data_tensor;
+
+    output_shapes = shape_inference(op.get(), input_shapes, constant_data);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({10}));
+}
+
+TEST_F(BincountV17StaticShapeInferenceTest, empty_data_with_zero_minlength) {
+    const auto data = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    op = make_op(data, 0);
+
+    input_shapes = StaticShapeVector{{0}};
+    auto data_tensor = ov::Tensor(element::i32, ov::Shape{0});
+    TensorMap constant_data;
+    constant_data[0] = data_tensor;
+
+    output_shapes = shape_inference(op.get(), input_shapes, constant_data);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({0}));
+}
+
+TEST_F(BincountV17StaticShapeInferenceTest, i64_data) {
+    const auto data = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+    op = make_op(data, 0);
+
+    input_shapes = StaticShapeVector{{4}};
+    // data = [0, 5, 2, 5] -> max is 5 -> output size = 6
+    const std::vector<int64_t> vals = {0, 5, 2, 5};
+    auto data_tensor = ov::Tensor(element::i64, ov::Shape{4});
+    std::memcpy(data_tensor.data(), vals.data(), vals.size() * sizeof(int64_t));
+    TensorMap constant_data;
+    constant_data[0] = data_tensor;
+
+    output_shapes = shape_inference(op.get(), input_shapes, constant_data);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({6}));
+}
+
+TEST_F(BincountV17StaticShapeInferenceTest, weighted_with_constant_data) {
+    const auto data = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    const auto weights = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1});
+    op = make_op(data, weights, 0);
+
+    input_shapes = StaticShapeVector{{3}, {3}};
+    // data = [0, 1, 2] -> max is 2 -> output size = 3
+    const std::vector<int32_t> vals = {0, 1, 2};
+    auto data_tensor = ov::Tensor(element::i32, ov::Shape{3});
+    std::memcpy(data_tensor.data(), vals.data(), vals.size() * sizeof(int32_t));
+    TensorMap constant_data;
+    constant_data[0] = data_tensor;
+
+    output_shapes = shape_inference(op.get(), input_shapes, constant_data);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({3}));
+}

--- a/tests/layer_tests/pytorch_tests/test_bincount.py
+++ b/tests/layer_tests/pytorch_tests/test_bincount.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestBincount(PytorchLayerTest):
+    def _prepare_input(self, with_weights=False, n=10, max_val=5):
+        data = np.random.randint(0, max_val, size=(n,)).astype(np.int32)
+        if not with_weights:
+            return (data,)
+        weights = np.random.randn(n).astype(np.float32)
+        return (data, weights)
+
+    def create_model(self, minlength=0, with_weights=False):
+        import torch
+
+        class aten_bincount_no_weights(torch.nn.Module):
+            def __init__(self, minlength):
+                super().__init__()
+                self.minlength = minlength
+
+            def forward(self, x):
+                return torch.bincount(x, minlength=self.minlength)
+
+        class aten_bincount_with_weights(torch.nn.Module):
+            def __init__(self, minlength):
+                super().__init__()
+                self.minlength = minlength
+
+            def forward(self, x, w):
+                return torch.bincount(x, weights=w, minlength=self.minlength)
+
+        if with_weights:
+            model_cls = aten_bincount_with_weights
+        else:
+            model_cls = aten_bincount_no_weights
+
+        ref_net = None
+        return model_cls(minlength), ref_net, "aten::bincount"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("minlength", [0, 3, 10])
+    def test_bincount_unweighted(self, minlength, ie_device, precision, ir_version):
+        self._test(*self.create_model(minlength=minlength, with_weights=False),
+                   ie_device, precision, ir_version,
+                   kwargs_to_prepare_input={"with_weights": False, "n": 15, "max_val": 8})
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("minlength", [0, 5])
+    def test_bincount_weighted(self, minlength, ie_device, precision, ir_version):
+        self._test(*self.create_model(minlength=minlength, with_weights=True),
+                   ie_device, precision, ir_version,
+                   kwargs_to_prepare_input={"with_weights": True, "n": 12, "max_val": 6})
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_bincount_empty(self, ie_device, precision, ir_version):
+        self._test(*self.create_model(minlength=5, with_weights=False),
+                   ie_device, precision, ir_version,
+                   kwargs_to_prepare_input={"with_weights": False, "n": 0, "max_val": 1})


### PR DESCRIPTION
## Summary

Implements `ov::op::v17::Bincount` — the OpenVINO equivalent of `torch.bincount`.

### Operation

```
Bincount(data, minlength=0) → i64                  # unweighted
Bincount(data, weights, minlength=0) → weights.type()  # weighted
```

- `data`: 1-D tensor of non-negative integers (i32, i64, u8, u16, u32, u64)
- `weights` (optional): 1-D float tensor (f32, f64, i32, i64), same length as `data`
- `minlength`: minimum output size (int64, default 0)
- Output: 1-D tensor, size = `max(max(data)+1, minlength)`
- Data-dependent output shape (similar to NonZero/Unique)

Reference: https://docs.pytorch.org/docs/stable/generated/torch.bincount.html

### Changes

#### Core OpSpec
- `src/core/include/openvino/op/bincount.hpp` — Op class declaration
- `src/core/src/op/bincount.cpp` — Op implementation (validate_and_infer_types, evaluate, clone)
- `src/core/shape_inference/include/bincount_shape_inference.hpp` — Template shape inference
- `src/core/reference/include/openvino/reference/bincount.hpp` — Reference kernel
- `src/core/include/openvino/opsets/opset17_tbl.hpp` — opset17 registration
- `src/core/dev_api/openvino/op/ops_decl.hpp` — Forward declaration
- `src/core/include/openvino/op/ops.hpp` — Op header include (alphabetical order)

#### PyTorch Frontend
- `src/frontends/pytorch/src/op/bincount.cpp` — Translator for `aten::bincount` and `aten.bincount.default`
- `src/frontends/pytorch/src/op_table.cpp` — Op registration

#### CPU Plugin
- `src/plugins/intel_cpu/src/nodes/bincount.h` — Node declaration
- `src/plugins/intel_cpu/src/nodes/bincount.cpp` — Node implementation with dynamic output sizing
- `src/plugins/intel_cpu/src/cpu_types.h/.cpp` — Type enum + name mapping
- `src/plugins/intel_cpu/src/nodes_factory.cpp` — Node factory registration
- `src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp` — Static shape inference registration

#### Python Bindings
- `src/bindings/python/src/openvino/opset17/ops.py` — `bincount()` function
- `src/bindings/python/src/openvino/opset17/__init__.py` — Export registration

#### Documentation
- `docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/condition/bincount-17.rst` — OPA spec
- `docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs.rst` — Index entry

#### Tests
- `src/core/tests/type_prop/bincount.cpp` — 16 type propagation tests ✅
- `src/core/tests/visitors/op/bincount.cpp` — 3 attribute serialization tests ✅
- `src/plugins/intel_cpu/tests/unit/shape_inference_test/bincount_shape_inference_test.cpp` — 5 CPU shape inference tests ✅
- `tests/layer_tests/pytorch_tests/test_bincount.py` — E2E frontend tests (requires PT frontend build)

### Build Status

| Component | Status |
|---|---|
| Core (`openvino_core_obj`) | ✅ Builds clean |
| CPU Plugin (`openvino_intel_cpu_plugin`) | ✅ Builds clean |
| Core unit tests (type_prop + visitors) | ✅ 19/19 passing |
| CPU shape inference tests | ✅ 5/5 passing |
| PyTorch frontend | ⚠️ Not verified (ENABLE_OV_PYTORCH_FRONTEND=OFF in this build) |
| GPU plugin | ❌ Not implemented (follow-up PR) |

### Design Notes

- Op derives from `ov::op::Op` (not `UnaryElementwiseArithmetic` — not element-wise)
- Data-dependent output shape: uses `set_input_is_relevant_to_shape(0)`; output lower bound = `minlength`, upper = ∞
- Constant folding: `evaluate()` is called during `validate_and_infer_types()` when input is constant
- CPU node: uses `InternalDynShapeInferFactory` + `redefineOutputMemory` (same pattern as `non_zero.cpp`)
- CPU shape inference registry: `OV_OP_SHAPE_INFER_MASK_REG(op::v17::Bincount, ShapeInferTA, bit::mask(0))`
- PyTorch FE: `translate_bincount_fx` delegates to `translate_bincount` (identical signatures)

### Known Limitations / Follow-up Items

1. **GPU plugin**: Not implemented in this PR. CPU is sufficient for initial model enablement.
2. **PyTorch frontend**: Code written and follows existing patterns but not compile-verified (PyTorch disabled in build).
3. **Functional tests**: CPU functional test file (`single_layer_tests/bincount.cpp`) not included — requires GPU plugin for a proper baseline.