### PR TITLE
[CPU] Enable Convert Gather fusion for hybrid precisions

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_gather_to_compressed.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gather_to_compressed.cpp
@@ -157,10 +157,10 @@ ov::pass::ConvertGatherToGatherCompressed::ConvertGatherToGatherCompressed() {
 
 ov::pass::MoveDecompressionAfterGather::MoveDecompressionAfterGather() {
     auto dicts = wrap_type<v0::Constant>(ov::pass::pattern::type_matches_any({element::f16, element::bf16}));
-    auto convert_predicate = [](ov::Output<ov::Node> output) -> bool {
-        return ov::pass::pattern::consumers_count(1)(output) && type_matches(ov::element::f32)(output);
-    };
-    auto convert = wrap_type<v0::Convert>({dicts}, convert_predicate);
+    // No consumers_count(1) check: when the Convert has other consumers (e.g. FC/MatMul weight tying in LLMs),
+    // we still want to peel the Gather branch off into Gather(bf16/f16) -> Convert(f32). The original Convert
+    // keeps feeding its other consumers — Gather+Convert is fused at the plugin level with no extra overhead.
+    auto convert = wrap_type<v0::Convert>({dicts}, type_matches(ov::element::f32));
     auto gather = wrap_type<v8::Gather>({convert, any_input(), wrap_type<v0::Constant>()});
 
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {

--- a/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
@@ -10,6 +10,7 @@
 #include "openvino/core/model.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
+#include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/reshape.hpp"
@@ -269,5 +270,37 @@ TEST_F(TransformationTestsF, MoveDecompressionAfterGatherBF16Weight) {
         auto convert = std::make_shared<v0::Convert>(gather, ov::element::f32);
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{convert}, ov::ParameterVector{input1});
+    }
+}
+
+// LLM weight tying: the Convert(bf16->f32) feeds both a Gather and a MatMul.
+// MoveDecompressionAfterGather should still peel the Gather branch off into Gather(bf16) -> Convert(f32),
+// leaving the original Convert in place for the MatMul consumer.
+TEST_F(TransformationTestsF, MoveDecompressionAfterGatherMultiConsumer) {
+    {
+        auto indices = std::make_shared<v0::Parameter>(ov::element::i32, ov::PartialShape{-1, 16});
+        auto matmul_input = std::make_shared<v0::Parameter>(ov::element::f32, ov::PartialShape{-1, 16});
+        auto axis_const = v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto weights_const = v0::Constant::create(ov::element::bf16, ov::Shape{32, 16}, {1});
+        auto convert = std::make_shared<v0::Convert>(weights_const, ov::element::f32);
+        auto gather = std::make_shared<v8::Gather>(convert, indices, axis_const);
+        auto matmul = std::make_shared<v0::MatMul>(matmul_input, convert, false, true);
+
+        model =
+            std::make_shared<ov::Model>(ov::OutputVector{gather, matmul}, ov::ParameterVector{indices, matmul_input});
+        manager.register_pass<MoveDecompressionAfterGather>();
+    }
+    {
+        auto indices = std::make_shared<v0::Parameter>(ov::element::i32, ov::PartialShape{-1, 16});
+        auto matmul_input = std::make_shared<v0::Parameter>(ov::element::f32, ov::PartialShape{-1, 16});
+        auto axis_const = v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto weights_const = v0::Constant::create(ov::element::bf16, ov::Shape{32, 16}, {1});
+        auto convert = std::make_shared<v0::Convert>(weights_const, ov::element::f32);
+        auto new_gather = std::make_shared<v8::Gather>(weights_const, indices, axis_const);
+        auto new_convert = std::make_shared<v0::Convert>(new_gather, ov::element::f32);
+        auto matmul = std::make_shared<v0::MatMul>(matmul_input, convert, false, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{new_convert, matmul},
+                                                ov::ParameterVector{indices, matmul_input});
     }
 }

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/bf16_embed_tokens_rms.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/bf16_embed_tokens_rms.cpp
@@ -46,10 +46,9 @@ public:
                                                    -1 /*disable group quantization*/,
                                                    ov::element::u8 /*data prc*/,
                                                    ov::element::f32 /*output prc*/,
-                                                   true /*add_subtract*/,
-                                                   false /*add reshape*/,
-                                                   false /*per tensor zp*/,
-                                                   false /*per tensor scale*/);
+                                                   utils::DecompressionType::full /*multiply*/,
+                                                   utils::DecompressionType::full /*subtract*/,
+                                                   false /*add reshape*/);
 
         auto gather_axis = utils::make_constant(ov::element::i32, {1}, std::vector<int>{0});
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/gather_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/gather_weights_decompression.cpp
@@ -28,10 +28,16 @@ const std::vector<GatherDecompressionShapeParams> input_shapes_basic = {
     {{2, 5}, {{}, {{2, 3}}}, 1, -1},
     {{15, 16, 2}, {{-1, -1}, {{2, 3}}}, 0, 0},
 };
