### PR TITLE
[GPU] Enable zero-copy subbuffers for usm_device on iGPUs

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
@@ -14,13 +14,6 @@
 
 namespace cldnn {
 
-/// @brief Page size alignment constant for cache blob serialization.
-/// This value (4KB) matches the typical OS page size on Windows, Linux, and macOS.
-inline constexpr uint32_t CACHE_PAGE_SIZE = 4096;
-
-/// @brief Alignment requirement for individual weight buffers within cache blobs.
-/// This alignment (128 bytes) ensures optimal GPU memory access patterns for weight data.
-inline constexpr uint32_t CACHE_SUB_BUFFER_ALIGNMENT = 128;
 struct memory;
 
 class BinaryOutputBuffer : public OutputBuffer<BinaryOutputBuffer> {
@@ -60,21 +53,6 @@ public:
     }
     size_t get_offset() const {
         return _offset;
-    }
-    bool is_offset_page_aligned() const {
-        return (get_offset() % CACHE_PAGE_SIZE == 0);
-    }
-
-    size_t get_bytes_to_page_boundary() const {
-        return CACHE_PAGE_SIZE - (get_offset() % CACHE_PAGE_SIZE);
-    }
-
-    bool is_offset_sub_buffer_aligned() const {
-        return (get_offset() % CACHE_SUB_BUFFER_ALIGNMENT == 0);
-    }
-
-    size_t get_bytes_to_sub_buffer_boundary() const {
-        return CACHE_SUB_BUFFER_ALIGNMENT - (get_offset() % CACHE_SUB_BUFFER_ALIGNMENT);
     }
 
 private:
@@ -117,15 +95,13 @@ public:
     std::streambuf* get_streambuf() const {
         return _stream.rdbuf();
     }
-    bool has_mmap_tensor() const {
+    bool is_valid_tensor() const {
         return _tensor_base_ptr != nullptr;
     }
-
-    bool is_mmap_tensor_4K_aligned() const {
-        return has_mmap_tensor() && (reinterpret_cast<std::uintptr_t>(_tensor_base_ptr) % CACHE_PAGE_SIZE == 0);
+    bool is_tensor_aligned(const size_t alignment) const {
+        return is_valid_tensor() && reinterpret_cast<std::uintptr_t>(_tensor_base_ptr) % alignment == 0;
     }
-
-    const size_t* get_mmap_tensor() const {
+    const size_t* get_tensor() const {
         return _tensor_base_ptr;
     }
 
@@ -142,7 +118,6 @@ public:
     size_t get_offset() const {
         return _offset;
     }
-
     void seek_current_ptr(std::streamsize size) {
         // Get current stream position
         std::streampos current_pos = _stream.tellg();
@@ -150,21 +125,7 @@ public:
         _stream.seekg(current_pos + static_cast<std::streampos>(size));
         _offset += size;
     }
-    bool is_offset_page_aligned() const {
-        return (get_offset() % CACHE_PAGE_SIZE == 0);
-    }
 
-    size_t get_bytes_to_page_boundary() const {
-        return CACHE_PAGE_SIZE - (get_offset() % CACHE_PAGE_SIZE);
-    }
-
-    bool is_offset_sub_buffer_aligned() const {
-        return (get_offset() % CACHE_SUB_BUFFER_ALIGNMENT == 0);
-    }
-
-    size_t get_bytes_to_sub_buffer_boundary() const {
-        return CACHE_SUB_BUFFER_ALIGNMENT - (get_offset() % CACHE_SUB_BUFFER_ALIGNMENT);
-    }
     void setKernelImplParams(void* impl_params) {
         _impl_params = impl_params;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -18,6 +18,8 @@
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
+#include "openvino/util/memory.hpp"
+#include "openvino/core/memory_util.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
 #include "openvino/util/mmap_object.hpp"
 #include "primitive.hpp"
@@ -393,12 +395,16 @@ public:
         ob << make_data(&data_size, sizeof(size_t));
 
         bool do_weightless_caching = cache_info->save(ob, data_size);
+        const auto& engine = mem->get_engine();
+        const auto& dev_info = engine->get_device_info();
         if (!do_weightless_caching) {
-            if (is_alloc_host_accessible(_allocation_type)) {
-                if (!ob.is_encrypted() && !ob.is_offset_sub_buffer_aligned()) {
-                    std::vector<uint8_t> pad(ob.get_bytes_to_sub_buffer_boundary(), 0);
-                    ob << make_data(pad.data(), pad.size());
+            if (engine->can_use_host_usm_zero_copy() && !ob.is_encrypted()) {
+                if (const auto pad = ov::util::align_padding_size(dev_info.sub_buffer_base_alignment.value_or(0), ob.get_offset()); pad > 0) {
+                    std::vector<uint8_t> zeros(pad, 0);
+                    ob << make_data(zeros.data(), zeros.size());
                 }
+            }
+            if (is_alloc_host_accessible(_allocation_type)) {
                 ob << make_data(mem->buffer_ptr(), data_size);
             } else {
                 std::vector<uint8_t> _buf;
@@ -414,7 +420,7 @@ public:
         primitive_base<data>::load(ib);
     }
 
-    void load_weights(BinaryInputBuffer& ib, std::shared_ptr<WeightsMemory> weights_memory, memory_ptr model_tensor_base) {
+    void load_weights(BinaryInputBuffer& ib, std::shared_ptr<WeightsMemory> weights_memory, memory_ptr host_buffer_base_ptr) {
         layout output_layout = layout();
         ib >> output_layout;
 
@@ -430,29 +436,28 @@ public:
 
         bool weightless_caching = false;
         ib >> weightless_caching;
-
-        bool enable_zero_copy_mode = ib.is_mmap_tensor_4K_aligned() && ib.get_engine().get_device_info().arch >= gpu_arch::xe2 &&
-                                     ib.get_engine().get_device_info().dev_type == device_type::integrated_gpu &&
-                                     _allocation_type == allocation_type::usm_host && !weightless_caching &&
-                                     model_tensor_base != nullptr;
-        if (!enable_zero_copy_mode) {
+        const auto& dev_info = ib.get_engine().get_device_info();
+        const bool can_use_zero_copy_mode = ib.get_engine().can_use_host_usm_zero_copy() && ib.is_tensor_aligned(ov::util::min_page_alignment) &&
+                                            host_buffer_base_ptr != nullptr && !weightless_caching;
+        if (!can_use_zero_copy_mode) {
             mem = ib.get_engine().allocate_memory(output_layout, _allocation_type, false);
         }
 
         bool is_weightless_caching = cache_info->load(ib, mem, weights_memory, weightless_caching);
 
         if (!is_weightless_caching) {
-            if (is_alloc_host_accessible(_allocation_type)) {
-                if (!ib.is_encrypted() && !ib.is_offset_sub_buffer_aligned()) {
-                    std::vector<uint8_t> pad(ib.get_bytes_to_sub_buffer_boundary(), 0);
-                    ib >> make_data(pad.data(), pad.size());
+            if (ib.get_engine().can_use_host_usm_zero_copy() && !ib.is_encrypted()) {
+                // Advance input stream past padding so subbuffer base offset meets use_host_ptr() alignment requirements.
+                if (const auto pad = ov::util::align_padding_size(dev_info.sub_buffer_base_alignment.value_or(0), ib.get_offset()); pad > 0) {
+                    ib.seek_current_ptr(pad);
                 }
-                if (enable_zero_copy_mode) {
-                    mem = ib.get_engine().create_subbuffer(*model_tensor_base, output_layout, ib.get_offset());
-                    ib.seek_current_ptr(data_size);
-                } else {
-                    ib >> make_data(std::move(mem->buffer_ptr()), data_size);
-                }
+            }
+            // Zero-copy: create subbuffer referencing mmap'd cache without host-to-device transfer.
+            if (can_use_zero_copy_mode) {
+                mem = ib.get_engine().create_subbuffer(*host_buffer_base_ptr, output_layout, ib.get_offset());
+                ib.seek_current_ptr(data_size);
+            } else if (is_alloc_host_accessible(_allocation_type)) {
+                ib >> make_data(std::move(mem->buffer_ptr()), data_size);
             } else {
                 const size_t DATA_BLOCK_SIZE = 4 * 1024 * 1024;
                 auto& eng = ib.get_engine();

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
@@ -146,7 +146,7 @@ struct device_info {
     uint32_t num_ccs;                           ///< Number of compute command streamers
     uint32_t sub_device_idx;                    ///< Index of sub-device
     std::optional<uint32_t> cacheline_size;     ///< Cache line size in bytes
-
+    std::optional<uint32_t> sub_buffer_base_alignment;  ///< Alignment requirement (in bytes) for sub-buffer offsets
     pci_bus_info pci_info;                      ///< PCI bus information for the device
 
     uint64_t timer_resolution;                  ///< [ZE] Resolution of device timer used for profiling in cycles/sec

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
@@ -112,6 +112,9 @@ public:
     /// Checks if the current engine supports speicied allocation @p type
     bool supports_allocation(allocation_type type) const;
 
+    /// Returns true if current engine supports zero copy via host buffer access
+    bool can_use_host_usm_zero_copy() const;
+
     /// Returns device structure which represents stores device capabilities
     const device_info& get_device_info() const;
 

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -11,6 +11,8 @@
 #include "openvino/runtime/system_conf.hpp"
 #include "openvino/runtime/threading/cpu_streams_info.hpp"
 #include "openvino/util/file_util.hpp"
+#include "openvino/util/memory.hpp"
+#include "openvino/core/memory_util.hpp"
 #include "openvino/util/parallel_read_streambuf.hpp"
 #include "common_utils/parallel_mem_streambuf.hpp"
 
@@ -1985,10 +1987,13 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
         ob << state_initializer.first;
         ob << state_initializer.second;
     }
-
-    if (!ob.is_encrypted() && !ob.is_offset_page_aligned()) {
-        std::vector<uint8_t> pad(ob.get_bytes_to_page_boundary(), 0);
-        ob << make_data(pad.data(), pad.size());
+    
+    const auto& dev_info = get_engine().get_device_info();
+    if (!ob.is_encrypted() && get_engine().can_use_host_usm_zero_copy()) {
+        if (const auto pad = ov::util::align_padding_size(dev_info.cacheline_size.value_or(0), ob.get_offset()); pad > 0) {
+            std::vector<uint8_t> zeros(pad, 0);
+            ob << make_data(zeros.data(), zeros.size());
+        }
     }
 }
 
@@ -2017,12 +2022,11 @@ void program::load(cldnn::BinaryInputBuffer& ib,
         }
     }
 
-    const bool can_use_mmap_zero_copy = ib.is_mmap_tensor_4K_aligned() && _engine.get_device_info().arch >= gpu_arch::xe2 &&
-                                        _engine.get_device_info().dev_type == device_type::integrated_gpu && !_config.get_enable_weightless();
-    memory_ptr model_tensor_base_ptr = nullptr;
-    if (can_use_mmap_zero_copy) {
-        model_tensor_base_ptr =
-            ib.get_engine().create_hostbuffer(ib.get_mmap_tensor(),
+    memory_ptr host_buffer_base_ptr = nullptr;
+
+    if (ib.get_engine().can_use_host_usm_zero_copy() && !_config.get_enable_weightless() && ib.is_tensor_aligned(ov::util::min_page_alignment)) {
+        host_buffer_base_ptr =
+            ib.get_engine().create_hostbuffer(ib.get_tensor(),
                                               ib.get_stream_size(),
                                               allocation_type::cl_mem,
                                               layout({{static_cast<tensor::value_type>(ib.get_stream_size()), 1, 1, 1}, data_types::u8, format::bfyx}));
@@ -2055,7 +2059,7 @@ void program::load(cldnn::BinaryInputBuffer& ib,
         std::shared_ptr<cldnn::primitive> prim;
         ib >> prim;
         if (auto data_prim = dynamic_cast<cldnn::data*>(prim.get())) {
-            data_prim->load_weights(ib, weights_memory, model_tensor_base_ptr);
+            data_prim->load_weights(ib, weights_memory, host_buffer_base_ptr);
         }
         get_or_create(prim);
     }
@@ -2214,10 +2218,11 @@ void program::load(cldnn::BinaryInputBuffer& ib,
         state_initializers[variable_id] = initializers;
     }
 
-    // At the end of load
-    if (!ib.is_encrypted() && !ib.is_offset_page_aligned()) {
-        std::vector<uint8_t> pad(ib.get_bytes_to_page_boundary(), 0);
-        ib >> make_data(pad.data(), pad.size());
+    const auto& dev_info = get_engine().get_device_info();
+    if (!ib.is_encrypted() && get_engine().can_use_host_usm_zero_copy()) {
+        if (const auto pad = ov::util::align_padding_size(dev_info.cacheline_size.value_or(0), ib.get_offset()); pad > 0) {
+            ib.seek_current_ptr(pad);
+        }
     }
 }
 

--- a/src/plugins/intel_gpu/src/runtime/engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/engine.cpp
@@ -105,6 +105,11 @@ bool engine::supports_allocation(allocation_type type) const {
     return _device->get_mem_caps().support_allocation_type(type);
 }
 
+bool engine::can_use_host_usm_zero_copy() const {
+    const auto& info = get_device_info();
+    return info.dev_type == cldnn::device_type::integrated_gpu && info.arch >= cldnn::gpu_arch::xe2 && supports_allocation(cldnn::allocation_type::usm_host);
+}
+
 allocation_type engine::get_lockable_preferred_memory_allocation_type(bool is_image_layout) const {
     if (!use_unified_shared_memory() || is_image_layout)
         return get_default_allocation_type();

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -209,6 +209,9 @@ device_info init_device_info(const cl::Device& device, const cl::Context& contex
     info.sub_device_idx = std::numeric_limits<uint32_t>::max();
 
     info.cacheline_size = device.getInfo<CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE>();
+    // Alignment requirement (in bits) for sub-buffer offsets, converting to bytes and ensuring at least 1 byte alignment.
+    auto bits = device.getInfo<CL_DEVICE_MEM_BASE_ADDR_ALIGN>(); 
+    info.sub_buffer_base_alignment = std::max<uint32_t>(1, bits / 8);
     info.execution_units_count = device.getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>();
 
     info.gpu_frequency = static_cast<uint32_t>(device.getInfo<CL_DEVICE_MAX_CLOCK_FREQUENCY>());

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
@@ -4,7 +4,6 @@
 
 #include "ocl_engine.hpp"
 #include "intel_gpu/runtime/utils.hpp"
-#include "intel_gpu/graph/serialization/binary_buffer.hpp"  // For CACHE_PAGE_SIZE
 #include "openvino/runtime/intel_gpu/remote_properties.hpp"
 
 #include "ocl_kernel.hpp"
@@ -381,6 +380,7 @@ memory_ptr ocl_engine::create_hostbuffer_impl(void* cpu_address, size_t data_siz
 #ifdef CL_MEM_FORCE_HOST_MEMORY_INTEL
     const size_t minimal_alignment = static_cast<size_t>(get_device_info().cacheline_size.value_or(0));
     OPENVINO_ASSERT(minimal_alignment > 0, "[GPU] cacheline_size must be > 0 for host pointer import");
+    OPENVINO_ASSERT(cpu_address != nullptr, "[GPU] shared buffer pointer is invalid");
     OPENVINO_ASSERT((reinterpret_cast<std::uintptr_t>(cpu_address) % minimal_alignment) == 0,
                     "[GPU] shared buffer pointer must be ", minimal_alignment, "-byte aligned");
     OPENVINO_ASSERT((data_size % minimal_alignment) == 0,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/cache_serialization_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/cache_serialization_test.cpp
@@ -330,9 +330,12 @@ membuf make_oversized_data_blob(const layout& output_layout, size_t malicious_da
     ob << weightless_caching;
 
     // Mirror the reader's alignment padding so stream offsets stay in sync.
-    if (!ob.is_encrypted() && !ob.is_offset_sub_buffer_aligned()) {
-        std::vector<uint8_t> pad(ob.get_bytes_to_sub_buffer_boundary(), 0);
-        ob << make_data(pad.data(), pad.size());
+    if (get_test_engine().can_use_host_usm_zero_copy() && !ob.is_encrypted()) {
+        if (const auto pad = ov::util::align_padding_size(get_test_engine().get_device_info().sub_buffer_base_alignment.value_or(0), ob.get_offset());
+            pad > 0) {
+            std::vector<uint8_t> zeros(pad, 0);
+            ob << make_data(zeros.data(), zeros.size());
+        }
     }
 
     // Actually provide malicious_data_size bytes of payload so the vulnerable


### PR DESCRIPTION
[GPU] Enable zero-copy subbuffers for usm_device on iGPUs

#### Details:
Description of the issue (symptom, root-cause, how it was resolved)
- Zero-copy handling for `usm_host` and `usm_shared` was already implemented in
  earlier PRs (#34494, #36539); this PR focuses on closing the `usm_device` gap.
- Previously, for `usm_device` allocations, a separate GPU `usm_device` buffer
  was allocated and filled from mapped host buffer data during cache load,
  causing duplicate allocation/copy overhead and increasing inference memory
  footprint.
- This change enables zero-copy subbuffer usage for supported XE2+ iGPUs in the
  `usm_device` flow, removing extra staging/copy in applicable cases.
- Blob offset alignment handling in deserialization is kept correct for
  subbuffer creation.

Implementation changes:
- Extend zero-copy eligibility in `data.hpp` to include `usm_device` while
  preserving existing `usm_host`/`usm_shared` behavior.
- Add/use helper check for zero-copy-capable device (XE2+ integrated GPU).
- Use `seek_current_ptr()` for padding skip during deserialization alignment.
- Refine zero-copy condition naming/readability in load path.

Changed files:
src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
src/plugins/intel_gpu/src/graph/program.cpp
src/plugins/intel_gpu/src/runtime/engine.cpp
src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
src/plugins/intel_gpu/tests/unit/test_cases/cache_serialization_test.cpp

Reproduction step and snapshot (if applicable. Do not attach for customer model)
NA

Problematic graph
NA

#### Checklist
- [x] Is it a proper fix? Yes (removes duplicate `usm_device` staging/copy in
      supported zero-copy cases)
- [x] Did you include test case for this fix, if necessary? NA
- [x] Did you review existing test that can be extended to cover this scenario?
      NA

#### Tickets:
 - CVS-176160

#### AI Assistance:
 - AI assistance used: yes
 - AI was used for wording refinement and commit message cleanup.