### PR TITLE
fix(agents-prototype): update model id and deprecated prompt frontmatter

### DIFF
--- a/.github/agents-prototype/analyze-and-convert.agent.md
+++ b/.github/agents-prototype/analyze-and-convert.agent.md
@@ -1,6 +1,6 @@
 ---
 name: Analyze and Convert Agent
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 description: Attempts HuggingFace model conversion to OpenVINO IR using a multi-strategy matrix, deeply probes model properties and requirements, classifies failures with full traceback analysis, and produces a structured diagnostic report with precise routing signals for the orchestrator.
 ---
 # Analyze and Convert Agent

--- a/.github/agents-prototype/core-opspec.agent.md
+++ b/.github/agents-prototype/core-opspec.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Core Opset Agent
 description: OpenVINO Core operation specialist. Implements missing or incomplete operation specifications in the OpenVINO opset — C++ class definition, shape inference, opset registration, reference kernel, and RST documentation. Invoked by OV Orchestrator after the FE Agent escalates with status=escalate_to_core, or directly when a core op is missing. On completion unlocks the parallel Transformation, CPU, and GPU agents.
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # Core OpSpec Agent
 

--- a/.github/agents-prototype/cpu.agent.md
+++ b/.github/agents-prototype/cpu.agent.md
@@ -1,7 +1,7 @@
 ---
 name: CPU Plugin Agent
 description: OpenVINO Intel CPU plugin specialist. Implements ISA-aware CPU kernels for new operations: node registration, JIT executors (AVX2/AVX-512/AMX), oneDNN-backed paths, and functional tests. Runs in parallel with the Transformation and GPU agents after Core OpSpec publishes the op spec.
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # CPU Agent
 

--- a/.github/agents-prototype/deployer.agent.md
+++ b/.github/agents-prototype/deployer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Deployer Agent
 description: First-attempt deployment specialist. Installs stable OpenVINO release packages, exports HuggingFace models to OpenVINO IR via optimum-cli, validates the IR, runs inference sanity checks, and performs LLM-assisted error classification to route failures to the appropriate specialist agent.
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # Deployer Agent
 

--- a/.github/agents-prototype/enable-operator.agent.md
+++ b/.github/agents-prototype/enable-operator.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Enable Operator Agent
 description: OpenVINO operator enablement entry point for the openvinotoolkit/openvino repository. Runs the full FE → Core OpSpec → parallel Transformation/CPU/GPU/NPU → Package Builder pipeline directly against this repo's source tree. Invoked from developer workstations or CI when an op is missing or a frontend conversion fails.
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # Enable Operator Agent
 

--- a/.github/agents-prototype/frontend.agent.md
+++ b/.github/agents-prototype/frontend.agent.md
@@ -2,7 +2,7 @@
 name: frontend
 description: Multi-framework Frontend specialist. Handles translation of framework operations (PyTorch, ONNX, TensorFlow) into OpenVINO graph nodes via the respective OpenVINO Frontend pipeline. Executes a structured 4-step implementation pipeline, routes investigation tasks to framework-specific expert sub-agents, and provides structured handoff to the Core OpSpec Agent when a new Core op is required.
 argument-hint: Describe the frontend conversion task, e.g. "Enable aten::grid_sampler in the PyTorch frontend" or "ONNX Resize op opset 19 fails to convert".
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # Frontend Agent
 

--- a/.github/agents-prototype/gpu.agent.md
+++ b/.github/agents-prototype/gpu.agent.md
@@ -1,7 +1,7 @@
 ---
 name: GPU Plugin Agent
 description: OpenVINO Intel GPU plugin specialist. Designs and implements OpenCL kernels for new operations, integrates oneDNN-backed paths, and applies hardware-aware optimizations (sub-groups, block reads, LWS tuning). Runs in parallel with the Transformation and CPU agents after Core OpSpec publishes the op spec. Reports skipped when no GPU hardware is available.
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # GPU Agent
 

--- a/.github/agents-prototype/npu.agent.md
+++ b/.github/agents-prototype/npu.agent.md
@@ -1,7 +1,7 @@
 ---
 name: NPU Plugin Agent
 description: OpenVINO NPU plugin agent. Validates and fixes NPU-specific compilation and inference issues, benchmarks performance with benchmark_app, and reports latency results to the OV Orchestrator. Runs in parallel with Transformation, CPU, and GPU agents; its result is non-blocking. Reports skipped when no NPU hardware is available.
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # NPU Agent
 

--- a/.github/agents-prototype/onnx-expert.agent.md
+++ b/.github/agents-prototype/onnx-expert.agent.md
@@ -2,7 +2,7 @@
 name: onnx-expert
 description: Investigate and fix ONNX model conversion issues in the OpenVINO ONNX Frontend. Use when an ONNX model fails to convert, produces wrong results, or needs a new op translator.
 argument-hint: A description of the ONNX conversion issue, e.g., "model.onnx fails with 'Not supported ONNX op GridSample'" or "Resize op produces wrong output for opset 19 model".
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 # tools: omitted — use all defaults (execute, read, edit, search, todo, web, agent)
 ---
 

--- a/.github/agents-prototype/package-builder.agent.md
+++ b/.github/agents-prototype/package-builder.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Package Builder Agent
 description: Package assembly specialist. Builds the final OpenVINO package incorporating all fixes applied by the OV Orchestrator's sub-agents.
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # Package Builder Agent
 

