### PR TITLE
[PyTorch FE] Fix aten::index_add conversion on torch.export path (default alpha elided)

### DIFF
--- a/src/frontends/pytorch/src/op/index_add.cpp
+++ b/src/frontends/pytorch/src/op/index_add.cpp
@@ -27,12 +27,20 @@ OutputVector translate_index_add(const NodeContext& context) {
     // aten::index_add(Tensor self, int dim, Tensor index, Tensor source, *, Scalar alpha=1) -> Tensor
     // aten::index_add.out(Tensor self, int dim, Tensor index, Tensor source, *, Scalar alpha=1, Tensor(a!) out) ->
     // Tensor(a!)
-    num_inputs_check(context, 5, 6);
+    num_inputs_check(context, 4, 6);
     auto input = context.get_input(0);
     auto dim = context.get_input(1);
     auto index = context.mark_node(std::make_shared<v0::Convert>(context.get_input(2), element::i32));
     auto src = context.get_input(3);
-    auto alpha = context.get_input(4);
+    // alpha is a keyword-only arg (default 1). torch.export elides it from the
+    // FX graph (aten.index_add.default arrives with 4 inputs), so synthesize the
+    // default when it is absent. ConvertLike below brings it to src's dtype.
+    Output<Node> alpha;
+    if (context.input_is_none(4)) {
+        alpha = context.mark_node(v0::Constant::create(element::f32, Shape{}, {1.0f}));
+    } else {
+        alpha = context.get_input(4);
+    }
     auto converted_alpha = context.mark_node(std::make_shared<v1::ConvertLike>(alpha, src));
     auto alpha_src = context.mark_node(std::make_shared<v1::Multiply>(converted_alpha, src));
     auto input_shape_rank = get_shape_rank(context, input);

--- a/tests/layer_tests/pytorch_tests/test_index_add.py
+++ b/tests/layer_tests/pytorch_tests/test_index_add.py
@@ -64,3 +64,32 @@ class TestIndexAdd(PytorchLayerTest):
             ir_version,
             kwargs_to_prepare_input={"dtype": dtype, "out": mode == "out"},
         )
+
+    def create_model_no_alpha(self, dim, index, src):
+        class aten_index_add_default(torch.nn.Module):
+            def __init__(self, dim, index, src):
+                super().__init__()
+                self.dim = dim
+                self.index = index
+                self.src = src
+
+            def forward(self, x: torch.Tensor):
+                # No alpha -> torch.export elides the default alpha=1, so
+                # aten.index_add.default reaches the frontend with 4 inputs (#35628).
+                return torch.index_add(x, self.dim, self.index, self.src)
+
+        return aten_index_add_default(dim, index, src), "aten::index_add"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_torch_export
+    @pytest.mark.parametrize("dim", [0, 1, -1])
+    @pytest.mark.parametrize("dtype", ["float32", "int32"])
+    def test_index_add_export_default_alpha(self, dim, dtype, ie_device, precision, ir_version):
+        index = torch.tensor([0, 2, 1])
+        src = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).to(getattr(torch, dtype))
+        self._test(
+            *self.create_model_no_alpha(dim, index, src),
+            ie_device, precision, ir_version,
+            trace_model=False, use_torch_export=True, fx_kind="aten.index_add",
+            kwargs_to_prepare_input={"dtype": dtype, "out": False},
+        )


### PR DESCRIPTION
### Details
Fixes #35628 — `aten::index_add` fails to convert via the `torch.export` path.

`aten::index_add(self, dim, index, source, *, Scalar alpha=1)` has a keyword-only `alpha` default. `torch.export` elides defaults from the FX graph, so `aten.index_add.default` reaches the frontend with **4** inputs, while `translate_index_add` required `num_inputs_check(context, 5, 6)` and read `get_input(4)` unconditionally — aborting with `Got less inputs 4 than expected 5`. (`jit.trace` is unaffected because it materializes `alpha=1` as an explicit 5th input, so existing trace tests pass.)

Fix (`src/frontends/pytorch/src/op/index_add.cpp`):
- lower the minimum to `num_inputs_check(context, 4, 6)`
- synthesize `alpha = 1.0` when input 4 is absent (`input_is_none(4)` is true for an out-of-range index); the existing `ConvertLike` brings it to `source`'s dtype.

The trailing `input_is_none(5)` (out-variant) is already safe for out-of-range. Same path covers `aten.index_add_.default` (in-place), which routes to the same translator.

### Validation (local, built from source)
- **Existing trace-path tests:** `test_index_add.py::test_scatter_reduce` — no regression.
- **The issue's exact reproducer** (`torch.export` → `convert_model`): now converts (28 ops) and matches PyTorch numerically (**max abs diff = 0.0**); previously raised `OpConversionFailure`.
- Added `test_index_add_export_default_alpha` (marked `precommit_torch_export`) exercising the elided-`alpha` export path so CI's export lane covers it.

### Tickets
Closes #35628
