### PR TITLE
Support code predictor fp16

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.cpp
@@ -1,0 +1,246 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "disable_fp16_comp_qwen3_omni_suffix.hpp"
+
+#include <deque>
+#include <optional>
+#include <unordered_set>
+#include <vector>
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/assign.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/read_value.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/scaled_dot_product_attention.hpp"
+#include "openvino/op/swish.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "transformations/rt_info/disable_precision_conversion.hpp"
+
+namespace ov::intel_gpu {
+
+namespace {
+
+struct GatedMLPBlock {
+    std::shared_ptr<ov::Node> source;
+    std::shared_ptr<ov::op::v1::Add> residual_add;
+    std::shared_ptr<ov::Node> residual_input;
+};
+
+std::optional<GatedMLPBlock> match_gated_mlp_block(const std::shared_ptr<ov::Node>& node) {
+    auto down = ov::as_type_ptr<ov::op::v0::MatMul>(node);
+    if (!down)
+        return std::nullopt;
+
+    std::shared_ptr<ov::op::v1::Multiply> product;
+    for (const auto& input : down->input_values()) {
+        product = ov::as_type_ptr<ov::op::v1::Multiply>(input.get_node_shared_ptr());
+        if (product)
+            break;
+    }
+    if (!product)
+        return std::nullopt;
+
+    std::shared_ptr<ov::op::v4::Swish> swish;
+    std::shared_ptr<ov::op::v0::MatMul> up;
+    for (const auto& input : product->input_values()) {
+        auto input_node = input.get_node_shared_ptr();
+        if (auto candidate = ov::as_type_ptr<ov::op::v4::Swish>(input_node))
+            swish = candidate;
+        else if (auto candidate = ov::as_type_ptr<ov::op::v0::MatMul>(input_node))
+            up = candidate;
+    }
+    if (!swish || !up)
+        return std::nullopt;
+
+    auto gate = ov::as_type_ptr<ov::op::v0::MatMul>(swish->input_value(0).get_node_shared_ptr());
+    if (!gate || gate->input_value(0) != up->input_value(0))
+        return std::nullopt;
+
+    std::shared_ptr<ov::op::v1::Add> residual_add;
+    for (const auto& target : down->output(0).get_target_inputs()) {
+        auto candidate = ov::as_type_ptr<ov::op::v1::Add>(target.get_node()->shared_from_this());
+        if (!candidate)
+            continue;
+        if (residual_add)
+            return std::nullopt;
+        residual_add = candidate;
+    }
+    if (!residual_add)
+        return std::nullopt;
+
+    std::shared_ptr<ov::Node> residual_input;
+    for (const auto& input : residual_add->input_values()) {
+        if (input.get_node() != down.get()) {
+            if (residual_input)
+                return std::nullopt;
+            residual_input = input.get_node_shared_ptr();
+        }
+    }
+    if (!residual_input)
+        return std::nullopt;
+
+    return GatedMLPBlock{gate->input_value(0).get_node_shared_ptr(), residual_add, residual_input};
+}
+
+bool depends_on(const std::shared_ptr<ov::Node>& node, const ov::Node* ancestor) {
+    std::deque<std::shared_ptr<ov::Node>> pending{node};
+    std::unordered_set<const ov::Node*> visited;
+    while (!pending.empty()) {
+        auto current = pending.front();
+        pending.pop_front();
+        if (!current || !visited.insert(current.get()).second)
+            continue;
+        if (current.get() == ancestor)
+            return true;
+        for (const auto& input : current->input_values())
+            pending.push_back(input.get_node_shared_ptr());
+    }
+    return false;
+}
+
+bool has_code_predictor_output_contract(const std::shared_ptr<ov::Model>& model) {
+    if (model->get_results().size() != 2)
+        return false;
+
+    bool has_code = false;
+    bool has_embedding = false;
+    for (const auto& result : model->get_results()) {
+        const auto output = result->input_value(0);
+        const auto& shape = output.get_partial_shape();
+        if (!shape.rank().is_static())
+            return false;
+
+        if (output.get_element_type() == ov::element::i64 && shape.rank().get_length() == 2 &&
+            shape[1].compatible(1)) {
+            has_code = true;
+        } else if (output.get_element_type() == ov::element::f32 && shape.rank().get_length() == 3 &&
+                   shape[1].compatible(1) && shape[2].compatible(1024)) {
+            has_embedding = true;
+        }
+    }
+    return has_code && has_embedding;
+}
+
+std::shared_ptr<ov::Node> find_sensitive_suffix_boundary(const std::shared_ptr<ov::Model>& model) {
+    size_t read_values = 0;
+    size_t assigns = 0;
+    size_t attentions = 0;
+    std::vector<GatedMLPBlock> blocks;
+
+    for (const auto& node : model->get_ordered_ops()) {
+        read_values += ov::is_type<ov::op::v6::ReadValue>(node);
+        assigns += ov::is_type<ov::op::v6::Assign>(node);
+        attentions += ov::is_type<ov::op::v13::ScaledDotProductAttention>(node);
+        if (auto block = match_gated_mlp_block(node))
+            blocks.push_back(*block);
+    }
+
+    if (read_values != 10 || assigns != 10 || attentions != 5 || blocks.size() != 5 ||
+        !has_code_predictor_output_contract(model)) {
+        return nullptr;
+    }
+
+    // Reject five unrelated MLPs. Each block source must be downstream of the
+    // preceding block's residual output, forming one transformer stack.
+    for (size_t i = 1; i < blocks.size(); ++i) {
+        if (!depends_on(blocks[i].source, blocks[i - 1].residual_add.get()))
+            return nullptr;
+    }
+
+    // The measured safe boundary is the residual input of the third MLP. It
+    // is the post-attention residual; the third MLP itself belongs to suffix.
+    return blocks[2].residual_input;
+}
+
+}  // namespace
+
+bool DisableFP16CompForQwen3OmniCodePredictorSuffix::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    auto boundary = find_sensitive_suffix_boundary(model);
+    if (!boundary)
+        return false;
+
+    std::deque<std::shared_ptr<ov::Node>> pending;
+    for (const auto& output : boundary->outputs()) {
+        for (const auto& input : output.get_target_inputs())
+            pending.push_back(input.get_node()->shared_from_this());
+    }
+
+    std::unordered_set<const ov::Node*> visited;
+    std::vector<std::shared_ptr<ov::op::v6::Assign>> cache_writes;
+    std::vector<std::shared_ptr<ov::Node>> protected_nodes;
+    bool changed = false;
+
+    while (!pending.empty()) {
+        auto node = pending.front();
+        pending.pop_front();
+        if (!node || !visited.insert(node.get()).second)
+            continue;
+
+        if (auto assign = ov::as_type_ptr<ov::op::v6::Assign>(node)) {
+            cache_writes.push_back(assign);
+            // Assign is a state sink. Do not follow its state/control edge
+            // back to ReadValue, which belongs to the next inference step.
+            continue;
+        } else if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(node)) {
+            // SDPA is decomposed after this pass and does not propagate the
+            // precision marker to its internal Transpose/scale operations.
+            // Keep the native f16 SDPA path and protect its surrounding
+            // projections/residual computation instead.
+        } else if (!ov::is_type<ov::op::v0::Result>(node)) {
+            // ConvertPrecision consults this attribute before lowering f32 to
+            // f16. Integer-only nodes are harmlessly unaffected.
+            ov::disable_conversion(node, ov::element::f16);
+            protected_nodes.push_back(node);
+            changed = true;
+        }
+
+        for (const auto& output : node->outputs()) {
+            for (const auto& input : output.get_target_inputs())
+                pending.push_back(input.get_node()->shared_from_this());
+        }
+    }
+
+    // Constants can be shared by early FP16 layers and the protected suffix.
+    // Put an explicit f16 -> f32 barrier on each protected edge. The f16
+    // midpoint prevents f32 requirements from propagating to the shared
+    // source. If constant-source folding evaluates the barrier, it produces a
+    // suffix-private value and still cannot affect an early consumer.
+    for (const auto& node : protected_nodes) {
+        for (size_t input_idx = 0; input_idx < node->get_input_size(); ++input_idx) {
+            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node->input_value(input_idx).get_node_shared_ptr());
+            if (!constant || !constant->get_output_element_type(0).is_real() ||
+                constant->output(0).get_target_inputs().size() < 2) {
+                continue;
+            }
+            auto to_f16 = std::make_shared<ov::op::v0::Convert>(constant, ov::element::f16);
+            auto to_f32 = std::make_shared<ov::op::v0::Convert>(to_f16, ov::element::f32);
+            to_f16->set_friendly_name(constant->get_friendly_name() + "/to_f16_boundary");
+            to_f32->set_friendly_name(constant->get_friendly_name() + "/to_fp32_suffix");
+            ov::copy_runtime_info(constant, {to_f16, to_f32});
+            ov::disable_conversion(to_f32, ov::element::f16);
+            node->input(input_idx).replace_source_output(to_f32->output(0));
+            changed = true;
+        }
+    }
+
+    // At this point Variables and Assign inputs are f32. ConvertPrecision
+    // later changes both Variable types and these unprotected Converts to f16,
+    // while the producer side remains f32. This avoids an f32 Assign input /
+    // f16 Variable type mismatch and keeps cache storage compact.
+    for (const auto& assign : cache_writes) {
+        auto cache_convert = std::make_shared<ov::op::v0::Convert>(assign->input_value(0), ov::element::f32);
+        cache_convert->set_friendly_name(assign->get_friendly_name() + "/to_fp16_cache");
+        assign->input(0).replace_source_output(cache_convert);
+        changed = true;
+    }
+
+    return changed;
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.cpp
@@ -6,30 +6,32 @@
 
 #include <deque>
 #include <optional>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
 #include "openvino/op/add.hpp"
 #include "openvino/op/assign.hpp"
