### PR TITLE
[GPU] Fixed missing check in quantize_gpu_ref kernel.

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/quantize_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/quantize_gpu_ref.cl
@@ -52,6 +52,26 @@ KERNEL(quantize_ref)(
     const int v = ((vuwzyx / OUTPUT_SIZE_X) / OUTPUT_SIZE_Y) / OUTPUT_SIZE_Z / OUTPUT_SIZE_W / OUTPUT_SIZE_U;
 #endif
 
+#if OUTPUT_LAYOUT_B_FS_YX_FSV16
+    if (of >= OUTPUT_FEATURE_NUM)
+        return;
+#else
+    if (x >= OUTPUT_SIZE_X || y >= OUTPUT_SIZE_Y || z >= OUTPUT_SIZE_Z)
+        return;
+#if OUTPUT_DIMS >= 6
+    if (w >= OUTPUT_SIZE_W)
+        return;
+#endif
+#if OUTPUT_DIMS >= 7
+    if (u >= OUTPUT_SIZE_U)
+        return;
+#endif
+#if OUTPUT_DIMS >= 8
+    if (v >= OUTPUT_SIZE_V)
+        return;
+#endif
+#endif
+
 #if INPUT0_DIMS == 8
     const int input_offset = INPUT0_GET_INDEX(b, of, v, u, w, z, y, x);
 #elif INPUT0_DIMS == 7
@@ -125,14 +145,6 @@ KERNEL(quantize_ref)(
 #endif
 
     INPUT0_TYPE val = input[input_offset];
-
-#if OUTPUT_LAYOUT_B_FS_YX_FSV16
-    if (of >= OUTPUT_FEATURE_NUM)
-        return;
-#else
-    if (x >= OUTPUT_SIZE_X || y >= OUTPUT_SIZE_Y || z >= OUTPUT_SIZE_Z)
-        return;
-#endif
 
     INPUT0_TYPE input_low_val  = input_low[input_low_offset];
     INPUT0_TYPE input_high_val  = input_high[input_high_offset];


### PR DESCRIPTION
### Details:
- Fixes a sporadic data race in the quantize_gpu_ref OpenCL kernel for output tensors with rank > 5.

- For non-b_fs_yx_fsv16 layouts the dispatch pads the spatial work-size to a multiple of 16 (Align(X\*Y\*Z\*W\*U\*V, 16)), creating extra work-items. The out-of-bounds check only validated x, y, z, so an extra work-item with an out-of-range w, u, or v was not stopped. OUTPUT_GET_INDEX then mapped it onto another slice's memory, so two work-items wrote the same output address and produced non-deterministic results.

- The fix extends the bounds check to also validate w, u, and v (guarded by OUTPUT_DIMS). Also, it moves the check before first input buffer access, to avoid OOB read.

- Reproduced sporadically by fusings_gpu/activation_eltwise_activation_quantize_u8.per_channel/15 (dims 1_2_3_4_5_3_2_3); tensor dumps confirmed the corruption was limited to the 8 extra elements.

### AI Assistance:
 - AI assistance used: yes
 - Bug root cause was found by AI
