### PR TITLE
[TESTS] Fix failing nightly PyTorch model hub tests

### DIFF
--- a/.github/workflows/job_pytorch_models_tests.yml
+++ b/.github/workflows/job_pytorch_models_tests.yml
@@ -126,7 +126,8 @@ jobs:
             -r ${MODEL_HUB_TESTS_INSTALL_DIR}/pytorch/envs/hf_transformers.txt \
             -r ${MODEL_HUB_TESTS_INSTALL_DIR}/pytorch/envs/easyocr.txt \
             -r ${MODEL_HUB_TESTS_INSTALL_DIR}/pytorch/envs/gfpgan.txt \
-            -r ${MODEL_HUB_TESTS_INSTALL_DIR}/pytorch/envs/tpsmm.txt
+            -r ${MODEL_HUB_TESTS_INSTALL_DIR}/pytorch/envs/tpsmm.txt \
+            -r ${MODEL_HUB_TESTS_INSTALL_DIR}/pytorch/envs/lightglue.txt
 
       - name: PyTorch Models Tests Not Timm or Torchvision
         if: ${{ inputs.model_scope == 'precommit' || inputs.model_scope == 'nightly_scope2' }}

--- a/tests/model_hub_tests/pytorch/envs/lightglue.txt
+++ b/tests/model_hub_tests/pytorch/envs/lightglue.txt
@@ -1,0 +1,3 @@
+# Extra dependencies for test_lightglue.py
+# kornia is required by lightglue_onnx/disk.py which is imported via __init__.py
+kornia

--- a/tests/model_hub_tests/pytorch/test_hf_transformers.py
+++ b/tests/model_hub_tests/pytorch/test_hf_transformers.py
@@ -437,6 +437,10 @@ class TestTransformersModel(TestTorchConvertModel):
                     example = dict(input_ids=encoded_input["input_ids"],
                                    token_type_ids=encoded_input["token_type_ids"],
                                    attention_mask=encoded_input["attention_mask"])
+                elif 'image-classification' in mi.tags:
+                    image_processor = AutoImageProcessor.from_pretrained(model_cached)
+                    encoded_input = image_processor(images=self.image, return_tensors="pt")
+                    example = dict(encoded_input)
                 else:
                     text = "Replace me by any text you'd like."
                     if auto_processor is not None and "Tokenizer" not in auto_processor:


### PR DESCRIPTION
### Details

Fix 5 nightly CI test failures in PyTorch model hub tests.

#### LightGlue tests (`test_convert_model[CPU]`, `test_convert_model_export[CPU]`)

**Root cause**: `lightglue_onnx/__init__.py` unconditionally imports `from .disk import DISK`, and `disk.py` has a top-level `import kornia`. The `kornia` package was not installed in the test environment.

**Fix**: Added `tests/model_hub_tests/pytorch/envs/lightglue.txt` with `kornia` as a dependency, and included it in the `Install deps for HF Transformers/LLM and other model tests` step in `job_pytorch_models_tests.yml`. The existing `tests/constraints.txt` already pins `kornia==0.8.3`.

#### BEiT / MobileViT / MobileViTV2 tests

**Root cause**: HuggingFace model info for these models returns `auto_model='AutoModel'` (not `'AutoModelForImageClassification'`), so the image-classification input preparation branch was never taken. The code fell through to a text-tokenizer fallback that failed silently (bare `except: pass`), leaving `example=None`. The final fallback then constructed a wrong 2D `[1, 100]` tensor instead of the required 4D image tensor `[1, 3, H, W]`, causing:
- `ValueError: not enough values to unpack (expected 4, got 2)` for BEiT
- `RuntimeError: Expected 3D (unbatched) or 4D (batched) input to conv2d, but got input of size: [1, 100]` for MobileViT/v2

**Fix**: Added an `elif 'image-classification' in mi.tags:` branch in `load_model()` that uses `AutoImageProcessor` to build the correct `pixel_values` input whenever a model carries the `image-classification` HuggingFace tag but has a generic `auto_model` value.

### Tickets
 - *N/A*