### PR TITLE
[`NPU`] [`WS`] Avoid reconstructing the `ov::Model` on blob import

### DIFF
--- a/src/frontends/onnx/frontend/src/frontend.cpp
+++ b/src/frontends/onnx/frontend/src/frontend.cpp
@@ -31,6 +31,7 @@
 #include "onnx_framework_node.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/core/so_extension.hpp"
+#include "openvino/core/weight_sharing_util.hpp"
 #include "openvino/frontend/common/path_util.hpp"
 #include "openvino/frontend/exception.hpp"
 #include "openvino/frontend/extension/telemetry.hpp"
@@ -106,12 +107,37 @@ bool is_graph_iterator_enabled() {
 // !!! Experimental feature, it may be changed or removed in the future !!!
 void enumerate_constants(const std::shared_ptr<ov::Model>& model) {
     const auto& operations = model->get_ordered_ops();
+    // first loop just to check if there are external weights or not (WA)
+    bool hasExternalWeights = false;
     for (uint32_t idx = 0; idx < operations.size(); ++idx) {
         const auto& const_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(operations[idx]);
         if (const_node == nullptr)
             continue;
-        const_node->get_rt_info()[ov::WeightlessCacheAttribute::get_type_info_static()] =
-            ov::WeightlessCacheAttribute(0, idx, const_node->get_element_type());
+
+        if (ov::wsh::Extension::get_constant_id(*const_node) != ov::wsh::invalid_constant_id) {
+            hasExternalWeights = true;
+            break;
+        }
+    }
+
+    for (uint32_t idx = 0; idx < operations.size(); ++idx) {
+        const auto& const_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(operations[idx]);
+        if (const_node == nullptr)
+            continue;
+
+        if (!hasExternalWeights) {
+            // topological order ids for internal weights only
+            const_node->get_rt_info()[ov::WeightlessCacheAttribute::get_type_info_static()] =
+                ov::WeightlessCacheAttribute(0, idx, const_node->get_element_type());
+            continue;
+        }
+
+        if (auto constant_id = ov::wsh::Extension::get_constant_id(*const_node);
+            constant_id != ov::wsh::invalid_constant_id) {
+            // populate WCAs with constant_id only for external weights
+            const_node->get_rt_info()[ov::WeightlessCacheAttribute::get_type_info_static()] =
+                ov::WeightlessCacheAttribute(0, constant_id, const_node->get_element_type());
+        }
     }
 }
 // !!! End of Experimental feature

--- a/src/frontends/onnx/frontend/src/frontend.cpp
+++ b/src/frontends/onnx/frontend/src/frontend.cpp
@@ -31,7 +31,6 @@
 #include "onnx_framework_node.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/core/so_extension.hpp"
-#include "openvino/core/weight_sharing_util.hpp"
 #include "openvino/frontend/common/path_util.hpp"
 #include "openvino/frontend/exception.hpp"
 #include "openvino/frontend/extension/telemetry.hpp"
@@ -107,37 +106,12 @@ bool is_graph_iterator_enabled() {
 // !!! Experimental feature, it may be changed or removed in the future !!!
 void enumerate_constants(const std::shared_ptr<ov::Model>& model) {
     const auto& operations = model->get_ordered_ops();
-    // first loop just to check if there are external weights or not (WA)
-    bool hasExternalWeights = false;
     for (uint32_t idx = 0; idx < operations.size(); ++idx) {
         const auto& const_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(operations[idx]);
         if (const_node == nullptr)
             continue;
-
-        if (ov::wsh::Extension::get_constant_id(*const_node) != ov::wsh::invalid_constant_id) {
-            hasExternalWeights = true;
-            break;
-        }
-    }
-
-    for (uint32_t idx = 0; idx < operations.size(); ++idx) {
-        const auto& const_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(operations[idx]);
-        if (const_node == nullptr)
-            continue;
-
-        if (!hasExternalWeights) {
-            // topological order ids for internal weights only
-            const_node->get_rt_info()[ov::WeightlessCacheAttribute::get_type_info_static()] =
-                ov::WeightlessCacheAttribute(0, idx, const_node->get_element_type());
-            continue;
-        }
-
-        if (auto constant_id = ov::wsh::Extension::get_constant_id(*const_node);
-            constant_id != ov::wsh::invalid_constant_id) {
-            // populate WCAs with constant_id only for external weights
-            const_node->get_rt_info()[ov::WeightlessCacheAttribute::get_type_info_static()] =
-                ov::WeightlessCacheAttribute(0, constant_id, const_node->get_element_type());
-        }
+        const_node->get_rt_info()[ov::WeightlessCacheAttribute::get_type_info_static()] =
+            ov::WeightlessCacheAttribute(0, idx, const_node->get_element_type());
     }
 }
 // !!! End of Experimental feature

--- a/src/plugins/intel_npu/src/compiler_adapter/include/weightless_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/weightless_graph.hpp
@@ -29,7 +29,7 @@ public:
                     const std::vector<GraphDescriptor>& initGraphDesc,
                     std::vector<NetworkMetadata> initMetadata,
                     std::optional<std::vector<ov::Tensor>> initBlobs,
-                    std::shared_ptr<const ov::Model>&& model,
+                    std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>>&& constants,
                     const FilteredConfig& config,
                     const bool blobIsPersistent = false);
 
@@ -108,7 +108,7 @@ private:
     std::vector<GraphDescriptor> _initsGraphDesc;
     std::optional<std::vector<ov::Tensor>> _initBlobs;
     std::vector<NetworkMetadata> _initsMetadata;
-    std::shared_ptr<const ov::Model> _model;
+    std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> _constants;
 
     std::vector<std::unique_ptr<CommandList>> _initsCommandLists;
     std::vector<std::unique_ptr<Fence>> _initsFences;

--- a/src/plugins/intel_npu/src/compiler_adapter/include/weightless_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/weightless_graph.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "graph.hpp"
 #include "intel_npu/utils/zero/zero_tensor.hpp"
 #include "openvino/op/constant.hpp"

--- a/src/plugins/intel_npu/src/compiler_adapter/include/weightless_utils.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/weightless_utils.hpp
@@ -5,9 +5,17 @@
 #pragma once
 
 #include "intel_npu/common/network_metadata.hpp"
+#include "openvino/op/constant.hpp"
 
 namespace intel_npu {
 
 bool isInitMetadata(const NetworkMetadata& networkMetadata);
+
+std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_constants_in_topological_order(
+    const std::shared_ptr<const ov::Model>& model);
+
+std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_constants_memory_mapped(
+    const std::string& weightsPath,
+    const std::vector<NetworkMetadata>& initNetworkMetadata);
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler_adapter/include/weightless_utils.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/weightless_utils.hpp
@@ -4,7 +4,13 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "intel_npu/common/network_metadata.hpp"
+#include "openvino/core/model.hpp"
 #include "openvino/op/constant.hpp"
 
 namespace intel_npu {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -204,6 +204,11 @@ std::shared_ptr<IGraph> DriverCompilerAdapter::compileWS(std::shared_ptr<ov::Mod
         _logger.info("Compilation memory usage: Peak %lld KB", compile_model_mem_end - compile_model_mem_start);
     }
 
+    auto constants = get_all_constants_in_topological_order(model);
+    // Note: Delete model prematurely, constants are still valid due to
+    // shared_ptr semantics.
+    model = nullptr;
+
     return std::make_shared<WeightlessGraph>(_zeGraphExt,
                                              _zeroInitStruct,
                                              mainGraphHandle,
@@ -212,7 +217,7 @@ std::shared_ptr<IGraph> DriverCompilerAdapter::compileWS(std::shared_ptr<ov::Mod
                                              initGraphDescriptors,
                                              std::move(initNetworkMetadata),
                                              /* initBlobs = */ std::nullopt,
-                                             std::move(model),
+                                             std::move(constants),
                                              updatedConfig);
 }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/parser.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/parser.cpp
@@ -10,6 +10,7 @@
 #include "intel_npu/config/options.hpp"
 #include "intel_npu/utils/vm/npu_vm_runtime_api.hpp"
 #include "weightless_graph.hpp"
+#include "weightless_utils.hpp"
 
 namespace intel_npu {
 
@@ -96,7 +97,12 @@ std::shared_ptr<IGraph> Parser::parse(const ov::Tensor& mainBlob,
     }
     _logger.debug("inits schedule parse end");
 
-    OPENVINO_ASSERT(model.has_value(), "Model is required for parsing weightless blobs.");
+    auto constants = model.has_value()
+                         ? get_all_constants_in_topological_order(model.value())
+                         : get_all_constants_memory_mapped(config.get<WEIGHTS_PATH>(), initNetworkMetadata);
+    // Note: Delete model prematurely, constants are still valid due to
+    // shared_ptr semantics.
+    model = std::nullopt;
 
     return std::make_shared<WeightlessGraph>(_zeGraphExt,
                                              _zeroInitStruct,
@@ -106,7 +112,7 @@ std::shared_ptr<IGraph> Parser::parse(const ov::Tensor& mainBlob,
                                              initGraphDescriptors,
                                              std::move(initNetworkMetadata),
                                              initBlobs,
-                                             std::move(model.value()),
+                                             std::move(constants),
                                              config,
                                              blobIsPersistent);
 }

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -233,6 +233,11 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compileWS(std::shared_ptr<ov::Mod
 
     _logger.debug("compile end");
 
+    auto constants = get_all_constants_in_topological_order(model);
+    // Note: Delete model prematurely, constants are still valid due to
+    // shared_ptr semantics.
+    model = nullptr;
+
     return std::make_shared<WeightlessGraph>(
         _zeGraphExt,
         _zeroInitStruct,
@@ -242,7 +247,7 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compileWS(std::shared_ptr<ov::Mod
         initGraphDescriptors,
         std::move(initNetworkMetadata),
         tensorsInits,
-        std::move(model),
+        std::move(constants),
         localConfig,
         /* persistentBlob = */ true);  // exporting the blob shall be available in such a scenario
 }

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -16,6 +16,7 @@
 #include "intel_npu/utils/zero/zero_cmd_queue_pool.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
 #include "openvino/core/memory_util.hpp"
+#include "openvino/core/weight_sharing_util.hpp"
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/util/common_util.hpp"
 
@@ -382,6 +383,7 @@ WeightlessGraph::InputData WeightlessGraph::allocate_inputs(
         // Note: By construction of the weight schedule, every constant from OV
         // model appears in exactly one schedule. Thus, one can delete
         // the handle to the constant memory early.
+        ov::wsh::Extension::hint_evict(*constants.at(id));
         constants.erase(id);
     }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -16,9 +16,8 @@
 #include "intel_npu/utils/zero/zero_cmd_queue_pool.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
 #include "openvino/core/memory_util.hpp"
-#include "openvino/core/model.hpp"
-#include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/runtime/make_tensor.hpp"
+#include "openvino/util/common_util.hpp"
 
 #define USE_SINGLE_THREADED_RUN_INIT 1
 
@@ -27,39 +26,6 @@ namespace intel_npu {
 namespace {
 
 constexpr uint8_t MAIN_SCHEDULE_INDEX = 0;
-
-std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_constants_in_topological_order(
-    const std::shared_ptr<const ov::Model>& model,
-    const Logger& logger) {
-    std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> constants;
-
-    // Match the inputs of the "init" model with the Constant nodes of the original model
-    for (auto&& node : model->get_ops()) {
-        if (!ov::is_type<ov::op::v0::Constant>(node)) {
-            continue;
-        }
-
-        auto constantNode = std::static_pointer_cast<ov::op::v0::Constant>(node);
-        ov::RTMap& runtimeInfoMap = constantNode->get_rt_info();
-        const auto& weightlessCacheAttrIt = runtimeInfoMap.find(ov::WeightlessCacheAttribute::get_type_info_static());
-        if (weightlessCacheAttrIt != runtimeInfoMap.end()) {
-            auto& weightlessCacheAttr = weightlessCacheAttrIt->second.as<ov::WeightlessCacheAttribute>();
-
-            auto& constant = constants[weightlessCacheAttr.bin_offset];
-            if (constant != nullptr) {
-                // if multiple constants point to the same buffer, ensure that
-                // their binary sizes are the same
-                OPENVINO_ASSERT(constant->get_byte_size() == constantNode->get_byte_size(),
-                                "Found ov::Constant that points to the common buffer but has mismatching byte size. "
-                                "This may indicate a bug in OV model compression.");
-                continue;
-            }
-            constant = std::move(constantNode);
-        }
-    }
-
-    return constants;
-}
 
 struct QueueData {
     int64_t initIndex = -1;
@@ -85,11 +51,11 @@ class Parallelizer {
     Task2Callable _task2;
 
 public:
-    Parallelizer(const std::shared_ptr<const ov::Model>& model,
+    Parallelizer(std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>>&& _constants,
                  Task1Callable&& task1,
                  Task2Callable&& task2,
                  const Logger& logger)
-        : _modelConstants(get_all_constants_in_topological_order(model, logger)),
+        : _modelConstants(std::move(_constants)),
           _task1(std::forward<Task1Callable>(task1)),
           _task2(std::forward<Task2Callable>(task2)) {}
 
@@ -149,8 +115,10 @@ public:
 
 // c++17 deduction guide
 template <typename Task1Callable, typename Task2Callable>
-Parallelizer(const std::shared_ptr<const ov::Model>&, Task1Callable&&, Task2Callable&&, const Logger&)
-    -> Parallelizer<Task1Callable, Task2Callable>;
+Parallelizer(std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>>&&,
+             Task1Callable&&,
+             Task2Callable&&,
+             const Logger&) -> Parallelizer<Task1Callable, Task2Callable>;
 
 void merge_two_maps(std::unordered_map<std::string, std::shared_ptr<ov::ITensor>>& dst,
                     std::unordered_map<std::string, std::shared_ptr<ov::ITensor>>& src) {
@@ -168,7 +136,7 @@ WeightlessGraph::WeightlessGraph(const std::shared_ptr<ZeGraphExtWrappers>& zeGr
                                  const std::vector<GraphDescriptor>& initGraphDesc,
                                  std::vector<NetworkMetadata> initMetadata,
                                  std::optional<std::vector<ov::Tensor>> initBlobs,
-                                 std::shared_ptr<const ov::Model>&& model,
+                                 std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>>&& constants,
                                  const FilteredConfig& config,
                                  const bool blobIsPersistent)
     : Graph(zeGraphExt,
@@ -183,7 +151,7 @@ WeightlessGraph::WeightlessGraph(const std::shared_ptr<ZeGraphExtWrappers>& zeGr
       _initsGraphDesc(initGraphDesc),
       _initBlobs(std::move(initBlobs)),
       _initsMetadata(std::move(initMetadata)),
-      _model(std::move(model)),
+      _constants(std::move(constants)),
       _wgLogger("WeightlessGraph", config.get<LOG_LEVEL>()) {
     if (!config.get<CREATE_EXECUTOR>() || config.get<DEFER_WEIGHTS_LOAD>()) {
         _wgLogger.info("Graph initialize is deferred from the \"WeightlessGraph\" constructor");
@@ -376,7 +344,10 @@ WeightlessGraph::InputData WeightlessGraph::allocate_inputs(
         const size_t currentInputSize =
             ov::util::get_memory_size(descriptor.precision, shape_size(tensorShapeFromCompiler));
 
-        const size_t id = std::stoi(descriptor.nameFromCompiler);
+        const auto& opt = ov::util::view_to_number<size_t>(descriptor.nameFromCompiler);
+        OPENVINO_ASSERT(opt.has_value(), "Failed to parse id for constant: ", descriptor.nameFromCompiler);
+
+        const size_t id = opt.value();
         auto constantIt = constants.find(id);
         OPENVINO_ASSERT(constantIt != constants.end(),
                         "Weights ID ",
@@ -448,15 +419,10 @@ WeightlessGraph::OutputData WeightlessGraph::allocate_outputs(const size_t initI
 }
 
 void WeightlessGraph::run_init_single_threaded() {
-    auto constants = get_all_constants_in_topological_order(_model, _wgLogger);
     const size_t numberOfInits = _initsGraphDesc.size();
 
-    // Note: Delete model prematurely, constants are still valid due to
-    // shared_ptr semantics.
-    _model = nullptr;
-
     for (size_t initIndex = 0; initIndex < numberOfInits; ++initIndex) {
-        auto [initInputsViewTensors, initInputsAllocatedTensor] = allocate_inputs(initIndex, constants);
+        auto [initInputsViewTensors, initInputsAllocatedTensor] = allocate_inputs(initIndex, _constants);
         auto [initOutputsViewTensors, initOutputsAllocatedTensor, initOutputsViewTensorsMap] =
             allocate_outputs(initIndex);
 
@@ -467,6 +433,8 @@ void WeightlessGraph::run_init_single_threaded() {
         merge_two_maps(_mainInputsViewTensors, initOutputsViewTensorsMap);
         _mainInputsAllocatedTensors.push_back(std::move(initOutputsAllocatedTensor));
     }
+    // Ensure constants are no longer kept in memory after all init schedules have been run
+    _constants.clear();
 }
 
 void WeightlessGraph::run_init_multi_threaded() {
@@ -480,7 +448,7 @@ void WeightlessGraph::run_init_multi_threaded() {
     // allocate I/O -> create Pipeline -> run Pipeline
     //                                    allocate I/O -> create Pipeline -> run Pipeline
     Parallelizer multiThreadedRunner(
-        _model,
+        std::move(_constants),
         [&](std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>>& constants,
             int64_t initIndex) -> QueueData {
             QueueData data{};
@@ -510,10 +478,6 @@ void WeightlessGraph::run_init_multi_threaded() {
         },
         _wgLogger);
 
-    // Note: Delete model prematurely, constants are still valid due to
-    // shared_ptr semantics.
-    _model = nullptr;
-
     multiThreadedRunner.callForAllAndWait(_initsGraphDesc.size());
 }
 
@@ -531,18 +495,18 @@ void WeightlessGraph::create_pipeline(const size_t initIndex,
 
     size_t io_index = 0;
     for (const auto& desc : _initsMetadata.at(initIndex).inputs) {
-        void* data = inputTensors.at(io_index++)->data();
+        const void* data = inputTensors.at(io_index++)->data();
         _zeGraphExt->setGraphArgumentValue(_initsGraphDesc.at(initIndex),
                                            desc.indexUsedByDriver,
-                                           static_cast<unsigned char*>(data));
+                                           static_cast<const unsigned char*>(data));
     }
 
     io_index = 0;
     for (const auto& desc : _initsMetadata.at(initIndex).outputs) {
-        void* data = outputTensors.at(io_index++)->data();
+        const void* data = outputTensors.at(io_index++)->data();
         _zeGraphExt->setGraphArgumentValue(_initsGraphDesc.at(initIndex),
                                            desc.indexUsedByDriver,
-                                           static_cast<unsigned char*>(data));
+                                           static_cast<const unsigned char*>(data));
     }
 
     _initsCommandLists.at(initIndex)->appendGraphExecute(

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -383,8 +383,10 @@ WeightlessGraph::InputData WeightlessGraph::allocate_inputs(
         // Note: By construction of the weight schedule, every constant from OV
         // model appears in exactly one schedule. Thus, one can delete
         // the handle to the constant memory early.
-        ov::wsh::Extension::hint_evict(*constants.at(id));
-        constants.erase(id);
+        if (constants.find(id) != constants.end()) {
+            ov::wsh::Extension::hint_evict(*constants.at(id));
+            constants.erase(id);
+        }
     }
 
     return {std::move(initInputsViewTensors), initInputsAllocatedTensor};

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -383,9 +383,9 @@ WeightlessGraph::InputData WeightlessGraph::allocate_inputs(
         // Note: By construction of the weight schedule, every constant from OV
         // model appears in exactly one schedule. Thus, one can delete
         // the handle to the constant memory early.
-        if (constants.find(id) != constants.end()) {
-            ov::wsh::Extension::hint_evict(*constants.at(id));
-            constants.erase(id);
+        if (auto it = constants.find(id); it != constants.end()) {
+            ov::wsh::Extension::hint_evict(*it->second);
+            constants.erase(it);
         }
     }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
@@ -78,10 +78,16 @@ std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_consta
                                                                                       byte_size,
                                                                                       mapped_memory);
 
-            constants.insert({id,
-                              std::make_shared<ov::op::v0::Constant>(descriptor.precision,
-                                                                     descriptor.shapeFromCompiler.to_shape(),
-                                                                     weight_buffer)});
+            auto [it, inserted] =
+                constants.emplace(id,
+                                  std::make_shared<ov::op::v0::Constant>(descriptor.precision,
+                                                                         descriptor.shapeFromCompiler.to_shape(),
+                                                                         weight_buffer));
+            if (!inserted) {
+                OPENVINO_ASSERT(it->second->get_byte_size() == byte_size,
+                                "Duplicate constant offset found with mismatching byte size: offset=",
+                                id);
+            }
         }
     }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
@@ -5,7 +5,6 @@
 #include "weightless_utils.hpp"
 
 #include "openvino/core/memory_util.hpp"
-#include "openvino/core/model.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
 #include "openvino/util/mmap_object.hpp"
@@ -63,10 +62,21 @@ std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_consta
             OPENVINO_ASSERT(opt.has_value(), "Failed parse id for constant: ", descriptor.nameFromCompiler);
 
             const size_t id = opt.value();
-            auto weight_buffer = std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(
-                mapped_memory->data() + id,
-                ov::util::get_memory_size(descriptor.precision, shape_size(descriptor.shapeFromCompiler.to_shape())),
-                mapped_memory);
+            const size_t byte_size =
+                ov::util::get_memory_size(descriptor.precision, shape_size(descriptor.shapeFromCompiler.to_shape()));
+            OPENVINO_ASSERT(id <= mapped_memory->size() && byte_size <= mapped_memory->size() - id,
+                            "Constant offset/size is out of bounds for mapped weights file: offset=",
+                            id,
+                            ", size=",
+                            byte_size,
+                            ", file_size=",
+                            mapped_memory->size(),
+                            ", name=",
+                            descriptor.nameFromCompiler);
+            auto weight_buffer =
+                std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(mapped_memory->data() + id,
+                                                                                      byte_size,
+                                                                                      mapped_memory);
 
             constants.insert({id,
                               std::make_shared<ov::op::v0::Constant>(descriptor.precision,

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
@@ -4,6 +4,12 @@
 
 #include "weightless_utils.hpp"
 
+#include "openvino/core/memory_util.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/core/rt_info/weightless_caching_attributes.hpp"
+#include "openvino/runtime/shared_buffer.hpp"
+#include "openvino/util/mmap_object.hpp"
+
 namespace intel_npu {
 
 bool isInitMetadata(const NetworkMetadata& networkMetadata) {
@@ -11,6 +17,65 @@ bool isInitMetadata(const NetworkMetadata& networkMetadata) {
         return false;
     }
     return networkMetadata.inputs.at(0).isInitInputWeights;
+}
+
+std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_constants_in_topological_order(
+    const std::shared_ptr<const ov::Model>& model) {
+    std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> constants;
+
+    // Match the inputs of the "init" model with the Constant nodes of the original model
+    for (auto&& node : model->get_ops()) {
+        if (!ov::is_type<ov::op::v0::Constant>(node)) {
+            continue;
+        }
+
+        auto constantNode = std::static_pointer_cast<ov::op::v0::Constant>(node);
+        ov::RTMap& runtimeInfoMap = constantNode->get_rt_info();
+        const auto& weightlessCacheAttrIt = runtimeInfoMap.find(ov::WeightlessCacheAttribute::get_type_info_static());
+        if (weightlessCacheAttrIt != runtimeInfoMap.end()) {
+            auto& weightlessCacheAttr = weightlessCacheAttrIt->second.as<ov::WeightlessCacheAttribute>();
+
+            auto& constant = constants[weightlessCacheAttr.bin_offset];
+            if (constant != nullptr) {
+                // if multiple constants point to the same buffer, ensure that
+                // their binary sizes are the same
+                OPENVINO_ASSERT(constant->get_byte_size() == constantNode->get_byte_size(),
+                                "Found ov::Constant that points to the common buffer but has mismatching byte size. "
+                                "This may indicate a bug in OV model compression.");
+                continue;
+            }
+            constant = std::move(constantNode);
+        }
+    }
+
+    return constants;
+}
+
+std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_constants_memory_mapped(
+    const std::string& weightsPath,
+    const std::vector<NetworkMetadata>& initNetworkMetadata) {
+    std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> constants;
+
+    auto mapped_memory = ov::load_mmap_object(weightsPath);
+    for (const auto& initMetadata : initNetworkMetadata) {
+        for (const IODescriptor& descriptor : initMetadata.inputs) {
+            const auto& opt = ov::util::view_to_number<size_t>(descriptor.nameFromCompiler);
+            OPENVINO_ASSERT(opt.has_value(), "Failed parse id for constant: ", descriptor.nameFromCompiler);
+
+            const size_t id = opt.value();
+            auto weight_buffer = std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(
+                mapped_memory->data() + id,
+                ov::util::get_memory_size(descriptor.precision, shape_size(descriptor.shapeFromCompiler.to_shape())),
+                mapped_memory);
+
+            constants.insert({id,
+                              std::make_shared<ov::op::v0::Constant>(descriptor.precision,
+                                                                     descriptor.shapeFromCompiler.to_shape(),
+                                                                     weight_buffer)});
+        }
+    }
+
+    return constants;
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
@@ -7,6 +7,7 @@
 #include "openvino/core/memory_util.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
+#include "openvino/util/common_util.hpp"
 #include "openvino/util/mmap_object.hpp"
 
 namespace intel_npu {
@@ -21,6 +22,8 @@ bool isInitMetadata(const NetworkMetadata& networkMetadata) {
 std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_constants_in_topological_order(
     const std::shared_ptr<const ov::Model>& model) {
     std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> constants;
+
+    OPENVINO_ASSERT(model != nullptr, "Model is required to extract constants in topological order.");
 
     // Match the inputs of the "init" model with the Constant nodes of the original model
     for (auto&& node : model->get_ops()) {
@@ -59,7 +62,7 @@ std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_consta
     for (const auto& initMetadata : initNetworkMetadata) {
         for (const IODescriptor& descriptor : initMetadata.inputs) {
             const auto& opt = ov::util::view_to_number<size_t>(descriptor.nameFromCompiler);
-            OPENVINO_ASSERT(opt.has_value(), "Failed parse id for constant: ", descriptor.nameFromCompiler);
+            OPENVINO_ASSERT(opt.has_value(), "Failed to parse id for constant: ", descriptor.nameFromCompiler);
 
             const size_t id = opt.value();
             const size_t byte_size =

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -42,7 +42,6 @@ const std::vector<size_t> CONSTANT_NODE_DUMMY_SHAPE{1};
 
 const char* NPU_PLUGIN_LIB_NAME = "openvino_intel_npu_plugin";
 constexpr std::string_view WEIGHTS_IR_EXTENSION = ".bin";
-constexpr std::string_view WEIGHTS_ONNX_EXTENSION = ".data_proxy";
 constexpr std::string_view ONNX_EXTENSION = ".onnx";
 
 /**

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -41,8 +41,8 @@ using namespace intel_npu;
 const std::vector<size_t> CONSTANT_NODE_DUMMY_SHAPE{1};
 
 const char* NPU_PLUGIN_LIB_NAME = "openvino_intel_npu_plugin";
-constexpr std::string_view WEIGHTS_EXTENSION = ".bin";
-constexpr std::string_view XML_EXTENSION = ".xml";
+constexpr std::string_view WEIGHTS_IR_EXTENSION = ".bin";
+constexpr std::string_view WEIGHTS_ONNX_EXTENSION = ".data_proxy";
 constexpr std::string_view ONNX_EXTENSION = ".onnx";
 
 /**
@@ -902,33 +902,23 @@ std::shared_ptr<ov::ICompiledModel> Plugin::parse(const ov::Tensor& tensorBig,
         if (!originalModel) {
             if (!localConfig.get<WEIGHTS_PATH>().empty()) {
                 const std::string weightsPath = localConfig.get<WEIGHTS_PATH>();
-                const size_t weightsPathLength = weightsPath.length();
-                std::string xmlPath = weightsPath;
-
-                if (weightsPathLength > WEIGHTS_EXTENSION.length() &&
-                    weightsPath.compare(weightsPathLength - WEIGHTS_EXTENSION.length(),
-                                        WEIGHTS_EXTENSION.length(),
-                                        WEIGHTS_EXTENSION) == 0) {
-                    xmlPath.replace(weightsPathLength - WEIGHTS_EXTENSION.length(),
-                                    WEIGHTS_EXTENSION.length(),
-                                    XML_EXTENSION);
-                } else if (weightsPathLength <= ONNX_EXTENSION.length() ||
-                           weightsPath.compare(weightsPathLength - ONNX_EXTENSION.length(),
-                                               ONNX_EXTENSION.length(),
-                                               ONNX_EXTENSION)) {
+                auto ext = ov::util::path_to_string(ov::util::make_path(weightsPath).extension());
+                if (ext == ONNX_EXTENSION) {
+                    originalModel = get_core()->read_model(ov::util::make_path(weightsPath),
+                                                           ov::util::make_path(weightsPath),
+                                                           properties);
+                    check_weightless_cache_attribute_occurrence(originalModel);
+                } else if (ext == WEIGHTS_IR_EXTENSION || ext == WEIGHTS_ONNX_EXTENSION) {
+                    // constants will be populated in parser
+                } else {
                     OPENVINO_THROW("Invalid path to the weights: ",
                                    weightsPath,
-                                   ". A \".bin\" or \".onnx\" extension was expected.");
+                                   ". A \".bin\", \".data_proxy\" or \".onnx\" extension was expected.");
                 }
-
-                originalModel =
-                    get_core()->read_model(ov::util::make_path(xmlPath), ov::util::make_path(weightsPath), properties);
             } else {
                 OPENVINO_THROW("Attempted to load a weightless compiled model, but no weights have been provided");
             }
         }
-
-        check_weightless_cache_attribute_occurrence(originalModel);
     }
 
     const std::optional<std::vector<ov::Tensor>> initBlobs =
@@ -958,7 +948,9 @@ std::shared_ptr<ov::ICompiledModel> Plugin::parse(const ov::Tensor& tensorBig,
     auto graph = parser->parse(tensorMain,
                                localConfig,
                                initBlobs,
-                               weightsSeparationEnabled ? std::make_optional(std::move(originalModel)) : std::nullopt,
+                               weightsSeparationEnabled && originalModel != nullptr
+                                   ? std::make_optional(std::move(originalModel))
+                                   : std::nullopt,
                                compatibilityDescriptor);
 
     graph->update_network_name("net" + std::to_string(_compiledModelLoadCounter++));

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -904,16 +904,14 @@ std::shared_ptr<ov::ICompiledModel> Plugin::parse(const ov::Tensor& tensorBig,
                 const std::string weightsPath = localConfig.get<WEIGHTS_PATH>();
                 auto ext = ov::util::path_to_string(ov::util::make_path(weightsPath).extension());
                 if (ext == ONNX_EXTENSION) {
-                    originalModel = get_core()->read_model(ov::util::make_path(weightsPath),
-                                                           ov::util::make_path(weightsPath),
-                                                           properties);
+                    originalModel = get_core()->read_model(weightsPath, weightsPath, properties);
                     check_weightless_cache_attribute_occurrence(originalModel);
-                } else if (ext == WEIGHTS_IR_EXTENSION || ext == WEIGHTS_ONNX_EXTENSION) {
+                } else if (ext == WEIGHTS_IR_EXTENSION) {
                     // constants will be populated in parser
                 } else {
                     OPENVINO_THROW("Invalid path to the weights: ",
                                    weightsPath,
-                                   ". A \".bin\", \".data_proxy\" or \".onnx\" extension was expected.");
+                                   ". A \".bin\" or \".onnx\" extension was expected.");
                 }
             } else {
                 OPENVINO_THROW("Attempted to load a weightless compiled model, but no weights have been provided");

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -132,6 +132,10 @@ std::shared_ptr<ov::Model> create_dummy_model(const std::vector<IODescriptor>& i
  * thrown. The weights separation flow in its current state cannot work without this attribuite.
  */
 void check_weightless_cache_attribute_occurrence(const std::shared_ptr<const ov::Model>& model) {
+    if (!model) {
+        return;
+    }
+
     for (const auto& ov_node : model->get_ordered_ops()) {
         if (!ov::is_type<ov::op::v0::Constant>(ov_node)) {
             continue;
@@ -904,7 +908,6 @@ std::shared_ptr<ov::ICompiledModel> Plugin::parse(const ov::Tensor& tensorBig,
                 auto ext = ov::util::path_to_string(ov::util::make_path(weightsPath).extension());
                 if (ext == ONNX_EXTENSION) {
                     originalModel = get_core()->read_model(weightsPath, weightsPath, properties);
-                    check_weightless_cache_attribute_occurrence(originalModel);
                 } else if (ext == WEIGHTS_IR_EXTENSION) {
                     // constants will be populated in parser
                 } else {
@@ -916,6 +919,8 @@ std::shared_ptr<ov::ICompiledModel> Plugin::parse(const ov::Tensor& tensorBig,
                 OPENVINO_THROW("Attempted to load a weightless compiled model, but no weights have been provided");
             }
         }
+
+        check_weightless_cache_attribute_occurrence(originalModel);
     }
 
     const std::optional<std::vector<ov::Tensor>> initBlobs =

--- a/src/plugins/intel_npu/tests/functional/behavior/weights_separation.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/weights_separation.hpp
@@ -379,6 +379,32 @@ TEST_P(WeightsSeparationTests, WrongInferenceResultIfWrongWeightsProvided) {
 }
 
 /**
+ * @brief compile -> delete .xml file -> import the result, ov::weights_path provided -> create inference request -> run
+ * one inference and check the result
+ */
+TEST_P(WeightsSeparationTests, CorrectInferenceResultIfWeightsPathUsedAndModelFileDeleted) {
+    model = createTestModel();
+
+    model_path = ov::util::path_join({utils::getCurrentWorkingDir(), utils::generateTestFilePrefix()}).string();
+    ov::serialize(model, model_path + ".xml", model_path + ".bin");
+
+    configuration.insert(ov::enable_weightless(true));
+    OV_ASSERT_NO_THROW(compiled_model = core->compile_model(model, target_device, configuration));
+    ASSERT_TRUE(compiled_model);
+
+    utils::removeFile(model_path + ".xml");
+
+    std::stringstream export_stream;
+    compiled_model.export_model(export_stream);
+
+    configuration.insert(ov::weights_path(model_path + ".bin"));
+    OV_ASSERT_NO_THROW(compiled_model = core->import_model(export_stream, target_device, configuration));
+    ASSERT_TRUE(compiled_model);
+
+    create_infer_request_and_check_result();
+}
+
+/**
  * @brief compile -> import the result shaped as a tensor, ov::hint::model provided -> create inference request -> run
  * one inference and check the result
  */


### PR DESCRIPTION
### Details:
 - *Changed logic in Plugin to read model only for `.onnx` extension given to `ov::weigths_path` property*
 - *If user provided files ending with `.bin` or `.data_proxy` extensions, plugin will try to memory map those files and generate constants map based on **offsets** for the `WeightlessGraph`*
 - *Offsets need to match original ones given by `WeightlessCacheAttribute` provided by frontends at model compilation:*
   - *`openvino_ir_frontend` will set everytime WCAs as actual offsets of weights within `.bin` file*
   - *`openvino_onnx_frontend` will set everytime WCAs as **topological order ids** thus a **workaround** for it was needed:*
     - *`.onnx` model with **internal weights** only will have WCAs populated with **topological order ids**;*
     - *`.onnx` model with **external weights** will populate WCAs **only with offsets from external weights**, the internal ones are being **skipped** when populating WCAs*
  - *`WeightlessGraph` will receive a map of constants instead of an `ov::Model`*:
    - *`get_all_constants_in_topological_order` will be called when a valid `ov::Model` was passed from Plugin (either for `.onnx` extensions or if `ov::hint::model` property was provided instead of `ov::weights_path`*
    - *NEW: `get_all_constants_memory_mapped` will populate constants based on IDs form graph descriptors*
 - *Used `hint_evict` API from `ov::wsh::Extension` to force releasing memory mapped weights after they have been copied in NPU device memory*

<summary>
AI generated diagram:
<details>

```mermaid
flowchart TD
    A["Plugin::parse&lpar;&rpar;<br/>weightsSeparationEnabled?"]

    A -->|No| B["Regular parse path<br/>&lpar;no WeightlessGraph constants flow&rpar;"]

    A -->|Yes| C{"Constants source selection"}

    C -->|"ov::hint::model provided"| D["Use provided ov::Model<br/>get_all_constants_in_topological_order&lpar;&rpar;"]
    C -->|"ov::weights_path = .onnx"| E["Read .onnx as ov::Model<br/>check WeightlessCacheAttribute<br/>get_all_constants_in_topological_order&lpar;&rpar;"]
    C -->|"ov::weights_path = .bin/.data_proxy"| F["Memory-map weights file<br/>get_all_constants_memory_mapped&lpar;&rpar;"]

    D --> G["WeightlessGraph receives constants map only"]
    E --> G
    F --> G

    G --> H["Copy constants to NPU init buffers"]
    H --> I["hint_evict&lpar;&rpar; + erase map entries"]

    J["Old path &lpar;removed&rpar;<br/>Plugin always reads ov::Model"] -.-x G
```
</details>
</summary>

### Tickets:
 - *C189551*

### AI Assistance:
 - *AI assistance used: no / <s>yes</s>*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
