### PR TITLE
[GHA] Configure name for Manylinux_2_28 Python API tests matrix job

### DIFF
--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -295,7 +295,7 @@ jobs:
           branch_name: ${{ inputs.target-branch }}
 
   Python_API_Tests:
-    name: Python API tests
+    name: Python API tests - Python ${{ matrix.python-version }}
     needs: [ Docker, Build, Smart_CI ]
     uses: ./.github/workflows/job_python_api_tests.yml
     strategy:


### PR DESCRIPTION
### Details:
Previously names for each job in the matrix were generated automatically, and they included container image name, which is long on its own, but also it contains a tag (https://github.com/openvinotoolkit/openvino/blob/master/.github/dockerfiles/docker_tag), which changes pretty often, thus changing the names, and it makes it very hard to track metrics for these jobs.