### PR TITLE
[AUTO][DOCS] Split AUTO telemetry documentation changes from PR #36745

### DIFF
--- a/docs/articles_en/assets/snippets/AUTO8.cpp
+++ b/docs/articles_en/assets/snippets/AUTO8.cpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <openvino/openvino.hpp>
+#include <openvino/runtime/auto/properties.hpp>
+
+int main() {
+//! [part8]
+ov::Core core;
+
+// read a network in IR, PaddlePaddle, or ONNX format
+std::shared_ptr<ov::Model> model = core.read_model("sample.xml");
+// compile a model on AUTO and set utilization threshold
+std::map<std::string, unsigned> utilization_threshold = {{"CPU", 78}, {"GPU", 55}};
+ov::CompiledModel compiled_model = core.compile_model(model, "AUTO",
+    {ov::intel_auto::devices_utilization_threshold(utilization_threshold)});
+//! [part8]
+    return 0;
+}

--- a/docs/articles_en/assets/snippets/ov_auto.py
+++ b/docs/articles_en/assets/snippets/ov_auto.py
@@ -181,14 +181,27 @@ def part7():
     #! [part7]
 
 
+def part8():
+    #! [part8]
+    core = ov.Core()
+
+    # compile a model on AUTO and set utilization threshold
+    compiled_model = core.compile_model(
+        model=model,
+        device_name="AUTO",
+        config={intel_auto.devices_utilization_threshold: {'CPU': 78, 'GPU': 55}},
+    )
+    #! [part8]
+
+
 def main():
     part3()
     part4()
     part5()
     part6()
     part7()
+    part8()
     core = ov.Core()
     if "GPU" not in core.available_devices:
         return 0
     part0()
-    part1()

--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/auto-device-selection.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/auto-device-selection.rst
@@ -106,93 +106,100 @@ Following the OpenVINO™ naming convention, the Automatic Device Selection mode
 It may be defined with no additional parameters, resulting in defaults being used, or configured further with
 the following setup options:
 
