### PR TITLE
[smart-ci] Pin fastcore for smartci

### DIFF
--- a/.github/actions/smart-ci/requirements.txt
+++ b/.github/actions/smart-ci/requirements.txt
@@ -1,3 +1,4 @@
 ghapi==1.0.4
 pyyaml==6.0.1
 jsonschema==4.19.1
+fastcore<2


### PR DESCRIPTION
With new release https://github.com/AnswerDotAI/fastcore/releases there are some breaking changes in APIs.

ghapi https://pypi.org/project/ghapi/#history is still not compatible with new API so we need to temporarily pin fastcore 

// When ghapi will have release with new fastcore support, we should bump ghapi pin version and unpin fastcore