### PR TITLE
[GPU] Make sure that cldnn::data::load_weights() checks the incoming

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -415,7 +415,7 @@ struct data : public primitive_base<data> {
         size_t data_size = 0;
         ib >> make_data(&data_size, sizeof(size_t));
 
-OPENVINO_ASSERT(data_size == output_layout.bytes_count(),
+        OPENVINO_ASSERT(data_size == output_layout.bytes_count(),
                "[GPU] Corrupt cache blob: data_size=", data_size,
                ", expected=", output_layout.bytes_count());
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -415,7 +415,9 @@ struct data : public primitive_base<data> {
         size_t data_size = 0;
         ib >> make_data(&data_size, sizeof(size_t));
 
-        OPENVINO_ASSERT(data_size == output_layout.bytes_count(), "corrupt blob");
+OPENVINO_ASSERT(data_size == output_layout.bytes_count(),
+               "[GPU] Corrupt cache blob: data_size=", data_size,
+               ", expected=", output_layout.bytes_count());
 
         bool weightless_caching = false;
         ib >> weightless_caching;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -411,9 +411,11 @@ struct data : public primitive_base<data> {
 
         allocation_type _allocation_type = allocation_type::unknown;
         ib >> make_data(&_allocation_type, sizeof(_allocation_type));
-        
+
         size_t data_size = 0;
         ib >> make_data(&data_size, sizeof(size_t));
+
+        OPENVINO_ASSERT(data_size == output_layout.bytes_count(), "corrupt blob");
 
         bool weightless_caching = false;
         ib >> weightless_caching;
@@ -425,7 +427,7 @@ struct data : public primitive_base<data> {
         if (!enable_zero_copy_mode) {
             mem = ib.get_engine().allocate_memory(output_layout, _allocation_type, false);
         }
-        
+
         bool is_weightless_caching = cache_info->load(ib, mem, weights_memory, weightless_caching);
 
         if (!is_weightless_caching) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/cache_serialization_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/cache_serialization_test.cpp
@@ -302,3 +302,75 @@ TEST(cache_serialization, moe_prefill_flags_all_true_round_trip) {
     ASSERT_EQ(loaded.use_gpu_mask_gen_prefill, true);
     ASSERT_EQ(loaded.use_grouped_gemm_prefill, true);
 }
+
+// --------------------------------------------------------------------------
+// data::load_weights — data_size / output_layout cross-validation
+// --------------------------------------------------------------------------
+// Regression test for a heap buffer overflow in data::load_weights.
+//
+// output_layout (which sizes the destination buffer) and data_size (how many
+// bytes are read into that buffer) are deserialized independently from the
+// cache blob. A corrupted/malicious blob can declare a data_size far larger
+// than the layout, and on the host-accessible path the bytes are read straight
+// into a buffer allocated solely from output_layout
+// (ib >> make_data(mem->buffer_ptr(), data_size)), overflowing it.
+namespace {
+// Build a blob in exactly the byte order that data::load_weights expects, with
+// a data_size that lies about how much payload follows the layout.
+membuf make_oversized_data_blob(const layout& output_layout, size_t malicious_data_size, allocation_type alloc_type) {
+    membuf mem_buf;
+    std::ostream out_mem(&mem_buf);
+    BinaryOutputBuffer ob(out_mem);
+
+    ob << output_layout;
+    ob << make_data(&alloc_type, sizeof(alloc_type));
+    ob << make_data(&malicious_data_size, sizeof(size_t));
+
+    bool weightless_caching = false;  // take the plain (non-weightless) path
+    ob << weightless_caching;
+
+    // Mirror the reader's alignment padding so stream offsets stay in sync.
+    if (!ob.is_encrypted() && !ob.is_offset_sub_buffer_aligned()) {
+        std::vector<uint8_t> pad(ob.get_bytes_to_sub_buffer_boundary(), 0);
+        ob << make_data(pad.data(), pad.size());
+    }
+
+    // Actually provide malicious_data_size bytes of payload so the vulnerable
+    // read() copies all of them into the (much smaller) destination buffer.
+    std::vector<uint8_t> payload(malicious_data_size, 0xAA);
+    ob << make_data(payload.data(), payload.size());
+
+    return mem_buf;
+}
+}  // namespace
+
+TEST(cache_serialization, load_weights_rejects_data_size_exceeding_layout) {
+    auto& engine = get_test_engine();
+
+    // Pick a host-accessible allocation type the test device actually supports,
+    // otherwise load_weights would take the device-copy path / fail to allocate.
+    allocation_type alloc_type = allocation_type::usm_host;
+    if (!engine.supports_allocation(allocation_type::usm_host)) {
+        if (engine.supports_allocation(allocation_type::usm_shared)) {
+            alloc_type = allocation_type::usm_shared;
+        } else {
+            GTEST_SKIP() << "Test device does not support host-accessible USM allocation";
+        }
+    }
+
+    // Victim buffer: 4 bytes. Attacker claims 64 KB of weight data.
+    layout small_layout({1, 1, 1, 4}, data_types::u8, format::bfyx);
+    const size_t malicious_data_size = 64 * 1024;
+    ASSERT_GT(malicious_data_size, small_layout.bytes_count());
+
+    membuf mem_buf = make_oversized_data_blob(small_layout, malicious_data_size, alloc_type);
+
+    std::istream in_mem(&mem_buf);
+    BinaryInputBuffer ib(in_mem, engine);
+
+    cldnn::data data_prim;
+    // weights_memory / model_tensor_base are null: non-weightless, non-zero-copy
+    // path, so mem is allocated from output_layout and the oversized read would
+    // overflow it. The cross-check must reject the blob first.
+    ASSERT_ANY_THROW(data_prim.load_weights(ib, /*weights_memory=*/nullptr, /*model_tensor_base=*/nullptr));
+}

--- a/src/plugins/intel_gpu/tests/unit/test_cases/cache_serialization_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/cache_serialization_test.cpp
@@ -372,5 +372,5 @@ TEST(cache_serialization, load_weights_rejects_data_size_exceeding_layout) {
     // weights_memory / model_tensor_base are null: non-weightless, non-zero-copy
     // path, so mem is allocated from output_layout and the oversized read would
     // overflow it. The cross-check must reject the blob first.
-    ASSERT_ANY_THROW(data_prim.load_weights(ib, /*weights_memory=*/nullptr, /*model_tensor_base=*/nullptr));
+ASSERT_THROW(data_prim.load_weights(ib, /*weights_memory=*/nullptr, /*model_tensor_base=*/nullptr), ov::AssertFailure);
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/cache_serialization_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/cache_serialization_test.cpp
@@ -372,5 +372,5 @@ TEST(cache_serialization, load_weights_rejects_data_size_exceeding_layout) {
     // weights_memory / model_tensor_base are null: non-weightless, non-zero-copy
     // path, so mem is allocated from output_layout and the oversized read would
     // overflow it. The cross-check must reject the blob first.
-ASSERT_THROW(data_prim.load_weights(ib, /*weights_memory=*/nullptr, /*model_tensor_base=*/nullptr), ov::AssertFailure);
+    ASSERT_THROW(data_prim.load_weights(ib, /*weights_memory=*/nullptr, /*model_tensor_base=*/nullptr), ov::AssertFailure);
 }


### PR DESCRIPTION
buffer size against the declared data_size in the cache blob.

### Tickets:
 - [CVS-189745](https://jira.devtools.intel.com/browse/CVS-189745)

### Details:
A crafted cache blob can declare a small layout (small allocation) but a large data_size, causing the deserializer to write attacker-controlled bytes past the end of the GPU/host buffer. This issue only applies to non-zero copy path.

### AI Assistance:
 - AI assistance used: yes
 - Bug root cause was found by AI and a unit test was added.
