### PR TITLE
[CPU]fix: coverity fix in cpu nodes

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/multinomial.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.cpp
@@ -209,7 +209,9 @@ void Multinomial::execute_convert_type() {
     // TODO RandomUniform - should use RandomUniform kernel to match other frameworks' seed results
     std::mt19937 gen;
     if (all_of(0U, m_global_seed, m_op_seed)) {
-        gen.seed(static_cast<uint32_t>(std::time(nullptr)));
+        const auto t = static_cast<uint64_t>(std::time(nullptr));
+        std::seed_seq seed{static_cast<uint32_t>(t), static_cast<uint32_t>(t >> 32)};
+        gen.seed(seed);
     } else {
         std::seed_seq seed{m_global_seed, m_op_seed};
         gen.seed(seed);

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -1958,11 +1958,7 @@ TopK::TopK(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& contex
 
         CPU_NODE_ASSERT(out_dims == out_idx_dims, "gets incorrect output tensor dimension sizes!");
 
-        if (axis < 0) {
-            axis += in_dims_size;
-        }
-        CPU_NODE_ASSERT(axis >= 0 && axis < in_dims_size,
-                        "gets incorrect input parameters dimensions and axis number!");
+        CPU_NODE_ASSERT(axis < in_dims_size, "gets incorrect input parameters dimensions and axis number!");
     } else {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }


### PR DESCRIPTION
### Details:
 - *topk.cpp: Macro compares unsigned to 0*
 - *multinomial.cpp: Use of 32-bit time_t*

### Tickets:
 - *190490*
 - *190491*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
