### PR TITLE
[CPU] Unit tests actualization

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_group_conv.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_group_conv.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #include "convert_group_conv.hpp"
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_group_conv.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_group_conv.cpp
@@ -62,9 +62,8 @@ ov::intel_cpu::ConvertGroupConvolution::ConvertGroupConvolution() {
         ov::NodeVector concat_inputs;
         for (int64_t g = 0; g < groups; g++) {
             auto out = split->output(g);
-            auto filter = std::make_shared<ov::op::v0::Squeeze>(
-                split_weights->output(g),
-                ov::op::v0::Constant::create<int64_t>(ov::element::i64, ov::Shape{}, {0}));
+            auto squeeze_axis = ov::op::v0::Constant::create<int64_t>(ov::element::i64, ov::Shape{}, {0});
+            auto filter = std::make_shared<ov::op::v0::Squeeze>(split_weights->output(g), squeeze_axis);
             auto conv = std::make_shared<ov::op::v1::Convolution>(out,
                                                                   filter,
                                                                   gconv->get_strides(),
@@ -73,6 +72,8 @@ ov::intel_cpu::ConvertGroupConvolution::ConvertGroupConvolution() {
                                                                   gconv->get_dilations(),
                                                                   gconv->get_auto_pad());
             concat_inputs.push_back(conv);
+            replace_nodes.push_back(squeeze_axis);
+            replace_nodes.push_back(filter);
             replace_nodes.push_back(conv);
         }
         auto concat = std::make_shared<ov::op::v0::Concat>(concat_inputs, 1);

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_reduce_no_keep_dims.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_reduce_no_keep_dims.cpp
@@ -28,7 +28,7 @@ ov::matcher_pass_callback ov::intel_cpu::ConvertReduceNoKeepDimsBase::convert_re
         reduce->set_keep_dims(true);
         const auto reduce_new = reduce->clone_with_new_inputs({reduce->input_value(0), reduce->input_value(1)});
         std::shared_ptr<ov::Node> squeeze = std::make_shared<ov::op::v0::Squeeze>(reduce_new, reduce->input_value(1));
-        squeeze->set_friendly_name(reduce_new->get_friendly_name());
+        squeeze->set_friendly_name(reduce->get_friendly_name());
         ov::copy_runtime_info(reduce, {reduce_new, squeeze});
         ov::replace_node(reduce, squeeze);
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_reduce_no_keep_dims.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_reduce_no_keep_dims.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #include "convert_reduce_no_keep_dims.hpp"
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.cpp
@@ -161,6 +161,7 @@ ov::intel_cpu::MoveReadValueInputsToSubgraph::MoveReadValueInputsToSubgraph() {
         new_rv->set_output(output);
 
         // Replace ReadValue with ov::intel_cpu::ReadValueWithSubgraph
+        new_rv->set_friendly_name(readvalue->get_friendly_name());
         ov::replace_node(readvalue, new_rv);
         ov::copy_runtime_info(subgraph_nodes, new_rv);
         new_rv->validate_and_infer_types();

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/convert_to_interaction.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/convert_to_interaction.cpp
@@ -208,7 +208,6 @@ ov::intel_cpu::ConvertInteractionInt8::ConvertInteractionInt8() {
         }
 
         auto interaction_node = std::make_shared<InteractionNode>(features_node);
-        interaction_node->set_friendly_name(final_concat_node->get_friendly_name());
         auto fq_inter_node = dense_fq_node->clone_with_new_inputs({interaction_node,
                                                                    dense_fq_node->input_value(1),
                                                                    dense_fq_node->input_value(2),

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv.cpp
@@ -6,12 +6,7 @@
 
 #include <memory>
 #include <openvino/core/model.hpp>
-#include <openvino/pass/manager.hpp>
-#include <ov_ops/type_relaxed.hpp>
-#include <string>
 #include <transformations/cpu_opset/arm/pass/convert_group_conv.hpp>
-#include <transformations/init_node_info.hpp>
-#include <transformations/utils/utils.hpp>
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/core/node_vector.hpp"
@@ -23,15 +18,13 @@
 #include "openvino/op/split.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/opsets/opset1_decl.hpp"
-#include "openvino/opsets/opset3_decl.hpp"
-#include "openvino/opsets/opset7_decl.hpp"
 
 using namespace testing;
 using namespace ov::intel_cpu;
 
 template <class T>
 static std::shared_ptr<ov::Model> createInitGraph(std::shared_ptr<ov::opset1::Parameter> param, ov::Shape weights_shape) {
-        auto weights = ov::opset1::Constant::create(ov::element::f32, weights_shape, { 1 });
+        auto weights = ov::opset1::Constant::create(ov::element::f32, weights_shape, {1});
         auto conv = std::make_shared<T>(param,
                                         weights,
                                         ov::Strides{1},
@@ -42,75 +35,56 @@ static std::shared_ptr<ov::Model> createInitGraph(std::shared_ptr<ov::opset1::Pa
         return std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{param});
 }
 
-TEST(TransformationTests, CheckConvertGroupConvIsApplied) {
-    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
-    {
-        auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 6, 224});
-        model = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 3, 5});
-        ov::pass::Manager manager;
-        manager.register_pass<ConvertGroupConvolution>();
-        manager.run_passes(model);
+static std::shared_ptr<ov::Model> createRefGraph(std::shared_ptr<ov::opset1::Parameter> param, ov::Shape weights_shape) {
+    const unsigned int groups = static_cast<unsigned int>(weights_shape[0]);
+    const unsigned int channel_axis = 1;
+    auto weights = ov::opset1::Constant::create(ov::element::f32, weights_shape, {1});
+    auto split_weights = std::make_shared<ov::opset1::Split>(weights,
+                                                             ov::opset1::Constant::create(ov::element::i64, ov::Shape{}, {0}),
+                                                             groups);
+    auto axis = ov::opset1::Constant::create(ov::element::i64, ov::Shape{}, {channel_axis});
+    auto split = std::make_shared<ov::opset1::Split>(param, axis, groups);
+    ov::NodeVector concat_inputs;
+    for (size_t g = 0; g < groups; g++) {
+        auto out = split->output(g);
+        auto filter = std::make_shared<ov::opset1::Squeeze>(split_weights->output(g),
+                                                            ov::opset1::Constant::create(ov::element::i64, ov::Shape{}, {0}));
+        auto conv = std::make_shared<ov::opset1::Convolution>(out,
+                                                              filter,
+                                                              ov::Strides{1},
+                                                              ov::CoordinateDiff{0},
+                                                              ov::CoordinateDiff{0},
+                                                              ov::Strides{1});
+        concat_inputs.push_back(conv);
     }
-    {
-        const unsigned int groups = 2;
-        const unsigned int channel_axis = 1;
-        auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 6, 224});
-        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{groups, 1, 3, 5}, { 1 });
-        auto split_weights = std::make_shared<ov::opset1::Split>(weights,
-                                                                     ov::opset1::Constant::create(ov::element::i64, ov::Shape{}, {0}),
-                                                                     groups);
-        auto axis  = ov::opset1::Constant::create(ov::element::i64, ov::Shape{}, {channel_axis});
-        auto split = std::make_shared<ov::opset1::Split>(param, axis, groups);
-        ov::NodeVector concat_inputs;
-        for (size_t g = 0; g < groups; g++) {
-            auto out = split->output(g);
-            auto filter = std::make_shared<ov::opset1::Squeeze>(split_weights->output(g),
-                                                                    ov::opset1::Constant::create(ov::element::i64, ov::Shape{}, {0}));
-            auto conv = std::make_shared<ov::opset1::Convolution>(out,
-                                                                      filter,
-                                                                      ov::Strides{1},
-                                                                      ov::CoordinateDiff{0},
-                                                                      ov::CoordinateDiff{0},
-                                                                      ov::Strides{1});
-            concat_inputs.push_back(conv);
-        }
-        auto concat = std::make_shared<ov::op::v0::Concat>(concat_inputs, 1);
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{param});
-    }
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    auto concat = std::make_shared<ov::op::v0::Concat>(concat_inputs, 1);
+    return std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{param});
 }
 
-TEST(TransformationTests, CheckConvertGroupConvIsNotAppliedForDepthwiseCase) {
-    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
-    {
-        auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 2, 224});
-        model = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 1, 5});
-        ov::pass::Manager manager;
+class ConvertGroupConvTests : public TransformationTestsF {
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
         manager.register_pass<ConvertGroupConvolution>();
-        manager.run_passes(model);
     }
-    {
-        auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 2, 224});
-        model_ref = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 1, 5});
-    }
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
+};
+
+TEST_F(ConvertGroupConvTests, Applied) {
+    auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 6, 224});
+    model = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 3, 5});
+    model_ref = createRefGraph(
+        std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 6, 224}),
+        ov::Shape{2, 1, 3, 5});
 }
 
-TEST(TransformationTests, CheckConvertGroupConvIsNotAppliedForDynamicShapes) {
-    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
-    {
-        auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{1, -1, 224});
-        model = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 1, 5});
-        ov::pass::Manager manager;
-        manager.register_pass<ConvertGroupConvolution>();
-        manager.run_passes(model);
-    }
-    {
-        auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{1, -1, 224});
-        model_ref = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 1, 5});
-    }
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
+TEST_F(ConvertGroupConvTests, Negative_DepthwiseCase) {
+    auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 2, 224});
+    model = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 1, 5});
+    // model_ref intentionally omitted — transformation should not fire
+}
+
+TEST_F(ConvertGroupConvTests, Negative_DynamicShapes) {
+    auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{1, -1, 224});
+    model = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 1, 5});
+    // model_ref intentionally omitted — transformation should not fire
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv.cpp
@@ -80,11 +80,9 @@ TEST_F(ConvertGroupConvTests, Applied) {
 TEST_F(ConvertGroupConvTests, Negative_DepthwiseCase) {
     auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 2, 224});
     model = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 1, 5});
-    // model_ref intentionally omitted — transformation should not fire
 }
 
 TEST_F(ConvertGroupConvTests, Negative_DynamicShapes) {
     auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{1, -1, 224});
     model = createInitGraph<ov::opset1::GroupConvolution>(param, ov::Shape{2, 1, 1, 5});
-    // model_ref intentionally omitted — transformation should not fire
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv1d.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv1d.cpp
@@ -6,12 +6,7 @@
 
 #include <memory>
 #include <openvino/core/model.hpp>
-#include <openvino/pass/manager.hpp>
-#include <ov_ops/type_relaxed.hpp>
-#include <string>
 #include <transformations/cpu_opset/arm/pass/convert_group_conv1d.hpp>
-#include <transformations/init_node_info.hpp>
-#include <transformations/utils/utils.hpp>
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/op/constant.hpp"
@@ -21,8 +16,6 @@
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/opsets/opset1_decl.hpp"
-#include "openvino/opsets/opset3_decl.hpp"
-#include "openvino/opsets/opset7_decl.hpp"
 
 using namespace testing;
 using namespace ov::intel_cpu;
