### PR TITLE
Revert "[GPU] Keep RMS normalization nodes in FP32 to prevent NaN from FP16 overflow (#36504)"

### DIFF
--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -49,7 +49,6 @@
 #include "openvino/pass/pattern/op/optional.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
-#include "ov_ops/rms.hpp"
 #include "transformations/common_optimizations/mark_precision_sensitive_shapeof_subgraphs.hpp"
 #include "transformations/fp16_compression/mark_floatpoint_range.hpp"
 #include "transformations/rt_info/disable_precision_conversion.hpp"
@@ -400,28 +399,6 @@ public:
     }
 };
 
-class MarkRMS : public MatcherPass {
-public:
-    OPENVINO_MATCHER_PASS_RTTI("MarkRMS");
-    MarkRMS() {
-        MATCHER_SCOPE(MarkRMS);
-        auto rms_pattern = pattern::wrap_type<ov::op::internal::RMS>([](const Output<Node>& output) -> bool {
-            return !is_conversion_disabled(output.get_node_shared_ptr(), element::f16);
-        });
-
-        matcher_pass_callback callback = [=](pattern::Matcher& m) {
-            const auto& node = m.get_match_root();
-            if (!node)
-                return false;
-
-            disable_conversion(node, element::f16);
-            return true;
-        };
-        auto m = make_shared<pattern::Matcher>(rms_pattern, matcher_name);
-        register_matcher(m, callback);
-    }
-};
-
 class PropagateDownDisableSensitivityForQuantized : public MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("PropagateDownDisableSensitivityForQuantized");
@@ -493,7 +470,6 @@ bool MarkSugraphsToKeepInMixedPrecision::run_on_model(const shared_ptr<ov::Model
     REGISTER_PASS(manager, MarkDivWithEps)
     REGISTER_PASS(manager, MarkExpInReduceOpPath)
     REGISTER_PASS(manager, MarkRandomUniform)
-    REGISTER_PASS(manager, MarkRMS)
     REGISTER_PASS(manager, PropagateDownDisableSensitivityForQuantized)
 
     // both Up and Down propagations are needed.

--- a/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
@@ -28,7 +28,6 @@
 #include "openvino/opsets/opset10_decl.hpp"
 #include "openvino/opsets/opset2_decl.hpp"
 #include "openvino/pass/manager.hpp"
-#include "ov_ops/rms.hpp"
 #include "transformations/convert_precision.hpp"
 #include "transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.hpp"
 #include "transformations/rt_info/disable_precision_conversion.hpp"
@@ -1385,44 +1384,4 @@ TEST_F(TransformationTestsF, MarkRandomUniformAsPrecisionSensitive) {
 
     model_ref = model->clone();
     manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map, empty_fuse_map, true, false, true);
-}
-
-TEST(TransformationTests, MarkRMS_keeps_rms_in_fp32) {
-    shared_ptr<Model> model, model_ref;
-    pass::Manager manager;
-    {
-        auto input = make_shared<v0::Parameter>(element::f32, PartialShape{1, 39, 768});
-        auto weight = v0::Constant::create(element::f32, Shape{768, 768}, {0.01f});
-        auto matmul = make_shared<v0::MatMul>(input, weight, false, true);
-
-        auto gamma = v0::Constant::create(element::f32, Shape{768}, {1.0f});
-        auto rms = make_shared<ov::op::internal::RMS>(matmul, gamma, 1e-6);
-
-        model = make_shared<Model>(OutputVector{rms}, ParameterVector{input});
-
-        manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
-        manager.run_passes(model);
-    }
-
-    {
-        auto input = make_shared<v0::Parameter>(element::f32, PartialShape{1, 39, 768});
-        auto weight = v0::Constant::create(element::f32, Shape{768, 768}, {0.01f});
-        auto matmul = make_shared<v0::MatMul>(input, weight, false, true);
-
-        auto gamma = v0::Constant::create(element::f32, Shape{768}, {1.0f});
-        auto rms = make_shared<ov::op::internal::RMS>(matmul, gamma, 1e-6);
-
-        disable_conversion(rms, element::f16);
-        disable_conversion(gamma, element::f16);
-
-        model_ref = make_shared<Model>(OutputVector{rms}, ParameterVector{input});
-    }
-
-    const FunctionsComparator func_comparator =
-        FunctionsComparator::with_default().enable(FunctionsComparator::RUNTIME_KEYS);
-    // need to compare twice to ensure that no extra nodes are marked
-    FunctionsComparator::Result result = func_comparator(model_ref, model);
-    ASSERT_TRUE(result.valid) << result.message;
-    result = func_comparator(model, model_ref);
-    ASSERT_TRUE(result.valid) << result.message;
 }


### PR DESCRIPTION
### Details:
- Revert PR #36504 which forces all RMS normalization nodes to FP32
- This change causes significant global LLM performance regression.

### Root Cause
PR #36504 was introduced to fix NaN in ParlerTTS Mini (CVS-187992) by keeping RMS nodes in FP32. However, it unconditionally marks ALL RMS nodes across all models, adding FP16↔FP32 conversion overhead on every transformer layer.

### Tickets:
 - *190812*