### PR TITLE
[GPU] Enable byxf layout for dynamic convolutions in attention-based models

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1507,6 +1507,8 @@ void program::set_layout_optimizer_attributes(layout_optimizer& lo) {
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
     bool is_dynamic_batch_onednn_conv = false;
+    size_t dynamic_batch_onednn_conv_count = 0;
+    bool has_sdpa = false;
     size_t total_non_byxf_onednn_conv_whitelist_layers = 0;
 
     // OneDNN previously selects formats like b_fs_yx_fsv16 or bs_fs_yx_bsv16_fsv16 based on batch size.
@@ -1535,6 +1537,8 @@ void program::set_layout_optimizer_attributes(layout_optimizer& lo) {
                 bool is_fp32_conv = (node->get_input_layout().data_type == data_types::f32) &&
                                     (node->get_output_layout().data_type == data_types::f32);
                 is_dynamic_batch_onednn_conv = is_dynamic_batch && !is_fp32_conv;
+                if (is_dynamic_batch_onednn_conv)
+                    dynamic_batch_onednn_conv_count++;
             } else {
 #endif
                 auto input_size = node->get_input_layout(0).get_tensor();
@@ -1700,6 +1704,9 @@ void program::set_layout_optimizer_attributes(layout_optimizer& lo) {
         if (prim.is_in_data_flow() && (byxf_onednn_conv_whitelist.count(prim.type()) == 0)) {
             total_non_byxf_onednn_conv_whitelist_layers++;
         }
+        if (prim.type() == cldnn::scaled_dot_product_attention::type_id()) {
+            has_sdpa = true;
+        }
 #endif
     }
 
@@ -1763,7 +1770,12 @@ void program::set_layout_optimizer_attributes(layout_optimizer& lo) {
             }
         }
     }
-    bool should_use_byxf_onednn_conv = is_dynamic_batch_onednn_conv && (total_non_byxf_onednn_conv_whitelist_layers == 0);
+
+    // WA: Limit byxf layout to models with few convolutions to avoid excessive reorders (CVS-185041)
+    constexpr size_t max_byxf_onednn_conv_count = 5;
+    bool should_use_byxf_onednn_conv = is_dynamic_batch_onednn_conv
+        && (total_non_byxf_onednn_conv_whitelist_layers == 0 ||
+            (has_sdpa && dynamic_batch_onednn_conv_count <= max_byxf_onednn_conv_count));
     if (should_use_byxf_onednn_conv)
         lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::byxf_onednn_convolution, 1);
 #endif


### PR DESCRIPTION
### Description of the issue (symptom, root-cause, how it was resolved)
- **Symptom**: FP16 dynamic-shape models with convolution + attention suffer 230x performance regression when batch ≥ 16. oneDNN `jit:ir` rejects `b_fs_yx_fsv16` (aBcd16b) layout at runtime and falls back to `ocl:ref:any`.
- **Root-cause**: The existing `byxf_onednn_convolution` optimization uses a strict whitelist to decide whether to switch convolutions to `byxf`/`acdb` format. Models containing ops like `rms`, `rope`, `sdpa`, `mvn` fail the whitelist check, so `b_fs_yx_fsv16` is selected at compile time. At runtime with mb ≥ 16, oneDNN internally expects `ABcd16a16b` but receives `aBcd16b`, causing `jit:ir` to reject and fall back to the reference kernel.
- **Fix**: Extend the `byxf_onednn_convolution` activation condition — if the model contains SDPA (ScaledDotProductAttention), bypass the whitelist check and enable `byxf` format for dynamic convolutions. This ensures `acdb` layout is used, which oneDNN `jit:ir` accepts at all batch sizes.

#### The code and line that caused this issue (if it is not changed directly)
- `intel_gpu/src/graph/layout_optimizer.cpp` : `set_onednn_dyn_conv_preferred_format()` — sets `b_fs_yx_fsv16` for FP16 dynamic conv when `byxf_onednn_convolution` attribute is not set
- `onednn_gpu/src/gpu/intel/conv/jit/config.cpp` : `init_tensor_layouts()` L769-776 — `VDISPATCH_CHECK` rejects `aBcd16b` when internal compute tag is `ABcd16a16b` (mb ≥ 16)

#### Reproduction step and snapshot

```
# benchdnn reproduction:
$ benchdnn --conv --engine=gpu:0 --mode=P --dt=f16:f16:f16 \
  --stag=aBcd16b --dtag=aBcd16b \
  mb16_ic480oc480_ih64oh32kh3sh2dh0ph1_iw50ow25kw3sw2dw0pw1
# → ocl:ref:any, 277 GFLOPS (vs 64K GFLOPS with acdb)
```

#### Problematic graph
- Graph contains: Convolution (dynamic batch, FP16) + SDPA + ops not in `byxf_onednn_conv_whitelist` (rms, mvn, reshape, etc.)
- All dimensions are fully dynamic (batch, spatial)
- `byxf_onednn_conv_whitelist` rejects the model, causing `b_fs_yx_fsv16` to be selected instead of `byxf`

#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [ ] Did you include test case for this fix, if necessary?
- [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