@@ -31,7 +24,7 @@ template <class T>
 static std::shared_ptr<ov::Model> createInitGraph(ov::Shape param_shape, ov::Shape weights_shape) {
         auto type = ov::element::f32;
         auto param = std::make_shared<ov::opset1::Parameter>(type, param_shape);
-        auto weights = ov::opset1::Constant::create(type, weights_shape, { 1 });
+        auto weights = ov::opset1::Constant::create(type, weights_shape, {1});
         bool is1Dinput = param_shape.size() == 3;
         auto conv = std::make_shared<T>(param,
                                         weights,
@@ -52,7 +45,7 @@ static std::shared_ptr<ov::Model> createTransformedGraph(ov::Shape param_shape, 
         };
         auto type = ov::element::f32;
         auto param = std::make_shared<ov::opset1::Parameter>(type, param_shape);
-        auto weights = ov::opset1::Constant::create(type, weights_shape, { 1 });
+        auto weights = ov::opset1::Constant::create(type, weights_shape, {1});
         auto input2d = getUnsqueeze(param);
         auto weights2d = getUnsqueeze(weights);
         auto conv2d = std::make_shared<T>(input2d,
@@ -67,62 +60,38 @@ static std::shared_ptr<ov::Model> createTransformedGraph(ov::Shape param_shape, 
         return std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{param});
 }
 
-TEST(TransformationTests, CheckConvertConv1DIsAppliedFor1DShapes) {
-    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
-    {
-        model = createInitGraph<ov::opset1::Convolution>(ov::Shape{2, 64, 7}, ov::Shape{ 30, 64, 1 });
-        ov::pass::Manager manager;
+class ConvertConv1DTests : public TransformationTestsF {
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
         manager.register_pass<ConvertConv1D>();
-        manager.run_passes(model);
     }
-    {
-        model_ref = createTransformedGraph<ov::opset1::Convolution>(ov::Shape{2, 64, 7}, ov::Shape{30, 64, 1});
-    }
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
-}
+};
 
-TEST(TransformationTests, CheckConvertConv1DIsNotAppliedFor2DShapes) {
-    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
-    {
-        model = createInitGraph<ov::opset1::Convolution>(ov::Shape{2, 64, 7, 1}, ov::Shape{30, 64, 1, 1});
-        ov::pass::Manager manager;
-        manager.register_pass<ConvertConv1D>();
-        manager.run_passes(model);
-    }
-    {
-        model_ref = createInitGraph<ov::opset1::Convolution>(ov::Shape{2, 64, 7, 1}, ov::Shape{30, 64, 1, 1});
-    }
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
-}
-
-TEST(TransformationTests, CheckConvertGroupConv1DIsAppliedFor1dShapes) {
-    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
-    {
-        model = createInitGraph<ov::opset1::GroupConvolution>(ov::Shape{1, 12, 64}, ov::Shape{4, 1, 3, 5});
-        ov::pass::Manager manager;
+class ConvertGroupConv1DTests : public TransformationTestsF {
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
         manager.register_pass<ConvertGroupConv1D>();
-        manager.run_passes(model);
     }
-    {
-        model_ref = createTransformedGraph<ov::opset1::GroupConvolution>(ov::Shape{1, 12, 64}, ov::Shape{4, 1, 3, 5});
-    }
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
+};
+
+TEST_F(ConvertConv1DTests, Applied_1DShapes) {
+    model = createInitGraph<ov::opset1::Convolution>(ov::Shape{2, 64, 7}, ov::Shape{30, 64, 1});
+    model_ref = createTransformedGraph<ov::opset1::Convolution>(ov::Shape{2, 64, 7}, ov::Shape{30, 64, 1});
 }
 
-TEST(TransformationTests, CheckConvertGroupConv1DIsNotAppliedFor2DShapes) {
-    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
-    {
-        model = createInitGraph<ov::opset1::GroupConvolution>(ov::Shape{1, 12, 64, 1}, ov::Shape{4, 1, 3, 5, 1});
-        ov::pass::Manager manager;
-        manager.register_pass<ConvertGroupConv1D>();
-        manager.run_passes(model);
-    }
-    {
-        model_ref = createInitGraph<ov::opset1::GroupConvolution>(ov::Shape{1, 12, 64, 1}, ov::Shape{4, 1, 3, 5, 1});
-    }
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
+TEST_F(ConvertConv1DTests, Negative_2DShapes) {
+    model = createInitGraph<ov::opset1::Convolution>(ov::Shape{2, 64, 7, 1}, ov::Shape{30, 64, 1, 1});
+    // model_ref intentionally omitted — transformation should not fire
+}
+
+TEST_F(ConvertGroupConv1DTests, Applied_1DShapes) {
+    model = createInitGraph<ov::opset1::GroupConvolution>(ov::Shape{1, 12, 64}, ov::Shape{4, 1, 3, 5});
+    model_ref = createTransformedGraph<ov::opset1::GroupConvolution>(ov::Shape{1, 12, 64}, ov::Shape{4, 1, 3, 5});
+}
+
+TEST_F(ConvertGroupConv1DTests, Negative_2DShapes) {
+    model = createInitGraph<ov::opset1::GroupConvolution>(ov::Shape{1, 12, 64, 1}, ov::Shape{4, 1, 3, 5, 1});
+    // model_ref intentionally omitted — transformation should not fire
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv1d.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv1d.cpp
@@ -83,7 +83,6 @@ TEST_F(ConvertConv1DTests, Applied_1DShapes) {
 
 TEST_F(ConvertConv1DTests, Negative_2DShapes) {
     model = createInitGraph<ov::opset1::Convolution>(ov::Shape{2, 64, 7, 1}, ov::Shape{30, 64, 1, 1});
-    // model_ref intentionally omitted — transformation should not fire
 }
 
 TEST_F(ConvertGroupConv1DTests, Applied_1DShapes) {
@@ -93,5 +92,4 @@ TEST_F(ConvertGroupConv1DTests, Applied_1DShapes) {
 
 TEST_F(ConvertGroupConv1DTests, Negative_2DShapes) {
     model = createInitGraph<ov::opset1::GroupConvolution>(ov::Shape{1, 12, 64, 1}, ov::Shape{4, 1, 3, 5, 1});
-    // model_ref intentionally omitted — transformation should not fire
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_multi_axis.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_multi_axis.cpp
@@ -5,13 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
-#include <openvino/core/model.hpp>
-#include <openvino/pass/manager.hpp>
-#include <ov_ops/type_relaxed.hpp>
-#include <string>
 #include <transformations/cpu_opset/arm/pass/convert_reduce_multi_axis.hpp>
-#include <transformations/init_node_info.hpp>
-#include <transformations/utils/utils.hpp>
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/op/constant.hpp"
@@ -21,90 +15,77 @@
 #include "openvino/op/reduce_prod.hpp"
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/opsets/opset1_decl.hpp"
-#include "openvino/opsets/opset3_decl.hpp"
-#include "openvino/opsets/opset7_decl.hpp"
 
 using namespace testing;
 using namespace ov::intel_cpu;
 
-template <class T>
-class ConvertReduceMultiAxisTest : public testing::Test {};
+struct ReduceMultiAxisTestParams {
+    std::string name;
+    std::function<std::shared_ptr<ov::Node>(const ov::Output<ov::Node>&, const ov::Output<ov::Node>&, bool)> makeReduce;
+    std::function<void(ov::pass::Manager&)> registerPass;
+};
 
-template <class T>
-static std::shared_ptr<ov::Model> createInitGraph(std::shared_ptr<ov::opset1::Parameter> param) {
-        auto axes = ov::opset1::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
-        auto reduce = std::make_shared<T>(param, axes, true);
-        return std::make_shared<ov::Model>(ov::OutputVector{reduce}, ov::ParameterVector{param});
+static auto makeReduceMultiAxisParams() {
+    return ::testing::Values(
+        ReduceMultiAxisTestParams{
+            "ReduceMin",
+            [](const ov::Output<ov::Node>& data, const ov::Output<ov::Node>& axes, bool keep_dims) {
+                return std::make_shared<ov::opset1::ReduceMin>(data, axes, keep_dims);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduceMin>(); }},
+        ReduceMultiAxisTestParams{
+            "ReduceMax",
+            [](const ov::Output<ov::Node>& data, const ov::Output<ov::Node>& axes, bool keep_dims) {
+                return std::make_shared<ov::opset1::ReduceMax>(data, axes, keep_dims);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduceMax>(); }},
+        ReduceMultiAxisTestParams{
+            "ReduceSum",
+            [](const ov::Output<ov::Node>& data, const ov::Output<ov::Node>& axes, bool keep_dims) {
+                return std::make_shared<ov::opset1::ReduceSum>(data, axes, keep_dims);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduceSum>(); }},
+        ReduceMultiAxisTestParams{
+            "ReduceProd",
+            [](const ov::Output<ov::Node>& data, const ov::Output<ov::Node>& axes, bool keep_dims) {
+                return std::make_shared<ov::opset1::ReduceProd>(data, axes, keep_dims);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduceProd>(); }});
 }
 
-template <class T>
-static std::shared_ptr<ov::Model> createRefGraph(ov::Shape param_shape) {
-        auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, param_shape);
-        std::vector<int64_t> axes = {0, 1};
-        std::shared_ptr<ov::Node> node = param;
-        for (auto axis : axes) {
+using ConvertReduceMultiAxisParams = std::tuple<ReduceMultiAxisTestParams, ov::PartialShape>;
+
+class ConvertReduceMultiAxisTest : public TransformationTestsF,
+                                   public WithParamInterface<ConvertReduceMultiAxisParams> {
+public:
+    static std::string getTestCaseName(const TestParamInfo<ConvertReduceMultiAxisParams>& info) {
+        const auto& [params, shape] = info.param;
+        return params.name + (shape.is_dynamic() ? "_Dynamic" : "_Static");
+    }
+};
+
+TEST_P(ConvertReduceMultiAxisTest, CompareWithRef) {
+    const auto& [params, shape] = GetParam();
+    auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, shape);
+    auto axes = ov::opset1::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
+    auto reduce = params.makeReduce(param, axes, true);
+    model = std::make_shared<ov::Model>(ov::OutputVector{reduce}, ov::ParameterVector{param});
+
+    if (shape.is_static()) {
+        auto ref_param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, shape);
+        std::shared_ptr<ov::Node> node = ref_param;
+        for (auto axis : std::vector<int64_t>{0, 1}) {
             auto reduction_axis = ov::opset1::Constant::create(ov::element::i64, ov::Shape{}, {axis});
-            node = std::make_shared<T>(node, reduction_axis, true);
+            node = params.makeReduce(node, reduction_axis, true);
         }
-
-        return std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{param});
-}
-
-template <class T>
-static bool registerAndRunReducePass(std::shared_ptr<ov::Model> model) {
-    ov::pass::Manager manager;
-    if (std::is_same<T, ov::opset1::ReduceMin>::value) {
-        manager.register_pass<ConvertReduceMin>();
-    } else if (std::is_same<T, ov::opset1::ReduceMax>::value) {
-        manager.register_pass<ConvertReduceMax>();
-    } else if (std::is_same<T, ov::opset1::ReduceSum>::value) {
-        manager.register_pass<ConvertReduceSum>();
-    } else if (std::is_same<T, ov::opset1::ReduceProd>::value) {
-        manager.register_pass<ConvertReduceProd>();
-    } else {
-        return false;
-    }
-    manager.run_passes(model);
-    return true;
-}
-
-static ov::Shape static_param_shape = ov::Shape{2, 19, 2, 9};
-static ov::PartialShape dynamic_param_shape = ov::PartialShape{2, -1, 2, 9};
-
-TYPED_TEST_SUITE_P(ConvertReduceMultiAxisTest);
-
-TYPED_TEST_P(ConvertReduceMultiAxisTest, CheckConvertReduceTransformationIsApplied) {
-    auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, static_param_shape);
-    auto model = createInitGraph<TypeParam>(param);
-    auto model_ref = createRefGraph<TypeParam>(static_param_shape);
-
-    if (!registerAndRunReducePass<TypeParam>(model)) {
-        FAIL() << "Reduce pass is not registered.";
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{ref_param});
     }
 
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    params.registerPass(manager);
 }
 
-TYPED_TEST_P(ConvertReduceMultiAxisTest, CheckConvertReduceTransformationIsNotAppliedForDynaimcShapes) {
-    auto param = std::make_shared<ov::opset1::Parameter>(ov::element::f32, dynamic_param_shape);
-    auto model = createInitGraph<TypeParam>(param);
-    auto model_ref = createInitGraph<TypeParam>(param);
-
-    if (!registerAndRunReducePass<TypeParam>(model)) {
-        FAIL() << "Reduce pass is not registered.";
-    }
-
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
-}
-
-REGISTER_TYPED_TEST_SUITE_P(ConvertReduceMultiAxisTest,
-                            CheckConvertReduceTransformationIsApplied,
-                            CheckConvertReduceTransformationIsNotAppliedForDynaimcShapes);
-
-using reduceTypes = ::testing::Types<ov::opset1::ReduceMin,
-                                     ov::opset1::ReduceMax,
-                                     ov::opset1::ReduceSum,
-                                     ov::opset1::ReduceProd>;
-INSTANTIATE_TYPED_TEST_SUITE_P(ConvertReduce, ConvertReduceMultiAxisTest, reduceTypes);
+INSTANTIATE_TEST_SUITE_P(TransformationTests, ConvertReduceMultiAxisTest,
+    ::testing::Combine(
+        makeReduceMultiAxisParams(),
+        ::testing::Values(ov::PartialShape{2, 19, 2, 9}, ov::PartialShape{2, -1, 2, 9})),
+    ConvertReduceMultiAxisTest::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_multi_axis.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_multi_axis.cpp
@@ -4,7 +4,11 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
 #include <transformations/cpu_opset/arm/pass/convert_reduce_multi_axis.hpp>
 
 #include "common_test_utils/ov_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
@@ -17,88 +17,95 @@
 #include "openvino/op/reduce_prod.hpp"
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/squeeze.hpp"
-#include "openvino/op/util/arithmetic_reductions_keep_dims.hpp"
-#include "openvino/op/util/logical_reduction_keep_dims.hpp"
 #include "openvino/opsets/opset1_decl.hpp"
 
 using namespace ov::intel_cpu;
 
-template <class T>
-class ConvertReduceNoKeepDimsTest : public testing::Test {};
+struct ReduceNoKeepDimsTestParams {
+    std::string name;
+    ov::element::Type dataType;
+    std::function<std::shared_ptr<ov::Node>(const ov::Output<ov::Node>&, const ov::Output<ov::Node>&, bool)> makeReduce;
+    std::function<void(ov::pass::Manager&)> registerPass;
+};
 
-template <class T>
-static std::shared_ptr<ov::Model> createInitGraph(std::shared_ptr<ov::opset1::Parameter> param) {
-        auto axes = ov::opset1::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
-        auto reduce = std::make_shared<T>(param, axes, false);
-        return std::make_shared<ov::Model>(ov::OutputVector{reduce}, ov::ParameterVector{param});
+static auto makeReduceNoKeepDimsParams() {
+    using namespace ov::op::util;
+    return ::testing::Values(
+        ReduceNoKeepDimsTestParams{
+            "ReduceMin", ov::element::f32,
+            [](const ov::Output<ov::Node>& d, const ov::Output<ov::Node>& a, bool k) {
+                return std::make_shared<ov::opset1::ReduceMin>(d, a, k);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduction<ArithmeticReductionKeepDims>>(); }},
+        ReduceNoKeepDimsTestParams{
+            "ReduceMax", ov::element::f32,
+            [](const ov::Output<ov::Node>& d, const ov::Output<ov::Node>& a, bool k) {
+                return std::make_shared<ov::opset1::ReduceMax>(d, a, k);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduction<ArithmeticReductionKeepDims>>(); }},
+        ReduceNoKeepDimsTestParams{
+            "ReduceSum", ov::element::f32,
+            [](const ov::Output<ov::Node>& d, const ov::Output<ov::Node>& a, bool k) {
+                return std::make_shared<ov::opset1::ReduceSum>(d, a, k);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduction<ArithmeticReductionKeepDims>>(); }},
+        ReduceNoKeepDimsTestParams{
+            "ReduceProd", ov::element::f32,
+            [](const ov::Output<ov::Node>& d, const ov::Output<ov::Node>& a, bool k) {
+                return std::make_shared<ov::opset1::ReduceProd>(d, a, k);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduction<ArithmeticReductionKeepDims>>(); }},
+        ReduceNoKeepDimsTestParams{
+            "ReduceMean", ov::element::f32,
+            [](const ov::Output<ov::Node>& d, const ov::Output<ov::Node>& a, bool k) {
+                return std::make_shared<ov::opset1::ReduceMean>(d, a, k);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduction<ArithmeticReductionKeepDims>>(); }},
+        ReduceNoKeepDimsTestParams{
+            "ReduceLogicalAnd", ov::element::boolean,
+            [](const ov::Output<ov::Node>& d, const ov::Output<ov::Node>& a, bool k) {
+                return std::make_shared<ov::opset1::ReduceLogicalAnd>(d, a, k);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduction<LogicalReductionKeepDims>>(); }},
+        ReduceNoKeepDimsTestParams{
+            "ReduceLogicalOr", ov::element::boolean,
+            [](const ov::Output<ov::Node>& d, const ov::Output<ov::Node>& a, bool k) {
+                return std::make_shared<ov::opset1::ReduceLogicalOr>(d, a, k);
+            },
+            [](ov::pass::Manager& m) { m.register_pass<ConvertReduction<LogicalReductionKeepDims>>(); }});
 }
 
-template <class T>
-static std::shared_ptr<ov::Model> createRefGraph(std::shared_ptr<ov::opset1::Parameter> param) {
-        auto axes = ov::opset1::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
-        auto reduce = std::make_shared<T>(param, axes, true);
-        auto squeeze = std::make_shared<ov::opset1::Squeeze>(reduce, axes);
-        return std::make_shared<ov::Model>(ov::OutputVector{squeeze}, ov::ParameterVector{param});
-}
+using ConvertReduceNoKeepDimsParams = std::tuple<ReduceNoKeepDimsTestParams, ov::PartialShape>;
 
-template <class T>
-static bool registerAndRunReducePass(std::shared_ptr<ov::Model> model) {
-    ov::pass::Manager manager;
-    if (std::is_base_of_v<ov::op::util::LogicalReductionKeepDims, T>) {
-        manager.register_pass<ConvertReduction<ov::op::util::LogicalReductionKeepDims>>();
-    } else if (std::is_base_of_v<ov::op::util::ArithmeticReductionKeepDims, T>) {
-        manager.register_pass<ConvertReduction<ov::op::util::ArithmeticReductionKeepDims>>();
-    } else {
-        return false;
+class ConvertReduceNoKeepDimsTest : public TransformationTestsF,
+                                    public WithParamInterface<ConvertReduceNoKeepDimsParams> {
+public:
+    static std::string getTestCaseName(const TestParamInfo<ConvertReduceNoKeepDimsParams>& info) {
+        const auto& [params, shape] = info.param;
+        return params.name + (shape.is_dynamic() ? "_Dynamic" : "_Static");
     }
-    manager.run_passes(model);
-    return true;
-}
+};
 
-static ov::Shape static_param_shape = ov::Shape{2, 19, 2, 9};
-static ov::PartialShape dynamic_param_shape = ov::PartialShape{2, -1, 2, 9};
+TEST_P(ConvertReduceNoKeepDimsTest, CompareWithRef) {
+    const auto& [params, shape] = GetParam();
+    auto param = std::make_shared<ov::opset1::Parameter>(params.dataType, shape);
+    auto axes = ov::opset1::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
+    auto reduce = params.makeReduce(param, axes, false);
+    model = std::make_shared<ov::Model>(ov::OutputVector{reduce}, ov::ParameterVector{param});
 
-TYPED_TEST_SUITE_P(ConvertReduceNoKeepDimsTest);
-
-TYPED_TEST_P(ConvertReduceNoKeepDimsTest, CheckConvertReduceTransformationIsAppliedForStaticShapes) {
-    ov::element::Type_t dataType =
-        std::is_base_of_v<ov::op::util::LogicalReductionKeepDims, TypeParam> ? ov::element::boolean : ov::element::f32;
-    auto param = std::make_shared<ov::opset1::Parameter>(dataType, static_param_shape);
-    auto model = createInitGraph<TypeParam>(param);
-    auto model_ref = createRefGraph<TypeParam>(param);
-
-    if (!registerAndRunReducePass<TypeParam>(model)) {
-        FAIL() << "Reduce pass is not registered.";
+    {
+        auto ref_param = std::make_shared<ov::opset1::Parameter>(params.dataType, shape);
+        auto ref_axes = ov::opset1::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
+        auto ref_reduce = params.makeReduce(ref_param, ref_axes, true);
+        auto squeeze = std::make_shared<ov::opset1::Squeeze>(ref_reduce, ref_axes);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{squeeze}, ov::ParameterVector{ref_param});
     }
 
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    params.registerPass(manager);
 }
 
-TYPED_TEST_P(ConvertReduceNoKeepDimsTest, CheckConvertReduceTransformationIsAppliedForDynaimcShapes) {
-    ov::element::Type_t dataType =
-        std::is_base_of_v<ov::op::util::LogicalReductionKeepDims, TypeParam> ? ov::element::boolean : ov::element::f32;
-    auto param = std::make_shared<ov::opset1::Parameter>(dataType, dynamic_param_shape);
-    auto model = createInitGraph<TypeParam>(param);
-    auto model_ref = createRefGraph<TypeParam>(param);
-
-    if (!registerAndRunReducePass<TypeParam>(model)) {
-        FAIL() << "Reduce pass is not registered.";
-    }
-
-    auto res = compare_functions(model, model_ref);
-    ASSERT_TRUE(res.first) << res.second;
-}
-
-REGISTER_TYPED_TEST_SUITE_P(ConvertReduceNoKeepDimsTest,
-                            CheckConvertReduceTransformationIsAppliedForStaticShapes,
-                            CheckConvertReduceTransformationIsAppliedForDynaimcShapes);
-
-using reduceTypes = ::testing::Types<ov::opset1::ReduceMin,
-                                     ov::opset1::ReduceMax,
-                                     ov::opset1::ReduceSum,
-                                     ov::opset1::ReduceProd,
-                                     ov::opset1::ReduceMean,
-                                     ov::opset1::ReduceLogicalAnd,
-                                     ov::opset1::ReduceLogicalOr>;
-INSTANTIATE_TYPED_TEST_SUITE_P(ConvertReduce, ConvertReduceNoKeepDimsTest, reduceTypes);
+INSTANTIATE_TEST_SUITE_P(TransformationTests, ConvertReduceNoKeepDimsTest,
+    ::testing::Combine(
+        makeReduceNoKeepDimsParams(),
+        ::testing::Values(ov::PartialShape{2, 19, 2, 9}, ov::PartialShape{2, -1, 2, 9})),
+    ConvertReduceNoKeepDimsTest::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
@@ -19,6 +19,7 @@
 #include "openvino/op/squeeze.hpp"
 #include "openvino/opsets/opset1_decl.hpp"
 
+using namespace testing;
 using namespace ov::intel_cpu;
 
 struct ReduceNoKeepDimsTestParams {

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
@@ -4,6 +4,11 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
 #include <transformations/cpu_opset/arm/pass/convert_reduce_no_keep_dims.hpp>
 
 #include "common_test_utils/ov_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
@@ -7,23 +7,16 @@
 #include <memory>
 #include <openvino/core/model.hpp>
 #include "openvino/opsets/opset1_decl.hpp"
-#include "openvino/opsets/opset3_decl.hpp"
-#include "openvino/opsets/opset7_decl.hpp"
 #include "openvino/opsets/opset8_decl.hpp"
-#include <openvino/pass/manager.hpp>
 #include <ov_ops/type_relaxed.hpp>
 #include <transformations/cpu_opset/common/pass/convert_matmul_to_fc.hpp>
-#include <transformations/init_node_info.hpp>
-#include <transformations/utils/utils.hpp>
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/op/constant.hpp"
 #include "ov_ops/fully_connected.hpp"
 #include "transformations/rt_info/decompression.hpp"
-#include "openvino/op/concat.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
-#include "openvino/op/shape_of.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/random_uniform.hpp"
@@ -31,41 +24,103 @@
 using namespace testing;
 using namespace ov::intel_cpu;
 
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest1) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 2}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, true, false);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
+class ConvertMatMulToFCTests : public TransformationTestsF {
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
         manager.register_pass<ConvertMatMulToFC>();
     }
+};
+
+struct MatMulToFCParam {
+    std::string name;
+    ov::PartialShape input_shape;
+    ov::Shape weights_shape;
+    bool transpose_a;
+    bool transpose_b;
+    ov::element::Type output_type;
+};
+
+class ConvertMatMulToFCParamTests : public ConvertMatMulToFCTests,
+                                    public WithParamInterface<MatMulToFCParam> {
+public:
+    static std::string getTestCaseName(const TestParamInfo<MatMulToFCParam>& info) {
+        return info.param.name;
+    }
+};
+
+TEST_P(ConvertMatMulToFCParamTests, CompareWithRef) {
+    const auto& p = GetParam();
     {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-        auto transpose_constant1 = ov::opset1::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
-        auto transpose1 = std::make_shared<ov::opset1::Transpose>(input1, transpose_constant1);
+        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, p.input_shape);
+        auto input2 = ov::opset1::Constant::create(ov::element::f32, p.weights_shape, {1});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, p.transpose_a, p.transpose_b);
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
+    }
+    {
+        auto make_transpose = [](const std::shared_ptr<ov::Node>& node, size_t rank) {
+            std::vector<int32_t> order(rank);
+            for (size_t i = 0; i < rank; ++i)
+                order[i] = static_cast<int32_t>(i);
+            std::swap(order[rank - 1], order[rank - 2]);
+            auto order_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{rank}, order);
+            return std::make_shared<ov::opset1::Transpose>(node, order_const);
+        };
 
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 2}, {1});
-        auto transpose_constant2 = ov::opset1::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
-        auto transpose2 = std::make_shared<ov::opset1::Transpose>(input2, transpose_constant2);
+        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, p.input_shape);
+        auto input2 = ov::opset1::Constant::create(ov::element::f32, p.weights_shape, {1});
 
-        auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
-            transpose1,
-            transpose2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
+        std::shared_ptr<ov::Node> fc_input = input1;
+        std::shared_ptr<ov::Node> fc_weights = input2;
 
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
+        if (p.transpose_a) {
+            fc_input = make_transpose(input1, p.input_shape.rank().get_length());
+        }
+        if (!p.transpose_b) {
+            fc_weights = make_transpose(input2, p.weights_shape.size());
+        }
+
+        std::shared_ptr<ov::Node> fc;
+        if (p.output_type != ov::element::dynamic) {
+            fc = std::make_shared<ov::op::internal::FullyConnected>(
+                fc_input, fc_weights,
+                std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
+                p.output_type);
+        } else {
+            fc = std::make_shared<ov::op::internal::FullyConnected>(
+                fc_input, fc_weights,
+                std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
+        }
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest2) {
+INSTANTIATE_TEST_SUITE_P(ConvertMatMulToFC, ConvertMatMulToFCParamTests,
+    ::testing::Values(
+        // transpose_b=true: MatMul(A, B, false, true) -> FC(A, B, bias)
+        MatMulToFCParam{"3d_static_2x2", {3, 2, 2}, {2, 2}, false, true, ov::element::dynamic},
+        MatMulToFCParam{"3d_dynamic_2x2", {-1, -1, 2}, {2, 2}, false, true, ov::element::dynamic},
+        MatMulToFCParam{"3d_static_3x2", {3, 2, 2}, {3, 2}, false, true, ov::element::dynamic},
+        MatMulToFCParam{"3d_dynamic_3x2", {-1, -1, 2}, {3, 2}, false, true, ov::element::dynamic},
+        MatMulToFCParam{"3d_dynamic_80x1", {-1, -1, 1}, {1, 80, 1}, false, true, ov::element::dynamic},
+        MatMulToFCParam{"4d_dynamic_10x5", {-1, -1, 1, 5}, {1, 10, 5}, false, true, ov::element::dynamic},
+        MatMulToFCParam{"3d_batch_dim", {5, 2, 3}, {1, 2, 3}, false, true, ov::element::dynamic},
+        MatMulToFCParam{"2d_equal", {2, 3}, {2, 3}, false, true, ov::element::dynamic},
+        MatMulToFCParam{"4d_static_6x5", {2, 3, 4, 5}, {6, 5}, false, true, ov::element::f32},
+        MatMulToFCParam{"4d_2d_to_4d", {2, 4}, {1, 1, 5, 4}, false, true, ov::element::f32},
+        MatMulToFCParam{"4d_3d_to_4d", {3, 2, 4}, {1, 1, 5, 4}, false, true, ov::element::f32},
+        MatMulToFCParam{"4d_4d_to_4d", {2, 3, 2, 4}, {1, 1, 5, 4}, false, true, ov::element::f32},
+        // transpose_a=true: MatMul(A, B, true, false) -> FC(Transpose(A), Transpose(B), bias)
+        MatMulToFCParam{"3d_transpose_a", {3, 2, 2}, {1, 2, 2}, true, false, ov::element::dynamic}),
+    ConvertMatMulToFCParamTests::getTestCaseName);
+
+TEST_F(ConvertMatMulToFCTests, BothParamsNotConverted) {
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 1, 2});
         auto input2 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, false);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1, input2});
-        manager.register_pass<ConvertMatMulToFC>();
     }
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 1, 2});
@@ -76,148 +131,15 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest2) {
     }
 }
 
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest3) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
-        auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest4) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
-        auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest7) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 2}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 2}, {1});
-        auto fc = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest8) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 2}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 2}, {1});
-
-        auto fc = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-        auto a_shape = std::make_shared<ov::opset3::ShapeOf>(input1);
-
-        auto I = ov::op::util::node_to_get_shape_value_of_indices_from_shape_node(a_shape, {0, 1});
-        auto O = ov::opset1::Constant::create(ov::element::i64, {1}, {3});
-        auto output_shape = std::make_shared<ov::opset1::Concat>(ov::OutputVector{I, O}, 0);
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest9) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
-        auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest10) {
+TEST_F(ConvertMatMulToFCTests, FullyDynamicRankNotConverted) {
     auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
     model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-    manager.register_pass<ConvertMatMulToFC>();
 }
 
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest13) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 1});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 80, 1}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 1});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 80, 1}, {1});
-        auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest14) {
+TEST_F(ConvertMatMulToFCTests, TypeRelaxedU8I8) {
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::u8, ov::PartialShape{-1, -1, 1});
         auto input2 = ov::opset1::Constant::create(ov::element::i8, ov::Shape{1, 80, 1}, {1});
@@ -230,7 +152,6 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest14) {
             true);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
     }
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::u8, ov::PartialShape{-1, -1, 1});
@@ -246,179 +167,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest14) {
     }
 }
 
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_1) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{2, 3, 4, 5});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{6, 5}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{2, 3, 4, 5});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{6, 5}, {1});
-
-        auto fc = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
-            ov::element::f32);
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_2) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 1, 5});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 10, 5}, {1});
-        auto fc = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 1, 5});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 10, 5}, {1});
-        auto fc = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_3) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{2, 4});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 5, 4}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{2, 4});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 5, 4}, {1});
-        auto fc = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
-            ov::element::f32);
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_4) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 4});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 5, 4}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 4});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 5, 4}, {1});
-        auto fc = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
-            ov::element::f32);
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_5) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{2, 3, 2, 4});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 5, 4}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{2, 3, 2, 4});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 5, 4}, {1});
-        auto fc = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
-            ov::element::f32);
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_1) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{5, 2, 3});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 3}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{5, 2, 3});
-        auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 3}, {1});
-        auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            input2,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_2) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{2, 3});
-        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 3}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, weights, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{2, 3});
-        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 3}, {1});
-        auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            weights,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_3) {
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{5, 2, 3});
-        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 3}, {1});
-        auto matmul = std::make_shared<ov::opset1::MatMul>(input1, weights, false, true);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{5, 2, 3});
-
-        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 3}, {1});
-        auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
-            input1,
-            weights,
-            std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_0) {
+TEST_F(ConvertMatMulToFCTests, DecompressF16Weights) {
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
         auto input2 = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 2, 2}, {1});
