### PR TITLE
Profiling starttime (#36488)

### DIFF
--- a/src/inference/include/openvino/runtime/profiling_info.hpp
+++ b/src/inference/include/openvino/runtime/profiling_info.hpp
@@ -62,6 +62,13 @@ struct ProfilingInfo {
      * @brief Node type.
      */
     std::string node_type;
+
+    /**
+     * @brief The node start timestamp, in microseconds, from the backend profiling clock epoch.
+     *
+     * A value of zero indicates an invalid/unavailable timestamp.
+     */
+    std::chrono::microseconds start_time;
 };
 
 }  // namespace ov

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -1755,7 +1756,11 @@ void Graph::GetPerfData(std::vector<ov::ProfilingInfo>& perfMap) const {
             ov::ProfilingInfo pc;
             pc.node_name = node->getName();
             uint64_t avg_time = node->PerfCounter().avg();
+            const bool has_measurement = node->PerfCounter().count() > 0;
             pc.cpu_time = pc.real_time = std::chrono::microseconds(avg_time);
+            pc.start_time = has_measurement ? std::chrono::duration_cast<std::chrono::microseconds>(
+                                                  node->PerfCounter().start().time_since_epoch())
+                                            : std::chrono::microseconds::zero();
             pc.status = avg_time > 0 ? ov::ProfilingInfo::Status::EXECUTED : ov::ProfilingInfo::Status::NOT_RUN;
             pc.exec_type = node->getPrimitiveDescriptorType();
             pc.node_type = node->typeStr;

--- a/src/plugins/intel_cpu/src/perf_count.h
+++ b/src/plugins/intel_cpu/src/perf_count.h
@@ -24,6 +24,14 @@ public:
         return _finish - _start;
     }
 
