### PR TITLE
[GPU] Add increase position ids for gemma4-26b-a2b

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -477,11 +477,85 @@ IncreasePositionIdsPrecisionForGPTOSS::IncreasePositionIdsPrecisionForGPTOSS() {
 }
 
 
+IncreasePositionIdsPrecisionForGemma4::IncreasePositionIdsPrecisionForGemma4() {
+    using namespace ov::pass::pattern;
+    using ov::pass::pattern::op::Or;
+
+    // Gemma4 RoPE pattern:
+    // MatMul (f16) → Convert (f16→f32) → Transpose → Concat → Sin/Cos → Unsqueeze → RoPE
+    // The difference from base IncreasePositionIdsPrecisionForRoPE is that
+    // there is a Convert node between MatMul and Transpose.
+    auto matmul = wrap_type<ov::op::v0::MatMul>();
+    auto convert_after_matmul = wrap_type<ov::op::v0::Convert>({matmul});
+    auto transpose_m = wrap_type<ov::op::v1::Transpose>({convert_after_matmul, any_input()});
+    auto concat = wrap_type<ov::op::v0::Concat>({transpose_m, transpose_m});
+    auto sin = wrap_type<ov::op::v0::Sin>({concat});
+    auto cos = wrap_type<ov::op::v0::Cos>({concat});
+
+    auto sin_unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({sin, wrap_type<ov::op::v0::Constant>()});
+    auto cos_unsqueeze = wrap_type<ov::op::v0::Unsqueeze>({cos, wrap_type<ov::op::v0::Constant>()});
+
+    auto rope_sin_input = std::make_shared<Or>(OutputVector{sin_unsqueeze, sin});
+    auto rope_cos_input = std::make_shared<Or>(OutputVector{cos_unsqueeze, cos});
+
+    auto rope = wrap_type<ov::op::internal::RoPE>({any_input(), rope_cos_input, rope_sin_input});
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+
+        auto matmul_node = ov::as_type_ptr<ov::op::v0::MatMul>(pattern_map.at(matmul).get_node_shared_ptr());
+        auto convert_node = ov::as_type_ptr<ov::op::v0::Convert>(pattern_map.at(convert_after_matmul).get_node_shared_ptr());
+
+        if (!matmul_node || transformation_callback(matmul_node))
+            return false;
+
+        const auto desired_et = ov::element::f32;
+        const auto original_et = matmul_node->get_output_element_type(0);
+        if (original_et == desired_et)
+            return false;
+
+        // Ensure both MatMul inputs are f32.
+        // - If input is a Convert node (e.g. Convert_3: i32→f16), replace it with i32→f32.
+        // - If input is not a Convert (e.g. Broadcast: f16), insert a new Convert(f16→f32) before it.
+        for (auto& input : matmul_node->inputs()) {
+            auto src_output = input.get_source_output();
+            auto src_node = src_output.get_node_shared_ptr();
+            if (src_output.get_element_type() == desired_et)
+                continue;
+
+            auto src_convert = ov::as_type_ptr<ov::op::v0::Convert>(src_node);
+            if (src_convert) {
+                auto new_convert = std::make_shared<ov::op::v0::Convert>(src_convert->input_value(0), desired_et);
+                new_convert->set_friendly_name(src_convert->get_friendly_name());
+                ov::copy_runtime_info(src_convert, new_convert);
+                ov::replace_node(src_convert, new_convert);
+            } else {
+                auto new_convert = std::make_shared<ov::op::v0::Convert>(src_output, desired_et);
+                new_convert->set_friendly_name(src_node->get_friendly_name() + "_to_f32");
+                ov::copy_runtime_info(src_node, new_convert);
+                input.replace_source_output(new_convert);
+            }
+        }
+
+        // Remove the Convert after MatMul (f16→f32) since MatMul now outputs f32.
+        // Just replace it with MatMul's output directly.
+        if (convert_node) {
+            ov::replace_node(convert_node, matmul_node);
+        }
+
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(rope, "IncreasePositionIdsPrecisionForGemma4");
+    this->register_matcher(m, callback);
+}
+
 IncreasePositionIdsPrecision::IncreasePositionIdsPrecision() {}
 
 bool IncreasePositionIdsPrecision::run_on_model(const std::shared_ptr<ov::Model>& model) {
     ov::pass::SymbolicOptimizations symbolic_optimizations(false, get_pass_config());
     auto symbolic_ctx_manager = symbolic_optimizations.get_manager();
+    symbolic_ctx_manager->register_pass<IncreasePositionIdsPrecisionForGemma4>();
     symbolic_ctx_manager->register_pass<IncreasePositionIdsPrecisionForRoPE>();
     symbolic_ctx_manager->register_pass<IncreasePositionIdsPrecisionForQwen25VL>();
     symbolic_ctx_manager->register_pass<IncreasePositionIdsPrecisionForQwen3VL>();

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
@@ -38,6 +38,12 @@ public:
     IncreasePositionIdsPrecisionForGPTOSS();
 };
 