@@ -427,7 +176,6 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_0) {
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, convert, false, false);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
     }
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
@@ -446,7 +194,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_0) {
     }
 }
 
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_1) {
+TEST_F(ConvertMatMulToFCTests, DecompressF16Weights_TransposeA) {
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
         auto input2 = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 2, 2}, {1});
@@ -455,7 +203,6 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_1) {
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, convert, true, false);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-        manager.register_pass<ConvertMatMulToFC>();
     }
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
@@ -476,7 +223,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_1) {
     }
 }
 
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_compressed_u8_weights) {
+TEST_F(ConvertMatMulToFCTests, CompressedU8WeightsWithSubMul) {
     {
         auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
         auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{1, 2, 2}, {1});
@@ -488,7 +235,6 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_compressed_u8_weights) {
         auto matmul = std::make_shared<ov::opset1::MatMul>(data, mul);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data});
-        manager.register_pass<ConvertMatMulToFC>();
     }
     {
         auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
@@ -510,7 +256,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_compressed_u8_weights) {
     }
 }
 
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_WithRandomUniform) {
+TEST_F(ConvertMatMulToFCTests, RandomUniformWeightsNotConverted) {
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, -1});
 
@@ -525,8 +271,6 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_WithRandomUniform) {
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, random_uniform, false, false);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
-
-        manager.register_pass<ConvertMatMulToFC>();
     }
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, -1});

