### PR TITLE
[EXPERIMENT][WIP][ONNX FE] Fix SequenceAt rank assertion and add dynamic-unit-split Loop idiom lowering

### DIFF
--- a/src/frontends/common/include/openvino/frontend/sequence_dynamic_unit_split.hpp
+++ b/src/frontends/common/include/openvino/frontend/sequence_dynamic_unit_split.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/frontend/visibility.hpp"
+#include "openvino/op/util/framework_node.hpp"
+
+namespace ov {
+namespace frontend {
+
+/// \brief SequenceDynamicUnitSplit represents a sequence produced by splitting `data`
+/// along `axis` into runtime-many, unit-length (size 1) slices, i.e. the ONNX
+/// `SplitToSequence` idiom where the number of slices is only known at runtime, but
+/// each individual slice is statically known to have length 1 along `axis` (e.g. a
+/// per-frame "for i in range(N_dynamic): x[i]" export idiom).
+///
+/// Because the slice count N is not known at graph-construction time, this sequence
+/// cannot be resolved into a fixed-length SequenceMark chain the way a static split
+/// can. It is only recognized by SequenceArrayLowering's narrow idiom lowering: a
+/// SequenceAt reading this sequence whose position is the iteration variable of the
+/// same enclosing Loop that captured it. Any other consumer (SequenceLength, a
+/// differently-indexed SequenceAt, etc.) is left unconverted, so it is reported by the
+/// universal unconverted-ops diagnostic rather than silently producing a wrong result.
+class FRONTEND_API SequenceDynamicUnitSplit : public ov::op::util::FrameworkNode {
+public:
+    OPENVINO_OP("SequenceDynamicUnitSplit", "util", ov::op::util::FrameworkNode);
+
+    SequenceDynamicUnitSplit(const Output<Node>& data, int64_t axis);
+
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& inputs) const override;
+
+    Output<Node> get_data() const {
+        return input_value(0);
+    }
+
+    int64_t get_axis() const {
+        return m_axis;
+    }
+
+private:
+    int64_t m_axis;
+};
+
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/common/src/sequence_dynamic_unit_split.cpp
+++ b/src/frontends/common/src/sequence_dynamic_unit_split.cpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/sequence_dynamic_unit_split.hpp"
+
+namespace ov {
+namespace frontend {
+
+SequenceDynamicUnitSplit::SequenceDynamicUnitSplit(const Output<Node>& data, int64_t axis)
+    : FrameworkNode({data}, 1),
+      m_axis(axis) {}
+
+std::shared_ptr<Node> SequenceDynamicUnitSplit::clone_with_new_inputs(const OutputVector& inputs) const {
+    OPENVINO_ASSERT(inputs.size() == 1, "SequenceDynamicUnitSplit requires 1 input");
+    return std::make_shared<SequenceDynamicUnitSplit>(inputs[0], m_axis);
+}
+
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/common_translators/src/sequence_array_lowering.cpp
+++ b/src/frontends/common_translators/src/sequence_array_lowering.cpp
@@ -12,6 +12,7 @@
 #include "openvino/core/model.hpp"
 #include "openvino/core/validation_util.hpp"
 #include "openvino/frontend/sequence_at.hpp"
+#include "openvino/frontend/sequence_dynamic_unit_split.hpp"
 #include "openvino/frontend/sequence_erase.hpp"
 #include "openvino/frontend/sequence_insert.hpp"
 #include "openvino/frontend/sequence_length.hpp"
@@ -539,6 +540,114 @@ bool lower_sequence_length(const std::shared_ptr<ov::frontend::SequenceLength>& 
     return true;
 }
 
+// Recognizes the idiom: a SplitToSequence with a dynamic (runtime-only) chunk count,
+// where every chunk is statically known to be length 1 (ai_onnx::split_to_sequence's
+// SequenceDynamicUnitSplit marker), captured as a Loop's invariant input and read
+// solely via SequenceAt(seq, position) where 'position' is that same Loop's own
+// iteration-number special body port. Lowers such reads directly to
+// Gather(data, position, axis) on the original (pre-split) tensor, so a statically
+// sized split never needs to be materialized at all.
+//
+// Conservative by design: a captured sequence is only rewritten when every consumer
+// of its body Parameter is a SequenceAt matching this exact idiom. Anything else
+// (SequenceLength, a differently-indexed SequenceAt, ...) is left untouched, so it is
+// reported by the universal unconverted-ops diagnostic instead of silently mismatching
+// SplitToSequence's keepdims-1 slice semantics.
+bool lower_dynamic_unit_split_loop_idiom(const std::shared_ptr<ov::Model>& model) {
+    bool changed = false;
+    for_each_model_postorder(model, [&changed](const std::shared_ptr<ov::Model>& m) {
+        for (const auto& node : m->get_ordered_ops()) {
+            auto loop = ov::as_type_ptr<v5::Loop>(node);
+            if (!loop) {
+                continue;
+            }
+            auto body = loop->get_function();
+            if (!body) {
+                continue;
+            }
+            const auto special_ports = loop->get_special_body_ports();
+            if (special_ports.current_iteration_input_idx < 0 ||
+                static_cast<size_t>(special_ports.current_iteration_input_idx) >= body->get_parameters().size()) {
+                continue;
+            }
+            const auto& iter_param =
+                body->get_parameters()[static_cast<size_t>(special_ports.current_iteration_input_idx)];
+
+            // Snapshot descriptors: rewiring below must not affect this iteration.
+            const auto descriptors = loop->get_input_descriptions();
+            for (const auto& d : descriptors) {
+                auto inv = ov::as_type_ptr<ov::op::util::MultiSubGraphOp::InvariantInputDescription>(d);
+                if (!inv || inv->m_body_parameter_index >= body->get_parameters().size()) {
+                    continue;
+                }
+                auto outer_src = unwrap_identity(loop->input_value(inv->m_input_index));
+                auto split_marker =
+                    ov::as_type_ptr<ov::frontend::SequenceDynamicUnitSplit>(outer_src.get_node_shared_ptr());
+                if (!split_marker) {
+                    // ai_onnx::split_to_sequence() always wraps its result in an outer
+                    // SequenceMark; unwrap that one-element wrapper too.
+                    if (auto mark = ov::as_type_ptr<ov::frontend::SequenceMark>(outer_src.get_node_shared_ptr())) {
+                        if (mark->size() == 1) {
+                            split_marker = ov::as_type_ptr<ov::frontend::SequenceDynamicUnitSplit>(
+                                unwrap_identity(mark->get_element(0)).get_node_shared_ptr());
+                        }
+                    }
+                }
+                if (!split_marker) {
+                    continue;
+                }
+
+                auto body_param = body->get_parameters()[inv->m_body_parameter_index];
+
+                // Require every consumer of body_param to be a SequenceAt indexed by
+                // this Loop's own iteration variable; otherwise leave it untouched.
+                std::vector<ov::frontend::SequenceAt*> matches;
+                bool all_match = true;
+                for (const auto& tin : body_param->output(0).get_target_inputs()) {
+                    auto at = ov::as_type<ov::frontend::SequenceAt>(tin.get_node());
+                    if (!at) {
+                        all_match = false;
+                        break;
+                    }
+                    auto pos_src = at->input_value(1);
+                    while (auto conv = ov::as_type_ptr<v0::Convert>(pos_src.get_node_shared_ptr())) {
+                        pos_src = conv->input_value(0);
+                    }
+                    if (pos_src.get_node_shared_ptr() != iter_param) {
+                        all_match = false;
+                        break;
+                    }
+                    matches.push_back(at);
+                }
+                if (!all_match || matches.empty()) {
+                    continue;
+                }
+
+                // Rebind the invariant input to the original (pre-split) tensor, then
+                // replace each matching SequenceAt with a keepdims-1 Gather.
+                loop->input(inv->m_input_index).replace_source_output(split_marker->get_data());
+                const auto axis = split_marker->get_axis();
+                for (auto* at : matches) {
+                    auto indices = at->input_value(1);
+                    if (indices.get_element_type() != ov::element::i64) {
+                        indices = std::make_shared<v0::Convert>(indices, ov::element::i64);
+                    }
+                    const auto idx_rank = indices.get_partial_shape().rank();
+                    if (idx_rank.is_static() && idx_rank.get_length() == 0) {
+                        auto unsqueeze_axes = v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+                        indices = std::make_shared<v0::Unsqueeze>(indices, unsqueeze_axes);
+                    }
+                    auto axis_const = v0::Constant::create(ov::element::i64, ov::Shape{}, {axis});
+                    auto gather = std::make_shared<ov::op::v8::Gather>(body_param, indices, axis_const);
+                    at->output(0).replace(gather->output(0));
+                }
+                changed = true;
+            }
+        }
+    });
+    return changed;
+}
+
 void finalize_lowering(const std::shared_ptr<ov::Model>& model) {
     disconnect_dead_sequence_back_edges(model);
     disconnect_dead_sequence_helpers(model);
@@ -558,9 +667,15 @@ bool SequenceArrayLowering::run_on_model(const std::shared_ptr<ov::Model>& model
     if (!sal_detail::model_has_sequence_reader(model)) {
         return false;
     }
+
+    // Handle the dynamic-unit-split-indexed-by-Loop-iteration-variable idiom first: it
+    // is resolved independently of SlotResolver's static-length slot machinery, and
+    // doing it first lets the (now dead) SequenceDynamicUnitSplit / SequenceAt nodes
+    // drop out of the ordered ops before the generic resolver runs.
+    bool overall_changed = sal_detail::lower_dynamic_unit_split_loop_idiom(model);
+
     sal_detail::SlotResolver resolver(model);
 
-    bool overall_changed = false;
     bool iter_changed = true;
     while (iter_changed) {
         std::vector<std::shared_ptr<ov::Node>> helpers;

--- a/src/frontends/onnx/frontend/src/op/sequence_at.cpp
+++ b/src/frontends/onnx/frontend/src/op/sequence_at.cpp
@@ -24,6 +24,23 @@ namespace onnx {
 namespace ai_onnx {
 namespace opset_11 {
 
+namespace {
+// The ONNX spec requires 'position' to be a scalar, but OV's own ONNX Loop
+// translator (op/loop.cpp) represents the Loop's iteration-counter special body
+// port as a rank-1, size-1 tensor (OV's own v5::Loop convention), not a true
+// rank-0 scalar. Accept that shape too: it is a shape-convention mismatch
+// between two parts of OV's own ONNX frontend, not a real modeling error, and
+// the downstream resolution paths already squeeze such indices to scalar
+// before use.
+bool is_scalar_like_position(const ov::PartialShape& position_shape) {
+    const auto& rank = position_shape.rank();
+    if (rank.compatible(0)) {
+        return true;
+    }
+    return rank.is_static() && rank.get_length() == 1 && position_shape[0].compatible(1);
+}
+}  // namespace
+
 /// @brief Implements the SequenceAt operator
 /// @param node Input ONNX node. Must have two inputs: a sequence and a position.
 ///             Sequence is represented as a SequenceMark node.
@@ -36,7 +53,8 @@ ov::OutputVector sequence_at(const ov::frontend::onnx::Node& node) {
     const auto& inputs = node.get_ov_inputs();
 
     auto position = inputs[1];
-    OPENVINO_ASSERT(position.get_partial_shape().rank().compatible(0), "SequenceAt: 'position' input must be a scalar");
+    OPENVINO_ASSERT(is_scalar_like_position(position.get_partial_shape()),
+                    "SequenceAt: 'position' input must be a scalar (or a rank-1, size-1 tensor)");
 
     // Fast path: input is a SequenceMark chain - resolve directly.
     if (const auto input_sequence = as_type_ptr<SequenceMark>(inputs[0].get_node_shared_ptr())) {

--- a/src/frontends/onnx/frontend/src/op/split_to_sequence.cpp
+++ b/src/frontends/onnx/frontend/src/op/split_to_sequence.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <memory>
@@ -11,7 +12,9 @@
 #include "exceptions.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/validation_util.hpp"
+#include "openvino/frontend/sequence_dynamic_unit_split.hpp"
 #include "openvino/frontend/sequence_mark.hpp"
+#include "openvino/op/broadcast.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/split.hpp"
@@ -84,6 +87,33 @@ ov::OutputVector split_with_scalar_split(const ov::frontend::onnx::Node& node, c
     return std::make_shared<ov::op::v1::VariadicSplit>(input, axis_const, split_lengths)->outputs();
 }
 
+/// @brief Detects the ONNX ConstantOfShape(value=1) idiom feeding a dynamic 'split'
+/// input. OV's ONNX frontend lowers ConstantOfShape to Broadcast(Constant(value),
+/// <shape>), so even when the resulting shape (and hence the number of chunks) is
+/// only known at runtime, the broadcast *value* is still a compile-time constant.
+/// When that value is 1, every chunk is statically known to have length 1 along the
+/// split axis, regardless of how many chunks there turn out to be at runtime.
+/// @param split The (dynamic) 1-D 'split' input
+/// @return true if every element of 'split' is provably 1
+bool is_unit_length_chunks(const ov::Output<ov::Node>& split) {
+    auto node = split.get_node_shared_ptr();
+    if (const auto convert = ov::as_type_ptr<ov::op::v0::Convert>(node)) {
+        node = convert->input_value(0).get_node_shared_ptr();
+    }
+    const auto broadcast = ov::as_type_ptr<ov::op::v3::Broadcast>(node);
+    if (!broadcast) {
+        return false;
+    }
+    const auto value_const = ov::util::get_constant_from_source(broadcast->input_value(0));
+    if (!value_const) {
+        return false;
+    }
+    const auto values = value_const->cast_vector<std::int64_t>();
+    return !values.empty() && std::all_of(values.begin(), values.end(), [](std::int64_t v) {
+               return v == 1;
+           });
+}
+
 /// @brief Implements the SplitToSequence operator with 1D 'split' input
 /// @param node Input ONNX node
 /// @param inputs Input tensors
@@ -91,8 +121,24 @@ ov::OutputVector split_with_scalar_split(const ov::frontend::onnx::Node& node, c
 ov::OutputVector split_with_1d_split(const ov::frontend::onnx::Node& node, const ov::OutputVector& inputs) {
     const auto& input = inputs[0];
     const auto& split = inputs[1];
-    const auto axis = node.get_attribute_as_constant<std::int64_t>("axis", 0);
 
+    if (!ov::util::get_constant_from_source(split)) {
+        // Dynamic split-count case: ov::op::v1::VariadicSplit fundamentally requires
+        // the number of output slots to be known at graph-construction time, which a
+        // genuinely runtime-determined split count can never provide. Narrow support:
+        // when every chunk is provably length 1 (see is_unit_length_chunks), defer
+        // resolution to SequenceArrayLowering, which recognizes the idiom of a
+        // SequenceAt indexed by the enclosing Loop's own iteration variable and lowers
+        // it directly to a Gather, without ever needing a statically-sized split.
+        OPENVINO_ASSERT(is_unit_length_chunks(split),
+                        "SplitToSequence: dynamic 'split' input is only supported when every chunk has "
+                        "statically-known length 1 (e.g. the ConstantOfShape(value=1) idiom); general "
+                        "dynamic-length splits are not supported");
+        const auto axis_value = node.get_attribute_value<std::int64_t>("axis", 0);
+        return {std::make_shared<ov::frontend::SequenceDynamicUnitSplit>(input, axis_value)};
+    }
+
+    const auto axis = node.get_attribute_as_constant<std::int64_t>("axis", 0);
     return std::make_shared<ov::op::v1::VariadicSplit>(input, axis, split)->outputs();
 }
 

--- a/src/frontends/onnx/tests/models/controlflow/sal_dynamic_unit_split_loop_idiom.prototxt
+++ b/src/frontends/onnx/tests/models/controlflow/sal_dynamic_unit_split_loop_idiom.prototxt
@@ -1,0 +1,193 @@
+ir_version: 9
+graph {
+  node {
+    input: "data"
+    output: "shape_of_data"
+    op_type: "Shape"
+  }
+  node {
+    input: "shape_of_data"
+    output: "split_counts"
+    op_type: "ConstantOfShape"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        int64_data: 1
+        name: "one"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "data"
+    input: "split_counts"
+    output: "dyn_seq"
+    op_type: "SplitToSequence"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "keepdims"
+      i: 1
+      type: INT
+    }
+  }
+  node {
+    input: "trip_count"
+    input: "cond_init"
+    input: "acc_init"
+    output: "acc_final"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "dyn_seq"
+          input: "iter_num"
+          output: "slot"
+          op_type: "SequenceAt"
+        }
+        node {
+          input: "acc_in"
+          input: "slot"
+          output: "acc_out"
+          op_type: "Add"
+        }
+        node {
+          input: "cond_in"
+          output: "cond_out"
+          op_type: "Identity"
+        }
+        name: "bug2_body"
+        input {
+          name: "iter_num"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "cond_in"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+              }
+            }
+          }
+        }
+        input {
+          name: "acc_in"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cond_out"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+              }
+            }
+          }
+        }
+        output {
+          name: "acc_out"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "sal_dynamic_unit_split_loop_idiom"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_param: "N"
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "trip_count"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "cond_init"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "acc_init"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "acc_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 16
+}

--- a/src/frontends/onnx/tests/models/controlflow/sal_sequence_at_loop_iter_index.prototxt
+++ b/src/frontends/onnx/tests/models/controlflow/sal_sequence_at_loop_iter_index.prototxt
@@ -1,0 +1,221 @@
+ir_version: 9
+graph {
+  node {
+    input: "s0"
+    input: "s1"
+    input: "s2"
+    output: "seq_init"
+    op_type: "SequenceConstruct"
+  }
+  node {
+    input: "trip_count"
+    input: "cond_init"
+    input: "seq_init"
+    input: "acc_init"
+    output: "seq_final"
+    output: "acc_final"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "seq_in"
+          input: "iter_num"
+          output: "slot"
+          op_type: "SequenceAt"
+        }
+        node {
+          input: "acc_in"
+          input: "slot"
+          output: "acc_out"
+          op_type: "Add"
+        }
+        node {
+          input: "cond_in"
+          output: "cond_out"
+          op_type: "Identity"
+        }
+        node {
+          input: "seq_in"
+          output: "seq_out"
+          op_type: "Identity"
+        }
+        name: "bug1_body"
+        input {
+          name: "iter_num"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "cond_in"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+              }
+            }
+          }
+        }
+        input {
+          name: "seq_in"
+          type {
+            sequence_type {
+              elem_type {
+                tensor_type {
+                  elem_type: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "acc_in"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cond_out"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+              }
+            }
+          }
+        }
+        output {
+          name: "seq_out"
+          type {
+            sequence_type {
+              elem_type {
+                tensor_type {
+                  elem_type: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "acc_out"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "sal_sequence_at_loop_iter_index"
+  input {
+    name: "trip_count"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "cond_init"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "s0"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "s1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "s2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "acc_init"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "acc_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 16
+}

--- a/src/frontends/onnx/tests/onnx_import_controlflow.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_controlflow.in.cpp
@@ -1089,3 +1089,65 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_sal_sequence_length_runtime_gate) {
     test_case.add_expected_output<float>(Shape{1}, {30.f});
     test_case.run();
 }
+
+/// @brief Regression: SequenceAt's `position` input wired directly to the
+/// enclosing Loop's own iteration-counter special body port.
+///
+/// ONNX exporters commonly declare the Loop body's iteration-counter input
+/// with shape [1] (rank 1) rather than a true rank-0 scalar (as seen e.g. in
+/// models produced by some PyTorch/TorchScript ONNX export paths). SequenceAt
+/// used to reject any non-rank-0 `position` input outright, even though the
+/// downstream lowering already tolerates a rank-1 size-1 index. This guards
+/// against that overly strict entry-point assertion: a 3-element sequence is
+/// read back inside a Loop using the loop's iteration counter as the index
+/// directly (no extra Squeeze/Cast wrapping it), and the values must be
+/// summed correctly over all iterations.
+OPENVINO_TEST(${BACKEND_NAME}, onnx_sal_sequence_at_loop_iter_index) {
+    const auto model = convert_model("controlflow/sal_sequence_at_loop_iter_index.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<int64_t>({3});    // trip_count
+    test_case.add_input<bool>({true});    // cond_init
+    test_case.add_input<float>({10.f});   // s0
+    test_case.add_input<float>({20.f});   // s1
+    test_case.add_input<float>({30.f});   // s2
+    test_case.add_input<float>({0.f});    // acc_init
+
+    // slot i is read on iteration i (0, 1, 2), so acc_final = 10 + 20 + 30 = 60.
+    test_case.add_expected_output<float>(Shape{1}, {60.f});
+    test_case.run();
+}
+
+/// @brief Regression: `SplitToSequence` with a genuinely dynamic (runtime-only)
+/// split count, consumed exclusively via `SequenceAt` indexed by the enclosing
+/// Loop's own iteration variable.
+///
+/// The `split` input is built from `Shape(data)` via `ConstantOfShape(value=1)`,
+/// so the number of output slots is unknown at graph-construction time (the
+/// number of TTS frames, in the real-world model this pattern was found in),
+/// even though every chunk is provably length 1. `ov::op::v1::VariadicSplit`
+/// (the pre-existing 1-D-split lowering path) requires the number of output
+/// slots to be known statically, so building it here previously failed with a
+/// generic "Cannot get length of dynamic dimension" error. Because this
+/// resulting sequence is captured implicitly (outer-scope capture, not listed
+/// as an explicit Loop node input - matching real exporter behavior) and read
+/// back only via `SequenceAt(iteration_var)`, the whole
+/// `SplitToSequence`+`SequenceAt` pair is semantically just "pick the i-th
+/// unit-length slice of `data` inside the loop" and must lower directly to a
+/// `Gather` on the original (pre-split) tensor, without ever materializing a
+/// statically-sized `VariadicSplit`.
+OPENVINO_TEST(${BACKEND_NAME}, onnx_sal_dynamic_unit_split_loop_idiom) {
+    const auto model = convert_model("controlflow/sal_dynamic_unit_split_loop_idiom.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    // `data`'s ONNX-declared shape is symbolic (dim_param), so its shape must be
+    // provided explicitly here.
+    test_case.add_input<float>(Shape{3}, {100.f, 200.f, 300.f});  // data
+    test_case.add_input<int64_t>({3});                            // trip_count
+    test_case.add_input<bool>({true});                  // cond_init
+    test_case.add_input<float>({0.f});                  // acc_init
+
+    // slot i is read on iteration i (0, 1, 2), so acc_final = 100 + 200 + 300 = 600.
+    test_case.add_expected_output<float>(Shape{1}, {600.f});
+    test_case.run();
+}

--- a/src/frontends/onnx/tests/runtime/interpreter/unit_test.manifest
+++ b/src/frontends/onnx/tests/runtime/interpreter/unit_test.manifest
@@ -21,6 +21,10 @@ INTERPRETER.onnx_loop_if_multi_slot_kv_update
 INTERPRETER.onnx_loop_if_kv_erase_insert
 INTERPRETER.onnx_sal_sequence_length_runtime_gate
 
+# Interpreter (template plugin) reference evaluate for Loop doesn't support a
+# Sequence-typed loop-carried value (independent of the If-inside-Loop gap above)
+INTERPRETER.onnx_sal_sequence_at_loop_iter_index
+
 # Activation function hardsigmoid unsupported
 onnx_model_gru_fwd_activations_relu_hardsigmoid
 onnx_model_lstm_fwd_hardsigmoid_activation


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

### Details

Two narrowly-scoped ONNX frontend + common_translators fixes required to unblock
conversion of `KittenML/kitten-tts-mini-0.8` (an ONNX-only, non-Transformers TTS
model), and more generally applicable to any ONNX model exhibiting these idioms.

**Bug #1 — `SequenceAt`'s `position` rank-0-only assertion**

`SequenceAt`'s `position` input previously rejected any non-rank-0 shape outright,
even though OV's own ONNX `Loop` translator (`op/loop.cpp`) represents the Loop's
iteration-counter special body port with shape `{1}` (OV's own convention) rather
than a true rank-0 scalar — a shape-convention mismatch between two parts of OV's
own frontend, not a real modeling error. The downstream lowering
(`sequence_array_lowering.cpp`'s `lower_sequence_at()`) already squeezes such
indices to scalar before use; only the entry-point assertion needed relaxing.

Fix: `src/frontends/onnx/frontend/src/op/sequence_at.cpp` — accept rank-1, size-1
`position` tensors in addition to true rank-0 scalars.

**Bug #2 — `SplitToSequence` with a genuinely dynamic (runtime-only) split count**

`SplitToSequence`'s 1-D-split lowering path always built
`ov::op::v1::VariadicSplit`, which requires the number of output slots to be known
at graph-construction time — fundamentally incompatible with a genuinely
runtime-only split count (e.g. `ConstantOfShape` fed by a runtime `Shape`, as seen
in this model's per-frame TTS output regulation loop).

Fix: added a narrow `FrameworkNode` marker (`frontend::SequenceDynamicUnitSplit`,
new files under `src/frontends/common/`) for the specific case where the split
count is dynamic but every chunk is statically provable to be length 1 (the
`ConstantOfShape(value=1)` idiom). Added a new `SequenceArrayLowering` pass
(`lower_dynamic_unit_split_loop_idiom`, in
`src/frontends/common_translators/src/sequence_array_lowering.cpp`) that
recognizes this marker captured as a `Loop`'s invariant input and consumed
*exclusively* via `SequenceAt` indexed by that same Loop's own iteration
variable, lowering it directly to `Gather(pre_split_data, iteration_var, axis)` —
bypassing the need for a statically-sized split entirely. Any other consumer
pattern is left unconverted (reported by the existing unconverted-ops
diagnostic), matching this idiom's narrow, root-cause-oriented scope rather than
attempting a fully general dynamic-`SplitToSequence` solution.

Both fixes build on the `SequenceMark`/`SequenceAt`/`SlotResolver` deferred
resolution infrastructure introduced by #36228 and #36445 (loop-carried KV-cache
sequence patterns), matching their code style and test conventions.

### Tickets

- Internal OMEGA model-enablement tracking: `openvinotoolkit/omega#52`
  (KittenML/kitten-tts-mini-0.8)

### Tests

Added two new regression tests to
`src/frontends/onnx/tests/onnx_import_controlflow.in.cpp`, each with a minimal
synthetic ONNX `Loop` fixture mirroring just the failing subgraph pattern (not
the full 78MB real model):

- `onnx_sal_sequence_at_loop_iter_index` — a `Loop` containing `SequenceAt` whose
  `position` is the loop's own iteration-counter port (rank-1 shape). Verifies
  conversion now succeeds and produces the correct accumulated result.
- `onnx_sal_dynamic_unit_split_loop_idiom` — a dynamic `SplitToSequence`
  (`ConstantOfShape(value=1)`-driven split count) inside a `Loop`, consumed only
  by `SequenceAt(iteration_var)`. Verifies conversion succeeds and the result is
  numerically correct (cross-checked against ONNXRuntime output for the same
  minimal graph before writing the OpenVINO expectation).

Full `ov_onnx_frontend_tests` suite (CPU + reference backends, 2015 tests) run
clean with these changes: **0 failures**, both new tests passing on `IE_CPU`.
One new test needed adding to the INTERPRETER (template/reference plugin)
skip-manifest for a pre-existing, unrelated reference-backend limitation
(`Loop::evaluate` doesn't support a Sequence-typed loop-carried value),
matching the existing precedent already in that same manifest file for the
If-inside-Loop reference-evaluate gap.

### Known Limitations

These two fixes are **independently correct and fully tested** (see Tests above),
but do **not** yet achieve full end-to-end conversion of the target model
`KittenML/kitten-tts-mini-0.8`. Once these two fixes stopped masking earlier
failures, a third, previously-unexercised issue surfaced:

- A pre-existing gap in the already-merged `SlotResolver`/`SequenceInsert`
  lowering infrastructure (#36228, #36445): when a single `Loop` mixes a growing
  KV-cache (`SequenceEmpty` → merged input → `SequenceInsert` → Loop output) with
  any other co-located sequence-shaped invariant/implicit-capture input,
  `validate_nodes_and_infer_types()` fails with `"Input descriptor for
  SequenceInsert_N node has been changed"`.
- This is **unrelated to, and out of scope for, this PR** — it is a pre-existing
  infrastructure gap, not something introduced by either fix here. It has been
  filed separately as **#36722**, with a minimal standalone repro (independent of
  the real model) and root-cause hypothesis.
- `com.microsoft.DynamicQuantizeLSTM` (ORT-contrib op) and `Squeeze` without an
  `axes` input are additional, separately-tracked, out-of-scope blockers for the
  real model.

Real end-to-end conversion of `kitten-tts-mini-0.8` remains blocked on #36722 plus
the `DynamicQuantizeLSTM` pre-pass above — tracked in openvinotoolkit/omega#52.

