### PR TITLE
[CPU][GPU] Recognize GatherMatmul as a decompression-multiply consumer

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -50,6 +50,7 @@
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/util/attr_types.hpp"
 #include "ov_ops/gather_compressed.hpp"
+#include "ov_ops/gather_matmul.hpp"
 
 // Common transformations
 #include "openvino/pass/constant_folding.hpp"
@@ -311,7 +312,8 @@ bool Transformations::is_decompression_multiply(const_node_ptr& node) {
     auto benefit_from_decompression = [&all_has_type](const std::set<ov::Input<ov::Node>>& consumers) {
         return all_has_type(consumers, ov::op::v0::MatMul::get_type_info_static()) ||
                all_has_type(consumers, ov::op::v1::Convolution::get_type_info_static()) ||
-               all_has_type(consumers, ov::op::v17::GroupedMatMul::get_type_info_static());
+               all_has_type(consumers, ov::op::v17::GroupedMatMul::get_type_info_static()) ||
+               all_has_type(consumers, ov::op::internal::GatherMatmul::get_type_info_static());
     };
 
     const auto consumers = node->get_output_target_inputs(0);

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -245,6 +245,7 @@ static bool is_decompression_multiply(const std::shared_ptr<const ov::Node> node
                                                           ov::op::internal::MOE::get_type_info_static(),
                                                           ov::op::v8::Gather::get_type_info_static(),
                                                           ov::op::v17::GroupedMatMul::get_type_info_static(),
+                                                          ov::op::internal::GatherMatmul::get_type_info_static(),
                                                           ov::op::v1::Convolution::get_type_info_static(),
                                                           ov::opset1::Convolution::get_type_info_static(),
                                                           ov::op::v1::ConvolutionBackpropData::get_type_info_static(),


### PR DESCRIPTION
This change allows a manually constructed GatherMatmul op with an appropriate dequantization subgraph as its weights (Constant->Convert->[Subtract]->Multiply) to be fused into GatherMatmulCompressed in both the CPU and GPU plugins.

`is_decompression_multiply()` in both the CPU and GPU plugin only recognized MatMul, Convolution and GroupedMatMul as consumers worth marking as weights decompression. This adds GatherMatmul to that allowlist in both plugins, consistent with how the other matmul-like ops are already handled.

Note: for the CPU plugin, https://github.com/openvinotoolkit/openvino/pull/36937 is also needed (CPU-specific Snippets tokenization fix) — without it, the dequantization chain feeding GatherMatmul gets tokenized into a generic Snippets Subgraph before ConvertGatherMatmulToGatherMatmulCompressed gets a chance to run, regardless of this allowlist change.

Verified via the llama.cpp OpenVINO backend integration that GatherMatmulCompressed now appears in the compiled execution graph on both CPU and GPU with these changes applied.

This could also benefit other projects/frontends that construct GatherMatmul with a compressible weights subgraph in the future.

### AI Assistance:

AI (GitHub Copilot) assisted in root-causing why a manually constructed GatherMatmul op was never being fused into GatherMatmulCompressed, and in drafting the small allowlist additions to is_decompression_multiply() in both the CPU (transformation_pipeline.cpp) and GPU (transformations_pipeline.cpp) plugins.

Human validation performed:

* Reviewed the generated diffs line-by-line before committing.
* Built both plugins (openvino_intel_cpu_plugin, openvino_intel_gpu_plugin) locally to confirm the change compiles cleanly with no warnings/errors.
* Verified end-to-end via an external integration (the llama.cpp OpenVINO backend, using test-llama-archs with OV_CPU_DUMP_IR/OV_GPU_DUMP_GRAPHS_PATH graph dumps) that GatherMatmulCompressed appears in the compiled execution graph on both CPU and GPU, with correctness confirmed via NMSE comparison against the reference backend.

