### PR TITLE
[GPU] proper linking order in func tests

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
@@ -29,8 +29,8 @@ ov_add_test_target(
         DEPENDENCIES
             openvino_intel_gpu_plugin
         LINK_LIBRARIES
-            openvino::reference
             funcSharedTests
+            openvino::reference
             OpenCL::NewHeaders # should come before OpenCL::OpenCL
             OpenCL::OpenCL
         LABELS


### PR DESCRIPTION
### Details:
 - apply proper link order (first should come library A which need library B)
 - delete error: /usr/bin/x86_64-linux-gnu-ld.bfd: ../../../../../../bin/intel64/Release/libfuncSharedTests.a(paged_attention_token_type.cpp.o): in function `ov::test::helpers::PrepareModel(ov::element::Type, long, long, int)':
paged_attention_token_type.cpp:(.text._ZN2ov4test7helpersL12PrepareModelENS_7element4TypeElli+0x2c07): undefined reference to `ov::reference::paged_attention_cache::PagedCacheManager::PagedCacheManager(ov::element::Type, ov::reference::paged_attention_cache::EvictionPolicy, unsigned long, float)'
collect2: error: ld returned 1 exit status
gmake[2]: *** [src/plugins/intel_gpu/tests/functional/CMakeFiles/ov_gpu_func_tests.dir/build.make:5556: ../bin/intel64/Release/ov_gpu_func_tests] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:7506: src/plugins/intel_gpu/tests/functional/CMakeFiles/ov_gpu_func_tests.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
### Tickets:
  no ticket - found when using ubuntu 26.04

### AI Assistance:
 - *AI assistance used:  yes
