### PR TITLE
[GPU] Do not force usm_host output for producers feeding `assign`

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cpu/assign.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/assign.cpp
@@ -27,6 +27,11 @@ struct assign_impl : public typed_primitive_impl<assign> {
         set_node_params(outer);
     }
 
+    // assign's execute_impl runs memcpy from the input buffer into the variable's memory.
+    // It does not access the input on the host side,
+    // so the input primitive does not need to allocate its output in lockable (usm_host) memory.
+    bool requires_lockable_input() const override { return false; }
+
     void set_node_params(const program_node& arg) override {
         OPENVINO_ASSERT(arg.is_type<assign>());
         const auto& node = arg.as<assign>();

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -81,6 +81,13 @@ struct primitive_impl {
     // class typed_primitive_gpu_impl override this with return false;
     virtual bool is_cpu() const { return true; }
     virtual bool is_onednn() const { return false; }
+
+    // Whether this impl needs its inputs to be in host-accessible (lockable) memory.
+    // Defaults to is_cpu(), because CPU impls typically read/write tensor data from the host.
+    // Impls whose execute path only performs GPU-side USM operations (e.g. an enqueue_memcpy
+    // between USM buffers) or that never touch tensor data (e.g. shape_of) should override
+    // this to return false so their input producers are not forced to allocate lockable memory.
+    virtual bool requires_lockable_input() const { return is_cpu(); }
     virtual void init_kernels(const kernels_cache& kernels_cache, const kernel_impl_params& params) = 0;
     virtual void init_by_cached_kernels(const kernels_cache&, std::vector<std::string>& cached_kernel_ids) {}
     virtual std::vector<std::string> get_cached_kernel_ids(const kernels_cache&) { return {}; }

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -135,7 +135,11 @@ bool has_cpu_user_not_shape_of(const program_node* user) {
         return false;
     }
     if (auto impl = user->get_selected_impl())
-        return impl->is_cpu() && !user->is_type<shape_of>();
+        // Use requires_lockable_input() rather than is_cpu() directly. Some impls are
+        // registered as CPU but do not actually access their inputs from the host
+        // (e.g. assign, which only enqueues USM memcpy).
+        // Those impls opt out of forcing their producer into lockable memory.
+        return impl->requires_lockable_input() && !user->is_type<shape_of>();
     return false;
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/variable.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/variable.cpp
@@ -9,6 +9,7 @@
 #include "random_generator.hpp"
 #include "test_utils.h"
 
+#include <intel_gpu/primitives/activation.hpp>
 #include <intel_gpu/primitives/assign.hpp>
 #include <intel_gpu/primitives/data.hpp>
 #include <intel_gpu/primitives/eltwise.hpp>
@@ -404,4 +405,108 @@ TEST(variable_test_common, different_output_data_type_cached) {
 #endif
 TEST(variable_test_common, variables_are_preserved_across_inferences_cached) {
     test_variables_are_preserved_across_inferences<int>(true);
+}
+
+// A GPU primitive feeding directly into `assign` must not be forced into
+// lockable (usm_host) memory. The input does not need to be host-accessible.
+TEST(variable_test_common, assign_producer_output_is_not_lockable) {
+    auto& engine = get_test_engine();
+    if (!engine.get_device_info().supports_usm) {
+        GTEST_SKIP() << "USM not supported on this device";
+    }
+    if (!engine.supports_allocation(allocation_type::usm_device)) {
+        GTEST_SKIP() << "usm_device not supported on this device";
+    }
+
+    const layout var_layout{ov::PartialShape{1, 4}, data_types::f32, format::bfyx};
+    const auto input_data = engine.allocate_memory(var_layout);
+    set_values<float>(input_data, {1.0f, 2.0f, 3.0f, 4.0f});
+
+    topology t;
+    t.add(input_layout("input", var_layout));
+    t.add(read_value{"read_value", {input_info("input")}, "v0", {var_layout}});
+    // "producer" is a GPU eltwise. Its only user is `assign`, so we can observe
+    // whether the allocator forces its output into usm_host.
+    t.add(eltwise{"producer", {input_info("input"), input_info("read_value")},
+                  eltwise_mode::sum, {}, var_layout.data_type});
+    t.add(assign{"assign", {input_info("producer")}, "v0", var_layout});
+
+    cldnn::network::ptr net = get_network(engine, t, get_test_default_config(engine),
+                                          get_test_stream_ptr(), false);
+
+    auto context = std::make_shared<RemoteContextImpl>(
+        "GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
+    auto variable = std::make_shared<VariableState>(
+        VariableStateInfo{"v0", var_layout}, context, net->get_shape_predictor());
+    net->set_variable("v0", variable);
+    net->set_input_data("input", input_data);
+    net->execute();
+
+    // Impl-level contract: assign is handled by CPU impl
+    // but does not require a host-accessible input.
+    auto assign_inst = net->get_primitive("assign");
+    ASSERT_NE(assign_inst->get_impl(), nullptr);
+    EXPECT_TRUE(assign_inst->get_impl()->is_cpu());
+    EXPECT_FALSE(assign_inst->get_impl()->requires_lockable_input());
+
+    // Check proper memory allocation
+    auto producer_inst = net->get_primitive("producer");
+    ASSERT_NE(producer_inst->output_memory_ptr(), nullptr);
+    EXPECT_NE(producer_inst->output_memory_ptr()->get_allocation_type(),
+              allocation_type::usm_host)
+        << "Producer output was forced into usm_host by `assign` user. "
+           "assign_impl::requires_lockable_input() should be false so the producer "
+           "can stay in device memory.";
+}
+
+// ---------------------------------------------------------------------------
+// Negative control: when the downstream user is a *real* CPU impl that reads
+// tensor data on the host, the producer output must still be allocated in
+// lockable memory. This guards against over-widening the requires_lockable_input()
+// opt-out in the future.
+// ---------------------------------------------------------------------------
+TEST(variable_test_common, real_cpu_user_still_forces_lockable) {
+    auto& engine = get_test_engine();
+    if (!engine.get_device_info().supports_usm) {
+        GTEST_SKIP() << "USM not supported on this device";
+    }
+    // On integrated devices the lockable and non-lockable USM types may
+    // coincide, making this control assertion meaningless.
+    if (engine.get_device_info().dev_type != device_type::discrete_gpu) {
+        GTEST_SKIP() << "Only meaningful on dGPU where lockable != device USM";
+    }
+
+    const layout in_layout{ov::PartialShape{1, 4}, data_types::f32, format::bfyx};
+    const auto input_data = engine.allocate_memory(in_layout);
+    set_values<float>(input_data, {1.0f, 2.0f, 3.0f, 4.0f});
+
+    topology t;
+    t.add(input_layout("input", in_layout));
+    t.add(eltwise{"producer", {input_info("input"), input_info("input")},
+                  eltwise_mode::sum, {}, in_layout.data_type});
+    // Force the activation user onto the CPU impl. CPU activation reads and
+    // writes tensor data on the host, so it truly requires lockable input.
+    t.add(activation{"consumer", input_info("producer"), activation_func::relu});
+
+    ExecutionConfig config = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc cpu_activation_impl = {format::bfyx, "", impl_types::cpu};
+    config.set_property(ov::intel_gpu::force_implementations(
+        ov::intel_gpu::ImplForcingMap{{"consumer", cpu_activation_impl}}));
+
+    cldnn::network::ptr net = get_network(engine, t, config, get_test_stream_ptr(), false);
+    net->set_input_data("input", input_data);
+    net->execute();
+
+    auto consumer_inst = net->get_primitive("consumer");
+    ASSERT_NE(consumer_inst->get_impl(), nullptr);
+    // Sanity: the forced CPU activation impl reports itself correctly.
+    EXPECT_TRUE(consumer_inst->get_impl()->is_cpu());
+    EXPECT_TRUE(consumer_inst->get_impl()->requires_lockable_input());
+
+    auto producer_inst = net->get_primitive("producer");
+    ASSERT_NE(producer_inst->output_memory_ptr(), nullptr);
+    EXPECT_EQ(producer_inst->output_memory_ptr()->get_allocation_type(),
+              allocation_type::usm_host)
+        << "Producer output should be lockable (usm_host on dGPU) when the "
+           "downstream user is a real CPU impl that reads tensor data on the host.";
 }


### PR DESCRIPTION
### Symptom:
* In a qwen3.6 model, `strided_slice_ref` and `gated_delta_net_ref` (whose outputs is connected to `assign`) were very slow on dGPU
* It is because `strided_slice` and `gated_delta_net` chose output buffer as usm_host because it is connected to `assign`

### Description:
* `assign_impl` is registered as impl_types::cpu but it never touches the input on the host. The lockable-memory heuristics in `primitive_inst::has_cpu_user_not_shape_of()` however checked `is_cpu()` directly, so on dGPU the producer feeding `assign` was chosen to use usm_host.
* It does not happen on SDPA primitive because kv-cache fuses `assign` too.
* If backend is chosen as PA, the pattern disappears. So there is no issue in PA backend.

### Fix: add `primitive_impl::requires_lockable_input()`
  * default is `is_cpu()`
  * override it to `false` in `assign_impl`
  * `has_cpu_user_not_shape_of` uses `requires_lockable_input` instead of `is_cpu`

### Tickets:
 - 190711, 190712

### AI Assistance:
 - *AI assistance used: yes*
 - Build, test, code review were done by human
