### PR TITLE
[ONNX FE] Add help for ops supported via openvino_tokenizers

### DIFF
--- a/docs/articles_en/about-openvino/release-notes-openvino.rst
+++ b/docs/articles_en/about-openvino/release-notes-openvino.rst
@@ -117,7 +117,7 @@ ONNX Framework Support
 ---------------------------------------------------------------------------------------------
 
 * Scan, Loop, and If operations have been improved to correctly handle models using graph initializers as direct outputs of control flow subgraphs, resolving conversion failures and incorrect results. Scan operation now validates ``num_scan_inputs`` and properly handles models where the loop body has fewer outputs than initial state values. 
-* Tokenizer operation support has been added via openvino-tokenizers integration, enabling conversion of ONNX models using StringNormalizer, LabelEncoder, Tokenizer, and TfIdfVectorizer operations when openvino-tokenizers is installed. Users receive guidance to install the package if missing. 
+* Tokenizer operation support has been added via openvino-tokenizers integration, enabling conversion of ONNX models using StringNormalizer, LabelEncoder, Tokenizer, and TfIdfVectorizer operations when openvino-tokenizers is installed. Users receive guidance to install the package if missing.  
 
 OpenVINO™ Model Server
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/articles_en/about-openvino/release-notes-openvino.rst
+++ b/docs/articles_en/about-openvino/release-notes-openvino.rst
@@ -117,7 +117,7 @@ ONNX Framework Support
 ---------------------------------------------------------------------------------------------
 
 * Scan, Loop, and If operations have been improved to correctly handle models using graph initializers as direct outputs of control flow subgraphs, resolving conversion failures and incorrect results. Scan operation now validates ``num_scan_inputs`` and properly handles models where the loop body has fewer outputs than initial state values. 
-* Tokenizer operation support has been added via openvino-tokenizers integration, enabling conversion of ONNX models using StringNormalizer, LabelEncoder, Tokenizer, and TfIdfVectorizer operations when openvino-tokenizers is installed. Users receive guidance to install the package if missing.  
+* Tokenizer operation support has been added via openvino-tokenizers integration, enabling conversion of ONNX models using StringNormalizer, LabelEncoder, Tokenizer, TfIdfVectorizer, SentencepieceTokenizer, SentencepieceDecoder, VectorToString, StringJoin, and StringSplit operations when openvino-tokenizers is installed. Users receive guidance to install the package if missing.  
 
 OpenVINO™ Model Server
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/articles_en/about-openvino/release-notes-openvino.rst
+++ b/docs/articles_en/about-openvino/release-notes-openvino.rst
@@ -117,7 +117,7 @@ ONNX Framework Support
 ---------------------------------------------------------------------------------------------
 
 * Scan, Loop, and If operations have been improved to correctly handle models using graph initializers as direct outputs of control flow subgraphs, resolving conversion failures and incorrect results. Scan operation now validates ``num_scan_inputs`` and properly handles models where the loop body has fewer outputs than initial state values. 
-* Tokenizer operation support has been added via openvino-tokenizers integration, enabling conversion of ONNX models using StringNormalizer, LabelEncoder, Tokenizer, and TfIdfVectorizer operations when openvino-tokenizers is installed. Users receive guidance to install the package if missing.
+* Tokenizer operation support has been added via openvino-tokenizers integration, enabling conversion of ONNX models using StringNormalizer, LabelEncoder, Tokenizer, and TfIdfVectorizer operations when openvino-tokenizers is installed. Users receive guidance to install the package if missing. 
 
 OpenVINO™ Model Server
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/articles_en/about-openvino/release-notes-openvino.rst
+++ b/docs/articles_en/about-openvino/release-notes-openvino.rst
@@ -117,7 +117,7 @@ ONNX Framework Support
 ---------------------------------------------------------------------------------------------
 
 * Scan, Loop, and If operations have been improved to correctly handle models using graph initializers as direct outputs of control flow subgraphs, resolving conversion failures and incorrect results. Scan operation now validates ``num_scan_inputs`` and properly handles models where the loop body has fewer outputs than initial state values. 
