### PR TITLE
[GPU] Enable DynamicQuantize  sharing to reduce redundant quantization

### DIFF
--- a/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
@@ -37,7 +37,16 @@ static bool should_skip_execution(const dynamic_quantize_node& node, const layou
         input_batch = act_layout.batch() * act_layout.feature();
     }
 
-    if (node.get_program().get_config().get_dynamic_quantization_threshold() >= input_batch) {
+    for (auto& user : node.get_users()) {
+        auto& fc_user = user->as<fully_connected>();
+        if (!can_skip_for_fully_connected(node, fc_user, act_layout, input_batch)) {
+            GPU_DEBUG_TRACE << node.id() << "  dyn_quan is not runtime-skipped: no equivalent FC fast path" << std::endl;
+            return false;
+        }
+    }
+
+    const auto dynamic_quantization_threshold = node.get_program().get_config().get_dynamic_quantization_threshold();
+    if (dynamic_quantization_threshold != 0 && dynamic_quantization_threshold >= input_batch) {
         GPU_DEBUG_TRACE << node.id() << "  dyn_quan is turned off: input batch size is too small - " << input_batch << " / "
                         << node.get_program().get_config().get_dynamic_quantization_threshold() << std::endl;
         return true;

--- a/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
@@ -24,11 +24,11 @@ static bool should_skip_execution(const dynamic_quantize_node& node, const layou
         || !act_layout.is_static())
         return false;
 
-    // Do not skip dynamic quantization if next node is not fully connected.(such as SDPA)
-    OPENVINO_ASSERT(node.get_users().size() == node.get_outputs_count(),
-                    "Dynamic quantization is supposed to have only one user-node with duplicated connection: ", node.id());
-    if (!(*node.get_users().begin())->is_type<fully_connected>())
-        return false;
+    // Do not skip dynamic quantization if any user node is not fully connected.(such as SDPA)
+    for (auto& user : node.get_users()) {
+        if (!user->is_type<fully_connected>())
+            return false;
+    }
 
     // If batch size is 1, dynamic_quantize is disabled for performance reason
     size_t input_batch = act_layout.batch();

--- a/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
@@ -37,16 +37,7 @@ static bool should_skip_execution(const dynamic_quantize_node& node, const layou
         input_batch = act_layout.batch() * act_layout.feature();
     }
 
-    for (auto& user : node.get_users()) {
-        auto& fc_user = user->as<fully_connected>();
-        if (!can_skip_for_fully_connected(node, fc_user, act_layout, input_batch)) {
-            GPU_DEBUG_TRACE << node.id() << "  dyn_quan is not runtime-skipped: no equivalent FC fast path" << std::endl;
-            return false;
-        }
-    }
-
-    const auto dynamic_quantization_threshold = node.get_program().get_config().get_dynamic_quantization_threshold();
-    if (dynamic_quantization_threshold != 0 && dynamic_quantization_threshold >= input_batch) {
+    if (node.get_program().get_config().get_dynamic_quantization_threshold() >= input_batch) {
         GPU_DEBUG_TRACE << node.id() << "  dyn_quan is turned off: input batch size is too small - " << input_batch << " / "
                         << node.get_program().get_config().get_dynamic_quantization_threshold() << std::endl;
         return true;

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1785,6 +1785,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             }
         }
 
+        // Deduplicate identical DynamicQuantize nodes sharing same input
+        manager.register_pass<ov::pass::SharedOpOptimization>();
+
         // Remove Pad in front of MaxPool if both the pads_begin and pads_end are zero.
         manager.register_pass<ov::pass::EliminatePad>();
 

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1782,11 +1782,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                                                                                     precomputed_reduction,
                                                                                     use_gs128_for_int8_per_token,
                                                                                     use_gs128_for_linear_attention);
+                // Deduplicate identical DynamicQuantize nodes sharing same input
+                manager.register_pass<ov::pass::SharedOpOptimization>();
             }
         }
-
-        // Deduplicate identical DynamicQuantize nodes sharing same input
-        manager.register_pass<ov::pass::SharedOpOptimization>();
 
         // Remove Pad in front of MaxPool if both the pads_begin and pads_end are zero.
         manager.register_pass<ov::pass::EliminatePad>();

