### PR TITLE
[GPU] Support non-transposed INT4 compressed weights in FullyConnected for shared weights scenario

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -271,6 +271,7 @@ public:
         int idx = !arg.bias_term() ? 1 : 2;
         int per_oc = PER_OC << shift_size;
         int grouped = (1 << prim->input_size) - 1;
+        auto ifm_dim_idx = prim->weights_transposed ? 1 : 0;
 
         bool has_decompression_scale = prim->decompression_scale.is_valid();
         if (has_decompression_scale) {
@@ -279,7 +280,7 @@ public:
 
             auto decompression_scale_idx = ++idx;
             auto scale_layout = arg.get_dependency(decompression_scale_idx).get_output_layout();
-            auto ngroups = scale_layout.get_dim(1);
+            auto ngroups = scale_layout.get_dim(ifm_dim_idx);
             if (scale_layout.count() == 1) {
                 _attrs->set_scales(DNNL_ARG_WEIGHTS, COMMON, dnnl::memory::dims{}, _ds_data_type);
             } else if (ngroups == 1) {
@@ -299,7 +300,7 @@ public:
                 if (dzp_layout.count() == 1) {
                     _attrs->set_zero_points(DNNL_ARG_WEIGHTS, COMMON, dnnl::memory::dims{}, _dzp_data_type);
                 } else {
-                    auto ngroups = dzp_layout.get_dim(1);
+                    auto ngroups = dzp_layout.get_dim(ifm_dim_idx);
                     if (ngroups == 1) {
                         _attrs->set_zero_points(DNNL_ARG_WEIGHTS, per_oc, dnnl::memory::dims{}, _dzp_data_type);
                     } else {
@@ -380,8 +381,11 @@ public:
                 auto decompression_scale_idx = ++idx;
                 auto scale_layout = arg.get_dependency(decompression_scale_idx).get_output_layout();
                 ds_data_type = convert_data_type(scale_layout.data_type);
-                auto ifm = arg.get_dependency(1).get_output_layout().get_dim(weight_rank - 1);
-                auto ngroups = scale_layout.get_dim(weight_rank - 1);
+                // For transposed weights [N, K], IFM (K) is the last dimension.
+                // For non-transposed weights [K, N], IFM (K) is the second-to-last dimension.
+                auto ifm_dim_idx = prim->weights_transposed ? (weight_rank - 1) : (weight_rank - 2);
+                auto ifm = arg.get_dependency(1).get_output_layout().get_dim(ifm_dim_idx);
+                auto ngroups = scale_layout.get_dim(ifm_dim_idx);
                 group_size = static_cast<int>(ifm / ngroups);
                 OPENVINO_ASSERT((group_size == 1 || ngroups == 1 || group_size % 16 == 0),
                     "[GPU] group_size should be aligned to 16 if it is not a single scale group or the group_size is not one.");
@@ -410,7 +414,8 @@ public:
                     auto dzp_rank = std::count_if(dzp_shape.begin(), dzp_shape.end(), [](ov::Dimension d) { return d.get_length() > 1; });
                     dzp_rank = std::max(static_cast<int64_t>(2), dzp_rank);
 
-                    auto ngroups = dzp_layout.get_dim(dzp_rank - 1);
+                    auto dzp_ifm_dim_idx = prim->weights_transposed ? (dzp_rank - 1) : (dzp_rank - 2);
+                    auto ngroups = dzp_layout.get_dim(dzp_ifm_dim_idx);
                     if (ngroups == 1 && dzp_rank <= 2) {
                         attr->set_zero_points(DNNL_ARG_WEIGHTS, per_oc, dnnl::memory::dims{}, dzp_data_type);
                     } else {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -387,9 +387,9 @@ public:
                 auto scale_layout = arg.get_dependency(decompression_scale_idx).get_output_layout();
                 ds_data_type = convert_data_type(scale_layout.data_type);
                 // IFM (K) dimension position depends on weight layout orientation.
-                auto ifm_dim_idx = prim->weights_transposed ? (weight_rank - 1) : (weight_rank - 2);
-                auto ifm = arg.get_dependency(1).get_output_layout().get_dim(ifm_dim_idx);
-                auto ngroups = scale_layout.get_dim(ifm_dim_idx);
+                const auto ifm_dim_idx = prim->weights_transposed ? (weight_rank - 1) : (weight_rank - 2);
+                const auto ifm = arg.get_dependency(1).get_output_layout().get_dim(ifm_dim_idx);
+                const auto ngroups = scale_layout.get_dim(ifm_dim_idx);
                 group_size = static_cast<int>(ifm / ngroups);
                 OPENVINO_ASSERT((group_size == 1 || ngroups == 1 || group_size % 16 == 0),
                     "[GPU] group_size should be aligned to 16 if it is not a single scale group or the group_size is not one.");

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -266,12 +266,17 @@ public:
         const kernel_impl_params* impl_params = reinterpret_cast<kernel_impl_params*>(ib.getKernelImplParams());
         auto prim = impl_params->typed_desc<fully_connected>();
         auto weights_layout = impl_params->get_input_layout(1);
+        auto weight_shape = weights_layout.get_partial_shape();
+        auto weight_rank = std::count_if(weight_shape.begin(), weight_shape.end(),
+            [](ov::Dimension d) { return d.get_length() > 1; });
+        weight_rank = std::max(static_cast<int64_t>(2), weight_rank);
+        auto ifm_dim_idx = prim->weights_transposed ? (weight_rank - 1) : (weight_rank - 2);
+
         auto shift_size = std::max<size_t>(prim->input_size - 2, 0);
         auto& arg = impl_params->get_program().get_node(impl_params->desc->id).as<fully_connected>();
         int idx = !arg.bias_term() ? 1 : 2;
         int per_oc = PER_OC << shift_size;
         int grouped = (1 << prim->input_size) - 1;
-        auto ifm_dim_idx = prim->weights_transposed ? 1 : 0;
 
         bool has_decompression_scale = prim->decompression_scale.is_valid();
         if (has_decompression_scale) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -270,7 +270,7 @@ public:
         auto weight_rank = std::count_if(weight_shape.begin(), weight_shape.end(),
             [](ov::Dimension d) { return d.get_length() > 1; });
         weight_rank = std::max(static_cast<int64_t>(2), weight_rank);
-        auto ifm_dim_idx = prim->weights_transposed ? (weight_rank - 1) : (weight_rank - 2);
+        const auto ifm_dim_idx = prim->weights_transposed ? (weight_rank - 1) : (weight_rank - 2);
 
         auto shift_size = std::max<size_t>(prim->input_size - 2, 0);
         auto& arg = impl_params->get_program().get_node(impl_params->desc->id).as<fully_connected>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -266,7 +266,7 @@ public:
         const kernel_impl_params* impl_params = reinterpret_cast<kernel_impl_params*>(ib.getKernelImplParams());
         auto prim = impl_params->typed_desc<fully_connected>();
         auto weights_layout = impl_params->get_input_layout(1);
-        auto weight_shape = weights_layout.get_partial_shape();
+        const auto& weight_shape = weights_layout.get_partial_shape();
         auto weight_rank = std::count_if(weight_shape.begin(), weight_shape.end(),
             [](ov::Dimension d) { return d.get_length() > 1; });
         weight_rank = std::max(static_cast<int64_t>(2), weight_rank);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -386,8 +386,7 @@ public:
                 auto decompression_scale_idx = ++idx;
                 auto scale_layout = arg.get_dependency(decompression_scale_idx).get_output_layout();
                 ds_data_type = convert_data_type(scale_layout.data_type);
-                // For transposed weights [N, K], IFM (K) is the last dimension.
-                // For non-transposed weights [K, N], IFM (K) is the second-to-last dimension.
+                // IFM (K) dimension position depends on weight layout orientation.
                 auto ifm_dim_idx = prim->weights_transposed ? (weight_rank - 1) : (weight_rank - 2);
                 auto ifm = arg.get_dependency(1).get_output_layout().get_dim(ifm_dim_idx);
                 auto ngroups = scale_layout.get_dim(ifm_dim_idx);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -285,7 +285,7 @@ public:
 
             auto decompression_scale_idx = ++idx;
             auto scale_layout = arg.get_dependency(decompression_scale_idx).get_output_layout();
-            auto ngroups = scale_layout.get_dim(ifm_dim_idx);
+            const auto ngroups = scale_layout.get_dim(ifm_dim_idx);
             if (scale_layout.count() == 1) {
                 _attrs->set_scales(DNNL_ARG_WEIGHTS, COMMON, dnnl::memory::dims{}, _ds_data_type);
             } else if (ngroups == 1) {

--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -139,7 +139,9 @@ static void validate_and_check_shapes(const std::shared_ptr<const ov::ITensor>& 
                     " != dst: ",
                     dst->get_element_type(),
                     ")");
-    OPENVINO_ASSERT(src->get_element_type().bitwidth() >= 8, "[GPU] Unsupported element type for copying: ", src->get_element_type());
+    // Sub-byte types (i4/u4) are allowed but only for contiguous (non-ROI) copies
+    OPENVINO_ASSERT(src->get_element_type().bitwidth() >= 8 || roi_shape.empty(),
+                    "[GPU] ROI copy is not supported for sub-byte element type: ", src->get_element_type());
 
     // If it's a simple copy_to/copy_from call, then change dst shape
     if (roi_shape.empty()) {
@@ -215,6 +217,22 @@ void RemoteTensorImpl::copy_to(const std::shared_ptr<ov::ITensor>& dst,
     auto dst_remote_tensor = std::dynamic_pointer_cast<RemoteTensorImpl>(dst);
     auto shape = roi_shape.empty() ? get_shape() : roi_shape;
 
+    // Sub-byte types (i4/u4) don't support strided copy — use flat contiguous copy
+    if (m_element_type.bitwidth() < 8) {
+        const auto byte_size = get_byte_size();
+        if (dst_remote_tensor != nullptr) {
+            auto src_mem = MemWrapper(stream, get_memory(), nullptr);
+            auto dst_mem = MemWrapper(stream, dst_remote_tensor->get_memory(), nullptr);
+            src_mem.copy_to(dst_mem, src_offset, dst_offset, byte_size);
+        } else {
+            OPENVINO_ASSERT(!std::dynamic_pointer_cast<ov::IRemoteTensor>(dst), "[GPU] Unsupported Remote Tensor type");
+            auto src_mem = MemWrapper(stream, get_memory(), nullptr);
+            auto dst_mem = MemWrapper(stream, nullptr, dst->data());
+            src_mem.copy_to(dst_mem, src_offset, dst_offset, byte_size);
+        }
+        return;
+    }
+
     ov::Strides roi_strides = calculate_strides(shape, m_element_type);
     if (dst_remote_tensor != nullptr) {
         GPU_DEBUG_TRACE_DETAIL << "Copying from RemoteTensor (" << get_memory()->get_allocation_type() << ") to RemoteTensor ("
@@ -248,6 +266,22 @@ void RemoteTensorImpl::copy_from(const std::shared_ptr<const ov::ITensor>& src,
 
     auto& stream = m_context->get_engine().get_service_stream();
     auto src_remote_tensor = std::dynamic_pointer_cast<const RemoteTensorImpl>(src);
+
+    // Sub-byte types (i4/u4) don't support strided copy — use flat contiguous copy
+    if (m_element_type.bitwidth() < 8) {
+        const auto byte_size = get_byte_size();
+        if (src_remote_tensor != nullptr) {
+            auto src_mem = MemWrapper(stream, src_remote_tensor->get_memory(), nullptr);
+            auto dst_mem = MemWrapper(stream, get_memory(), nullptr);
+            src_mem.copy_to(dst_mem, src_offset, dst_offset, byte_size);
+        } else {
+            OPENVINO_ASSERT(!std::dynamic_pointer_cast<const ov::IRemoteTensor>(src), "[GPU] Unsupported Remote Tensor type");
+            auto src_mem = MemWrapper(stream, nullptr, const_cast<void*>(src->data()));
+            auto dst_mem = MemWrapper(stream, get_memory(), nullptr);
+            src_mem.copy_to(dst_mem, src_offset, dst_offset, byte_size);
+        }
+        return;
+    }
 
     ov::Strides roi_strides = calculate_strides(shape, m_element_type);
     if (src_remote_tensor != nullptr) {

--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -139,7 +139,7 @@ static void validate_and_check_shapes(const std::shared_ptr<const ov::ITensor>& 
                     " != dst: ",
                     dst->get_element_type(),
                     ")");
-    // Sub-byte types (i4/u4) are allowed but only for contiguous (non-ROI) copies
+    // Sub-byte types require contiguous (non-ROI) copies
     OPENVINO_ASSERT(src->get_element_type().bitwidth() >= 8 || roi_shape.empty(),
                     "[GPU] ROI copy is not supported for sub-byte element type: ", src->get_element_type());
 
@@ -217,7 +217,7 @@ void RemoteTensorImpl::copy_to(const std::shared_ptr<ov::ITensor>& dst,
     auto dst_remote_tensor = std::dynamic_pointer_cast<RemoteTensorImpl>(dst);
     auto shape = roi_shape.empty() ? get_shape() : roi_shape;
 
-    // Sub-byte types (i4/u4) don't support strided copy — use flat contiguous copy
+    // Sub-byte types use flat contiguous copy
     if (m_element_type.bitwidth() < 8) {
         const auto byte_size = get_byte_size();
         if (dst_remote_tensor != nullptr) {
@@ -267,7 +267,7 @@ void RemoteTensorImpl::copy_from(const std::shared_ptr<const ov::ITensor>& src,
     auto& stream = m_context->get_engine().get_service_stream();
     auto src_remote_tensor = std::dynamic_pointer_cast<const RemoteTensorImpl>(src);
 
-    // Sub-byte types (i4/u4) don't support strided copy — use flat contiguous copy
+    // Sub-byte types use flat contiguous copy
     if (m_element_type.bitwidth() < 8) {
         const auto byte_size = get_byte_size();
         if (src_remote_tensor != nullptr) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -224,7 +224,19 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
 
         // Weights normalization
         bool is_small_matmul = true;
-        if (supports_immad && shape_a.is_static() && shape_b.is_static()) {
+
+        // When compressed weights come from a Parameter (shared/external weights) and
+        // the original matmul does not transpose B, we must avoid inserting a runtime
+        // Transpose node because the GPU permute kernel does not support INT4 data type.
+        // Instead, use the non-transposed weight layout and let oneDNN handle it natively.
+        bool is_parameter_compressed_weight = is_compressed_weight &&
+            !matmul->get_transpose_b() &&
+            pattern_map.count(weights_param_m) &&
+            pattern_map.at(weights_param_m).get_node_shared_ptr() != nullptr;
+
+        if (is_parameter_compressed_weight) {
+            is_small_matmul = false;
+        } else if (supports_immad && shape_a.is_static() && shape_b.is_static()) {
              auto output_shape = matmul->get_output_shape(0);
              size_t k = 0;
              if (matmul->get_transpose_a())

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -225,14 +225,16 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         // Weights normalization
         bool is_small_matmul = true;
 
-        // When compressed weights come from a Parameter (shared/external weights) and
-        // the original matmul does not transpose B, we must avoid inserting a runtime
-        // Transpose node because the GPU permute kernel does not support INT4 data type.
+        // When sub-byte (INT4) compressed weights come from a Parameter (shared/external weights)
+        // and the original matmul does not transpose B, we must avoid inserting a runtime
+        // Transpose node because the GPU permute kernel does not support sub-byte data types.
         // Instead, use the non-transposed weight layout and let oneDNN handle it natively.
+        // Note: u8/i8 weights CAN be transposed by the GPU kernel, so this only applies to sub-byte types.
         bool is_parameter_compressed_weight = is_compressed_weight &&
             !matmul->get_transpose_b() &&
             pattern_map.count(weights_param_m) &&
-            pattern_map.at(weights_param_m).get_node_shared_ptr() != nullptr;
+            pattern_map.at(weights_param_m).get_node_shared_ptr() != nullptr &&
+            pattern_map.at(weights_param_m).get_element_type().bitwidth() < 8;
 
         if (is_parameter_compressed_weight) {
             is_small_matmul = false;

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -227,7 +227,7 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
 
         // Sub-byte Parameter weights can't be transposed at runtime (permute kernel doesn't support them).
         // Use non-transposed FC layout instead; requires XMX for the oneDNN path.
-        bool is_parameter_compressed_weight = supports_immad &&
+        const bool is_parameter_compressed_weight = supports_immad &&
             is_compressed_weight &&
             !matmul->get_transpose_b() &&
             pattern_map.count(weights_param_m) != 0 &&

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -225,12 +225,8 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         // Weights normalization
         bool is_small_matmul = true;
 
-        // When sub-byte (INT4) compressed weights come from a Parameter (shared/external weights)
-        // and the original matmul does not transpose B, we must avoid inserting a runtime
-        // Transpose node because the GPU permute kernel does not support sub-byte data types.
-        // Instead, use the non-transposed weight layout and let oneDNN handle it natively.
-        // Note: u8/i8 weights CAN be transposed by the GPU kernel, so this only applies to sub-byte types.
-        // Requires XMX (supports_immad) because only the oneDNN path supports non-transposed weights.
+        // Sub-byte Parameter weights can't be transposed at runtime (permute kernel doesn't support them).
+        // Use non-transposed FC layout instead; requires XMX for the oneDNN path.
         bool is_parameter_compressed_weight = supports_immad &&
             is_compressed_weight &&
             !matmul->get_transpose_b() &&

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -230,7 +230,7 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         bool is_parameter_compressed_weight = supports_immad &&
             is_compressed_weight &&
             !matmul->get_transpose_b() &&
-            pattern_map.count(weights_param_m) &&
+            pattern_map.count(weights_param_m) != 0 &&
             pattern_map.at(weights_param_m).get_node_shared_ptr() != nullptr &&
             pattern_map.at(weights_param_m).get_element_type().bitwidth() < 8;
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -229,6 +229,7 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         // Use non-transposed FC layout instead; requires XMX for the oneDNN path.
         const bool is_parameter_compressed_weight = supports_immad &&
             is_compressed_weight &&
+            !transpose_node &&
             !matmul->get_transpose_b() &&
             pattern_map.count(weights_param_m) != 0 &&
             pattern_map.at(weights_param_m).get_node_shared_ptr() != nullptr &&

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -295,7 +295,7 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
                 }
             } else {
                 if (!matmul->get_transpose_b()) {
-                    if (can_reuse_transpose(fc_input_b)) {
+                    if (!is_parameter_compressed_weight && can_reuse_transpose(fc_input_b)) {
                         fc_input_b = transpose_node;
                     }
                 } else {

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -230,7 +230,9 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
         // Transpose node because the GPU permute kernel does not support sub-byte data types.
         // Instead, use the non-transposed weight layout and let oneDNN handle it natively.
         // Note: u8/i8 weights CAN be transposed by the GPU kernel, so this only applies to sub-byte types.
-        bool is_parameter_compressed_weight = is_compressed_weight &&
+        // Requires XMX (supports_immad) because only the oneDNN path supports non-transposed weights.
+        bool is_parameter_compressed_weight = supports_immad &&
+            is_compressed_weight &&
             !matmul->get_transpose_b() &&
             pattern_map.count(weights_param_m) &&
             pattern_map.at(weights_param_m).get_node_shared_ptr() != nullptr &&

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/ocl_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/ocl_remote_tensor_tests.cpp
@@ -2892,12 +2892,12 @@ TEST_P(RemoteTensorSubByte, smoke_CopyTo) {
 
 INSTANTIATE_TEST_SUITE_P(smoke_copy_sub_byte,
                          RemoteTensorSubByte,
-                         ::testing::Combine(::testing::Values(ov::element::i4),
+                         ::testing::Combine(::testing::Values(ov::element::i4, ov::element::u2),
                                             ::testing::Values(RemoteTensorSharingType::PLUGIN_CL_TENSOR,
                                                               RemoteTensorSharingType::PLUGIN_USM_DEVICE_TENSOR,
                                                               RemoteTensorSharingType::PLUGIN_HOST_TENSOR),
-                                            ::testing::Values(ov::Shape{4, 16},    // even: 64 i4 = 32 bytes
-                                                              ov::Shape{3, 5})),   // odd: 15 i4 = 8 bytes, last nibble padded
+                                            ::testing::Values(ov::Shape{4, 16},
+                                                              ov::Shape{3, 5})),
                          RemoteTensorSubByte::getTestCaseName);
 
 TEST(RemoteTensor, smoke_CanSetRoiRemoteTensor) {

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/ocl_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/ocl_remote_tensor_tests.cpp
@@ -2787,6 +2787,119 @@ INSTANTIATE_TEST_SUITE_P(copy_tests,
                                                                   ov::Coordinate{0, 1, 1, 0}, ov::Coordinate{4, 2, 2, 3}
                                                               })));
 
+namespace {
+// Sub-byte (i4) tensors can't be indexed per element, so fill/compare at byte granularity.
+void fill_bytes(ov::Tensor& tensor) {
+    auto* ptr = static_cast<uint8_t*>(tensor.data());
+    for (size_t i = 0; i < tensor.get_byte_size(); ++i) {
+        ptr[i] = static_cast<uint8_t>((i * 37 + 11) & 0xFF);
+    }
+}
+
+// Sub-byte copy is a flat whole-byte copy, so the padded tail nibble must round-trip byte-for-byte too.
+void expect_bytes_eq(const ov::Tensor& expected, const ov::Tensor& actual) {
+    ASSERT_EQ(expected.get_byte_size(), actual.get_byte_size());
+    const auto* e = static_cast<const uint8_t*>(expected.data());
+    const auto* a = static_cast<const uint8_t*>(actual.data());
+    for (size_t i = 0; i < expected.get_byte_size(); ++i) {
+        ASSERT_EQ(e[i], a[i]) << "byte mismatch at offset " << i;
+    }
+}
+}  // namespace
+
+using RemoteTensorSubByteParams = std::tuple<ov::element::Type, RemoteTensorSharingType, ov::Shape>;
+
+struct RemoteTensorSubByte : ::testing::TestWithParam<RemoteTensorSubByteParams> {
+    static std::string getTestCaseName(const testing::TestParamInfo<RemoteTensorSubByteParams>& obj) {
+        const auto& [type, sharing_type, shape] = obj.param;
+        std::ostringstream result;
+        result << "type=" << type.get_type_name() << "_sharing=" << sharing_type << "_shape=";
+        for (size_t i = 0; i < shape.size(); ++i) {
+            result << (i ? "x" : "") << shape[i];
+        }
+        return result.str();
+    }
+};
+
+TEST_P(RemoteTensorSubByte, smoke_CopyFrom) {
+#if defined(ANDROID)
+    GTEST_SKIP();
+#endif
+    const auto& [type, sharing_type, shape] = GetParam();
+
+    auto core = ov::Core();
+    auto remote_context = core.get_default_context(ov::test::utils::DEVICE_GPU);
+    auto gpu_context = remote_context.as<ov::intel_gpu::ocl::ClContext>();
+
+    auto host_ref = ov::Tensor(type, shape);
+    fill_bytes(host_ref);
+
+    // host -> remote, then read back remote -> host
+    auto remote_dst = create_tensor(gpu_context, sharing_type, type, shape);
+    remote_dst.copy_from(host_ref);
+    ASSERT_EQ(remote_dst.get_shape(), shape);
+
+    auto host_out = ov::Tensor(type, shape);
+    remote_dst.copy_to(host_out);
+    expect_bytes_eq(host_ref, host_out);
+
+    // remote -> remote
+    auto remote_src = create_tensor(gpu_context, sharing_type, type, shape);
+    remote_src.copy_from(host_ref);
+
+    auto remote_dst2 = create_tensor(gpu_context, sharing_type, type, shape);
+    remote_dst2.copy_from(remote_src);
+    ASSERT_EQ(remote_dst2.get_shape(), shape);
+
+    auto host_out2 = ov::Tensor(type, shape);
+    remote_dst2.copy_to(host_out2);
+    expect_bytes_eq(host_ref, host_out2);
+}
+
+TEST_P(RemoteTensorSubByte, smoke_CopyTo) {
+#if defined(ANDROID)
+    GTEST_SKIP();
+#endif
+    const auto& [type, sharing_type, shape] = GetParam();
+
+    auto core = ov::Core();
+    auto remote_context = core.get_default_context(ov::test::utils::DEVICE_GPU);
+    auto gpu_context = remote_context.as<ov::intel_gpu::ocl::ClContext>();
+
+    auto host_ref = ov::Tensor(type, shape);
+    fill_bytes(host_ref);
+
+    // remote -> remote via copy_to
+    auto remote_src = create_tensor(gpu_context, sharing_type, type, shape);
+    remote_src.copy_from(host_ref);
+
+    auto remote_dst = create_tensor(gpu_context, sharing_type, type, shape);
+    remote_src.copy_to(remote_dst);
+    ASSERT_EQ(remote_dst.get_shape(), shape);
+
+    auto host_out = ov::Tensor(type, shape);
+    remote_dst.copy_to(host_out);
+    expect_bytes_eq(host_ref, host_out);
+
+    // host -> remote via host.copy_to(remote)
+    auto remote_dst2 = create_tensor(gpu_context, sharing_type, type, shape);
+    host_ref.copy_to(remote_dst2);
+
+    auto host_out2 = ov::Tensor(type, shape);
+    remote_dst2.copy_to(host_out2);
+    expect_bytes_eq(host_ref, host_out2);
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_copy_sub_byte,
+                         RemoteTensorSubByte,
+                         ::testing::Combine(::testing::Values(ov::element::i4),
+                                            ::testing::Values(RemoteTensorSharingType::PLUGIN_CL_TENSOR,
+                                                              RemoteTensorSharingType::PLUGIN_USM_DEVICE_TENSOR,
+                                                              RemoteTensorSharingType::PLUGIN_HOST_TENSOR),
+                                            ::testing::Values(ov::Shape{4, 16},    // even: 64 i4 = 32 bytes
+                                                              ov::Shape{3, 5})),   // odd: 15 i4 = 8 bytes, last nibble padded
+                         RemoteTensorSubByte::getTestCaseName);
+
 TEST(RemoteTensor, smoke_CanSetRoiRemoteTensor) {
 #if defined(ANDROID)
     GTEST_SKIP();

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -9,6 +9,7 @@
 #include "intel_gpu/runtime/internal_properties.hpp"
 #include "intel_gpu/runtime/utils.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/runtime/intel_gpu/properties.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
@@ -249,9 +250,15 @@ TEST_P(MatmulWeightsDecompression, Inference) {
                  param_weights,
                  dyn_quan_group_size,
                  abs_threshold_f16] = GetParam();
-    // Sub-byte parameter weights with transposed layout still need runtime transpose, which GPU can't do
-    if (param_weights && weights_precision.bitwidth() < 8 && transpose_weights) {
-        GTEST_SKIP();
+    // Sub-byte parameter weights need the non-transposed FC path which requires XMX
+    if (param_weights && weights_precision.bitwidth() < 8) {
+        if (transpose_weights) {
+            GTEST_SKIP() << "Sub-byte parameter weights with transposed layout need runtime transpose, which GPU can't do";
+        }
+        const auto caps = core->get_property(targetDevice, ov::device::capabilities);
+        if (std::find(caps.begin(), caps.end(), ov::intel_gpu::capability::HW_MATMUL) == caps.end()) {
+            GTEST_SKIP() << "Non-transposed sub-byte parameter weights require XMX (HW_MATMUL capability)";
+        }
     }
     SKIP_IF_CURRENT_TEST_IS_DISABLED(); // This is necessary because of check_results
     run();

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -249,8 +249,8 @@ TEST_P(MatmulWeightsDecompression, Inference) {
                  param_weights,
                  dyn_quan_group_size,
                  abs_threshold_f16] = GetParam();
-    // Skip tests for 4-bit parameter weights because 4-bit transpose is not supported
-    if (param_weights && weights_precision != ov::element::u8) {
+    // Sub-byte parameter weights with transposed layout still need runtime transpose, which GPU can't do
+    if (param_weights && weights_precision.bitwidth() < 8 && transpose_weights) {
         GTEST_SKIP();
     }
     SKIP_IF_CURRENT_TEST_IS_DISABLED(); // This is necessary because of check_results

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -1081,3 +1081,30 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF16_NoXMX_Transp
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
     }
 }
+
+// Verify that Parameter INT4 compressed weights skip the Transpose and produce FC with transpose_b=false
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_ParameterCompressedWeights_NoTranspose) {
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{128, 2048});
+        auto weights = std::make_shared<ov::opset1::Parameter>(ov::element::u4, ov::Shape{2048, 8192});
+        auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f32);
+        auto scale = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 8192}, {0.1f});
+        auto mul = std::make_shared<ov::opset1::Multiply>(convert, scale);
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input, mul, false, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input, weights});
+        manager.register_pass<ConvertMatMulToFullyConnected>();
+    }
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{128, 2048});
+        auto weights = std::make_shared<ov::opset1::Parameter>(ov::element::u4, ov::Shape{2048, 8192});
+        auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f32);
+        auto scale = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 8192}, {0.1f});
+        auto mul = std::make_shared<ov::opset1::Multiply>(convert, scale);
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        // transpose_b=false: weights stay in [K, N] layout, no Transpose inserted
+        auto fc = std::make_shared<op::FullyConnected>(input, mul, no_bias, ov::element::f32, /*transpose_b=*/false);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input, weights});
+    }
+}

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -466,10 +466,8 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_compressed_u8_par
         auto mul_const = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 2}, {1});
         auto mul = std::make_shared<ov::opset1::Multiply>(sub, mul_const);
 
-        auto transpose_const = ov::opset1::Constant::create(ov::element::i32, {3}, {0, 2, 1});
-        auto transpose = std::make_shared<ov::opset1::Transpose>(mul, transpose_const);
         auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
-        auto matmul = std::make_shared<op::FullyConnected>(data, transpose, no_bias);
+        auto matmul = std::make_shared<op::FullyConnected>(data, mul, no_bias, ov::element::f32, false);
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data, weights});
     }

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -466,8 +466,10 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_compressed_u8_par
         auto mul_const = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 2}, {1});
         auto mul = std::make_shared<ov::opset1::Multiply>(sub, mul_const);
 