-* Tokenizer operation support has been added via openvino-tokenizers integration, enabling conversion of ONNX models using StringNormalizer, LabelEncoder, Tokenizer, TfIdfVectorizer, SentencepieceTokenizer, SentencepieceDecoder, VectorToString, StringJoin, and StringSplit operations when openvino-tokenizers is installed. Users receive guidance to install the package if missing.  
+* Tokenizer operation support has been added via openvino-tokenizers integration, enabling conversion of ONNX models using StringNormalizer, LabelEncoder, Tokenizer, and TfIdfVectorizer operations when openvino-tokenizers is installed. Users receive guidance to install the package if missing.
 
 OpenVINO™ Model Server
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/frontends/onnx/docs/check_supported_ops.py
+++ b/src/frontends/onnx/docs/check_supported_ops.py
@@ -52,7 +52,9 @@ known_domains = {
     "MICROSOFT_DOMAIN":"com.microsoft",
     "PYTORCH_ATEN_DOMAIN":"org.pytorch.aten",
     "MMDEPLOY_DOMAIN":"mmdeploy",
-    "AIONNX_ML_DOMAIN":"ai.onnx.ml"
+    "AIONNX_ML_DOMAIN":"ai.onnx.ml",
+    "AIONNX_DOMAIN":"",
+    "AIONNX_CONTRIB_DOMAIN":"ai.onnx.contrib"
 }
 
 hdr = ""

--- a/src/frontends/onnx/docs/supported_ops.md
+++ b/src/frontends/onnx/docs/supported_ops.md
@@ -337,4 +337,10 @@ OpenVINO provides support for operations of Default Opset (empty in table below)
 |org.pytorch.aten        |adaptive_avg_pool2d                                     |1                       |1                               |                                |
 |mmdeploy                |MMCVRoIAlignRotated                                     |1                       |1                               |                                |
 |mmdeploy                |NMSRotated                                              |1                       |1                               |                                |
+|ai.onnx.ml              |LabelEncoder                                            |                        |1                               |                                |
 |ai.onnx.ml              |Normalizer                                              |1                       |1                               |                                |
+|ai.onnx.contrib         |SentencepieceDecoder                                    |                        |1                               |                                |
+|ai.onnx.contrib         |SentencepieceTokenizer                                  |                        |1                               |                                |
+|ai.onnx.contrib         |StringJoin                                              |                        |1                               |                                |
+|ai.onnx.contrib         |StringSplit                                             |                        |1                               |                                |
+|ai.onnx.contrib         |VectorToString                                          |                        |1                               |                                |

--- a/src/frontends/onnx/docs/supported_ops.md
+++ b/src/frontends/onnx/docs/supported_ops.md
@@ -192,13 +192,13 @@ OpenVINO provides support for operations of Default Opset (empty in table below)
 |                        |Sqrt                                                    |1                       |13, 6, 1                        |                                |
 |                        |Squeeze                                                 |13, 1                   |21, 13, 11, 1                   |                                |
 |                        |StringConcat                                            |                        |20                              |                                |
-|                        |StringNormalizer                                        |                        |10                              |                                |
+|                        |StringNormalizer                                        |                        |10                              |Supported through openvino_tokenizers|
 |                        |StringSplit                                             |                        |20                              |                                |
 |                        |Sub                                                     |7, 1                    |14, 13, 7, 6, 1                 |                                |
 |                        |Sum                                                     |8, 1                    |13, 8, 6, 1                     |                                |
 |                        |Tan                                                     |7                       |22, 7                           |                                |
 |                        |Tanh                                                    |1                       |13, 6, 1                        |                                |
-|                        |TfIdfVectorizer                                         |                        |9                               |                                |
+|                        |TfIdfVectorizer                                         |                        |9                               |Supported through openvino_tokenizers|
 |                        |ThresholdedRelu                                         |10                      |22, 10                          |                                |
 |                        |Tile                                                    |1                       |13, 6, 1                        |                                |
 |                        |TopK                                                    |11, 10, 1               |11, 10, 1                       |                                |
@@ -311,7 +311,7 @@ OpenVINO provides support for operations of Default Opset (empty in table below)
 |com.microsoft           |Snpe                                                    |                        |1                               |                                |
 |com.microsoft           |SparseAttention                                         |                        |1                               |                                |
 |com.microsoft           |SparseToDenseMatMul                                     |                        |1                               |                                |
-|com.microsoft           |Tokenizer                                               |                        |1                               |                                |
+|com.microsoft           |Tokenizer                                               |                        |1                               |Supported through openvino_tokenizers|
 |com.microsoft           |TorchEmbedding                                          |                        |1                               |                                |
 |com.microsoft           |TransposeMatMul                                         |                        |1                               |                                |
 |com.microsoft           |Trilu                                                   |1                       |1                               |                                |
