### PR TITLE
[GPU] Enable RMS fusion to match RMS without gamma

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/rms_fusion.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/rms_fusion.hpp
@@ -30,7 +30,7 @@ namespace pass {
 class RMSFusion : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("RMSFusion");
-    RMSFusion(bool force_tail_convert = true, bool enable_div_x = false, bool enable_without_gamma = false);
+    RMSFusion(bool force_tail_convert = true, bool enable_without_gamma = false);
 };
 
 }  // namespace pass

--- a/src/common/transformations/include/transformations/common_optimizations/rms_fusion.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/rms_fusion.hpp
@@ -4,34 +4,29 @@
 
 #pragma once
 
-#include "openvino/pass/manager.hpp"
+#include "openvino/pass/backward_graph_rewrite.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "transformations_visibility.hpp"
 
 namespace ov {
 namespace pass {
 
+class TRANSFORMATIONS_API RMSFusionMatcher;
 class TRANSFORMATIONS_API RMSFusion;
 
 }  // namespace pass
 }  // namespace ov
 
-namespace ov {
-namespace pass {
-
-class TRANSFORMATIONS_API RMSFusion;
-
-}  // namespace pass
-}  // namespace ov
-
-namespace ov {
-namespace pass {
-
-class RMSFusion : public ov::pass::MatcherPass {
+class ov::pass::RMSFusionMatcher : public ov::pass::MatcherPass {
 public:
-    OPENVINO_MATCHER_PASS_RTTI("RMSFusion");
-    RMSFusion(bool force_tail_convert = true, bool enable_without_gamma = false);
+    OPENVINO_MATCHER_PASS_RTTI("RMSFusionMatcher");
+    RMSFusionMatcher(bool force_tail_convert = true, bool enable_without_gamma = false);
 };
 
-}  // namespace pass
-}  // namespace ov
+class ov::pass::RMSFusion : public ov::pass::BackwardGraphRewrite {
+public:
+    OPENVINO_GRAPH_REWRITE_RTTI("RMSFusion");
+    RMSFusion(bool force_tail_convert = true, bool enable_without_gamma = false) {
+        add_matcher<RMSFusionMatcher>(force_tail_convert, enable_without_gamma);
+    }
+};

--- a/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
@@ -141,6 +141,14 @@ RMSFusion::RMSFusion(bool force_tail_convert, bool enable_div_x, bool enable_wit
         auto mul_or_div_node = pattern_map.at(mul_or_div).get_node_shared_ptr();
         bool elementwise_affine = pattern_map.count(mul_with_gamma);
 
+        // Avoid partial fusion (fusing without gamma) when gamma Multiply follows
+        if (!elementwise_affine && m.get_match_root() == mul_or_div_node) {
+            for (auto& target : mul_or_div_node->output(0).get_target_inputs()) {
+                if (ov::is_type<v1::Multiply>(target.get_node()))
+                    return false;
+            }
+        }
+
         std::shared_ptr<ov::Node> gamma_node;
         if (elementwise_affine) {
             gamma_node = pattern_map.at(gamma).get_node_shared_ptr();

--- a/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
@@ -28,7 +28,7 @@ namespace op_util = ov::op::util;
 
 namespace ov::pass {
 
-RMSFusion::RMSFusion(bool force_tail_convert, bool enable_div_x, bool enable_without_gamma) {
+RMSFusion::RMSFusion(bool force_tail_convert, bool enable_without_gamma) {
     // Detect RMS decomposition pattern
     //  x * 1/Sqrt(ReduceMean(x^2,axes)+eps) * gamma
     auto x = pattern::any_input();
@@ -87,15 +87,9 @@ RMSFusion::RMSFusion(bool force_tail_convert, bool enable_div_x, bool enable_wit
     // x * 1/Sqrt(ReduceMean(x^2,axes)+eps)
     auto mul1 = pattern::wrap_type<v1::Multiply>({x, div_or_pow});
 
-    std::shared_ptr<pattern::op::Or> mul_or_div;
-    // TODO: Check div_x pattern failed in CPU CI Pytorch layer test.
-    if (enable_div_x) {
-        // x / Sqrt(ReduceMean(x^2,axes)+eps)
-        auto div_x = pattern::wrap_type<v1::Divide>({x, sqrt});
-        mul_or_div = std::make_shared<pattern::op::Or>(OutputVector{mul1, div_x});
-    } else {
-        mul_or_div = std::make_shared<pattern::op::Or>(OutputVector{mul1});
-    }
+    // x / Sqrt(ReduceMean(x^2,axes)+eps)
+    auto div_x = pattern::wrap_type<v1::Divide>({x, sqrt});
+    auto mul_or_div = std::make_shared<pattern::op::Or>(OutputVector{mul1, div_x});
 
     // Pattern 1: RMS with gamma (learnable parameter)
     // x * 1/Sqrt(ReduceMean(x^2,axes)+eps) * gamma (gamma is constant)

--- a/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
@@ -91,24 +91,19 @@ RMSFusion::RMSFusion(bool force_tail_convert, bool enable_without_gamma) {
     auto div_x = pattern::wrap_type<v1::Divide>({x, sqrt});
     auto mul_or_div = std::make_shared<pattern::op::Or>(OutputVector{mul1, div_x});
 
-    // Pattern 1: RMS with gamma (learnable parameter)
     // x * 1/Sqrt(ReduceMean(x^2,axes)+eps) * gamma (gamma is constant)
     auto gamma = pattern::wrap_type<v0::Constant>();
     auto gamma_convert = pattern::optional<v0::Convert>(gamma);
-    auto mul_with_gamma = pattern::wrap_type<v1::Multiply>({gamma_convert, mul_or_div});
 
     std::shared_ptr<ov::Node> rms_mul;
     if (enable_without_gamma) {
-        // Pattern 2: RMS without gamma, but multiplied with dynamic input
-        // RMS(x) * scale where scale is non-constant (e.g., gate, activation, residual)
-        // This allows partial fusion: only fuse up to mul_or_div
-        auto scale = pattern::any_input(pattern::class_other_than<v0::Constant>());
-        auto mul_with_scale = pattern::wrap_type<v1::Multiply>({mul_or_div, scale});
-        // Pattern 3: RMS without gamma (unit normalization, e.g. Gemma v_norm)
-        // x * 1/Sqrt(ReduceMean(x^2,axes)+eps) — no trailing Multiply
-        rms_mul = std::make_shared<pattern::op::Or>(OutputVector{mul_with_gamma, mul_with_scale, mul_or_div});
+        // When enable_without_gamma is true, the trailing gamma Multiply is optional:
+        // - If present (gamma is Constant): fuse gamma into RMS
+        // - If absent: create RMS without gamma (e.g., Gemma v_norm, LTX-Video)
+        // Requires BackwardGraphRewrite to ensure gamma Multiply is visited first.
+        rms_mul = pattern::optional<v1::Multiply>({mul_or_div, gamma_convert});
     } else {
-        rms_mul = mul_with_gamma;
+        rms_mul = pattern::wrap_type<v1::Multiply>({gamma_convert, mul_or_div});
     }
 
     std::shared_ptr<ov::Node> comp = rms_mul;
@@ -133,15 +128,7 @@ RMSFusion::RMSFusion(bool force_tail_convert, bool enable_without_gamma) {
         }
 
         auto mul_or_div_node = pattern_map.at(mul_or_div).get_node_shared_ptr();
-        bool elementwise_affine = pattern_map.count(mul_with_gamma);
-
-        // Avoid partial fusion (fusing without gamma) when gamma Multiply follows
-        if (!elementwise_affine && m.get_match_root() == mul_or_div_node) {
-            for (auto& target : mul_or_div_node->output(0).get_target_inputs()) {
-                if (ov::is_type<v1::Multiply>(target.get_node()))
-                    return false;
-            }
-        }
+        bool elementwise_affine = pattern_map.count(rms_mul);
 
         std::shared_ptr<ov::Node> gamma_node;
         if (elementwise_affine) {
@@ -172,14 +159,7 @@ RMSFusion::RMSFusion(bool force_tail_convert, bool enable_without_gamma) {
             ov::replace_node(m.get_match_root(), rms);
         } else {
             rms->set_friendly_name(mul_or_div_node->get_friendly_name());
-            NodeVector nodes_to_fuse;
-            auto mul_with_scale_node = m.get_match_root();
-            for (const auto& matched_node : m.get_matched_nodes()) {
-                if (matched_node != mul_with_scale_node) {
-                    nodes_to_fuse.push_back(matched_node);
-                }
-            }
-            ov::copy_runtime_info(nodes_to_fuse, rms);
+            ov::copy_runtime_info(m.get_matched_nodes(), rms);
             ov::replace_node(mul_or_div_node, rms);
         }
 

--- a/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
@@ -188,5 +188,4 @@ RMSFusion::RMSFusion(bool force_tail_convert, bool enable_div_x, bool enable_wit
     this->register_matcher(m, callback);
 }
 
-
 }  // namespace ov::pass

--- a/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
@@ -110,7 +110,9 @@ RMSFusion::RMSFusion(bool force_tail_convert, bool enable_div_x, bool enable_wit
         // This allows partial fusion: only fuse up to mul_or_div
         auto scale = pattern::any_input(pattern::class_other_than<v0::Constant>());
         auto mul_with_scale = pattern::wrap_type<v1::Multiply>({mul_or_div, scale});
-        rms_mul = std::make_shared<pattern::op::Or>(OutputVector{mul_with_gamma, mul_with_scale});
+        // Pattern 3: RMS without gamma (unit normalization, e.g. Gemma v_norm)
+        // x * 1/Sqrt(ReduceMean(x^2,axes)+eps) — no trailing Multiply
+        rms_mul = std::make_shared<pattern::op::Or>(OutputVector{mul_with_gamma, mul_with_scale, mul_or_div});
     } else {
         rms_mul = mul_with_gamma;
     }
@@ -185,5 +187,6 @@ RMSFusion::RMSFusion(bool force_tail_convert, bool enable_div_x, bool enable_wit
     auto m = std::make_shared<pattern::Matcher>(comp, "RMSFusion");
     this->register_matcher(m, callback);
 }
+
 
 }  // namespace ov::pass

--- a/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
@@ -28,7 +28,7 @@ namespace op_util = ov::op::util;
 
 namespace ov::pass {
 
-RMSFusion::RMSFusion(bool force_tail_convert, bool enable_without_gamma) {
+RMSFusionMatcher::RMSFusionMatcher(bool force_tail_convert, bool enable_without_gamma) {
     // Detect RMS decomposition pattern
     //  x * 1/Sqrt(ReduceMean(x^2,axes)+eps) * gamma
     auto x = pattern::any_input();

--- a/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
@@ -667,3 +667,28 @@ TEST_F(TransformationTestsF, RMSNormFusionTest19_MulSquare_NoGamma_DynamicScale)
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
+
+// Power(-0.5) direct path without gamma, no trailing Multiply (unit normalization)
+TEST_F(TransformationTestsF, RMSNormFusionTest20_PowerNegHalf_NoGamma) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 8, 256});
+        auto power_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {2.f});
+        auto power = std::make_shared<ov::op::v1::Power>(input, power_const);
+        auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+        auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
+        auto eps = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1e-6f});
+        auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps);
+        auto neg_half = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {-0.5f});
+        auto rsqrt = std::make_shared<ov::op::v1::Power>(add_eps, neg_half);
+        auto mul = std::make_shared<ov::op::v1::Multiply>(input, rsqrt);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
+        manager.register_pass<RMSFusion>(false, true, true);
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 8, 256});
+        auto rms = std::make_shared<ov::op::internal::RMS>(input, 1e-6f, ov::element::f32);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
+}

