### PR TITLE
[ONNX FE] Support const std::string* for zero-copy string tensors

### DIFF
--- a/src/frontends/onnx/frontend/src/core/tensor.cpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.cpp
@@ -421,8 +421,9 @@ std::vector<std::string> Tensor::get_data() const {
         if (data_any.is<std::vector<std::string>>()) {
             return data_any.as<std::vector<std::string>>();
         } else if (data_any.is<const std::string*>()) {
-            const std::string* str_ptr = data_any.as<const std::string*>();
-            size_t count = m_tensor_place->get_data_size();
+            const auto* str_ptr = data_any.as<const std::string*>();
+            const auto count = m_tensor_place->get_data_size();
+            FRONT_END_GENERAL_CHECK(str_ptr != nullptr || count == 0, "String tensor data pointer is null");
             return std::vector<std::string>(str_ptr, str_ptr + count);
         }
 

--- a/src/frontends/onnx/frontend/src/core/tensor.cpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.cpp
@@ -417,14 +417,17 @@ std::vector<std::string> Tensor::get_data() const {
         FRONT_END_GENERAL_CHECK(!m_tensor_place->is_raw(), "Loading strings from raw data isn't supported");
         const auto& data_any = m_tensor_place->get_data_any();
 
-        // Support both std::vector<std::string> and const std::string*; both are copied into the
-        // returned std::vector, but the const std::string* path avoids an intermediate copy during decode
+        // Support both std::vector<std::string> (copy is already owned) and const std::string*
+        // (no intermediate copy at decode time; still copied here when returning std::vector)
         if (data_any.is<std::vector<std::string>>()) {
             return data_any.as<std::vector<std::string>>();
         } else if (data_any.is<const std::string*>()) {
             const auto* str_ptr = data_any.as<const std::string*>();
             const auto count = m_tensor_place->get_data_size();
-            FRONT_END_GENERAL_CHECK(str_ptr != nullptr || count == 0, "String tensor data pointer is null");
+            if (count == 0) {
+                return {};
+            }
+            FRONT_END_GENERAL_CHECK(str_ptr != nullptr, "String tensor data pointer is null");
             return std::vector<std::string>(str_ptr, str_ptr + count);
         }
 

--- a/src/frontends/onnx/frontend/src/core/tensor.cpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.cpp
@@ -417,7 +417,8 @@ std::vector<std::string> Tensor::get_data() const {
         FRONT_END_GENERAL_CHECK(!m_tensor_place->is_raw(), "Loading strings from raw data isn't supported");
         const auto& data_any = m_tensor_place->get_data_any();
 
-        // Support both std::vector<std::string> (with copy) and const std::string* (without copy)
+        // Support both std::vector<std::string> and const std::string*; both are copied into the
+        // returned std::vector, but the const std::string* path avoids an intermediate copy during decode
         if (data_any.is<std::vector<std::string>>()) {
             return data_any.as<std::vector<std::string>>();
         } else if (data_any.is<const std::string*>()) {

--- a/src/frontends/onnx/frontend/src/core/tensor.cpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.cpp
@@ -415,9 +415,18 @@ std::vector<std::string> Tensor::get_data() const {
     }
     if (m_tensor_place != nullptr) {
         FRONT_END_GENERAL_CHECK(!m_tensor_place->is_raw(), "Loading strings from raw data isn't supported");
-        FRONT_END_GENERAL_CHECK(m_tensor_place->get_data_any().is<std::vector<std::string>>(),
-                                "Tensor data type mismatch for strings");
-        return m_tensor_place->get_data_any().as<std::vector<std::string>>();
+        const auto& data_any = m_tensor_place->get_data_any();
+
+        // Support both std::vector<std::string> (with copy) and const std::string* (without copy)
+        if (data_any.is<std::vector<std::string>>()) {
+            return data_any.as<std::vector<std::string>>();
+        } else if (data_any.is<const std::string*>()) {
+            const std::string* str_ptr = data_any.as<const std::string*>();
+            size_t count = m_tensor_place->get_data_size();
+            return std::vector<std::string>(str_ptr, str_ptr + count);
+        }
+
+        FRONT_END_THROW("Tensor data type mismatch for strings");
     }
     if (m_tensor_proto->has_raw_data()) {
         FRONT_END_THROW("Loading strings from raw data isn't supported");

--- a/src/frontends/onnx/frontend/src/input_model.cpp
+++ b/src/frontends/onnx/frontend/src/input_model.cpp
@@ -689,7 +689,8 @@ void InputModel::InputModelONNXImpl::load_model() {
             tensor_place->set_input_index(tensor_decoder->get_input_idx());
             tensor_place->set_output_index(output_idx);
 
-            const bool has_data = tensor_place->get_data() != nullptr || tensor_place->get_data_location() != nullptr;
+            const bool has_data = tensor_place->get_data() != nullptr || tensor_place->get_data_location() != nullptr ||
+                                  !tensor_place->get_data_any().empty();
             // Skip constants that are not graph outputs — they don't contribute to the model graph.
             if (has_data && output_idx < 0)
                 continue;

--- a/src/frontends/onnx/frontend/src/translate_session.cpp
+++ b/src/frontends/onnx/frontend/src/translate_session.cpp
@@ -80,7 +80,8 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
     auto create_const_or_param = [&](const std::string& name,
                                      const std::shared_ptr<ov::frontend::onnx::TensorONNXPlace>& input_tensor) {
         std::shared_ptr<ov::Node> node;
-        if (input_tensor->get_data_location() != nullptr || input_tensor->get_data() != nullptr) {
+        if (input_tensor->get_data_location() != nullptr || input_tensor->get_data() != nullptr ||
+            !input_tensor->get_data_any().empty()) {
             Tensor tensor = Tensor(input_tensor);
             node = tensor.get_ov_constant();
         } else if (input_tensor->get_partial_shape() == PartialShape{0}) {  // empty constant
@@ -209,7 +210,8 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
         if (!m_tensor_values.count(name)) {
             auto place_it = all_tensor_places.find(name);
             if (place_it != all_tensor_places.end() &&
-                (place_it->second->get_data() != nullptr || place_it->second->get_data_location() != nullptr)) {
+                (place_it->second->get_data() != nullptr || place_it->second->get_data_location() != nullptr ||
+                 !place_it->second->get_data_any().empty())) {
                 create_const_or_param(name, place_it->second);
             } else if (auto parent_value = lookup_tensor(name); parent_value.get_node() != nullptr) {
                 // lookup_tensor() resolved the name from a parent scope. For non-constant

--- a/src/frontends/onnx/tests/CMakeLists.txt
+++ b/src/frontends/onnx/tests/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SRC
     onnx_ops_registration.cpp
     onnx_reader_external_data.cpp
     skip_tests_config.cpp
+    string_tensor_external_data_test.cpp
     ../frontend/src/core/graph_iterator_proto.cpp
     ../frontend/src/core/decoder_proto.cpp
 )

--- a/src/frontends/onnx/tests/string_tensor_external_data_test.cpp
+++ b/src/frontends/onnx/tests/string_tensor_external_data_test.cpp
@@ -1,0 +1,165 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "openvino/frontend/manager.hpp"
+#include "openvino/frontend/onnx/decoder.hpp"
+#include "openvino/frontend/onnx/graph_iterator.hpp"
+#include "openvino/op/constant.hpp"
+
+using namespace ov::frontend::onnx;
+
+namespace {
+
+// Minimal DecoderBaseTensor exposing a single graph output tensor whose data lives entirely in
+// TensorMetaInfo::m_tensor_data_any (as either const std::string* or std::vector<std::string>),
+// with no raw m_tensor_data pointer set. Used to drive that data through the full ONNX FE
+// pipeline without needing an ONNX protobuf model.
+class SingleTensorDecoder : public DecoderBaseTensor {
+public:
+    explicit SingleTensorDecoder(TensorMetaInfo info) : m_info(std::move(info)) {}
+
+    const TensorMetaInfo& get_tensor_info() const override {
+        return m_info;
+    }
+    int64_t get_input_idx() const override {
+        return -1;
+    }
+    int64_t get_output_idx() const override {
+        return 0;
+    }
+
+    ov::Any get_attribute(const std::string&) const override {
+        return {};
+    }
+    size_t get_input_size() const override {
+        return 0;
+    }
+    void get_input_node(size_t, std::string&, std::string&, size_t&) const override {}
+    const std::string& get_op_type() const override {
+        static const std::string type = "Tensor";
+        return type;
+    }
+    const std::string& get_op_name() const override {
+        static const std::string name;
+        return name;
+    }
+
+private:
+    TensorMetaInfo m_info;
+};
+
+// GraphIterator yielding exactly one DecoderBaseTensor (a graph output with inline data) and no
+// operation nodes.
+class SingleTensorGraphIterator : public GraphIterator {
+public:
+    explicit SingleTensorGraphIterator(std::shared_ptr<DecoderBase> decoder) : m_decoder(std::move(decoder)) {}
+
+    size_t size() const override {
+        return 1;
+    }
+    void reset() override {
+        m_done = false;
+    }
+    void next() override {
+        m_done = true;
+    }
+    bool is_end() const override {
+        return m_done;
+    }
+    std::shared_ptr<DecoderBase> get_decoder() const override {
+        return m_done ? nullptr : m_decoder;
+    }
+    int64_t get_opset_version(const std::string&) const override {
+        return 1;
+    }
+    std::map<std::string, std::string> get_metadata() const override {
+        return {};
+    }
+    std::filesystem::path get_model_dir() const override {
+        return {};
+    }
+
+private:
+    std::shared_ptr<DecoderBase> m_decoder;
+    bool m_done = false;
+};
+
+std::shared_ptr<ov::Model> convert_single_string_tensor(TensorMetaInfo info) {
+    auto decoder = std::make_shared<SingleTensorDecoder>(std::move(info));
+    auto iterator = std::make_shared<SingleTensorGraphIterator>(decoder);
+    auto graph_iter = std::dynamic_pointer_cast<GraphIterator>(iterator);
+
+    auto frontend = ov::frontend::FrontEndManager().load_by_framework("onnx");
+    EXPECT_NE(frontend, nullptr);
+    EXPECT_TRUE(frontend->supported(graph_iter));
+
+    auto input_model = frontend->load(graph_iter);
+    EXPECT_NE(input_model, nullptr);
+    return frontend->convert(input_model);
+}
+
+}  // namespace
+
+// Drives a STRING output tensor backed by `const std::string*` (the new zero-copy path) through
+// the full ONNX FE pipeline via a custom GraphIterator/DecoderBaseTensor, and verifies that
+// Tensor::get_data<std::string>() correctly materializes it into an ov::op::v0::Constant. This
+// also exercises the create_const_or_param() get_data_any() dispatch fix in translate_session.cpp:
+// without it, this tensor would be misclassified as a Parameter instead of a Constant.
+TEST(StringTensorExternalData, ConstStringPointerPath_ThroughConvert) {
+    static const std::string tensor_name = "str_out";
+    std::string backing_strings[3] = {"hello", "world", "test"};
+
+    TensorMetaInfo info;
+    info.m_partial_shape = ov::PartialShape{3};
+    info.m_element_type = ov::element::string;
+    info.m_tensor_data = nullptr;
+    info.m_tensor_data_any = static_cast<const std::string*>(backing_strings);
+    info.m_tensor_data_size = 3;
+    info.m_tensor_name = &tensor_name;
+    info.m_is_raw = false;
+
+    std::shared_ptr<ov::Model> model;
+    ASSERT_NO_THROW(model = convert_single_string_tensor(info));
+    ASSERT_NE(model, nullptr);
+
+    ASSERT_EQ(model->get_results().size(), 1u);
+    auto constant = ov::as_type_ptr<ov::op::v0::Constant>(model->get_results()[0]->get_input_node_shared_ptr(0));
+    ASSERT_NE(constant, nullptr);
+    EXPECT_EQ(constant->get_element_type(), ov::element::string);
+    EXPECT_EQ(constant->get_value_strings(), (std::vector<std::string>{"hello", "world", "test"}));
+}
+
+// Same as above but exercises the pre-existing std::vector<std::string> storage path through the
+// same convert() pipeline, as a backward-compatibility counterpart to the test above.
+TEST(StringTensorExternalData, VectorStringPath_ThroughConvert) {
+    static const std::string tensor_name = "str_out";
+    std::vector<std::string> backing_strings = {"foo", "bar", "baz"};
+
+    TensorMetaInfo info;
+    info.m_partial_shape = ov::PartialShape{3};
+    info.m_element_type = ov::element::string;
+    info.m_tensor_data = nullptr;
+    info.m_tensor_data_any = backing_strings;
+    info.m_tensor_data_size = 3;
+    info.m_tensor_name = &tensor_name;
+    info.m_is_raw = false;
+
+    std::shared_ptr<ov::Model> model;
+    ASSERT_NO_THROW(model = convert_single_string_tensor(info));
+    ASSERT_NE(model, nullptr);
+
+    ASSERT_EQ(model->get_results().size(), 1u);
+    auto constant = ov::as_type_ptr<ov::op::v0::Constant>(model->get_results()[0]->get_input_node_shared_ptr(0));
+    ASSERT_NE(constant, nullptr);
+    EXPECT_EQ(constant->get_element_type(), ov::element::string);
+    EXPECT_EQ(constant->get_value_strings(), (std::vector<std::string>{"foo", "bar", "baz"}));
+}

--- a/src/frontends/onnx/tests/string_tensor_external_data_test.cpp
+++ b/src/frontends/onnx/tests/string_tensor_external_data_test.cpp
@@ -93,18 +93,18 @@ private:
     bool m_done = false;
 };
 
-std::shared_ptr<ov::Model> convert_single_string_tensor(TensorMetaInfo info) {
+void convert_single_string_tensor(TensorMetaInfo info, std::shared_ptr<ov::Model>& model) {
     auto decoder = std::make_shared<SingleTensorDecoder>(std::move(info));
     auto iterator = std::make_shared<SingleTensorGraphIterator>(decoder);
     auto graph_iter = std::dynamic_pointer_cast<GraphIterator>(iterator);
 
     auto frontend = ov::frontend::FrontEndManager().load_by_framework("onnx");
-    EXPECT_NE(frontend, nullptr);
-    EXPECT_TRUE(frontend->supported(graph_iter));
+    ASSERT_NE(frontend, nullptr);
+    ASSERT_TRUE(frontend->supported(graph_iter));
 
     auto input_model = frontend->load(graph_iter);
-    EXPECT_NE(input_model, nullptr);
-    return frontend->convert(input_model);
+    ASSERT_NE(input_model, nullptr);
+    model = frontend->convert(input_model);
 }
 
 }  // namespace
@@ -128,7 +128,7 @@ TEST(StringTensorExternalData, ConstStringPointerPath_ThroughConvert) {
     info.m_is_raw = false;
 
     std::shared_ptr<ov::Model> model;
-    ASSERT_NO_THROW(model = convert_single_string_tensor(info));
+    ASSERT_NO_THROW(ASSERT_NO_FATAL_FAILURE(convert_single_string_tensor(info, model)));
     ASSERT_NE(model, nullptr);
 
     ASSERT_EQ(model->get_results().size(), 1u);
@@ -154,7 +154,7 @@ TEST(StringTensorExternalData, VectorStringPath_ThroughConvert) {
     info.m_is_raw = false;
 
     std::shared_ptr<ov::Model> model;
-    ASSERT_NO_THROW(model = convert_single_string_tensor(info));
+    ASSERT_NO_THROW(ASSERT_NO_FATAL_FAILURE(convert_single_string_tensor(info, model)));
     ASSERT_NE(model, nullptr);
 
     ASSERT_EQ(model->get_results().size(), 1u);


### PR DESCRIPTION
TensorMetaInfo::m_tensor_data_any now accepts both std::vector<std::string>
(existing, with copy) and const std::string* (new, zero-copy) for string
tensor data. This enables ONNX Runtime to pass
string arrays without intermediate copies.