### PR TITLE
[ONNX] Enhance GroupQueryAttention to handle null inputs and improve interoperability

### DIFF
--- a/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
@@ -53,13 +53,13 @@ private:
     // PER_CHANNEL -> [1, kv_num_heads, 1, head_size]; PER_TENSOR -> [1, 1, 1, 1].
     std::shared_ptr<ov::Node> make_kv_scale(const ov::Output<ov::Node>& scale,
                                             int64_t kv_num_heads,
-                                            const std::string& quant_type);
+                                            ov::op::internal::GroupQueryAttentionQuantType quant_type);
     // Dequantize a quantized (i8/u8/f8e4m3) KV cache to compute_type: x = q * scale (symmetric, zero point = 0).
     std::shared_ptr<ov::Node> dequantize_kv(const ov::Output<ov::Node>& quantized,
                                             const ov::Output<ov::Node>& scale,
                                             int64_t kv_num_heads,
                                             int64_t kv_cache_bit_width,
-                                            const std::string& quant_type,
+                                            ov::op::internal::GroupQueryAttentionQuantType quant_type,
                                             const ov::element::Type& compute_type);
     // Quantize current float KV tokens into the cache type: integer i8/u8 uses clamp(round(x / scale))
     // (round-half-to-even); f8e4m3 uses clamp(x / scale, +/-448) then Convert (no integer round).
@@ -67,6 +67,6 @@ private:
                                           const ov::Output<ov::Node>& scale,
                                           int64_t kv_num_heads,
                                           int64_t kv_cache_bit_width,
-                                          const std::string& quant_type,
+                                          ov::op::internal::GroupQueryAttentionQuantType quant_type,
                                           const ov::element::Type& cache_type);
 };

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -79,6 +79,8 @@ ov::pass::GroupQueryAttentionDecomposition::GroupQueryAttentionDecomposition() {
 
 ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     std::shared_ptr<ov::op::internal::GroupQueryAttention> node) {
+    using GQAInputs = ov::op::internal::GroupQueryAttentionInputs;
+
     const auto num_heads = node->get_num_heads();
     const auto kv_num_heads = node->get_kv_num_heads();
     const auto scale = node->get_scale();
@@ -88,25 +90,32 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     const auto smooth_softmax = node->get_smooth_softmax();
     // TODO: add softcap support
 
-    auto Q = node->input_value(0);
-    auto K = node->input_value(1);
-    auto V = node->input_value(2);
-    auto past_key = node->input_value(3);
-    auto past_value = node->input_value(4);
-    auto seqlens_k = node->input_value(5);
-    auto total_sequence_length = node->input_value(6);
+    auto Q = node->input_value(static_cast<size_t>(GQAInputs::QUERY));
+    auto K = node->input_value(static_cast<size_t>(GQAInputs::KEY));
+    auto V = node->input_value(static_cast<size_t>(GQAInputs::VALUE));
+    auto past_key = node->input_value(static_cast<size_t>(GQAInputs::PAST_KEY));
+    auto past_value = node->input_value(static_cast<size_t>(GQAInputs::PAST_VALUE));
+    auto seqlens_k = node->input_value(static_cast<size_t>(GQAInputs::SEQLENS_K));
+    auto total_sequence_length = node->input_value(static_cast<size_t>(GQAInputs::TOTAL_SEQUENCE_LENGTH));
 
-    // Quantized KV cache (com.microsoft spec): past/present KV are i8/u8/f8e4m3 and are dequantized before the
-    // attention math and (re)quantized when appended to the cache. Scales live at inputs 12 (K) / 13 (V).
+    // Quantized KV cache (com.microsoft spec): past/present KV are i8/u8 and are dequantized before the
+    // attention math and (re)quantized when appended to the cache. Scales live at ONNX K_SCALE / V_SCALE positions.
     const bool kv_quantized = node->is_kv_quantized();
     const auto kv_cache_bit_width = node->get_kv_cache_bit_width();
     const auto k_quant_type = node->get_k_quant_type();
     const auto v_quant_type = node->get_v_quant_type();
     const auto kv_cache_type = past_key.get_element_type();
     ov::Output<ov::Node> k_scale, v_scale;
+
+    // Get k_scale and v_scale from their actual input indices by accounting for null ONNX inputs.
+    // Note: validate_and_infer_types() already verified these indices are valid when kv_quantized is true,
+    // so we skip redundant bounds checks here.
+
     if (kv_quantized) {
-        k_scale = node->input_value(12);
-        v_scale = node->input_value(13);
+        auto k_scale_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::K_SCALE));
+        auto v_scale_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::V_SCALE));
+        k_scale = node->input_value(static_cast<size_t>(k_scale_idx));
+        v_scale = node->input_value(static_cast<size_t>(v_scale_idx));
     }
 
     auto is_null = [](const ov::Output<ov::Node>& output) {
@@ -135,16 +144,24 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     const auto curr_seqlen_scalar = register_new_node<v0::Squeeze>(current_seqlen);
 
     if (do_rotary) {
-        auto cos_cache = node->input_value(7);
-        auto sin_cache = node->input_value(8);
+        // Get cos_cache and sin_cache from their actual input indices (ONNX COS_CACHE and SIN_CACHE).
+        // validate_and_infer_types() already verified these inputs exist and indices are valid when do_rotary is true.
+        auto cos_cache_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::COS_CACHE));
+        auto sin_cache_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::SIN_CACHE));
+        auto cos_cache = node->input_value(static_cast<size_t>(cos_cache_idx));
+        auto sin_cache = node->input_value(static_cast<size_t>(sin_cache_idx));
 
         ov::Output<ov::Node> position_ids =
             register_new_node<v4::Range>(zero_without_shape, curr_seqlen_scalar, one_without_shape, ov::element::i64);
-        if (node->get_input_size() > 9 && !is_null(node->input_value(9))) {
+        // Check if position_ids is provided (optional input), using actual input index
+        if (node->has_input(static_cast<int64_t>(GQAInputs::POSITION_IDS))) {
+            auto position_ids_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::POSITION_IDS));
             // Flatten position_ids to 1D so that Gather produces 2D [seqlen, head_size/2] output,
             // ensuring correct 4D shapes after Unsqueeze in rotaryEmbedding.
             const auto neg_one = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1}));
-            position_ids = register_new_node<v1::Reshape>(node->input_value(9), neg_one, false);
+            position_ids = register_new_node<v1::Reshape>(node->input_value(static_cast<size_t>(position_ids_idx)),
+                                                          neg_one,
+                                                          false);
         } else {
             position_ids = register_new_node<v1::Add>(position_ids, past_seqlen);
         }
@@ -305,8 +322,8 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     }
 
     ov::Output<ov::Node> external_bias;
-    if (node->get_input_size() > 10 && !is_null(node->input_value(10))) {
-        external_bias = node->input_value(10);
+    if (node->has_input(static_cast<int64_t>(GQAInputs::ATTENTION_BIAS))) {
+        external_bias = node->input_value(static_cast<int64_t>(GQAInputs::ATTENTION_BIAS));
     }
     const auto mask = make_attention_mask(curr_seqlen_scalar,
                                           concat_kv_len_scalar,
@@ -321,11 +338,11 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     // this with its sink input: a [1, num_heads, 1, 1] tensor appended as one logit column, included in
     // the softmax, then sliced out. head_sink provides a per-head value; plain smooth_softmax uses 0.
     ov::Output<ov::Node> sink;
-    const bool has_head_sink = node->get_input_size() > 11 && !is_null(node->input_value(11));
+    const bool has_head_sink = node->has_input(static_cast<int64_t>(GQAInputs::HEAD_SINK));
     if (has_head_sink || smooth_softmax) {
         const auto sink_shape = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, -1, 1, 1}));
         if (has_head_sink) {
-            auto head_sink = node->input_value(11);
+            auto head_sink = node->input_value(static_cast<int64_t>(GQAInputs::HEAD_SINK));
             if (head_sink.get_element_type() != T) {
                 head_sink = register_new_node<v0::Convert>(head_sink, T);
             }

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -90,12 +90,19 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     const auto smooth_softmax = node->get_smooth_softmax();
     // TODO: add softcap support
 
-    auto Q = node->input_value(static_cast<size_t>(GQAInputs::QUERY));
-    auto K = node->input_value(static_cast<size_t>(GQAInputs::KEY));
-    auto V = node->input_value(static_cast<size_t>(GQAInputs::VALUE));
-    auto past_key = node->input_value(static_cast<size_t>(GQAInputs::PAST_KEY));
-    auto past_value = node->input_value(static_cast<size_t>(GQAInputs::PAST_VALUE));
-    auto seqlens_k = node->input_value(static_cast<size_t>(GQAInputs::SEQLENS_K));
+    const auto get_input = [&](const GQAInputs input_pos) -> ov::Output<ov::Node> {
+        const auto original_pos = static_cast<int64_t>(input_pos);
+        const bool exists = node->has_input(original_pos);
+        OPENVINO_ASSERT(exists, "Missing required GroupQueryAttention input at original position ", original_pos);
+        return node->input_value(static_cast<size_t>(original_pos));
+    };
+
+    auto Q = get_input(GQAInputs::QUERY);
+    auto K = get_input(GQAInputs::KEY);
+    auto V = get_input(GQAInputs::VALUE);
+    auto past_key = get_input(GQAInputs::PAST_KEY);
+    auto past_value = get_input(GQAInputs::PAST_VALUE);
+    auto seqlens_k = get_input(GQAInputs::SEQLENS_K);
 
     // Quantized KV cache (com.microsoft spec): past/present KV are i8/u8/f8e4m3 and are dequantized before the
     // attention math and (re)quantized when appended to the cache. Scales live at ONNX K_SCALE / V_SCALE positions.
@@ -106,14 +113,12 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     const auto kv_cache_type = past_key.get_element_type();
     ov::Output<ov::Node> k_scale, v_scale;
 
-    // Get k_scale and v_scale from their actual input indices by accounting for null ONNX inputs.
+    // Get k_scale and v_scale from their actual input indices.
     // Note: validate_and_infer_types() already verified these indices are valid when kv_quantized is true,
     // so we skip redundant bounds checks here.
     if (kv_quantized) {
-        auto k_scale_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::K_SCALE));
-        auto v_scale_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::V_SCALE));
-        k_scale = node->input_value(static_cast<size_t>(k_scale_idx));
-        v_scale = node->input_value(static_cast<size_t>(v_scale_idx));
+        k_scale = get_input(GQAInputs::K_SCALE);
+        v_scale = get_input(GQAInputs::V_SCALE);
     }
 
     // The length of all tokens (past + current) is `seqlens_k` + 1.
@@ -140,22 +145,17 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     if (do_rotary) {
         // Get cos_cache and sin_cache from their actual input indices (ONNX COS_CACHE and SIN_CACHE).
         // validate_and_infer_types() already verified these inputs exist and indices are valid when do_rotary is true.
-        auto cos_cache_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::COS_CACHE));
-        auto sin_cache_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::SIN_CACHE));
-        auto cos_cache = node->input_value(static_cast<size_t>(cos_cache_idx));
-        auto sin_cache = node->input_value(static_cast<size_t>(sin_cache_idx));
+        auto cos_cache = get_input(GQAInputs::COS_CACHE);
+        auto sin_cache = get_input(GQAInputs::SIN_CACHE);
 
         ov::Output<ov::Node> position_ids =
             register_new_node<v4::Range>(zero_without_shape, curr_seqlen_scalar, one_without_shape, ov::element::i64);
         // Check if position_ids is provided (optional input), using actual input index
         if (node->has_input(static_cast<int64_t>(GQAInputs::POSITION_IDS))) {
-            auto position_ids_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::POSITION_IDS));
             // Flatten position_ids to 1D so that Gather produces 2D [seqlen, head_size/2] output,
             // ensuring correct 4D shapes after Unsqueeze in rotaryEmbedding.
             const auto neg_one = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1}));
-            position_ids = register_new_node<v1::Reshape>(node->input_value(static_cast<size_t>(position_ids_idx)),
-                                                          neg_one,
-                                                          false);
+            position_ids = register_new_node<v1::Reshape>(get_input(GQAInputs::POSITION_IDS), neg_one, false);
         } else {
             position_ids = register_new_node<v1::Add>(position_ids, past_seqlen);
         }

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -590,8 +590,11 @@ std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::make_kv_sc
         // the (static) scale length when known, otherwise falls back to a -1 wildcard.
         int64_t head_size = -1;
         const auto& scale_pshape = scale.get_partial_shape();
-        if (scale_pshape.rank().is_static() && scale_pshape.rank().get_length() == 1 && scale_pshape[0].is_static()) {
-            head_size = scale_pshape[0].get_length() / kv_num_heads;
+        if (scale_pshape.is_static()) {
+            // Element count alone determines head_size, regardless of rank/dim order (e.g. rank 1
+            // [kv_num_heads*head_size], rank 2 [kv_num_heads,head_size], rank 4
+            // [1,kv_num_heads,1,head_size] all resolve the same way).
+            head_size = static_cast<int64_t>(ov::shape_size(scale_pshape.to_shape())) / kv_num_heads;
         }
         target_shape = {1, kv_num_heads, 1, head_size};
     } else {

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -116,10 +116,6 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
         v_scale = node->input_value(static_cast<size_t>(v_scale_idx));
     }
 
-    auto is_null = [](const ov::Output<ov::Node>& output) {
-        return output.get_node_shared_ptr()->description() == "NullNode";
-    };
-
     // The length of all tokens (past + current) is `seqlens_k` + 1.
     // current = Q.shape[2], past = `seqlens_k` + 1 - current
 

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -57,7 +57,7 @@ namespace v8 = ov::op::v8;
 namespace v13 = ov::op::v13;
 namespace v15 = ov::op::v15;
 ov::pass::GroupQueryAttentionDecomposition::GroupQueryAttentionDecomposition() {
-    MATCHER_SCOPE(GroupQeuryAttentionDecomposition);
+    MATCHER_SCOPE(GroupQueryAttentionDecomposition);
     auto pattern_node = ov::pass::pattern::wrap_type<ov::op::internal::GroupQueryAttention>();
 
     matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -91,10 +91,10 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     // TODO: add softcap support
 
     const auto get_input = [&](const GQAInputs input_pos) -> ov::Output<ov::Node> {
-        const auto original_pos = static_cast<int64_t>(input_pos);
+        const auto original_pos = static_cast<size_t>(input_pos);
         const bool exists = node->has_input(original_pos);
         OPENVINO_ASSERT(exists, "Missing required GroupQueryAttention input at original position ", original_pos);
-        return node->input_value(static_cast<size_t>(original_pos));
+        return node->input_value(original_pos);
     };
 
     auto Q = get_input(GQAInputs::QUERY);
@@ -151,7 +151,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
         ov::Output<ov::Node> position_ids =
             register_new_node<v4::Range>(zero_without_shape, curr_seqlen_scalar, one_without_shape, ov::element::i64);
         // Check if position_ids is provided (optional input), using actual input index
-        if (node->has_input(static_cast<int64_t>(GQAInputs::POSITION_IDS))) {
+        if (node->has_input(static_cast<size_t>(GQAInputs::POSITION_IDS))) {
             // Flatten position_ids to 1D so that Gather produces 2D [seqlen, head_size/2] output,
             // ensuring correct 4D shapes after Unsqueeze in rotaryEmbedding.
             const auto neg_one = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1}));
@@ -316,7 +316,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     }
 
     ov::Output<ov::Node> external_bias;
-    if (node->has_input(static_cast<int64_t>(GQAInputs::ATTENTION_BIAS))) {
+    if (node->has_input(static_cast<size_t>(GQAInputs::ATTENTION_BIAS))) {
         external_bias = get_input(GQAInputs::ATTENTION_BIAS);
     }
     const auto mask = make_attention_mask(curr_seqlen_scalar,
@@ -332,7 +332,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     // this with its sink input: a [1, num_heads, 1, 1] tensor appended as one logit column, included in
     // the softmax, then sliced out. head_sink provides a per-head value; plain smooth_softmax uses 0.
     ov::Output<ov::Node> sink;
-    const bool has_head_sink = node->has_input(static_cast<int64_t>(GQAInputs::HEAD_SINK));
+    const bool has_head_sink = node->has_input(static_cast<size_t>(GQAInputs::HEAD_SINK));
     if (has_head_sink || smooth_softmax) {
         const auto sink_shape = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, -1, 1, 1}));
         if (has_head_sink) {
@@ -569,15 +569,16 @@ std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::rotaryEmbe
     return output.get_node_shared_ptr();
 }
 
