### PR TITLE
[GPU] Fix fully_connected_onednn::load() crash for scalar weight zero-point on supports_immad (Xe3/PTL)

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -290,19 +290,23 @@ public:
         bool has_decompression_zp = prim->decompression_zero_point.is_valid() || prim->decompression_zero_point_scalar.has_value();
         if (has_decompression_zp) {
             ib >> make_data(&_dzp_data_type, sizeof(dnnl::memory::data_type));
-            auto decompression_zp_idx = ++idx;
-            auto dzp_layout = arg.get_dependency(decompression_zp_idx).get_output_layout();
+            if (prim->decompression_zero_point.is_valid()) {
+                auto decompression_zp_idx = ++idx;
+                auto dzp_layout = arg.get_dependency(decompression_zp_idx).get_output_layout();
 
-            if (dzp_layout.count() == 1) {
-                _attrs->set_zero_points(DNNL_ARG_WEIGHTS, COMMON, dnnl::memory::dims{}, _dzp_data_type);
-            } else {
-                auto ngroups = dzp_layout.get_dim(1);
-                if (ngroups == 1) {
-                    _attrs->set_zero_points(DNNL_ARG_WEIGHTS, per_oc, dnnl::memory::dims{}, _dzp_data_type);
+                if (dzp_layout.count() == 1) {
+                    _attrs->set_zero_points(DNNL_ARG_WEIGHTS, COMMON, dnnl::memory::dims{}, _dzp_data_type);
                 } else {
-                    _attrs->set_zero_points(DNNL_ARG_WEIGHTS, grouped, {_ds_group_size, 1}, _dzp_data_type);
+                    auto ngroups = dzp_layout.get_dim(1);
+                    if (ngroups == 1) {
+                        _attrs->set_zero_points(DNNL_ARG_WEIGHTS, per_oc, dnnl::memory::dims{}, _dzp_data_type);
+                    } else {
+                        _attrs->set_zero_points(DNNL_ARG_WEIGHTS, grouped, {_ds_group_size, 1}, _dzp_data_type);
+                    }
                 }
             }
+            // Note: scalar ZP (decompression_zero_point_scalar) requires no dependency node,
+            // so skip get_dependency(). The scalar value is used during inference directly.
         }
 
         bool is_dyn_quan_input = impl_params->get_input_layout(0).data_type == data_types::i8 || impl_params->get_input_layout(0).data_type == data_types::u8;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1487,12 +1487,6 @@ public:
         if (engine.get_device_info().dev_type == device_type::discrete_gpu)
             GTEST_SKIP();
 
-        // TODO: program::load crashes with "invalid vector subscript" for static-shape
-        // caching on iGPU with immad (Xe3)
-        // ticket: 185579
-        if (is_caching_test && !is_dynamic && engine.get_device_info().supports_immad)
-            GTEST_SKIP();
-
         long int batch_num = batch;
         long int ifm_num = 1024;
         long int ofm_num = 4096;


### PR DESCRIPTION
### Details:
 - *Fix fully_connected_onednn::load() crash for scalar weight zero-point on supports_immad (Xe3/PTL)*

### Problem:
fully_connected_gpu_tests.compressed_int4_scale_dyn_cache crashes with "invalid vector subscript" during program cache deserialization on Xe3/PTL iGPU (supports_immad=true).

The crash happens in fully_connected_onednn::load(). The condition for deserializing the weight zero-point was:

```cpp
bool has_decompression_zp = prim->decompression_zero_point.is_valid()
                         || prim->decompression_zero_point_scalar.has_value();
if (has_decompression_zp) {
    ib >> make_data(&_dzp_data_type, ...);
    auto decompression_zp_idx = ++idx;
    arg.get_dependency(decompression_zp_idx)...;  // crash
}
```
When the FC primitive uses a scalar zero-point (decompression_zero_point_scalar is set, but decompression_zero_point is empty — no dependency node), load() still incremented idx and called get_dependency() on an out-of-range index. dependencies.at(idx) threw std::out_of_range ("invalid vector subscript").

This only manifests on supports_immad hardware because fully_connected_onednn is only selected there.

### Root Cause:
Asymmetry between create() and load(). The create() function correctly gates get_dependency() on prim->decompression_zero_point.is_valid() alone. load() used the broader condition that includes scalar-only ZP, which has no corresponding dependency node.

### Fix:
In load(), guard the get_dependency() call with prim->decompression_zero_point.is_valid() — matching create(). The outer has_decompression_zp condition is kept to read _dzp_data_type from the binary stream, preserving format compatibility with existing serialized caches.
```cpp
bool has_decompression_zp = prim->decompression_zero_point.is_valid()
                         || prim->decompression_zero_point_scalar.has_value();
if (has_decompression_zp) {
    ib >> make_data(&_dzp_data_type, sizeof(dnnl::memory::data_type));
    if (prim->decompression_zero_point.is_valid()) {  // ← fix: skip get_dependency() for scalar ZP
        auto decompression_zp_idx = ++idx;
        auto dzp_layout = arg.get_dependency(decompression_zp_idx).get_output_layout();
        ...
    }
}
```
Also removed the GTEST_SKIP() workaround guard from test_compressed_int4_scale_dyn_quan() that was masking this bug.

### Tickets:
 - *CVS-185579*

### AI Assistance:
 - *AI assistance used:  yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
