### PR TITLE
[NPUW] Enable int8/int4 quantized-KV GroupQueryAttention on NPU

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/gqa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/gqa_compiled_model.cpp
@@ -12,6 +12,7 @@
 #include "logging.hpp"
 #include "npuw_transformations/collapse_unqdq.hpp"
 #include "npuw_transformations/conv_to_matmul.hpp"
+#include "npuw_transformations/dequantize_gqa_kv.hpp"
 #include "npuw_transformations/drop_zp_subtract.hpp"
 #include "npuw_transformations/untangle_dq_scale.hpp"
 #include "openvino/core/version.hpp"
@@ -113,6 +114,11 @@ ov::npuw::GQACompiledModel::PreparedState ov::npuw::GQACompiledModel::prepare(co
                               : stage == GQAModelStage::GENERATE ? "generate"
                                                                  : "unknown"));
 
+    // Dequantize any int8 KV cache around the GroupQueryAttention op, keeping the op float, so it routes to
+    // the native fused float-GQA lowering (the quantized op is otherwise unlowerable by vpux). Runs first, so
+    // the downstream QDQ-cleanup passes and the online partitioner only ever see the float op + plain QDQ nodes.
+    ov::npuw::DequantizeGQAKVCache dequantize_gqa_kv;
+    dequantize_gqa_kv.run_on_model(model);
     // Untangle shared scale constants so every DequantizeLinear Multiply
     // gets its own copy.  Some exporters reuse a single scale node across
     // multiple layers; NPUW's FOLD pass requires per-instance scalars.

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/dequantize_gqa_kv.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/dequantize_gqa_kv.cpp
@@ -9,7 +9,13 @@
 #include <vector>
 
 #include "openvino/core/rt_info.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/bitwise_and.hpp"
+#include "openvino/op/bitwise_left_shift.hpp"
+#include "openvino/op/bitwise_or.hpp"
+#include "openvino/op/bitwise_right_shift.hpp"
 #include "openvino/op/clamp.hpp"
+#include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/divide.hpp"
@@ -19,12 +25,18 @@
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/round.hpp"
 #include "openvino/op/select.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/variadic_split.hpp"
 
 namespace {
 
 namespace v0 = ov::op::v0;
 namespace v1 = ov::op::v1;
 namespace v5 = ov::op::v5;
+namespace v13 = ov::op::v13;
+namespace v15 = ov::op::v15;
 using ov::op::internal::GroupQueryAttention;
 
 // Reshape the flat per-(layer,role) scale into the KV cache layout [1, kv_num_heads, 1, head_size]
@@ -62,10 +74,15 @@ std::shared_ptr<ov::Node> make_kv_scale(const ov::Output<ov::Node>& scale,
     return std::make_shared<v1::Reshape>(scale, shape_const, false);
 }
 
-// Symmetric dequantization: Convert(i8 -> compute) * scale. Applied to the isolated KV inputs only.
+// Symmetric dequantization to the compute type, applied to the isolated KV inputs only.
+//  - 8-bit: Convert(i8 -> compute) * scale.
+//  - 4-bit: u8 stores two signed values per byte (low nibble = even channel, high = odd) biased by +8.
+//    Unpack nibbles -> interleave back along head_size -> (Convert - 8) * scale. Mirrors the common
+//    GroupQueryAttentionDecomposition::dequantize_kv 4-bit path.
 ov::Output<ov::Node> dequantize_kv(const ov::Output<ov::Node>& quantized,
                                    const ov::Output<ov::Node>& scale,
                                    int64_t kv_num_heads,
+                                   int64_t kv_cache_bit_width,
                                    const std::string& quant_type,
                                    const ov::element::Type& compute_type) {
     auto scale4d = make_kv_scale(scale, kv_num_heads, quant_type);
@@ -73,14 +90,37 @@ ov::Output<ov::Node> dequantize_kv(const ov::Output<ov::Node>& quantized,
     if (scale.get_element_type() != compute_type) {
         scale_ct = std::make_shared<v0::Convert>(scale4d, compute_type);
     }
+
+    if (kv_cache_bit_width == 4) {
+        const auto qtype = quantized.get_element_type();
+        const auto axis_last = v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+        const auto mask_low = v0::Constant::create(qtype, ov::Shape{}, {0x0F});
+        const auto shift_4 = v0::Constant::create(qtype, ov::Shape{}, {4});
+        const auto low_nibble = std::make_shared<v13::BitwiseAnd>(quantized, mask_low);
+        const auto high_nibble = std::make_shared<v15::BitwiseRightShift>(quantized, shift_4);
+        const auto low_u = std::make_shared<v0::Unsqueeze>(low_nibble, axis_last);
+        const auto high_u = std::make_shared<v0::Unsqueeze>(high_nibble, axis_last);
+        const auto interleaved = std::make_shared<v0::Concat>(ov::OutputVector{low_u, high_u}, -1);
+        const auto flat_shape = v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 0, 0, -1});
+        const auto unpacked = std::make_shared<v1::Reshape>(interleaved, flat_shape, true);
+        const auto zp = std::make_shared<v0::Convert>(v0::Constant::create(qtype, ov::Shape{}, {8}), compute_type);
+        const auto conv = std::make_shared<v0::Convert>(unpacked, compute_type);
+        const auto unbiased = std::make_shared<v1::Subtract>(conv, zp);
+        return std::make_shared<v1::Multiply>(unbiased, scale_ct);
+    }
+
     const auto converted = std::make_shared<v0::Convert>(quantized, compute_type);
     return std::make_shared<v1::Multiply>(converted, scale_ct);
 }
 
 // Symmetric quantize-on-write: clamp(round(x * inv_scale)) -> cache_type, with MLAS SafeInvScale zero guard.
