### PR TITLE
[GPU] Enable f8e4m3fn quantized-KV GroupQueryAttention (dynamic path)

### DIFF
--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -4840,12 +4840,14 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_tensor) {
     // Same tiny dynamic-past config as the i8 tests but with an f8e4m3fn KV cache (8-bit float, unpacked one byte
     // per element) and a single per-tensor scale for K and V. Quantize-on-write clamps to +/-448 and casts to the
     // f8e4m3fn grid (no integer round); expected values come from an independent numpy oracle.
+    // query [1, 1, 32]
     std::vector<float> query = {
         0.676199973f,   -0.186399996f, 0.0131000001f, 0.163000003f,   -0.315600008f, 0.00079999998f, -0.00039999999f,
         -0.701900005f,  0.407099992f,  0.240199998f,  -0.250200003f,  -0.068599999f, 0.202099994f,   -0.104500003f,
         -0.0970999971f, -0.58130002f,  0.221799999f,  0.0496000014f,  0.109800003f,  -0.610599995f,  0.660300016f,
         0.0617000014f,  -0.154899999f, 0.811600029f,  -0.0182000007f, -0.580299973f, -0.162100002f,  -0.915300012f,
         0.419800013f,   -0.166600004f, -0.296999991f, 0.42899999f};
+    // past_key [1, 1, 2, 8]
     std::vector<ov::float8_e4m3> past_key = {-0.6875f,
                                              0.21875f,
                                              -0.8125f,
@@ -4862,6 +4864,7 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_tensor) {
                                              -0.75f,
                                              0.15625f,
                                              0.875f};
+    // past_value [1, 1, 2, 8]
     std::vector<ov::float8_e4m3> past_value = {0.109375f,
                                                -0.203125f,
                                                0.75f,
@@ -4880,6 +4883,7 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_tensor) {
                                                0.6875f};
     std::vector<int> seqlens_k = {2};
     std::vector<int> total_sequence_length = {3};
+    // expected_output [1, 1, 16]
     std::vector<float> expected_output = {-0.0147730736f,
                                           -0.162738219f,
                                           -0.0295751505f,
@@ -4896,10 +4900,12 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_tensor) {
                                           -0.0642310604f,
                                           -0.0949096084f,
                                           0.150861159f};
+    // expected_present_key [1, 1, 3, 8]
     std::vector<ov::float8_e4m3> expected_present_key = {-0.6875f, 0.21875f, -0.8125f, -0.25f,      -0.46875f, 0.5625f,
                                                          0.6875f,  -0.125f,  0.34375f, -0.0703125f, 0.234375f, -0.3125f,
                                                          -0.6875f, -0.75f,   0.15625f, 0.875f,      9.f,       2.f,
                                                          4.5f,     -26.f,    28.f,     2.5f,        -6.5f,     36.f};
+    // expected_present_value [1, 1, 3, 8]
     std::vector<ov::float8_e4m3> expected_present_value = {
         0.109375f, -0.203125f, 0.75f,       0.09375f, 0.0390625f, 0.1015625f, -0.0546875f, -0.125f,
         -0.5625f,  0.203125f,  -0.0390625f, 0.46875f, -0.140625f, -0.75f,     -0.0390625f, 0.6875f,
@@ -4915,19 +4921,22 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_tensor) {
     test_case.add_expected_output<ov::float8_e4m3>(Shape{1, 1, 3, 8}, expected_present_key);
     test_case.add_expected_output<ov::float8_e4m3>(Shape{1, 1, 3, 8}, expected_present_value);
     // Mixed float output + f8e4m3fn present KV: floats compared by ULP tolerance, present KV bit-exact.
-    test_case.run(11);
+    const size_t tolerance_bits = 11;
+    test_case.run(tolerance_bits);
 }
 
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_channel) {
     const auto model = convert_model("com.microsoft/gqa_f8e4m3fnkv_per_channel.onnx");
 
     // f8e4m3fn KV cache with per-channel scales (dynamic past). Expected values from the independent numpy oracle.
+    // query [1, 1, 32]
     std::vector<float> query = {
         -0.0771000013f,  -0.711199999f,  0.261900008f,  0.35769999f,    0.166199997f,  -0.369399995f, -0.0784000009f,
         -0.236300007f,   -0.119900003f,  0.51880002f,   0.611800015f,   0.267800003f,  0.219500005f,  0.270700008f,
         -0.00490000006f, -0.0303000007f, -0.269499987f, -0.0222999994f, 0.903999984f,  0.347600013f,  -0.136800006f,
         -0.188800007f,   -0.345800012f,  0.149700001f,  0.156599998f,   -0.577199996f, 0.194499999f,  -0.227799997f,
         0.57069999f,     0.0627000034f,  0.687099993f,  -0.183300003f};
+    // past_key [1, 1, 2, 8]
     std::vector<ov::float8_e4m3> past_key = {-0.1171875f,
                                              0.1171875f,
                                              0.4375f,
@@ -4944,6 +4953,7 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_channel) {
                                              0.05078125f,
                                              -0.03125f,
                                              0.3125f};
+    // past_value [1, 1, 2, 8]
     std::vector<ov::float8_e4m3> past_value = {0.203125f,
                                                0.140625f,
                                                0.375f,
@@ -4962,6 +4972,7 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_channel) {
                                                0.203125f};
     std::vector<int> seqlens_k = {2};
     std::vector<int> total_sequence_length = {3};
+    // expected_output [1, 1, 16]
     std::vector<float> expected_output = {0.0507653244f,
                                           -0.229811132f,
                                           0.0769735426f,
@@ -4978,10 +4989,12 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_channel) {
                                           0.0231143273f,
                                           0.240510762f,
                                           -0.0635833964f};
+    // expected_present_key [1, 1, 3, 8]
     std::vector<ov::float8_e4m3> expected_present_key = {
         -0.1171875f, 0.1171875f, 0.4375f,   0.21875f,  -0.5f, 0.0703125f,  0.009765625f, -0.171875f,
         -0.25f,      0.6875f,    -0.15625f, -0.34375f, 0.25f, 0.05078125f, -0.03125f,    0.3125f,
         -10.f,       -0.625f,    24.f,      10.f,      -5.f,  -4.5f,       -8.f,         2.5f};
+    // expected_present_value [1, 1, 3, 8]
     std::vector<ov::float8_e4m3> expected_present_value = {
         0.203125f, 0.140625f, 0.375f,      0.1171875f, -0.25f, -0.140625f, -0.203125f, 0.0859375f,
         -0.4375f,  -0.75f,    0.03515625f, -0.5625f,   -0.75f, 0.15625f,   -0.28125f,  0.203125f,
@@ -4996,7 +5009,8 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_per_channel) {
     test_case.add_expected_output<float>(Shape{1, 1, 16}, expected_output);
     test_case.add_expected_output<ov::float8_e4m3>(Shape{1, 1, 3, 8}, expected_present_key);
     test_case.add_expected_output<ov::float8_e4m3>(Shape{1, 1, 3, 8}, expected_present_value);
-    test_case.run(11);
+    const size_t tolerance_bits = 11;
+    test_case.run(tolerance_bits);
 }
 
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_present_type_is_f8e4m3) {

--- a/src/frontends/onnx/tests/runtime/ie/unit_test.manifest
+++ b/src/frontends/onnx/tests/runtime/ie/unit_test.manifest
@@ -359,13 +359,6 @@ IE_GPU.onnx_model_gather_elements_int32_axis_0
 IE_GPU.onnx_model_gather_elements_int8_axis_1
 IE_GPU.onnx_model_gather_elements_float_3D_axis_2
 
-# GroupQueryAttention with an f8e4m3 quantized KV cache: the GPU plugin has no f8e4m3 Slice/reorder
-# layout yet ("No layout format available"), so the fp8 variants remain skipped on GPU. The i8/i4
-# variants are enabled (see KeepGQAKVScalePrecision + i8/u8 ScatterUpdate/Slice support). fp8 GPU is
-# tracked as a separate follow-up; numerics stay covered on CPU/INTERPRETER meanwhile.
-IE_GPU.onnx_model_gqa_f8e4m3fnkv_per_channel
-IE_GPU.onnx_model_gqa_f8e4m3fnkv_per_tensor
-
 IE_CPU/ElemTypesTests/1.onnx_test_add_abc_set_precission
 
 # RuntimeError: Unsupported dynamic ops: v4::Interpolate - Ticket: 50691

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -919,6 +919,13 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
 
             should_fuse |= legacy_fusion;
 
+            // fp8 concatenation/scatter_update take a byte-copy kernel path that cannot run fused ops
+            // (ACTIVATION does not compile on the 1-byte fp8 struct), so block fusion into an fp8 output.
+            if (should_fuse && input.get_output_layout().data_type == data_types::f8e4m3 &&
+                (input.is_type<concatenation>() || input.is_type<scatter_update>())) {
+                should_fuse = false;
+            }
+
             if (!should_fuse)
                 return;
 
@@ -1000,7 +1007,9 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
 
             should_fuse |= input_data.is_type<gather_elements>() && quantize_node.get_scale_shift_opt();
 
-            should_fuse |= input_data.is_type<scatter_update>() && quantize_node.get_scale_shift_opt();
+            // fp8 scatter_update byte-copies its data; fused ops don't compile on the fp8 struct, so don't fuse into it.
+            should_fuse |=
+                input_data.is_type<scatter_update>() && quantize_node.get_scale_shift_opt() && input_data.get_output_layout().data_type != data_types::f8e4m3;
 
             should_fuse |= input_data.is_type<scatter_nd_update>() && quantize_node.get_scale_shift_opt();
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
@@ -95,14 +95,7 @@ public:
 namespace detail {
 
 attach_concatenation_impl::attach_concatenation_impl() {
-    auto dyn_types = {
-        data_types::i8,
-        data_types::u8,
-        data_types::f16,
-        data_types::f32,
-        data_types::i32,
-        data_types::i64
-    };
+    auto dyn_types = {data_types::i8, data_types::u8, data_types::f16, data_types::f32, data_types::i32, data_types::i64, data_types::f8e4m3};
 
     auto dyn_formats = {
         format::bfyx,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.hpp
@@ -37,11 +37,8 @@ struct ScatterUpdateImplementationManager : public ImplementationManager {
             format::bfwzyx
         };
 
-        static const std::vector<ov::element::Type_t> supported_in_types = {ov::element::f32,
-                                                                            ov::element::f16,
-                                                                            ov::element::i32,
-                                                                            ov::element::i8,
-                                                                            ov::element::u8};
+        static const std::vector<ov::element::Type_t> supported_in_types =
+            {ov::element::f32, ov::element::f16, ov::element::i32, ov::element::i8, ov::element::u8, ov::element::f8e4m3};
 
         static const std::vector<ov::element::Type_t> supported_out_types = {
             ov::element::f32,
@@ -49,6 +46,7 @@ struct ScatterUpdateImplementationManager : public ImplementationManager {
             ov::element::i32,
             ov::element::i8,
             ov::element::u8,
+            ov::element::f8e4m3,
         };
 
         const auto& in0_layout = node.get_input_layout(0);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
@@ -181,14 +181,7 @@ private:
 namespace detail {
 
 attach_slice_impl::attach_slice_impl() {
-    auto types = {
-        data_types::f32,
-        data_types::f16,
-        data_types::i8,
-        data_types::u8,
-        data_types::i32,
-        data_types::i64
-    };
+    auto types = {data_types::f32, data_types::f16, data_types::i8, data_types::u8, data_types::i32, data_types::i64, data_types::f8e4m3};
 
     auto formats = {
         format::bfyx,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_ref.cl
@@ -3,7 +3,9 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
+#if INPUT0_IS_F8E4M3
 #include "include/f8_utils.cl"  // fp8e4m3_t typedef
+#endif
 
 #define GET_INDEX(prefix, ORDER) CAT(prefix, _GET_INDEX)(ORDER)
 
@@ -35,7 +37,7 @@ KERNEL(concatenation_gpu_ref)(
 #if HAS_FUSED_OPS
         FUSED_OPS;
         output[output_offset] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT);
-#elif INPUT0_IS_FP8
+#elif INPUT0_IS_F8E4M3
         // fp8 is a 1-byte struct; Concat just moves data (in/out dtype match), so copy the byte
         // (TO_OUTPUT_TYPE/ACTIVATION won't compile on it).
         output[output_offset] = result;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_ref.cl
@@ -3,6 +3,7 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
+#include "include/f8_utils.cl"  // fp8e4m3_t typedef
 
 #define GET_INDEX(prefix, ORDER) CAT(prefix, _GET_INDEX)(ORDER)
 
@@ -34,6 +35,10 @@ KERNEL(concatenation_gpu_ref)(
 #if HAS_FUSED_OPS
         FUSED_OPS;
         output[output_offset] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT);
+#elif INPUT0_IS_FP8
+        // fp8 is a 1-byte struct; Concat just moves data (in/out dtype match), so copy the byte
+        // (TO_OUTPUT_TYPE/ACTIVATION won't compile on it).
+        output[output_offset] = result;
 #else
         output[output_offset] = TO_OUTPUT_TYPE(ACTIVATION(result, ACTIVATION_PARAMS));
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data.cl
@@ -232,6 +232,10 @@ KERNEL (reorder_data)(
     #else
         #define __TO_OUTPUT_REORDER_TYPE(res) TO_OUTPUT_REORDER_TYPE_SAT(res)
     #endif
+    #elif F8E5M2_OUTPUT || F8E4M3_OUTPUT || F8E8M0_OUTPUT
+        // fp8 encoders are overloaded on float/half only; a non-float `res` (e.g. uchar from an integer
+        // input) makes the call ambiguous, so encode from float. (f8->f8 identity is handled below.)
+        #define __TO_OUTPUT_REORDER_TYPE(res) TO_OUTPUT_REORDER_TYPE(convert_float(res))
     #else
         #define __TO_OUTPUT_REORDER_TYPE(res) TO_OUTPUT_REORDER_TYPE(res)
     #endif
@@ -261,6 +265,10 @@ KERNEL (reorder_data)(
 
         atomic_and(&output_u32[main_idx], ~(0x0F << shift));
         atomic_or(&output_u32[main_idx], (val_u32 << shift));
+    #elif (F8E5M2_INPUT && F8E5M2_OUTPUT) || (F8E4M3_INPUT && F8E4M3_OUTPUT) || (F8E8M0_INPUT && F8E8M0_OUTPUT)
+        // f8->f8 layout reorder: `res` is already the fp8 OUTPUT_TYPE, so store it directly. Re-encoding
+        // via TO_OUTPUT_TYPE/ACTIVATION has no overload for the fp8 struct (and a copy needs none).
+        output[output_idx] = res;
     #else
         output[output_idx] = ACTIVATION_TYPED(OUTPUT_REORDER, __TO_OUTPUT_REORDER_TYPE(res), ACTIVATION_PARAMS_TYPED);
     #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
@@ -3,6 +3,7 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
+#include "include/f8_utils.cl"  // fp8e4m3_t typedef
 
 #define AXIS_B (0)
 #define AXIS_F (1)
@@ -132,6 +133,9 @@ KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
     #if HAS_FUSED_OPS
         FUSED_OPS_FIRST_KERNEL;
         output[output_idx] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT_FIRST_KERNEL);
+    #elif INPUT0_IS_FP8
+        // fp8 is a 1-byte struct; ScatterUpdate just moves data, so copy the byte (ACTIVATION won't compile on it).
+        output[output_idx] = val;
     #else
         output[output_idx] = ACTIVATION(val, ACTIVATION_PARAMS);
     #endif
@@ -232,6 +236,9 @@ KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
     #if HAS_FUSED_OPS
         FUSED_OPS_SECOND_KERNEL;
         output[output_idx] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT_SECOND_KERNEL);
+    #elif INPUT2_IS_FP8
+        // fp8 is a 1-byte struct; ScatterUpdate just moves data, so copy the byte (ACTIVATION won't compile on it).
+        output[output_idx] = val;
     #else
         output[output_idx] = ACTIVATION(val, ACTIVATION_PARAMS);
     #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
@@ -3,7 +3,9 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
+#if INPUT0_IS_F8E4M3 || INPUT2_IS_F8E4M3
 #include "include/f8_utils.cl"  // fp8e4m3_t typedef
+#endif
 
 #define AXIS_B (0)
 #define AXIS_F (1)
@@ -133,7 +135,7 @@ KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
     #if HAS_FUSED_OPS
         FUSED_OPS_FIRST_KERNEL;
         output[output_idx] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT_FIRST_KERNEL);
-    #elif INPUT0_IS_FP8
+    #elif INPUT0_IS_F8E4M3
         // fp8 is a 1-byte struct; ScatterUpdate just moves data, so copy the byte (ACTIVATION won't compile on it).
         output[output_idx] = val;
     #else
@@ -236,7 +238,7 @@ KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
     #if HAS_FUSED_OPS
         FUSED_OPS_SECOND_KERNEL;
         output[output_idx] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT_SECOND_KERNEL);
-    #elif INPUT2_IS_FP8
+    #elif INPUT2_IS_F8E4M3
         // fp8 is a 1-byte struct; ScatterUpdate just moves data, so copy the byte (ACTIVATION won't compile on it).
         output[output_idx] = val;
     #else

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
@@ -3,7 +3,9 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
+#if INPUT0_IS_F8E4M3
 #include "include/f8_utils.cl"  // fp8e4m3_t typedef
+#endif
 
 #define BRING_INTO_RANGE(VAL, MAX) \
     clamp((long)VAL < 0l ? (long)VAL + (long)MAX : (long)VAL, 0l, (long)MAX-1l);
@@ -85,7 +87,7 @@ KERNEL(slice_ref)(OPTIONAL_SHAPE_INFO_ARG
         slice_begin_dim4 + output_dim4 * slice_step[4]);
 #endif
 
-#if INPUT0_IS_FP8
+#if INPUT0_IS_F8E4M3
     // fp8 is a 1-byte struct; Slice just moves data, so copy the byte (ACTIVATION won't compile on it).
     output[output_index] = input[input_index];
 #else

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
@@ -3,6 +3,7 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
+#include "include/f8_utils.cl"  // fp8e4m3_t typedef
 
 #define BRING_INTO_RANGE(VAL, MAX) \
     clamp((long)VAL < 0l ? (long)VAL + (long)MAX : (long)VAL, 0l, (long)MAX-1l);
@@ -84,7 +85,12 @@ KERNEL(slice_ref)(OPTIONAL_SHAPE_INFO_ARG
         slice_begin_dim4 + output_dim4 * slice_step[4]);
 #endif
 
+#if INPUT0_IS_FP8
+    // fp8 is a 1-byte struct; Slice just moves data, so copy the byte (ACTIVATION won't compile on it).
+    output[output_index] = input[input_index];
+#else
     output[output_index] = ACTIVATION(input[input_index], ACTIVATION_PARAMS);
+#endif
 }
 
 #undef LOAD_BUFFER;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.cpp
@@ -17,12 +17,14 @@ ParamsKey ConcatenationKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::INT64);
+    k.EnableInputDataType(Datatype::F8E4M3);
     k.EnableOutputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT64);
+    k.EnableOutputDataType(Datatype::F8E4M3);
     k.EnableInputLayout(DataLayout::bf);
     k.EnableInputLayout(DataLayout::fb);
     k.EnableInputLayout(DataLayout::bfyx);
@@ -65,6 +67,10 @@ ParamsKey ConcatenationKernelRef::GetSupportedKey() const {
 JitConstants ConcatenationKernelRef::GetJitConstants(const concatenation_params& params) const {
     auto cldnnJit = ConcatenationKernelBase::GetJitConstants(params);
     auto input_format = params.inputs[0].GetLayout();
+
+    // Flag fp8 input so the kernel copies the byte instead of running ACTIVATION on the fp8 struct
+    // (see concatenation_gpu_ref.cl).
+    cldnnJit.AddConstant(MakeJitConstant("INPUT0_IS_FP8", params.inputs[0].GetDType() == Datatype::F8E4M3));
 
     if (params.inputs[0].Feature().v != 1) {
         cldnnJit.AddConstant(MakeJitConstant("CHECK_FEATURES", 1));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.cpp
@@ -70,7 +70,7 @@ JitConstants ConcatenationKernelRef::GetJitConstants(const concatenation_params&
 
     // Flag fp8 input so the kernel copies the byte instead of running ACTIVATION on the fp8 struct
     // (see concatenation_gpu_ref.cl).
-    cldnnJit.AddConstant(MakeJitConstant("INPUT0_IS_FP8", params.inputs[0].GetDType() == Datatype::F8E4M3));
+    cldnnJit.AddConstant(MakeJitConstant("INPUT0_IS_F8E4M3", params.inputs[0].GetDType() == Datatype::F8E4M3));
 
     if (params.inputs[0].Feature().v != 1) {
         cldnnJit.AddConstant(MakeJitConstant("CHECK_FEATURES", 1));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -39,11 +39,13 @@ ParamsKey ScatterUpdateKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::UINT8);
+    k.EnableInputDataType(Datatype::F8E4M3);
     k.EnableOutputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::UINT8);
+    k.EnableOutputDataType(Datatype::F8E4M3);
     k.EnableAllInputLayout();
     k.EnableAllOutputLayout();
     k.EnableTensorOffset();
@@ -185,6 +187,11 @@ static std::string GetSecondIterOutputIndexOrder(const scatter_update_params& pa
 JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params& params) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
     size_t axis_value = GetScatterUpdateChannelIndex(params);
+
+    // Flag fp8 inputs so the kernel copies the byte instead of running ACTIVATION on the fp8 struct
+    // (see scatter_update_ref.cl). INPUT0 = dictionary (first kernel), INPUT2 = updates (second).
+    jit.AddConstant(MakeJitConstant("INPUT0_IS_FP8", params.inputs[0].GetDType() == Datatype::F8E4M3));
+    jit.AddConstant(MakeJitConstant("INPUT2_IS_FP8", params.inputs[2].GetDType() == Datatype::F8E4M3));
 
     const auto input2_has_padding = params.inputs[2].has_dynamic_pad() || params.inputs[2].PitchesDifferFromLogicalDims();
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -190,8 +190,8 @@ JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params
 
     // Flag fp8 inputs so the kernel copies the byte instead of running ACTIVATION on the fp8 struct
     // (see scatter_update_ref.cl). INPUT0 = dictionary (first kernel), INPUT2 = updates (second).
-    jit.AddConstant(MakeJitConstant("INPUT0_IS_FP8", params.inputs[0].GetDType() == Datatype::F8E4M3));
-    jit.AddConstant(MakeJitConstant("INPUT2_IS_FP8", params.inputs[2].GetDType() == Datatype::F8E4M3));
+    jit.AddConstant(MakeJitConstant("INPUT0_IS_F8E4M3", params.inputs[0].GetDType() == Datatype::F8E4M3));
+    jit.AddConstant(MakeJitConstant("INPUT2_IS_F8E4M3", params.inputs[2].GetDType() == Datatype::F8E4M3));
 
     const auto input2_has_padding = params.inputs[2].has_dynamic_pad() || params.inputs[2].PitchesDifferFromLogicalDims();
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
@@ -82,6 +82,7 @@ ParamsKey SliceKernelRef::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::UINT8);
+    k.EnableInputDataType(Datatype::F8E4M3);
     k.EnableInputDataType(Datatype::F16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT32);
@@ -92,6 +93,7 @@ ParamsKey SliceKernelRef::GetSupportedKey() const {
     k.EnableOutputDataType(Datatype::INT64);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::UINT8);
+    k.EnableOutputDataType(Datatype::F8E4M3);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableInputLayout(DataLayout::bfzyx);
     k.EnableOutputLayout(DataLayout::bfyx);
@@ -121,6 +123,10 @@ bool SliceKernelRef::Validate(const Params &p) const {
 
 JitConstants SliceKernelRef::GetJitConstants(const slice_params& params) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
+
+    // Flag fp8 input so the kernel copies the byte instead of running ACTIVATION on the fp8 struct
+    // (see slice_ref.cl).
+    jit.AddConstant(MakeJitConstant("INPUT0_IS_FP8", params.inputs[0].GetDType() == Datatype::F8E4M3));
 
     // Define axes size as constant:
     if (params.compile_time_axes.empty()) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
@@ -126,7 +126,7 @@ JitConstants SliceKernelRef::GetJitConstants(const slice_params& params) const {
 
     // Flag fp8 input so the kernel copies the byte instead of running ACTIVATION on the fp8 struct
     // (see slice_ref.cl).
-    jit.AddConstant(MakeJitConstant("INPUT0_IS_FP8", params.inputs[0].GetDType() == Datatype::F8E4M3));
+    jit.AddConstant(MakeJitConstant("INPUT0_IS_F8E4M3", params.inputs[0].GetDType() == Datatype::F8E4M3));
 
     // Define axes size as constant:
     if (params.compile_time_axes.empty()) {

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_primitive_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_primitive_fusing_test.cpp
@@ -2,28 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "intel_gpu/primitives/permute.hpp"
-#include "test_utils.h"
-#include "random_generator.hpp"
+#include <memory>
 
-#include "intel_gpu/runtime/engine.hpp"
-
-#include "intel_gpu/graph/network.hpp"
-#include "intel_gpu/graph/program.hpp"
+#include "convolution_inst.h"
 #include "data_inst.h"
+#include "depth_to_space_inst.h"
 #include "eltwise_inst.h"
-#include "reduce_inst.h"
-#include "reshape_inst.h"
 #include "fully_connected_inst.h"
 #include "gemm_inst.h"
-#include "convolution_inst.h"
-#include "depth_to_space_inst.h"
+#include "intel_gpu/graph/network.hpp"
+#include "intel_gpu/graph/program.hpp"
+#include "intel_gpu/primitives/concatenation.hpp"
+#include "intel_gpu/primitives/permute.hpp"
+#include "intel_gpu/primitives/scatter_update.hpp"
+#include "intel_gpu/runtime/engine.hpp"
 #include "pass_manager.h"
-#include "to_string_utils.h"
-
 #include "program_wrapper.h"
-
-#include <memory>
+#include "random_generator.hpp"
+#include "reduce_inst.h"
+#include "reshape_inst.h"
+#include "test_utils.h"
+#include "to_string_utils.h"
 
 using namespace cldnn;
 using namespace ::tests;
@@ -48,6 +47,70 @@ TEST(prepare_primitive_fusing, fuse_activation_to_fc_dyn) {
 
     ASSERT_NE(prog, nullptr);
     ASSERT_FALSE(has_node_with_type<activation>(*prog));
+}
+
+// fp8 concatenation/scatter_update take a byte-copy kernel path that cannot run fused ops, so
+// prepare_primitive_fusing must not fuse an activation into an f8e4m3 scatter_update (unlike a
+// regular f16 cache, where the activation is fused).
+TEST(prepare_primitive_fusing, dont_fuse_activation_into_fp8_scatter_update) {
+    auto& engine = get_test_engine();
+
+    auto activation_survives_fusing = [&](data_types kv_dt) -> bool {
+        auto indices = engine.allocate_memory({ov::PartialShape{2}, data_types::f32, format::bfyx});
+        auto updates = engine.allocate_memory({ov::PartialShape{2, 4}, kv_dt, format::bfyx});
+        auto in_layout = layout{ov::PartialShape{4, 4}, kv_dt, format::bfyx};
+
+        topology topology;
+        topology.add(input_layout("input", in_layout));
+        topology.add(data("indices", indices));
+        topology.add(data("updates", updates));
+        topology.add(scatter_update("scatter", input_info("input"), input_info("indices"), input_info("updates"), 0));
+        topology.add(activation("act", input_info("scatter"), activation_func::abs));
+        topology.add(reorder("reorder", input_info("act"), format::bfyx, data_types::f32));
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        auto prog = program::build_program(engine, topology, config, false, true);
+
+        program_wrapper::apply_opt_pass<prepare_primitive_fusing>(*prog);
+        return has_node(*prog, "act");
+    };
+
+    // Control: a regular f16 KV cache fuses the activation into scatter_update (node is removed).
+    ASSERT_FALSE(activation_survives_fusing(data_types::f16));
+    // fp8 scatter_update byte-copies; fusion is blocked so the activation stays a separate node.
+    ASSERT_TRUE(activation_survives_fusing(data_types::f8e4m3));
+}
+
+// Same byte-copy concern for concatenation: activation must not be fused into an f8e4m3 concat.
+TEST(prepare_primitive_fusing, dont_fuse_activation_into_fp8_concatenation) {
+    auto& engine = get_test_engine();
+
+    auto activation_survives_fusing = [&](data_types kv_dt) -> bool {
+        auto in0_layout = layout{ov::PartialShape{1, 2, 4}, kv_dt, format::bfyx};
+        auto in1_layout = layout{ov::PartialShape{1, 2, 4}, kv_dt, format::bfyx};
+
+        topology topology;
+        topology.add(input_layout("in0", in0_layout));
+        topology.add(input_layout("in1", in1_layout));
+        topology.add(concatenation("concat", {input_info("in0"), input_info("in1")}, 1));
+        topology.add(activation("act", input_info("concat"), activation_func::abs));
+        topology.add(reorder("reorder", input_info("act"), format::bfyx, data_types::f32));
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        auto prog = program::build_program(engine, topology, config, false, true);
+
+        program_wrapper::apply_opt_pass<prepare_primitive_fusing>(*prog);
+        return has_node(*prog, "act");
+    };
+
+    // Control: a regular f16 concat fuses the activation (node is removed).
+    ASSERT_FALSE(activation_survives_fusing(data_types::f16));
+    // fp8 concat byte-copies; fusion is blocked so the activation stays a separate node.
+    ASSERT_TRUE(activation_survives_fusing(data_types::f8e4m3));
 }
 
 TEST(prepare_primitive_fusing, dont_fuse_incompatible_eltwise) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -2463,3 +2463,39 @@ INSTANTIATE_TEST_SUITE_P(smoke,
         TestParamType_concat_fsv32(1, { 64, 64, 64, 64 }, 1, 1, data_types::i8)
     ),
     concat_gpu_b_fs_yx_fsv32_force::PrintToStringParamName);
+
+// f8e4m3 Concat: exercises the f8 in/out path enabled for a quantized KV cache (GroupQueryAttention
+// f8e4m3 dynamic Slice+Concat). Uses a dynamic shape (as GQA does) and concatenates two f8 inputs along
+// the feature axis; values are exactly representable so the result is exact.
+TEST(concat_gpu, dynamic_f8e4m3) {
+    auto& engine = get_test_engine();
+
+    layout layout0_dyn = {{1, -1, 2, 2}, data_types::f8e4m3, format::bfyx};
+    layout layout1_dyn = {{1, -1, 2, 2}, data_types::f8e4m3, format::bfyx};
+
+    topology topology(input_layout("input0", layout0_dyn),
+                      input_layout("input1", layout1_dyn),
+                      concatenation("concat", {input_info("input0"), input_info("input1")}, 1, data_types::f8e4m3));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    auto network = cldnn::network::build_network(engine, topology, config);
+
+    auto input0 = engine.allocate_memory({{1, 1, 2, 2}, data_types::f8e4m3, format::bfyx});
+    auto input1 = engine.allocate_memory({{1, 1, 2, 2}, data_types::f8e4m3, format::bfyx});
+    set_values<ov::float8_e4m3>(input0, {0.5f, 1.0f, 1.5f, 2.0f});
+    set_values<ov::float8_e4m3>(input1, {-0.5f, -1.0f, -1.5f, -2.0f});
+
+    network->set_input_data("input0", input0);
+    network->set_input_data("input1", input1);
+    auto outputs = network->execute();
+    ASSERT_EQ(outputs.begin()->first, "concat");
+
+    auto output_memory = outputs.at("concat").get_memory();
+    cldnn::mem_lock<ov::float8_e4m3, mem_lock_type::read> output_ptr(output_memory, get_test_stream());
+
+    std::vector<float> expected = {0.5f, 1.0f, 1.5f, 2.0f, -0.5f, -1.0f, -1.5f, -2.0f};
+    ASSERT_EQ(output_ptr.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i)
+        ASSERT_EQ(expected[i], static_cast<float>(output_ptr[i])) << "i=" << i;
+}

--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_update_gpu_test.cpp
@@ -2343,3 +2343,41 @@ TEST(scatter_update_gpu_i8, d8111_axisB) {
 TEST(scatter_update_gpu_u8, d8111_axisB) {
     test_int_d8111_axisB<uint8_t>(false);
 }
+
+// f8e4m3 ScatterUpdate: values are exactly representable, so the scattered (byte-moved) result is
+// exact. Uses plain bfyx directly - the fp8 reorder-to-blocked-format path used by the i8/u8 helper
+// above is unsupported. Covers the f8 path enabled for a quantized KV cache (GroupQueryAttention f8e4m3).
+TEST(scatter_update_gpu_f8e4m3, d8111_axisB) {
+    auto& engine = get_test_engine();
+
+    //  Dictionary: 1..8; Indexes: 4,3,1,7; Updates: 9,10,11,12; Axis 0 -> Output: 1,11,3,10,9,6,7,12
+    auto dictionary = engine.allocate_memory({ov::PartialShape{8, 1, 1, 1}, data_types::f8e4m3, format::bfyx});
+    auto indices = engine.allocate_memory({ov::PartialShape{4, 1, 1, 1}, data_types::f32, format::bfyx});
+    auto updates = engine.allocate_memory({ov::PartialShape{4, 1, 1, 1}, data_types::f8e4m3, format::bfyx});
+
+    set_values<ov::float8_e4m3>(dictionary, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
+    set_values(indices, {4.f, 3.f, 1.f, 7.f});
+    set_values<ov::float8_e4m3>(updates, {9.0f, 10.0f, 11.0f, 12.0f});
+
+    topology topology;
+    topology.add(input_layout("InputDictionary", dictionary->get_layout()));
+    topology.add(input_layout("InputText", indices->get_layout()));
+    topology.add(input_layout("InputUpdates", updates->get_layout()));
+    topology.add(scatter_update("scatter_update", input_info("InputDictionary"), input_info("InputText"), input_info("InputUpdates"), 0));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    cldnn::network network(engine, topology, config);
+    network.set_input_data("InputDictionary", dictionary);
+    network.set_input_data("InputText", indices);
+    network.set_input_data("InputUpdates", updates);
+    auto outputs = network.execute();
+
+    auto output = outputs.at("scatter_update").get_memory();
+    cldnn::mem_lock<ov::float8_e4m3, mem_lock_type::read> output_ptr(output, get_test_stream());
+
+    std::vector<ov::float8_e4m3> expected_results = {1.0f, 11.0f, 3.0f, 10.0f, 9.0f, 6.0f, 7.0f, 12.0f};
+    ASSERT_EQ(output_ptr.size(), expected_results.size());
+    for (size_t i = 0; i < expected_results.size(); ++i)
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << "i=" << i;
+}

--- a/src/plugins/intel_gpu/tests/unit/test_cases/slice_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/slice_gpu_test.cpp
@@ -372,4 +372,45 @@ TEST(slice_gpu_i8, bfyx) {
         ASSERT_EQ(expected_results[i], output_ptr[i]) << "i=" << i;
 }
 
-} // anonymous namespace
+// f8e4m3 Slice: values are exactly representable, so the sliced (byte-moved) result is exact. Covers
+// the f8 output path enabled for a quantized KV cache (GroupQueryAttention f8e4m3 dynamic Slice+Concat).
+TEST(slice_gpu_f8e4m3, bfyx) {
+    auto& engine = get_test_engine();
+
+    // input [1,1,2,4] f8e4m3, slice axis 2 -> [1,1,1,4] (second row).
+    auto input = engine.allocate_memory({ov::PartialShape{1, 1, 2, 4}, data_types::f8e4m3, format::bfyx});
+    auto start = engine.allocate_memory({ov::PartialShape{1}, data_types::i64, format::bfyx});
+    auto stop = engine.allocate_memory({ov::PartialShape{1}, data_types::i64, format::bfyx});
+    auto step = engine.allocate_memory({ov::PartialShape{1}, data_types::i64, format::bfyx});
+    auto axes = engine.allocate_memory({ov::PartialShape{1}, data_types::i64, format::bfyx});
+
+    set_values<ov::float8_e4m3>(input, {1.0f, 2.0f, 3.0f, 4.0f, -0.5f, -1.5f, -2.5f, -0.25f});
+    set_values<int64_t>(start, {1});
+    set_values<int64_t>(stop, {2});
+    set_values<int64_t>(step, {1});
+    set_values<int64_t>(axes, {2});
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(data("start", start));
+    topology.add(data("stop", stop));
+    topology.add(data("step", step));
+    topology.add(data("axes", axes));
+    topology.add(slice("slice", {input_info("input"), input_info("start"), input_info("stop"), input_info("step"), input_info("axes")}));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    cldnn::network network(engine, topology, config);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+
+    auto output = outputs.at("slice").get_memory();
+    cldnn::mem_lock<ov::float8_e4m3, mem_lock_type::read> output_ptr(output, get_test_stream());
+
+    std::vector<ov::float8_e4m3> expected_results = {-0.5f, -1.5f, -2.5f, -0.25f};
+    ASSERT_EQ(output_ptr.size(), expected_results.size());
+    for (size_t i = 0; i < expected_results.size(); ++i)
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << "i=" << i;
+}
+
+}  // anonymous namespace


### PR DESCRIPTION
### Details:
Enables the com.microsoft `GroupQueryAttention` op with an **f8e4m3fn** quantized KV cache on the
Intel GPU plugin, for the dynamic (Slice+Concat) cache-assembly path. This extends the i8/i4 GPU
support (#36751, #36798) to fp8. f8e4m3fn KV is part of the com.microsoft GQA spec
(`T_CACHE = {float, float16, bfloat16, uint8, int8, float8e4m3fn}`, scales `T_KV_SCALE = tensor(float)`,
symmetric, ±448 clamp) and already worked on CPU/TEMPLATE via the device-agnostic
`GroupQueryAttentionDecomposition`; only GPU primitive gaps remained.

Spec reference: https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftgroupqueryattention

`fp8e4m3_t` is a 1-byte struct with no arithmetic/convert overloads, so beyond widening the
supported-type lists the reference kernels needed fp8-aware handling (all GPU-plugin-local; core op
and decomposition untouched):

- **Slice / Concat / ScatterUpdate** ref kernels: include `f8_utils.cl` for the `fp8e4m3_t` typedef,
  and on the identity (no-activation) store copy the byte directly when the tensor is fp8 —
  `ACTIVATION`/`TO_OUTPUT_TYPE` don't compile on the struct. Gated by an `INPUT*_IS_F8E4M3` jit flag
  (the `f8_utils.cl` include is guarded on it, so it is not pulled into — and does not bloat —
  non-fp8 kernels); non-fp8 paths are textually unchanged.
- **reorder_data.cl**: (a) an f8→f8 layout reorder stores the already-encoded value directly;
  (b) a non-float input reordered to fp8 encodes from `float` to resolve the ambiguous fp8-encoder
  overload. Both gated on fp8 flags.
- Add `f8e4m3` to the Slice/Concat/ScatterUpdate impl and kernel supported-type lists.

Tests: un-skip the 2 `IE_GPU.onnx_model_gqa_f8e4m3fnkv_{per_channel,per_tensor}` conformance tests
(present KV checked bit-exact, float output by ULP tolerance). GQA quantized-KV suite is **36/36**
across IE_GPU / IE_CPU / INTERPRETER (i8/i4/f8); a dedicated `scatter_update_gpu_f8e4m3` unit test
covers the fp8 scatter byte-copy path, and **356** GPU reorder unit tests remain green (the
shared-kernel change is a regression-safe, fp8-gated addition).

Out of scope / follow-up: the **static** (ScatterUpdate) f8 path still fails implementation selection
in `add_required_reorders` for the fp8 dtype (i8/i4 static pass through the same path unchanged); it
is tracked as a separate follow-up and no static f8 GQA test is added here.

Builds on #36798 (int8/int4 GPU GQA), now merged to master; this PR is rebased on top.

### Tickets:
 - CVS-190527

### AI Assistance:
 - AI assistance used: yes
 - Aided GPU debug, unit testing & understand OCL pass.