### PR TITLE
Fix resource leak in test_read_model_from_tensor

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_core.py
+++ b/src/bindings/python/tests/test_runtime/test_core.py
@@ -169,7 +169,8 @@ def test_read_model_from_tensor(request, tmp_path):
     serialize(relu_model, xml_path, bin_path)
     arr = np.ones(shape=(10), dtype=np.int8)
     arr.tofile(bin_path)
-    model = open(xml_path).read()
+    with open(xml_path) as f:
+        model = f.read()
     tensor = tensor_from_file(bin_path)
     model = core.read_model(model=model, weights=tensor)
     assert isinstance(model, Model)


### PR DESCRIPTION
## Motivation

In `test_read_model_from_tensor`, `open(xml_path).read()` opens a file without using a context manager, which can leak a file descriptor if an exception occurs between `open()` and the implicit close.

## Changes

Replace `model = open(xml_path).read()` with a `with` statement to ensure the file handle is properly closed after reading:

```python
with open(xml_path) as f:
    model = f.read()
```

## Testing

This is a defensive resource management improvement that does not change functional behavior. The existing test logic remains identical.