-std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::make_kv_scale(const ov::Output<ov::Node>& scale,
-                                                                                    int64_t kv_num_heads,
-                                                                                    const std::string& quant_type) {
+std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::make_kv_scale(
+    const ov::Output<ov::Node>& scale,
+    int64_t kv_num_heads,
+    ov::op::internal::GroupQueryAttentionQuantType quant_type) {
     // The KV cache is laid out as [batch, kv_num_heads, seq_len, head_size]. Reshape the flat scale so it
     // broadcasts along that layout. A fully static target shape is used (no -1 wildcard) so the result stays
     // static-shaped for plugins (e.g. NPU) that require static shapes. A fresh shape Constant is built per
     // call so no two GQA layers alias it.
     std::vector<int64_t> target_shape;
-    if (quant_type == "PER_CHANNEL") {
+    if (quant_type == ov::op::internal::GroupQueryAttentionQuantType::PER_CHANNEL) {
         // Per-channel scale has kv_num_heads * head_size elements, head-major (scale[kv_head * head_size + ch]).
         // Reshape to [1, kv_num_heads, 1, head_size] to broadcast over batch and seq. head_size is derived from
         // the (static) scale length when known, otherwise falls back to a -1 wildcard.
@@ -601,7 +602,7 @@ std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::dequantize
     const ov::Output<ov::Node>& scale,
     int64_t kv_num_heads,
     int64_t kv_cache_bit_width,
-    const std::string& quant_type,
+    ov::op::internal::GroupQueryAttentionQuantType quant_type,
     const ov::element::Type& compute_type) {
     // Symmetric dequantization matching ONNX Runtime MLAS/CUDA QDQ. The actual Convert(->float) * scale
     // (optionally - zero_point) chain is built via the shared ov::decomposition::low_precision_dequantize
@@ -643,12 +644,13 @@ std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::dequantize
     return dequant.get_node_shared_ptr();
 }
 
-std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::quantize_kv(const ov::Output<ov::Node>& current,
-                                                                                  const ov::Output<ov::Node>& scale,
-                                                                                  int64_t kv_num_heads,
-                                                                                  int64_t kv_cache_bit_width,
-                                                                                  const std::string& quant_type,
-                                                                                  const ov::element::Type& cache_type) {
+std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::quantize_kv(
+    const ov::Output<ov::Node>& current,
+    const ov::Output<ov::Node>& scale,
+    int64_t kv_num_heads,
+    int64_t kv_cache_bit_width,
+    ov::op::internal::GroupQueryAttentionQuantType quant_type,
+    const ov::element::Type& cache_type) {
     // Symmetric quantize-on-write: q = clamp(round(x * inv_scale)). Rounding is round-half-to-even to match the
     // ONNX Runtime MLAS/CUDA reference (std::rintf). Clamp is applied before the narrowing Convert to avoid
     // overflow on out-of-range values. inv_scale mirrors MLAS SafeInvScale: a zero scale maps to 1.0 so the step

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -317,7 +317,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
 
     ov::Output<ov::Node> external_bias;
     if (node->has_input(static_cast<int64_t>(GQAInputs::ATTENTION_BIAS))) {
-        external_bias = node->input_value(static_cast<int64_t>(GQAInputs::ATTENTION_BIAS));
+        external_bias = get_input(GQAInputs::ATTENTION_BIAS);
     }
     const auto mask = make_attention_mask(curr_seqlen_scalar,
                                           concat_kv_len_scalar,
@@ -336,7 +336,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     if (has_head_sink || smooth_softmax) {
         const auto sink_shape = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, -1, 1, 1}));
         if (has_head_sink) {
-            auto head_sink = node->input_value(static_cast<int64_t>(GQAInputs::HEAD_SINK));
+            auto head_sink = get_input(GQAInputs::HEAD_SINK);
             if (head_sink.get_element_type() != T) {
                 head_sink = register_new_node<v0::Convert>(head_sink, T);
             }

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -9,6 +9,7 @@
 #include "itt.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/decompositions/low_precision_dequantize.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/bitwise_and.hpp"
@@ -90,9 +91,14 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     const auto smooth_softmax = node->get_smooth_softmax();
     // TODO: add softcap support
 
+    const auto has_input = [&](const GQAInputs input_pos) {
+        const auto pos = static_cast<size_t>(input_pos);
+        return (pos < node->get_input_size()) && !ov::util::is_empty_constant_tensor(node->input_value(pos));
+    };
+
     const auto get_input = [&](const GQAInputs input_pos) -> ov::Output<ov::Node> {
         const auto original_pos = static_cast<size_t>(input_pos);
-        const bool exists = node->has_input(original_pos);
+        const bool exists = has_input(input_pos);
         OPENVINO_ASSERT(exists, "Missing required GroupQueryAttention input at original position ", original_pos);
         return node->input_value(original_pos);
     };
@@ -151,7 +157,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
         ov::Output<ov::Node> position_ids =
             register_new_node<v4::Range>(zero_without_shape, curr_seqlen_scalar, one_without_shape, ov::element::i64);
         // Check if position_ids is provided (optional input), using actual input index
-        if (node->has_input(static_cast<size_t>(GQAInputs::POSITION_IDS))) {
+        if (has_input(GQAInputs::POSITION_IDS)) {
             // Flatten position_ids to 1D so that Gather produces 2D [seqlen, head_size/2] output,
             // ensuring correct 4D shapes after Unsqueeze in rotaryEmbedding.
             const auto neg_one = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1}));
@@ -316,7 +322,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     }
 
     ov::Output<ov::Node> external_bias;
-    if (node->has_input(static_cast<size_t>(GQAInputs::ATTENTION_BIAS))) {
+    if (has_input(GQAInputs::ATTENTION_BIAS)) {
         external_bias = get_input(GQAInputs::ATTENTION_BIAS);
     }
     const auto mask = make_attention_mask(curr_seqlen_scalar,
@@ -332,7 +338,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     // this with its sink input: a [1, num_heads, 1, 1] tensor appended as one logit column, included in
     // the softmax, then sliced out. head_sink provides a per-head value; plain smooth_softmax uses 0.
     ov::Output<ov::Node> sink;
-    const bool has_head_sink = node->has_input(static_cast<size_t>(GQAInputs::HEAD_SINK));
+    const bool has_head_sink = has_input(GQAInputs::HEAD_SINK);
     if (has_head_sink || smooth_softmax) {
         const auto sink_shape = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, -1, 1, 1}));
         if (has_head_sink) {

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -96,9 +96,8 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     auto past_key = node->input_value(static_cast<size_t>(GQAInputs::PAST_KEY));
     auto past_value = node->input_value(static_cast<size_t>(GQAInputs::PAST_VALUE));
     auto seqlens_k = node->input_value(static_cast<size_t>(GQAInputs::SEQLENS_K));
-    auto total_sequence_length = node->input_value(static_cast<size_t>(GQAInputs::TOTAL_SEQUENCE_LENGTH));
 
-    // Quantized KV cache (com.microsoft spec): past/present KV are i8/u8 and are dequantized before the
+    // Quantized KV cache (com.microsoft spec): past/present KV are i8/u8/f8e4m3 and are dequantized before the
     // attention math and (re)quantized when appended to the cache. Scales live at ONNX K_SCALE / V_SCALE positions.
     const bool kv_quantized = node->is_kv_quantized();
     const auto kv_cache_bit_width = node->get_kv_cache_bit_width();
@@ -110,7 +109,6 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     // Get k_scale and v_scale from their actual input indices by accounting for null ONNX inputs.
     // Note: validate_and_infer_types() already verified these indices are valid when kv_quantized is true,
     // so we skip redundant bounds checks here.
-
     if (kv_quantized) {
         auto k_scale_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::K_SCALE));
         auto v_scale_idx = node->get_input_index(static_cast<int64_t>(GQAInputs::V_SCALE));

--- a/src/common/transformations/tests/op_conversions/group_query_attention_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/group_query_attention_decomposition_test.cpp
@@ -38,30 +38,10 @@ constexpr int64_t NUM_HEADS = 2;
 constexpr int64_t KV_NUM_HEADS = 1;
 constexpr int64_t HEAD_SIZE = 16;
 
-// Stand-in for an absent optional input. The decomposition detects missing inputs by node description
-// ("NullNode"), matching the ONNX frontend's NullNode, so a filler must report the same description
-// rather than be a real Parameter (which would be treated as a supplied position_ids / bias / etc.).
-// Declared without the OPENVINO_OP macro so no export/visibility attributes are applied to this
-// test-local type (the macro's RTTI attributes are rejected under -Werror on some toolchains).
-class NullNode : public op::Op {
-public:
-    static const ov::DiscreteTypeInfo& get_type_info_static() {
-        static const ov::DiscreteTypeInfo info{"NullNode", "test"};
-        return info;
-    }
-    const ov::DiscreteTypeInfo& get_type_info() const override {
-        return get_type_info_static();
-    }
-    std::string description() const override {
-        return "NullNode";
-    }
-    NullNode() {
-        set_output_size(1);
-    }
-    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector&) const override {
-        return std::make_shared<NullNode>();
-    }
-};
+std::shared_ptr<op::v0::Constant> make_absent_optional_input() {
+    // Optional ONNX inputs are represented as an empty tensor.
+    return op::v0::Constant::create(element::f32, Shape{0}, {});
+}
 
 // Chainable so each test case reads as a one-liner without C++20 designated initializers.
 struct GqaParams {
@@ -143,7 +123,7 @@ std::shared_ptr<Model> make_gqa_model(const GqaParams& p) {
     };
     auto pad_to = [&](size_t idx) {
         while (args.size() < idx)
-            args.push_back(std::make_shared<NullNode>());  // absent optional input
+            args.push_back(make_absent_optional_input());  // absent optional input
     };
 
     // The internal op receives Q/K/V already transposed to [batch, heads, seq, head_size] (the ONNX FE

--- a/src/common/transformations/tests/op_conversions/group_query_attention_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/group_query_attention_decomposition_test.cpp
@@ -40,7 +40,7 @@ constexpr int64_t HEAD_SIZE = 16;
 
 std::shared_ptr<op::v0::Constant> make_absent_optional_input() {
     // Optional ONNX inputs are represented as an empty tensor.
-    return op::v0::Constant::create(element::f32, Shape{0}, {});
+    return op::v0::Constant::create(element::dynamic, Shape{0}, {});
 }
 
 // Chainable so each test case reads as a one-liner without C++20 designated initializers.
@@ -112,7 +112,8 @@ struct GqaParams {
 std::shared_ptr<Model> make_gqa_model(const GqaParams& p) {
     const auto f32 = element::f32;
     const int64_t stored_head = p.kv_cache_bit_width == 4 ? HEAD_SIZE / 2 : HEAD_SIZE;  // 4-bit packs 2/byte
-    const std::string quant = p.kv_cache_bit_width == 0 ? "NONE" : "PER_TENSOR";
+    const auto quant = p.kv_cache_bit_width == 0 ? op::internal::GroupQueryAttentionQuantType::NONE
+                                                 : op::internal::GroupQueryAttentionQuantType::PER_TENSOR;
 
     OutputVector args;
     ParameterVector params;
@@ -194,8 +195,8 @@ std::shared_ptr<GroupQueryAttention> make_gqa_op(const Dimension& batch,
                                                  /*do_rotary*/ false,
                                                  /*rotary_interleaved*/ false,
                                                  /*kv_cache_bit_width*/ 0,
-                                                 "NONE",
-                                                 "NONE",
+                                                 op::internal::GroupQueryAttentionQuantType::NONE,
+                                                 op::internal::GroupQueryAttentionQuantType::NONE,
                                                  local_window_size,
                                                  sliding_window_cache,
                                                  /*smooth_softmax*/ false);

--- a/src/core/dev_api/openvino/core/validation_util.hpp
+++ b/src/core/dev_api/openvino/core/validation_util.hpp
@@ -53,6 +53,12 @@ OPENVINO_API std::shared_ptr<op::v0::Constant> constantfold_subgraph(const Outpu
 /// \return Shared pointer to constant data or nullptr.
 OPENVINO_API std::shared_ptr<op::v0::Constant> get_constant_from_source(const Output<Node>& source);
 
+/// \brief Checks whether the source is a Constant with zero elements.
+///
+/// \param source  Node output to check.
+/// \return        True if source is Constant and has empty shape, otherwise false.
+OPENVINO_API bool is_empty_constant_tensor(const Output<Node>& source);
+
 /// \brief Make scalar tensor which stores maximum value of ov::element::Type.
 /// \param et  Element type to get its maximum.
 /// \return Tensor with maximum value.

--- a/src/core/dev_api/openvino/core/validation_util.hpp
+++ b/src/core/dev_api/openvino/core/validation_util.hpp
@@ -53,10 +53,10 @@ OPENVINO_API std::shared_ptr<op::v0::Constant> constantfold_subgraph(const Outpu
 /// \return Shared pointer to constant data or nullptr.
 OPENVINO_API std::shared_ptr<op::v0::Constant> get_constant_from_source(const Output<Node>& source);
 
-/// \brief Checks whether the source is a Constant with zero elements.
+/// \brief Checks whether the source is a Constant with shape {0}.
 ///
 /// \param source  Node output to check.
-/// \return        True if source is Constant and has empty shape, otherwise false.
+/// \return        True if source is Constant and has shape {0}, otherwise false.
 OPENVINO_API bool is_empty_constant_tensor(const Output<Node>& source);
 
 /// \brief Make scalar tensor which stores maximum value of ov::element::Type.

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <string>
+#include <vector>
 
 #include "openvino/op/op.hpp"
 

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -101,8 +101,6 @@ public:
         return m_kv_cache_bit_width != 0 && m_k_quant_type != GroupQueryAttentionQuantType::NONE;
     }
 
-    bool has_input(size_t input_position) const;
-
 private:
     int64_t m_num_heads = 0;
     int64_t m_kv_num_heads = 0;

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -23,8 +23,8 @@ enum class GroupQueryAttentionInputs : int64_t {
     POSITION_IDS = 9,           // Position IDs (optional)
     ATTENTION_BIAS = 10,        // Attention bias (optional)
     HEAD_SINK = 11,             // Head sink (optional, required if smooth_softmax=1)
-    K_SCALE = 12,  // Quantization scale for K (optional, required if kv_cache_bit_width != 0)
-    V_SCALE = 13,  // Quantization scale for V (optional, required if kv_cache_bit_width != 0)
+    K_SCALE = 12,               // Quantization scale for K (optional, required if kv_cache_bit_width != 0)
+    V_SCALE = 13,               // Quantization scale for V (optional, required if kv_cache_bit_width != 0)
     // Positions 14-15 are reserved (QK-Norm, not supported)
 };
 

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -3,11 +3,32 @@
 //
 #pragma once
 
+#include <algorithm>
 #include <string>
 
 #include "openvino/op/op.hpp"
 
 namespace ov::op::internal {
+
+// ONNX GroupQueryAttention input position enumeration
+// Matches com.microsoft.GroupQueryAttention spec
+enum class GroupQueryAttentionInputs : int64_t {
+    QUERY = 0,                  // Q or packed QKV
+    KEY = 1,                    // K (optional if Q is packed QKV)
+    VALUE = 2,                  // V (optional if Q is packed QKV)
+    PAST_KEY = 3,               // KV cache key (optional)
+    PAST_VALUE = 4,             // KV cache value (optional)
+    SEQLENS_K = 5,              // Sequence lengths (mandatory)
+    TOTAL_SEQUENCE_LENGTH = 6,  // Total sequence length (mandatory)
+    COS_CACHE = 7,              // RoPE cos cache (optional, required if do_rotary=1)
+    SIN_CACHE = 8,              // RoPE sin cache (optional, required if do_rotary=1)
+    POSITION_IDS = 9,           // Position IDs (optional)
+    ATTENTION_BIAS = 10,        // Attention bias (optional)
+    HEAD_SINK = 11,             // Head sink (optional, required if smooth_softmax=1)
+    K_SCALE = 12,  // Quantization scale for K (optional, required if kv_cache_bit_width != 0)
+    V_SCALE = 13,  // Quantization scale for V (optional, required if kv_cache_bit_width != 0)
+    // Positions 14-15 are reserved (QK-Norm, not supported)
+};
 
 // This is an experimental operation that is implemented in the plugins.
 class OPENVINO_API GroupQueryAttention : public Op {
@@ -26,7 +47,8 @@ public:
                         const std::string& v_quant_type = "NONE",
                         int64_t local_window_size = -1,
                         bool sliding_window_cache = false,
-                        bool smooth_softmax = false);
+                        bool smooth_softmax = false,
+                        const std::vector<int64_t>& null_onnx_input_positions = {});
     void validate_and_infer_types() override;
     bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
@@ -75,6 +97,30 @@ public:
         return m_kv_cache_bit_width != 0 && m_k_quant_type != "NONE";
     }
 
+    // Get ONNX input positions that are null/missing (were NullNode in ONNX but not included in OV inputs)
+    const std::vector<int64_t>& get_null_onnx_input_positions() const {
+        return m_null_onnx_input_positions;
+    }
+
+    // Check if a specific input position exists (was not filtered as NullNode)
+    bool has_input(int64_t onnx_position) const {
+        return std::find(m_null_onnx_input_positions.begin(), m_null_onnx_input_positions.end(), onnx_position) ==
+               m_null_onnx_input_positions.end();
+    }
+
+    // Calculate the actual input index in the OV graph for a given ONNX input position.
+    // Accounts for optional inputs that were filtered out (NullNode).
+    // For example, if ONNX inputs 3,4 are null and we want ONNX position 12,
+    // we count null inputs < 12, and return 12 - 2 = 10.
+    int64_t get_input_index(int64_t onnx_position) const {
+        int64_t null_before_count = std::count_if(m_null_onnx_input_positions.begin(),
+                                                  m_null_onnx_input_positions.end(),
+                                                  [onnx_position](int64_t null_pos) {
+                                                      return null_pos < onnx_position;
+                                                  });
+        return onnx_position - null_before_count;
+    }
+
 private:
     int64_t m_num_heads = 0;
     int64_t m_kv_num_heads = 0;
@@ -84,9 +130,13 @@ private:
     int64_t m_kv_cache_bit_width = 0;
     std::string m_k_quant_type = "NONE";
     std::string m_v_quant_type = "NONE";
+<<<<<<< HEAD
     int64_t m_local_window_size = -1;
     bool m_sliding_window_cache = false;
     bool m_smooth_softmax = false;
+=======
+    std::vector<int64_t> m_null_onnx_input_positions = {};
+>>>>>>> d897403e7f ([ONNX] Enhance GroupQueryAttention to handle null inputs and improve index mapping)
 };
 
 }  // namespace ov::op::internal

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -98,7 +98,6 @@ public:
         return m_kv_cache_bit_width != 0 && m_k_quant_type != "NONE";
     }
 
-    // Get original input positions that are null/missing and therefore omitted from OV inputs.
     const std::vector<int64_t>& get_null_input_positions() const {
         return m_null_input_positions;
     }
@@ -107,7 +106,6 @@ public:
         return static_cast<int64_t>(get_input_size() + m_null_input_positions.size());
     }
 
-    // Check if a specific original input position exists and was not filtered as NullNode.
     bool has_input(int64_t input_position) const {
         if (input_position < 0 || input_position >= get_original_input_count()) {
             return false;

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -10,14 +10,12 @@
 
 namespace ov::op::internal {
 
-// ONNX GroupQueryAttention input position enumeration
-// Matches com.microsoft.GroupQueryAttention spec
 enum class GroupQueryAttentionInputs : int64_t {
-    QUERY = 0,                  // Q or packed QKV
-    KEY = 1,                    // K (optional if Q is packed QKV)
-    VALUE = 2,                  // V (optional if Q is packed QKV)
-    PAST_KEY = 3,               // KV cache key (optional)
-    PAST_VALUE = 4,             // KV cache value (optional)
+    QUERY = 0,                  // Q (mandatory)
+    KEY = 1,                    // K (mandatory)
+    VALUE = 2,                  // V (mandatory)
+    PAST_KEY = 3,               // KV cache key (mandatory)
+    PAST_VALUE = 4,             // KV cache value (mandatory)
     SEQLENS_K = 5,              // Sequence lengths (mandatory)
     TOTAL_SEQUENCE_LENGTH = 6,  // Total sequence length (mandatory)
     COS_CACHE = 7,              // RoPE cos cache (optional, required if do_rotary=1)

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -35,6 +35,29 @@ enum class GroupQueryAttentionQuantType {
     PER_CHANNEL,
 };
 
+}  // namespace ov::op::internal
+
+namespace ov {
+
+template <>
+class OPENVINO_API AttributeAdapter<op::internal::GroupQueryAttentionQuantType>
+    : public EnumAttributeAdapterBase<op::internal::GroupQueryAttentionQuantType> {
+public:
+    AttributeAdapter(op::internal::GroupQueryAttentionQuantType& value)
+        : EnumAttributeAdapterBase<op::internal::GroupQueryAttentionQuantType>(value) {}
+
+    ~AttributeAdapter() override;
+
+    OPENVINO_RTTI("AttributeAdapter<ov::op::internal::GroupQueryAttentionQuantType>");
+};
+
+OPENVINO_API
+std::ostream& operator<<(std::ostream& s, const op::internal::GroupQueryAttentionQuantType& quant_type);
+
+}  // namespace ov
+
+namespace ov::op::internal {
+
 // This is an experimental operation that is implemented in the plugins.
 class OPENVINO_API GroupQueryAttention : public Op {
 public:

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -48,7 +48,7 @@ public:
                         int64_t local_window_size = -1,
                         bool sliding_window_cache = false,
                         bool smooth_softmax = false,
-                        const std::vector<int64_t>& null_onnx_input_positions = {});
+                        const std::vector<int64_t>& null_input_positions = {});
     void validate_and_infer_types() override;
     bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
@@ -97,28 +97,35 @@ public:
         return m_kv_cache_bit_width != 0 && m_k_quant_type != "NONE";
     }
 
-    // Get ONNX input positions that are null/missing (were NullNode in ONNX but not included in OV inputs)
-    const std::vector<int64_t>& get_null_onnx_input_positions() const {
-        return m_null_onnx_input_positions;
+    // Get original input positions that are null/missing and therefore omitted from OV inputs.
+    const std::vector<int64_t>& get_null_input_positions() const {
+        return m_null_input_positions;
     }
 
-    // Check if a specific input position exists (was not filtered as NullNode)
-    bool has_input(int64_t onnx_position) const {
-        return std::find(m_null_onnx_input_positions.begin(), m_null_onnx_input_positions.end(), onnx_position) ==
-               m_null_onnx_input_positions.end();
+    int64_t get_original_input_count() const {
+        return static_cast<int64_t>(get_input_size() + m_null_input_positions.size());
     }
 
-    // Calculate the actual input index in the OV graph for a given ONNX input position.
+    // Check if a specific original input position exists and was not filtered as NullNode.
+    bool has_input(int64_t input_position) const {
+        if (input_position < 0 || input_position >= get_original_input_count()) {
+            return false;
+        }
+        return std::find(m_null_input_positions.begin(), m_null_input_positions.end(), input_position) ==
+               m_null_input_positions.end();
+    }
+
+    // Calculate the actual input index in the OV graph for a given original input position.
     // Accounts for optional inputs that were filtered out (NullNode).
-    // For example, if ONNX inputs 3,4 are null and we want ONNX position 12,
+    // For example, if original inputs 3,4 are null and we want position 12,
     // we count null inputs < 12, and return 12 - 2 = 10.
-    int64_t get_input_index(int64_t onnx_position) const {
-        int64_t null_before_count = std::count_if(m_null_onnx_input_positions.begin(),
-                                                  m_null_onnx_input_positions.end(),
-                                                  [onnx_position](int64_t null_pos) {
-                                                      return null_pos < onnx_position;
+    int64_t get_input_index(int64_t input_position) const {
+        int64_t null_before_count = std::count_if(m_null_input_positions.begin(),
+                                                  m_null_input_positions.end(),
+                                                  [input_position](int64_t null_pos) {
+                                                      return null_pos < input_position;
                                                   });
-        return onnx_position - null_before_count;
+        return input_position - null_before_count;
     }
 
 private:
@@ -130,13 +137,10 @@ private:
     int64_t m_kv_cache_bit_width = 0;
     std::string m_k_quant_type = "NONE";
     std::string m_v_quant_type = "NONE";
-<<<<<<< HEAD
     int64_t m_local_window_size = -1;
     bool m_sliding_window_cache = false;
     bool m_smooth_softmax = false;
-=======
-    std::vector<int64_t> m_null_onnx_input_positions = {};
->>>>>>> d897403e7f ([ONNX] Enhance GroupQueryAttention to handle null inputs and improve index mapping)
+    std::vector<int64_t> m_null_input_positions = {};
 };
 
 }  // namespace ov::op::internal

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -3,7 +3,6 @@
 //
 #pragma once
 
-#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -48,8 +47,7 @@ public:
                         const std::string& v_quant_type = "NONE",
                         int64_t local_window_size = -1,
                         bool sliding_window_cache = false,
-                        bool smooth_softmax = false,
-                        const std::vector<int64_t>& null_input_positions = {});
+                        bool smooth_softmax = false);
     void validate_and_infer_types() override;
     bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
@@ -98,34 +96,7 @@ public:
         return m_kv_cache_bit_width != 0 && m_k_quant_type != "NONE";
     }
 
-    const std::vector<int64_t>& get_null_input_positions() const {
-        return m_null_input_positions;
-    }
-
-    int64_t get_original_input_count() const {
-        return static_cast<int64_t>(get_input_size() + m_null_input_positions.size());
-    }
-
-    bool has_input(int64_t input_position) const {
-        if (input_position < 0 || input_position >= get_original_input_count()) {
-            return false;
-        }
-        return std::find(m_null_input_positions.begin(), m_null_input_positions.end(), input_position) ==
-               m_null_input_positions.end();
-    }
-
-    // Calculate the actual input index in the OV graph for a given original input position.
-    // Accounts for optional inputs that were filtered out (NullNode).
-    // For example, if original inputs 3,4 are null and we want position 12,
-    // we count null inputs < 12, and return 12 - 2 = 10.
-    int64_t get_input_index(int64_t input_position) const {
-        int64_t null_before_count = std::count_if(m_null_input_positions.begin(),
-                                                  m_null_input_positions.end(),
-                                                  [input_position](int64_t null_pos) {
-                                                      return null_pos < input_position;
-                                                  });
-        return input_position - null_before_count;
-    }
+    bool has_input(int64_t input_position) const;
 
 private:
     int64_t m_num_heads = 0;
@@ -139,7 +110,6 @@ private:
     int64_t m_local_window_size = -1;
     bool m_sliding_window_cache = false;
     bool m_smooth_softmax = false;
-    std::vector<int64_t> m_null_input_positions = {};
 };
 
 }  // namespace ov::op::internal

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -35,6 +35,9 @@ enum class GroupQueryAttentionQuantType {
     PER_CHANNEL,
 };
 
+OPENVINO_API
+std::ostream& operator<<(std::ostream& s, const GroupQueryAttentionQuantType& quant_type);
+
 }  // namespace ov::op::internal
 
 namespace ov {
@@ -50,9 +53,6 @@ public:
 
     OPENVINO_RTTI("AttributeAdapter<ov::op::internal::GroupQueryAttentionQuantType>");
 };
