### PR TITLE
 [GPU] Move cache compatibility checks from EP to device plugin

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/compiled_model.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/compiled_model.hpp
@@ -50,6 +50,11 @@ public:
     // Format: meta=<ver>;ov=<ov>;desc=[<driver/hw features>]
     static std::string build_runtime_requirements(const cldnn::device_info& info);
 
+    // Single source of truth for the GPU compatibility policy: returns true if the persisted
+    // descriptor 'requirements' can run on the device described by 'info'. Shared by import_model()
+    // and the ov::compatibility_check property so the two never diverge if the policy changes.
+    static bool is_runtime_requirements_compatible(const std::string& requirements, const cldnn::device_info& info);
+
     // Version of the runtime requirements descriptor persisted in the blob. Bump this whenever
     // build_runtime_requirements() changes (its format or the fields it emits) so the importer
     // can detect and reject descriptors produced by a different build.

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -106,8 +106,8 @@ CompiledModel::CompiledModel(cldnn::BinaryInputBuffer& ib,
     ib >> m_runtime_requirements;
 
     // Reject a blob compiled for a different runtime (OpenVINO version/driver). The descriptor is
-    // device-deterministic, so a mismatch means the cached kernels cannot run here. Mirrors NPU:
-    // throwing lets the caller (cache layer / OV EP) recompile instead of consuming a bad blob.
+    // device-deterministic, so a mismatch means the cached kernels cannot run here. Throwing lets
+    // the caller (cache layer / OV EP) recompile instead of consuming a bad blob.
     const std::string current_runtime_requirements =
         build_runtime_requirements(m_context->get_engine().get_device_info());
     OPENVINO_ASSERT(m_runtime_requirements == current_runtime_requirements,

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -108,15 +108,13 @@ CompiledModel::CompiledModel(cldnn::BinaryInputBuffer& ib,
     ib >> m_runtime_requirements;
 
     // Descriptor content mismatch => blob built for a different runtime (OpenVINO version/driver).
-    // The descriptor is device-deterministic, so a mismatch means the cached kernels can't run here.
-    const std::string current_runtime_requirements =
-        build_runtime_requirements(m_context->get_engine().get_device_info());
-    if (m_runtime_requirements != current_runtime_requirements) {
+    const auto& device_info = m_context->get_engine().get_device_info();
+    if (!is_runtime_requirements_compatible(m_runtime_requirements, device_info)) {
         OPENVINO_THROW("[GPU] Cannot import compiled blob: it was built for a different runtime "
                        "configuration (OpenVINO version/driver mismatch) and cannot be executed on "
                        "this device.\n"
                        "  blob:    ", m_runtime_requirements, "\n"
-                       "  current: ", current_runtime_requirements);
+                       "  current: ", build_runtime_requirements(device_info));
     }
 
     {
@@ -298,6 +296,13 @@ std::string CompiledModel::build_runtime_requirements(const cldnn::device_info& 
        << ";eus=" << info.execution_units_count << "]";
     return ss.str();
 }
+
+bool CompiledModel::is_runtime_requirements_compatible(const std::string& requirements, const cldnn::device_info& info) {
+    // v1 policy: exact match of the full, device-deterministic descriptor. Change this single
+    // function to adjust the policy (e.g. OpenVINO-version-only) for both import and compatibility_check.
+    return requirements == build_runtime_requirements(info);
+}
+
 const std::vector<std::shared_ptr<Graph>>& CompiledModel::get_graphs() const {
     return m_graphs;
 }

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -86,36 +86,38 @@ CompiledModel::CompiledModel(cldnn::BinaryInputBuffer& ib,
     , m_wait_executor(std::make_shared<ov::threading::CPUStreamsExecutor>(ov::threading::IStreamsExecutor::Config{"Intel GPU plugin wait executor"}))
     , m_model_name("")
     , m_loaded_from_cache(loaded_from_cache) {
-    // After ov::CacheMode the blob must start with the magic-guarded compatibility-descriptor
-    // block written by export_model. A blob lacking the magic was produced by an OpenVINO build
-    // predating this feature; cross-version blob import is not supported, so fail fast.
+    // The compiled blob starts (after ov::CacheMode) with a magic-guarded, versioned
+    // compatibility descriptor. Any rejection below throws ov::Exception;
+    // So the caller (cache layer / OV EP) catches it and recompiles instead of consuming a bad blob.
+
+    // Missing magic => blob produced by an OpenVINO build predating this feature.
     uint64_t requirements_magic = 0;
     ib >> requirements_magic;
-    OPENVINO_ASSERT(requirements_magic == runtime_requirements_magic,
-                    "[GPU] Cannot import compiled blob: missing compatibility descriptor "
-                    "(blob produced by an incompatible OpenVINO version).");
+    if (requirements_magic != runtime_requirements_magic) {
+        OPENVINO_THROW("[GPU] Cannot import compiled blob: missing compatibility descriptor "
+                       "(blob produced by an incompatible OpenVINO version).");
+    }
 
+    // Unknown descriptor version => on-disk contract we can't parse safely.
     uint32_t requirements_version = 0;
     ib >> requirements_version;
-    // An unrecognized version means the descriptor block follows an on-disk contract we don't
-    // understand, so the remainder of the blob cannot be parsed safely. Fail the import; the
-    // caching layer then falls back to recompiling the model.
-    OPENVINO_ASSERT(requirements_version == runtime_requirements_version,
-                    "[GPU] Unsupported compatibility descriptor version ", requirements_version,
-                    " in compiled blob (expected ", runtime_requirements_version, ").");
+    if (requirements_version != runtime_requirements_version) {
+        OPENVINO_THROW("[GPU] Unsupported compatibility descriptor version ", requirements_version,
+                       " in compiled blob (expected ", runtime_requirements_version, ").");
+    }
     ib >> m_runtime_requirements;
 
-    // Reject a blob compiled for a different runtime (OpenVINO version/driver). The descriptor is
-    // device-deterministic, so a mismatch means the cached kernels cannot run here. Throwing lets
-    // the caller (cache layer / OV EP) recompile instead of consuming a bad blob.
+    // Descriptor content mismatch => blob built for a different runtime (OpenVINO version/driver).
+    // The descriptor is device-deterministic, so a mismatch means the cached kernels can't run here.
     const std::string current_runtime_requirements =
         build_runtime_requirements(m_context->get_engine().get_device_info());
-    OPENVINO_ASSERT(m_runtime_requirements == current_runtime_requirements,
-                    "[GPU] Cannot import compiled blob: it was built for a different runtime "
-                    "configuration (OpenVINO version/driver mismatch) and cannot be executed on "
-                    "this device.\n"
-                    "  blob:    ", m_runtime_requirements, "\n"
-                    "  current: ", current_runtime_requirements);
+    if (m_runtime_requirements != current_runtime_requirements) {
+        OPENVINO_THROW("[GPU] Cannot import compiled blob: it was built for a different runtime "
+                       "configuration (OpenVINO version/driver mismatch) and cannot be executed on "
+                       "this device.\n"
+                       "  blob:    ", m_runtime_requirements, "\n"
+                       "  current: ", current_runtime_requirements);
+    }
 
     {
         size_t num_params = 0;

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -105,6 +105,18 @@ CompiledModel::CompiledModel(cldnn::BinaryInputBuffer& ib,
                     " in compiled blob (expected ", runtime_requirements_version, ").");
     ib >> m_runtime_requirements;
 
+    // Reject a blob compiled for a different runtime (OpenVINO version/driver). The descriptor is
+    // device-deterministic, so a mismatch means the cached kernels cannot run here. Mirrors NPU:
+    // throwing lets the caller (cache layer / OV EP) recompile instead of consuming a bad blob.
+    const std::string current_runtime_requirements =
+        build_runtime_requirements(m_context->get_engine().get_device_info());
+    OPENVINO_ASSERT(m_runtime_requirements == current_runtime_requirements,
+                    "[GPU] Cannot import compiled blob: it was built for a different runtime "
+                    "configuration (OpenVINO version/driver mismatch) and cannot be executed on "
+                    "this device.\n"
+                    "  blob:    ", m_runtime_requirements, "\n"
+                    "  current: ", current_runtime_requirements);
+
     {
         size_t num_params = 0;
         ib >> num_params;

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -705,10 +705,10 @@ ov::Any Plugin::get_metric(const std::string& name, const ov::AnyMap& options) c
         if (auto it = options.find(ov::runtime_requirements.name()); it != options.end()) {
             const auto& requirements = it->second.as<std::string>();
             if (!requirements.empty()) {
-                // v1: full-string equality against the current device descriptor.
-                const auto current = CompiledModel::build_runtime_requirements(device_info);
-                return requirements == current ? ov::CompatibilityCheck::SUPPORTED
-                                               : ov::CompatibilityCheck::UNSUPPORTED;
+                // Same compatibility policy as the import_model() guard (single source of truth).
+                return CompiledModel::is_runtime_requirements_compatible(requirements, device_info)
+                           ? ov::CompatibilityCheck::SUPPORTED
+                           : ov::CompatibilityCheck::UNSUPPORTED;
             }
         }
         return ov::CompatibilityCheck::NOT_APPLICABLE;

--- a/src/plugins/intel_gpu/tests/functional/behavior/compatibility_string.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/compatibility_string.cpp
@@ -184,6 +184,40 @@ TEST_F(CompatibilityStringGPU, ImportRejectsCorruptedDescriptorHeader) {
     }
 }
 
+// import_model must reject a blob whose descriptor content doesn't match this device (a different
+// OpenVINO version or GPU driver) -- the CVS-189661 guard, mirroring NPU. A single descriptor byte
+// is altered in place (same length, so the blob layout and page-aligned graph are untouched), so
+// the failure comes from the content mismatch, not the structural magic/version guard.
+TEST_F(CompatibilityStringGPU, ImportRejectsMismatchedRuntimeRequirements) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    ov::Core core;
+    ov::CompiledModel compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU));
+    const auto requirements = compiled_model.get_property(ov::runtime_requirements);
+    ASSERT_FALSE(requirements.empty());
+
+    std::stringstream good_blob;
+    OV_ASSERT_NO_THROW(compiled_model.export_model(good_blob));
+    std::string data = good_blob.str();
+
+    // Descriptor string bytes follow [ ov::CacheMode ][ uint64 magic ][ uint32 version ][ size_t len ].
+    const size_t descriptor_offset =
+        sizeof(ov::CacheMode) + sizeof(uint64_t) + sizeof(uint32_t) + sizeof(uint64_t);
+    ASSERT_GT(data.size(), descriptor_offset);
+
+    // Sanity: the untouched blob imports cleanly.
+    {
+        std::stringstream blob(data);
+        ov::CompiledModel imported;
+        OV_ASSERT_NO_THROW(imported = core.import_model(blob, ov::test::utils::DEVICE_GPU));
+    }
+
+    // Alter one descriptor byte in place so the persisted requirements no longer match the device.
+    data[descriptor_offset] ^= 0x01;
+    std::stringstream blob(data);
+    EXPECT_THROW((void)core.import_model(blob, ov::test::utils::DEVICE_GPU), ov::Exception);
+}
+
 // Mirror of the ONNX Runtime OrtCompiledModelCompatibility states that the GPU plugin
 // can actually produce. OpenVINO's ov::CompatibilityCheck has 3 states and the GPU
 // plugin never reports a "runs but suboptimal" outcome, so the ORT

--- a/src/plugins/intel_gpu/tests/functional/behavior/compatibility_string.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/compatibility_string.cpp
@@ -185,9 +185,9 @@ TEST_F(CompatibilityStringGPU, ImportRejectsCorruptedDescriptorHeader) {
 }
 
 // import_model must reject a blob whose descriptor content doesn't match this device (a different
-// OpenVINO version or GPU driver) -- the CVS-189661 guard, mirroring NPU. A single descriptor byte
-// is altered in place (same length, so the blob layout and page-aligned graph are untouched), so
-// the failure comes from the content mismatch, not the structural magic/version guard.
+// OpenVINO version or GPU driver) -- the CVS-189661 guard. A single descriptor byte is altered in
+// place (same length, so the blob layout and page-aligned graph are untouched), so the failure
+// comes from the content mismatch, not the structural magic/version guard.
 TEST_F(CompatibilityStringGPU, ImportRejectsMismatchedRuntimeRequirements) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
     ov::Core core;


### PR DESCRIPTION
### Details:
Moves cache-compatibility checking into the GPU plugin (CVS-178344). import_model now rejects a cached blob if its persisted compatibility descriptor doesn't match the current device (OpenVINO version or GPU driver), mirroring the existing NPU plugin behavior.
The blob stores a magic-guarded, versioned descriptor (meta=1.0;ov=<M.m.p>;desc=[driver=<ver>;ip=<gfx_ip>;eus=<n>]). Import rejects the blob when the magic marker is missing, the descriptor version is unknown, or the descriptor doesn't match the device — throwing ov::Exception, same as NPU.
The comparison logic lives in one place, CompiledModel::is_runtime_requirements_compatible(), shared by both the import_model guard and the ov::compatibility_check property, so the two always stay in sync. Descriptor fields come from build_runtime_requirements(); changing fields or the comparison policy is a one-place edit each.

### Testing
- New test CompatibilityStringGPU.ImportRejectsMismatchedRuntimeRequirements: mutates one descriptor byte in an exported blob in place and confirms import_model throws.
- Full CompatibilityStringGPU suite (10 tests) passes on Intel Arc B580 (Xe2), oneDNN rls-v3.13.
- Manually verified with the hello_classification export/import reproducer: a matching blob imports and runs; a blob with a mismatched OV version is rejected with a clear error.

### Tickets:
 - CVS-189661
 - CVS-178344 (parent requirement)