+//  - 8-bit: Clamp[-128,127] -> Convert(i8).
+//  - 4-bit: Clamp[-8,7] -> +8 bias -> Convert(u8) -> pack channel pairs into nibbles (low|high<<4).
+//    Mirrors the common GroupQueryAttentionDecomposition::quantize_kv 4-bit path.
 ov::Output<ov::Node> quantize_kv(const ov::Output<ov::Node>& current,
                                  const ov::Output<ov::Node>& scale,
                                  int64_t kv_num_heads,
+                                 int64_t kv_cache_bit_width,
                                  const std::string& quant_type,
                                  const ov::element::Type& cache_type) {
     const auto compute_type = current.get_element_type();
@@ -96,6 +136,28 @@ ov::Output<ov::Node> quantize_kv(const ov::Output<ov::Node>& current,
     const auto inv = std::make_shared<v1::Divide>(one, safe);
     const auto scaled = std::make_shared<v1::Multiply>(current, inv);
     const auto rounded = std::make_shared<v5::Round>(scaled, v5::Round::RoundMode::HALF_TO_EVEN);
+
+    if (kv_cache_bit_width == 4) {
+        const auto clamped = std::make_shared<v0::Clamp>(rounded, -8.0, 7.0);
+        const auto bias = v0::Constant::create(compute_type, ov::Shape{}, {8});
+        const auto biased = std::make_shared<v1::Add>(clamped, bias);
+        const auto as_u8 = std::make_shared<v0::Convert>(biased, cache_type);
+        const auto pair_shape = v0::Constant::create(ov::element::i64, ov::Shape{5}, {0, 0, 0, -1, 2});
+        const auto paired = std::make_shared<v1::Reshape>(as_u8, pair_shape, true);
+        const auto axis_last = v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+        const auto split =
+            std::make_shared<v1::VariadicSplit>(paired,
+                                                v0::Constant::create(ov::element::i64, ov::Shape{}, {-1}),
+                                                v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 1}));
+        const auto low = std::make_shared<v0::Squeeze>(split->output(0), axis_last);
+        const auto high = std::make_shared<v0::Squeeze>(split->output(1), axis_last);
+        const auto shift_4 = v0::Constant::create(cache_type, ov::Shape{}, {4});
+        const auto mask_low = v0::Constant::create(cache_type, ov::Shape{}, {0x0F});
+        const auto low_masked = std::make_shared<v13::BitwiseAnd>(low, mask_low);
+        const auto high_shifted = std::make_shared<v15::BitwiseLeftShift>(high, shift_4);
+        return std::make_shared<v13::BitwiseOr>(low_masked, high_shifted);
+    }
+
     const auto clamped = std::make_shared<v0::Clamp>(rounded, -128.0, 127.0);
     return std::make_shared<v0::Convert>(clamped, cache_type);
 }