-
-OPENVINO_API
-std::ostream& operator<<(std::ostream& s, const op::internal::GroupQueryAttentionQuantType& quant_type);
 
 }  // namespace ov
 

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -3,6 +3,7 @@
 //
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -10,7 +11,7 @@
 
 namespace ov::op::internal {
 
-enum class GroupQueryAttentionInputs : int64_t {
+enum class GroupQueryAttentionInputs : size_t {
     QUERY = 0,                  // Q (mandatory)
     KEY = 1,                    // K (mandatory)
     VALUE = 2,                  // V (mandatory)
@@ -28,6 +29,12 @@ enum class GroupQueryAttentionInputs : int64_t {
     // Positions 14-15 are reserved (QK-Norm, not supported)
 };
 
+enum class GroupQueryAttentionQuantType {
+    NONE,
+    PER_TENSOR,
+    PER_CHANNEL,
+};
+
 // This is an experimental operation that is implemented in the plugins.
 class OPENVINO_API GroupQueryAttention : public Op {
 public:
@@ -41,8 +48,8 @@ public:
                         bool do_rotary,
                         bool rotary_interleaved,
                         int64_t kv_cache_bit_width = 0,
-                        const std::string& k_quant_type = "NONE",
-                        const std::string& v_quant_type = "NONE",
+                        GroupQueryAttentionQuantType k_quant_type = GroupQueryAttentionQuantType::NONE,
+                        GroupQueryAttentionQuantType v_quant_type = GroupQueryAttentionQuantType::NONE,
                         int64_t local_window_size = -1,
                         bool sliding_window_cache = false,
                         bool smooth_softmax = false);
@@ -68,10 +75,10 @@ public:
     int64_t get_kv_cache_bit_width() const {
         return m_kv_cache_bit_width;
     }
-    const std::string& get_k_quant_type() const {
+    GroupQueryAttentionQuantType get_k_quant_type() const {
         return m_k_quant_type;
     }
-    const std::string& get_v_quant_type() const {
+    GroupQueryAttentionQuantType get_v_quant_type() const {
         return m_v_quant_type;
     }
     // Mistral-style local (sliding-window) attention. -1 disables the window (pure causal); a value
@@ -91,10 +98,10 @@ public:
     }
     // KV cache is quantized when a bit width is set and a K quantization scheme is selected.
     bool is_kv_quantized() const {
-        return m_kv_cache_bit_width != 0 && m_k_quant_type != "NONE";
+        return m_kv_cache_bit_width != 0 && m_k_quant_type != GroupQueryAttentionQuantType::NONE;
     }
 
-    bool has_input(int64_t input_position) const;
+    bool has_input(size_t input_position) const;
 
 private:
     int64_t m_num_heads = 0;
@@ -103,8 +110,8 @@ private:
     bool m_do_rotary = false;
     bool m_rotary_interleaved = false;
     int64_t m_kv_cache_bit_width = 0;
-    std::string m_k_quant_type = "NONE";
-    std::string m_v_quant_type = "NONE";
+    GroupQueryAttentionQuantType m_k_quant_type = GroupQueryAttentionQuantType::NONE;
+    GroupQueryAttentionQuantType m_v_quant_type = GroupQueryAttentionQuantType::NONE;
     int64_t m_local_window_size = -1;
     bool m_sliding_window_cache = false;
     bool m_smooth_softmax = false;

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -19,7 +19,8 @@ GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
                                          const std::string& v_quant_type,
                                          int64_t local_window_size,
                                          bool sliding_window_cache,
-                                         bool smooth_softmax)
+                                         bool smooth_softmax,
+                                         const std::vector<int64_t>& null_onnx_input_positions)
     : Op(args),
       m_num_heads(num_heads),
       m_kv_num_heads(kv_num_heads),
@@ -31,7 +32,8 @@ GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
       m_v_quant_type(v_quant_type),
       m_local_window_size(local_window_size),
       m_sliding_window_cache(sliding_window_cache),
-      m_smooth_softmax(smooth_softmax) {
+      m_smooth_softmax(smooth_softmax),
+      m_null_onnx_input_positions(null_onnx_input_positions) {
     constructor_validate_and_infer_types();
 }
 
@@ -139,13 +141,23 @@ void GroupQueryAttention::validate_and_infer_types() {
                               m_k_quant_type,
                               " and ",
                               m_v_quant_type);
+        // Check that ONNX positions 12 (k_scale) and 13 (v_scale) are present (not filtered out as NullNode)
         NODE_VALIDATION_CHECK(this,
-                              get_input_size() > 13,
-                              "GroupQueryAttention with quantized KV cache requires k_scale (input 12) and "
-                              "v_scale (input 13)");
+                              has_input(static_cast<int64_t>(GroupQueryAttentionInputs::K_SCALE)) &&
+                                  has_input(static_cast<int64_t>(GroupQueryAttentionInputs::V_SCALE)),
+                              "GroupQueryAttention with quantized KV cache requires k_scale (ONNX input 12) and "
+                              "v_scale (ONNX input 13) to be present");
+        // Verify that the computed input indices for k_scale and v_scale are valid
+        auto k_scale_idx = get_input_index(static_cast<int64_t>(GroupQueryAttentionInputs::K_SCALE));
+        auto v_scale_idx = get_input_index(static_cast<int64_t>(GroupQueryAttentionInputs::V_SCALE));
         NODE_VALIDATION_CHECK(this,
-                              get_input_element_type(12) == element::f32 && get_input_element_type(13) == element::f32,
-                              "GroupQueryAttention k_scale/v_scale must be f32");
+                              k_scale_idx >= 0 && k_scale_idx < static_cast<int64_t>(get_input_size()) &&
+                                  v_scale_idx >= 0 && v_scale_idx < static_cast<int64_t>(get_input_size()),
+                              "GroupQueryAttention computed OV indices for k_scale and v_scale are out of bounds");
+        NODE_VALIDATION_CHECK(
+            this,
+            get_input_element_type(k_scale_idx) == element::f32 && get_input_element_type(v_scale_idx) == element::f32,
+            "GroupQueryAttention k_scale/v_scale must be f32");
     }
 
     set_output_type(0, q_type, PartialShape{batch_size, sequence_len, head_size * m_num_heads});
@@ -167,6 +179,7 @@ bool GroupQueryAttention::visit_attributes(AttributeVisitor& visitor) {
     visitor.on_attribute("sliding_window_cache", m_sliding_window_cache);
     visitor.on_attribute("smooth_softmax", m_smooth_softmax);
     visitor.on_attribute("v_quant_type", m_v_quant_type);
+    visitor.on_attribute("null_onnx_input_positions", m_null_onnx_input_positions);
     return true;
 }
 
@@ -184,7 +197,8 @@ std::shared_ptr<ov::Node> GroupQueryAttention::clone_with_new_inputs(const ov::O
                                                  m_v_quant_type,
                                                  m_local_window_size,
                                                  m_sliding_window_cache,
-                                                 m_smooth_softmax);
+                                                 m_smooth_softmax,
+                                                 m_null_onnx_input_positions);
 }
 
 }  // namespace ov::op::internal

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -127,6 +127,10 @@ void GroupQueryAttention::validate_and_infer_types() {
                               pos,
                               ") to be present");
 
+        if (!present) {
+            return;
+        }
+
         const auto& pshape = get_input_partial_shape(pos);
         const auto& rank = pshape.rank();
         const bool rank_ok = rank.is_dynamic() || allowed_ranks.size() == 0 ||

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -273,8 +273,8 @@ void GroupQueryAttention::validate_and_infer_types() {
                               "GroupQueryAttention supports k/v quant types: {PER_TENSOR, PER_CHANNEL}, got: ",
                               as_string(m_k_quant_type));
 
-        check_input(GroupQueryAttentionInputs::K_SCALE, {0, 1}, {element::f32, element::f16}, true);
-        check_input(GroupQueryAttentionInputs::V_SCALE, {0, 1}, {element::f32, element::f16}, true);
+        check_input(GroupQueryAttentionInputs::K_SCALE, {0, 1, 2, 3, 4}, {element::f32, element::f16}, true);
+        check_input(GroupQueryAttentionInputs::V_SCALE, {0, 1, 2, 3, 4}, {element::f32, element::f16}, true);
     }
 
     // present_key/present_value keep the past KV layout: kv head size may differ from query head size

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -154,7 +154,7 @@ void GroupQueryAttention::validate_and_infer_types() {
                 {4},
                 {element::f32, element::f16, element::i8, element::u8, element::f8e4m3});
     check_input(GroupQueryAttentionInputs::SEQLENS_K, {1, 2}, integral_types);