+    [[nodiscard]] std::chrono::high_resolution_clock::time_point start() const {
+        return _start;
+    }
+
+    [[nodiscard]] std::chrono::high_resolution_clock::time_point finish() const {
+        return _finish;
+    }
+
     [[nodiscard]] uint64_t avg() const {
         return (num == 0) ? 0 : total_duration / num;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/profiling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/profiling.hpp
@@ -89,8 +89,10 @@ private:
 
 /// @brief Represents profiling interval as its type and value.
 struct profiling_interval {
-    profiling_stage stage;                    ///< @brief Display name.
-    std::shared_ptr<profiling_period> value;  ///< @brief Interval value.
+    profiling_stage stage;                                              ///< @brief Display name.
+    std::shared_ptr<profiling_period> value;                            ///< @brief Interval value.
+    std::chrono::nanoseconds start = std::chrono::nanoseconds::zero();  ///< @brief Interval start timestamp.
+    bool is_valid_start = false;                                        ///< @brief Whether start is valid.
 };
 
 /// @brief Represents list of @ref profiling_interval

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -35,8 +35,43 @@
 #include <algorithm>
 #include <fstream>
 #include <utility>
+#include <optional>
 #include <sys/types.h>
 #include <sys/stat.h>
+
+namespace {
+
+std::optional<std::chrono::microseconds> extract_start_time_from_intervals(
+    const std::vector<cldnn::instrumentation::profiling_interval>& intervals) {
+    std::optional<std::chrono::microseconds> earliest_timestamp;
+    std::optional<std::chrono::microseconds> executing_timestamp;
+
+    for (const auto& interval : intervals) {
+        if (!interval.is_valid_start) {
+            continue;
+        }
+
+        auto interval_start = std::chrono::duration_cast<std::chrono::microseconds>(interval.start);
+        if (!earliest_timestamp.has_value() || interval_start < earliest_timestamp.value()) {
+            earliest_timestamp = interval_start;
+        }
+
+        if (interval.stage == cldnn::instrumentation::profiling_stage::executing) {
+            if (!executing_timestamp.has_value() || interval_start < executing_timestamp.value()) {
+                executing_timestamp = interval_start;
+            }
+        }
+    }
+
+    auto start_time = executing_timestamp.value_or(earliest_timestamp.value_or(std::chrono::microseconds::zero()));
+    if (start_time == std::chrono::microseconds::zero()) {
+        return std::nullopt;
+    }
+
+    return start_time;
+}
+
+}  // namespace
 
 namespace ov::intel_gpu {
 
@@ -667,6 +702,13 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
         auto layerName = getClearName(perfIter->second.first);
 
         const auto& perfCounter = perfIter->second.second;
+        std::optional<std::chrono::microseconds> start_time;
+
+        auto execIter = executedPrimitives.find(primId);
+        if (execIter != executedPrimitives.end() && execIter->second) {
+            cldnn::instrumentation::profiling_info cldnnInfo{primId, execIter->second->get_profiling_info()};
+            start_time = extract_start_time_from_intervals(cldnnInfo.intervals);
+        }
 
         if (!perfCounter.parentPrimitive.empty() && combinePrimByIRLayers)
             return false;
@@ -692,6 +734,7 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
         extPerfEntry.status = perfCounter.status;
         extPerfEntry.cpu_time = std::chrono::microseconds(perfCounter.cpu_avg());
         extPerfEntry.real_time = std::chrono::microseconds(perfCounter.realTime_avg());
+        extPerfEntry.start_time = start_time.value_or(std::chrono::microseconds::zero());
         extPerfEntry.node_name = layerName;
 
         if (combinePrimByIRLayers) {
@@ -743,6 +786,7 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
             // Collect timings
             long long cpuTime = 0;
             long long deviceTime = 0;
+            std::optional<std::chrono::microseconds> start_time;
 
             for (auto &interval : cldnnInfo.intervals) {
                 using duration_t = std::chrono::duration<long long, std::chrono::microseconds::period>;
@@ -756,6 +800,8 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
                     cpuTime += count;
                 }
             }
+
+            start_time = extract_start_time_from_intervals(cldnnInfo.intervals);
 
             std::string layerName = getClearName(primId);
 
@@ -780,6 +826,7 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
                     extPerfEntry.status = ov::ProfilingInfo::Status::EXECUTED;
                     extPerfEntry.cpu_time = std::chrono::microseconds(cpuTime);
                     extPerfEntry.real_time = std::chrono::microseconds(deviceTime);
+                    extPerfEntry.start_time = start_time.value_or(std::chrono::microseconds::zero());
 
                     if (pi.type_id == "input_layout") {
                         extPerfEntry.node_type = "Input";
@@ -806,9 +853,10 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
 
         if (first_res != result.end() && second_res != result.end() && first_res != second_res) {
             std::swap(first_res->second.cpu_time,        second_res->second.cpu_time);
-            std::swap(first_res->second.real_time,   second_res->second.real_time);
+            std::swap(first_res->second.real_time,       second_res->second.real_time);
             std::swap(first_res->second.status,          second_res->second.status);
             std::swap(first_res->second.exec_type,       second_res->second.exec_type);
+            std::swap(first_res->second.start_time,      second_res->second.start_time);
         }
     }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.cpp
@@ -25,10 +25,10 @@ bool is_event_profiled(const cl::Event& event) {
     return false;
 }
 
-instrumentation::profiling_interval get_profiling_interval(instrumentation::profiling_stage stage, cl_ulong start,  cl_ulong end) {
+instrumentation::profiling_interval get_profiling_interval(instrumentation::profiling_stage stage, cl_ulong start, cl_ulong end) {
     auto diff = std::chrono::nanoseconds(end - start);
     auto period = std::make_shared<instrumentation::profiling_period_basic>(diff);
-    return { stage, period };
+    return { stage, period, std::chrono::nanoseconds(start), true };
 }
 
 }  // namespace
@@ -219,12 +219,24 @@ bool ocl_events::get_profiling_info_impl(std::list<instrumentation::profiling_in
     }
 
     for (auto& period : profiling_periods) {
+        auto& durations = all_durations[period.stage];
+        if (durations.empty()) {
+            auto zero_period = std::make_shared<instrumentation::profiling_period_basic>(std::chrono::nanoseconds(0));
+            info.push_back({period.stage, zero_period});
+            continue;
+        }
+
+        // Find min start across all merged (non-overlapping) intervals for this stage.
+        // The OCL timestamps are absolute nanoseconds from the device profiling clock.
+        unsigned long long min_start = durations.front().first;
         unsigned long long sum = 0;
-        for (auto& duration : all_durations[period.stage]) {
+        for (auto& duration : durations) {
+            if (duration.first < min_start)
+                min_start = duration.first;
             sum += (duration.second - duration.first);
         }
 
-        info.push_back(get_profiling_interval(period.stage, 0, sum));
+        info.push_back(get_profiling_interval(period.stage, min_start, min_start + sum));
     }
 
     return true;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -226,6 +226,11 @@ ocl_stream::ocl_stream(const ocl_engine &engine, const ExecutionConfig& config)
     queue_builder.set_supports_queue_families(queue_families_extension);
 
     _command_queue = queue_builder.build(context, device);
+#if defined(CL_VERSION_2_1)
+    if (config.get_enable_profiling()) {
+        _profiling_device = _engine.get_cl_device();
+    }
+#endif
 }
 
 ocl_stream::ocl_stream(const ocl_engine &engine, const ExecutionConfig& config, void *handle)
@@ -233,6 +238,11 @@ ocl_stream::ocl_stream(const ocl_engine &engine, const ExecutionConfig& config, 
     , _engine(engine) {
     auto casted_handle = static_cast<cl_command_queue>(handle);
     _command_queue = ocl_queue_type(casted_handle, true);
+#if defined(CL_VERSION_2_1)
+    if (config.get_enable_profiling()) {
+        _profiling_device = _engine.get_cl_device();
+    }
+#endif
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
@@ -348,7 +358,7 @@ event::ptr ocl_stream::enqueue_marker(std::vector<event::ptr> const& deps, bool 
         sync_events(deps, is_output);
         return std::make_shared<ocl_event>(_last_barrier_ev, _last_barrier);
     } else {
-        return std::make_shared<ocl_user_event>(_engine.get_cl_context(), true);
+        return std::make_shared<ocl_user_event>(_engine.get_cl_context(), true, _profiling_device);
     }
 }
 
@@ -359,7 +369,7 @@ event::ptr ocl_stream::group_events(std::vector<event::ptr> const& deps) {
 }
 
 event::ptr ocl_stream::create_user_event(bool set) {
-    return std::make_shared<ocl_user_event>(_engine.get_cl_context(), set);
+    return std::make_shared<ocl_user_event>(_engine.get_cl_context(), set, _profiling_device);
 }
 
 event::ptr ocl_stream::create_base_event() {

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.hpp
@@ -27,7 +27,8 @@ public:
         , _command_queue(other._command_queue)
         , _queue_counter(other._queue_counter.load())
         , _last_barrier(other._last_barrier.load())
-        , _last_barrier_ev(other._last_barrier_ev) {}
+        , _last_barrier_ev(other._last_barrier_ev)
+        , _profiling_device(other._profiling_device) {}
 
     ~ocl_stream() = default;
 
@@ -65,6 +66,7 @@ private:
     std::atomic<uint64_t> _queue_counter{0};
     std::atomic<uint64_t> _last_barrier{0};
     cl::Event _last_barrier_ev;
+    cl::Device _profiling_device;
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
     std::shared_ptr<dnnl::stream> _onednn_stream = nullptr;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.cpp
@@ -3,9 +3,27 @@
 //
 
 #include "ocl_user_event.hpp"
+#include "CL/cl.h"
 #include <list>
 
 using namespace cldnn::ocl;
+
+ocl_user_event::ocl_user_event(const cl::Context& ctx,
+                               bool is_set,
+                               const cl::Device& device)
+    : ocl_base_event()
+    , _ctx(ctx)
+    , _event(_ctx) {
+#if defined(CL_VERSION_2_1)
+    if (device.get() != nullptr) {
+        _device = device;
+    }
+#endif
+
+    if (is_set) {
+        set();
+    }
+}
 
 void ocl_user_event::set_impl() {
     // we simulate "wrapper_cast" here to cast from cl::Event to cl::UserEvent which both wrap the same cl_event
@@ -15,6 +33,15 @@ void ocl_user_event::set_impl() {
     static_cast<cl::UserEvent&&>(get()).setStatus(CL_COMPLETE);
     _duration = std::unique_ptr<cldnn::instrumentation::profiling_period_basic>(
         new cldnn::instrumentation::profiling_period_basic(_timer.uptime()));
+#if defined(CL_VERSION_2_1)
+    if (_device.get() != nullptr) {
+        cl_ulong device_ts = 0;
+        cl_ulong host_ts = 0;
+        if (clGetDeviceAndHostTimer(_device.get(), &device_ts, &host_ts) == CL_SUCCESS) {
+            _exec_start = std::chrono::nanoseconds(static_cast<long long>(device_ts)) - _duration->value();
+        }
+    }
+#endif
 }
 
 bool ocl_user_event::get_profiling_info_impl(std::list<cldnn::instrumentation::profiling_interval>& info) {
@@ -23,7 +50,16 @@ bool ocl_user_event::get_profiling_info_impl(std::list<cldnn::instrumentation::p
     }
 
     auto period = std::make_shared<instrumentation::profiling_period_basic>(_duration->value());
-    info.push_back({ instrumentation::profiling_stage::executing, period });
+    info.push_back({ instrumentation::profiling_stage::duration, period });
+
+    if (_device.get() != nullptr) {
+        auto zero_period = std::make_shared<instrumentation::profiling_period_basic>(std::chrono::nanoseconds::zero());
+        info.push_back({ instrumentation::profiling_stage::starting, zero_period, _exec_start, true });
+        info.push_back({ instrumentation::profiling_stage::executing, period, _exec_start, true });
+    } else {
+        info.push_back({ instrumentation::profiling_stage::executing, period });
+    }
+
     return true;
 }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.hpp
@@ -17,14 +17,9 @@ namespace cldnn {
 namespace ocl {
 
 struct ocl_user_event : public ocl_base_event {
-    explicit ocl_user_event(const cl::Context& ctx, bool is_set = false)
-    : ocl_base_event()
-    , _ctx(ctx)
-    , _event(_ctx) {
-        if (is_set) {
-            set();
-        }
-    }
+    explicit ocl_user_event(const cl::Context& ctx,
+                            bool is_set = false,
+                            const cl::Device& device = cl::Device());
 
     void set_impl() override;
     bool get_profiling_info_impl(std::list<instrumentation::profiling_interval>& info) override;
@@ -33,6 +28,8 @@ struct ocl_user_event : public ocl_base_event {
 protected:
     cldnn::instrumentation::timer<> _timer;
     std::unique_ptr<cldnn::instrumentation::profiling_period_basic> _duration;
+    std::chrono::nanoseconds _exec_start = std::chrono::nanoseconds::zero();
+    cl::Device _device;
     const cl::Context& _ctx;
     cl::UserEvent _event;
 

--- a/src/plugins/intel_gpu/src/runtime/ze/ze_base_event.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_base_event.hpp
@@ -39,6 +39,13 @@ protected:
             : ((timestamp_max_value - timestamp.kernelStart) + timestamp.kernelEnd + 1) * timestamp_freq;
         return std::chrono::nanoseconds(static_cast<uint64_t>(d));
     }
+
+    // Converts a single hardware timestamp tick to nanoseconds (absolute device time).
+    static std::chrono::nanoseconds tick_to_nanoseconds(const device_info& info, uint64_t tick) {
+        constexpr double NS_IN_SEC = 1000000000.0;
+        const double timestamp_freq = NS_IN_SEC / info.timer_resolution;
+        return std::chrono::nanoseconds(static_cast<uint64_t>(tick * timestamp_freq));
+    }
 };
 
 }  // namespace ze

--- a/src/plugins/intel_gpu/src/runtime/ze/ze_counter_based_event.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_counter_based_event.cpp
@@ -57,12 +57,19 @@ bool ze_counter_based_event::get_profiling_info_impl(std::list<instrumentation::
     auto &dev_info = m_factory.get_engine().get_device_info();
     auto wallclock_time = timestamp_to_duration(dev_info, timestamp.global);
     auto exec_time = timestamp_to_duration(dev_info, timestamp.context);
+    auto submit_time = wallclock_time - exec_time;
 
-    auto period_exec = std::make_shared<instrumentation::profiling_period_basic>(timestamp_to_duration(dev_info, timestamp.context));
-    auto period_submit = std::make_shared<instrumentation::profiling_period_basic>(wallclock_time - exec_time);
+    // abs_start is the absolute device time (ns) when the command was submitted.
+    auto abs_start = tick_to_nanoseconds(dev_info, timestamp.global.kernelStart);
 
-    info.push_back({ instrumentation::profiling_stage::executing, period_exec });
-    info.push_back({ instrumentation::profiling_stage::submission, period_submit });
+    auto period_exec = std::make_shared<instrumentation::profiling_period_basic>(exec_time);
+    auto period_submit = std::make_shared<instrumentation::profiling_period_basic>(submit_time);
+
+    // Report start + duration for upper-layer profiling. Real end timestamp is intentionally omitted.
+    auto exec_start = abs_start + submit_time;
+
+    info.push_back({ instrumentation::profiling_stage::submission, period_submit, abs_start, true });
+    info.push_back({ instrumentation::profiling_stage::executing, period_exec, exec_start, true });
 
     return true;
 }

--- a/src/plugins/intel_gpu/src/runtime/ze/ze_event.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_event.cpp
@@ -62,12 +62,16 @@ bool ze_event::get_profiling_info_impl(std::list<instrumentation::profiling_inte
     auto &dev_info = m_factory.get_engine().get_device_info();
     auto wallclock_time = timestamp_to_duration(dev_info, timestamp.global);
     auto exec_time = timestamp_to_duration(dev_info, timestamp.context);
+    auto submit_time = wallclock_time - exec_time;
 
-    auto period_exec = std::make_shared<instrumentation::profiling_period_basic>(timestamp_to_duration(dev_info, timestamp.context));
-    auto period_submit = std::make_shared<instrumentation::profiling_period_basic>(wallclock_time - exec_time);
+    // abs_start is the absolute device time (ns) when the command was submitted.
+    auto abs_start = tick_to_nanoseconds(dev_info, timestamp.global.kernelStart);
 
-    info.push_back({ instrumentation::profiling_stage::executing, period_exec });
-    info.push_back({ instrumentation::profiling_stage::submission, period_submit });
+    auto period_exec = std::make_shared<instrumentation::profiling_period_basic>(exec_time);
+    auto period_submit = std::make_shared<instrumentation::profiling_period_basic>(submit_time);
+
+    info.push_back({ instrumentation::profiling_stage::submission, period_submit, abs_start, true });
+    info.push_back({ instrumentation::profiling_stage::executing, period_exec, abs_start + submit_time, true });
 
     return true;
 }

--- a/src/plugins/intel_gpu/src/runtime/ze/ze_events.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ze/ze_events.cpp
@@ -104,31 +104,18 @@ bool ze_events::get_profiling_info_impl(std::list<instrumentation::profiling_int
         return total_time;
     };
 
-    // Submission time is calculated as difference between merged context and wallclock intervals
-    // May probably be more accurate if we sum all sub-intervals of wallclock timestamps not covered by execution intervals
     using intervals_t = std::vector<ze_kernel_timestamp_data_t>;
-    auto get_submission_time = [&device_info](const intervals_t& s_timestamps,
-                                              const intervals_t& e_timestamps) {
-        auto get_minmax = [](const intervals_t& timestamps) {
-            uint64_t min_val = std::min_element(timestamps.begin(), timestamps.end(),
-                [](const ze_kernel_timestamp_data_t& lhs, const ze_kernel_timestamp_data_t& rhs) {
-                    return bool(lhs.kernelStart < rhs.kernelStart);
-            })->kernelStart;
-            uint64_t max_val = std::max_element(timestamps.begin(), timestamps.end(),
-                [](const ze_kernel_timestamp_data_t& lhs, const ze_kernel_timestamp_data_t& rhs) {
-                    return lhs.kernelEnd < rhs.kernelEnd;
-            })->kernelEnd;
+    auto get_minmax = [](const intervals_t& timestamps) {
+        uint64_t min_val = std::min_element(timestamps.begin(), timestamps.end(),
+            [](const ze_kernel_timestamp_data_t& lhs, const ze_kernel_timestamp_data_t& rhs) {
+                return bool(lhs.kernelStart < rhs.kernelStart);
+        })->kernelStart;
+        uint64_t max_val = std::max_element(timestamps.begin(), timestamps.end(),
+            [](const ze_kernel_timestamp_data_t& lhs, const ze_kernel_timestamp_data_t& rhs) {
+                return lhs.kernelEnd < rhs.kernelEnd;
+        })->kernelEnd;
 
-            return ze_kernel_timestamp_data_t{min_val, max_val};
-        };
-
-        auto submission_interval = get_minmax(s_timestamps);
-        auto exec_interval = get_minmax(e_timestamps);
-
-        auto wallclock_time = timestamp_to_duration(device_info, submission_interval);
-        auto exec_time = timestamp_to_duration(device_info, exec_interval);
-
-        return wallclock_time - exec_time;
+        return ze_kernel_timestamp_data_t{min_val, max_val};
     };
 
     for (size_t i = 0; i < _events.size(); i++) {
@@ -143,14 +130,22 @@ bool ze_events::get_profiling_info_impl(std::list<instrumentation::profiling_int
         add_or_merge(all_context_timestamps, timestamp.context);
     }
     OPENVINO_ASSERT(!all_global_timestamps.empty() && !all_context_timestamps.empty(), "[GPU] Expected non-empty kernel timestamps");
-    auto submit_time = get_submission_time(all_global_timestamps, all_context_timestamps);
+
+    // Reuse get_minmax results to avoid redundant traversals.
+    // Submission time = wallclock span (global) minus execution span (context bounding box).
+    auto global_minmax = get_minmax(all_global_timestamps);
+    auto context_minmax = get_minmax(all_context_timestamps);
+    auto submit_time = timestamp_to_duration(device_info, global_minmax) - timestamp_to_duration(device_info, context_minmax);
     auto exec_time = get_total_exec_time(all_context_timestamps);
+
+    // Absolute device start = earliest global.kernelStart tick converted to nanoseconds.
+    auto abs_start = tick_to_nanoseconds(device_info, global_minmax.kernelStart);
 
     auto period_exec = std::make_shared<instrumentation::profiling_period_basic>(exec_time);
     auto period_submit = std::make_shared<instrumentation::profiling_period_basic>(submit_time);
 
-    info.push_back({ instrumentation::profiling_stage::executing, period_exec });
-    info.push_back({ instrumentation::profiling_stage::submission, period_submit });
+    info.push_back({instrumentation::profiling_stage::submission, period_submit, abs_start, true});
+    info.push_back({instrumentation::profiling_stage::executing, period_exec, abs_start + submit_time, true});
 
     return true;
 }

--- a/src/plugins/intel_npu/src/al/include/intel_npu/profiling.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/profiling.hpp
@@ -20,6 +20,8 @@ LayerStatistics convertLayersToIeProfilingInfo(const std::vector<LayerInfo>& lay
     for (const auto& layer : layerInfo) {
         ov::ProfilingInfo& info = perfCounts.emplace_back();
         info.status = ov::ProfilingInfo::Status::EXECUTED;
+        info.start_time =
+            std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::nanoseconds(layer.start_time_ns));
         const auto real_time_ns = std::chrono::nanoseconds(layer.duration_ns);
         info.real_time = std::chrono::duration_cast<std::chrono::microseconds>(real_time_ns);
         const auto cpu_time_ns = std::chrono::nanoseconds(layer.dma_ns + layer.sw_ns + layer.dpu_ns);

--- a/src/plugins/intel_npu/src/backend/src/zero_profiling.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_profiling.cpp
@@ -165,21 +165,24 @@ NpuInferStatistics NpuInferProfiling::getNpuInferStatistics() const {
         std::chrono::microseconds(convertCCtoUS(_npu_infer_stats_accu_cc / _npu_infer_stats_cnt)),
         "AVG",
         "AVG",
-        "AVG"};
+        "AVG",
+        std::chrono::microseconds::zero()};
     npuPerfCounts.push_back(std::move(info_avg));
     ov::ProfilingInfo info_min = {ov::ProfilingInfo::Status::EXECUTED,
                                   std::chrono::microseconds(convertCCtoUS(_npu_infer_stats_min_cc)),
                                   std::chrono::microseconds(convertCCtoUS(_npu_infer_stats_min_cc)),
                                   "MIN",
                                   "MIN",
-                                  "MIN"};
+                                  "MIN",
+                                  std::chrono::microseconds::zero()};
     npuPerfCounts.push_back(std::move(info_min));
     ov::ProfilingInfo info_max = {ov::ProfilingInfo::Status::EXECUTED,
                                   std::chrono::microseconds(convertCCtoUS(_npu_infer_stats_max_cc)),
                                   std::chrono::microseconds(convertCCtoUS(_npu_infer_stats_max_cc)),
                                   "MAX",
                                   "MAX",
-                                  "MAX"};
+                                  "MAX",
+                                  std::chrono::microseconds::zero()};
     npuPerfCounts.push_back(std::move(info_max));
     return npuPerfCounts;
 }


### PR DESCRIPTION
### Details:
The current OV profiling Information only contain the node's execution cost, it lost the operator's execution order. This PR want to capture all operator's start execution time point.
 - Add `start_time` for profiling
 - Implement CPU/GPU/NPU's start time sampling.

#### The CPU profiling results:
<img width="2905" height="427" alt="image"
src="https://github.com/user-attachments/assets/eab7e7cb-6bb0-42bf-8aba-5c0cfc373383" />

#### The GPU profiling results:
<img width="2719" height="352" alt="image"
src="https://github.com/user-attachments/assets/daff48d2-a641-4b9b-a5b5-76911733bf50" />

#### The NPU profiling result:
<img width="3054" height="986" alt="image"
src="https://github.com/user-attachments/assets/92abc20a-a648-480b-92d3-1e30db42b99d" />

### Tickets:
 - [CVS-184645](https://jira.devtools.intel.com/browse/CVS-184645)

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