@@ -337,10 +337,10 @@ OpenVINO provides support for operations of Default Opset (empty in table below)
 |org.pytorch.aten        |adaptive_avg_pool2d                                     |1                       |1                               |                                |
 |mmdeploy                |MMCVRoIAlignRotated                                     |1                       |1                               |                                |
 |mmdeploy                |NMSRotated                                              |1                       |1                               |                                |
-|ai.onnx.ml              |LabelEncoder                                            |                        |1                               |                                |
+|ai.onnx.ml              |LabelEncoder                                            |                        |1                               |Supported through openvino_tokenizers|
 |ai.onnx.ml              |Normalizer                                              |1                       |1                               |                                |
-|ai.onnx.contrib         |SentencepieceDecoder                                    |                        |1                               |                                |
-|ai.onnx.contrib         |SentencepieceTokenizer                                  |                        |1                               |                                |
-|ai.onnx.contrib         |StringJoin                                              |                        |1                               |                                |
-|ai.onnx.contrib         |StringSplit                                             |                        |1                               |                                |
-|ai.onnx.contrib         |VectorToString                                          |                        |1                               |                                |
+|ai.onnx.contrib         |SentencepieceDecoder                                    |                        |1                               |Supported through openvino_tokenizers|
+|ai.onnx.contrib         |SentencepieceTokenizer                                  |                        |1                               |Supported through openvino_tokenizers|
+|ai.onnx.contrib         |StringJoin                                              |                        |1                               |Supported through openvino_tokenizers|
+|ai.onnx.contrib         |StringSplit                                             |                        |1                               |Supported through openvino_tokenizers|
+|ai.onnx.contrib         |VectorToString                                          |                        |1                               |Supported through openvino_tokenizers|

--- a/src/frontends/onnx/frontend/src/core/operator_set.hpp
+++ b/src/frontends/onnx/frontend/src/core/operator_set.hpp
@@ -30,6 +30,9 @@ extern const char* MICROSOFT_DOMAIN;
 extern const char* PYTORCH_ATEN_DOMAIN;
 extern const char* MMDEPLOY_DOMAIN;
 extern const char* AIONNX_ML_DOMAIN;