-    check_input(GroupQueryAttentionInputs::TOTAL_SEQUENCE_LENGTH, {0, 1}, integral_types);
+    check_input(GroupQueryAttentionInputs::TOTAL_SEQUENCE_LENGTH, {0, 1}, integral_types, false);
 
     if (m_do_rotary) {
         check_input(GroupQueryAttentionInputs::COS_CACHE, {2}, {}, true);

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -34,20 +34,6 @@ GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
       m_sliding_window_cache(sliding_window_cache),
       m_smooth_softmax(smooth_softmax),
       m_null_input_positions(null_input_positions) {
-    const auto original_input_count = static_cast<int64_t>(args.size() + m_null_input_positions.size());
-    std::vector<uint8_t> seen_positions(static_cast<size_t>(original_input_count), 0);
-    for (const auto pos : m_null_input_positions) {
-        OPENVINO_ASSERT(pos >= 0 && pos < original_input_count,
-                        "GroupQueryAttention null_input_positions contains out-of-range position: ",
-                        pos,
-                        ", expected in [0, ",
-                        original_input_count,
-                        ")");
-        OPENVINO_ASSERT(seen_positions[static_cast<size_t>(pos)] == 0,
-                        "GroupQueryAttention null_input_positions contains duplicate position: ",
-                        pos);
-        seen_positions[static_cast<size_t>(pos)] = 1;
-    }
     constructor_validate_and_infer_types();
 }
 
@@ -77,6 +63,21 @@ void GroupQueryAttention::validate_and_infer_types() {
     // with front eviction instead of growing. Otherwise present = past + current.
     if (!m_sliding_window_cache && (output_kv_len.is_dynamic() || sequence_len.is_dynamic())) {
         output_kv_len += sequence_len;
+    }
+
+    const auto original_input_count = get_original_input_count();
+    std::vector<uint8_t> seen_positions(static_cast<size_t>(original_input_count), 0);
+    for (const auto pos : m_null_input_positions) {
+        OPENVINO_ASSERT(pos >= 0 && pos < original_input_count,
+                        "GroupQueryAttention null_input_positions contains out-of-range position: ",
+                        pos,
+                        ", expected in [0, ",
+                        original_input_count,
+                        ")");
+        OPENVINO_ASSERT(seen_positions[static_cast<size_t>(pos)] == 0,
+                        "GroupQueryAttention null_input_positions contains duplicate position: ",
+                        pos);
+        seen_positions[static_cast<size_t>(pos)] = 1;
     }
 
     // Query/activation (input 0) is always float; attention itself is computed in float precision.

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -9,7 +9,7 @@
 #include "itt.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/shape.hpp"
-#include "openvino/op/constant.hpp"
+#include "openvino/core/validation_util.hpp"
 
 namespace ov::op::internal {
 
@@ -118,7 +118,7 @@ void GroupQueryAttention::validate_and_infer_types() {
                                  const std::vector<element::Type>& allowed_types,
                                  bool required = true) {
         const auto pos = static_cast<size_t>(input);
-        const bool present = has_input(pos);
+        const bool present = (pos < get_input_size()) && !ov::util::is_empty_constant_tensor(input_value(pos));
         NODE_VALIDATION_CHECK(this,
                               !required || present,
                               "GroupQueryAttention requires ",
@@ -291,15 +291,6 @@ void GroupQueryAttention::validate_and_infer_types() {
     for (auto&& port : {1, 2}) {
         set_output_type(port, kv_cache_type, kv_shape);
     }
-}
-
-bool GroupQueryAttention::has_input(size_t input_position) const {
-    if (input_position >= get_input_size()) {
-        return false;
-    }
-    const auto input_node = input_value(input_position).get_node_shared_ptr();
-    const auto constant = ov::as_type_ptr<v0::Constant>(input_node);
-    return !(constant && ov::shape_size(constant->get_shape()) == 0);
 }
 
 bool GroupQueryAttention::visit_attributes(AttributeVisitor& visitor) {

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -4,6 +4,8 @@
 
 #include "openvino/op/group_query_attention.hpp"
 
+#include <algorithm>
+
 #include "itt.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/op/constant.hpp"
@@ -49,27 +51,126 @@ void GroupQueryAttention::validate_and_infer_types() {
     // 3. Present_value tensor of shape [B, N, S, H].
     // Note: seqlens_k represents the number of 1's in the attention_mask minus 1.
 
-    const auto& q_shape = get_input_partial_shape(0);
+    const auto input_name = [](GroupQueryAttentionInputs input) -> const char* {
+        switch (input) {
+        case GroupQueryAttentionInputs::QUERY:
+            return "query";
+        case GroupQueryAttentionInputs::KEY:
+            return "key";
+        case GroupQueryAttentionInputs::VALUE:
+            return "value";
+        case GroupQueryAttentionInputs::PAST_KEY:
+            return "past_key";
+        case GroupQueryAttentionInputs::PAST_VALUE:
+            return "past_value";
+        case GroupQueryAttentionInputs::SEQLENS_K:
+            return "seqlens_k";
+        case GroupQueryAttentionInputs::TOTAL_SEQUENCE_LENGTH:
+            return "total_sequence_length";
+        case GroupQueryAttentionInputs::COS_CACHE:
+            return "cos_cache";
+        case GroupQueryAttentionInputs::SIN_CACHE:
+            return "sin_cache";
+        case GroupQueryAttentionInputs::POSITION_IDS:
+            return "position_ids";
+        case GroupQueryAttentionInputs::ATTENTION_MASK:
+            return "attention_mask";
+        case GroupQueryAttentionInputs::HEAD_SINK:
+            return "head_sink";
+        case GroupQueryAttentionInputs::K_SCALE:
+            return "k_scale";
+        case GroupQueryAttentionInputs::V_SCALE:
+            return "v_scale";
+        }
+        return "unknown";
+    };
+
+    const auto check_input = [&](GroupQueryAttentionInputs input,
+                                 std::initializer_list<int64_t> allowed_ranks,
+                                 const std::vector<element::Type>& allowed_types,
+                                 bool required = true) {
+        const auto pos = static_cast<int64_t>(input);
+        const bool present = has_input(pos);
+        NODE_VALIDATION_CHECK(this,
+                              !required || present,
+                              "GroupQueryAttention requires ",
+                              input_name(input),
+                              " (ONNX input ",
+                              pos,
+                              ") to be present");
+        if (!present) {
+            return false;
+        }
+
+        const auto& pshape = get_input_partial_shape(static_cast<size_t>(input));
+        const auto& rank = pshape.rank();
+        const bool rank_ok = rank.is_dynamic() || allowed_ranks.size() == 0 ||
+                             std::any_of(allowed_ranks.begin(), allowed_ranks.end(), [&](int64_t allowed_rank) {
+                                 return rank.compatible(allowed_rank);
+                             });
+        NODE_VALIDATION_CHECK(this,
+                              rank_ok,
+                              "GroupQueryAttention expects ",
+                              input_name(input),
+                              " rank to be one of the allowed values, got shape ",
+                              pshape);
+
+        const auto& type = get_input_element_type(static_cast<size_t>(input));
+        const bool type_ok = type.is_dynamic() || allowed_types.size() == 0 ||
+                             std::find(allowed_types.begin(), allowed_types.end(), type) != allowed_types.end();
+        NODE_VALIDATION_CHECK(this,
+                              type_ok,
+                              "GroupQueryAttention expects ",
+                              input_name(input),
+                              " element type to be one of the allowed values, got ",
+                              type);
+        return true;
+    };
+
+    const auto integral_types = []() {
+        std::vector<element::Type> types;
+        for (const auto& type_info : element::Type::get_known_types()) {
+            if (type_info->is_integral_number()) {
+                types.push_back(*type_info);
+            }
+        }
+        return types;
+    }();
+
+    NODE_VALIDATION_CHECK(this, m_num_heads > 0, "GroupQueryAttention expects num_heads > 0, got: ", m_num_heads);
+    NODE_VALIDATION_CHECK(this,
+                          m_kv_num_heads > 0,
+                          "GroupQueryAttention expects kv_num_heads > 0, got: ",
+                          m_kv_num_heads);
+
+    // Base input checks in input_check-style form: required + rank/type whitelist.
+    check_input(GroupQueryAttentionInputs::QUERY, {4}, {element::f16, element::f32});
+    check_input(GroupQueryAttentionInputs::KEY, {4}, {element::f16, element::f32});
+    check_input(GroupQueryAttentionInputs::VALUE, {4}, {element::f16, element::f32});
+    check_input(GroupQueryAttentionInputs::PAST_KEY,
+                {4},
+                {element::f32, element::f16, element::i8, element::u8, element::f8e4m3});
+    check_input(GroupQueryAttentionInputs::PAST_VALUE,
+                {4},
+                {element::f32, element::f16, element::i8, element::u8, element::f8e4m3});
+    check_input(GroupQueryAttentionInputs::SEQLENS_K, {1, 2}, integral_types);
+    check_input(GroupQueryAttentionInputs::TOTAL_SEQUENCE_LENGTH, {0, 1}, integral_types);
+
+    if (m_do_rotary) {
+        check_input(GroupQueryAttentionInputs::COS_CACHE, {2}, {}, true);
+        check_input(GroupQueryAttentionInputs::SIN_CACHE, {2}, {}, true);
+        check_input(GroupQueryAttentionInputs::POSITION_IDS, {1, 2}, integral_types, false);
+    }
+    check_input(GroupQueryAttentionInputs::ATTENTION_BIAS, {4}, {}, false);
+
+    const auto q_shape = get_input_partial_shape(static_cast<size_t>(GroupQueryAttentionInputs::QUERY));
+    const auto past_k_shape = get_input_partial_shape(static_cast<size_t>(GroupQueryAttentionInputs::PAST_KEY));
+
+    const auto& q_type = get_input_element_type(static_cast<size_t>(GroupQueryAttentionInputs::QUERY));
+
     const auto& batch_size = q_shape[0];
     const auto& sequence_len = q_shape[2];
     const auto& head_size = q_shape[3];
-    // present_key/present_value keep the past KV layout: kv head size may differ from the query head size
-    // when the cache is quantized (e.g. 4-bit values packed two per byte), so take it from past_key (input 3).
-    const auto& past_kv_shape = get_input_partial_shape(3);
-    auto kv_shape = PartialShape{batch_size, m_kv_num_heads, past_kv_shape[2], past_kv_shape[3]};
-    auto& output_kv_len = kv_shape[2];
-
-    // A windowed KV cache keeps the past buffer's own (capacity) sequence dimension: it rolls in place
-    // with front eviction instead of growing. Otherwise present = past + current.
-    if (!m_sliding_window_cache && (output_kv_len.is_dynamic() || sequence_len.is_dynamic())) {
-        output_kv_len += sequence_len;
-    }
-
-    // Query/activation (input 0) is always float; attention itself is computed in float precision.
-    const auto& q_type = get_input_element_type(static_cast<size_t>(GroupQueryAttentionInputs::QUERY));
-    NODE_VALIDATION_CHECK(this,
-                          q_type == element::f32 || q_type == element::f16,
-                          "GroupQueryAttention supports following query element types: {f32, f16}");
 
     // The op is reachable directly from a loaded IR, so mirror the ONNX frontend's sliding-window
     // preconditions here as well: local_window_size must be -1 (disabled) or >= 1, and a windowed cache
@@ -117,20 +218,8 @@ void GroupQueryAttention::validate_and_infer_types() {
     // The KV cache (past_key/past_value, input 3/4) may be quantized. present_key/present_value inherit the
     // cache element type so a quantized (i8/u8/f8e4m3) cache round-trips from past to present, matching the ONNX spec.
     const auto& kv_cache_type = get_input_element_type(static_cast<size_t>(GroupQueryAttentionInputs::PAST_KEY));
-    NODE_VALIDATION_CHECK(this,
-                          kv_cache_type == element::f32 || kv_cache_type == element::f16 ||
-                              kv_cache_type == element::i8 || kv_cache_type == element::u8 ||
-                              kv_cache_type == element::f8e4m3,
-                          "GroupQueryAttention supports following KV cache element types: {f32, f16, i8, u8, f8e4m3}");
-
     if (is_kv_quantized()) {
-        // Quantized KV cache: i8 (8-bit), u8 (4-bit values packed two per byte), or f8e4m3 (8-bit float). Requires
-        // float dequant scales.
-        NODE_VALIDATION_CHECK(
-            this,
-            kv_cache_type == element::i8 || kv_cache_type == element::u8 || kv_cache_type == element::f8e4m3,
-            "GroupQueryAttention with quantized KV cache requires an i8, u8, or f8e4m3 past/present "
-            "KV type");
+        // Quantized KV cache: i8 (8-bit), u8 (4-bit values packed two per byte), or f8e4m3 (8-bit float).
         NODE_VALIDATION_CHECK(this,
                               m_kv_cache_bit_width == 8 || m_kv_cache_bit_width == 4,
                               "GroupQueryAttention supports kv_cache_bit_width of 8 or 4, got: ",
@@ -141,28 +230,30 @@ void GroupQueryAttention::validate_and_infer_types() {
                               m_k_quant_type,
                               " and ",
                               m_v_quant_type);
-        // Check that ONNX positions 12 (k_scale) and 13 (v_scale) are present
-        // (i.e. not represented by empty constants).
         NODE_VALIDATION_CHECK(this,
-                              has_input(static_cast<int64_t>(GroupQueryAttentionInputs::K_SCALE)) &&
-                                  has_input(static_cast<int64_t>(GroupQueryAttentionInputs::V_SCALE)),
-                              "GroupQueryAttention with quantized KV cache requires k_scale (ONNX input 12) and "
-                              "v_scale (ONNX input 13) to be present");
-        // Verify that k_scale and v_scale are f32.
-        const auto k_scale_idx = static_cast<size_t>(GroupQueryAttentionInputs::K_SCALE);
-        const auto v_scale_idx = static_cast<size_t>(GroupQueryAttentionInputs::V_SCALE);
-        NODE_VALIDATION_CHECK(
-            this,
-            get_input_element_type(k_scale_idx) == element::f32 && get_input_element_type(v_scale_idx) == element::f32,
-            "GroupQueryAttention k_scale/v_scale must be f32");
+                              kv_cache_type.bitwidth() == static_cast<size_t>(m_kv_cache_bit_width),
+                              "GroupQueryAttention with quantized KV cache requires a past/present KV type "
+                              "with bitwidth matching kv_cache_bit_width (",
+                              m_kv_cache_bit_width,
+                              "), got: ",
+                              kv_cache_type);
+        NODE_VALIDATION_CHECK(this,
+                              m_k_quant_type == "PER_TENSOR" || m_k_quant_type == "PER_CHANNEL",
+                              "GroupQueryAttention supports k/v quant types: {PER_TENSOR, PER_CHANNEL}, got: ",
+                              m_k_quant_type);
+
+        check_input(GroupQueryAttentionInputs::K_SCALE, {0, 1}, {element::f32, element::f16}, true);
+        check_input(GroupQueryAttentionInputs::V_SCALE, {0, 1}, {element::f32, element::f16}, true);
     }
 
-    if (m_do_rotary) {
-        NODE_VALIDATION_CHECK(this,
-                              has_input(static_cast<int64_t>(GroupQueryAttentionInputs::COS_CACHE)) &&
-                                  has_input(static_cast<int64_t>(GroupQueryAttentionInputs::SIN_CACHE)),
-                              "GroupQueryAttention with do_rotary enabled requires cos_cache (ONNX input 7) and "
-                              "sin_cache (ONNX input 8) to be present");
+    // present_key/present_value keep the past KV layout: kv head size may differ from query head size
+    // when the cache is quantized (e.g. 4-bit values packed two per byte).
+    auto kv_shape = PartialShape{batch_size, m_kv_num_heads, past_k_shape[2], past_k_shape[3]};
+    auto& output_kv_len = kv_shape[2];
+    // A windowed KV cache keeps the past buffer's own (capacity) sequence dimension: it rolls in place
+    // with front eviction instead of growing. Otherwise present = past + current.
+    if (!m_sliding_window_cache && (output_kv_len.is_dynamic() || sequence_len.is_dynamic())) {
+        output_kv_len += sequence_len;
     }
 
     set_output_type(0, q_type, PartialShape{batch_size, sequence_len, head_size * m_num_heads});

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -231,13 +231,6 @@ void GroupQueryAttention::validate_and_infer_types() {
                               " and ",
                               m_v_quant_type);
         NODE_VALIDATION_CHECK(this,
-                              kv_cache_type.bitwidth() == static_cast<size_t>(m_kv_cache_bit_width),
-                              "GroupQueryAttention with quantized KV cache requires a past/present KV type "
-                              "with bitwidth matching kv_cache_bit_width (",
-                              m_kv_cache_bit_width,
-                              "), got: ",
-                              kv_cache_type);
-        NODE_VALIDATION_CHECK(this,
                               m_k_quant_type == "PER_TENSOR" || m_k_quant_type == "PER_CHANNEL",
                               "GroupQueryAttention supports k/v quant types: {PER_TENSOR, PER_CHANNEL}, got: ",
                               m_k_quant_type);

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -5,6 +5,8 @@
 #include "openvino/op/group_query_attention.hpp"
 
 #include "itt.hpp"
+#include "openvino/core/shape.hpp"
+#include "openvino/op/constant.hpp"
 
 namespace ov::op::internal {
 
@@ -19,8 +21,7 @@ GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
                                          const std::string& v_quant_type,
                                          int64_t local_window_size,
                                          bool sliding_window_cache,
-                                         bool smooth_softmax,
-                                         const std::vector<int64_t>& null_input_positions)
+                                         bool smooth_softmax)
     : Op(args),
       m_num_heads(num_heads),
       m_kv_num_heads(kv_num_heads),
@@ -32,8 +33,7 @@ GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
       m_v_quant_type(v_quant_type),
       m_local_window_size(local_window_size),
       m_sliding_window_cache(sliding_window_cache),
-      m_smooth_softmax(smooth_softmax),
-      m_null_input_positions(null_input_positions) {
+      m_smooth_softmax(smooth_softmax) {
     constructor_validate_and_infer_types();
 }
 
@@ -63,21 +63,6 @@ void GroupQueryAttention::validate_and_infer_types() {
     // with front eviction instead of growing. Otherwise present = past + current.
     if (!m_sliding_window_cache && (output_kv_len.is_dynamic() || sequence_len.is_dynamic())) {
         output_kv_len += sequence_len;
-    }
-
-    const auto original_input_count = get_original_input_count();
-    std::vector<uint8_t> seen_positions(static_cast<size_t>(original_input_count), 0);
-    for (const auto pos : m_null_input_positions) {
-        OPENVINO_ASSERT(pos >= 0 && pos < original_input_count,
-                        "GroupQueryAttention null_input_positions contains out-of-range position: ",
-                        pos,
-                        ", expected in [0, ",
-                        original_input_count,
-                        ")");
-        OPENVINO_ASSERT(seen_positions[static_cast<size_t>(pos)] == 0,
-                        "GroupQueryAttention null_input_positions contains duplicate position: ",
-                        pos);
-        seen_positions[static_cast<size_t>(pos)] = 1;
     }
 
     // Query/activation (input 0) is always float; attention itself is computed in float precision.
@@ -156,19 +141,20 @@ void GroupQueryAttention::validate_and_infer_types() {
                               m_k_quant_type,
                               " and ",
                               m_v_quant_type);
-        // Check that ONNX positions 12 (k_scale) and 13 (v_scale) are present (not filtered out as NullNode)
+        // Check that ONNX positions 12 (k_scale) and 13 (v_scale) are present
+        // (i.e. not represented by empty constants).
         NODE_VALIDATION_CHECK(this,
                               has_input(static_cast<int64_t>(GroupQueryAttentionInputs::K_SCALE)) &&
                                   has_input(static_cast<int64_t>(GroupQueryAttentionInputs::V_SCALE)),
                               "GroupQueryAttention with quantized KV cache requires k_scale (ONNX input 12) and "
                               "v_scale (ONNX input 13) to be present");
-        // Verify that the computed input indices for k_scale and v_scale are valid
-        auto k_scale_idx = get_input_index(static_cast<int64_t>(GroupQueryAttentionInputs::K_SCALE));
-        auto v_scale_idx = get_input_index(static_cast<int64_t>(GroupQueryAttentionInputs::V_SCALE));
-        NODE_VALIDATION_CHECK(this,
-                              get_input_element_type(static_cast<size_t>(k_scale_idx)) == element::f32 &&
-                                  get_input_element_type(static_cast<size_t>(v_scale_idx)) == element::f32,
-                              "GroupQueryAttention k_scale/v_scale must be f32");
+        // Verify that k_scale and v_scale are f32.
+        const auto k_scale_idx = static_cast<size_t>(GroupQueryAttentionInputs::K_SCALE);
+        const auto v_scale_idx = static_cast<size_t>(GroupQueryAttentionInputs::V_SCALE);
+        NODE_VALIDATION_CHECK(
+            this,
+            get_input_element_type(k_scale_idx) == element::f32 && get_input_element_type(v_scale_idx) == element::f32,
+            "GroupQueryAttention k_scale/v_scale must be f32");
     }
 
     if (m_do_rotary) {
@@ -185,6 +171,15 @@ void GroupQueryAttention::validate_and_infer_types() {
     }
 }
 
+bool GroupQueryAttention::has_input(int64_t input_position) const {
+    if (input_position < 0 || input_position >= static_cast<int64_t>(get_input_size())) {
+        return false;
+    }
+    const auto input_node = input_value(static_cast<size_t>(input_position)).get_node_shared_ptr();
+    const auto constant = ov::as_type_ptr<v0::Constant>(input_node);
+    return !(constant && ov::shape_size(constant->get_shape()) == 0);
+}
+
 bool GroupQueryAttention::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(GroupQueryAttention_visit_attributes);
     visitor.on_attribute("do_rotary", m_do_rotary);
@@ -198,7 +193,6 @@ bool GroupQueryAttention::visit_attributes(AttributeVisitor& visitor) {
     visitor.on_attribute("sliding_window_cache", m_sliding_window_cache);
     visitor.on_attribute("smooth_softmax", m_smooth_softmax);
     visitor.on_attribute("v_quant_type", m_v_quant_type);
-    visitor.on_attribute("null_input_positions", m_null_input_positions);
     return true;
 }
 
@@ -216,8 +210,7 @@ std::shared_ptr<ov::Node> GroupQueryAttention::clone_with_new_inputs(const ov::O
                                                  m_v_quant_type,
                                                  m_local_window_size,
                                                  m_sliding_window_cache,
-                                                 m_smooth_softmax,
-                                                 m_null_input_positions);
+                                                 m_smooth_softmax);
 }
 
 }  // namespace ov::op::internal

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -11,34 +11,30 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/validation_util.hpp"
 
+namespace ov::op::internal {}  // namespace ov::op::internal
+
+namespace ov {
+
+std::ostream& operator<<(std::ostream& s, const op::internal::GroupQueryAttentionQuantType& quant_type) {
+    return s << as_string(quant_type);
+}
+
+template <>
+OPENVINO_API EnumNames<op::internal::GroupQueryAttentionQuantType>&
+EnumNames<op::internal::GroupQueryAttentionQuantType>::get() {
+    static auto enum_names = EnumNames<op::internal::GroupQueryAttentionQuantType>(
+        "op::internal::GroupQueryAttentionQuantType",
+        {{"NONE", op::internal::GroupQueryAttentionQuantType::NONE},
+         {"PER_TENSOR", op::internal::GroupQueryAttentionQuantType::PER_TENSOR},
+         {"PER_CHANNEL", op::internal::GroupQueryAttentionQuantType::PER_CHANNEL}});
+    return enum_names;
+}
+
+AttributeAdapter<op::internal::GroupQueryAttentionQuantType>::~AttributeAdapter() = default;
+
+}  // namespace ov
+
 namespace ov::op::internal {
-
-namespace {
-const char* quant_type_to_string(GroupQueryAttentionQuantType quant_type) {
-    switch (quant_type) {
-    case GroupQueryAttentionQuantType::NONE:
-        return "NONE";
-    case GroupQueryAttentionQuantType::PER_TENSOR:
-        return "PER_TENSOR";
-    case GroupQueryAttentionQuantType::PER_CHANNEL:
-        return "PER_CHANNEL";
-    }
-    OPENVINO_THROW("Unsupported GroupQueryAttentionQuantType enum value");
-}
-
-GroupQueryAttentionQuantType quant_type_from_string(const std::string& quant_type) {
-    if (quant_type == "NONE") {
-        return GroupQueryAttentionQuantType::NONE;
-    }
-    if (quant_type == "PER_TENSOR") {
-        return GroupQueryAttentionQuantType::PER_TENSOR;
-    }
-    if (quant_type == "PER_CHANNEL") {
-        return GroupQueryAttentionQuantType::PER_CHANNEL;
-    }
-    OPENVINO_THROW("Unsupported GroupQueryAttention quant type: ", quant_type);
-}
-}  // namespace
 
 GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
                                          int64_t num_heads,
@@ -268,14 +264,14 @@ void GroupQueryAttention::validate_and_infer_types() {
         NODE_VALIDATION_CHECK(this,
                               m_k_quant_type == m_v_quant_type,
                               "GroupQueryAttention requires matching k_quant_type and v_quant_type, got: ",
-                              quant_type_to_string(m_k_quant_type),
+                              m_k_quant_type,
                               " and ",
-                              quant_type_to_string(m_v_quant_type));
+                              m_v_quant_type);
         NODE_VALIDATION_CHECK(this,
                               m_k_quant_type == GroupQueryAttentionQuantType::PER_TENSOR ||
                                   m_k_quant_type == GroupQueryAttentionQuantType::PER_CHANNEL,
                               "GroupQueryAttention supports k/v quant types: {PER_TENSOR, PER_CHANNEL}, got: ",
-                              quant_type_to_string(m_k_quant_type));
+                              m_k_quant_type);
 
         check_input(GroupQueryAttentionInputs::K_SCALE, {0, 1}, {element::f32, element::f16}, true);
         check_input(GroupQueryAttentionInputs::V_SCALE, {0, 1}, {element::f32, element::f16}, true);
@@ -299,10 +295,8 @@ void GroupQueryAttention::validate_and_infer_types() {
 
 bool GroupQueryAttention::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(GroupQueryAttention_visit_attributes);
-    std::string k_quant_type = quant_type_to_string(m_k_quant_type);
-    std::string v_quant_type = quant_type_to_string(m_v_quant_type);
     visitor.on_attribute("do_rotary", m_do_rotary);
-    visitor.on_attribute("k_quant_type", k_quant_type);
+    visitor.on_attribute("k_quant_type", m_k_quant_type);
     visitor.on_attribute("kv_cache_bit_width", m_kv_cache_bit_width);
     visitor.on_attribute("kv_num_heads", m_kv_num_heads);
     visitor.on_attribute("local_window_size", m_local_window_size);
@@ -311,9 +305,7 @@ bool GroupQueryAttention::visit_attributes(AttributeVisitor& visitor) {
     visitor.on_attribute("scale", m_scale);
     visitor.on_attribute("sliding_window_cache", m_sliding_window_cache);
     visitor.on_attribute("smooth_softmax", m_smooth_softmax);
-    visitor.on_attribute("v_quant_type", v_quant_type);
-    m_k_quant_type = quant_type_from_string(k_quant_type);
-    m_v_quant_type = quant_type_from_string(v_quant_type);
+    visitor.on_attribute("v_quant_type", m_v_quant_type);
     return true;
 }
 

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -34,6 +34,20 @@ GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
       m_sliding_window_cache(sliding_window_cache),
       m_smooth_softmax(smooth_softmax),
       m_null_input_positions(null_input_positions) {
+    const auto original_input_count = static_cast<int64_t>(args.size() + m_null_input_positions.size());
+    std::vector<uint8_t> seen_positions(static_cast<size_t>(original_input_count), 0);
+    for (const auto pos : m_null_input_positions) {
+        OPENVINO_ASSERT(pos >= 0 && pos < original_input_count,
+                        "GroupQueryAttention null_input_positions contains out-of-range position: ",
+                        pos,
+                        ", expected in [0, ",
+                        original_input_count,
+                        ")");
+        OPENVINO_ASSERT(seen_positions[static_cast<size_t>(pos)] == 0,
+                        "GroupQueryAttention null_input_positions contains duplicate position: ",
+                        pos);
+        seen_positions[static_cast<size_t>(pos)] = 1;
+    }
     constructor_validate_and_infer_types();
 }
 
@@ -66,7 +80,7 @@ void GroupQueryAttention::validate_and_infer_types() {
     }
 
     // Query/activation (input 0) is always float; attention itself is computed in float precision.
-    const auto& q_type = get_input_element_type(0);
+    const auto& q_type = get_input_element_type(static_cast<size_t>(GroupQueryAttentionInputs::QUERY));
     NODE_VALIDATION_CHECK(this,
                           q_type == element::f32 || q_type == element::f16,
                           "GroupQueryAttention supports following query element types: {f32, f16}");
@@ -116,7 +130,7 @@ void GroupQueryAttention::validate_and_infer_types() {
 
     // The KV cache (past_key/past_value, input 3/4) may be quantized. present_key/present_value inherit the
     // cache element type so a quantized (i8/u8/f8e4m3) cache round-trips from past to present, matching the ONNX spec.
-    const auto& kv_cache_type = get_input_element_type(3);
+    const auto& kv_cache_type = get_input_element_type(static_cast<size_t>(GroupQueryAttentionInputs::PAST_KEY));
     NODE_VALIDATION_CHECK(this,
                           kv_cache_type == element::f32 || kv_cache_type == element::f16 ||
                               kv_cache_type == element::i8 || kv_cache_type == element::u8 ||
@@ -150,14 +164,18 @@ void GroupQueryAttention::validate_and_infer_types() {
         // Verify that the computed input indices for k_scale and v_scale are valid
         auto k_scale_idx = get_input_index(static_cast<int64_t>(GroupQueryAttentionInputs::K_SCALE));
         auto v_scale_idx = get_input_index(static_cast<int64_t>(GroupQueryAttentionInputs::V_SCALE));
-        NODE_VALIDATION_CHECK(this,
-                              k_scale_idx >= 0 && k_scale_idx < static_cast<int64_t>(get_input_size()) &&
-                                  v_scale_idx >= 0 && v_scale_idx < static_cast<int64_t>(get_input_size()),
-                              "GroupQueryAttention computed OV indices for k_scale and v_scale are out of bounds");
         NODE_VALIDATION_CHECK(
             this,
             get_input_element_type(k_scale_idx) == element::f32 && get_input_element_type(v_scale_idx) == element::f32,
             "GroupQueryAttention k_scale/v_scale must be f32");
+    }
+
+    if (m_do_rotary) {
+        NODE_VALIDATION_CHECK(this,
+                              has_input(static_cast<int64_t>(GroupQueryAttentionInputs::COS_CACHE)) &&
+                                  has_input(static_cast<int64_t>(GroupQueryAttentionInputs::SIN_CACHE)),
+                              "GroupQueryAttention with do_rotary enabled requires cos_cache (ONNX input 7) and "
+                              "sin_cache (ONNX input 8) to be present");
     }
 
     set_output_type(0, q_type, PartialShape{batch_size, sequence_len, head_size * m_num_heads});

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -11,13 +11,15 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/validation_util.hpp"
 
-namespace ov::op::internal {}  // namespace ov::op::internal
+namespace ov::op::internal {
 
-namespace ov {
-
-std::ostream& operator<<(std::ostream& s, const op::internal::GroupQueryAttentionQuantType& quant_type) {
+std::ostream& operator<<(std::ostream& s, const GroupQueryAttentionQuantType& quant_type) {
     return s << as_string(quant_type);
 }
+
+}  // namespace ov::op::internal
+
+namespace ov {
 
 template <>
 OPENVINO_API EnumNames<op::internal::GroupQueryAttentionQuantType>&
@@ -262,14 +264,14 @@ void GroupQueryAttention::validate_and_infer_types() {
         NODE_VALIDATION_CHECK(this,
                               m_k_quant_type == m_v_quant_type,
                               "GroupQueryAttention requires matching k_quant_type and v_quant_type, got: ",
-                              m_k_quant_type,
+                              as_string(m_k_quant_type),
                               " and ",
-                              m_v_quant_type);
+                              as_string(m_v_quant_type));
         NODE_VALIDATION_CHECK(this,
                               m_k_quant_type == GroupQueryAttentionQuantType::PER_TENSOR ||
                                   m_k_quant_type == GroupQueryAttentionQuantType::PER_CHANNEL,
                               "GroupQueryAttention supports k/v quant types: {PER_TENSOR, PER_CHANNEL}, got: ",
-                              m_k_quant_type);
+                              as_string(m_k_quant_type));
 
         check_input(GroupQueryAttentionInputs::K_SCALE, {0, 1}, {element::f32, element::f16}, true);
         check_input(GroupQueryAttentionInputs::V_SCALE, {0, 1}, {element::f32, element::f16}, true);

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -164,10 +164,10 @@ void GroupQueryAttention::validate_and_infer_types() {
         // Verify that the computed input indices for k_scale and v_scale are valid
         auto k_scale_idx = get_input_index(static_cast<int64_t>(GroupQueryAttentionInputs::K_SCALE));
         auto v_scale_idx = get_input_index(static_cast<int64_t>(GroupQueryAttentionInputs::V_SCALE));
-        NODE_VALIDATION_CHECK(
-            this,
-            get_input_element_type(k_scale_idx) == element::f32 && get_input_element_type(v_scale_idx) == element::f32,
-            "GroupQueryAttention k_scale/v_scale must be f32");
+        NODE_VALIDATION_CHECK(this,
+                              get_input_element_type(static_cast<size_t>(k_scale_idx)) == element::f32 &&
+                                  get_input_element_type(static_cast<size_t>(v_scale_idx)) == element::f32,
+                              "GroupQueryAttention k_scale/v_scale must be f32");
     }
 
     if (m_do_rotary) {

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -110,7 +110,7 @@ void GroupQueryAttention::validate_and_infer_types() {
     };
 
     const auto check_input = [&](GroupQueryAttentionInputs input,
-                                 std::initializer_list<int64_t> allowed_ranks,
+                                 std::initializer_list<Rank> allowed_ranks,
                                  const std::vector<element::Type>& allowed_types,
                                  bool required = true) {
         const auto pos = static_cast<size_t>(input);
@@ -129,10 +129,8 @@ void GroupQueryAttention::validate_and_infer_types() {
 
         const auto& pshape = get_input_partial_shape(pos);
         const auto& rank = pshape.rank();
-        const bool rank_ok = rank.is_dynamic() || allowed_ranks.size() == 0 ||
-                             std::any_of(allowed_ranks.begin(), allowed_ranks.end(), [&](int64_t allowed_rank) {
-                                 return rank.compatible(allowed_rank);
-                             });
+        const bool rank_ok =
+            rank.is_dynamic() || allowed_ranks.size() == 0 || ov::util::is_rank_compatible_any_of(rank, allowed_ranks);
         NODE_VALIDATION_CHECK(this,
                               rank_ok,
                               "GroupQueryAttention expects ",

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -20,7 +20,7 @@ GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
                                          int64_t local_window_size,
                                          bool sliding_window_cache,
                                          bool smooth_softmax,
-                                         const std::vector<int64_t>& null_onnx_input_positions)
+                                         const std::vector<int64_t>& null_input_positions)
     : Op(args),
       m_num_heads(num_heads),
       m_kv_num_heads(kv_num_heads),
@@ -33,7 +33,7 @@ GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
       m_local_window_size(local_window_size),
       m_sliding_window_cache(sliding_window_cache),
       m_smooth_softmax(smooth_softmax),
-      m_null_onnx_input_positions(null_onnx_input_positions) {
+      m_null_input_positions(null_input_positions) {
     constructor_validate_and_infer_types();
 }
 
@@ -179,7 +179,7 @@ bool GroupQueryAttention::visit_attributes(AttributeVisitor& visitor) {
     visitor.on_attribute("sliding_window_cache", m_sliding_window_cache);
     visitor.on_attribute("smooth_softmax", m_smooth_softmax);
     visitor.on_attribute("v_quant_type", m_v_quant_type);
-    visitor.on_attribute("null_onnx_input_positions", m_null_onnx_input_positions);
+    visitor.on_attribute("null_input_positions", m_null_input_positions);
     return true;
 }
 
@@ -198,7 +198,7 @@ std::shared_ptr<ov::Node> GroupQueryAttention::clone_with_new_inputs(const ov::O
                                                  m_local_window_size,
                                                  m_sliding_window_cache,
                                                  m_smooth_softmax,
-                                                 m_null_onnx_input_positions);
+                                                 m_null_input_positions);
 }
 
 }  // namespace ov::op::internal

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -7,10 +7,38 @@
 #include <algorithm>
 
 #include "itt.hpp"
+#include "openvino/core/except.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/op/constant.hpp"
 
 namespace ov::op::internal {
+
+namespace {
+const char* quant_type_to_string(GroupQueryAttentionQuantType quant_type) {
+    switch (quant_type) {
+    case GroupQueryAttentionQuantType::NONE:
+        return "NONE";
+    case GroupQueryAttentionQuantType::PER_TENSOR:
+        return "PER_TENSOR";
+    case GroupQueryAttentionQuantType::PER_CHANNEL:
+        return "PER_CHANNEL";
+    }
+    OPENVINO_THROW("Unsupported GroupQueryAttentionQuantType enum value");
+}
+
+GroupQueryAttentionQuantType quant_type_from_string(const std::string& quant_type) {
+    if (quant_type == "NONE") {
+        return GroupQueryAttentionQuantType::NONE;
+    }
+    if (quant_type == "PER_TENSOR") {
+        return GroupQueryAttentionQuantType::PER_TENSOR;
+    }
+    if (quant_type == "PER_CHANNEL") {
+        return GroupQueryAttentionQuantType::PER_CHANNEL;
+    }
+    OPENVINO_THROW("Unsupported GroupQueryAttention quant type: ", quant_type);
+}
+}  // namespace
 
 GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
                                          int64_t num_heads,
@@ -19,8 +47,8 @@ GroupQueryAttention::GroupQueryAttention(const OutputVector& args,
                                          bool do_rotary,
                                          bool rotary_interleaved,
                                          int64_t kv_cache_bit_width,
-                                         const std::string& k_quant_type,
-                                         const std::string& v_quant_type,
+                                         GroupQueryAttentionQuantType k_quant_type,
+                                         GroupQueryAttentionQuantType v_quant_type,
                                          int64_t local_window_size,
                                          bool sliding_window_cache,
                                          bool smooth_softmax)
@@ -89,7 +117,7 @@ void GroupQueryAttention::validate_and_infer_types() {
                                  std::initializer_list<int64_t> allowed_ranks,
                                  const std::vector<element::Type>& allowed_types,
                                  bool required = true) {
-        const auto pos = static_cast<int64_t>(input);
+        const auto pos = static_cast<size_t>(input);
         const bool present = has_input(pos);
         NODE_VALIDATION_CHECK(this,
                               !required || present,
@@ -98,11 +126,8 @@ void GroupQueryAttention::validate_and_infer_types() {
                               " (ONNX input ",
                               pos,
                               ") to be present");
-        if (!present) {
-            return false;
-        }
 
-        const auto& pshape = get_input_partial_shape(static_cast<size_t>(input));
+        const auto& pshape = get_input_partial_shape(pos);
         const auto& rank = pshape.rank();
         const bool rank_ok = rank.is_dynamic() || allowed_ranks.size() == 0 ||
                              std::any_of(allowed_ranks.begin(), allowed_ranks.end(), [&](int64_t allowed_rank) {
@@ -115,7 +140,7 @@ void GroupQueryAttention::validate_and_infer_types() {
                               " rank to be one of the allowed values, got shape ",
                               pshape);
 
-        const auto& type = get_input_element_type(static_cast<size_t>(input));
+        const auto& type = get_input_element_type(pos);
         const bool type_ok = type.is_dynamic() || allowed_types.size() == 0 ||
                              std::find(allowed_types.begin(), allowed_types.end(), type) != allowed_types.end();
         NODE_VALIDATION_CHECK(this,
@@ -124,7 +149,6 @@ void GroupQueryAttention::validate_and_infer_types() {
                               input_name(input),
                               " element type to be one of the allowed values, got ",
                               type);
-        return true;
     };
 
     const auto integral_types = []() {
@@ -240,13 +264,14 @@ void GroupQueryAttention::validate_and_infer_types() {
         NODE_VALIDATION_CHECK(this,
                               m_k_quant_type == m_v_quant_type,
                               "GroupQueryAttention requires matching k_quant_type and v_quant_type, got: ",
-                              m_k_quant_type,
+                              quant_type_to_string(m_k_quant_type),
                               " and ",
-                              m_v_quant_type);
+                              quant_type_to_string(m_v_quant_type));
         NODE_VALIDATION_CHECK(this,
-                              m_k_quant_type == "PER_TENSOR" || m_k_quant_type == "PER_CHANNEL",
+                              m_k_quant_type == GroupQueryAttentionQuantType::PER_TENSOR ||
+                                  m_k_quant_type == GroupQueryAttentionQuantType::PER_CHANNEL,
                               "GroupQueryAttention supports k/v quant types: {PER_TENSOR, PER_CHANNEL}, got: ",
-                              m_k_quant_type);
+                              quant_type_to_string(m_k_quant_type));
 
         check_input(GroupQueryAttentionInputs::K_SCALE, {0, 1}, {element::f32, element::f16}, true);
         check_input(GroupQueryAttentionInputs::V_SCALE, {0, 1}, {element::f32, element::f16}, true);
@@ -268,19 +293,21 @@ void GroupQueryAttention::validate_and_infer_types() {
     }
 }
 
-bool GroupQueryAttention::has_input(int64_t input_position) const {
-    if (input_position < 0 || input_position >= static_cast<int64_t>(get_input_size())) {
+bool GroupQueryAttention::has_input(size_t input_position) const {
+    if (input_position >= get_input_size()) {
         return false;
     }
-    const auto input_node = input_value(static_cast<size_t>(input_position)).get_node_shared_ptr();
+    const auto input_node = input_value(input_position).get_node_shared_ptr();
     const auto constant = ov::as_type_ptr<v0::Constant>(input_node);
     return !(constant && ov::shape_size(constant->get_shape()) == 0);
 }
 
 bool GroupQueryAttention::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(GroupQueryAttention_visit_attributes);
+    std::string k_quant_type = quant_type_to_string(m_k_quant_type);
+    std::string v_quant_type = quant_type_to_string(m_v_quant_type);
     visitor.on_attribute("do_rotary", m_do_rotary);
-    visitor.on_attribute("k_quant_type", m_k_quant_type);
+    visitor.on_attribute("k_quant_type", k_quant_type);
     visitor.on_attribute("kv_cache_bit_width", m_kv_cache_bit_width);
     visitor.on_attribute("kv_num_heads", m_kv_num_heads);
     visitor.on_attribute("local_window_size", m_local_window_size);
@@ -289,7 +316,9 @@ bool GroupQueryAttention::visit_attributes(AttributeVisitor& visitor) {
     visitor.on_attribute("scale", m_scale);
     visitor.on_attribute("sliding_window_cache", m_sliding_window_cache);
     visitor.on_attribute("smooth_softmax", m_smooth_softmax);
-    visitor.on_attribute("v_quant_type", m_v_quant_type);
+    visitor.on_attribute("v_quant_type", v_quant_type);
+    m_k_quant_type = quant_type_from_string(k_quant_type);
+    m_v_quant_type = quant_type_from_string(v_quant_type);
     return true;
 }
 

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -218,7 +218,20 @@ void GroupQueryAttention::validate_and_infer_types() {
     // The KV cache (past_key/past_value, input 3/4) may be quantized. present_key/present_value inherit the
     // cache element type so a quantized (i8/u8/f8e4m3) cache round-trips from past to present, matching the ONNX spec.
     const auto& kv_cache_type = get_input_element_type(static_cast<size_t>(GroupQueryAttentionInputs::PAST_KEY));
+    const auto& past_value_type = get_input_element_type(static_cast<size_t>(GroupQueryAttentionInputs::PAST_VALUE));
+    NODE_VALIDATION_CHECK(this,
+                          kv_cache_type.compatible(past_value_type),
+                          "GroupQueryAttention expects past_key and past_value element types to match, got ",
+                          kv_cache_type,
+                          " and ",
+                          past_value_type);
     if (is_kv_quantized()) {
+        NODE_VALIDATION_CHECK(
+            this,
+            kv_cache_type == element::i8 || kv_cache_type == element::u8 || kv_cache_type == element::f8e4m3,
+            "GroupQueryAttention expects quantized KV cache element type to be one of ",
+            "{i8, u8, f8e4m3}, got ",
+            kv_cache_type);
         // Quantized KV cache: i8 (8-bit), u8 (4-bit values packed two per byte), or f8e4m3 (8-bit float).
         NODE_VALIDATION_CHECK(this,
                               m_kv_cache_bit_width == 8 || m_kv_cache_bit_width == 4,

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -73,8 +73,8 @@ void GroupQueryAttention::validate_and_infer_types() {
             return "sin_cache";
         case GroupQueryAttentionInputs::POSITION_IDS:
             return "position_ids";
-        case GroupQueryAttentionInputs::ATTENTION_MASK:
-            return "attention_mask";
+        case GroupQueryAttentionInputs::ATTENTION_BIAS:
+            return "attention_bias";
         case GroupQueryAttentionInputs::HEAD_SINK:
             return "head_sink";
         case GroupQueryAttentionInputs::K_SCALE:

--- a/src/core/src/validation_util.cpp
+++ b/src/core/src/validation_util.cpp
@@ -165,12 +165,8 @@ std::shared_ptr<Constant> get_constant_from_source(const ov::Output<ov::Node>& s
 }
 
 bool is_empty_constant_tensor(const Output<Node>& source) {
-    if (!source.get_node()) {
-        return false;
-    }
-
     const auto constant = ov::as_type_ptr<Constant>(source.get_node_shared_ptr());
-    return constant != nullptr && ov::shape_size(constant->get_shape()) == 0;
+    return constant != nullptr && constant->get_shape() == Shape{0};
 }
 
 template <class T>

--- a/src/core/src/validation_util.cpp
+++ b/src/core/src/validation_util.cpp
@@ -164,6 +164,15 @@ std::shared_ptr<Constant> get_constant_from_source(const ov::Output<ov::Node>& s
     }
 }
 
+bool is_empty_constant_tensor(const Output<Node>& source) {
+    if (!source.get_node()) {
+        return false;
+    }
+
+    const auto constant = ov::as_type_ptr<Constant>(source.get_node_shared_ptr());
+    return constant != nullptr && ov::shape_size(constant->get_shape()) == 0;
+}
+
 template <class T>
 Tensor make_tensor_of_max_value(const element::Type_t et) {
     Tensor t{et, Shape{}};

--- a/src/core/tests/type_prop/group_query_attention.cpp
+++ b/src/core/tests/type_prop/group_query_attention.cpp
@@ -22,14 +22,14 @@ namespace {
 ov::OutputVector make_valid_gqa_args(const element::Type& t = element::f32) {
     using ov::op::v0::Parameter;
 
-    const auto query = std::make_shared<Parameter>(t, PartialShape{3, 6, 4, 8});
-    const auto key = std::make_shared<Parameter>(t, PartialShape{3, 2, 4, 8});
-    const auto value = std::make_shared<Parameter>(t, PartialShape{3, 2, 4, 8});
+    const auto query = std::make_shared<Parameter>(t, PartialShape{1, 6, 4, 8});
+    const auto key = std::make_shared<Parameter>(t, PartialShape{1, 2, 4, 8});
+    const auto value = std::make_shared<Parameter>(t, PartialShape{1, 2, 4, 8});
 
-    const auto past_key = std::make_shared<Parameter>(t, PartialShape{3, 2, 5, 8});
-    const auto past_value = std::make_shared<Parameter>(t, PartialShape{3, 2, 5, 8});
+    const auto past_key = std::make_shared<Parameter>(t, PartialShape{1, 2, 5, 8});
+    const auto past_value = std::make_shared<Parameter>(t, PartialShape{1, 2, 5, 8});
 
-    const auto seqlens_k = std::make_shared<Parameter>(element::i32, PartialShape{3});
+    const auto seqlens_k = std::make_shared<Parameter>(element::i32, PartialShape{1});
     const auto total_sequence_length = std::make_shared<Parameter>(element::i32, PartialShape{});
 
     return {query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
@@ -52,12 +52,12 @@ ov::OutputVector make_valid_gqa_quant_args(const element::Type& kv_type,
     using ov::op::v0::Parameter;
     const auto empty = Constant::create(element::f32, Shape{0}, {});
 
-    const auto query = std::make_shared<Parameter>(element::f32, PartialShape{3, 6, 4, 8});
-    const auto key = std::make_shared<Parameter>(element::f32, PartialShape{3, 2, 4, 8});
-    const auto value = std::make_shared<Parameter>(element::f32, PartialShape{3, 2, 4, 8});
-    const auto past_key = std::make_shared<Parameter>(kv_type, PartialShape{3, 2, 5, 8});
-    const auto past_value = std::make_shared<Parameter>(kv_type, PartialShape{3, 2, 5, 8});
-    const auto seqlens_k = std::make_shared<Parameter>(element::i32, PartialShape{3});
+    const auto query = std::make_shared<Parameter>(element::f32, PartialShape{1, 6, 4, 8});
+    const auto key = std::make_shared<Parameter>(element::f32, PartialShape{1, 2, 4, 8});
+    const auto value = std::make_shared<Parameter>(element::f32, PartialShape{1, 2, 4, 8});
+    const auto past_key = std::make_shared<Parameter>(kv_type, PartialShape{1, 2, 5, 8});
+    const auto past_value = std::make_shared<Parameter>(kv_type, PartialShape{1, 2, 5, 8});
+    const auto seqlens_k = std::make_shared<Parameter>(element::i32, PartialShape{1});
     const auto total_sequence_length = std::make_shared<Parameter>(element::i32, PartialShape{});
     // positions 7-11: cos_cache, sin_cache, position_ids, attention_mask, head_sink (all absent)
     const auto k_scale = std::make_shared<Parameter>(scale_type, PartialShape{});
@@ -88,18 +88,18 @@ TEST(type_prop, group_query_attention_gqa_output_shapes) {
     EXPECT_EQ(op->get_output_element_type(0), element::f32);
     EXPECT_EQ(op->get_output_element_type(1), element::f32);
     EXPECT_EQ(op->get_output_element_type(2), element::f32);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, 4, 48}));
-    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, 5, 8}));
-    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, 4, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{1, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{1, 2, 5, 8}));
 }
 
 TEST(type_prop, group_query_attention_mha_output_shapes) {
-    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 4, 8});
-    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 4, 8});
-    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 4, 8});
-    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 5, 8});
-    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 5, 8});
-    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{3});
+    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, 4, 8});
+    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, 4, 8});
+    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, 4, 8});
+    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, 5, 8});
+    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, 5, 8});
+    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{1});
     const auto total_sequence_length = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{});
 
     const auto args = ov::OutputVector{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
@@ -107,49 +107,49 @@ TEST(type_prop, group_query_attention_mha_output_shapes) {
     const auto op = std::make_shared<op::internal::GroupQueryAttention>(args, 2, 2, 1.0f, false, false);
 
     EXPECT_EQ(op->get_output_size(), 3);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, 4, 16}));