+class IncreasePositionIdsPrecisionForGemma4 : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("IncreasePositionIdsPrecisionForGemma4");
+    IncreasePositionIdsPrecisionForGemma4();
+};
+
 
 /**
  * @brief This pass adds additional convert nodes on the position_ids input branch (around MatMul or Multiply operation),

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
@@ -1082,3 +1082,85 @@ TEST(IncreasePrecisionTest, IncreaseRMSInputPrecisionForQwenVLMerger) {
     EXPECT_TRUE(ov::as_type_ptr<ov::op::v0::Convert>(rms_user) != nullptr)
         << "rms_m output should feed into Convert node";
 }
+
+// Gemma4 pattern: MatMul → Convert(f16→f32) → Transpose → Concat → Sin/Cos → Unsqueeze → RoPE
+TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForGemma4) {
+    {
+        // Gemma4 rotary embedding: position_ids path goes through Convert(i32→f16) then MatMul(f16)
+        // followed by Convert(f16→f32) → Transpose → Concat → Sin/Cos → Unsqueeze → RoPE
+        auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{-1, -1});
+        auto convert_i32 = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
+        auto unsqueeze_const = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
+        auto unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(convert_i32, unsqueeze_const);
+        auto convert_f16 = std::make_shared<ov::op::v0::Convert>(unsqueeze, ov::element::f16);
+
+        // Broadcast frequency matrix (f16)
+        auto freq_const = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 128, 1});
+        auto shape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{1, 128, 1});
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(freq_const, shape_const);
+
+        // MatMul in f16
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(broadcast, convert_f16);
+
+        // Convert after MatMul (f16→f32)
+        auto convert_after_matmul = std::make_shared<ov::op::v0::Convert>(matmul, ov::element::f32);
+
+        // Transpose
+        auto transpose_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{0, 2, 1});
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(convert_after_matmul, transpose_const);
+
+        // Concat → Sin/Cos
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{transpose, transpose}, 2);
+        auto cos = std::make_shared<ov::op::v0::Cos>(concat);
+        auto sin = std::make_shared<ov::op::v0::Sin>(concat);
+
+        // Unsqueeze → RoPE
+        auto unsqueeze_const2 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{2});
+        auto cos_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(cos, unsqueeze_const2);
+        auto sin_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(sin, unsqueeze_const2);
+
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_unsqueeze, sin_unsqueeze}, ov::op::internal::RoPE::Config());
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{position_ids, rope_input});
+        manager.register_pass<IncreasePositionIdsPrecision>();
+    }
+    {
+        // Expected: Convert_3 becomes i32→f32, Broadcast gets a Convert(f16→f32),
+        // MatMul executes in f32, Convert after MatMul is removed.
+        auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{-1, -1});
+        auto convert_i32 = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
+        auto unsqueeze_const = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1});
+        auto unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(convert_i32, unsqueeze_const);
+        auto convert_f32 = std::make_shared<ov::op::v0::Convert>(unsqueeze, ov::element::f32);
+
+        // Broadcast frequency matrix (f16) + Convert to f32
+        auto freq_const = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 128, 1});
+        auto shape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{1, 128, 1});
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(freq_const, shape_const);
+        auto broadcast_to_f32 = std::make_shared<ov::op::v0::Convert>(broadcast, ov::element::f32);
+
+        // MatMul in f32 (no Convert after)
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(broadcast_to_f32, convert_f32);
+
+        // Transpose (directly from MatMul, Convert removed)
+        auto transpose_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{0, 2, 1});
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(matmul, transpose_const);
+
+        // Concat → Sin/Cos
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{transpose, transpose}, 2);
+        auto cos = std::make_shared<ov::op::v0::Cos>(concat);
+        auto sin = std::make_shared<ov::op::v0::Sin>(concat);
+
+        // Unsqueeze → RoPE
+        auto unsqueeze_const2 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{2});
+        auto cos_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(cos, unsqueeze_const2);
+        auto sin_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(sin, unsqueeze_const2);
+
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_unsqueeze, sin_unsqueeze}, ov::op::internal::RoPE::Config());
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{position_ids, rope_input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}


### PR DESCRIPTION
## Details

**Problem:** gemma4-26b-a4b-it model enters an infinite repetition loop on GPU when generating long sequences (position_ids > 2048) due to FP16 precision loss in the rotary embedding computation.

**Root cause:** The existing `IncreasePositionIdsPrecisionForRoPE` pass does not match Gemma4's rotary embedding graph pattern. Gemma4 has an extra `Convert` node between `MatMul` and `Transpose` (`MatMul → Convert → Transpose → Concat → Sin/Cos → Unsqueeze → RoPE`), while the existing pattern expects `MatMul → Transpose`. As a result, the rotary embedding `MatMul` remains in FP16, causing `position_ids` (e.g., 2851) to be rounded (2851→2850 in f16). This 1-unit error propagates through the frequency matrix multiplication → sin/cos → RoPE into every transformer layer's attention, eventually flipping token selections and triggering a self-reinforcing repetition loop.

**Fix:** Added a new `IncreasePositionIdsPrecisionForGemma4` MatcherPass that matches the Gemma4-specific pattern:
- Pattern: `MatMul → Convert(f16→f32) → Transpose → Concat → Sin/Cos → [Unsqueeze] → RoPE`
- Callback: changes `Convert_3` (i32→f16) to (i32→f32), inserts `Convert(f16→f32)` before Broadcast input, and removes the now-redundant Convert after MatMul.

Added unit test `IncreasePositionIdsPrecisionForGemma4`.

## Tickets

- [CVS-187785](https://jira.devtools.intel.com/browse/CVS-187785)

## AI Assistance

- AI assistance used: yes
- AI was used for per-iteration logit comparison analysis, tensor dump comparison scripting, exec graph subgraph extraction, and matcher log interpretation. All code changes were manually reviewed and validated with end-to-end accuracy tests.