### PR TITLE
[c-api] Enhance ov_get_error_info documentation

### DIFF
--- a/src/bindings/c/include/openvino/c/ov_common.h
+++ b/src/bindings/c/include/openvino/c/ov_common.h
@@ -217,9 +217,11 @@ typedef struct {
 } ov_encryption_callbacks;
 
 /**
- * @brief Print the error info.
+ * @brief Returns a human-readable description of the given status code.
  * @ingroup ov_base_c_api
- * @param ov_status_e a status code.
+ * @param status A status code.
+ * @return A pointer to a static, null-terminated string describing the status.
+ *         The returned pointer is valid for the lifetime of the process and MUST NOT be passed to ov_free().
  */
 OPENVINO_C_API(const char*)
 ov_get_error_info(ov_status_e status);

--- a/src/bindings/c/tests/ov_util_test.cpp
+++ b/src/bindings/c/tests/ov_util_test.cpp
@@ -51,3 +51,41 @@ TEST(ov_util, no_log_callback) {
     EXPECT_NO_THROW(test_log_msg("default"));
     EXPECT_TRUE(got_message.empty());
 }
+
+TEST(ov_util, ov_get_error_info_returns_static_pointer) {
+    const char* p1 = ov_get_error_info(GENERAL_ERROR);
+    const char* p2 = ov_get_error_info(GENERAL_ERROR);
+    EXPECT_EQ(p1, p2) << "ov_get_error_info must return a pointer to static storage, not a newly allocated string";
+
+    // Every known status code must return a non-null, non-empty string.
+    const auto all_codes = {OK,
+                            GENERAL_ERROR,
+                            NOT_IMPLEMENTED,
+                            NETWORK_NOT_LOADED,
+                            PARAMETER_MISMATCH,
+                            NOT_FOUND,
+                            OUT_OF_BOUNDS,
+                            UNEXPECTED,
+                            REQUEST_BUSY,
+                            RESULT_NOT_READY,
+                            NOT_ALLOCATED,
+                            INFER_NOT_STARTED,
+                            NETWORK_NOT_READ,
+                            INFER_CANCELLED,
+                            INVALID_C_PARAM,
+                            UNKNOWN_C_ERROR,
+                            NOT_IMPLEMENT_C_METHOD,
+                            UNKNOW_EXCEPTION};
+    for (auto code : all_codes) {
+        const char* msg = ov_get_error_info(code);
+        EXPECT_NE(nullptr, msg) << "ov_get_error_info returned NULL for status " << code;
+        EXPECT_GT(std::strlen(msg), 0u) << "ov_get_error_info returned empty string for status " << code;
+        // Intentionally NOT calling ov_free(msg): the pointer is borrowed static storage.
+    }
+}
+
+TEST(ov_util, ov_get_error_info_out_of_range) {
+    const char* msg = ov_get_error_info(static_cast<ov_status_e>(-9999));
+    EXPECT_NE(nullptr, msg);
+    EXPECT_GT(std::strlen(msg), 0u);
+}


### PR DESCRIPTION
### Details:
 - Update C-API documentation about using the `ov_get_error_info` function
 - Add unit test to check pointer from error message

### Tickets:
- CVS-187633