-const std::vector<bool> add_decompression_sub = {true, false};
+const std::vector<ov::test::utils::DecompressionType> decompression_multiply_types = {
+    ov::test::utils::DecompressionType::scalar,
+    ov::test::utils::DecompressionType::full,
+};
+const std::vector<ov::test::utils::DecompressionType> decompression_subtract_types = {
+    ov::test::utils::DecompressionType::empty,
+    ov::test::utils::DecompressionType::scalar,
+    ov::test::utils::DecompressionType::full,
+};
 const std::vector<bool> reshape_on_decompression = {true, false};
-const std::vector<bool> per_tensor_zp = {true, false};
-const std::vector<bool> per_tensor_scale = {true, false};
 
 INSTANTIATE_TEST_SUITE_P(smoke_GatherCompressedWeights_basic,
                          GatherWeightsDecompression,
@@ -39,10 +45,9 @@ INSTANTIATE_TEST_SUITE_P(smoke_GatherCompressedWeights_basic,
                                             ::testing::ValuesIn(input_shapes_basic),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(output_precisions),
-                                            ::testing::ValuesIn(add_decompression_sub),
-                                            ::testing::ValuesIn(reshape_on_decompression),
-                                            ::testing::ValuesIn(per_tensor_zp),
-                                            ::testing::ValuesIn(per_tensor_scale)),
+                                            ::testing::ValuesIn(decompression_multiply_types),
+                                            ::testing::ValuesIn(decompression_subtract_types),
+                                            ::testing::ValuesIn(reshape_on_decompression)),
                          GatherWeightsDecompression::get_test_case_name);
 
 // fp16/bf16 constant + convert(16bit to f32) + gather to gather(f16/bf16 input and f32 output)

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_gather_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_gather_weights_decompression.cpp
@@ -40,14 +40,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatmulAndGatherSharedWeightsDecompression,
 // F16/bf16 constant followed by a single Convert(f32) shared between Gather and MatMul,
 // covering the Convert-Gather fusion for hybrid precisions.
 const std::vector<ElementType> hybrid_weights_precisions = {ov::element::bf16, ov::element::f16};
-const std::vector<GatherDecompressionShapeParams> hybrid_input_shapes = {
-    {{128, 256}, {{}, {{256, 256}}}, 1, 0},
-};
 
 INSTANTIATE_TEST_SUITE_P(smoke_MatmulAndGatherSharedWeightsDecompression_ConvertOnly,
                          SharedMatmulAndGatherWeightsDecompression,
                          ::testing::Combine(::testing::Values(utils::DEVICE_CPU),
-                                            ::testing::ValuesIn(hybrid_input_shapes),
+                                            ::testing::Values(input_shapes[0]),
                                             ::testing::ValuesIn(hybrid_weights_precisions),
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::test::utils::DecompressionType::empty),

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_gather_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_gather_weights_decompression.cpp
@@ -21,7 +21,10 @@ const std::vector<GatherDecompressionShapeParams> input_shapes = {
 };
 const std::vector<ElementType> weights_precisions = {ov::element::u8, ov::element::u4, ov::element::i4};
 const std::vector<ElementType> decompression_precisions = {ov::element::f32};
-const std::vector<bool> decompression_subtract = {true, false};
+const std::vector<ov::test::utils::DecompressionType> decompression_subtract_types = {
+    ov::test::utils::DecompressionType::full,
+    ov::test::utils::DecompressionType::empty
+};
 
 INSTANTIATE_TEST_SUITE_P(smoke_MatmulAndGatherSharedWeightsDecompression,
                          SharedMatmulAndGatherWeightsDecompression,
@@ -29,7 +32,26 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatmulAndGatherSharedWeightsDecompression,
                                             ::testing::ValuesIn(input_shapes),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(decompression_precisions),
-                                            ::testing::ValuesIn(decompression_subtract),
+                                            ::testing::Values(ov::test::utils::DecompressionType::full),
+                                            ::testing::ValuesIn(decompression_subtract_types),
+                                            ::testing::Values(true)),
+                         SharedMatmulAndGatherWeightsDecompression::getTestCaseName);
+
+// F16/bf16 constant followed by a single Convert(f32) shared between Gather and MatMul,
+// covering the Convert-Gather fusion for hybrid precisions.
+const std::vector<ElementType> hybrid_weights_precisions = {ov::element::bf16, ov::element::f16};
+const std::vector<GatherDecompressionShapeParams> hybrid_input_shapes = {
+    {{128, 256}, {{}, {{256, 256}}}, 1, 0},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatmulAndGatherSharedWeightsDecompression_ConvertOnly,
+                         SharedMatmulAndGatherWeightsDecompression,
+                         ::testing::Combine(::testing::Values(utils::DEVICE_CPU),
+                                            ::testing::ValuesIn(hybrid_input_shapes),
+                                            ::testing::ValuesIn(hybrid_weights_precisions),
+                                            ::testing::ValuesIn(decompression_precisions),
+                                            ::testing::Values(ov::test::utils::DecompressionType::empty),
+                                            ::testing::Values(ov::test::utils::DecompressionType::empty),
                                             ::testing::Values(true)),
                          SharedMatmulAndGatherWeightsDecompression::getTestCaseName);
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/gather_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/gather_weights_decompression.cpp
@@ -26,10 +26,16 @@ const std::vector<GatherDecompressionShapeParams> input_shapes_basic = {
     {{2, 5}, {{}, {{2, 3}}}, 1, -1},
     {{15, 16, 2}, {{-1, -1}, {{2, 3}}}, 0, 0},
 };