--- a/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
@@ -273,7 +273,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest8) {
         auto comp = std::make_shared<ov::op::v0::Convert>(mul, ov::element::f16);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{comp}, ov::ParameterVector{input});
-        manager.register_pass<RMSFusion>(true, true);
+        manager.register_pass<RMSFusion>(true);
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 6});
@@ -307,7 +307,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest9) {
         auto mul = std::make_shared<ov::op::v1::Multiply>(gamma, div);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
-        manager.register_pass<RMSFusion>(false, true);
+        manager.register_pass<RMSFusion>(false);
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 6});
@@ -342,7 +342,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest10) {
         auto mul2 = std::make_shared<ov::op::v1::Multiply>(mul1, scale);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input, scale});
-        manager.register_pass<RMSFusion>(false, false, true);
+        manager.register_pass<RMSFusion>(false, true);
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 6});
@@ -374,7 +374,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest11) {
         auto mul2 = std::make_shared<ov::op::v1::Multiply>(mul1, scale);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input, scale});
-        manager.register_pass<RMSFusion>(false, false, true);
+        manager.register_pass<RMSFusion>(false, true);
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
@@ -517,7 +517,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest15_PowerNegHalf_NoGammaScale) {
         auto mul2 = std::make_shared<ov::op::v1::Multiply>(mul1, scale);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input, scale});