--- a/src/plugins/intel_gpu/tests/unit/transformations/dynamic_quantize_sharing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/dynamic_quantize_sharing_test.cpp
@@ -6,6 +6,7 @@
 #include "common_test_utils/ov_test_utils.hpp"
 
 #include "openvino/core/model.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/result.hpp"
 #include "openvino/pass/manager.hpp"

--- a/src/plugins/intel_gpu/tests/unit/transformations/dynamic_quantize_sharing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/dynamic_quantize_sharing_test.cpp
@@ -1,0 +1,160 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+#include "common_test_utils/ov_test_utils.hpp"
+
+#include "openvino/core/model.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/pass/manager.hpp"
+
+#include "intel_gpu/op/fully_connected_compressed.hpp"
+#include "intel_gpu/op/placeholder.hpp"
+#include "ov_ops/dynamic_quantize.hpp"
+#include "transformations/common_optimizations/shared_ops_optimization.hpp"
+
+using namespace testing;
+using namespace ov::intel_gpu;
+
+namespace ov {
+namespace test {
+namespace intel_gpu {
+
+using DynamicQuantize = ov::op::internal::DynamicQuantize;
+
+static DynamicQuantize::Attributes make_dq_attrs(uint64_t group_size, size_t input_rank = 3) {
+    DynamicQuantize::Attributes attrs;
+    attrs.quantization_type = DynamicQuantize::QuantizationType::Symmetric;
+    attrs.quantization_dt = ov::element::i8;
+    attrs.scale_dt = ov::element::f16;
+    attrs.zp_dt = ov::element::dynamic;
+    attrs.output_storage_type = DynamicQuantize::OutputStorageType::Planar;
+    attrs.group_sizes = std::vector<uint64_t>(input_rank, 1);
+    attrs.group_sizes.back() = group_size;
+    return attrs;
+}
+
+// 2 identical DQ nodes sharing same input merged into 1
+TEST_F(TransformationTestsF, DynamicQuantizeSharing_TwoConsumers) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, -1, 4096});
+        auto weight1 = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+        auto weight2 = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+        auto scale1 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 64});
+        auto scale2 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 64});
+        auto bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+
+        auto dq_attrs = make_dq_attrs(64);
+        auto dq1 = std::make_shared<DynamicQuantize>(input, dq_attrs);
+        auto dq2 = std::make_shared<DynamicQuantize>(input, dq_attrs);
+
+        auto fc1 = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq1->output(0), weight1, bias, scale1);
+        auto fc2 = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq2->output(0), weight2, bias, scale2);
+
+        auto result1 = std::make_shared<ov::op::v0::Result>(fc1);
+        auto result2 = std::make_shared<ov::op::v0::Result>(fc2);
+        model = std::make_shared<ov::Model>(ov::ResultVector{result1, result2}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::SharedOpOptimization>();
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, -1, 4096});
+        auto weight1 = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+        auto weight2 = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+        auto scale1 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 64});
+        auto scale2 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 64});
+        auto bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+
+        auto dq_attrs = make_dq_attrs(64);
+        auto dq_shared = std::make_shared<DynamicQuantize>(input, dq_attrs);
+
+        auto fc1 = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq_shared->output(0), weight1, bias, scale1);
+        auto fc2 = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq_shared->output(0), weight2, bias, scale2);
+
+        auto result1 = std::make_shared<ov::op::v0::Result>(fc1);
+        auto result2 = std::make_shared<ov::op::v0::Result>(fc2);
+        model_ref = std::make_shared<ov::Model>(ov::ResultVector{result1, result2}, ov::ParameterVector{input});
+    }
+}
+
+// 5 identical DQ nodes sharing same input merged into 1
+TEST_F(TransformationTestsF, DynamicQuantizeSharing_FiveConsumers) {
+    const size_t num_consumers = 5;
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, -1, 4096});
+        auto bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto dq_attrs = make_dq_attrs(64);
+
+        ov::ResultVector results;
+        for (size_t i = 0; i < num_consumers; i++) {
+            auto weight = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+            auto scale = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 64});
+            auto dq = std::make_shared<DynamicQuantize>(input, dq_attrs);
+            auto fc = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq->output(0), weight, bias, scale);
+            results.push_back(std::make_shared<ov::op::v0::Result>(fc));
+        }
+        model = std::make_shared<ov::Model>(results, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::SharedOpOptimization>();
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, -1, 4096});
+        auto bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto dq_attrs = make_dq_attrs(64);
+        auto dq_shared = std::make_shared<DynamicQuantize>(input, dq_attrs);
+
+        ov::ResultVector results;
+        for (size_t i = 0; i < num_consumers; i++) {
+            auto weight = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+            auto scale = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 64});
+            auto fc = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq_shared->output(0), weight, bias, scale);
+            results.push_back(std::make_shared<ov::op::v0::Result>(fc));
+        }
+        model_ref = std::make_shared<ov::Model>(results, ov::ParameterVector{input});
+    }
+}
+
+// DQ nodes with different group sizes should NOT be merged
+TEST_F(TransformationTestsF, DynamicQuantizeSharing_DifferentGroupSize_NoMerge) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, -1, 4096});
+        auto weight1 = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+        auto weight2 = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+        auto scale1 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 64});
+        auto scale2 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 32});
+        auto bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+
+        auto dq1 = std::make_shared<DynamicQuantize>(input, make_dq_attrs(64));
+        auto dq2 = std::make_shared<DynamicQuantize>(input, make_dq_attrs(128));
+
+        auto fc1 = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq1->output(0), weight1, bias, scale1);
+        auto fc2 = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq2->output(0), weight2, bias, scale2);
+
+        auto result1 = std::make_shared<ov::op::v0::Result>(fc1);
+        auto result2 = std::make_shared<ov::op::v0::Result>(fc2);
+        model = std::make_shared<ov::Model>(ov::ResultVector{result1, result2}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::SharedOpOptimization>();
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, -1, 4096});
+        auto weight1 = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+        auto weight2 = std::make_shared<ov::op::v0::Constant>(ov::element::u4, ov::Shape{1024, 4096});
+        auto scale1 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 64});
+        auto scale2 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1024, 32});
+        auto bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+
+        auto dq1 = std::make_shared<DynamicQuantize>(input, make_dq_attrs(64));
+        auto dq2 = std::make_shared<DynamicQuantize>(input, make_dq_attrs(128));
+
+        auto fc1 = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq1->output(0), weight1, bias, scale1);
+        auto fc2 = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(dq2->output(0), weight2, bias, scale2);
+
+        auto result1 = std::make_shared<ov::op::v0::Result>(fc1);
+        auto result2 = std::make_shared<ov::op::v0::Result>(fc2);
+        model_ref = std::make_shared<ov::Model>(ov::ResultVector{result1, result2}, ov::ParameterVector{input});
+    }
+}
+
+}  // namespace intel_gpu
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Problem
When DynamicQuantize (DQ) nodes are inserted before FullyConnected operations during GPU plugin graph optimization, identical DQ nodes with the same input are created independently for each FC consumer. This results in redundant quantization computation and increased graph complexity.
### Solution
Register SharedOpOptimization after DynamicQuantize insertion to deduplicate identical DQ nodes sharing the same input. Relax single-user assertion in dynamic_quantize graph node to allow shared consumers. 

<img width="849" height="403" alt="image" src="https://github.com/user-attachments/assets/9b1fc955-cc2c-4f27-a29a-6cd0db7ef7e5" />

#### Gemma-4-26B-A4B-it
- 156 DQ nodes -> 121 DQ nodes (35 eliminated, ~22% reduction)
 - gate+up FC sharing: 30 pairs across all 30 layers (gate_proj and up_proj share the same FFN input after RMS normalization)
 - Q+K FC sharing: 5 pairs in sliding window layers (L5, L11, L17, L23, L29 have separate Q/K FCs sharing the same attention input)
#### SD3.5 large
Model | DQ Sharing OFF | DQ Sharing ON | Reduced
-- | -- | -- | --
0   (text encoder) | 98 | 98 | 0
1   (text encoder) | 258 | 258 | 0
2 | 240 | 192 | 48
3   (transformer) | 768 | 616 | 152
4   (decoder) | 8 | 4 | 4
Total | 1372 | 1168 | 204


### Tickets:
 - *CVS-166834*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
