### PR TITLE
[GPU] Guard native format-selection logic against dynamic shapes

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -532,6 +532,9 @@ bool should_use_winograd_2x3_s1(const convolution_node& node,
         return false;
 
     auto prim = node.get_primitive();
+    // count()/spatial() below require a static shape.
+    if (input_layout.is_dynamic())
+        return false;
     if (input_layout.data_type != data_types::f16
         || (input_layout.is_static() && input_layout.feature() % 64 != 0)  // current algorithm is effective for ifm to be multiply of 64
         || weights_layout.spatial(0) != 3     // weights have to be 3x3 by definiton
@@ -561,6 +564,9 @@ layout_optimizer::layout_optimizer(bool output_size_handling_enabled)
 }
 
 bool layout_optimizer::is_depthwise(const convolution_node& node) const {
+        // feature() requires a static shape.
+        if (node.get_input_layout(0).is_dynamic() || node.get_output_layout(0).is_dynamic())
+            return false;
         const auto output_channels = node.get_output_layout(0).feature();
         const auto input_channels = node.get_input_layout(0).feature();
 
@@ -720,7 +726,8 @@ static bool has_reorder_before_mvn(const program_node& node, size_t cur_depth, s
             auto reorder_first_user = node.get_users().front();
             if (reorder_first_user->is_type<reshape>()) {
                 for (auto& reshape_user : reorder_first_user->get_users()) {
-                    if (reshape_user->is_type<mvn>() && node.get_output_layout().get_linear_size() > reorder_size_threshold) {
+                    if (reshape_user->is_type<mvn>() && !node.get_output_layout().is_dynamic() &&
+                        node.get_output_layout().get_linear_size() > reorder_size_threshold) {
                         GPU_DEBUG_LOG << node.id() << ": " << node.get_output_layout().to_short_string() << " : heavy reorder" << std::endl;
                         return true;
                     }

--- a/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
@@ -566,6 +566,34 @@ TEST(reorder_inputs, mvn_expected_plain_format) {
 //    }
 //}
 
+TEST(reorder_inputs, dynamic_conv_chain_no_throw) {
+    // conv2 is fully static (feature comes from weights.out_ch) so it enters
+    // the native format-selection heuristics, which then inspect the previous
+    // conv whose input is still dynamic. Those helpers used to call feature()/
+    // count()/get_linear_size() on the dynamic layout and throw.
+    auto& engine = get_test_engine();
+    auto input_layout_dyn = layout{ ov::PartialShape{1, ov::Dimension::dynamic(), 1, 3000},
+                                    data_types::f16,
+                                    format::bfyx };
+    auto weights1 = engine.allocate_memory({ {384,  80, 1, 3}, data_types::f16, format::bfyx });
+    auto weights2 = engine.allocate_memory({ {384, 384, 1, 3}, data_types::f16, format::bfyx });
+
+    topology topology;
+    topology.add(input_layout("input", input_layout_dyn));
+    topology.add(data("weights1", weights1));
+    topology.add(data("weights2", weights2));
+    topology.add(convolution("conv1", input_info("input"),  "weights1", "", 1, {1, 1}, {1, 1}, {0, 1}, {0, 1}, false));
+    topology.add(convolution("conv2", input_info("conv1"), "weights2", "", 1, {1, 1}, {1, 1}, {0, 1}, {0, 1}, false));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    program::ptr prog = nullptr;
+    OV_ASSERT_NO_THROW(prog = program::build_program(engine, topology, config));
+    ASSERT_NE(prog, nullptr);
+}
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
 TEST(reorder_inputs, has_reshape_user) {
     auto& engine = get_test_engine();


### PR DESCRIPTION
### Description of the issue (symptom, root-cause, how it was resolved)
 - **Symptom**: `[GPU] get_dims() is called for dynamic shape` thrown during `compile_model` when a conv chain has a dynamic-input predecessor followed by a fully static conv. oneDNN path is unaffected.
 - **Root cause**: Helpers in the native (heuristic) format-selection logic call `feature()`/`count()`/`get_linear_size()` on neighboring conv layouts without checking `is_dynamic()` first.
 - **Resolution**: Add `is_dynamic()` guards so the helpers return the safe fallback (`false`) before the static-only accessors. Static-shape behavior unchanged.

#### The code and line that caused this issue (if it is not changed directly)
 - `intel_gpu/src/graph/layout_optimizer.cpp`
   - `should_use_winograd_2x3_s1()` — `count()`/`spatial()`
   - `is_depthwise()` — `feature()`
   - `has_reorder_before_mvn()` — `get_linear_size()`

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
```python
import openvino as ov
from optimum.intel import OVModelForSpeechSeq2Seq
m = OVModelForSpeechSeq2Seq.from_pretrained(<whisper_dir>, device="GPU", compile=False)
m.reshape(1, -1)
ov.Core().compile_model(m.encoder.model, "GPU")   # throws before the fix
```
Regression test: `ov_gpu_unit_tests --gtest_filter='reorder_inputs.dynamic_conv_chain_no_throw'`

#### Problematic graph
```
input [1, ?, 1, 3000]  ->  conv1 [1, 384, 1, 3000]  ->  conv2 [1, 384, 1, 3000]
       (dyn feature)         (fully static)                (fully static)
```
conv2 is static → passes the early dynamic guard in `get_expected_format()` → enters the native format-selection logic → walks back to dynamic-input conv1 → throws.

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? — Reviewed `reorder_inputs_test.cpp`; existing dynamic-conv tests trip the early guard in `get_expected_format()` and never reach the native format-selection logic, so a new conv-chain test was needed.

### Tickets:
 - [CVS-190230](https://jira.devtools.intel.com/browse/CVS-190230)