+extern const char* AIONNX_CONTRIB_DOMAIN;
+// The default ONNX opset ("ai.onnx") is registered/looked up under an empty domain string.
+extern const char* AIONNX_DOMAIN;
 
 /// \brief Registering a versions range of translator in global map of translators (preferred to use)
 extern bool register_translator(const std::string name,

--- a/src/frontends/onnx/frontend/src/frontend.cpp
+++ b/src/frontends/onnx/frontend/src/frontend.cpp
@@ -285,13 +285,24 @@ ov::frontend::AdditionalErrorCallback make_onnx_tokenizer_callback() {
                            "documentation: "
                            "https://docs.openvino.ai/latest/openvino_docs_Extensibility_UG_Frontend_Extensions.html \n";
 
-        // Check for tokenizer operations
+        // Check for tokenizer operations. Unsupported operation names are formatted by make_onnx_extractor() as
+        // "OpType-version" for the default ONNX opset (empty domain) or "domain.OpType" for custom domains.
         const auto& all_tokenizer_ops = ov::frontend::onnx::get_supported_ops_via_tokenizers();
         std::string unsupported_ops_from_tokenizers;
         size_t tokenizer_counter = 0;
         for (const auto& unsupported_operation : unsupported_ops) {
-            if (std::find(all_tokenizer_ops.begin(), all_tokenizer_ops.end(), unsupported_operation) !=
-                all_tokenizer_ops.end()) {
+            const auto is_tokenizer_op =
+                std::any_of(all_tokenizer_ops.begin(),
+                            all_tokenizer_ops.end(),
+                            [&unsupported_operation](const std::pair<std::string, std::string>& op_and_domain) {
+                                const auto& [op_type, domain] = op_and_domain;
+                                if (domain.empty()) {
+                                    const auto prefix = op_type + "-";
+                                    return unsupported_operation.rfind(prefix, 0) == 0;
+                                }
+                                return unsupported_operation == domain + "." + op_type;
+                            });
+            if (is_tokenizer_op) {
                 if (tokenizer_counter > 0) {
                     unsupported_ops_from_tokenizers += ", ";
                 }

--- a/src/frontends/onnx/frontend/src/ops_bridge.cpp
+++ b/src/frontends/onnx/frontend/src/ops_bridge.cpp
@@ -46,7 +46,6 @@ const char* PYTORCH_ATEN_DOMAIN = "org.pytorch.aten";
 const char* MMDEPLOY_DOMAIN = "mmdeploy";
 const char* AIONNX_ML_DOMAIN = "ai.onnx.ml";
 const char* AIONNX_CONTRIB_DOMAIN = "ai.onnx.contrib";
-// The default ONNX opset ("ai.onnx") is registered/looked up under an empty domain string.
 const char* AIONNX_DOMAIN = "";
 
 // Central storage of supported translators for operations

--- a/src/frontends/onnx/frontend/src/ops_bridge.cpp
+++ b/src/frontends/onnx/frontend/src/ops_bridge.cpp
@@ -45,6 +45,9 @@ const char* MICROSOFT_DOMAIN = "com.microsoft";
 const char* PYTORCH_ATEN_DOMAIN = "org.pytorch.aten";
 const char* MMDEPLOY_DOMAIN = "mmdeploy";
 const char* AIONNX_ML_DOMAIN = "ai.onnx.ml";
+const char* AIONNX_CONTRIB_DOMAIN = "ai.onnx.contrib";
+// The default ONNX opset ("ai.onnx") is registered/looked up under an empty domain string.
+const char* AIONNX_DOMAIN = "";
 
 // Central storage of supported translators for operations
 typedef std::unordered_map<std::string, DomainOpset> SupportedOps;
@@ -265,8 +268,20 @@ OperatorsBridge::OperatorsBridge() {
     // custom ops
 }
 
-const std::vector<std::string> get_supported_ops_via_tokenizers() {
-    return {"StringNormalizer", "LabelEncoder", "Tokenizer", "TfIdfVectorizer"};
+const std::vector<std::pair<std::string, std::string>>& get_supported_ops_via_tokenizers() {
+    // op_type -> domain, empty domain (AIONNX_DOMAIN) denotes the default ONNX opset ("ai.onnx")
+    static const std::vector<std::pair<std::string, std::string>> ops{
+        {"StringNormalizer", AIONNX_DOMAIN},
+        {"TfIdfVectorizer", AIONNX_DOMAIN},
+        {"LabelEncoder", AIONNX_ML_DOMAIN},
+        {"Tokenizer", MICROSOFT_DOMAIN},
+        {"SentencepieceTokenizer", AIONNX_CONTRIB_DOMAIN},
+        {"SentencepieceDecoder", AIONNX_CONTRIB_DOMAIN},
+        {"VectorToString", AIONNX_CONTRIB_DOMAIN},
+        {"StringJoin", AIONNX_CONTRIB_DOMAIN},
+        {"StringSplit", AIONNX_CONTRIB_DOMAIN},
+    };
+    return ops;
 }
 #undef REGISTER_OPERATOR
 #undef REGISTER_OPERATOR_WITH_DOMAIN

--- a/src/frontends/onnx/frontend/src/ops_bridge.hpp
+++ b/src/frontends/onnx/frontend/src/ops_bridge.hpp
@@ -10,6 +10,8 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "core/operator_set.hpp"
 #include "openvino/frontend/onnx/extension/conversion.hpp"
@@ -89,7 +91,9 @@ private:
     std::unordered_map<std::string, DomainOpset> m_map;
 };
 
-const std::vector<std::string> get_supported_ops_via_tokenizers();
+// Returns operations convertible via the openvino-tokenizers extension as (op_type, domain) pairs.
+// An empty domain denotes the default ONNX opset ("ai.onnx").
+const std::vector<std::pair<std::string, std::string>>& get_supported_ops_via_tokenizers();
 
 }  // namespace onnx
 }  // namespace frontend


### PR DESCRIPTION
### Details:
 - Fixed the ONNX FE "install openvino-tokenizers" warning: unconverted-op names are now matched against tokenizer-supported ops using domain-aware comparison instead of a broken plain-string match (`get_supported_ops_via_tokenizers()` now returns `(op_type, domain)` pairs).
 - Added missing `ai.onnx.contrib` ops to the tokenizer op list: `SentencepieceTokenizer`, `SentencepieceDecoder`, `VectorToString`, `StringJoin`, `StringSplit`.
 - Declared `AIONNX_DOMAIN` (default opset) and `AIONNX_CONTRIB_DOMAIN` constants in `operator_set.hpp`, alongside existing domain constants.
 - Updated `supported_ops.md` (new `LabelEncoder`/`ai.onnx.contrib` rows, "Supported through openvino_tokenizers" limitation notes) and `check_supported_ops.py` (`known_domains`) accordingly.

### Tickets:
 - *ticket-id*

### AI Assistance:
 - AI assistance used: yes
 - GitHub Copilot was used to implement, update documentation, and verify the build.