### PR TITLE
Offload-to-Disk (OTD) support for MoE GEMM primitives

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_3gemm_fused_compressed.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_3gemm_fused_compressed.hpp
@@ -10,6 +10,7 @@
 #include "ov_ops/moe_compressed.hpp"
 #include "intel_gpu/runtime/engine.hpp"
 #include "intel_gpu/runtime/memory.hpp"
+#include "moe_otd_descriptor.hpp"
 #include "primitive.hpp"
 
 namespace cldnn {
@@ -25,36 +26,6 @@ struct moe_weights {
     cldnn::memory::ptr down_w = nullptr;
     cldnn::memory::ptr down_s = nullptr;
     cldnn::memory::ptr down_z = nullptr;
-};
-
-/// @brief Lightweight, serializable descriptor for the offload-to-disk (OTD) weight strategy.
-/// @details Consolidates the OTD plumbing so the primitive carries a single cohesive field
-/// instead of loose members. Empty/zero values mean OTD is disabled (fully resident). This is
-/// the only OTD state that participates in blob-cache serialization; the runtime
-/// IExpertWeightProvider is rebuilt from it on the impl side.
-struct moe_otd_descriptor {
-    std::vector<size_t> weight_bin_offsets;
-    std::filesystem::path weights_path;
-    size_t lru_expert_num = 0;
-
-    bool operator==(const moe_otd_descriptor& rhs) const {
-        return weight_bin_offsets == rhs.weight_bin_offsets && weights_path == rhs.weights_path &&
-               lru_expert_num == rhs.lru_expert_num;
-    }
-
-    void save(BinaryOutputBuffer& ob) const {
-        ob << weight_bin_offsets;
-        ob << weights_path.string();
-        ob << lru_expert_num;
-    }
-
-    void load(BinaryInputBuffer& ib) {
-        ib >> weight_bin_offsets;
-        std::string path_str;
-        ib >> path_str;
-        weights_path = path_str;
-        ib >> lru_expert_num;
-    }
 };
 
 /// @brief moe compressed primitive

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_gemm.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "primitive.hpp"
+#include "moe_otd_descriptor.hpp"
 #include "ov_ops/moe_compressed.hpp"
 
 namespace cldnn {
@@ -43,17 +44,25 @@ struct moe_gemm : public primitive_base<moe_gemm> {
              const ov::op::internal::MOECompressed::Config& moe_config)
           : primitive_base(id, inputs),
             num_experts_per_token(static_cast<int32_t>(moe_config.top_k)),
-            has_batch_dim(moe_config.has_batch_dim) {}
+            has_batch_dim(moe_config.has_batch_dim),
+            _moe_config(moe_config) {}
 
     bool has_bias = false;
     int32_t num_experts_per_token = 0;
     bool has_batch_dim = true;
+
+    // OTD support fields
+    moe_otd_descriptor _otd;
+    bool is_up_gemm = true;  // true = up (gate_up fused), false = down
+    ov::op::internal::MOECompressed::Config _moe_config{};
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, has_bias);
         seed = hash_combine(seed, num_experts_per_token);
         seed = hash_combine(seed, has_batch_dim);
+        seed = hash_combine(seed, _otd.lru_expert_num);
+        seed = hash_combine(seed, is_up_gemm);
         return seed;
     }
 
@@ -63,7 +72,9 @@ struct moe_gemm : public primitive_base<moe_gemm> {
         auto rhs_casted = downcast<const moe_gemm>(rhs);
         return has_bias == rhs_casted.has_bias &&
                num_experts_per_token == rhs_casted.num_experts_per_token &&
-               has_batch_dim == rhs_casted.has_batch_dim;
+               has_batch_dim == rhs_casted.has_batch_dim &&
+               _otd == rhs_casted._otd &&
+               is_up_gemm == rhs_casted.is_up_gemm;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
@@ -71,6 +82,9 @@ struct moe_gemm : public primitive_base<moe_gemm> {
         ob << has_bias;
         ob << num_experts_per_token;
         ob << has_batch_dim;
+        _otd.save(ob);
+        ob << is_up_gemm;
+        ob << make_data(&_moe_config, sizeof(_moe_config));
     }
 
     void load(BinaryInputBuffer& ib) override {
@@ -78,6 +92,9 @@ struct moe_gemm : public primitive_base<moe_gemm> {
         ib >> has_bias;
         ib >> num_experts_per_token;
         ib >> has_batch_dim;
+        _otd.load(ib);
+        ib >> is_up_gemm;
+        ib >> make_data(&_moe_config, sizeof(_moe_config));
     }
 };
 }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_otd_descriptor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_otd_descriptor.hpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "primitive.hpp"
