### PR TITLE
[JS API] Add ov.getOpenvinoVersion() 

### DIFF
--- a/samples/js/node/benchmark/asynchronous_benchmark.js
+++ b/samples/js/node/benchmark/asynchronous_benchmark.js
@@ -27,6 +27,9 @@ async function main() {
   let deviceName = 'CPU';
   const args = process.argv;
 
+  console.log('OpenVINO:');
+  console.log(`${'Build '.padEnd(39, '.')} ${ov.version}`);
+
   if (args.length === 4) {
     deviceName = args[2];
   } else if (args.length !== 3) {

--- a/samples/js/node/benchmark/asynchronous_benchmark.js
+++ b/samples/js/node/benchmark/asynchronous_benchmark.js
@@ -27,8 +27,7 @@ async function main() {
   let deviceName = 'CPU';
   const args = process.argv;
 
-  console.log('OpenVINO:');
-  console.log(`${'Build '.padEnd(39, '.')} ${ov.version}`);
+  console.log(`${ov.getOpenvinoVersion()}`);
 
   if (args.length === 4) {
     deviceName = args[2];

--- a/src/bindings/js/node/include/addon.hpp
+++ b/src/bindings/js/node/include/addon.hpp
@@ -42,3 +42,8 @@ Napi::Object init_module(Napi::Env env, Napi::Object exports);
  * @brief Saves model in a specified path.
  */
 Napi::Value save_model_sync(const Napi::CallbackInfo& info);
+
+/**
+ * @brief Returns the version of the OpenVINO runtime library loaded by the addon.
+ */
+Napi::Value get_openvino_version(const Napi::CallbackInfo& info);

--- a/src/bindings/js/node/include/helper.hpp
+++ b/src/bindings/js/node/include/helper.hpp
@@ -136,6 +136,12 @@ Napi::Boolean cpp_to_js<bool, Napi::Boolean>(const Napi::CallbackInfo& info, con
 
 Napi::Object cpp_to_js(const Napi::Env& env, const ov::CompiledModel& compiled_model);
 
+/**
+ * @brief Creates a JavaScript object with the `buildNumber` and `description` of an ov::Version.
+ * The object also exposes a non-enumerable `toString()` returning a formatted, multi-line string.
+ */
+Napi::Object cpp_to_js(const Napi::Env& env, const ov::Version& version);
+
 /** @brief Takes Napi::Value and parse Napi::Array or Napi::Object to ov::TensorVector. */
 ov::TensorVector parse_input_data(const Napi::Value& input);
 

--- a/src/bindings/js/node/lib/addon.ts
+++ b/src/bindings/js/node/lib/addon.ts
@@ -806,6 +806,17 @@ export interface NodeAddon {
    */
   saveModelSync(model: Model, path: string, compressToFp16?: boolean): void;
 
+  /**
+   * The build number of the OpenVINO runtime library currently loaded by the
+   * addon, for example `"2026.3.0-21905-bb42a2f2073"`.
+   *
+   * @remarks
+   * This reflects the version of the underlying OpenVINO core binary that is
+   * actually executing. It should not differ from the `version` field declared in
+   * the package's `package.json`.
+   */
+  version: string;
+
   element: typeof element;
   resizeAlgorithm: typeof resizeAlgorithm;
 }

--- a/src/bindings/js/node/lib/addon.ts
+++ b/src/bindings/js/node/lib/addon.ts
@@ -26,6 +26,19 @@ export type elementTypeString =
 export type OVAny = string | number | boolean;
 
 /**
+ * Version information that describes the OpenVINO runtime or a device plugin.
+ *
+ * @remarks
+ * The object also defines a non-enumerable `toString()` that returns a
+ * formatted, multi-line representation (description, version and build number).
+ * It does not appear in `Object.keys()`, spread or `JSON.stringify()`.
+ */
+export interface Version {
+  buildNumber: string;
+  description: string;
+}
+
+/**
  * Core represents an OpenVINO runtime Core entity.
  *
  * User applications can create several Core class instances.
@@ -117,10 +130,7 @@ export interface Core {
    * @param deviceName A device name to identify a plugin.
    */
   getVersions(deviceName: string): {
-    [deviceName: string]: {
-      buildNumber: string;
-      description: string;
-    };
+    [deviceName: string]: Version;
   };
   /**
    * Asynchronously imports a previously exported compiled model from a Tensor.
@@ -807,15 +817,15 @@ export interface NodeAddon {
   saveModelSync(model: Model, path: string, compressToFp16?: boolean): void;
 
   /**
-   * The build number of the OpenVINO runtime library currently loaded by the
-   * addon, for example `"2026.3.0-21905-bb42a2f2073"`.
+   * It returns the version of the underlying OpenVINO core binary that is
+   * actually executing, which can differ from the `version` field declared in
+   * the package's `package.json`.
    *
    * @remarks
-   * This reflects the version of the underlying OpenVINO core binary that is
-   * actually executing. It should not differ from the `version` field declared in
-   * the package's `package.json`.
+   * Use `String(version)`, a template literal or `version.toString()` to print a
+   * formatted, multi-line representation. See {@link Version}.
    */
-  version: string;
+  getOpenvinoVersion(): Version;
 
   element: typeof element;
   resizeAlgorithm: typeof resizeAlgorithm;

--- a/src/bindings/js/node/src/addon.cpp
+++ b/src/bindings/js/node/src/addon.cpp
@@ -75,6 +75,8 @@ Napi::Object init_module(Napi::Env env, Napi::Object exports) {
 
     init_function(env, exports, "saveModelSync", save_model_sync);
 
+    exports.Set("version", Napi::String::New(env, ov::get_openvino_version().buildNumber));
+
     preprocess::init(env, exports);
     element::init(env, exports);
 

--- a/src/bindings/js/node/src/addon.cpp
+++ b/src/bindings/js/node/src/addon.cpp
@@ -57,6 +57,10 @@ Napi::Value save_model_sync(const Napi::CallbackInfo& info) {
     return info.Env().Undefined();
 }
 
+Napi::Value get_openvino_version(const Napi::CallbackInfo& info) {
+    return cpp_to_js(info.Env(), ov::get_openvino_version());
+}
+
 /** @brief Initialize native add-on */
 Napi::Object init_module(Napi::Env env, Napi::Object exports) {
     auto addon_data = new AddonData();
@@ -74,8 +78,7 @@ Napi::Object init_module(Napi::Env env, Napi::Object exports) {
     init_class(env, exports, "Node", &NodeWrap::get_class, addon_data->node);
 
     init_function(env, exports, "saveModelSync", save_model_sync);
-
-    exports.Set("version", Napi::String::New(env, ov::get_openvino_version().buildNumber));
+    init_function(env, exports, "getOpenvinoVersion", get_openvino_version);
 
     preprocess::init(env, exports);
     element::init(env, exports);

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -272,12 +272,7 @@ Napi::Value CoreWrap::get_versions(const Napi::CallbackInfo& info) {
     Napi::Object versions_object = Napi::Object::New(info.Env());
 
     for (const auto& dev : devices_map) {
-        Napi::Object device_properties = Napi::Object::New(info.Env());
-
-        device_properties.Set("buildNumber", Napi::String::New(info.Env(), dev.second.buildNumber));
-        device_properties.Set("description", Napi::String::New(info.Env(), dev.second.description));
-
-        versions_object.Set(dev.first, device_properties);
+        versions_object.Set(dev.first, cpp_to_js(info.Env(), dev.second));
     }
 
     return versions_object;

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -12,6 +12,7 @@
 #include "node/include/tensor_impl.hpp"
 #include "node/include/type_validation.hpp"
 #include "openvino/runtime/make_tensor.hpp"
+#include "openvino/util/common_util.hpp"
 
 const std::vector<std::string>& get_supported_types() {
     static const std::vector<std::string> supported_element_types =
@@ -332,10 +333,7 @@ Napi::Object cpp_to_js(const Napi::Env& env, const ov::Version& version) {
 
     std::ostringstream formatted;
     formatted << version;
-    std::string formatted_str = formatted.str();
-    while (!formatted_str.empty() && (formatted_str.back() == '\n' || formatted_str.back() == '\r')) {
-        formatted_str.pop_back();
-    }
+    const std::string formatted_str{ov::util::rtrim(formatted.str())};
     const auto to_string_fn = Napi::Function::New(
         env,
         [formatted_str](const Napi::CallbackInfo& cb) -> Napi::Value {

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -342,9 +342,12 @@ Napi::Object cpp_to_js(const Napi::Env& env, const ov::Version& version) {
             return Napi::String::New(cb.Env(), formatted_str);
         },
         "toString");
-    // toString() is defined as a non-enumerable method so
-    // it does not show up in Object.keys()/spread and keeps the object a pure data shape.
-    version_obj.DefineProperty(Napi::PropertyDescriptor::Value("toString", to_string_fn, napi_default));
+    // toString() is defined as a non-enumerable method so it does not show up
+    // in Object.keys()/spread and keeps the object a pure data shape.
+    version_obj.DefineProperty(
+        Napi::PropertyDescriptor::Value("toString",
+                                        to_string_fn,
+                                        static_cast<napi_property_attributes>(napi_writable | napi_configurable)));
     return version_obj;
 }
 

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -4,6 +4,8 @@
 
 #include "node/include/helper.hpp"
 
+#include <sstream>
+
 #include "node/include/compiled_model.hpp"
 #include "node/include/node_wrap.hpp"
 #include "node/include/tensor.hpp"
@@ -321,6 +323,29 @@ Napi::Object cpp_to_js(const Napi::Env& env, const ov::CompiledModel& compiled_m
     const auto cm = Napi::ObjectWrap<CompiledModelWrap>::Unwrap(obj);
     cm->set_compiled_model(compiled_model);
     return obj;
+}
+
+Napi::Object cpp_to_js(const Napi::Env& env, const ov::Version& version) {
+    Napi::Object version_obj = Napi::Object::New(env);
+    version_obj.Set("buildNumber", Napi::String::New(env, version.buildNumber));
+    version_obj.Set("description", Napi::String::New(env, version.description));
+
+    std::ostringstream formatted;
+    formatted << version;
+    std::string formatted_str = formatted.str();
+    while (!formatted_str.empty() && (formatted_str.back() == '\n' || formatted_str.back() == '\r')) {
+        formatted_str.pop_back();
+    }
+    const auto to_string_fn = Napi::Function::New(
+        env,
+        [formatted_str](const Napi::CallbackInfo& cb) -> Napi::Value {
+            return Napi::String::New(cb.Env(), formatted_str);
+        },
+        "toString");
+    // toString() is defined as a non-enumerable method so
+    // it does not show up in Object.keys()/spread and keeps the object a pure data shape.
+    version_obj.DefineProperty(Napi::PropertyDescriptor::Value("toString", to_string_fn, napi_default));
+    return version_obj;
 }
 
 ov::TensorVector parse_input_data(const Napi::Value& input) {

--- a/src/bindings/js/node/tests/unit/basic.test.js
+++ b/src/bindings/js/node/tests/unit/basic.test.js
@@ -115,6 +115,13 @@ describe("ov basic tests.", () => {
     });
   });
 
+  describe("ov.version", () => {
+    it("is a non-empty string", () => {
+      assert.strictEqual(typeof ov.version, "string");
+      assert.ok(ov.version.length > 0);
+    });
+  });
+
   it("CompiledModel type", () => {
     assert.ok(compiledModel instanceof ov.CompiledModel);
   });

--- a/src/bindings/js/node/tests/unit/basic.test.js
+++ b/src/bindings/js/node/tests/unit/basic.test.js
@@ -104,6 +104,12 @@ describe("ov basic tests.", () => {
       assert.strictEqual(typeof deviceVersion.CPU.description, "string");
     });
 
+    it("getVersions() entry has a non-enumerable toString()", () => {
+      const cpuVersion = core.getVersions("CPU").CPU;
+      assert.ok(cpuVersion.toString().includes(cpuVersion.buildNumber));
+      assert.deepStrictEqual(Object.keys(cpuVersion), ["buildNumber", "description"]);
+    });
+
     it("getVersions() throws if no arguments are passed", () => {
       assert.throws(() => core.getVersions(), {
         message: "getVersions() method expects 1 argument of string type.",
@@ -115,10 +121,20 @@ describe("ov basic tests.", () => {
     });
   });
 
-  describe("ov.version", () => {
-    it("is a non-empty string", () => {
-      assert.strictEqual(typeof ov.version, "string");
-      assert.ok(ov.version.length > 0);
+  describe("ov.getOpenvinoVersion()", () => {
+    it("returns a Version object with string fields", () => {
+      const version = ov.getOpenvinoVersion();
+      assert.strictEqual(typeof version, "object");
+      assert.strictEqual(typeof version.buildNumber, "string");
+      assert.strictEqual(typeof version.description, "string");
+    });
+
+    it("toString() returns a formatted string with the build number", () => {
+      const version = ov.getOpenvinoVersion();
+      const formatted = version.toString();
+      assert.strictEqual(typeof formatted, "string");
+      assert.ok(formatted.includes(version.buildNumber));
+      assert.deepStrictEqual(Object.keys(version), ["buildNumber", "description"]);
     });
   });
 


### PR DESCRIPTION
### Details:
 - Adds `getOpenvinoVersion()`
 > console.log(`${ov.getOpenvinoVersion()}`);

outputs e.g.:
<img width="592" height="79" alt="image" src="https://github.com/user-attachments/assets/9d9d20b7-e357-443d-b759-aa510d564e14" />


### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-167938

### AI Assistance:
 - AI assistance used: yes, draft of changes
