### PR TITLE
[CPU][Snippets] Skip tokenizing GatherMatmul's dequantization weights path

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -39,6 +39,7 @@
 #include "openvino/op/util/convolution_backprop_base.hpp"
 #include "openvino/op/util/multi_subgraph_base.hpp"
 #include "openvino/op/util/sub_graph_base.hpp"
+#include "ov_ops/gather_matmul.hpp"
 #include "snippets/pass/tokenization.hpp"
 #include "transformations/utils/utils.hpp"
 #include "utils/cpu_utils.hpp"
@@ -259,7 +260,7 @@ auto is_skipped_op(const std::shared_ptr<ov::Node>& op) -> bool {
 }
 
 bool isSuitableMatMulWithConstantPath(const std::shared_ptr<Node>& node) {
-    return ov::is_type_any_of<ov::op::v0::MatMul, ov::op::v17::GroupedMatMul>(node) &&
+    return ov::is_type_any_of<ov::op::v0::MatMul, ov::op::v17::GroupedMatMul, ov::op::internal::GatherMatmul>(node) &&
            !ov::is_type<ov::op::v0::Constant>(node->get_input_node_shared_ptr(1)) &&
            ov::op::util::is_on_path<ov::op::v0::Constant>(node->input_value(1));
 }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
@@ -58,6 +58,7 @@
 #include "openvino/op/util/arithmetic_reductions_keep_dims.hpp"
 #include "openvino/op/util/multi_subgraph_base.hpp"
 #include "openvino/op/util/sub_graph_base.hpp"
+#include "ov_ops/gather_matmul.hpp"
 #include "snippets/pass/tokenization.hpp"
 #include "transformations/utils/utils.hpp"
 #include "utils/cpu_utils.hpp"
@@ -505,7 +506,7 @@ bool isSuitableGatherChild(const std::shared_ptr<const Node>& node) {
            node->get_output_element_type(0) == ov::element::f32;
 }
 bool isSuitableMatMulWithConstantPath(const std::shared_ptr<Node>& node) {
-    return ov::is_type_any_of<ov::op::v0::MatMul, ov::op::v17::GroupedMatMul>(node) &&
+    return ov::is_type_any_of<ov::op::v0::MatMul, ov::op::v17::GroupedMatMul, ov::op::internal::GatherMatmul>(node) &&
            !ov::is_type<ov::op::v0::Constant>(node->get_input_node_shared_ptr(1)) &&
            ov::op::util::is_on_path<ov::op::v0::Constant>(node->input_value(1));
 }


### PR DESCRIPTION
`isSuitableMatMulWithConstantPath()` only recognized MatMul and GroupedMatMul as ops whose constant-derived weights path should be protected from Snippets tokenization. This adds GatherMatmul to that check, consistent with how MatMul/GroupedMatMul are already handled.

Without this fix, the dequantization chain (Constant->Convert->[Subtract]->Multiply) feeding a GatherMatmul's weights gets tokenized into a generic Snippets Subgraph by SnippetsTokenization before ConvertGatherMatmulToGatherMatmulCompressed gets a chance to run — once tokenized, the op-type-based pattern in that pass can no longer match, so GatherMatmul is never fused into GatherMatmulCompressed.

This is required (in addition to https://github.com/openvinotoolkit/openvino/pull/36936, the `is_decompression_multiply` allowlist fix) for a manually constructed GatherMatmul op with a compressible weights subgraph to actually be fused into GatherMatmulCompressed on CPU.

Verified via the llama.cpp OpenVINO backend integration that GatherMatmulCompressed now appears in the compiled execution graph on CPU with this change applied (in combination with the allowlist fix).

### AI Assistance:

AI (GitHub Copilot) assisted in root-causing why GatherMatmul was not fused to GatherMatmulCompressed even with the `is_decompression_multiply` allowlist fix, and in drafting the fix to isSuitableMatMulWithConstantPath() in both variants.

Human validation performed:

* Reviewed the generated diff line-by-line before committing.
* Built the CPU plugin locally to confirm the change compiles cleanly.
* Verified end-to-end via the llama.cpp OpenVINO backend (test-llama-archs with OV_CPU_DUMP_IR) that GatherMatmulCompressed (not plain GatherMatmul) appears in the compiled graph, with correctness confirmed via NMSE comparison against the reference backend.