-        manager.register_pass<RMSFusion>(false, false, true);
+        manager.register_pass<RMSFusion>(false, true);
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 6});
@@ -655,7 +655,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest19_MulSquare_NoGamma_DynamicScale)
         auto mul2 = std::make_shared<ov::op::v1::Multiply>(mul1, scale);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input, scale});
-        manager.register_pass<RMSFusion>(false, false, true);
+        manager.register_pass<RMSFusion>(false, true);
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, 2048});
@@ -683,7 +683,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest20_PowerNegHalf_NoGamma) {
         auto mul = std::make_shared<ov::op::v1::Multiply>(input, rsqrt);
 
         model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
-        manager.register_pass<RMSFusion>(false, true, true);
+        manager.register_pass<RMSFusion>(false, true);
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 8, 256});

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -748,7 +748,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             const int32_t vec_size = 8;
             return static_cast<int32_t>((gamma_shape.back() / vec_size)) > static_cast<int32_t>(device_info.max_work_group_size);
         });
-        manager.register_pass<ov::pass::RMSFusion>(false, true, true);
+        manager.register_pass<ov::pass::RMSFusion>(false, true);
         manager.register_pass<DisableFP16CompForGemma3RMSPattern>();
         manager.register_pass<DisableFP16ComForGPTOSSROPEPattern>();
         manager.register_pass<DisableFP16CompCumSumSinGen>();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -741,7 +741,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             return !is_decompression_multiply(node, device_info.supports_immad);
         });
 
