### PR TITLE
[ARM][CPU] Fix int8 FullyConnected accuracy for u8 activations

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.cpp
@@ -64,7 +64,7 @@ static void initFCAttrs(const FCAttrs& attrs,
                         const MemoryArgs& memory,
                         arm_compute::GEMMInfo& fullyConnectedLayerInfo) {
     aclTensorAttrs.hasLayoutTypeNHWC = memory.at(ARG_SRC)->getDescPtr()->hasLayoutType(LayoutType::nspc);
-    aclfcAttrs.inputPrecision = memory.at(ARG_SRC)->getDescPtr()->getPrecision();
+    aclfcAttrs.inputPrecision = memory.at(ARG_WEI)->getDescPtr()->getPrecision();
     aclfcAttrs.weightsNonTransposed = attrs.weightsNonTransposed;
 
     if (!attrs.postOps.empty()) {


### PR DESCRIPTION
### Details
`ACLLowpFullyConnectedExecutor` with u8 (QASYMM8) activations and i8 (QASYMM8_SIGNED) weights produced numerically wrong results, causing a complete accuracy collapse of int8 transformer encoders on ARM CPU (e.g. bert-base-ner). i8-activation FullyConnected was unaffected.

###  Root cause
`ACLLowpFullyConnectedExecutor::initFCAttrs` set `aclfcAttrs.inputPrecision` to the source (activation) precision. `prepareWeightMemory` uses that precision as the weight repack target (`cloneWithNewPrecision(inputPrecision)` + `reorderData`). For a u8-activation FC this converts the signed i8 weights to u8, saturating every negative weight to 0, corrupting the GEMM. ACL then multiplies the u8 activations by the non-negative "weights" and returns garbage. The ACL kernel itself is correct; this is purely an OpenVINO weight-preparation bug.

**Evidence** (`bert-base-ner`, `MatMul_31`): the weights actually handed to ACL had min=0, max=127 (all non-negative), whereas the graph i8 weights are `min=-127`, `max=127`. The FC output was ~999451 (a large constant DC offset) instead of the correct ~289.
i8-activation FCs were fine only incidentally: there `inputPrecision == i8 == weights precision`, so the repack did not change precision.

### Fix
On the low-precision path the weights are always i8, so repack them as i8 regardless of the activation precision: derive `aclfcAttrs.inputPrecision` from the weights descriptor (ARG_WEI) instead of ARG_SRC. This makes the repack a layout-only reorder (no precision conversion), preserving the signed weights.

### Tickets:
 - CVS-181775