### PR TITLE
[GPU] Change tensor type fallback from usm_host to usm_device

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -324,10 +324,10 @@ void RemoteTensorImpl::allocate() {
         } else if (engine.supports_allocation(cldnn::allocation_type::sycl_buffer)) {
             m_memory_object = engine.allocate_memory(m_layout, cldnn::allocation_type::sycl_buffer, reset);
         } else {
-            // Fall back to usm_host and override memory type
-            GPU_DEBUG_INFO << "[Warning] [GPU] Could not allocate cl_mem, using usm_host allocation instead\n";
-            m_mem_type = TensorType::BT_USM_HOST_INTERNAL;
-            m_memory_object = engine.allocate_memory(m_layout, cldnn::allocation_type::usm_host, reset);
+            // Fall back to usm_device and override memory type
+            GPU_DEBUG_INFO << "[Warning] [GPU] Could not allocate cl_mem, using usm_device allocation instead\n";
+            m_mem_type = TensorType::BT_USM_DEVICE_INTERNAL;
+            m_memory_object = engine.allocate_memory(m_layout, cldnn::allocation_type::usm_device, reset);
         }
         break;
     }


### PR DESCRIPTION
### Details:
 - Change fallback from usm_host to usm_device when cl_mem memory is not supported.
 - Improves performance when running with Level Zero runtime on systems with dGPUs that do not support interoperability (cl_mem).

### Benchmarks:
Used Ubuntu 24.04 with BMG GPU.

Benchmark on Llama-3.1-8B-Instruct inference. Measured 2nd token latency.
| Master (OCL) | Master (ZE) | This PR (ZE) |
| --- | --- | --- |
| 16.89ms | 23.11ms | 17.52ms |

Benchmark on Phi-3.5-mini-instruct inference. Measured 2nd token latency.
| Master (OCL) | Master (ZE) | This PR (ZE) |
| --- | --- | --- |
| 9.04ms | 27.48ms | 9.79ms |

### Tickets:
 - [CVS-182272](https://jira.devtools.intel.com/browse/CVS-182272)

### AI Assistance:
 - *AI assistance used: no*
