### PR TITLE
[GPU] Fix build failure when MOE fusion is disabled with fp32

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -644,7 +644,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         // MOE: TiledMoeBlock -> GatherMatmuls(compressed) -> MoeOp(compressed) -> MoeOpWithRouting(compressed).
         // Gated on supports_immad (systolic-only) and oneDNN (required for expert GEMM dispatch).
         // Note: even though we are already inside `if (supports_immad)`, oneDNN can still be explicitly disabled by the user.
-        if (device_info.supports_immad && config.get_use_onednn()) {
+        if (device_info.supports_immad && config.get_use_onednn() && !config.get_moe_disable_fusion()) {
             const std::vector<ov::element::Type> supported_compressed_weights_types{ov::element::u4,
                                                                                     ov::element::i4,
                                                                                     ov::element::i8,
@@ -660,7 +660,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 supported_compressed_weights_types);
             manager.register_pass<ov::intel_gpu::FuseMoERouter>();
 
-            if (!config.get_moe_disable_fusion()) {
+            {
                 // PA models flatten batch into seq.
                 const bool has_batch_dim = !is_pa;
                 // MOE3GemmCompressed kernel dispatches expert GEMMs through


### PR DESCRIPTION
### Details:
- When `INFERENCE_PRECISION_HINT=f32` is set with `MOE_DISABLE_FUSION=1`, the MOE fusion pass was still partially applied, causing a build program failure.
- Moved the `moe_disable_fusion` check to guard the entire MOE optimization block including GatherMatmuls and FuseMoERouter passes.

### Tickets:
 - *CVS-187785*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
