### PR TITLE
[GPU] Enable sub-group cooperative DynamicQuantize for GS=64

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_opt.cl
@@ -46,124 +46,8 @@
 
 
 // ***********************************************
-#if DYNAMIC_QUANTIZAION_IMPL_MODE == MODE_SMALL_GS_SG
+#if DYNAMIC_QUANTIZAION_IMPL_MODE == MODE_SMALL_GS
 // ***********************************************
-// Sub-group cooperative version: SIMD threads process one quantization group together.
-// Each thread reads QUANTIZE_GROUP_SIZE/SIMD elements, uses sub_group_reduce_max.
-
-#if ASYMMETRIC_QUANTIZATION
-#error "UNIMPLMENTED: asymmetric quantization when group size is small (SG mode)"
-#endif
-
-#define ELEMS_PER_THREAD (QUANTIZE_GROUP_SIZE / SIMD)
-
-REQD_SUB_GROUP_SIZE(SIMD)
-KERNEL(dynamic_quantize_gpu_opt)(
-    OPTIONAL_SHAPE_INFO_ARG
-    const __global INPUT0_TYPE* input,
-    __global OUTPUT_TYPE* output,
-    __global OUTPUT1_TYPE* output_scale
-#if GENERATE_PRECOMPUTED_REDUCTION
-    , __global OUTPUT2_TYPE* output_precomputed_reduction
-#endif
-    ) {
-
-    const uint sglid = get_sub_group_local_id();
-
-#if OUTPUT_DIMS == 2
-    const uint b = get_global_id(1);
-    const uint f_grp = get_global_id(2);
-    const uint input_offset = INPUT0_GET_INDEX(b, f_grp * QUANTIZE_GROUP_SIZE, 0, 0);
-    const uint output_offset = OUTPUT_GET_INDEX(b, f_grp * QUANTIZE_GROUP_SIZE, 0, 0);
-#else
-    const uint bf = get_global_id(1);
-    const uint b = bf / INPUT0_FEATURE_NUM;
-    const uint f = bf % INPUT0_FEATURE_NUM;
-    const uint y_grp = get_global_id(2);
-    const uint input_offset = INPUT0_GET_INDEX(b, f, y_grp * QUANTIZE_GROUP_SIZE, 0);
-    const uint output_offset = OUTPUT_GET_INDEX(b, f, y_grp * QUANTIZE_GROUP_SIZE, 0);
-#endif
-
-    // Each thread reads ELEMS_PER_THREAD consecutive elements
-    const uint thread_offset = sglid * ELEMS_PER_THREAD;
-    half local_max = ACT_MIN_VAL;
-
-#if ELEMS_PER_THREAD == 4
-    half4 my_data = vload4(0, &input[input_offset + thread_offset]);
-    local_max = fmax(fmax(fabs(my_data[0]), fabs(my_data[1])), fmax(fabs(my_data[2]), fabs(my_data[3])));
-#elif ELEMS_PER_THREAD == 2
-    half2 my_data = vload2(0, &input[input_offset + thread_offset]);
-    local_max = fmax(fabs(my_data[0]), fabs(my_data[1]));
-#else
-    half my_data[ELEMS_PER_THREAD];
-    unroll_for (uint i = 0; i < ELEMS_PER_THREAD; ++i) {
-        my_data[i] = input[input_offset + thread_offset + i];
-        local_max = fmax(local_max, fabs(my_data[i]));
-    }
-#endif
-
-    // Sub-group cooperative max reduction
-    half max_value = sub_group_reduce_max(local_max);
-    max_value = fmax(max_value, ACT_MIN_VAL);
-
-#if IS_MXFP
-    SCALE_TYPE quan_scale = (SCALE_TYPE)(exp2(floor(log2(_convert_float(OUTPUT_VAL_MAX) / convert_float(max_value)))));
-#else
-    SCALE_TYPE quan_scale = TO_SCALE_TYPE(OUTPUT_VAL_MAX) / max_value;
-    FOR_PRECOMPUTED_REDUCTION(int precomputed_reduction = 0);
-#endif
-
-    // Quantize and store
-#if ELEMS_PER_THREAD == 4
-    #if IS_F8
-    MAKE_VECTOR_TYPE(OUTPUT_TYPE, 4) qval = TO_TYPE_N_SAT(OUTPUT_TYPE, 4, convert_float4(my_data) * (MAKE_VECTOR_TYPE(SCALE_TYPE, 4))quan_scale);
-    vstore4(qval.data, 0, (char*)(&output[output_offset + thread_offset]));
-    #else
-    MAKE_VECTOR_TYPE(OUTPUT_TYPE, 4) qval = convert_char4_rte(my_data * (half4)quan_scale);
-    FOR_PRECOMPUTED_REDUCTION(precomputed_reduction = qval[0] + qval[1] + qval[2] + qval[3]);
-    vstore4(qval, 0, &output[output_offset + thread_offset]);
-    #endif
-#elif ELEMS_PER_THREAD == 2
-    #if IS_F8
-    MAKE_VECTOR_TYPE(OUTPUT_TYPE, 2) qval = TO_TYPE_N_SAT(OUTPUT_TYPE, 2, convert_float2(my_data) * (MAKE_VECTOR_TYPE(SCALE_TYPE, 2))quan_scale);
-    vstore2(qval.data, 0, (char*)(&output[output_offset + thread_offset]));
-    #else
-    MAKE_VECTOR_TYPE(OUTPUT_TYPE, 2) qval = convert_char2_rte(my_data * (half2)quan_scale);
-    FOR_PRECOMPUTED_REDUCTION(precomputed_reduction = qval[0] + qval[1]);
-    vstore2(qval, 0, &output[output_offset + thread_offset]);
-    #endif
-#else
-    unroll_for (uint i = 0; i < ELEMS_PER_THREAD; ++i) {
-    #if IS_F8
-        output[output_offset + thread_offset + i] = TO_TYPE_N_SAT(OUTPUT_TYPE, 1, convert_float(my_data[i]) * quan_scale);
-    #else
-        output[output_offset + thread_offset + i] = convert_char_rte(my_data[i] * quan_scale);
-        FOR_PRECOMPUTED_REDUCTION(precomputed_reduction += output[output_offset + thread_offset + i]);
-    #endif
-    }
-#endif
-
-#if !IS_MXFP && GENERATE_PRECOMPUTED_REDUCTION
-    precomputed_reduction = sub_group_reduce_add(precomputed_reduction);
-#endif
-
-    if (sglid == 0) {
-#if OUTPUT_DIMS == 2
-        const uint output_idx = OUTPUT1_GET_INDEX(b, f_grp, 0, 0);
-#else
-        const uint output_idx = OUTPUT1_GET_INDEX(b, f, y_grp, 0);
-#endif
-        output_scale[output_idx] = TO_OUTPUT1_TYPE(1.0h / quan_scale);
-#if !(IS_MXFP)
-        FOR_PRECOMPUTED_REDUCTION(output_precomputed_reduction[output_idx] = precomputed_reduction);
-#endif
-    }
-}
-
-// ***********************************************
-#elif DYNAMIC_QUANTIZAION_IMPL_MODE == MODE_SMALL_GS
-// ***********************************************
-// Original single-WI version for MODE_SMALL_GS
 
 #if ASYMMETRIC_QUANTIZATION
 #error "UNIMPLMENTED: asymmetric quantization when group size is small"
