### PR TITLE
[CPU][ARM] Fuse int8 FullyConnected output requantization into ACL GEMM

### DIFF
--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -272,10 +272,7 @@ void GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales(Graph& graph) {
         // (ConvertFullyConnectedBias), so the dequantization Multiply directly follows the FC and is folded as the
         // FC dequantization scale, enabling a fused quantized output stage.
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
-        if (none_of(parentNode->getType(),
-                    Type::Convolution,
-                    Type::MatMul,
-                    Type::FullyConnected)) {
+        if (none_of(parentNode->getType(), Type::Convolution, Type::MatMul, Type::FullyConnected)) {
             return false;
         }
 #else

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -268,9 +268,22 @@ void GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales(Graph& graph) {
         }
         auto parentNode = node->getParentEdgeAt(0)->getParent();
         auto scaleNode = node->getParentEdgeAt(1)->getParent();
+        // FullyConnected is included on ARM: the int8 ACL FC executor swaps bias before the dequantization Multiply
+        // (ConvertFullyConnectedBias), so the dequantization Multiply directly follows the FC and is folded as the
+        // FC dequantization scale, enabling a fused quantized output stage.
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+        if (none_of(parentNode->getType(),
+                    Type::Convolution,
+                    Type::MatMul,
+                    Type::Deconvolution,
+                    Type::FullyConnected)) {
+            return false;
+        }
+#else
         if (none_of(parentNode->getType(), Type::Convolution, Type::MatMul, Type::Deconvolution)) {
             return false;
         }
+#endif
         if (!scaleNode->isConstant()) {
             return false;
         }

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -268,9 +268,6 @@ void GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales(Graph& graph) {
         }
         auto parentNode = node->getParentEdgeAt(0)->getParent();
         auto scaleNode = node->getParentEdgeAt(1)->getParent();
-        // FullyConnected is included on ARM: the int8 ACL FC executor swaps bias before the dequantization Multiply
-        // (ConvertFullyConnectedBias), so the dequantization Multiply directly follows the FC and is folded as the
-        // FC dequantization scale, enabling a fused quantized output stage.
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
         if (none_of(parentNode->getType(), Type::Convolution, Type::MatMul, Type::FullyConnected)) {
             return false;

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -275,7 +275,6 @@ void GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales(Graph& graph) {
         if (none_of(parentNode->getType(),
                     Type::Convolution,
                     Type::MatMul,
-                    Type::Deconvolution,
                     Type::FullyConnected)) {
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_conv.cpp
@@ -101,13 +101,8 @@ ACLConvolutionExecutor::ACLConvolutionExecutor(const ConvAttrs& attrs,
                 }
             }
 
-            if (fqOutputScale.size() == 1 && fqOutputScale[0] == 1.0F && fqOutputShift.size() == 1 &&
-                fqOutputShift[0] == std::trunc(fqOutputShift[0])) {
-                for (auto& v : fqInputShift) {
-                    v += fqOutputShift[0];
-                }
-                fqOutputShift.clear();
-            }
+            foldFakeQuantizeOutputShift(fqInputShift, fqOutputScale, fqOutputShift);
+            fqOutputShift.clear();
         } else {
             OPENVINO_THROW("ACLConvolutionExecutor: the executor supports FakeQuantize and Activation post ops only");
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -9,6 +9,7 @@
 #include <arm_compute/core/QuantizationInfo.h>
 #include <arm_compute/core/TensorInfo.h>
 #include <arm_compute/core/TensorShape.h>
+#include <arm_compute/core/utils/quantization/AsymmHelpers.h>
 #include <arm_compute/function_info/GEMMInfo.h>
 
 #include <any>
@@ -31,6 +32,12 @@
 
 namespace ov::intel_cpu {
 
+// ACL destination requantization supports only per-tensor scale/shift, so the fused FakeQuantize
+// must carry single-element input scale/shift.
+static bool isPerTensorFakeQuantize(const FakeQuantizePostOp& fq) {
+    return fq.inputScale().size() == 1 && fq.inputShift().size() <= 1;
+}
+
 static bool checkPostOps(const PostOps& postOps) {
     if (postOps.empty()) {
         return true;
@@ -40,8 +47,12 @@ static bool checkPostOps(const PostOps& postOps) {
         return false;
     }
 
-    if (const auto& activation = std::any_cast<const ActivationPostOp>(postOps.data())) {
+    if (const auto* const activation = std::any_cast<const ActivationPostOp>(postOps.data())) {
         return checkActivationLayerInfo(convertToEltwiseAlgorithm(activation->type()));
+    }
+    if (const auto* const fq = std::any_cast<const FakeQuantizePostOp>(postOps.data())) {
+        // Per-tensor FakeQuantize is fused into the GEMM as a quantized output stage (i8/u8 dst).
+        return isPerTensorFakeQuantize(*fq);
     }
     return false;
 }
@@ -56,11 +67,13 @@ static void initFCAttrs(const FCAttrs& attrs,
     aclfcAttrs.weightsNonTransposed = attrs.weightsNonTransposed;
 
     if (!attrs.postOps.empty()) {
-        const auto& activation = std::any_cast<const ActivationPostOp&>(attrs.postOps[0]);
-        fullyConnectedLayerInfo.set_activation_info(getActivationLayerInfo(convertToEltwiseAlgorithm(activation.type()),
-                                                                           activation.alpha(),
-                                                                           activation.beta(),
-                                                                           activation.gamma()));
+        if (const auto* const activation = std::any_cast<const ActivationPostOp>(attrs.postOps.data())) {
+            fullyConnectedLayerInfo.set_activation_info(
+                getActivationLayerInfo(convertToEltwiseAlgorithm(activation->type()),
+                                       activation->alpha(),
+                                       activation->beta(),
+                                       activation->gamma()));
+        }
     }
 
     if (memory.at(ARG_SRC)->getPrecision() != memory.at(ARG_WEI)->getPrecision()) {
@@ -73,6 +86,17 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
                                                              const ExecutorContext::CPtr& context) {
     dequantizationScales = getDeQuantizedScales(memory);
     initFCAttrs(attrs, aclTensorAttrs, aclfcAttrs, memory, gemmInfo);
+
+    // Capture a fused per-tensor FakeQuantize requantization for the quantized dst path. The output scale/shift are
+    // applied as the GEMMLowp output stage built in validateTensorsInfo(); see acl_conv.cpp for the conv analogue.
+    hasQuantizedDst = any_of(memory.at(ARG_DST)->getPrecision(), ov::element::i8, ov::element::u8);
+    if (hasQuantizedDst && !attrs.postOps.empty()) {
+        if (const auto* const fq = std::any_cast<const FakeQuantizePostOp>(attrs.postOps.data())) {
+            fqInputScale = fq->inputScale();
+            fqInputShift = fq->inputShift();
+        }
+    }
+
     packedWeights =
         acl_fc_executor::prepareWeightMemory(memory, context, attrs, aclfcAttrs, expectedWeightFormat, weiTensorInfo);
 }
@@ -82,8 +106,21 @@ bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
            UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);
-    VERIFY(dstType(config) == ov::element::f32, UNSUPPORTED_DST_PRECISIONS);
+    // f32 dst keeps the dequantized-output path (no output stage). i8/u8 dst fuses a per-tensor FakeQuantize
+    // requantization into a GEMMLowp output stage. NEGEMMLowpMatrixMultiplyCore couples a quantized dst with an
+    // S32 bias (float dst requires F32 bias), so the bias precision is verified together with the dst type.
+    VERIFY(any_of(dstType(config), ov::element::f32, ov::element::i8, ov::element::u8), UNSUPPORTED_DST_PRECISIONS);
     VERIFY(checkPostOps(config.attrs.postOps), UNSUPPORTED_TYPE_OF_POSTOPS);
+    const bool isQuantizedDst = any_of(dstType(config), ov::element::i8, ov::element::u8);
+    if (isQuantizedDst) {
+        // The output stage requires a fused per-tensor FakeQuantize to derive the requantization multiplier.
+        const bool hasFakeQuantize = !config.attrs.postOps.empty() &&
+                                     std::any_cast<const FakeQuantizePostOp>(config.attrs.postOps.data()) != nullptr;
+        VERIFY(hasFakeQuantize, UNSUPPORTED_TYPE_OF_POSTOPS);
+        if (!config.descs.at(ARG_BIAS)->empty()) {
+            VERIFY(config.descs.at(ARG_BIAS)->getPrecision() == ov::element::i32, UNSUPPORTED_BIAS_PRECISIONS);
+        }
+    }
     VERIFY(any_of(srcRank(config), 2U, 3U, 4U), UNSUPPORTED_SRC_RANK);
     VERIFY(any_of(weiRank(config), 2U, 3U, 4U), UNSUPPORTED_WEI_RANK);
     return true;
@@ -103,6 +140,41 @@ arm_compute::Status ACLLowpFullyConnectedExecutor::validateTensorsInfo(const ACL
 
     const auto& tensor_info_weights = aclMemoryInfos[ACLArgs::ACL_WEI];
     tensor_info_weights->set_quantization_info(arm_compute::QuantizationInfo(1.F));
+
+    // Quantized dst path: derive the destination quantization from the fused per-tensor FakeQuantize and build a
+    // GEMMLowp output stage so NEGEMMLowpMatrixMultiplyCore requantizes int32 accumulators back to i8/u8 in-kernel.
+    // NEGEMMLowpMatrixMultiplyCore couples this with an S32 bias (verified in supports()); the float dst path keeps
+    // the default NONE output stage. The requantization multiplier follows ACL's own conv pipeline
+    // (CpuGemmConv2d -> calculate_quantized_multipliers): multiplier = src_scale * wei_scale / dst_scale.
+    const auto& tensor_info_dst = aclMemoryInfos[ACLArgs::ACL_DST];
+    const bool quantizedDst =
+        any_of(tensor_info_dst->data_type(), arm_compute::DataType::QASYMM8, arm_compute::DataType::QASYMM8_SIGNED);
+    if (hasQuantizedDst && quantizedDst) {
+        const auto dstPrecision =
+            tensor_info_dst->data_type() == arm_compute::DataType::QASYMM8_SIGNED ? ov::element::i8 : ov::element::u8;
+        tensor_info_dst->set_quantization_info(getDstQuantizationInfo(fqInputScale, fqInputShift, dstPrecision));
+
+        const auto oqinfo = tensor_info_dst->quantization_info().uniform();
+        const auto [type_min, type_max] =
+            arm_compute::quantization::get_min_max_values_from_quantized_data_type(tensor_info_dst->data_type());
+
+        arm_compute::GEMMLowpOutputStageInfo outputStage;
+        outputStage.type = arm_compute::GEMMLowpOutputStageType::QUANTIZE_DOWN_FIXEDPOINT;
+        outputStage.gemmlowp_offset = oqinfo.offset;
+        outputStage.gemmlowp_min_bound = type_min;
+        outputStage.gemmlowp_max_bound = type_max;
+        outputStage.is_quantized_per_channel = false;
+        outputStage.output_data_type = tensor_info_dst->data_type();
+        const auto multipliersStatus =
+            arm_compute::quantization::calculate_quantized_multipliers(tensor_info->quantization_info(),
+                                                                       tensor_info_weights->quantization_info(),
+                                                                       tensor_info_dst->quantization_info(),
+                                                                       outputStage);
+        if (!multipliersStatus) {
+            return multipliersStatus;
+        }
+        gemmInfo.set_gemmlowp_output_stage(outputStage);
+    }
 
     auto matMulValid = arm_compute::NEGEMMLowpMatrixMultiplyCore::validate(aclMemoryInfos[ACLArgs::ACL_SRC_0].get(),
                                                                            aclMemoryInfos[ACLArgs::ACL_WEI].get(),

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -85,13 +85,9 @@ static void initFCAttrs(const FCAttrs& attrs,
 ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attrs,
                                                              const MemoryArgs& memory,
                                                              const ExecutorContext::CPtr& context) {
-    // The (possibly per-channel) dequantization scale folded from the post-FC dequantization Multiply is provided via
-    // FCAttrs::dqScales (GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales), mirroring ConvAttrs::dqScales.
     dequantizationScales = attrs.dqScales;
     initFCAttrs(attrs, aclTensorAttrs, aclfcAttrs, memory, gemmInfo);
 
-    // Capture a fused per-tensor FakeQuantize requantization for the quantized dst path. The output scale/shift are
-    // applied as the GEMMLowp output stage built in validateTensorsInfo(); see acl_conv.cpp for the conv analogue.
     hasQuantizedDst = any_of(memory.at(ARG_DST)->getPrecision(), ov::element::i8, ov::element::u8);
     if (hasQuantizedDst && !attrs.postOps.empty()) {
         if (const auto* const fq = std::any_cast<const FakeQuantizePostOp>(attrs.postOps.data())) {
@@ -110,14 +106,10 @@ bool ACLLowpFullyConnectedExecutor::supports(const FCConfig& config) {
            UNSUPPORTED_ACL_COMMON_PRECONDITION);
     VERIFY(any_of(srcType(config), ov::element::u8, ov::element::i8), UNSUPPORTED_SRC_PRECISIONS);
     VERIFY(weiType(config) == ov::element::i8, UNSUPPORTED_WEI_PRECISIONS);
-    // f32 dst keeps the dequantized-output path (no output stage). i8/u8 dst fuses a per-tensor FakeQuantize
-    // requantization into a GEMMLowp output stage. NEGEMMLowpMatrixMultiplyCore couples a quantized dst with an
-    // S32 bias (float dst requires F32 bias), so the bias precision is verified together with the dst type.
     VERIFY(any_of(dstType(config), ov::element::f32, ov::element::i8, ov::element::u8), UNSUPPORTED_DST_PRECISIONS);
     VERIFY(checkPostOps(config.attrs.postOps), UNSUPPORTED_TYPE_OF_POSTOPS);
     const bool isQuantizedDst = any_of(dstType(config), ov::element::i8, ov::element::u8);
     if (isQuantizedDst) {
-        // The output stage requires a fused per-tensor FakeQuantize to derive the requantization multiplier.
         const bool hasFakeQuantize = !config.attrs.postOps.empty() &&
                                      std::any_cast<const FakeQuantizePostOp>(config.attrs.postOps.data()) != nullptr;
         VERIFY(hasFakeQuantize, UNSUPPORTED_TYPE_OF_POSTOPS);
@@ -135,10 +127,6 @@ void ACLLowpFullyConnectedExecutor::updateTensorsShapes(ACLShapes& aclMemoryShap
 }
 
 arm_compute::Status ACLLowpFullyConnectedExecutor::validateTensorsInfo(const ACLInfos& aclMemoryInfos) {
-    // The fused dequantization scales are applied as the weights QuantizationInfo, mirroring the ACL conv path
-    // (acl_conv.cpp): the activation QuantizationInfo stays trivial and the (possibly per-channel) requantization
-    // lives on the weights. calculate_quantized_multipliers() then produces
-    // multiplier_i = src_scale(1.0) * wei_scale[i] / dst_scale.
     const auto& tensor_info = aclMemoryInfos[ACLArgs::ACL_SRC_0];
     tensor_info->set_quantization_info(arm_compute::QuantizationInfo(1.F));
 
@@ -147,16 +135,8 @@ arm_compute::Status ACLLowpFullyConnectedExecutor::validateTensorsInfo(const ACL
                                                    ? arm_compute::QuantizationInfo(1.F)
                                                    : arm_compute::QuantizationInfo(dequantizationScales));
 
-    // Quantized dst path: derive the destination quantization from the fused per-tensor FakeQuantize and build a
-    // GEMMLowp output stage so NEGEMMLowpMatrixMultiplyCore requantizes int32 accumulators back to i8/u8 in-kernel.
-    // NEGEMMLowpMatrixMultiplyCore couples this with an S32 bias (verified in supports()); the float dst path keeps
-    // the default NONE output stage. The requantization multiplier follows ACL's own conv pipeline
-    // (CpuGemmConv2d -> calculate_quantized_multipliers): multiplier = src_scale * wei_scale / dst_scale.
     const auto& tensor_info_dst = aclMemoryInfos[ACLArgs::ACL_DST];
     if (hasQuantizedDst) {
-        // hasQuantizedDst (set in the ctor from the i8/u8 OV dst precision) always implies an ACL
-        // QASYMM8/QASYMM8_SIGNED dst, since initTensorInfo() maps S8/U8 to QASYMM8_SIGNED/QASYMM8 via
-        // convertToQuantizedType().
         const bool quantizedDst =
             any_of(tensor_info_dst->data_type(), arm_compute::DataType::QASYMM8, arm_compute::DataType::QASYMM8_SIGNED);
         OPENVINO_ASSERT(quantizedDst, "ACLLowpFullyConnectedExecutor: quantized dst expected for the output stage");
@@ -173,12 +153,6 @@ arm_compute::Status ACLLowpFullyConnectedExecutor::validateTensorsInfo(const ACL
         outputStage.gemmlowp_offset = oqinfo.offset;
         outputStage.gemmlowp_min_bound = type_min;
         outputStage.gemmlowp_max_bound = type_max;
-        // The FakeQuantize requantization (dst scale/shift) is always per-tensor here (gated by
-        // isPerTensorFakeQuantize() in checkPostOps()), but the weights quantization may be per-channel when the
-        // fused dequantization scale is a vector. calculate_quantized_multipliers() keys the per-channel multiplier
-        // path off the weights scale vector size, so the output stage must advertise it as per-channel accordingly.
-        // ACL's GEMMLowp accepts a QASYMM8_SIGNED weights tensor carrying a per-channel QuantizationInfo (the
-        // QSYMM8_PER_CHANNEL data type is not required); see CpuGemmLowpMatrixMultiplyCore::validate().
         outputStage.is_quantized_per_channel = dequantizationScales.size() > 1;
         outputStage.output_data_type = tensor_info_dst->data_type();
         const auto multipliersStatus =

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -13,6 +13,7 @@
 #include <arm_compute/function_info/GEMMInfo.h>
 
 #include <any>
+#include <cmath>
 #include <memory>
 
 #include "acl_fullyconnected_utils.hpp"
@@ -84,7 +85,10 @@ static void initFCAttrs(const FCAttrs& attrs,
 ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attrs,
                                                              const MemoryArgs& memory,
                                                              const ExecutorContext::CPtr& context) {
-    dequantizationScales = getDeQuantizedScales(memory);
+    // The (possibly per-channel) dequantization scale folded from the post-FC dequantization Multiply is provided via
+    // FCAttrs::dqScales on ARM (GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales), mirroring ConvAttrs::dqScales.
+    // Fall back to the ARG_DST_DEQ_SCALE memory (the FullyConnectedQuantizedLegacy path) when attrs carries none.
+    dequantizationScales = attrs.dqScales.empty() ? getDeQuantizedScales(memory) : attrs.dqScales;
     initFCAttrs(attrs, aclTensorAttrs, aclfcAttrs, memory, gemmInfo);
 
     // Capture a fused per-tensor FakeQuantize requantization for the quantized dst path. The output scale/shift are
@@ -94,6 +98,20 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
         if (const auto* const fq = std::any_cast<const FakeQuantizePostOp>(attrs.postOps.data())) {
             fqInputScale = fq->inputScale();
             fqInputShift = fq->inputShift();
+            const auto fqOutputScale = fq->outputScale();
+            const auto fqOutputShift = fq->outputShift();
+            // Fold an integer FakeQuantize output shift (with unit output scale) into the input shift, mirroring the
+            // conv path (acl_conv.cpp). For a signed i8 dst the requantization FakeQuantize is typically
+            // round(x * inScale + 128) - 128, i.e. inShift ~= +128 and outShift == -128; folding yields the true
+            // per-tensor output offset (~0) used as the GEMMLowp output stage offset. Without this fold the offset is
+            // wrong whenever inShift drifts just below 128 (the previous >=128 normalization in getDstQuantizationInfo
+            // does not see outShift), which corrupts the requantized result.
+            if (fqOutputScale.size() == 1 && fqOutputScale[0] == 1.0F && fqOutputShift.size() == 1 &&
+                fqOutputShift[0] == std::trunc(fqOutputShift[0])) {
+                for (auto& v : fqInputShift) {
+                    v += fqOutputShift[0];
+                }
+            }
         }
     }
 
@@ -131,25 +149,30 @@ void ACLLowpFullyConnectedExecutor::updateTensorsShapes(ACLShapes& aclMemoryShap
 }
 
 arm_compute::Status ACLLowpFullyConnectedExecutor::validateTensorsInfo(const ACLInfos& aclMemoryInfos) {
+    // The dequantization scales fused into the FC (the per-channel weight scale * per-tensor activation scale,
+    // collapsed to a single element by getDeQuantizedScales() when uniform) are applied as the weights
+    // QuantizationInfo, mirroring the ACL conv path (acl_conv.cpp): the activation QuantizationInfo stays trivial
+    // and the (possibly per-channel) requantization lives on the weights. calculate_quantized_multipliers() then
+    // produces multiplier_i = src_scale(1.0) * wei_scale[i] / dst_scale, i.e. one multiplier per output channel for
+    // a per-channel weight scale, or a single multiplier for the per-tensor case.
     const auto& tensor_info = aclMemoryInfos[ACLArgs::ACL_SRC_0];
-    if (dequantizationScales.empty()) {
-        tensor_info->set_quantization_info(arm_compute::QuantizationInfo(1.F));
-    } else {
-        tensor_info->set_quantization_info(arm_compute::QuantizationInfo(dequantizationScales[0]));
-    }
+    tensor_info->set_quantization_info(arm_compute::QuantizationInfo(1.F));
 
     const auto& tensor_info_weights = aclMemoryInfos[ACLArgs::ACL_WEI];
-    tensor_info_weights->set_quantization_info(arm_compute::QuantizationInfo(1.F));
+    tensor_info_weights->set_quantization_info(dequantizationScales.empty()
+                                                   ? arm_compute::QuantizationInfo(1.F)
+                                                   : arm_compute::QuantizationInfo(dequantizationScales));
 
     // Quantized dst path: derive the destination quantization from the fused per-tensor FakeQuantize and build a
     // GEMMLowp output stage so NEGEMMLowpMatrixMultiplyCore requantizes int32 accumulators back to i8/u8 in-kernel.
     // NEGEMMLowpMatrixMultiplyCore couples this with an S32 bias (verified in supports()); the float dst path keeps
     // the default NONE output stage. The requantization multiplier follows ACL's own conv pipeline
     // (CpuGemmConv2d -> calculate_quantized_multipliers): multiplier = src_scale * wei_scale / dst_scale.
+    // hasQuantizedDst (set in the ctor from the i8/u8 OV dst precision) already implies an ACL
+    // QASYMM8/QASYMM8_SIGNED dst, since initTensorInfo() maps S8/U8 to QASYMM8_SIGNED/QASYMM8 via
+    // convertToQuantizedType(), so no separate ACL data-type check is needed here.
     const auto& tensor_info_dst = aclMemoryInfos[ACLArgs::ACL_DST];
-    const bool quantizedDst =
-        any_of(tensor_info_dst->data_type(), arm_compute::DataType::QASYMM8, arm_compute::DataType::QASYMM8_SIGNED);
-    if (hasQuantizedDst && quantizedDst) {
+    if (hasQuantizedDst) {
         const auto dstPrecision =
             tensor_info_dst->data_type() == arm_compute::DataType::QASYMM8_SIGNED ? ov::element::i8 : ov::element::u8;
         tensor_info_dst->set_quantization_info(getDstQuantizationInfo(fqInputScale, fqInputShift, dstPrecision));
@@ -163,7 +186,13 @@ arm_compute::Status ACLLowpFullyConnectedExecutor::validateTensorsInfo(const ACL
         outputStage.gemmlowp_offset = oqinfo.offset;
         outputStage.gemmlowp_min_bound = type_min;
         outputStage.gemmlowp_max_bound = type_max;
-        outputStage.is_quantized_per_channel = false;
+        // The FakeQuantize requantization (dst scale/shift) is always per-tensor here (gated by
+        // isPerTensorFakeQuantize() in checkPostOps()), but the weights quantization may be per-channel when the
+        // fused dequantization scale is a vector. calculate_quantized_multipliers() keys the per-channel multiplier
+        // path off the weights scale vector size, so the output stage must advertise it as per-channel accordingly.
+        // ACL's GEMMLowp accepts a QASYMM8_SIGNED weights tensor carrying a per-channel QuantizationInfo (the
+        // QSYMM8_PER_CHANNEL data type is not required); see CpuGemmLowpMatrixMultiplyCore::validate().
+        outputStage.is_quantized_per_channel = dequantizationScales.size() > 1;
         outputStage.output_data_type = tensor_info_dst->data_type();
         const auto multipliersStatus =
             arm_compute::quantization::calculate_quantized_multipliers(tensor_info->quantization_info(),

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -84,8 +84,8 @@ static void initFCAttrs(const FCAttrs& attrs,
 
 ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attrs,
                                                              const MemoryArgs& memory,
-                                                             const ExecutorContext::CPtr& context) {
-    dequantizationScales = attrs.dqScales;
+                                                             const ExecutorContext::CPtr& context)
+    : dequantizationScales(attrs.dqScales) {
     initFCAttrs(attrs, aclTensorAttrs, aclfcAttrs, memory, gemmInfo);
 
     hasQuantizedDst = any_of(memory.at(ARG_DST)->getPrecision(), ov::element::i8, ov::element::u8);

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -13,7 +13,6 @@
 #include <arm_compute/function_info/GEMMInfo.h>
 
 #include <any>
-#include <cmath>
 #include <memory>
 
 #include "acl_fullyconnected_utils.hpp"
@@ -27,6 +26,7 @@
 #include "nodes/executors/fullyconnected_config.hpp"
 #include "nodes/executors/implementation_utils.hpp"
 #include "nodes/executors/memory_arguments.hpp"
+#include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 #include "utils/general_utils.h"
@@ -86,9 +86,8 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
                                                              const MemoryArgs& memory,
                                                              const ExecutorContext::CPtr& context) {
     // The (possibly per-channel) dequantization scale folded from the post-FC dequantization Multiply is provided via
-    // FCAttrs::dqScales on ARM (GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales), mirroring ConvAttrs::dqScales.
-    // Fall back to the ARG_DST_DEQ_SCALE memory (the FullyConnectedQuantizedLegacy path) when attrs carries none.
-    dequantizationScales = attrs.dqScales.empty() ? getDeQuantizedScales(memory) : attrs.dqScales;
+    // FCAttrs::dqScales (GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales), mirroring ConvAttrs::dqScales.
+    dequantizationScales = attrs.dqScales;
     initFCAttrs(attrs, aclTensorAttrs, aclfcAttrs, memory, gemmInfo);
 
     // Capture a fused per-tensor FakeQuantize requantization for the quantized dst path. The output scale/shift are
@@ -98,20 +97,7 @@ ACLLowpFullyConnectedExecutor::ACLLowpFullyConnectedExecutor(const FCAttrs& attr
         if (const auto* const fq = std::any_cast<const FakeQuantizePostOp>(attrs.postOps.data())) {
             fqInputScale = fq->inputScale();
             fqInputShift = fq->inputShift();
-            const auto fqOutputScale = fq->outputScale();
-            const auto fqOutputShift = fq->outputShift();
-            // Fold an integer FakeQuantize output shift (with unit output scale) into the input shift, mirroring the
-            // conv path (acl_conv.cpp). For a signed i8 dst the requantization FakeQuantize is typically
-            // round(x * inScale + 128) - 128, i.e. inShift ~= +128 and outShift == -128; folding yields the true
-            // per-tensor output offset (~0) used as the GEMMLowp output stage offset. Without this fold the offset is
-            // wrong whenever inShift drifts just below 128 (the previous >=128 normalization in getDstQuantizationInfo
-            // does not see outShift), which corrupts the requantized result.
-            if (fqOutputScale.size() == 1 && fqOutputScale[0] == 1.0F && fqOutputShift.size() == 1 &&
-                fqOutputShift[0] == std::trunc(fqOutputShift[0])) {
-                for (auto& v : fqInputShift) {
-                    v += fqOutputShift[0];
-                }
-            }
+            foldFakeQuantizeOutputShift(fqInputShift, fq->outputScale(), fq->outputShift());
         }
     }
 
@@ -149,12 +135,10 @@ void ACLLowpFullyConnectedExecutor::updateTensorsShapes(ACLShapes& aclMemoryShap
 }
 
 arm_compute::Status ACLLowpFullyConnectedExecutor::validateTensorsInfo(const ACLInfos& aclMemoryInfos) {
-    // The dequantization scales fused into the FC (the per-channel weight scale * per-tensor activation scale,
-    // collapsed to a single element by getDeQuantizedScales() when uniform) are applied as the weights
-    // QuantizationInfo, mirroring the ACL conv path (acl_conv.cpp): the activation QuantizationInfo stays trivial
-    // and the (possibly per-channel) requantization lives on the weights. calculate_quantized_multipliers() then
-    // produces multiplier_i = src_scale(1.0) * wei_scale[i] / dst_scale, i.e. one multiplier per output channel for
-    // a per-channel weight scale, or a single multiplier for the per-tensor case.
+    // The fused dequantization scales are applied as the weights QuantizationInfo, mirroring the ACL conv path
+    // (acl_conv.cpp): the activation QuantizationInfo stays trivial and the (possibly per-channel) requantization
+    // lives on the weights. calculate_quantized_multipliers() then produces
+    // multiplier_i = src_scale(1.0) * wei_scale[i] / dst_scale.
     const auto& tensor_info = aclMemoryInfos[ACLArgs::ACL_SRC_0];
     tensor_info->set_quantization_info(arm_compute::QuantizationInfo(1.F));
 
@@ -168,11 +152,14 @@ arm_compute::Status ACLLowpFullyConnectedExecutor::validateTensorsInfo(const ACL
     // NEGEMMLowpMatrixMultiplyCore couples this with an S32 bias (verified in supports()); the float dst path keeps
     // the default NONE output stage. The requantization multiplier follows ACL's own conv pipeline
     // (CpuGemmConv2d -> calculate_quantized_multipliers): multiplier = src_scale * wei_scale / dst_scale.
-    // hasQuantizedDst (set in the ctor from the i8/u8 OV dst precision) already implies an ACL
-    // QASYMM8/QASYMM8_SIGNED dst, since initTensorInfo() maps S8/U8 to QASYMM8_SIGNED/QASYMM8 via
-    // convertToQuantizedType(), so no separate ACL data-type check is needed here.
     const auto& tensor_info_dst = aclMemoryInfos[ACLArgs::ACL_DST];
     if (hasQuantizedDst) {
+        // hasQuantizedDst (set in the ctor from the i8/u8 OV dst precision) always implies an ACL
+        // QASYMM8/QASYMM8_SIGNED dst, since initTensorInfo() maps S8/U8 to QASYMM8_SIGNED/QASYMM8 via
+        // convertToQuantizedType().
+        const bool quantizedDst =
+            any_of(tensor_info_dst->data_type(), arm_compute::DataType::QASYMM8, arm_compute::DataType::QASYMM8_SIGNED);
+        OPENVINO_ASSERT(quantizedDst, "ACLLowpFullyConnectedExecutor: quantized dst expected for the output stage");
         const auto dstPrecision =
             tensor_info_dst->data_type() == arm_compute::DataType::QASYMM8_SIGNED ? ov::element::i8 : ov::element::u8;
         tensor_info_dst->set_quantization_info(getDstQuantizationInfo(fqInputScale, fqInputShift, dstPrecision));

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.hpp
@@ -42,8 +42,6 @@ private:
     ACLFCAttrs aclfcAttrs;
     std::vector<float> dequantizationScales;
 
-    // Requantization parameters captured from a fused per-tensor FakeQuantize post op.
-    // Populated only for the quantized destination path (i8/u8 dst); empty otherwise.
     std::vector<float> fqInputScale;
     std::vector<float> fqInputShift;
     bool hasQuantizedDst = false;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "acl_common_executor.hpp"
 #include "acl_fullyconnected_utils.hpp"
 #include "nodes/executors/fullyconnected_config.hpp"
@@ -39,6 +41,12 @@ private:
     MemoryCPtr packedWeights;
     ACLFCAttrs aclfcAttrs;
     std::vector<float> dequantizationScales;
+
+    // Requantization parameters captured from a fused per-tensor FakeQuantize post op.
+    // Populated only for the quantized destination path (i8/u8 dst); empty otherwise.
+    std::vector<float> fqInputScale;
+    std::vector<float> fqInputShift;
+    bool hasQuantizedDst = false;
 };
 
 using ACLLowpFullyConnectedExecutorPtr = std::shared_ptr<ACLLowpFullyConnectedExecutor>;

--- a/src/plugins/intel_cpu/src/nodes/executors/common/common_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/common_utils.hpp
@@ -74,11 +74,6 @@ inline void multiplyAndBroadcastScales(std::vector<float>& dstScales,
     }
 }
 
-// Fold an integer FakeQuantize output shift (with unit output scale) into the input shift. For a signed i8 dst the
-// requantization FakeQuantize is typically round(x * inScale + 128) - 128, i.e. inShift ~= +128 and outShift == -128;
-// folding yields the true per-tensor output offset (~0) used as the ACL requantization offset. Without this fold the
-// offset is wrong whenever inShift drifts just below 128 (getDstQuantizationInfo()'s >=128 normalization does not see
-// outShift), which corrupts the requantized result. Shared by the ACL int8 Convolution and FullyConnected executors.
 inline void foldFakeQuantizeOutputShift(std::vector<float>& fqInputShift,
                                         const std::vector<float>& fqOutputScale,
                                         const std::vector<float>& fqOutputShift) {

--- a/src/plugins/intel_cpu/src/nodes/executors/common/common_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/common_utils.hpp
@@ -74,6 +74,22 @@ inline void multiplyAndBroadcastScales(std::vector<float>& dstScales,
     }
 }
 
+// Fold an integer FakeQuantize output shift (with unit output scale) into the input shift. For a signed i8 dst the
+// requantization FakeQuantize is typically round(x * inScale + 128) - 128, i.e. inShift ~= +128 and outShift == -128;
+// folding yields the true per-tensor output offset (~0) used as the ACL requantization offset. Without this fold the
+// offset is wrong whenever inShift drifts just below 128 (getDstQuantizationInfo()'s >=128 normalization does not see
+// outShift), which corrupts the requantized result. Shared by the ACL int8 Convolution and FullyConnected executors.
+inline void foldFakeQuantizeOutputShift(std::vector<float>& fqInputShift,
+                                        const std::vector<float>& fqOutputScale,
+                                        const std::vector<float>& fqOutputShift) {
+    if (fqOutputScale.size() == 1 && fqOutputScale[0] == 1.0F && fqOutputShift.size() == 1 &&
+        fqOutputShift[0] == std::trunc(fqOutputShift[0])) {
+        for (auto& v : fqInputShift) {
+            v += fqOutputShift[0];
+        }
+    }
+}
+
 [[maybe_unused]] static std::vector<float> getDeQuantizedScales(const MemoryArgs& memory) {
     if (memory.find(ARG_DST_DEQ_SCALE) == memory.end()) {
         return {};

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 #include "config.h"
 #include "executor_config.hpp"
@@ -20,6 +21,11 @@ struct FCAttrs {
     bool constantWeights = true;
 
     ov::intel_cpu::Config::ModelType modelType = ov::intel_cpu::Config::ModelType::Unknown;
+
+    // Per-channel (or per-tensor) dequantization scales folded from the post-FC dequantization Multiply by
+    // GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales (ARM int8). Mirrors ConvAttrs::dqScales; consumed by the
+    // ACL int8 FullyConnected executor as the weights requantization scale.
+    std::vector<float> dqScales;
 
     PostOps postOps;
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
@@ -22,9 +22,6 @@ struct FCAttrs {
 
     ov::intel_cpu::Config::ModelType modelType = ov::intel_cpu::Config::ModelType::Unknown;
 
-    // Per-channel (or per-tensor) dequantization scales folded from the post-FC dequantization Multiply by
-    // GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales (ARM int8). Mirrors ConvAttrs::dqScales; consumed by the
-    // ACL int8 FullyConnected executor as the weights requantization scale.
     std::vector<float> dqScales;
 
     PostOps postOps;

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -108,12 +108,8 @@ static const TypeMapping aclFCTypeMapping {
 
 static const TypeMapping aclLowpFCTypeMapping {
     // {src, wei, bia, dst}                  pt<src, wei, bias, dst>
-    // Quantized dst: a per-tensor FakeQuantize requantization is fused into the GEMMLowp output stage. The bias is
-    // kept as i32 (provided by ConvertFullyConnectedBias on ARM); NEGEMMLowpMatrixMultiplyCore couples the quantized
-    // dst with an S32 bias, see ACLLowpFullyConnectedExecutor::supports().
     {{_u8, _i8, _i32 | _dynamic, _u8},             {bypass(), bypass(), bypass(),  bypass()}},
     {{_i8, _i8, _i32 | _dynamic, _i8},             {bypass(), bypass(), bypass(),  bypass()}},
-    // Float dst: dequantized output, no output stage, f32 bias.
     {{_u8 | _i8, _i8, _any, _f32},                 {bypass(), bypass(), use<3>(), bypass()}}
 };
 

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -108,6 +108,12 @@ static const TypeMapping aclFCTypeMapping {
 
 static const TypeMapping aclLowpFCTypeMapping {
     // {src, wei, bia, dst}                  pt<src, wei, bias, dst>
+    // Quantized dst: a per-tensor FakeQuantize requantization is fused into the GEMMLowp output stage. The bias is
+    // kept as i32 (provided by ConvertFullyConnectedBias on ARM); NEGEMMLowpMatrixMultiplyCore couples the quantized
+    // dst with an S32 bias, see ACLLowpFullyConnectedExecutor::supports().
+    {{_u8, _i8, _i32 | _dynamic, _u8},             {bypass(), bypass(), bypass(),  bypass()}},
+    {{_i8, _i8, _i32 | _dynamic, _i8},             {bypass(), bypass(), bypass(),  bypass()}},
+    // Float dst: dequantized output, no output stage, f32 bias.
     {{_u8 | _i8, _i8, _any, _f32},                 {bypass(), bypass(), use<3>(), bypass()}}
 };
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -574,10 +574,6 @@ void FullyConnected::initSupportedPrimitiveDescriptors() {
     attrs.dynamicQuantizationGroupSize = context->getConfig().fcDynamicQuantizationGroupSize;
     attrs.modelType = context->getConfig().modelType;
 
-    // Per-channel dequantization scales folded from the post-FC dequantization Multiply
-    // (GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales on ARM int8). Mirrors Convolution::initSupportedPrimitive-
-    // Descriptors(); the ACL int8 FC executor applies them as the weights requantization scale so the per-channel
-    // requantization is fused into the GEMMLowp output stage instead of running as a standalone Multiply.
     attrs.dqScales = getDQScales();
 
     attrs.postOps = getPostOps(fusedWith);

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -574,6 +574,12 @@ void FullyConnected::initSupportedPrimitiveDescriptors() {
     attrs.dynamicQuantizationGroupSize = context->getConfig().fcDynamicQuantizationGroupSize;
     attrs.modelType = context->getConfig().modelType;
 
+    // Per-channel dequantization scales folded from the post-FC dequantization Multiply
+    // (GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales on ARM int8). Mirrors Convolution::initSupportedPrimitive-
+    // Descriptors(); the ACL int8 FC executor applies them as the weights requantization scale so the per-channel
+    // requantization is fused into the GEMMLowp output stage instead of running as a standalone Multiply.
+    attrs.dqScales = getDQScales();
+
     attrs.postOps = getPostOps(fusedWith);
 
     const auto& srcTypes = getOriginalInputPrecisions();

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_fc_bias.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_fc_bias.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #include "convert_fc_bias.hpp"
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_fc_bias.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_fc_bias.cpp
@@ -1,0 +1,85 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "convert_fc_bias.hpp"
+
+#include <memory>
+
+#include "fc_mul_add_fq_block.hpp"
+#include "low_precision/network_helper.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/node.hpp"
+#include "openvino/core/node_output.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/core/type.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/round.hpp"
+#include "openvino/opsets/opset1.hpp"
+#include "openvino/pass/matcher_pass.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "ov_ops/type_relaxed.hpp"
+#include "transformations/rt_info/dequantization_node.hpp"
+
+using namespace ov::pass;
+
+ov::intel_cpu::ConvertFullyConnectedBias::ConvertFullyConnectedBias() {
+    auto fc_mul_add_fq = std::make_shared<ov::intel_cpu::FCMulAddFQBlock>(true);
+
+    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        const auto matmul_out = fc_mul_add_fq->get_anchor("matmul", pattern_map);
+        const auto mul_out = fc_mul_add_fq->get_anchor("multiply", pattern_map);
+        const auto add_out = fc_mul_add_fq->get_anchor("add", pattern_map);
+        const auto fq_out = fc_mul_add_fq->get_anchor("fake_quantize", pattern_map);
+        if (!matmul_out || !mul_out || !add_out || !fq_out) {
+            return false;
+        }
+
+        auto fakeQuantize = ov::as_type_ptr<ov::op::v0::FakeQuantize>(fq_out->get_node_shared_ptr());
+        auto mul = mul_out->get_node_shared_ptr();
+        auto matmul = matmul_out->get_node_shared_ptr();
+        auto add = add_out->get_node_shared_ptr();
+        if (!fakeQuantize || !mul || !matmul || !add) {
+            return false;
+        }
+
+        // ACL int8 FullyConnected requantization requires the activation and FakeQuantize output types to match.
+        if (fakeQuantize->get_output_element_type(0) != matmul->get_input_element_type(0)) {
+            return false;
+        }
+        auto new_mul = ov::as_type_ptr<ov::opset1::Multiply>(
+            low_precision::NetworkHelper::swapMultiplyAndAdd(ov::as_type_ptr<ov::opset1::Add>(add), 0));
+        if (!new_mul) {
+            return false;
+        }
+        // mark Multiply as dequantization node to avoid its conversion to PowerStatic
+        ov::mark_as_dequantization_node(new_mul);
+
+        add = ov::as_type_ptr<ov::opset1::Add>(new_mul->get_input_node_shared_ptr(0));
+        auto bias_const = ov::as_type_ptr<ov::op::v0::Constant>(add->get_input_node_shared_ptr(1));
+        if (!add || !bias_const) {
+            return false;
+        }
+        auto round = std::make_shared<ov::op::v5::Round>(bias_const, ov::op::v5::Round::RoundMode::HALF_TO_EVEN);
+        auto convert_to_i32 = std::make_shared<ov::op::v0::Convert>(round, ov::element::i32);
+
+        auto new_add = std::make_shared<ov::op::TypeRelaxed<ov::op::v1::Add>>(
+            ov::element::TypeVector{ov::element::f32, ov::element::f32},
+            ov::element::TypeVector{ov::element::f32},
+            ov::op::TemporaryReplaceOutputType(add->input_value(0), ov::element::f32).get(),
+            ov::op::TemporaryReplaceOutputType(convert_to_i32->output(0), ov::element::f32).get());
+        new_add->set_friendly_name(add->get_friendly_name());
+        ov::copy_runtime_info({add, bias_const}, {round, convert_to_i32, new_add});
+        ov::replace_node(add, new_add);
+
+        return true;
+    };
+
+    auto matcher = std::make_shared<pattern::Matcher>(fc_mul_add_fq, "ConvertFullyConnectedBias");
+    register_matcher(matcher, callback);
+}

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_fc_bias.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_fc_bias.hpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #pragma once
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_fc_bias.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_fc_bias.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+
+/*
+ * Description:
+ *     ConvertFullyConnectedBias detects the int8 FullyConnected requantization pattern
+ *     MatMul -> Multiply -> Add(bias) -> FakeQuantize
+ *     and inserts a Convert to i32 between the constant bias and the Add node.
+ *     Convert to i32 is necessary because the ACL int8 FullyConnected executor supports i32 bias only.
+ *     Also, the order of Add and Multiply is swapped to satisfy ACL requirements (the dequantization Multiply
+ *     must directly follow the GEMM, with the bias added as an i32 input). This mirrors ConvertConvolutionBias.
+ *
+ * Before:  MatMul -> Multiply -> Add(bias f16/f32) -> FakeQuantize -> Result
+ * After:   MatMul -> Add(Round(bias)->Convert i32) -> Multiply -> FakeQuantize -> Result
+ *
+ * Supported patterns:
+ *     1. u8 source, i8 weights
+ *     2. i8 source, i8 weights
+ */
+
+namespace ov::intel_cpu {
+
+class ConvertFullyConnectedBias : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("ConvertFullyConnectedBias");
+    ConvertFullyConnectedBias();
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/fc_mul_add_fq_block.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/fc_mul_add_fq_block.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "fc_mul_add_fq_block.hpp"
+
+#include <memory>
+
+#include "openvino/core/node.hpp"
+#include "openvino/core/node_output.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/pass/pattern/op/block.hpp"
+#include "openvino/pass/pattern/op/label.hpp"
+#include "openvino/pass/pattern/op/predicate.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+using namespace ov::pass::pattern;
+
+ov::intel_cpu::FCMulAddFQBlock::FCMulAddFQBlock(const bool require_int_fq_output)
+    : ov::pass::pattern::op::Block({}, {}, "FCMulAddFQBlock") {
+    // int8 FullyConnected is lowered to a MatMul with i8 activations and i8 weights.
+    auto activation = any_input(type_matches_any({element::i8, element::u8}));
+    auto weights = any_input(type_matches(element::i8));
+    auto matmul = wrap_type<ov::op::v0::MatMul>({activation, weights});
+
+    auto multiply = wrap_type<ov::op::v1::Multiply>({matmul, any_input()});
+    auto bias_const = wrap_type<ov::op::v0::Constant>([](const ov::Output<ov::Node>& output) {
+        return !type_matches(ov::element::i32)(output);
+    });
+    auto add = wrap_type<ov::op::v1::Add>({multiply, bias_const});
+
+    ov::pass::pattern::op::Predicate predicate =
+        require_int_fq_output ? type_matches_any({element::i8, element::u8}) : ov::pass::pattern::op::Predicate();
+    auto fake_quantize =
+        wrap_type<ov::op::v0::FakeQuantize>({add, any_input(), any_input(), any_input(), any_input()}, predicate);
+
+    m_inputs = ov::OutputVector{matmul};
+    m_outputs = ov::OutputVector{fake_quantize};
+
+    register_anchor("matmul", matmul);
+    register_anchor("multiply", multiply);
+    register_anchor("add", add);
+    register_anchor("fake_quantize", fake_quantize);
+}

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/fc_mul_add_fq_block.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/fc_mul_add_fq_block.cpp
@@ -4,8 +4,6 @@
 
 #include "fc_mul_add_fq_block.hpp"
 
-#include <memory>
-
 #include "openvino/core/node.hpp"
 #include "openvino/core/node_output.hpp"
 #include "openvino/core/type/element_type.hpp"
@@ -16,6 +14,7 @@
 #include "openvino/op/multiply.hpp"
 #include "openvino/pass/pattern/op/block.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/predicate.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/fc_mul_add_fq_block.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/fc_mul_add_fq_block.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/pattern/op/block.hpp"
+
+/*
+ * Description:
+ *     FCMulAddFQBlock is a reusable pattern block that matches the int8 FullyConnected requantization chain:
+ *         MatMul -> Multiply -> Add -> FakeQuantize
+ *
+ *     The MatMul activation and weights inputs are i8 (the int8 FullyConnected case lowered by LPT). The bias Add
+ *     consumes a non-i32 constant; the FakeQuantize requantizes the result back to i8/u8.
+ */
+
+namespace ov::intel_cpu {
+
+class FCMulAddFQBlock : public ov::pass::pattern::op::Block {
+public:
+    explicit FCMulAddFQBlock(bool require_int_fq_output);
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -297,8 +297,6 @@ bool isACLInt8MatMulFQChainMarked(const std::shared_ptr<Node>& node) {
     if (!match_acl_int8_matmul_fq_chain(node)) {
         return false;
     }
-    // Keep the no-activation MatMul-Add-Mul-FQ requantization chain out of Subgraph tokenization so it can be
-    // fused into the int8 ACL FullyConnected executor's quantized output stage.
     snippets::pass::SetSnippetsNodeType(node, snippets::pass::SnippetsNodeType::SkippedByPlugin);
 
     const auto mul = ov::as_type_ptr<ov::op::v1::Multiply>(node->get_input_node_shared_ptr(0));

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -292,6 +292,26 @@ bool isACLInt8ConvFQChainMarked(const std::shared_ptr<Node>& node) {
     }
     return true;
 }
+
+bool isACLInt8MatMulFQChainMarked(const std::shared_ptr<Node>& node) {
+    if (!match_acl_int8_matmul_fq_chain(node)) {
+        return false;
+    }
+    // Keep the no-activation MatMul-Add-Mul-FQ requantization chain out of Subgraph tokenization so it can be
+    // fused into the int8 ACL FullyConnected executor's quantized output stage.
+    snippets::pass::SetSnippetsNodeType(node, snippets::pass::SnippetsNodeType::SkippedByPlugin);
+
+    const auto mul = ov::as_type_ptr<ov::op::v1::Multiply>(node->get_input_node_shared_ptr(0));
+    if (!mul) {
+        return true;
+    }
+    snippets::pass::SetSnippetsNodeType(mul, snippets::pass::SnippetsNodeType::SkippedByPlugin);
+
+    if (const auto add = ov::as_type_ptr<ov::op::v1::Add>(mul->get_input_node_shared_ptr(0)); add) {
+        snippets::pass::SetSnippetsNodeType(add, snippets::pass::SnippetsNodeType::SkippedByPlugin);
+    }
+    return true;
+}
 #endif
 
 }  // namespace
@@ -308,6 +328,9 @@ bool SnippetsMarkSkipped::run_on_model(const std::shared_ptr<ov::Model>& m) {
             continue;
         }
         if (isACLInt8ConvFQChainMarked(node)) {
+            continue;
+        }
+        if (isACLInt8MatMulFQChainMarked(node)) {
             continue;
         }
 #endif

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -240,6 +240,7 @@
 #    include "openvino/opsets/opset1_decl.hpp"
 #    include "transformations/cpu_opset/arm/pass/align_unsupported_lp_conv_fq_precision.hpp"
 #    include "transformations/cpu_opset/arm/pass/convert_conv_bias.hpp"
+#    include "transformations/cpu_opset/arm/pass/convert_fc_bias.hpp"
 #    include "transformations/cpu_opset/arm/pass/convert_group_conv.hpp"
 #    include "transformations/cpu_opset/arm/pass/convert_group_conv1d.hpp"
 #    include "transformations/cpu_opset/arm/pass/convert_reduce_multi_axis.hpp"
@@ -966,6 +967,7 @@ void Transformations::runLptPasses(const std::vector<ov::element::Type>& default
     lowPrecPass->add_markup<AlignUnsupportedLPConvFQPrecision>();
 #endif
     CPU_REGISTER_PASS_ARM(lptManager, ConvertConvolutionBias);
+    CPU_REGISTER_PASS_ARM(lptManager, ConvertFullyConnectedBias);
     CPU_REGISTER_PASS_ARM(lptManager, FallbackUnsupportedLPConvToFP16);
     CPU_SET_CALLBACK_ARM(
         lptManager,
@@ -1631,7 +1633,8 @@ void Transformations::PostSnippets() {
     CPU_SET_CALLBACK_ARM(
         postSnippetsManager,
         [](const_node_ptr& node) -> bool {
-            return match_acl_int8_pooling_fq_chain(node) || match_acl_int8_conv_fq_chain(node);
+            return match_acl_int8_pooling_fq_chain(node) || match_acl_int8_conv_fq_chain(node) ||
+                   match_acl_int8_matmul_fq_chain(node);
         },
         ov::pass::FakeQuantizeDecomposition);
     CPU_REGISTER_PASS_COMMON(postSnippetsManager, ov::pass::FakeConvertDecomposition);

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -121,10 +121,6 @@ bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node) {
 }
 
 bool match_acl_int8_matmul_fq_chain(const std::shared_ptr<const ov::Node>& node) {
-    // Returns true if a MatMul-Add-Mul-FQ chain (the no-activation int8 requantization) will be fused into the int8
-    // ACL FullyConnected executor and handled as a quantized output stage. The chain order is the post-swap form
-    // produced by ConvertFullyConnectedBias on ARM (bias Add before dequantization Multiply), mirroring the conv
-    // ConvAddMul pattern. The ACL int8 FC executor supports only matching activation and FQ output types.
     if (!ov::is_type<const ov::op::v0::FakeQuantize>(node) ||
         none_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
         return false;
@@ -146,9 +142,6 @@ bool match_acl_int8_matmul_fq_chain(const std::shared_ptr<const ov::Node>& node)
         return false;
     }
 
-    // The ACL int8 FC executor requantizes through a per-tensor output stage only. Per-channel requantization must
-    // stay decomposed (snippet), otherwise the kept FakeQuantize would have no executor to fuse into. The FakeQuantize
-    // input range (ports 1-2) is per-tensor when its constants hold a single element.
     const auto is_per_tensor_input = [](const ov::Output<ov::Node>& input) {
         const auto constant = ov::as_type_ptr<const ov::op::v0::Constant>(input.get_node_shared_ptr());
         return constant != nullptr && shape_size(constant->get_shape()) == 1;

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -20,8 +20,10 @@
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/avg_pool.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/matmul.hpp"
 #include "openvino/op/max_pool.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/util/attr_types.hpp"
@@ -116,6 +118,42 @@ bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node) {
     return ov::is_type<const ov::op::v0::FakeQuantize>(node) &&
            any_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8) &&
            (match_conv_fq_same_types(node) || match_fq_mul_conv_bias_same_types(node, FQMulAddPattern::ConvAddMul));
+}
+
+bool match_acl_int8_matmul_fq_chain(const std::shared_ptr<const ov::Node>& node) {
+    // Returns true if a MatMul-Add-Mul-FQ chain (the no-activation int8 requantization) will be fused into the int8
+    // ACL FullyConnected executor and handled as a quantized output stage. The chain order is the post-swap form
+    // produced by ConvertFullyConnectedBias on ARM (bias Add before dequantization Multiply), mirroring the conv
+    // ConvAddMul pattern. The ACL int8 FC executor supports only matching activation and FQ output types.
+    if (!ov::is_type<const ov::op::v0::FakeQuantize>(node) ||
+        none_of(node->get_output_element_type(0), ov::element::Type_t::u8, ov::element::Type_t::i8)) {
+        return false;
+    }
+
+    auto matmul_m =
+        wrap_type<ov::op::v0::MatMul>({any_input(type_matches_any({ov::element::i8, ov::element::u8})), any_input()});
+    auto add_m = wrap_type<ov::op::v1::Add>({matmul_m, any_input()});
+    auto mul_m = wrap_type<ov::op::v1::Multiply>({add_m, any_input()});
+    auto fq_m = wrap_type<ov::op::v0::FakeQuantize>({mul_m, any_input(), any_input(), any_input(), any_input()});
+    Matcher matcher(fq_m);
+    if (!matcher.match(std::const_pointer_cast<ov::Node>(node))) {
+        return false;
+    }
+
+    const auto& pattern_map = matcher.get_pattern_value_map();
+    const auto matmul = pattern_map.at(matmul_m).get_node_shared_ptr();
+    if (matmul->get_input_element_type(0) != node->get_output_element_type(0)) {
+        return false;
+    }
+
+    // The ACL int8 FC executor requantizes through a per-tensor output stage only. Per-channel requantization must
+    // stay decomposed (snippet), otherwise the kept FakeQuantize would have no executor to fuse into. The FakeQuantize
+    // input range (ports 1-2) is per-tensor when its constants hold a single element.
+    const auto is_per_tensor_input = [](const ov::Output<ov::Node>& input) {
+        const auto constant = ov::as_type_ptr<const ov::op::v0::Constant>(input.get_node_shared_ptr());
+        return constant != nullptr && shape_size(constant->get_shape()) == 1;
+    };
+    return is_per_tensor_input(node->input_value(1)) && is_per_tensor_input(node->input_value(2));
 }
 
 bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& node,

--- a/src/plugins/intel_cpu/src/transformations/utils.hpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.hpp
@@ -57,6 +57,8 @@ bool match_conv_fq_same_types(const std::shared_ptr<const ov::Node>& node);
 
 bool match_acl_int8_conv_fq_chain(const std::shared_ptr<const ov::Node>& node);
 
+bool match_acl_int8_matmul_fq_chain(const std::shared_ptr<const ov::Node>& node);
+
 bool match_acl_int8_pooling_fq_chain(const std::shared_ptr<const ov::Node>& node);
 
 bool is_acl_int8_avg_pool_lpt_skipped(const std::shared_ptr<const ov::Node>& node,

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_fc_bias.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_fc_bias.cpp
@@ -29,9 +29,6 @@
 
 using namespace ov::intel_cpu;
 
-// int8 FullyConnected is lowered to a MatMul(act, weights) at this stage. The MatMul is built as a TypeRelaxed
-// op with f32 internal types for the quantized case (mirroring createConvolution in convert_conv_bias.cpp).
-// Shapes: activation {1, 64} x weights {64, 16} -> output {1, 16}, bias {1, 16} broadcasts on the output.
 static std::shared_ptr<ov::Node> createMatMul(ov::element::Type input_type,
                                               ov::element::Type weights_type,
                                               std::shared_ptr<ov::op::v0::Parameter>& input) {
@@ -75,10 +72,6 @@ static std::shared_ptr<ov::op::v0::FakeQuantize> createFakeQuantize(const ov::Ou
         ov::test::utils::make_fake_quantize(input, input_type, levels, {}, {low}, {high}, {low}, {high}));
 }
 
-// Build the per-channel (or per-tensor) dequantization scale Constant. The scale lives on the MatMul output channel
-// (last) axis; a {1, 16} per-channel scale exercises the int8 FC per-channel requantization path, while a {1}
-// per-tensor scale exercises the common per-tensor case. ConvertFullyConnectedBias only swaps the Multiply/Add and
-// rounds the bias, so it must apply to both shapes identically.
 static std::shared_ptr<ov::op::v0::Constant> createDequantScale(bool per_channel) {
     if (per_channel) {
         std::vector<float> scales(16);
@@ -123,7 +116,6 @@ static std::shared_ptr<ov::Model> createRefGraph(ov::element::Type input_type,
     auto round = std::make_shared<ov::op::v5::Round>(bias, ov::op::v5::Round::RoundMode::HALF_TO_EVEN);
     auto convert = std::make_shared<ov::op::v0::Convert>(round, ov::element::i32);
 
-    // The transformation creates a TypeRelaxed Add and then swaps Add/Multiply.
     auto add = createAdd(matmul, convert, true);
     auto dequant_scale = createDequantScale(per_channel_scale);
     auto multiply = std::make_shared<ov::op::v1::Multiply>(add, dequant_scale);
@@ -148,10 +140,7 @@ TEST_F(TransformationTestsF, ConvertFullyConnectedBias_I8Act_I8Weights_Applied) 
     model_ref = createRefGraph(ov::element::i8, ov::element::i8, ov::element::f32);
 }
 
-// i8 act, i8 weights, f32 bias, PER-CHANNEL dequantization scale ({1, 16} on the output-channel axis) ->
-// transformation should be applied. The per-channel dequantization Multiply is folded as the FC per-channel weight
-// requantization scale (GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales) and applied by the int8 ACL FullyConnected
-// executor via a per-channel GEMMLowp output stage; ConvertFullyConnectedBias itself is scale-shape-agnostic.
+// i8 act, i8 weights, f32 bias, PER-CHANNEL dequantization scale -> transformation should be applied
 TEST_F(TransformationTestsF, ConvertFullyConnectedBias_I8Act_I8Weights_PerChannelScale_Applied) {
     model = createInitGraph(ov::element::i8, ov::element::i8, ov::element::f32, false, true);
     manager.register_pass<ConvertFullyConnectedBias>();
@@ -159,16 +148,12 @@ TEST_F(TransformationTestsF, ConvertFullyConnectedBias_I8Act_I8Weights_PerChanne
 }
 
 // u8 act, u8 weights, f32 bias -> transformation should NOT be applied.
-// KEY DIFFERENCE vs ConvertConvolutionBias: the FC pattern requires weights == i8
-// (type_matches(element::i8) at fc_mul_add_fq_block.cpp:28), whereas the conv pattern allows u8 weights
-// (type_matches_any({i8, u8}) at conv_mul_add_fq_block.cpp:35). So u8 weights must NOT match for FC.
 TEST_F(TransformationTestsF, ConvertFullyConnectedBias_U8Act_U8Weights_NotApplied) {
     model = createInitGraph(ov::element::u8, ov::element::u8, ov::element::f32);
     manager.register_pass<ConvertFullyConnectedBias>();
 }
 
-// bias already i32 -> transformation should NOT be applied (bias_const predicate rejects i32,
-// fc_mul_add_fq_block.cpp:32-34)
+// bias already i32 -> transformation should NOT be applied
 TEST_F(TransformationTestsF, ConvertFullyConnectedBias_BiasAlreadyI32_NotApplied) {
     model = createInitGraph(ov::element::u8, ov::element::i8, ov::element::i32);
     manager.register_pass<ConvertFullyConnectedBias>();
@@ -181,7 +166,6 @@ TEST_F(TransformationTestsF, ConvertFullyConnectedBias_F32Act_F32Weights_NotAppl
 }
 
 // fq output does not match activation precision -> transformation should NOT be applied
-// (guard at convert_fc_bias.cpp:52-54: FakeQuantize output type must equal MatMul activation input type)
 TEST_F(TransformationTestsF, ConvertFullyConnectedBias_FqOutputDoesNotMatchActivationPrecision_NotApplied) {
     model = createInitGraph(ov::element::i8, ov::element::i8, ov::element::f32, true);
     manager.register_pass<ConvertFullyConnectedBias>();

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_fc_bias.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_fc_bias.cpp
@@ -1,0 +1,161 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/cpu_opset/arm/pass/convert_fc_bias.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "common_test_utils/node_builders/fake_quantize.hpp"
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/round.hpp"
+#include "openvino/pass/manager.hpp"
+#include "ov_ops/type_relaxed.hpp"
+#include "transformations/init_node_info.hpp"
+#include "transformations/rt_info/dequantization_node.hpp"
+#include "transformations/utils/utils.hpp"
+#include "utils/general_utils.h"
+
+using namespace ov::intel_cpu;
+
+// int8 FullyConnected is lowered to a MatMul(act, weights) at this stage. The MatMul is built as a TypeRelaxed
+// op with f32 internal types for the quantized case (mirroring createConvolution in convert_conv_bias.cpp).
+// Shapes: activation {1, 64} x weights {64, 16} -> output {1, 16}, bias {1, 16} broadcasts on the output.
+static std::shared_ptr<ov::Node> createMatMul(ov::element::Type input_type,
+                                              ov::element::Type weights_type,
+                                              std::shared_ptr<ov::op::v0::Parameter>& input) {
+    input = std::make_shared<ov::op::v0::Parameter>(input_type, ov::Shape{1, 64});
+    auto weights = ov::op::v0::Constant::create(weights_type, ov::Shape{64, 16}, {1});
+
+    if (input_type == ov::element::f32 && weights_type == ov::element::f32) {
+        return std::make_shared<ov::op::v0::MatMul>(input, weights, false, false);
+    } else {
+        return std::make_shared<ov::op::TypeRelaxed<ov::op::v0::MatMul>>(
+            ov::element::TypeVector{ov::element::f32, ov::element::f32},
+            ov::element::TypeVector{ov::element::f32},
+            ov::op::TemporaryReplaceOutputType(input, ov::element::f32).get(),
+            ov::op::TemporaryReplaceOutputType(weights, ov::element::f32).get(),
+            false,
+            false);
+    }
+}
+
+static std::shared_ptr<ov::Node> createAdd(const ov::Output<ov::Node>& input1,
+                                           const ov::Output<ov::Node>& input2,
+                                           bool force_type_relaxed = false) {
+    if (!force_type_relaxed && input1.get_element_type() == input2.get_element_type()) {
+        return std::make_shared<ov::op::v1::Add>(input1, input2);
+    } else {
+        return std::make_shared<ov::op::TypeRelaxed<ov::op::v1::Add>>(
+            ov::element::TypeVector{ov::element::f32, ov::element::f32},
+            ov::element::TypeVector{ov::element::f32},
+            ov::op::TemporaryReplaceOutputType(input1, ov::element::f32).get(),
+            ov::op::TemporaryReplaceOutputType(input2, ov::element::f32).get());
+    }
+}
+
+static std::shared_ptr<ov::op::v0::FakeQuantize> createFakeQuantize(const ov::Output<ov::Node>& input,
+                                                                    ov::element::Type input_type,
+                                                                    size_t levels = 256) {
+    const bool is_signed = input_type == ov::element::i8;
+    const float low = is_signed ? -128.0f : 0.0f;
+    const float high = is_signed ? 127.0f : 255.0f;
+    return ov::as_type_ptr<ov::op::v0::FakeQuantize>(
+        ov::test::utils::make_fake_quantize(input, input_type, levels, {}, {low}, {high}, {low}, {high}));
+}
+
+// Pattern: Input -> MatMul -> Multiply -> Add(bias) -> FQ -> Result
+static std::shared_ptr<ov::Model> createInitGraph(ov::element::Type input_type,
+                                                  ov::element::Type weights_type,
+                                                  ov::element::Type bias_type,
+                                                  bool keep_fq_output_precision = false) {
+    std::shared_ptr<ov::op::v0::Parameter> input;
+    auto matmul = createMatMul(input_type, weights_type, input);
+
+    auto dequant_scale = ov::op::v0::Constant::create(ov::element::f32, {1}, {0.5f});
+    auto multiply = std::make_shared<ov::op::v1::Multiply>(matmul, dequant_scale);
+
+    auto bias = ov::op::v0::Constant::create(bias_type, {1, 16}, {1.5f});
+    auto add = createAdd(multiply, bias);
+
+    auto fq = createFakeQuantize(add, input_type, 256);
+    fq->set_output_type(0, keep_fq_output_precision ? ov::element::f32 : input_type, fq->get_output_shape(0));
+
+    return std::make_shared<ov::Model>(ov::OutputVector{fq}, ov::ParameterVector{input});
+}
+
+// Pattern: Input -> MatMul -> Add(Round(bias)->Convert(i32)) -> Multiply -> FQ -> Result
+static std::shared_ptr<ov::Model> createRefGraph(ov::element::Type input_type,
+                                                 ov::element::Type weights_type,
+                                                 ov::element::Type bias_type) {
+    std::shared_ptr<ov::op::v0::Parameter> input;
+    auto matmul = createMatMul(input_type, weights_type, input);
+
+    auto bias = ov::op::v0::Constant::create(bias_type, {1, 16}, {1.5f});
+    auto round = std::make_shared<ov::op::v5::Round>(bias, ov::op::v5::Round::RoundMode::HALF_TO_EVEN);
+    auto convert = std::make_shared<ov::op::v0::Convert>(round, ov::element::i32);
+
+    // The transformation creates a TypeRelaxed Add and then swaps Add/Multiply.
+    auto add = createAdd(matmul, convert, true);
+    auto dequant_scale = ov::op::v0::Constant::create(ov::element::f32, {1}, {0.5f});
+    auto multiply = std::make_shared<ov::op::v1::Multiply>(add, dequant_scale);
+    ov::mark_as_dequantization_node(multiply);
+
+    auto fq = createFakeQuantize(multiply, input_type, 256);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{fq}, ov::ParameterVector{input});
+}
+
+// u8 act, i8 weights, f32 bias -> transformation should be applied
+TEST_F(TransformationTestsF, ConvertFullyConnectedBias_U8Act_I8Weights_Applied) {
+    model = createInitGraph(ov::element::u8, ov::element::i8, ov::element::f32);
+    manager.register_pass<ConvertFullyConnectedBias>();
+    model_ref = createRefGraph(ov::element::u8, ov::element::i8, ov::element::f32);
+}
+
+// i8 act, i8 weights, f32 bias -> transformation should be applied
+TEST_F(TransformationTestsF, ConvertFullyConnectedBias_I8Act_I8Weights_Applied) {
+    model = createInitGraph(ov::element::i8, ov::element::i8, ov::element::f32);
+    manager.register_pass<ConvertFullyConnectedBias>();
+    model_ref = createRefGraph(ov::element::i8, ov::element::i8, ov::element::f32);
+}
+
+// u8 act, u8 weights, f32 bias -> transformation should NOT be applied.
+// KEY DIFFERENCE vs ConvertConvolutionBias: the FC pattern requires weights == i8
+// (type_matches(element::i8) at fc_mul_add_fq_block.cpp:28), whereas the conv pattern allows u8 weights
+// (type_matches_any({i8, u8}) at conv_mul_add_fq_block.cpp:35). So u8 weights must NOT match for FC.
+TEST_F(TransformationTestsF, ConvertFullyConnectedBias_U8Act_U8Weights_NotApplied) {
+    model = createInitGraph(ov::element::u8, ov::element::u8, ov::element::f32);
+    manager.register_pass<ConvertFullyConnectedBias>();
+}
+
+// bias already i32 -> transformation should NOT be applied (bias_const predicate rejects i32,
+// fc_mul_add_fq_block.cpp:32-34)
+TEST_F(TransformationTestsF, ConvertFullyConnectedBias_BiasAlreadyI32_NotApplied) {
+    model = createInitGraph(ov::element::u8, ov::element::i8, ov::element::i32);
+    manager.register_pass<ConvertFullyConnectedBias>();
+}
+
+// f32 act, f32 weights -> transformation should NOT be applied (not quantized case)
+TEST_F(TransformationTestsF, ConvertFullyConnectedBias_F32Act_F32Weights_NotApplied) {
+    model = createInitGraph(ov::element::f32, ov::element::f32, ov::element::f32);
+    manager.register_pass<ConvertFullyConnectedBias>();
+}
+
+// fq output does not match activation precision -> transformation should NOT be applied
+// (guard at convert_fc_bias.cpp:52-54: FakeQuantize output type must equal MatMul activation input type)
+TEST_F(TransformationTestsF, ConvertFullyConnectedBias_FqOutputDoesNotMatchActivationPrecision_NotApplied) {
+    model = createInitGraph(ov::element::i8, ov::element::i8, ov::element::f32, true);
+    manager.register_pass<ConvertFullyConnectedBias>();
+}

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_fc_bias.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_fc_bias.cpp
@@ -75,15 +75,31 @@ static std::shared_ptr<ov::op::v0::FakeQuantize> createFakeQuantize(const ov::Ou
         ov::test::utils::make_fake_quantize(input, input_type, levels, {}, {low}, {high}, {low}, {high}));
 }
 
+// Build the per-channel (or per-tensor) dequantization scale Constant. The scale lives on the MatMul output channel
+// (last) axis; a {1, 16} per-channel scale exercises the int8 FC per-channel requantization path, while a {1}
+// per-tensor scale exercises the common per-tensor case. ConvertFullyConnectedBias only swaps the Multiply/Add and
+// rounds the bias, so it must apply to both shapes identically.
+static std::shared_ptr<ov::op::v0::Constant> createDequantScale(bool per_channel) {
+    if (per_channel) {
+        std::vector<float> scales(16);
+        for (size_t i = 0; i < scales.size(); ++i) {
+            scales[i] = 0.25f + 0.05f * static_cast<float>(i);
+        }
+        return ov::op::v0::Constant::create(ov::element::f32, {1, 16}, scales);
+    }
+    return ov::op::v0::Constant::create(ov::element::f32, {1}, {0.5f});
+}
+
 // Pattern: Input -> MatMul -> Multiply -> Add(bias) -> FQ -> Result
 static std::shared_ptr<ov::Model> createInitGraph(ov::element::Type input_type,
                                                   ov::element::Type weights_type,
                                                   ov::element::Type bias_type,
-                                                  bool keep_fq_output_precision = false) {
+                                                  bool keep_fq_output_precision = false,
+                                                  bool per_channel_scale = false) {
     std::shared_ptr<ov::op::v0::Parameter> input;
     auto matmul = createMatMul(input_type, weights_type, input);
 
-    auto dequant_scale = ov::op::v0::Constant::create(ov::element::f32, {1}, {0.5f});
+    auto dequant_scale = createDequantScale(per_channel_scale);
     auto multiply = std::make_shared<ov::op::v1::Multiply>(matmul, dequant_scale);
 
     auto bias = ov::op::v0::Constant::create(bias_type, {1, 16}, {1.5f});
@@ -98,7 +114,8 @@ static std::shared_ptr<ov::Model> createInitGraph(ov::element::Type input_type,
 // Pattern: Input -> MatMul -> Add(Round(bias)->Convert(i32)) -> Multiply -> FQ -> Result
 static std::shared_ptr<ov::Model> createRefGraph(ov::element::Type input_type,
                                                  ov::element::Type weights_type,
-                                                 ov::element::Type bias_type) {
+                                                 ov::element::Type bias_type,
+                                                 bool per_channel_scale = false) {
     std::shared_ptr<ov::op::v0::Parameter> input;
     auto matmul = createMatMul(input_type, weights_type, input);
 
@@ -108,7 +125,7 @@ static std::shared_ptr<ov::Model> createRefGraph(ov::element::Type input_type,
 
     // The transformation creates a TypeRelaxed Add and then swaps Add/Multiply.
     auto add = createAdd(matmul, convert, true);
-    auto dequant_scale = ov::op::v0::Constant::create(ov::element::f32, {1}, {0.5f});
+    auto dequant_scale = createDequantScale(per_channel_scale);
     auto multiply = std::make_shared<ov::op::v1::Multiply>(add, dequant_scale);
     ov::mark_as_dequantization_node(multiply);
 
@@ -129,6 +146,16 @@ TEST_F(TransformationTestsF, ConvertFullyConnectedBias_I8Act_I8Weights_Applied) 
     model = createInitGraph(ov::element::i8, ov::element::i8, ov::element::f32);
     manager.register_pass<ConvertFullyConnectedBias>();
     model_ref = createRefGraph(ov::element::i8, ov::element::i8, ov::element::f32);
+}
+
+// i8 act, i8 weights, f32 bias, PER-CHANNEL dequantization scale ({1, 16} on the output-channel axis) ->
+// transformation should be applied. The per-channel dequantization Multiply is folded as the FC per-channel weight
+// requantization scale (GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales) and applied by the int8 ACL FullyConnected
+// executor via a per-channel GEMMLowp output stage; ConvertFullyConnectedBias itself is scale-shape-agnostic.
+TEST_F(TransformationTestsF, ConvertFullyConnectedBias_I8Act_I8Weights_PerChannelScale_Applied) {
+    model = createInitGraph(ov::element::i8, ov::element::i8, ov::element::f32, false, true);
+    manager.register_pass<ConvertFullyConnectedBias>();
+    model_ref = createRefGraph(ov::element::i8, ov::element::i8, ov::element::f32, true);
 }
 
 // u8 act, u8 weights, f32 bias -> transformation should NOT be applied.


### PR DESCRIPTION
### Details
On ARM (aarch64), the int8 FullyConnected ACL executor `ACLLowpFullyConnectedExecutor` only emitted an f32 destination and rejected FakeQuantize post-ops. As a result, the output requantization of an int8 MatMul/FC ran as a standalone decomposed snippet (jit_f32/jit_f16) instead of being fused into the primitive as it is on x86 (via oneDNN output scales).

In transformer models this requantization snippet is a large share of runtime even when the FC itself already runs in int8. For example, roberta-base runs 100% int8 FC yet spends ~36% of inference in FakeQuantize/dequant snippets.

This PR fuses the no-activation requantization chain
```
  MatMul -> Mul(dequant) -> Add(bias) -> per-tensor FakeQuantize -> i8
```
into the ACL int8 GEMM as a quantized output stage, so the FullyConnected emits i8 directly mirroring the existing int8 Convolution path.

### Changes (all ARM-gated; the x86 dnnl FC path is untouched)
  - New ARM LPT transform ConvertFullyConnectedBias + reusable FCMulAddFQBlock pattern _ swaps Multiply/Add and rounds the bias to i32, producing MatMul -> Add(i32 bias) -> Mul(dequant) -> FQ (mirrors `ConvertConvolutionBias` / `ConvMulAddFQBlock`).
  - `graph_optimizer`: add `FullyConnected` to `FuseConvMatmulFCDeconvAndDQScales` so the dequant Multiply folds as the FC DQ scale. (Without this, the chain ran as standalone Eltwise+FQ, slower than baseline.)
  - `aclLowpFCTypeMapping`: add i8/u8 destination rows alongside the existing f32 row.
  - `ACLLowpFullyConnectedExecutor`: accept a single per-tensor FakeQuantize post-op; build the destination QuantizationInfo and a `GEMMLowpOutputStage` (`QUANTIZE_DOWN_FIXEDPOINT`) via calculate_quantized_multipliers; require i32 bias for a quantized destination.
  - `match_acl_int8_matmul_fq_chain` + `FakeQuantizeDecomposition` keep-gate + aarch64 `snippets_mark_skipped`: keep the chain out of snippet tokenization. A per-tensor guard keeps per-channel requantization on the snippet fallback.

###  Scope
No-activation chains only. FFN-with-Gelu and residual-Add chains are intentionally left decomposed. In-GEMM GELU fusion is numerically incorrect on ACL: `NEGEMMLowpMatrixMultiplyCore` applies the activation after requantization (on the i8 output), and arm_gemm maps only ReLU-family activations _ verified by a standalone probe showing ~62% relative logit error for GELU despite validate() accepting the config.