### PR TITLE
Add liburing as 3rdparty dependency. Build it and link to libopenvino

### DIFF
--- a/.github/workflows/linux_riscv_conan.yml
+++ b/.github/workflows/linux_riscv_conan.yml
@@ -155,6 +155,7 @@ jobs:
             git submodule update --init -- ${OPENVINO_REPO}/thirdparty/gtest
             git submodule update --init -- ${OPENVINO_REPO}/thirdparty/gflags
             git submodule update --init -- ${OPENVINO_REPO}/thirdparty/telemetry
+            git submodule update --init -- ${OPENVINO_REPO}/thirdparty/liburing/liburing
             git submodule update --init -- ${OPENVINO_REPO}/src/plugins/intel_cpu
             git submodule update --init -- ${OPENVINO_REPO}/thirdparty/flatbuffers/flatbuffers
             # ONNX is no longer consumed from Conan (Conan Center Index lacks onnx 1.22),

--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "src/plugins/intel_cpu/thirdparty/xbyak_riscv"]
 	path = src/plugins/intel_cpu/thirdparty/xbyak_riscv
 	url = https://github.com/herumi/xbyak_riscv.git
+[submodule "thirdparty/liburing/liburing"]
+	path = thirdparty/liburing/liburing
+	url = https://github.com/axboe/liburing.git

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -220,7 +220,7 @@ ov_dependent_option(ENABLE_JS "Enables JS API building" ${ENABLE_JS_DEFAULT} "NO
 
 ov_option(ENABLE_OPENVINO_DEBUG "Enable output for OPENVINO_DEBUG statements" OFF)
 
-ov_dependent_option(ENABLE_IO_URING "Enables io_uring feature" ON "LINUX" OFF)
+ov_dependent_option(ENABLE_IO_URING "Enables io_uring feature" OFF "LINUX" OFF)
 
 if(NOT BUILD_SHARED_LIBS AND ENABLE_OV_TF_FRONTEND)
     set(FORCE_FRONTENDS_USE_PROTOBUF ON)

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -220,6 +220,8 @@ ov_dependent_option(ENABLE_JS "Enables JS API building" ${ENABLE_JS_DEFAULT} "NO
 
 ov_option(ENABLE_OPENVINO_DEBUG "Enable output for OPENVINO_DEBUG statements" OFF)
 
+ov_dependent_option(ENABLE_IO_URING "Enables io_uring feature" ON "LINUX" OFF)
+
 if(NOT BUILD_SHARED_LIBS AND ENABLE_OV_TF_FRONTEND)
     set(FORCE_FRONTENDS_USE_PROTOBUF ON)
 else()

--- a/licensing/runtime-third-party-programs.txt
+++ b/licensing/runtime-third-party-programs.txt
@@ -1928,3 +1928,32 @@ Copyright (c) 2022-2023 Intel Corporation
    limitations under the License.
 
 -------------------------------------------------------------
+28. liburing (https://github.com/axboe/liburing)
+
+liburing is dual-licensed under LGPL-2.1 OR MIT. OpenVINO uses it under the
+MIT license (all liburing sources compiled into OpenVINO carry the
+"SPDX-License-Identifier: MIT" tag).
+
+MIT License
+
+Copyright 2020 Jens Axboe
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/licensing/third-party-programs.txt
+++ b/licensing/third-party-programs.txt
@@ -1984,3 +1984,33 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 -------------------------------------------------------------
+
+34. liburing (https://github.com/axboe/liburing)
+
+liburing is dual-licensed under LGPL-2.1 OR MIT. OpenVINO uses it under the
+MIT license (all liburing sources compiled into OpenVINO carry the
+"SPDX-License-Identifier: MIT" tag).
+
+MIT License
+
+Copyright 2020 Jens Axboe
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-------------------------------------------------------------

--- a/src/cmake/openvino.cmake
+++ b/src/cmake/openvino.cmake
@@ -62,6 +62,10 @@ if(BUILD_SHARED_LIBS)
     target_link_libraries(${TARGET_NAME} PRIVATE openvino::shutdown)
 endif()
 
+if(LINUX)
+    target_link_libraries(${TARGET_NAME} PRIVATE openvino::liburing)
+endif()
+
 if (TBBBIND_2_5_FOUND)
     target_link_libraries(${TARGET_NAME} PRIVATE ${TBBBIND_2_5_IMPORTED_TARGETS})
 endif()

--- a/src/cmake/openvino.cmake
+++ b/src/cmake/openvino.cmake
@@ -62,10 +62,6 @@ if(BUILD_SHARED_LIBS)
     target_link_libraries(${TARGET_NAME} PRIVATE openvino::shutdown)
 endif()
 
-if(LINUX)
-    target_link_libraries(${TARGET_NAME} PRIVATE openvino::liburing)
-endif()
-
 if (TBBBIND_2_5_FOUND)
     target_link_libraries(${TARGET_NAME} PRIVATE ${TBBBIND_2_5_IMPORTED_TARGETS})
 endif()

--- a/src/common/util/CMakeLists.txt
+++ b/src/common/util/CMakeLists.txt
@@ -98,7 +98,7 @@ target_include_directories(${TARGET_NAME}
     PUBLIC $<BUILD_INTERFACE:${UTIL_INCLUDE_DIR}>
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-if (LINUX)
+if (ENABLE_IO_URING AND LINUX)
     target_link_libraries(${TARGET_NAME} PRIVATE openvino::liburing)
 endif()
 

--- a/src/common/util/CMakeLists.txt
+++ b/src/common/util/CMakeLists.txt
@@ -98,6 +98,10 @@ target_include_directories(${TARGET_NAME}
     PUBLIC $<BUILD_INTERFACE:${UTIL_INCLUDE_DIR}>
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
+if (LINUX)
+    target_link_libraries(${TARGET_NAME} PRIVATE openvino::liburing)
+endif()
+
 ov_add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})
 ov_ncc_naming_style(FOR_TARGET ${TARGET_NAME}
                     SOURCE_DIRECTORIES ${UTIL_INCLUDE_DIR})

--- a/thirdparty/dependencies.cmake
+++ b/thirdparty/dependencies.cmake
@@ -555,6 +555,18 @@ if(ENABLE_SNAPPY_COMPRESSION)
 endif()
 
 #
+# liburing (io_uring)
+#
+
+if(LINUX)
+    add_subdirectory(thirdparty/liburing EXCLUDE_FROM_ALL)
+    set_property(TARGET openvino_liburing PROPERTY EXPORT_NAME liburing)
+    ov_developer_package_export_targets(TARGET openvino::liburing
+        INSTALL_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:openvino::liburing,INTERFACE_INCLUDE_DIRECTORIES>/)
+    ov_install_static_lib(openvino_liburing ${OV_CPACK_COMP_CORE})
+endif()
+
+#
 # ONNX
 #
 

--- a/thirdparty/dependencies.cmake
+++ b/thirdparty/dependencies.cmake
@@ -558,7 +558,7 @@ endif()
 # liburing (io_uring)
 #
 
-if(LINUX)
+if(ENABLE_IO_URING AND LINUX)
     add_subdirectory(thirdparty/liburing EXCLUDE_FROM_ALL)
     set_property(TARGET openvino_liburing PROPERTY EXPORT_NAME liburing)
     ov_developer_package_export_targets(TARGET openvino::liburing

--- a/thirdparty/liburing/CMakeLists.txt
+++ b/thirdparty/liburing/CMakeLists.txt
@@ -1,0 +1,64 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# liburing (io_uring) is a Linux-only library. It ships an autotools-style
+# `configure` script that generates a few host-specific headers
+# (config-host.h, compat.h, io_uring_version.h). Both that configure step and
+# the actual compilation are driven from CMake here, so liburing is built as a
+# static library as part of the OpenVINO build.
+
+project(liburing C)
+
+set(TARGET_NAME "openvino_liburing")
+
+set(LIBURING_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/liburing")
+
+#
+# Run liburing's own configure script to generate config-host.h, compat.h and
+# io_uring_version.h. '--use-libc' avoids the nolibc path so the sources build
+# with the standard toolchain. The generated files are gitignored by liburing,
+# so the submodule working tree stays clean.
+#
+if(NOT EXISTS "${LIBURING_SOURCE_DIR}/src/include/liburing/compat.h")
+    message(STATUS "Configuring liburing")
+    execute_process(
+        COMMAND sh configure --use-libc --cc=${CMAKE_C_COMPILER}
+        WORKING_DIRECTORY "${LIBURING_SOURCE_DIR}"
+        RESULT_VARIABLE _liburing_configure_result
+        OUTPUT_VARIABLE _liburing_configure_output
+        ERROR_VARIABLE _liburing_configure_output)
+    if(NOT _liburing_configure_result EQUAL 0)
+        message(FATAL_ERROR "liburing configure failed:\n${_liburing_configure_output}")
+    endif()
+endif()
+
+#
+# liburing static library
+#
+set(liburing_srcs
+    "${LIBURING_SOURCE_DIR}/src/setup.c"
+    "${LIBURING_SOURCE_DIR}/src/queue.c"
+    "${LIBURING_SOURCE_DIR}/src/register.c"
+    "${LIBURING_SOURCE_DIR}/src/syscall.c"
+    "${LIBURING_SOURCE_DIR}/src/version.c")
+
+add_library(${TARGET_NAME} STATIC ${liburing_srcs})
+add_library(openvino::liburing ALIAS ${TARGET_NAME})
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_ID MATCHES "^(Apple)?Clang$")
+    target_compile_options(${TARGET_NAME} PRIVATE -Wno-all)
+endif()
+
+target_compile_definitions(${TARGET_NAME} PRIVATE
+    _GNU_SOURCE
+    _LARGEFILE_SOURCE
+    _FILE_OFFSET_BITS=64
+    LIBURING_INTERNAL)
+
+# Force-include the generated config-host.h, like liburing's own build does.
+target_compile_options(${TARGET_NAME} PRIVATE "-include" "${LIBURING_SOURCE_DIR}/config-host.h")
+
+target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${LIBURING_SOURCE_DIR}/src/include>)
+
+set_target_properties(${TARGET_NAME} PROPERTIES FOLDER thirdparty)


### PR DESCRIPTION
### Details:
 - Add liburing as 3rdparty dependency. Version 2.15
 - Add cmake to build it as static lib and add link it to core utils
 - Update third-party-programs

### Tickets:
 - CVS-189524

### AI Assistance:
 - *AI assistance used: yes*

