### PR TITLE
[GPU] Enable sdpa_micro for bidirectional attention and sliding window

### DIFF
--- a/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
@@ -222,8 +222,7 @@ static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> phi3_sli
     return {mask, offset};
 }
 
-static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>>
-gptoss_gemma3_gemma4_sliding_window_pattern() {
+static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> gptoss_gemma3_sliding_window_pattern() {
     auto q_idx = any_input();
     auto kv_idx = any_input();
 
@@ -239,18 +238,21 @@ gptoss_gemma3_gemma4_sliding_window_pattern() {
     auto bitwise_and_3 = wrap_type<v13::BitwiseAnd>({bitwise_and_2, any_input()});
     auto broadcast = wrap_type<v3::Broadcast>({bitwise_and_3, any_input()});
     auto select = wrap_type<v1::Select>({broadcast, any_input(), any_input()});
+    auto mask = pattern::optional<v8::Slice>({select, any_input(), any_input(), any_input(), any_input()});
 
-    auto sw_const = wrap_type<v0::Constant>();
+    return {mask, offset};
+}
+
+static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> gemma4_sliding_window_pattern() {
+    auto sw_const = wrap_type<v0::Constant>(ov::pass::pattern::has_static_shape() && ov::pass::pattern::rank_equals(0));
     auto ge = wrap_type<v1::GreaterEqual>({any_input(), sw_const});
     auto unsqueeze_0 = wrap_type<v0::Unsqueeze>({ge, any_input()});
     auto unsqueeze_1 = wrap_type<v0::Unsqueeze>({unsqueeze_0, any_input()});
     auto inner_select = wrap_type<v1::Select>({unsqueeze_1, any_input(), any_input()});
     auto outer_select = wrap_type<v1::Select>({any_input(), any_input(), inner_select});
+    auto mask = pattern::optional<v8::Slice>({outer_select, any_input(), any_input(), any_input(), any_input()});
 
-    auto mask_input = std::make_shared<Or>(OutputVector{select, outer_select});
-    auto mask = pattern::optional<v8::Slice>({mask_input, any_input(), any_input(), any_input(), any_input()});
-
-    return {mask, offset, sw_const};
+    return {mask, sw_const};
 }
 
 typedef std::
@@ -412,9 +414,13 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
     std::shared_ptr<ov::Node> phi3_mask, phi3_offset;
     std::tie(phi3_mask, phi3_offset) = phi3_sliding_window_pattern();
 
-    // gpt-oss, gemma3 and gemma4 sliding layer cases
-    std::shared_ptr<ov::Node> gptoss_gemma3_mask, gptoss_gemma3_offset, gemma4_sw_const;
-    std::tie(gptoss_gemma3_mask, gptoss_gemma3_offset, gemma4_sw_const) = gptoss_gemma3_gemma4_sliding_window_pattern();
+    // gpt-oss and gemma3 cases
+    std::shared_ptr<ov::Node> gptoss_gemma3_mask, gptoss_gemma3_offset;
+    std::tie(gptoss_gemma3_mask, gptoss_gemma3_offset) = gptoss_gemma3_sliding_window_pattern();
+
+    // gemma4 sliding layer case
+    std::shared_ptr<ov::Node> gemma4_mask, gemma4_sw_const;
+    std::tie(gemma4_mask, gemma4_sw_const) = gemma4_sliding_window_pattern();
 
     // Scale's shape limitations according to SDPA specification
     auto scale_predicate = [=](const Output<Node>& output) -> bool {
@@ -440,6 +446,7 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
                                                           jais_alibi_mask,
                                                           baichuan2_13b_alibi_mask,
                                                           gptoss_gemma3_mask,
+                                                          gemma4_mask,
                                                           any_input()});
 
     auto sdpa_with_4_inputs = wrap_type<v13::ScaledDotProductAttention>({q, k_to_sdpa, v_to_sdpa, mask_to_sdpa});
@@ -654,16 +661,12 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
         } else if (pattern_map.count(gemma4_sw_const)) {
             auto sw_node = pattern_map.at(gemma4_sw_const).get_node_shared_ptr();
             auto const_node = ov::as_type_ptr<v0::Constant>(sw_node);
-            if (const_node && ov::shape_size(const_node->get_shape()) == 1) {
-                auto val = const_node->cast_vector<int64_t>();
-                if (!val.empty() && val[0] > 0) {
-                    sliding_window = v0::Constant::create(element::i32, Shape{}, {static_cast<int32_t>(val[0])});
-                } else {
-                    sliding_window = v0::Constant::create(element::i32, Shape{}, {0});
-                }
-            } else {
-                sliding_window = v0::Constant::create(element::i32, Shape{}, {0});
-            }
+            OPENVINO_ASSERT(const_node, "Gemma4 sliding window constant is not a Constant node");
+            auto val = const_node->cast_vector<int64_t>();
+            OPENVINO_ASSERT(!val.empty() && val[0] > 0,
+                            "Gemma4 sliding window constant must be a positive value, got: ",
+                            val.empty() ? 0 : val[0]);
+            sliding_window = v0::Constant::create(element::i32, Shape{}, {static_cast<int32_t>(val[0])});
         } else {
             sliding_window = v0::Constant::create(element::i32, Shape{}, {0});
         }

--- a/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
@@ -244,15 +244,15 @@ static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> gptoss_g
 }
 
 static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> gemma4_sliding_window_pattern() {
-    auto sw_const = wrap_type<v0::Constant>(ov::pass::pattern::has_static_shape() && ov::pass::pattern::rank_equals(0));
-    auto ge = wrap_type<v1::GreaterEqual>({any_input(), sw_const});
+    auto offset = wrap_type<v0::Constant>();
+    auto ge = wrap_type<v1::GreaterEqual>({any_input(), offset});
     auto unsqueeze_0 = wrap_type<v0::Unsqueeze>({ge, any_input()});
     auto unsqueeze_1 = wrap_type<v0::Unsqueeze>({unsqueeze_0, any_input()});
     auto inner_select = wrap_type<v1::Select>({unsqueeze_1, any_input(), any_input()});
     auto outer_select = wrap_type<v1::Select>({any_input(), any_input(), inner_select});
     auto mask = pattern::optional<v8::Slice>({outer_select, any_input(), any_input(), any_input(), any_input()});
 
-    return {mask, sw_const};
+    return {mask, offset};
 }
 
 typedef std::
@@ -419,8 +419,8 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
     std::tie(gptoss_gemma3_mask, gptoss_gemma3_offset) = gptoss_gemma3_sliding_window_pattern();
 
     // gemma4 sliding layer case
-    std::shared_ptr<ov::Node> gemma4_mask, gemma4_sw_const;
-    std::tie(gemma4_mask, gemma4_sw_const) = gemma4_sliding_window_pattern();
+    std::shared_ptr<ov::Node> gemma4_mask, gemma4_offset;
+    std::tie(gemma4_mask, gemma4_offset) = gemma4_sliding_window_pattern();
 
     // Scale's shape limitations according to SDPA specification
     auto scale_predicate = [=](const Output<Node>& output) -> bool {
@@ -658,15 +658,15 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
                 offset = std::make_shared<v0::Convert>(offset, element::i32);
             }
             sliding_window = std::make_shared<v1::Multiply>(offset, v0::Constant::create(element::i32, Shape{}, {-1}));
