### PR TITLE
[NPUW] Kokoro: Add an alias for pred_dur node

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
@@ -144,10 +144,9 @@ KokoroSplitResult KokoroSplit::split_model(const std::shared_ptr<ov::Model>& mod
 std::shared_ptr<ov::Node> ov::npuw::KokoroSplit::find_pred_dur_node(const std::shared_ptr<ov::Model>& model) {
     // TODO Look for pred_dur node name or Sequence Max -> Convert (?) -> Squeeze -> Result
     for (const auto& op : model->get_results()) {
-        const auto& name = op->get_name();
         const auto& output_names = op->output(0).get_names();
-        for (const auto* candidate : {"pred_dur", "phonemes"}) {
-            if (name == candidate || output_names.count(candidate) != 0) {
+        for (const char* candidate : {"pred_dur", "phonemes"}) {
+            if (output_names.count(candidate) != 0) {
                 return op;
             }
         }

--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_split.cpp
@@ -145,11 +145,9 @@ std::shared_ptr<ov::Node> ov::npuw::KokoroSplit::find_pred_dur_node(const std::s
     // TODO Look for pred_dur node name or Sequence Max -> Convert (?) -> Squeeze -> Result
     for (const auto& op : model->get_results()) {
         const auto& name = op->get_name();
-        if (name == "pred_dur") {
-            return op;
-        }
-        for (const auto& output_name : op->output(0).get_names()) {
-            if (output_name == "pred_dur") {
+        const auto& output_names = op->output(0).get_names();
+        for (const auto* candidate : {"pred_dur", "phonemes"}) {
+            if (name == candidate || output_names.count(candidate) != 0) {
                 return op;
             }
         }


### PR DESCRIPTION
### Details:
 - Add an alias for pred_dur node of Kokoro split:
 optimum-intel uses "phonemes" as an output name for pred_dur
https://github.com/huggingface/optimum-intel/blob/main/optimum/exporters/openvino/model_configs.py#L6239

### Tickets:
 - C-187702, E-225219

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation: build, tests*