@@ -108,7 +170,8 @@ bool ov::npuw::DequantizeGQAKVCache::run_on_model(const std::shared_ptr<ov::Mode
     std::vector<std::shared_ptr<GroupQueryAttention>> targets;
     for (const auto& op : model->get_ordered_ops()) {
         auto gqa = ov::as_type_ptr<GroupQueryAttention>(op);
-        if (gqa && gqa->is_kv_quantized() && gqa->get_kv_cache_bit_width() == 8) {
+        if (gqa && gqa->is_kv_quantized() &&
+            (gqa->get_kv_cache_bit_width() == 8 || gqa->get_kv_cache_bit_width() == 4)) {
             targets.push_back(gqa);
         }
     }
@@ -120,6 +183,7 @@ bool ov::npuw::DequantizeGQAKVCache::run_on_model(const std::shared_ptr<ov::Mode
             continue;
         }
         const int64_t kv_num_heads = node->get_kv_num_heads();
+        const int64_t bit_width = node->get_kv_cache_bit_width();
         const auto compute_type = node->get_input_element_type(0);  // Q precision = attention math type
         const auto cache_type = node->get_input_element_type(PAST_KEY);
         const std::string k_qt = node->get_k_quant_type();
@@ -128,8 +192,8 @@ bool ov::npuw::DequantizeGQAKVCache::run_on_model(const std::shared_ptr<ov::Mode
         const auto v_scale = args[V_SCALE];
 
         // Dequantize the two separate KV inputs (never the packed QKV at input 0).
-        const auto past_key_f = dequantize_kv(args[PAST_KEY], k_scale, kv_num_heads, k_qt, compute_type);
-        const auto past_value_f = dequantize_kv(args[PAST_VALUE], v_scale, kv_num_heads, v_qt, compute_type);
+        const auto past_key_f = dequantize_kv(args[PAST_KEY], k_scale, kv_num_heads, bit_width, k_qt, compute_type);
+        const auto past_value_f = dequantize_kv(args[PAST_VALUE], v_scale, kv_num_heads, bit_width, v_qt, compute_type);
 
         // Rebuild the op float: keep inputs [0, 12), swap dequantized KV, drop scale inputs, strip trailing
         // NullNode placeholders down to the 7 mandatory inputs (unused optional slots serialize as an
@@ -148,9 +212,11 @@ bool ov::npuw::DequantizeGQAKVCache::run_on_model(const std::shared_ptr<ov::Mode
                                                                node->get_rotary_interleaved());
         float_gqa->set_friendly_name(node->get_friendly_name());
 
-        // Requantize the float present KV back to int8 so downstream/model outputs keep the i8 contract.
-        const auto present_key_i8 = quantize_kv(float_gqa->output(1), k_scale, kv_num_heads, k_qt, cache_type);
-        const auto present_value_i8 = quantize_kv(float_gqa->output(2), v_scale, kv_num_heads, v_qt, cache_type);
+        // Requantize the float present KV back to the packed cache type so model outputs keep the i8/i4 contract.
+        const auto present_key_i8 =
+            quantize_kv(float_gqa->output(1), k_scale, kv_num_heads, bit_width, k_qt, cache_type);
+        const auto present_value_i8 =
+            quantize_kv(float_gqa->output(2), v_scale, kv_num_heads, bit_width, v_qt, cache_type);
 
         node->output(0).replace(float_gqa->output(0));
         node->output(1).replace(present_key_i8);

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/dequantize_gqa_kv.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/dequantize_gqa_kv.cpp
@@ -1,0 +1,162 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "dequantize_gqa_kv.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/equal.hpp"
+#include "openvino/op/group_query_attention.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/round.hpp"
+#include "openvino/op/select.hpp"
+
+namespace {
+
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+namespace v5 = ov::op::v5;
+using ov::op::internal::GroupQueryAttention;
+
+// Reshape the flat per-(layer,role) scale into the KV cache layout [1, kv_num_heads, 1, head_size]
+// (PER_CHANNEL) or [1,1,1,1] (PER_TENSOR). When the scale is a Constant, build a FRESH single-reader
+// Constant that owns a memcpy'd copy of the data (data-copy ctor) so each (layer,K/V) scale has a unique
+// pointer: NPUW's FOLD pass needs that to build a complete per-instance scale bank (exporters reuse one
+// scale node across identical layers; a Reshape/aliased clone gets deduped and breaks weight-bank matching).
+std::shared_ptr<ov::Node> make_kv_scale(const ov::Output<ov::Node>& scale,
+                                        int64_t kv_num_heads,
+                                        const std::string& quant_type) {
+    const bool per_channel = (quant_type == "PER_CHANNEL");
+    int64_t head_size = 1;
+    if (per_channel) {
+        const auto& ps = scale.get_partial_shape();
+        if (ps.rank().is_static() && ps.rank().get_length() == 1 && ps[0].is_static()) {
+            head_size = ps[0].get_length() / kv_num_heads;
+        } else {
+            head_size = -1;
+        }
+    }
+    const ov::Shape new_shape{1,
+                              static_cast<size_t>(per_channel ? kv_num_heads : 1),
+                              1,
+                              static_cast<size_t>(per_channel ? head_size : 1)};
+
+    if (const auto scale_const = ov::as_type_ptr<v0::Constant>(scale.get_node_shared_ptr())) {
+        if (!per_channel || head_size > 0) {
+            return std::make_shared<v0::Constant>(scale_const->get_element_type(),
+                                                  new_shape,
+                                                  scale_const->get_data_ptr());
+        }
+    }
+    std::vector<int64_t> target = {1, per_channel ? kv_num_heads : 1, 1, per_channel ? head_size : 1};
+    const auto shape_const = v0::Constant::create(ov::element::i64, ov::Shape{target.size()}, target);
+    return std::make_shared<v1::Reshape>(scale, shape_const, false);
+}
+
+// Symmetric dequantization: Convert(i8 -> compute) * scale. Applied to the isolated KV inputs only.
+ov::Output<ov::Node> dequantize_kv(const ov::Output<ov::Node>& quantized,
+                                   const ov::Output<ov::Node>& scale,
+                                   int64_t kv_num_heads,
+                                   const std::string& quant_type,
+                                   const ov::element::Type& compute_type) {
+    auto scale4d = make_kv_scale(scale, kv_num_heads, quant_type);
+    ov::Output<ov::Node> scale_ct = scale4d;
+    if (scale.get_element_type() != compute_type) {
+        scale_ct = std::make_shared<v0::Convert>(scale4d, compute_type);
+    }
+    const auto converted = std::make_shared<v0::Convert>(quantized, compute_type);
+    return std::make_shared<v1::Multiply>(converted, scale_ct);
+}
+
+// Symmetric quantize-on-write: clamp(round(x * inv_scale)) -> cache_type, with MLAS SafeInvScale zero guard.
+ov::Output<ov::Node> quantize_kv(const ov::Output<ov::Node>& current,
+                                 const ov::Output<ov::Node>& scale,
+                                 int64_t kv_num_heads,
+                                 const std::string& quant_type,
+                                 const ov::element::Type& cache_type) {
+    const auto compute_type = current.get_element_type();
+    auto scale4d = make_kv_scale(scale, kv_num_heads, quant_type);
+    ov::Output<ov::Node> scale_ct = scale4d;
+    if (scale.get_element_type() != compute_type) {
+        scale_ct = std::make_shared<v0::Convert>(scale4d, compute_type);
+    }
+    const auto one = v0::Constant::create(compute_type, ov::Shape{}, {1});
+    const auto zero = v0::Constant::create(compute_type, ov::Shape{}, {0});
+    const auto is_zero = std::make_shared<v1::Equal>(scale_ct, zero);
+    const auto safe = std::make_shared<v1::Select>(is_zero, one, scale_ct);
+    const auto inv = std::make_shared<v1::Divide>(one, safe);
+    const auto scaled = std::make_shared<v1::Multiply>(current, inv);
+    const auto rounded = std::make_shared<v5::Round>(scaled, v5::Round::RoundMode::HALF_TO_EVEN);
+    const auto clamped = std::make_shared<v0::Clamp>(rounded, -128.0, 127.0);
+    return std::make_shared<v0::Convert>(clamped, cache_type);
+}
+
+}  // namespace
+
+bool ov::npuw::DequantizeGQAKVCache::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    bool changed = false;
+    // Collect first so we can safely replace while iterating.
+    std::vector<std::shared_ptr<GroupQueryAttention>> targets;
+    for (const auto& op : model->get_ordered_ops()) {
+        auto gqa = ov::as_type_ptr<GroupQueryAttention>(op);
+        if (gqa && gqa->is_kv_quantized() && gqa->get_kv_cache_bit_width() == 8) {
+            targets.push_back(gqa);
+        }
+    }
+
+    constexpr size_t PAST_KEY = 3, PAST_VALUE = 4, K_SCALE = 12, V_SCALE = 13;
+    for (const auto& node : targets) {
+        const auto& args = node->input_values();
+        if (args.size() <= V_SCALE) {
+            continue;
+        }
+        const int64_t kv_num_heads = node->get_kv_num_heads();
+        const auto compute_type = node->get_input_element_type(0);  // Q precision = attention math type
+        const auto cache_type = node->get_input_element_type(PAST_KEY);
+        const std::string k_qt = node->get_k_quant_type();
+        const std::string v_qt = node->get_v_quant_type();
+        const auto k_scale = args[K_SCALE];
+        const auto v_scale = args[V_SCALE];
+
+        // Dequantize the two separate KV inputs (never the packed QKV at input 0).
+        const auto past_key_f = dequantize_kv(args[PAST_KEY], k_scale, kv_num_heads, k_qt, compute_type);
+        const auto past_value_f = dequantize_kv(args[PAST_VALUE], v_scale, kv_num_heads, v_qt, compute_type);
+
+        // Rebuild the op float: keep inputs [0, 12), swap dequantized KV, drop scale inputs, strip trailing
+        // NullNode placeholders down to the 7 mandatory inputs (unused optional slots serialize as an
+        // unsupported "extension" op otherwise), and use the plain float constructor (no quant metadata).
+        ov::OutputVector new_args(args.begin(), args.begin() + K_SCALE);
+        new_args[PAST_KEY] = past_key_f;
+        new_args[PAST_VALUE] = past_value_f;
+        while (new_args.size() > 7 && new_args.back().get_node_shared_ptr()->description() == "NullNode") {
+            new_args.pop_back();
+        }
+        auto float_gqa = std::make_shared<GroupQueryAttention>(new_args,
+                                                               node->get_num_heads(),
+                                                               node->get_kv_num_heads(),
+                                                               node->get_scale(),
+                                                               node->get_do_rotary(),
+                                                               node->get_rotary_interleaved());
+        float_gqa->set_friendly_name(node->get_friendly_name());
+
+        // Requantize the float present KV back to int8 so downstream/model outputs keep the i8 contract.
+        const auto present_key_i8 = quantize_kv(float_gqa->output(1), k_scale, kv_num_heads, k_qt, cache_type);
+        const auto present_value_i8 = quantize_kv(float_gqa->output(2), v_scale, kv_num_heads, v_qt, cache_type);
+
+        node->output(0).replace(float_gqa->output(0));
+        node->output(1).replace(present_key_i8);
+        node->output(2).replace(present_value_i8);
+        ov::copy_runtime_info(node, float_gqa);
+        changed = true;
+    }
+    return changed;
+}

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/dequantize_gqa_kv.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/dequantize_gqa_kv.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/pass.hpp"
+
+namespace ov::npuw {
+
+// Makes a quantized-KV (int8) com.microsoft GroupQueryAttention lowerable on the NPU by dequantizing its
+// KV cache *around* the op while keeping the op itself intact and float.
+//
+// The NPU (vpux) compiler has a native fused lowering for the FLOAT GroupQueryAttention op — the same one the
+// fp16 KV-cache path uses — but not for the quantized variant: carrying the int8 KV + per-channel scales into
+// the intact op makes vpux reconstruct the packed [B, num_heads+2*kv_num_heads, S, H] QKV and try to apply the
+// per-KV-head scale onto it, which fails ("non broadcastable dimensions 60 and 10"). This pass instead:
+//
+//   past_key(i8) --Convert--Multiply(scale[1,kv,1,H])--> float --+
+//                                                                 |--> [ intact FLOAT GroupQueryAttention ] --+
+//   past_value(i8) --Convert--Multiply(scale)---------> float ---+                                           |
+//   present_key(float) --Multiply(1/scale)-Round-Clamp-Convert--> i8   (requant, restores the i8 KV I/O) <---+
+//
+// The dequant Multiply is applied ONLY to the op's separate KV inputs (3/4), each [B, kv_num_heads, S, H], so
+// the scale broadcasts cleanly and never touches the packed QKV. The rebuilt op carries no quant metadata
+// (kv_cache_bit_width=0, k/v_quant_type="NONE") so it routes to the known-good float lowering. Each (layer, K/V)
+// scale is materialized as a fresh single-reader Constant (data-copy) so NPUW's FOLD pass can build a complete
+// per-instance scale bank. Float GQA is left untouched.
+class DequantizeGQAKVCache : public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("ov::npuw::DequantizeGQAKVCache");
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+};
+
+}  // namespace ov::npuw

--- a/src/plugins/intel_npu/src/plugin/sources.cmake
+++ b/src/plugins/intel_npu/src/plugin/sources.cmake
@@ -113,6 +113,8 @@ set(NPUW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_transformations/conv_to_matmul.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_transformations/decompose_gqa.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_transformations/decompose_gqa.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_transformations/dequantize_gqa_kv.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_transformations/dequantize_gqa_kv.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_transformations/drop_zp_subtract.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_transformations/drop_zp_subtract.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_transformations/right_align_mask_slice_for_conv.cpp

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -100,6 +100,7 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/conv_to_matmul.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/convert_kvcache_to_precision.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/dequantize_gqa_kv.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/drop_zp_subtract.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/untangle_dq_scale.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/lora_stateful_to_stateless.cpp
@@ -147,6 +148,7 @@ target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/executor_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_compiled_model_graph_options_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npuw/dequantize_gqa_kv_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/stored_tokens_state_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_infer_request_variant_switch_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/lincache_utils_test.cpp

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -103,6 +103,7 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/conv_to_matmul.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/convert_kvcache_to_precision.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/dequantize_gqa_kv.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/drop_zp_subtract.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/untangle_dq_scale.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/lora_stateful_to_stateless.cpp
@@ -151,6 +152,7 @@ target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/executor_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_compiled_model_graph_options_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npuw/dequantize_gqa_kv_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/stored_tokens_state_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_infer_request_variant_switch_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/lincache_utils_test.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/dequantize_gqa_kv_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/dequantize_gqa_kv_test.cpp
@@ -1,0 +1,176 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "npuw_transformations/dequantize_gqa_kv.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "openvino/core/model.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/group_query_attention.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/round.hpp"
+
+namespace {
+
+template <class Op>
+std::size_t count_ops(const std::shared_ptr<ov::Model>& model) {
+    const auto ops = model->get_ops();
+    return std::count_if(ops.begin(), ops.end(), [](const auto& op) {
+        return ov::is_type<Op>(op);
+    });
+}
+
+std::shared_ptr<ov::op::internal::GroupQueryAttention> find_gqa(const std::shared_ptr<ov::Model>& model) {
+    for (const auto& op : model->get_ordered_ops()) {
+        if (auto gqa = ov::as_type_ptr<ov::op::internal::GroupQueryAttention>(op)) {
+            return gqa;
+        }
+    }
+    return nullptr;
+}
+
+// Build a GroupQueryAttention with an int8 PER_CHANNEL quantized KV cache: separate float Q/K/V, int8
+// past_key/past_value, and f32 per-channel k_scale/v_scale at inputs 12/13 (com.microsoft layout). Mirrors
+// the orca int8 op contract (num_heads=4, kv_num_heads=2, head_size=16 here for a small test).
+std::shared_ptr<ov::Model> build_int8_gqa_model() {
+    constexpr int64_t num_heads = 4, kv_num_heads = 2, head_size = 16, seq = 1, past = 8;
+    auto query = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, num_heads, seq, head_size});
+    auto key = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, kv_num_heads, seq, head_size});
+    auto value = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, kv_num_heads, seq, head_size});
+    auto past_key =
+        std::make_shared<ov::op::v0::Parameter>(ov::element::i8, ov::Shape{1, kv_num_heads, past, head_size});
+    auto past_value =
+        std::make_shared<ov::op::v0::Parameter>(ov::element::i8, ov::Shape{1, kv_num_heads, past, head_size});
+    auto seqlens_k = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1, 1});
+    auto total_sequence_length = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
+
+    const auto scale_len = static_cast<size_t>(kv_num_heads * head_size);
+    auto k_scale =
+        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{scale_len}, std::vector<float>(scale_len, 0.02f));
+    auto v_scale =
+        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{scale_len}, std::vector<float>(scale_len, 0.03f));
+    auto null = std::make_shared<ov::op::v0::Constant>(ov::element::f32, ov::Shape{0});  // stand-in for optional slots
+
+    // inputs: 0..6 mandatory, 7/8 rotary (unused here), 9/10/11 optional, 12/13 scales.
+    ov::OutputVector args{query,
+                          key,
+                          value,
+                          past_key,
+                          past_value,
+                          seqlens_k,
+                          total_sequence_length,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          k_scale,
+                          v_scale};
+    auto gqa = std::make_shared<ov::op::internal::GroupQueryAttention>(args,
+                                                                       num_heads,
+                                                                       kv_num_heads,
+                                                                       0.0f,   // scale (0 => default 1/sqrt(head))
+                                                                       false,  // do_rotary
+                                                                       false,  // rotary_interleaved
+                                                                       8,      // kv_cache_bit_width
+                                                                       "PER_CHANNEL",
+                                                                       "PER_CHANNEL");
+
+    ov::ResultVector results = {std::make_shared<ov::op::v0::Result>(gqa->output(0)),
+                                std::make_shared<ov::op::v0::Result>(gqa->output(1)),
+                                std::make_shared<ov::op::v0::Result>(gqa->output(2))};
+    ov::ParameterVector params = {query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
+    return std::make_shared<ov::Model>(results, params, "int8_gqa_model");
+}
+
+// Same head config but a plain FLOAT KV cache (no quant) — the pass must leave it untouched.
+std::shared_ptr<ov::Model> build_float_gqa_model() {
+    constexpr int64_t num_heads = 4, kv_num_heads = 2, head_size = 16, seq = 1, past = 8;
+    auto query = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, num_heads, seq, head_size});
+    auto key = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, kv_num_heads, seq, head_size});
+    auto value = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, kv_num_heads, seq, head_size});
+    auto past_key =
+        std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, kv_num_heads, past, head_size});
+    auto past_value =
+        std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, kv_num_heads, past, head_size});
+    auto seqlens_k = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1, 1});
+    auto total_sequence_length = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
+
+    auto gqa = std::make_shared<ov::op::internal::GroupQueryAttention>(
+        ov::OutputVector{query, key, value, past_key, past_value, seqlens_k, total_sequence_length},
+        num_heads,
+        kv_num_heads,
+        0.0f,
+        false,
+        false);
+
+    ov::ResultVector results = {std::make_shared<ov::op::v0::Result>(gqa->output(0)),
+                                std::make_shared<ov::op::v0::Result>(gqa->output(1)),
+                                std::make_shared<ov::op::v0::Result>(gqa->output(2))};
+    ov::ParameterVector params = {query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
+    return std::make_shared<ov::Model>(results, params, "float_gqa_model");
+}
+
+}  // namespace
+
+// The int8 quantized op is rewritten to a FLOAT GroupQueryAttention (no quant metadata, scale inputs dropped)
+// sandwiched by dequant (Convert+Multiply on the KV inputs) and requant (Round+Clamp+Convert on present KV).
+TEST(DequantizeGQAKVCache, RewritesQuantizedOpToFloatWithDequantRequant) {
+    auto model = build_int8_gqa_model();
+    ASSERT_NE(find_gqa(model), nullptr);
+    ASSERT_TRUE(find_gqa(model)->is_kv_quantized());
+
+    ov::npuw::DequantizeGQAKVCache pass;
+    const bool changed = pass.run_on_model(model);
+    EXPECT_TRUE(changed);
+
+    // The op survives but is now float: quant metadata cleared and the scale inputs (12/13) dropped. (Trailing
+    // real NullNode placeholders are also stripped for the orca FE graph; here the optional slots are stand-in
+    // Constants, so only the scale-drop is asserted — the input count is < the original 14, never including 12/13.)
+    auto gqa = find_gqa(model);
+    ASSERT_NE(gqa, nullptr);
+    EXPECT_FALSE(gqa->is_kv_quantized());
+    EXPECT_EQ(gqa->get_kv_cache_bit_width(), 0);
+    EXPECT_LT(gqa->get_input_size(), 14u);
+    EXPECT_GE(gqa->get_input_size(), 7u);
+
+    // The dequantized KV inputs (3/4) are now float, matching Q.
+    EXPECT_EQ(gqa->get_input_element_type(3), gqa->get_input_element_type(0));
+    EXPECT_EQ(gqa->get_input_element_type(4), gqa->get_input_element_type(0));
+
+    // Requant restores int8 present KV at the model outputs.
+    EXPECT_EQ(model->get_results()[1]->get_input_element_type(0), ov::element::i8);
+    EXPECT_EQ(model->get_results()[2]->get_input_element_type(0), ov::element::i8);
+
+    // Dequant/requant primitives are present (Round + Clamp are unique to the requant path).
+    EXPECT_EQ(count_ops<ov::op::v5::Round>(model), 2u);  // K + V present requant
+    EXPECT_EQ(count_ops<ov::op::v0::Clamp>(model), 2u);
+    EXPECT_GT(count_ops<ov::op::v1::Multiply>(model), 0u);
+}
+
+// A float GQA (is_kv_quantized()==false) must be left completely untouched (no regression to the fp16 path).
+TEST(DequantizeGQAKVCache, LeavesFloatOpUntouched) {
+    auto model = build_float_gqa_model();
+    ASSERT_NE(find_gqa(model), nullptr);
+    ASSERT_FALSE(find_gqa(model)->is_kv_quantized());
+
+    ov::npuw::DequantizeGQAKVCache pass;
+    const bool changed = pass.run_on_model(model);
+
+    EXPECT_FALSE(changed);
+    EXPECT_EQ(count_ops<ov::op::v5::Round>(model), 0u);
+    EXPECT_EQ(count_ops<ov::op::v0::Clamp>(model), 0u);
+    auto gqa = find_gqa(model);
+    ASSERT_NE(gqa, nullptr);
+    EXPECT_EQ(gqa->get_input_size(), 7u);
+}