-        pass_config->set_callback<ov::pass::RMSFusion>([OV_CAPTURE_CPY_AND_THIS](const_node_ptr& root) -> bool {
+        pass_config->set_callback<ov::pass::RMSFusionMatcher>([OV_CAPTURE_CPY_AND_THIS](const_node_ptr& root) -> bool {
             if (!root->get_input_partial_shape(0).is_static()) {
                 return false;
             }
@@ -749,8 +749,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             const int32_t vec_size = 8;
             return static_cast<int32_t>((gamma_shape.back() / vec_size)) > static_cast<int32_t>(device_info.max_work_group_size);
         });
-        auto rms_backward = manager.register_pass<ov::pass::BackwardGraphRewrite>();
-        rms_backward->add_matcher<ov::pass::RMSFusion>(false, true);
+        manager.register_pass<ov::pass::RMSFusion>(false, true);
         manager.register_pass<DisableFP16CompForGemma3RMSPattern>();
         manager.register_pass<DisableFP16ComForGPTOSSROPEPattern>();
         manager.register_pass<DisableFP16CompCumSumSinGen>();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -74,6 +74,7 @@
 #include "openvino/op/util/sub_graph_base.hpp"
 #include "openvino/opsets/opset1_decl.hpp"
 #include "openvino/opsets/opset10_decl.hpp"
+#include "openvino/pass/backward_graph_rewrite.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/sdpa_to_vlsdpa.hpp"
@@ -748,7 +749,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             const int32_t vec_size = 8;
             return static_cast<int32_t>((gamma_shape.back() / vec_size)) > static_cast<int32_t>(device_info.max_work_group_size);
         });
-        manager.register_pass<ov::pass::RMSFusion>(false, true);
+        auto rms_backward = manager.register_pass<ov::pass::BackwardGraphRewrite>();
+        rms_backward->add_matcher<ov::pass::RMSFusion>(false, true);
         manager.register_pass<DisableFP16CompForGemma3RMSPattern>();
         manager.register_pass<DisableFP16ComForGPTOSSROPEPattern>();
         manager.register_pass<DisableFP16CompCumSumSinGen>();


### PR DESCRIPTION
### Problem:
Gemma4 model uses unit normalization (v_norm) that applies RMS normalization without a learnable gamma parameter: `x * 1/Sqrt(ReduceMean(x^2, axes) + eps)`. This pattern was not matched by the existing RMSFusion pass, which required a trailing Multiply with gamma.

### Solution:
Extend the existing RMSFusion pass with a third pattern branch (mul_or_div as terminal node in the Or pattern:`(x * rsqrt(mean(x^2) + eps))` without a trailing gamma multiply) to match RMS without gamma.


### Tickets:
 - *CVS-190918*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
