### PR TITLE
[PyTorch FE] Support aten::_sparse_mm

### DIFF
--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -397,6 +397,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::_pad_packed_sequence", op::translate_pad_packed_sequence},
         {"aten::_set_item", op::translate_set_item},
         {"aten::_shape_as_tensor", op::translate_shape_as_tensor},
+        {"aten::_sparse_mm", op::translate_1to1_match_2_inputs<opset10::MatMul>},
         {"aten::_unique2", op::translate_unique2},
         {"aten::_upsample_bicubic2d_aa", op::translate_upsample_bicubic2d_aa},
         {"aten::_upsample_bilinear2d_aa", op::translate_upsample_bilinear2d_aa},
@@ -771,6 +772,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         // aten::tensor_split - Supported in limited set of patterns
         {"aten::tile", op::translate_1to1_match_2_inputs<opset10::Tile>},
         {"aten::to", op::translate_to},
+        {"aten::to_sparse", op::skip_node},  // OpenVINO has no sparse layout; dense passthrough (aten::_sparse_mm becomes MatMul)
         {"aten::topk", op::translate_topk},
         {"aten::transpose", op::quantizable_op<op::translate_transpose>},
         {"aten::tril", op::translate_tril},

--- a/tests/layer_tests/pytorch_tests/test_sparse_mm.py
+++ b/tests/layer_tests/pytorch_tests/test_sparse_mm.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestSparseMM(PytorchLayerTest):
+    def _prepare_input(self, m, k, n):
+        return (
+            self.random.randn(m, k).astype(np.float32),
+            self.random.randn(k, n).astype(np.float32),
+        )
+
+    def create_model(self):
+        import torch
+
+        class aten_sparse_mm(torch.nn.Module):
+            def forward(self, a, b):
+                # torch.sparse.mm dispatches to aten::_sparse_mm; a.to_sparse()
+                # produces the sparse operand. Densely this equals a @ b.
+                return torch.sparse.mm(a.to_sparse(), b)
+
+        return aten_sparse_mm(), "aten::_sparse_mm"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.parametrize(("m", "k", "n"), [(2, 3, 4), (5, 10, 7), (3, 5, 4)])
+    def test_sparse_mm(self, m, k, n, ie_device, precision, ir_version):
+        self._test(*self.create_model(), ie_device, precision, ir_version,
+                   kwargs_to_prepare_input={"m": m, "k": k, "n": n})


### PR DESCRIPTION
### Details
Adds PyTorch FE support for `aten::_sparse_mm` (#29685).

OpenVINO has no sparse tensor layout, but the op is dense-equivalent to a matrix multiply. The TorchScript graph for `torch.sparse.mm(a.to_sparse(), b)` is:

```
%s = aten::to_sparse(%a)
%r = aten::_sparse_mm(%s, %b)
```

and `torch.sparse.mm(a.to_sparse(), b)` equals `a @ b` exactly. So:

- **`aten::_sparse_mm`** → `MatMul` (reusing `translate_1to1_match_2_inputs<opset10::MatMul>`, the same mapping used by `aten::mm` / `aten::matmul` / `aten::bmm`).
- **`aten::to_sparse`** → `skip_node` (dense passthrough — there is no sparse layout in OpenVINO, and densifying makes the subsequent `_sparse_mm` a plain `MatMul`).

No new translator file is needed — both are existing helpers.

> Note on a previous attempt (#33708): it wrapped `_sparse_mm` in a `PtFrameworkNode` fallback and tested by passing `torch.sparse_coo_tensor(...)` directly as a model input. OpenVINO cannot represent a sparse COO tensor as a graph input, so that path can't actually convert/run. Routing through `to_sparse` (dense in, dense out) keeps every value densely representable and produces an exact result.

### Validation
Built OpenVINO from source and ran the new layer test locally on **CPU / FP32** — all pass:

```
tests/layer_tests/pytorch_tests> pytest test_sparse_mm.py
test_sparse_mm.py ...  3 passed   ((m,k,n) = (2,3,4), (5,10,7), (3,5,4))
```

New test: `tests/layer_tests/pytorch_tests/test_sparse_mm.py`.

### Tickets
Closes #29685
