### PR TITLE
Cmake error fix clean

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,7 @@ Babel==2.18.0
 beautifulsoup4==4.15.0
 breathe==4.36.0
 certifi==2026.6.17
+cmake>=3.26
 colorama==0.4.6
 Cython==3.2.8
 docutils==0.21.2


### PR DESCRIPTION
### Details:
The master branch now requires CMake 3.26 at configure time, but docs publishing environments can still expose an older system CMake such as 3.18.0. The release branch continues to build there because it has not raised the top-level CMake minimum.

Add CMake to the documentation requirements so dependency installation provides a compatible cmake executable before the docs CMake configure step runs.

### Tickets:
- no ticket

### AI Assistance:
- AI assistance used: no
