### PR TITLE
[GPU] Fix per_layer_inputs shape in SDPAToPagedAttention for Gemma-4-e2b

### DIFF
--- a/src/core/src/pass/sdpa_to_paged_attention.cpp
+++ b/src/core/src/pass/sdpa_to_paged_attention.cpp
@@ -106,6 +106,17 @@ bool ov::pass::SDPAToPagedAttention::run_on_model(const std::shared_ptr<ov::Mode
         input_ids_node->set_partial_shape(PartialShape{-1, -1});
     }
 
+    // In PA mode batch and seq dims are merged. Fix per_layer_inputs (PLE) to match:
+    // [batch, seq, ...] -> [total_tokens, 1, ...] since Unsqueeze inserts seq=1 on the main path.
+    if (auto pli = get_parameter(model, "per_layer_inputs")) {
+        auto ps = pli->get_partial_shape();
+        if (ps.rank().is_static() && ps.rank().get_length() == 4) {
+            ps[1] = 1;
+            pli->set_partial_shape(ps);
+            pli->validate_and_infer_types();
+        }
+    }
+
     auto input_ids_target_inputs = input_ids_node->get_output_target_inputs(0);
     auto processed_input_ids =
         std::make_shared<v0::Unsqueeze>(input_ids_node, v0::Constant::create(element::i32, Shape{}, {1}));