-    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, 5, 8}));
-    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, 4, 16}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{1, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{1, 2, 5, 8}));
 }
 
 TEST(type_prop, group_query_attention_dynamic_seq_len) {
-    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 6, -1, 8});
-    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, -1, 8});
-    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, -1, 8});
-    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, -1, 8});
-    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, -1, 8});
-    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{3});
+    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 6, -1, 8});
+    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, -1, 8});
+    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, -1, 8});
+    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, -1, 8});
+    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, -1, 8});
+    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{1});
     const auto total_sequence_length = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{});
 
     const auto args = ov::OutputVector{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
 
     const auto op = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, -1, 48}));
-    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, -1, 8}));
-    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, -1, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, -1, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{1, 2, -1, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{1, 2, -1, 8}));
 }
 
 TEST(type_prop, group_query_attention_dynamic_kv_len_accumulates) {
-    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 6, {1, 4}, 8});
-    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, {1, 4}, 8});
-    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, {1, 4}, 8});
-    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, {5, 9}, 8});
-    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, {5, 9}, 8});
-    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{3});
+    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 6, {1, 4}, 8});
+    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, {1, 4}, 8});
+    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, {1, 4}, 8});
+    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, {5, 9}, 8});
+    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 2, {5, 9}, 8});
+    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{1});
     const auto total_sequence_length = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{});
 
     const auto args = ov::OutputVector{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
 
     const auto op = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false);
 
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, {1, 4}, 48}));
-    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, {6, 13}, 8}));
-    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, {6, 13}, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, {1, 4}, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{1, 2, {6, 13}, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{1, 2, {6, 13}, 8}));
 }
 
 TEST(type_prop, group_query_attention_invalid_query_rank) {
     auto args = make_valid_gqa_args();
-    args[0] = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 6, 8});
+    args[0] = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 6, 8});
 
     OV_EXPECT_THROW(std::ignore = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false),
                     ov::NodeValidationFailure,
