### PR TITLE
[PyOV] Skip dependency review for `pytz==2026.2` due to faulty license discovery

### DIFF
--- a/.github/dependency_review.yml
+++ b/.github/dependency_review.yml
@@ -23,4 +23,5 @@ vulnerability-check: true
 allow-dependencies-licenses:
   - 'pkg:pypi/PyGithub@2.2.0'
   - 'pkg:pypi/psycopg2-binary'
+  - 'pkg:pypi/pytz@2026.2' # MIT license, but dependency review flags it as MIT AND ZPL-2.1: https://github.com/stub42/pytz/blob/release_2026.2/LICENSE.txt
   - 'pkg:npm/@sinclair/typebox@0.34.49' # It has only an MIT license, but the dependency check actions reports it as MIT AND Zlib, see https://github.com/sinclairzx81/sinclair-typebox?tab=License-1-ov-file

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -28,7 +28,7 @@ pytest==9.1.1
 pytest-html==4.2.0
 pytest-metadata==3.1.1
 py>=1.11.0
-pytz==2026.1.post1
+pytz==2026.2
 pyyaml==6.0.3
 requests==2.34.2
 six==1.17.0


### PR DESCRIPTION
### Details:
 - `pytz` Dependabot PR at https://github.com/openvinotoolkit/openvino/pull/35656 keeps failing the dependency review, because the job misdiscovers the license as `MIT AND ZPL-2.1`, while the license is `MIT` as indicated [here](https://github.com/stub42/pytz/blob/release_2026.2/LICENSE.txt)
 - The fix is to manually whitelist `pytz==2026.2` as an approved package

### Tickets:
 - N/A