--- a/src/plugins/intel_gpu/tests/functional/behavior/paged_attention_dynamic_query_compile.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/paged_attention_dynamic_query_compile.cpp
@@ -1,0 +1,120 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "openvino/op/constant.hpp"
+#include "openvino/op/paged_attention.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/runtime/core.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+namespace {
+
+// Build a minimal PA model that reproduces the gemma-4-e2b crash scenario:
+// query input is fully dynamic [?, ?] and the reshape input producer is 2D.
+// Without num_q_heads in rt_info, CreatePagedAttentionExtensionOp crashes
+// trying to access reshape_input[2] on a rank-2 shape.
+std::shared_ptr<ov::Model> make_pa_model_dynamic_query(bool set_num_q_heads_rt_info) {
+    const int64_t num_q_heads = 8;
+    const int64_t k_head_size = 256;
+    const int64_t num_kv_heads = 4;
+    const int64_t v_head_size = 256;
+
+    // Reshape with 2D input to simulate CommonOptimizations output.
+    // PA query becomes fully dynamic [?, ?] — same as gemma-4-e2b PA[1]+.
+    auto reshape_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, -1});
+    auto reshape_shape = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {0, -1});
+    auto reshape = std::make_shared<ov::op::v1::Reshape>(reshape_input, reshape_shape, true);
+
+    auto pa_key = std::make_shared<ov::op::v0::Parameter>(
+        ov::element::f16, ov::PartialShape{-1, num_kv_heads * k_head_size});
+    auto pa_value = std::make_shared<ov::op::v0::Parameter>(
+        ov::element::f16, ov::PartialShape{-1, num_kv_heads * v_head_size});
+    auto pa_key_cache = std::make_shared<ov::op::v0::Parameter>(
+        ov::element::f16, ov::PartialShape{-1, num_kv_heads, k_head_size, 16});
+    auto pa_value_cache = std::make_shared<ov::op::v0::Parameter>(
+        ov::element::f16, ov::PartialShape{-1, num_kv_heads, 16, v_head_size});
+
+    auto pa_past_lens = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto pa_subseq_begins = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto pa_block_indices = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto pa_block_indices_begins = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto pa_scale = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.0f / std::sqrt(float(k_head_size))});
+    auto pa_sliding_window = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    auto pa_alibi_slopes = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{0}, {});
+    auto pa_max_context_len = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{});
+    auto pa_score_agg_window = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    auto pa_rotated_block_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_rotation_deltas = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_rotation_trig_lut = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{0}, {});
+    auto pa_xattn_threshold = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{0}, {});
+    auto pa_xattn_block_size = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_xattn_stride = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_sinks = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{0}, {});
+    auto pa_arkv_start = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    auto pa_arkv_evict = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_arkv_div_idx = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_arkv_div_begins = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_token_type_ids = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_qq_bias = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{0}, {});
+    auto pa_qq_bias_begins = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+
+    ov::OutputVector pa_args = {
+        reshape->output(0),                                                 // 0: query (from 2D reshape)
+        pa_key, pa_value, pa_key_cache, pa_value_cache,                     // 1-4
+        pa_past_lens, pa_subseq_begins, pa_block_indices,                   // 5-7
+        pa_block_indices_begins, pa_scale, pa_sliding_window,               // 8-10
+        pa_alibi_slopes, pa_max_context_len, pa_score_agg_window,           // 11-13
+        pa_rotated_block_indices, pa_rotation_deltas, pa_rotation_trig_lut, // 14-16
+        pa_xattn_threshold, pa_xattn_block_size, pa_xattn_stride,           // 17-19
+        pa_sinks, pa_arkv_start, pa_arkv_evict,                             // 20-22
+        pa_arkv_div_idx, pa_arkv_div_begins, pa_token_type_ids,             // 23-25
+        pa_qq_bias, pa_qq_bias_begins                                        // 26-27
+    };
+
+    auto pa_node = std::make_shared<ov::op::PagedAttentionExtension>(pa_args);
+
+    pa_node->get_rt_info()["num_k_heads"] = num_kv_heads;
+    pa_node->get_rt_info()["k_head_size"] = k_head_size;
+    pa_node->get_rt_info()["num_v_heads"] = num_kv_heads;
+    pa_node->get_rt_info()["v_head_size"] = v_head_size;
+
+    if (set_num_q_heads_rt_info) {
+        pa_node->get_rt_info()["num_q_heads"] = num_q_heads;
+    }
+
+    auto result = std::make_shared<ov::op::v0::Result>(pa_node->output(0));
+
+    return std::make_shared<ov::Model>(
+        ov::ResultVector{result},
+        ov::ParameterVector{reshape_input, pa_key, pa_value, pa_key_cache, pa_value_cache,
+                            pa_past_lens, pa_subseq_begins, pa_block_indices,
+                            pa_block_indices_begins, pa_max_context_len});
+}
+
+class PagedAttentionDynamicQueryTest : public ::testing::Test {};
+
+// Reproduces gemma-4-e2b crash: PA query is fully dynamic [?, ?] with 2D reshape input.
+// With num_q_heads in rt_info, compile must succeed (CVS-184666 fix).
+TEST_F(PagedAttentionDynamicQueryTest, smoke_CompileDynamicQueryWithRtInfo) {
+    auto model = make_pa_model_dynamic_query(true);
+
+    ov::Core core;
+    ov::CompiledModel compiled_model;
+    ASSERT_NO_THROW(compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU));
+}
+
+// Without num_q_heads in rt_info and a 2D reshape input, compile must throw
+// a clear assertion rather than crashing with "Accessing out-of-range dimension".
+TEST_F(PagedAttentionDynamicQueryTest, smoke_CompileDynamicQueryWithoutRtInfoThrows) {
+    auto model = make_pa_model_dynamic_query(false);
+
+    ov::Core core;
+    ASSERT_ANY_THROW(core.compile_model(model, ov::test::utils::DEVICE_GPU));
+}
+
+}  // namespace