-#include "openvino/op/constant.hpp"
-#include "openvino/op/convert.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/read_value.hpp"
 #include "openvino/op/result.hpp"
 #include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/swish.hpp"
-#include "openvino/core/rt_info.hpp"
 #include "transformations/rt_info/disable_precision_conversion.hpp"
 
 namespace ov::intel_gpu {
-
 namespace {
 
 struct GatedMLPBlock {
     std::shared_ptr<ov::Node> source;
     std::shared_ptr<ov::op::v1::Add> residual_add;
     std::shared_ptr<ov::Node> residual_input;
+};
+
+struct SensitiveMatch {
+    std::shared_ptr<ov::Node> suffix_boundary;
+    std::vector<std::shared_ptr<ov::op::v13::ScaledDotProductAttention>> attentions;
 };
 
 std::optional<GatedMLPBlock> match_gated_mlp_block(const std::shared_ptr<ov::Node>& node) {
@@ -104,6 +106,79 @@ bool depends_on(const std::shared_ptr<ov::Node>& node, const ov::Node* ancestor)
     return false;
 }
 
+std::vector<std::shared_ptr<ov::op::v6::ReadValue>> collect_read_values(const ov::Output<ov::Node>& output) {
+    std::deque<std::shared_ptr<ov::Node>> pending{output.get_node_shared_ptr()};
+    std::unordered_set<const ov::Node*> visited;
+    std::vector<std::shared_ptr<ov::op::v6::ReadValue>> read_values;
+    while (!pending.empty()) {
+        auto current = pending.front();
+        pending.pop_front();
+        if (!current || !visited.insert(current.get()).second)
+            continue;
+        if (auto read_value = ov::as_type_ptr<ov::op::v6::ReadValue>(current))
+            read_values.push_back(read_value);
+        for (const auto& input : current->input_values())
+            pending.push_back(input.get_node_shared_ptr());
+    }
+    return read_values;
+}
+
+std::vector<std::shared_ptr<ov::op::v6::ReadValue>> difference(
+    const std::vector<std::shared_ptr<ov::op::v6::ReadValue>>& values,
+    const std::vector<std::shared_ptr<ov::op::v6::ReadValue>>& excluded) {
+    std::unordered_set<const ov::Node*> excluded_nodes;
+    for (const auto& node : excluded)
+        excluded_nodes.insert(node.get());
+
+    std::vector<std::shared_ptr<ov::op::v6::ReadValue>> result;
+    for (const auto& node : values) {
+        if (!excluded_nodes.count(node.get()))
+            result.push_back(node);
+    }
+    return result;
+}
+
+bool is_stateful_attention(const std::shared_ptr<ov::op::v13::ScaledDotProductAttention>& attention,
+                           const std::unordered_set<std::string>& assigned_variables) {
+    if (attention->get_input_size() < 3)
+        return false;
+
+    const auto query_states = collect_read_values(attention->input_value(0));
+    const auto key_states = difference(collect_read_values(attention->input_value(1)), query_states);
+    auto value_states = difference(collect_read_values(attention->input_value(2)), query_states);
+    if (key_states.size() != 1)
+        return false;
+    value_states = difference(value_states, key_states);
+    if (value_states.size() != 1)
+        return false;
+
+    return assigned_variables.count(key_states.front()->get_variable_id()) &&
+           assigned_variables.count(value_states.front()->get_variable_id());
+}
+
+bool find_direct_attention(const std::shared_ptr<ov::Node>& branch,
+                           const std::unordered_set<std::string>& assigned_variables,
+                           std::shared_ptr<ov::op::v13::ScaledDotProductAttention>& attention) {
+    std::deque<std::shared_ptr<ov::Node>> pending{branch};
+    std::unordered_set<const ov::Node*> visited;
+    attention.reset();
+    while (!pending.empty()) {
+        auto current = pending.front();
+        pending.pop_front();
+        if (!current || !visited.insert(current.get()).second)
+            continue;
+        if (auto candidate = ov::as_type_ptr<ov::op::v13::ScaledDotProductAttention>(current)) {
+            if (attention && attention != candidate)
+                return false;
+            attention = candidate;
+            continue;
+        }
+        for (const auto& input : current->input_values())
+            pending.push_back(input.get_node_shared_ptr());
+    }
+    return !attention || is_stateful_attention(attention, assigned_variables);
+}
+
 bool has_code_predictor_output_contract(const std::shared_ptr<ov::Model>& model) {
     if (model->get_results().size() != 2)
         return false;
@@ -115,7 +190,6 @@ bool has_code_predictor_output_contract(const std::shared_ptr<ov::Model>& model)
         const auto& shape = output.get_partial_shape();
         if (!shape.rank().is_static())
             return false;
-
         if (output.get_element_type() == ov::element::i64 && shape.rank().get_length() == 2 &&
             shape[1].compatible(1)) {
             has_code = true;
@@ -127,120 +201,224 @@ bool has_code_predictor_output_contract(const std::shared_ptr<ov::Model>& model)
     return has_code && has_embedding;
 }
 
-std::shared_ptr<ov::Node> find_sensitive_suffix_boundary(const std::shared_ptr<ov::Model>& model) {
-    size_t read_values = 0;
-    size_t assigns = 0;
-    size_t attentions = 0;
+std::optional<SensitiveMatch> find_sensitive_regions(const std::shared_ptr<ov::Model>& model) {
     std::vector<GatedMLPBlock> blocks;
-
+    std::unordered_set<std::string> assigned_variables;
     for (const auto& node : model->get_ordered_ops()) {
-        read_values += ov::is_type<ov::op::v6::ReadValue>(node);
-        assigns += ov::is_type<ov::op::v6::Assign>(node);
-        attentions += ov::is_type<ov::op::v13::ScaledDotProductAttention>(node);
+        if (auto assign = ov::as_type_ptr<ov::op::v6::Assign>(node))
+            assigned_variables.insert(assign->get_variable_id());
         if (auto block = match_gated_mlp_block(node))
             blocks.push_back(*block);
     }
+    if (!has_code_predictor_output_contract(model))
+        return std::nullopt;
 
-    if (read_values != 10 || assigns != 10 || attentions != 5 || blocks.size() != 5 ||
-        !has_code_predictor_output_contract(model)) {
-        return nullptr;
+    struct BlockLink {
+        bool valid = false;
+        std::optional<size_t> predecessor;
+        std::shared_ptr<ov::op::v13::ScaledDotProductAttention> attention;
+    };
+    std::vector<BlockLink> links(blocks.size());
+    std::vector<std::vector<size_t>> successors(blocks.size());
+
+    for (size_t i = 0; i < blocks.size(); ++i) {
+        auto attention_residual = ov::as_type_ptr<ov::op::v1::Add>(blocks[i].residual_input);
+        if (!attention_residual || attention_residual->get_input_size() != 2 ||
+            !depends_on(blocks[i].source, attention_residual.get()))
+            continue;
+
+        std::optional<size_t> predecessor;
+        bool ambiguous_predecessor = false;
+        size_t predecessor_input = 0;
+        for (size_t input_idx = 0; input_idx < attention_residual->get_input_size(); ++input_idx) {
+            const auto* input_node = attention_residual->input_value(input_idx).get_node();
+            for (size_t candidate = 0; candidate < blocks.size(); ++candidate) {
+                if (input_node != blocks[candidate].residual_add.get())
+                    continue;
+                if (predecessor && *predecessor != candidate)
+                    ambiguous_predecessor = true;
+                else
+                    predecessor = candidate;
+                predecessor_input = input_idx;
+            }
+        }
+        if (ambiguous_predecessor)
+            continue;
+
+        std::shared_ptr<ov::op::v13::ScaledDotProductAttention> attention;
+        if (predecessor) {
+            const auto branch = attention_residual->input_value(1 - predecessor_input).get_node_shared_ptr();
+            if (!find_direct_attention(branch, assigned_variables, attention) || !attention)
+                continue;
+        } else {
+            std::shared_ptr<ov::op::v13::ScaledDotProductAttention> first;
+            std::shared_ptr<ov::op::v13::ScaledDotProductAttention> second;
+            if (!find_direct_attention(attention_residual->input_value(0).get_node_shared_ptr(),
+                                       assigned_variables,
+                                       first) ||
+                !find_direct_attention(attention_residual->input_value(1).get_node_shared_ptr(),
+                                       assigned_variables,
+                                       second) ||
+                static_cast<bool>(first) == static_cast<bool>(second))
+                continue;
+            attention = first ? first : second;
+        }
+
+        links[i] = BlockLink{true, predecessor, attention};
+        if (predecessor)
+            successors[*predecessor].push_back(i);
     }
 
-    // Reject five unrelated MLPs. Each block source must be downstream of the
-    // preceding block's residual output, forming one transformer stack.
-    for (size_t i = 1; i < blocks.size(); ++i) {
-        if (!depends_on(blocks[i].source, blocks[i - 1].residual_add.get()))
-            return nullptr;
-    }
+    std::optional<SensitiveMatch> match;
+    for (size_t candidate = 0; candidate < blocks.size(); ++candidate) {
+        if (!links[candidate].valid || !links[candidate].predecessor || successors[candidate].size() != 1)
+            continue;
+        const auto previous = *links[candidate].predecessor;
+        if (!links[previous].valid || !links[previous].predecessor || successors[previous].size() != 1)
+            continue;
+        const auto first = *links[previous].predecessor;
+        if (!links[first].valid || links[first].predecessor || successors[first].size() != 1)
+            continue;
+        const auto next = successors[candidate].front();
+        if (!links[next].valid || successors[next].size() != 1)
+            continue;
+        const auto last = successors[next].front();
+        if (!links[last].valid || !successors[last].empty())
+            continue;
 
-    // The measured safe boundary is the residual input of the third MLP. It
-    // is the post-attention residual; the third MLP itself belongs to suffix.
-    return blocks[2].residual_input;
+        bool feeds_all_results = true;
+        for (const auto& result : model->get_results()) {
+            if (!depends_on(result->input_value(0).get_node_shared_ptr(), blocks[last].residual_add.get())) {
+                feeds_all_results = false;
+                break;
+            }
+        }
+        if (!feeds_all_results)
+            continue;
+        if (match)
+            return std::nullopt;
+
+        match = SensitiveMatch{blocks[candidate].residual_input,
+                               {links[first].attention,
+                                links[previous].attention,
+                                links[candidate].attention,
+                                links[next].attention,
+                                links[last].attention}};
+    }
+    return match;
 }
 
-}  // namespace
-
-bool DisableFP16CompForQwen3OmniCodePredictorSuffix::run_on_model(const std::shared_ptr<ov::Model>& model) {
-    auto boundary = find_sensitive_suffix_boundary(model);
-    if (!boundary)
-        return false;
-
-    std::deque<std::shared_ptr<ov::Node>> pending;
-    for (const auto& output : boundary->outputs()) {
-        for (const auto& input : output.get_target_inputs())
-            pending.push_back(input.get_node()->shared_from_this());
-    }
-
+std::vector<std::shared_ptr<ov::op::v0::MatMul>> find_nearest_matmuls(const ov::Output<ov::Node>& output) {
+    std::deque<std::shared_ptr<ov::Node>> pending{output.get_node_shared_ptr()};
     std::unordered_set<const ov::Node*> visited;
-    std::vector<std::shared_ptr<ov::op::v6::Assign>> cache_writes;
-    std::vector<std::shared_ptr<ov::Node>> protected_nodes;
-    bool changed = false;
-
+    std::vector<std::shared_ptr<ov::op::v0::MatMul>> result;
     while (!pending.empty()) {
         auto node = pending.front();
         pending.pop_front();
         if (!node || !visited.insert(node.get()).second)
             continue;
-
-        if (auto assign = ov::as_type_ptr<ov::op::v6::Assign>(node)) {
-            cache_writes.push_back(assign);
-            // Assign is a state sink. Do not follow its state/control edge
-            // back to ReadValue, which belongs to the next inference step.
+        if (auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(node)) {
+            result.push_back(matmul);
             continue;
-        } else if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(node)) {
-            // SDPA is decomposed after this pass and does not propagate the
-            // precision marker to its internal Transpose/scale operations.
-            // Keep the native f16 SDPA path and protect its surrounding
-            // projections/residual computation instead.
-        } else if (!ov::is_type<ov::op::v0::Result>(node)) {
-            // ConvertPrecision consults this attribute before lowering f32 to
-            // f16. Integer-only nodes are harmlessly unaffected.
-            ov::disable_conversion(node, ov::element::f16);
-            protected_nodes.push_back(node);
-            changed = true;
         }
+        for (const auto& input : node->input_values())
+            pending.push_back(input.get_node_shared_ptr());
+    }
+    return result;
+}
 
+void protect_attention_input(const ov::Output<ov::Node>& output) {
+    std::deque<std::shared_ptr<ov::Node>> pending{output.get_node_shared_ptr()};
+    std::unordered_set<const ov::Node*> visited;
+    while (!pending.empty()) {
+        auto node = pending.front();
+        pending.pop_front();
+        if (!node || !visited.insert(node.get()).second)
+            continue;
+        ov::disable_conversion(node, ov::element::f16);
+        if (ov::is_type<ov::op::v0::MatMul>(node) || ov::is_type<ov::op::v6::ReadValue>(node))
+            continue;
+        for (const auto& input : node->input_values())
+            pending.push_back(input.get_node_shared_ptr());
+    }
+}
+
+}  // namespace
+
+static bool mark_qwen3_omni_code_predictor_precision(const std::shared_ptr<ov::Model>& model) {
+    const auto match = find_sensitive_regions(model);
+    if (!match || !match->suffix_boundary || match->attentions.size() != 5)
+        return false;
+
+    const auto query_projections = find_nearest_matmuls(match->attentions.front()->input_value(0));
+    if (query_projections.empty())
+        return false;
+    for (const auto& projection : query_projections)
+        ov::disable_conversion(projection, ov::element::f16);
+
+    // Trial-3: preserve the complete Q/K/V frontiers, SDPA reductions, and
+    // their paired recurrent KV state. This removes both attention arithmetic
+    // rounding and cross-step cache rounding while leaving the first two MLPs
+    // on the native FP16 path.
+    std::unordered_set<std::string> protected_variable_ids;
+    for (const auto& attention : match->attentions) {
+        ov::disable_conversion(attention, ov::element::f16);
+        for (size_t input_idx = 0; input_idx < 3; ++input_idx) {
+            protect_attention_input(attention->input_value(input_idx));
+            for (const auto& state : collect_read_values(attention->input_value(input_idx)))
+                protected_variable_ids.insert(state->get_variable_id());
+        }
+    }
+    for (const auto& node : model->get_ordered_ops()) {
+        if (auto read = ov::as_type_ptr<ov::op::v6::ReadValue>(node)) {
+            if (protected_variable_ids.count(read->get_variable_id())) {
+                ov::disable_conversion(read, ov::element::f16);
+            }
+        } else if (auto assign = ov::as_type_ptr<ov::op::v6::Assign>(node)) {
+            if (protected_variable_ids.count(assign->get_variable_id())) {
+                ov::disable_conversion(assign, ov::element::f16);
+            }
+        }
+    }
+
+    std::deque<std::shared_ptr<ov::Node>> pending;
+    for (const auto& output : match->suffix_boundary->outputs()) {
+        for (const auto& input : output.get_target_inputs())
+            pending.push_back(input.get_node()->shared_from_this());
+    }
+
+    std::unordered_set<const ov::Node*> visited;
+    while (!pending.empty()) {
+        auto node = pending.front();
+        pending.pop_front();
+        if (!node || !visited.insert(node.get()).second)
+            continue;
+        if (ov::is_type<ov::op::v6::Assign>(node)) {
+            continue;
+        } else if (!ov::is_type<ov::op::v0::Result>(node)) {
+            ov::disable_conversion(node, ov::element::f16);
+        }
         for (const auto& output : node->outputs()) {
             for (const auto& input : output.get_target_inputs())
                 pending.push_back(input.get_node()->shared_from_this());
         }
     }
+    return true;
+}
 
-    // Constants can be shared by early FP16 layers and the protected suffix.
-    // Put an explicit f16 -> f32 barrier on each protected edge. The f16
-    // midpoint prevents f32 requirements from propagating to the shared
-    // source. If constant-source folding evaluates the barrier, it produces a
-    // suffix-private value and still cannot affect an early consumer.
-    for (const auto& node : protected_nodes) {
-        for (size_t input_idx = 0; input_idx < node->get_input_size(); ++input_idx) {
-            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node->input_value(input_idx).get_node_shared_ptr());
-            if (!constant || !constant->get_output_element_type(0).is_real() ||
-                constant->output(0).get_target_inputs().size() < 2) {
-                continue;
-            }
-            auto to_f16 = std::make_shared<ov::op::v0::Convert>(constant, ov::element::f16);
-            auto to_f32 = std::make_shared<ov::op::v0::Convert>(to_f16, ov::element::f32);
-            to_f16->set_friendly_name(constant->get_friendly_name() + "/to_f16_boundary");
-            to_f32->set_friendly_name(constant->get_friendly_name() + "/to_fp32_suffix");
-            ov::copy_runtime_info(constant, {to_f16, to_f32});
-            ov::disable_conversion(to_f32, ov::element::f16);
-            node->input(input_idx).replace_source_output(to_f32->output(0));
-            changed = true;
-        }
-    }
+ConvertPrecisionForQwen3OmniCodePredictor::ConvertPrecisionForQwen3OmniCodePredictor(
+    const precisions_map& precisions)
+    : m_precisions(precisions) {}
 
-    // At this point Variables and Assign inputs are f32. ConvertPrecision
-    // later changes both Variable types and these unprotected Converts to f16,
-    // while the producer side remains f32. This avoids an f32 Assign input /
-    // f16 Variable type mismatch and keeps cache storage compact.
-    for (const auto& assign : cache_writes) {
-        auto cache_convert = std::make_shared<ov::op::v0::Convert>(assign->input_value(0), ov::element::f32);
-        cache_convert->set_friendly_name(assign->get_friendly_name() + "/to_fp16_cache");
-        assign->input(0).replace_source_output(cache_convert);
-        changed = true;
-    }
-
-    return changed;
+bool ConvertPrecisionForQwen3OmniCodePredictor::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    const bool is_qwen3_omni_code_predictor = mark_qwen3_omni_code_predictor_precision(model);
+    ov::pass::ConvertPrecision convert_precision(m_precisions,
+                                                 {},
+                                                 true,
+                                                 false,
+                                                 !is_qwen3_omni_code_predictor);
+    convert_precision.set_pass_config(get_pass_config());
+    return convert_precision.run_on_model(model);
 }
 
 }  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.cpp
@@ -27,11 +27,13 @@ struct GatedMLPBlock {
     std::shared_ptr<ov::Node> source;
     std::shared_ptr<ov::op::v1::Add> residual_add;
     std::shared_ptr<ov::Node> residual_input;
+    std::vector<std::shared_ptr<ov::op::v0::MatMul>> input_projections;
 };
 
 struct SensitiveMatch {
     std::shared_ptr<ov::Node> suffix_boundary;
     std::vector<std::shared_ptr<ov::op::v13::ScaledDotProductAttention>> attentions;
+    std::unordered_set<const ov::Node*> fp16_mlp_input_projections;
 };
 
 std::optional<GatedMLPBlock> match_gated_mlp_block(const std::shared_ptr<ov::Node>& node) {
@@ -87,7 +89,7 @@ std::optional<GatedMLPBlock> match_gated_mlp_block(const std::shared_ptr<ov::Nod
     if (!residual_input)
         return std::nullopt;
 
-    return GatedMLPBlock{gate->input_value(0).get_node_shared_ptr(), residual_add, residual_input};
+    return GatedMLPBlock{gate->input_value(0).get_node_shared_ptr(), residual_add, residual_input, {gate, up}};
 }
 
 bool depends_on(const std::shared_ptr<ov::Node>& node, const ov::Node* ancestor) {
@@ -298,45 +300,37 @@ std::optional<SensitiveMatch> find_sensitive_regions(const std::shared_ptr<ov::M
         if (match)
             return std::nullopt;
 
+        std::unordered_set<const ov::Node*> fp16_mlp_input_projections;
+        for (const auto block_idx : {candidate, next, last}) {
+            for (const auto& projection : blocks[block_idx].input_projections)
+                fp16_mlp_input_projections.insert(projection.get());
+        }
         match = SensitiveMatch{blocks[candidate].residual_input,
                                {links[first].attention,
                                 links[previous].attention,
                                 links[candidate].attention,
                                 links[next].attention,
-                                links[last].attention}};
+                                links[last].attention},
+                               std::move(fp16_mlp_input_projections)};
     }
     return match;
 }
 