@@ -281,10 +165,12 @@ KERNEL(dynamic_quantize_gpu_opt)(
 #endif
     const uint offset = b_offset + VEC_SIZE * sglid;
 
+#if (QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE) > 1
     const uint local_id = get_local_id(1);
     __local half local_mem_max[BLOCK_NUM];
     __local half local_mem_min[BLOCK_NUM];
     FOR_PRECOMPUTED_REDUCTION(__local int local_mem_reduction[BLOCK_NUM]);
+#endif
 
     MAKE_VECTOR_TYPE(INPUT0_TYPE, VEC_SIZE) val;
     MAKE_VECTOR_TYPE(INPUT0_TYPE, VEC_SIZE) abs_val;
@@ -316,6 +202,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
     min_value = sub_group_reduce_min(grp_min);
 #endif
 
+#if (QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE) > 1
     const uint blocks_per_group = QUANTIZE_GROUP_SIZE / block_size;
     const uint group_id = local_id / blocks_per_group;
     const uint block_in_group = local_id % blocks_per_group;
@@ -341,6 +228,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
         min_value = fmin(min_value, local_mem_min[group_base_idx + j]);
 #endif
     }
+#endif
 
 #if ASYMMETRIC_QUANTIZATION
     OUTPUT1_TYPE scale = (OUTPUT1_TYPE)((CHAR_MAX - CHAR_MIN) / (max_value - min_value));