--- a/src/plugins/intel_gpu/tests/functional/behavior/paged_attention_dynamic_query_compile.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/paged_attention_dynamic_query_compile.cpp
@@ -14,18 +14,93 @@
 
 namespace {
 
-// Build a minimal PA model that reproduces the gemma-4-e2b crash scenario:
-// query input is fully dynamic [?, ?] and the reshape input producer is 2D.
-// Without num_q_heads in rt_info, CreatePagedAttentionExtensionOp crashes
-// trying to access reshape_input[2] on a rank-2 shape.
-std::shared_ptr<ov::Model> make_pa_model_dynamic_query(bool set_num_q_heads_rt_info) {
+// Build a PA model where query is fully dynamic [?, ?] to simulate
+// the gemma-4-e2b scenario after PLE broadcast makes shapes dynamic.
+// This verifies that PA compile handles static query correctly when
+// the per_layer_inputs fix is applied (CVS-184666).
+std::shared_ptr<ov::Model> make_pa_model_with_static_query() {
     const int64_t num_q_heads = 8;
     const int64_t k_head_size = 256;
     const int64_t num_kv_heads = 4;
     const int64_t v_head_size = 256;
+    const int64_t query_dim = num_q_heads * k_head_size;  // 2048
 
-    // Reshape with 2D input to simulate CommonOptimizations output.
-    // PA query becomes fully dynamic [?, ?] — same as gemma-4-e2b PA[1]+.
+    // Query input with STATIC dim1 — this is what the per_layer_inputs fix achieves.
+    // Before the fix, PLE broadcast made this [?, ?] causing GPU crash.
+    auto query_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, query_dim});
+
+    auto pa_key = std::make_shared<ov::op::v0::Parameter>(
+        ov::element::f16, ov::PartialShape{-1, num_kv_heads * k_head_size});
+    auto pa_value = std::make_shared<ov::op::v0::Parameter>(
+        ov::element::f16, ov::PartialShape{-1, num_kv_heads * v_head_size});
+    auto pa_key_cache = std::make_shared<ov::op::v0::Parameter>(
+        ov::element::f16, ov::PartialShape{-1, num_kv_heads, k_head_size, 16});
+    auto pa_value_cache = std::make_shared<ov::op::v0::Parameter>(
+        ov::element::f16, ov::PartialShape{-1, num_kv_heads, 16, v_head_size});
+
+    auto pa_past_lens = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto pa_subseq_begins = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto pa_block_indices = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto pa_block_indices_begins = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto pa_scale = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.0f / std::sqrt(float(k_head_size))});
+    auto pa_sliding_window = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    auto pa_alibi_slopes = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{0}, {});
+    auto pa_max_context_len = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{});
+    auto pa_score_agg_window = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    auto pa_rotated_block_indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_rotation_deltas = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_rotation_trig_lut = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{0}, {});
+    auto pa_xattn_threshold = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{0}, {});
+    auto pa_xattn_block_size = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    auto pa_xattn_stride = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    auto pa_sinks = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{0}, {});
+    auto pa_arkv_start = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    auto pa_arkv_evict = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_arkv_div_idx = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_arkv_div_begins = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_token_type_ids = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_qq_bias = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{0}, {});
+    auto pa_qq_bias_begins = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+
+    ov::OutputVector pa_args = {
+        query_input,                                                            // 0: query [?, 2048] (static dim1)
+        pa_key, pa_value, pa_key_cache, pa_value_cache,                         // 1-4
+        pa_past_lens, pa_subseq_begins, pa_block_indices,                       // 5-7
+        pa_block_indices_begins, pa_scale, pa_sliding_window,                   // 8-10
+        pa_alibi_slopes, pa_max_context_len, pa_score_agg_window,               // 11-13
+        pa_rotated_block_indices, pa_rotation_deltas, pa_rotation_trig_lut,     // 14-16
+        pa_xattn_threshold, pa_xattn_block_size, pa_xattn_stride,              // 17-19
+        pa_sinks, pa_arkv_start, pa_arkv_evict,                                 // 20-22
+        pa_arkv_div_idx, pa_arkv_div_begins, pa_token_type_ids,                 // 23-25
+        pa_qq_bias, pa_qq_bias_begins                                           // 26-27
+    };
+
+    auto pa_node = std::make_shared<ov::op::PagedAttentionExtension>(pa_args);
+
+    pa_node->get_rt_info()["num_k_heads"] = num_kv_heads;
+    pa_node->get_rt_info()["k_head_size"] = k_head_size;
+    pa_node->get_rt_info()["num_v_heads"] = num_kv_heads;
+    pa_node->get_rt_info()["v_head_size"] = v_head_size;
+
+    auto result = std::make_shared<ov::op::v0::Result>(pa_node->output(0));
+
+    return std::make_shared<ov::Model>(
+        ov::ResultVector{result},
+        ov::ParameterVector{query_input, pa_key, pa_value, pa_key_cache, pa_value_cache,
+                            pa_past_lens, pa_subseq_begins, pa_block_indices,
+                            pa_block_indices_begins, pa_max_context_len});
+}
+
+// Build a PA model where query is fully dynamic [?, ?] to simulate
+// what happens WITHOUT the per_layer_inputs fix (PLE broadcast scenario).
+std::shared_ptr<ov::Model> make_pa_model_with_dynamic_query() {
+    const int64_t k_head_size = 256;
+    const int64_t num_kv_heads = 4;
+    const int64_t v_head_size = 256;
+
+    // Reshape with 2D dynamic input -> query becomes [?, ?]
+    // This simulates the graph state when per_layer_inputs broadcast
+    // makes layer outputs dynamic.
     auto reshape_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{-1, -1});
     auto reshape_shape = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {0, -1});
     auto reshape = std::make_shared<ov::op::v1::Reshape>(reshape_input, reshape_shape, true);
