### PR TITLE
[GPU] Fix incorrect gemm results on IMMAD iGPU by adding post-ops validation to oneDNN path

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
@@ -6,6 +6,8 @@
 #include "intel_gpu/runtime/utils.hpp"
 #include "registry/implementation_manager.hpp"
 
+#include "utils.hpp"
+
 #include <memory>
 
 namespace cldnn {
@@ -80,6 +82,9 @@ struct GemmImplementationManager : public ImplementationManager {
             return false;
 
         if (gemm_prim->indirect_a || gemm_prim->indirect_b)
+            return false;
+
+        if (!is_supported_post_ops(node))
             return false;
 
         return true;

--- a/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
@@ -600,16 +600,6 @@ class gemm_2in_act_scale_eltwise : public GemmFusingTest {};
 TEST_P(gemm_2in_act_scale_eltwise, basic) {
     auto p = GetParam();
 
-    // TODO: Fused JIT int8 gemm kernel produces incorrect results with activation_func::negative
-    // on iGPU with IMMAD (Xe3+). The negation is skipped in the fused path, causing sign flips.
-    // Only affects auto-selected kernels; forced OCL kernels (gemm_mmad_int8 etc.) work correctly.
-    // Ticket: 185581
-    if (engine.get_device_info().supports_immad &&
-        engine.get_device_info().dev_type == cldnn::device_type::integrated_gpu &&
-        (p.data_type_in0 == data_types::u8 || p.data_type_in0 == data_types::i8) &&
-        p.kernel_name.empty())
-        GTEST_SKIP();
-
     create_topologies(
         input_layout("input0", get_input_layout(p, 0)),
         input_layout("input1", get_input_layout(p, 1)),


### PR DESCRIPTION
### Details:
  - Add post-ops validation to oneDNN gemm implementation to prevent incorrect results when unsupported activations (negative, negation, sign) are fused on IMMAD iGPUs.
### Description of the issue (symptom, root-cause, how it was resolved)
  - **Symptom**:
    - `fusings_gpu/gemm_2in_act_scale_eltwise.basic/2` (u8) and `basic/3` (i8) tests fail on PTL iGPU (IMMAD/Xe3+).
    - Output values show sign-flip: `ref=29.88` vs `opt=-31.13` (delta=61.0).
    - Fused kernel is `jit:gemm:any__u8` / `jit:gemm:any__i8` (oneDNN JIT path).
    - Non-IMMAD GPUs (A770 dGPU, UHD 770 iGPU) pass all tests.

  - **Root Cause**:
    - `gemm_onednn.hpp::validate_impl()` is missing the `is_supported_post_ops()` check that is present in both `convolution_onednn.hpp` (line 98) and `deconvolution_onednn.hpp` (line 100).
    - Without this check, the oneDNN gemm implementation incorrectly accepts fused `activation_func::negative` post-ops on IMMAD iGPUs.
    - In `utils.cpp` line 749, `activation_func::negative` maps to `dnnl::algorithm::undef`, meaning oneDNN cannot execute this activation — it is silently skipped, producing sign-flipped outputs.
    - On non-IMMAD GPUs, the early `supports_immad` check in `validate_impl()` rejects oneDNN gemm entirely, so the fallback OCL kernel (`gemm_mmad_int8`) handles activation correctly. This is why the bug only manifests on Xe3+ iGPUs.

  - **Resolution**:
    - Added `#include "utils.hpp"` and `if (!is_supported_post_ops(node)) return false;` to `GemmImplementationManager::validate_impl()` in `gemm_onednn.hpp`, matching the established pattern used by convolution and deconvolution oneDNN implementations.
    - When unsupported post-ops are detected, oneDNN gemm is rejected and the GPU plugin falls back to the OCL `gemm_mmad_int8` kernel which correctly handles all activation types.
    - Removed the `GTEST_SKIP` workaround in `gemm_fusion_test.cpp` that was added as a temporary mitigation for this issue.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
```cmd
:: On PTL iGPU machine (Windows 11, driver 32.0.101.8861)
:: After removing GTEST_SKIP workaround from gemm_fusion_test.cpp:
cd C:\Users\gta\Downloads\openvino\bin\intel64\Debug
ov_gpu_unit_tests.exe --gtest_filter="fusings_gpu/gemm_2in_act_scale_eltwise.basic/*"
```

#### Before fix (2 FAILED):
```
[  FAILED  ] fusings_gpu/gemm_2in_act_scale_eltwise.basic/2
  ref[0] = -0.044117629528045654, opt[0] = -1.4558823108673096 (delta=1.41)
  fused: jit:gemm:any__u8 (oneDNN)

[  FAILED  ] fusings_gpu/gemm_2in_act_scale_eltwise.basic/3
  ref[0] = 29.884805679321289, opt[0] = -31.134805679321289 (delta=61.0, sign flip!)
  fused: jit:gemm:any__i8 (oneDNN)
```

#### After fix (6 PASSED, 157 gemm fusion tests all PASS):
```
[  PASSED  ] 6 tests.
  fusings_gpu/gemm_2in_act_scale_eltwise.basic/0 (f32) - OK
  fusings_gpu/gemm_2in_act_scale_eltwise.basic/1 (f16) - OK
  fusings_gpu/gemm_2in_act_scale_eltwise.basic/2 (u8)  - OK
  fusings_gpu/gemm_2in_act_scale_eltwise.basic/3 (i8)  - OK
  fusings_gpu/gemm_2in_act_scale_eltwise.basic/4 (f32) - OK
  fusings_gpu/gemm_2in_act_scale_eltwise.basic/5 (f16) - OK
```

#### Execution path diagram

```
Before fix (BUG):                          After fix (CORRECT):

validate_impl()                            validate_impl()
  ├─ supports_immad=true ✓                   ├─ supports_immad=true ✓
  ├─ dtype=u8/i8 ✓                           ├─ dtype=u8/i8 ✓
  ├─ [MISSING post-ops check]               ├─ is_supported_post_ops() → FALSE ✗
  └─ return true ← WRONG                    └─ return false ← CORRECT
       │                                          │
       ▼                                          ▼ (fallback)
  oneDNN jit:gemm:any                        OCL gemm_mmad_int8
  negative→undef→SKIPPED                     negative→correctly applied
  Result: SIGN FLIP ✗                        Result: CORRECT ✓
```

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - Existing `gemm_2in_act_scale_eltwise` test (basic/2, basic/3) directly covers this fix. The GTEST_SKIP removal re-activates it as a permanent regression guard. No additional test needed.

### Tickets:
  - *CVS-185581*