-+----------------------------------------------+--------------------------------------------------------------------+
-| Property(C++ version)                        | Values and Description                                             |
-+==============================================+====================================================================+
-| <device candidate list>                      | **Values**:                                                        |
-|                                              |                                                                    |
-|                                              | empty                                                              |
-|                                              |                                                                    |
-|                                              | ``AUTO``                                                           |
-|                                              |                                                                    |
-|                                              | ``AUTO: <device names>`` (comma-separated, no spaces)              |
-|                                              |                                                                    |
-|                                              | Lists the devices available for selection.                         |
-|                                              | The device sequence will be taken as priority from high to low.    |
-|                                              | If not specified, ``AUTO`` will be used as default,                |
-|                                              | and all devices will be "viewed" as candidates.                    |
-+----------------------------------------------+--------------------------------------------------------------------+
-| ``ov::device::priorities``                   | **Values**:                                                        |
-|                                              |                                                                    |
-|                                              | ``<device names>`` (comma-separated, no spaces)                    |
-|                                              |                                                                    |
-|                                              | Specifies the devices for AUTO to select.                          |
-|                                              | The device sequence will be taken as priority from high to low.    |
-|                                              | This configuration is optional.                                    |
-+----------------------------------------------+--------------------------------------------------------------------+
-| ``ov::hint::performance_mode``               | **Values**:                                                        |
-|                                              |                                                                    |
-|                                              | ``ov::hint::PerformanceMode::LATENCY``                             |
-|                                              |                                                                    |
-|                                              | ``ov::hint::PerformanceMode::THROUGHPUT``                          |
-|                                              |                                                                    |
-|                                              | ``ov::hint::PerformanceMode::CUMULATIVE_THROUGHPUT``               |
-|                                              |                                                                    |
-|                                              | Specifies the performance option preferred by the application.     |
-+----------------------------------------------+--------------------------------------------------------------------+
-| ``ov::hint::model_priority``                 | **Values**:                                                        |
-|                                              |                                                                    |
-|                                              | ``ov::hint::Priority::HIGH``                                       |
-|                                              |                                                                    |
-|                                              | ``ov::hint::Priority::MEDIUM``                                     |
-|                                              |                                                                    |
-|                                              | ``ov::hint::Priority::LOW``                                        |
-|                                              |                                                                    |
-|                                              | Indicates the priority for a model.                                |
-|                                              |                                                                    |
-|                                              | IMPORTANT: This property is not fully supported yet.               |
-+----------------------------------------------+--------------------------------------------------------------------+
-| ``ov::execution_devices``                    | Lists the runtime target devices on which the inferences are being |
-|                                              | executed.                                                          |
-|                                              |                                                                    |
-|                                              | Examples of returning results could be ``(CPU)`` (``CPU`` is a     |
-|                                              | temporary device, indicating that CPU is used for acceleration at  |
-|                                              | the model compilation stage), ``CPU``, ``GPU``, ``CPU GPU``,       |
-|                                              | ``GPU.0``, etc.                                                    |
-+----------------------------------------------+--------------------------------------------------------------------+
-| ``ov::intel_auto::enable_startup_fallback``  | **Values**:                                                        |
-|                                              |                                                                    |
-|                                              | ``true``                                                           |
-|                                              |                                                                    |
-|                                              | ``false``                                                          |
-|                                              |                                                                    |
-|                                              | Enables/disables CPU as acceleration (or the helper device) in the |
-|                                              | beginning. The default value is ``true``, indicating that CPU is   |
-|                                              | used as acceleration by default.                                   |
-+----------------------------------------------+--------------------------------------------------------------------+
-| ``ov::intel_auto::enable_runtime_fallback``  | **Values**:                                                        |
-|                                              |                                                                    |
-|                                              | ``true``                                                           |
-|                                              |                                                                    |
-|                                              | ``false``                                                          |
-|                                              |                                                                    |
-|                                              | Enables/disables runtime fallback to other devices and performs    |
-|                                              | the failed inference request again, if inference request fails on  |
-|                                              | the currently selected device.                                     |
-|                                              |                                                                    |
-|                                              | The default value is ``true``.                                     |
-+----------------------------------------------+--------------------------------------------------------------------+
-| ``ov::intel_auto::schedule_policy``          | **Values**:                                                        |
-|                                              |                                                                    |
-|                                              | ``ROUND_ROBIN``                                                    |
-|                                              |                                                                    |
-|                                              | ``DEVICE_PRIORITY``                                                |
-|                                              |                                                                    |
-|                                              | Specify the schedule policy of infer request assigned to hardware  |
-|                                              | plugin for AUTO cumulative mode.                                   |
-|                                              |                                                                    |
-|                                              | The default value is ``DEVICE_PRIORITY``.                          |
-+----------------------------------------------+--------------------------------------------------------------------+
++---------------------------------------------------+--------------------------------------------------------------------+
+| Property(C++ version)                             | Values and Description                                             |
++===================================================+====================================================================+
+| <device candidate list>                           | **Values**:                                                        |
+|                                                   |                                                                    |
+|                                                   | empty                                                              |
+|                                                   |                                                                    |
+|                                                   | ``AUTO``                                                           |
+|                                                   |                                                                    |
+|                                                   | ``AUTO: <device names>`` (comma-separated, no spaces)              |
+|                                                   |                                                                    |
+|                                                   | Lists the devices available for selection.                         |
+|                                                   | The device sequence will be taken as priority from high to low.    |
+|                                                   | If not specified, ``AUTO`` will be used as default,                |
+|                                                   | and all devices will be "viewed" as candidates.                    |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::device::priorities``                        | **Values**:                                                        |
+|                                                   |                                                                    |
+|                                                   | ``<device names>`` (comma-separated, no spaces)                    |
+|                                                   |                                                                    |
+|                                                   | Specifies the devices for AUTO to select.                          |
+|                                                   | The device sequence will be taken as priority from high to low.    |
+|                                                   | This configuration is optional.                                    |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::hint::performance_mode``                    | **Values**:                                                        |
+|                                                   |                                                                    |
+|                                                   | ``ov::hint::PerformanceMode::LATENCY``                             |
+|                                                   |                                                                    |
+|                                                   | ``ov::hint::PerformanceMode::THROUGHPUT``                          |
+|                                                   |                                                                    |
+|                                                   | ``ov::hint::PerformanceMode::CUMULATIVE_THROUGHPUT``               |
+|                                                   |                                                                    |
+|                                                   | Specifies the performance option preferred by the application.     |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::hint::model_priority``                      | **Values**:                                                        |
+|                                                   |                                                                    |
+|                                                   | ``ov::hint::Priority::HIGH``                                       |
+|                                                   |                                                                    |
+|                                                   | ``ov::hint::Priority::MEDIUM``                                     |
+|                                                   |                                                                    |
+|                                                   | ``ov::hint::Priority::LOW``                                        |
+|                                                   |                                                                    |
+|                                                   | Indicates the priority for a model.                                |
+|                                                   |                                                                    |
+|                                                   | IMPORTANT: This property is not fully supported yet.               |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::execution_devices``                         | Lists the runtime target devices on which the inferences are being |
+|                                                   | executed.                                                          |
+|                                                   |                                                                    |
+|                                                   | Examples of returning results could be ``(CPU)`` (``CPU`` is a     |
+|                                                   | temporary device, indicating that CPU is used for acceleration at  |
+|                                                   | the model compilation stage), ``CPU``, ``GPU``, ``CPU GPU``,       |
+|                                                   | ``GPU.0``, etc.                                                    |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::intel_auto::enable_startup_fallback``       | **Values**:                                                        |
+|                                                   |                                                                    |
+|                                                   | ``true``                                                           |
+|                                                   |                                                                    |
+|                                                   | ``false``                                                          |
+|                                                   |                                                                    |
+|                                                   | Enables/disables CPU as acceleration (or the helper device) in the |
+|                                                   | beginning. The default value is ``true``, indicating that CPU is   |
+|                                                   | used as acceleration by default.                                   |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::intel_auto::enable_runtime_fallback``       | **Values**:                                                        |
+|                                                   |                                                                    |
+|                                                   | ``true``                                                           |
+|                                                   |                                                                    |
+|                                                   | ``false``                                                          |
+|                                                   |                                                                    |
+|                                                   | Enables/disables runtime fallback to other devices and performs    |
+|                                                   | the failed inference request again, if inference request fails on  |
+|                                                   | the currently selected device.                                     |
+|                                                   |                                                                    |
+|                                                   | The default value is ``true``.                                     |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::intel_auto::schedule_policy``               | **Values**:                                                        |
+|                                                   |                                                                    |
+|                                                   | ``ROUND_ROBIN``                                                    |
+|                                                   |                                                                    |
+|                                                   | ``DEVICE_PRIORITY``                                                |
+|                                                   |                                                                    |
+|                                                   | Specify the schedule policy of infer request assigned to hardware  |
+|                                                   | plugin for AUTO cumulative mode.                                   |
+|                                                   |                                                                    |
+|                                                   | The default value is ``DEVICE_PRIORITY``.                          |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::intel_auto::devices_utilization_threshold`` | Specify the utilization threshold for each device for selection    |
+|                                                   |                                                                    |
+|                                                   | The default value is empty (No limit).                             |
+|                                                   |                                                                    |
+|                                                   | This property can be used to control the load balancing behavior   |
+|                                                   | of the AUTO mode.                                                  |
++---------------------------------------------------+--------------------------------------------------------------------+
 
 Inference with AUTO is configured similarly to when device plugins are used:
 you compile the model on the plugin with configuration and execute inference.