-const std::vector<bool> add_decompression_sub = {true, false};
+const std::vector<ov::test::utils::DecompressionType> decompression_multiply_types = {
+    ov::test::utils::DecompressionType::scalar,
+    ov::test::utils::DecompressionType::full,
+};
+const std::vector<ov::test::utils::DecompressionType> decompression_subtract_types = {
+    ov::test::utils::DecompressionType::empty,
+    ov::test::utils::DecompressionType::scalar,
+    ov::test::utils::DecompressionType::full,
+};
 const std::vector<bool> reshape_on_decompression = {true, false};
-const std::vector<bool> per_tensor_zp = {true, false};
-const std::vector<bool> per_tensor_scale = {true, false};
 
 INSTANTIATE_TEST_SUITE_P(smoke_GatherCompressedWeights_basic,
                          GatherWeightsDecompression,
@@ -37,10 +43,9 @@ INSTANTIATE_TEST_SUITE_P(smoke_GatherCompressedWeights_basic,
                                             ::testing::ValuesIn(input_shapes_basic),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(output_precisions),
-                                            ::testing::ValuesIn(add_decompression_sub),
-                                            ::testing::ValuesIn(reshape_on_decompression),
-                                            ::testing::ValuesIn(per_tensor_zp),
-                                            ::testing::ValuesIn(per_tensor_scale)),
+                                            ::testing::ValuesIn(decompression_multiply_types),
+                                            ::testing::ValuesIn(decompression_subtract_types),
+                                            ::testing::ValuesIn(reshape_on_decompression)),
                          GatherWeightsDecompression::get_test_case_name);
 
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_gather_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_gather_weights_decompression.cpp
@@ -32,7 +32,10 @@ const std::vector<GatherDecompressionShapeParams> input_shapes = {
 };
 const std::vector<ElementType> weights_precisions = {ov::element::u8, ov::element::u4, ov::element::i4};
 const std::vector<ElementType> decompression_precisions = {ov::element::f32, ov::element::f16};
-const std::vector<bool> decompression_subtract = {true, false};
+const std::vector<ov::test::utils::DecompressionType> decompression_subtract_types = {
+    ov::test::utils::DecompressionType::full,
+    ov::test::utils::DecompressionType::empty
+};
 
 INSTANTIATE_TEST_SUITE_P(smoke_MatmulAndGatherSharedWeightsDecompression,
                          SharedMatmulAndGatherWeightsDecompression,
@@ -40,7 +43,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatmulAndGatherSharedWeightsDecompression,
                                             ::testing::ValuesIn(input_shapes),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(decompression_precisions),
-                                            ::testing::ValuesIn(decompression_subtract),
+                                            ::testing::Values(ov::test::utils::DecompressionType::full),
+                                            ::testing::ValuesIn(decompression_subtract_types),
                                             ::testing::Values(true)),
                          SharedMatmulAndGatherWeightsDecompression::getTestCaseName);
 

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/gather_weights_decompression.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/gather_weights_decompression.hpp
@@ -33,14 +33,13 @@ protected:
  *             Gather
  */
 
