### PR TITLE
[DRAFT][GPU] Enable HW-free offline kernel compilation

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -294,6 +294,11 @@ public:
     void load(cldnn::BinaryInputBuffer& ib, std::shared_ptr<const ov::Model> model_ptr = nullptr,
               std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheMap> cache_attr_map = nullptr);
 
+    // Runs the propagate_constants pass on an already-loaded (deserialized) program. Used on the
+    // import path for blobs produced by offline compile-only, which skip constant folding at compile
+    // time (no GPU there); folding is deferred to import where a real GPU is present.
+    void run_import_time_constant_folding();
+
     bool is_loaded_from_cache() const { return _loaded_from_cache; }
 
     bool is_new_shape_infer() const { return new_shape_infer; }

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/graph.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/graph.hpp
@@ -47,10 +47,21 @@ public:
 
     bool is_loaded() const;
 
+    // True when this Graph was built for HW-free offline (compile-only) export: no cldnn::network
+    // is created and the model must not be executed. This is decided by the CONSTRUCTION PATH
+    // (compile vs import), NOT by get_config().get_offline_compile() -- the latter is re-derived
+    // from the OV_GPU_OFFLINE_COMPILE env at every finalize(), which pollutes the import/execute
+    // path too (import forces the property off but apply_env_options re-enables it). Runtime gates
+    // must key on this flag so that imported (executable) models behave correctly regardless of env.
+    bool is_compile_only() const { return m_compile_only; }
+
     std::vector<ov::ProfilingInfo> get_profiling_info() const;
     void update_profiling_info();
 
-    cldnn::engine& get_engine() const { return m_context->get_engine(); }
+    // For the offline compile-only path, return the HW-free stub engine (fabricated device_info, no
+    // cl::Context) instead of the context's real engine, so the compile passes + blob export never
+    // depend on a real GPU. m_offline_engine is only ever set in the compile ctor (import leaves it null).
+    cldnn::engine& get_engine() const { return m_offline_engine ? *m_offline_engine : m_context->get_engine(); }
     const ExecutionConfig& get_config() const { return m_config; }
 
     const std::map<size_t, cldnn::layout>& get_input_layouts() const { return m_input_layouts; }
@@ -89,6 +100,15 @@ private:
     std::mutex m_infer_mutex;
 
     std::shared_ptr<cldnn::network> m_network;
+    // Offline (HW-free) compile: the built program is kept here and NO network is created
+    // (no GPU memory / weight upload). Used only for exporting the compiled blob. See Graph::build.
+    std::shared_ptr<cldnn::program> m_program;
+    // Set once at construction (see is_compile_only): true only for the offline compile-only path.
+    bool m_compile_only = false;
+    // HW-free stub engine (fabricated device_info, no cl::Context) used to build/export the offline
+    // compile-only program without touching a real GPU. Set only in the compile ctor when offline;
+    // owned here for the Graph's lifetime because program/export hold engine references. See get_engine.
+    std::shared_ptr<cldnn::engine> m_offline_engine;
     std::map<std::string, cldnn::primitive_id> primitiveIDs;
     std::map<size_t, std::vector<cldnn::primitive_id>> inputPrimitiveIDs;
     std::map<size_t, cldnn::primitive_id> prevPrimitiveIDs;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
@@ -136,6 +136,14 @@ static constexpr Property<size_t, PropertyMutability::RW> max_kernels_per_batch{
 static constexpr Property<bool, PropertyMutability::RW> use_onednn{"GPU_USE_ONEDNN"};
 static constexpr Property<bool, PropertyMutability::RW> use_cm{"GPU_USE_CM"};
 
+// HW-free offline compilation: when enabled, kernels are compiled ahead-of-time via ocloc
+// for the target device (offline_compile_device), the cldnn::network is NOT built (no GPU memory /
+// weight upload) and driver JIT is skipped for OCLC batches. The resulting program is exported as a
+// blob for later import on the target GPU.
+static constexpr Property<bool, PropertyMutability::RW> offline_compile{"GPU_OFFLINE_COMPILE"};
+// ocloc `-device` target: e.g. "0x4680" (device id) or "12.2.0" (ip version). Empty = unset.
+static constexpr Property<std::string, PropertyMutability::RW> offline_compile_device{"GPU_OFFLINE_COMPILE_DEVICE"};
+
 static constexpr Property<bool, ov::PropertyMutability::RW> help{"HELP"};
 static constexpr Property<size_t, ov::PropertyMutability::RW> verbose{"VERBOSE"};
 static constexpr Property<bool, ov::PropertyMutability::RW> verbose_color{"VERBOSE_COLOR"};

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -53,6 +53,10 @@ OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, partial_build_program, false, "
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, allow_new_shape_infer, false, "Switch between new and old shape inference flow. Shall be removed soon")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, use_onednn, false, "Enable/Disable onednn for usage for particular model/platform")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, use_cm, true, "Enable/Disable CM for usage for particular model/platform")
+// RELEASE (not RELEASE_INTERNAL) so they are settable through the public compile_model config map
+// (set_user_property filters user AnyMap by RELEASE visibility). Later fed by the OV EP.
+OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, offline_compile, false, "HW-free offline compilation: compile kernels via ocloc, skip network build, export program blob")
+OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, offline_compile_device, std::string(""), "ocloc -device target for offline compilation, e.g. 0x4680 or 12.2.0")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, max_kernels_per_batch, 8, "Controls how many kernels we combine into batch for more efficient ocl compilation")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, impls_cache_capacity, 300, "Controls capacity of LRU implementations cache that is created for each program object for dynamic models")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, asym_dynamic_quantization, false, "Enforce asymmetric mode for dynamically quantized activations")

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
@@ -22,6 +22,11 @@
 #include "intel_gpu/runtime/itt.hpp"
 #include "intel_gpu/runtime/file_util.hpp"
 
+// POC: dynamic-load ocloc offline compiler (bypass dump for validation).
+#include "runtime/ocl/ocloc_offline_compiler.hpp"
+// HW-free placeholder kernel for the offline export path (no driver JIT, no cl::Context).
+#include "runtime/ocl/offline_kernel.hpp"
+
 #ifdef WIN32
 #include <sdkddkver.h>
 #ifdef NTDDI_WIN10_RS5
@@ -30,6 +35,7 @@
 #endif
 
 #include <cassert>
+#include <iostream>
 #include <sstream>
 #include <fstream>
 #include <set>
