### PR TITLE
[ONNX FE] Alias raw initializer weights zero-copy into Constants

### DIFF
--- a/src/frontends/onnx/frontend/include/openvino/frontend/onnx/decoder.hpp
+++ b/src/frontends/onnx/frontend/include/openvino/frontend/onnx/decoder.hpp
@@ -21,6 +21,10 @@ struct ONNX_FRONTEND_API TensorMetaInfo {
     const std::string* m_tensor_name;
     std::shared_ptr<std::string> m_external_location;
     bool m_is_raw;
+    // Keeps the storage that m_tensor_data points into alive for as long as it is referenced, so the
+    // bytes can be aliased instead of copied (for raw initializers this is the parsed model itself).
+    // Left empty when no such owner exists; in that case consumers must copy the data before use.
+    std::shared_ptr<void> m_data_owner;
 };
 
 class ONNX_FRONTEND_API DecoderBase : public ov::frontend::DecoderBase {

--- a/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
+++ b/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
@@ -447,6 +447,10 @@ ov::frontend::onnx::TensorMetaInfo extract_tensor_meta_info(const TensorProto* t
         if (tensor_info->has_raw_data()) {
             tensor_meta_info.m_tensor_data = reinterpret_cast<const uint8_t*>(tensor_info->raw_data().data());
             tensor_meta_info.m_tensor_data_size = tensor_info->raw_data().size();
+            // The raw bytes live inside the parsed model, which the iterator owns. Pin that owner so
+            // the bytes can be aliased into a Constant (zero-copy) without outliving their storage;
+            // the model isn't mutated, so this is safe to run more than once for the same tensor.
+            tensor_meta_info.m_data_owner = graph_iterator->get_model();
             tensor_meta_info.m_is_raw = true;
         } else {
             const auto assign_numeric_data = [&](const auto& container) {

--- a/src/frontends/onnx/frontend/src/core/graph_iterator_proto.hpp
+++ b/src/frontends/onnx/frontend/src/core/graph_iterator_proto.hpp
@@ -112,6 +112,12 @@ public:
         return m_graph;
     }
 
+    // Owning handle to the parsed model. Raw initializer bytes live inside it, so it can be used as
+    // a keep-alive owner to alias those bytes into Constants without copying (see extract_tensor_meta_info).
+    const std::shared_ptr<ModelProto>& get_model() const {
+        return m_model;
+    }
+
     std::int64_t get_opset_version(const std::string& domain) const override;
 
     std::map<std::string, std::string> get_metadata() const override;

--- a/src/frontends/onnx/frontend/src/core/tensor.cpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.cpp
@@ -5,6 +5,7 @@
 #include "core/tensor.hpp"
 
 #include "input_model.hpp"
+#include "openvino/runtime/shared_buffer.hpp"
 #include "openvino/util/file_util.hpp"
 
 namespace ov {
@@ -538,7 +539,13 @@ std::shared_ptr<ov::op::v0::Constant> Tensor::get_ov_constant() const {
     } else if (m_tensor_place != nullptr) {
         auto elemnt_type = m_tensor_place->get_element_type();
 
-        if (!m_tensor_place->is_const_data_reusable() || elemnt_type == ov::element::string) {
+        // Zero-copy aliasing is only valid for raw_data: its declared size is a byte count and its
+        // layout already matches OV's storage format. Type-specific fields (e.g. int32_data) store
+        // an element count instead and may need narrowing conversion, so they must always be copied.
+        // It also requires an owner to keep the aliased buffer alive (see TensorMetaInfo::m_data_owner);
+        // without one the data must be copied, otherwise the Constant would outlive the source memory.
+        if (!m_tensor_place->is_const_data_reusable() || elemnt_type == ov::element::string ||
+            !m_tensor_place->is_raw() || m_tensor_place->get_data_owner() == nullptr) {
             switch (elemnt_type) {
             case ov::element::f32:
             case ov::element::f64:
@@ -592,8 +599,14 @@ std::shared_ptr<ov::op::v0::Constant> Tensor::get_ov_constant() const {
             }
         } else {
             const void* data_ptr = m_tensor_place->get_data();
-            auto constant_buffer = std::make_shared<const void*>(data_ptr);
-            constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, data_ptr, constant_buffer);
+            // Alias the existing memory instead of copying it. When the tensor place tracks an owner
+            // (for example, an initializer's raw bytes detached from the parsed ONNX model), that
+            // owner is kept alive for the buffer's lifetime so the aliased pointer stays valid.
+            auto constant_buffer = std::make_shared<ov::SharedBuffer<std::shared_ptr<void>>>(
+                const_cast<char*>(static_cast<const char*>(data_ptr)),
+                m_tensor_place->get_data_size(),
+                m_tensor_place->get_data_owner());
+            constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, constant_buffer);
         }
     } else {
         FRONT_END_THROW("Tensor shape doesn't match data size");

--- a/src/frontends/onnx/frontend/src/core/tensor.hpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.hpp
@@ -89,7 +89,8 @@ public:
                     const ov::Any& data_any,
                     std::shared_ptr<std::string> data_location,
                     const bool is_raw,
-                    const bool reuse_const_data = false)
+                    const bool reuse_const_data = false,
+                    std::shared_ptr<void> data_owner = nullptr)
         : ov::frontend::onnx::TensorPlace(input_model, pshape, type, names),
           m_input_model(input_model),
           m_data(data),
@@ -97,7 +98,8 @@ public:
           m_data_size(data_size),
           m_data_location(data_location),
           m_is_raw(is_raw),
-          m_reuse_const_data(reuse_const_data) {};
+          m_reuse_const_data(reuse_const_data),
+          m_data_owner(std::move(data_owner)) {};
 
     void translate(ov::Output<ov::Node>& output);
 
@@ -146,6 +148,10 @@ public:
         return m_reuse_const_data;
     }
 
+    const std::shared_ptr<void>& get_data_owner() const {
+        return m_data_owner;
+    }
+
     detail::MappedMemoryHandles get_mmap_cache();
     detail::LocalStreamHandles get_stream_cache();
     std::filesystem::path get_model_dir() const;
@@ -159,6 +165,7 @@ protected:
     std::shared_ptr<std::string> m_data_location;
     bool m_is_raw;
     bool m_reuse_const_data;
+    std::shared_ptr<void> m_data_owner;
 };
 
 class Tensor {

--- a/src/frontends/onnx/frontend/src/frontend.cpp
+++ b/src/frontends/onnx/frontend/src/frontend.cpp
@@ -187,7 +187,14 @@ ov::frontend::InputModel::Ptr FrontEnd::load_impl(const std::vector<ov::Any>& va
             std::make_shared<GraphIteratorProto>(enable_mmap ? Internal_MMAP : Internal_Stream);
         graph_iterator->initialize(model_path);
         graph_iterator->reset();
-        return std::make_shared<unify::InputModel>(graph_iterator, enable_mmap, m_extensions.telemetry);
+        // Initializer raw bytes live inside the parsed ModelProto, which the graph iterator owns and
+        // keeps alive (see extract_tensor_meta_info), so it is safe to alias them into Constants
+        // instead of copying, avoiding a duplicate in-memory copy of the model's weights.
+        constexpr bool reuse_const_data = true;
+        return std::make_shared<unify::InputModel>(graph_iterator,
+                                                   enable_mmap,
+                                                   m_extensions.telemetry,
+                                                   reuse_const_data);
     };
 
     if (const auto path = get_path_from_any(variants[0])) {

--- a/src/frontends/onnx/frontend/src/input_model.cpp
+++ b/src/frontends/onnx/frontend/src/input_model.cpp
@@ -666,7 +666,8 @@ std::shared_ptr<ov::frontend::onnx::TensorONNXPlace> decode_tensor_place(
                                                               tensor_meta_info.m_tensor_data_any,
                                                               tensor_meta_info.m_external_location,
                                                               tensor_meta_info.m_is_raw,
-                                                              reuse_const_data);
+                                                              reuse_const_data,
+                                                              tensor_meta_info.m_data_owner);
     return tensor_place;
 }
 


### PR DESCRIPTION
### Details:
 - The ONNX frontend previously **copied** every `raw_data` initializer's bytes into the resulting `ov::op::v0::Constant`, duplicating the model's weights in memory. This PR aliases those bytes directly into the Constant via `ov::SharedBuffer`, so a model's weights exist only once in memory after loading.
 - The parsed `ModelProto` already owns the raw initializer bytes and is kept alive by the `GraphIteratorProto`. It is pinned as the `SharedBuffer` keep-alive owner through the new `TensorMetaInfo::m_data_owner` field (populated from `GraphIteratorProto::get_model()`), so the aliased pointer stays valid for the Constant's lifetime.
 - The model is **not** mutated to achieve this, so extracting a tensor's meta info is idempotent and safe to run more than once for the same tensor — including shared `If`/`Loop`/`Scan` subgraph bodies that reference the parent `ModelProto`.
 - Aliasing is deliberately narrow: only `raw_data` (whose declared size is a byte count with an OV-compatible layout) and only when an owner is present. Type-specific proto fields (e.g. `int32_data`, which store element counts and may need narrowing) and owner-less external iterators continue to copy.

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes
 - AI (Claude Code) was used to review the initial zero-copy implementation, identify a design flaw (weights were being detached/moved out of the `ModelProto`, causing a double-move corruption for re-translated subgraph bodies and mutating shared state), and refactor toward the simpler ModelProto-as-owner design in this PR. Human validation: local build of `openvino_onnx_frontend` passes and clang-format pre-commit hook applied; behavioral correctness to be confirmed by CI (ONNX frontend unit tests).