@@ -363,7 +251,6 @@ KERNEL(dynamic_quantize_gpu_opt)(
 #endif
 
 #if GENERATE_PRECOMPUTED_REDUCTION
-    // TODO: Optimize this part
     // Calculate local reduction for this work-item
     int precomputed_reduction = 0;
     MAKE_VECTOR_TYPE(OUTPUT2_TYPE, VEC_SIZE) val_int = CAT(CONVERT_INT_N, _rte)(val);
@@ -373,6 +260,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
     // Reduce within subgroup
     precomputed_reduction = sub_group_reduce_add(precomputed_reduction);
 
+#if (QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE) > 1
     // Store to local memory for cross-block aggregation
     if (sglid == 0) {
         local_mem_reduction[local_id] = precomputed_reduction;
@@ -381,7 +269,6 @@ KERNEL(dynamic_quantize_gpu_opt)(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Aggregate reduction across all blocks in this quantization group
-    // Only the first work-item in each group does this
     if (sglid == 0 && block_in_group == 0) {
         int total_reduction = 0;
         unroll_for (int j = 0; j < QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE; j++) {
@@ -389,6 +276,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
         }
         precomputed_reduction = total_reduction;
     }
+#endif
 #endif
 
     if (sglid == 0 && blockid == 0) {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_opt.cl
@@ -46,8 +46,124 @@
 
 
 // ***********************************************
-#if DYNAMIC_QUANTIZAION_IMPL_MODE == MODE_SMALL_GS
+#if DYNAMIC_QUANTIZAION_IMPL_MODE == MODE_SMALL_GS_SG
 // ***********************************************
+// Sub-group cooperative version: SIMD threads process one quantization group together.
+// Each thread reads QUANTIZE_GROUP_SIZE/SIMD elements, uses sub_group_reduce_max.
+
+#if ASYMMETRIC_QUANTIZATION
+#error "UNIMPLMENTED: asymmetric quantization when group size is small (SG mode)"
+#endif
+
+#define ELEMS_PER_THREAD (QUANTIZE_GROUP_SIZE / SIMD)
+
+REQD_SUB_GROUP_SIZE(SIMD)
+KERNEL(dynamic_quantize_gpu_opt)(
+    OPTIONAL_SHAPE_INFO_ARG
+    const __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output,
+    __global OUTPUT1_TYPE* output_scale
+#if GENERATE_PRECOMPUTED_REDUCTION
+    , __global OUTPUT2_TYPE* output_precomputed_reduction
+#endif
+    ) {
+
+    const uint sglid = get_sub_group_local_id();
+
+#if OUTPUT_DIMS == 2
+    const uint b = get_global_id(1);
+    const uint f_grp = get_global_id(2);
+    const uint input_offset = INPUT0_GET_INDEX(b, f_grp * QUANTIZE_GROUP_SIZE, 0, 0);
+    const uint output_offset = OUTPUT_GET_INDEX(b, f_grp * QUANTIZE_GROUP_SIZE, 0, 0);
+#else
+    const uint bf = get_global_id(1);
+    const uint b = bf / INPUT0_FEATURE_NUM;
+    const uint f = bf % INPUT0_FEATURE_NUM;
+    const uint y_grp = get_global_id(2);
+    const uint input_offset = INPUT0_GET_INDEX(b, f, y_grp * QUANTIZE_GROUP_SIZE, 0);
+    const uint output_offset = OUTPUT_GET_INDEX(b, f, y_grp * QUANTIZE_GROUP_SIZE, 0);
+#endif
+
+    // Each thread reads ELEMS_PER_THREAD consecutive elements
+    const uint thread_offset = sglid * ELEMS_PER_THREAD;
+    half local_max = ACT_MIN_VAL;
+
+#if ELEMS_PER_THREAD == 4
+    half4 my_data = vload4(0, &input[input_offset + thread_offset]);
+    local_max = fmax(fmax(fabs(my_data[0]), fabs(my_data[1])), fmax(fabs(my_data[2]), fabs(my_data[3])));
+#elif ELEMS_PER_THREAD == 2
+    half2 my_data = vload2(0, &input[input_offset + thread_offset]);
+    local_max = fmax(fabs(my_data[0]), fabs(my_data[1]));
+#else
+    half my_data[ELEMS_PER_THREAD];
+    unroll_for (uint i = 0; i < ELEMS_PER_THREAD; ++i) {
+        my_data[i] = input[input_offset + thread_offset + i];
+        local_max = fmax(local_max, fabs(my_data[i]));
+    }
+#endif
+
+    // Sub-group cooperative max reduction
+    half max_value = sub_group_reduce_max(local_max);
+    max_value = fmax(max_value, ACT_MIN_VAL);
+
+#if IS_MXFP
+    SCALE_TYPE quan_scale = (SCALE_TYPE)(exp2(floor(log2(_convert_float(OUTPUT_VAL_MAX) / convert_float(max_value)))));
+#else
+    SCALE_TYPE quan_scale = TO_SCALE_TYPE(OUTPUT_VAL_MAX) / max_value;
+    FOR_PRECOMPUTED_REDUCTION(int precomputed_reduction = 0);
+#endif
+
+    // Quantize and store
+#if ELEMS_PER_THREAD == 4
+    #if IS_F8
+    MAKE_VECTOR_TYPE(OUTPUT_TYPE, 4) qval = TO_TYPE_N_SAT(OUTPUT_TYPE, 4, convert_float4(my_data) * (MAKE_VECTOR_TYPE(SCALE_TYPE, 4))quan_scale);
+    vstore4(qval.data, 0, (char*)(&output[output_offset + thread_offset]));
+    #else
+    MAKE_VECTOR_TYPE(OUTPUT_TYPE, 4) qval = convert_char4_rte(my_data * (half4)quan_scale);
+    FOR_PRECOMPUTED_REDUCTION(precomputed_reduction = qval[0] + qval[1] + qval[2] + qval[3]);
+    vstore4(qval, 0, &output[output_offset + thread_offset]);
+    #endif
+#elif ELEMS_PER_THREAD == 2
+    #if IS_F8
+    MAKE_VECTOR_TYPE(OUTPUT_TYPE, 2) qval = TO_TYPE_N_SAT(OUTPUT_TYPE, 2, convert_float2(my_data) * (MAKE_VECTOR_TYPE(SCALE_TYPE, 2))quan_scale);
+    vstore2(qval.data, 0, (char*)(&output[output_offset + thread_offset]));
+    #else
+    MAKE_VECTOR_TYPE(OUTPUT_TYPE, 2) qval = convert_char2_rte(my_data * (half2)quan_scale);
+    FOR_PRECOMPUTED_REDUCTION(precomputed_reduction = qval[0] + qval[1]);
+    vstore2(qval, 0, &output[output_offset + thread_offset]);
+    #endif
+#else
+    unroll_for (uint i = 0; i < ELEMS_PER_THREAD; ++i) {
+    #if IS_F8
+        output[output_offset + thread_offset + i] = TO_TYPE_N_SAT(OUTPUT_TYPE, 1, convert_float(my_data[i]) * quan_scale);
+    #else
+        output[output_offset + thread_offset + i] = convert_char_rte(my_data[i] * quan_scale);
+        FOR_PRECOMPUTED_REDUCTION(precomputed_reduction += output[output_offset + thread_offset + i]);
+    #endif
+    }
+#endif
+
+#if !IS_MXFP && GENERATE_PRECOMPUTED_REDUCTION
+    precomputed_reduction = sub_group_reduce_add(precomputed_reduction);
+#endif
+
+    if (sglid == 0) {
+#if OUTPUT_DIMS == 2
+        const uint output_idx = OUTPUT1_GET_INDEX(b, f_grp, 0, 0);
+#else
+        const uint output_idx = OUTPUT1_GET_INDEX(b, f, y_grp, 0);
+#endif
+        output_scale[output_idx] = TO_OUTPUT1_TYPE(1.0h / quan_scale);
+#if !(IS_MXFP)
+        FOR_PRECOMPUTED_REDUCTION(output_precomputed_reduction[output_idx] = precomputed_reduction);
+#endif
+    }
+}
+
+// ***********************************************
+#elif DYNAMIC_QUANTIZAION_IMPL_MODE == MODE_SMALL_GS
+// ***********************************************
+// Original single-WI version for MODE_SMALL_GS
 
 #if ASYMMETRIC_QUANTIZATION
 #error "UNIMPLMENTED: asymmetric quantization when group size is small"

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_opt.cl
@@ -44,6 +44,7 @@
     #define FOR_PRECOMPUTED_REDUCTION(x)
 #endif
 
+#define BLOCKS_PER_GROUP (QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE)
 
 // ***********************************************
 #if DYNAMIC_QUANTIZAION_IMPL_MODE == MODE_SMALL_GS
@@ -148,7 +149,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
     const uint b = (uint)get_global_id(2);
     const uint f_grp = get_global_id(1) * VEC_SIZE * SIMD / QUANTIZE_GROUP_SIZE;
     const uint sglid = get_sub_group_local_id();
-    const uint blockid = (uint)get_global_id(1) % (QUANTIZE_GROUP_SIZE / VEC_SIZE / SIMD);
+    const uint blockid = (uint)get_global_id(1) % BLOCKS_PER_GROUP;
 #if OUTPUT_DIMS == 2
     const uint input_offset = INPUT0_GET_INDEX (b, f_grp * QUANTIZE_GROUP_SIZE + VEC_SIZE * sglid, 0, 0);
     const uint output_offset = OUTPUT_GET_INDEX(b, f_grp * QUANTIZE_GROUP_SIZE + VEC_SIZE * sglid, 0, 0);
@@ -165,7 +166,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
 #endif
     const uint offset = b_offset + VEC_SIZE * sglid;
 
-#if (QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE) > 1
+#if BLOCKS_PER_GROUP > 1
     const uint local_id = get_local_id(1);
     __local half local_mem_max[BLOCK_NUM];
     __local half local_mem_min[BLOCK_NUM];
@@ -202,7 +203,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
     min_value = sub_group_reduce_min(grp_min);
 #endif
 
-#if (QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE) > 1
+#if BLOCKS_PER_GROUP > 1
     const uint blocks_per_group = QUANTIZE_GROUP_SIZE / block_size;
     const uint group_id = local_id / blocks_per_group;
     const uint block_in_group = local_id % blocks_per_group;
@@ -222,7 +223,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
 #if ASYMMETRIC_QUANTIZATION
     min_value = fmin(min_value, local_mem_min[group_base_idx]);
 #endif
-    unroll_for (int j = 1; j < QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE; j++) {
+    unroll_for (int j = 1; j < BLOCKS_PER_GROUP; j++) {
         max_value = fmax(max_value, local_mem_max[group_base_idx + j]);
 #if ASYMMETRIC_QUANTIZATION
         min_value = fmin(min_value, local_mem_min[group_base_idx + j]);
@@ -260,7 +261,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
     // Reduce within subgroup
     precomputed_reduction = sub_group_reduce_add(precomputed_reduction);
 
-#if (QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE) > 1
+#if BLOCKS_PER_GROUP > 1
     // Store to local memory for cross-block aggregation
     if (sglid == 0) {
         local_mem_reduction[local_id] = precomputed_reduction;
@@ -271,7 +272,7 @@ KERNEL(dynamic_quantize_gpu_opt)(
     // Aggregate reduction across all blocks in this quantization group
     if (sglid == 0 && block_in_group == 0) {
         int total_reduction = 0;
-        unroll_for (int j = 0; j < QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE; j++) {
+        unroll_for (int j = 0; j < BLOCKS_PER_GROUP; j++) {
             total_reduction += local_mem_reduction[group_base_idx + j];
         }
         precomputed_reduction = total_reduction;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_opt.cl
@@ -44,8 +44,6 @@
     #define FOR_PRECOMPUTED_REDUCTION(x)
 #endif
 
-#define BLOCKS_PER_GROUP (QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE)
-
 // ***********************************************
 #if DYNAMIC_QUANTIZAION_IMPL_MODE == MODE_SMALL_GS
 // ***********************************************

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -4,7 +4,7 @@
 
 #include "dynamic_quantize_kernel_opt.h"
 #include "kernel_selector_utils.h"
-#include <cstdlib>
+#include <algorithm>
 #include <string>
 
 
@@ -15,8 +15,7 @@ namespace kernel_selector {
 enum class DynQuanMode {
     SMALL_GS = 1,
     LARGE_GS = 2,
-    PER_TOKEN = 3,
-    SMALL_GS_SG = 4
+    PER_TOKEN = 3
 };
 
 static std::pair<size_t, size_t> get_input_bf_size(const dynamic_quantize_params& params) {
@@ -38,14 +37,13 @@ static std::pair<size_t, size_t> get_input_bf_size(const dynamic_quantize_params
 }
 
 static DynQuanMode get_dynamic_quantize_mode(const dynamic_quantize_params& params) {
-    if (params.group_sizes.back() <= 64 && params.group_sizes.back() >= simd) {
-        return DynQuanMode::SMALL_GS_SG;
-    } else if (params.group_sizes.back() <= 64) {
-        return DynQuanMode::SMALL_GS;
-    } else if (params.group_sizes.back() == std::numeric_limits<uint64_t>::max()) {
+    auto gs = params.group_sizes.back();
+    if (gs == std::numeric_limits<uint64_t>::max()) {
         return DynQuanMode::PER_TOKEN;
-    } else {
+    } else if (gs >= simd * 2) {
         return DynQuanMode::LARGE_GS;
+    } else {
+        return DynQuanMode::SMALL_GS;
     }
 }
 
@@ -53,9 +51,11 @@ static size_t get_match_vector_size(const dynamic_quantize_params& params) {
     auto block_sizes = { 8, 4, 2 };
     auto bf = get_input_bf_size(params);
     auto f = bf.second;
+    auto gs = params.group_sizes.back();
+    size_t max_vec_size = (gs != std::numeric_limits<uint64_t>::max()) ? gs / simd : 8;
 
     for (auto block_size : block_sizes) {
-        if ((f / simd) % block_size == 0) {
+        if (static_cast<size_t>(block_size) <= max_vec_size && (f / simd) % block_size == 0) {
             return block_size;
         }
     }
@@ -100,7 +100,6 @@ JitConstants DynamicQuantizeKernelOpt::GetJitConstants(const dynamic_quantize_pa
     jit.AddConstant(MakeJitConstant("MODE_SMALL_GS", static_cast<int>(DynQuanMode::SMALL_GS)));
     jit.AddConstant(MakeJitConstant("MODE_LARGE_GS", static_cast<int>(DynQuanMode::LARGE_GS)));
     jit.AddConstant(MakeJitConstant("MODE_PER_TOKEN", static_cast<int>(DynQuanMode::PER_TOKEN)));
-    jit.AddConstant(MakeJitConstant("MODE_SMALL_GS_SG", static_cast<int>(DynQuanMode::SMALL_GS_SG)));
     jit.AddConstant(MakeJitConstant("F8E5M2_OUTPUT", params.outputs[0].GetDType() == Datatype::F8E5M2 ? 1 : 0));
     jit.AddConstant(MakeJitConstant("F8E4M3_OUTPUT", params.outputs[0].GetDType() == Datatype::F8E4M3 ? 1 : 0));
     jit.AddConstant(MakeJitConstant("IS_MXFP", params.outputs[1].GetDType() == Datatype::F8E8M0 ? 1 : 0));
@@ -121,12 +120,7 @@ CommonDispatchData DynamicQuantizeKernelOpt::SetDefault(const dynamic_quantize_p
     CommonDispatchData dispatchData;
     auto mode = get_dynamic_quantize_mode(params);
 
-    if (mode == DynQuanMode::SMALL_GS_SG) {
-        auto bf_size = get_input_bf_size(params);
-        size_t num_groups = bf_size.second / params.group_sizes.back();
-        dispatchData.gws = {simd, bf_size.first, num_groups};
-        dispatchData.lws = {simd, 1, 1};
-    } else if (mode == DynQuanMode::SMALL_GS) {
+    if (mode == DynQuanMode::SMALL_GS) {
         auto bf_size = get_input_bf_size(params);
         dispatchData.gws = {bf_size.first, bf_size.second / params.group_sizes.back(), 1};
         dispatchData.lws = {1, 1, 1};

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -4,6 +4,7 @@
 
 #include "dynamic_quantize_kernel_opt.h"
 #include "kernel_selector_utils.h"
+#include <cstdlib>
 #include <string>
 
 
@@ -14,7 +15,8 @@ namespace kernel_selector {
 enum class DynQuanMode {
     SMALL_GS = 1,
     LARGE_GS = 2,
-    PER_TOKEN = 3
+    PER_TOKEN = 3,
+    SMALL_GS_SG = 4
 };
 
 static std::pair<size_t, size_t> get_input_bf_size(const dynamic_quantize_params& params) {
@@ -36,12 +38,15 @@ static std::pair<size_t, size_t> get_input_bf_size(const dynamic_quantize_params
 }
 
 static DynQuanMode get_dynamic_quantize_mode(const dynamic_quantize_params& params) {
-    if (params.group_sizes.back() <= 64)
+    if (params.group_sizes.back() <= 64 && params.group_sizes.back() >= simd) {
+        return DynQuanMode::SMALL_GS_SG;
+    } else if (params.group_sizes.back() <= 64) {
         return DynQuanMode::SMALL_GS;
-    else if (params.group_sizes.back() == std::numeric_limits<uint64_t>::max())
+    } else if (params.group_sizes.back() == std::numeric_limits<uint64_t>::max()) {
         return DynQuanMode::PER_TOKEN;
-    else
+    } else {
         return DynQuanMode::LARGE_GS;
+    }
 }
 
 static size_t get_match_vector_size(const dynamic_quantize_params& params) {
@@ -95,6 +100,7 @@ JitConstants DynamicQuantizeKernelOpt::GetJitConstants(const dynamic_quantize_pa
     jit.AddConstant(MakeJitConstant("MODE_SMALL_GS", static_cast<int>(DynQuanMode::SMALL_GS)));
     jit.AddConstant(MakeJitConstant("MODE_LARGE_GS", static_cast<int>(DynQuanMode::LARGE_GS)));
     jit.AddConstant(MakeJitConstant("MODE_PER_TOKEN", static_cast<int>(DynQuanMode::PER_TOKEN)));
+    jit.AddConstant(MakeJitConstant("MODE_SMALL_GS_SG", static_cast<int>(DynQuanMode::SMALL_GS_SG)));
     jit.AddConstant(MakeJitConstant("F8E5M2_OUTPUT", params.outputs[0].GetDType() == Datatype::F8E5M2 ? 1 : 0));
     jit.AddConstant(MakeJitConstant("F8E4M3_OUTPUT", params.outputs[0].GetDType() == Datatype::F8E4M3 ? 1 : 0));
     jit.AddConstant(MakeJitConstant("IS_MXFP", params.outputs[1].GetDType() == Datatype::F8E8M0 ? 1 : 0));
@@ -115,7 +121,12 @@ CommonDispatchData DynamicQuantizeKernelOpt::SetDefault(const dynamic_quantize_p
     CommonDispatchData dispatchData;
     auto mode = get_dynamic_quantize_mode(params);
 
-    if (mode == DynQuanMode::SMALL_GS) {
+    if (mode == DynQuanMode::SMALL_GS_SG) {
+        auto bf_size = get_input_bf_size(params);
+        size_t num_groups = bf_size.second / params.group_sizes.back();
+        dispatchData.gws = {simd, bf_size.first, num_groups};
+        dispatchData.lws = {simd, 1, 1};
+    } else if (mode == DynQuanMode::SMALL_GS) {
         auto bf_size = get_input_bf_size(params);
         dispatchData.gws = {bf_size.first, bf_size.second / params.group_sizes.back(), 1};
         dispatchData.lws = {1, 1, 1};

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -4,7 +4,6 @@
 
 #include "dynamic_quantize_kernel_opt.h"
 #include "kernel_selector_utils.h"
-#include <algorithm>
 #include <string>
 
 
@@ -94,6 +93,7 @@ JitConstants DynamicQuantizeKernelOpt::GetJitConstants(const dynamic_quantize_pa
     jit.AddConstant(MakeJitConstant("VEC_SIZE", vec_size));
     jit.AddConstant(MakeJitConstant("SIMD", simd));
     jit.AddConstant(MakeJitConstant("QUANTIZE_GROUP_SIZE", params.group_sizes.back()));
+    jit.AddConstant(MakeJitConstant("BLOCKS_PER_GROUP", params.group_sizes.back() / simd / vec_size));
     jit.AddConstant(MakeJitConstant("ASYMMETRIC_QUANTIZATION", params.use_asymmetric_quantization));
     jit.AddConstant(MakeJitConstant("GENERATE_PRECOMPUTED_REDUCTION", params.generate_precomputed_reduction));
     jit.AddConstant(MakeJitConstant("DYNAMIC_QUANTIZAION_IMPL_MODE", static_cast<int>(mode)));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -40,7 +40,7 @@ static DynQuanMode get_dynamic_quantize_mode(const dynamic_quantize_params& para
     auto gs = params.group_sizes.back();
     if (gs == std::numeric_limits<uint64_t>::max()) {
         return DynQuanMode::PER_TOKEN;
-    } else if (gs >= simd * 2) {
+    } else if (gs > simd * 2) {
         return DynQuanMode::LARGE_GS;
     } else {
         return DynQuanMode::SMALL_GS;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
@@ -519,3 +519,22 @@ TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs128_K2560_sym_prec
                                 "dynamic_quantize_gpu_opt", SetInnerMostDimValuesZero::No,
                                 PrecomputeSum::Enabled);
 }
+
+// Sub-group cooperative mode (SMALL_GS_SG) for GS=64, 32, 16
+TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs64_sg) {
+    this->test_dynamic_quantization(false, {-1, 1, 4096}, {1, 1, 4096}, QuantizationType::Symmetric, 64,
+                                data_types::i8, data_types::f16, data_types::dynamic, OutputStorageType::Planar,
+                                "dynamic_quantize_gpu_opt");
+}
+
+TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs32_sg) {
+    this->test_dynamic_quantization(false, {-1, 1, 4096}, {1, 1, 4096}, QuantizationType::Symmetric, 32,
+                                data_types::i8, data_types::f16, data_types::dynamic, OutputStorageType::Planar,
+                                "dynamic_quantize_gpu_opt");
+}
+
+TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs16_sg) {
+    this->test_dynamic_quantization(false, {-1, 1, 4096}, {1, 1, 4096}, QuantizationType::Symmetric, 16,
+                                data_types::i8, data_types::f16, data_types::dynamic, OutputStorageType::Planar,
+                                "dynamic_quantize_gpu_opt");
+}

--- a/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
@@ -520,7 +520,7 @@ TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs128_K2560_sym_prec
                                 PrecomputeSum::Enabled);
 }
 
-// LARGE_GS mode for small group sizes (GS=64, 32, 16)
+// GS=64: LARGE_GS mode, GS=32/16: SMALL_GS mode
 TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs64) {
     this->test_dynamic_quantization(false, {-1, 1, 4096}, {1, 1, 4096}, QuantizationType::Symmetric, 64,
                                 data_types::i8, data_types::f16, data_types::dynamic, OutputStorageType::Planar,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
@@ -520,20 +520,20 @@ TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs128_K2560_sym_prec
                                 PrecomputeSum::Enabled);
 }
 
-// Sub-group cooperative mode (SMALL_GS_SG) for GS=64, 32, 16
-TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs64_sg) {
+// LARGE_GS mode for small group sizes (GS=64, 32, 16)
+TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs64) {
     this->test_dynamic_quantization(false, {-1, 1, 4096}, {1, 1, 4096}, QuantizationType::Symmetric, 64,
                                 data_types::i8, data_types::f16, data_types::dynamic, OutputStorageType::Planar,
                                 "dynamic_quantize_gpu_opt");
 }
 
-TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs32_sg) {
+TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs32) {
     this->test_dynamic_quantization(false, {-1, 1, 4096}, {1, 1, 4096}, QuantizationType::Symmetric, 32,
                                 data_types::i8, data_types::f16, data_types::dynamic, OutputStorageType::Planar,
                                 "dynamic_quantize_gpu_opt");
 }
 
-TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs16_sg) {
+TEST_F(dynamic_quantization_gpu_tests, dynamic_quantize_opt_gs16) {
     this->test_dynamic_quantization(false, {-1, 1, 4096}, {1, 1, 4096}, QuantizationType::Symmetric, 16,
                                 data_types::i8, data_types::f16, data_types::dynamic, OutputStorageType::Planar,
                                 "dynamic_quantize_gpu_opt");


### PR DESCRIPTION
### Problem
The DynamicQuantize kernel for small group sizes (GS ≤ 64) currently uses a single work-item (SMALL_GS mode) to process each quantization group sequentially. The single work-item approach underutilizes GPU parallelism. One thread reads, reduces, and quantizes an entire group (e.g., 64 elements) alone, while the sub-group variant distributes work across 16 threads with hardware-accelerated sub_group_reduce_max.

### Solution
Extend LARGE_GS mode to handle GS=64. When BLOCKS_PER_GROUP (= QUANTIZE_GROUP_SIZE / SIMD / VEC_SIZE) equals 1, barrier synchronization and local memory are eliminated at compile-time - achieving sub-group cooperative processing with zero overhead. Fallback to single WI (SMALL_GS) remains for GS ≤ 32. Applicable to all INT4 weight-compressed LLMs using GS=64 DynamicQuantize (Gemma4, Qwen, Llama, etc.).

### Tickets:
 - *CVS-190917*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