--- a/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <string>
+#include <vector>
 #include <openvino/core/model.hpp>
 #include "openvino/opsets/opset1_decl.hpp"
 #include "openvino/opsets/opset8_decl.hpp"

--- a/src/plugins/intel_cpu/tests/unit/transformations/convert_to_leaky_relu_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/convert_to_leaky_relu_test.cpp
@@ -4,143 +4,91 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <memory>
 
 #include <openvino/core/model.hpp>
 #include "openvino/opsets/opset1_decl.hpp"
 #include <transformations/cpu_opset/common/pass/convert_to_leaky_relu.hpp>
 #include <transformations/cpu_opset/common/op/leaky_relu.hpp>
-#include <transformations/init_node_info.hpp>
-#include <transformations/utils/utils.hpp>
 #include <ov_ops/type_relaxed.hpp>
-#include <openvino/pass/manager.hpp>
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/op/prelu.hpp"
 
 using namespace testing;
 using namespace ov::intel_cpu;
 
-TEST(TransformationTests, ConvertToLeakyReluTest1) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+class ConvertToLeakyReluTests : public TransformationTestsF {
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        manager.register_pass<ConvertToLeakyRelu>();
+    }
+};
+
+TEST_F(ConvertToLeakyReluTests, StaticShape) {
     {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 16, 16 });
-        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, { -2.f });
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 3, 16, 16});
+        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, {-2.f});
         auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
-
-        f = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ConvertToLeakyRelu>();
-        m.run_passes(f);
+        model = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
     }
-
     {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 16, 16 });
-        auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
-
-        f_ref = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 3, 16, 16});
+        auto leaky_relu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{leaky_relu}, ov::ParameterVector{input});
     }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertToLeakyReluTest2) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+TEST_F(ConvertToLeakyReluTests, DynamicRank4) {
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, { -2.f });
+        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, {-2.f});
         auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
-
-        f = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ConvertToLeakyRelu>();
-        m.run_passes(f);
+        model = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
     }
-
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
-
-        f_ref = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
+        auto leaky_relu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{leaky_relu}, ov::ParameterVector{input});
     }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertToLeakyReluTest3) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+TEST_F(ConvertToLeakyReluTests, FullyDynamic) {
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
-        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, { -2.f });
+        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, {-2.f});
         auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
-
-        f = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ConvertToLeakyRelu>();
-        m.run_passes(f);
+        model = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
     }
-
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
-        auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
-
-        f_ref = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
+        auto leaky_relu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{leaky_relu}, ov::ParameterVector{input});
     }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertToLeakyReluTest4) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+TEST_F(ConvertToLeakyReluTests, TypeRelaxed) {
     {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::u8, ov::Shape{ 1, 3, 16, 16 });
-        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, { -2.f });
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::u8, ov::Shape{1, 3, 16, 16});
+        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, {-2.f});
         auto relaxed_prelu = std::make_shared<ov::op::TypeRelaxed<ov::opset1::PRelu>>(
-            ov::element::TypeVector{ ov::element::f32, ov::element::f32 },
-            ov::element::TypeVector{ ov::element::f32 },
+            ov::element::TypeVector{ov::element::f32, ov::element::f32},
+            ov::element::TypeVector{ov::element::f32},
             ov::op::TemporaryReplaceOutputType(input, ov::element::f32).get(),
             ov::op::TemporaryReplaceOutputType(slope, ov::element::f32).get());
-
-        f = std::make_shared<ov::Model>(ov::OutputVector{relaxed_prelu}, ov::ParameterVector{input});
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ConvertToLeakyRelu>();
-        m.run_passes(f);
+        model = std::make_shared<ov::Model>(ov::OutputVector{relaxed_prelu}, ov::ParameterVector{input});
     }
-
     {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::u8, ov::Shape{ 1, 3, 16, 16 });
-        auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
-
-        f_ref = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::u8, ov::Shape{1, 3, 16, 16});
+        auto leaky_relu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{leaky_relu}, ov::ParameterVector{input});
     }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertToLeakyReluTest5) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 16, 16 });
-        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 3 }, { -2.f, -1.f, -2.f });
-        auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
-
-        f = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
-        f_ref = f;
-
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ConvertToLeakyRelu>();
-        m.run_passes(f);
-    }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+TEST_F(ConvertToLeakyReluTests, Negative_NonScalarSlope) {
+    auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 3, 16, 16});
+    auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3}, {-2.f, -1.f, -2.f});
+    auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
+    model = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
+    // model_ref intentionally omitted — transformation should not fire
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/convert_to_leaky_relu_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/convert_to_leaky_relu_test.cpp
@@ -17,7 +17,8 @@
 using namespace testing;
 using namespace ov::intel_cpu;
 
-class ConvertToLeakyReluTests : public TransformationTestsF {
+class ConvertToLeakyReluTests : public TransformationTestsF,
+                                public WithParamInterface<ov::PartialShape> {
 protected:
     void SetUp() override {
         TransformationTestsF::SetUp();
@@ -25,49 +26,29 @@ protected:
     }
 };
 
-TEST_F(ConvertToLeakyReluTests, StaticShape) {
+TEST_P(ConvertToLeakyReluTests, CompareWithRef) {
+    const auto& shape = GetParam();
     {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 3, 16, 16});
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, shape);
         auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, {-2.f});
         auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
         model = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
     }
     {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 3, 16, 16});
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, shape);
         auto leaky_relu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{leaky_relu}, ov::ParameterVector{input});
     }
 }
 
-TEST_F(ConvertToLeakyReluTests, DynamicRank4) {
-    {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, {-2.f});
-        auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
-        model = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
-    }
-    {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        auto leaky_relu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{leaky_relu}, ov::ParameterVector{input});
-    }
-}
+INSTANTIATE_TEST_SUITE_P(TransformationTests, ConvertToLeakyReluTests,
+    ::testing::Values(
+        ov::PartialShape{1, 3, 16, 16},
+        ov::PartialShape::dynamic(4),
+        ov::PartialShape::dynamic()));
 
-TEST_F(ConvertToLeakyReluTests, FullyDynamic) {
-    {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
-        auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, {-2.f});
-        auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
-        model = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
-    }
-    {
-        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
-        auto leaky_relu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{leaky_relu}, ov::ParameterVector{input});
-    }
-}
-
-TEST_F(ConvertToLeakyReluTests, TypeRelaxed) {
+TEST_F(TransformationTestsF, ConvertToLeakyRelu_TypeRelaxed) {
+    manager.register_pass<ConvertToLeakyRelu>();
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::u8, ov::Shape{1, 3, 16, 16});
         auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, {-2.f});
@@ -85,10 +66,10 @@ TEST_F(ConvertToLeakyReluTests, TypeRelaxed) {
     }
 }
 
-TEST_F(ConvertToLeakyReluTests, Negative_NonScalarSlope) {
+TEST_F(TransformationTestsF, ConvertToLeakyRelu_Negative_NonScalarSlope) {
+    manager.register_pass<ConvertToLeakyRelu>();
     auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 3, 16, 16});
     auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3}, {-2.f, -1.f, -2.f});
     auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
     model = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
-    // model_ref intentionally omitted — transformation should not fire
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
@@ -5,10 +5,10 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
-
 #include <openvino/core/model.hpp>
 #include "openvino/opsets/opset1_decl.hpp"
 #include "openvino/opsets/opset5_decl.hpp"

--- a/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
@@ -34,13 +34,12 @@ static size_t getGateCount(SeqType type) {
     return 1;
 }
 
-static std::shared_ptr<ov::Model> buildOriginalModel(SeqType type, bool dynamic) {
+static std::shared_ptr<ov::Model> buildOriginalModel(SeqType type, const ov::PartialShape& inputShape) {
     const size_t hidden_size = 128;
     const size_t input_size = 16;
     const size_t gates = getGateCount(type);
 
-    auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32,
-        dynamic ? ov::PartialShape{2, -1, -1} : ov::PartialShape{2, 1, 16});
+    auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, inputShape);
     auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 1, hidden_size});
 
     auto w_val = std::vector<float>(gates * hidden_size * input_size, 0);
@@ -89,13 +88,12 @@ static std::shared_ptr<ov::Model> buildOriginalModel(SeqType type, bool dynamic)
     return std::make_shared<ov::Model>(results, params);
 }
 
-static std::shared_ptr<ov::Model> buildRefModel(SeqType type, bool dynamic) {
+static std::shared_ptr<ov::Model> buildRefModel(SeqType type, const ov::PartialShape& inputShape) {
     const size_t hidden_size = 128;
     const size_t input_size = 16;
     const size_t gates = getGateCount(type);
 
-    auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32,
-        dynamic ? ov::PartialShape{2, -1, -1} : ov::PartialShape{2, 1, 16});
+    auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, inputShape);
     auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 1, hidden_size});
 
     auto w_val = std::vector<float>(gates * hidden_size * input_size, 0);
@@ -106,7 +104,7 @@ static std::shared_ptr<ov::Model> buildRefModel(SeqType type, bool dynamic) {
     auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, gates * hidden_size}, b_val);
 
     std::shared_ptr<ov::Node> reshape_before;