@@ -52,8 +127,8 @@ std::shared_ptr<ov::Model> make_pa_model_dynamic_query(bool set_num_q_heads_rt_i
     auto pa_rotation_deltas = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
     auto pa_rotation_trig_lut = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{0}, {});
     auto pa_xattn_threshold = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{0}, {});
-    auto pa_xattn_block_size = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
-    auto pa_xattn_stride = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
+    auto pa_xattn_block_size = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    auto pa_xattn_stride = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
     auto pa_sinks = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{0}, {});
     auto pa_arkv_start = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
     auto pa_arkv_evict = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
@@ -64,16 +139,16 @@ std::shared_ptr<ov::Model> make_pa_model_dynamic_query(bool set_num_q_heads_rt_i
     auto pa_qq_bias_begins = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, {});
 
     ov::OutputVector pa_args = {
-        reshape->output(0),                                                 // 0: query (from 2D reshape)
-        pa_key, pa_value, pa_key_cache, pa_value_cache,                     // 1-4
-        pa_past_lens, pa_subseq_begins, pa_block_indices,                   // 5-7
-        pa_block_indices_begins, pa_scale, pa_sliding_window,               // 8-10
-        pa_alibi_slopes, pa_max_context_len, pa_score_agg_window,           // 11-13
-        pa_rotated_block_indices, pa_rotation_deltas, pa_rotation_trig_lut, // 14-16
-        pa_xattn_threshold, pa_xattn_block_size, pa_xattn_stride,           // 17-19
-        pa_sinks, pa_arkv_start, pa_arkv_evict,                             // 20-22
-        pa_arkv_div_idx, pa_arkv_div_begins, pa_token_type_ids,             // 23-25
-        pa_qq_bias, pa_qq_bias_begins                                        // 26-27
+        reshape->output(0),                                                     // 0: query [?, ?] (fully dynamic)
+        pa_key, pa_value, pa_key_cache, pa_value_cache,                         // 1-4
+        pa_past_lens, pa_subseq_begins, pa_block_indices,                       // 5-7
+        pa_block_indices_begins, pa_scale, pa_sliding_window,                   // 8-10
+        pa_alibi_slopes, pa_max_context_len, pa_score_agg_window,               // 11-13
+        pa_rotated_block_indices, pa_rotation_deltas, pa_rotation_trig_lut,     // 14-16
+        pa_xattn_threshold, pa_xattn_block_size, pa_xattn_stride,              // 17-19
+        pa_sinks, pa_arkv_start, pa_arkv_evict,                                 // 20-22
+        pa_arkv_div_idx, pa_arkv_div_begins, pa_token_type_ids,                 // 23-25
+        pa_qq_bias, pa_qq_bias_begins                                           // 26-27
     };
 
     auto pa_node = std::make_shared<ov::op::PagedAttentionExtension>(pa_args);