-        } else if (pattern_map.count(gemma4_sw_const)) {
-            auto sw_node = pattern_map.at(gemma4_sw_const).get_node_shared_ptr();
-            auto const_node = ov::as_type_ptr<v0::Constant>(sw_node);
-            OPENVINO_ASSERT(const_node, "Gemma4 sliding window constant is not a Constant node");
-            auto val = const_node->cast_vector<int64_t>();
-            OPENVINO_ASSERT(!val.empty() && val[0] > 0,
-                            "Gemma4 sliding window constant must be a positive value, got: ",
-                            val.empty() ? 0 : val[0]);
-            sliding_window = v0::Constant::create(element::i32, Shape{}, {static_cast<int32_t>(val[0])});
+        } else if (pattern_map.count(gemma4_offset)) {
+            auto offset = pattern_map.at(gemma4_offset).get_node_shared_ptr();
+            if (pattern_map.at(gemma4_offset).get_partial_shape().rank() != 0) {
+                offset = std::make_shared<v15::Squeeze>(offset);
+            }
+            if (offset->get_element_type() != element::i32) {
+                offset = std::make_shared<v0::Convert>(offset, element::i32);
+            }
+            sliding_window = offset;
         } else {
             sliding_window = v0::Constant::create(element::i32, Shape{}, {0});
         }

--- a/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
@@ -5,6 +5,7 @@
 #include "transformations/paged_attention/state_management_pattern.hpp"
 
 #include <tuple>
+#include <unordered_set>
 
 #include "openvino/cc/pass/itt.hpp"
 #include "openvino/core/graph_util.hpp"
@@ -221,6 +222,19 @@ static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> phi3_sli
     return {mask, offset};
 }
 
+static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> gemma4_sliding_window_pattern() {
+    // Gemma4 sliding layer mask topology:
+    // Slice(Select(_, _, Select(Unsqueeze(Unsqueeze(GreaterEqual(Subtract(_, _), sw_const))), _, _)), ...)
+    auto sw_const = wrap_type<v0::Constant>();
+    auto ge = wrap_type<v1::GreaterEqual>({any_input(), sw_const});
+    auto unsqueeze_0 = wrap_type<v0::Unsqueeze>({ge, any_input()});
+    auto unsqueeze_1 = wrap_type<v0::Unsqueeze>({unsqueeze_0, any_input()});
+    auto inner_select = wrap_type<v1::Select>({unsqueeze_1, any_input(), any_input()});
+    auto outer_select = wrap_type<v1::Select>({any_input(), any_input(), inner_select});
+    auto mask = wrap_type<v8::Slice>({outer_select, any_input(), any_input(), any_input(), any_input()});
+    return {mask, sw_const};
+}
+
 static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> gptoss_gemma3_sliding_window_pattern() {
     auto q_idx = any_input();
     auto kv_idx = any_input();
@@ -405,6 +419,10 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
     std::shared_ptr<ov::Node> gptoss_gemma3_mask, gptoss_gemma3_offset;
     std::tie(gptoss_gemma3_mask, gptoss_gemma3_offset) = gptoss_gemma3_sliding_window_pattern();
 
+    // Gemma4 sliding layer case
+    std::shared_ptr<ov::Node> gemma4_mask, gemma4_sw_const;
+    std::tie(gemma4_mask, gemma4_sw_const) = gemma4_sliding_window_pattern();
+
     // Scale's shape limitations according to SDPA specification
     auto scale_predicate = [=](const Output<Node>& output) -> bool {
         return output.get_partial_shape() == ov::PartialShape{} ||
@@ -429,6 +447,7 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
                                                           jais_alibi_mask,
                                                           baichuan2_13b_alibi_mask,
                                                           gptoss_gemma3_mask,
+                                                          gemma4_mask,
                                                           any_input()});
 
     auto sdpa_with_4_inputs = wrap_type<v13::ScaledDotProductAttention>({q, k_to_sdpa, v_to_sdpa, mask_to_sdpa});
@@ -640,6 +659,19 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
                 offset = std::make_shared<v0::Convert>(offset, element::i32);
             }
             sliding_window = std::make_shared<v1::Multiply>(offset, v0::Constant::create(element::i32, Shape{}, {-1}));
+        } else if (pattern_map.count(gemma4_sw_const)) {
+            auto sw_node = pattern_map.at(gemma4_sw_const).get_node_shared_ptr();
+            auto const_node = ov::as_type_ptr<v0::Constant>(sw_node);
+            if (const_node && ov::shape_size(const_node->get_shape()) == 1) {
+                auto val = const_node->cast_vector<int64_t>();
+                if (!val.empty() && val[0] > 0) {
+                    sliding_window = v0::Constant::create(element::i32, Shape{}, {static_cast<int32_t>(val[0])});
+                } else {
+                    sliding_window = v0::Constant::create(element::i32, Shape{}, {0});
+                }
+            } else {
+                sliding_window = v0::Constant::create(element::i32, Shape{}, {0});
+            }
         } else {
             sliding_window = v0::Constant::create(element::i32, Shape{}, {0});
         }

--- a/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
@@ -414,8 +414,7 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
 
     // gpt-oss, gemma3 and gemma4 sliding layer cases
     std::shared_ptr<ov::Node> gptoss_gemma3_mask, gptoss_gemma3_offset, gemma4_sw_const;
-    std::tie(gptoss_gemma3_mask, gptoss_gemma3_offset, gemma4_sw_const) =
-        gptoss_gemma3_gemma4_sliding_window_pattern();
+    std::tie(gptoss_gemma3_mask, gptoss_gemma3_offset, gemma4_sw_const) = gptoss_gemma3_gemma4_sliding_window_pattern();
 
     // Scale's shape limitations according to SDPA specification
     auto scale_predicate = [=](const Output<Node>& output) -> bool {

--- a/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/state_management_pattern.cpp
@@ -222,20 +222,8 @@ static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> phi3_sli
     return {mask, offset};
 }
 
