### PR TITLE
[GPU] Fix: Disable non-transposed MatMul→FC path on Intel GPUs without XMX 

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -232,8 +232,8 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
              // dimension. When both M and N are large the GEMM becomes
              // compute-bound and the transposed layout (acb) is faster (the
              // non-transposed kernel can regress by up to ~1.3x there). Restrict
-             // the non-transposed path to K >= 8192 and (M <= 512 or N <= 4096)
-             // to keep the wins while avoiding those regressions.
+             // the non-transposed path to XMX-capable GPUs (supports_immad) with
+             // K >= 8192 and (M <= 512 or N <= 4096) to keep the wins while avoiding those regressions.
              if (supports_immad && k >= 8192 && (m <= 512 || n <= 4096) &&
                  matmul->get_input_element_type(0) == ov::element::f16 && !is_compressed_weight) {
                  is_small_matmul = false;

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -234,7 +234,7 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
              // non-transposed kernel can regress by up to ~1.3x there). Restrict
              // the non-transposed path to K >= 8192 and (M <= 512 or N <= 4096)
              // to keep the wins while avoiding those regressions.
-             if (k >= 8192 && (m <= 512 || n <= 4096) &&
+             if (supports_immad && k >= 8192 && (m <= 512 || n <= 4096) &&
                  matmul->get_input_element_type(0) == ov::element::f16 && !is_compressed_weight) {
                  is_small_matmul = false;
              }

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -856,7 +856,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF16_NonTranspose
         auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, false);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
-        manager.register_pass<ConvertMatMulToFullyConnected>();
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
     }
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{512, 8192});
@@ -876,7 +876,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF16_NonTranspose
         auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, false);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
-        manager.register_pass<ConvertMatMulToFullyConnected>();
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
     }
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{4096, 8192});
@@ -940,7 +940,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF16_MatMulTransp
         auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, true);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
-        manager.register_pass<ConvertMatMulToFullyConnected>();
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
     }
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 8192});
@@ -971,6 +971,31 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF32_Transposed) 
         auto transpose = std::make_shared<ov::opset1::Transpose>(weights, transpose_constant);
         auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<op::FullyConnected>(input, transpose, no_bias, ov::element::f32, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
+    }
+}
+
+// Large f16 matmul on non-XMX hardware (supports_immad=false):
+// K>=8192 and M<=512 would normally enable the non-transposed path, but without XMX
+// the non-transposed path is unavailable, so the transposed path is used instead.
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF16_NoXMX_Transposed) {
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{512, 8192});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{8192, 4096}, {1});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
+        manager.register_pass<ConvertMatMulToFullyConnected>();  // supports_immad=false (no XMX)
+    }
+    {
+        // Expected: weights transposed + FC with transpose_b=true
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{512, 8192});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{8192, 4096}, {1});
+        auto transpose_constant = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {1, 0});
+        auto transpose = std::make_shared<ov::opset1::Transpose>(weights, transpose_constant);
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto fc = std::make_shared<op::FullyConnected>(input, transpose, no_bias, ov::element::f16, true);
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
     }


### PR DESCRIPTION
### Details:
 Problem:                                                                                                                                                                     
 The ConvertMatMulToFullyConnected pass contains an optimization that uses a non-transposed weight layout (transpose_b=false) for large f16 MatMul operations (K ≥ 8192 with  
 thin M or N dimensions). This path relies on the oneDNN abc (non-transposed) kernel, which is optimized for GPU generations with XMX (DPAS systolic array) support.          
                                                                                                                                                                              
 On older Intel GPU generations that lack XMX hardware, the non-transposed kernel is not performant and can cause regressions. Additionally, these older     
 GPUs do not support the non-transposed weight layout in the FullyConnected primitive.                                                                                        
                                                                                                                                                                              
 Solution:                                                                                                                                                                    
 Guard the non-transposed path with a supports_immad check so it is only enabled on GPUs that have XMX support:  

### Tickets:
 - CVS-189962

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
