### PR TITLE
[GPU] Make moe_disable_fusion an internal property

### DIFF
--- a/.github/workflows/ubuntu_24.yml
+++ b/.github/workflows/ubuntu_24.yml
@@ -247,6 +247,7 @@ jobs:
       runner-group: 'Intel-GPU'
       image: ${{ fromJSON(needs.docker.outputs.images).ov_test.ubuntu_24_04_x64_dgpu }}
       options: "--group-add 44 --group-add 993 --device /dev/dri/renderD129:/dev/dri/renderD129"
+    if: ${{ github.event_name == 'schedule' }}
 
   dGPU_B580_Nightly:
       name: dGPU Arc-B580 Tests Nightly

--- a/.github/workflows/ubuntu_24.yml
+++ b/.github/workflows/ubuntu_24.yml
@@ -247,7 +247,6 @@ jobs:
       runner-group: 'Intel-GPU'
       image: ${{ fromJSON(needs.docker.outputs.images).ov_test.ubuntu_24_04_x64_dgpu }}
       options: "--group-add 44 --group-add 993 --device /dev/dri/renderD129:/dev/dri/renderD129"
-    if: ${{ github.event_name == 'schedule' }}
 
   dGPU_B580_Nightly:
       name: dGPU Arc-B580 Tests Nightly

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
@@ -167,7 +167,7 @@ static constexpr Property<bool, ov::PropertyMutability::RW> disable_horizontal_f
 static constexpr Property<bool, ov::PropertyMutability::RW> disable_fc_swiglu_fusion{"GPU_DISABLE_FC_SWIGLU_FUSION"};
 static constexpr Property<bool, ov::PropertyMutability::RW> disable_gated_mlp_fusion{"GPU_DISABLE_GATED_MLP_FUSION"};
 static constexpr Property<bool, ov::PropertyMutability::RW> disable_fake_alignment{"GPU_DISABLE_FAKE_ALIGNMENT"};
-static constexpr Property<bool, ov::PropertyMutability::RW> disable_moe_opt{"GPU_DISABLE_MOE_OPT"};
+static constexpr Property<bool, ov::PropertyMutability::RW> moe_disable_fusion{"GPU_MOE_DISABLE_FUSION"};
 static constexpr Property<bool, ov::PropertyMutability::RW> moe_use_micro_gemm_prefill{"GPU_MOE_USE_MICRO_GEMM_PREFILL"};
 static constexpr Property<bool, ov::PropertyMutability::RW> moe_use_gpu_mask_gen_prefill{"GPU_MOE_USE_GPU_MASK_GEN_PREFILL"};
 static constexpr Property<bool, ov::PropertyMutability::RW> moe_use_grouped_gemm_prefill{"GPU_MOE_USE_GROUPED_GEMM_PREFILL"};

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -66,6 +66,7 @@ OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, moe_use_micro_gemm_prefill, tru
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, moe_use_gpu_mask_gen_prefill, false, "MoE 3GEMM: generate routing masks on GPU instead of CPU for the micro-kernel prefill path")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, moe_use_grouped_gemm_prefill, true, "MoE 3GEMM: use a single OneDNN grouped matmul per GEMM layer for the prefill path. Takes priority over micro-kernel GEMM")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, moe_batched_gemv_threshold, 32, "MoE 3-GEMM: token count (<=) that selects the batched GEMV decode path instead of the prefill path")
+OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, moe_disable_fusion, false, "Disable fusion of MoE subgraph to composite MoE operation")
 
 OV_CONFIG_DEBUG_GLOBAL_OPTION(ov::intel_gpu, help, false, "Print help message for all config options")
 OV_CONFIG_DEBUG_GLOBAL_OPTION(ov::intel_gpu, verbose, 0, "Enable logging for debugging purposes. The higher value the more verbose output. 0 - Disabled, 4 - Maximum verbosity")