@@ -168,9 +168,9 @@ TEST(type_prop, group_query_attention_rotary_inputs_static_shapes) {
     const auto args = make_valid_gqa_rotary_args();
     const auto op = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, true, false);
 
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, 4, 48}));
-    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, 5, 8}));
-    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, 4, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{1, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{1, 2, 5, 8}));
 }
 
 // ---------- quantized KV cache ----------
@@ -190,9 +190,9 @@ TEST(type_prop, group_query_attention_kv_cache_int8_per_tensor) {
     EXPECT_EQ(op->get_output_element_type(0), element::f32);
     EXPECT_EQ(op->get_output_element_type(1), element::i8);
     EXPECT_EQ(op->get_output_element_type(2), element::i8);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, 4, 48}));
-    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, 5, 8}));
-    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, 4, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{1, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{1, 2, 5, 8}));
 }
 
 TEST(type_prop, group_query_attention_kv_cache_uint4_not_supported) {

--- a/src/core/tests/type_prop/group_query_attention.cpp
+++ b/src/core/tests/type_prop/group_query_attention.cpp
@@ -50,7 +50,7 @@ ov::OutputVector make_valid_gqa_quant_args(const element::Type& kv_type,
                                            const element::Type& scale_type = element::f32) {
     using ov::op::v0::Constant;
     using ov::op::v0::Parameter;
-    const auto empty = Constant::create(element::f32, Shape{0}, {});
+    const auto empty = Constant::create(element::dynamic, Shape{0}, {});
 
     const auto query = std::make_shared<Parameter>(element::f32, PartialShape{1, 6, 4, 8});
     const auto key = std::make_shared<Parameter>(element::f32, PartialShape{1, 2, 4, 8});
@@ -177,6 +177,7 @@ TEST(type_prop, group_query_attention_rotary_inputs_static_shapes) {
 
 TEST(type_prop, group_query_attention_kv_cache_int8_per_tensor) {
     const auto args = make_valid_gqa_quant_args(element::i8, 8);
+    const auto quantize_type = op::internal::GroupQueryAttentionQuantType::PER_TENSOR;
     const auto op = std::make_shared<op::internal::GroupQueryAttention>(args,
                                                                         6,
                                                                         2,
@@ -184,8 +185,8 @@ TEST(type_prop, group_query_attention_kv_cache_int8_per_tensor) {
                                                                         false,
                                                                         false,
                                                                         8,
-                                                                        "PER_TENSOR",
-                                                                        "PER_TENSOR");
+                                                                        quantize_type,
+                                                                        quantize_type);
 
     EXPECT_EQ(op->get_output_element_type(0), element::f32);
     EXPECT_EQ(op->get_output_element_type(1), element::i8);
@@ -198,40 +199,50 @@ TEST(type_prop, group_query_attention_kv_cache_int8_per_tensor) {
 TEST(type_prop, group_query_attention_kv_cache_uint4_not_supported) {
     // u4 is not in the allowed past_key/past_value type list; remove this when u4 support is added.
     const auto args = make_valid_gqa_quant_args(element::u4, 4);
+    const auto quantize_type = op::internal::GroupQueryAttentionQuantType::PER_TENSOR;
     OV_EXPECT_THROW(
         std::ignore = std::make_shared<
-            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 4, "PER_CHANNEL", "PER_CHANNEL"),
+            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 4, quantize_type, quantize_type),
         ov::NodeValidationFailure,
         HasSubstr("past_key"));
 }
 
 TEST(type_prop, group_query_attention_kv_cache_mismatched_quant_types) {
     const auto args = make_valid_gqa_quant_args(element::i8, 8);
-    OV_EXPECT_THROW(
-        std::ignore = std::make_shared<
-            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 8, "PER_TENSOR", "PER_CHANNEL"),
-        ov::NodeValidationFailure,
-        HasSubstr("matching k_quant_type and v_quant_type"));
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::internal::GroupQueryAttention>(
+                        args,
+                        6,
+                        2,
+                        1.0f,
+                        false,
+                        false,
+                        8,
+                        op::internal::GroupQueryAttentionQuantType::PER_TENSOR,
+                        op::internal::GroupQueryAttentionQuantType::PER_CHANNEL),
+                    ov::NodeValidationFailure,
+                    HasSubstr("matching k_quant_type and v_quant_type"));
 }
 
 TEST(type_prop, group_query_attention_kv_cache_mismatched_past_types) {
     auto args = make_valid_gqa_quant_args(element::i8, 8);
     args[static_cast<size_t>(op::internal::GroupQueryAttentionInputs::PAST_VALUE)] =
         std::make_shared<op::v0::Parameter>(element::u8, PartialShape{1, 2, 5, 8});
+    const auto quantize_type = op::internal::GroupQueryAttentionQuantType::PER_TENSOR;
 
     OV_EXPECT_THROW(
         std::ignore = std::make_shared<
-            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 8, "PER_TENSOR", "PER_TENSOR"),
+            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 8, quantize_type, quantize_type),
         ov::NodeValidationFailure,
         HasSubstr("past_key and past_value element types to match"));
 }
 
 TEST(type_prop, group_query_attention_quantized_kv_requires_quantized_cache_type) {
     const auto args = make_valid_gqa_quant_args(element::f32, 8);
+    const auto quantize_type = op::internal::GroupQueryAttentionQuantType::PER_TENSOR;
 
     OV_EXPECT_THROW(
         std::ignore = std::make_shared<
-            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 8, "PER_TENSOR", "PER_TENSOR"),
+            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 8, quantize_type, quantize_type),
         ov::NodeValidationFailure,
         HasSubstr("quantized KV cache element type"));
 }

