### PR TITLE
ci: ensure docs build uses required CMake

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -146,6 +146,28 @@ jobs:
           (cd ${OPENVINO_REPO}/docs/openvino_sphinx_theme && python3 -m pip install .)
           python3 -m pip install ${OPENVINO_REPO}/docs/openvino_custom_sphinx_sitemap
 
+      - name: Ensure required CMake version
+        run: |
+          python3 - <<'PY'
+          import re
+          import subprocess
+          import sys
+
+          required = (3, 26, 0)
+
+          try:
+              output = subprocess.check_output(["cmake", "--version"], text=True)
+          except (FileNotFoundError, subprocess.CalledProcessError):
+              current = None
+          else:
+              match = re.search(r"version\s+(\d+)\.(\d+)\.(\d+)", output)
+              current = tuple(map(int, match.groups())) if match else None
+
+          if current is None or current < required:
+              subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "cmake==3.26.4"])
+          PY
+          cmake --version
+
       - name: Validate benchmarks files
         run: python3 ${OPENVINO_REPO}/docs/scripts/tests/validate_benchmarks.py ${OPENVINO_REPO}/docs/sphinx_setup/_static/benchmarks_files/
 


### PR DESCRIPTION
### Details:
OpenVINO now requires CMake 3.26 or newer, but the online Documentation workflow can fail before the docs build if the runner image exposes an older cmake executable, such as 3.18.0. The top-level CMake requirement is already correct, so lowering it would only hide the real environment problem.

Add a guard in the docs workflow after Python dependencies are installed and before the CMake configure step. The guard checks the visible cmake version, installs the pinned cmake==3.26.4 wheel only when cmake is missing or older than 3.26, and prints the final cmake version to make future failures easier to diagnose.

This fixes the GitHub Documentation workflow path that runs .github/workflows/build_doc.yml. It does not change other publication systems or external docs builders; if an online docs job bypasses this workflow, that environment still needs its own CMake update.

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: yes*
 - *Used AI to troubleshoot and come up with a solution. Tested that docs build correctly.*
