### PR TITLE
[TRANSFORMATIONS] Serialize DynamicQuantize attributes via visit_attributes

### DIFF
--- a/src/common/transformations/include/ov_ops/dynamic_quantize.hpp
+++ b/src/common/transformations/include/ov_ops/dynamic_quantize.hpp
@@ -52,6 +52,8 @@ public:
     /// \param config Dynamic quantization configuration
     DynamicQuantize(const Output<Node>& data, const Attributes& attrs);
 
+    bool visit_attributes(ov::AttributeVisitor& visitor) override;
+
     void validate_and_infer_types() override;
 
     std::shared_ptr<Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
@@ -89,4 +91,28 @@ protected:
 
 }  // namespace internal
 }  // namespace op
+
+std::ostream& operator<<(std::ostream& s, const op::internal::DynamicQuantize::QuantizationType& quantization_type);
+std::ostream& operator<<(std::ostream& s, const op::internal::DynamicQuantize::OutputStorageType& output_storage_type);
+
+template <>
+class AttributeAdapter<op::internal::DynamicQuantize::QuantizationType>
+    : public EnumAttributeAdapterBase<op::internal::DynamicQuantize::QuantizationType> {
+public:
+    AttributeAdapter(op::internal::DynamicQuantize::QuantizationType& value)
+        : EnumAttributeAdapterBase<op::internal::DynamicQuantize::QuantizationType>(value) {}
+
+    OPENVINO_RTTI("AttributeAdapter<op::internal::DynamicQuantize::QuantizationType>");
+};
+
+template <>
+class AttributeAdapter<op::internal::DynamicQuantize::OutputStorageType>
+    : public EnumAttributeAdapterBase<op::internal::DynamicQuantize::OutputStorageType> {
+public:
+    AttributeAdapter(op::internal::DynamicQuantize::OutputStorageType& value)
+        : EnumAttributeAdapterBase<op::internal::DynamicQuantize::OutputStorageType>(value) {}
+
+    OPENVINO_RTTI("AttributeAdapter<op::internal::DynamicQuantize::OutputStorageType>");
+};
+
 }  // namespace ov

--- a/src/common/transformations/src/ov_ops/dynamic_quantize.cpp
+++ b/src/common/transformations/src/ov_ops/dynamic_quantize.cpp
@@ -45,6 +45,19 @@ DynamicQuantize::DynamicQuantize(const Output<Node>& data, const Attributes& att
     validate_and_infer_types();
 }
 
+bool DynamicQuantize::visit_attributes(ov::AttributeVisitor& visitor) {
+    visitor.on_attribute("quantization_type", m_attrs.quantization_type);
+    visitor.on_attribute("quantization_dt", m_attrs.quantization_dt);
+    visitor.on_attribute("scale_dt", m_attrs.scale_dt);
+    visitor.on_attribute("zp_dt", m_attrs.zp_dt);
+    visitor.on_attribute("precomputed_reduction_dt", m_attrs.precomputed_reduction_dt);
+    visitor.on_attribute("precomputed_reduction", m_attrs.precomputed_reduction);
+    visitor.on_attribute("group_sizes", m_attrs.group_sizes);
+    visitor.on_attribute("scales_zp_output_order", m_attrs.scales_zp_output_order);
+    visitor.on_attribute("output_storage_type", m_attrs.output_storage_type);
+    return true;
+}
+
 void DynamicQuantize::validate_and_infer_types() {
     std::vector<ov::PartialShape> input_shapes = {get_input_partial_shape(0)};
 
@@ -136,4 +149,25 @@ std::vector<ov::PartialShape> DynamicQuantize::shape_infer(const DynamicQuantize
 
 }  // namespace internal
 }  // namespace op
+
+template <>
+OPENVINO_API EnumNames<op::internal::DynamicQuantize::QuantizationType>&
+EnumNames<op::internal::DynamicQuantize::QuantizationType>::get() {
+    static auto enum_names = EnumNames<op::internal::DynamicQuantize::QuantizationType>(
+        "op::internal::DynamicQuantize::QuantizationType",
+        {{"Symmetric", op::internal::DynamicQuantize::QuantizationType::Symmetric},
+         {"Asymmetric", op::internal::DynamicQuantize::QuantizationType::Asymmetric}});
+    return enum_names;
+}
+
+template <>
+OPENVINO_API EnumNames<op::internal::DynamicQuantize::OutputStorageType>&
+EnumNames<op::internal::DynamicQuantize::OutputStorageType>::get() {
+    static auto enum_names = EnumNames<op::internal::DynamicQuantize::OutputStorageType>(
+        "op::internal::DynamicQuantize::OutputStorageType",
+        {{"Planar", op::internal::DynamicQuantize::OutputStorageType::Planar},
+         {"InterleavedScalesZP", op::internal::DynamicQuantize::OutputStorageType::InterleavedScalesZP}});
+    return enum_names;
+}
+
 }  // namespace ov

