### PR TITLE
[PyTorch FE] Support aten::take, aten::str, aten::Delete operations

### DIFF
--- a/src/frontends/pytorch/src/op/take.cpp
+++ b/src/frontends/pytorch/src/op/take.cpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/reshape.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+OutputVector translate_take(const NodeContext& context) {
+    // aten::take(Tensor self, Tensor index) -> Tensor
+    // aten::take.out(Tensor self, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
+    num_inputs_check(context, 2, 3);
+    auto x = context.get_input(0);
+    auto index = context.get_input(1);
+    index = context.mark_node(std::make_shared<ov::op::v0::Convert>(index, element::i32));
+    // Flatten the input tensor to 1D
+    auto minus_1 = context.mark_node(ov::op::v0::Constant::create(element::i32, Shape{1}, {-1}));
+    x = context.mark_node(std::make_shared<ov::op::v1::Reshape>(x, minus_1, false));
+    // Use Gather to select elements from the flattened input along axis 0
+    auto axis_0 = context.mark_node(ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+    auto gather = context.mark_node(std::make_shared<ov::op::v8::Gather>(x, index, axis_0));
+    if (!context.input_is_none(2)) {
+        context.mutate_input(2, gather);
+    }
+    return {gather};
+};
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -267,6 +267,7 @@ OP_CONVERTER(translate_sub);
 OP_CONVERTER(translate_sub_);
 OP_CONVERTER(translate_sum);
 OP_CONVERTER(translate_t);
+OP_CONVERTER(translate_take);
 OP_CONVERTER(translate_take_along_dim);
 OP_CONVERTER(translate_to);
 OP_CONVERTER(translate_topk);
@@ -495,6 +496,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::constant_pad_nd", op::translate_constant_pad_nd},
         {"aten::copy", op::skip_node},
         {"aten::copy_", op::translate_copy_},
+        {"aten::Delete", op::skip_node},
         {"aten::cos", op::optional_out<op::translate_1to1_match_1_inputs_with_fp32_type_alignment<opset10::Cos>, 1>},
         {"aten::cos_", op::inplace_op<op::translate_1to1_match_1_inputs<opset10::Cos>>},
         {"aten::cosh", op::optional_out<op::translate_1to1_match_1_inputs_with_fp32_type_alignment<opset10::Cosh>, 1>},
@@ -755,6 +757,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::split_with_sizes_copy", op::translate_split_with_sizes},
         {"aten::sqrt", op::optional_out<op::translate_1to1_match_1_inputs_with_fp32_type_alignment<opset10::Sqrt>, 1>},
         {"aten::sqrt_", op::inplace_op<op::translate_1to1_match_1_inputs_with_fp32_type_alignment<opset10::Sqrt>>},
+        {"aten::str", op::skip_node},
         {"aten::square", op::translate_square},
         {"aten::squeeze", op::quantizable_op<op::translate_squeeze>},
         {"aten::squeeze_copy", op::quantizable_op<op::translate_squeeze>},
@@ -767,6 +770,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::sum", op::translate_sum},
         {"aten::swapaxes", op::quantizable_op<op::translate_transpose>},
         {"aten::t", op::translate_t},
+        {"aten::take", op::translate_take},
         {"aten::take_along_dim", op::translate_take_along_dim},
         {"aten::tan", op::optional_out<op::translate_1to1_match_1_inputs_with_fp32_type_alignment<opset10::Tan>, 1>},
         {"aten::tan_", op::inplace_op<op::translate_1to1_match_1_inputs<opset10::Tan>>},
@@ -1136,12 +1140,14 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.squeeze_copy.dims", op::translate_squeeze},
         {"aten.stack.default", op::translate_stack_fx},
         {"aten.std.correction", op::translate_std_fx},
+        {"aten.str.default", op::skip_node},
         {"aten.sub.default", op::translate_sub_fx},
         {"aten.sub.Tensor", op::translate_sub_fx},
         {"aten.sum.default", op::translate_sum_fx},
         {"aten.sum.dim_IntList", op::translate_sum_fx},
         {"aten.sym_size.int", op::translate_size},
         {"aten.t.default", op::translate_t},
+        {"aten.take.default", op::translate_take},
         {"aten.take_along_dim.default", op::translate_take_along_dim},
         {"aten.tan.default", op::translate_1to1_match_1_inputs_with_fp32_type_alignment<opset10::Tan>},
         {"aten.tanh.default", op::translate_1to1_match_1_inputs_with_fp32_type_alignment<opset10::Tanh>},

--- a/tests/layer_tests/pytorch_tests/test_take.py
+++ b/tests/layer_tests/pytorch_tests/test_take.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from pytorch_layer_test_class import PytorchLayerTest, skip_if_export
+
+
+class TestTake(PytorchLayerTest):
+    def _prepare_input(self, m, n, out=False):
+        import numpy as np
+        total_elements = m * n
+        index = np.random.randint(0, total_elements, (n,), dtype=np.int64)
+        inp = np.random.randn(m, n)
+        if out:
+            out_tensor = np.zeros_like(index, dtype=inp.dtype)
+            return (inp, index, out_tensor)
+        return (inp, index)
+
+    def create_model(self, out):
+        import torch
+
+        class aten_take(torch.nn.Module):
+            def __init__(self, out=False):
+                super().__init__()
+                if out:
+                    self.forward = self.forward_out
+
+            def forward(self, x, index):
+                return torch.take(x, index)
+
+            def forward_out(self, x, index, out):
+                return torch.take(x, index, out=out)
+
+        return aten_take(out), "aten::take"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_torch_export
+    @pytest.mark.parametrize("m", [2, 10, 100])
+    @pytest.mark.parametrize("n", [2, 10, 100])
+    @pytest.mark.parametrize("out", [skip_if_export(True), False])
+    def test_take(self, m, n, out, ie_device, precision, ir_version):
+        self._test(*self.create_model(out), ie_device, precision, ir_version, kwargs_to_prepare_input={
+            "m": m, "n": n, "out": out
+        })


### PR DESCRIPTION
### Details
This PR adds support for three PyTorch ATen operations that were missing from the PyTorch Frontend:

- **aten::take** - Returns a new tensor with elements from input at given indices, treating input as 1D. Implemented via flatten + Gather.
- **aten::str** - String conversion operation, handled as skip_node since it does not affect inference computation.
- **aten::Delete** - Memory deallocation operation, handled as skip_node since it is a no-op for inference.

### Changes
- New file: src/frontends/pytorch/src/op/take.cpp - Translation function for aten::take
- Modified: src/frontends/pytorch/src/op_table.cpp - Registered aten::take, aten::str, aten::Delete in TorchScript map and aten.take.default, aten.str.default in FX map
- New file: tests/layer_tests/pytorch_tests/test_take.py - Layer tests for aten::take

Fixes: #28707