@@ -98,7 +99,6 @@ OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_horizontal_fc_fusion, false, "Disa
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_fc_swiglu_fusion, false, "Disable pass which merges FC and SwiGLU ops")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_gated_mlp_fusion, true, "Disable pass which fuses FC+SwiGLU to GatedMLP")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_fake_alignment, false, "Disable fake alignment feature which tries to keep gpu friendly memory alignment for arbitrary tensor shapes")
-OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_moe_opt, false, "Disable mixture of expert optimization")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_memory_reuse, false, "Disable memory reuse for activation tensors")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_runtime_skip_reorder, false, "Disable skip reorder optimization applied in runtime")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, load_dump_raw_binary, std::vector<std::string>{}, "List of layers to load raw binary")

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -592,8 +592,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             return false;
         }();
 
-        const bool disable_moe_opt = GPU_DEBUG_VALUE_OR(config.get_disable_moe_opt(), false);
-
         // MOE: TiledMoeBlock -> GatherMatmuls(compressed) -> MoeOp(compressed) -> MoeOpWithRouting(compressed).
         // Gated on supports_immad (systolic-only) and oneDNN (required for expert GEMM dispatch).
         // Note: even though we are already inside `if (supports_immad)`, oneDNN can still be explicitly disabled by the user.
@@ -612,7 +610,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 supported_compressed_weights_types);
             manager.register_pass<ov::intel_gpu::FuseMoERouter>();
 
-            if (!disable_moe_opt) {
+            if (!config.get_moe_disable_fusion()) {
                 // PA models flatten batch into seq.
                 const bool has_batch_dim = !is_pa;
                 // MOE3GemmCompressed kernel dispatches expert GEMMs through

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/moe.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/moe.cpp
@@ -87,7 +87,7 @@ protected:
     void SetUp() override {
         const auto& [moe_params, pattern_type, routing_type, wp, dp, sp, dm, ds, rd, gs, gi, fgm, act, pes, lnm, uwd] = GetParam();
         if (fgm) {
-            set_disable_moe_opt();
+            set_disable_moe_fusion();
         }
         targetDevice = ov::test::utils::DEVICE_GPU;
         // MoE fusion (and the GatherMatmul-based fallback) is gated on supports_immad.
@@ -201,24 +201,24 @@ protected:
     void TearDown() override {
         ov::test::SubgraphBaseTest::TearDown();
         if (std::get<11>(GetParam())) {
-            unset_disable_moe_opt();
+            unset_disable_moe_fusion();
         }
     }
 
 private:
-    static void set_disable_moe_opt() {
+    static void set_disable_moe_fusion() {
 #ifdef _WIN32
-        _putenv_s("OV_GPU_DISABLE_MOE_OPT", "1");
+        _putenv_s("OV_GPU_MOE_DISABLE_FUSION", "1");
 #else
-        ::setenv("OV_GPU_DISABLE_MOE_OPT", "1", 1);
+        ::setenv("OV_GPU_MOE_DISABLE_FUSION", "1", 1);
 #endif
     }
 
-    static void unset_disable_moe_opt() {
+    static void unset_disable_moe_fusion() {
 #ifdef _WIN32
-        _putenv_s("OV_GPU_DISABLE_MOE_OPT", "");
+        _putenv_s("OV_GPU_MOE_DISABLE_FUSION", "");
 #else
-        ::unsetenv("OV_GPU_DISABLE_MOE_OPT");
+        ::unsetenv("OV_GPU_MOE_DISABLE_FUSION");
 #endif
     }
 };


### PR DESCRIPTION
### Details:
 - `moe_disable_fusion` was previously a debug-only property (`OV_CONFIG_DEBUG_OPTION`), gated on `ENABLE_DEBUG_CAPS`. This caused `smoke_MoE*` functional tests to fail in release builds because the property was silently ignored when debug caps were disabled.
 - Promoted `moe_disable_fusion` to `OV_CONFIG_RELEASE_INTERNAL_OPTION` so it is registered and settable in all build types via the `OV_GPU_MOE_DISABLE_FUSION` environment variable.
 - Renamed the property from `GPU_DISABLE_MOE_OPT` to `GPU_MOE_DISABLE_FUSION` for consistency with the other MoE properties.

### Tickets:
 - *CVS-189663*

### AI Assistance:
 - AI assistance used: yes
 - Root cause analysis and fix approach identified with Claude Code. Change implemented and validated by human (build succeeded, nightly CI failures are pre-existing and unrelated to MoE).