--- a/src/plugins/intel_npu/tests/unit/npuw/dequantize_gqa_kv_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/dequantize_gqa_kv_test.cpp
@@ -11,6 +11,8 @@
 #include <vector>
 
 #include "openvino/core/model.hpp"
+#include "openvino/op/bitwise_and.hpp"
+#include "openvino/op/bitwise_or.hpp"
 #include "openvino/op/clamp.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
@@ -39,18 +41,25 @@ std::shared_ptr<ov::op::internal::GroupQueryAttention> find_gqa(const std::share
     return nullptr;
 }
 
-// Build a GroupQueryAttention with an int8 PER_CHANNEL quantized KV cache: separate float Q/K/V, int8
-// past_key/past_value, and f32 per-channel k_scale/v_scale at inputs 12/13 (com.microsoft layout). Mirrors
-// the orca int8 op contract (num_heads=4, kv_num_heads=2, head_size=16 here for a small test).
-std::shared_ptr<ov::Model> build_int8_gqa_model() {
+// Build a GroupQueryAttention with a PER_CHANNEL quantized KV cache (int8 or int4): separate float Q/K/V,
+// quantized past_key/past_value, and f32 per-channel k_scale/v_scale at inputs 12/13 (com.microsoft layout).
+// Mirrors the orca quantized op contract (num_heads=4, kv_num_heads=2, head_size=16 here for a small test).
+//   * bit_width==8: past/present KV are i8 [.., head_size].
+//   * bit_width==4: past/present KV are u8-packed (two nibbles/byte) [.., head_size/2].
+std::shared_ptr<ov::Model> build_quant_gqa_model(int64_t bit_width) {
     constexpr int64_t num_heads = 4, kv_num_heads = 2, head_size = 16, seq = 1, past = 8;
+    const auto cache_type = (bit_width == 4) ? ov::element::u8 : ov::element::i8;
+    const int64_t stored_head = (bit_width == 4) ? head_size / 2 : head_size;  // int4 packs 2/byte
+
     auto query = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, num_heads, seq, head_size});
     auto key = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, kv_num_heads, seq, head_size});
     auto value = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, kv_num_heads, seq, head_size});
     auto past_key =