-std::vector<std::shared_ptr<ov::op::v0::MatMul>> find_nearest_matmuls(const ov::Output<ov::Node>& output) {
+void protect_attention_input(const ov::Output<ov::Node>& output, bool protect_projection) {
     std::deque<std::shared_ptr<ov::Node>> pending{output.get_node_shared_ptr()};
     std::unordered_set<const ov::Node*> visited;
-    std::vector<std::shared_ptr<ov::op::v0::MatMul>> result;
     while (!pending.empty()) {
         auto node = pending.front();
         pending.pop_front();
         if (!node || !visited.insert(node.get()).second)
             continue;
-        if (auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(node)) {
-            result.push_back(matmul);
+        if (ov::is_type<ov::op::v0::MatMul>(node)) {
+            if (protect_projection)
+                ov::disable_conversion(node, ov::element::f16);
             continue;
         }
-        for (const auto& input : node->input_values())
-            pending.push_back(input.get_node_shared_ptr());
-    }
-    return result;
-}
-
-void protect_attention_input(const ov::Output<ov::Node>& output) {
-    std::deque<std::shared_ptr<ov::Node>> pending{output.get_node_shared_ptr()};
-    std::unordered_set<const ov::Node*> visited;
-    while (!pending.empty()) {
-        auto node = pending.front();
-        pending.pop_front();
-        if (!node || !visited.insert(node.get()).second)
-            continue;
         ov::disable_conversion(node, ov::element::f16);
-        if (ov::is_type<ov::op::v0::MatMul>(node) || ov::is_type<ov::op::v6::ReadValue>(node))
+        if (ov::is_type<ov::op::v6::ReadValue>(node))
             continue;
         for (const auto& input : node->input_values())
             pending.push_back(input.get_node_shared_ptr());
@@ -350,21 +344,17 @@ static bool mark_qwen3_omni_code_predictor_precision(const std::shared_ptr<ov::M
     if (!match || !match->suffix_boundary || match->attentions.size() != 5)
         return false;
 
-    const auto query_projections = find_nearest_matmuls(match->attentions.front()->input_value(0));
-    if (query_projections.empty())
-        return false;
-    for (const auto& projection : query_projections)
-        ov::disable_conversion(projection, ov::element::f16);
-
-    // Trial-3: preserve the complete Q/K/V frontiers, SDPA reductions, and
-    // their paired recurrent KV state. This removes both attention arithmetic
-    // rounding and cross-step cache rounding while leaving the first two MLPs
-    // on the native FP16 path.
+    // Preserve SDPA arithmetic, the recurrent KV state, and all non-projection
+    // Q/K/V frontier operations. Layer 0 projections stay FP32; layers 1-2 use
+    // FP16; layers 3-4 are kept FP32 by the downstream suffix.
     std::unordered_set<std::string> protected_variable_ids;
-    for (const auto& attention : match->attentions) {
+    for (size_t layer = 0; layer < match->attentions.size(); ++layer) {
+        const auto& attention = match->attentions[layer];
         ov::disable_conversion(attention, ov::element::f16);
         for (size_t input_idx = 0; input_idx < 3; ++input_idx) {
-            protect_attention_input(attention->input_value(input_idx));
+            // Layer 0 projections remain FP32. Layers 1-2 use FP16, while
+            // layers 3-4 are protected again by the downstream suffix.
+            protect_attention_input(attention->input_value(input_idx), layer == 0);
             for (const auto& state : collect_read_values(attention->input_value(input_idx)))
                 protected_variable_ids.insert(state->get_variable_id());
         }
@@ -395,7 +385,8 @@ static bool mark_qwen3_omni_code_predictor_precision(const std::shared_ptr<ov::M
             continue;
         if (ov::is_type<ov::op::v6::Assign>(node)) {
             continue;
-        } else if (!ov::is_type<ov::op::v0::Result>(node)) {
+        } else if (!ov::is_type<ov::op::v0::Result>(node) &&
+                   !match->fp16_mlp_input_projections.count(node.get())) {
             ov::disable_conversion(node, ov::element::f16);
         }
         for (const auto& output : node->outputs()) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov::intel_gpu {
+
+/**
+ * @brief Keeps the numerically sensitive suffix of Qwen3-Omni's stateful
+ *        code predictor in FP32 when the model is compiled with an FP16 hint.
+ *
+ * The protected region starts after layer 2 attention and contains layer 2
+ * MLP, layers 3-4, final normalization, head, and sampling. Stateful KV cache
+ * variables remain FP16. Explicit Convert nodes at Assign inputs form the
+ * FP32-compute to FP16-cache boundary.
+ *
+ * Activation is based only on a strict graph contract: five serial Gated-MLP
+ * transformer blocks, five SDPA nodes, ten state pairs, and the predictor's
+ * code/embedding output shapes. Model, node, and tensor names are ignored.
+ */
+class DisableFP16CompForQwen3OmniCodePredictorSuffix : public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("DisableFP16CompForQwen3OmniCodePredictorSuffix");
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+};
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.hpp
@@ -4,27 +4,40 @@
 
 #pragma once
 
-#include "openvino/pass/graph_rewrite.hpp"
+#include "transformations/convert_precision.hpp"
 
 namespace ov::intel_gpu {
 
 /**
- * @brief Keeps the numerically sensitive suffix of Qwen3-Omni's stateful
- *        code predictor in FP32 when the model is compiled with an FP16 hint.
+ * @brief Runs GPU floating-point precision conversion with the Trial-3
+ *        protection required by Qwen3-Omni's stateful code predictor.
  *
- * The protected region starts after layer 2 attention and contains layer 2
- * MLP, layers 3-4, final normalization, head, and sampling. Stateful KV cache
- * variables remain FP16. Explicit Convert nodes at Assign inputs form the
- * FP32-compute to FP16-cache boundary.
+ * The protected regions are the first layer's fused Q/K/V projection and a
+ * suffix starting after layer 2 attention that contains layer 2 MLP, layers
+ * 3-4, final normalization, head, and sampling. The five structurally matched
+ * SDPA reductions, their Q/K/V compute frontiers, and stateful KV caches are
+ * also protected. The first two MLPs remain FP16.
  *
- * Activation is based only on a strict graph contract: five serial Gated-MLP
- * transformer blocks, five SDPA nodes, ten state pairs, and the predictor's
- * code/embedding output shapes. Model, node, and tensor names are ignored.
+ * Before the ordinary ConvertPrecision implementation runs, this pass marks
+ * the sensitive nodes. A successful match selects a conversion configuration
+ * that leaves this model's Variables in FP32; a failed match selects the
+ * ordinary GPU configuration that converts Variables normally. This keeps all
+ * CodePredictor-specific decisions out of generic ConvertPrecision.
+ *
+ * Activation is based only on a strict graph contract: a connected five-layer
+ * attention-residual/Gated-MLP stack, structurally paired KV-cache state, and
+ * the predictor's code/embedding outputs. Unrelated operation/state counts and
+ * model, node, and tensor names are ignored.
  */
-class DisableFP16CompForQwen3OmniCodePredictorSuffix : public ov::pass::ModelPass {
+class ConvertPrecisionForQwen3OmniCodePredictor : public ov::pass::ModelPass {
 public:
-    OPENVINO_MODEL_PASS_RTTI("DisableFP16CompForQwen3OmniCodePredictorSuffix");
+    OPENVINO_MODEL_PASS_RTTI("ConvertPrecisionForQwen3OmniCodePredictor");
+    explicit ConvertPrecisionForQwen3OmniCodePredictor(const precisions_map& precisions);
+
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+
+private:
+    precisions_map m_precisions;
 };
 
 }  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.hpp
@@ -12,11 +12,11 @@ namespace ov::intel_gpu {
  * @brief Runs GPU floating-point precision conversion with the Trial-3
  *        protection required by Qwen3-Omni's stateful code predictor.
  *
- * The protected regions are the first layer's fused Q/K/V projection and a
- * suffix starting after layer 2 attention that contains layer 2 MLP, layers
- * 3-4, final normalization, head, and sampling. The five structurally matched
- * SDPA reductions, their Q/K/V compute frontiers, and stateful KV caches are
- * also protected. The first two MLPs remain FP16.
+ * The protected regions are the first layer's Q/K/V projections, all five
+ * SDPA reductions and stateful KV caches, and a suffix starting after layer 2
+ * attention. Layers 1-2 Q/K/V projections and the gate/up projections in
+ * layers 2-4 use FP16. Down projections, residual accumulation, normalization,
+ * final head, and sampling remain FP32. The first two MLPs remain FP16.
  *
  * Before the ordinary ConvertPrecision implementation runs, this pass marks
  * the sensitive nodes. A successful match selects a conversion configuration

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -115,6 +115,7 @@
 #include "plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.hpp"
 #include "plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.hpp"
 #include "plugin/transformations/disable_fp16_comp_rms.hpp"
+#include "plugin/transformations/disable_fp16_comp_qwen3_omni_suffix.hpp"
 #include "plugin/transformations/swiglu_fusion_with_clamp.hpp"
 #include "plugin/transformations/disable_fp16_comp_cumsum_sin_gen.hpp"
 #include "plugin/transformations/disable_fp16_comp_sin_gen.hpp"
@@ -705,6 +706,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<DisableFP16CompForGemma3RMSPattern>();
         manager.register_pass<DisableFP16ComForGPTOSSROPEPattern>();
         manager.register_pass<DisableFP16CompCumSumSinGen>();
+        manager.register_pass<DisableFP16CompForQwen3OmniCodePredictorSuffix>();
         // HiFiGAN matches a strict suffix of the CumSumSinGen chain — skip
         // when the same Sin was already marked above.
         pass_config->set_callback<DisableFP16ComSinGenPatternForHiFiGAN>(

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -660,8 +660,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             }
         }
 
-        type_to_fuse_map empty_fuse_map = {};
-
         // fuse softmax, MVN patterns, so that they will not be marked as precision sensitive in ConvertPrecision
         manager.register_pass<ov::pass::SoftmaxFusion>();
         manager.register_pass<ov::pass::MVNFusion>();
@@ -706,15 +704,12 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<DisableFP16CompForGemma3RMSPattern>();
         manager.register_pass<DisableFP16ComForGPTOSSROPEPattern>();
         manager.register_pass<DisableFP16CompCumSumSinGen>();
-        manager.register_pass<DisableFP16CompForQwen3OmniCodePredictorSuffix>();
         // HiFiGAN matches a strict suffix of the CumSumSinGen chain — skip
         // when the same Sin was already marked above.
         pass_config->set_callback<DisableFP16ComSinGenPatternForHiFiGAN>(
             [](const_node_ptr& node) -> bool { return ov::is_conversion_disabled(node, ov::element::f16); });
         manager.register_pass<DisableFP16ComSinGenPatternForHiFiGAN>();
-        const bool keep_precision_sensitive_in_fp32_1 = true;
         const bool convert_input_output_precision = false;
-        const bool store_original_precision_as_rt_attribute = true;
         const auto add_precision_sensitive_convert = true;
 
         manager.register_pass<ov::pass::KeepDequantizationPrecision>(
@@ -722,11 +717,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         // Keep xattention threshold in fp32 to avoid boundary issues caused by fp16 quantization.
         manager.register_pass<ov::intel_gpu::KeepXAttentionThresholdPrecision>();
 
-        manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,
-                                                          empty_fuse_map,
-                                                          keep_precision_sensitive_in_fp32_1,
-                                                          convert_input_output_precision,
-                                                          store_original_precision_as_rt_attribute);
+        manager.register_pass<ConvertPrecisionForQwen3OmniCodePredictor>(fp_convert_precision_map);
 
         manager.register_pass<ov::pass::CommonOptimizations>();
 


### PR DESCRIPTION
Preserve numerically sensitive Qwen3-Omni CodePredictor regions in FP32 while keeping safe projections in FP16.

### Details:
- Add a strict structural matcher for the five-layer stateful CodePredictor without relying on model, node, or tensor names. Keep SDPA operations and recurrent KV states in FP32 to prevent attention errors from propagating across autoregressive steps. Preserve sensitive MLP down projections, residual accumulation, normalization, output head, and sampling in FP32 because FP16 materialization can irreversibly lose critical numerical precision. Keep Layer 0 Q/K/V projections in FP32 while allowing Layer 1–2 Q/K/V and Layer 2–4 MLP gate/up projections to use FP16 where reduced precision is safe. Apply this policy through a CodePredictor-specific wrapper around the existing GPU precision conversion. Fall back to the ordinary GPU conversion behavior when the graph does not match uniquely, avoiding changes to generic ConvertPrecision behavior or unrelated models.

### Tickets:
 - CVS-190210

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