-using GatherWeightsDecompressionParams = std::tuple<std::string,        // Device name
+using GatherWeightsDecompressionParams = std::tuple<std::string,                          // Device name
                                                     GatherDecompressionShapeParams,
-                                                    ov::element::Type,  // data type
-                                                    ov::element::Type,  // output type
-                                                    bool,               // decompression subtract
-                                                    bool,               // reshape on decompression constants
-                                                    bool,               // per-tensor scale
-                                                    bool>;              // per-tensor zero-point
+                                                    ov::element::Type,                    // data type
+                                                    ov::element::Type,                    // output type
+                                                    ov::test::utils::DecompressionType,   // decompression multiply type
+                                                    ov::test::utils::DecompressionType,   // decompression subtract type
+                                                    bool>;                                // reshape on decompression constants
 
 class GatherWeightsDecompression : public testing::WithParamInterface<GatherWeightsDecompressionParams>,
                                    virtual public ov::test::GatherWeightsDecompressionBase {
@@ -55,10 +54,9 @@ protected:
                                              const int group_size,
                                              const ov::element::Type data_precision,
                                              const ov::element::Type output_precision,
-                                             const bool add_subtract,
-                                             const bool reshape_on_decompression,
-                                             const bool per_tensor_zp,
-                                             const bool per_tensor_scale);
+                                             const ov::test::utils::DecompressionType decompression_multiply_type,
+                                             const ov::test::utils::DecompressionType decompression_subtract_type,
+                                             const bool reshape_on_decompression);
     void check_results();
     void SetUp() override;
 };

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/shared_matmul_gather_weights_decompression.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/shared_matmul_gather_weights_decompression.hpp
@@ -31,12 +31,13 @@ namespace test {
  *               Matmul(transpose_b = true)             Gather
 */
 
-using SharedMatmulAndGatherWeightsDecompressionParams = std::tuple<std::string,                 // target device
+using SharedMatmulAndGatherWeightsDecompressionParams = std::tuple<std::string,                        // target device
                                                                    GatherDecompressionShapeParams,
-                                                                   ElementType,                 // weights precision
-                                                                   ElementType,                 // decompression precision
-                                                                   bool,                        // decompression subtract
-                                                                   bool>;                       // use matmul decompression implementation
+                                                                   ElementType,                        // weights precision
+                                                                   ElementType,                        // decompression precision
+                                                                   ov::test::utils::DecompressionType, // multiply type
+                                                                   ov::test::utils::DecompressionType, // subtract type
+                                                                   bool>;                              // use matmul decompression implementation
 
 class SharedMatmulAndGatherWeightsDecompression : public testing::WithParamInterface<SharedMatmulAndGatherWeightsDecompressionParams>,
                                                   virtual public SubgraphBaseTest {
@@ -51,7 +52,8 @@ protected:
                                             const int group_size,
                                             const ov::element::Type data_precision,
                                             const ov::element::Type output_precision,
-                                            const bool add_subtract);
+                                            const ov::test::utils::DecompressionType decompression_multiply_type,
+                                            const ov::test::utils::DecompressionType decompression_subtract_type);
     void SetUp() override;
     void check_results();
 };

--- a/src/tests/functional/plugin/shared/src/subgraph/gather_weights_decompression.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/gather_weights_decompression.cpp
@@ -49,19 +49,17 @@ std::string GatherWeightsDecompression::get_test_case_name(
                  shape_params,
                  data_precision,
                  output_precision,
-                 decompression_sub,
-                 reshape_on_decompression,
-                 per_tensor_zp,
-                 per_tensor_scale] = obj.param;
+                 decompression_multiply_type,
+                 decompression_subtract_type,
+                 reshape_on_decompression] = obj.param;
     std::ostringstream result;
     result << "target_device=" << target_device << "_";
     result << shape_params << "_";
     result << "data_precision=" << data_precision << "_";
     result << "output_precision=" << output_precision << "_";
