### PR TITLE
[NPUW] Add Eagle3 speculative decoding models to model builder

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
@@ -5,8 +5,8 @@
 #include "model_builder.hpp"
 
 #include <algorithm>
-#include <limits>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "model_builder_internal.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
@@ -58,7 +58,6 @@ ov::Output<ov::Node> make_linear(const ov::Output<ov::Node>& input,
 
     return matmul->output(0);
 }
-
 
 ov::Output<ov::Node> make_embedding(const ov::Output<ov::Node>& input_ids,
                                     size_t vocab_size,
@@ -127,7 +126,6 @@ ov::Output<ov::Node> make_conv1d(const ov::Output<ov::Node>& input,
     return add->output(0);
 }
 
-
 ov::Output<ov::Node> make_transformer_layers(const ov::Output<ov::Node>& initial,
                                              size_t num_layers,
                                              const std::string& prefix_base,
@@ -139,8 +137,6 @@ ov::Output<ov::Node> make_transformer_layers(const ov::Output<ov::Node>& initial
     }
     return current;
 }
-
-
 
 std::shared_ptr<ov::Model> ModelBuilder::get_model_with_one_op() {
     auto param = std::make_shared<ov::opset11::Parameter>(ov::element::i64, ov::PartialShape{1, 3, 2, 2});
@@ -333,12 +329,6 @@ std::shared_ptr<ov::Model> ModelBuilder::get_model_with_repeated_blocks_and_para
     return std::make_shared<ov::Model>(ov::OutputVector{result->output(0)});
 }
 
-// Builds a model with N identical repeated blocks (using get_block(), same structure as
-// get_model_with_repeated_blocks_and_results) where "head" blocks additionally expose
-// their output via a MatMul to a separate Parameter-weighted projection group, mimicking
-// Gemma4's KV-sharing pattern:
-//   - Non-head blocks: block_output → next_block (only internal consumer)
-//   - Head blocks:     block_output → next_block  (internal)
 // Builds a model with N identical repeated blocks where "head" blocks additionally
 // expose their interior Relu via a cross-group MatMul, reproducing the Gemma4
 // KV-sharing asymmetry pattern.
@@ -625,15 +615,19 @@ std::shared_ptr<ov::op::v0::Parameter> ModelBuilder::parameter(ov::element::Type
 void ModelBuilder::clear() {
     m_nodes.clear();
     m_sinks.clear();
+    m_extra_results.clear();
     m_name_idx = 0;
 }
 
-ov::Output<ov::Node> ModelBuilder::setup_position_ids(LLMConfig& config, const ov::Output<ov::Node>& seq_source) {
-    OPENVINO_ASSERT(!(config.internal_position_ids && config.position_ids.get_node()),
+ov::Output<ov::Node> ModelBuilder::setup_position_ids(BaseModelConfig& config,
+                                                      const ov::Output<ov::Node>& seq_source,
+                                                      bool internal_position_ids,
+                                                      size_t rotary_dim) {
+    OPENVINO_ASSERT(!(internal_position_ids && config.position_ids.get_node()),
                     "internal_position_ids and position_ids are mutually exclusive");
     ov::Output<ov::Node> position_ids_output;
 
-    if (config.internal_position_ids) {
+    if (internal_position_ids) {
         auto shape = std::make_shared<ov::opset11::ShapeOf>(seq_source, ov::element::i64);
         auto idx1 = ov::opset11::Constant::create(ov::element::i64, ov::Shape{}, {1});
         auto axis0 = ov::opset11::Constant::create(ov::element::i64, ov::Shape{}, {0});
@@ -654,15 +648,48 @@ ov::Output<ov::Node> ModelBuilder::setup_position_ids(LLMConfig& config, const o
     }
     // config.rope set without position_ids means RoPE was pre-built with position_ids baked in
     if (position_ids_output.get_node() && !config.rope) {
-        if (config.rotary_dim > 0 && config.rotary_dim < config.head_dim) {
-            config.rope =
-                PartialRotationRoPE(config.head_dim, config.rotary_dim, config.precision, position_ids_output);
+        if (rotary_dim > 0 && rotary_dim < config.head_dim) {
+            config.rope = PartialRotationRoPE(config.head_dim, rotary_dim, config.precision, position_ids_output);
         } else {
             config.rope = HalfRotationRoPE(config.head_dim, config.precision, position_ids_output);
         }
     }
 
     return position_ids_output;
+}
+
+KVCacheFn ModelBuilder::make_decoder_kv_cache_fn(const ov::Output<ov::Node>& batch_source,
+                                                 const ov::Output<ov::Node>& beam_idx,
+                                                 size_t kv_heads,
+                                                 size_t head_dim,
+                                                 ov::element::Type precision) {
+    return [this, batch_source, beam_idx, kv_heads, head_dim, precision](
+               const ov::Output<ov::Node>& k,
+               const ov::Output<ov::Node>& v,
+               size_t layer) -> std::pair<ov::Output<ov::Node>, ov::Output<ov::Node>> {
+        auto layer_str = std::to_string(layer);
+        auto k_cache = make_kv_cache_concat(k,
+                                            batch_source,
+                                            beam_idx,
+                                            kv_heads,
+                                            head_dim,
+                                            make_kv_var_id(layer_str, ".", "key"),
+                                            precision);
+        auto v_cache = make_kv_cache_concat(v,
+                                            batch_source,
+                                            beam_idx,
+                                            kv_heads,
+                                            head_dim,
+                                            make_kv_var_id(layer_str, ".", "value"),
+                                            precision);
+        m_sinks.push_back(std::dynamic_pointer_cast<ov::op::Sink>(k_cache.assign));
+        m_sinks.push_back(std::dynamic_pointer_cast<ov::op::Sink>(v_cache.assign));
+        return {k_cache.concatenated, v_cache.concatenated};
+    };
+}
+
+void ModelBuilder::add_output(const std::shared_ptr<ov::op::v0::Result>& result) {
+    m_extra_results.push_back(result);
 }
 
 std::shared_ptr<ov::Model> ModelBuilder::make_model(const ov::Output<ov::Node>& output,
@@ -672,7 +699,13 @@ std::shared_ptr<ov::Model> ModelBuilder::make_model(const ov::Output<ov::Node>& 
     res->set_friendly_name(result_name);
     res->output(0).set_names({result_name});
 
-    return std::make_shared<ov::Model>(ov::OutputVector{res->output(0)}, m_sinks, model_name);
+    ov::OutputVector outputs{res->output(0)};
+    for (const auto& extra : m_extra_results) {
+        outputs.push_back(extra->output(0));
+    }
+    m_extra_results.clear();
+
+    return std::make_shared<ov::Model>(outputs, m_sinks, model_name);
 }
 
 std::shared_ptr<ov::Model> ModelBuilder::build_llm(const LLMConfig& config_in) {
@@ -722,7 +755,7 @@ std::shared_ptr<ov::Model> ModelBuilder::build_llm(const LLMConfig& config_in) {
         seq_source = input_ids->output(0);
     }
 
-    setup_position_ids(config, seq_source);
+    setup_position_ids(config, seq_source, config.internal_position_ids, config.rotary_dim);
 
     ov::Output<ov::Node> beam_idx_output;
     if (config.use_kv_cache) {
@@ -770,48 +803,16 @@ std::shared_ptr<ov::Model> ModelBuilder::build_llm(const LLMConfig& config_in) {
                                                      config.head_dim);
     }
 
-    const auto hs = config.hidden_size;
     const auto kv_heads = config.get_kv_heads();
 
-    Attention attn{};
-    attn.hidden_size = hs;
-    attn.num_heads = config.num_heads;
-    attn.num_kv_heads = kv_heads;
-    attn.head_dim = config.head_dim;
-    attn.precision = prec;
-    attn.weight_fn = config.weight;
-    attn.bias_fn = config.attn_bias;
-    attn.qk_norm = config.qk_norm;
-    attn.rope_fn = config.rope;
+    Attention attn = config.make_attention();
     attn.sdpa_mask = default_mask;
     attn.shared_broadcast_shape = shared_broadcast;
-    attn.output_gate = config.attn_output_gate;
 
     // Non-hybrid: standard past_key_values naming. Hybrid full-attention layers get
     // per-attn-layer cache_params naming (set below inside build_full_attn_layer).
     if (config.use_kv_cache && !config.is_linear_layer) {
-        attn.kv_cache_fn = [&](const ov::Output<ov::Node>& k,
-                               const ov::Output<ov::Node>& v,
-                               size_t layer) -> std::pair<ov::Output<ov::Node>, ov::Output<ov::Node>> {
-            auto layer_str = std::to_string(layer);
-            auto k_cache = make_kv_cache_concat(k,
-                                                seq_source,
-                                                beam_idx_output,
-                                                kv_heads,
-                                                config.head_dim,
-                                                make_kv_var_id(layer_str, ".", "key"),
-                                                prec);
-            auto v_cache = make_kv_cache_concat(v,
-                                                seq_source,
-                                                beam_idx_output,
-                                                kv_heads,
-                                                config.head_dim,
-                                                make_kv_var_id(layer_str, ".", "value"),
-                                                prec);
-            m_sinks.push_back(std::dynamic_pointer_cast<ov::op::Sink>(k_cache.assign));
-            m_sinks.push_back(std::dynamic_pointer_cast<ov::op::Sink>(v_cache.assign));
-            return {k_cache.concatenated, v_cache.concatenated};
-        };
+        attn.kv_cache_fn = make_decoder_kv_cache_fn(seq_source, beam_idx_output, kv_heads, config.head_dim, prec);
     }
 
     // Wire linear-mixer runtime inputs once — all layers share the same graph plumbing.
@@ -862,21 +863,46 @@ std::shared_ptr<ov::Model> ModelBuilder::build_llm(const LLMConfig& config_in) {
                                : make_post_norm_layer(input, config.norm, fn, config.ffn, prefix);
     };
 
+    std::vector<ov::Output<ov::Node>> layer_outputs;
     auto current =
         make_transformer_layers(hidden_states,
                                 config.num_layers,
                                 "model.layers.",
                                 [&](const ov::Output<ov::Node>& input, const std::string& prefix, size_t layer) {
+                                    ov::Output<ov::Node> out;
                                     if (config.is_linear_layer && config.is_linear_layer(layer)) {
-                                        return build_linear_layer(input, prefix, layer);
+                                        out = build_linear_layer(input, prefix, layer);
+                                    } else {
+                                        // Per-layer mask: N sliding layers then 1 full, repeating.
+                                        if (has_sliding && config.sliding_to_full_ratio > 0) {
+                                            const size_t cycle = config.sliding_to_full_ratio + 1;
+                                            attn.sdpa_mask = (layer % cycle == cycle - 1) ? full_mask : sliding_mask;
+                                        }
+                                        out = build_full_attn_layer(input, prefix, layer);
                                     }
-                                    // Per-layer mask: N sliding layers then 1 full, repeating.
-                                    if (has_sliding && config.sliding_to_full_ratio > 0) {
-                                        const size_t cycle = config.sliding_to_full_ratio + 1;
-                                        attn.sdpa_mask = (layer % cycle == cycle - 1) ? full_mask : sliding_mask;
+                                    if (!config.eagle3_capture_layers.empty()) {
+                                        layer_outputs.push_back(out);
                                     }
-                                    return build_full_attn_layer(input, prefix, layer);
+                                    return out;
                                 });
+
+    if (!config.eagle3_capture_layers.empty()) {
+        OPENVINO_ASSERT(config.lm_head_weight,
+                        "eagle3_capture_layers requires an LM head (lm_head_weight): without one the model's "
+                        "primary output is already named \"last_hidden_state\", clashing with the Eagle3 capture");
+        ov::OutputVector captured;
+        for (size_t idx : config.eagle3_capture_layers) {
+            OPENVINO_ASSERT(idx < layer_outputs.size(),
+                            "eagle3_capture_layers index (",
+                            idx,
+                            ") must be < num_layers (",
+                            layer_outputs.size(),
+                            ")");
+            captured.push_back(layer_outputs[idx]);
+        }
+        auto hidden = make_eagle3_hidden_capture(captured, config.hidden_size, prec, config.weight);
+        add_output(make_manually_added_result(hidden, "last_hidden_state"));
+    }
 
     auto final_norm = config.norm(current, "model.norm");
 
@@ -934,14 +960,7 @@ std::shared_ptr<ov::Model> ModelBuilder::build_whisper_encoder(const WhisperConf
     auto embedded = std::make_shared<ov::opset11::Add>(transposed, pos_embed);
     embedded->set_friendly_name("model.encoder.pos_embed_add");
 
-    Attention enc_attn{};
-    enc_attn.hidden_size = d;
-    enc_attn.num_heads = config.num_heads;
-    enc_attn.num_kv_heads = config.num_heads;
-    enc_attn.head_dim = config.head_dim;
-    enc_attn.precision = prec;
-    enc_attn.weight_fn = config.weight;
-    enc_attn.bias_fn = config.attn_bias;
+    Attention enc_attn = config.make_attention();
     enc_attn.o_proj_name = "self_attn.out_proj";
 
     auto current =
@@ -971,7 +990,6 @@ std::shared_ptr<ov::Model> ModelBuilder::build_whisper_encoder(const WhisperConf
 
     return make_model(encoder_output, "last_hidden_state", "synthetic_whisper_encoder");
 }
-
 
 std::shared_ptr<ov::Model> ModelBuilder::build_whisper_decoder(const WhisperConfig& config_in) {
     clear();
@@ -1019,14 +1037,7 @@ std::shared_ptr<ov::Model> ModelBuilder::build_whisper_decoder(const WhisperConf
     auto shared_mask = make_whisper_causal_mask(cache_pos, "model.decoder.", config.boolean_causal_mask);
 
     // Self-attention (layer-0 reuses pre-built key Variable)
-    Attention self_attn{};
-    self_attn.hidden_size = d;
-    self_attn.num_heads = heads;
-    self_attn.num_kv_heads = heads;
-    self_attn.head_dim = hd;
-    self_attn.precision = prec;
-    self_attn.weight_fn = config.weight;
-    self_attn.bias_fn = config.attn_bias;
+    Attention self_attn = config.make_attention();
     self_attn.o_proj_name = "self_attn.out_proj";
     self_attn.sdpa_mask = shared_mask;
 
@@ -1064,14 +1075,7 @@ std::shared_ptr<ov::Model> ModelBuilder::build_whisper_decoder(const WhisperConf
     };
 
     // Cross-attention (store-only encoder KV cache)
-    Attention cross_attn{};
-    cross_attn.hidden_size = d;
-    cross_attn.num_heads = heads;
-    cross_attn.num_kv_heads = heads;
-    cross_attn.head_dim = hd;
-    cross_attn.precision = prec;
-    cross_attn.weight_fn = config.weight;
-    cross_attn.bias_fn = config.attn_bias;
+    Attention cross_attn = config.make_attention();
     cross_attn.o_proj_name = "encoder_attn.out_proj";
     cross_attn.attn_prefix = "encoder_attn.";
 
@@ -1154,14 +1158,7 @@ std::shared_ptr<ov::Model> ModelBuilder::build_embedding_encoder(const BertConfi
 
     auto sdpa_mask = make_padding_mask(attention_mask->output(0), prec);
 
-    Attention bert_attn{};
-    bert_attn.hidden_size = hs;
-    bert_attn.num_heads = config.num_heads;
-    bert_attn.num_kv_heads = config.num_heads;
-    bert_attn.head_dim = config.head_dim;
-    bert_attn.precision = prec;
-    bert_attn.weight_fn = config.weight;
-    bert_attn.bias_fn = config.attn_bias;
+    Attention bert_attn = config.make_attention();
     bert_attn.sdpa_mask = sdpa_mask;
 
     auto current =

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "model_builder_attention.hpp"
+#include "model_builder_eagle3.hpp"
 #include "model_builder_ffn.hpp"
 #include "model_builder_masks.hpp"
 #include "model_builder_moe.hpp"
@@ -157,6 +158,24 @@ struct BaseModelConfig {
     size_t get_kv_heads() const {
         return num_kv_heads == 0 ? num_heads : num_kv_heads;
     }
+
+    /// Project the config's attention-relevant fields into an Attention functor.
+    /// Model-specific wiring (sdpa_mask, kv_cache_fn, o_proj_name, ...) stays at
+    /// the call site; a derived config with extra attention knobs shadows this
+    /// and extends the base projection (see LLMConfig).
+    Attention make_attention() const {
+        Attention attn{};
+        attn.hidden_size = hidden_size;
+        attn.num_heads = num_heads;
+        attn.num_kv_heads = get_kv_heads();
+        attn.head_dim = head_dim;
+        attn.precision = precision;
+        attn.weight_fn = weight;
+        attn.bias_fn = attn_bias;
+        attn.qk_norm = qk_norm;
+        attn.rope_fn = rope;
+        return attn;
+    }
 };
 
 /// Sliding-window mask construction. Inputs: seq_source (input_ids/inputs_embeds),
@@ -204,6 +223,43 @@ struct LLMConfig : public BaseModelConfig {
     /// Token mixer for linear layers (e.g. GatedDeltaNetMixer or ShortConvMixer). build_llm wires
     /// its seq_source/beam_idx. A new mixer type needs no build_llm change.
     std::shared_ptr<LinearMixer> linear_mixer;
+
+    /// Eagle3 target: capture these layers' outputs (residual stream after each
+    /// listed layer), concat + fc them into an extra "last_hidden_state" output
+    /// marked "manually_added_output". Empty = no capture. GenAI's default pick
+    /// is {2, num_layers / 2, num_layers - 3}.
+    std::vector<size_t> eagle3_capture_layers;
+
+    /// Extends the base projection with the LLM-only attention knobs.
+    Attention make_attention() const {
+        Attention attn = BaseModelConfig::make_attention();
+        attn.output_gate = attn_output_gate;
+        return attn;
+    }
+};
+
+/// Eagle3 draft model ("midlayer" decoder). Combines token embeddings with the
+/// target-provided "hidden_states" input and emits draft-vocab "logits" plus a
+/// "last_hidden_state" output. vocab_size is the *target* vocab (embedding
+/// table); lm_head uses draft_vocab_size.
+struct Eagle3DraftConfig : public BaseModelConfig {
+    size_t draft_vocab_size = 320;
+
+    /// Number of target layers whose hidden states are concatenated into the
+    /// "hidden_states" input, i.e. its feature width is num_captured_layers *
+    /// hidden_size. When > 1 the draft carries an "model.fc" projection back to
+    /// hidden_size (as in the real NPU export); when 1 the hidden state feeds the
+    /// midlayer directly. GenAI captures 3.
+    size_t num_captured_layers = 3;
+
+    /// Leave "hidden_states"' feature dim dynamic (as in the raw export) so
+    /// ReshapeToStatic must recover it from the "last_hidden_state" output via
+    /// Eagle3Extension::get_static_input. Only valid with num_captured_layers==1,
+    /// where that fallback width (hidden_size) matches the input.
+    bool dynamic_hidden_states = false;
+
+    bool use_tree_mask = false;  ///< Add the optional "eagle_tree_mask" input (topk pipeline).
+    bool with_d2t = false;       ///< Emit the raw-export "d2t" output (GenAI removes it before NPUW).
 };
 
 struct WhisperConfig : public BaseModelConfig {
@@ -264,6 +320,7 @@ public:
                                                      const std::string& name);
 
     std::shared_ptr<ov::Model> build_llm(const LLMConfig& config);
+    std::shared_ptr<ov::Model> build_eagle3_draft(const Eagle3DraftConfig& config);
     std::shared_ptr<ov::Model> build_whisper_encoder(const WhisperConfig& config);
     std::shared_ptr<ov::Model> build_whisper_decoder(const WhisperConfig& config);
     std::shared_ptr<ov::Model> build_embedding_encoder(const BertConfig& config);
@@ -271,8 +328,24 @@ public:
     void clear();
 
 private:
-    /// May auto-create HalfRotationRoPE on config.rope (hence non-const ref).
-    ov::Output<ov::Node> setup_position_ids(LLMConfig& config, const ov::Output<ov::Node>& seq_source);
+    /// May auto-create a RoPE functor on config.rope (hence non-const ref):
+    /// HalfRotationRoPE, or PartialRotationRoPE when 0 < rotary_dim < head_dim.
+    ov::Output<ov::Node> setup_position_ids(BaseModelConfig& config,
+                                            const ov::Output<ov::Node>& seq_source,
+                                            bool internal_position_ids = false,
+                                            size_t rotary_dim = 0);
+
+    /// Standard per-layer KV cache read/concat/assign closure shared by decoder
+    /// builders. Captures by value; registers Assign sinks on this builder.
+    KVCacheFn make_decoder_kv_cache_fn(const ov::Output<ov::Node>& batch_source,
+                                       const ov::Output<ov::Node>& beam_idx,
+                                       size_t kv_heads,
+                                       size_t head_dim,
+                                       ov::element::Type precision);
+
+    /// Queue an extra Result for the next make_model() call (e.g. Eagle3
+    /// "last_hidden_state"). Consumed and cleared by make_model().
+    void add_output(const std::shared_ptr<ov::op::v0::Result>& result);
 
     std::shared_ptr<ov::Model> make_model(const ov::Output<ov::Node>& output,
                                           const std::string& result_name,
@@ -283,6 +356,7 @@ private:
 
     std::vector<std::shared_ptr<ov::Node>> m_nodes;
     ov::SinkVector m_sinks;
+    ov::ResultVector m_extra_results;
     size_t m_name_idx = 0;
 };
 

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_attention.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_attention.cpp
@@ -61,18 +61,17 @@ ov::Output<ov::Node> make_repeat_kv(const ov::Output<ov::Node>& kv,
                                     const std::string& name,
                                     const ov::Output<ov::Node>& shared_broadcast_shape) {
     const size_t actual_kv_heads = (num_kv_heads == 0) ? num_heads : num_kv_heads;
-    const size_t n_rep = num_heads / actual_kv_heads;
-
-    if (!shared_broadcast_shape.get_node() && n_rep == 1) {
-        return kv;
-    }
-
     OPENVINO_ASSERT(num_heads % actual_kv_heads == 0,
                     "num_heads (",
                     num_heads,
                     ") must be divisible by num_kv_heads (",
                     actual_kv_heads,
                     ")");
+    const size_t n_rep = num_heads / actual_kv_heads;
+
+    if (!shared_broadcast_shape.get_node() && n_rep == 1) {
+        return kv;
+    }
 
     ov::Output<ov::Node> broadcast_shape_output;
     if (shared_broadcast_shape.get_node()) {
@@ -148,9 +147,9 @@ KVCacheReadState make_kv_cache_read(const ov::Output<ov::Node>& batch_source,
                                                         std::vector<int64_t>{static_cast<int64_t>(head_dim)});
 
     auto init_shape = std::make_shared<ov::opset11::Concat>(ov::OutputVector{batch_dim->output(0),
-                                                                              num_heads_const->output(0),
-                                                                              zero_seq->output(0),
-                                                                              head_dim_const->output(0)},
+                                                                             num_heads_const->output(0),
+                                                                             zero_seq->output(0),
+                                                                             head_dim_const->output(0)},
                                                             0);
     init_shape->set_friendly_name(name + "_init_shape");
 

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_eagle3.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_eagle3.cpp
@@ -1,0 +1,192 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Eagle3 speculative decoding model support.
+//
+// Mirrors the models NPUW receives after GenAI's Eagle3 preprocessing
+// (openvino.genai eagle3_model_transforms.cpp):
+//   - Target: a regular decoder LLM whose selected layer outputs are captured,
+//     concatenated ("eagle3_hidden_states_concat"), projected by the draft's fc
+//     ("eagle3_hidden_state_fc") and exposed as an extra "last_hidden_state"
+//     output marked with "manually_added_output" rt_info.
+//   - Draft: a single "midlayer" decoder that combines token embeddings with a
+//     "hidden_states" input (dual RMSNorm + Concat feeding 2*hidden-wide Q/K/V
+//     projections), outputs draft-vocab "logits" plus the midlayer residual as
+//     "last_hidden_state". The raw export's fc has already been rehomed to the
+//     target model, so "hidden_states" is consumed directly.
+//
+
+#include "model_builder_eagle3.hpp"
+
+#include <cstdint>
+#include <vector>
+
+#include "model_builder.hpp"
+#include "openvino/op/ops.hpp"
+#include "openvino/opsets/opset11.hpp"
+
+namespace ov {
+namespace test {
+namespace npuw {
+
+std::shared_ptr<ov::op::v0::Result> make_manually_added_result(const ov::Output<ov::Node>& value,
+                                                               const std::string& name) {
+    auto result = std::make_shared<ov::op::v0::Result>(value);
+    result->set_friendly_name(name);
+    result->output(0).set_names({name});
+    result->get_rt_info()[kManuallyAddedOutput] = true;
+    return result;
+}
+
+ov::Output<ov::Node> make_eagle3_hidden_capture(const ov::OutputVector& captured_layers,
+                                                size_t hidden_size,
+                                                ov::element::Type precision,
+                                                const WeightFn& fc_weight) {
+    OPENVINO_ASSERT(!captured_layers.empty(), "Eagle3 hidden capture requires at least one layer output");
+
+    ov::Output<ov::Node> hidden = captured_layers.front();
+    if (captured_layers.size() > 1) {
+        auto concat = std::make_shared<ov::opset11::Concat>(captured_layers, -1);
+        concat->set_friendly_name("eagle3_hidden_states_concat");
+        hidden = concat->output(0);
+    }
+
+    if (fc_weight) {
+        hidden = make_linear(hidden,
+                             captured_layers.size() * hidden_size,
+                             hidden_size,
+                             "eagle3_hidden_state_fc",
+                             precision,
+                             fc_weight);
+    }
+    return hidden;
+}
+
+ov::Output<ov::Node> make_eagle3_d2t(size_t draft_vocab_size, size_t target_vocab_size) {
+    OPENVINO_ASSERT(draft_vocab_size > 0 && draft_vocab_size <= target_vocab_size,
+                    "Eagle3 d2t requires 0 < draft_vocab_size (",
+                    draft_vocab_size,
+                    ") <= target_vocab_size (",
+                    target_vocab_size,
+                    ")");
+    // Monotonic spread of the draft vocab over the target vocab, stored as
+    // offsets: target_id = draft_id + d2t[draft_id].
+    std::vector<int64_t> offsets(draft_vocab_size);
+    for (size_t i = 0; i < draft_vocab_size; ++i) {
+        offsets[i] = static_cast<int64_t>(i * target_vocab_size / draft_vocab_size) - static_cast<int64_t>(i);
+    }
+    auto d2t = ov::opset11::Constant::create(ov::element::i64, ov::Shape{draft_vocab_size}, offsets);
+    d2t->set_friendly_name("model.d2t");
+    return d2t->output(0);
+}
+
+std::shared_ptr<ov::Model> ModelBuilder::build_eagle3_draft(const Eagle3DraftConfig& config_in) {
+    clear();
+
+    Eagle3DraftConfig config = config_in;
+    if (!config.norm)
+        config.norm = RMSNorm(config.hidden_size, config.precision);
+    if (!config.ffn)
+        config.ffn = SwiGLU(config.hidden_size, config.intermediate_size, config.precision, config.weight);
+
+    const auto prec = config.precision;
+    const auto hs = config.hidden_size;
+    const auto kv_heads = config.get_kv_heads();
+    const std::string layer = "model.midlayer.";
+
+    OPENVINO_ASSERT(config.num_captured_layers >= 1, "Eagle3 draft requires num_captured_layers >= 1");
+    OPENVINO_ASSERT(config.lm_head_weight,
+                    "Eagle3 draft requires lm_head_weight: draft-vocab \"logits\" are its primary output");
+    OPENVINO_ASSERT(!config.dynamic_hidden_states || config.num_captured_layers == 1,
+                    "dynamic_hidden_states relies on the get_static_input fallback (hidden_size width), "
+                    "so it is only valid with num_captured_layers == 1");
+    const size_t hidden_width = config.num_captured_layers * hs;
+
+    auto input_ids = parameter(ov::element::i64, ov::PartialShape{-1, -1}, "input_ids");
+    // Feature dim is num_captured_layers * hidden_size. Kept static like the real
+    // NPU export, unless dynamic_hidden_states forces the ReshapeToStatic fallback
+    // to recover it from the last_hidden_state output.
+    auto hidden_feat = config.dynamic_hidden_states ? ov::Dimension(-1) : ov::Dimension(hidden_width);
+    auto hidden_states = parameter(ov::element::f32, ov::PartialShape{-1, -1, hidden_feat}, "hidden_states");
+    auto attention_mask = parameter(ov::element::i64, ov::PartialShape{-1, -1}, "attention_mask");
+    auto beam_idx = parameter(ov::element::i32, ov::PartialShape{-1}, "beam_idx");
+
+    setup_position_ids(config, input_ids->output(0));
+
+    ov::Output<ov::Node> hidden_in = hidden_states->output(0);
+    if (prec != ov::element::f32) {
+        auto cvt = std::make_shared<ov::op::v0::Convert>(hidden_in, prec);
+        cvt->set_friendly_name("model.hidden_states_convert");
+        hidden_in = cvt->output(0);
+    }
+
+    // fc projects the concatenated multi-layer hidden state back to hidden_size.
+    // GenAI keeps this in the NPU draft (it rehomes fc into the target only for
+    // the continuous-batching pipeline). A single captured layer needs no fc.
+    ov::Output<ov::Node> hidden_proj = hidden_in;
+    if (hidden_width != hs) {
+        hidden_proj = make_linear(hidden_in, hidden_width, hs, "model.fc", prec, config.weight);
+    }
+
+    // Dual-stream front: normalized token embedding and normalized hidden state
+    // are concatenated into a 2*hidden-wide attention input.
+    auto embed = make_embedding(input_ids->output(0), config.vocab_size, hs, "model.embed_tokens", prec);
+    auto embed_normed = config.norm(embed, layer + "input_layernorm");
+    auto hidden_normed = config.norm(hidden_proj, layer + "hidden_norm");
+    auto cat = std::make_shared<ov::opset11::Concat>(ov::OutputVector{embed_normed, hidden_normed}, -1);
+    cat->set_friendly_name(layer + "concat");
+
+    ov::Output<ov::Node> sdpa_mask = make_causal_mask(input_ids->output(0), attention_mask->output(0), prec);
+    if (config.use_tree_mask) {
+        // Additive tree mask for the topk pipeline. NPUW reshapes it to
+        // {1,1,1,1} (prefill) / {1,1,input,kvcache} (generate), both of which
+        // broadcast onto the causal mask.
+        auto tree_mask = parameter(prec, ov::PartialShape{-1, 1, -1, -1}, "eagle_tree_mask");
+        auto masked = std::make_shared<ov::opset11::Add>(sdpa_mask, tree_mask);
+        masked->set_friendly_name("model.tree_mask_add");
+        sdpa_mask = masked->output(0);
+    }
+
+    Attention attn = config.make_attention();
+    attn.sdpa_mask = sdpa_mask;
+    attn.kv_cache_fn =
+        make_decoder_kv_cache_fn(input_ids->output(0), beam_idx->output(0), kv_heads, config.head_dim, prec);
+
+    // Q/K/V project from the 2*hidden concat, so the layer projects explicitly
+    // and uses Attention's pre-projected entry point.
+    const size_t cat_dim = 2 * hs;
+    const size_t kv_dim = kv_heads * config.head_dim;
+    auto q = make_linear(cat, cat_dim, hs, layer + "self_attn.q_proj", prec, config.weight, config.attn_bias);
+    auto k = make_linear(cat, cat_dim, kv_dim, layer + "self_attn.k_proj", prec, config.weight, config.attn_bias);
+    auto v = make_linear(cat, cat_dim, kv_dim, layer + "self_attn.v_proj", prec, config.weight, config.attn_bias);
+    auto attn_out = attn(q, k, v, layer, 0);
+
+    // Residual anchors on the fc-projected hidden state (the "midlayer" add).
+    auto residual1 = std::make_shared<ov::opset11::Add>(hidden_proj, attn_out);
+    residual1->set_friendly_name(layer + "attn_residual");
+
+    auto normed2 = config.norm(residual1->output(0), layer + "post_attention_layernorm");
+    auto ffn_out = config.ffn(normed2, layer + "mlp");
+    auto residual2 = std::make_shared<ov::opset11::Add>(residual1, ffn_out);
+    residual2->set_friendly_name(layer + "ffn_residual");
+
+    // GenAI taps the midlayer residual as the draft's last_hidden_state.
+    add_output(make_manually_added_result(residual2->output(0), "last_hidden_state"));
+
+    if (config.with_d2t) {
+        auto d2t = make_eagle3_d2t(config.draft_vocab_size, config.vocab_size);
+        auto d2t_result = std::make_shared<ov::op::v0::Result>(d2t);
+        d2t_result->set_friendly_name("d2t");
+        d2t_result->output(0).set_names({"d2t"});
+        add_output(d2t_result);
+    }
+
+    auto final_norm = config.norm(residual2->output(0), "model.norm");
+    auto logits = make_lm_head(final_norm, hs, config.draft_vocab_size, "lm_head", prec, config.lm_head_weight);
+
+    return make_model(logits, "logits", "synthetic_eagle3_draft");
+}
+
+}  // namespace npuw
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_eagle3.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_eagle3.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "model_builder_types.hpp"
+#include "openvino/core/node.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/result.hpp"
+
+namespace ov {
+namespace test {
+namespace npuw {
+
+/// rt_info key GenAI stamps on the Eagle3 "last_hidden_state" Results it adds.
+/// NPUW's LM-head cut skips Results carrying it (see llm_compiled_model.cpp).
+inline constexpr const char* kManuallyAddedOutput = "manually_added_output";
+
+/// Result carrying the "manually_added_output" rt_info marker, mirroring
+/// GenAI's transform_hidden_state (eagle3_model_transforms.cpp).
+std::shared_ptr<ov::op::v0::Result> make_manually_added_result(const ov::Output<ov::Node>& value,
+                                                               const std::string& name);
+
+/// Eagle3 target-side hidden state capture. Concatenates the captured layer
+/// outputs on the last axis ("eagle3_hidden_states_concat") and, when fc_weight
+/// is truthy, projects the concat back to hidden_size ("eagle3_hidden_state_fc")
+/// the way GenAI's move_fc_from_draft_to_main rehomes the draft's fc into the
+/// target model for the NPU pipeline. An empty fc_weight returns the raw concat
+/// (continuous-batching pipeline form).
+ov::Output<ov::Node> make_eagle3_hidden_capture(const ov::OutputVector& captured_layers,
+                                                size_t hidden_size,
+                                                ov::element::Type precision,
+                                                const WeightFn& fc_weight);
+
+/// Draft-to-target vocab mapping table: i64 Constant [draft_vocab_size] holding
+/// per-token id offsets (target_id = draft_id + d2t[draft_id]), as in the raw
+/// Eagle3 draft export's "d2t" output. GenAI extracts and removes it before the
+/// model reaches NPUW; emit it only to model the raw export form.
+ov::Output<ov::Node> make_eagle3_d2t(size_t draft_vocab_size, size_t target_vocab_size);
+
+}  // namespace npuw
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -118,6 +118,7 @@ ov_add_test_target(
             # model builder (test utility)
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_attention.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_eagle3.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_ffn.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_moe.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_masks.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_test_helpers.hpp
@@ -69,8 +69,7 @@ inline std::shared_ptr<ov::Model> build_dynamic_attention_llm_model() {
     for (const auto& input : model->inputs()) {
         const auto& name = input.get_any_name();
         const auto& pshape = input.get_partial_shape();
-        if (name.find("input_ids") != std::string::npos ||
-            name.find("token_type_ids") != std::string::npos) {
+        if (name.find("input_ids") != std::string::npos || name.find("token_type_ids") != std::string::npos) {
             new_shapes[name] = ov::PartialShape{1, kSeq};
         } else if (name.find("attention_mask") != std::string::npos) {
             new_shapes[name] = ov::PartialShape{1, kSeq + kPast};
@@ -113,8 +112,7 @@ inline std::shared_ptr<ov::Model> build_llm_test_model_with_kv_fake_convert(cons
         auto inject_fake_convert = [&](size_t input_idx, const std::string& suffix) {
             auto fake_convert_1 =
                 std::make_shared<ov::op::v13::FakeConvert>(sdpa->input_value(input_idx), scale, fake_convert_type);
-            auto fake_convert_2 =
-                std::make_shared<ov::op::v13::FakeConvert>(fake_convert_1, scale, fake_convert_type);
+            auto fake_convert_2 = std::make_shared<ov::op::v13::FakeConvert>(fake_convert_1, scale, fake_convert_type);
             fake_convert_1->set_friendly_name(sdpa->get_friendly_name() + "/" + suffix + "_1");
             fake_convert_2->set_friendly_name(sdpa->get_friendly_name() + "/" + suffix + "_2");
             sdpa->input(input_idx).replace_source_output(fake_convert_2);
@@ -168,6 +166,42 @@ inline std::shared_ptr<ov::Model> build_lfm2_llm_test_model() {
 inline std::shared_ptr<ov::Model> build_whisper_decoder_test_model() {
     ModelBuilder mb;
     return mb.build_whisper_decoder(make_test_model_config<WhisperConfig>());
+}
+
+/// Eagle3 target: regular LLM whose captured layer outputs feed the extra
+/// "last_hidden_state" output (concat of 3 layers -> fc, GenAI NPU form).
+inline std::shared_ptr<ov::Model> build_eagle3_target_test_model() {
+    auto cfg = make_test_model_config<LLMConfig>();
+    cfg.num_layers = 8;
+    cfg.eagle3_capture_layers = {2, 4, 5};  // GenAI default pick: {2, N/2, N-3}
+    ModelBuilder mb;
+    return mb.build_llm(cfg);
+}
+
+/// Eagle3 draft: single-"midlayer" decoder taking a target "hidden_states" input
+/// and emitting draft-vocab logits. Captures 3 layers (feature width 3*hidden)
+/// with an "model.fc" projection, matching the real NPU export. GQA keeps it
+/// close to real Eagle3 draft heads.
+inline std::shared_ptr<ov::Model> build_eagle3_draft_test_model(bool use_tree_mask = false) {
+    auto cfg = make_test_model_config<Eagle3DraftConfig>();
+    cfg.num_kv_heads = 2;
+    cfg.draft_vocab_size = 128;
+    cfg.use_tree_mask = use_tree_mask;
+    ModelBuilder mb;
+    return mb.build_eagle3_draft(cfg);
+}
+
+/// Eagle3 draft variant with a single captured layer and a dynamic
+/// "hidden_states" feature dim, so ReshapeToStatic must recover the width from
+/// the "last_hidden_state" output (Eagle3Extension::get_static_input fallback).
+inline std::shared_ptr<ov::Model> build_eagle3_draft_dynamic_hidden_test_model() {
+    auto cfg = make_test_model_config<Eagle3DraftConfig>();
+    cfg.num_kv_heads = 2;
+    cfg.draft_vocab_size = 128;
+    cfg.num_captured_layers = 1;
+    cfg.dynamic_hidden_states = true;
+    ModelBuilder mb;
+    return mb.build_eagle3_draft(cfg);
 }
 
 inline std::shared_ptr<ov::Model> build_embedding_test_model() {
@@ -316,8 +350,8 @@ public:
 };
 
 struct CompileCall {
-    std::string                friendly_name;
-    ov::AnyMap                 props;
+    std::string friendly_name;
+    ov::AnyMap props;
     std::shared_ptr<ov::Model> model;
 };
 

--- a/src/plugins/intel_npu/tests/unit/npuw/pipeline_passes/eagle3_model_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pipeline_passes/eagle3_model_test.cpp
@@ -1,0 +1,204 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Pipeline-level tests for Eagle3 speculative-decoding models produced by the
+// test-engine ModelBuilder: the target model's manually-added
+// "last_hidden_state" output must survive the LLM sub-pipeline (and never be
+// mistaken for the LM head), and the draft model's Eagle3-specific inputs
+// ("hidden_states", "eagle_tree_mask") must be resolved to static shapes by
+// ReshapeToStatic via Eagle3Extension::get_static_input.
+
+#include <gtest/gtest.h>
+
+#include "llm_pass_test_fixture.hpp"
+
+namespace {
+
+using ov::test::npuw::RecordingFactory;
+
+class Eagle3ModelTest : public ov::test::npuw::LLMPassTestFixture {
+protected:
+    static ov::AnyMap eagle_props() {
+        return {{"NPUW_EAGLE", "YES"}};
+    }
+};
+
+// Target model: the "last_hidden_state" output (3-layer concat -> fc) must be
+// present and static on both prefill and generate sub-models, alongside logits.
+TEST_F(Eagle3ModelTest, TargetModelKeepsLastHiddenStateThroughPipeline) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+    ASSERT_NO_THROW(
+        compiled = create_compiled_model(ov::test::npuw::build_eagle3_target_test_model(), eagle_props(), recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& prefill = require_sub_model(recorder, "_prefill");
+    const auto& generate = require_sub_model_containing(recorder, "_kv");
+
+    // fc projects the 3x64 concat back to hidden_size=64
+    const auto prefill_hidden = find_output(prefill.model, "last_hidden_state");
+    ASSERT_TRUE(prefill_hidden.has_value()) << "last_hidden_state output missing on prefill model";
+    ASSERT_TRUE(prefill_hidden->get_partial_shape().is_static());
+    EXPECT_EQ(prefill_hidden->get_shape(), (ov::Shape{1, 128, 64}));
+
+    const auto generate_hidden = find_output(generate.model, "last_hidden_state");
+    ASSERT_TRUE(generate_hidden.has_value()) << "last_hidden_state output missing on generate model";
+    ASSERT_TRUE(generate_hidden->get_partial_shape().is_static());
+    EXPECT_EQ(generate_hidden->get_shape(), (ov::Shape{1, 1, 64}));
+
+    // The regular LM head path must be untouched: the default 3-model pipeline
+    // splits it into a "_lm_head" sub-model producing "logits", while the
+    // prefill model exposes the cut point as "output_embeds".
+    const auto& lm_head = require_sub_model(recorder, "_lm_head");
+    EXPECT_TRUE(find_output(lm_head.model, "logits").has_value()) << "logits output missing on lm_head model";
+    EXPECT_TRUE(find_output(prefill.model, ov::npuw::LLMCompiledModel::output_embeds).has_value())
+        << "output_embeds output missing on prefill model";
+}
+
+// With a shared LM head, the head cut must pick the real lm_head MatMul and
+// skip the manually-added last_hidden_state Result — even though that Result
+// is also fed by a MatMul (eagle3_hidden_state_fc).
+TEST_F(Eagle3ModelTest, TargetSharedHeadCutSkipsManuallyAddedOutput) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+    auto props = eagle_props();
+    props["NPUW_LLM_SHARED_HEAD"] = "YES";
+    ASSERT_NO_THROW(compiled =
+                        create_compiled_model(ov::test::npuw::build_eagle3_target_test_model(), props, recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& lm_head = require_sub_model(recorder, "_lm_head");
+    (void)lm_head;
+
+    const auto& prefill = require_sub_model(recorder, "_prefill");
+    EXPECT_TRUE(find_output(prefill.model, ov::npuw::LLMCompiledModel::output_embeds).has_value())
+        << "output_embeds missing on prefill model after LM head cut";
+
+    const auto hidden = find_output(prefill.model, "last_hidden_state");
+    ASSERT_TRUE(hidden.has_value()) << "last_hidden_state was consumed by the LM head cut";
+    ASSERT_TRUE(hidden->get_partial_shape().is_static());
+    EXPECT_EQ(hidden->get_shape(), (ov::Shape{1, 128, 64}));
+}
+
+// Draft model (real NPU form): 3 captured layers -> "hidden_states" feature dim
+// 3*hidden_size, projected by "model.fc". ReshapeToStatic must fix the static
+// width and set the seq dim per phase.
+TEST_F(Eagle3ModelTest, DraftHiddenStatesStaticWidthWithFc) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+    ASSERT_NO_THROW(
+        compiled = create_compiled_model(ov::test::npuw::build_eagle3_draft_test_model(), eagle_props(), recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& prefill = require_sub_model(recorder, "_prefill");
+    const auto& generate = require_sub_model_containing(recorder, "_kv");
+
+    EXPECT_TRUE(all_inputs_static(prefill.model));
+    EXPECT_TRUE(all_inputs_static(generate.model));
+
+    // 3 captured layers * hidden_size(64) = 192
+    const auto prefill_hidden = input_shape(prefill.model, "hidden_states");
+    ASSERT_TRUE(prefill_hidden.has_value()) << "hidden_states input missing or dynamic on prefill model";
+    EXPECT_EQ(*prefill_hidden, (ov::Shape{1, 128, 192}));
+
+    const auto generate_hidden = input_shape(generate.model, "hidden_states");
+    ASSERT_TRUE(generate_hidden.has_value()) << "hidden_states input missing or dynamic on generate model";
+    EXPECT_EQ(*generate_hidden, (ov::Shape{1, 1, 192}));
+
+    // Draft outputs: the midlayer residual tap (hidden_size wide) rides on both
+    // sub-models, and draft-vocab logits land in the split-out "_lm_head" model.
+    const auto prefill_hidden_out = find_output(prefill.model, "last_hidden_state");
+    ASSERT_TRUE(prefill_hidden_out.has_value());
+    ASSERT_TRUE(prefill_hidden_out->get_partial_shape().is_static());
+    EXPECT_EQ(prefill_hidden_out->get_shape().back(), 64u);
+    EXPECT_TRUE(find_output(generate.model, "last_hidden_state").has_value());
+
+    const auto& lm_head = require_sub_model(recorder, "_lm_head");
+    const auto logits = find_output(lm_head.model, "logits");
+    ASSERT_TRUE(logits.has_value()) << "logits output missing on lm_head model";
+    ASSERT_TRUE(logits->get_partial_shape().is_static());
+    EXPECT_EQ(logits->get_shape().back(), 128u) << "logits must use the draft vocab size";
+}
+
+// Draft model with a dynamic "hidden_states" feature dim (single captured
+// layer, no fc): ReshapeToStatic must recover the width from the
+// "last_hidden_state" output via Eagle3Extension::get_static_input.
+TEST_F(Eagle3ModelTest, DraftHiddenStatesResolvedFromLastHiddenState) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+    ASSERT_NO_THROW(compiled = create_compiled_model(ov::test::npuw::build_eagle3_draft_dynamic_hidden_test_model(),
+                                                     eagle_props(),
+                                                     recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& prefill = require_sub_model(recorder, "_prefill");
+    const auto& generate = require_sub_model_containing(recorder, "_kv");
+
+    EXPECT_TRUE(all_inputs_static(prefill.model));
+    EXPECT_TRUE(all_inputs_static(generate.model));
+
+    // No fc: width resolves to hidden_size(64) via the last_hidden_state fallback.
+    const auto prefill_hidden = input_shape(prefill.model, "hidden_states");
+    ASSERT_TRUE(prefill_hidden.has_value()) << "hidden_states input missing or dynamic on prefill model";
+    EXPECT_EQ(*prefill_hidden, (ov::Shape{1, 128, 64}));
+
+    const auto generate_hidden = input_shape(generate.model, "hidden_states");
+    ASSERT_TRUE(generate_hidden.has_value()) << "hidden_states input missing or dynamic on generate model";
+    EXPECT_EQ(*generate_hidden, (ov::Shape{1, 1, 64}));
+}
+
+// Draft model with the optional topk tree mask: prefill collapses it to
+// {1,1,1,1}; generate spans all past KV positions per token.
+TEST_F(Eagle3ModelTest, DraftTreeMaskStaticShapes) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+    ASSERT_NO_THROW(
+        compiled = create_compiled_model(ov::test::npuw::build_eagle3_draft_test_model(true), eagle_props(), recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& prefill = require_sub_model(recorder, "_prefill");
+    const auto& generate = require_sub_model_containing(recorder, "_kv");
+
+    const auto prefill_mask = input_shape(prefill.model, "eagle_tree_mask");
+    ASSERT_TRUE(prefill_mask.has_value()) << "eagle_tree_mask input missing or dynamic on prefill model";
+    EXPECT_EQ(*prefill_mask, (ov::Shape{1, 1, 1, 1}));
+
+    // kvcache size = MAX_PROMPT_LEN(128) + MIN_RESPONSE_LEN(64)
+    const auto generate_mask = input_shape(generate.model, "eagle_tree_mask");
+    ASSERT_TRUE(generate_mask.has_value()) << "eagle_tree_mask input missing or dynamic on generate model";
+    EXPECT_EQ(*generate_mask, (ov::Shape{1, 1, 1, 192}));
+}
+
+// Raw-export draft form: the "d2t" output GenAI extracts and strips before the
+// model reaches NPUW. Builder-level structural check only — no pipeline run.
+TEST(Eagle3DraftBuilderTest, D2tOutputMatchesRawExportForm) {
+    auto cfg = ov::test::npuw::make_test_model_config<ov::test::npuw::Eagle3DraftConfig>();
+    cfg.draft_vocab_size = 128;
+    cfg.with_d2t = true;
+    ov::test::npuw::ModelBuilder mb;
+    const auto model = mb.build_eagle3_draft(cfg);
+
+    std::shared_ptr<ov::op::v0::Constant> d2t;
+    for (const auto& out : model->outputs()) {
+        if (out.get_names().count("d2t")) {
+            d2t = ov::as_type_ptr<ov::op::v0::Constant>(out.get_node_shared_ptr()->get_input_node_shared_ptr(0));
+        }
+    }
+    ASSERT_NE(d2t, nullptr) << "d2t output missing or not fed by a Constant";
+    EXPECT_EQ(d2t->get_element_type(), ov::element::i64);
+    ASSERT_EQ(d2t->get_shape(), (ov::Shape{cfg.draft_vocab_size}));
+
+    // Offsets must map the draft vocab into the target vocab strictly monotonically.
+    const auto offsets = d2t->cast_vector<int64_t>();
+    int64_t prev_target = -1;
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        const int64_t target = static_cast<int64_t>(i) + offsets[i];
+        ASSERT_GE(target, 0) << "d2t maps draft id " << i << " below 0";
+        ASSERT_LT(target, static_cast<int64_t>(cfg.vocab_size)) << "d2t maps draft id " << i << " past target vocab";
+        ASSERT_GT(target, prev_target) << "d2t mapping must be strictly increasing at draft id " << i;
+        prev_target = target;
+    }
+}
+
+}  // namespace


### PR DESCRIPTION
### Details:
 - Add Eagle3 target and draft model support to the NPUW test-engine model builder, mirroring the models NPUW receives after GenAI's Eagle3 preprocessing (openvino.genai eagle3_model_transforms.cpp

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: yes*
- *Implementation and tests developed with AI assistance (Claude Code). Human validation.*
