### PR TITLE
[GPU] Disable SDPAToVLSDPA transformation when inference precision is not f16

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.hpp
@@ -54,6 +54,14 @@ struct PagedAttentionOpt : public ImplementationManager {
             return false;
         }
 
+        // OCL PA kernel requires head_size >= 16 (SUBGROUPS_PER_WG = head_size / SUBGROUP_SIZE)
+        OPENVINO_ASSERT(desc->k_head_size >= 16 && desc->v_head_size >= 16,
+                        "[GPU] OCL PagedAttention kernel does not support head_size < 16."
+                        " k_head_size=",
+                        desc->k_head_size,
+                        ", v_head_size=",
+                        desc->v_head_size);
+
         const auto& q_layout = node.get_input_layout(0);
         const auto& k_layout = node.get_input_layout(1);
         const auto& v_layout = node.get_input_layout(2);

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -606,6 +606,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                         return true;
                     }
 
+                    if (infer_precision != ov::element::f16) {
+                        return true;  // CM vlsdpa kernel only supports f16
+                    }
+
                     return false;
                 });
 


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - [SDPA] GPU plugin crashes with `[GPU] No layout format available for vlsdpa` when inference precision is f32
   - Root cause: VLSDPA only has a CM implementation that supports f16. When inference precision is f32, no valid implementation exists and add_required_reorders asserts.
   - Fix: Skip SDPAToVLSDPA transformation when inference precision is not f16, falling back to the standard SDPA path.
 - [PA] PA backend crashes with `CL_BUILD_PROGRAM_FAILURE: remainder by zero` when head_size < 16
   - Root cause: OCL PA kernel calculates `SUBGROUPS_PER_WG = V_HEAD_SIZE / SUBGROUP_SIZE`. When head_size < 16, this results in 0, causing divide-by-zero during kernel compilation.
   - Fix: Add OPENVINO_ASSERT in OCL PA validate_impl to reject head_size < 16 with a clear error message.

#### The code and line that caused this issue (if it is not changed directly)
 - `intel_gpu/src/graph/impls/cm/vl_sdpa_opt.hpp` — `validate_impl()` only accepts f16
 - `intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl:12` — `#define SUBGROUPS_PER_WG ((V_HEAD_SIZE / SUBGROUP_SIZE) * SG_SCALE_FACTOR)`

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - [SDPA] Load a VLM model with VLSDPA-eligible SDPA nodes on GPU with `INFERENCE_PRECISION_HINT=f32`
 - [PA] Load a model (head_size < 16) with `ATTENTION_BACKEND=PA` on GPU

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *190523*