@@ -432,6 +439,29 @@ The ``ov::hint::model_priority`` property enables you to control the priorities 
         .. doxygensnippet:: docs/articles_en/assets/snippets/AUTO4.cpp
             :language: cpp
             :fragment: [part4]
+
+
+Configuring Load Balancing
+++++++++++++++++++++++++++
+
+The ``ov::intel_auto::devices_utilization_threshold`` property enables you to control the load balancing behavior of the AUTO mode. It specifies the utilization threshold for each device for selection. The device that exceeds the threshold will not be selected for inference by AUTO.
+
+.. tab-set::
+
+    .. tab-item:: Python
+        :sync: py
+
+        .. doxygensnippet:: docs/articles_en/assets/snippets/ov_auto.py
+           :language: python
+           :fragment: [part8]
+
+    .. tab-item:: C++
+        :sync: cpp
+
+        .. doxygensnippet:: docs/articles_en/assets/snippets/AUTO8.cpp
+            :language: cpp
+            :fragment: [part8]
+
 
 
 Checking Target Runtime Devices

--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/auto-device-selection.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/auto-device-selection.rst
@@ -200,6 +200,40 @@ the following setup options:
 |                                                   | This property can be used to control the load balancing behavior   |
 |                                                   | of the AUTO mode.                                                  |
 +---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::intel_auto::``                              | **Type**: ``dict[str, int]``                                       |