+
+namespace cldnn {
+
+/// @brief Lightweight, serializable descriptor for the offload-to-disk (OTD) weight strategy.
+/// @details Consolidates the OTD plumbing so the primitive carries a single cohesive field
+/// instead of loose members. Empty/zero values mean OTD is disabled (fully resident). This is
+/// the only OTD state that participates in blob-cache serialization; the runtime
+/// IExpertWeightProvider is rebuilt from it on the impl side.
+struct moe_otd_descriptor {
+    std::vector<size_t> weight_bin_offsets;
+    std::filesystem::path weights_path;
+    size_t lru_expert_num = 0;
+
+    bool operator==(const moe_otd_descriptor& rhs) const {
+        return weight_bin_offsets == rhs.weight_bin_offsets && weights_path == rhs.weights_path &&
+               lru_expert_num == rhs.lru_expert_num;
+    }
+
+    void save(BinaryOutputBuffer& ob) const {
+        ob << weight_bin_offsets;
+        ob << weights_path.string();
+        ob << lru_expert_num;
+    }
+
+    void load(BinaryInputBuffer& ib) {
+        ib >> weight_bin_offsets;
+        std::string path_str;
+        ib >> path_str;
+        weights_path = path_str;
+        ib >> lru_expert_num;
+    }
+};
+
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -623,6 +623,10 @@ static void optimize_gather_matmul_decompression_parameters(gather_matmul_node& 
 
 static void optimize_moe_gemm_decompression_parameters(moe_gemm_node& node, program& p) {
     auto prim = node.get_primitive();
+    if (prim->_otd.lru_expert_num > 0) {
+        // OTD routed weights: skip compile-time reorder — transpose done at runtime during disk loading.
+        return;
+    }
     // Production has bias; tests may not.
     const size_t scale_idx = prim->has_bias ? static_cast<size_t>(moe_gemm::WEIGHT_SCALE)
                                             : static_cast<size_t>(moe_gemm::WEIGHT_SCALE) - 1;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_otd_runtime.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_otd_runtime.cpp
@@ -103,6 +103,34 @@ void maybe_transpose_scale_zp(const cldnn::MOECompressed::Config& config,
         return;
     }
 
+    // ZP handling: u4 (packed 4-bit) requires unpack/transpose/repack;
+    // u8 (INT8) is 1 byte per element, transposed like scales.
+    const auto zp_et = ov::element::Type(layout.data_type);
+    const size_t zp_bitwidth = zp_et.bitwidth();
+    if (zp_bitwidth >= 8) {
+        // u8 or larger: transpose like scale (1+ bytes per element)
+        const size_t byte_per_elem = zp_bitwidth / 8;
+        OPENVINO_ASSERT(elem_count * byte_per_elem == per_expert_size,
+                        "Unexpected zp payload size for offset_pos=",
+                        offset_pos,
+                        ", expected=",
+                        elem_count * byte_per_elem,
+                        ", got=",
+                        per_expert_size);
+
+        std::vector<uint8_t> transposed(per_expert_size, 0);
+        for (size_t o = 0; o < oc; o++) {
+            for (size_t g = 0; g < group_count; g++) {
+                const size_t src_idx = o * group_count + g;
+                const size_t dst_idx = g * oc + o;
+                std::memcpy(transposed.data() + dst_idx * byte_per_elem, payload.data() + src_idx * byte_per_elem, byte_per_elem);
+            }
+        }
+        payload.swap(transposed);
+        return;
+    }
+
+    // u4 packed: 2 elements per byte
     OPENVINO_ASSERT(elem_count % 2 == 0, "Unexpected odd element count for packed zp offset_pos=", offset_pos, ", elem_count=", elem_count);
     OPENVINO_ASSERT(elem_count / 2 == per_expert_size,
                     "Unexpected zp payload size for offset_pos=",

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.cpp
@@ -8,8 +8,16 @@
 #include "primitive_onednn_base.h"
 
 #include <oneapi/dnnl/dnnl.hpp>
+#ifdef OV_GPU_WITH_ZE_RT
+#include <oneapi/dnnl/dnnl_ze.hpp>
+#else
+#include <oneapi/dnnl/dnnl_ocl.hpp>
+#endif
 
+#include <algorithm>
 #include <memory>
+#include <map>
+#include <utility>
 
 namespace cldnn {
 namespace onednn {
@@ -22,8 +30,29 @@ struct moe_gemm_onednn : typed_primitive_onednn_impl<moe_gemm> {
 
     // OTD members
     mutable std::shared_ptr<Moe2GemmOtdContext> _otd_ctx;
+    mutable memory::ptr _scratch_offsets;  // [lru_expert_num] i32 scratch for remapped offsets
+    mutable memory::ptr _scratch_bias;     // [lru_expert_num, N] scratch for per-batch gathered bias
     bool _is_up_gemm = true;
     size_t _lru_expert_num = 0;
+
+    // Per-batch primitives for prefill overflow: built lazily, keyed by (M, num_groups).
+    // Each batch of the overflow split runs a grouped matmul with M = batch token count.
+    mutable std::shared_ptr<dnnl::primitive_attr> _otd_attr;
+    struct BatchPrim {
+        dnnl::matmul::primitive_desc pd;
+        dnnl::matmul prim;
+        dnnl::memory::desc scratchpad_md;  // scratchpad requirement for this PD (mode=user)
+        memory::ptr scratchpad;            // backing USM allocation for the scratchpad
+    };
+    mutable std::map<std::pair<int64_t, int64_t>, BatchPrim> _batch_prim_cache;
+    // Cached geometry for building per-batch PDs at runtime
+    dnnl::memory::dim _otd_N = 0;
+    dnnl::memory::dim _otd_K = 0;
+    dnnl::memory::data_type _otd_src_dt = dnnl::memory::data_type::undef;
+    dnnl::memory::data_type _otd_dst_dt = dnnl::memory::data_type::undef;
+    dnnl::memory::data_type _otd_wei_dt = dnnl::memory::data_type::undef;
+    dnnl::memory::data_type _otd_bias_dt = dnnl::memory::data_type::undef;
+    bool _otd_has_bias = false;
 
 protected:
     std::unique_ptr<primitive_impl> clone() const override {
@@ -105,8 +134,64 @@ protected:
         return args;
     }
 
+    // OTD-aware get_arguments: uses remapped offset buffer for input/output grouping
+    std::unordered_map<int, dnnl::memory> get_arguments_otd(moe_gemm_inst& instance) const {
+        std::unordered_map<int, dnnl::memory> args;
+        auto moe_cfg = MoEGemmImplementationManager::get_moe_cfg(*instance.get_impl_params());
+
+        // Input/Output use the SCRATCH offset buffer (slot-remapped)
+        {
+            auto& input = instance.input_memory(moe_gemm::MoEGemmInputIdx::INPUT);
+            dnnl::memory input_mem = input.get_onednn_grouped_memory(_pd.src_desc(0), *_scratch_offsets);
+            args.insert({DNNL_ARG_SRC, input_mem});
+        }
+        {
+            auto& output = instance.output_memory(0);
+            dnnl::memory output_mem = output.get_onednn_grouped_memory(_pd.dst_desc(0), *_scratch_offsets);
+            args.insert({DNNL_ARG_DST, output_mem});
+        }
+        // Weight/scales/zp from resident buffers (sized for lru_expert_num)
+        {
+            auto& weights = instance.input_memory(moe_gemm::MoEGemmInputIdx::WEIGHT);
+            dnnl::memory weights_mem = weights.get_onednn_memory(_pd.weights_desc(0), 0);
+            args.insert({DNNL_ARG_WEIGHTS, weights_mem});
+        }
+        if (moe_cfg.is_weight_quantized) {
+            auto& wei_scales = instance.input_memory(moe_cfg.weight_scale_idx);
+            auto wei_scales_shape = wei_scales.get_layout().get_shape();
+            dnnl::memory::dim d0 = static_cast<dnnl::memory::dim>(_lru_expert_num);
+            dnnl::memory::dim d1 = wei_scales_shape[1];
+            dnnl::memory::dim d2 = wei_scales_shape[2];
+            dnnl::memory::dims wei_scales_dims = (moe_cfg.weight_group_size == -1)
+                ? dnnl::memory::dims{d0, d1}
+                : dnnl::memory::dims{d0, d2, d1};
+            dnnl::memory::format_tag wei_scales_fmt = (moe_cfg.weight_group_size == -1)
+                ? dnnl::memory::format_tag::ab
+                : dnnl::memory::format_tag::abc;
+            dnnl::memory::desc wei_scales_md(
+                wei_scales_dims, convert_data_type(wei_scales.get_layout().data_type), wei_scales_fmt);
+            dnnl::memory wei_scales_mem = wei_scales.get_onednn_memory(wei_scales_md, 0);
+            args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, wei_scales_mem});
+
+            if (!moe_cfg.is_weight_symmetric_quantized) {
+                auto& wei_zp = instance.input_memory(moe_cfg.weight_zp_idx);
+                dnnl::memory::desc wei_zp_md(
+                    wei_scales_dims, convert_data_type(wei_zp.get_layout().data_type), wei_scales_fmt);
+                dnnl::memory wei_zp_mem = wei_zp.get_onednn_memory(wei_zp_md, 0);
+                args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zp_mem});
+            }
+        }
+        if (moe_cfg.has_bias) {
+            auto& bias = instance.input_memory(moe_gemm::MoEGemmInputIdx::BIAS);
+            dnnl::memory bias_mem = bias.get_onednn_memory(_pd.weights_desc(1), 0);
+            args.insert({DNNL_ARG_BIAS, bias_mem});
+        }
+        return args;
+    }
+
     // OTD pre-execution: load needed experts from disk into the weight buffer
-    void prepare_otd_execution(moe_gemm_inst& instance) const {
+    // Returns true if execution was handled internally (batched), false if caller should execute.
+    bool prepare_otd_execution(moe_gemm_inst& instance) const {
         auto& network = instance.get_network();
         auto& stream = network.get_stream();
 
@@ -137,13 +222,351 @@ protected:
         std::vector<int32_t> expert_ids_cpu(num_active);
         experts_ids_mem.copy_to(stream, expert_ids_cpu.data(), 0, 0, num_active * sizeof(int32_t), true);
 
-        std::vector<uint32_t> expert_ids_u32(num_active);
+        // Deduplicate and sort active expert IDs
+        std::vector<uint32_t> unique_experts;
+        unique_experts.reserve(num_active);
         for (size_t i = 0; i < num_active; i++) {
-            expert_ids_u32[i] = static_cast<uint32_t>(expert_ids_cpu[i]);
+            unique_experts.push_back(static_cast<uint32_t>(expert_ids_cpu[i]));
+        }
+        std::sort(unique_experts.begin(), unique_experts.end());
+        unique_experts.erase(std::unique(unique_experts.begin(), unique_experts.end()), unique_experts.end());
+
+        // Read original offset buffer from GPU (needed for both overflow and normal paths)
+        auto& orig_offsets_mem = instance.input_memory(moe_gemm::MoEGemmInputIdx::INPUT_OFFSET_PER_EXPERT);
+        const auto& orig_shape = orig_offsets_mem.get_layout().get_shape();
+        const size_t num_experts_in_offset = orig_shape[0];
+
+        std::vector<int32_t> orig_offsets(num_experts_in_offset);
+        orig_offsets_mem.copy_to(stream, orig_offsets.data(), 0, 0, num_experts_in_offset * sizeof(int32_t), true);
+
+        // Always use the per-batch execution path. When unique_experts <= capacity,
+        // this is a single batch (no pointer shift). When it exceeds capacity, it splits
+        // into chunks. Each batch builds a PD with M = batch token count so the grouped
+        // matmul constraint (last_offset == M) is satisfied.
+        //
+        // For decode (few tokens), take the swap-free per-expert path: each expert's weight
+        // is read directly from its resident LRU slot, avoiding the GPU->GPU relocations that
+        // the contiguous-slot grouped path needs. Detected by total gathered rows being small
+        // (<= capacity), which guarantees all active experts fit resident simultaneously.
+        const int32_t total_tokens = unique_experts.empty()
+            ? 0
+            : orig_offsets[unique_experts.back()];
+        const bool is_decode = total_tokens > 0 &&
+                               total_tokens <= static_cast<int32_t>(_lru_expert_num);
+        if (is_decode) {
+            execute_decode(instance, stream, unique_experts, orig_offsets);
+        } else {
+            execute_batched(instance, stream, unique_experts, orig_offsets);
+        }
+        return true;  // Execution already done
+    }
+
+    // Helper to create a grouped dnnl::memory with a byte offset on the data pointer.
+    // This allows the grouped matmul to operate on a shifted region of the SRC/DST buffer.
+    // offsets_byte_offset shifts the group-offset buffer pointer too, so several single-group
+    // calls can share one offsets scratch buffer (each reads its own entry).
+    dnnl::memory make_shifted_grouped_memory(const dnnl::memory::desc& desc,
+                                              const memory& data_mem,
+                                              const memory& offsets_mem,
+                                              int64_t data_byte_offset,
+                                              const engine& eng,
+                                              int64_t offsets_byte_offset = 0) const {
+        void* data_ptr = reinterpret_cast<uint8_t*>(data_mem.buffer_ptr()) + data_byte_offset;
+        void* offsets_ptr = reinterpret_cast<uint8_t*>(offsets_mem.buffer_ptr()) + offsets_byte_offset;
+        auto onednn_engine = eng.get_onednn_engine();
+#ifdef OV_GPU_WITH_ZE_RT
+        return dnnl::ze_interop::make_memory(desc, onednn_engine, std::vector<void*>{data_ptr, offsets_ptr});
+#else
+        return dnnl::ocl_interop::make_memory(desc, onednn_engine, dnnl::ocl_interop::memory_kind::usm,
+            std::vector<void*>{data_ptr, offsets_ptr});
+#endif
+    }
+
+    // Build (or fetch from cache) a grouped matmul primitive for a specific
+    // (M = batch token count, num_groups = experts in this batch).
+    // Used for prefill overflow where the number of active experts exceeds capacity.
+    BatchPrim&
+    get_batch_primitive(int64_t M, int64_t num_groups, engine& eng) const {
+        auto key = std::make_pair(M, num_groups);
+        auto it = _batch_prim_cache.find(key);
+        if (it != _batch_prim_cache.end())
+            return it->second;
+
+        auto onednn_engine = eng.get_onednn_engine();
+        dnnl::memory::dims input_dims = {M, _otd_K};
+        dnnl::memory::dims weights_dims = {num_groups, _otd_K, _otd_N};
+        dnnl::memory::dims output_dims = {M, _otd_N};
+
+        auto input_md = dnnl::memory::desc::grouped(input_dims, _otd_src_dt, 0, num_groups);
+        auto output_md = dnnl::memory::desc::grouped(output_dims, _otd_dst_dt, 0, num_groups);
+        auto weights_md = dnnl::memory::desc(weights_dims, _otd_wei_dt, dnnl::memory::format_tag::acb);
+
+        dnnl::matmul::primitive_desc pd = _otd_has_bias
+            ? dnnl::matmul::primitive_desc(onednn_engine, input_md, weights_md,
+                  dnnl::memory::desc({num_groups, _otd_N}, _otd_bias_dt, dnnl::memory::format_tag::ab),
+                  output_md, *_otd_attr)
+            : dnnl::matmul::primitive_desc(onednn_engine, input_md, weights_md, output_md, *_otd_attr);
+        dnnl::matmul prim(pd);
+
+        // Scratchpad mode is 'user' (see program_node.cpp), so the caller must supply
+        // DNNL_ARG_SCRATCHPAD. Allocate a backing buffer sized for this PD's requirement.
+        auto scratchpad_md = pd.scratchpad_desc();
+        memory::ptr scratchpad;
+        if (scratchpad_md.get_size() > 0) {
+            auto sp_layout = cldnn::layout(
+                ov::Shape{scratchpad_md.get_size()}, cldnn::data_types::u8, cldnn::format::bfyx);
+            scratchpad = eng.allocate_memory(sp_layout, cldnn::allocation_type::usm_device, false);
         }
 
-        // Load experts for this direction into their original positions
-        _otd_ctx->load_experts(stream, expert_ids_u32, _is_up_gemm);
+        BatchPrim bp{std::move(pd), std::move(prim), std::move(scratchpad_md), std::move(scratchpad)};
+        auto res = _batch_prim_cache.emplace(key, std::move(bp));
+        return res.first->second;
+    }
+
+
+    // Decode-optimized path (small token count). Instead of forcing experts into contiguous
+    // slots for a single grouped matmul (which requires GPU->GPU swaps every token), acquire
+    // each expert's resident LRU slot and issue one single-group matmul per expert, reading
+    // its weight/scale/zp directly from that slot via a byte offset. Resident experts stay in
+    // place (zero copy on a cache hit), mirroring the 3GEMM gather-matmul behaviour.
+    void execute_decode(moe_gemm_inst& instance, stream& stream,
+                        const std::vector<uint32_t>& all_experts,
+                        const std::vector<int32_t>& orig_offsets) const {
+        auto& network = instance.get_network();
+        auto& eng = network.get_engine();
+        auto moe_cfg = MoEGemmImplementationManager::get_moe_cfg(*instance.get_impl_params());
+
+        auto& input = instance.input_memory(moe_gemm::MoEGemmInputIdx::INPUT);
+        auto& output = instance.output_memory(0);
+        auto& weights = instance.input_memory(moe_gemm::MoEGemmInputIdx::WEIGHT);
+
+        auto src_layout = input.get_layout();
+        auto dst_layout = output.get_layout();
+        const size_t src_row_bytes = src_layout.get_shape().back() * ov::element::Type(src_layout.data_type).size();
+        const size_t dst_row_bytes = dst_layout.get_shape().back() * ov::element::Type(dst_layout.data_type).size();
+
+        const size_t num_experts_total = _otd_ctx->num_experts;
+        const size_t weight_per_expert = weights.get_layout().bytes_count() / num_experts_total;
+
+        // Per-expert scale/zp geometry (resident buffers reinterpreted to logical num_experts).
+        size_t scale_per_expert = 0;
+        size_t zp_per_expert = 0;
+        dnnl::memory::dim sc_oc = 0;  // scale/zp OC dim (shape[1])
+        dnnl::memory::dim sc_g = 0;   // scale/zp group dim (shape[2])
+        if (moe_cfg.is_weight_quantized) {
+            auto& wei_scales = instance.input_memory(moe_cfg.weight_scale_idx);
+            scale_per_expert = wei_scales.get_layout().bytes_count() / num_experts_total;
+            const auto ss = wei_scales.get_layout().get_shape();
+            sc_oc = static_cast<dnnl::memory::dim>(ss[1]);
+            sc_g = static_cast<dnnl::memory::dim>(ss[2]);
+            if (!moe_cfg.is_weight_symmetric_quantized) {
+                auto& wei_zp = instance.input_memory(moe_cfg.weight_zp_idx);
+                zp_per_expert = wei_zp.get_layout().bytes_count() / num_experts_total;
+            }
+        }
+
+        // Pure-LRU acquire: each expert -> resident slot (hit = no copy, miss = disk load).
+        auto slots = _otd_ctx->acquire_experts_lru(stream, all_experts, _is_up_gemm);
+        stream.finish();  // ensure any disk uploads complete before the matmuls read them
+
+        const int64_t n = static_cast<int64_t>(all_experts.size());
+        for (int64_t i = 0; i < n; i++) {
+            const uint32_t expert = all_experts[i];
+            const int32_t token_start = (i == 0) ? 0 : orig_offsets[all_experts[i - 1]];
+            const int64_t M = static_cast<int64_t>(orig_offsets[expert]) - token_start;
+            if (M <= 0)
+                continue;
+            const size_t slot = slots[i];
+
+            // Write this expert's single group-offset (= M) at index i so concurrent enqueues
+            // do not clobber each other's offset entry before execution.
+            int32_t off_val = static_cast<int32_t>(M);
+            _scratch_offsets->copy_from(stream, &off_val, 0, static_cast<size_t>(i) * sizeof(int32_t),
+                                        sizeof(int32_t), true);
+
+            auto& pd_prim = get_batch_primitive(M, 1, eng);
+            auto& pd = pd_prim.pd;
+
+            std::unordered_map<int, dnnl::memory> args;
+            const int64_t src_off = static_cast<int64_t>(token_start) * static_cast<int64_t>(src_row_bytes);
+            const int64_t dst_off = static_cast<int64_t>(token_start) * static_cast<int64_t>(dst_row_bytes);
+            const int64_t off_bytes = i * static_cast<int64_t>(sizeof(int32_t));
+            args.insert({DNNL_ARG_SRC, make_shifted_grouped_memory(pd.src_desc(), input, *_scratch_offsets, src_off, eng, off_bytes)});
+            args.insert({DNNL_ARG_DST, make_shifted_grouped_memory(pd.dst_desc(), output, *_scratch_offsets, dst_off, eng, off_bytes)});
+            args.insert({DNNL_ARG_WEIGHTS, weights.get_onednn_memory(pd.weights_desc(),
+                            static_cast<int64_t>(slot * weight_per_expert))});
+
+            if (pd_prim.scratchpad)
+                args.insert({DNNL_ARG_SCRATCHPAD, pd_prim.scratchpad->get_onednn_memory(pd_prim.scratchpad_md, 0)});
+
+            if (moe_cfg.is_weight_quantized) {
+                auto& wei_scales = instance.input_memory(moe_cfg.weight_scale_idx);
+                dnnl::memory::dims sdims = (moe_cfg.weight_group_size == -1)
+                    ? dnnl::memory::dims{1, sc_oc}
+                    : dnnl::memory::dims{1, sc_g, sc_oc};
+                dnnl::memory::format_tag sfmt = (moe_cfg.weight_group_size == -1)
+                    ? dnnl::memory::format_tag::ab
+                    : dnnl::memory::format_tag::abc;
+                dnnl::memory::desc smd(sdims, convert_data_type(wei_scales.get_layout().data_type), sfmt);
+                args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS,
+                             wei_scales.get_onednn_memory(smd, static_cast<int64_t>(slot * scale_per_expert))});
+
+                if (!moe_cfg.is_weight_symmetric_quantized) {
+                    auto& wei_zp = instance.input_memory(moe_cfg.weight_zp_idx);
+                    dnnl::memory::desc zmd(sdims, convert_data_type(wei_zp.get_layout().data_type), sfmt);
+                    args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
+                                 wei_zp.get_onednn_memory(zmd, static_cast<int64_t>(slot * zp_per_expert))});
+                }
+            }
+
+            if (_otd_has_bias) {
+                auto& bias = instance.input_memory(moe_gemm::MoEGemmInputIdx::BIAS);
+                // Bias is a full [num_experts, N] buffer (not OTD-compacted): index by expert id.
+                const size_t bias_row_bytes =
+                    static_cast<size_t>(_otd_N) * dnnl::memory::data_type_size(_otd_bias_dt);
+                dnnl::memory::desc bmd({1, _otd_N}, _otd_bias_dt, dnnl::memory::format_tag::ab);
+                args.insert({DNNL_ARG_BIAS, bias.get_onednn_memory(bmd,
+                                static_cast<int64_t>(expert * bias_row_bytes))});
+            }
+
+            try {
+                pd_prim.prim.execute(stream.get_onednn_stream(), args);
+            } catch (dnnl::error& err) {
+                OPENVINO_THROW("OTD decode execution failed at expert=", expert,
+                    " M=", M, " slot=", slot, " error: ", err.what());
+            }
+        }
+        stream.finish();
+    }
+
+
+    void execute_batched(moe_gemm_inst& instance, stream& stream,
+                         const std::vector<uint32_t>& all_experts,
+                         const std::vector<int32_t>& orig_offsets) const {
+        auto& network = instance.get_network();
+        auto& eng = network.get_engine();
+        auto moe_cfg = MoEGemmImplementationManager::get_moe_cfg(*instance.get_impl_params());
+
+        auto& input = instance.input_memory(moe_gemm::MoEGemmInputIdx::INPUT);
+        auto& output = instance.output_memory(0);
+        auto& weights = instance.input_memory(moe_gemm::MoEGemmInputIdx::WEIGHT);
+
+        // Compute element strides for SRC and DST
+        auto src_layout = input.get_layout();
+        auto dst_layout = output.get_layout();
+        size_t src_row_bytes = src_layout.get_shape().back() * ov::element::Type(src_layout.data_type).size();
+        size_t dst_row_bytes = dst_layout.get_shape().back() * ov::element::Type(dst_layout.data_type).size();
+
+        const size_t total = all_experts.size();
+        for (size_t batch_start = 0; batch_start < total; batch_start += _lru_expert_num) {
+            size_t batch_end = std::min(batch_start + _lru_expert_num, total);
+            std::vector<uint32_t> batch_experts(all_experts.begin() + batch_start,
+                                                 all_experts.begin() + batch_end);
+            const int64_t num_groups = static_cast<int64_t>(batch_experts.size());
+
+            // Load this batch of experts into slots
+            _otd_ctx->load_experts(stream, batch_experts, _is_up_gemm);
+            // Ensure the weight/scale/zp uploads complete before the matmul reads them.
+            stream.finish();
+
+            // Compute the token start position for this batch:
+            // batch_token_start = end offset of the expert just before this batch.
+            int32_t batch_token_start = 0;
+            if (batch_start > 0) {
+                uint32_t prev_expert = all_experts[batch_start - 1];
+                batch_token_start = orig_offsets[prev_expert];
+            }
+
+            // Build relative offset buffer for this batch. Because the grouped matmul
+            // requires the last offset to equal M, and M for this batch is the batch's
+            // token count, we make offsets relative to batch_token_start.
+            std::vector<int32_t> remapped_offsets(num_groups, 0);
+            int32_t last_offset = 0;
+            for (int64_t i = 0; i < num_groups; i++) {
+                last_offset = orig_offsets[batch_experts[i]] - batch_token_start;
+                remapped_offsets[i] = last_offset;
+            }
+            const int64_t M = last_offset;  // total tokens in this batch
+
+            if (M == 0)
+                continue;  // no tokens for this batch (shouldn't happen for active experts)
+
+            _scratch_offsets->copy_from(stream, remapped_offsets.data(), 0, 0,
+                                        num_groups * sizeof(int32_t), true);
+
+            // Build (or fetch) a per-batch primitive with M and num_groups
+            auto& pd_prim = get_batch_primitive(M, num_groups, eng);
+            auto& batch_pd = pd_prim.pd;
+            auto& batch_prim = pd_prim.prim;
+
+            // Build arguments with shifted SRC/DST pointers.
+            std::unordered_map<int, dnnl::memory> args;
+            int64_t src_offset = static_cast<int64_t>(batch_token_start) * static_cast<int64_t>(src_row_bytes);
+            int64_t dst_offset = static_cast<int64_t>(batch_token_start) * static_cast<int64_t>(dst_row_bytes);
+
+            args.insert({DNNL_ARG_SRC, make_shifted_grouped_memory(batch_pd.src_desc(), input, *_scratch_offsets, src_offset, eng)});
+            args.insert({DNNL_ARG_DST, make_shifted_grouped_memory(batch_pd.dst_desc(), output, *_scratch_offsets, dst_offset, eng)});
+            args.insert({DNNL_ARG_WEIGHTS, weights.get_onednn_memory(batch_pd.weights_desc(), 0)});
+
+            // Scratchpad (mode=user): must be supplied explicitly for correct results.
+            if (pd_prim.scratchpad)
+                args.insert({DNNL_ARG_SCRATCHPAD, pd_prim.scratchpad->get_onednn_memory(pd_prim.scratchpad_md, 0)});
+
+            if (moe_cfg.is_weight_quantized) {
+                auto& wei_scales = instance.input_memory(moe_cfg.weight_scale_idx);
+                auto wei_scales_shape = wei_scales.get_layout().get_shape();
+                dnnl::memory::dim d0 = static_cast<dnnl::memory::dim>(num_groups);
+                dnnl::memory::dim d1 = wei_scales_shape[1];
+                dnnl::memory::dim d2 = wei_scales_shape[2];
+                dnnl::memory::dims wei_scales_dims = (moe_cfg.weight_group_size == -1)
+                    ? dnnl::memory::dims{d0, d1}
+                    : dnnl::memory::dims{d0, d2, d1};
+                dnnl::memory::format_tag wei_scales_fmt = (moe_cfg.weight_group_size == -1)
+                    ? dnnl::memory::format_tag::ab
+                    : dnnl::memory::format_tag::abc;
+                dnnl::memory::desc wei_scales_md(
+                    wei_scales_dims, convert_data_type(wei_scales.get_layout().data_type), wei_scales_fmt);
+                args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, wei_scales.get_onednn_memory(wei_scales_md, 0)});
+
+                if (!moe_cfg.is_weight_symmetric_quantized) {
+                    auto& wei_zp = instance.input_memory(moe_cfg.weight_zp_idx);
+                    dnnl::memory::desc wei_zp_md(
+                        wei_scales_dims, convert_data_type(wei_zp.get_layout().data_type), wei_scales_fmt);
+                    args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zp.get_onednn_memory(wei_zp_md, 0)});
+                }
+            }
+
+            if (_otd_has_bias) {
+                auto& bias = instance.input_memory(moe_gemm::MoEGemmInputIdx::BIAS);
+                // Bias is a full [num_experts, N] buffer (not OTD-compacted). Gather the
+                // batch's experts' bias rows into a scratch buffer so group g maps to the
+                // expert loaded into slot g (matching weights/scales/zp compaction).
+                const size_t bias_row_bytes =
+                    static_cast<size_t>(_otd_N) * dnnl::memory::data_type_size(_otd_bias_dt);
+                for (int64_t g = 0; g < num_groups; g++) {
+                    const size_t expert = batch_experts[g];
+                    _scratch_bias->copy_from(stream, bias,
+                                             expert * bias_row_bytes,   // src offset
+                                             static_cast<size_t>(g) * bias_row_bytes,  // dst offset
+                                             bias_row_bytes, true);
+                }
+                dnnl::memory::desc bias_md({num_groups, _otd_N}, _otd_bias_dt, dnnl::memory::format_tag::ab);
+                args.insert({DNNL_ARG_BIAS, _scratch_bias->get_onednn_memory(bias_md, 0)});
+            }
+
+            // Execute this batch
+            try {
+                batch_prim.execute(stream.get_onednn_stream(), args);
+                // Serialize batches: the next batch's load_experts overwrites the
+                // weight/scale/zp slots, so the matmul reading them must finish first.
+                stream.finish();
+            } catch (dnnl::error& err) {
+                OPENVINO_THROW("OTD batched execution failed at batch_start=", batch_start,
+                    " batch_token_start=", batch_token_start,
+                    " M=", M, " num_groups=", num_groups,
+                    " error: ", err.what());
+            }
+        }
     }
 
     event::ptr execute_impl(const std::vector<event::ptr>& events,
@@ -152,27 +575,38 @@ protected:
             return parent::execute_impl(events, instance);
         }
 
