### PR TITLE
[ONNX FE] Align behavior of AveragePool-7, 10, 11, 19 with original framework

### DIFF
--- a/src/frontends/onnx/frontend/src/utils/pooling_factory.cpp
+++ b/src/frontends/onnx/frontend/src/utils/pooling_factory.cpp
@@ -55,10 +55,13 @@ PoolingFactory::PoolingFactory(const Node& node)
 
 ov::OutputVector PoolingFactory::make_avg_pool() const {
     const bool count_include_pad = m_onnx_node.get_attribute_value<std::int64_t>("count_include_pad", 0);
+    const bool is_ceil_mode = m_rounding_type == ov::op::RoundingType::CEIL;
 
-    if (std::all_of(m_dilations.begin(), m_dilations.end(), [](size_t d) {
-            return d == static_cast<size_t>(1);
-        })) {
+    const bool has_dilations = std::any_of(m_dilations.begin(), m_dilations.end(), [](size_t d) {
+        return d != static_cast<size_t>(1);
+    });
+
+    if (!has_dilations && !is_ceil_mode) {
         return {std::make_shared<v1::AvgPool>(m_inputs.at(0),
                                               m_strides,
                                               m_padding_below,
@@ -68,6 +71,8 @@ ov::OutputVector PoolingFactory::make_avg_pool() const {
                                               m_rounding_type,
                                               m_auto_pad)};
     }
+    // ONNX ceil_mode must not let a window start in padding; only CEIL_TORCH enforces that.
+    const auto rounding_type = is_ceil_mode ? ov::op::RoundingType::CEIL_TORCH : m_rounding_type;
     return {std::make_shared<v16::AvgPool>(m_inputs.at(0),
                                            m_strides,
                                            m_dilations,
@@ -75,7 +80,7 @@ ov::OutputVector PoolingFactory::make_avg_pool() const {
                                            m_padding_above,
                                            m_kernel_shape,
                                            !count_include_pad,
-                                           m_rounding_type,
+                                           rounding_type,
                                            m_auto_pad)};
 }
 

--- a/src/frontends/onnx/tests/__init__.py
+++ b/src/frontends/onnx/tests/__init__.py
@@ -154,7 +154,6 @@ xfail_issue_125488 = xfail_test(reason="ImageDecoder operation is not supported"
 skip_issue_125487 = pytest.mark.skip(reason="GridSample doesn't support volumetric (5D) inputs")
 skip_issue_125489 = pytest.mark.skip(reason="IsInf changed behavior since opset-20") # Need to enable after opset-20 will be released
 skip_issue_124587 = pytest.mark.skip(reason="Fail on new macos machines")
-xfail_issue_125491 = xfail_test(reason="AveragePool mismatch with differences in shapes")
 xfail_issue_125492 = xfail_test(reason="DFT mismatch")
 xfail_issue_125493 = xfail_test(reason="Reduce* mismatch")
 xfail_issue_122776 = xfail_test(reason="test_mish_expanded_cpu - "
@@ -177,7 +176,6 @@ skip_issue_119896 = pytest.mark.skip(reason="Unsupported element type: FLOAT8")
 # ONNX 1.18
 xfail_issue_171767 = pytest.mark.skip(reason="Unsupported element type: FLOAT4E2M1")
 xfail_issue_171771 = pytest.mark.skip(reason="Mismatches in tests: Top K values")
-xfail_issue_171772 = pytest.mark.skip(reason="Mismatches in tests: AveragePool")
 
 # Attention op (ONNX opset 23/24) -- requires ONNX >= 1.23; CI uses ONNX 1.18.
 # Tests pass locally when ONNX >= 1.23 is installed.

--- a/src/frontends/onnx/tests/models/average_pool_2d_ceil_last_window_starts_on_pad.prototxt
+++ b/src/frontends/onnx/tests/models/average_pool_2d_ceil_last_window_starts_on_pad.prototxt
@@ -1,0 +1,87 @@
+ir_version: 10
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "averagepool_2d_ceil_last_window_starts_on_pad"
+  node {
+    input: "x"
+    output: "y"
+    op_type: "AveragePool"
+    attribute {
+      name: "ceil_mode"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "count_include_pad"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "kernel_shape"
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+  }
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 22
+}

--- a/src/frontends/onnx/tests/onnx_import_convpool.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_convpool.in.cpp
@@ -352,8 +352,8 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_average_pool_2d_ceil_last_window_start
     const auto model = convert_model("average_pool_2d_ceil_last_window_starts_on_pad.onnx");
 
     auto test_case = ov::test::TestCase(model, s_device);
-    test_case.add_input<float>({0.858f, 0.0786f, 0.2692f, 0.1537f, 0.8816f, 0.4353f, 0.5772f, 0.6623f, 0.9067f,
-                                0.9483f, 0.597f, 0.763f});
+    test_case.add_input<float>(
+        {0.858f, 0.0786f, 0.2692f, 0.1537f, 0.8816f, 0.4353f, 0.5772f, 0.6623f, 0.9067f, 0.9483f, 0.597f, 0.763f});
     test_case.add_expected_output<float>(Shape{1, 3, 1, 1}, {0.15105554f, 0.28404441f, 0.35722222f});
     test_case.run();
 }

--- a/src/frontends/onnx/tests/onnx_import_convpool.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_convpool.in.cpp
@@ -348,6 +348,16 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_average_pool_2d_dilations_include_pad_
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_average_pool_2d_ceil_last_window_starts_on_pad) {
+    const auto model = convert_model("average_pool_2d_ceil_last_window_starts_on_pad.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({0.858f, 0.0786f, 0.2692f, 0.1537f, 0.8816f, 0.4353f, 0.5772f, 0.6623f, 0.9067f,
+                                0.9483f, 0.597f, 0.763f});
+    test_case.add_expected_output<float>(Shape{1, 3, 1, 1}, {0.15105554f, 0.28404441f, 0.35722222f});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_max_pool_empty_auto_pad) {
     const auto model = convert_model("max_pool_empty_auto_pad.onnx");
 

--- a/src/frontends/onnx/tests/tests_python/test_backend.py
+++ b/src/frontends/onnx/tests/tests_python/test_backend.py
@@ -57,7 +57,6 @@ from tests import (
     xfail_issue_125488,
     skip_issue_125487,
     skip_issue_125489,
-    xfail_issue_125491,
     xfail_issue_125492,
     xfail_issue_122775,
     xfail_issue_122776,
@@ -69,7 +68,6 @@ from tests import (
     xfail_issue_139938,
     xfail_issue_171767,
     xfail_issue_171771,
-    xfail_issue_171772,
     xfail_attention_onnx_version,
     xfail_attention_nan_robustness,
 )
@@ -510,10 +508,6 @@ tests_expected_to_fail = [
         "OnnxBackendNodeModelTest.test_isinf_float16_cpu",
     ),
     (
-        xfail_issue_125491,
-        "OnnxBackendNodeModelTest.test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True_cpu",
-    ),
-    (
         xfail_issue_125492,
         "OnnxBackendNodeModelTest.test_dft_axis_opset19_cpu",
         "OnnxBackendNodeModelTest.test_dft_inverse_opset19_cpu",
@@ -580,11 +574,6 @@ tests_expected_to_fail = [
         "OnnxBackendNodeModelTest.test_top_k_same_values_2d_cpu",
         "OnnxBackendNodeModelTest.test_top_k_same_values_cpu",
         "OnnxBackendNodeModelTest.test_top_k_same_values_largest_cpu",
-    ),
-    (
-        xfail_issue_171772,
-        "OnnxBackendNodeModelTest.test_averagepool_2d_ceil_last_window_starts_on_pad_cpu",
-        "OnnxBackendNodeModelTest.test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True_cpu",
     ),
     (
         xfail_attention_onnx_version,


### PR DESCRIPTION
### Details:
ONNX's `ceil_mode=1` spec requires that sliding windows which would start in the padded region are ignored (not counted toward the output shape). OpenVINO's ONNX AveragePool loader was mapping ceil_mode=1 to RoundingType::CEIL, which does not enforce this, whereas RoundingType::CEIL_TORCH does. This produced an extra, incorrect output element whenever the last pooling window landed in padding.

- Removed the xfail on two ONNX conformance tests this was masking (`test_averagepool_2d_ceil_last_window_starts_on_pad`, `test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True`).
- Add an regression test mirroring the conformance case, with expected values cross-checked against onnxruntime.

| Opset | AveragePool addition | Status before this PR |
|---|---|---|
| 7 | count_include_pad | correct |
| 10 | ceil_mode | mapped to `CEIL` instead of `CEIL_TORCH`, allowing windows to start in padding |
| 11 | pads/auto_pad clarifications | correct |
| 19 | dilations | added in #30842, but inherited the same ceil_mode bug when combined with ceil_mode=1 |


### Tickets:
Closes: #20553 

### AI Assistance:
 - *AI assistance used: no / yes* yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).* Used for code review, built and verified.
