### PR TITLE
[Python][benchmark_app] Apply built preprocessing model

### DIFF
--- a/tests/samples_tests/smoke_tests/test_benchmark_app.py
+++ b/tests/samples_tests/smoke_tests/test_benchmark_app.py
@@ -21,6 +21,7 @@ import pathlib
 import pytest
 from common.samples_common_test_class import get_devices, get_cmd_output, prepend
 from openvino import opset8 as opset
+from openvino.tools.benchmark.utils.utils import AppInputInfo, pre_post_processing
 import openvino as ov
 
 def get_executable(sample_language):
@@ -226,6 +227,47 @@ def test_input_output_tensor_name_collision(sample_language, device, in_node_nam
             ).uniform(0, 256, data_shape).astype(np.int32)
         )
     verify(sample_language, device, iop=iop, model=model, inp=inp, cache=cache, tmp_path=tmp_path, batch=None, tm='1')
+
+
+def test_pre_post_processing_returns_built_model():
+    param = opset.parameter([1, 3, 16, 16], ov.Type.f32, name='input')
+    result = opset.result(opset.relu(param), name='output')
+    model = ov.Model([result], [param], 'model_with_preprocessing')
+
+    input_info = AppInputInfo()
+    input_info.name = model.inputs[0].any_name
+    input_info.node_name = model.inputs[0].node.friendly_name
+    input_info.element_type = model.inputs[0].element_type
+    input_info.layout = ov.Layout('NCHW')
+    input_info.partial_shape = model.inputs[0].partial_shape
+
+    processed_model = pre_post_processing(model, [input_info], 'i32', 'i64', '')
+
+    assert processed_model.inputs[0].element_type == ov.Type.i32
+    assert processed_model.outputs[0].element_type == ov.Type.i64
+
+
+@pytest.mark.skipif('CPU' not in get_devices(), reason='CPU is required to compile the test model')
+def test_python_benchmark_app_applies_preprocessing_model(tmp_path):
+    param = opset.parameter([1, 3, 16, 16], ov.Type.f32, name='input')
+    result = opset.result(opset.relu(param), name='output')
+    model = ov.Model([result], [param], 'model_with_preprocessing')
+    model_path = tmp_path / 'model_with_preprocessing.xml'
+    ov.save_model(model, model_path)
+
+    output = get_cmd_output(
+        get_executable('Python'),
+        '-m', model_path,
+        '-d', 'CPU',
+        '-niter', '0',
+        '-ip', 'i32',
+        '-op', 'i64',
+    )
+
+    assert 'Model compiled successfully' in output
+    assert any(' : i32 /' in line for line in output.splitlines())
+    assert any(' : i64 /' in line for line in output.splitlines())
+
 
 @pytest.mark.parametrize('sample_language', ['C++', 'Python'])
 @pytest.mark.parametrize('device', get_devices())

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -447,7 +447,7 @@ def main():
             # --------------------- 6. Configuring inputs and outputs of the model --------------------------------------------------
             next_step()
 
-            pre_post_processing(model, app_inputs_info, args.input_precision, args.output_precision, args.input_output_precision)
+            model = pre_post_processing(model, app_inputs_info, args.input_precision, args.output_precision, args.input_output_precision)
             print_inputs_and_outputs_info(model)
 
             # --------------------- 7. Loading the model to the device -------------------------------------------------

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
@@ -146,7 +146,7 @@ def pre_post_processing(model: Model, app_inputs_info, input_precision: str, out
     for info in app_inputs_info:
         pre_post_processor.input(info.name).model().set_layout(info.layout)
 
-    model = pre_post_processor.build()
+    return pre_post_processor.build()
 
 
 def parse_input_output_precision(arg_map: str):


### PR DESCRIPTION
### Details:
 - Category: Python benchmark_app correctness fix.
 - `PrePostProcessor.build()` returns the model containing preprocessing/postprocessing changes.
 - Python `benchmark_app` called `build()` but discarded the returned model, so `compile_model()` could still receive the original model.
 - This change assigns the returned model before printing I/O info and compiling, matching the neighboring C++ benchmark_app flow (`model = preproc.build()`).
 - Adds regression coverage for the helper return value and for the Python CLI compile-only path with `-ip i32 -op i64`.

### Test category:
 - Static Python syntax/format validation.
 - Python benchmark_app smoke/regression tests added for CI.

### Test output:
```text
$ git --no-optional-locks diff --check
# no output

$ python -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(encoding='utf-8'), filename=p) for p in ['tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py','tools/benchmark_tool/openvino/tools/benchmark/main.py','tests/samples_tests/smoke_tests/test_benchmark_app.py']]; print('AST parse ok')"
AST parse ok
```

Targeted pytest was not run locally because this workspace Python environment does not have the OpenVINO runtime package or installed `benchmark_app`:

```text
$ python -c "import openvino as ov; print(ov.__version__)"
ModuleNotFoundError: No module named 'openvino'
```

### Performance impact:
 - No new benchmark-loop work.
 - No new helper/function abstraction.
 - The same `PrePostProcessor.build()` call already existed; the fix only uses its returned model.
 - Benchmark numbers may change only for user-requested preprocessing/postprocessing options that were previously ignored by the Python path.

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes.
 - Used to inspect the Python benchmark_app flow, compare it with the neighboring C++ benchmark_app implementation, identify the minimal fix, and draft focused tests/PR text.
 - Human validation performed: reviewed contribution/AI policy docs, compared neighboring code style, checked the diff, ran the static validation commands shown above.