--- a/src/core/tests/visitors/op/dynamic_quantize.cpp
+++ b/src/core/tests/visitors/op/dynamic_quantize.cpp
@@ -1,0 +1,83 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ov_ops/dynamic_quantize.hpp"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "visitors/visitors.hpp"
+
+using ov::op::internal::DynamicQuantize;
+using ov::op::v0::Parameter;
+using ov::test::NodeBuilder;
+
+// Whole-dimension group size marker: one scale per whole axis.
+constexpr uint64_t WHOLE_DIM = std::numeric_limits<uint64_t>::max();
+
+TEST(attributes, dynamic_quantize_attr_symmetric_per_tensor) {
+    NodeBuilder::opset().insert<DynamicQuantize>();
+
+    auto data = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape{1, 4, 8});
+
+    DynamicQuantize::Attributes attrs;
+    attrs.quantization_type = DynamicQuantize::QuantizationType::Symmetric;
+    attrs.quantization_dt = ov::element::u8;
+    attrs.scale_dt = ov::element::f32;
+    attrs.group_sizes = {WHOLE_DIM, WHOLE_DIM, WHOLE_DIM};
+    attrs.output_storage_type = DynamicQuantize::OutputStorageType::Planar;
+
+    auto op = std::make_shared<DynamicQuantize>(data, attrs);
+
+    // NodeBuilder serializes the attributes through visit_attributes and rebuilds the op
+    // from them. Without a visit_attributes override the group_sizes are dropped and the
+    // rebuild trips the shape_infer rank check (regression guard for the empty-group_sizes bug).
+    NodeBuilder builder(op, {data});
+    auto g_op = ov::as_type_ptr<DynamicQuantize>(builder.create());
+
+    EXPECT_EQ(g_op->get_quantization_type(), op->get_quantization_type());
+    EXPECT_EQ(g_op->get_attrs().quantization_dt, op->get_attrs().quantization_dt);
+    EXPECT_EQ(g_op->get_attrs().scale_dt, op->get_attrs().scale_dt);
+    EXPECT_EQ(g_op->get_group_sizes(), op->get_group_sizes());
+    EXPECT_EQ(g_op->get_scales_zp_output_order(), op->get_scales_zp_output_order());
+    EXPECT_EQ(g_op->get_output_storage_type(), op->get_output_storage_type());
+
+    EXPECT_EQ(g_op->get_output_element_type(0), op->get_output_element_type(0));
+    EXPECT_EQ(g_op->get_output_partial_shape(0), op->get_output_partial_shape(0));
+    EXPECT_EQ(g_op->get_output_partial_shape(1), op->get_output_partial_shape(1));
+}
+
+TEST(attributes, dynamic_quantize_attr_asymmetric_grouped) {
+    NodeBuilder::opset().insert<DynamicQuantize>();
+
+    auto data = std::make_shared<Parameter>(ov::element::f16, ov::PartialShape{1, 4, 8});
+
+    DynamicQuantize::Attributes attrs;
+    attrs.quantization_type = DynamicQuantize::QuantizationType::Asymmetric;
+    attrs.quantization_dt = ov::element::i8;
+    attrs.scale_dt = ov::element::f16;
+    attrs.zp_dt = ov::element::i8;
+    attrs.group_sizes = {1, 1, 8};
+    attrs.scales_zp_output_order = {0, 1, 2};
+    attrs.output_storage_type = DynamicQuantize::OutputStorageType::Planar;
+
+    auto op = std::make_shared<DynamicQuantize>(data, attrs);
+
+    NodeBuilder builder(op, {data});
+    auto g_op = ov::as_type_ptr<DynamicQuantize>(builder.create());
+
+    EXPECT_EQ(g_op->get_quantization_type(), op->get_quantization_type());
+    EXPECT_EQ(g_op->get_attrs().quantization_dt, op->get_attrs().quantization_dt);
+    EXPECT_EQ(g_op->get_attrs().scale_dt, op->get_attrs().scale_dt);
+    EXPECT_EQ(g_op->get_attrs().zp_dt, op->get_attrs().zp_dt);
+    EXPECT_EQ(g_op->get_group_sizes(), op->get_group_sizes());
+    EXPECT_EQ(g_op->get_scales_zp_output_order(), op->get_scales_zp_output_order());
+    EXPECT_EQ(g_op->get_output_storage_type(), op->get_output_storage_type());
+
+    EXPECT_EQ(g_op->get_output_element_type(0), op->get_output_element_type(0));
+    EXPECT_EQ(g_op->get_output_partial_shape(0), op->get_output_partial_shape(0));
+    EXPECT_EQ(g_op->get_output_partial_shape(1), op->get_output_partial_shape(1));
+    EXPECT_EQ(g_op->get_output_partial_shape(2), op->get_output_partial_shape(2));
+}


### PR DESCRIPTION
### Details
`ov::op::internal::DynamicQuantize` did not override `visit_attributes()`, so its
`Attributes` (quantization_type, per-tensor data types, precomputed_reduction,
group_sizes, scales_zp_output_order, output_storage_type) were silently dropped
whenever the op crossed an IR serialization boundary — e.g. `ov::pass::Serialize`
/ `StreamSerialize`, which the NPU in-plugin (`NPU_COMPILER_TYPE=PLUGIN`, VCL)
compile path uses.

On deserialization the op was reconstructed with the default (empty) `Attributes`.
With a rank-N input but empty `group_sizes`, `shape_infer` then failed with:

    Scale_shape and group_size are supposed to have same rank: N / 0

The in-plugin path that clones the model (`clone_with_new_inputs` keeps `m_attrs`)
was unaffected, which is why the failure only surfaced through the
serialize → deserialize round-trip.

### Fix
- Override `visit_attributes()` to serialize every `Attributes` field.
- Register `EnumNames` / `AttributeAdapter` for `QuantizationType` and
  `OutputStorageType` so the enums round-trip through IR (mirrors the existing GLU op).

### Tests
- Added a `NodeBuilder` attribute round-trip regression test
  `src/core/tests/visitors/op/dynamic_quantize.cpp` covering the symmetric
  per-tensor (whole-dim group_sizes) and asymmetric grouped cases. Before the fix
  the rebuild step trips the rank check above; after the fix all attributes round-trip.

### Tickets
- EISW-220941