### PR TITLE
[NPU][Tests] Update tests for older driver

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/import_export.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/import_export.hpp
@@ -8,6 +8,7 @@
 #include <sstream>
 
 #include "common/npu_test_env_cfg.hpp"
+#include "common/utils.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 #include "openvino/runtime/make_tensor.hpp"
@@ -121,6 +122,9 @@ TEST_P(OVCompiledGraphImportExportTestNPU, SameBlobAfterImportExport) {
 }
 
 TEST_P(OVCompiledGraphImportExportTestNPU, ImportingEncryptedBlobThrows) {
+    // Encryption callbacks require L0 graph ext version >= 1.17
+    NPU_SKIP_IF_GRAPH_EXT_LOWER_THAN(1, 17);
+
     ov::Core core;
     std::stringstream encrypted_blob_stream;
 
@@ -199,6 +203,9 @@ TEST_P(OVCompiledGraphImportExportTestNPU, SameEncryptedBlobViaExportAndManualFu
 }
 
 TEST_P(OVCompiledGraphImportExportTestNPU, DifferentSizesOfEncryptedVsDecryptedBlobWorks) {
+    // Encryption callbacks require L0 graph ext version >= 1.17
+    NPU_SKIP_IF_GRAPH_EXT_LOWER_THAN(1, 17);
+
     ov::Core core;
     std::stringstream encrypted_blob_stream;
 

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/model_cache.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/model_cache.hpp
@@ -7,8 +7,10 @@
 #include <behavior/compiled_model/model_cache.hpp>
 #include <memory>
 
+#include "common/utils.hpp"
 #include "common_test_utils/test_assertions.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
+#include "intel_npu/npu_private_properties.hpp"
 #include "openvino/core/model_util.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/add.hpp"
@@ -159,7 +161,33 @@ namespace test {
 
 namespace behavior {
 
-using OVWeightlessCacheAccuracyNPU = WeightlessCacheAccuracy;
+class OVWeightlessCacheAccuracyNPU : public WeightlessCacheAccuracy {
+protected:
+    void SetUp() override {
+        WeightlessCacheAccuracy::SetUp();
+
+        // Encryption not requested or secure compilation support is available
+        // > Nothing to skip, continue with the test
+        if (!m_do_encryption || !ov::test::utils::isGraphExtVersionLowerThan(1u, 17u)) {
+            return;
+        }
+
+        // Encryption requested and secure compilation support is not available for DRIVER path
+        // > Search compiler type in test config; for empty test config, check device default compiler
+        // > Skip test for DRIVER compiler
+        const auto& params = GetParam();
+        const auto& config = std::get<4>(params);
+
+        const auto it = config.find(ov::intel_npu::compiler_type.name());
+        const bool testUsesDriverCompiler =
+            (it != config.end()) ? (it->second.as<ov::intel_npu::CompilerType>() == ov::intel_npu::CompilerType::DRIVER)
+                                 : ov::test::utils::isDefaultDriverCompiler(m_target_device);
+
+        if (testUsesDriverCompiler) {
+            GTEST_SKIP() << "Secure compilation is not supported by the current DRIVER compiler.";
+        }
+    }
+};
 
 TEST_P(OVWeightlessCacheAccuracyNPU, SimpleTestModel) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.hpp
@@ -240,6 +240,9 @@ TEST_P(ClassPluginPropertiesTestSuite4NPU, CanNotSetGetInexistentProperty) {
 using ClassPluginPropertiesTestSuite5NPU = ClassExecutableNetworkGetPropertiesTestNPU;
 
 TEST_P(ClassPluginPropertiesTestSuite5NPU, CanSetMutablePropertiesToCompiledModel) {
+    // Encryption callbacks require L0 graph ext version >= 1.17
+    NPU_SKIP_IF_GRAPH_EXT_LOWER_THAN(1, 17);
+
     // ie.set_property won't call plugin Engine::SetConfig due to empty string-ov::Plugin map from core_impl
     // workaround to overcome this is to call first ie.get_property which calls get_plugin() from core_impl and
     // populates plugin map

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/life_time.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/life_time.hpp
@@ -158,6 +158,9 @@ TEST_P(OVHoldersTestNPU, LoadedRemoteContext) {
 }
 
 TEST_P(OVHoldersTestNPU, CompileModelWithEncryptionWorksAfterConfigDeallocate) {
+    // Encryption callbacks require L0 graph ext version >= 1.17
+    NPU_SKIP_IF_GRAPH_EXT_LOWER_THAN(1, 17);
+
     ov::CompiledModel compiled_model;
     {
         ov::AnyMap copy_configuration = configuration;

--- a/src/plugins/intel_npu/tests/functional/common/utils.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/utils.hpp
@@ -240,7 +240,7 @@ private:
 inline bool isDefaultDriverCompiler(const std::string& target_device) {
     ov::Core core;
     auto compiler_type = core.get_property(target_device, ov::intel_npu::compiler_type);
-    if (compiler_type == ov::intel_npu::CompilerType::DRIVER){
+    if (compiler_type == ov::intel_npu::CompilerType::DRIVER) {
         return true;
     }
     return false;
@@ -252,9 +252,11 @@ inline bool isGraphExtVersionLowerThan(uint32_t major, uint32_t minor) {
     return graph_ext_version < required_version;
 }
 
-#define NPU_SKIP_IF_GRAPH_EXT_LOWER_THAN(major, minor) \
-    if (ov::test::utils::isGraphExtVersionLowerThan(major, minor)) { \
-        GTEST_SKIP() << "Test skipped because L0 graph ext version is lower than " #major "." #minor; \
+#define NPU_SKIP_IF_GRAPH_EXT_LOWER_THAN(major, minor)                                                    \
+    {                                                                                                     \
+        if (ov::test::utils::isGraphExtVersionLowerThan(major, minor)) {                                  \
+            GTEST_SKIP() << "Test skipped because L0 graph ext version is lower than " #major "." #minor; \
+        }                                                                                                 \
     }
 
 }  // namespace utils

--- a/src/plugins/intel_npu/tests/functional/common/utils.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/utils.hpp
@@ -9,6 +9,7 @@
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 #include "common_test_utils/unicode_utils.hpp"
 #include "intel_npu/utils/logger/logger.hpp"
+#include "intel_npu/utils/zero/zero_init.hpp"
 #include "npu_test_env_cfg.hpp"
 #include "openvino/core/log.hpp"
 #include "openvino/runtime/core.hpp"
@@ -235,6 +236,26 @@ public:
 private:
     ov::log::Level _previousLevel;
 };
+
+inline bool isDefaultDriverCompiler(const std::string& target_device) {
+    ov::Core core;
+    auto compiler_type = core.get_property(target_device, ov::intel_npu::compiler_type);
+    if (compiler_type == ov::intel_npu::CompilerType::DRIVER){
+        return true;
+    }
+    return false;
+}
+
+inline bool isGraphExtVersionLowerThan(uint32_t major, uint32_t minor) {
+    const auto graph_ext_version = ::intel_npu::ZeroInitStructsHolder::getInstance()->getGraphDdiTable().version();
+    const auto required_version = ZE_MAKE_VERSION(major, minor);
+    return graph_ext_version < required_version;
+}
+
+#define NPU_SKIP_IF_GRAPH_EXT_LOWER_THAN(major, minor) \
+    if (ov::test::utils::isGraphExtVersionLowerThan(major, minor)) { \
+        GTEST_SKIP() << "Test skipped because L0 graph ext version is lower than " #major "." #minor; \
+    }
 
 }  // namespace utils
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -906,6 +906,24 @@ Example:
     </skip_config>
 
     <skip_config>
+        <message>UD12 driver does not support secure compilation</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <driver_version>2020568</driver_version>
+        </enable_rules>
+        <filters>
+            <filter>.*WeightlessCacheAccuracy.ReadConcatSplitAssign.*do_encryption=True.*(config=_|NPU_COMPILER_TYPE\[DRIVER\]).*</filter>
+            <filter>.*WeightlessCacheAccuracy.SingleConcatWithConstant.*do_encryption=True.*(config=_|NPU_COMPILER_TYPE\[DRIVER\]).*</filter>
+            <filter>.*WeightlessCacheAccuracy.TiWithLstmCell.*do_encryption=True.*config=_.*</filter>
+            <filter>.*OVClassCompiledModelPropertiesTests.CanUseCache.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
+            <filter>.*OVClassCompileModelWithCorrectPropertiesTest.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
+            <filter>.*OVClassCompiledModelGetPropertyTest.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
+            <filter>.*OVCompileModelGetExecutionDeviceTests.CanGetExecutionDeviceInfo.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
+            <filter>.*CompileModelWithCacheEncryptionTest.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
         <message>PV driver cannot compile models securely</message>
         <enable_rules>
             <backend>LEVEL0</backend>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -923,6 +923,17 @@ Example:
         </filters>
     </skip_config>
 
+    <!-- E#210236-->
+    <skip_config>
+        <message>Test fails sporadically with newer Windows drivers</message>
+        <enable_rules>
+            <operating_system>windows</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*samePlatformProduceTheSameBlobCacheEnabled.*</filter>
+        </filters>
+    </skip_config>
+
     <skip_config>
         <message>PV driver cannot compile models securely</message>
         <enable_rules>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -925,7 +925,7 @@ Example:
 
     <!-- E#210236-->
     <skip_config>
-        <message>Test fails sporadically with newer Windows drivers</message>
+        <message>Test fails sporadically on NPU Windows drivers</message>
         <enable_rules>
             <operating_system>windows</operating_system>
         </enable_rules>


### PR DESCRIPTION
### Details:
 - *Secure compilation requires L0 GraphExt version 1.17 or higher. Older drivers fail during compile_model with "Secure compilation is not supported by the current driver version.".* 
 - *Need to update and disable encryption tests so that an older release (UD12) driver can be used for NPU CI validation.*
   - *Adjusted `OVWeightlessCacheAccuracyNPU::SetUp()`: skip NPU weightless cache encryption tests when secure compilation is unsupported*
   - *Add skip rules for OV shared encryption tests on NPU: required for older NPU release driver (UD12).*
   - *Added helper functions in common/utils.hpp for checking default device compiler, L0 graph ext version.*
- *Disable `smoke_BehaviorTest/TestCompiledModelNPU.samePlatformProduceTheSameBlobCacheEnabled` due to sporadic failures seen for newer NPU Windows drivers.*

### Tickets:
 - *E-224319*
 - *E-210236*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
