### PR TITLE
Do not suppress warning in cpu 3rd party deps

### DIFF
--- a/cmake/developer_package/compile_flags/functions.cmake
+++ b/cmake/developer_package/compile_flags/functions.cmake
@@ -300,7 +300,8 @@ function(ov_disable_all_warnings)
         get_target_property(target_type ${target} TYPE)
 
         if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR (OV_COMPILER_IS_INTEL_LLVM AND WIN32))
-            target_compile_options(${target} PRIVATE /WX-)
+            # restrict to C/CXX sources only
+            target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:/WX->)
         elseif(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG OR (OV_COMPILER_IS_INTEL_LLVM AND UNIX))
             target_compile_options(${target} PRIVATE -w)
             # required for LTO

--- a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
@@ -151,7 +151,7 @@ function(ov_add_onednn)
     add_subdirectory(onednn EXCLUDE_FROM_ALL)
 
     # 3rd-party code (Windows): don't fail the build on its warnings, but don't hide them either
-    if(WIN32)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR (OV_COMPILER_IS_INTEL_LLVM AND WIN32))
         target_compile_options(dnnl PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:/WX->)
     endif()
 
@@ -184,7 +184,7 @@ endif()
 if(ENABLE_MLAS_FOR_CPU)
     add_subdirectory(mlas EXCLUDE_FROM_ALL)
     # 3rd-party code (Windows): don't fail the build on its warnings, but don't hide them either
-    if(WIN32)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR (OV_COMPILER_IS_INTEL_LLVM AND WIN32))
         target_compile_options(mlas PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:/WX->)
     endif()
     ov_install_static_lib(mlas ${OV_CPACK_COMP_CORE})

--- a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
@@ -4,21 +4,7 @@
 
 project(intel_cpu_thirdparty)
 
-# Suppress warnings from thirdparty code only (not from intel_cpu/src)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # C4849 OpenMP 'reduction' clause ignored in 'simd' directive
-    ov_add_compiler_flags(/wd4849)
-    # C4661 no suitable definition provided for explicit template instantiation request
-    ov_add_compiler_flags(/wd4661)
-    # Re-apply warning suppressions inside ov_add_onednn() function scope
-    # (needed because function() creates new variable scope in CMake)
-    ov_add_compiler_flags(/wd4018)
-    ov_add_compiler_flags(/wd4267)
-    ov_add_compiler_flags(/wd4244)
-    ov_add_compiler_flags(/wd4334)
-    ov_add_compiler_flags(/wd4146)
-    ov_add_compiler_flags(/wd5002)
-elseif(OV_COMPILER_IS_INTEL_LLVM AND WIN32)
+if(OV_COMPILER_IS_INTEL_LLVM AND WIN32)
     ov_add_compiler_flags("/Wno-microsoft-include")
 endif()
 
@@ -164,6 +150,9 @@ function(ov_add_onednn)
 
     add_subdirectory(onednn EXCLUDE_FROM_ALL)
 
+    # 3rd-party code: don't fail the build on its warnings, but don't hide them either
+    ov_disable_all_warnings(dnnl)
+
     # install static libraries
     ov_install_static_lib(dnnl ${OV_CPACK_COMP_CORE})
 
@@ -192,6 +181,8 @@ endif()
 
 if(ENABLE_MLAS_FOR_CPU)
     add_subdirectory(mlas EXCLUDE_FROM_ALL)
+    # 3rd-party code: don't fail the build on its warnings, but don't hide them either
+    ov_disable_all_warnings(mlas)
     ov_install_static_lib(mlas ${OV_CPACK_COMP_CORE})
 endif()
 

--- a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
@@ -150,8 +150,10 @@ function(ov_add_onednn)
 
     add_subdirectory(onednn EXCLUDE_FROM_ALL)
 
-    # 3rd-party code: don't fail the build on its warnings, but don't hide them either
-    ov_disable_all_warnings(dnnl)
+    # 3rd-party code (Windows): don't fail the build on its warnings, but don't hide them either
+    if(WIN32)
+        target_compile_options(dnnl PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:/WX->)
+    endif()
 
     # install static libraries
     ov_install_static_lib(dnnl ${OV_CPACK_COMP_CORE})
@@ -181,8 +183,10 @@ endif()
 
 if(ENABLE_MLAS_FOR_CPU)
     add_subdirectory(mlas EXCLUDE_FROM_ALL)
-    # 3rd-party code: don't fail the build on its warnings, but don't hide them either
-    ov_disable_all_warnings(mlas)
+    # 3rd-party code (Windows): don't fail the build on its warnings, but don't hide them either
+    if(WIN32)
+        target_compile_options(mlas PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:/WX->)
+    endif()
     ov_install_static_lib(mlas ${OV_CPACK_COMP_CORE})
 endif()
 


### PR DESCRIPTION
### Details:
 - Do not suppress warnings in CPU third-party dependencies on Windows. Instead, disable warnings-as-errors for the affected libraries: oneDNN and MLAS.
 
### Tickets:
 - CVS-184181

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks): Consulting*