-        // OTD path: load needed experts from disk, then execute normally
+        // OTD path: load needed experts, remap offsets, execute with reduced weight buffer
         auto& network = instance.get_network();
         auto& stream = network.get_stream();
         auto net_id = network.get_id();
 
-        // Load experts on-demand
-        prepare_otd_execution(instance);
+        // Load experts on-demand and build remapped offset buffer
+        bool already_executed = prepare_otd_execution(instance);
 
-        // Use normal (non-remapped) arguments — experts loaded into original positions
-        _args[net_id] = get_arguments(instance);
-
-        // Execute oneDNN primitive
         event::ptr event;
-        if (!instance.can_be_optimized()) {
-            try {
-                _prim.execute(stream.get_onednn_stream(), _args[net_id]);
-            } catch (dnnl::error& err) {
-                OPENVINO_THROW(err.what());
-            }
+        if (already_executed) {
+            // Batched execution already done in prepare_otd_execution
             if (instance.needs_completion_event())
                 event = stream.enqueue_marker({});
+        } else {
+            // Use OTD arguments with remapped offset buffer
+            _args[net_id] = get_arguments_otd(instance);
+
+            // Execute oneDNN primitive
+            if (!instance.can_be_optimized()) {
+                try {
+                    _prim.execute(stream.get_onednn_stream(), _args[net_id]);
+                } catch (dnnl::error& err) {
+                    OPENVINO_THROW(err.what());
+                }
+                if (instance.needs_completion_event())
+                    event = stream.enqueue_marker({});
+            }
+        }
+
+        // After gemm_down, invalidate slot mapping for next iteration
+        if (!_is_up_gemm) {
+            _otd_ctx->slots_valid = false;
         }
 
         return event;
@@ -275,20 +709,53 @@ public:
             }
         }
 
