### PR TITLE
[NPU] Workaround for CID compatibility string tests

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/compatibility_string.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/compatibility_string.hpp
@@ -131,6 +131,8 @@ TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsIsSupported) {
     } else {
         ASSERT_TRUE(it == properties.cend());
     }
+    // #E224500 workaround until driver fix
+    compiledModel = {};
 }
 
 TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsValueIsReadableWhenSupported) {
@@ -171,6 +173,8 @@ TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsValueIsReadableWhen
                         ov::Exception,
                         testing::HasSubstr("Unsupported configuration key: RUNTIME_REQUIREMENTS"));
     }
+    // #E224500 workaround until driver fix
+    compiledModel = {};
 }
 
 TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsIsNotSupportedForWS) {


### PR DESCRIPTION
### Details:
Adding a workaround to fix object destruction order until a driver fix is available.

### Tickets:
-  *C-190155*
 - *E-224500*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