-    if (dynamic) {
+    if (inputShape.is_dynamic()) {
         auto data = std::make_shared<ov::opset1::ShapeOf>(X);
         auto reshape_before_pattern = std::make_shared<ov::opset8::Gather>(data,
             ov::opset1::Constant::create(ov::element::i32, {3}, {1, 0, 2}),
@@ -153,20 +151,20 @@ static std::shared_ptr<ov::Model> buildRefModel(SeqType type, bool dynamic) {
     return std::make_shared<ov::Model>(results, params);
 }
 
-using OptimizeSeqTransposeParams = std::tuple<SeqType, bool /*dynamic*/>;
+using OptimizeSeqTransposeParams = std::tuple<SeqType, ov::PartialShape>;
 
 class OptimizeSequenceTransposesTests : public TransformationTestsF,
                                         public WithParamInterface<OptimizeSeqTransposeParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<OptimizeSeqTransposeParams>& info) {
-        const auto& [seqType, isDynamic] = info.param;
+        const auto& [seqType, shape] = info.param;
         std::ostringstream ss;
         switch (seqType) {
             case SeqType::LSTM: ss << "LSTM"; break;
             case SeqType::RNN:  ss << "RNN"; break;
             case SeqType::GRU:  ss << "GRU"; break;
         }
-        ss << (isDynamic ? "_Dynamic" : "_Static");
+        ss << (shape.is_dynamic() ? "_Dynamic" : "_Static");
         return ss.str();
     }
 
@@ -174,9 +172,9 @@ protected:
     void SetUp() override {
         TransformationTestsF::SetUp();
         disable_rt_info_check();
-        const auto& [seqType, isDynamic] = GetParam();
-        model = buildOriginalModel(seqType, isDynamic);
-        model_ref = buildRefModel(seqType, isDynamic);
+        const auto& [seqType, shape] = GetParam();
+        model = buildOriginalModel(seqType, shape);
+        model_ref = buildRefModel(seqType, shape);
         switch (seqType) {
             case SeqType::LSTM: manager.register_pass<OptimizeLSTMSequenceTransposes>(); break;
             case SeqType::RNN:  manager.register_pass<OptimizeRNNSequenceTransposes>(); break;
@@ -190,5 +188,5 @@ TEST_P(OptimizeSequenceTransposesTests, CompareWithRef) {}
 INSTANTIATE_TEST_SUITE_P(TransformationTests, OptimizeSequenceTransposesTests,
     ::testing::Combine(
         ::testing::Values(SeqType::LSTM, SeqType::RNN, SeqType::GRU),
-        ::testing::Values(false, true)),
+        ::testing::Values(ov::PartialShape{2, 1, 16}, ov::PartialShape{2, -1, -1})),
     OptimizeSequenceTransposesTests::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
@@ -5,6 +5,9 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #include <openvino/core/model.hpp>
 #include "openvino/opsets/opset1_decl.hpp"

--- a/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <memory>
 
 #include <openvino/core/model.hpp>
@@ -12,10 +11,6 @@
 #include "openvino/opsets/opset5_decl.hpp"
 #include "openvino/opsets/opset8_decl.hpp"
 #include <transformations/cpu_opset/common/pass/rnn_sequences_optimization.hpp>
-#include <transformations/init_node_info.hpp>
-#include <transformations/utils/utils.hpp>
-#include <ov_ops/type_relaxed.hpp>
-#include <openvino/pass/manager.hpp>
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/op/gather.hpp"
 #include "openvino/op/gru_sequence.hpp"
@@ -28,437 +23,172 @@
 using namespace testing;
 using namespace ov::intel_cpu;
 
-TEST(TransformationTests, OptimizeLSTMSequenceTransposesTest) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-        auto Z = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
+enum class SeqType { LSTM, RNN, GRU };
 
-        auto w_val = std::vector<float>(512 * 16, 0);
-        auto r_val = std::vector<float>(512 * 128, 0);
-        auto b_val = std::vector<float>(512, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512 }, b_val);
-
-        auto transpose_before_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 1, 0, 2 });
-        auto transpose_before = std::make_shared<ov::opset1::Transpose>(X, transpose_before_const);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::LSTMSequence>(transpose_before, Y, Z, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto transpose_after_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 2, 1, 0, 3 });
-        auto transpose_after = std::make_shared<ov::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(transpose_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        const auto Co = std::make_shared<ov::opset1::Result>(lstm_seq->output(2));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-        Co->set_friendly_name("Co");
-
-        f = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho, Co }, ov::ParameterVector{ X, Y, Z });
-
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<OptimizeLSTMSequenceTransposes>();
-        m.run_passes(f);
+static size_t getGateCount(SeqType type) {
+    switch (type) {
+        case SeqType::LSTM: return 4;  // 4*hidden_size
+        case SeqType::GRU:  return 3;  // 3*hidden_size
+        case SeqType::RNN:  return 1;  // 1*hidden_size
     }
-
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-        auto Z = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-
-        auto w_val = std::vector<float>(512 * 16, 0);
-        auto r_val = std::vector<float>(512 * 128, 0);
-        auto b_val = std::vector<float>(512, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512 }, b_val);
-
-        auto reshape_before_const  = ov::opset1::Constant::create(ov::element::i64, ov::Shape{ 3 }, { 1, 2, 16 });
-        auto reshape_before = std::make_shared<ov::opset1::Reshape>(X, reshape_before_const, false);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::LSTMSequence>(reshape_before, Y, Z, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto reshape_after_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 2, 1, 1, 128 });
-        auto reshape_after = std::make_shared<ov::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(reshape_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        const auto Co = std::make_shared<ov::opset1::Result>(lstm_seq->output(2));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-        Co->set_friendly_name("Co");
-
-        f_ref = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho, Co }, ov::ParameterVector{ X, Y, Z });
-    }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    return 1;
 }
 
-TEST(TransformationTests, OptimizeLSTMSequenceTransposesDynamicTest) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 1, 1, 128 });
-        auto Z = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 1, 1, 128 });
+static std::shared_ptr<ov::Model> buildOriginalModel(SeqType type, bool dynamic) {
+    const size_t hidden_size = 128;
+    const size_t input_size = 16;
+    const size_t gates = getGateCount(type);
 
-        auto w_val = std::vector<float>(512 * 16, 0);
-        auto r_val = std::vector<float>(512 * 128, 0);
-        auto b_val = std::vector<float>(512, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512 }, b_val);
+    auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32,
+        dynamic ? ov::PartialShape{2, -1, -1} : ov::PartialShape{2, 1, 16});
+    auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 1, hidden_size});
 
-        auto transpose_before_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 1, 0, 2 });
-        auto transpose_before = std::make_shared<ov::opset1::Transpose>(X, transpose_before_const);
+    auto w_val = std::vector<float>(gates * hidden_size * input_size, 0);
+    auto r_val = std::vector<float>(gates * hidden_size * hidden_size, 0);
+    auto b_val = std::vector<float>(gates * hidden_size, 0);
+    auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, gates * hidden_size, input_size}, w_val);
+    auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, gates * hidden_size, hidden_size}, r_val);
+    auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, gates * hidden_size}, b_val);
 
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::LSTMSequence>(transpose_before, Y, Z, seq_lengths, W, R, B, 128,
+    auto transpose_before_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{3}, {1, 0, 2});
+    auto transpose_before = std::make_shared<ov::opset1::Transpose>(X, transpose_before_const);
+
+    auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{1}, {2});
+
+    std::shared_ptr<ov::Node> seq_node;
+    ov::ParameterVector params;
+    if (type == SeqType::LSTM) {
+        auto Z = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 1, hidden_size});
+        seq_node = std::make_shared<ov::opset5::LSTMSequence>(transpose_before, Y, Z, seq_lengths, W, R, B, hidden_size,
             ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto transpose_after_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 2, 1, 0, 3 });
-        auto transpose_after = std::make_shared<ov::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(transpose_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        const auto Co = std::make_shared<ov::opset1::Result>(lstm_seq->output(2));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-        Co->set_friendly_name("Co");
-
-        f = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho, Co }, ov::ParameterVector{ X, Y, Z });
-
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<OptimizeLSTMSequenceTransposes>();
-        m.run_passes(f);
+        params = {X, Y, Z};
+    } else if (type == SeqType::RNN) {
+        seq_node = std::make_shared<ov::opset5::RNNSequence>(transpose_before, Y, seq_lengths, W, R, B, hidden_size,
+            ov::op::RecurrentSequenceDirection::FORWARD);
+        params = {X, Y};
+    } else {
+        seq_node = std::make_shared<ov::opset5::GRUSequence>(transpose_before, Y, seq_lengths, W, R, B, hidden_size,
+            ov::op::RecurrentSequenceDirection::FORWARD);
+        params = {X, Y};
     }
 
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 1, 1, 128 });
-        auto Z = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 1, 1, 128 });
+    auto transpose_after_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {2, 1, 0, 3});
+    auto transpose_after = std::make_shared<ov::opset1::Transpose>(seq_node->output(0), transpose_after_const);
 
-        auto w_val = std::vector<float>(512 * 16, 0);
-        auto r_val = std::vector<float>(512 * 128, 0);
-        auto b_val = std::vector<float>(512, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 512 }, b_val);
+    auto Y_out = std::make_shared<ov::opset1::Result>(transpose_after);
+    auto Ho = std::make_shared<ov::opset1::Result>(seq_node->output(1));
+    Y_out->set_friendly_name("Y_out");
+    Ho->set_friendly_name("Ho");
 
+    ov::ResultVector results{Y_out, Ho};
+    if (type == SeqType::LSTM) {
+        auto Co = std::make_shared<ov::opset1::Result>(seq_node->output(2));
+        Co->set_friendly_name("Co");
+        results.push_back(Co);
+    }
+    return std::make_shared<ov::Model>(results, params);
+}
+
+static std::shared_ptr<ov::Model> buildRefModel(SeqType type, bool dynamic) {
+    const size_t hidden_size = 128;
+    const size_t input_size = 16;
+    const size_t gates = getGateCount(type);
+
+    auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32,
+        dynamic ? ov::PartialShape{2, -1, -1} : ov::PartialShape{2, 1, 16});
+    auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 1, hidden_size});
+
+    auto w_val = std::vector<float>(gates * hidden_size * input_size, 0);
+    auto r_val = std::vector<float>(gates * hidden_size * hidden_size, 0);
+    auto b_val = std::vector<float>(gates * hidden_size, 0);
+    auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, gates * hidden_size, input_size}, w_val);
+    auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, gates * hidden_size, hidden_size}, r_val);
+    auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, gates * hidden_size}, b_val);
+
+    std::shared_ptr<ov::Node> reshape_before;
+    if (dynamic) {
         auto data = std::make_shared<ov::opset1::ShapeOf>(X);
         auto reshape_before_pattern = std::make_shared<ov::opset8::Gather>(data,
-            ov::opset1::Constant::create(ov::element::i32, { 3 }, { 1, 0, 2 }),
-            ov::opset1::Constant::create(ov::element::i32, {}, { 0 }));
-        auto reshape_before = std::make_shared<ov::opset1::Reshape>(X, reshape_before_pattern, false);
+            ov::opset1::Constant::create(ov::element::i32, {3}, {1, 0, 2}),
+            ov::opset1::Constant::create(ov::element::i32, {}, {0}));
+        reshape_before = std::make_shared<ov::opset1::Reshape>(X, reshape_before_pattern, false);
+    } else {
+        auto reshape_before_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{3}, {1, 2, 16});
+        reshape_before = std::make_shared<ov::opset1::Reshape>(X, reshape_before_const, false);
+    }
 
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::LSTMSequence>(reshape_before, Y, Z, seq_lengths, W, R, B, 128,
+    auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{1}, {2});
+
+    std::shared_ptr<ov::Node> seq_node;
+    ov::ParameterVector params;
+    if (type == SeqType::LSTM) {
+        auto Z = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 1, hidden_size});
+        seq_node = std::make_shared<ov::opset5::LSTMSequence>(reshape_before, Y, Z, seq_lengths, W, R, B, hidden_size,
             ov::op::RecurrentSequenceDirection::FORWARD);
+        params = {X, Y, Z};
+    } else if (type == SeqType::RNN) {
+        seq_node = std::make_shared<ov::opset5::RNNSequence>(reshape_before, Y, seq_lengths, W, R, B, hidden_size,
+            ov::op::RecurrentSequenceDirection::FORWARD);
+        params = {X, Y};
+    } else {
+        seq_node = std::make_shared<ov::opset5::GRUSequence>(reshape_before, Y, seq_lengths, W, R, B, hidden_size,
+            ov::op::RecurrentSequenceDirection::FORWARD);
+        params = {X, Y};
+    }
 
-        auto reshape_after_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 2, 1, 1, 128 });
-        auto reshape_after = std::make_shared<ov::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
+    auto reshape_after_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{4}, {2, 1, 1, 128});
+    auto reshape_after = std::make_shared<ov::opset1::Reshape>(seq_node->output(0), reshape_after_const, false);
 
-        const auto Y_out = std::make_shared<ov::opset1::Result>(reshape_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        const auto Co = std::make_shared<ov::opset1::Result>(lstm_seq->output(2));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
+    auto Y_out = std::make_shared<ov::opset1::Result>(reshape_after);
+    auto Ho = std::make_shared<ov::opset1::Result>(seq_node->output(1));
+    Y_out->set_friendly_name("Y_out");
+    Ho->set_friendly_name("Ho");
+
+    ov::ResultVector results{Y_out, Ho};
+    if (type == SeqType::LSTM) {
+        auto Co = std::make_shared<ov::opset1::Result>(seq_node->output(2));
         Co->set_friendly_name("Co");
-
-        f_ref = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho, Co }, ov::ParameterVector{ X, Y, Z });
+        results.push_back(Co);
     }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    return std::make_shared<ov::Model>(results, params);
 }
 
-TEST(TransformationTests, OptimizeRNNSequenceTransposesTest) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
+using OptimizeSeqTransposeParams = std::tuple<SeqType, bool /*dynamic*/>;
 
-        auto w_val = std::vector<float>(128 * 16, 0);
-        auto r_val = std::vector<float>(128 * 128, 0);
-        auto b_val = std::vector<float>(128, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128 }, b_val);
-
-        auto transpose_before_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 1, 0, 2 });
-        auto transpose_before = std::make_shared<ov::opset1::Transpose>(X, transpose_before_const);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::RNNSequence>(transpose_before, Y, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto transpose_after_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 2, 1, 0, 3 });
-        auto transpose_after = std::make_shared<ov::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(transpose_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-
-        f = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho }, ov::ParameterVector{ X, Y });
-
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<OptimizeRNNSequenceTransposes>();
-        m.run_passes(f);
+class OptimizeSequenceTransposesTests : public TransformationTestsF,
+                                        public WithParamInterface<OptimizeSeqTransposeParams> {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<OptimizeSeqTransposeParams>& info) {
+        const auto& [seqType, isDynamic] = info.param;
+        std::ostringstream ss;
+        switch (seqType) {
+            case SeqType::LSTM: ss << "LSTM"; break;
+            case SeqType::RNN:  ss << "RNN"; break;
+            case SeqType::GRU:  ss << "GRU"; break;
+        }
+        ss << (isDynamic ? "_Dynamic" : "_Static");
+        return ss.str();
     }
 
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-
-        auto w_val = std::vector<float>(128 * 16, 0);
-        auto r_val = std::vector<float>(128 * 128, 0);
-        auto b_val = std::vector<float>(128, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128 }, b_val);
-
-        auto reshape_before_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{ 3 }, { 1, 2, 16 });
-        auto reshape_before = std::make_shared<ov::opset1::Reshape>(X, reshape_before_const, false);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::RNNSequence>(reshape_before, Y, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto reshape_after_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 2, 1, 1, 128 });
-        auto reshape_after = std::make_shared<ov::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(reshape_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-
-        f_ref = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho }, ov::ParameterVector{ X, Y });
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        disable_rt_info_check();
+        const auto& [seqType, isDynamic] = GetParam();
+        model = buildOriginalModel(seqType, isDynamic);
+        model_ref = buildRefModel(seqType, isDynamic);
+        switch (seqType) {
+            case SeqType::LSTM: manager.register_pass<OptimizeLSTMSequenceTransposes>(); break;
+            case SeqType::RNN:  manager.register_pass<OptimizeRNNSequenceTransposes>(); break;
+            case SeqType::GRU:  manager.register_pass<OptimizeGRUSequenceTransposes>(); break;
+        }
     }