-        std::make_shared<ov::op::v0::Parameter>(ov::element::i8, ov::Shape{1, kv_num_heads, past, head_size});
+        std::make_shared<ov::op::v0::Parameter>(cache_type,
+                                                ov::Shape{1, kv_num_heads, past, static_cast<size_t>(stored_head)});
     auto past_value =
-        std::make_shared<ov::op::v0::Parameter>(ov::element::i8, ov::Shape{1, kv_num_heads, past, head_size});
+        std::make_shared<ov::op::v0::Parameter>(cache_type,
+                                                ov::Shape{1, kv_num_heads, past, static_cast<size_t>(stored_head)});
     auto seqlens_k = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1, 1});
     auto total_sequence_length = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
 
@@ -82,7 +91,7 @@ std::shared_ptr<ov::Model> build_int8_gqa_model() {
                                                                        0.0f,   // scale (0 => default 1/sqrt(head))
                                                                        false,  // do_rotary
                                                                        false,  // rotary_interleaved
-                                                                       8,      // kv_cache_bit_width
+                                                                       bit_width,
                                                                        "PER_CHANNEL",
                                                                        "PER_CHANNEL");
 
@@ -90,7 +99,11 @@ std::shared_ptr<ov::Model> build_int8_gqa_model() {
                                 std::make_shared<ov::op::v0::Result>(gqa->output(1)),
                                 std::make_shared<ov::op::v0::Result>(gqa->output(2))};
     ov::ParameterVector params = {query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
-    return std::make_shared<ov::Model>(results, params, "int8_gqa_model");
+    return std::make_shared<ov::Model>(results, params, "quant_gqa_model");
+}
+
+std::shared_ptr<ov::Model> build_int8_gqa_model() {
+    return build_quant_gqa_model(8);
 }
 
 // Same head config but a plain FLOAT KV cache (no quant) — the pass must leave it untouched.