--- a/.github/agents-prototype/pytorch-expert.agent.md
+++ b/.github/agents-prototype/pytorch-expert.agent.md
@@ -2,7 +2,7 @@
 name: pytorch-expert
 description: Investigate and fix PyTorch model conversion issues in the OpenVINO PyTorch Frontend. Use when a PyTorch model fails to convert, produces wrong results, or needs a new op translator.
 argument-hint: A description of the PyTorch issue, e.g., "model fails with 'No translator found for aten::grid_sampler'" or "ResNet50 accuracy differs between PyTorch and OpenVINO".
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 # tools: omitted — use all defaults (execute, read, edit, search, todo, web, agent)
 ---
 

--- a/.github/agents-prototype/transformation.agent.md
+++ b/.github/agents-prototype/transformation.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Transformation Agent
 description: Tier-2 OpenVINO graph transformation specialist. Implements pattern-based graph fusion transformations and custom graph rewrite rules in OpenVINO Core (src/common/transformations/). Invoked after Core OpSpec publishes the op spec — the transformation is what makes the new op composable with the rest of the graph optimization pipeline.
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # Transformation Agent
 

--- a/.github/agents-prototype/verify-implementation.agent.md
+++ b/.github/agents-prototype/verify-implementation.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Verify Implementation Agent
 description: Build and test verification gate. Called by Enable Operator Agent after all coding agents complete. Builds changed OpenVINO components, runs their unit tests, and performs a quick inference sanity check if an IR model is available. Returns pass/fail with details before the E2E conversion gate.
-model: claude-sonnet-4.6
+model: claude-sonnet-5
 ---
 # Verify Implementation Agent
 

--- a/.github/prompts/add-core-op.prompt.md
+++ b/.github/prompts/add-core-op.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Add a new operation to the OpenVINO Core opset — class definition, shape inference, registration, reference kernel, and documentation.
 ---
 

--- a/.github/prompts/add-cpu-op.prompt.md
+++ b/.github/prompts/add-cpu-op.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Add a new operation to the OpenVINO CPU plugin — ISA-aware kernel (AVX2/AVX-512/AMX), oneDNN-backed paths, and functional tests.
 ---
 

--- a/.github/prompts/add-fe-op.prompt.md
+++ b/.github/prompts/add-fe-op.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Add a new operation to the OpenVINO Frontend — translate a framework op (ONNX/PyTorch/TF) into an OpenVINO graph node.
 ---
 

--- a/.github/prompts/add-fusion-transformation.prompt.md
+++ b/.github/prompts/add-fusion-transformation.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Add a graph fusion transformation to OpenVINO Core transformations pipeline — MatcherPass/FunctionPass, registration, and tests.
 ---
 

--- a/.github/prompts/add-gpu-op.prompt.md
+++ b/.github/prompts/add-gpu-op.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Add a new operation to the OpenVINO GPU plugin — OpenCL kernel design, oneDNN-backed paths, sub-group / LWS tuning, and tests.
 ---
 

--- a/.github/prompts/analyze-and-convert.prompt.md
+++ b/.github/prompts/analyze-and-convert.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Analyze a model and attempt conversion to OpenVINO IR — probe properties, try conversion strategies, classify failures, and produce a structured report.
 ---
 

--- a/.github/prompts/conversion-issues.prompt.md
+++ b/.github/prompts/conversion-issues.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Diagnose and fix model conversion issues — auto-detect failure type (unsupported op, shape inference, dtype mismatch) and route to the correct fix strategy.
 ---
 

--- a/.github/prompts/python-bootstrap.prompt.md
+++ b/.github/prompts/python-bootstrap.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Bootstrap Python environment for OpenVINO development. Path A for release packages, Path B for source builds.
 ---
 

--- a/.github/prompts/submit-draft-pr.prompt.md
+++ b/.github/prompts/submit-draft-pr.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Create a draft pull request with existing-PR deduplication. Centralized PR creation skill for all OpenVINO agents.
 ---
 

--- a/.github/prompts/verify-conversion.prompt.md
+++ b/.github/prompts/verify-conversion.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: E2E verification gate — convert a model and run inference to verify numerically sane output through the OV plugin layer.
 ---
 


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR was prepared by a GitHub Copilot coding agent (Claude Sonnet 5) in an interactive VS Code session, at the explicit request of the repository maintainer.**
> Please review the diff before merging.

### Details:
 - `.github/agents-prototype/*.agent.md` (13 files): updated `model: claude-sonnet-4.6` -> `model: claude-sonnet-5`.
 - `.github/prompts/*.prompt.md` (10 files): replaced the deprecated `mode: agent` frontmatter field with the current `agent: agent` field, per the [VS Code prompt file frontmatter reference](https://code.visualstudio.com/docs/copilot/customization/prompt-files#_prompt-file-format) (the `mode` field was renamed to `agent`).
 - Metadata-only change; no changes to prompt/agent body instructions or behavior beyond keeping frontmatter in sync with the currently supported model id and schema.

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes
 - Changes were made by GitHub Copilot (Claude Sonnet 5) in VS Code, directed interactively by the repository maintainer. Verification performed by the agent: repo-wide search confirms no remaining `claude-sonnet-4.6` or `mode: agent` occurrences under `.github/agents-prototype` or `.github/prompts`; the frontmatter field rename was cross-checked against current VS Code documentation. Human review of this PR by a maintainer is still required before merge.