-    result << "decompression_subtract=" << decompression_sub << "_";
-    result << "reshape_on_decompression=" << reshape_on_decompression << "_";
-    result << "per_tensor_zp=" << per_tensor_zp;
-    result << "per_tensor_scale=" << per_tensor_scale;
+    result << "decompression_multiply=" << decompression_multiply_type << "_";
+    result << "decompression_subtract=" << decompression_subtract_type << "_";
+    result << "reshape_on_decompression=" << reshape_on_decompression;
 
     return result.str();
 }
@@ -73,24 +71,17 @@ std::shared_ptr<ov::Model> GatherWeightsDecompression::init_subgraph(const ov::S
                                                                      const int group_size,
                                                                      const ov::element::Type data_precision,
                                                                      const ov::element::Type output_precision,
-                                                                     const bool add_subtract,
-                                                                     const bool reshape_on_decompression,
-                                                                     const bool per_tensor_zp,
-                                                                     const bool per_tensor_scale) {
+                                                                     const ov::test::utils::DecompressionType decompression_multiply_type,
+                                                                     const ov::test::utils::DecompressionType decompression_subtract_type,
+                                                                     const bool reshape_on_decompression) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::i32, indices_shape)};
     auto axis_const = ov::op::v0::Constant::create(ov::element::i32, {1}, {axis});
-    const auto subtract_type = add_subtract
-                                   ? (per_tensor_zp ? ov::test::utils::DecompressionType::scalar
-                                                    : ov::test::utils::DecompressionType::full)
-                                   : ov::test::utils::DecompressionType::empty;
-    const auto multiply_type = per_tensor_scale ? ov::test::utils::DecompressionType::scalar
-                                                : ov::test::utils::DecompressionType::full;
     const auto data_subgraph = ov::test::utils::initGatherDecompressionSubgraph(data_shape,
                                                                                 group_size,
                                                                                 data_precision,
                                                                                 output_precision,
-                                                                                multiply_type,
-                                                                                subtract_type,
+                                                                                decompression_multiply_type,
+                                                                                decompression_subtract_type,
                                                                                 reshape_on_decompression);
 
     auto gather = std::make_shared<ov::op::v8::Gather>(data_subgraph, params[0], axis_const, batch_dims);
@@ -109,10 +100,9 @@ void GatherWeightsDecompression::SetUp() {
                  shape_params,
                  data_precision,
                  output_precision,
-                 decompression_sub,
-                 reshape_on_decompression,
-                 per_tensor_zp,
-                 per_tensor_scale] = GetParam();
+                 decompression_multiply_type,
+                 decompression_subtract_type,
+                 reshape_on_decompression] = GetParam();
     targetDevice = _targetDevice;
 
     init_input_shapes({shape_params.indices_shape, {{}, {{shape_params.data_shape}}}});
@@ -127,10 +117,9 @@ void GatherWeightsDecompression::SetUp() {
                              shape_params.decompression_group_size,
                              data_precision,
                              output_precision,
-                             decompression_sub,
-                             reshape_on_decompression,
-                             per_tensor_zp,
-                             per_tensor_scale);
+                             decompression_multiply_type,
+                             decompression_subtract_type,
+                             reshape_on_decompression);
 
     if (output_precision == ov::element::f16) {
         abs_threshold = 1.0f;

--- a/src/tests/functional/plugin/shared/src/subgraph/gather_weights_decompression.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/gather_weights_decompression.cpp
@@ -79,14 +79,19 @@ std::shared_ptr<ov::Model> GatherWeightsDecompression::init_subgraph(const ov::S
                                                                      const bool per_tensor_scale) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::i32, indices_shape)};
     auto axis_const = ov::op::v0::Constant::create(ov::element::i32, {1}, {axis});
+    const auto subtract_type = add_subtract
+                                   ? (per_tensor_zp ? ov::test::utils::DecompressionType::scalar
+                                                    : ov::test::utils::DecompressionType::full)
+                                   : ov::test::utils::DecompressionType::empty;
+    const auto multiply_type = per_tensor_scale ? ov::test::utils::DecompressionType::scalar
+                                                : ov::test::utils::DecompressionType::full;
     const auto data_subgraph = ov::test::utils::initGatherDecompressionSubgraph(data_shape,
                                                                                 group_size,
                                                                                 data_precision,
                                                                                 output_precision,
-                                                                                add_subtract,
-                                                                                reshape_on_decompression,
-                                                                                per_tensor_zp,
-                                                                                per_tensor_scale);
+                                                                                multiply_type,
+                                                                                subtract_type,
+                                                                                reshape_on_decompression);
 
     auto gather = std::make_shared<ov::op::v8::Gather>(data_subgraph, params[0], axis_const, batch_dims);
     gather->set_friendly_name("gather_node");