+        auto transpose_const = ov::opset1::Constant::create(ov::element::i32, {3}, {0, 2, 1});
+        auto transpose = std::make_shared<ov::opset1::Transpose>(mul, transpose_const);
         auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
-        auto matmul = std::make_shared<op::FullyConnected>(data, mul, no_bias, ov::element::f32, false);
+        auto matmul = std::make_shared<op::FullyConnected>(data, transpose, no_bias);
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data, weights});
     }

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -1093,7 +1093,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_ParameterCompressedWe
         auto matmul = std::make_shared<ov::opset1::MatMul>(input, mul, false, false);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input, weights});
-        manager.register_pass<ConvertMatMulToFullyConnected>();
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);
     }
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{128, 2048});


### PR DESCRIPTION
This PR fixes compilation failure when shared weights feature (`ep.share_ep_contexts`) is enabled for models with non-transposed INT4 compressed weights. 

Main Ticket: [CVS-186154](https://jira.devtools.intel.com/browse/CVS-186154)
Subbyte Problem Ticket: [CVS-180701](https://jira.devtools.intel.com/browse/CVS-180701)

---

### Problem Description

When the shared weights feature is enabled, model weights are represented as `Parameter` nodes instead of `Constant` nodes. The `ConvertMatMulToFullyConnected` transformation inserts a runtime `Transpose` node to convert weights from `[K, N]` to `[N, K]` layout (required by the FC primitive's default transposed-weights assumption).

For constant weights, this transpose is folded at compile time. For parameter weights, it must execute at runtime, but the **GPU permute kernel does not support sub-byte data types (u4/i4)**, causing a compilation failure:

```
[GPU] Could not find a suitable kernel for transpose:Transpose_130977
params raw string: INT4_BFYX_v1_p0_0_v1_p0_0_v8192_p0_0_v2048_p0_0;INT4_BFYX_v1_p0_0_v1_p0_0_v2048_p0_0_v8192_p0_0
```

### Implemented Solution

Instead of transposing INT4 parameter weights at runtime, pass them directly in non-transposed layout (`[K, N]`) and let oneDNN handle this format natively via `format_tag::ab`. The infrastructure for `weights_transposed=false` already existed in the GPU plugin but was never triggered for compressed weights.

#### Main Changes

**1. `convert_matmul_to_fc.cpp`: Skip transpose for sub-byte parameter weights**

When sub-byte (`bitwidth < 8`, i.e. u4/i4) compressed weights originate from a `Parameter` node and the original `MatMul` has `transpose_b=false`, use the non-transposed FC path (`transpose_b=false`) instead of inserting a Transpose node. Byte-sized types (u8/i8) are unaffected — the GPU permute kernel handles them correctly.

**2. `fully_connected_onednn.cpp`: Fix decompression scale/zero-point dimension index**

The decompression scale group size calculation assumed weights are always in transposed layout `[N, K]`, using `get_dim(weight_rank - 1)` to find the IFM (K) dimension. For non-transposed weights `[K, N]`, K is at `get_dim(weight_rank - 2)`.

**3. `remote_tensor.cpp`: Enable sub-byte tensor copy for shared weights**

The remote tensor copy path rejected sub-byte types (i4/u4) with an assertion. When shared weights are copied to GPU memory, this blocked INT4 parameter weights. Added flat contiguous copy path for sub-byte types.

If we need more features for INT4 we can explore/reopen: CVS-180701, https://github.com/openvinotoolkit/openvino/pull/34751 - it contains ROI and strided layout support.

**4. `convert_matmul_to_fc_test.cpp`: Add minimal unit test**

Unit test to verify that sub-byte Parameter compressed weights (u4) skip the Transpose and produce FC with `transpose_b=false`.

### Reproduction Steps

A detailed description is available in the description section of the JIRA ticket: [CVS-186154](https://jira.devtools.intel.com/browse/CVS-186154).

### AI assistance:
> [!NOTE]  
> AI assistance used to implement fix and unit test. The generated code were verified for correctness, manually built, executed, and fixed as needed.