@@ -173,4 +186,36 @@ TEST(DequantizeGQAKVCache, LeavesFloatOpUntouched) {
     auto gqa = find_gqa(model);
     ASSERT_NE(gqa, nullptr);
     EXPECT_EQ(gqa->get_input_size(), 7u);
+}
+
+// int4 (u8-packed, 2 nibbles/byte) quantized op: same rewrite, but dequant unpacks nibbles
+// (BitwiseAnd/BitwiseRightShift + Subtract of the +8 bias) and requant repacks (BitwiseAnd/BitwiseOr).
+// The op becomes float; present KV is restored to the packed u8 cache type.
+TEST(DequantizeGQAKVCache, RewritesInt4QuantizedOpToFloatWithBitwiseUnpackRepack) {
+    auto model = build_quant_gqa_model(4);
+    auto src = find_gqa(model);
+    ASSERT_NE(src, nullptr);
+    ASSERT_TRUE(src->is_kv_quantized());
+    ASSERT_EQ(src->get_kv_cache_bit_width(), 4);
+
+    ov::npuw::DequantizeGQAKVCache pass;
+    const bool changed = pass.run_on_model(model);
+    EXPECT_TRUE(changed);
+
+    // Op is now float (quant metadata cleared, scale inputs dropped), KV inputs match Q.
+    auto gqa = find_gqa(model);
+    ASSERT_NE(gqa, nullptr);
+    EXPECT_FALSE(gqa->is_kv_quantized());
+    EXPECT_EQ(gqa->get_kv_cache_bit_width(), 0);
+    EXPECT_EQ(gqa->get_input_element_type(3), gqa->get_input_element_type(0));
+
+    // Requant restores the packed u8 cache type at the present-KV model outputs.
+    EXPECT_EQ(model->get_results()[1]->get_input_element_type(0), ov::element::u8);
+    EXPECT_EQ(model->get_results()[2]->get_input_element_type(0), ov::element::u8);
+
+    // int4-specific: Bitwise nibble unpack (dequant) + repack (requant) are present; Round/Clamp still there.
+    EXPECT_GT(count_ops<ov::op::v13::BitwiseAnd>(model), 0u);
+    EXPECT_GT(count_ops<ov::op::v13::BitwiseOr>(model), 0u);
+    EXPECT_EQ(count_ops<ov::op::v5::Round>(model), 2u);
+    EXPECT_EQ(count_ops<ov::op::v0::Clamp>(model), 2u);
 }