@@ -308,12 +314,74 @@ void kernels_cache::build_batch(const batch_program& batch, compiled_kernels& co
     ///////////////////////////////////////////////////////////////////////////////////
     std::vector<uint8_t> precompiled;
     if (is_cache_enabled()) {
+        // A cached driver binary would bypass the ocloc offline path below (no export override
+        // registered) and leak a non-HW-free kernel into the blob. Offline compile must not consume
+        // the cl_cache; disable kernels caching when compiling offline.
+        OPENVINO_ASSERT(!_config.get_offline_compile(),
+                        "[GPU offline] kernels cache (cl_cache) must be disabled for HW-free offline "
+                        "compile; a cached driver binary would bypass ocloc.");
         std::lock_guard<std::mutex> lock(cacheAccessMutex);
         precompiled = ov::util::load_binary(ov::util::make_path(cached_bin_name));
     }
     std::vector<kernel::ptr> kernels;
     if (!precompiled.empty()) {
         _builder->build_kernels(precompiled.data(), precompiled.size(), KernelFormat::NATIVE_BIN, "", kernels);
+    } else if (_offline_export) {
+        // ===== HW-free offline compilation (context-less, no driver JIT) =====
+        // Triggered by the GPU_OFFLINE_COMPILE config option. Each OCLC batch is compiled by ocloc
+        // HW-free and wrapped in an offline_kernel placeholder (id = entry point, binary = ocloc bytes).
+        // We do NOT driver-JIT here: build_kernels(SOURCE) would need a real cl::Context, which the
+        // offline path deliberately avoids (a stub device_info engine replaces the real one at compile
+        // time). The
+        // placeholder is never executed (offline compile never builds a cldnn::network); its bytes are
+        // serialized into the exported blob and loaded exactly once, at import time
+        // (clCreateProgramWithBinary in the inference process). NO fallback: if ocloc fails, abort loudly.
+        // NOTE: loadability/target-match is not validated here (that would require loading it); a
+        // wrong-target binary fails at import time instead.
+        auto combined_source = join_strings(batch.source);
+
+        // HW-free guarantee: offline compile must cover EVERY batch via ocloc, or it is not HW-free.
+        // Only plain OCLC (non-microkernel) batches can be ocloc-compiled today; CM / OCLC_V2 /
+        // microkernel batches cannot. Fail loudly instead of skipping so that "offline compile
+        // succeeds" == "100% ocloc coverage". (onednn is also force-disabled in execution_config
+        // under offline, since it JITs via the driver and bypasses ocloc.)
+        OPENVINO_ASSERT(batch.language == kernel_language::OCLC && !batch.has_microkernels,
+                        "[GPU offline] batch ", batch.hash_value,
+                        " uses a kernel path ocloc cannot compile HW-free (language enum=",
+                        static_cast<int>(batch.language), ", has_microkernels=", batch.has_microkernels,
+                        "). Offline compile requires 100% OCLC coverage; force these primitives onto "
+                        "the ocl path or extend ocloc coverage.");
+
+        const std::string device_arg = _config.get_offline_compile_device();  // ocloc -device target
+        OPENVINO_ASSERT(!device_arg.empty(),
+                        "[GPU] GPU_OFFLINE_COMPILE requires GPU_OFFLINE_COMPILE_DEVICE (e.g. 0x4680 or 12.2.0)");
+
+        std::string ocloc_log;
+        std::vector<uint8_t> ocloc_bin =
+            cldnn::ocloc_poc::ocloc_compile_ocl_c(combined_source, batch.options, device_arg, &ocloc_log);
+
+        OPENVINO_ASSERT(!ocloc_bin.empty(),
+                        "[GPU offline] ocloc compile produced no binary for batch ", batch.hash_value,
+                        " (device=", device_arg, "). Log:\n", ocloc_log);
+
+        // One placeholder per entry point in the batch; all share the same batch program binary
+        // (matches ocl_kernel::get_binary(), which returns the whole program). entry_point_to_id is
+        // populated from source parsing (no compile needed). At import, build_kernels(NATIVE_BIN) on
+        // this zebin reconstructs one real kernel per entry point -> entry_point@id mapping matches.
+        for (const auto& ep : batch.entry_point_to_id)
+            kernels.push_back(std::make_shared<ocl::offline_kernel>(ep.first, ocloc_bin));
+        OPENVINO_ASSERT(kernels.size() == batch.kernels_counter,
+                        "[GPU offline] placeholder kernel count (", kernels.size(),
+                        ") != batch kernel count (", batch.kernels_counter, ") for batch ", batch.hash_value);
+
+        if (dump_sources && dump_file.good())
+            dump_file << "\n/* Offline (ocloc, HW-free): no driver build log */\n";
+
+        // TODO(productization): drop this std::cerr marker. Kept visible (not GPU_DEBUG_LOG, which is
+        // compiled out without ENABLE_DEBUG_CAPS) for offline-compile verification.
+        std::cerr << "[GPU offline] batch " << batch.hash_value
+                  << " device=" << device_arg
+                  << " ocloc_bin=" << ocloc_bin.size() << "B (context-less, load-once)" << std::endl;
     } else {
         auto combined_source = join_strings(batch.source);
         _builder->build_kernels(combined_source.data(), combined_source.size(), KernelFormat::SOURCE, batch.options, kernels);
@@ -521,6 +589,13 @@ void kernels_cache::add_to_cached_kernels(const std::vector<kernel::ptr>& kernel
 }
 
 void kernels_cache::save(BinaryOutputBuffer& ob) const {
+    // TODO(productization): drop this std::cerr marker. Authoritative count of UNIQUE
+    // kernel binaries serialized into the exported blob (dedup by binary), independent of how many
+    // build_batch/ocloc calls produced them. For offline this is the real "kernels in blob" number.
+    if (_offline_export) {
+        std::cerr << "[GPU offline] serializing " << _cached_binaries.size()
+                  << " unique kernel binaries into blob" << std::endl;
+    }
     ob << _cached_binaries.size();
 
     auto is_zebin = [](const std::vector<unsigned char>& bin) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.hpp
@@ -116,6 +116,12 @@ private:
     bool is_cache_enabled() const;
 
     bool _reuse_kernels = false;
+    // When true, build_batch emits HW-free ocloc placeholder kernels (no driver JIT, no cl::Context)
+    // for export instead of building runnable kernels. Set ONLY for the top-level offline compile-only
+    // program. It is NOT derived from _config.get_offline_compile() inside build_batch because that flag
+    // is env-polluted (OV_GPU_OFFLINE_COMPILE) in the inference process: the import-time constant-folding
+    // internal network there would otherwise emit non-executable placeholders and crash on execution.
+    bool _offline_export = false;
 
 public:
     explicit kernels_cache(engine& engine,
@@ -127,6 +133,7 @@ public:
     std::vector<kernel::ptr> get_kernels(const kernel_impl_params& params) const;
 
     void set_kernels_reuse(bool reuse_kernels) { _reuse_kernels = reuse_kernels; }
+    void set_offline_export(bool offline_export) { _offline_export = offline_export; }
     bool get_kernels_reuse() const { return _reuse_kernels; }
 
     // forces compilation of all pending kernels/programs

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -243,6 +243,11 @@ void program::init_program() {
                                                                           kernel_selector::KernelBase::get_db().get_batch_headers()));
 
         _kernels_cache->set_kernels_reuse(_config.get_enable_kernels_reuse());
+        // Emit HW-free ocloc placeholder kernels for export ONLY for the top-level offline compile-only
+        // program. Internal helper networks (e.g. propagate_constants' constant-folding network) always
+        // execute during their own build, so they must build runnable kernels via driver JIT even when
+        // the (env-polluted) offline flag is set in the inference process. See kernels_cache::_offline_export.
+        _kernels_cache->set_offline_export(_config.get_offline_compile() && !is_internal);
     }
 
     if (!_compilation_context)
@@ -618,10 +623,17 @@ void program::post_optimize_graph(bool is_internal) {
     apply_opt_pass<remove_redundant_reorders>(false, true);  // TODO: do we need it at this place also?
 
     auto partial_build = _config.get_partial_build_program();
+    // Offline compile-only (HW-free) skips constant folding here: propagate_constants folds constant
+    // sub-expressions / pre-reorders weights by building a temporary network and executing it on the
+    // GPU, which the compiling process must avoid. The folding is deferred to import time
+    // (Graph import ctor -> program::run_import_time_constant_folding), where a real GPU is present.
+    // The surviving unfolded constant nodes are serialized as-is and folded on import before the
+    // executable network is built.
+    auto offline_compile = _config.get_offline_compile();
 #ifdef GPU_DEBUG_CONFIG
-    if (!is_internal && (!partial_build || !_config.get_dry_run_path().empty())) {
+    if (!is_internal && !offline_compile && (!partial_build || !_config.get_dry_run_path().empty())) {
 #else
-    if (!is_internal && !partial_build) {
+    if (!is_internal && !offline_compile && !partial_build) {
 #endif
         // ToDo remove hidden dependencies from propagate_constants pass
         apply_opt_pass<propagate_constants>();
@@ -639,6 +651,14 @@ void program::post_optimize_graph(bool is_internal) {
         get_processing_order().calculate_BFS_processing_order();
 
     apply_opt_pass<mark_state_init_subgraphs>();
+}
+
+void program::run_import_time_constant_folding() {
+    // Deferred counterpart of the propagate_constants skip in post_optimize_graph for offline
+    // compile-only blobs. propagate_constants is self-contained (builds its own internal network to
+    // fold/execute the constant sub-graph) and safe to run on a deserialized program: it folds the
+    // surviving constant nodes into data nodes before the executable network is built.
+    apply_opt_pass<propagate_constants>();
 }
 
 // mark if the node is constant assuming that all dependencies are marked properly

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -62,7 +62,10 @@ CompiledModel::CompiledModel(std::shared_ptr<ov::Model> model,
       m_outputs(ov::ICompiledModel::outputs()),
       m_loaded_from_cache(false) {
     auto graph_base = std::make_shared<Graph>(model, m_context, m_config, 0);
-    for (uint16_t n = 0; n < m_config.get_num_streams(); n++) {
+    // Offline (HW-free) compile is compile-only (no inference): a single program-only graph is
+    // enough to export the blob; per-stream inference graphs would deref the (absent) network.
+    const uint16_t num_graphs = m_config.get_offline_compile() ? 1 : m_config.get_num_streams();
+    for (uint16_t n = 0; n < num_graphs; n++) {
         auto graph = n == 0 ? graph_base : std::make_shared<Graph>(graph_base, n);
         m_graphs.push_back(graph);
     }
@@ -299,9 +302,17 @@ std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request(
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "CompiledModel::create_sync_infer_request");
     OPENVINO_ASSERT(!m_graphs.empty(), "[GPU] Model not loaded");
 
+    // Offline (HW-free, compile-only) models build no cldnn::network (graph.cpp), so is_loaded()
+    // (== get_network() != nullptr) is false. We must still allow the request to be CONSTRUCTED:
+    // ORT's OpenVINO EP eagerly creates one infer request during CompileModel (ov_compute.cc
+    // InitFooter -> InferRequestPool) BEFORE exporting the EPContext blob. That request is never
+    // run (SyncInferRequest::infer() throws if offline); it just needs to construct so export can
+    // proceed. The real execution model is produced by import_model, which forces offline=false.
     for (auto& graph : m_graphs) {
         OPENVINO_ASSERT(graph != nullptr, "[GPU] Model not loaded: graph is nullptr");
-        OPENVINO_ASSERT(graph->is_loaded(), "[GPU] Model not loaded: invalid graph");
+        // Compile-only (offline) graphs have no network by design; allow the request to be constructed
+        // (see create_sync_infer_request comment). Executable graphs must be loaded.
+        OPENVINO_ASSERT(graph->is_compile_only() || graph->is_loaded(), "[GPU] Model not loaded: invalid graph");
     }
 
     return std::make_shared<SyncInferRequest>(std::static_pointer_cast<const CompiledModel>(shared_from_this()));

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -22,6 +22,7 @@
 #include "intel_gpu/runtime/itt.hpp"
 #include "intel_gpu/plugin/graph.hpp"
 #include "intel_gpu/plugin/simple_math.hpp"
+#include "runtime/ocl/offline_engine.hpp"
 
 #include "intel_gpu/primitives/dynamic_quantize.hpp"
 #include "dynamic_quantize_inst.h"
@@ -29,6 +30,7 @@
 #include <list>
 #include <set>
 #include <unordered_set>
+#include <iostream>
 #include <sstream>
 #include <chrono>
 #include <cmath>
@@ -44,9 +46,25 @@ Graph::Graph(std::shared_ptr<ov::Model> model, const RemoteContextImpl::Ptr& con
     : m_context(context)
     , m_config(config)
     , m_stream_id(stream_id) {
+    // Offline compile-only (HW-free): build the program with a stub engine (fabricated
+    // device_info, no cl::Context) so the compile passes + blob export never touch a real GPU. Gated on
+    // config.get_offline_compile(), which is reliable here: this ctor runs only in the compiler process
+    // (compile_model); the import ctor is used by the inference process and leaves m_offline_engine null.
+    // Once set, get_engine() below (and at export) returns the stub instead of the context's real engine.
+    if (config.get_offline_compile()) {
+        auto dev = std::make_shared<cldnn::ocl::offline_device>(
+            cldnn::ocl::make_offline_device_info(config.get_offline_compile_device()));
+        m_offline_engine = std::make_shared<cldnn::ocl::offline_engine>(dev);
+        std::cerr << "[GPU offline] using stub device_info engine (" << dev->get_info().dev_name
+                  << ", no cl::Context) for compile-only program" << std::endl;
+    }
+
     auto program_builder = std::make_shared<ProgramBuilder>(model, get_engine(), config);
     m_config = program_builder->get_config();
 
+    // Compile path: honor the offline (compile-only) request. The import constructor leaves this
+    // false so imported models always build a network and run, regardless of the polluting env var.
+    m_compile_only = m_config.get_offline_compile();
     build(program_builder->get_compiled_program());
 
     primitiveIDs = program_builder->primitive_ids;
@@ -96,11 +114,23 @@ Graph::Graph(cldnn::BinaryInputBuffer &ib, const RemoteContextImpl::Ptr& context
     m_config.visit_attributes(visitor);
     m_config.set_user_property(config.get_user_properties()); // Copy user properties if those were modified on import call
     m_config.set_user_property({ov::hint::model(std::shared_ptr<const ov::Model>(nullptr))});
+    // The blob may have been produced with GPU_OFFLINE_COMPILE=true; visit_attributes above restored
+    // that flag. Capture it now (before forcing it off): an offline compile-only blob skipped constant
+    // folding at compile time and must have it applied here at import, where a real GPU is present.
+    const bool blob_was_offline_compiled = m_config.get_offline_compile();
+    // Import must always build a real network (offline compile-only applies to the export path only),
+    // so force it off here.
+    m_config.set_user_property({ov::intel_gpu::offline_compile(false)});
     m_config.finalize(context.get(), nullptr);
 
     auto imported_prog = std::make_shared<cldnn::program>(get_engine(), m_config);
     // Not passing MODEL_PTR through m_config because values in m_config are immutable after config finalization.
     imported_prog->load(ib, config.get_model(), config.get_weightless_attr());
+    if (blob_was_offline_compiled) {
+        // Deferred constant folding: fold the surviving constant nodes into data nodes before the
+        // executable network is built (see program::run_import_time_constant_folding).
+        imported_prog->run_import_time_constant_folding();
+    }
     build(imported_prog);
 }
 
@@ -177,6 +207,16 @@ Graph::~Graph() {
 
 void Graph::build(std::shared_ptr<cldnn::program> program) {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "Graph::build");
+
+    // Offline (HW-free) compile: keep the compiled program only, do NOT build a cldnn::network.
+    // The network constructor allocates GPU memory and uploads weights (allocate_primitives) which
+    // is pure waste when we only want to export the compiled blob.
+    // Gate on m_compile_only (construction-path), NOT get_offline_compile(): the env var re-enables
+    // the config flag on the import/execute path too, but imported models must always build a network.
+    if (m_compile_only) {
+        m_program = program;
+        return;
+    }
 
     auto external_queue = m_context->get_external_queue();
     if (external_queue) {
@@ -539,6 +579,14 @@ void Graph::export_model(cldnn::BinaryOutputBuffer &ob) {
     }
     OstreamAttributeVisitor<cldnn::BinaryOutputBuffer> visitor(ob);
     m_config.visit_attributes(visitor);
+
+    // Offline compile: no network was built; serialize the program directly using a scratch stream.
+    if (m_program) {
+        auto stream = get_engine().create_stream(m_config);
+        ob.set_stream(stream.get());
+        m_program->save(ob);
+        return;
+    }
 
     ob.set_stream(m_network->get_stream_ptr().get());
     m_network->get_program()->save(ob);

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstdlib>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -26,6 +28,7 @@
 #include "intel_gpu/runtime/internal_properties.hpp"
 #include "intel_gpu/runtime/itt.hpp"
 #include "intel_gpu/runtime/profiling.hpp"
+#include "runtime/ocl/offline_engine.hpp"
 #include "openvino/core/any.hpp"
 #include "openvino/core/deprecated.hpp"
 #include "openvino/op/util/op_types.hpp"
@@ -247,12 +250,30 @@ Plugin::Plugin() {
     set_device_name("GPU");
     register_primitives();
 
-    cldnn::device_query device_query;
-    m_device_map = device_query.get_available_devices();
+    // HW-free offline: on a no-GPU sandbox the compiler process must still load the GPU plugin.
+    // device_query naturally returns an empty map when no GPU is present, and may throw if the ICD is
+    // present but restricted — tolerate both so plugin construction never aborts. The execute process on
+    // a real GPU box enumerates normally and is unaffected.
+    try {
+        cldnn::device_query device_query;
+        m_device_map = device_query.get_available_devices();
+    } catch (const std::exception& ex) {
+        std::cerr << "[GPU offline] device enumeration failed (" << ex.what()
+                  << "); continuing HW-free" << std::endl;
+    }
 
     // Set default configs for each device
     for (const auto& device : m_device_map) {
         m_configs_map.insert({device.first, ExecutionConfig(ov::device::id(device.first))});
+    }
+
+    // HW-free fallback: no GPU enumerated (no-GPU sandbox) → install a default config keyed on the
+    // default device id so compile_model's offline branch (stub context) can proceed. Dead code when a
+    // GPU is present (m_configs_map already non-empty) → non-offline / execute path unaffected.
+    if (m_configs_map.empty()) {
+        m_configs_map.insert({m_default_device_id, ExecutionConfig(ov::device::id(m_default_device_id))});
+        std::cerr << "[GPU offline] no GPU enumerated; installed default config for device '"
+                  << m_default_device_id << "'" << std::endl;
     }
 
     // Set common info for compiled_model_runtime_properties
@@ -263,13 +284,42 @@ Plugin::Plugin() {
 std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<const ov::Model>& model, const ov::AnyMap& orig_config) const {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "Plugin::compile_model");
     std::string device_id = get_device_id(orig_config);
-    auto context = get_default_context(device_id);
-    GPU_DEBUG_SET_ACTIVE_LUID(context->get_device().get_info().luid);
 
     OPENVINO_ASSERT(m_configs_map.find(device_id) != m_configs_map.end(), "[GPU] compile_model: Couldn't find config for GPU with id ", device_id);
 
     ExecutionConfig config = m_configs_map.at(device_id);
     config.set_user_property(orig_config, OptionVisibility::RELEASE);
+
+    // HW-free offline compile-only: use a stub context (fabricated device_info, no cl::Context / real
+    // GPU) instead of the real default context, so the whole compile touches no GPU. Only reached in the
+    // compiler process (compile_model); the inference process imports via import_model with a real
+    // context. NOTE: the offline flag/target usually arrive via the OV_GPU_OFFLINE_COMPILE[_DEVICE] env
+    // (chromium) which is only applied during config.finalize() below -- too late for this pre-context
+    // decision -- so we also peek the env directly here (the config path covers config-driven use).
+    // This env peek is a temporary transitional mechanism; it will be replaced by EP metadata.
+    bool offline = config.get_offline_compile();
+    std::string offline_target = config.get_offline_compile_device();
+    if (!offline) {
+        if (const char* env_off = std::getenv("OV_GPU_OFFLINE_COMPILE")) {
+            std::string v(env_off);
+            offline = (v == "1" || v == "true" || v == "TRUE" || v == "yes" || v == "YES");
+        }
+        if (offline && offline_target.empty()) {
+            if (const char* env_dev = std::getenv("OV_GPU_OFFLINE_COMPILE_DEVICE"))
+                offline_target = env_dev;
+        }
+    }
+
+    std::shared_ptr<RemoteContextImpl> context;
+    if (offline) {
+        auto dev = std::make_shared<cldnn::ocl::offline_device>(
+            cldnn::ocl::make_offline_device_info(offline_target));
+        context = std::make_shared<RemoteContextImpl>(get_device_name() + "." + device_id,
+                                                      std::vector<cldnn::device::ptr>{dev});
+    } else {
+        context = get_default_context(device_id);
+    }
+    GPU_DEBUG_SET_ACTIVE_LUID(context->get_device().get_info().luid);
 
     auto transformed_model = clone_and_transform_model(model, config, context);
 
@@ -553,10 +603,14 @@ ov::Any Plugin::get_property(const std::string& name, const ov::AnyMap& options)
         return res;
     }
 
-    OPENVINO_ASSERT(!m_device_map.empty(), "[GPU] Can't get ", name, " property as no supported devices found or an error happened during devices query.\n"
-                                           "[GPU] Please check OpenVINO documentation for GPU drivers setup guide.\n");
-
+    // Metrics read hardware device_info from m_device_map, so they require an enumerated device. Config
+    // properties (mutable, e.g. PERFORMANCE_HINT) are served from m_configs_map, which the HW-free
+    // fallback (ctor) populates even with no GPU — so don't block those on an empty device map. This keeps
+    // the compiler process (no GPU / OV_GPU_FORCE_NO_DEVICE_QUERY) able to answer config queries that OV
+    // core issues during compile_model.
     if (is_metric(name)) {
+        OPENVINO_ASSERT(!m_device_map.empty(), "[GPU] Can't get ", name, " property as no supported devices found or an error happened during devices query.\n"
+                                               "[GPU] Please check OpenVINO documentation for GPU drivers setup guide.\n");
         return get_metric(name, options);
     }
 

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -9,6 +9,8 @@
 #include "intel_gpu/plugin/usm_host_tensor.hpp"
 #include "intel_gpu/runtime/itt.hpp"
 #include "intel_gpu/runtime/device_query.hpp"
+#include "runtime/ocl/offline_engine.hpp"
+#include <iostream>
 #include <memory>
 
 namespace ov::intel_gpu {
@@ -276,9 +278,16 @@ void RemoteContextImpl::initialize() {
     std::call_once(m_initialize_flag, [this]() {
         GPU_DEBUG_INFO << "Initialize RemoteContext for " << m_device_name << " (" << m_device->get_info().dev_name << ")" << std::endl;
 
-        m_device->initialize();  // Initialize associated device before use
-        m_engine = cldnn::engine::create(
-            cldnn::get_default_engine_type(), cldnn::get_default_runtime_type(), m_device);
+        if (dynamic_cast<cldnn::ocl::offline_device*>(m_device.get())) {
+            // HW-free offline compile-only context: build a stub engine (no cl::Context / device init).
+            // Self-identified by the device type, so no env dependency. See offline_engine.
+            m_engine = std::make_shared<cldnn::ocl::offline_engine>(m_device);
+            std::cerr << "[GPU offline] RemoteContext uses stub offline_engine (no cl::Context)" << std::endl;
+        } else {
+            m_device->initialize();  // Initialize associated device before use
+            m_engine = cldnn::engine::create(
+                cldnn::get_default_engine_type(), cldnn::get_default_runtime_type(), m_device);
+        }
 
         init_properties();
 

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -99,7 +99,14 @@ SyncInferRequest::SyncInferRequest(const std::shared_ptr<const CompiledModel>& c
     init_mappings();
     allocate_inputs();
     allocate_outputs();
-    allocate_states();
+    // Compile-only (offline) models build no cldnn::network, so there are no stateful variables to
+    // allocate and get_network() is null (allocate_states() would deref null at get_variables_info()).
+    // Such a request is only constructed by ORT's EP during CompileModel and never run (infer() throws
+    // when compile-only). init_mappings/allocate_inputs/allocate_outputs use only port metadata +
+    // engine, which are available without a network. Key on is_compile_only(), not the env-pollutable
+    // get_offline_compile().
+    if (!m_graph->is_compile_only())
+        allocate_states();
 }
 
 SyncInferRequest::~SyncInferRequest() {
@@ -115,6 +122,14 @@ SyncInferRequest::~SyncInferRequest() {
 }
 
 void SyncInferRequest::infer() {
+    // Compile-only (HW-free offline) models build no cldnn::network and cannot be executed in place.
+    // ORT's EP only constructs this request during CompileModel (to export the EPContext blob) and
+    // never runs it, so this guard fires only on genuine misuse. Import the exported blob to infer.
+    // Key on is_compile_only(), not the env-pollutable get_offline_compile() (which is also true on
+    // the import/execute path when OV_GPU_OFFLINE_COMPILE is set in the environment).
+    OPENVINO_ASSERT(!m_graph->is_compile_only(),
+                    "[GPU] This model was compiled with GPU_OFFLINE_COMPILE (compile-only); it can be "
+                    "exported but not executed. Import the exported blob on the target GPU to infer.");
     // String can be constructed once in the constructor
     OV_ITT_SCOPED_TASK_BASE(itt::domains::intel_gpu_inference,  m_itt_infer_request_str.c_str());
     setup_stream_graph();
@@ -1069,10 +1084,16 @@ void SyncInferRequest::init_mappings() {
         m_input_ports_map[input_idx] = inputs[input_idx];
     }
 
+    // Offline (compile-only) models build no cldnn::network; out_port_index_to_internal() reads
+    // network->get_output_ids() and would deref null. m_output_names_map is only consumed during
+    // inference (prepare_output), and compile-only requests never run (infer() throws), so skip it.
+    // Key on is_compile_only() (construction-path), NOT the env-pollutable get_offline_compile().
+    const bool compile_only = m_graph->is_compile_only();
     const auto& outputs = get_outputs();
     for (size_t output_idx = 0; output_idx < outputs.size(); ++output_idx) {
         m_output_ports_map[output_idx] = outputs[output_idx];
-        m_output_names_map[output_idx] = m_graph->out_port_index_to_internal(output_idx);
+        if (!compile_only)
+            m_output_names_map[output_idx] = m_graph->out_port_index_to_internal(output_idx);
     }
 }
 

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -154,6 +154,13 @@ ExecutionConfig ExecutionConfig::clone() const {
 }
 
 void ExecutionConfig::finalize(cldnn::engine& engine) {
+    // Already finalized: PluginConfig::finalize would early-return without touching the context, so skip
+    // building it. This also avoids eagerly initializing a RemoteContextImpl (which calls engine::create)
+    // for an already-finalized config — required for the HW-free offline stub engine, whose device is not
+    // an ocl_device and would fail ocl_engine's device cast. The temporary context is otherwise unused
+    // whenever the config is already finalized.
+    if (m_is_finalized)
+        return;
     auto ctx = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
     PluginConfig::finalize(ctx.get(), nullptr);
 }
@@ -340,6 +347,14 @@ void ExecutionConfig::finalize_impl(const IRemoteContext* context) {
     }
     if (!is_set_by_user(ov::intel_gpu::use_onednn) && info.supports_immad) {
         m_use_onednn = true;
+    }
+    // HW-free offline compile: onednn primitives compile their kernels via onednn's own
+    // JIT against the GPU driver (primitive_onednn_base.h init_kernels() is a no-op) and never go
+    // through kernels_cache/ocloc, so they cannot be HW-free compiled. Force every primitive onto the
+    // ocl (kernels_cache) path so offline_compile == 100% ocloc coverage. This overrides the
+    // supports_immad auto-enable above (matters on dGPU/Arc; iGPUs without XMX already keep it off).
+    if (get_offline_compile() && m_use_onednn) {
+        m_use_onednn = false;
     }
     if (get_use_onednn()) {
         m_queue_type = QueueTypes::in_order;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocloc_offline_compiler.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocloc_offline_compiler.hpp
@@ -1,0 +1,202 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// POC ONLY — dynamic-load wrapper around NEO ocloc's in-memory `oclocInvoke`.
+//
+// Purpose: validate that the OV GPU plugin can compile a kernel's OpenCL C source
+// through NEO ocloc's offline (HW-free) path (oclocInvoke -> IGC), instead of the
+// driver JIT (clBuildProgram). This wrapper only compiles source -> native binary
+// bytes; it does NOT create cl::Kernel objects. See the POC plan.
+//
+// No build-system change: ocloc is loaded at runtime via LoadLibrary/dlopen and the
+// oclocInvoke/oclocFreeOutput signatures are declared locally (copied from
+// compute-runtime/shared/offline_compiler/source/ocloc_api.h), so we do NOT include
+// any compute-runtime header.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace cldnn {
+namespace ocloc_poc {
+
+// Signatures copied verbatim from ocloc_api.h (extern "C").
+using ocloc_invoke_fn = int (*)(unsigned int numArgs, const char* argv[],
+                                const uint32_t numSources, const uint8_t** dataSources,
+                                const uint64_t* lenSources, const char** nameSources,
+                                const uint32_t numInputHeaders, const uint8_t** dataInputHeaders,
+                                const uint64_t* lenInputHeaders, const char** nameInputHeaders,
+                                uint32_t* numOutputs, uint8_t*** dataOutputs,
+                                uint64_t** lenOutputs, char*** nameOutputs);
+using ocloc_free_output_fn = int (*)(uint32_t* numOutputs, uint8_t*** dataOutputs,
+                                     uint64_t** lenOutputs, char*** nameOutputs);
+
+struct ocloc_api {
+    ocloc_invoke_fn invoke = nullptr;
+    ocloc_free_output_fn free_output = nullptr;
+    bool ok() const { return invoke != nullptr && free_output != nullptr; }
+};
+
+inline const char* getenv_or_null(const char* name) {
+    const char* v = std::getenv(name);
+    return (v && v[0]) ? v : nullptr;
+}
+
+// Loads ocloc once (thread-safe) and caches the resolved function pointers.
+// Search order for the shared library:
+//   1) $OV_GPU_OCLOC_PATH (full path to the DLL/SO), if set
+//   2) plain name via system loader ("ocloc64.dll" / "libocloc.so")
+//   3) known Intel oneAPI install path (Windows)
+inline const ocloc_api& load_ocloc() {
+    static ocloc_api api;
+    static std::once_flag once;
+    std::call_once(once, [] {
+#ifdef _WIN32
+        HMODULE handle = nullptr;
+        if (const char* p = getenv_or_null("OV_GPU_OCLOC_PATH"))
+            handle = LoadLibraryA(p);
+        if (!handle)
+            handle = LoadLibraryA("ocloc64.dll");
+        if (!handle)
+            handle = LoadLibraryA("C:\\Program Files (x86)\\Intel\\oneAPI\\ocloc\\2025.2\\bin\\ocloc64.dll");
+        if (handle) {
+            api.invoke = reinterpret_cast<ocloc_invoke_fn>(GetProcAddress(handle, "oclocInvoke"));
+            api.free_output = reinterpret_cast<ocloc_free_output_fn>(GetProcAddress(handle, "oclocFreeOutput"));
+        }
+#else
+        void* handle = nullptr;
+        if (const char* p = getenv_or_null("OV_GPU_OCLOC_PATH"))
+            handle = dlopen(p, RTLD_LAZY | RTLD_LOCAL);
+        if (!handle)
+            handle = dlopen("libocloc.so", RTLD_LAZY | RTLD_LOCAL);
+        if (handle) {
+            api.invoke = reinterpret_cast<ocloc_invoke_fn>(dlsym(handle, "oclocInvoke"));
+            api.free_output = reinterpret_cast<ocloc_free_output_fn>(dlsym(handle, "oclocFreeOutput"));
+        }
+#endif
+    });
+    return api;
+}
+
+// Compiles a single OpenCL C source string to a device native binary via ocloc.
+// `device_arg` is passed to ocloc `-device` (e.g. "0x4680" or "12.2.0").
+// `options` (OpenCL build flags) are forwarded via ocloc `-options`.
+// Returns the ocloc `.bin` output on success, or empty vector on any failure.
+inline std::vector<uint8_t> ocloc_compile_ocl_c(const std::string& source,
+                                                const std::string& options,
+                                                const std::string& device_arg,
+                                                std::string* log_out = nullptr) {
+    const ocloc_api& api = load_ocloc();
+    if (!api.ok()) {
+        if (log_out)
+            *log_out += "[GPU offline] ocloc library not loaded\n";
+        return {};
+    }
+
+    // oclocInvoke drives IGC/FCL global/process-wide state and is not reentrant.
+    // build_batch runs batches in parallel (kernels_cache task executor), so
+    // serialize all ocloc calls to avoid intermittent failures / empty output.
+    static std::mutex ocloc_call_mutex;
+    std::lock_guard<std::mutex> call_lock(ocloc_call_mutex);
+
+    // argv: ocloc compile -device <id> [-options "<opts>"] -file kernel.cl
+    std::vector<const char*> argv;
+    argv.push_back("ocloc");
+    argv.push_back("compile");
+    argv.push_back("-device");
+    argv.push_back(device_arg.c_str());
+    // -exclude_ir: emit native-ISA-only zebin (no embedded SPIR-V). Without this, ocloc emits
+    // a "fat" zebin (native ISA + SPIR-V IR); loading it on a mismatched device makes the driver
+    // silently re-JIT from the IR (masking a target mismatch). With IR excluded, a wrong-target
+    // binary fails to load -- which is what we want to validate that the native binary is used.
+    argv.push_back("-exclude_ir");
+    if (!options.empty()) {
+        argv.push_back("-options");
+        argv.push_back(options.c_str());
+    }
+    argv.push_back("-file");
+    argv.push_back("kernel.cl");
+
+    // NOTE: ocloc's in-memory source path (OclocArgHelper::loadDataFromFile) copies
+    // exactly `length` bytes and does NOT null-terminate, yet offline_compiler.cpp
+    // reads the buffer as a C-string (strstr / char*->std::string) -> heap over-read
+    // -> intermittent garbage ("source file is not valid UTF-8" past real EOF).
+    // Work around it by including the string's guaranteed NUL terminator in `length`
+    // (std::string::data()[size()] == '\0', reading it is well-defined).
+    const uint8_t* src_data[] = { reinterpret_cast<const uint8_t*>(source.data()) };
+    const uint64_t src_len[]  = { static_cast<uint64_t>(source.size() + 1) };
+    const char*    src_name[] = { "kernel.cl" };
+
+    uint32_t num_out = 0;
+    uint8_t** out_data = nullptr;
+    uint64_t* out_len = nullptr;
+    char**    out_name = nullptr;
+
+    int rc = api.invoke(static_cast<unsigned>(argv.size()), argv.data(),
+                        1, src_data, src_len, src_name,
+                        0, nullptr, nullptr, nullptr,
+                        &num_out, &out_data, &out_len, &out_name);
+
+    std::vector<uint8_t> result;
+    if (log_out)
+        *log_out += "[GPU offline] rc=" + std::to_string(rc) + " numOutputs=" + std::to_string(num_out) + "\n";
+
+    // Scan outputs even when rc != 0 so a valid .bin is not discarded, and so we
+    // can capture ocloc's stdout.log (the failure reason). ocloc returns raw C
+    // arrays; index them behind the clang unsafe-buffer pragma (POC-local).
+#if defined(__clang__)
+#pragma clang unsafe_buffer_usage begin
+#endif
+    if (out_data && out_len && out_name) {
+        int best = -1;
+        bool found_bin = false;
+        for (uint32_t i = 0; i < num_out; ++i) {
+            std::string name = out_name[i] ? out_name[i] : "";
+            uint64_t len = out_len[i];
+            if (log_out)
+                *log_out += "  [" + std::to_string(i) + "] " + name + " (" + std::to_string(len) + " bytes)\n";
+            if (log_out && name == "stdout.log" && out_data[i] && len > 0) {
+                *log_out += "--- ocloc stdout.log ---\n";
+                log_out->append(reinterpret_cast<const char*>(out_data[i]), static_cast<size_t>(len));
+                if (!log_out->empty() && log_out->back() != '\n')
+                    *log_out += "\n";
+            }
+            bool is_bin = name.size() >= 4 && name.compare(name.size() - 4, 4, ".bin") == 0;
+            if (is_bin) {
+                best = static_cast<int>(i);
+                found_bin = true;
+            } else if (!found_bin && name != "stdout.log" && (best < 0 || len > out_len[best])) {
+                best = static_cast<int>(i);
+            }
+        }
+        if (best >= 0 && out_data[best] && out_len[best] > 0)
+            result.assign(out_data[best], out_data[best] + out_len[best]);
+    }
+#if defined(__clang__)
+#pragma clang unsafe_buffer_usage end
+#endif
+
+    if (api.free_output)
+        api.free_output(&num_out, &out_data, &out_len, &out_name);
+
+    return result;
+}
+
+}  // namespace ocloc_poc
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/runtime/ocl/offline_device.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/offline_device.hpp
@@ -1,0 +1,125 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "intel_gpu/runtime/device.hpp"
+#include "intel_gpu/runtime/device_info.hpp"
+#include "intel_gpu/runtime/memory_caps.hpp"
+#include "openvino/core/except.hpp"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace cldnn {
+namespace ocl {
+
+// HW-free device holding a fabricated device_info for offline compile-only. No real cl::Device: it is
+// never enumerated by device_query and never initialized against hardware. Mirrors the dummy_device
+// test helper (device_test.cpp). Used by offline_engine so the compile passes read device metadata
+// without a GPU. device_info is NOT serialized into the blob, so the values are hardcoded here.
+class offline_device : public device {
+public:
+    explicit offline_device(const device_info& info)
+        : _info(info)
+        , _mem_caps(info.supports_usm
+                        ? std::vector<allocation_type>{allocation_type::cl_mem, allocation_type::usm_host,
+                                                       allocation_type::usm_shared, allocation_type::usm_device}
+                        : std::vector<allocation_type>{allocation_type::cl_mem}) {}
+
+    const device_info& get_info() const override { return _info; }
+    memory_capabilities get_mem_caps() const override { return _mem_caps; }
+    void initialize() override {}
+    bool is_initialized() const override { return true; }
+    bool is_same(const device::ptr other) override { return this == other.get(); }
+    void set_mem_caps(const memory_capabilities& memory_capabilities) override { _mem_caps = memory_capabilities; }
+
+private:
+    device_info _info;
+    memory_capabilities _mem_caps;
+};
+
+// Returns a fabricated device_info for the offline compile target. The field values are captured once
+// from a real device (Intel UHD Graphics 770, 0x4680, driver 32.0.101.6129) and hardcoded, because
+// device_info is never serialized. Any device target (from EP metadata) is accepted: the
+// 0x4680-derived profile is used as the base and, when device_arg is a 0xXXXX hex id, device_id is
+// overridden. For targets other than 0x4680 a one-time warning is logged -- kernel/layout selection
+// fidelity is only guaranteed for 0x4680 until per-device profiles are added.
+inline device_info make_offline_device_info(const std::string& device_arg) {
+    device_info info{};
+    // Captured from a real 0x4680 device.
+    info.execution_units_count = 32;
+    info.gpu_frequency = 1500;
+    info.max_work_group_size = 512;
+    info.max_local_mem_size = 65536;
+    info.max_global_mem_size = 31714639872ULL;
+    info.max_alloc_mem_size = 4294959104ULL;
+    info.max_global_cache_size = 1966080;
+    info.max_image2d_width = 16384;
+    info.max_image2d_height = 16384;
+    info.supports_fp16 = true;
+    info.supports_fp64 = false;
+    info.supports_fp16_denorms = true;
+    info.supports_khr_subgroups = false;
+    info.supports_intel_subgroups = true;
+    info.supports_intel_subgroups_short = true;
+    info.supports_intel_subgroups_char = true;
+    info.supports_intel_required_subgroup_size = true;
+    info.supports_queue_families = true;
+    info.supports_image = true;
+    info.supports_intel_planar_yuv = true;
+    info.supports_work_group_collective_functions = true;
+    info.supports_non_uniform_work_group = true;
+    info.supports_imad = true;
+    info.supports_immad = false;
+    info.supports_mutable_command_list = false;
+    info.supports_usm = true;
+    info.has_separate_cache = false;
+    info.supports_cp_offload = false;
+    info.supports_counter_based_events = false;
+    info.supports_leo = false;
+    info.supported_simd_sizes = {8, 16, 32};
+    info.vendor_id = INTEL_VENDOR_ID;  // 0x8086
+    info.dev_name = "Intel(R) UHD Graphics 770";
+    info.driver_version = "32.0.101.6129";
+    info.dev_type = device_type::integrated_gpu;
+    info.gfx_ver = {12, 2, 0};
+    info.arch = gpu_arch::xe_lp;  // enum value 3
+    info.ip_version = 50364416;
+    info.device_id = 0x4680;
+    info.num_slices = 1;
+    info.num_sub_slices_per_slice = 4;
+    info.num_eus_per_sub_slice = 8;
+    info.num_threads_per_eu = 7;
+    info.num_ccs = 1;
+    info.sub_device_idx = 0xFFFFFFFF;  // captured 4294967295 (UINT32_MAX = no sub-device)
+    info.pci_info = {0, 0, 2, 0};  // domain, bus, device, function
+    info.timer_resolution = 0;
+    info.kernel_timestamp_valid_bits = 0;
+    info.compute_queue_group_ordinal = 0;
+    info.device_memory_ordinal = 0;
+    // uuid / luid left default (not used by compile-time passes).
+
+    // Accept any device target. If device_arg is a 0xXXXX hex id, override device_id with it. For any
+    // target other than 0x4680, the fields above are a 0x4680-derived approximation: warn once that
+    // kernel/layout fidelity is only guaranteed for 0x4680 (add per-device profiles when needed).
+    const bool is_4680 = (device_arg == "0x4680" || device_arg == "0X4680");
+    if (!device_arg.empty() && (device_arg.rfind("0x", 0) == 0 || device_arg.rfind("0X", 0) == 0)) {
+        try {
+            info.device_id = static_cast<uint32_t>(std::stoul(device_arg, nullptr, 16));
+        } catch (...) {
+            // leave the captured default device_id
+        }
+    }
+    if (!is_4680) {
+        std::cerr << "[GPU offline] make_offline_device_info: using 0x4680-derived device_info profile "
+                     "for target " << device_arg << "; kernel/layout fidelity only guaranteed for 0x4680"
+                  << std::endl;
+    }
+    return info;
+}
+
+}  // namespace ocl
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/runtime/ocl/offline_engine.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/offline_engine.hpp
@@ -1,0 +1,94 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "intel_gpu/runtime/engine.hpp"
+#include "offline_device.hpp"
+#include "offline_stream.hpp"
+#include "offline_kernel_builder.hpp"
+#include "offline_memory.hpp"
+#include "openvino/core/except.hpp"
+
+#include <memory>
+
+namespace cldnn {
+namespace ocl {
+
+// HW-free engine for offline compile-only. It carries a fabricated device_info via
+// offline_device and creates NO cl::Context. It reports engine_types::ocl so the compile passes select
+// the ocl impl path. Only the three methods the compile-only passes actually reach are functional:
+//   - create_stream()          -> a no-op offline_stream (stored as program::_stream, never enqueued)
+//   - create_kernel_builder()  -> offline_kernel_builder (stored by kernels_cache; offline path never
+//                                 calls build_kernels, it emits ocloc placeholders)
+//   - get_device_info()        -> base engine returns _device->get_info() (the fabricated info)
+// Every other (memory/context/usm) method throws: reaching it means a real network is being built or
+// executed on the compile-only engine, which must not happen (offline compile builds no network).
+class offline_engine : public engine {
+public:
+    explicit offline_engine(const device::ptr dev) : engine(dev) {
+        // Provide a service stream so any get_service_stream() call does not dereference null.
+        _service_stream.reset(new offline_stream());
+    }
+
+    engine_types type() const override { return engine_types::ocl; }
+    runtime_types runtime_type() const override { return runtime_types::ocl; }
+    backend_types backend_type() const override { return backend_types::ocl; }
+
+    stream_ptr create_stream(const ExecutionConfig& /*config*/) const override {
+        return std::make_shared<offline_stream>();
+    }
+    stream_ptr create_stream(const ExecutionConfig& /*config*/, void* /*handle*/) const override {
+        return std::make_shared<offline_stream>();
+    }
+    std::shared_ptr<kernel_builder> create_kernel_builder() const override {
+        return std::make_shared<offline_kernel_builder>();
+    }
+
+    allocation_type get_default_allocation_type() const override { return allocation_type::usm_host; }
+
+    memory_ptr allocate_memory(const layout& layout, allocation_type type, bool /*reset*/ = true) override {
+        // Host-backed allocation (no cl::Context). Used for constant weights, which are memcpy'd in via
+        // mem_lock and serialized into the blob. The buffer is zero-initialized so reset is a no-op.
+        return std::make_shared<offline_memory>(this, layout, type);
+    }
+    memory_ptr reinterpret_handle(const layout& /*new_layout*/, shared_mem_params /*params*/) override {
+        OPENVINO_THROW("[GPU offline] engine::reinterpret_handle is not available on the compile-only engine");
+    }
+    memory_ptr create_subbuffer(const memory& /*memory*/, const layout& /*new_layout*/, size_t /*byte_offset*/) override {
+        OPENVINO_THROW("[GPU offline] engine::create_subbuffer is not available on the compile-only engine");
+    }
+    memory_ptr create_mmap_hostbuffer(const void* /*mmapped_address*/, size_t /*data_size*/,
+                                      allocation_type /*_allocation_type*/, const layout /*output_layout*/) override {
+        OPENVINO_THROW("[GPU offline] engine::create_mmap_hostbuffer is not available on the compile-only engine");
+    }
+    memory_ptr reinterpret_buffer(const memory& memory, const layout& new_layout) override {
+        // Return a view over the same host buffer with a new layout (e.g. constant reshaping in
+        // prepare_primitive_fusing at compile time). Only offline_memory is produced by this engine.
+        const auto* om = dynamic_cast<const offline_memory*>(&memory);
+        OPENVINO_ASSERT(om, "[GPU offline] reinterpret_buffer expects offline_memory on the compile-only engine");
+        return std::make_shared<offline_memory>(this, new_layout, memory.get_allocation_type(), om->shared_buffer());
+    }
+    memory_ptr import_buffer(const layout& /*layout*/, ov::intel_gpu::os_handle_param /*external_handle*/) override {
+        OPENVINO_THROW("[GPU offline] engine::import_buffer is not available on the compile-only engine");
+    }
+    bool is_the_same_buffer(const memory& /*mem1*/, const memory& /*mem2*/) override {
+        OPENVINO_THROW("[GPU offline] engine::is_the_same_buffer is not available on the compile-only engine");
+    }
+    // No real CL/L0 context exists. Returning null (rather than throwing) lets RemoteContextImpl::
+    // init_properties() store a null ocl_context handle harmlessly (compile-only never uses it).
+    void* get_user_context(runtime_types /*rt_type*/) const override { return nullptr; }
+    allocation_type detect_usm_allocation_type(const void* /*memory*/) const override {
+        OPENVINO_THROW("[GPU offline] engine::detect_usm_allocation_type is not available on the compile-only engine");
+    }
+
+#ifdef ENABLE_ONEDNN_FOR_GPU
+    void create_onednn_engine(const ExecutionConfig& /*config*/) override {
+        OPENVINO_THROW("[GPU offline] engine::create_onednn_engine is not available on the compile-only engine");
+    }
+#endif
+};
+
+}  // namespace ocl
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/runtime/ocl/offline_kernel.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/offline_kernel.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "intel_gpu/runtime/kernel.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace cldnn {
+namespace ocl {
+
+// HW-free placeholder kernel used ONLY on the offline (GPU_OFFLINE_COMPILE) export path.
+// It holds just an entry-point id and a pre-compiled (ocloc) binary; it carries NO cl::Kernel
+// handle and is NEVER executed (offline compile never builds a cldnn::network). It exists so
+// build_batch can produce serializable kernels without driver-JIT'ing against a real cl::Context.
+// The compiler/serialization side only reads get_id() (entry point) and get_binary() (bytes);
+// import reconstructs real ocl_kernels from these bytes via build_kernels(NATIVE_BIN).
+class offline_kernel : public kernel {
+    std::string _id;
+    std::vector<uint8_t> _binary;
+
+public:
+    offline_kernel(std::string id, std::vector<uint8_t> binary)
+        : _id(std::move(id))
+        , _binary(std::move(binary)) { }
+
+    std::string get_id() const override { return _id; }
+    std::vector<uint8_t> get_binary() const override { return _binary; }
+    std::string get_build_log() const override { return {}; }
+
+    std::shared_ptr<kernel> clone(bool /*reuse_kernel_handle*/ = false) const override {
+        return std::make_shared<offline_kernel>(_id, _binary);
+    }
+
+    bool is_same(const kernel& other) const override {
+        auto other_ptr = dynamic_cast<const offline_kernel*>(&other);
+        return other_ptr != nullptr && other_ptr->_id == _id && other_ptr->_binary == _binary;
+    }
+};
+
+}  // namespace ocl
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/runtime/ocl/offline_kernel_builder.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/offline_kernel_builder.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "intel_gpu/runtime/kernel_builder.hpp"
+#include "openvino/core/except.hpp"
+
+#include <string>
+#include <vector>
+
+namespace cldnn {
+namespace ocl {
+
+// HW-free kernel builder for the offline compile-only engine. The offline kernels_cache path compiles
+// via ocloc and wraps the result in offline_kernel placeholders; it never calls build_kernels. This
+// builder exists only so engine::create_kernel_builder() can return a non-null builder without a
+// cl::Context. Any call means a non-offline code path is compiling kernels on the compile-only engine.
+class offline_kernel_builder : public kernel_builder {
+public:
+    void build_kernels(const void* /*src*/,
+                       size_t /*src_bytes*/,
+                       KernelFormat /*src_format*/,
+                       const std::string& /*options*/,
+                       std::vector<kernel::ptr>& /*out*/) const override {
+        OPENVINO_THROW("[GPU offline] kernel_builder::build_kernels is not available on the compile-only "
+                       "engine (offline batches are compiled by ocloc into offline_kernel placeholders)");
+    }
+};
+
+}  // namespace ocl
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/runtime/ocl/offline_memory.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/offline_memory.hpp
@@ -1,0 +1,79 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "intel_gpu/runtime/memory.hpp"
+#include "openvino/core/except.hpp"
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace cldnn {
+namespace ocl {
+
+// HW-free host-backed memory for the offline compile-only engine. Owns a plain host buffer (no
+// cl::Context / device allocation), held via shared_ptr so reinterpret_buffer can produce a view over
+// the same bytes with a different layout. Constant weights are allocated here at compile time, filled
+// via mem_lock + memcpy (constant.cpp), possibly reinterpreted (prepare_primitive_fusing), and
+// serialized into the blob (they stay host-side because iGPU has has_separate_cache=false, so
+// program::transfer_memory_to_device is skipped). lock() returns the host buffer; host-pointer copy
+// paths are implemented; memory<->memory device paths are not reachable at compile-only and throw.
+class offline_memory : public memory {
+public:
+    offline_memory(engine* engine, const layout& layout, allocation_type type)
+        : memory(engine, layout, type, nullptr)
+        , _buf(std::make_shared<std::vector<uint8_t>>(layout.bytes_count(), 0)) {}
+
+    // View constructor: shares the underlying buffer with a different layout (reinterpret_buffer).
+    offline_memory(engine* engine, const layout& layout, allocation_type type,
+                   std::shared_ptr<std::vector<uint8_t>> buf)
+        : memory(engine, layout, type, nullptr)
+        , _buf(std::move(buf)) {}
+
+    std::shared_ptr<std::vector<uint8_t>> shared_buffer() const { return _buf; }
+
+    void* lock(const stream& /*stream*/, mem_lock_type /*type*/ = mem_lock_type::read_write) override {
+        return _buf->data();
+    }
+    void unlock(const stream& /*stream*/) override {}
+
+    // usm_host is host-accessible: data::save serializes constant weights straight from buffer_ptr()
+    // (not via copy_to), so it must return the host buffer rather than the base-class nullptr.
+    void* buffer_ptr() const override { return _buf->data(); }
+
+    event::ptr fill(stream& /*stream*/, unsigned char pattern, const std::vector<event::ptr>&, bool) override {
+        std::fill(_buf->begin(), _buf->end(), pattern);
+        return nullptr;
+    }
+
+    shared_mem_params get_internal_params(runtime_types /*rt_type*/) const override {
+        return { shared_mem_type::shared_mem_empty, nullptr, nullptr, nullptr,
+#ifdef _WIN32
+            nullptr,
+#else
+            0,
+#endif
+            0 };
+    }
+
+    event::ptr copy_from(stream& /*stream*/, const void* src_ptr, size_t src_offset, size_t dst_offset, size_t size, bool /*blocking*/) override {
+        std::memcpy(_buf->data() + dst_offset, static_cast<const uint8_t*>(src_ptr) + src_offset, size);
+        return nullptr;
+    }
+    event::ptr copy_from(stream& /*stream*/, const memory& /*src_mem*/, size_t, size_t, size_t, bool) override {
+        OPENVINO_THROW("[GPU offline] memory::copy_from(memory) is not available on the compile-only engine");
+    }
+    event::ptr copy_to(stream& /*stream*/, void* dst_ptr, size_t src_offset, size_t dst_offset, size_t size, bool /*blocking*/) const override {
+        std::memcpy(static_cast<uint8_t*>(dst_ptr) + dst_offset, _buf->data() + src_offset, size);
+        return nullptr;
+    }
+
+private:
+    std::shared_ptr<std::vector<uint8_t>> _buf;
+};
+
+}  // namespace ocl
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/runtime/ocl/offline_stream.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/offline_stream.hpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "intel_gpu/runtime/stream.hpp"
+#include "intel_gpu/runtime/memory.hpp"
+#include "openvino/core/except.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace cldnn {
+namespace ocl {
+
+// HW-free no-op stream used ONLY on the offline compile-only path (see offline_engine). The offline
+// program never builds/executes a cldnn::network, so no kernel is ever enqueued; every execution
+// method throws (a call means a network is being run on a compile-only engine, which is a logic error).
+// Sync/wait ops are no-ops so any stray flush/finish during program build/serialization is harmless.
+class offline_stream : public stream {
+public:
+    offline_stream() : stream(QueueTypes::in_order, SyncMethods::none) {}
+
+    void flush() const override {}
+    void finish() const override {}
+    void wait() override {}
+
+    void set_arguments(kernel&, const kernel_arguments_desc&, const kernel_arguments_data&) override {
+        OPENVINO_THROW("[GPU offline] stream::set_arguments is not available on the compile-only engine");
+    }
+    event::ptr enqueue_kernel(kernel&,
+                              const kernel_arguments_desc&,
+                              const kernel_arguments_data&,
+                              std::vector<event::ptr> const&,
+                              bool /*is_output_event*/ = false) override {
+        OPENVINO_THROW("[GPU offline] stream::enqueue_kernel is not available on the compile-only engine");
+    }
+    event::ptr enqueue_marker(std::vector<event::ptr> const&, bool /*is_output_event*/ = false) override {
+        OPENVINO_THROW("[GPU offline] stream::enqueue_marker is not available on the compile-only engine");
+    }
+    void enqueue_barrier() override {
+        OPENVINO_THROW("[GPU offline] stream::enqueue_barrier is not available on the compile-only engine");
+    }
+    event::ptr group_events(std::vector<event::ptr> const&) override {
+        OPENVINO_THROW("[GPU offline] stream::group_events is not available on the compile-only engine");
+    }
+    void wait_for_events(const std::vector<event::ptr>&) override {
+        OPENVINO_THROW("[GPU offline] stream::wait_for_events is not available on the compile-only engine");
+    }
+    event::ptr create_user_event(bool /*set*/) override {
+        OPENVINO_THROW("[GPU offline] stream::create_user_event is not available on the compile-only engine");
+    }
+    event::ptr create_base_event() override {
+        OPENVINO_THROW("[GPU offline] stream::create_base_event is not available on the compile-only engine");
+    }
+    std::unique_ptr<surfaces_lock> create_surfaces_lock(const std::vector<memory::ptr>&) const override {
+        OPENVINO_THROW("[GPU offline] stream::create_surfaces_lock is not available on the compile-only engine");
+    }
+
+#ifdef ENABLE_ONEDNN_FOR_GPU
+    dnnl::stream& get_onednn_stream() override {
+        OPENVINO_THROW("[GPU offline] stream::get_onednn_stream is not available on the compile-only engine");
+    }
+#endif
+};
+
+}  // namespace ocl
+}  // namespace cldnn


### PR DESCRIPTION
This PR is to support the feature request from issue https://jira.devtools.intel.com/browse/CVS-187876

Add a compile-only path to the intel_gpu plugin that compiles all kernels ahead-of-time via ocloc for a target device and exports a program blob, WITHOUT touching a real GPU (no cl::Context, no device enumeration, no network build). The blob is later imported and executed on the target GPU in a separate process. This is the OpenVINO-side enablement for the WebNN GPU two-process model (compiler process is HW-free; inference process runs on real hardware).

## What / how

New config (public RELEASE options, settable via the compile_model config map, later to be fed by the OV EP; today also peekable from env as a transitional mechanism):
  - GPU_OFFLINE_COMPILE (bool)          -- enable offline compile
  - GPU_OFFLINE_COMPILE_DEVICE (string) -- ocloc `-device` target, e.g.
                                          "0x4680" (device id) or "12.2.0"

Compile path (compiler process, HW-free):
  - plugin.cpp: compile_model builds a stub RemoteContext from a fabricated offline_device (no cl::Context) instead of the real default context.
  - graph.cpp: the compile ctor builds the program on a stub offline_engine (fabricated device_info) and sets m_compile_only; Graph::build keeps the program only and does NOT create a cldnn::network (no GPU alloc / weight upload); export_model serializes the program directly.
  - kernels_cache.cpp: each OCLC batch is compiled HW-free via ocloc and wrapped in an offline_kernel placeholder (no driver JIT, no cl_cache). Asserts 100% OCLC coverage (CM / OCLC_V2 / microkernel batches fail loudly rather than silently leaking a non-HW-free kernel).
  - execution_config.cpp: force use_onednn OFF under offline (onednn JITs via the driver and bypasses kernels_cache/ocloc, so it can't be HW-free).
  - program.cpp: skip propagate_constants at compile time (it folds by building+executing a temp network on GPU); defer it to import.

Import path (inference process, real GPU) -- unchanged behavior guaranteed:
  - Import ctor forces GPU_OFFLINE_COMPILE off (env may re-enable the config flag, so runtime gates key on the construction-path m_compile_only flag, never on get_offline_compile()), always builds a real network, and runs run_import_time_constant_folding() to apply the deferred folding.

No-GPU tolerance (compiler process on a sandbox with no GPU):
  - plugin ctor wraps device_query in try/catch and installs a default config when enumeration yields nothing, so the plugin loads with no GPU present.
  - get_property serves config properties (e.g. PERFORMANCE_HINT) from the config map even with an empty device map; only true metrics still require an enumerated device.

New HW-free stub runtime shims under src/runtime/ocl/: offline_device, offline_engine, offline_stream, offline_memory, offline_kernel, offline_kernel_builder, and ocloc_offline_compiler (dynamic-loads ocloc).

## Validation

With the offline options enabled (GPU_OFFLINE_COMPILE=true, GPU_OFFLINE_COMPILE_DEVICE=0x4680), a two-process test over a single-op Add model (two f32 runtime inputs, no constants -- one minimal kernel batch):

  1. Compile side (HW-free): compile_model takes the offline branch -- ocloc compiles the Add batch context-less, no cldnn::network is built, and the program blob (~16 KB) is exported to disk (inputs persisted alongside it). Logs confirm: "using stub device_info engine", per-batch "ocloc_bin=...B (context-less, load-once)", "serializing N unique kernel binaries into blob". No GPU allocation, no driver JIT.

  2. Import side (real GPU): a separate process reads the exported blob, import_model builds a real network from it and infers. Result: GPU(f32) vs CPU  max|diff| = 0.000e+00  -> PASS.

End-to-end in the chromium WebNN GPU stack, the compiler process produces the blob with an all-stub, context-less compile and the inference process imports and runs correctly. Validated on both MobileNet and SD Turbo.

Conclusion: HW-free offline compilation works -- the compiler process performs a full kernel compile + blob export with no real GPU context, and the exported blob imports and produces correct results on the target GPU. All compile-time GPU touch-points are closed (stub engine/context, no network build, onednn forced off, constant folding deferred to import).

## Next steps

  - Add an OV-EP virtual GPU device so a machine with no physical GPU can select the GPU target and pass the offline flag + target through the compile config, replacing the transitional global OV_GPU_OFFLINE_COMPILE[_DEVICE] env peek.
  - Have chromium pass the real target through an EP option (depends on the virtual-device work above).
  - Harden the remaining no-GPU crash sites on demand (get_metric empty-map UB, query_model / import_model / get_max_batch_size) once a real sandbox exercises them.
  - Extend ocloc coverage beyond plain OCLC (OCLC_V2 / CM / microkernels).
  - Productization cleanup: remove the std::cerr "[GPU offline]" markers and the hardcoded oneAPI ocloc DLL path; upstream the NEO NUL-device fix.


@huningxin @ibelem 