--- a/src/core/tests/type_prop/group_query_attention.cpp
+++ b/src/core/tests/type_prop/group_query_attention.cpp
@@ -173,6 +173,14 @@ TEST(type_prop, group_query_attention_rotary_inputs_static_shapes) {
     EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{1, 2, 5, 8}));
 }
 
+TEST(type_prop, group_query_attention_quant_type_enum_names) {
+    EXPECT_EQ(as_string(op::internal::GroupQueryAttentionQuantType::NONE), "NONE");
+    EXPECT_EQ(as_string(op::internal::GroupQueryAttentionQuantType::PER_TENSOR), "PER_TENSOR");
+    EXPECT_EQ(as_string(op::internal::GroupQueryAttentionQuantType::PER_CHANNEL), "PER_CHANNEL");
+    EXPECT_EQ(as_enum<op::internal::GroupQueryAttentionQuantType>("PER_TENSOR"),
+              op::internal::GroupQueryAttentionQuantType::PER_TENSOR);
+}
+
 // ---------- quantized KV cache ----------
 
 TEST(type_prop, group_query_attention_kv_cache_int8_per_tensor) {

--- a/src/core/tests/type_prop/group_query_attention.cpp
+++ b/src/core/tests/type_prop/group_query_attention.cpp
@@ -214,5 +214,27 @@ TEST(type_prop, group_query_attention_kv_cache_mismatched_quant_types) {
         HasSubstr("matching k_quant_type and v_quant_type"));
 }
 
+TEST(type_prop, group_query_attention_kv_cache_mismatched_past_types) {
+    auto args = make_valid_gqa_quant_args(element::i8, 8);
+    args[static_cast<size_t>(op::internal::GroupQueryAttentionInputs::PAST_VALUE)] =
+        std::make_shared<op::v0::Parameter>(element::u8, PartialShape{1, 2, 5, 8});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<
+            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 8, "PER_TENSOR", "PER_TENSOR"),
+        ov::NodeValidationFailure,
+        HasSubstr("past_key and past_value element types to match"));
+}
+
+TEST(type_prop, group_query_attention_quantized_kv_requires_quantized_cache_type) {
+    const auto args = make_valid_gqa_quant_args(element::f32, 8);
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<
+            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 8, "PER_TENSOR", "PER_TENSOR"),
+        ov::NodeValidationFailure,
+        HasSubstr("quantized KV cache element type"));
+}
+
 }  // namespace testing
 }  // namespace ov

--- a/src/core/tests/type_prop/group_query_attention.cpp
+++ b/src/core/tests/type_prop/group_query_attention.cpp
@@ -1,0 +1,218 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/group_query_attention.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+
+namespace ov {
+namespace testing {
+using ::testing::HasSubstr;
+
+namespace {
+ov::OutputVector make_valid_gqa_args(const element::Type& t = element::f32) {
+    using ov::op::v0::Parameter;
+
+    const auto query = std::make_shared<Parameter>(t, PartialShape{3, 6, 4, 8});
+    const auto key = std::make_shared<Parameter>(t, PartialShape{3, 2, 4, 8});
+    const auto value = std::make_shared<Parameter>(t, PartialShape{3, 2, 4, 8});
+
+    const auto past_key = std::make_shared<Parameter>(t, PartialShape{3, 2, 5, 8});
+    const auto past_value = std::make_shared<Parameter>(t, PartialShape{3, 2, 5, 8});
+
+    const auto seqlens_k = std::make_shared<Parameter>(element::i32, PartialShape{3});
+    const auto total_sequence_length = std::make_shared<Parameter>(element::i32, PartialShape{});
+
+    return {query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
+}
+
+ov::OutputVector make_valid_gqa_rotary_args(const element::Type& t = element::f32) {
+    auto args = make_valid_gqa_args(t);
+    const auto cos_cache = std::make_shared<op::v0::Parameter>(t, PartialShape{16, 4});
+    const auto sin_cache = std::make_shared<op::v0::Parameter>(t, PartialShape{16, 4});
+    args.push_back(cos_cache);
+    args.push_back(sin_cache);
+    return args;
+}
+
+// Fills optional inputs 7-11 with empty constants (treated as absent by has_input).
+ov::OutputVector make_valid_gqa_quant_args(const element::Type& kv_type,
+                                           int64_t kv_cache_bit_width,
+                                           const element::Type& scale_type = element::f32) {
+    using ov::op::v0::Constant;
+    using ov::op::v0::Parameter;
+    const auto empty = Constant::create(element::f32, Shape{0}, {});
+
+    const auto query = std::make_shared<Parameter>(element::f32, PartialShape{3, 6, 4, 8});
+    const auto key = std::make_shared<Parameter>(element::f32, PartialShape{3, 2, 4, 8});
+    const auto value = std::make_shared<Parameter>(element::f32, PartialShape{3, 2, 4, 8});
+    const auto past_key = std::make_shared<Parameter>(kv_type, PartialShape{3, 2, 5, 8});
+    const auto past_value = std::make_shared<Parameter>(kv_type, PartialShape{3, 2, 5, 8});
+    const auto seqlens_k = std::make_shared<Parameter>(element::i32, PartialShape{3});
+    const auto total_sequence_length = std::make_shared<Parameter>(element::i32, PartialShape{});
+    // positions 7-11: cos_cache, sin_cache, position_ids, attention_mask, head_sink (all absent)
+    const auto k_scale = std::make_shared<Parameter>(scale_type, PartialShape{});
+    const auto v_scale = std::make_shared<Parameter>(scale_type, PartialShape{});
+
+    return {query,
+            key,
+            value,
+            past_key,
+            past_value,
+            seqlens_k,
+            total_sequence_length,
+            empty,
+            empty,
+            empty,
+            empty,
+            empty,
+            k_scale,
+            v_scale};
+}
+}  // namespace
+
+TEST(type_prop, group_query_attention_gqa_output_shapes) {
+    const auto args = make_valid_gqa_args();
+    const auto op = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false);
+
+    EXPECT_EQ(op->get_output_size(), 3);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_element_type(1), element::f32);
+    EXPECT_EQ(op->get_output_element_type(2), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, 4, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, 5, 8}));
+}
+
+TEST(type_prop, group_query_attention_mha_output_shapes) {
+    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 4, 8});
+    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 4, 8});
+    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 4, 8});
+    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 5, 8});
+    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, 5, 8});
+    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{3});
+    const auto total_sequence_length = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{});
+
+    const auto args = ov::OutputVector{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
+
+    const auto op = std::make_shared<op::internal::GroupQueryAttention>(args, 2, 2, 1.0f, false, false);
+
+    EXPECT_EQ(op->get_output_size(), 3);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, 4, 16}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, 5, 8}));
+}
+
+TEST(type_prop, group_query_attention_dynamic_seq_len) {
+    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 6, -1, 8});
+    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, -1, 8});
+    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, -1, 8});
+    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, -1, 8});
+    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, -1, 8});
+    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{3});
+    const auto total_sequence_length = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{});
+
+    const auto args = ov::OutputVector{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
+
+    const auto op = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, -1, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, -1, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, -1, 8}));
+}
+
+TEST(type_prop, group_query_attention_dynamic_kv_len_accumulates) {
+    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 6, {1, 4}, 8});
+    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, {1, 4}, 8});
+    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, {1, 4}, 8});
+    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, {5, 9}, 8});
+    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 2, {5, 9}, 8});
+    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{3});
+    const auto total_sequence_length = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{});
+
+    const auto args = ov::OutputVector{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
+
+    const auto op = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false);
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, {1, 4}, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, {6, 13}, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, {6, 13}, 8}));
+}
+
+TEST(type_prop, group_query_attention_invalid_query_rank) {
+    auto args = make_valid_gqa_args();
+    args[0] = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{3, 6, 8});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false),
+                    ov::NodeValidationFailure,
+                    HasSubstr("query rank"));
+}
+
+TEST(type_prop, group_query_attention_do_rotary_requires_cos_sin) {
+    const auto args = make_valid_gqa_args();
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, true, false),
+                    ov::NodeValidationFailure,
+                    HasSubstr("cos_cache"));
+}
+
+TEST(type_prop, group_query_attention_rotary_inputs_static_shapes) {
+    const auto args = make_valid_gqa_rotary_args();
+    const auto op = std::make_shared<op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, true, false);
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, 4, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, 5, 8}));
+}
+
+// ---------- quantized KV cache ----------
+
+TEST(type_prop, group_query_attention_kv_cache_int8_per_tensor) {
+    const auto args = make_valid_gqa_quant_args(element::i8, 8);
+    const auto op = std::make_shared<op::internal::GroupQueryAttention>(args,
+                                                                        6,
+                                                                        2,
+                                                                        1.0f,
+                                                                        false,
+                                                                        false,
+                                                                        8,
+                                                                        "PER_TENSOR",
+                                                                        "PER_TENSOR");
+
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_element_type(1), element::i8);
+    EXPECT_EQ(op->get_output_element_type(2), element::i8);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{3, 4, 48}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{3, 2, 5, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(2), (PartialShape{3, 2, 5, 8}));
+}
+
+TEST(type_prop, group_query_attention_kv_cache_uint4_not_supported) {
+    // u4 is not in the allowed past_key/past_value type list; remove this when u4 support is added.
+    const auto args = make_valid_gqa_quant_args(element::u4, 4);
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<
+            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 4, "PER_CHANNEL", "PER_CHANNEL"),
+        ov::NodeValidationFailure,
+        HasSubstr("past_key"));
+}
+
+TEST(type_prop, group_query_attention_kv_cache_mismatched_quant_types) {
+    const auto args = make_valid_gqa_quant_args(element::i8, 8);
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<
+            op::internal::GroupQueryAttention>(args, 6, 2, 1.0f, false, false, 8, "PER_TENSOR", "PER_CHANNEL"),
+        ov::NodeValidationFailure,
+        HasSubstr("matching k_quant_type and v_quant_type"));
+}
+
+}  // namespace testing
+}  // namespace ov

--- a/src/core/tests/type_prop/sources.cmake
+++ b/src/core/tests/type_prop/sources.cmake
@@ -92,6 +92,7 @@ set(OV_CORE_TESTS_TYPE_PROP_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/group_convolution_backprop_data.cpp
     ${CMAKE_CURRENT_LIST_DIR}/group_normalization.cpp
     ${CMAKE_CURRENT_LIST_DIR}/grouped_matmul.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/group_query_attention.cpp
     ${CMAKE_CURRENT_LIST_DIR}/gru_cell.cpp
     ${CMAKE_CURRENT_LIST_DIR}/gru_sequence.cpp
     ${CMAKE_CURRENT_LIST_DIR}/hard_sigmoid.cpp

--- a/src/core/tests/validation_utils.cpp
+++ b/src/core/tests/validation_utils.cpp
@@ -65,6 +65,21 @@ TEST(get_constant_from_source, return_nullptr_for_empty_output) {
     ASSERT_EQ(res, nullptr);
 }
 
+TEST(is_empty_constant_tensor, returns_true_for_empty_constant) {
+    const auto empty = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{0}, {});
+    ASSERT_TRUE(ov::util::is_empty_constant_tensor(empty));
+}
+
+TEST(is_empty_constant_tensor, returns_false_for_non_empty_constant) {
+    const auto non_empty = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1}, {1.0f});
+    ASSERT_FALSE(ov::util::is_empty_constant_tensor(non_empty));
+}
+
+TEST(is_empty_constant_tensor, returns_false_for_non_constant_node) {
+    const auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});
+    ASSERT_FALSE(ov::util::is_empty_constant_tensor(param));
+}
+
 TEST(constantfold_subgraph, split) {
     std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8};
     auto constant = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{input.size()}, input);

--- a/src/core/tests/validation_utils.cpp
+++ b/src/core/tests/validation_utils.cpp
@@ -80,6 +80,20 @@ TEST(is_empty_constant_tensor, returns_false_for_non_constant_node) {
     ASSERT_FALSE(ov::util::is_empty_constant_tensor(param));
 }
 
+TEST(is_empty_constant_tensor, returns_false_for_scalar_constant) {
+    const auto scalar = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.0f});
+    ASSERT_FALSE(ov::util::is_empty_constant_tensor(scalar));
+}
+
+TEST(is_empty_constant_tensor, returns_false_for_multi_dim_zero_element_constant) {
+    const auto multi_dim_empty = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{5, 1, 0, 5}, {});
+    ASSERT_FALSE(ov::util::is_empty_constant_tensor(multi_dim_empty));
+}
+
+TEST(is_empty_constant_tensor, returns_false_for_empty_output) {
+    ASSERT_FALSE(ov::util::is_empty_constant_tensor(ov::Output<ov::Node>()));
+}
+
 TEST(constantfold_subgraph, split) {
     std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8};
     auto constant = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{input.size()}, input);

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
@@ -189,8 +189,9 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
     }
 
     // Process optional inputs: only add non-NullNode inputs and record omitted positions.