### PR DESCRIPTION
### What
Enables compilation of `com.microsoft::GroupQueryAttention` with an **int8/int4 quantized KV cache** on the Intel NPU (NPUW path). Adds a small NPUW `ModelPass`, `DequantizeGQAKVCache`, that dequantizes the quantized KV cache **around** the GroupQueryAttention op while keeping the op itself intact and **float** — so it lowers via the driver's existing native fused float-GQA path (the same one the fp16 KV cache already uses).

### Why
The NPU (vpux) compiler has no lowering for the *quantized* GroupQueryAttention op — the intact int8/int4 op reaches the driver as an unsupported node and fails to compile. Rather than decompose the op (which the NPU compiler cannot legalize for grouped-query attention), this pass keeps the fused op and moves the quantization to its boundary:

```
past_kv (i8/u4) -> Convert*scale (dequant) -> [ intact FLOAT GroupQueryAttention ] -> Round/Clamp/Convert (requant) -> present_kv (i8/u4)
```

The rewrite is gated on `is_kv_quantized()`, so **float GQA is untouched (no regression)**. Quant math mirrors the common `GroupQueryAttentionDecomposition` (int8: `Convert*scale`; int4: `u8` nibble unpack/repack via `Bitwise*`).

### Scope
- **NPUW path only** (`NPUW_GQA:YES` -> `GQACompiledModel`); registered in `GQACompiledModel::prepare`.
- Reuses PR #36676's quantized-KV op metadata; introduces **no** new op or frontend change.

### Depends on
**#36676** — this pass reads the quantized-KV getters (`is_kv_quantized`, `get_kv_cache_bit_width`, `get_k/v_quant_type`) that #36676 adds to `ov::op::internal::GroupQueryAttention`. **Merge #36676 first.**

### Tests
`ov_npu_unit_tests --gtest_filter=DequantizeGQAKVCache.*` — 3 cases (int8 rewrite, int4 Bitwise unpack/repack, float-untouched). Validated end-to-end on NPU: int8 compiles + infers coherently; int4 compiles + produces finite output.

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