-static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> gemma4_sliding_window_pattern() {
-    // Gemma4 sliding layer mask topology:
-    // Slice(Select(_, _, Select(Unsqueeze(Unsqueeze(GreaterEqual(Subtract(_, _), sw_const))), _, _)), ...)
-    auto sw_const = wrap_type<v0::Constant>();
-    auto ge = wrap_type<v1::GreaterEqual>({any_input(), sw_const});
-    auto unsqueeze_0 = wrap_type<v0::Unsqueeze>({ge, any_input()});
-    auto unsqueeze_1 = wrap_type<v0::Unsqueeze>({unsqueeze_0, any_input()});
-    auto inner_select = wrap_type<v1::Select>({unsqueeze_1, any_input(), any_input()});
-    auto outer_select = wrap_type<v1::Select>({any_input(), any_input(), inner_select});
-    auto mask = wrap_type<v8::Slice>({outer_select, any_input(), any_input(), any_input(), any_input()});
-    return {mask, sw_const};
-}
-
-static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> gptoss_gemma3_sliding_window_pattern() {
+static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>>
+gptoss_gemma3_gemma4_sliding_window_pattern() {
     auto q_idx = any_input();
     auto kv_idx = any_input();
 
@@ -251,9 +239,18 @@ static std::tuple<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> gptoss_g
     auto bitwise_and_3 = wrap_type<v13::BitwiseAnd>({bitwise_and_2, any_input()});
     auto broadcast = wrap_type<v3::Broadcast>({bitwise_and_3, any_input()});
     auto select = wrap_type<v1::Select>({broadcast, any_input(), any_input()});
-    auto mask = pattern::optional<v8::Slice>({select, any_input(), any_input(), any_input(), any_input()});
 
-    return {mask, offset};
+    auto sw_const = wrap_type<v0::Constant>();
+    auto ge = wrap_type<v1::GreaterEqual>({any_input(), sw_const});
+    auto unsqueeze_0 = wrap_type<v0::Unsqueeze>({ge, any_input()});
+    auto unsqueeze_1 = wrap_type<v0::Unsqueeze>({unsqueeze_0, any_input()});
+    auto inner_select = wrap_type<v1::Select>({unsqueeze_1, any_input(), any_input()});
+    auto outer_select = wrap_type<v1::Select>({any_input(), any_input(), inner_select});
+
+    auto mask_input = std::make_shared<Or>(OutputVector{select, outer_select});
+    auto mask = pattern::optional<v8::Slice>({mask_input, any_input(), any_input(), any_input(), any_input()});
+
+    return {mask, offset, sw_const};
 }
 
 typedef std::
@@ -415,13 +412,10 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
     std::shared_ptr<ov::Node> phi3_mask, phi3_offset;
     std::tie(phi3_mask, phi3_offset) = phi3_sliding_window_pattern();
 
-    // gpt-oss and gemma3 cases
-    std::shared_ptr<ov::Node> gptoss_gemma3_mask, gptoss_gemma3_offset;
-    std::tie(gptoss_gemma3_mask, gptoss_gemma3_offset) = gptoss_gemma3_sliding_window_pattern();
-
-    // Gemma4 sliding layer case
-    std::shared_ptr<ov::Node> gemma4_mask, gemma4_sw_const;
-    std::tie(gemma4_mask, gemma4_sw_const) = gemma4_sliding_window_pattern();
+    // gpt-oss, gemma3 and gemma4 sliding layer cases
+    std::shared_ptr<ov::Node> gptoss_gemma3_mask, gptoss_gemma3_offset, gemma4_sw_const;
+    std::tie(gptoss_gemma3_mask, gptoss_gemma3_offset, gemma4_sw_const) =
+        gptoss_gemma3_gemma4_sliding_window_pattern();
 
     // Scale's shape limitations according to SDPA specification
     auto scale_predicate = [=](const Output<Node>& output) -> bool {
@@ -447,7 +441,6 @@ ov::pass::StateManagementPattern::StateManagementPattern(PaParams& pa_params,
                                                           jais_alibi_mask,
                                                           baichuan2_13b_alibi_mask,
                                                           gptoss_gemma3_mask,
-                                                          gemma4_mask,
                                                           any_input()});
 
     auto sdpa_with_4_inputs = wrap_type<v13::ScaledDotProductAttention>({q, k_to_sdpa, v_to_sdpa, mask_to_sdpa});

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -6365,7 +6365,7 @@ TEST(SDPAToPA, Gemma3n_SharedKVCache_TwoLayersSameReadValue) {
 TEST(SDPAToPA, SingleLayerSlidingWindow) {
     // Simplified Gemma3-270 model with a single attention layer.
     // The key part is the sliding window mask subgraph (BitwiseAnd chain)
-    // that gptoss_gemma3_sliding_window_pattern() must match to extract the window size.
+    // that gptoss_gemma3_gemma4_sliding_window_pattern() must match to extract the window size.
 
     const int num_heads = 4;
     const int head_dim = 256;
@@ -6541,7 +6541,6 @@ TEST(SDPAToPA, Gemma4_PerLayerSlidingWindow) {
     auto shape_pos = makeOP<v3::ShapeOf>({position_ids}, {{"output_type", "i64"}});
     auto batch_dim = makeOP<v8::Gather>({shape_pos, {0}, 0}, {{"batch_dims", 0}});
 
-    // Gemma4 sliding layer mask: Slice(Select(_, _, Select(Unsqueeze(Unsqueeze(GreaterEqual(Subtract, sw_const))))), ...)
     auto make_gemma4_sliding_mask = [&](std::shared_ptr<ov::Node> pos_ids, int64_t sw_size) {
         auto shape_pos = makeOP<v3::ShapeOf>({pos_ids}, {{"output_type", "i64"}});
         auto cur_len = makeOP<v8::Gather>({shape_pos, 1, 0}, {{"batch_dims", 0}});
@@ -6576,8 +6575,7 @@ TEST(SDPAToPA, Gemma4_PerLayerSlidingWindow) {
     };
 
     // Gemma4 global layer mask: Slice(Broadcast(...)) - no GreaterEqual pattern
-    auto make_gemma4_global_mask = [&](std::shared_ptr<ov::Node> pos_ids,
-                                       std::shared_ptr<ov::Node> attn_mask) {
+    auto make_gemma4_global_mask = [&](std::shared_ptr<ov::Node> pos_ids, std::shared_ptr<ov::Node> attn_mask) {
         auto shape_pos = makeOP<v3::ShapeOf>({pos_ids}, {{"output_type", "i64"}});
         auto cur_len = makeOP<v8::Gather>({shape_pos, 1, 0}, {{"batch_dims", 0}});
         auto batch = makeOP<v8::Gather>({shape_pos, {0}, 0}, {{"batch_dims", 0}});
@@ -6616,7 +6614,8 @@ TEST(SDPAToPA, Gemma4_PerLayerSlidingWindow) {
     auto [k_concat_0, k_assign_0] = make_kv_cache(K_0, "past_key_values.0.key");
     auto [v_concat_0, v_assign_0] = make_kv_cache(V_0, "past_key_values.0.value");
     auto mask_0 = make_gemma4_sliding_mask(position_ids, sliding_window_size);
-    auto sdpa_0 = makeOP<v13::ScaledDotProductAttention>({Q_0, k_concat_0, v_concat_0, mask_0, 1.0f}, {{"causal", false}});
+    auto sdpa_0 =
+        makeOP<v13::ScaledDotProductAttention>({Q_0, k_concat_0, v_concat_0, mask_0, 1.0f}, {{"causal", false}});
 
     // Layer 1: Global attention (sw=0)
     auto Q_1 = make_projection(sdpa_0, hidden_size, num_heads);
@@ -6625,13 +6624,13 @@ TEST(SDPAToPA, Gemma4_PerLayerSlidingWindow) {
     auto [k_concat_1, k_assign_1] = make_kv_cache(K_1, "past_key_values.1.key");
     auto [v_concat_1, v_assign_1] = make_kv_cache(V_1, "past_key_values.1.value");
     auto mask_1 = make_gemma4_global_mask(position_ids, attention_mask);
-    auto sdpa_1 = makeOP<v13::ScaledDotProductAttention>({Q_1, k_concat_1, v_concat_1, mask_1, 1.0f}, {{"causal", false}});
+    auto sdpa_1 =
+        makeOP<v13::ScaledDotProductAttention>({Q_1, k_concat_1, v_concat_1, mask_1, 1.0f}, {{"causal", false}});
 
     auto res = std::make_shared<v0::Result>(sdpa_1);
-    auto model = std::make_shared<ov::Model>(
-        OutputVector{res},
-        SinkVector{k_assign_0, v_assign_0, k_assign_1, v_assign_1},
-        params);
+    auto model = std::make_shared<ov::Model>(OutputVector{res},
+                                             SinkVector{k_assign_0, v_assign_0, k_assign_1, v_assign_1},
+                                             params);
 
     ov::pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::SDPAToPagedAttention>();

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -6607,6 +6607,11 @@ TEST(SDPAToPA, Gemma4_PerLayerSlidingWindow) {
         return makeOP<v1::Transpose>({reshape, {0, 2, 1, 3}});
     };
 
+    auto merge_heads_to_hidden = [&](std::shared_ptr<ov::Node> x) {
+        auto transposed = makeOP<v1::Transpose>({x, {0, 2, 1, 3}});
+        return makeOP<v1::Reshape>({transposed, {0, 0, hidden_size}}, {{"special_zero", true}});
+    };
+
     // Layer 0: Sliding window (sw=1024)
     auto Q_0 = make_projection(embeddings, hidden_size, num_heads);
     auto K_0 = make_projection(embeddings, hidden_size, num_heads);
@@ -6616,11 +6621,12 @@ TEST(SDPAToPA, Gemma4_PerLayerSlidingWindow) {
     auto mask_0 = make_gemma4_sliding_mask(position_ids, sliding_window_size);
     auto sdpa_0 =
         makeOP<v13::ScaledDotProductAttention>({Q_0, k_concat_0, v_concat_0, mask_0, 1.0f}, {{"causal", false}});
+    auto sdpa_0_hidden = merge_heads_to_hidden(sdpa_0);
 
     // Layer 1: Global attention (sw=0)
-    auto Q_1 = make_projection(sdpa_0, hidden_size, num_heads);
-    auto K_1 = make_projection(sdpa_0, hidden_size, num_heads);
-    auto V_1 = make_projection(sdpa_0, hidden_size, num_heads);
+    auto Q_1 = make_projection(sdpa_0_hidden, hidden_size, num_heads);
+    auto K_1 = make_projection(sdpa_0_hidden, hidden_size, num_heads);
+    auto V_1 = make_projection(sdpa_0_hidden, hidden_size, num_heads);
     auto [k_concat_1, k_assign_1] = make_kv_cache(K_1, "past_key_values.1.key");
     auto [v_concat_1, v_assign_1] = make_kv_cache(V_1, "past_key_values.1.value");
     auto mask_1 = make_gemma4_global_mask(position_ids, attention_mask);

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -6365,7 +6365,7 @@ TEST(SDPAToPA, Gemma3n_SharedKVCache_TwoLayersSameReadValue) {
 TEST(SDPAToPA, SingleLayerSlidingWindow) {
     // Simplified Gemma3-270 model with a single attention layer.
     // The key part is the sliding window mask subgraph (BitwiseAnd chain)
-    // that gptoss_gemma3_gemma4_sliding_window_pattern() must match to extract the window size.
+    // that gptoss_gemma3_sliding_window_pattern() must match to extract the window size.
 
     const int num_heads = 4;
     const int head_dim = 256;

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -6520,6 +6520,144 @@ TEST(SDPAToPA, SingleLayerSlidingWindow) {
     EXPECT_EQ(offset_node->cast_vector<int64_t>()[0], sliding_window_offset);
 }
 
+TEST(SDPAToPA, Gemma4_PerLayerSlidingWindow) {
+    // Gemma4 model with 2 layers: one sliding (sw=1024), one global (sw=0).
+    // Verifies that gemma4_sliding_window_pattern() correctly extracts per-layer sliding window values.
+
+    const int num_heads = 4;
+    const int head_dim = 128;
+    const int hidden_size = num_heads * head_dim;
+    const int64_t sliding_window_size = 1024;
+
+    auto input_ids = make_param(PartialShape{DYN, DYN}, element::i64, "input_ids");
+    auto attention_mask = make_param(PartialShape{DYN, DYN}, element::i64, "attention_mask");
+    auto position_ids = make_param(PartialShape{DYN, DYN}, element::i64, "position_ids");
+    auto beam_idx = make_param(PartialShape{DYN}, element::i32, "beam_idx");
+    auto params = nodes_to_params({input_ids, attention_mask, position_ids, beam_idx});
+
+    auto embed_weight = makeConst(element::f32, ov::Shape{32000, (size_t)hidden_size}, MOCK_VALUE);
+    auto embeddings = makeOP<v8::Gather>({embed_weight, input_ids, 0}, {{"batch_dims", 0}});
+
+    auto shape_pos = makeOP<v3::ShapeOf>({position_ids}, {{"output_type", "i64"}});
+    auto batch_dim = makeOP<v8::Gather>({shape_pos, {0}, 0}, {{"batch_dims", 0}});
+
+    // Gemma4 sliding layer mask: Slice(Select(_, _, Select(Unsqueeze(Unsqueeze(GreaterEqual(Subtract, sw_const))))), ...)
+    auto make_gemma4_sliding_mask = [&](std::shared_ptr<ov::Node> pos_ids, int64_t sw_size) {
+        auto shape_pos = makeOP<v3::ShapeOf>({pos_ids}, {{"output_type", "i64"}});
+        auto cur_len = makeOP<v8::Gather>({shape_pos, 1, 0}, {{"batch_dims", 0}});
+
+        // q_idx and kv_idx ranges
+        auto q_range = makeOP<v4::Range>({0, cur_len, 1}, {{"output_type", "i64"}});
+        auto q_unsq = makeOP<v0::Unsqueeze>({q_range, 1});
+        auto kv_range = makeOP<v4::Range>({0, cur_len, 1}, {{"output_type", "i64"}});
+        auto kv_unsq = makeOP<v0::Unsqueeze>({kv_range, 0});
+
+        // distance = q_idx - kv_idx
+        auto subtract = makeOP<v1::Subtract>({q_unsq, kv_unsq}, {numpy_broadcast});
+
+        // GreaterEqual(distance, sw_const) -> true where distance >= sw (out of window)
+        auto sw_const = makeConst(element::i64, ov::Shape({}), {sw_size});
+        auto ge = makeOP<v1::GreaterEqual>({subtract, sw_const}, {numpy_broadcast});
+
+        // Unsqueeze twice to get [1, 1, seq, seq] shape
+        auto unsq_0 = makeOP<v0::Unsqueeze>({ge, 0});
+        auto unsq_1 = makeOP<v0::Unsqueeze>({unsq_0, 0});
+
+        // inner Select: where(ge, -inf, 0) -> mask out tokens outside window
+        auto inner_select = makeOP<v1::Select>({unsq_1, -65504.0f, 0.0f}, {numpy_broadcast});
+
+        // outer Select: combine with causal mask
+        auto causal = makeConst(element::boolean, ov::Shape({}), {1});
+        auto outer_select = makeOP<v1::Select>({causal, 0.0f, inner_select}, {numpy_broadcast});
+
+        // Slice (identity slice to match pattern)
+        auto cur_len_unsq = makeOP<v0::Unsqueeze>({cur_len, 0});
+        return makeOP<v8::Slice>({outer_select, {0}, cur_len_unsq, {1}, {3}});
+    };
+
+    // Gemma4 global layer mask: Slice(Broadcast(...)) - no GreaterEqual pattern
+    auto make_gemma4_global_mask = [&](std::shared_ptr<ov::Node> pos_ids,
+                                       std::shared_ptr<ov::Node> attn_mask) {
+        auto shape_pos = makeOP<v3::ShapeOf>({pos_ids}, {{"output_type", "i64"}});
+        auto cur_len = makeOP<v8::Gather>({shape_pos, 1, 0}, {{"batch_dims", 0}});
+        auto batch = makeOP<v8::Gather>({shape_pos, {0}, 0}, {{"batch_dims", 0}});
+
+        auto attn_bool = makeOP<v0::Convert>({attn_mask}, {{"destination_type", "boolean"}});
+        auto cur_len_unsq = makeOP<v0::Unsqueeze>({cur_len, 0});
+        auto bcast_shape = makeOP<v0::Concat>({batch, {1l}, cur_len_unsq, cur_len_unsq}, {{"axis", 0}});
+        auto bcast = makeOP<v3::Broadcast>({attn_bool, bcast_shape}, {{"mode", "bidirectional"}});
+        return makeOP<v8::Slice>({bcast, {0}, cur_len_unsq, {1}, {3}});
+    };
+
+    auto make_kv_cache = [&](std::shared_ptr<ov::Node> cur, const std::string& var_id) {
+        auto var = std::make_shared<ov::op::util::Variable>(
+            ov::op::util::VariableInfo{ov::PartialShape{DYN, num_heads, DYN, head_dim}, ov::element::f32, var_id});
+        auto init_shape =
+            makeOP<v0::Concat>({batch_dim, {(int64_t)num_heads}, {0l}, {(int64_t)head_dim}}, {{"axis", 0}});
+        auto init = makeOP<v3::Broadcast>({0.0f, init_shape}, {{"mode", "numpy"}});
+        std::shared_ptr<ov::Node> read = std::make_shared<v6::ReadValue>(init, var);
+        auto past = makeOP<v8::Gather>({read, beam_idx, 0}, {{"batch_dims", 0}});
+        auto concat = makeOP<v0::Concat>({past, cur}, {{"axis", -2}});
+        auto assign = std::make_shared<v6::Assign>(concat, var);
+        return std::make_pair(concat, assign);
+    };
+
+    auto make_projection = [&](std::shared_ptr<ov::Node> input, int out_size, int heads) {
+        auto weight = makeConst(element::f32, ov::Shape({(size_t)out_size, (size_t)hidden_size}), MOCK_VALUE);
+        auto matmul = makeOP<v0::MatMul>({input, weight}, {{"transpose_a", false}, {"transpose_b", true}});
+        auto reshape = makeOP<v1::Reshape>({matmul, {0, 0, heads, head_dim}}, {{"special_zero", true}});
+        return makeOP<v1::Transpose>({reshape, {0, 2, 1, 3}});
+    };
+
+    // Layer 0: Sliding window (sw=1024)
+    auto Q_0 = make_projection(embeddings, hidden_size, num_heads);
+    auto K_0 = make_projection(embeddings, hidden_size, num_heads);
+    auto V_0 = make_projection(embeddings, hidden_size, num_heads);
+    auto [k_concat_0, k_assign_0] = make_kv_cache(K_0, "past_key_values.0.key");
+    auto [v_concat_0, v_assign_0] = make_kv_cache(V_0, "past_key_values.0.value");
+    auto mask_0 = make_gemma4_sliding_mask(position_ids, sliding_window_size);
+    auto sdpa_0 = makeOP<v13::ScaledDotProductAttention>({Q_0, k_concat_0, v_concat_0, mask_0, 1.0f}, {{"causal", false}});
+
+    // Layer 1: Global attention (sw=0)
+    auto Q_1 = make_projection(sdpa_0, hidden_size, num_heads);
+    auto K_1 = make_projection(sdpa_0, hidden_size, num_heads);
+    auto V_1 = make_projection(sdpa_0, hidden_size, num_heads);
+    auto [k_concat_1, k_assign_1] = make_kv_cache(K_1, "past_key_values.1.key");
+    auto [v_concat_1, v_assign_1] = make_kv_cache(V_1, "past_key_values.1.value");
+    auto mask_1 = make_gemma4_global_mask(position_ids, attention_mask);
+    auto sdpa_1 = makeOP<v13::ScaledDotProductAttention>({Q_1, k_concat_1, v_concat_1, mask_1, 1.0f}, {{"causal", false}});
+
+    auto res = std::make_shared<v0::Result>(sdpa_1);
+    auto model = std::make_shared<ov::Model>(
+        OutputVector{res},
+        SinkVector{k_assign_0, v_assign_0, k_assign_1, v_assign_1},
+        params);
+
+    ov::pass::Manager pass_manager;
+    pass_manager.register_pass<ov::pass::SDPAToPagedAttention>();
+    pass_manager.run_passes(model);
+
+    // Find all PagedAttention nodes
+    std::vector<std::shared_ptr<ov::op::PagedAttentionExtension>> pa_nodes;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (auto node = ov::as_type_ptr<ov::op::PagedAttentionExtension>(op)) {
+            pa_nodes.push_back(node);
+        }
+    }
+    ASSERT_EQ(pa_nodes.size(), 2u) << "Expected 2 PA nodes (sliding + global)";
+
+    // PA input port 10 is sliding_window
+    // Layer 0 (sliding): should be Constant(1024)
+    auto sw_0 = ov::as_type_ptr<v0::Constant>(pa_nodes[0]->input_value(10).get_node_shared_ptr());
+    ASSERT_NE(sw_0, nullptr) << "Layer 0 sliding_window should be a Constant";
+    EXPECT_EQ(sw_0->cast_vector<int32_t>()[0], (int32_t)sliding_window_size);
+
+    // Layer 1 (global): should be Constant(0)
+    auto sw_1 = ov::as_type_ptr<v0::Constant>(pa_nodes[1]->input_value(10).get_node_shared_ptr());
+    ASSERT_NE(sw_1, nullptr) << "Layer 1 sliding_window should be a Constant";
+    EXPECT_EQ(sw_1->cast_vector<int32_t>()[0], 0);
+}
+
 TEST_F(SDPAToPATest, SDPAToPA_LFM2_EliminateConvPaddingMaskGating) {
     {
         auto attention_mask = make_param(PartialShape{DYN, DYN}, element::i32, "attention_mask");

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -6652,10 +6652,19 @@ TEST(SDPAToPA, Gemma4_PerLayerSlidingWindow) {
     ASSERT_EQ(pa_nodes.size(), 2u) << "Expected 2 PA nodes (sliding + global)";
 
     // PA input port 10 is sliding_window
-    // Layer 0 (sliding): should be Constant(1024)
-    auto sw_0 = ov::as_type_ptr<v0::Constant>(pa_nodes[0]->input_value(10).get_node_shared_ptr());
-    ASSERT_NE(sw_0, nullptr) << "Layer 0 sliding_window should be a Constant";
-    EXPECT_EQ(sw_0->cast_vector<int32_t>()[0], (int32_t)sliding_window_size);
+    // Layer 0 (sliding): Trace through Convert -> Squeeze -> original Constant
+    auto trace_to_const = [](const ov::Output<ov::Node>& output) -> std::shared_ptr<v0::Constant> {
+        auto node = output.get_node_shared_ptr();
+        if (ov::as_type_ptr<v0::Convert>(node))
+            node = node->input_value(0).get_node_shared_ptr();
+        if (ov::as_type_ptr<v15::Squeeze>(node))
+            node = node->input_value(0).get_node_shared_ptr();
+        return ov::as_type_ptr<v0::Constant>(node);
+    };
+
+    auto sw_0 = trace_to_const(pa_nodes[0]->input_value(10));
+    ASSERT_NE(sw_0, nullptr) << "Layer 0 sliding_window should trace to a Constant";
+    EXPECT_EQ(sw_0->cast_vector<int64_t>()[0], sliding_window_size);
 
     // Layer 1 (global): should be Constant(0)
     auto sw_1 = ov::as_type_ptr<v0::Constant>(pa_nodes[1]->input_value(10).get_node_shared_ptr());

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -272,6 +272,8 @@ JitConstants make_uint4_kv_cache_jit_constants(const kernel_impl_params& params)
         jit.make("PACKED_V_HEAD_SIZE", (kernel_selector::Align(desc->v_head_size / u4_elems_per_byte, subgroup_size)));
         jit.make("PACKED_ADJUSTED_V_HEAD_SIZE", (kernel_selector::Align(desc->v_head_size / u4_elems_per_byte, subgroup_size)) + scales_zp_size);
 
+        // Dual-nibble V-cache optimization: each lane reads 1 packed byte (2 nibbles) via BLOCK_READN
+        // Only applicable when PACKED_V_HEAD_SIZE is divisible by SUBGROUP_SIZE (no padding lanes needed)
         if (is_v_head_aligned_for_dual_nibble(desc->v_head_size)) {
             jit.make("USE_DUAL_NIBBLE_V_OPT", 1);
         }
@@ -1496,6 +1498,9 @@ public:
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
         rt_params->use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(rt_params->stage);
+        if (desc->has_token_type_ids && rt_params->stage != PagedAttentionStage::PREFILL) {
+            rt_params->use_micro_sdpa = false;
+        }
 #else
         rt_params->use_micro_sdpa = false;
 #endif
@@ -1678,6 +1683,10 @@ public:
         } else {
             can_use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(stage);
             if (stage == PagedAttentionStage::GENERATE) {
+                can_use_micro_sdpa = false;
+            }
+            const auto desc = params.typed_desc<paged_attention>();
+            if (desc->has_token_type_ids && stage != PagedAttentionStage::PREFILL) {
                 can_use_micro_sdpa = false;
             }
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -272,8 +272,6 @@ JitConstants make_uint4_kv_cache_jit_constants(const kernel_impl_params& params)
         jit.make("PACKED_V_HEAD_SIZE", (kernel_selector::Align(desc->v_head_size / u4_elems_per_byte, subgroup_size)));
         jit.make("PACKED_ADJUSTED_V_HEAD_SIZE", (kernel_selector::Align(desc->v_head_size / u4_elems_per_byte, subgroup_size)) + scales_zp_size);
 
-        // Dual-nibble V-cache optimization: each lane reads 1 packed byte (2 nibbles) via BLOCK_READN
-        // Only applicable when PACKED_V_HEAD_SIZE is divisible by SUBGROUP_SIZE (no padding lanes needed)
         if (is_v_head_aligned_for_dual_nibble(desc->v_head_size)) {
             jit.make("USE_DUAL_NIBBLE_V_OPT", 1);
         }
@@ -1497,7 +1495,7 @@ public:
         }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-        rt_params->use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(rt_params->stage) && desc->has_token_type_ids == false;
+        rt_params->use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(rt_params->stage);
 #else
         rt_params->use_micro_sdpa = false;
 #endif
@@ -1678,7 +1676,7 @@ public:
         if (rt_params != nullptr && rt_params->num_of_partitions != 0) {
             can_use_micro_sdpa = rt_params->use_micro_sdpa;
         } else {
-            can_use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(stage) && desc->has_token_type_ids == false;
+            can_use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(stage);
             if (stage == PagedAttentionStage::GENERATE) {
                 can_use_micro_sdpa = false;
             }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1685,7 +1685,6 @@ public:
             if (stage == PagedAttentionStage::GENERATE) {
                 can_use_micro_sdpa = false;
             }
-            const auto desc = params.typed_desc<paged_attention>();
             if (desc->has_token_type_ids && stage != PagedAttentionStage::PREFILL) {
                 can_use_micro_sdpa = false;
             }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1384,6 +1384,15 @@ public:
         return false;
     }
 
+    bool can_use_micro_sdpa_for(const kernel_impl_params& params, const PagedAttentionStage& stage) const {
+        if (!supports_micro_sdpa(params) || !valid_micro_stage(stage))
+            return false;
+        const auto desc = params.typed_desc<paged_attention>();
+        if (desc->has_token_type_ids && stage != PagedAttentionStage::PREFILL)
+            return false;
+        return true;
+    }
+
     bool supports_micro_sdpa(const kernel_impl_params& params) const {
         auto& engine = params.get_program().get_engine();
         const auto desc = params.typed_desc<paged_attention>();
@@ -1497,10 +1506,7 @@ public:
         }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-        rt_params->use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(rt_params->stage);
-        if (desc->has_token_type_ids && rt_params->stage != PagedAttentionStage::PREFILL) {
-            rt_params->use_micro_sdpa = false;
-        }
+        rt_params->use_micro_sdpa = can_use_micro_sdpa_for(params, rt_params->stage);
 #else
         rt_params->use_micro_sdpa = false;
 #endif
@@ -1508,7 +1514,6 @@ public:
         rt_params->query_block_size = get_query_block_size(rt_params->stage, rt_params->use_micro_sdpa);
 
         if (rt_params->stage == PagedAttentionStage::GENERATE) {
-            rt_params->use_micro_sdpa = false;
             if (desc->has_sink_input) {
                 rt_params->use_gqa_kernel = false;
             } else {
@@ -1681,13 +1686,7 @@ public:
         if (rt_params != nullptr && rt_params->num_of_partitions != 0) {
             can_use_micro_sdpa = rt_params->use_micro_sdpa;
         } else {
-            can_use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(stage);
-            if (stage == PagedAttentionStage::GENERATE) {
-                can_use_micro_sdpa = false;
-            }
-            if (desc->has_token_type_ids && stage != PagedAttentionStage::PREFILL) {
-                can_use_micro_sdpa = false;
-            }
+            can_use_micro_sdpa = can_use_micro_sdpa_for(params, stage);
         }
 #endif
         GPU_DEBUG_TRACE_DETAIL << "get_internal_buffer_descs: stage = " << static_cast<size_t>(stage) << std::endl;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1074,6 +1074,10 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
     } else {
         jit.make("WITH_ATTN_MASK", 0);
         jit.make("PAGED_ATTENTION_BLOCK_SIZE", config.paged_attention_block_size);
+        const auto desc = params.typed_desc<paged_attention>();
+        if (desc->has_token_type_ids && m_is_prefill) {
+            jit.make("HAS_TOKEN_TYPE_IDS", 1);
+        }
     }
 
     if (config.has_const_scale_val) {
@@ -1362,6 +1366,10 @@ Arguments SDPAMicroGenerator::get_arguments_desc(const kernel_impl_params& param
             args.push_back({ArgumentDescriptor::Types::INPUT, PagedAttentionInputIdx::QQ_BIAS});  // qq_bias
             args.push_back(
                 {ArgumentDescriptor::Types::INPUT, PagedAttentionInputIdx::QQ_BIAS_BEGINS});  // qq_bias_begins                              // qq_bias_num
+        }
+
+        if (desc->has_token_type_ids && m_is_prefill) {
+            args.push_back({ArgumentDescriptor::Types::INPUT, PagedAttentionInputIdx::TOKEN_TYPE_IDS});  // token_type_ids
         }
 
         args.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 3});  // blocked_indexes_start_and_gws_mapping

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
@@ -234,15 +234,21 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     #if HAS_TOKEN_TYPE_IDS && IS_PAGED_ATTENTION && IS_PREFILL
     /* Extend causal_k to cover the full bidirectional group that overlaps
        the current WG's query range. Without this, future K positions in
-       the same image-token group would be skipped entirely. */
+       the same image-token group would be skipped entirely.
+       Only lane 0 performs the scan; result is broadcast to all WIs. */
     {
         int wg_q_end = min((int)wg_j0 + ugemm_kq_wg_tile_n, k) - 1;
+        int bidir_causal_k = causal_k;
         if (wg_q_end >= 0 && wg_q_end < k && token_type_ids[wg_q_end] == 1) {
             int bidir_end = wg_q_end + 1;
-            while (bidir_end < k && token_type_ids[bidir_end] == 1)
-                bidir_end++;
-            causal_k = max(causal_k, bidir_end);
+            if (get_sub_group_local_id() == 0) {
+                while (bidir_end < k && token_type_ids[bidir_end] == 1)
+                    bidir_end++;
+            }
+            bidir_end = sub_group_broadcast(bidir_end, 0);
+            bidir_causal_k = max(causal_k, bidir_end);
         }
+        causal_k = bidir_causal_k;
     }
     #endif
 #endif
@@ -260,11 +266,15 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     #if HAS_TOKEN_TYPE_IDS && IS_PAGED_ATTENTION && IS_PREFILL
     /* Extend sliding window start to include the full bidirectional group
        that overlaps the window boundary. Without this, K positions in the
-       same image-token group but before window_k_begin would be skipped. */
+       same image-token group but before window_k_begin would be skipped.
+       Only lane 0 performs the scan; result is broadcast to all WIs. */
     if (window_k_begin > 0 && token_type_ids[window_k_begin] == 1) {
-        while (window_k_begin > 0 && token_type_ids[window_k_begin - 1] == 1) {
-            window_k_begin--;
+        int wb = window_k_begin;
+        if (get_sub_group_local_id() == 0) {
+            while (wb > 0 && token_type_ids[wb - 1] == 1)
+                wb--;
         }
+        window_k_begin = sub_group_broadcast(wb, 0);
     }
     #endif
     window_k0_begin = (window_k_begin / ugemm_kq_wg_tile_m) * ugemm_kq_wg_tile_m;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
@@ -168,6 +168,9 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         const global QQ_BIAS_DATA_T *qq_bias,
         const global QQ_BIAS_BEGINS_DATA_T *qq_bias_begins,
 #endif
+#if HAS_TOKEN_TYPE_IDS
+        const __global int* token_type_ids,
+#endif
 #if IS_PAGED_ATTENTION
         const __global int* blocked_indexes_start_and_gws_mapping
 #else
@@ -697,6 +700,28 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         #endif
     #endif
 
+    #if HAS_TOKEN_TYPE_IDS && IS_PAGED_ATTENTION && IS_PREFILL
+        /* Apply causal mask with bidirectional exception for image tokens */
+        {
+            const int k_base = k0 + sg_i0_kq;
+            for (int j = 0; j < (ugemm_kq_c_type_block1 * ugemm_kq_c_type_nblock1); j++) {
+                const int offset_k = k_base + j;
+                for (int i0 = 0; i0 < (ugemm_kq_c_type_block0 * ugemm_kq_c_type_nblock0); i0 += SUBGROUP_SIZE) {
+                    int i = i0 + get_sub_group_local_id();
+                    const int offset_q = col_offset + i;
+                    if (greater_than(offset_k, offset_q)) {
+                        bool is_bidirectional = (offset_k < q && offset_q < q &&
+                                                 token_type_ids[offset_k] == 1 &&
+                                                 token_type_ids[offset_q] == 1);
+                        if (!is_bidirectional) {
+                            tile_access(S_tile, i0, j, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
+                                        ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0) = -FLT_MAX;
+                        }
+                    }
+                }
+            }
+        }
+    #else
         /* Apply causal mask */
         const int causal_k_begin = k0 + sg_i0_kq;
         const int causal_k_end = causal_k_begin

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
@@ -231,6 +231,20 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     #else
         causal_k = min(k, (int)wg_j0 + ugemm_kq_wg_tile_n);
     #endif
+    #if HAS_TOKEN_TYPE_IDS && IS_PAGED_ATTENTION && IS_PREFILL
+    /* Extend causal_k to cover the full bidirectional group that overlaps
+       the current WG's query range. Without this, future K positions in
+       the same image-token group would be skipped entirely. */
+    {
+        int wg_q_end = min((int)wg_j0 + ugemm_kq_wg_tile_n, k) - 1;
+        if (wg_q_end >= 0 && wg_q_end < k && token_type_ids[wg_q_end] == 1) {
+            int bidir_end = wg_q_end + 1;
+            while (bidir_end < k && token_type_ids[bidir_end] == 1)
+                bidir_end++;
+            causal_k = max(causal_k, bidir_end);
+        }
+    }
+    #endif
 #endif
 
     int window_k_begin = 0;
@@ -242,6 +256,16 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         window_k_begin = MAX(0, past_len + (int)wg_j0 - SLIDING_WINDOW_SIZE + 1);
     #else
         window_k_begin = MAX(0, (int)wg_j0 - SLIDING_WINDOW_SIZE + 1);
+    #endif
+    #if HAS_TOKEN_TYPE_IDS && IS_PAGED_ATTENTION && IS_PREFILL
+    /* Extend sliding window start to include the full bidirectional group
+       that overlaps the window boundary. Without this, K positions in the
+       same image-token group but before window_k_begin would be skipped. */
+    if (window_k_begin > 0 && token_type_ids[window_k_begin] == 1) {
+        while (window_k_begin > 0 && token_type_ids[window_k_begin - 1] == 1) {
+            window_k_begin--;
+        }
+    }
     #endif
     window_k0_begin = (window_k_begin / ugemm_kq_wg_tile_m) * ugemm_kq_wg_tile_m;
 #endif
@@ -701,7 +725,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     #endif
 
     #if HAS_TOKEN_TYPE_IDS && IS_PAGED_ATTENTION && IS_PREFILL
-        /* Apply causal mask with bidirectional exception for image tokens */
+        /* Apply causal mask with bidirectional for image tokens */
         {
             const int k_base = k0 + sg_i0_kq;
             for (int j = 0; j < (ugemm_kq_c_type_block1 * ugemm_kq_c_type_nblock1); j++) {
@@ -710,9 +734,24 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
                     int i = i0 + get_sub_group_local_id();
                     const int offset_q = col_offset + i;
                     if (greater_than(offset_k, offset_q)) {
-                        bool is_bidirectional = (offset_k < q && offset_q < q &&
-                                                 token_type_ids[offset_k] == 1 &&
-                                                 token_type_ids[offset_q] == 1);
+                        bool is_bidirectional = false;
+                        if (offset_k < q && offset_q < q &&
+                            token_type_ids[offset_k] == 1 &&
+                            token_type_ids[offset_q] == 1) {
+                            /* Verify no 0 exists between q and k (same 1-group).
+                               Scan from the smaller to the larger index so this
+                               works both for future tokens (k>q) and for past
+                               tokens outside the sliding window (k<q). */
+                            is_bidirectional = true;
+                            const int scan_begin = min(offset_q, offset_k) + 1;
+                            const int scan_end = max(offset_q, offset_k);
+                            for (int p = scan_begin; p < scan_end; p++) {
+                                if (token_type_ids[p] != 1) {
+                                    is_bidirectional = false;
+                                    break;
+                                }
+                            }
+                        }
                         if (!is_bidirectional) {
                             tile_access(S_tile, i0, j, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
                                         ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0) = -FLT_MAX;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
@@ -745,6 +745,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     #else
         }
     #endif
+    #endif
 #endif
 
 #if HAS_QQ_BIAS && IS_PAGED_ATTENTION && (IS_PREFILL == 0)

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.h
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.h
@@ -1822,6 +1822,7 @@ public:
     struct gpu_outputs {
         std::map<cldnn::primitive_id, cldnn::network_output> outputs;
         cldnn::memory::ptr key_cache_mem;
+        cldnn::network::ptr network;
     };
 
     gpu_outputs run_gpu_inference(PagedAttentionManager& pam, T& p) {
@@ -2170,6 +2171,7 @@ public:
         last_block_indices_begins = pam.block_indices_begins;
 
         result.outputs = network->execute();
+        result.network = network;
 
         last_output_data_mem = result.outputs.at("output_data").get_memory();
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
@@ -110,8 +110,23 @@ TEST_P(paged_attention_token_type_micro_sdpa_prefill_test, prefill_only) {
     ASSERT_TRUE(this->pam.has_value());
     auto& pam = *this->pam;
 
-    apply_token_type_test_data(pam, p, p.token_type_test_data);
+    // Run opt path (FA_V2 disabled) to get reference output
+    auto p_ref = p;
+    p_ref.disable_flashattn_v2 = DISABLE_FA_V2;
+    apply_token_type_test_data(pam, p_ref, p_ref.token_type_test_data);
+    auto ref_result = run_gpu_inference(pam, p_ref);
+    cldnn::memory::ptr ref_output_mem = ref_result.outputs.at("output_data").get_memory();
+    ASSERT_TRUE(ref_output_mem);
+    std::vector<float> ref_output(ref_output_mem->count());
+    {
+        cldnn::mem_lock<ov::float16, cldnn::mem_lock_type::read> ref_ptr(ref_output_mem, tests::get_test_stream());
+        for (size_t i = 0; i < ref_output.size(); i++) {
+            ref_output[i] = static_cast<float>(ref_ptr[i]);
+        }
+    }
 
+    // Run micro SDPA path (FA_V2 enabled)
+    apply_token_type_test_data(pam, p, p.token_type_test_data);
     auto result = run_gpu_inference(pam, p);
 
     // Verify micro SDPA kernel was actually executed
@@ -123,8 +138,9 @@ TEST_P(paged_attention_token_type_micro_sdpa_prefill_test, prefill_only) {
     EXPECT_TRUE(dump_info.get_entries().find("sdpa_micro") != std::string::npos)
         << "Expected micro SDPA kernel for PREFILL with token_type_ids, got: " << dump_info.get_entries();
 
+    // Compare micro SDPA output against opt path reference
     cldnn::memory::ptr output_data_mem = result.outputs.at("output_data").get_memory();
-    compare_token_type_output(output_data_mem, p.token_type_test_data.expectedOutput);
+    compare_token_type_output(output_data_mem, ref_output);
 }
 
 static std::vector<paged_attention_token_type_test_params> make_micro_sdpa_prefill_test_params() {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
@@ -105,6 +105,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_paged_attention_token_type,
 class paged_attention_token_type_micro_sdpa_prefill_test : public paged_attention_token_type_test {};
 
 TEST_P(paged_attention_token_type_micro_sdpa_prefill_test, prefill_only) {
+    auto& engine = tests::get_test_engine();
+    if (!engine.get_device_info().supports_immad)
+        GTEST_SKIP() << "Micro SDPA requires DPAS/XMX support";
+
     auto p = GetParam();
 
     ASSERT_TRUE(this->pam.has_value());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
@@ -34,6 +34,7 @@ public:
         ASSERT_EQ(data_output_mem->count(), expected_output.size());
         cldnn::mem_lock<ov::float16, cldnn::mem_lock_type::read> mem_ptr(data_output_mem, tests::get_test_stream());
         constexpr float token_type_tolerance = 1e-2f;
+
         for (size_t i = 0; i < data_output_mem->count(); i++) {
             ASSERT_NEAR(static_cast<float>(mem_ptr[i]), expected_output[i], token_type_tolerance) << " at index=" << i;
         }
@@ -114,22 +115,7 @@ TEST_P(paged_attention_token_type_micro_sdpa_prefill_test, prefill_only) {
     ASSERT_TRUE(this->pam.has_value());
     auto& pam = *this->pam;
 
-    // Run opt path (FA_V2 disabled) to get reference output
-    auto p_ref = p;
-    p_ref.disable_flashattn_v2 = DISABLE_FA_V2;
-    apply_token_type_test_data(pam, p_ref, p_ref.token_type_test_data);
-    auto ref_result = run_gpu_inference(pam, p_ref);
-    cldnn::memory::ptr ref_output_mem = ref_result.outputs.at("output_data").get_memory();
-    ASSERT_TRUE(ref_output_mem);
-    std::vector<float> ref_output(ref_output_mem->count());
-    {
-        cldnn::mem_lock<ov::float16, cldnn::mem_lock_type::read> ref_ptr(ref_output_mem, tests::get_test_stream());
-        for (size_t i = 0; i < ref_output.size(); i++) {
-            ref_output[i] = static_cast<float>(ref_ptr[i]);
-        }
-    }
-
-    // Run micro SDPA path (FA_V2 enabled)
+    // Run micro SDPA path
     apply_token_type_test_data(pam, p, p.token_type_test_data);
     auto result = run_gpu_inference(pam, p);
 
@@ -142,9 +128,9 @@ TEST_P(paged_attention_token_type_micro_sdpa_prefill_test, prefill_only) {
     EXPECT_TRUE(dump_info.get_entries().find("sdpa_micro") != std::string::npos)
         << "Expected micro SDPA kernel for PREFILL with token_type_ids, got: " << dump_info.get_entries();
 
-    // Compare micro SDPA output against opt path reference
+    // Compare micro SDPA output against golden data
     cldnn::memory::ptr output_data_mem = result.outputs.at("output_data").get_memory();
-    compare_token_type_output(output_data_mem, ref_output);
+    compare_token_type_output(output_data_mem, p.token_type_test_data.expectedOutput);
 }
 
 static std::vector<paged_attention_token_type_test_params> make_micro_sdpa_prefill_test_params() {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
@@ -98,3 +98,51 @@ INSTANTIATE_TEST_SUITE_P(smoke_paged_attention_token_type,
                          paged_attention_token_type_test,
                          ::testing::ValuesIn(make_token_type_test_params(test::PagedAttentionTokenTypeTestData::GetTestData())),
                          get_token_type_test_name);
+
+#ifdef ENABLE_ONEDNN_FOR_GPU
+// Verify that micro SDPA is used for PREFILL when token_type_ids is present,
+// and produces correct results with bidirectional mask.
+class paged_attention_token_type_micro_sdpa_prefill_test : public paged_attention_token_type_test {};
+
+TEST_P(paged_attention_token_type_micro_sdpa_prefill_test, prefill_only) {
+    auto p = GetParam();
+
+    ASSERT_TRUE(this->pam.has_value());
+    auto& pam = *this->pam;
+
+    apply_token_type_test_data(pam, p, p.token_type_test_data);
+
+    auto result = run_gpu_inference(pam, p);
+
+    // Verify micro SDPA kernel was actually executed
+    auto pa_inst = result.network->get_primitive("paged_attention");
+    ASSERT_NE(pa_inst, nullptr);
+    auto* impl = pa_inst->get_impl();
+    ASSERT_NE(impl, nullptr);
+    auto dump_info = impl->get_kernels_dump_info(*pa_inst->get_impl_params());
+    EXPECT_TRUE(dump_info.get_entries().find("sdpa_micro") != std::string::npos)
+        << "Expected micro SDPA kernel for PREFILL with token_type_ids, got: " << dump_info.get_entries();
+
+    cldnn::memory::ptr output_data_mem = result.outputs.at("output_data").get_memory();
+    compare_token_type_output(output_data_mem, p.token_type_test_data.expectedOutput);
+}
+
+static std::vector<paged_attention_token_type_test_params> make_micro_sdpa_prefill_test_params() {
+    auto test_data = test::PagedAttentionTokenTypeTestData::GetTestData();
+    std::vector<paged_attention_token_type_test_params> params;
+    for (const auto& data : test_data) {
+        params.push_back(make_token_type_test_param(data, ENABLE_FA_V2));
+    }
+    return params;
+}
+
+static std::string get_micro_sdpa_prefill_test_name(const testing::TestParamInfo<paged_attention_token_type_test_params>& obj) {
+    const auto& p = obj.param;
+    return p.token_type_test_data.name + "_SW" + std::to_string(p.sliding_window_size) + "_MicroSDPA_Prefill";
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_paged_attention_token_type_micro_sdpa_prefill,
+                         paged_attention_token_type_micro_sdpa_prefill_test,
+                         ::testing::ValuesIn(make_micro_sdpa_prefill_test_params()),
+                         get_micro_sdpa_prefill_test_name);
+#endif


### PR DESCRIPTION
### Summary:
 - Gemma4 prefill path support for bidirectional attention in DPAS flow
 - Transformer pattern updates for Gemma4 sliding-window topology handling

#### Gemma4 prefill path support for bidirectional attention in DPAS flow
- Gemma4 prefill has bidirectional token cases not fully handled by the DPAS masking path.
- Added/adjusted prefill masking logic so bidirectional token pairs are handled correctly while preserving the existing causal fallback behavior.
#### Transformer pattern updates for Gemma4 sliding-window topology handling
- Gemma4 had no dedicated match pattern in the SDPA-to-PagedAttention transformation path.
Because of this gap, the conversion could unexpectedly set the sliding-window size to 0, which led to incorrect outputs for prompts longer than 1K tokens.
- The issue was reproducible in benchmark runs on both CPU and GPU, so this change adds Gemma4 sliding-window pattern support in the shared matcher flow.
#### Reproducer
```
(hbenv) hyunback@PTLH-02 C:\dev\hyunback\openvino.genai2>python ./tools/llm_bench/benchmark.py -m C:\dev\models\ov-share-13.sclab.intel.com\WW24_llm-optimum_2026.3.0-22130\gemma-4-26b-a4b-it\pytorch\ov\OV_FP16-4BIT_DEFAULT -d GPU --task visual_text_gen -ic 128 -n 3 -pf C:\dev\hyunback\frameworks.ai.openvino.llm.prompts\32_1024\gemma-4-26b-a4b-it.jsonl -lc config_pa.json --cb_config cb_config2.json -pi 1
(hbenv) hyunback@PTLH-02 C:\dev\hyunback\openvino.genai2>type config_pa.json
{
    "ATTENTION_BACKEND": "PA",
    "CACHE_DIR": ""
}
(hbenv) hyunback@PTLH-02 C:\dev\hyunback\openvino.genai2>type cb_config2.json
{"enable_prefix_caching": false, "max_num_batched_tokens": 1048576}
```


### Tickets:
 - *CVS-189466 , CVS-190366*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