+};
 
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
-}
+TEST_P(OptimizeSequenceTransposesTests, CompareWithRef) {}
 
-TEST(TransformationTests, OptimizeRNNSequenceTransposesDynamicTest) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-
-        auto w_val = std::vector<float>(128 * 16, 0);
-        auto r_val = std::vector<float>(128 * 128, 0);
-        auto b_val = std::vector<float>(128, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128 }, b_val);
-
-        auto transpose_before_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 1, 0, 2 });
-        auto transpose_before = std::make_shared<ov::opset1::Transpose>(X, transpose_before_const);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::RNNSequence>(transpose_before, Y, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto transpose_after_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 2, 1, 0, 3 });
-        auto transpose_after = std::make_shared<ov::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(transpose_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-
-        f = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho }, ov::ParameterVector{ X, Y });
-
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<OptimizeRNNSequenceTransposes>();
-        m.run_passes(f);
-    }
-
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-
-        auto w_val = std::vector<float>(128 * 16, 0);
-        auto r_val = std::vector<float>(128 * 128, 0);
-        auto b_val = std::vector<float>(128, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 128 }, b_val);
-
-        auto data = std::make_shared<ov::opset1::ShapeOf>(X);
-        auto reshape_before_pattern = std::make_shared<ov::opset8::Gather>(data,
-            ov::opset1::Constant::create(ov::element::i32, { 3 }, { 1, 0, 2 }),
-            ov::opset1::Constant::create(ov::element::i32, {}, { 0 }));
-        auto reshape_before = std::make_shared<ov::opset1::Reshape>(X, reshape_before_pattern, false);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::RNNSequence>(reshape_before, Y, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto reshape_after_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 2, 1, 1, 128 });
-        auto reshape_after = std::make_shared<ov::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(reshape_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-
-        f_ref = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho }, ov::ParameterVector{ X, Y });
-    }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
-}
-
-TEST(TransformationTests, OptimizeGRUSequenceTransposesTest) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-
-        auto w_val = std::vector<float>(384 * 16, 0);
-        auto r_val = std::vector<float>(384 * 128, 0);
-        auto b_val = std::vector<float>(384, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384 }, b_val);
-
-        auto transpose_before_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 1, 0, 2 });
-        auto transpose_before = std::make_shared<ov::opset1::Transpose>(X, transpose_before_const);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::GRUSequence>(transpose_before, Y, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto transpose_after_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 2, 1, 0, 3 });
-        auto transpose_after = std::make_shared<ov::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(transpose_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-
-        f = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho }, ov::ParameterVector{ X, Y });
-
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<OptimizeGRUSequenceTransposes>();
-        m.run_passes(f);
-    }
-
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-
-        auto w_val = std::vector<float>(384 * 16, 0);
-        auto r_val = std::vector<float>(384 * 128, 0);
-        auto b_val = std::vector<float>(384, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384 }, b_val);
-
-        auto reshape_before_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{ 3 }, { 1, 2, 16 });
-        auto reshape_before = std::make_shared<ov::opset1::Reshape>(X, reshape_before_const, false);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::GRUSequence>(reshape_before, Y, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto reshape_after_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 2, 1, 1, 128 });
-        auto reshape_after = std::make_shared<ov::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(reshape_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-
-        f_ref = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho }, ov::ParameterVector{ X, Y });
-    }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
-}
-
-TEST(TransformationTests, OptimizeGRUSequenceTransposesDynamicTest) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-
-        auto w_val = std::vector<float>(384 * 16, 0);
-        auto r_val = std::vector<float>(384 * 128, 0);
-        auto b_val = std::vector<float>(384, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384 }, b_val);
-
-        auto transpose_before_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 3 }, { 1, 0, 2 });
-        auto transpose_before = std::make_shared<ov::opset1::Transpose>(X, transpose_before_const);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::GRUSequence>(transpose_before, Y, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto transpose_after_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 4 }, { 2, 1, 0, 3 });
-        auto transpose_after = std::make_shared<ov::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(transpose_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-
-        f = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho }, ov::ParameterVector{ X, Y });
-
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<OptimizeGRUSequenceTransposes>();
-        m.run_passes(f);
-    }
-
-    {
-        auto X = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 1, 128 });
-
-        auto w_val = std::vector<float>(384 * 16, 0);
-        auto r_val = std::vector<float>(384 * 128, 0);
-        auto b_val = std::vector<float>(384, 0);
-        auto W = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384, 16 }, w_val);
-        auto R = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384, 128 }, r_val);
-        auto B = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 384 }, b_val);
-
-        auto data = std::make_shared<ov::opset1::ShapeOf>(X);
-        auto reshape_before_pattern = std::make_shared<ov::opset8::Gather>(data,
-            ov::opset1::Constant::create(ov::element::i32, { 3 }, { 1, 0, 2 }),
-            ov::opset1::Constant::create(ov::element::i32, {}, { 0 }));
-        auto reshape_before = std::make_shared<ov::opset1::Reshape>(X, reshape_before_pattern, false);
-
-        auto seq_lengths = ov::opset1::Constant::create(ov::element::i32, ov::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ov::opset5::GRUSequence>(reshape_before, Y, seq_lengths, W, R, B, 128,
-            ov::op::RecurrentSequenceDirection::FORWARD);
-
-        auto reshape_after_const = ov::opset1::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 2, 1, 1, 128 });
-        auto reshape_after = std::make_shared<ov::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
-
-        const auto Y_out = std::make_shared<ov::opset1::Result>(reshape_after);
-        const auto Ho = std::make_shared<ov::opset1::Result>(lstm_seq->output(1));
-        Y_out->set_friendly_name("Y_out");
-        Ho->set_friendly_name("Ho");
-
-        f_ref = std::make_shared<ov::Model>(ov::ResultVector{ Y_out, Ho }, ov::ParameterVector{ X, Y });
-    }
-
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
-}
+INSTANTIATE_TEST_SUITE_P(TransformationTests, OptimizeSequenceTransposesTests,
+    ::testing::Combine(
+        ::testing::Values(SeqType::LSTM, SeqType::RNN, SeqType::GRU),
+        ::testing::Values(false, true)),
+    OptimizeSequenceTransposesTests::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/unit/transformations/readvalue_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/readvalue_subgraph.cpp
@@ -6,7 +6,6 @@
 
 #include <sstream>
 #include <transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.hpp>
-#include <transformations/init_node_info.hpp>
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/op/add.hpp"
@@ -52,51 +51,45 @@ static std::shared_ptr<ov::intel_cpu::ReadValueWithSubgraph> constructRVWithSubG
     return readvalue;
 }
 
