### PR TITLE
[GHA] Set timeout for clinfo step in gpu tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -338,6 +338,7 @@ jobs:
           popd
 
       - name: Verify GPU device availability
+        timeout-minutes: 5
         run: clinfo
 
       - name: Restore coverage notes

--- a/.github/workflows/job_gpu_rope_tests.yml
+++ b/.github/workflows/job_gpu_rope_tests.yml
@@ -136,6 +136,7 @@ jobs:
       # See .github/dockerfiles/ov_test/ubuntu_22_04_x64_igpu/Dockerfile.
 
       - name: Verify devices
+        timeout-minutes: 5
         run: clinfo
 
       - name: Setup Python 3.11

--- a/.github/workflows/job_gpu_tests.yml
+++ b/.github/workflows/job_gpu_tests.yml
@@ -80,7 +80,9 @@ jobs:
 
       - name: Verify devices
         timeout-minutes: 5
-        run: clinfo
+        run: |
+          clinfo
+          sleep 320
 
       #
       # Tests

--- a/.github/workflows/job_gpu_tests.yml
+++ b/.github/workflows/job_gpu_tests.yml
@@ -79,10 +79,7 @@ jobs:
         working-directory: ${{ env.INSTALL_DIR }}
 
       - name: Verify devices
-        timeout-minutes: 5
-        run: |
-          clinfo
-          sleep 320
+        run: clinfo
 
       #
       # Tests

--- a/.github/workflows/job_gpu_tests.yml
+++ b/.github/workflows/job_gpu_tests.yml
@@ -79,6 +79,7 @@ jobs:
         working-directory: ${{ env.INSTALL_DIR }}
 
       - name: Verify devices
+        timeout-minutes: 5
         run: clinfo
 
       #


### PR DESCRIPTION
### Details:
 - clinfo step on self-hosted runners sometimes hangs and is being terminated by the overall timeout of the job, but we can detect it earlier and set individual timeout for this step

### AI Assistance:
 - *AI assistance used: no