--- a/src/tests/functional/plugin/shared/src/subgraph/shared_matmul_gather_weights_decompression.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/shared_matmul_gather_weights_decompression.cpp
@@ -18,7 +18,8 @@ std::string SharedMatmulAndGatherWeightsDecompression::getTestCaseName(const tes
                  shape_params,
                  weights_precision,
                  decompression_precision,
-                 decompression_subtract,
+                 decompression_multiply_type,
+                 decompression_subtract_type,
                  use_decompression_impl] = obj.param;
 
     std::ostringstream result;
@@ -26,7 +27,8 @@ std::string SharedMatmulAndGatherWeightsDecompression::getTestCaseName(const tes
     result << shape_params << "_";
     result << "weights_precision=" << weights_precision << "_";
     result << "decompression_precision=" << decompression_precision << "_";
-    result << "decompression_subtract=" << decompression_subtract << "_";
+    result << "decompression_multiply=" << decompression_multiply_type << "_";
+    result << "decompression_subtract=" << decompression_subtract_type << "_";
     result << "use_decompression_impl=" << use_decompression_impl;
     return result.str();
 }
@@ -38,16 +40,16 @@ std::shared_ptr<ov::Model> SharedMatmulAndGatherWeightsDecompression::initSubgra
                                                                                    const int group_size,
                                                                                    const ov::element::Type data_precision,
                                                                                    const ov::element::Type output_precision,
-                                                                                   const bool add_subtract) {
+                                                                                   const ov::test::utils::DecompressionType decompression_multiply_type,
+                                                                                   const ov::test::utils::DecompressionType decompression_subtract_type) {
     const auto indices_data = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, indices_shape);
     const auto axis_const = ov::op::v0::Constant::create(ov::element::i32, {1}, {axis});
     const auto decompression_subgraph = ov::test::utils::initGatherDecompressionSubgraph(data_shape,
                                                                                          group_size,
                                                                                          data_precision,
                                                                                          output_precision,
-                                                                                         add_subtract,
-                                                                                         false,
-                                                                                         false,
+                                                                                         decompression_multiply_type,
+                                                                                         decompression_subtract_type,
                                                                                          false);
     const auto gather = std::make_shared<ov::op::v8::Gather>(decompression_subgraph, indices_data, axis_const, batch_dims);
 
@@ -69,7 +71,8 @@ void SharedMatmulAndGatherWeightsDecompression::SetUp() {
                  shape_params,
                  weights_precision,
                  decompression_precision,
-                 decompression_subtract,
+                 decompression_multiply_type,
+                 decompression_subtract_type,
                  use_decompression_impl] = GetParam();
     targetDevice = _targetDevice;
 
@@ -82,13 +85,14 @@ void SharedMatmulAndGatherWeightsDecompression::SetUp() {
                             shape_params.decompression_group_size,
                             weights_precision,
                             decompression_precision,
-                            decompression_subtract);
+                            decompression_multiply_type,
+                            decompression_subtract_type);
 }
 
 void SharedMatmulAndGatherWeightsDecompression::check_results() {
     const auto& test_param = GetParam();
     const ov::element::Type compressed_weights_precision = std::get<2>(test_param);
-    const auto use_matmul_decompression_impl = std::get<5>(test_param);
+    const auto use_matmul_decompression_impl = std::get<6>(test_param);
 
     const auto results = compiledModel.get_runtime_model()->get_results();
     EXPECT_EQ(results.size(), 2);

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/subgraph_builders/weights_decompression_builders.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/subgraph_builders/weights_decompression_builders.hpp
@@ -58,10 +58,9 @@ std::shared_ptr<ov::Node> initGatherDecompressionSubgraph(const ov::Shape& data_
                                                           const int group_size,
                                                           const ov::element::Type data_precision,
                                                           const ov::element::Type output_precision,
-                                                          const bool add_subtract,
-                                                          const bool reshape_on_decompression_constant,
-                                                          const bool per_tensor_zp,
-                                                          const bool per_tensor_scale);
+                                                          const DecompressionType decompression_multiply_type,
+                                                          const DecompressionType decompression_subtract_type,
+                                                          const bool reshape_on_decompression_constant);
 
 }  // namespace utils
 }  // namespace test