+| ``devices_utilization_threshold``                 |                                                                    |
+|                                                   | Per-device utilization thresholds (in percent, ``[0, 100]``).      |
+|                                                   | AUTO skips a candidate device whose current utilization is at or   |
+|                                                   | above its threshold and selects the next available device. Keys    |
+|                                                   | are device names (e.g. ``"CPU"``, ``"GPU.0"``); values are the     |
+|                                                   | corresponding threshold percent.                                   |
+|                                                   |                                                                    |
+|                                                   | Example: ``{"CPU": 80, "GPU": 70}``                                |
+|                                                   |                                                                    |
+|                                                   | The default value is empty (no threshold applied).                 |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``ov::intel_auto::perf_curve_table``              | **Type**: ``dict[str, dict[int, float]]``                          |
+|                                                   |                                                                    |
+|                                                   | Per-device performance curve mapping utilization percent           |
+|                                                   | (``[0, 100]``) to a relative performance score. AUTO ranks         |
+|                                                   | candidate devices in ascending order of their interpolated score   |
+|                                                   | at the current utilization and selects the one with the lowest     |
+|                                                   | score. If both ``devices_utilization_threshold`` and               |
+|                                                   | ``perf_curve_table`` are set, AUTO first filters candidates by     |
+|                                                   | ``devices_utilization_threshold``. Then it ranks only the          |
+|                                                   | threshold-passing candidates with ``perf_curve_table`` when        |
+|                                                   | curve entries are available and utilization can be scored. If no   |
+|                                                   | candidate gets scored by the curve, AUTO keeps threshold result    |
+|                                                   | and selects by priority among the remaining candidates.            |
+|                                                   | Allowed device keys: ``"CPU"``, ``"iGPU"``, ``"dGPU"``, ``"NPU"``. |
+|                                                   | Each device's curve must have at least one entry. Scores must be   |
+|                                                   | non-negative and finite.                                           |
+|                                                   |                                                                    |
+|                                                   | Example: ``{"CPU": {0: 0.0, 100: 100.0},``                         |
+|                                                   | ``"NPU": {0: 0.0, 100: 50.0}}``                                    |
+|                                                   |                                                                    |
+|                                                   | The default value is empty (curve ranking disabled).               |
++---------------------------------------------------+--------------------------------------------------------------------+
 
 Inference with AUTO is configured similarly to when device plugins are used:
 you compile the model on the plugin with configuration and execute inference.


### PR DESCRIPTION
This PR extracts the AUTO telemetry documentation updates from [PR#36745](https://github.com/openvinotoolkit/openvino/pull/36745) into a standalone docs-only change for independent review and merge.
### Details:
 - *item1*
 - *...*

### Tickets:
 - CVS-182107

### AI Assistance:
 - *AI assistance used: no*
