### PR TITLE
[ONNX FE] Support fp8 (float8e4m3fn) KV cache in GroupQueryAttention

### DIFF
--- a/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
@@ -36,14 +36,15 @@ private:
     std::shared_ptr<ov::Node> make_kv_scale(const ov::Output<ov::Node>& scale,
                                             int64_t kv_num_heads,
                                             const std::string& quant_type);
-    // Dequantize a quantized (i8/u8) KV cache to compute_type: x = q * scale (symmetric, zero point = 0).
+    // Dequantize a quantized (i8/u8/f8e4m3) KV cache to compute_type: x = q * scale (symmetric, zero point = 0).
     std::shared_ptr<ov::Node> dequantize_kv(const ov::Output<ov::Node>& quantized,
                                             const ov::Output<ov::Node>& scale,
                                             int64_t kv_num_heads,
                                             int64_t kv_cache_bit_width,
                                             const std::string& quant_type,
                                             const ov::element::Type& compute_type);
-    // Quantize current float KV tokens into the cache type: q = clamp(round(x / scale)) (round-half-to-even).
+    // Quantize current float KV tokens into the cache type: integer i8/u8 uses clamp(round(x / scale))
+    // (round-half-to-even); f8e4m3 uses clamp(x / scale, +/-448) then Convert (no integer round).
     std::shared_ptr<ov::Node> quantize_kv(const ov::Output<ov::Node>& current,
                                           const ov::Output<ov::Node>& scale,
                                           int64_t kv_num_heads,

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -445,6 +445,14 @@ std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::quantize_k
     const auto safe_scale = register_new_node<v1::Select>(is_zero_scale, one, scale_ct);
     const auto inv_scale = register_new_node<v1::Divide>(one, safe_scale);
     const auto scaled = register_new_node<v1::Multiply>(current, inv_scale);
+
+    if (cache_type == ov::element::f8e4m3) {
+        // f8e4m3 cache: no integer Round (Convert rounds to the f8e4m3 grid). Clamp to +/-448 (f8e4m3 max)
+        // first: Convert to f8e4m3 maps out-of-range magnitudes to NaN, not saturation.
+        const auto clamped = register_new_node<v0::Clamp>(scaled, -448.0, 448.0);
+        return register_new_node<v0::Convert>(clamped, cache_type);
+    }
+
     const auto rounded = register_new_node<v5::Round>(scaled, v5::Round::RoundMode::HALF_TO_EVEN);
 
     if (kv_cache_bit_width == 4) {

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -90,7 +90,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     auto seqlens_k = node->input_value(5);
     auto total_sequence_length = node->input_value(6);
 
-    // Quantized KV cache (com.microsoft spec): past/present KV are i8/u8 and are dequantized before the
+    // Quantized KV cache (com.microsoft spec): past/present KV are i8/u8/f8e4m3 and are dequantized before the
     // attention math and (re)quantized when appended to the cache. Scales live at inputs 12 (K) / 13 (V).
     const bool kv_quantized = node->is_kv_quantized();
     const auto kv_cache_bit_width = node->get_kv_cache_bit_width();

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -63,18 +63,22 @@ void GroupQueryAttention::validate_and_infer_types() {
                           "GroupQueryAttention supports following query element types: {f32, f16}");
 
     // The KV cache (past_key/past_value, input 3/4) may be quantized. present_key/present_value inherit the
-    // cache element type so a quantized (i8/u8) cache round-trips from past to present, matching the ONNX spec.
+    // cache element type so a quantized (i8/u8/f8e4m3) cache round-trips from past to present, matching the ONNX spec.
     const auto& kv_cache_type = get_input_element_type(3);
     NODE_VALIDATION_CHECK(this,
                           kv_cache_type == element::f32 || kv_cache_type == element::f16 ||
-                              kv_cache_type == element::i8 || kv_cache_type == element::u8,
-                          "GroupQueryAttention supports following KV cache element types: {f32, f16, i8, u8}");
+                              kv_cache_type == element::i8 || kv_cache_type == element::u8 ||
+                              kv_cache_type == element::f8e4m3,
+                          "GroupQueryAttention supports following KV cache element types: {f32, f16, i8, u8, f8e4m3}");
 
     if (is_kv_quantized()) {
-        // Quantized KV cache: i8 (8-bit) or u8 (4-bit values packed two per byte). Requires float dequant scales.
-        NODE_VALIDATION_CHECK(this,
-                              kv_cache_type == element::i8 || kv_cache_type == element::u8,
-                              "GroupQueryAttention with quantized KV cache requires an i8 or u8 past/present KV type");
+        // Quantized KV cache: i8 (8-bit), u8 (4-bit values packed two per byte), or f8e4m3 (8-bit float). Requires
+        // float dequant scales.
+        NODE_VALIDATION_CHECK(
+            this,
+            kv_cache_type == element::i8 || kv_cache_type == element::u8 || kv_cache_type == element::f8e4m3,
+            "GroupQueryAttention with quantized KV cache requires an i8, u8, or f8e4m3 past/present "
+            "KV type");
         NODE_VALIDATION_CHECK(this,
                               m_kv_cache_bit_width == 8 || m_kv_cache_bit_width == 4,
                               "GroupQueryAttention supports kv_cache_bit_width of 8 or 4, got: ",

--- a/src/frontends/onnx/tests/models/com.microsoft/gqa_f8e4m3fnkv_per_channel.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/gqa_f8e4m3fnkv_per_channel.prototxt
@@ -1,0 +1,241 @@
+ir_version: 10
+graph {
+  node {
+    input: "query"
+    input: ""
+    input: ""
+    input: "past_key"
+    input: "past_value"
+    input: "seqlens_k"
+    input: "total_sequence_length"
+    input: ""
+    input: ""
+    input: ""
+    input: ""
+    input: ""
+    input: "k_scale"
+    input: "v_scale"
+    output: "output"
+    output: "present_key"
+    output: "present_value"
+    op_type: "GroupQueryAttention"
+    attribute {
+      name: "do_rotary"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "k_quant_type"
+      s: "PER_CHANNEL"
+      type: STRING
+    }
+    attribute {
+      name: "kv_cache_bit_width"
+      i: 8
+      type: INT
+    }
+    attribute {
+      name: "kv_num_heads"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "num_heads"
+      i: 2
+      type: INT
+    }
+    attribute {
+      name: "v_quant_type"
+      s: "PER_CHANNEL"
+      type: STRING
+    }
+    domain: "com.microsoft"
+  }
+  name: "GQA_DynQuant"
+  initializer {
+    dims: 8
+    data_type: 1
+    float_data: 0.02684
+    float_data: 0.03718
+    float_data: 0.03622
+    float_data: 0.03502
+    float_data: 0.02828
+    float_data: 0.04075
+    float_data: 0.04241
+    float_data: 0.05875
+    name: "k_scale"
+  }
+  initializer {
+    dims: 8
+    data_type: 1
+    float_data: 0.05982
+    float_data: 0.04612
+    float_data: 0.04303
+    float_data: 0.05891
+    float_data: 0.06436
+    float_data: 0.05375
+    float_data: 0.06002
+    float_data: 0.06696
+    name: "v_scale"
+  }
+  input {
+    name: "query"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_param: "sequence_length"
+          }
+          dim {
+            dim_value: 32
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "past_key"
+    type {
+      tensor_type {
+        elem_type: 17
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_param: "past_sequence_length"
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "past_value"
+    type {
+      tensor_type {
+        elem_type: 17
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_param: "past_sequence_length"
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "seqlens_k"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "total_sequence_length"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_param: "sequence_length"
+          }
+          dim {
+            dim_value: 16
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "present_key"
+    type {
+      tensor_type {
+        elem_type: 17
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_param: "total_sequence_length"
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "present_value"
+    type {
+      tensor_type {
+        elem_type: 17
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_param: "total_sequence_length"
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 21
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/com.microsoft/gqa_f8e4m3fnkv_per_tensor.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/gqa_f8e4m3fnkv_per_tensor.prototxt
@@ -1,0 +1,227 @@
+ir_version: 10
+graph {
+  node {
+    input: "query"
+    input: ""
+    input: ""
+    input: "past_key"
+    input: "past_value"
+    input: "seqlens_k"
+    input: "total_sequence_length"
+    input: ""
+    input: ""
+    input: ""
+    input: ""
+    input: ""
+    input: "k_scale"
+    input: "v_scale"
+    output: "output"
+    output: "present_key"
+    output: "present_value"
+    op_type: "GroupQueryAttention"
+    attribute {
+      name: "do_rotary"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "k_quant_type"
+      s: "PER_TENSOR"
+      type: STRING
+    }
+    attribute {
+      name: "kv_cache_bit_width"
+      i: 8
+      type: INT
+    }
+    attribute {
+      name: "kv_num_heads"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "num_heads"
+      i: 2
+      type: INT
+    }
+    attribute {
+      name: "v_quant_type"
+      s: "PER_TENSOR"
+      type: STRING
+    }
+    domain: "com.microsoft"
+  }
+  name: "GQA_DynQuant"
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.02382
+    name: "k_scale"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.059
+    name: "v_scale"
+  }
+  input {
+    name: "query"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_param: "sequence_length"
+          }
+          dim {
+            dim_value: 32
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "past_key"
+    type {
+      tensor_type {
+        elem_type: 17
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_param: "past_sequence_length"
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "past_value"
+    type {
+      tensor_type {
+        elem_type: 17
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_param: "past_sequence_length"
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "seqlens_k"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "total_sequence_length"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_param: "sequence_length"
+          }
+          dim {
+            dim_value: 16
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "present_key"
+    type {
+      tensor_type {
+        elem_type: 17
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_param: "total_sequence_length"
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "present_value"
+    type {
+      tensor_type {
+        elem_type: 17
+        shape {
+          dim {
+            dim_param: "batch_size"
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_param: "total_sequence_length"
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 21
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -4567,6 +4567,180 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_i8kv_present_type_is_int8) {
     EXPECT_EQ(model->outputs()[2].get_element_type(), element::i8);
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_tensor) {
+    const auto model = convert_model("com.microsoft/gqa_f8e4m3fnkv_per_tensor.onnx");
+
+    // Same tiny dynamic-past config as the i8 tests but with an f8e4m3fn KV cache (8-bit float, unpacked one byte
+    // per element) and a single per-tensor scale for K and V. Quantize-on-write clamps to +/-448 and casts to the
+    // f8e4m3fn grid (no integer round); expected values come from an independent numpy oracle.
+    std::vector<float> query = {
+        0.676199973f,   -0.186399996f, 0.0131000001f, 0.163000003f,   -0.315600008f, 0.00079999998f, -0.00039999999f,
+        -0.701900005f,  0.407099992f,  0.240199998f,  -0.250200003f,  -0.068599999f, 0.202099994f,   -0.104500003f,
+        -0.0970999971f, -0.58130002f,  0.221799999f,  0.0496000014f,  0.109800003f,  -0.610599995f,  0.660300016f,
+        0.0617000014f,  -0.154899999f, 0.811600029f,  -0.0182000007f, -0.580299973f, -0.162100002f,  -0.915300012f,
+        0.419800013f,   -0.166600004f, -0.296999991f, 0.42899999f};
+    std::vector<ov::float8_e4m3> past_key = {-0.6875f,
+                                             0.21875f,
+                                             -0.8125f,
+                                             -0.25f,
+                                             -0.46875f,
+                                             0.5625f,
+                                             0.6875f,
+                                             -0.125f,
+                                             0.34375f,
+                                             -0.0703125f,
+                                             0.234375f,
+                                             -0.3125f,
+                                             -0.6875f,
+                                             -0.75f,
+                                             0.15625f,
+                                             0.875f};
+    std::vector<ov::float8_e4m3> past_value = {0.109375f,
+                                               -0.203125f,
+                                               0.75f,
+                                               0.09375f,
+                                               0.0390625f,
+                                               0.1015625f,
+                                               -0.0546875f,
+                                               -0.125f,
+                                               -0.5625f,
+                                               0.203125f,
+                                               -0.0390625f,
+                                               0.46875f,
+                                               -0.140625f,
+                                               -0.75f,
+                                               -0.0390625f,
+                                               0.6875f};
+    std::vector<int> seqlens_k = {2};
+    std::vector<int> total_sequence_length = {3};
+    std::vector<float> expected_output = {-0.0147730736f,
+                                          -0.162738219f,
+                                          -0.0295751505f,
+                                          -0.248367518f,
+                                          0.111748219f,
+                                          -0.0586159788f,
+                                          -0.0833739191f,
+                                          0.134082437f,
+                                          -0.0149462344f,
+                                          -0.186042979f,
+                                          -0.0367756262f,
+                                          -0.28629908f,
+                                          0.128175616f,
+                                          -0.0642310604f,
+                                          -0.0949096084f,
+                                          0.150861159f};
+    std::vector<ov::float8_e4m3> expected_present_key = {-0.6875f, 0.21875f, -0.8125f, -0.25f,      -0.46875f, 0.5625f,
+                                                         0.6875f,  -0.125f,  0.34375f, -0.0703125f, 0.234375f, -0.3125f,
+                                                         -0.6875f, -0.75f,   0.15625f, 0.875f,      9.f,       2.f,
+                                                         4.5f,     -26.f,    28.f,     2.5f,        -6.5f,     36.f};
+    std::vector<ov::float8_e4m3> expected_present_value = {
+        0.109375f, -0.203125f, 0.75f,       0.09375f, 0.0390625f, 0.1015625f, -0.0546875f, -0.125f,
+        -0.5625f,  0.203125f,  -0.0390625f, 0.46875f, -0.140625f, -0.75f,     -0.0390625f, 0.6875f,
+        -0.3125f,  -10.f,      -2.75f,      -16.f,    7.f,        -2.75f,     -5.f,        7.5f};
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>(Shape{1, 1, 32}, query);
+    test_case.add_input<ov::float8_e4m3>(Shape{1, 1, 2, 8}, past_key);
+    test_case.add_input<ov::float8_e4m3>(Shape{1, 1, 2, 8}, past_value);
+    test_case.add_input<int>(Shape{1, 1}, seqlens_k);
+    test_case.add_input<int>(Shape{}, total_sequence_length);
+    test_case.add_expected_output<float>(Shape{1, 1, 16}, expected_output);
+    test_case.add_expected_output<ov::float8_e4m3>(Shape{1, 1, 3, 8}, expected_present_key);
+    test_case.add_expected_output<ov::float8_e4m3>(Shape{1, 1, 3, 8}, expected_present_value);
+    // Mixed float output + f8e4m3fn present KV: floats compared by ULP tolerance, present KV bit-exact.
+    test_case.run(11);
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_channel) {
+    const auto model = convert_model("com.microsoft/gqa_f8e4m3fnkv_per_channel.onnx");
+
+    // f8e4m3fn KV cache with per-channel scales (dynamic past). Expected values from the independent numpy oracle.
+    std::vector<float> query = {
+        -0.0771000013f,  -0.711199999f,  0.261900008f,  0.35769999f,    0.166199997f,  -0.369399995f, -0.0784000009f,
+        -0.236300007f,   -0.119900003f,  0.51880002f,   0.611800015f,   0.267800003f,  0.219500005f,  0.270700008f,
+        -0.00490000006f, -0.0303000007f, -0.269499987f, -0.0222999994f, 0.903999984f,  0.347600013f,  -0.136800006f,
+        -0.188800007f,   -0.345800012f,  0.149700001f,  0.156599998f,   -0.577199996f, 0.194499999f,  -0.227799997f,
+        0.57069999f,     0.0627000034f,  0.687099993f,  -0.183300003f};
+    std::vector<ov::float8_e4m3> past_key = {-0.1171875f,
+                                             0.1171875f,
+                                             0.4375f,
+                                             0.21875f,
+                                             -0.5f,
+                                             0.0703125f,
+                                             0.009765625f,
+                                             -0.171875f,
+                                             -0.25f,
+                                             0.6875f,
+                                             -0.15625f,
+                                             -0.34375f,
+                                             0.25f,
+                                             0.05078125f,
+                                             -0.03125f,
+                                             0.3125f};
+    std::vector<ov::float8_e4m3> past_value = {0.203125f,
+                                               0.140625f,
+                                               0.375f,
+                                               0.1171875f,
+                                               -0.25f,
+                                               -0.140625f,
+                                               -0.203125f,
+                                               0.0859375f,
+                                               -0.4375f,
+                                               -0.75f,
+                                               0.03515625f,
+                                               -0.5625f,
+                                               -0.75f,
+                                               0.15625f,
+                                               -0.28125f,
+                                               0.203125f};
+    std::vector<int> seqlens_k = {2};
+    std::vector<int> total_sequence_length = {3};
+    std::vector<float> expected_output = {0.0507653244f,
+                                          -0.229811132f,
+                                          0.0769735426f,
+                                          -0.0896462128f,
+                                          0.193254322f,
+                                          0.0225280188f,
+                                          0.2341986f,
+                                          -0.0617800318f,
+                                          0.0521740392f,
+                                          -0.235356137f,
+                                          0.0786823854f,
+                                          -0.0916523263f,
+                                          0.198932081f,
+                                          0.0231143273f,
+                                          0.240510762f,
+                                          -0.0635833964f};
+    std::vector<ov::float8_e4m3> expected_present_key = {
+        -0.1171875f, 0.1171875f, 0.4375f,   0.21875f,  -0.5f, 0.0703125f,  0.009765625f, -0.171875f,
+        -0.25f,      0.6875f,    -0.15625f, -0.34375f, 0.25f, 0.05078125f, -0.03125f,    0.3125f,
+        -10.f,       -0.625f,    24.f,      10.f,      -5.f,  -4.5f,       -8.f,         2.5f};
+    std::vector<ov::float8_e4m3> expected_present_value = {
+        0.203125f, 0.140625f, 0.375f,      0.1171875f, -0.25f, -0.140625f, -0.203125f, 0.0859375f,
+        -0.4375f,  -0.75f,    0.03515625f, -0.5625f,   -0.75f, 0.15625f,   -0.28125f,  0.203125f,
+        2.5f,      -13.f,     4.5f,        -3.75f,     9.f,    1.125f,     11.f,       -2.75f};
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>(Shape{1, 1, 32}, query);
+    test_case.add_input<ov::float8_e4m3>(Shape{1, 1, 2, 8}, past_key);
+    test_case.add_input<ov::float8_e4m3>(Shape{1, 1, 2, 8}, past_value);
+    test_case.add_input<int>(Shape{1, 1}, seqlens_k);
+    test_case.add_input<int>(Shape{}, total_sequence_length);
+    test_case.add_expected_output<float>(Shape{1, 1, 16}, expected_output);
+    test_case.add_expected_output<ov::float8_e4m3>(Shape{1, 1, 3, 8}, expected_present_key);
+    test_case.add_expected_output<ov::float8_e4m3>(Shape{1, 1, 3, 8}, expected_present_value);
+    test_case.run(11);
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_present_type_is_f8e4m3) {
+    // Type-inference check: an f8e4m3fn KV cache round-trips to f8e4m3 present outputs; attention output stays float.
+    const auto model = convert_model("com.microsoft/gqa_f8e4m3fnkv_per_channel.onnx");
+    ASSERT_EQ(model->get_results().size(), 3);
+    EXPECT_EQ(model->outputs()[0].get_element_type(), element::f32);
+    EXPECT_EQ(model->outputs()[1].get_element_type(), element::f8e4m3);
+    EXPECT_EQ(model->outputs()[2].get_element_type(), element::f8e4m3);
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_qk_norm_unsupported_throws) {
     // q_norm_weight/k_norm_weight (QK-Norm) inputs are not implemented and must be rejected.
     try {

--- a/src/frontends/onnx/tests/runtime/ie/unit_test.manifest
+++ b/src/frontends/onnx/tests/runtime/ie/unit_test.manifest
@@ -359,13 +359,15 @@ IE_GPU.onnx_model_gather_elements_int32_axis_0
 IE_GPU.onnx_model_gather_elements_int8_axis_1
 IE_GPU.onnx_model_gather_elements_float_3D_axis_2
 
-# GroupQueryAttention with a quantized KV cache appends tokens via ScatterUpdate on i8/u8
+# GroupQueryAttention with a quantized KV cache appends tokens via ScatterUpdate on i8/u8/f8e4m3
 # data, for which the GPU plugin has no layout ("No layout format available for scatterupdate
 # ... data_type: i8"). The numerics are covered on CPU/INTERPRETER; GPU is skipped here.
 IE_GPU.onnx_model_gqa_i8kv_per_channel
 IE_GPU.onnx_model_gqa_i8kv_per_tensor
 IE_GPU.onnx_model_gqa_i4kv_per_channel
 IE_GPU.onnx_model_gqa_i4kv_per_tensor
+IE_GPU.onnx_model_gqa_f8e4m3fnkv_per_channel
+IE_GPU.onnx_model_gqa_f8e4m3fnkv_per_tensor
 
 IE_CPU/ElemTypesTests/1.onnx_test_add_abc_set_precission
 


### PR DESCRIPTION
### What
Extends quantized-KV `com.microsoft::GroupQueryAttention` to an **fp8 (`float8e4m3fn`)** KV cache, on top of the int8/int4 support in #36676. `past_key`/`past_value` (and `present_*`) may now be `f8e4m3`, with f32 `k_scale`/`v_scale` and `k_quant_type`/`v_quant_type` (`PER_TENSOR`/`PER_CHANNEL`) exactly as for int8/int4. Conforms to the ORT spec whose `T_CACHE` includes `tensor(float8e4m3fn)`: https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftgroupqueryattention

### Why
fp8 is the third KV quantization format the spec allows (with int8/int4), halving KV bandwidth like int8 while staying floating-point (no integer rounding). It is already the default-on KV format in ORT's CUDA EP.

### How
fp8 is signaled by the **cache element type** (`float8e4m3fn`) with `kv_cache_bit_width = 8` (same width as int8, disambiguated by element type). Purely additive:
- **Op validation**: accept `f8e4m3` as a KV-cache type; `present_*` inherit the cache dtype (fp8→fp8) like i8/u8; f32 scale requirement unchanged.
- **`quantize_kv`**: new `f8e4m3` arm — no integer round (the `Convert` rounds to the f8e4m3 grid); clamp to `[-448, +448]` before `Convert`, since `Convert(f32→f8e4m3)` overflows to NaN, not saturation. Mirrors OV's `FakeConvertDecomposition` and the ORT reference (`kFp8E4M3Max = 448`).
- **`dequantize_kv`**: unchanged — fp8 reuses the existing 8-bit `Convert(f8e4m3→compute) * scale` path (symmetric, no zero-point), matching ORT `x = float(fp8) * scale`.

The KV-cache assembly (`ScatterUpdate` / `Slice`+`Concat`, left-aligned) is **untouched** (branches on shape, not element type), so int8/int4 behavior is bit-identical.

### Reference conformance
- CUDA QDQ kernel (fp8 branch, `clamp(±448)`+cast, symmetric): https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qdq.cuh
- CUDA registration under `USE_FP8_KV_CACHE`: https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
- Scale is f32 (`T_KV_SCALE = tensor(float)`) for fp8 as for int8/int4.

fp8 KV is a **storage** format — attention math runs in float (KV dequantized before SDPA), as in ORT. ORT's CPU/MLAS has no fp8, so tests validate against an independent reference replicating the ORT CUDA fp8 math.

### Tests
- `gqa_f8e4m3fnkv_per_{tensor,channel}`: `float8e4m3fn` KV (unpacked, 1 byte/elem), f32 scales, `kv_cache_bit_width=8`, dynamic past — same tiny config as the int8/int4 tests.
- Numeric tests use expected values from an independent numpy oracle (`clamp(x/scale,±448)→f8e4m3`, `load=f8*scale`); present-KV bit-exact, output at ULP tolerance. Plus a `present_type_is_f8e4m3` type-inference check.
- Pass on **CPU + INTERPRETER**; GPU manifest-skipped (quantized-KV `ScatterUpdate` has no i8/u8/f8 GPU layout — same as int8/int4).

### Scope / follow-ups
- **CPU/TEMPLATE only.** GPU numeric and NPU/NPUW fp8 deferred to follow-up PRs.
- Builds on #36676 (merged).


Tickets - https://jira.devtools.intel.com/browse/CVS-190171
 