### PR TITLE
docs: align npm platform support after PR #36665

### DIFF
--- a/docs/articles_en/get-started/install-openvino/install-openvino-npm.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-npm.rst
@@ -11,8 +11,8 @@ Install Intel® Distribution of OpenVINO™ Toolkit from npm Registry
    Note that the npm distribution:
 
    * offers the JavaScript API only
-   * is dedicated to users of all major OSes: Windows, Linux, and macOS
-     (all x86_64 / arm64 architectures)
+   * is dedicated to users of Windows and Linux on x86_64 and arm64,
+     and macOS on arm64
    * macOS offers support only for CPU inference
 
    Before installing OpenVINO, see the


### PR DESCRIPTION
### Details:
 - After merging the [#PR36665](https://github.com/openvinotoolkit/openvino/pull/36665) to master, this page describing npm support as covering all x86_64/arm64 architectures across Widnows, Linux, and macOS will become inaccurate. Because of that, updated it to clarify platform support: Windows nad Linux on x86_64/arm64, and macOS on arm64. 

### Tickets:
 - No ticket

### AI Assistance:
 - AI assistance used: no