--- a/src/tests/test_utils/common_test_utils/src/subgraph_builders/weights_decompression_builders.cpp
+++ b/src/tests/test_utils/common_test_utils/src/subgraph_builders/weights_decompression_builders.cpp
@@ -543,10 +543,9 @@ std::shared_ptr<ov::Node> initGatherDecompressionSubgraph(const ov::Shape& data_
                                                           const int group_size,
                                                           const ov::element::Type data_precision,
                                                           const ov::element::Type output_precision,
-                                                          const bool add_subtract,
-                                                          const bool reshape_on_decompression_constant,
-                                                          const bool per_tensor_zp,
-                                                          const bool per_tensor_scale) {
+                                                          const DecompressionType decompression_multiply_type,
+                                                          const DecompressionType decompression_subtract_type,
+                                                          const bool reshape_on_decompression_constant) {
     const bool group_decompression = group_size != -1;
     // Weights has shape [I, D], where
     // I - index
@@ -567,14 +566,35 @@ std::shared_ptr<ov::Node> initGatherDecompressionSubgraph(const ov::Shape& data_
         original_data_shape.insert(original_data_shape.begin() + data_idx + 1, group_size);
     }
 
-    const auto up_to = data_precision == ov::element::i4 ? 7 : 15;
-    ov::test::utils::InputGenerateData generate_data(0, up_to);
-    if (data_precision.is_signed())
-        generate_data.start_from = -1;
-    auto weights_tensor = ov::test::utils::create_and_fill_tensor(data_precision, original_data_shape, generate_data);
+    const bool floating_weights = data_precision.is_real();
+    ov::Tensor weights_tensor;
+    if (floating_weights) {
+        weights_tensor = ov::test::utils::create_and_fill_tensor_real_distribution(data_precision,
+                                                                                   original_data_shape,
+                                                                                   -1.f,
+                                                                                   1.f,
+                                                                                   1);
+    } else {
+        const auto up_to = data_precision == ov::element::i4 ? 7 : 15;
+        ov::test::utils::InputGenerateData generate_data(0, up_to);
+        if (data_precision.is_signed())
+            generate_data.start_from = -1;
+        weights_tensor = ov::test::utils::create_and_fill_tensor(data_precision, original_data_shape, generate_data);
+    }
     auto weights = std::make_shared<ov::op::v0::Constant>(weights_tensor);
     weights->set_friendly_name("Compressed_weights");
     auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, output_precision);
+
+    // For real (f16/bf16) weights with no scale/zero-point, the subgraph is just Constant -> Convert.
+    // This mirrors the f16-only-Convert path in initMatMulDecompressionSubgraph and is used to
+    // exercise the Convert-Gather fusion for hybrid precisions. The Convert must be marked as
+    // decompression to prevent ConstantFolding from collapsing Constant(bf16)+Convert(f32) into
+    // a single Constant(f32) — without the marker, Gather would see fp32 weights directly.
+    if (floating_weights && decompression_multiply_type == DecompressionType::empty &&
+        decompression_subtract_type == DecompressionType::empty) {
+        ov::mark_as_decompression(weights_convert);
+        return weights_convert;
+    }
 
     std::shared_ptr<ov::Node> mul_parent = weights_convert;
 
