### PR TITLE
[NPU] Disable -Warray-bounds GCC check due to false positive error

### DIFF
--- a/src/plugins/intel_npu/CMakeLists.txt
+++ b/src/plugins/intel_npu/CMakeLists.txt
@@ -64,6 +64,10 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     ov_add_compiler_flags(-fno-gnu-unique)
+    # Disable -Warray-bounds for GCC 15 and later due to false positive in the compiler.
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0)
+        ov_add_compiler_flags(-Wno-array-bounds)
+    endif()
 endif()
 
 if(CMAKE_COMPILE_WARNING_AS_ERROR)


### PR DESCRIPTION
### Details:
 - GCC 15+ triggers a false positive -Werror=array-bounds warning in the NPU plugin. Suppress the warning for GCC 15 and later to restore a clean build without masking real issues.
 - Fix compilation of intel_npu in **Ubuntu26.04**

### Tickets:
 - CVS-189182

### AI Assistance:
 - *AI assistance used:  yes*
 - *manual checks for error and code correctness*
