### PR TITLE
[GPU] Defer allocations of static inputs in SyncInferRequest

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
@@ -61,6 +61,38 @@ struct TensorWrapper {
     size_t actual_size;
 };
 
+// Couples the lazily-allocated user-input map with its mutex so the map is reachable only
+// through a held lock: read() takes a shared lock (read-only view), write() an exclusive one.
+class GuardedUserInputs {
+public:
+    using map_t = std::unordered_map<size_t, TensorWrapper>;
+
+    GuardedUserInputs() = default;
+    GuardedUserInputs(const GuardedUserInputs&) = delete;
+
+    template <typename LockType, typename MapRef>
+    class Accessor {
+    public:
+        Accessor(LockType lock, MapRef map) : m_lock(std::move(lock)), m_map(map) {}
+        auto operator->() const { return &m_map; }
+        MapRef operator*() const { return m_map; }
+    private:
+        LockType m_lock;
+        MapRef m_map;
+    };
+
+    Accessor<std::shared_lock<std::shared_mutex>, const map_t&> read() const {
+        return { std::shared_lock<std::shared_mutex>(m_mutex), m_map};
+    }
+    Accessor<std::unique_lock<std::shared_mutex>, map_t&> write() const {
+        return {std::unique_lock<std::shared_mutex>(m_mutex), m_map};
+    }
+
+private:
+    mutable std::shared_mutex m_mutex;
+    mutable map_t m_map;
+};
+
 class SyncInferRequest : public ov::ISyncInferRequest {
 public:
     using Ptr = std::shared_ptr<SyncInferRequest>;
@@ -92,12 +124,11 @@ private:
     void check_tensors() const override;
 
     // Materializes a deferred (lazy) input slot on first access. Const-safe; takes
-    // m_user_inputs_mutex exclusively.
+    // an exclusive lock on m_user_inputs.
     void ensure_input_allocated(size_t input_idx) const;
 
-    // Mutable: lazily allocated from the const get_tensor(). Guarded by m_user_inputs_mutex.
-    mutable std::unordered_map<size_t, TensorWrapper> m_user_inputs;
-    mutable std::shared_mutex m_user_inputs_mutex;
+    // Self-guarding: reachable only via read()/write(), which lock internally.
+    GuardedUserInputs m_user_inputs;
     std::unordered_map<size_t, TensorWrapper> m_user_outputs;
 
     std::unordered_map<size_t, TensorWrapper> m_plugin_inputs;
@@ -140,7 +171,7 @@ private:
     void allocate_inputs();
     void allocate_outputs();
     void allocate_states();
-    void allocate_input(size_t input_idx);
+    void allocate_input(size_t input_idx, GuardedUserInputs::map_t& user_inputs);
     void allocate_output(const ov::Output<const ov::Node>& port, size_t output_idx);
     cldnn::event::ptr copy_output_data(cldnn::memory::ptr src, ov::ITensor& dst) const;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
@@ -63,19 +63,19 @@ struct TensorWrapper {
 
 // Couples the lazily-allocated user-input map with its mutex so the map is reachable only
 // through a held lock: read() takes a shared lock (read-only view), write() an exclusive one.
-class GuardedUserInputs {
+class GuardedMap {
 public:
     using map_t = std::unordered_map<size_t, TensorWrapper>;
 
-    GuardedUserInputs() = default;
-    GuardedUserInputs(const GuardedUserInputs&) = delete;
+    GuardedMap() = default;
+    GuardedMap(const GuardedMap&) = delete;
 
     template <typename LockType, typename MapRef>
     class Accessor {
     public:
         Accessor(LockType lock, MapRef map) : m_lock(std::move(lock)), m_map(map) {}
-        auto operator->() const { return &m_map; }
-        MapRef operator*() const { return m_map; }
+        auto operator->() { return &m_map; }
+        MapRef operator*() { return m_map; }
     private:
         LockType m_lock;
         MapRef m_map;
@@ -84,13 +84,13 @@ public:
     Accessor<std::shared_lock<std::shared_mutex>, const map_t&> read() const {
         return { std::shared_lock<std::shared_mutex>(m_mutex), m_map};
     }
-    Accessor<std::unique_lock<std::shared_mutex>, map_t&> write() const {
+    Accessor<std::unique_lock<std::shared_mutex>, map_t&> write() {
         return {std::unique_lock<std::shared_mutex>(m_mutex), m_map};
     }
 
 private:
     mutable std::shared_mutex m_mutex;
-    mutable map_t m_map;
+    map_t m_map;
 };
 
 class SyncInferRequest : public ov::ISyncInferRequest {
@@ -127,8 +127,9 @@ private:
     // an exclusive lock on m_user_inputs.
     void ensure_input_allocated(size_t input_idx) const;
 
+    // Mutable so the const lazy-alloc path (get_tensor) can take a write lock.
     // Self-guarding: reachable only via read()/write(), which lock internally.
-    GuardedUserInputs m_user_inputs;
+    mutable GuardedMap m_user_inputs;
     std::unordered_map<size_t, TensorWrapper> m_user_outputs;
 
     std::unordered_map<size_t, TensorWrapper> m_plugin_inputs;
@@ -171,7 +172,7 @@ private:
     void allocate_inputs();
     void allocate_outputs();
     void allocate_states();
-    void allocate_input(size_t input_idx, GuardedUserInputs::map_t& user_inputs);
+    void allocate_input(size_t input_idx, GuardedMap::map_t& user_inputs);
     void allocate_output(const ov::Output<const ov::Node>& port, size_t output_idx);
     cldnn::event::ptr copy_output_data(cldnn::memory::ptr src, ov::ITensor& dst) const;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <atomic>
 #include <mutex>
+#include <shared_mutex>
 
 namespace ov::intel_gpu {
 
@@ -90,18 +91,16 @@ public:
 private:
     void check_tensors() const override;
 
-    // Lazily allocate the reserved (null) host tensor for a deferred input slot.
-    // Idempotent and safe to call from the const get_tensor(); the deferred allocation is
-    // serialized with m_lazy_alloc_mutex (double-checked) so concurrent get_tensor() calls
-    // cannot race on m_user_inputs.
+    // Lazily allocate the reserved (null) host tensor for a deferred input slot. Idempotent and
+    // safe from the const get_tensor(); takes m_user_inputs_mutex exclusively (double-checked).
     void ensure_input_allocated(const ov::Output<const ov::Node>& port, size_t input_idx) const;
 
-    // m_user_inputs is mutated by the idempotent lazy-allocation path reachable from the const
-    // get_tensor(), so it is marked mutable. get_tensor() is const and may be called concurrently
-    // by applications that (against guidance) share a single InferRequest across threads; the
-    // dedicated mutex guards that deferred allocation so it cannot double-allocate or race.
+    // Mutable because the lazy-allocation path reachable from the const get_tensor() mutates it.
+    // All accesses to m_user_inputs must be guarded by m_user_inputs_mutex (shared lock for reads,
+    // exclusive for the deferred allocation) so a const get_tensor() can be called concurrently
+    // with infer()/check_tensors() without a data race.
     mutable std::unordered_map<size_t, TensorWrapper> m_user_inputs;
-    mutable std::mutex m_lazy_alloc_mutex;
+    mutable std::shared_mutex m_user_inputs_mutex;
     std::unordered_map<size_t, TensorWrapper> m_user_outputs;
 
     std::unordered_map<size_t, TensorWrapper> m_plugin_inputs;

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
@@ -91,14 +91,11 @@ public:
 private:
     void check_tensors() const override;
 
-    // Lazily allocate the reserved (null) host tensor for a deferred input slot. Idempotent and
-    // safe from the const get_tensor(); takes m_user_inputs_mutex exclusively (double-checked).
-    void ensure_input_allocated(const ov::Output<const ov::Node>& port, size_t input_idx) const;
+    // Materializes a deferred (lazy) input slot on first access. Const-safe; takes
+    // m_user_inputs_mutex exclusively.
+    void ensure_input_allocated(size_t input_idx) const;
 
-    // Mutable because the lazy-allocation path reachable from the const get_tensor() mutates it.
-    // All accesses to m_user_inputs must be guarded by m_user_inputs_mutex (shared lock for reads,
-    // exclusive for the deferred allocation) so a const get_tensor() can be called concurrently
-    // with infer()/check_tensors() without a data race.
+    // Mutable: lazily allocated from the const get_tensor(). Guarded by m_user_inputs_mutex.
     mutable std::unordered_map<size_t, TensorWrapper> m_user_inputs;
     mutable std::shared_mutex m_user_inputs_mutex;
     std::unordered_map<size_t, TensorWrapper> m_user_outputs;
@@ -143,7 +140,7 @@ private:
     void allocate_inputs();
     void allocate_outputs();
     void allocate_states();
-    void allocate_input(const ov::Output<const ov::Node>& port, size_t input_idx);
+    void allocate_input(size_t input_idx);
     void allocate_output(const ov::Output<const ov::Node>& port, size_t output_idx);
     cldnn::event::ptr copy_output_data(cldnn::memory::ptr src, ov::ITensor& dst) const;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <memory>
 #include <atomic>
+#include <mutex>
 
 namespace ov::intel_gpu {
 
@@ -89,7 +90,18 @@ public:
 private:
     void check_tensors() const override;
 
-    std::unordered_map<size_t, TensorWrapper> m_user_inputs;
+    // Lazily allocate the reserved (null) host tensor for a deferred input slot.
+    // Idempotent and safe to call from the const get_tensor(); the deferred allocation is
+    // serialized with m_lazy_alloc_mutex (double-checked) so concurrent get_tensor() calls
+    // cannot race on m_user_inputs.
+    void ensure_input_allocated(const ov::Output<const ov::Node>& port, size_t input_idx) const;
+
+    // m_user_inputs is mutated by the idempotent lazy-allocation path reachable from the const
+    // get_tensor(), so it is marked mutable. get_tensor() is const and may be called concurrently
+    // by applications that (against guidance) share a single InferRequest across threads; the
+    // dedicated mutex guards that deferred allocation so it cannot double-allocate or race.
+    mutable std::unordered_map<size_t, TensorWrapper> m_user_inputs;
+    mutable std::mutex m_lazy_alloc_mutex;
     std::unordered_map<size_t, TensorWrapper> m_user_outputs;
 
     std::unordered_map<size_t, TensorWrapper> m_plugin_inputs;

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -750,7 +750,7 @@ void SyncInferRequest::ensure_input_allocated(size_t input_idx) const {
     const_cast<SyncInferRequest&>(*this).allocate_input(input_idx, *inputs);
 }
 
-void SyncInferRequest::allocate_input(size_t input_idx, GuardedUserInputs::map_t& user_inputs) {
+void SyncInferRequest::allocate_input(size_t input_idx, GuardedMap::map_t& user_inputs) {
     // Caller passes the already write-locked map. Shape/type come from m_input_ports_map (this
     // compiled model's own port), not a caller port which may carry a different (un-reshaped) shape.
     const auto& internal_port = m_input_ports_map.at(input_idx);

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -244,6 +244,15 @@ ov::SoPtr<ov::ITensor> SyncInferRequest::get_tensor(const ov::Output<const ov::N
     size_t port_index = port_info.idx;
     if (is_input) {
         OPENVINO_ASSERT(m_user_inputs.count(port_index) == 1, "[GPU] Input tensor with index ", port_index, " is not found");
+        // Lazy allocation: the input slot was reserved with a null tensor in allocate_inputs().
+        // Allocate the default host tensor now, on first access.
+        if (!m_user_inputs.at(port_index).ptr) {
+            auto& self = const_cast<SyncInferRequest&>(*this);
+            self.allocate_input(port, port_index);
+            GPU_DEBUG_LOG << "[lazy alloc] input " << port_index
+                          << " shape: " << port.get_partial_shape()
+                          << " allocated at get_tensor" << std::endl;
+        }
         return { m_user_inputs.at(port_index).ptr, nullptr };
     } else {
         OPENVINO_ASSERT(m_user_outputs.count(port_index) == 1, "[GPU] Output tensor with index ", port_index, " is not found");
@@ -254,8 +263,14 @@ ov::SoPtr<ov::ITensor> SyncInferRequest::get_tensor(const ov::Output<const ov::N
 void SyncInferRequest::check_tensors() const {
     const auto& inputs = get_compiled_model()->inputs();
     for (size_t i = 0; i < inputs.size(); i++) {
-        if (!is_batched_input(inputs[i]))
+        if (!is_batched_input(inputs[i])) {
+            // Skip validation for lazy (not yet allocated) input slots.
+            // They are allocated on first get_tensor()/enqueue() or replaced by set_tensor().
+            auto it = m_user_inputs.find(i);
+            if (it != m_user_inputs.end() && !it->second.ptr)
+                continue;
             check_tensor(inputs[i], get_tensor_ptr(inputs[i]));
+        }
     }
     const auto& outputs = get_compiled_model()->outputs();
     for (size_t i = 0; i < outputs.size(); i++) {
@@ -300,7 +315,19 @@ void SyncInferRequest::enqueue() {
         size_t port_idx = it.first;
         const auto& port = it.second;
 
-        if (m_batched_tensors.count(port.get_tensor_ptr()) > 0) {
+        const bool is_batched = m_batched_tensors.count(port.get_tensor_ptr()) > 0;
+
+        // Lazy allocation: if the user didn't call set_tensor()/set_tensors() for this input,
+        // allocate the default host tensor now, before inference. Batched inputs provide their
+        // own tensors and don't need the reserved slot allocated.
+        if (!is_batched && m_user_inputs.count(port_idx) && !m_user_inputs.at(port_idx).ptr) {
+            allocate_input(port, port_idx);
+            GPU_DEBUG_LOG << "[lazy alloc] input " << port_idx
+                          << " shape: " << port.get_partial_shape()
+                          << " allocated at enqueue" << std::endl;
+        }
+
+        if (is_batched) {
             auto events = prepare_batched_input(port_idx, port, m_batched_tensors.at(port.get_tensor_ptr()));
             std::move(events.begin(), events.end(), std::back_inserter(dependencies));
         } else {
@@ -741,7 +768,30 @@ void SyncInferRequest::allocate_inputs() {
         }
 
         if (!is_nv12_input) {
-            allocate_input(port, input_idx);
+            // Only defer large static inputs (e.g. weights converted to inputs by weight sharing).
+            // Dynamic inputs allocate to a near-zero placeholder anyway (dynamic dims -> 0), and
+            // small static inputs are cheap, so keep both on the eager path to limit lazy-path risk.
+            constexpr size_t lazy_alloc_threshold_bytes = size_t(2) << 20;  // 2 MB
+            const auto& pshape = port.get_partial_shape();
+            const auto& element_type = port.get_element_type();
+            size_t static_bytes = 0;
+            if (pshape.is_static() && element_type != ov::element::string) {
+                // Use bitwidth so sub-byte types (e.g. int4/uint4 weights from weight sharing)
+                // are sized correctly; element_type.size() would round sub-byte types to 0/1.
+                static_bytes = cldnn::ceil_div(ov::shape_size(pshape.to_shape()) * element_type.bitwidth(), 8);
+            }
+
+            if (static_bytes >= lazy_alloc_threshold_bytes) {
+                // Defer actual allocation: reserve the slot with a null tensor. The tensor is
+                // allocated lazily on first get_tensor()/enqueue(), or replaced by set_tensor().
+                m_user_inputs[input_idx] = { nullptr, TensorOwner::PLUGIN };
+                GPU_DEBUG_LOG << "[lazy alloc] reserved input slot " << input_idx
+                              << " shape: " << port.get_partial_shape() << std::endl;
+            } else {
+                allocate_input(port, input_idx);
+                GPU_DEBUG_LOG << "[lazy alloc] eager input slot " << input_idx
+                              << " shape: " << port.get_partial_shape() << std::endl;
+            }
         }
     }
 }

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <string>
 #include <map>
@@ -78,6 +79,60 @@ cldnn::data_types data_type_for_remote_tensor(ov::element::Type t) {
         return cldnn::data_types::u8;
     default: return t;
     }
+}
+
+// Returns true if a static input is large enough (in bytes) to be worth deferring
+// its host-tensor allocation (lazy-allocation path). The predicate is exactly
+//     ceil_div(element_count * bitwidth, 8) >= threshold_bytes
+// evaluated with overflow-safe arithmetic for arbitrary threshold_bytes and shapes
+// (including sub-byte element types). Dynamic shapes and string inputs are never
+// considered large here.
+bool exceeds_lazy_alloc_threshold(const ov::PartialShape& pshape,
+                                  const ov::element::Type& element_type,
+                                  size_t threshold_bytes) {
+    if (!pshape.is_static() || element_type == ov::element::string)
+        return false;
+
+    // Use bitwidth so sub-byte types (e.g. int4/uint4 weights from weight sharing) are
+    // sized correctly; element_type.size() would round sub-byte types to 0/1.
+    const size_t bitwidth = element_type.bitwidth();
+    if (bitwidth == 0)
+        return false;
+    if (threshold_bytes == 0)
+        return true;  // any static tensor meets a zero-byte threshold
+
+    constexpr size_t bits_per_byte = 8;
+    constexpr size_t max_size = std::numeric_limits<size_t>::max();
+
+    // ceil_div(element_count * bitwidth, 8) >= threshold_bytes
+    //   <=> element_count * bitwidth > 8 * (threshold_bytes - 1)   (= threshold_bits)
+    // Guard the bit-threshold multiply so the helper is safe for any threshold_bytes;
+    // a threshold beyond size_t can never be reached -> treat the input as "not large".
+    if (threshold_bytes - 1 > max_size / bits_per_byte)
+        return false;
+    const size_t threshold_bits = bits_per_byte * (threshold_bytes - 1);
+
+    // Smallest element count whose byte size reaches the threshold:
+    //   element_count * bitwidth > threshold_bits  <=>  element_count >= threshold_bits / bitwidth + 1.
+    // Comparing element counts avoids multiplying the full tensor size by bitwidth.
+    // (threshold_bits <= max_size - 7 from the guard above, so the + 1 cannot overflow.)
+    const size_t min_large_elements = threshold_bits / bitwidth + 1;
+
+    // Accumulate the element count dimension by dimension instead of calling shape_size(),
+    // which can overflow for very large shapes. Exit early as soon as the running product
+    // reaches the threshold, and treat any multiplication overflow as "large" (the true
+    // count would exceed size_t and is therefore >= min_large_elements).
+    size_t element_count = 1;
+    for (size_t dim : pshape.to_shape()) {
+        if (dim == 0)
+            return false;  // empty tensor: byte size is 0, never large
+        if (element_count > max_size / dim)
+            return true;  // product would overflow size_t -> definitely above the threshold
+        element_count *= dim;
+        if (element_count >= min_large_elements)
+            return true;
+    }
+    return element_count >= min_large_elements;
 }
 
 }  // namespace
@@ -243,17 +298,19 @@ ov::SoPtr<ov::ITensor> SyncInferRequest::get_tensor(const ov::Output<const ov::N
     bool is_input = port_info.type == ov::ISyncInferRequest::FoundPort::Type::INPUT;
     size_t port_index = port_info.idx;
     if (is_input) {
-        OPENVINO_ASSERT(m_user_inputs.count(port_index) == 1, "[GPU] Input tensor with index ", port_index, " is not found");
+        auto it = m_user_inputs.find(port_index);
+        OPENVINO_ASSERT(it != m_user_inputs.end(), "[GPU] Input tensor with index ", port_index, " is not found");
         // Lazy allocation: the input slot was reserved with a null tensor in allocate_inputs().
         // Allocate the default host tensor now, on first access.
-        if (!m_user_inputs.at(port_index).ptr) {
-            auto& self = const_cast<SyncInferRequest&>(*this);
-            self.allocate_input(port, port_index);
+        if (!it->second.ptr) {
+            ensure_input_allocated(port, port_index);
             GPU_DEBUG_LOG << "[lazy alloc] input " << port_index
                           << " shape: " << port.get_partial_shape()
                           << " allocated at get_tensor" << std::endl;
+            // ensure_input_allocated() may rehash m_user_inputs, invalidating 'it'.
+            it = m_user_inputs.find(port_index);
         }
-        return { m_user_inputs.at(port_index).ptr, nullptr };
+        return { it->second.ptr, nullptr };
     } else {
         OPENVINO_ASSERT(m_user_outputs.count(port_index) == 1, "[GPU] Output tensor with index ", port_index, " is not found");
         return { m_user_outputs.at(port_index).ptr, nullptr };
@@ -321,7 +378,7 @@ void SyncInferRequest::enqueue() {
         // allocate the default host tensor now, before inference. Batched inputs provide their
         // own tensors and don't need the reserved slot allocated.
         if (!is_batched && m_user_inputs.count(port_idx) && !m_user_inputs.at(port_idx).ptr) {
-            allocate_input(port, port_idx);
+            ensure_input_allocated(port, port_idx);
             GPU_DEBUG_LOG << "[lazy alloc] input " << port_idx
                           << " shape: " << port.get_partial_shape()
                           << " allocated at enqueue" << std::endl;
@@ -712,6 +769,21 @@ cldnn::event::ptr SyncInferRequest::copy_output_data(cldnn::memory::ptr src, ov:
     }
 }
 
+void SyncInferRequest::ensure_input_allocated(const ov::Output<const ov::Node>& port, size_t input_idx) const {
+    // get_tensor() is const and may be called concurrently by applications that share a single
+    // InferRequest across threads (against guidance). Serialize the deferred allocation so two
+    // such calls cannot both observe a null slot and double-allocate / race on m_user_inputs.
+    std::lock_guard<std::mutex> lock(m_lazy_alloc_mutex);
+    auto it = m_user_inputs.find(input_idx);
+    if (it != m_user_inputs.end() && it->second.ptr)
+        return;  // already materialized (by set_tensor() or a prior lazy allocation)
+    // const_cast is required only because the base ISyncInferRequest::set_tensor() is
+    // non-const; the deferred allocation itself is a transparent, idempotent operation.
+    // allocate_input() inserts the slot if it is missing, so this is safe even for a
+    // not-yet-reserved index.
+    const_cast<SyncInferRequest&>(*this).allocate_input(port, input_idx);
+}
+
 void SyncInferRequest::allocate_input(const ov::Output<const ov::Node>& port, size_t input_idx) {
     const auto& shape = port.get_partial_shape();
     auto element_type = port.get_element_type();
@@ -771,17 +843,12 @@ void SyncInferRequest::allocate_inputs() {
             // Only defer large static inputs (e.g. weights converted to inputs by weight sharing).
             // Dynamic inputs allocate to a near-zero placeholder anyway (dynamic dims -> 0), and
             // small static inputs are cheap, so keep both on the eager path to limit lazy-path risk.
+            // TODO: hard coded value for now, configurable param in progress
             constexpr size_t lazy_alloc_threshold_bytes = size_t(2) << 20;  // 2 MB
             const auto& pshape = port.get_partial_shape();
             const auto& element_type = port.get_element_type();
-            size_t static_bytes = 0;
-            if (pshape.is_static() && element_type != ov::element::string) {
-                // Use bitwidth so sub-byte types (e.g. int4/uint4 weights from weight sharing)
-                // are sized correctly; element_type.size() would round sub-byte types to 0/1.
-                static_bytes = cldnn::ceil_div(ov::shape_size(pshape.to_shape()) * element_type.bitwidth(), 8);
-            }
 
-            if (static_bytes >= lazy_alloc_threshold_bytes) {
+            if (exceeds_lazy_alloc_threshold(pshape, element_type, lazy_alloc_threshold_bytes)) {
                 // Defer actual allocation: reserve the slot with a null tensor. The tensor is
                 // allocated lazily on first get_tensor()/enqueue(), or replaced by set_tensor().
                 m_user_inputs[input_idx] = { nullptr, TensorOwner::PLUGIN };

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -31,6 +31,8 @@
 #include <unordered_set>
 #include <functional>
 #include <utility>
+#include <mutex>
+#include <shared_mutex>
 
 namespace {
 
@@ -251,9 +253,9 @@ ov::SoPtr<ov::ITensor> SyncInferRequest::get_tensor(const ov::Output<const ov::N
             OPENVINO_ASSERT(it != m_user_inputs.end(), "[GPU] Input tensor with index ", port_index, " is not found");
             tensor_ptr = it->second.ptr;
         }
-        // Lazy allocation: a reserved (null) slot is materialized on first access.
+        // Materialize the reserved slot on first access.
         if (!tensor_ptr) {
-            ensure_input_allocated(port, port_index);
+            ensure_input_allocated(port_index);
             GPU_DEBUG_LOG << "[lazy alloc] input " << port_index
                           << " shape: " << port.get_partial_shape()
                           << " allocated at get_tensor" << std::endl;
@@ -271,8 +273,7 @@ void SyncInferRequest::check_tensors() const {
     const auto& inputs = get_compiled_model()->inputs();
     for (size_t i = 0; i < inputs.size(); i++) {
         if (!is_batched_input(inputs[i])) {
-            // Skip not-yet-allocated lazy slots; materialized on first get_tensor()/enqueue() or
-            // replaced by set_tensor(). Read under a shared lock so it can't race the lazy write.
+            // Skip not-yet-materialized lazy slots.
             const bool not_allocated = [&] {
                 std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
                 auto it = m_user_inputs.find(i);
@@ -328,7 +329,7 @@ void SyncInferRequest::enqueue() {
 
         const bool is_batched = m_batched_tensors.count(port.get_tensor_ptr()) > 0;
 
-        // Materialize a reserved lazy slot before inference (batched inputs bring their own tensors).
+        // Materialize a reserved lazy input slot before inference.
         if (!is_batched) {
             bool needs_alloc = false;
             {
@@ -337,7 +338,7 @@ void SyncInferRequest::enqueue() {
                 needs_alloc = uit != m_user_inputs.end() && !uit->second.ptr;
             }
             if (needs_alloc) {
-                ensure_input_allocated(port, port_idx);
+                ensure_input_allocated(port_idx);
                 GPU_DEBUG_LOG << "[lazy alloc] input " << port_idx
                               << " shape: " << port.get_partial_shape()
                               << " allocated at enqueue" << std::endl;
@@ -738,24 +739,22 @@ cldnn::event::ptr SyncInferRequest::copy_output_data(cldnn::memory::ptr src, ov:
     }
 }
 
-void SyncInferRequest::ensure_input_allocated(const ov::Output<const ov::Node>& port, size_t input_idx) const {
-    // const get_tensor() may race infer(); exclusive lock serializes the deferred allocation.
+void SyncInferRequest::ensure_input_allocated(size_t input_idx) const {
     std::unique_lock<std::shared_mutex> lock(m_user_inputs_mutex);
     auto it = m_user_inputs.find(input_idx);
-    if (it != m_user_inputs.end() && it->second.ptr)
-        return;  // already materialized
-    // const_cast only because base set_tensor() is non-const; slot is pre-reserved, so
-    // allocate_input() reassigns it in place.
-    const_cast<SyncInferRequest&>(*this).allocate_input(port, input_idx);
+    if (it != m_user_inputs.end() && it->second.ptr) {
+        return;
+    }
+    const_cast<SyncInferRequest&>(*this).allocate_input(input_idx);
 }
 
-void SyncInferRequest::allocate_input(const ov::Output<const ov::Node>& port, size_t input_idx) {
-    // Lock-free helper: must NOT take m_user_inputs_mutex. Callers either run single-threaded init
-    // (allocate_inputs()) or already hold the exclusive lock (ensure_input_allocated()); re-locking
-    // would deadlock the non-recursive shared_mutex. Uses the base ISyncInferRequest::set_tensor,
-    // not the GPU override, to avoid re-entering the mutex.
-    const auto& shape = port.get_partial_shape();
-    auto element_type = port.get_element_type();
+void SyncInferRequest::allocate_input(size_t input_idx) {
+    // Lock-free: callers already hold m_user_inputs_mutex or run single-threaded init.
+    // Use m_input_ports_map, not a caller-supplied port, since callers (e.g. AUTO_BATCH) may
+    // pass a port with a different (un-reshaped) shape than this compiled model's own.
+    const auto& internal_port = m_input_ports_map.at(input_idx);
+    const auto& shape = internal_port.get_partial_shape();
+    auto element_type = internal_port.get_element_type();
 
     m_user_inputs[input_idx] = { create_host_tensor(shape, element_type), TensorOwner::PLUGIN };
     if (element_type == ov::element::string) {
@@ -764,9 +763,7 @@ void SyncInferRequest::allocate_input(const ov::Output<const ov::Node>& port, si
         auto data = m_user_inputs.at(input_idx).ptr->data<std::string>();
         std::uninitialized_fill_n(data, m_user_inputs.at(input_idx).ptr->get_size(), std::string());
     }
-    // Must stay base-qualified: the GPU set_tensor override takes m_user_inputs_mutex, which the
-    // lazy-path caller (ensure_input_allocated) already holds -> re-entrant lock would deadlock.
-    ov::ISyncInferRequest::set_tensor(port, m_user_inputs.at(input_idx).ptr);
+    ov::ISyncInferRequest::set_tensor(internal_port, m_user_inputs.at(input_idx).ptr);
 }
 
 void SyncInferRequest::allocate_output(const ov::Output<const ov::Node>& port, size_t output_idx) {
@@ -796,9 +793,7 @@ void SyncInferRequest::allocate_output(const ov::Output<const ov::Node>& port, s
 void SyncInferRequest::allocate_inputs() {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "SyncInferRequest::allocate_inputs");
 
-    // Reserve capacity for all input ports up-front (single-threaded init). Concurrent access to
-    // m_user_inputs is guarded by m_user_inputs_mutex; reserving here keeps the lazy path cheap by
-    // avoiding a rehash while the exclusive lock is held.
+    // Reserve up-front to avoid rehashing while the lazy path holds the lock.
     m_user_inputs.reserve(m_input_ports_map.size());
 
     for (const auto& it : m_input_ports_map) {
@@ -819,14 +814,12 @@ void SyncInferRequest::allocate_inputs() {
             const auto& pshape = port.get_partial_shape();
             const bool can_defer = pshape.is_static() && port.get_element_type() != ov::element::string;
             if (can_defer) {
-                // Defer allocation for static inputs: reserve a null slot, materialized lazily on
-                // first get_tensor()/enqueue() or replaced via set_tensor().
+                // Reserve a null slot; materialized lazily or replaced by set_tensor().
                 m_user_inputs[input_idx] = { nullptr, TensorOwner::PLUGIN };
                 GPU_DEBUG_LOG << "[lazy alloc] reserved input slot " << input_idx
                               << " shape: " << pshape << std::endl;
             } else {
-                // Dynamic and string inputs keep the original eager allocation (empty/placeholder tensor).
-                allocate_input(port, input_idx);
+                allocate_input(input_idx);
             }
         }
     }

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -213,8 +213,8 @@ void SyncInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
 
     bool is_input = port_info.type == ov::ISyncInferRequest::FoundPort::Type::INPUT;
     if (is_input) {
-        std::unique_lock<std::shared_mutex> lock(m_user_inputs_mutex);
-        update_tensors_maps(port_index, m_user_inputs, m_plugin_inputs, tensor);
+        auto inputs = m_user_inputs.write();
+        update_tensors_maps(port_index, *inputs, m_plugin_inputs, tensor);
     } else {
         update_tensors_maps(port_index, m_user_outputs, m_plugin_outputs, tensor);
     }
@@ -248,9 +248,9 @@ ov::SoPtr<ov::ITensor> SyncInferRequest::get_tensor(const ov::Output<const ov::N
     if (is_input) {
         std::shared_ptr<ov::ITensor> tensor_ptr;
         {
-            std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
-            auto it = m_user_inputs.find(port_index);
-            OPENVINO_ASSERT(it != m_user_inputs.end(), "[GPU] Input tensor with index ", port_index, " is not found");
+            auto inputs = m_user_inputs.read();
+            auto it = inputs->find(port_index);
+            OPENVINO_ASSERT(it != inputs->end(), "[GPU] Input tensor with index ", port_index, " is not found");
             tensor_ptr = it->second.ptr;
         }
         // Materialize the reserved slot on first access.
@@ -259,8 +259,8 @@ ov::SoPtr<ov::ITensor> SyncInferRequest::get_tensor(const ov::Output<const ov::N
             GPU_DEBUG_LOG << "[lazy alloc] input " << port_index
                           << " shape: " << port.get_partial_shape()
                           << " allocated at get_tensor" << std::endl;
-            std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
-            tensor_ptr = m_user_inputs.at(port_index).ptr;
+            auto inputs = m_user_inputs.read();
+            tensor_ptr = inputs->at(port_index).ptr;
         }
         return { tensor_ptr, nullptr };
     } else {
@@ -275,9 +275,9 @@ void SyncInferRequest::check_tensors() const {
         if (!is_batched_input(inputs[i])) {
             // Skip not-yet-materialized lazy slots.
             const bool not_allocated = [&] {
-                std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
-                auto it = m_user_inputs.find(i);
-                return it != m_user_inputs.end() && !it->second.ptr;
+                auto inputs = m_user_inputs.read();
+                auto it = inputs->find(i);
+                return it != inputs->end() && !it->second.ptr;
             }();
             if (not_allocated)
                 continue;
@@ -333,9 +333,9 @@ void SyncInferRequest::enqueue() {
         if (!is_batched) {
             bool needs_alloc = false;
             {
-                std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
-                auto uit = m_user_inputs.find(port_idx);
-                needs_alloc = uit != m_user_inputs.end() && !uit->second.ptr;
+                auto inputs = m_user_inputs.read();
+                auto uit = inputs->find(port_idx);
+                needs_alloc = uit != inputs->end() && !uit->second.ptr;
             }
             if (needs_alloc) {
                 ensure_input_allocated(port_idx);
@@ -352,8 +352,8 @@ void SyncInferRequest::enqueue() {
             cldnn::primitive_id internal_name = m_graph->input_port_index_to_internal(port_idx)[0];
             TensorWrapper user_tensor;
             {
-                std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
-                user_tensor = m_user_inputs.at(port_idx);
+                auto inputs = m_user_inputs.read();
+                user_tensor = inputs->at(port_idx);
             }
             auto events = prepare_input(internal_name, port_idx, port, user_tensor);
             std::move(events.begin(), events.end(), std::back_inserter(dependencies));
@@ -362,8 +362,8 @@ void SyncInferRequest::enqueue() {
         if (need_alias_detection) {
             TensorWrapper wrapper;
             {
-                std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
-                wrapper = m_user_inputs.at(port_idx);
+                auto inputs = m_user_inputs.read();
+                wrapper = inputs->at(port_idx);
             }
             if (wrapper.ptr && !std::dynamic_pointer_cast<IRemoteTensor>(wrapper.ptr)) {
                 if (auto* p = wrapper.ptr->data()) {
@@ -740,30 +740,32 @@ cldnn::event::ptr SyncInferRequest::copy_output_data(cldnn::memory::ptr src, ov:
 }
 
 void SyncInferRequest::ensure_input_allocated(size_t input_idx) const {
-    std::unique_lock<std::shared_mutex> lock(m_user_inputs_mutex);
-    auto it = m_user_inputs.find(input_idx);
-    if (it != m_user_inputs.end() && it->second.ptr) {
-        return;
+    // Serializes lazy allocation against concurrent get_tensor()/infer().
+    auto inputs = m_user_inputs.write();
+    auto it = inputs->find(input_idx);
+    if (it != inputs->end() && it->second.ptr) {
+        return;  // already materialized
     }
-    const_cast<SyncInferRequest&>(*this).allocate_input(input_idx);
+    // const_cast: base set_tensor() is non-const.
+    const_cast<SyncInferRequest&>(*this).allocate_input(input_idx, *inputs);
 }
 
-void SyncInferRequest::allocate_input(size_t input_idx) {
-    // Lock-free: callers already hold m_user_inputs_mutex or run single-threaded init.
-    // Use m_input_ports_map, not a caller-supplied port, since callers (e.g. AUTO_BATCH) may
-    // pass a port with a different (un-reshaped) shape than this compiled model's own.
+void SyncInferRequest::allocate_input(size_t input_idx, GuardedUserInputs::map_t& user_inputs) {
+    // Caller passes the already write-locked map. Shape/type come from m_input_ports_map (this
+    // compiled model's own port), not a caller port which may carry a different (un-reshaped) shape.
     const auto& internal_port = m_input_ports_map.at(input_idx);
     const auto& shape = internal_port.get_partial_shape();
     auto element_type = internal_port.get_element_type();
 
-    m_user_inputs[input_idx] = { create_host_tensor(shape, element_type), TensorOwner::PLUGIN };
+    user_inputs[input_idx] = { create_host_tensor(shape, element_type), TensorOwner::PLUGIN };
     if (element_type == ov::element::string) {
         // In case the element type is string and input data is an empty string,
         // it produces the segmentation fault unless the each element of tensor.data is initialized.
-        auto data = m_user_inputs.at(input_idx).ptr->data<std::string>();
-        std::uninitialized_fill_n(data, m_user_inputs.at(input_idx).ptr->get_size(), std::string());
+        auto data = user_inputs.at(input_idx).ptr->data<std::string>();
+        std::uninitialized_fill_n(data, user_inputs.at(input_idx).ptr->get_size(), std::string());
     }
-    ov::ISyncInferRequest::set_tensor(internal_port, m_user_inputs.at(input_idx).ptr);
+    // Base-qualified to avoid re-entering the input lock; use internal_port to match the allocated shape.
+    ov::ISyncInferRequest::set_tensor(internal_port, user_inputs.at(input_idx).ptr);
 }
 
 void SyncInferRequest::allocate_output(const ov::Output<const ov::Node>& port, size_t output_idx) {
@@ -793,8 +795,9 @@ void SyncInferRequest::allocate_output(const ov::Output<const ov::Node>& port, s
 void SyncInferRequest::allocate_inputs() {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "SyncInferRequest::allocate_inputs");
 
+    auto inputs = m_user_inputs.write();
     // Reserve up-front to avoid rehashing while the lazy path holds the lock.
-    m_user_inputs.reserve(m_input_ports_map.size());
+    inputs->reserve(m_input_ports_map.size());
 
     for (const auto& it : m_input_ports_map) {
         size_t input_idx = it.first;
@@ -815,11 +818,12 @@ void SyncInferRequest::allocate_inputs() {
             const bool can_defer = pshape.is_static() && port.get_element_type() != ov::element::string;
             if (can_defer) {
                 // Reserve a null slot; materialized lazily or replaced by set_tensor().
-                m_user_inputs[input_idx] = { nullptr, TensorOwner::PLUGIN };
+                (*inputs)[input_idx] = { nullptr, TensorOwner::PLUGIN };
                 GPU_DEBUG_LOG << "[lazy alloc] reserved input slot " << input_idx
                               << " shape: " << pshape << std::endl;
             } else {
-                allocate_input(input_idx);
+                // Dynamic/string inputs stay eager.
+                allocate_input(input_idx, *inputs);
             }
         }
     }

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -25,7 +25,6 @@
 
 #include <algorithm>
 #include <iterator>
-#include <limits>
 #include <memory>
 #include <string>
 #include <map>
@@ -79,60 +78,6 @@ cldnn::data_types data_type_for_remote_tensor(ov::element::Type t) {
         return cldnn::data_types::u8;
     default: return t;
     }
-}
-
-// Returns true if a static input is large enough (in bytes) to be worth deferring
-// its host-tensor allocation (lazy-allocation path). The predicate is exactly
-//     ceil_div(element_count * bitwidth, 8) >= threshold_bytes
-// evaluated with overflow-safe arithmetic for arbitrary threshold_bytes and shapes
-// (including sub-byte element types). Dynamic shapes and string inputs are never
-// considered large here.
-bool exceeds_lazy_alloc_threshold(const ov::PartialShape& pshape,
-                                  const ov::element::Type& element_type,
-                                  size_t threshold_bytes) {
-    if (!pshape.is_static() || element_type == ov::element::string)
-        return false;
-
-    // Use bitwidth so sub-byte types (e.g. int4/uint4 weights from weight sharing) are
-    // sized correctly; element_type.size() would round sub-byte types to 0/1.
-    const size_t bitwidth = element_type.bitwidth();
-    if (bitwidth == 0)
-        return false;
-    if (threshold_bytes == 0)
-        return true;  // any static tensor meets a zero-byte threshold
-
-    constexpr size_t bits_per_byte = 8;
-    constexpr size_t max_size = std::numeric_limits<size_t>::max();
-
-    // ceil_div(element_count * bitwidth, 8) >= threshold_bytes
-    //   <=> element_count * bitwidth > 8 * (threshold_bytes - 1)   (= threshold_bits)
-    // Guard the bit-threshold multiply so the helper is safe for any threshold_bytes;
-    // a threshold beyond size_t can never be reached -> treat the input as "not large".
-    if (threshold_bytes - 1 > max_size / bits_per_byte)
-        return false;
-    const size_t threshold_bits = bits_per_byte * (threshold_bytes - 1);
-
-    // Smallest element count whose byte size reaches the threshold:
-    //   element_count * bitwidth > threshold_bits  <=>  element_count >= threshold_bits / bitwidth + 1.
-    // Comparing element counts avoids multiplying the full tensor size by bitwidth.
-    // (threshold_bits <= max_size - 7 from the guard above, so the + 1 cannot overflow.)
-    const size_t min_large_elements = threshold_bits / bitwidth + 1;
-
-    // Accumulate the element count dimension by dimension instead of calling shape_size(),
-    // which can overflow for very large shapes. Exit early as soon as the running product
-    // reaches the threshold, and treat any multiplication overflow as "large" (the true
-    // count would exceed size_t and is therefore >= min_large_elements).
-    size_t element_count = 1;
-    for (size_t dim : pshape.to_shape()) {
-        if (dim == 0)
-            return false;  // empty tensor: byte size is 0, never large
-        if (element_count > max_size / dim)
-            return true;  // product would overflow size_t -> definitely above the threshold
-        element_count *= dim;
-        if (element_count >= min_large_elements)
-            return true;
-    }
-    return element_count >= min_large_elements;
 }
 
 }  // namespace
@@ -266,6 +211,7 @@ void SyncInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
 
     bool is_input = port_info.type == ov::ISyncInferRequest::FoundPort::Type::INPUT;
     if (is_input) {
+        std::unique_lock<std::shared_mutex> lock(m_user_inputs_mutex);
         update_tensors_maps(port_index, m_user_inputs, m_plugin_inputs, tensor);
     } else {
         update_tensors_maps(port_index, m_user_outputs, m_plugin_outputs, tensor);
@@ -298,19 +244,23 @@ ov::SoPtr<ov::ITensor> SyncInferRequest::get_tensor(const ov::Output<const ov::N
     bool is_input = port_info.type == ov::ISyncInferRequest::FoundPort::Type::INPUT;
     size_t port_index = port_info.idx;
     if (is_input) {
-        auto it = m_user_inputs.find(port_index);
-        OPENVINO_ASSERT(it != m_user_inputs.end(), "[GPU] Input tensor with index ", port_index, " is not found");
-        // Lazy allocation: the input slot was reserved with a null tensor in allocate_inputs().
-        // Allocate the default host tensor now, on first access.
-        if (!it->second.ptr) {
+        std::shared_ptr<ov::ITensor> tensor_ptr;
+        {
+            std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
+            auto it = m_user_inputs.find(port_index);
+            OPENVINO_ASSERT(it != m_user_inputs.end(), "[GPU] Input tensor with index ", port_index, " is not found");
+            tensor_ptr = it->second.ptr;
+        }
+        // Lazy allocation: a reserved (null) slot is materialized on first access.
+        if (!tensor_ptr) {
             ensure_input_allocated(port, port_index);
             GPU_DEBUG_LOG << "[lazy alloc] input " << port_index
                           << " shape: " << port.get_partial_shape()
                           << " allocated at get_tensor" << std::endl;
-            // ensure_input_allocated() may rehash m_user_inputs, invalidating 'it'.
-            it = m_user_inputs.find(port_index);
+            std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
+            tensor_ptr = m_user_inputs.at(port_index).ptr;
         }
-        return { it->second.ptr, nullptr };
+        return { tensor_ptr, nullptr };
     } else {
         OPENVINO_ASSERT(m_user_outputs.count(port_index) == 1, "[GPU] Output tensor with index ", port_index, " is not found");
         return { m_user_outputs.at(port_index).ptr, nullptr };
@@ -321,10 +271,14 @@ void SyncInferRequest::check_tensors() const {
     const auto& inputs = get_compiled_model()->inputs();
     for (size_t i = 0; i < inputs.size(); i++) {
         if (!is_batched_input(inputs[i])) {
-            // Skip validation for lazy (not yet allocated) input slots.
-            // They are allocated on first get_tensor()/enqueue() or replaced by set_tensor().
-            auto it = m_user_inputs.find(i);
-            if (it != m_user_inputs.end() && !it->second.ptr)
+            // Skip not-yet-allocated lazy slots; materialized on first get_tensor()/enqueue() or
+            // replaced by set_tensor(). Read under a shared lock so it can't race the lazy write.
+            const bool not_allocated = [&] {
+                std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
+                auto it = m_user_inputs.find(i);
+                return it != m_user_inputs.end() && !it->second.ptr;
+            }();
+            if (not_allocated)
                 continue;
             check_tensor(inputs[i], get_tensor_ptr(inputs[i]));
         }
@@ -374,14 +328,20 @@ void SyncInferRequest::enqueue() {
 
         const bool is_batched = m_batched_tensors.count(port.get_tensor_ptr()) > 0;
 
-        // Lazy allocation: if the user didn't call set_tensor()/set_tensors() for this input,
-        // allocate the default host tensor now, before inference. Batched inputs provide their
-        // own tensors and don't need the reserved slot allocated.
-        if (!is_batched && m_user_inputs.count(port_idx) && !m_user_inputs.at(port_idx).ptr) {
-            ensure_input_allocated(port, port_idx);
-            GPU_DEBUG_LOG << "[lazy alloc] input " << port_idx
-                          << " shape: " << port.get_partial_shape()
-                          << " allocated at enqueue" << std::endl;
+        // Materialize a reserved lazy slot before inference (batched inputs bring their own tensors).
+        if (!is_batched) {
+            bool needs_alloc = false;
+            {
+                std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
+                auto uit = m_user_inputs.find(port_idx);
+                needs_alloc = uit != m_user_inputs.end() && !uit->second.ptr;
+            }
+            if (needs_alloc) {
+                ensure_input_allocated(port, port_idx);
+                GPU_DEBUG_LOG << "[lazy alloc] input " << port_idx
+                              << " shape: " << port.get_partial_shape()
+                              << " allocated at enqueue" << std::endl;
+            }
         }
 
         if (is_batched) {
@@ -389,12 +349,21 @@ void SyncInferRequest::enqueue() {
             std::move(events.begin(), events.end(), std::back_inserter(dependencies));
         } else {
             cldnn::primitive_id internal_name = m_graph->input_port_index_to_internal(port_idx)[0];
-            auto events = prepare_input(internal_name, port_idx, port, m_user_inputs.at(port_idx));
+            TensorWrapper user_tensor;
+            {
+                std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
+                user_tensor = m_user_inputs.at(port_idx);
+            }
+            auto events = prepare_input(internal_name, port_idx, port, user_tensor);
             std::move(events.begin(), events.end(), std::back_inserter(dependencies));
         }
 
         if (need_alias_detection) {
-            const auto& wrapper = m_user_inputs.at(port_idx);
+            TensorWrapper wrapper;
+            {
+                std::shared_lock<std::shared_mutex> lock(m_user_inputs_mutex);
+                wrapper = m_user_inputs.at(port_idx);
+            }
             if (wrapper.ptr && !std::dynamic_pointer_cast<IRemoteTensor>(wrapper.ptr)) {
                 if (auto* p = wrapper.ptr->data()) {
                     input_host_ptrs.insert(p);
@@ -770,21 +739,21 @@ cldnn::event::ptr SyncInferRequest::copy_output_data(cldnn::memory::ptr src, ov:
 }
 
 void SyncInferRequest::ensure_input_allocated(const ov::Output<const ov::Node>& port, size_t input_idx) const {
-    // get_tensor() is const and may be called concurrently by applications that share a single
-    // InferRequest across threads (against guidance). Serialize the deferred allocation so two
-    // such calls cannot both observe a null slot and double-allocate / race on m_user_inputs.
-    std::lock_guard<std::mutex> lock(m_lazy_alloc_mutex);
+    // const get_tensor() may race infer(); exclusive lock serializes the deferred allocation.
+    std::unique_lock<std::shared_mutex> lock(m_user_inputs_mutex);
     auto it = m_user_inputs.find(input_idx);
     if (it != m_user_inputs.end() && it->second.ptr)
-        return;  // already materialized (by set_tensor() or a prior lazy allocation)
-    // const_cast is required only because the base ISyncInferRequest::set_tensor() is
-    // non-const; the deferred allocation itself is a transparent, idempotent operation.
-    // allocate_input() inserts the slot if it is missing, so this is safe even for a
-    // not-yet-reserved index.
+        return;  // already materialized
+    // const_cast only because base set_tensor() is non-const; slot is pre-reserved, so
+    // allocate_input() reassigns it in place.
     const_cast<SyncInferRequest&>(*this).allocate_input(port, input_idx);
 }
 
 void SyncInferRequest::allocate_input(const ov::Output<const ov::Node>& port, size_t input_idx) {
+    // Lock-free helper: must NOT take m_user_inputs_mutex. Callers either run single-threaded init
+    // (allocate_inputs()) or already hold the exclusive lock (ensure_input_allocated()); re-locking
+    // would deadlock the non-recursive shared_mutex. Uses the base ISyncInferRequest::set_tensor,
+    // not the GPU override, to avoid re-entering the mutex.
     const auto& shape = port.get_partial_shape();
     auto element_type = port.get_element_type();
 
@@ -795,6 +764,8 @@ void SyncInferRequest::allocate_input(const ov::Output<const ov::Node>& port, si
         auto data = m_user_inputs.at(input_idx).ptr->data<std::string>();
         std::uninitialized_fill_n(data, m_user_inputs.at(input_idx).ptr->get_size(), std::string());
     }
+    // Must stay base-qualified: the GPU set_tensor override takes m_user_inputs_mutex, which the
+    // lazy-path caller (ensure_input_allocated) already holds -> re-entrant lock would deadlock.
     ov::ISyncInferRequest::set_tensor(port, m_user_inputs.at(input_idx).ptr);
 }
 
@@ -825,6 +796,11 @@ void SyncInferRequest::allocate_output(const ov::Output<const ov::Node>& port, s
 void SyncInferRequest::allocate_inputs() {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "SyncInferRequest::allocate_inputs");
 
+    // Reserve capacity for all input ports up-front (single-threaded init). Concurrent access to
+    // m_user_inputs is guarded by m_user_inputs_mutex; reserving here keeps the lazy path cheap by
+    // avoiding a rehash while the exclusive lock is held.
+    m_user_inputs.reserve(m_input_ports_map.size());
+
     for (const auto& it : m_input_ports_map) {
         size_t input_idx = it.first;
         const auto& port = it.second;
@@ -840,24 +816,17 @@ void SyncInferRequest::allocate_inputs() {
         }
 
         if (!is_nv12_input) {
-            // Only defer large static inputs (e.g. weights converted to inputs by weight sharing).
-            // Dynamic inputs allocate to a near-zero placeholder anyway (dynamic dims -> 0), and
-            // small static inputs are cheap, so keep both on the eager path to limit lazy-path risk.
-            // TODO: hard coded value for now, configurable param in progress
-            constexpr size_t lazy_alloc_threshold_bytes = size_t(2) << 20;  // 2 MB
             const auto& pshape = port.get_partial_shape();
-            const auto& element_type = port.get_element_type();
-
-            if (exceeds_lazy_alloc_threshold(pshape, element_type, lazy_alloc_threshold_bytes)) {
-                // Defer actual allocation: reserve the slot with a null tensor. The tensor is
-                // allocated lazily on first get_tensor()/enqueue(), or replaced by set_tensor().
+            const bool can_defer = pshape.is_static() && port.get_element_type() != ov::element::string;
+            if (can_defer) {
+                // Defer allocation for static inputs: reserve a null slot, materialized lazily on
+                // first get_tensor()/enqueue() or replaced via set_tensor().
                 m_user_inputs[input_idx] = { nullptr, TensorOwner::PLUGIN };
                 GPU_DEBUG_LOG << "[lazy alloc] reserved input slot " << input_idx
-                              << " shape: " << port.get_partial_shape() << std::endl;
+                              << " shape: " << pshape << std::endl;
             } else {
+                // Dynamic and string inputs keep the original eager allocation (empty/placeholder tensor).
                 allocate_input(port, input_idx);
-                GPU_DEBUG_LOG << "[lazy alloc] eager input slot " << input_idx
-                              << " shape: " << port.get_partial_shape() << std::endl;
             }
         }
     }

--- a/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
@@ -106,8 +106,7 @@ static std::shared_ptr<ov::Model> makeStaticInputModel(ov::Shape& shape_out) {
     return std::make_shared<ov::Model>(results, ov::ParameterVector{param});
 }
 
-// Regression: a static input must be inferable when set_tensor() is never called. The reserved
-// (null) slot is materialized lazily in enqueue(), and check_tensors() must not fail for it.
+// Static input must be inferable when set_tensor() is never called.
 TEST(TensorTest, smoke_lazyAllocStaticInputInferWithoutSetTensor) {
     ov::Shape shape;
     auto model = makeStaticInputModel(shape);
@@ -116,10 +115,8 @@ TEST(TensorTest, smoke_lazyAllocStaticInputInferWithoutSetTensor) {
     auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
     auto request = compiled_model.create_infer_request();
 
-    // Do NOT set any input tensor: the slot stays reserved until enqueue() allocates it.
     OV_ASSERT_NO_THROW(request.infer());
 
-    // The lazily-allocated input tensor must now be valid and correctly shaped.
     ov::Tensor in;
     OV_ASSERT_NO_THROW(in = request.get_input_tensor(0));
     ASSERT_EQ(in.get_shape(), shape);
@@ -127,9 +124,7 @@ TEST(TensorTest, smoke_lazyAllocStaticInputInferWithoutSetTensor) {
     OV_ASSERT_NO_THROW(request.get_output_tensor(0));
 }
 
-// Regression: accessing the input via get_tensor() before infer() must materialize the reserved
-// slot on the const get_tensor() path (a different entry point than enqueue()), and inference
-// must still work afterwards.
+// get_tensor() before infer() must also materialize the lazy slot.
 TEST(TensorTest, smoke_lazyAllocStaticInputGetTensorBeforeInfer) {
     ov::Shape shape;
     auto model = makeStaticInputModel(shape);
@@ -138,13 +133,62 @@ TEST(TensorTest, smoke_lazyAllocStaticInputGetTensorBeforeInfer) {
     auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
     auto request = compiled_model.create_infer_request();
 
-    // First access via get_tensor() must materialize the reserved slot.
     ov::Tensor in;
     OV_ASSERT_NO_THROW(in = request.get_input_tensor(0));
     ASSERT_EQ(in.get_shape(), shape);
     ASSERT_NE(in.data(), nullptr);
 
     OV_ASSERT_NO_THROW(request.infer());
+}
+
+// AUTO_BATCH's shared buffer must be sized batch=N, not the slot's own batch=1 port. Checked
+// by value: an offset bug doesn't change the exposed shape, only which bytes get read/written.
+TEST(TensorTest, smoke_lazyAllocAutoBatchUsesBatchedShapeNotSlotShape) {
+    constexpr int kBatch = 4;
+    ov::Shape shape;
+    auto model = makeStaticInputModel(shape);
+
+    auto core = ov::Core();
+    // Non-zero timeout so requests are actually batched together (same value used in
+    // auto_batch/tests/functional/behavior/ov_plugin/auto_batching_tests.cpp).
+    auto compiled_model = core.compile_model(model,
+                                             "BATCH:" + std::string(ov::test::utils::DEVICE_GPU) +
+                                                 "(" + std::to_string(kBatch) + ")",
+                                             ov::auto_batch_timeout(1000));
+
+    std::vector<ov::InferRequest> requests;
+    for (int i = 0; i < kBatch; ++i) {
+        requests.push_back(compiled_model.create_infer_request());
+    }
+
+    // Distinct value per slot: an offset bug would mix these together.
+    for (int i = 0; i < kBatch; ++i) {
+        ov::Tensor in;
+        OV_ASSERT_NO_THROW(in = requests[i].get_input_tensor(0));
+        ASSERT_EQ(in.get_shape(), shape);
+        auto* in_data = in.data<float>();
+        ASSERT_NE(in_data, nullptr);
+        std::fill_n(in_data, in.get_size(), static_cast<float>(i + 1));
+    }
+
+    for (auto& req : requests) {
+        OV_ASSERT_NO_THROW(req.start_async());
+    }
+    for (auto& req : requests) {
+        OV_ASSERT_NO_THROW(req.wait());
+    }
+
+    // Relu(i+1) == i+1; a corrupted shared buffer would mix values across slots.
+    for (int i = 0; i < kBatch; ++i) {
+        ov::Tensor out;
+        OV_ASSERT_NO_THROW(out = requests[i].get_output_tensor(0));
+        ASSERT_EQ(out.get_shape(), shape);
+        const auto* data = out.data<float>();
+        ASSERT_NE(data, nullptr);
+        for (size_t j = 0; j < out.get_size(); ++j) {
+            ASSERT_FLOAT_EQ(data[j], static_cast<float>(i + 1)) << "slot " << i << " element " << j;
+        }
+    }
 }
 
 static std::shared_ptr<ov::Model> makeDynamicInputModel() {
@@ -177,11 +221,8 @@ TEST(TensorTest, smoke_eagerAllocDynamicInputInfer) {
     ASSERT_EQ(out.get_shape(), concrete);
 }
 
-// Data-race guard for the lazy input path: many threads race on the first get_tensor() of a fresh
-// request, all hitting the reserved-null slot at once. The double-checked lock in
-// ensure_input_allocated() must collapse them into one allocation, so every thread must observe the
-// same backing buffer. A fresh request per iteration re-arms the race. Run under TSan for full
-// coverage (TSan is Linux-only; on Windows this still catches divergent-buffer/crash regressions).
+// Many threads race on the first get_tensor() of a fresh request; ensure_input_allocated()'s
+// lock must collapse them into a single allocation so all threads observe the same buffer.
 TEST(TensorTest, smoke_lazyAllocStaticInputConcurrentFirstGetTensorRace) {
     ov::Shape shape;
     auto model = makeStaticInputModel(shape);
@@ -195,8 +236,7 @@ TEST(TensorTest, smoke_lazyAllocStaticInputConcurrentFirstGetTensorRace) {
     std::atomic<bool> failed{false};
 
     for (int iter = 0; iter < kIterations && !failed.load(); ++iter) {
-        // Fresh request: input slot starts reserved (null), so the first get_tensor() from any
-        // thread races to materialize it. No infer() runs, so the async BUSY gate does not serialize.
+        // Fresh request re-arms the race for each iteration.
         auto request = compiled_model.create_infer_request();
 
         std::atomic<int> ready{0};
@@ -208,7 +248,6 @@ TEST(TensorTest, smoke_lazyAllocStaticInputConcurrentFirstGetTensorRace) {
         for (int t = 0; t < kThreads; ++t) {
             threads.emplace_back([&, t] {
                 ready.fetch_add(1, std::memory_order_acq_rel);
-                // yield-spin until released: all threads hit get_tensor() at nearly the same instant.
                 while (!go.load(std::memory_order_acquire)) {
                     std::this_thread::yield();
                 }
@@ -225,7 +264,7 @@ TEST(TensorTest, smoke_lazyAllocStaticInputConcurrentFirstGetTensorRace) {
             });
         }
 
-        // Release all threads at once to maximize contention on the reserved-null slot.
+        // Release all threads at once to maximize contention.
         while (ready.load(std::memory_order_acquire) < kThreads) {
             std::this_thread::yield();
         }
@@ -235,8 +274,7 @@ TEST(TensorTest, smoke_lazyAllocStaticInputConcurrentFirstGetTensorRace) {
             th.join();
         }
 
-        // Every racer must have been handed the SAME buffer; a divergent pointer means the
-        // double-checked lock failed to collapse duplicate allocations (a real race).
+        // All racers must observe the same buffer.
         const void* first = observed[0];
         for (int t = 1; t < kThreads; ++t) {
             if (observed[t] != first) {

--- a/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
@@ -91,6 +91,62 @@ INSTANTIATE_TEST_SUITE_P(smoke_GPU_BehaviorTests, InferRequestIOPrecision,
                                  ::testing::Values(ov::test::utils::DEVICE_GPU)),
                          InferRequestIOPrecision::getTestCaseName);
 
+// Builds a model with a single large (>= 2 MB) static input feeding a Relu, so that the
+// GPU plugin takes the deferred (lazy) host-tensor allocation path for that input.
+static std::shared_ptr<ov::Model> makeLargeStaticInputModel(ov::Shape& shape_out) {
+    // 524289 * 4 bytes (f32) = ~2.0 MB, just above the 2 MB lazy-allocation threshold.
+    const ov::Shape shape{1, 524289};
+    shape_out = shape;
+    auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+    param->set_friendly_name("big_input");
+    param->output(0).get_tensor().set_names({"big_input"});
+    auto relu = std::make_shared<ov::op::v0::Relu>(param);
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(relu)};
+    return std::make_shared<ov::Model>(results, ov::ParameterVector{param});
+}
+
+// Regression test: a large static input must still be inferable when the user never calls
+// set_tensor(). The reserved (null) slot has to be allocated lazily inside enqueue(), and
+// check_tensors() must not fail for the reserved slot before that happens.
+TEST(TensorTest, smoke_lazyAllocLargeStaticInputInferWithoutSetTensor) {
+    ov::Shape shape;
+    auto model = makeLargeStaticInputModel(shape);
+
+    auto core = ov::Core();
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    auto request = compiled_model.create_infer_request();
+
+    // Intentionally do NOT set any input tensor: the slot stays reserved (null) until
+    // enqueue() allocates it. infer() (which runs check_tensors internally) must not throw.
+    OV_ASSERT_NO_THROW(request.infer());
+
+    // After inference the lazily-allocated input tensor must be valid and correctly shaped.
+    ov::Tensor in;
+    OV_ASSERT_NO_THROW(in = request.get_input_tensor(0));
+    ASSERT_EQ(in.get_shape(), shape);
+    ASSERT_NE(in.data(), nullptr);
+    OV_ASSERT_NO_THROW(request.get_output_tensor(0));
+}
+
+// Regression test: accessing the large static input via get_tensor() before infer() must
+// trigger the lazy allocation on that path (const get_tensor()), and inference must still work.
+TEST(TensorTest, smoke_lazyAllocLargeStaticInputGetTensorBeforeInfer) {
+    ov::Shape shape;
+    auto model = makeLargeStaticInputModel(shape);
+
+    auto core = ov::Core();
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    auto request = compiled_model.create_infer_request();
+
+    // First access via get_tensor() must materialize the reserved slot.
+    ov::Tensor in;
+    OV_ASSERT_NO_THROW(in = request.get_input_tensor(0));
+    ASSERT_EQ(in.get_shape(), shape);
+    ASSERT_NE(in.data(), nullptr);
+
+    OV_ASSERT_NO_THROW(request.infer());
+}
+
 TEST(TensorTest, smoke_canSetShapeForPreallocatedTensor) {
     auto core = ov::Core();
     using namespace ov::preprocess;

--- a/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <atomic>
+#include <thread>
+#include <vector>
+
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "common_test_utils/common_utils.hpp"
@@ -91,36 +95,31 @@ INSTANTIATE_TEST_SUITE_P(smoke_GPU_BehaviorTests, InferRequestIOPrecision,
                                  ::testing::Values(ov::test::utils::DEVICE_GPU)),
                          InferRequestIOPrecision::getTestCaseName);
 
-// Builds a model with a single large (>= 2 MB) static input feeding a Relu, so that the
-// GPU plugin takes the deferred (lazy) host-tensor allocation path for that input.
-static std::shared_ptr<ov::Model> makeLargeStaticInputModel(ov::Shape& shape_out) {
-    // 524289 * 4 bytes (f32) = ~2.0 MB, just above the 2 MB lazy-allocation threshold.
-    const ov::Shape shape{1, 524289};
+static std::shared_ptr<ov::Model> makeStaticInputModel(ov::Shape& shape_out) {
+    const ov::Shape shape{1, 64};
     shape_out = shape;
     auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
-    param->set_friendly_name("big_input");
-    param->output(0).get_tensor().set_names({"big_input"});
+    param->set_friendly_name("static_input");
+    param->output(0).get_tensor().set_names({"static_input"});
     auto relu = std::make_shared<ov::op::v0::Relu>(param);
     ov::ResultVector results{std::make_shared<ov::op::v0::Result>(relu)};
     return std::make_shared<ov::Model>(results, ov::ParameterVector{param});
 }
 
-// Regression test: a large static input must still be inferable when the user never calls
-// set_tensor(). The reserved (null) slot has to be allocated lazily inside enqueue(), and
-// check_tensors() must not fail for the reserved slot before that happens.
-TEST(TensorTest, smoke_lazyAllocLargeStaticInputInferWithoutSetTensor) {
+// Regression: a static input must be inferable when set_tensor() is never called. The reserved
+// (null) slot is materialized lazily in enqueue(), and check_tensors() must not fail for it.
+TEST(TensorTest, smoke_lazyAllocStaticInputInferWithoutSetTensor) {
     ov::Shape shape;
-    auto model = makeLargeStaticInputModel(shape);
+    auto model = makeStaticInputModel(shape);
 
     auto core = ov::Core();
     auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
     auto request = compiled_model.create_infer_request();
 
-    // Intentionally do NOT set any input tensor: the slot stays reserved (null) until
-    // enqueue() allocates it. infer() (which runs check_tensors internally) must not throw.
+    // Do NOT set any input tensor: the slot stays reserved until enqueue() allocates it.
     OV_ASSERT_NO_THROW(request.infer());
 
-    // After inference the lazily-allocated input tensor must be valid and correctly shaped.
+    // The lazily-allocated input tensor must now be valid and correctly shaped.
     ov::Tensor in;
     OV_ASSERT_NO_THROW(in = request.get_input_tensor(0));
     ASSERT_EQ(in.get_shape(), shape);
@@ -128,11 +127,12 @@ TEST(TensorTest, smoke_lazyAllocLargeStaticInputInferWithoutSetTensor) {
     OV_ASSERT_NO_THROW(request.get_output_tensor(0));
 }
 
-// Regression test: accessing the large static input via get_tensor() before infer() must
-// trigger the lazy allocation on that path (const get_tensor()), and inference must still work.
-TEST(TensorTest, smoke_lazyAllocLargeStaticInputGetTensorBeforeInfer) {
+// Regression: accessing the input via get_tensor() before infer() must materialize the reserved
+// slot on the const get_tensor() path (a different entry point than enqueue()), and inference
+// must still work afterwards.
+TEST(TensorTest, smoke_lazyAllocStaticInputGetTensorBeforeInfer) {
     ov::Shape shape;
-    auto model = makeLargeStaticInputModel(shape);
+    auto model = makeStaticInputModel(shape);
 
     auto core = ov::Core();
     auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
@@ -145,6 +145,107 @@ TEST(TensorTest, smoke_lazyAllocLargeStaticInputGetTensorBeforeInfer) {
     ASSERT_NE(in.data(), nullptr);
 
     OV_ASSERT_NO_THROW(request.infer());
+}
+
+static std::shared_ptr<ov::Model> makeDynamicInputModel() {
+    auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32,
+                                                         ov::PartialShape{1, ov::Dimension::dynamic()});
+    param->set_friendly_name("dyn_input");
+    param->output(0).get_tensor().set_names({"dyn_input"});
+    auto relu = std::make_shared<ov::op::v0::Relu>(param);
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(relu)};
+    return std::make_shared<ov::Model>(results, ov::ParameterVector{param});
+}
+
+TEST(TensorTest, smoke_eagerAllocDynamicInputInfer) {
+    auto model = makeDynamicInputModel();
+
+    auto core = ov::Core();
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+    auto request = compiled_model.create_infer_request();
+
+    // Eagerly allocated: accessing the tensor before set/infer must not throw.
+    OV_ASSERT_NO_THROW(request.get_input_tensor(0));
+
+    const ov::Shape concrete{1, 8};
+    ov::Tensor input(ov::element::f32, concrete);
+    OV_ASSERT_NO_THROW(request.set_input_tensor(0, input));
+    OV_ASSERT_NO_THROW(request.infer());
+
+    ov::Tensor out;
+    OV_ASSERT_NO_THROW(out = request.get_output_tensor(0));
+    ASSERT_EQ(out.get_shape(), concrete);
+}
+
+// Data-race guard for the lazy input path: many threads race on the first get_tensor() of a fresh
+// request, all hitting the reserved-null slot at once. The double-checked lock in
+// ensure_input_allocated() must collapse them into one allocation, so every thread must observe the
+// same backing buffer. A fresh request per iteration re-arms the race. Run under TSan for full
+// coverage (TSan is Linux-only; on Windows this still catches divergent-buffer/crash regressions).
+TEST(TensorTest, smoke_lazyAllocStaticInputConcurrentFirstGetTensorRace) {
+    ov::Shape shape;
+    auto model = makeStaticInputModel(shape);
+
+    auto core = ov::Core();
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+
+    constexpr int kThreads = 8;
+    constexpr int kIterations = 100;
+
+    std::atomic<bool> failed{false};
+
+    for (int iter = 0; iter < kIterations && !failed.load(); ++iter) {
+        // Fresh request: input slot starts reserved (null), so the first get_tensor() from any
+        // thread races to materialize it. No infer() runs, so the async BUSY gate does not serialize.
+        auto request = compiled_model.create_infer_request();
+
+        std::atomic<int> ready{0};
+        std::atomic<bool> go{false};
+        std::vector<const void*> observed(kThreads, nullptr);
+
+        std::vector<std::thread> threads;
+        threads.reserve(kThreads);
+        for (int t = 0; t < kThreads; ++t) {
+            threads.emplace_back([&, t] {
+                ready.fetch_add(1, std::memory_order_acq_rel);
+                // yield-spin until released: all threads hit get_tensor() at nearly the same instant.
+                while (!go.load(std::memory_order_acquire)) {
+                    std::this_thread::yield();
+                }
+                try {
+                    auto in = request.get_input_tensor(0);
+                    if (in.get_shape() != shape || in.data() == nullptr) {
+                        failed.store(true);
+                    }
+                    observed[t] = in.data();
+                } catch (...) {
+                    // Any exception on the concurrent first-touch materialization is a failure.
+                    failed.store(true);
+                }
+            });
+        }
+
+        // Release all threads at once to maximize contention on the reserved-null slot.
+        while (ready.load(std::memory_order_acquire) < kThreads) {
+            std::this_thread::yield();
+        }
+        go.store(true, std::memory_order_release);
+
+        for (auto& th : threads) {
+            th.join();
+        }
+
+        // Every racer must have been handed the SAME buffer; a divergent pointer means the
+        // double-checked lock failed to collapse duplicate allocations (a real race).
+        const void* first = observed[0];
+        for (int t = 1; t < kThreads; ++t) {
+            if (observed[t] != first) {
+                failed.store(true);
+            }
+        }
+    }
+
+    ASSERT_FALSE(failed.load());
 }
 
 TEST(TensorTest, smoke_canSetShapeForPreallocatedTensor) {


### PR DESCRIPTION
SyncInferRequest by default allocates inputs with static shapes, this might cause extra memory bloat for "weight sharing" where the current approach requires weights as input conversion (in that case a large weight becomes a large input). This PR defers that allocation. The real allocation happens in get_tensor()/enque() - when "asked" for the tensor for the first, time, or when set_tensor() is called then the user provided tensor will be used as the input, with no extra copy made.

thread safety note:
While the SyncInferRequest objects are not thread safe, we ensured that the const member functions - for lazy allocations - are thread safe. So for example `get_tensor()` can be called from multiple threads. This is covered in unit test(s).

Memory consumptions tests:
- For Models that require Weight as Input conversion the memory reduction is the same as the weight size converted to inputs. In that case The app creates its own set of (remote)tensors and then calls set_tensor on the infer request.

## Performance & Memory Validation

Tested on Intel Arc GPU, using `benchmark_app` with `-b 1` (disables AUTO_BATCH to isolate the GPU plugin's own behavior). For testing I had env flag that turned on or off the lazy alloc feature.

### 1. Steady-state throughput regression check

`-d GPU -hint throughput -t 10 -b 1`, default input shapes/nireq.

| Model | Lazy alloc | Iterations | Median latency | Throughput |
|---|---|---|---|---|
| resnet50_fp16 | ON | 19,988 | 1.97 ms | 1998.29 FPS |
| resnet50_fp16 | OFF | 20,340 | 1.97 ms | 2033.31 FPS |
| yolov3_fp16 | ON | 5,480 | 7.23 ms | 547.38 FPS |
| yolov3_fp16 | OFF | 5,480 | 7.21 ms | 547.50 FPS |
| mobilenetv3_fp16 | ON | 51,284 | 0.76 ms | 5127.75 FPS |
| mobilenetv3_fp16 | OFF | 52,148 | 0.74 ms | 5214.39 FPS |
| inceptionv4_fp16 | ON | 5,596 | 7.10 ms | 558.94 FPS |
| inceptionv4_fp16 | OFF | 5,632 | 7.12 ms | 562.56 FPS |

Result: no throughput regression (all deltas ≤1.7%, within normal run-to-run noise).

On IGPU - Panther Lake - 4 Xe3 Cores - Result: no throughput regression (all deltas ≤1.1%, within run-to-run noise).

### 2. Peak host memory — `set_tensor()`/device-memory flow

Benchmark rebuilt with OpenCL support (`-use_device_mem`) so `set_tensor()` is used to attach app-owned remote GPU tensors. Input spatial size enlarged and `-nireq` increased to amplify the effect; process. Input dtype is `u8` in all cases (as configured by benchmark_app for image-like inputs).

| Model | Input shape | Per-tensor size | `-nireq` | Est. total (size × nireq) | Lazy ON (peak WS) | Lazy OFF (peak WS) | Diff | Throughput (ON / OFF) |
|---|---|---|---|---|---|---|---|---|
| resnet50_fp16 | `[1,3,720,1280]` | 2.64 MB | 64 | 168.75 MB | 398.33 MB | 647.18 MB | **−248.85 MB** | 299.68 / 299.72 FPS |
| yolov3_fp16 | `[1,416,416,3]` (native; reshape not supported by detection head) | 0.50 MB | 256 | 126.78 MB | 1625.93 MB | 1757.99 MB | **−132.06 MB** | 568.42 / 569.91 FPS |
| mobilenetv3_fp16 | `[1,1280,1280,3]` | 4.69 MB | 64 | 300.00 MB | 975.43 MB | 1263.45 MB | **−288.02 MB** | 567.55 / 564.09 FPS |
| inceptionv4_fp16 | `[1,1280,1280,3]` | 4.69 MB | 64 | 300.00 MB | 937.49 MB | 1223.25 MB | **−285.76 MB** | 90.36 / 90.33 FPS |

Result: lazy allocation reduces peak host memory by ~130–290 MB across all four models, tracking the estimated `input tensor size × nireq` wasted-allocation figure within ~10–25% (the remainder is likely allocator overhead/rounding), with no throughput cost in any case.

on iGPU, Panther Lake, 4 Xe3 Cores:

| Model | Input shape | Per-tensor size | -nireq | Est. total (size × nireq) | Lazy ON (peak WS) | Lazy OFF (peak WS) | Diff | Throughput (ON / OFF) |
|---|---|---|---|---|---|---|---|---|
| resnet50_fp16 | [1,3,720,1280] | 2.64 MB | 64 | 168.75 MB | 974.17 MB | 1044.84 MB | **−70.67 MB** | 67.15 / 66.85 FPS |
| yolov3_fp16 | [1,416,416,3] (native; reshape not supported by detection head) | 0.50 MB | 64 | 31.69 MB | 1058.48 MB | 1091.54 MB | **−33.06 MB** | 153.10 / 153.31 FPS |
| mobilenetv3_fp16 | [1,1280,1280,3] | 4.69 MB | 64 | 300.00 MB | 1784.41 MB | 1997.10 MB | **−212.69 MB** | 135.49 / 134.96 FPS |
| inceptionv4_fp16 | [1,1280,1280,3] | 4.69 MB | 64 | 300.00 MB | 2344.63 MB | 2557.52 MB | **−212.89 MB** | 19.45 / 19.47 FPS |

### Tickets:
CVS-186068

### AI Assistance:
 - AI assistance used: yes
 - how used: code generation, unit tests
