### PR TITLE
[ONNX FE] Support int8 KV-cache in GroupQueryAttention

### DIFF
--- a/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
@@ -10,9 +10,14 @@
 #include "core/operator_set.hpp"
 #include "exceptions.hpp"
 #include "openvino/frontend/exception.hpp"
+#include "openvino/op/clamp.hpp"
 #include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
 #include "openvino/op/divide.hpp"
+#include "openvino/op/multiply.hpp"
 #include "openvino/op/reshape.hpp"
+#include "openvino/op/round.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/transpose.hpp"
 #include "utils/attention.hpp"
@@ -25,6 +30,83 @@ namespace ov::frontend::onnx::com_microsoft {
 
 namespace detail {
 using ov::frontend::onnx::attention::get_dimensions;
+
+// Reshape a per-channel KV scale [kv_num_heads * head_dim] to [1, kv_num_heads, 1, head_dim] so it
+// broadcasts over the [B, kv_num_heads, S, head_dim] KV layout used inside GroupQueryAttention.
+//
+// Built as a fresh Constant that owns a copy of this layer's scale data (the memcpy ctor), giving a
+// unique data pointer and no inherited weightless-cache attribute. This is required for NPUW FOLD:
+// a shape-Constant or buffer-sharing clone would be deduped/aliased across the identical layers and
+// break per-layer weight-bank matching during compile.
+inline ov::Output<ov::Node> reshape_scale_4d(const ov::Output<ov::Node>& scale,
+                                             int64_t kv_num_heads,
+                                             const std::string& base) {
+    auto scale_const = ov::as_type_ptr<v0::Constant>(scale.get_node_shared_ptr());
+    const auto& ps = scale.get_partial_shape();
+    if (scale_const && ps.is_static()) {
+        const int64_t total = static_cast<int64_t>(ov::shape_size(ps.to_shape()));
+        const int64_t head_dim = total / kv_num_heads;
+        const ov::Shape new_shape{1, static_cast<size_t>(kv_num_heads), 1, static_cast<size_t>(head_dim)};
+        auto reshaped = std::make_shared<v0::Constant>(scale_const->get_element_type(),
+                                                       new_shape,
+                                                       scale_const->get_data_ptr());
+        reshaped->set_friendly_name(base + "/scale_4d");
+        return reshaped;
+    }
+    // Fallback for a non-constant scale (not expected for baked-initializer scales).
+    const auto target = v0::Constant::create(ov::element::i64,
+                                             ov::Shape{4},
+                                             std::vector<int64_t>{int64_t{1}, kv_num_heads, int64_t{1}, int64_t{-1}});
+    target->set_friendly_name(base + "/scale_shape");
+    auto r = std::make_shared<v1::Reshape>(scale, target, false);
+    r->set_friendly_name(base + "/scale_reshape");
+    return r;
+}
+
+// Symmetric per-channel dequantize of an int8 KV tensor: Convert(int8->f32) * scale.
+// Each call clones its own single-reader scale Constant (see reshape_scale_4d).
+inline ov::Output<ov::Node> dequantize_kv(const ov::Output<ov::Node>& quant,
+                                          const ov::Output<ov::Node>& scale,
+                                          int64_t kv_num_heads,
+                                          const ov::element::Type& compute_type,
+                                          const std::string& base) {
+    auto q_f = std::make_shared<v0::Convert>(quant, ov::element::f32);
+    q_f->set_friendly_name(base + "/dq_convert_f32");
+    auto scale4d = reshape_scale_4d(scale, kv_num_heads, base + "/dq");
+    auto mul = std::make_shared<v1::Multiply>(q_f, scale4d);
+    mul->set_friendly_name(base + "/dq_mul");
+    ov::Output<ov::Node> deq = mul;
+    if (compute_type != ov::element::f32) {
+        auto cvt = std::make_shared<v0::Convert>(deq, compute_type);
+        cvt->set_friendly_name(base + "/dq_convert_compute");
+        deq = cvt;
+    }
+    return deq;
+}
+
+// Symmetric per-channel requantize of the present KV back to int8: round(value / scale) clamped to
+// [-128, 127], so the present_* graph outputs keep their declared int8 type. Own single-reader scale.
+inline ov::Output<ov::Node> quantize_kv(const ov::Output<ov::Node>& value,
+                                        const ov::Output<ov::Node>& scale,
+                                        int64_t kv_num_heads,
+                                        const std::string& base) {
+    ov::Output<ov::Node> v_f = value;
+    if (value.get_element_type() != ov::element::f32) {
+        auto cvt = std::make_shared<v0::Convert>(value, ov::element::f32);
+        cvt->set_friendly_name(base + "/q_convert_f32");
+        v_f = cvt;
+    }
+    auto scale4d = reshape_scale_4d(scale, kv_num_heads, base + "/q");
+    auto scaled = std::make_shared<v1::Divide>(v_f, scale4d);
+    scaled->set_friendly_name(base + "/q_div");
+    auto rounded = std::make_shared<v5::Round>(scaled, v5::Round::RoundMode::HALF_TO_EVEN);
+    rounded->set_friendly_name(base + "/q_round");
+    auto clamped = std::make_shared<v0::Clamp>(rounded, -128.0, 127.0);
+    clamped->set_friendly_name(base + "/q_clamp");
+    auto out = std::make_shared<v0::Convert>(clamped, ov::element::i8);
+    out->set_friendly_name(base + "/q_convert_i8");
+    return out;
+}
 }  // namespace detail
 
 namespace opset_1 {
@@ -45,6 +127,31 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
     const auto scale = node.get_attribute_value<float>("scale", 0.0f);
     const auto do_rotary = node.get_attribute_value<int64_t>("do_rotary", 0);
     const auto rotary_interleaved = node.get_attribute_value<int64_t>("rotary_interleaved", 0);
+
+    // int8 KV-cache mode: KV is stored int8 and the op carries kv_cache_bit_width plus per-channel
+    // scale inputs (key=12, value=13). The internal op only supports f16/f32 KV, so dequantize past
+    // KV before it and requantize present KV after it, leaving the int8 KV graph I/O unchanged.
+    const auto kv_cache_bit_width = node.get_attribute_value<int64_t>("kv_cache_bit_width", 0);
+    constexpr size_t k_scale_index = 12;
+    constexpr size_t v_scale_index = 13;
+    constexpr size_t kv_op_inputs_end = 9;  // op consumes inputs 0..8 (Q,K,V,pastK,pastV,seqlens,total,cos,sin)
+    const bool int8_kv_cache = kv_cache_bit_width > 0 &&
+                               common::is_input_valid(onnx_op_inputs, k_scale_index) &&
+                               common::is_input_valid(onnx_op_inputs, v_scale_index);
+    // Layer-scoped base name for the inserted dequant/requant nodes (per-layer unique for NPUW FOLD).
+    const std::string gqa_name = !node.get_name().empty() ? node.get_name() : node.output(0);
+    if (int8_kv_cache) {
+        FRONT_END_OP_CONVERSION_CHECK(kv_cache_bit_width == 8,
+                                      "GroupQueryAttention: only 8-bit int KV cache is supported.");
+        const auto k_qt = node.get_attribute_value<std::string>("k_quant_type", "PER_CHANNEL");
+        const auto v_qt = node.get_attribute_value<std::string>("v_quant_type", "PER_CHANNEL");
+        FRONT_END_OP_CONVERSION_CHECK(k_qt == "PER_CHANNEL" && v_qt == "PER_CHANNEL",
+                                      "GroupQueryAttention: only PER_CHANNEL int8 KV quantization is supported, got "
+                                      "k_quant_type=",
+                                      k_qt,
+                                      ", v_quant_type=",
+                                      v_qt);
+    }
 
     if (0 != do_rotary) {
         constexpr size_t cos_cache_index = 7;
@@ -118,6 +225,41 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
         V = std::make_shared<v1::Transpose>(V, perm);
         ov_op_inputs.push_back(std::move(K));
         ov_op_inputs.push_back(std::move(V));
+    }
+
+    // Forward the remaining op inputs (past_key=3, past_value=4, seqlens=5, total=6, cos=7, sin=8).
+    // For an int8 KV cache, dequantize past_key/past_value to the compute type so the internal op
+    // (and the downstream NPUW decomposition) sees plain f16/f32 KV, exactly like the fp16 model.
+    // The trailing quantization inputs (scales at 12/13) are consumed here, not forwarded to the op.
+    const auto compute_type = ov_op_inputs[0].get_element_type();
+
+    // Forward op inputs 3..8; in int8 mode dequantize past_key/past_value (3/4) and drop the
+    // trailing scale inputs (the op itself only takes inputs 0..8).
+    const size_t forward_end = int8_kv_cache ? std::min(onnx_op_inputs.size(), kv_op_inputs_end) : onnx_op_inputs.size();
+    for (size_t i = ov_op_inputs.size(); i < forward_end; ++i) {
+        if (int8_kv_cache && (i == 3 || i == 4)) {
+            const auto& kv_scale = (i == 3) ? onnx_op_inputs[k_scale_index] : onnx_op_inputs[v_scale_index];
+            const std::string base = gqa_name + (i == 3 ? "/past_key" : "/past_value");
+            ov_op_inputs.push_back(detail::dequantize_kv(onnx_op_inputs[i], kv_scale, kv_num_heads, compute_type, base));
+        } else {
+            ov_op_inputs.push_back(onnx_op_inputs[i]);
+        }
+    }
+
+    if (int8_kv_cache) {
+        // Requantize the present_key/present_value (op outputs 1/2) back to int8.
+        auto gqa = std::make_shared<internal::GroupQueryAttention>(ov_op_inputs,
+                                                                   num_heads,
+                                                                   kv_num_heads,
+                                                                   scale,
+                                                                   do_rotary,
+                                                                   rotary_interleaved);
+        const auto gqa_outputs = gqa->outputs();
+        return {gqa_outputs[0],
+                detail::quantize_kv(gqa_outputs[1], onnx_op_inputs[k_scale_index], kv_num_heads,
+                                    gqa_name + "/present_key"),
+                detail::quantize_kv(gqa_outputs[2], onnx_op_inputs[v_scale_index], kv_num_heads,
+                                    gqa_name + "/present_value")};
     }
 
     for (size_t i = ov_op_inputs.size(); i < onnx_op_inputs.size(); ++i) {


### PR DESCRIPTION
The com.microsoft GroupQueryAttention contrib op can carry an int8 KV cache (attribute kv_cache_bit_width=8 with per-channel k_scale/v_scale inputs and int8 past/present key/value I/O). The internal GroupQueryAttention op only supports f16/f32 KV, so such models previously failed to compile.

Translate the int8 KV path in the frontend:
- dequantize past_key/past_value (Convert int8->f32, multiply by per-channel scale) before feeding the op, so it sees plain float KV;
- requantize present_key/present_value (divide by scale, round-half-to-even, clamp to [-128,127], convert to int8) so the graph keeps its int8 KV I/O.

Each layer's scale is materialized as its own single-reader Constant that owns a fresh copy of the data, so the inserted nodes stay per-layer-distinct and fold correctly on the NPUW/NPU compile path.

The path is gated on kv_cache_bit_width>0 and the presence of the scale inputs; f16/f32 models are unaffected.

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-189842

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