-    // ONNX GroupQueryAttention optional input positions:
-    // 3: past_key, 4: past_value, 7: cos_cache, 8: sin_cache, 9: position_ids, 10: mask, 12: k_scale, 13: v_scale
+    FRONT_END_OP_CONVERSION_CHECK(
+        common::is_input_valid(onnx_op_inputs, 3) && common::is_input_valid(onnx_op_inputs, 4),
+        "GroupQueryAttention: past_key (input 3) and past_value (input 4) must not be NullNode.");
     for (size_t i = ov_op_inputs.size(); i < onnx_op_inputs.size(); ++i) {
         if (!ov::op::util::is_null(onnx_op_inputs[i])) {
             ov_op_inputs.push_back(onnx_op_inputs[i]);

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
@@ -49,8 +49,22 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
     const auto rotary_interleaved = node.get_attribute_value<int64_t>("rotary_interleaved", 0);
     // Quantized KV cache attributes (com.microsoft spec). Default to the unquantized (float KV) behavior.
     const auto kv_cache_bit_width = node.get_attribute_value<int64_t>("kv_cache_bit_width", 0);
-    const auto k_quant_type = node.get_attribute_value<std::string>("k_quant_type", "NONE");
-    const auto v_quant_type = node.get_attribute_value<std::string>("v_quant_type", "NONE");
+    const auto parse_quant_type = [&](const std::string& quant_type_name) {
+        using QuantType = ov::op::internal::GroupQueryAttentionQuantType;
+        if (quant_type_name == "NONE") {
+            return QuantType::NONE;
+        }
+        if (quant_type_name == "PER_TENSOR") {
+            return QuantType::PER_TENSOR;
+        }
+        if (quant_type_name == "PER_CHANNEL") {
+            return QuantType::PER_CHANNEL;
+        }
+        FRONT_END_GENERAL_CHECK(false, "GroupQueryAttention: unsupported quant type '", quant_type_name, "'.");
+        return QuantType::NONE;
+    };
+    const auto k_quant_type = parse_quant_type(node.get_attribute_value<std::string>("k_quant_type", "NONE"));
+    const auto v_quant_type = parse_quant_type(node.get_attribute_value<std::string>("v_quant_type", "NONE"));
     // Sliding-window / softcap / smooth-softmax attributes (com.microsoft spec). Default to no-op values,
     // matching the ONNX Runtime defaults (local_window_size = -1 disables the window).
     const auto local_window_size = node.get_attribute_value<int64_t>("local_window_size", -1);
@@ -146,7 +160,7 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
     OutputVector ov_op_inputs;
 
     const auto make_empty_optional_input = []() {
-        return v0::Constant::create<float>(ov::element::f32, ov::Shape{0}, {})->output(0);
+        return v0::Constant::create(ov::element::dynamic, ov::Shape{0}, {})->output(0);
     };
 
     if (ov::op::util::is_null(K) && ov::op::util::is_null(V)) {

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
@@ -143,7 +143,7 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
     const auto hidden_size_node = detail::get_dimensions(q_shape_node, {2});
 
     OutputVector ov_op_inputs;
-    std::vector<int64_t> null_onnx_input_positions;
+    std::vector<int64_t> null_input_positions;
 
     if (ov::op::util::is_null(K) && ov::op::util::is_null(V)) {
         auto total_num_heads_node =
@@ -188,15 +188,14 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
         ov_op_inputs.push_back(std::move(V));
     }
 
-    // Process optional inputs: only add non-NullNode inputs, record null positions
+    // Process optional inputs: only add non-NullNode inputs and record omitted positions.
     // ONNX GroupQueryAttention optional input positions:
     // 3: past_key, 4: past_value, 7: cos_cache, 8: sin_cache, 9: position_ids, 10: mask, 12: k_scale, 13: v_scale
     for (size_t i = ov_op_inputs.size(); i < onnx_op_inputs.size(); ++i) {
         if (!ov::op::util::is_null(onnx_op_inputs[i])) {
             ov_op_inputs.push_back(onnx_op_inputs[i]);
         } else {
-            // Record that ONNX input position i is null (was NullNode)
-            null_onnx_input_positions.push_back(static_cast<int64_t>(i));
+            null_input_positions.push_back(static_cast<int64_t>(i));
         }
     }
 
@@ -212,7 +211,7 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
                                                            local_window_size,
                                                            sliding_window_cache != 0,
                                                            smooth_softmax != 0,
-                                                           null_onnx_input_positions)
+                                                           null_input_positions)
         ->outputs();
 }
 

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
@@ -146,7 +146,7 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
     OutputVector ov_op_inputs;
 
     const auto make_empty_optional_input = []() {
-        return v0::Constant::create(ov::element::f32, ov::Shape{0}, {})->output(0);
+        return v0::Constant::create<float>(ov::element::f32, ov::Shape{0}, {})->output(0);
     };
 
     if (ov::op::util::is_null(K) && ov::op::util::is_null(V)) {

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
@@ -191,7 +191,7 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
     // Process optional inputs: only add non-NullNode inputs and record omitted positions.
     FRONT_END_OP_CONVERSION_CHECK(
         common::is_input_valid(onnx_op_inputs, 3) && common::is_input_valid(onnx_op_inputs, 4),
-        "GroupQueryAttention: past_key (input 3) and past_value (input 4) must not be NullNode.");
+        "GroupQueryAttention: past_key (input 3) and past_value (input 4) must be provided as tensors");
     for (size_t i = ov_op_inputs.size(); i < onnx_op_inputs.size(); ++i) {
         if (!ov::op::util::is_null(onnx_op_inputs[i])) {
             ov_op_inputs.push_back(onnx_op_inputs[i]);

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
@@ -192,10 +192,12 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
         ov_op_inputs.push_back(std::move(V));
     }
 
-    // Process optional inputs: use a zero-sized Constant placeholder for missing optional ONNX inputs.
     FRONT_END_OP_CONVERSION_CHECK(
         common::is_input_valid(onnx_op_inputs, 3) && common::is_input_valid(onnx_op_inputs, 4),
         "GroupQueryAttention: past_key (input 3) and past_value (input 4) must be provided as tensors");
+    // Process optional inputs: use a zero-sized Constant placeholder for missing optional ONNX inputs.
+    // Note: When the ONNX's input index changed, the corresponding index in the GroupQueryAttentionInputs enum must
+    // also be updated and  may need mapping the index manually.
     for (size_t i = ov_op_inputs.size(); i < inputs_count_max; ++i) {
         if (i < onnx_op_inputs.size() && !ov::op::util::is_null(onnx_op_inputs[i])) {
             ov_op_inputs.push_back(onnx_op_inputs[i]);

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
@@ -11,6 +11,7 @@
 #include "exceptions.hpp"
 #include "openvino/frontend/exception.hpp"
 #include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/divide.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/shape_of.hpp"
@@ -143,7 +144,10 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
     const auto hidden_size_node = detail::get_dimensions(q_shape_node, {2});
 
     OutputVector ov_op_inputs;
-    std::vector<int64_t> null_input_positions;
+
+    const auto make_empty_optional_input = []() {
+        return v0::Constant::create(ov::element::f32, ov::Shape{0}, {})->output(0);
+    };
 
     if (ov::op::util::is_null(K) && ov::op::util::is_null(V)) {
         auto total_num_heads_node =
@@ -188,15 +192,15 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
         ov_op_inputs.push_back(std::move(V));
     }
 
-    // Process optional inputs: only add non-NullNode inputs and record omitted positions.
+    // Process optional inputs: use a zero-sized Constant placeholder for missing optional ONNX inputs.
     FRONT_END_OP_CONVERSION_CHECK(
         common::is_input_valid(onnx_op_inputs, 3) && common::is_input_valid(onnx_op_inputs, 4),
         "GroupQueryAttention: past_key (input 3) and past_value (input 4) must be provided as tensors");
-    for (size_t i = ov_op_inputs.size(); i < onnx_op_inputs.size(); ++i) {
-        if (!ov::op::util::is_null(onnx_op_inputs[i])) {
+    for (size_t i = ov_op_inputs.size(); i < inputs_count_max; ++i) {
+        if (i < onnx_op_inputs.size() && !ov::op::util::is_null(onnx_op_inputs[i])) {
             ov_op_inputs.push_back(onnx_op_inputs[i]);
         } else {
-            null_input_positions.push_back(static_cast<int64_t>(i));
+            ov_op_inputs.push_back(make_empty_optional_input());
         }
     }
 
@@ -211,8 +215,7 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
                                                            v_quant_type,
                                                            local_window_size,
                                                            sliding_window_cache != 0,
-                                                           smooth_softmax != 0,
-                                                           null_input_positions)
+                                                           smooth_softmax != 0)
         ->outputs();
 }
 

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/group_query_attention.cpp
@@ -143,6 +143,8 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
     const auto hidden_size_node = detail::get_dimensions(q_shape_node, {2});
 
     OutputVector ov_op_inputs;
+    std::vector<int64_t> null_onnx_input_positions;
+
     if (ov::op::util::is_null(K) && ov::op::util::is_null(V)) {
         auto total_num_heads_node =
             v0::Constant::create(ov::element::i64, ov::Shape{1}, {num_heads + kv_num_heads + kv_num_heads});
@@ -186,8 +188,16 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
         ov_op_inputs.push_back(std::move(V));
     }
 
+    // Process optional inputs: only add non-NullNode inputs, record null positions
+    // ONNX GroupQueryAttention optional input positions:
+    // 3: past_key, 4: past_value, 7: cos_cache, 8: sin_cache, 9: position_ids, 10: mask, 12: k_scale, 13: v_scale
     for (size_t i = ov_op_inputs.size(); i < onnx_op_inputs.size(); ++i) {
-        ov_op_inputs.push_back(onnx_op_inputs[i]);
+        if (!ov::op::util::is_null(onnx_op_inputs[i])) {
+            ov_op_inputs.push_back(onnx_op_inputs[i]);
+        } else {
+            // Record that ONNX input position i is null (was NullNode)
+            null_onnx_input_positions.push_back(static_cast<int64_t>(i));
+        }
     }
 
     return std::make_shared<internal::GroupQueryAttention>(ov_op_inputs,
@@ -201,7 +211,8 @@ ov::OutputVector group_query_attention(const ov::frontend::onnx::Node& node) {
                                                            v_quant_type,
                                                            local_window_size,
                                                            sliding_window_cache != 0,
-                                                           smooth_softmax != 0)
+                                                           smooth_softmax != 0,
+                                                           null_onnx_input_positions)
         ->outputs();
 }
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/keep_gqa_kv_scale_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/keep_gqa_kv_scale_precision_test.cpp
@@ -8,6 +8,7 @@
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/core/model.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/group_query_attention.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/result.hpp"
@@ -32,20 +33,27 @@ constexpr size_t v_scale_idx = 13;
 std::shared_ptr<ov::Model> make_gqa_model(bool quantized) {
     const auto kv_et = quantized ? ov::element::i8 : ov::element::f16;
 
-    ov::ParameterVector params(14);
-    params[0] = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 2, 1, 16});  // query
-    params[1] = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 1, 1, 16});  // key
-    params[2] = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 1, 1, 16});  // value
-    params[3] = std::make_shared<ov::op::v0::Parameter>(kv_et, ov::PartialShape{1, 1, 8, 16});             // past_key
-    params[4] = std::make_shared<ov::op::v0::Parameter>(kv_et, ov::PartialShape{1, 1, 8, 16});             // past_value
-    params[5] = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{1});            // seqlens_k
-    params[6] = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{1});            // total_sequence_length
-    for (size_t i = 7; i <= 11; ++i)  // rotary / optional placeholders, unread by validate_and_infer_types
-        params[i] = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1});
-    params[k_scale_idx] = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});  // k_scale
-    params[v_scale_idx] = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1});  // v_scale
+    ov::ParameterVector params;
+    ov::OutputVector args(14);
 
-    ov::OutputVector args(params.begin(), params.end());
+    const auto add_param = [&](size_t idx, const ov::element::Type& et, const ov::PartialShape& pshape) {
+        auto p = std::make_shared<ov::op::v0::Parameter>(et, pshape);
+        params.push_back(p);
+        args[idx] = p;
+    };
+
+    add_param(0, ov::element::f16, ov::PartialShape{1, 2, 1, 16});  // query
+    add_param(1, ov::element::f16, ov::PartialShape{1, 1, 1, 16});  // key
+    add_param(2, ov::element::f16, ov::PartialShape{1, 1, 1, 16});  // value
+    add_param(3, kv_et, ov::PartialShape{1, 1, 8, 16});             // past_key
+    add_param(4, kv_et, ov::PartialShape{1, 1, 8, 16});             // past_value
+    add_param(5, ov::element::i32, ov::PartialShape{1});            // seqlens_k
+    add_param(6, ov::element::i32, ov::PartialShape{1});            // total_sequence_length
+    for (size_t i = 7; i <= 11; ++i)                                // empty Constants are treated as absent optional inputs by has_input()
+        args[i] = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{0}, {});
+    add_param(k_scale_idx, ov::element::f32, ov::PartialShape{1});  // k_scale
+    add_param(v_scale_idx, ov::element::f32, ov::PartialShape{1});  // v_scale
+
     auto gqa = std::make_shared<GroupQueryAttention>(args,
                                                      /*num_heads*/ 2,
                                                      /*kv_num_heads*/ 1,

--- a/src/plugins/intel_gpu/tests/unit/transformations/keep_gqa_kv_scale_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/keep_gqa_kv_scale_precision_test.cpp
@@ -21,6 +21,7 @@ using namespace ov::intel_gpu;
 namespace {
 
 using ov::op::internal::GroupQueryAttention;
+using ov::op::internal::GroupQueryAttentionQuantType;
 
 // k_scale / v_scale are inputs 12 / 13 of GroupQueryAttention.
 constexpr size_t k_scale_idx = 12;
@@ -50,9 +51,12 @@ std::shared_ptr<ov::Model> make_gqa_model(bool quantized) {
     add_param(5, ov::element::i32, ov::PartialShape{1});            // seqlens_k
     add_param(6, ov::element::i32, ov::PartialShape{1});            // total_sequence_length
     for (size_t i = 7; i <= 11; ++i)                                // empty Constants are treated as absent optional inputs by has_input()
-        args[i] = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{0}, {});
+        args[i] = ov::op::v0::Constant::create(ov::element::dynamic, ov::Shape{0}, {});
     add_param(k_scale_idx, ov::element::f32, ov::PartialShape{1});  // k_scale
     add_param(v_scale_idx, ov::element::f32, ov::PartialShape{1});  // v_scale
+
+    // Keep this test compatible with both string-based and enum-based quant type APIs.
+    const auto quant_type = quantized ? GroupQueryAttentionQuantType::PER_CHANNEL : GroupQueryAttentionQuantType::NONE;
 
     auto gqa = std::make_shared<GroupQueryAttention>(args,
                                                      /*num_heads*/ 2,
@@ -61,8 +65,8 @@ std::shared_ptr<ov::Model> make_gqa_model(bool quantized) {
                                                      /*do_rotary*/ false,
                                                      /*rotary_interleaved*/ false,
                                                      /*kv_cache_bit_width*/ quantized ? 8 : 0,
-                                                     /*k_quant_type*/ quantized ? "PER_CHANNEL" : "NONE",
-                                                     /*v_quant_type*/ quantized ? "PER_CHANNEL" : "NONE");
+                                                     /*k_quant_type*/ quant_type,
+                                                     /*v_quant_type*/ quant_type);
 
     ov::ResultVector results{std::make_shared<ov::op::v0::Result>(gqa->output(0)),
                              std::make_shared<ov::op::v0::Result>(gqa->output(1)),

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
@@ -57,15 +57,24 @@ public:
         const auto rotary_interleaved = node->get_rotary_interleaved();
         // TODO: add softcap support
 
-        auto Q = node->input_value(0);
-        auto K = node->input_value(1);
-        auto V = node->input_value(2);
-        auto past_key = node->input_value(3);
-        auto past_value = node->input_value(4);
-        auto seqlens_k = node->input_value(5);
-        auto total_sequence_length = node->input_value(6);
-        auto cos_cache = node->input_value(7);
-        auto sin_cache = node->input_value(8);
+        const auto get_input = [&](ov::op::internal::GroupQueryAttentionInputs input_pos,
+                                   const bool is_required = true) -> ov::Output<ov::Node> {
+            const auto original_pos = static_cast<int64_t>(input_pos);
+            const bool exists = node->has_input(original_pos);
+            OPENVINO_ASSERT(!is_required || exists,
+                            "Missing required GroupQueryAttention input at original position ",
+                            original_pos);
+            return exists ? node->input_value(node->get_input_index(original_pos)) : ov::Output<ov::Node>{};
+        };
+
+        auto Q = get_input(ov::op::internal::GroupQueryAttentionInputs::QUERY);
+        auto K = get_input(ov::op::internal::GroupQueryAttentionInputs::KEY);
+        auto V = get_input(ov::op::internal::GroupQueryAttentionInputs::VALUE);
+        auto past_key = get_input(ov::op::internal::GroupQueryAttentionInputs::PAST_KEY);
+        auto past_value = get_input(ov::op::internal::GroupQueryAttentionInputs::PAST_VALUE);
+        auto seqlens_k = get_input(ov::op::internal::GroupQueryAttentionInputs::SEQLENS_K);
+        auto cos_cache = get_input(ov::op::internal::GroupQueryAttentionInputs::COS_CACHE, do_rotary);
+        auto sin_cache = get_input(ov::op::internal::GroupQueryAttentionInputs::SIN_CACHE, do_rotary);
 
         // The length of all tokens (past + current) is `seqlens_k` + 1.
         // current = Q.shape[2], past = `seqlens_k` + 1 - current

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
@@ -64,7 +64,8 @@ public:
             OPENVINO_ASSERT(!is_required || exists,
                             "Missing required GroupQueryAttention input at original position ",
                             original_pos);
-            return exists ? node->input_value(node->get_input_index(original_pos)) : ov::Output<ov::Node>{};
+            return exists ? node->input_value(static_cast<size_t>(node->get_input_index(original_pos)))
+                          : ov::Output<ov::Node>{};
         };
 
         auto Q = get_input(ov::op::internal::GroupQueryAttentionInputs::QUERY);

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
@@ -5,6 +5,7 @@
 #include "decompose_gqa.hpp"
 
 #include "openvino/core/graph_util.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/op/group_query_attention.hpp"
 #include "openvino/op/ops.hpp"
 #include "openvino/op/range.hpp"
@@ -57,9 +58,14 @@ public:
         const auto rotary_interleaved = node->get_rotary_interleaved();
         // TODO: add softcap support
 
+        const auto has_input = [&](ov::op::internal::GroupQueryAttentionInputs input_pos) {
+            const auto pos = static_cast<size_t>(input_pos);
+            return pos < node->get_input_size() && !ov::util::is_empty_constant_tensor(node->input_value(pos));
+        };
+
         const auto get_input = [&](ov::op::internal::GroupQueryAttentionInputs input_pos) -> ov::Output<ov::Node> {
             const auto original_pos = static_cast<int64_t>(input_pos);
-            const bool exists = node->has_input(original_pos);
+            const bool exists = has_input(input_pos);
             OPENVINO_ASSERT(exists, "Missing required GroupQueryAttention input at original position ", original_pos);
             return node->input_value(static_cast<size_t>(original_pos));
         };

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
@@ -57,15 +57,11 @@ public:
         const auto rotary_interleaved = node->get_rotary_interleaved();
         // TODO: add softcap support
 
-        const auto get_input = [&](ov::op::internal::GroupQueryAttentionInputs input_pos,
-                                   const bool is_required = true) -> ov::Output<ov::Node> {
+        const auto get_input = [&](ov::op::internal::GroupQueryAttentionInputs input_pos) -> ov::Output<ov::Node> {
             const auto original_pos = static_cast<int64_t>(input_pos);
             const bool exists = node->has_input(original_pos);
-            OPENVINO_ASSERT(!is_required || exists,
-                            "Missing required GroupQueryAttention input at original position ",
-                            original_pos);
-            return exists ? node->input_value(static_cast<size_t>(node->get_input_index(original_pos)))
-                          : ov::Output<ov::Node>{};
+            OPENVINO_ASSERT(exists, "Missing required GroupQueryAttention input at original position ", original_pos);
+            return node->input_value(static_cast<size_t>(original_pos));
         };
 
         auto Q = get_input(ov::op::internal::GroupQueryAttentionInputs::QUERY);
@@ -74,8 +70,6 @@ public:
         auto past_key = get_input(ov::op::internal::GroupQueryAttentionInputs::PAST_KEY);
         auto past_value = get_input(ov::op::internal::GroupQueryAttentionInputs::PAST_VALUE);
         auto seqlens_k = get_input(ov::op::internal::GroupQueryAttentionInputs::SEQLENS_K);
-        auto cos_cache = get_input(ov::op::internal::GroupQueryAttentionInputs::COS_CACHE, do_rotary);
-        auto sin_cache = get_input(ov::op::internal::GroupQueryAttentionInputs::SIN_CACHE, do_rotary);
 
         // The length of all tokens (past + current) is `seqlens_k` + 1.
         // current = Q.shape[2], past = `seqlens_k` + 1 - current
@@ -99,6 +93,8 @@ public:
         const auto curr_seqlen_scalar = register_new_node<v0::Squeeze>(current_seqlen);
 
         if (do_rotary) {
+            auto cos_cache = get_input(ov::op::internal::GroupQueryAttentionInputs::COS_CACHE);
+            auto sin_cache = get_input(ov::op::internal::GroupQueryAttentionInputs::SIN_CACHE);
             ov::Output<ov::Node> position_ids = register_new_node<v4::Range>(zero_without_shape,
                                                                              curr_seqlen_scalar,
                                                                              one_without_shape,

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.cpp
@@ -13,8 +13,8 @@
 #include "online/compiler.hpp"
 #include "online/utils/utils.hpp"  // getMetaDesc
 #include "openvino/core/parallel.hpp"
-#include "openvino/core/validation_util.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/slice.hpp"
 #include "openvino/op/util/op_types.hpp"

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.cpp
@@ -13,6 +13,7 @@
 #include "online/compiler.hpp"
 #include "online/utils/utils.hpp"  // getMetaDesc
 #include "openvino/core/parallel.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/slice.hpp"
@@ -1556,7 +1557,12 @@ void Partitioner::saveRepeatedConstants(const std::string& func_name) {
             return;
         }
 
+        bool empty_constant = ov::util::is_empty_constant_tensor(proto_node);
+
         bool all_identical = std::all_of(instances.begin(), instances.end(), [&](const CTPtr& other_node) -> bool {
+            if (empty_constant) {
+                return ov::util::is_empty_constant_tensor(other_node);
+            }
             return (other_node->output(0).get_shape() == proto_node->output(0).get_shape()) &&
                    values_are_the_same(proto_node, other_node);
         });


### PR DESCRIPTION
### Details:
 - The ONNX's default unused input is `NullNode` to take the input position and let the user to get input node with index.
 - But the OV doesn't support `NullNode`, that makes the compile error.

### Solution:
 - Add the missing input index in the operator
 - Check the index before using it.
 

### Tickets:
 - [CVS-190171](https://jira.devtools.intel.com/browse/CVS-190171)

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