-        // For 2GEMM OTD, don't reduce num_experts in PD — full weight buffer is allocated.
-        // OTD only provides lazy disk-loading, not memory reduction.
-        auto prim_desc = get_moe_gemm_primitive_descriptor(impl_params, *attr, 0);
+        // For 2GEMM OTD, use lru_expert_num as the grouped matmul group count.
+        // Weight buffer is physically sized for lru_expert_num experts (partial upload).
+        const size_t lru_expert_num = prim->_otd.lru_expert_num;
+        auto prim_desc = get_moe_gemm_primitive_descriptor(impl_params, *attr,
+            lru_expert_num > 0 ? lru_expert_num : 0);
 
         auto impl = std::make_unique<moe_gemm_onednn>(engine, config, attr, *prim_desc);
 
         // Set up OTD context if enabled
-        const size_t lru_expert_num = prim->_otd.lru_expert_num;
         if (lru_expert_num > 0) {
-            // For 2GEMM, use num_experts as capacity (no memory reduction, just lazy loading)
             auto weights_layout = impl_params.get_input_layout(moe_gemm::MoEGemmInputIdx::WEIGHT);
             const size_t num_experts = weights_layout.get_shape()[0];
-            impl->_lru_expert_num = num_experts;
+            impl->_lru_expert_num = lru_expert_num;
             impl->_is_up_gemm = prim->is_up_gemm;
+
+            // Store attr and geometry for building per-batch PDs during prefill overflow
+            impl->_otd_attr = attr;
+            auto input_layout = impl_params.get_input_layout(moe_gemm::MoEGemmInputIdx::INPUT);
+            auto output_layout = impl_params.get_output_layout();
+            const auto& experts_weight_shape = weights_layout.get_shape();
+            impl->_otd_N = static_cast<dnnl::memory::dim>(experts_weight_shape[1]);
+            impl->_otd_K = static_cast<dnnl::memory::dim>(
+                experts_weight_shape.size() == 4 ? experts_weight_shape[2] * experts_weight_shape[3]
+                                                 : experts_weight_shape[2]);
+            impl->_otd_src_dt = convert_data_type(input_layout.data_type);
+            impl->_otd_dst_dt = convert_data_type(output_layout.data_type);
+            impl->_otd_wei_dt = convert_data_type(weights_layout.data_type);
+            impl->_otd_has_bias = moe_cfg.has_bias;
+            if (moe_cfg.has_bias) {
+                auto bias_layout = impl_params.get_input_layout(moe_gemm::MoEGemmInputIdx::BIAS);
+                impl->_otd_bias_dt = convert_data_type(bias_layout.data_type);
+            }
+
+            // Allocate scratch offset buffer [lru_expert_num] i32 USM
+            auto offset_layout = cldnn::layout(
+                ov::Shape{lru_expert_num}, cldnn::data_types::i32, cldnn::format::bfyx);
+            impl->_scratch_offsets = engine.allocate_memory(offset_layout, cldnn::allocation_type::usm_host, false);
+
+            // Allocate scratch bias buffer [lru_expert_num, N] to gather per-batch expert bias.
+            // Bias is not OTD-compacted, so each batch must gather its experts' bias rows.
+            if (moe_cfg.has_bias) {
+                auto bias_layout = impl_params.get_input_layout(moe_gemm::MoEGemmInputIdx::BIAS);
+                auto sb_layout = cldnn::layout(
+                    ov::Shape{lru_expert_num, static_cast<size_t>(impl->_otd_N)},
+                    bias_layout.data_type, cldnn::format::bfyx);
+                impl->_scratch_bias = engine.allocate_memory(sb_layout, cldnn::allocation_type::usm_device, false);
+            }
 
             std::string prim_id = prim->id;
             std::string moe_layer_id = prim_id;
@@ -298,7 +765,8 @@ public:
 
             impl->_otd_ctx = Moe2GemmOtdRegistry::instance().get_or_create(
                 moe_layer_id,
-                num_experts,  // capacity = full expert count
+                lru_expert_num,  // capacity = LRU expert count
+                num_experts,     // total experts in model
                 prim->_moe_config,
                 prim->_otd.weight_bin_offsets,
                 prim->_otd.weights_path);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.cpp
@@ -3,12 +3,12 @@
 //
 
 #include "moe_gemm_onednn.hpp"
+#include "moe_gemm_otd_context.hpp"
 #include "intel_gpu/runtime/utils.hpp"
 #include "primitive_onednn_base.h"
 
 #include <oneapi/dnnl/dnnl.hpp>
 
-#include <algorithm>
 #include <memory>
 
 namespace cldnn {
@@ -19,6 +19,11 @@ struct moe_gemm_onednn : typed_primitive_onednn_impl<moe_gemm> {
     using parent::parent;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::onednn::moe_gemm_onednn)
+
+    // OTD members
+    mutable std::shared_ptr<Moe2GemmOtdContext> _otd_ctx;
+    bool _is_up_gemm = true;
+    size_t _lru_expert_num = 0;
 
 protected:
     std::unique_ptr<primitive_impl> clone() const override {
@@ -100,9 +105,83 @@ protected:
         return args;
     }
 
+    // OTD pre-execution: load needed experts from disk into the weight buffer
+    void prepare_otd_execution(moe_gemm_inst& instance) const {
+        auto& network = instance.get_network();
+        auto& stream = network.get_stream();
+
+        // Bind resident buffers — each direction binds its own buffers independently
+        if (_is_up_gemm && !_otd_ctx->resident.up_w) {
+            auto moe_cfg = MoEGemmImplementationManager::get_moe_cfg(*instance.get_impl_params());
+            _otd_ctx->resident.up_w = instance.input_memory_ptr(moe_gemm::MoEGemmInputIdx::WEIGHT);
+            if (moe_cfg.is_weight_quantized)
+                _otd_ctx->resident.up_s = instance.input_memory_ptr(moe_cfg.weight_scale_idx);
+            if (moe_cfg.is_weight_quantized && !moe_cfg.is_weight_symmetric_quantized)
+                _otd_ctx->resident.up_z = instance.input_memory_ptr(moe_cfg.weight_zp_idx);
+            _otd_ctx->bound = true;
+        } else if (!_is_up_gemm && !_otd_ctx->resident.down_w) {
+            auto moe_cfg = MoEGemmImplementationManager::get_moe_cfg(*instance.get_impl_params());
+            _otd_ctx->resident.down_w = instance.input_memory_ptr(moe_gemm::MoEGemmInputIdx::WEIGHT);
+            if (moe_cfg.is_weight_quantized)
+                _otd_ctx->resident.down_s = instance.input_memory_ptr(moe_cfg.weight_scale_idx);
+            if (moe_cfg.is_weight_quantized && !moe_cfg.is_weight_symmetric_quantized)
+                _otd_ctx->resident.down_z = instance.input_memory_ptr(moe_cfg.weight_zp_idx);
+            _otd_ctx->bound = true;
+        }
+
+        // Read expert IDs from GPU
+        auto& experts_ids_mem = instance.input_memory(moe_gemm::MoEGemmInputIdx::EXPERTS_IDS);
+        const auto& experts_shape = experts_ids_mem.get_layout().get_shape();
+        const size_t num_active = experts_shape[0];
+
+        std::vector<int32_t> expert_ids_cpu(num_active);
+        experts_ids_mem.copy_to(stream, expert_ids_cpu.data(), 0, 0, num_active * sizeof(int32_t), true);
+
+        std::vector<uint32_t> expert_ids_u32(num_active);
+        for (size_t i = 0; i < num_active; i++) {
+            expert_ids_u32[i] = static_cast<uint32_t>(expert_ids_cpu[i]);
+        }
+
+        // Load experts for this direction into their original positions
+        _otd_ctx->load_experts(stream, expert_ids_u32, _is_up_gemm);
+    }
+
+    event::ptr execute_impl(const std::vector<event::ptr>& events,
+                            typed_primitive_inst<moe_gemm>& instance) override {
+        if (!_otd_ctx || _lru_expert_num == 0) {
+            return parent::execute_impl(events, instance);
+        }
+
+        // OTD path: load needed experts from disk, then execute normally
+        auto& network = instance.get_network();
+        auto& stream = network.get_stream();
+        auto net_id = network.get_id();
+
+        // Load experts on-demand
+        prepare_otd_execution(instance);
+
+        // Use normal (non-remapped) arguments — experts loaded into original positions
+        _args[net_id] = get_arguments(instance);
+
+        // Execute oneDNN primitive
+        event::ptr event;
+        if (!instance.can_be_optimized()) {
+            try {
+                _prim.execute(stream.get_onednn_stream(), _args[net_id]);
+            } catch (dnnl::error& err) {
+                OPENVINO_THROW(err.what());
+            }
+            if (instance.needs_completion_event())
+                event = stream.enqueue_marker({});
+        }
+
+        return event;
+    }
+
     static std::shared_ptr<dnnl::matmul::primitive_desc>
         get_moe_gemm_primitive_descriptor(const kernel_impl_params& impl_params,
-                                          const dnnl::primitive_attr& attr = dnnl::primitive_attr()) {
+                                          const dnnl::primitive_attr& attr = dnnl::primitive_attr(),
+                                          size_t lru_expert_num_override = 0) {
         auto& engine = impl_params.prog->get_engine();
         auto prim = impl_params.typed_desc<moe_gemm>();
         auto moe_cfg = MoEGemmImplementationManager::get_moe_cfg(impl_params);
@@ -115,7 +194,10 @@ protected:
         const auto& experts_weight_shape = weights_layout.get_shape();
         dnnl::memory::dim N = experts_weight_shape[1];
         dnnl::memory::dim K = experts_weight_shape.size() == 4 ? experts_weight_shape[2] * experts_weight_shape[3] : experts_weight_shape[2];
-        dnnl::memory::dim num_experts = experts_weight_shape[0];
+        // When OTD is enabled, use lru_expert_num instead of the full num_experts
+        dnnl::memory::dim num_experts = lru_expert_num_override > 0
+            ? static_cast<dnnl::memory::dim>(lru_expert_num_override)
+            : experts_weight_shape[0];
 
         dnnl::memory::dims input_dims = {total_tokens, K};
         dnnl::memory::dims weights_dims = {num_experts, K, N};
@@ -193,9 +275,36 @@ public:
             }
         }
 
-        auto prim_desc = get_moe_gemm_primitive_descriptor(impl_params, *attr);
+        // For 2GEMM OTD, don't reduce num_experts in PD — full weight buffer is allocated.
+        // OTD only provides lazy disk-loading, not memory reduction.
+        auto prim_desc = get_moe_gemm_primitive_descriptor(impl_params, *attr, 0);
 
-        return std::make_unique<moe_gemm_onednn>(engine, config, attr, *prim_desc);
+        auto impl = std::make_unique<moe_gemm_onednn>(engine, config, attr, *prim_desc);
+
+        // Set up OTD context if enabled
+        const size_t lru_expert_num = prim->_otd.lru_expert_num;
+        if (lru_expert_num > 0) {
+            // For 2GEMM, use num_experts as capacity (no memory reduction, just lazy loading)
+            auto weights_layout = impl_params.get_input_layout(moe_gemm::MoEGemmInputIdx::WEIGHT);
+            const size_t num_experts = weights_layout.get_shape()[0];
+            impl->_lru_expert_num = num_experts;
+            impl->_is_up_gemm = prim->is_up_gemm;
+
+            std::string prim_id = prim->id;
+            std::string moe_layer_id = prim_id;
+            auto pos = prim_id.rfind("_moe_gemm_");
+            if (pos != std::string::npos)
+                moe_layer_id = prim_id.substr(0, pos);
+
+            impl->_otd_ctx = Moe2GemmOtdRegistry::instance().get_or_create(
+                moe_layer_id,
+                num_experts,  // capacity = full expert count
+                prim->_moe_config,
+                prim->_otd.weight_bin_offsets,
+                prim->_otd.weights_path);
+        }
+
+        return impl;
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_otd_context.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_otd_context.cpp
@@ -4,9 +4,16 @@
 
 #include "moe_gemm_otd_context.hpp"
 
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstring>
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
+#include "intel_gpu/runtime/engine.hpp"
 #include "impls/ocl_v2/moe/moe_otd_runtime.hpp"
 
 namespace cldnn {
@@ -41,101 +48,281 @@ static void transpose_scale_or_zp(const layout& mem_layout,
     payload.swap(transposed);
 }
 
+void Moe2GemmOtdContext::load_expert_from_disk(stream& s, bool is_up, size_t slot, uint32_t expert) {
+    using namespace ov::intel_gpu::ocl;
+    auto* perf = moe_otd::get_perf_counters();
+
+    std::array<std::pair<size_t, bool>, 3> spec = is_up
+        ? std::array<std::pair<size_t, bool>, 3>{{{UP_W, false}, {UP_S, true}, {UP_Z, true}}}
+        : std::array<std::pair<size_t, bool>, 3>{{{DOWN_W, false}, {DOWN_S, true}, {DOWN_Z, true}}};
+    std::array<memory::ptr, 3> mems = is_up
+        ? std::array<memory::ptr, 3>{{resident.up_w, resident.up_s, resident.up_z}}
+        : std::array<memory::ptr, 3>{{resident.down_w, resident.down_s, resident.down_z}};
+
+    for (size_t t = 0; t < 3; t++) {
+        auto& mem = mems[t];
+        if (!mem)
+            continue;
+        const bool needs_transpose = spec[t].second;
+        const size_t per_expert_size = mem->get_layout().bytes_count() / num_experts;
+        const size_t base_offset = weight_bin_offsets[spec[t].first];
+        const size_t src_offset = base_offset + expert * per_expert_size;
+        const size_t dst_offset = slot * per_expert_size;
+
+        std::vector<uint8_t> payload(per_expert_size);
+        if (perf) {
+            auto t0 = std::chrono::steady_clock::now();
+            weight_reader->read(reinterpret_cast<char*>(payload.data()), per_expert_size, src_offset);
+            auto t1 = std::chrono::steady_clock::now();
+            perf->disk_io_ns.fetch_add(
+                static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()),
+                std::memory_order_relaxed);
+        } else {
+            weight_reader->read(reinterpret_cast<char*>(payload.data()), per_expert_size, src_offset);
+        }
+
+        if (needs_transpose) {
+            const auto& shape = mem->get_layout().get_shape();
+            const size_t tensor_oc = (shape.size() >= 2) ? shape[1] : 0;
+            const size_t tensor_gc = (shape.size() >= 3) ? shape[2] : 0;
+            if (perf) {
+                auto t0 = std::chrono::steady_clock::now();
+                transpose_scale_or_zp(mem->get_layout(), payload, per_expert_size, tensor_oc, tensor_gc);
+                auto t1 = std::chrono::steady_clock::now();
+                perf->transpose_ns.fetch_add(
+                    static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()),
+                    std::memory_order_relaxed);
+            } else {
+                transpose_scale_or_zp(mem->get_layout(), payload, per_expert_size, tensor_oc, tensor_gc);
+            }
+        }
+
+        if (perf) {
+            auto t0 = std::chrono::steady_clock::now();
+            mem->copy_from(s, payload.data(), 0, dst_offset, per_expert_size, true);
+            auto t1 = std::chrono::steady_clock::now();
+            perf->gpu_copy_ns.fetch_add(
+                static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()),
+                std::memory_order_relaxed);
+            perf->tensor_load_count.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            mem->copy_from(s, payload.data(), 0, dst_offset, per_expert_size, true);
+        }
+    }
+}
+
 std::vector<size_t> Moe2GemmOtdContext::load_experts(stream& s, const std::vector<uint32_t>& expert_ids, bool is_up) {
     using namespace ov::intel_gpu::ocl;
 
+    // expert_ids must be sorted and unique (caller guarantees this).
+    // The grouped matmul reads weight slot g for token-group g, and token groups are laid
+    // out in sorted-expert order, so expert_ids[i] MUST end up physically at slot i for the
+    // slots consumed by this matmul call. Slots [n, capacity) act as an LRU cache that keeps
+    // previously loaded experts resident across tokens: on a subsequent token an expert that
+    // is still resident is moved into place with a GPU->GPU copy (no disk/transpose/upload),
+    // and experts displaced from the active region are parked into free cache slots instead
+    // of being evicted. This is what makes decode fast (mirrors the 3GEMM LRU behaviour while
+    // respecting the grouped-matmul contiguity constraint).
+    const size_t n = std::min(expert_ids.size(), capacity);
     std::vector<size_t> slots(expert_ids.size());
+    for (size_t i = 0; i < slots.size(); i++)
+        slots[i] = i;  // group g always reads slot g
+
     auto* perf = moe_otd::get_perf_counters();
-    auto& loaded_set = is_up ? loaded_up : loaded_down;
+    auto& slot_contents = is_up ? slot_contents_up : slot_contents_down;
+    auto& swap_tmp = is_up ? swap_tmp_up : swap_tmp_down;
 
-    // Select tensor info for this direction
-    struct TensorInfo {
+    // Collect the valid (non-null) tensors for this direction together with their per-expert
+    // byte size, so weight/scale/zp are always moved/loaded together and stay consistent.
+    struct TInfo {
         size_t offset_idx;
-        memory::ptr mem;
+        memory* mem;
         bool needs_transpose;
+        size_t per_expert_size;
     };
-    std::array<TensorInfo, 3> tensors = is_up
-        ? std::array<TensorInfo, 3>{{
-            {UP_W, resident.up_w, false},
-            {UP_S, resident.up_s, true},
-            {UP_Z, resident.up_z, true},
-          }}
-        : std::array<TensorInfo, 3>{{
-            {DOWN_W, resident.down_w, false},
-            {DOWN_S, resident.down_s, true},
-            {DOWN_Z, resident.down_z, true},
-          }};
+    std::array<std::pair<size_t, bool>, 3> spec = is_up
+        ? std::array<std::pair<size_t, bool>, 3>{{{UP_W, false}, {UP_S, true}, {UP_Z, true}}}
+        : std::array<std::pair<size_t, bool>, 3>{{{DOWN_W, false}, {DOWN_S, true}, {DOWN_Z, true}}};
+    std::array<memory::ptr, 3> mems = is_up
+        ? std::array<memory::ptr, 3>{{resident.up_w, resident.up_s, resident.up_z}}
+        : std::array<memory::ptr, 3>{{resident.down_w, resident.down_s, resident.down_z}};
 
-    for (size_t i = 0; i < expert_ids.size() && i < capacity; i++) {
+    std::vector<TInfo> tensors;
+    tensors.reserve(3);
+    size_t max_expert_size = 0;
+    for (size_t t = 0; t < 3; t++) {
+        if (!mems[t])
+            continue;
+        const size_t per_expert_size = mems[t]->get_layout().bytes_count() / num_experts;
+        tensors.push_back(TInfo{spec[t].first, mems[t].get(), spec[t].second, per_expert_size});
+        max_expert_size = std::max(max_expert_size, per_expert_size);
+    }
+    if (tensors.empty())
+        return slots;
+
+    // Lazily allocate the GPU->GPU swap scratch (one expert slot of the largest tensor).
+    if (!swap_tmp || swap_tmp->get_layout().bytes_count() < max_expert_size) {
+        auto* eng = tensors.front().mem->get_engine();
+        auto tmp_layout = cldnn::layout(ov::Shape{max_expert_size}, cldnn::data_types::u8, cldnn::format::bfyx);
+        swap_tmp = eng->allocate_memory(tmp_layout, cldnn::allocation_type::usm_device, false);
+    }
+
+    // GPU->GPU move of one expert slot (all tensors) from -> to (overwrites destination).
+    // Blocking to match the proven-correct disk-upload path: the Level Zero queue may route
+    // copies to a dedicated copy engine, so we synchronize rather than rely on in-order
+    // ordering relative to the following matmul.
+    auto dev_move = [&](size_t from, size_t to) {
+        for (auto& t : tensors)
+            t.mem->copy_from(s, *t.mem, from * t.per_expert_size, to * t.per_expert_size, t.per_expert_size, true);
+    };
+    // GPU->GPU swap of two expert slots (all tensors) via the scratch buffer.
+    auto dev_swap = [&](size_t a, size_t b) {
+        for (auto& t : tensors) {
+            swap_tmp->copy_from(s, *t.mem, a * t.per_expert_size, 0, t.per_expert_size, true);
+            t.mem->copy_from(s, *t.mem, b * t.per_expert_size, a * t.per_expert_size, t.per_expert_size, true);
+            t.mem->copy_from(s, *swap_tmp, 0, b * t.per_expert_size, t.per_expert_size, true);
+        }
+    };
+
+    // Set of experts required by this call (used to protect them from cache eviction).
+    std::unordered_set<uint32_t> needed(expert_ids.begin(), expert_ids.begin() + n);
+    // Current location of every resident expert: expert_id -> slot.
+    std::unordered_map<uint32_t, size_t> loc;
+    for (size_t sl = 0; sl < capacity; sl++)
+        if (slot_contents[sl] >= 0)
+            loc.emplace(static_cast<uint32_t>(slot_contents[sl]), sl);
+
+    // Pick a cache slot in [n, capacity) to park a displaced expert: prefer an empty slot,
+    // otherwise the first slot holding an expert not needed by this call. Returns SIZE_MAX
+    // when the cache region is full of still-needed experts (only possible when n == capacity).
+    auto pick_parking = [&]() -> size_t {
+        for (size_t p = n; p < capacity; p++)
+            if (slot_contents[p] < 0)
+                return p;
+        for (size_t p = n; p < capacity; p++)
+            if (!needed.count(static_cast<uint32_t>(slot_contents[p])))
+                return p;
+        return std::numeric_limits<size_t>::max();
+    };
+
+    for (size_t i = 0; i < n; i++) {
         const uint32_t expert = expert_ids[i];
-        const size_t slot = expert;  // Direct mapping: expert_id = position in weight buffer
-        slots[i] = slot;
 
-        if (loaded_set[expert]) {
+        // Already in the right slot: pure cache hit, nothing to do.
+        if (slot_contents[i] == static_cast<int32_t>(expert)) {
             if (perf)
                 perf->gpu_hits.fetch_add(1, std::memory_order_relaxed);
             continue;
         }
 
-        if (perf)
-            perf->gpu_misses.fetch_add(1, std::memory_order_relaxed);
+        auto it = loc.find(expert);
+        if (it != loc.end()) {
+            // Resident elsewhere: swap it into slot i (GPU->GPU, no disk).
+            const size_t sl = it->second;
+            dev_swap(i, sl);
+            const int32_t displaced = slot_contents[i];
+            slot_contents[i] = static_cast<int32_t>(expert);
+            slot_contents[sl] = displaced;
+            loc[expert] = i;
+            if (displaced >= 0)
+                loc[static_cast<uint32_t>(displaced)] = sl;
+            if (perf)
+                perf->gpu_hits.fetch_add(1, std::memory_order_relaxed);
+            continue;
+        }
 
-        for (auto& [offset_idx, mem, needs_transpose] : tensors) {
-            if (!mem)
-                continue;
-
-            const auto total_bytes = mem->get_layout().bytes_count();
-            const size_t per_expert_size = total_bytes / capacity;
-            const size_t base_offset = weight_bin_offsets[offset_idx];
-            const size_t src_offset = base_offset + expert * per_expert_size;
-            const size_t dst_offset = slot * per_expert_size;
-
-            std::vector<uint8_t> payload(per_expert_size);
-
-            if (perf) {
-                auto t0 = std::chrono::steady_clock::now();
-                weight_reader->read(reinterpret_cast<char*>(payload.data()), per_expert_size, src_offset);
-                auto t1 = std::chrono::steady_clock::now();
-                perf->disk_io_ns.fetch_add(
-                    static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()),
-                    std::memory_order_relaxed);
+        // Cache miss: expert must be loaded from disk into slot i. Preserve the expert
+        // currently occupying slot i by parking it into a free cache slot when possible.
+        const int32_t displaced = slot_contents[i];
+        if (displaced >= 0) {
+            const size_t park = pick_parking();
+            if (park != std::numeric_limits<size_t>::max()) {
+                const int32_t evicted = slot_contents[park];
+                dev_move(i, park);
+                slot_contents[park] = displaced;
+                loc[static_cast<uint32_t>(displaced)] = park;
+                if (evicted >= 0)
+                    loc.erase(static_cast<uint32_t>(evicted));
             } else {
-                weight_reader->read(reinterpret_cast<char*>(payload.data()), per_expert_size, src_offset);
-            }
-
-            // Transpose scale/zp from [OC, G] to [G, OC]
-            // Derive OC and G from the actual memory shape [E, OC, G] rather than config
-            if (needs_transpose) {
-                const auto& shape = mem->get_layout().get_shape();
-                const size_t tensor_oc = (shape.size() >= 2) ? shape[1] : 0;
-                const size_t tensor_gc = (shape.size() >= 3) ? shape[2] : 0;
-                if (perf) {
-                    auto t0 = std::chrono::steady_clock::now();
-                    transpose_scale_or_zp(mem->get_layout(), payload, per_expert_size, tensor_oc, tensor_gc);
-                    auto t1 = std::chrono::steady_clock::now();
-                    perf->transpose_ns.fetch_add(
-                        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()),
-                        std::memory_order_relaxed);
-                } else {
-                    transpose_scale_or_zp(mem->get_layout(), payload, per_expert_size, tensor_oc, tensor_gc);
-                }
-            }
-
-            // Copy to GPU
-            if (perf) {
-                auto t0 = std::chrono::steady_clock::now();
-                mem->copy_from(s, payload.data(), 0, dst_offset, per_expert_size, true);
-                auto t1 = std::chrono::steady_clock::now();
-                perf->gpu_copy_ns.fetch_add(
-                    static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()),
-                    std::memory_order_relaxed);
-                perf->tensor_load_count.fetch_add(1, std::memory_order_relaxed);
-            } else {
-                mem->copy_from(s, payload.data(), 0, dst_offset, per_expert_size, true);
+                loc.erase(static_cast<uint32_t>(displaced));
             }
         }
 
-        loaded_set[expert] = true;
+        if (perf)
+            perf->gpu_misses.fetch_add(1, std::memory_order_relaxed);
+        load_expert_from_disk(s, is_up, i, expert);
+        slot_contents[i] = static_cast<int32_t>(expert);
+        loc[expert] = i;
+    }
+
+    return slots;
+}
+
+std::vector<size_t> Moe2GemmOtdContext::acquire_experts_lru(stream& s, const std::vector<uint32_t>& expert_ids, bool is_up) {
+    using namespace ov::intel_gpu::ocl;
+    auto* perf = moe_otd::get_perf_counters();
+    auto& slot_contents = is_up ? slot_contents_up : slot_contents_down;
+    auto& slot_used = is_up ? slot_used_up : slot_used_down;
+
+    std::vector<size_t> slots(expert_ids.size());
+
+    // Current residency: expert_id -> slot.
+    std::unordered_map<uint32_t, size_t> loc;
+    for (size_t sl = 0; sl < capacity; sl++)
+        if (slot_contents[sl] >= 0)
+            loc.emplace(static_cast<uint32_t>(slot_contents[sl]), sl);
+
+    // Experts needed by this call must not be evicted to make room for one another.
+    std::unordered_set<uint32_t> needed(expert_ids.begin(), expert_ids.end());
+
+    // Choose a slot for a miss: prefer an empty slot, otherwise evict the least-recently-used
+    // slot whose expert is not needed by this call.
+    auto pick_victim = [&]() -> size_t {
+        for (size_t sl = 0; sl < capacity; sl++)
+            if (slot_contents[sl] < 0)
+                return sl;
+        size_t victim = std::numeric_limits<size_t>::max();
+        uint64_t oldest = std::numeric_limits<uint64_t>::max();
+        for (size_t sl = 0; sl < capacity; sl++) {
+            if (needed.count(static_cast<uint32_t>(slot_contents[sl])))
+                continue;
+            if (slot_used[sl] < oldest) {
+                oldest = slot_used[sl];
+                victim = sl;
+            }
+        }
+        return victim;
+    };
+
+    for (size_t i = 0; i < expert_ids.size(); i++) {
+        const uint32_t expert = expert_ids[i];
+
+        auto it = loc.find(expert);
+        if (it != loc.end()) {
+            // Hit: reuse the resident slot, no copy.
+            const size_t sl = it->second;
+            slots[i] = sl;
+            slot_used[sl] = ++lru_tick;
+            if (perf)
+                perf->gpu_hits.fetch_add(1, std::memory_order_relaxed);
+            continue;
+        }
+
+        // Miss: load into a free/evicted slot (no relocation of other experts).
+        const size_t sl = pick_victim();
+        OPENVINO_ASSERT(sl != std::numeric_limits<size_t>::max(),
+                        "acquire_experts_lru: no slot available (active experts exceed capacity)");
+        const int32_t evicted = slot_contents[sl];
+        if (evicted >= 0)
+            loc.erase(static_cast<uint32_t>(evicted));
+
+        if (perf)
+            perf->gpu_misses.fetch_add(1, std::memory_order_relaxed);
+        load_expert_from_disk(s, is_up, sl, expert);
+        slot_contents[sl] = static_cast<int32_t>(expert);
+        slot_used[sl] = ++lru_tick;
+        loc[expert] = sl;
+        slots[i] = sl;
     }
 
     return slots;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_otd_context.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_otd_context.cpp
@@ -1,0 +1,145 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "moe_gemm_otd_context.hpp"
+
+#include <chrono>
+#include <cstring>
+
+#include "impls/ocl_v2/moe/moe_otd_runtime.hpp"
+
+namespace cldnn {
+namespace onednn {
+
+// Transpose scale/zp from [OC, G] to [G, OC] layout for oneDNN consumption.
+// This is the 2GEMM variant that computes OC from the actual per-expert memory size.
+static void transpose_scale_or_zp(const layout& mem_layout,
+                                  std::vector<uint8_t>& payload,
+                                  size_t per_expert_size,
+                                  size_t oc,
+                                  size_t group_count) {
+    const auto elem_type = ov::element::Type(mem_layout.data_type);
+    const size_t elem_size = elem_type.bitwidth() / 8;
+    if (elem_size == 0 || oc == 0 || group_count == 0)
+        return;
+
+    const size_t expected_size = oc * group_count * elem_size;
+    if (expected_size != per_expert_size)
+        return;  // Dimensions don't match, skip transpose
+
+    std::vector<uint8_t> transposed(per_expert_size, 0);
+    for (size_t o = 0; o < oc; o++) {
+        for (size_t g = 0; g < group_count; g++) {
+            const size_t src_elem_idx = o * group_count + g;
+            const size_t dst_elem_idx = g * oc + o;
+            std::memcpy(transposed.data() + dst_elem_idx * elem_size,
+                        payload.data() + src_elem_idx * elem_size,
+                        elem_size);
+        }
+    }
+    payload.swap(transposed);
+}
+
+std::vector<size_t> Moe2GemmOtdContext::load_experts(stream& s, const std::vector<uint32_t>& expert_ids, bool is_up) {
+    using namespace ov::intel_gpu::ocl;
+
+    std::vector<size_t> slots(expert_ids.size());
+    auto* perf = moe_otd::get_perf_counters();
+    auto& loaded_set = is_up ? loaded_up : loaded_down;
+
+    // Select tensor info for this direction
+    struct TensorInfo {
+        size_t offset_idx;
+        memory::ptr mem;
+        bool needs_transpose;
+    };
+    std::array<TensorInfo, 3> tensors = is_up
+        ? std::array<TensorInfo, 3>{{
+            {UP_W, resident.up_w, false},
+            {UP_S, resident.up_s, true},
+            {UP_Z, resident.up_z, true},
+          }}
+        : std::array<TensorInfo, 3>{{
+            {DOWN_W, resident.down_w, false},
+            {DOWN_S, resident.down_s, true},
+            {DOWN_Z, resident.down_z, true},
+          }};
+
+    for (size_t i = 0; i < expert_ids.size() && i < capacity; i++) {
+        const uint32_t expert = expert_ids[i];
+        const size_t slot = expert;  // Direct mapping: expert_id = position in weight buffer
+        slots[i] = slot;
+
+        if (loaded_set[expert]) {
+            if (perf)
+                perf->gpu_hits.fetch_add(1, std::memory_order_relaxed);
+            continue;
+        }
+
+        if (perf)
+            perf->gpu_misses.fetch_add(1, std::memory_order_relaxed);
+
+        for (auto& [offset_idx, mem, needs_transpose] : tensors) {
+            if (!mem)
+                continue;
+
+            const auto total_bytes = mem->get_layout().bytes_count();
+            const size_t per_expert_size = total_bytes / capacity;
+            const size_t base_offset = weight_bin_offsets[offset_idx];
+            const size_t src_offset = base_offset + expert * per_expert_size;
+            const size_t dst_offset = slot * per_expert_size;
+
+            std::vector<uint8_t> payload(per_expert_size);
+
+            if (perf) {
+                auto t0 = std::chrono::steady_clock::now();
+                weight_reader->read(reinterpret_cast<char*>(payload.data()), per_expert_size, src_offset);
+                auto t1 = std::chrono::steady_clock::now();
+                perf->disk_io_ns.fetch_add(
+                    static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()),
+                    std::memory_order_relaxed);
+            } else {
+                weight_reader->read(reinterpret_cast<char*>(payload.data()), per_expert_size, src_offset);
+            }
+
+            // Transpose scale/zp from [OC, G] to [G, OC]
+            // Derive OC and G from the actual memory shape [E, OC, G] rather than config
+            if (needs_transpose) {
+                const auto& shape = mem->get_layout().get_shape();
+                const size_t tensor_oc = (shape.size() >= 2) ? shape[1] : 0;
+                const size_t tensor_gc = (shape.size() >= 3) ? shape[2] : 0;
+                if (perf) {
+                    auto t0 = std::chrono::steady_clock::now();
+                    transpose_scale_or_zp(mem->get_layout(), payload, per_expert_size, tensor_oc, tensor_gc);
+                    auto t1 = std::chrono::steady_clock::now();
+                    perf->transpose_ns.fetch_add(
+                        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()),
+                        std::memory_order_relaxed);
+                } else {
+                    transpose_scale_or_zp(mem->get_layout(), payload, per_expert_size, tensor_oc, tensor_gc);
+                }
+            }
+
+            // Copy to GPU
+            if (perf) {
+                auto t0 = std::chrono::steady_clock::now();
+                mem->copy_from(s, payload.data(), 0, dst_offset, per_expert_size, true);
+                auto t1 = std::chrono::steady_clock::now();
+                perf->gpu_copy_ns.fetch_add(
+                    static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()),
+                    std::memory_order_relaxed);
+                perf->tensor_load_count.fetch_add(1, std::memory_order_relaxed);
+            } else {
+                mem->copy_from(s, payload.data(), 0, dst_offset, per_expert_size, true);
+            }
+        }
+
+        loaded_set[expert] = true;
+    }
+
+    return slots;
+}
+
+}  // namespace onednn
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_otd_context.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_otd_context.hpp
@@ -1,0 +1,129 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "intel_gpu/primitives/moe_otd_descriptor.hpp"
+#include "intel_gpu/runtime/memory.hpp"
+#include "intel_gpu/runtime/stream.hpp"
+#include "ov_ops/moe_compressed.hpp"
+#include "impls/ocl_v2/moe/moe_otd_runtime.hpp"
+
+namespace cldnn {
+namespace onednn {
+
+/// @brief Shared OTD context for a pair of moe_gemm_up / moe_gemm_down primitives.
+/// Both primitives within the same MOE layer share one context instance so that
+/// expert weights loaded by gemm_up remain valid for gemm_down.
+struct Moe2GemmOtdContext {
+    // 2GEMM offset layout: [up_w, up_s, up_z, down_w, down_s, down_z]
+    static constexpr size_t offset_count = 6;
+    // Offset index constants
+    static constexpr size_t UP_W = 0;
+    static constexpr size_t UP_S = 1;
+    static constexpr size_t UP_Z = 2;
+    static constexpr size_t DOWN_W = 3;
+    static constexpr size_t DOWN_S = 4;
+    static constexpr size_t DOWN_Z = 5;
+
+    size_t capacity = 0;  // Total expert count (= num_experts for 2GEMM)
+    ov::op::internal::MOECompressed::Config moe_config{};
+    std::vector<size_t> weight_bin_offsets;
+    std::vector<bool> loaded_up;    // loaded_up[expert_id] = true if up weights loaded
+    std::vector<bool> loaded_down;  // loaded_down[expert_id] = true if down weights loaded
+    std::unique_ptr<ov::intel_gpu::ocl::moe_otd::ParallelWeightReader> weight_reader;
+
+    // Resident GPU memory buffers (one slot per LRU entry)
+    struct ResidentBuffers {
+        memory::ptr up_w;
+        memory::ptr up_s;
+        memory::ptr up_z;
+        memory::ptr down_w;
+        memory::ptr down_s;
+        memory::ptr down_z;
+    } resident{};
+    bool bound = false;
+
+    // Slot mapping from current iteration
+    std::vector<size_t> current_slots;
+    std::vector<int32_t> current_expert_ids;  // active expert IDs for this iteration
+
+    Moe2GemmOtdContext(size_t lru_capacity,
+                       const ov::op::internal::MOECompressed::Config& config,
+                       std::vector<size_t> bin_offsets,
+                       const std::filesystem::path& weights_path)
+        : capacity(lru_capacity),
+          moe_config(config),
+          weight_bin_offsets(std::move(bin_offsets)),
+          loaded_up(lru_capacity, false),
+          loaded_down(lru_capacity, false),
+          weight_reader(std::make_unique<ov::intel_gpu::ocl::moe_otd::ParallelWeightReader>(weights_path)) {}
+
+    void bind(memory::ptr up_w, memory::ptr up_s, memory::ptr up_z,
+              memory::ptr down_w, memory::ptr down_s, memory::ptr down_z) {
+        resident.up_w = std::move(up_w);
+        resident.up_s = std::move(up_s);
+        resident.up_z = std::move(up_z);
+        resident.down_w = std::move(down_w);
+        resident.down_s = std::move(down_s);
+        resident.down_z = std::move(down_z);
+        bound = true;
+    }
+
+    // Load requested experts for the given direction (is_up=true → up weights, false → down weights).
+    std::vector<size_t> load_experts(stream& s, const std::vector<uint32_t>& expert_ids, bool is_up);
+};
+
+/// @brief Global registry for Moe2GemmOtdContext instances, keyed by MOE layer base name.
+/// Both gemm_up and gemm_down from the same MOE op share one context.
+class Moe2GemmOtdRegistry {
+public:
+    static Moe2GemmOtdRegistry& instance() {
+        static Moe2GemmOtdRegistry reg;
+        return reg;
+    }
+
+    std::shared_ptr<Moe2GemmOtdContext> get_or_create(const std::string& moe_layer_id,
+                                                       size_t capacity,
+                                                       const ov::op::internal::MOECompressed::Config& config,
+                                                       const std::vector<size_t>& bin_offsets,
+                                                       const std::filesystem::path& weights_path) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto it = _contexts.find(moe_layer_id);
+        if (it != _contexts.end()) {
+            return it->second;
+        }
+        auto ctx = std::make_shared<Moe2GemmOtdContext>(capacity, config, bin_offsets, weights_path);
+        _contexts[moe_layer_id] = ctx;
+        return ctx;
+    }
+
+    std::shared_ptr<Moe2GemmOtdContext> get(const std::string& moe_layer_id) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto it = _contexts.find(moe_layer_id);
+        if (it != _contexts.end()) {
+            return it->second;
+        }
+        return nullptr;
+    }
+
+    void clear() {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _contexts.clear();
+    }
+
+private:
+    Moe2GemmOtdRegistry() = default;
+    std::mutex _mutex;
+    std::unordered_map<std::string, std::shared_ptr<Moe2GemmOtdContext>> _contexts;
+};
+
+}  // namespace onednn
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_otd_context.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_otd_context.hpp
@@ -33,11 +33,17 @@ struct Moe2GemmOtdContext {
     static constexpr size_t DOWN_S = 4;
     static constexpr size_t DOWN_Z = 5;
 
-    size_t capacity = 0;  // Total expert count (= num_experts for 2GEMM)
+    size_t capacity = 0;      // LRU slot count (= lru_expert_num)
+    size_t num_experts = 0;    // Total experts in the model (for per-expert-size computation)
     ov::op::internal::MOECompressed::Config moe_config{};
     std::vector<size_t> weight_bin_offsets;
-    std::vector<bool> loaded_up;    // loaded_up[expert_id] = true if up weights loaded
-    std::vector<bool> loaded_down;  // loaded_down[expert_id] = true if down weights loaded
+    // Per-slot tracking: slot_contents_up[slot] = expert_id loaded there (-1 if empty)
+    std::vector<int32_t> slot_contents_up;
+    std::vector<int32_t> slot_contents_down;
+    // Per-slot last-use tick for LRU eviction on the decode (non-relocating) path.
+    std::vector<uint64_t> slot_used_up;
+    std::vector<uint64_t> slot_used_down;
+    uint64_t lru_tick = 0;
     std::unique_ptr<ov::intel_gpu::ocl::moe_otd::ParallelWeightReader> weight_reader;
 
     // Resident GPU memory buffers (one slot per LRU entry)
@@ -51,19 +57,30 @@ struct Moe2GemmOtdContext {
     } resident{};
     bool bound = false;
 
-    // Slot mapping from current iteration
-    std::vector<size_t> current_slots;
-    std::vector<int32_t> current_expert_ids;  // active expert IDs for this iteration
+    // One-slot scratch buffers used to swap expert weights between resident slots
+    // (GPU->GPU) without a disk round-trip. Sized to the largest per-expert tensor of
+    // each direction, allocated on first use and never reallocated afterwards so that
+    // in-flight async copies keep a valid backing pointer.
+    memory::ptr swap_tmp_up;
+    memory::ptr swap_tmp_down;
+
+    // Slot mapping from current iteration (set by gemm_up, reused by gemm_down)
+    std::unordered_map<uint32_t, size_t> expert_to_slot;  // expert_id → LRU slot
+    bool slots_valid = false;  // true after gemm_up loaded, cleared after gemm_down executes
 
     Moe2GemmOtdContext(size_t lru_capacity,
+                       size_t total_experts,
                        const ov::op::internal::MOECompressed::Config& config,
                        std::vector<size_t> bin_offsets,
                        const std::filesystem::path& weights_path)
         : capacity(lru_capacity),
+          num_experts(total_experts),
           moe_config(config),
           weight_bin_offsets(std::move(bin_offsets)),
-          loaded_up(lru_capacity, false),
-          loaded_down(lru_capacity, false),
+          slot_contents_up(lru_capacity, -1),
+          slot_contents_down(lru_capacity, -1),
+          slot_used_up(lru_capacity, 0),
+          slot_used_down(lru_capacity, 0),
           weight_reader(std::make_unique<ov::intel_gpu::ocl::moe_otd::ParallelWeightReader>(weights_path)) {}
 
     void bind(memory::ptr up_w, memory::ptr up_s, memory::ptr up_z,
@@ -79,6 +96,16 @@ struct Moe2GemmOtdContext {
 
     // Load requested experts for the given direction (is_up=true → up weights, false → down weights).
     std::vector<size_t> load_experts(stream& s, const std::vector<uint32_t>& expert_ids, bool is_up);
+
+    // Decode path: acquire a resident slot for each expert using a pure LRU cache WITHOUT
+    // relocating experts to contiguous slots. Returns slot[i] for expert_ids[i]. Hits reuse
+    // the existing slot (no copy); misses load from disk into a free/evicted slot. Callers
+    // then issue one matmul per expert reading its weight from slot[i], avoiding the GPU->GPU
+    // swaps required by the grouped (contiguous-slot) prefill path.
+    std::vector<size_t> acquire_experts_lru(stream& s, const std::vector<uint32_t>& expert_ids, bool is_up);
+
+    // Load a single expert's W/S/Z from disk into the given slot (read + transpose + upload).
+    void load_expert_from_disk(stream& s, bool is_up, size_t slot, uint32_t expert);
 };
 
 /// @brief Global registry for Moe2GemmOtdContext instances, keyed by MOE layer base name.
@@ -92,6 +119,7 @@ public:
 
     std::shared_ptr<Moe2GemmOtdContext> get_or_create(const std::string& moe_layer_id,
                                                        size_t capacity,
+                                                       size_t num_experts,
                                                        const ov::op::internal::MOECompressed::Config& config,
                                                        const std::vector<size_t>& bin_offsets,
                                                        const std::filesystem::path& weights_path) {
@@ -100,7 +128,7 @@ public:
         if (it != _contexts.end()) {
             return it->second;
         }
-        auto ctx = std::make_shared<Moe2GemmOtdContext>(capacity, config, bin_offsets, weights_path);
+        auto ctx = std::make_shared<Moe2GemmOtdContext>(capacity, num_experts, config, bin_offsets, weights_path);
         _contexts[moe_layer_id] = ctx;
         return ctx;
     }

--- a/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
@@ -147,12 +147,74 @@ static void CreateMOECompressedOp(ProgramBuilder& p, const std::shared_ptr<ov::o
         // input6 : compressed_weights_input_down {#experts, ofm, num_groups, group_size}
         // input7 : scale_input_down {#experts, ofm, num_groups, 1}
         // input8 : bias_down {#experts, 1, ofm}
+        // (with has_zp: input5=zp_up, input6=bias_up, input7=down_weight, ...)
         // moe_mask_gen
         // moe_gather
         // moe_gemm_up + bias
         // swiglu_with_clamp
         // moe_gemm_down + bias
         // moe_scatter_reduce
+
+        // --- OTD setup for 2GEMM ---
+        // Bin offset layout: [up_w, up_s, up_z, down_w, down_s, down_z] (6 elements)
+        static constexpr size_t moe_2gemm_offset_count = 6;
+        moe_otd_descriptor otd_desc;
+        {
+            const size_t otd_ratio = p.get_config().get_offload_ratio();
+            if (otd_ratio > 0 && otd_ratio < 100) {
+                otd_desc.lru_expert_num = std::max<size_t>(1, static_cast<size_t>(config.num_expert) * (100 - otd_ratio) / 100);
+            }
+            if (otd_desc.lru_expert_num > 0) {
+                otd_desc.weights_path = std::filesystem::path(p.get_config().get_weights_path());
+                OPENVINO_ASSERT(!otd_desc.weights_path.empty(),
+                                "ov::weights_path property is not set. OTD requires a valid path to the model .bin file.");
+                OPENVINO_ASSERT(std::filesystem::exists(otd_desc.weights_path),
+                                "OTD weights file does not exist: ", otd_desc.weights_path);
+
+                auto get_const_offset_2gemm = [&](size_t index) -> size_t {
+                    auto node = op->input_value(index).get_node_shared_ptr();
+                    auto const_op = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
+                    OPENVINO_ASSERT(const_op != nullptr, "Expected constant input for MOE 2GEMM OTD, got: ",
+                                    node->get_type_name(), " name: ", node->get_friendly_name());
+                    const auto& rt_info = const_op->get_rt_info();
+                    auto attr_it = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
+                    if (attr_it != rt_info.end()) {
+                        return attr_it->second.as<ov::WeightlessCacheAttribute>().bin_offset;
+                    }
+                    auto source_buf = ov::weight_sharing::Extension::get_constant_source_buffer(*const_op);
+                    if (source_buf) {
+                        return ov::weight_sharing::Extension::get_constant_id(*const_op);
+                    }
+                    auto otd_it = rt_info.find("otd_bin_offset");
+                    if (otd_it != rt_info.end()) {
+                        return static_cast<size_t>(otd_it->second.as<int64_t>());
+                    }
+                    OPENVINO_THROW("OTD 2GEMM: Cannot determine bin offset for MOE weight constant. "
+                                   "Constant name: ", const_op->get_friendly_name(), ", input_index: ", index);
+                };
+
+                // Populate 6 offsets: [up_w, up_s, up_z, down_w, down_s, down_z]
+                otd_desc.weight_bin_offsets.resize(moe_2gemm_offset_count, 0);
+                if (config.has_zp) {
+                    // inputs: 3=up_w, 4=up_s, 5=up_zp, 6=up_bias, 7=down_w, 8=down_s, 9=down_zp, 10=down_bias
+                    otd_desc.weight_bin_offsets[0] = get_const_offset_2gemm(3);  // up_w
+                    otd_desc.weight_bin_offsets[1] = get_const_offset_2gemm(4);  // up_s
+                    otd_desc.weight_bin_offsets[2] = get_const_offset_2gemm(5);  // up_z
+                    otd_desc.weight_bin_offsets[3] = get_const_offset_2gemm(7);  // down_w
+                    otd_desc.weight_bin_offsets[4] = get_const_offset_2gemm(8);  // down_s
+                    otd_desc.weight_bin_offsets[5] = get_const_offset_2gemm(9);  // down_z
+                } else {
+                    // inputs: 3=up_w, 4=up_s, 5=up_bias, 6=down_w, 7=down_s, 8=down_bias
+                    otd_desc.weight_bin_offsets[0] = get_const_offset_2gemm(3);  // up_w
+                    otd_desc.weight_bin_offsets[1] = get_const_offset_2gemm(4);  // up_s
+                    otd_desc.weight_bin_offsets[2] = 0;                          // up_z (not present)
+                    otd_desc.weight_bin_offsets[3] = get_const_offset_2gemm(6);  // down_w
+                    otd_desc.weight_bin_offsets[4] = get_const_offset_2gemm(7);  // down_s
+                    otd_desc.weight_bin_offsets[5] = 0;                          // down_z (not present)
+                }
+            }
+        }
+
         std::string prim_name_base = layer_type_name_ID(op);
         auto moe_mask_gen_name = prim_name_base + "_moe_mask_gen";
         auto moe_mask_gen_reshape_name = prim_name_base + "_moe_mask_gen_reshape";
@@ -201,6 +263,8 @@ static void CreateMOECompressedOp(ProgramBuilder& p, const std::shared_ptr<ov::o
         }
         auto moe_gemm_up = cldnn::moe_gemm(moe_gemm_up_name, moe_gemm_up_inputs, config);
         moe_gemm_up.has_bias = true;
+        moe_gemm_up._otd = otd_desc;
+        moe_gemm_up.is_up_gemm = true;
         p.add_primitive(*op, moe_gemm_up);
 
         // GPT-OSS swiglu: stride-2 interleave (gate=swish, up=clamp+add).
@@ -236,6 +300,8 @@ static void CreateMOECompressedOp(ProgramBuilder& p, const std::shared_ptr<ov::o
 
         auto moe_gemm_down = cldnn::moe_gemm(moe_gemm_down_name, moe_gemm_down_inputs, config);
         moe_gemm_down.has_bias = true;
+        moe_gemm_down._otd = otd_desc;
+        moe_gemm_down.is_up_gemm = false;
         p.add_primitive(*op, moe_gemm_down);
         auto moe_scatter_reduce_prim =
             cldnn::moe_scatter_reduction(moe_scatter_reduce_name,

--- a/src/plugins/intel_gpu/src/plugin/ops/moe_offload_constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/moe_offload_constant.cpp
@@ -49,18 +49,7 @@ PartialUploadDesc try_prepare_partial_upload(ProgramBuilder& p,
     const size_t otd_ratio = p.get_config().get_offload_ratio();
     // Only routed expert weights are partially uploaded; shared experts stay fully resident.
     // ratio=0 (all resident) or ratio=100 (all on disk, invalid) → no partial upload.
-    // Only 3GEMM (GEMM3_SWIGLU) supports partial upload. 2GEMM needs full allocation
-    // because the grouped matmul requires all active experts in the weight buffer.
-    bool is_3gemm_constant = false;
-    const auto users = op->get_output_target_inputs(0);
-    for (const auto& input : users) {
-        const auto* node = input.get_node();
-        if (auto moe_op = dynamic_cast<const ov::op::internal::MOECompressed*>(node)) {
-            if (moe_op->get_config().expert_type == ov::op::internal::MOE::Expert_type::GEMM3_SWIGLU)
-                is_3gemm_constant = true;
-        }
-    }
-    const bool partial_moe_const_upload = otd_ratio > 0 && otd_ratio < 100 && get_moe_constant_role(op) == MoEConstantRole::RoutedExpert && is_3gemm_constant;
+    const bool partial_moe_const_upload = otd_ratio > 0 && otd_ratio < 100 && get_moe_constant_role(op) == MoEConstantRole::RoutedExpert;
     if (!partial_moe_const_upload || const_layout.bytes_count() == 0 || const_shape.empty() || const_shape[0] == 0) {
         return desc;
     }

--- a/src/plugins/intel_gpu/src/plugin/ops/moe_offload_constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/moe_offload_constant.cpp
@@ -49,7 +49,18 @@ PartialUploadDesc try_prepare_partial_upload(ProgramBuilder& p,
     const size_t otd_ratio = p.get_config().get_offload_ratio();
     // Only routed expert weights are partially uploaded; shared experts stay fully resident.
     // ratio=0 (all resident) or ratio=100 (all on disk, invalid) → no partial upload.
-    const bool partial_moe_const_upload = otd_ratio > 0 && otd_ratio < 100 && get_moe_constant_role(op) == MoEConstantRole::RoutedExpert;
+    // Only 3GEMM (GEMM3_SWIGLU) supports partial upload. 2GEMM needs full allocation
+    // because the grouped matmul requires all active experts in the weight buffer.
+    bool is_3gemm_constant = false;
+    const auto users = op->get_output_target_inputs(0);
+    for (const auto& input : users) {
+        const auto* node = input.get_node();
+        if (auto moe_op = dynamic_cast<const ov::op::internal::MOECompressed*>(node)) {
+            if (moe_op->get_config().expert_type == ov::op::internal::MOE::Expert_type::GEMM3_SWIGLU)
+                is_3gemm_constant = true;
+        }
+    }
+    const bool partial_moe_const_upload = otd_ratio > 0 && otd_ratio < 100 && get_moe_constant_role(op) == MoEConstantRole::RoutedExpert && is_3gemm_constant;
     if (!partial_moe_const_upload || const_layout.bytes_count() == 0 || const_shape.empty() || const_shape[0] == 0) {
         return desc;
     }


### PR DESCRIPTION
This pull request introduces Offload-to-Disk (OTD) support for Mixture-of-Experts (MoE) GEMM primitives in the Intel GPU plugin, enabling lazy loading of expert weights from disk at runtime. The main changes include refactoring the OTD descriptor into its own header, integrating OTD fields and logic into `moe_gemm`, and implementing the runtime and oneDNN backend support for on-demand expert loading. Additionally, scale/zero-point tensor transposition is handled for oneDNN compatibility.

**OTD (Offload-to-Disk) Support Integration:**

* The `moe_otd_descriptor` struct was moved to a new header (`moe_otd_descriptor.hpp`) and included where needed, centralizing OTD configuration and serialization logic. [[1]](diffhunk://#diff-64c734cd0069b8483e038f792e1bb17048004f12a71aaf84fd9f086c40db8569R13) [[2]](diffhunk://#diff-b39a851196b3c74d0b19fcd83d17b9ded0786efea6d3a5d1906ee3ddf0d69048R7) [[3]](diffhunk://#diff-9cf3c3a0b5ed11af4325016a43d987e7ea53e4f1ee6000df1bfee409b5b1e510R1-R44)
* The `moe_gemm` primitive now contains OTD-related fields (`_otd`, `is_up_gemm`, `_moe_config`), and its serialization/deserialization and equality/hash methods were updated to include these fields. [[1]](diffhunk://#diff-b39a851196b3c74d0b19fcd83d17b9ded0786efea6d3a5d1906ee3ddf0d69048L46-R65) [[2]](diffhunk://#diff-b39a851196b3c74d0b19fcd83d17b9ded0786efea6d3a5d1906ee3ddf0d69048L66-R97)
* The graph optimizer skips compile-time reorder for OTD-enabled nodes, since transposition occurs at runtime.

**oneDNN Backend and Runtime Logic:**

* The oneDNN implementation (`moe_gemm_onednn`) was extended with OTD context members, and the execution path now loads required experts from disk before computation. [[1]](diffhunk://#diff-02d640d834ef1603d49bb9c440e9687eb95c2ea893e8c45759af627f4094a080R6-L11) [[2]](diffhunk://#diff-02d640d834ef1603d49bb9c440e9687eb95c2ea893e8c45759af627f4094a080R23-R27) [[3]](diffhunk://#diff-02d640d834ef1603d49bb9c440e9687eb95c2ea893e8c45759af627f4094a080R108-R184)
* The primitive descriptor creation ensures the full expert buffer is allocated (no memory reduction), and OTD context is initialized if enabled. [[1]](diffhunk://#diff-02d640d834ef1603d49bb9c440e9687eb95c2ea893e8c45759af627f4094a080L118-R200) [[2]](diffhunk://#diff-02d640d834ef1603d49bb9c440e9687eb95c2ea893e8c45759af627f4094a080L196-R307)
* The new `moe_gemm_otd_context.cpp` implements expert loading, including disk I/O, transposition of scale/zp tensors, and GPU upload.

**Tensor Transposition and Data Handling:**

* The OCL runtime and oneDNN OTD context now handle transposition of scale and zero-point tensors from `[OC, G]` to `[G, OC]` layout as required by oneDNN, for both INT8 and packed 4-bit data. [[1]](diffhunk://#diff-04c9289ec3d91f30058bf0d36d91bbdfa07dfa569687f6cb649ad7b89ff7ec6dR106-R133) [[2]](diffhunk://#diff-b093d87a8b1834167d33bce203b1e7fa072541feed06065309f1d0eec9ac6cc8R1-R145)

These changes collectively enable efficient, on-demand loading of expert weights for large MoE models, reducing memory footprint and improving scalability.

Tickets: CVS-186598