@@ -592,17 +612,19 @@ std::shared_ptr<ov::Node> initGatherDecompressionSubgraph(const ov::Shape& data_
     if (reshape_on_decompression_constant)
         scaleshift_const_shape.erase(std::remove(scaleshift_const_shape.begin(), scaleshift_const_shape.end(), 1),
                                      scaleshift_const_shape.end());
-    if (add_subtract) {
-        auto shift_tensor_shape = per_tensor_zp ? ov::Shape{1} : scaleshift_const_shape;
+    if (decompression_subtract_type != DecompressionType::empty) {
+        const bool scalar_zp = decompression_subtract_type == DecompressionType::scalar;
+        auto shift_tensor_shape = scalar_zp ? ov::Shape{1} : scaleshift_const_shape;
+        const auto up_to = data_precision == ov::element::i4 ? 7 : 15;
         auto shift_tensor = ov::test::utils::create_and_fill_tensor(data_precision,
                                                                     shift_tensor_shape,
                                                                     ov::test::utils::InputGenerateData(0, up_to));
-        if (per_tensor_zp && data_precision.bitwidth() == 4) {
+        if (scalar_zp && data_precision.bitwidth() == 4) {
             static_cast<uint8_t*>(shift_tensor.data())[0] = 0x88;
         }
         auto shift_const = std::make_shared<ov::op::v0::Constant>(shift_tensor);
         std::shared_ptr<ov::Node> shift_convert = std::make_shared<ov::op::v0::Convert>(shift_const, output_precision);
-        if (reshape_on_decompression_constant && !per_tensor_zp) {
+        if (reshape_on_decompression_constant && !scalar_zp) {
             auto shift_reshape_const = ov::op::v0::Constant::create(ov::element::i32,
                                                                     {scaleshift_target_shape.size()},
                                                                     scaleshift_target_shape);
@@ -612,26 +634,31 @@ std::shared_ptr<ov::Node> initGatherDecompressionSubgraph(const ov::Shape& data_
         mul_parent = std::make_shared<ov::op::v1::Subtract>(weights_convert, shift_convert);
     }
 
-    ov::test::utils::InputGenerateData in_data;
-    in_data.start_from = -0.5;
-    in_data.range = 1;
-    in_data.resolution = 30000;
-    auto scale_tensor_shape = per_tensor_scale ? ov::Shape{1} : scaleshift_const_shape;
-    auto scale_tensor = ov::test::utils::create_and_fill_tensor(output_precision, scale_tensor_shape, in_data);
-    for (size_t i = 0; i < scale_tensor.get_size(); i++) {
-        if (output_precision == ov::element::f16)
-            scale_tensor.data<ov::float16>()[i] /= ov::float16(16.f);
-        else if (output_precision == ov::element::f32)
-            scale_tensor.data<float>()[i] /= 16.f;
+    std::shared_ptr<ov::Node> last_node = mul_parent;
+    if (decompression_multiply_type != DecompressionType::empty) {
+        const bool scalar_scale = decompression_multiply_type == DecompressionType::scalar;
+        ov::test::utils::InputGenerateData in_data;
+        in_data.start_from = -0.5;
+        in_data.range = 1;
+        in_data.resolution = 30000;
+        auto scale_tensor_shape = scalar_scale ? ov::Shape{1} : scaleshift_const_shape;
+        auto scale_tensor = ov::test::utils::create_and_fill_tensor(output_precision, scale_tensor_shape, in_data);
+        for (size_t i = 0; i < scale_tensor.get_size(); i++) {
+            if (output_precision == ov::element::f16)
+                scale_tensor.data<ov::float16>()[i] /= ov::float16(16.f);
+            else if (output_precision == ov::element::f32)
+                scale_tensor.data<float>()[i] /= 16.f;
+        }
+        std::shared_ptr<ov::Node> scale_const = std::make_shared<ov::op::v0::Constant>(scale_tensor);
+        if (reshape_on_decompression_constant && !scalar_scale) {
+            auto scale_reshape_const = ov::op::v0::Constant::create(ov::element::i32,
+                                                                    {scaleshift_target_shape.size()},
+                                                                    scaleshift_target_shape);
+            auto scale_reshape = std::make_shared<ov::op::v1::Reshape>(scale_const, scale_reshape_const, false);
+            scale_const = scale_reshape;
+        }
+        last_node = std::make_shared<ov::op::v1::Multiply>(mul_parent, scale_const);
     }
-    std::shared_ptr<ov::Node> scale_const = std::make_shared<ov::op::v0::Constant>(scale_tensor);
-    if (reshape_on_decompression_constant && !per_tensor_scale) {
-        auto scale_reshape_const =
-            ov::op::v0::Constant::create(ov::element::i32, {scaleshift_target_shape.size()}, scaleshift_target_shape);
-        auto scale_reshape = std::make_shared<ov::op::v1::Reshape>(scale_const, scale_reshape_const, false);
-        scale_const = scale_reshape;
-    }
-    std::shared_ptr<ov::Node> last_node = std::make_shared<ov::op::v1::Multiply>(mul_parent, scale_const);
 
     if (group_decompression) {
         auto reshape_target_shape = std::vector<int>{static_cast<int>(data_shape[0]), -1};


### PR DESCRIPTION
### Details:
 - *Enable Convert Gather fusion for bf16/fp16 input precision with fp32 output precision.*
 - *Subgraph tests are added to make sure the original issue from the bitnet model can be reproduced beforehand.*

### Tickets:
 - *[CVS-173569](https://jira.devtools.intel.com/browse/CVS-173569)*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used during the root-cause and implementation. Human-AI discussions were performed to make sure AI followed human design exactly. Subgraph tests were verified manually.