@@ -82,10 +157,6 @@ std::shared_ptr<ov::Model> make_pa_model_dynamic_query(bool set_num_q_heads_rt_i
     pa_node->get_rt_info()["k_head_size"] = k_head_size;
     pa_node->get_rt_info()["num_v_heads"] = num_kv_heads;
     pa_node->get_rt_info()["v_head_size"] = v_head_size;
-
-    if (set_num_q_heads_rt_info) {
-        pa_node->get_rt_info()["num_q_heads"] = num_q_heads;
-    }
 
     auto result = std::make_shared<ov::op::v0::Result>(pa_node->output(0));
 
@@ -96,22 +167,22 @@ std::shared_ptr<ov::Model> make_pa_model_dynamic_query(bool set_num_q_heads_rt_i
                             pa_block_indices_begins, pa_max_context_len});
 }
 
-class PagedAttentionDynamicQueryTest : public ::testing::Test {};
+class PagedAttentionPLETest : public ::testing::Test {};
 
-// Reproduces gemma-4-e2b crash: PA query is fully dynamic [?, ?] with 2D reshape input.
-// With num_q_heads in rt_info, compile must succeed (CVS-184666 fix).
-TEST_F(PagedAttentionDynamicQueryTest, smoke_CompileDynamicQueryWithRtInfo) {
-    auto model = make_pa_model_dynamic_query(true);
+// With per_layer_inputs fix applied, PA query dim1 is static.
+// GPU compile must succeed (this is the post-fix state).
+TEST_F(PagedAttentionPLETest, smoke_CompileStaticQueryAfterPLEFix) {
+    auto model = make_pa_model_with_static_query();
 
     ov::Core core;
     ov::CompiledModel compiled_model;
     ASSERT_NO_THROW(compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU));
 }
 
-// Without num_q_heads in rt_info and a 2D reshape input, compile must throw
-// a clear assertion rather than crashing with "Accessing out-of-range dimension".
-TEST_F(PagedAttentionDynamicQueryTest, smoke_CompileDynamicQueryWithoutRtInfoThrows) {
-    auto model = make_pa_model_dynamic_query(false);
+// Without the fix, PA query becomes [?, ?] (fully dynamic due to PLE broadcast).
+// GPU compile must fail because heads_num cannot be determined at compile time.
+TEST_F(PagedAttentionPLETest, smoke_CompileDynamicQueryWithoutPLEFixThrows) {
+    auto model = make_pa_model_with_dynamic_query();
 
     ov::Core core;
     ASSERT_ANY_THROW(core.compile_model(model, ov::test::utils::DEVICE_GPU));


### PR DESCRIPTION
### Problem
Gemma-4-e2b-it crashes during GPU compile_model with PagedAttention enabled.

The SDPAToPagedAttention pass merges batch and seq dims of `inputs_embeds` into 2D. It inserts an Unsqueeze to produce `[total_tokens, 1, hidden]` for downstream consumers. However, the `per_layer_inputs` parameter (PLE) retains its original shape `[?, ?, ?, 256]`.

When added to the PLE projection output `[?, 1, 35, 256]`, broadcasting on dim1 (1 vs ?) makes all downstream shapes dynamic. This propagates through every layer's residual Add. All PA query shapes become `[?, ?]` instead of `[?, 2048]`.

On GPU, this causes a crash — `heads_num` must be computed at compile time from a static query dimension. On CPU, it silently degrades into unnecessary dynamic shape inference across 34 layers.

### Solution

Set `per_layer_inputs` dim1=1 in SDPAToPagedAttention. This matches the PA mode convention where batch×seq are merged and Unsqueeze inserts seq=1. It is consistent with what the GenAI CB runtime already provides: `[total_num_tokens, 1, num_hidden_layers, hidden_size]`.

All 35 PA query shapes become static. GPU/CPU compile succeeds. The broadcast-induced dynamic propagation is eliminated.
### Tickets:
 - *CVS-190998*

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
