### PR TITLE
[ONNX FE] Remove leftover debug log in GraphIteratorProto creation

### DIFF
--- a/src/frontends/onnx/frontend/src/frontend.cpp
+++ b/src/frontends/onnx/frontend/src/frontend.cpp
@@ -182,7 +182,6 @@ ov::frontend::InputModel::Ptr FrontEnd::load_impl(const std::vector<ov::Any>& va
         enable_mmap = variants[1].as<bool>();
 
     const auto create_iterator_model = [&](const std::filesystem::path& model_path) {
-        OPENVINO_DEBUG("[ONNX Frontend] Enabled an experimental GraphIteratorProto interface!!!");
         GraphIteratorProto::Ptr graph_iterator =
             std::make_shared<GraphIteratorProto>(enable_mmap ? Internal_MMAP : Internal_Stream);
         graph_iterator->initialize(model_path);


### PR DESCRIPTION
### Details:
- Removes a leftover `OPENVINO_DEBUG` log line in `FrontEnd::load_impl` printed on every model load when the experimental `GraphIteratorProto` interface is used (enabled by default).

### Tickets:
- N/A