-TEST(TransformationTests, ReadValueWithSubgraph_1) {
-    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
+TEST_F(TransformationTestsF, ReadValueWithSubgraph_1) {
+    disable_rt_info_check();
+    disable_result_friendly_names_check();
+    const ov::PartialShape shape{1, 1, 2};
+    const ov::element::Type type = ov::element::f32;
+    auto variable = std::make_shared<ov::op::util::Variable>(
+        ov::op::util::VariableInfo{ov::PartialShape{1, 1, 2}, type, "var_id"});
+
     {
-        const ov::PartialShape shape{1, 1, 2};
-        const ov::element::Type type = ov::element::f32;
-        std::shared_ptr<ov::op::util::Variable> variable = std::make_shared<ov::op::util::Variable>(
-            ov::op::util::VariableInfo{ov::PartialShape{1, 1, 2}, type, "var_id"});
+        auto input = std::make_shared<ov::op::v0::Parameter>(type, shape);
 
-        {
-            auto input = std::make_shared<ov::op::v0::Parameter>(type, shape);
+        auto mm_weights =
+            std::make_shared<ov::op::v0::Constant>(type, ov::Shape{2, 2}, std::vector<float>{1, 2, 3, 4});
 
-            auto mm_weights =
-                std::make_shared<ov::op::v0::Constant>(type, ov::Shape{2, 2}, std::vector<float>{1, 2, 3, 4});
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input, mm_weights, false, false);
 
-            auto matmul = std::make_shared<ov::op::v0::MatMul>(input, mm_weights, false, false);
+        auto readvalue = std::make_shared<ov::op::v6::ReadValue>(matmul, variable);
 
-            auto readvalue = std::make_shared<ov::op::v6::ReadValue>(matmul, variable);
+        auto assign = std::make_shared<ov::op::v6::Assign>(readvalue, variable);
 
-            auto assign = std::make_shared<ov::op::v6::Assign>(readvalue, variable);
+        auto result = std::make_shared<ov::op::v0::Result>(readvalue);
+        model = std::make_shared<ov::Model>(ov::ResultVector{result},
+                                            ov::SinkVector{assign},
+                                            ov::ParameterVector{input});
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(type, shape);
 
-            auto result = std::make_shared<ov::op::v0::Result>(readvalue);
-            model = std::make_shared<ov::Model>(ov::ResultVector{result},
+        auto readvalue = constructRVWithSubGraph(input, type, variable);
+
+        auto assign = std::make_shared<ov::op::v6::Assign>(readvalue, variable);
+
+        auto result = std::make_shared<ov::op::v0::Result>(readvalue);
+
+        model_ref = std::make_shared<ov::Model>(ov::ResultVector{result},
                                                 ov::SinkVector{assign},
                                                 ov::ParameterVector{input});
-
-            ov::pass::Manager manager;
-            manager.register_pass<ov::intel_cpu::MoveReadValueInputsToSubgraph>();
-            manager.run_passes(model);
-        }
-        {
-            auto input = std::make_shared<ov::op::v0::Parameter>(type, shape);
-
-            auto readvalue = constructRVWithSubGraph(input, type, variable);
-
-            auto assign = std::make_shared<ov::op::v6::Assign>(readvalue, variable);
-
-            auto result = std::make_shared<ov::op::v0::Result>(readvalue);
-
-            model_ref = std::make_shared<ov::Model>(ov::ResultVector{result},
-                                                    ov::SinkVector{assign},
-                                                    ov::ParameterVector{input});
-        }
-        auto res = compare_functions(model, model_ref, 0, 0, 0, 0, 0, 0);
-        ASSERT_TRUE(res.first) << res.second;
     }
+    manager.register_pass<ov::intel_cpu::MoveReadValueInputsToSubgraph>();
 }
 
 /***************************************************************************************************
@@ -155,82 +148,76 @@ static std::shared_ptr<ov::intel_cpu::ReadValueWithSubgraph> constructRVWithSubG
     return readvalue;
 }
 
-TEST(TransformationTests, ReadValueWithSubgraph_2) {
-    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
+TEST_F(TransformationTestsF, ReadValueWithSubgraph_2) {
+    disable_rt_info_check();
+    disable_result_friendly_names_check();
+    const ov::PartialShape shape{1, 2, 4};
+    const ov::element::Type in_type = ov::element::f32;
+    const ov::element::Type out_type = ov::element::i32;
+
+    auto variable =
+        std::make_shared<ov::op::util::Variable>(ov::op::util::VariableInfo{shape, out_type, "var_id"});
+
     {
-        const ov::PartialShape shape{1, 2, 4};
-        const ov::element::Type in_type = ov::element::f32;
-        const ov::element::Type out_type = ov::element::i32;
+        auto input = std::make_shared<ov::op::v0::Parameter>(in_type, shape);
+        input->set_friendly_name("input");
 
-        std::shared_ptr<ov::op::util::Variable> variable =
-            std::make_shared<ov::op::util::Variable>(ov::op::util::VariableInfo{shape, out_type, "var_id"});
+        auto convert = std::make_shared<ov::op::v0::Convert>(input, out_type);
+        convert->set_friendly_name("convert");
 
-        {
-            auto input = std::make_shared<ov::op::v0::Parameter>(in_type, shape);
-            input->set_friendly_name("input");
+        auto add1 = std::make_shared<ov::op::v1::Add>(convert, create_const_node(ov::Shape{4}));
+        add1->set_friendly_name("add1");
 
-            auto convert = std::make_shared<ov::op::v0::Convert>(input, out_type);
-            convert->set_friendly_name("convert");
+        auto add2 = std::make_shared<ov::op::v1::Add>(convert, create_const_node(ov::Shape{4}));
+        add2->set_friendly_name("add2");
 
-            auto add1 = std::make_shared<ov::op::v1::Add>(convert, create_const_node(ov::Shape{4}));
-            add1->set_friendly_name("add1");
+        auto add3 = std::make_shared<ov::op::v1::Add>(add2, convert);
+        add3->set_friendly_name("add3");
 
-            auto add2 = std::make_shared<ov::op::v1::Add>(convert, create_const_node(ov::Shape{4}));
-            add2->set_friendly_name("add2");
+        auto add4 = std::make_shared<ov::op::v1::Add>(add2, add3);
+        add4->set_friendly_name("add4");
 
-            auto add3 = std::make_shared<ov::op::v1::Add>(add2, convert);
-            add3->set_friendly_name("add3");
+        auto add5 = std::make_shared<ov::op::v1::Add>(add1, add4);
+        add5->set_friendly_name("add5");
 
-            auto add4 = std::make_shared<ov::op::v1::Add>(add2, add3);
-            add4->set_friendly_name("add4");
+        auto readvalue = std::make_shared<ov::op::v6::ReadValue>(add5, variable);
+        readvalue->set_friendly_name("readvalue");
 
-            auto add5 = std::make_shared<ov::op::v1::Add>(add1, add4);
-            add5->set_friendly_name("add5");
+        auto assign = std::make_shared<ov::op::v6::Assign>(readvalue, variable);
+        assign->set_friendly_name("assign");
 
-            auto readvalue = std::make_shared<ov::op::v6::ReadValue>(add5, variable);
-            readvalue->set_friendly_name("readvalue");
+        auto result1 = std::make_shared<ov::op::v0::Result>(readvalue);
+        result1->set_friendly_name("result1");
 
-            auto assign = std::make_shared<ov::op::v6::Assign>(readvalue, variable);
-            assign->set_friendly_name("assign");
+        auto result2 = std::make_shared<ov::op::v0::Result>(add3);
+        result2->set_friendly_name("result2");
 
-            auto result1 = std::make_shared<ov::op::v0::Result>(readvalue);
-            result1->set_friendly_name("result1");
+        model = std::make_shared<ov::Model>(ov::ResultVector{result1, result2},
+                                            ov::SinkVector{assign},
+                                            ov::ParameterVector{input});
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(in_type, shape);
 
-            auto result2 = std::make_shared<ov::op::v0::Result>(add3);
-            result2->set_friendly_name("result2");
+        auto convert = std::make_shared<ov::op::v0::Convert>(input, out_type);
 
-            model = std::make_shared<ov::Model>(ov::ResultVector{result1, result2},
+        auto add2 = std::make_shared<ov::op::v1::Add>(convert, create_const_node(ov::Shape{4}));
+
+        auto add3 = std::make_shared<ov::op::v1::Add>(add2, convert);
+
+        auto readvalue = constructRVWithSubGraph2({convert, add2, add3}, out_type, variable);
+
+        auto assign = std::make_shared<ov::op::v6::Assign>(readvalue, variable);
+
+        auto result1 = std::make_shared<ov::op::v0::Result>(readvalue);
+
+        auto result2 = std::make_shared<ov::op::v0::Result>(add3);
+
+        model_ref = std::make_shared<ov::Model>(ov::ResultVector{result1, result2},
                                                 ov::SinkVector{assign},
                                                 ov::ParameterVector{input});
-
-            ov::pass::Manager manager;
-            manager.register_pass<ov::intel_cpu::MoveReadValueInputsToSubgraph>();
-            manager.run_passes(model);
-        }
-        {
-            auto input = std::make_shared<ov::op::v0::Parameter>(in_type, shape);
-
-            auto convert = std::make_shared<ov::op::v0::Convert>(input, out_type);
-
-            auto add2 = std::make_shared<ov::op::v1::Add>(convert, create_const_node(ov::Shape{4}));
-
-            auto add3 = std::make_shared<ov::op::v1::Add>(add2, convert);
-
-            auto readvalue = constructRVWithSubGraph2({convert, add2, add3}, out_type, variable);
-
-            auto assign = std::make_shared<ov::op::v6::Assign>(readvalue, variable);
-
-            auto result1 = std::make_shared<ov::op::v0::Result>(readvalue);
-
-            auto result2 = std::make_shared<ov::op::v0::Result>(add3);
-
-            model_ref = std::make_shared<ov::Model>(ov::ResultVector{result1, result2},
-                                                    ov::SinkVector{assign},
-                                                    ov::ParameterVector{input});
-        }
-        auto res = compare_functions(model, model_ref, 0, 0, 0, 0, 0, 0);
-        ASSERT_TRUE(res.first) << res.second;
     }
+    manager.register_pass<ov::intel_cpu::MoveReadValueInputsToSubgraph>();
 }
 
 static std::shared_ptr<ov::intel_cpu::ReadValueWithSubgraph> constructRVWithSubGraph3(

--- a/src/plugins/intel_cpu/tests/unit/transformations/readvalue_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/readvalue_subgraph.cpp
@@ -53,7 +53,6 @@ static std::shared_ptr<ov::intel_cpu::ReadValueWithSubgraph> constructRVWithSubG
 
 TEST_F(TransformationTestsF, ReadValueWithSubgraph_1) {
     disable_rt_info_check();
-    disable_result_friendly_names_check();
     const ov::PartialShape shape{1, 1, 2};
     const ov::element::Type type = ov::element::f32;
     auto variable = std::make_shared<ov::op::util::Variable>(
@@ -150,7 +149,6 @@ static std::shared_ptr<ov::intel_cpu::ReadValueWithSubgraph> constructRVWithSubG
 
 TEST_F(TransformationTestsF, ReadValueWithSubgraph_2) {
     disable_rt_info_check();
-    disable_result_friendly_names_check();
     const ov::PartialShape shape{1, 2, 4};
     const ov::element::Type in_type = ov::element::f32;
     const ov::element::Type out_type = ov::element::i32;

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -180,102 +180,63 @@ static std::shared_ptr<ov::Model> makeSDPA(const ov::PartialShape& inputShape, b
     return std::make_shared<Model>(results, sinks, ParameterVector{q, k, v, init, beam_idx}, "ConcatSDP");
 }
 
-TEST(TransformationTests, StateConcatSDPA) {
+TEST_F(TransformationTestsF, StateConcatSDPA) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
+    test_skipped = true;
     GTEST_SKIP() << "Skipping StateConcatSDPA test on Android X64";
 #endif
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        using namespace ov;
-        auto inputShape = ov::PartialShape{-1, 8, -1, 64};
-        {
-            f = makeSDPA(inputShape);
-            pass::Manager m;
-            m.register_pass<ov::pass::InitNodeInfo>();
-            m.register_pass<StatefulSDPAFusion>();
-            m.run_passes(f);
-        }
-        //construct ref interaction
-        {
-            f_ref = makeSDPA(inputShape, true);
-        }
-        auto res = compare_functions(f, f_ref);
-        ASSERT_TRUE(res.first) << res.second;
-    }
+    auto inputShape = ov::PartialShape{-1, 8, -1, 64};
+    model = makeSDPA(inputShape);
+    model_ref = makeSDPA(inputShape, true);
+    manager.register_pass<StatefulSDPAFusion>();
 }
 
-TEST(TransformationTests, StateConcatSDPAWithConvert) {
+TEST_F(TransformationTestsF, StateConcatSDPAWithConvert) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
+    test_skipped = true;
     GTEST_SKIP() << "Skipping StateConcatSDPAWithConvert test on Android X64";
 #endif
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        using namespace ov;
-        auto inputShape = ov::PartialShape{-1, 8, -1, 64};
-        {
-            f = makeSDPA(inputShape, false, true);
-            pass::Manager m;
-            m.register_pass<ov::pass::InitNodeInfo>();
-            m.register_pass<StatefulSDPAFusion>();
-            m.run_passes(f);
-        }
-        //construct ref interaction
-        {
-            f_ref = makeSDPA(inputShape, true, true);
-        }
-        auto res = compare_functions(f, f_ref);
-        ASSERT_TRUE(res.first) << res.second;
-    }
+    auto inputShape = ov::PartialShape{-1, 8, -1, 64};
+    model = makeSDPA(inputShape, false, true);
+    model_ref = makeSDPA(inputShape, true, true);
+    manager.register_pass<StatefulSDPAFusion>();
 }
 
-TEST(TransformationTests, StateConcatSDPAMixtral) {
+TEST_F(TransformationTestsF, StateConcatSDPAMixtral) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
+    test_skipped = true;
     GTEST_SKIP() << "Skipping StateConcatSDPAMixtral test on Android X64";
 #endif
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        using namespace ov;
-        auto inputShape = ov::PartialShape{-1, 32, -1, 64};
-        {
-            f = makeSDPA(inputShape, false, false, true);
-            pass::Manager m;
-            m.register_pass<ov::pass::InitNodeInfo>();
-            m.register_pass<StatefulSDPAFusion>();
-            m.run_passes(f);
-        }
-        //construct ref interaction
-        {
-            f_ref = makeSDPA(inputShape, true, false, true);
-        }
-        auto res = compare_functions(f, f_ref);
-        ASSERT_TRUE(res.first) << res.second;
-    }
+    auto inputShape = ov::PartialShape{-1, 32, -1, 64};
+    model = makeSDPA(inputShape, false, false, true);
+    model_ref = makeSDPA(inputShape, true, false, true);
+    manager.register_pass<StatefulSDPAFusion>();
 }
 
-TEST(TransformationTests, StateConcatSDPAWithExtraNode) {
+TEST_F(TransformationTestsF, StateConcatSDPAWithExtraNode) {
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
+    test_skipped = true;
     GTEST_SKIP() << "Skipping StateConcatSDPAWithExtraNode test on Android X64";
 #endif
     // when some unexpected extra nodes exist in SDPA, the fusion should fail
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
-    {
-        using namespace ov;
-        auto inputShape = ov::PartialShape{-1, 32, -1, 64};
-        size_t i = static_cast<size_t>(InsertPoint::At_None) + 1;
-        size_t end = static_cast<size_t>(InsertPoint::At_End);
-        // check each position
-        for (; i < end; i++) {
-            InsertPoint at = static_cast<InsertPoint>(i);
-            f = makeSDPA(inputShape, false, true, true, at);
-            f_ref = makeSDPA(inputShape, false, true, true, at);
-            pass::Manager m;
-            m.register_pass<ov::pass::InitNodeInfo>();
-            m.register_pass<StatefulSDPAFusion>();
-            m.run_passes(f);
-            auto res = compare_functions(f, f_ref);
-            ASSERT_TRUE(res.first) << res.second;
-        }
+    // This test iterates over insert points so cannot use the simple model/model_ref pattern.
+    // We use a loop with manual comparison for each insertion point.
+    auto inputShape = ov::PartialShape{-1, 32, -1, 64};
+    size_t i = static_cast<size_t>(InsertPoint::At_None) + 1;
+    size_t end = static_cast<size_t>(InsertPoint::At_End);
+    for (; i < end; i++) {
+        InsertPoint at = static_cast<InsertPoint>(i);
+        auto f = makeSDPA(inputShape, false, true, true, at);
+        auto f_ref = makeSDPA(inputShape, false, true, true, at);
+        ov::pass::Manager m;
+        m.register_pass<ov::pass::InitNodeInfo>();
+        m.register_pass<StatefulSDPAFusion>();
+        m.run_passes(f);
+        auto res = compare_functions(f, f_ref);
+        ASSERT_TRUE(res.first) << res.second;
     }
+    // Prevent fixture TearDown comparison since we already compared manually
+    test_skipped = true;
 }
 
 // Build a model with two SDPA blocks sharing the same KV-cache Variables.

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -213,31 +213,33 @@ TEST_F(TransformationTestsF, StateConcatSDPAMixtral) {
     manager.register_pass<StatefulSDPAFusion>();
 }
 
-TEST_F(TransformationTestsF, StateConcatSDPAWithExtraNode) {
+class StateConcatSDPAWithExtraNodeTests : public TransformationTestsF,
+                                         public WithParamInterface<InsertPoint> {
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
 #if defined(OPENVINO_ARCH_X86_64) && (defined(__ANDROID__) || defined(ANDROID))
-    test_skipped = true;
-    GTEST_SKIP() << "Skipping StateConcatSDPAWithExtraNode test on Android X64";
+        test_skipped = true;
+        GTEST_SKIP() << "Skipping StateConcatSDPAWithExtraNode test on Android X64";
 #endif
-    // when some unexpected extra nodes exist in SDPA, the fusion should fail
-    // This test iterates over insert points so cannot use the simple model/model_ref pattern.
-    // We use a loop with manual comparison for each insertion point.
-    auto inputShape = ov::PartialShape{-1, 32, -1, 64};
-    size_t i = static_cast<size_t>(InsertPoint::At_None) + 1;
-    size_t end = static_cast<size_t>(InsertPoint::At_End);
-    for (; i < end; i++) {
-        InsertPoint at = static_cast<InsertPoint>(i);
-        auto f = makeSDPA(inputShape, false, true, true, at);
-        auto f_ref = makeSDPA(inputShape, false, true, true, at);
-        ov::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<StatefulSDPAFusion>();
-        m.run_passes(f);
-        auto res = compare_functions(f, f_ref);
-        ASSERT_TRUE(res.first) << res.second;
+        auto inputShape = ov::PartialShape{-1, 32, -1, 64};
+        InsertPoint at = GetParam();
+        model = makeSDPA(inputShape, false, true, true, at);
+        model_ref = makeSDPA(inputShape, false, true, true, at);
+        manager.register_pass<StatefulSDPAFusion>();
     }
-    // Prevent fixture TearDown comparison since we already compared manually
-    test_skipped = true;
-}
+};
+
+TEST_P(StateConcatSDPAWithExtraNodeTests, FusionShouldNotFire) {}
+
+INSTANTIATE_TEST_SUITE_P(TransformationTests, StateConcatSDPAWithExtraNodeTests,
+    ::testing::Values(
+        InsertPoint::At_Convert,
+        InsertPoint::At_Gather,
+        InsertPoint::At_MQ_Unsqueeze,
+        InsertPoint::At_MQ_Broadcast,
+        InsertPoint::At_MQ_Multiply,
+        InsertPoint::At_MQ_Reshape));
 
 // Build a model with two SDPA blocks sharing the same KV-cache Variables.
 // One ReadValue per Variable fans out to two independent Gather -> Concat -> SDPA paths,

--- a/src/plugins/intel_cpu/tests/unit/transformations/x64/convert_to_interaction.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/x64/convert_to_interaction.cpp
@@ -26,19 +26,23 @@ using namespace testing;
 using namespace ov::intel_cpu;
 using namespace ov;
 
-static std::shared_ptr<ov::op::v0::FakeQuantize> createFQ(const std::shared_ptr<ov::Node>& input) {
+static std::shared_ptr<ov::op::v0::FakeQuantize> createFQ(const std::shared_ptr<ov::Node>& input,
+                                                           const std::string& name = "") {
     auto input_low = std::make_shared<ov::op::v0::Constant>(element::f32, ov::Shape{1}, std::vector<float>{0});
     auto input_high = std::make_shared<ov::op::v0::Constant>(element::f32, ov::Shape{1}, std::vector<float>{49.4914f});
     auto output_low = std::make_shared<ov::op::v0::Constant>(element::f32, ov::Shape{1}, std::vector<float>{0});
     auto output_high = std::make_shared<ov::op::v0::Constant>(element::f32, ov::Shape{1}, std::vector<float>{49.4914f});
-    return std::make_shared<ov::op::v0::FakeQuantize>(input, input_low, input_high, output_low, output_high, 256);
+    auto fq = std::make_shared<ov::op::v0::FakeQuantize>(input, input_low, input_high, output_low, output_high, 256);
+    if (!name.empty())
+        fq->set_friendly_name(name);
+    return fq;
 }
 
 static std::shared_ptr<ov::Model> makeInteraction(const ov::PartialShape& inputShape, bool intraFQ = false, bool postFQ = false) {
     std::shared_ptr<ov::opset1::Parameter> input = std::make_shared<ov::opset1::Parameter>(element::f32, inputShape);
     std::shared_ptr<ov::Node> dense_feature = nullptr;
     if (intraFQ) {
-        dense_feature = createFQ(input);
+        dense_feature = createFQ(input, "fq_dense_init");
     } else {
         dense_feature = input;
     }
@@ -49,7 +53,7 @@ static std::shared_ptr<ov::Model> makeInteraction(const ov::PartialShape& inputS
         auto sparse_input = std::make_shared<ov::opset1::Parameter>(element::f32, inputShape);
         std::shared_ptr<ov::Node> sparse_feat = nullptr;
         if (intraFQ) {
-            sparse_feat = createFQ(sparse_input);
+            sparse_feat = createFQ(sparse_input, "fq_sparse_init_" + std::to_string(i));
         } else {
             sparse_feat = sparse_input;
         }
@@ -76,7 +80,7 @@ static std::shared_ptr<ov::Model> makeInteraction(const ov::PartialShape& inputS
     auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, transpose1);
     std::shared_ptr<ov::Node> inter = nullptr;
     if (intraFQ) {
-        inter = createFQ(matmul);
+        inter = createFQ(matmul, "fq_matmul");
     } else {
         inter = matmul;
     }
@@ -179,25 +183,18 @@ TEST_F(TransformationTestsF, ConvertInteractionInt8WithIntraFQ) {
     manager.register_pass<ConvertInteractionInt8>();
     {
         auto dense_input = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-        auto dense_feature = createFQ(dense_input);
+        auto dense_feature = createFQ(dense_input, "fq_dense");
         NodeVector features{dense_feature};
         ParameterVector inputsParams{dense_input};
         const size_t sparse_feature_num = 26;
         for (size_t i = 0; i < sparse_feature_num; i++) {
             auto sparse_input = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-            auto sparse_feat = createFQ(sparse_input);
+            auto sparse_feat = createFQ(sparse_input, "fq_sparse_" + std::to_string(i));
             features.push_back(sparse_feat);
             inputsParams.push_back(sparse_input);
         }
         auto interaction = std::make_shared<ov::intel_cpu::InteractionNode>(features);
-        auto fq = createFQ(interaction);
+        auto fq = createFQ(interaction, "fq_output");
         model_ref = std::make_shared<ov::Model>(fq, inputsParams, "interaction");
     }
-    // The ref model has multiple FQ nodes with auto-generated names that collide,
-    // causing the UniqueNamesHolder check in TearDown to fail.
-    // Run passes and compare manually to preserve original test semantics.
-    manager.run_passes(model);
-    auto res = comparator.compare(model, model_ref);
-    ASSERT_TRUE(res.valid) << res.message;
-    test_skipped = true;
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/x64/convert_to_interaction.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/x64/convert_to_interaction.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <memory>
 #include "openvino/opsets/opset1_decl.hpp"
 #include "openvino/opsets/opset8_decl.hpp"
@@ -12,9 +11,6 @@
 #include <transformations/cpu_opset/x64/pass/convert_to_interaction.hpp>
 #include <transformations/common_optimizations/nop_elimination.hpp>
 #include <transformations/smart_reshape/matmul_sr.hpp>
-#include <transformations/init_node_info.hpp>
-#include <transformations/utils/utils.hpp>
-#include <openvino/pass/manager.hpp>
 #include "ov_ops/type_relaxed.hpp"
 
 #include "common_test_utils/ov_test_utils.hpp"
@@ -128,109 +124,80 @@ static std::shared_ptr<ov::Model> makeInteraction(const ov::PartialShape& inputS
     return model;
 }
 
-TEST(TransformationTests, ConvertToInteractionTest1) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+TEST_F(TransformationTestsF, ConvertToInteraction) {
+    disable_rt_info_check();
+    auto inputShape = ov::PartialShape{3, 4};
+    model = makeInteraction(inputShape);
+    manager.register_pass<ov::pass::NopElimination>();
+    manager.register_pass<ov::pass::TransposeMatMul>();
+    manager.register_pass<ConvertToInteraction>();
     {
-        using namespace ov;
-        //construct interaction graph
-        auto inputShape = ov::PartialShape{3, 4};
-        {
-            f = makeInteraction(inputShape);
-            pass::Manager m;
-            m.register_pass<ov::pass::InitNodeInfo>();
-            m.register_pass<ov::pass::NopElimination>();
-            m.register_pass<ov::pass::TransposeMatMul>();
-            m.register_pass<ConvertToInteraction>();
-            m.run_passes(f);
+        auto dense_feature = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+        NodeVector features{dense_feature};
+        ParameterVector inputsParams{dense_feature};
+        const size_t sparse_feature_num = 26;
+        for (size_t i = 0; i < sparse_feature_num; i++) {
+            auto sparse_feat = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+            features.push_back(sparse_feat);
+            inputsParams.push_back(sparse_feat);
         }
-        //construct ref interaction
-        {
-            auto dense_feature = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-            NodeVector features{dense_feature};
-            ParameterVector inputsParams{dense_feature};
-            const size_t sparse_feature_num = 26;
-            for (size_t i = 0; i < sparse_feature_num; i++) {
-                auto sparse_feat = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-                features.push_back(sparse_feat);
-                inputsParams.push_back(sparse_feat);
-            }
-            auto interaction = std::make_shared<ov::intel_cpu::InteractionNode>(features);
-            f_ref = std::make_shared<ov::Model>(interaction, inputsParams, "interaction");
-        }
-        auto res = compare_functions(f, f_ref);
-        ASSERT_TRUE(res.first) << res.second;
+        auto interaction = std::make_shared<ov::intel_cpu::InteractionNode>(features);
+        model_ref = std::make_shared<ov::Model>(interaction, inputsParams, "interaction");
     }
 }
 
-TEST(TransformationTests, FuseFQtoInteractionTest1) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+TEST_F(TransformationTestsF, FuseFQtoInteraction) {
+    disable_rt_info_check();
+    auto inputShape = ov::PartialShape{3, 4};
+    model = makeInteraction(inputShape, false, true);
+    manager.register_pass<ov::pass::NopElimination>();
+    manager.register_pass<ov::pass::TransposeMatMul>();
+    manager.register_pass<ConvertToInteraction>();
+    manager.register_pass<FuseFQtoInteraction>();
     {
-        using namespace ov;
-        //construct interaction graph
-        auto inputShape = ov::PartialShape{3, 4};
-        {
-            f = makeInteraction(inputShape, false, true);
-            pass::Manager m;
-            m.register_pass<ov::pass::InitNodeInfo>();
-            m.register_pass<ov::pass::NopElimination>();
-            m.register_pass<ov::pass::TransposeMatMul>();
-            m.register_pass<ConvertToInteraction>();
-            m.register_pass<FuseFQtoInteraction>();
-            m.run_passes(f);
+        auto dense_feature = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+        NodeVector features{dense_feature};
+        ParameterVector inputsParams{dense_feature};
+        const size_t sparse_feature_num = 26;
+        for (size_t i = 0; i < sparse_feature_num; i++) {
+            auto sparse_feat = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+            features.push_back(sparse_feat);
+            inputsParams.push_back(sparse_feat);
         }
-        //construct ref interaction
-        {
-            auto dense_feature = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-            NodeVector features{dense_feature};
-            ParameterVector inputsParams{dense_feature};
-            const size_t sparse_feature_num = 26;
-            for (size_t i = 0; i < sparse_feature_num; i++) {
-                auto sparse_feat = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-                features.push_back(sparse_feat);
-                inputsParams.push_back(sparse_feat);
-            }
-            auto interaction = std::make_shared<ov::op::TypeRelaxed<ov::intel_cpu::InteractionNode>>(
-                ov::intel_cpu::InteractionNode(features), element::i8);
-            f_ref = std::make_shared<ov::Model>(interaction, inputsParams, "interaction");
-        }
-        auto res = compare_functions(f, f_ref);
-        ASSERT_TRUE(res.first) << res.second;
+        auto interaction = std::make_shared<ov::op::TypeRelaxed<ov::intel_cpu::InteractionNode>>(
+            ov::intel_cpu::InteractionNode(features), element::i8);
+        model_ref = std::make_shared<ov::Model>(interaction, inputsParams, "interaction");
     }
 }
 
-TEST(TransformationTests, FuseFQtoInteractionTest2) {
-    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+TEST_F(TransformationTestsF, ConvertInteractionInt8WithIntraFQ) {
+    disable_rt_info_check();
+    auto inputShape = ov::PartialShape{3, 4};
+    model = makeInteraction(inputShape, true);
+    manager.register_pass<ov::pass::NopElimination>();
+    manager.register_pass<ov::pass::TransposeMatMul>();
+    manager.register_pass<ConvertInteractionInt8>();
     {
-        using namespace ov;
-        //construct interaction graph
-        auto inputShape = ov::PartialShape{3, 4};
-        {
-            f = makeInteraction(inputShape, true);
-            pass::Manager m;
-            m.register_pass<ov::pass::InitNodeInfo>();
-            m.register_pass<ov::pass::NopElimination>();
-            m.register_pass<ov::pass::TransposeMatMul>();
-            m.register_pass<ConvertInteractionInt8>();
-            m.run_passes(f);
+        auto dense_input = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+        auto dense_feature = createFQ(dense_input);
+        NodeVector features{dense_feature};
+        ParameterVector inputsParams{dense_input};
+        const size_t sparse_feature_num = 26;
+        for (size_t i = 0; i < sparse_feature_num; i++) {
+            auto sparse_input = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
+            auto sparse_feat = createFQ(sparse_input);
+            features.push_back(sparse_feat);
+            inputsParams.push_back(sparse_input);
         }
-        //construct ref interaction
-        {
-            auto dense_input = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-            auto dense_feature = createFQ(dense_input);
-            NodeVector features{dense_feature};
-            ParameterVector inputsParams{dense_input};
-            const size_t sparse_feature_num = 26;
-            for (size_t i = 0; i < sparse_feature_num; i++) {
-                auto sparse_input = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
-                auto sparse_feat = createFQ(sparse_input);
-                features.push_back(sparse_feat);
-                inputsParams.push_back(sparse_input);
-            }
-            auto interaction = std::make_shared<ov::intel_cpu::InteractionNode>(features);
-            auto fq = createFQ(interaction);
-            f_ref = std::make_shared<ov::Model>(fq, inputsParams, "interaction");
-        }
-        auto res = compare_functions(f, f_ref);
-        ASSERT_TRUE(res.first) << res.second;
+        auto interaction = std::make_shared<ov::intel_cpu::InteractionNode>(features);
+        auto fq = createFQ(interaction);
+        model_ref = std::make_shared<ov::Model>(fq, inputsParams, "interaction");
     }
+    // The ref model has multiple FQ nodes with auto-generated names that collide,
+    // causing the UniqueNamesHolder check in TearDown to fail.
+    // Run passes and compare manually to preserve original test semantics.
+    manager.run_passes(model);
+    auto res = comparator.compare(model, model_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+    test_skipped = true;
 }


### PR DESCRIPTION
### Details:
- Modernized 10 CPU plugin unit tests to use `TransformationTestsF` base class, replacing legacy `TEST()` macros, manual `pass::Manager` setup, and `compare_functions()` calls
- Converted applicable tests to parametrized `TEST_P` fixtures (by `ov::PartialShape` and reduction type); replaced `TYPED_TEST_P` patterns with runtime parametrization using struct+lambda params
- Renamed non-descriptive numbered test cases to descriptive names throughout
- Fixed 4 underlying transformation bugs discovered during test refactoring:
  - `ConvertToInteraction`: duplicate friendly name assignment
  - `MoveReadValueInputsToSubgraph`: missing friendly name propagation to replacement node
  - `ConvertReduceNoKeepDims`: squeeze node was given the same name as `reduce_new` (should use original `reduce` name)
  - `ConvertGroupConvolution`: `squeeze_axis` and filter `Squeeze` nodes missing from `copy_runtime_info` call

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes
 - GitHub Copilot (Claude Sonnet) was used to assess, plan, and implement test refactoring and transformation fixes. All changes were validated by building `ov_cpu_unit_tests` locally and running the full test suite.