### PR TITLE
[GPU] The environment variable `OV_GPU_OPENCL_PLATFORM_NAME` added

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
@@ -6,7 +6,9 @@
 #include "intel_gpu/runtime/debug_configuration.hpp"
 #include "ocl_device.hpp"
 #include "ocl_common.hpp"
+#include "openvino/util/env_util.hpp"
 
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -188,9 +190,28 @@ std::vector<device::ptr> ocl_device_detector::create_device_list() const {
     error_code = clGetPlatformIDs(num_platforms, platform_ids.data(), NULL);
     OPENVINO_ASSERT(error_code == CL_SUCCESS, create_device_error_msg, "[GPU] clGetPlatformIDs error code: ", std::to_string(error_code));
 
+    const std::string wanted_platform = ov::util::getenv_string("OV_GPU_OPENCL_PLATFORM_NAME");
     std::vector<device::ptr> supported_devices;
+    std::vector<std::string> available_platform_names;
+    bool wanted_platform_found = false;
     for (auto& id : platform_ids) {
         cl::Platform platform = cl::Platform(id);
+        if (!wanted_platform.empty()) {
+            std::string platform_name;
+            try {
+                platform_name = platform.getInfo<CL_PLATFORM_NAME>();
+            } catch (const std::exception& ex) {
+                GPU_DEBUG_LOG << "Skipping platform: failed to query CL_PLATFORM_NAME: " << ex.what() << std::endl;
+                continue;
+            }
+            available_platform_names.push_back(platform_name);
+            if (platform_name != wanted_platform) {
+                GPU_DEBUG_LOG << "Skipping platform '" << platform_name << "' (OV_GPU_OPENCL_PLATFORM_NAME='"
+                              << wanted_platform << "')" << std::endl;
+                continue;
+            }
+            wanted_platform_found = true;
+        }
 
         try {
             std::vector<cl::Device> devices;
@@ -211,6 +232,23 @@ std::vector<device::ptr> ocl_device_detector::create_device_list() const {
             continue;
         }
     }
+
+    if (!wanted_platform.empty() && !wanted_platform_found) {
+        std::stringstream available;
+        available << "[";
+        for (size_t i = 0; i < available_platform_names.size(); i++) {
+            available << "'" << available_platform_names[i] << "'";
+            if (i + 1 < available_platform_names.size())
+                available << ", ";
+        }
+        available << "]";
+        OPENVINO_THROW("[GPU] OV_GPU_OPENCL_PLATFORM_NAME='",
+                       wanted_platform,
+                       "' did not match any available OpenCL platform.\n",
+                       "[GPU] Available platforms: ",
+                       available.str());
+    }
+
     return supported_devices;
 }
 


### PR DESCRIPTION
### Details:
 - Adds an opt-in environment variable, `OV_GPU_OPENCL_PLATFORM_NAME`, that restricts GPU device enumeration to a single OpenCL platform, matched by exact `CL_PLATFORM_NAME`.
 - Today the GPU plugin enumerates GPU devices from every installed OpenCL platform in the plugin constructor. On a multi-platform machine this surfaces unwanted devices and, worse, can crash device enumeration when a misbehaving platform is touched: https://github.com/openvinotoolkit/openvino/issues/33923
 - Because enumeration runs at construction the control is an environment variable (the only channel available that early), applied inside `ocl_device_detector::create_device_list()`.

### Behavior:
 - Unset / empty (default): strict no-op. All platforms enumerated exactly as before. Zero backward-compatibility risk.
 - Set: only the platform whose `CL_PLATFORM_NAME` matches exactly is enumerated. Every other platform is skipped before `getDevices()` / any context creation, so an offending platform such as `OpenCLOn12` is never touched and cannot crash enumeration.
 - Set to a name that matches nothing: the plugin fails fast at load with an error that lists the available platform names.

### Tickets:
 - CVS-183851
 - https://github.com/openvinotoolkit/openvino/issues/33941
