### PR TITLE
CVS-191119 Use an event for host sync

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_dynamic_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_dynamic_pipeline.cpp
@@ -49,6 +49,9 @@ DynamicPipeline::DynamicPipeline(const std::shared_ptr<ZeroInitStructsHolder>& i
                                  std::shared_ptr<IDynamicGraph::GraphArguments> requestBinding,
                                  size_t batch_size)
     : IPipeline(init_structs, graph, batch_size, config, "DynamicPipeline") {
+
+    _sync_output_with_fences = false;
+
     OV_ITT_SCOPED_TASK(itt::domains::LevelZeroBackend, "Zero_infer_request::DynamicPipeline::DynamicPipeline");
 
     OPENVINO_ASSERT(!_run_inferences_sequentially, "In-order execution doesn't work for dynamic pipeline");
@@ -209,6 +212,8 @@ void DynamicPipeline::push() {
         ze_event_handle_t event = nullptr;
         if (_sync_output_with_fences) {
             fence = _fences.at(i)->handle();
+        } else {
+            event = _events.at(i)->handle();
         }
 
         auto& command_lists = _command_lists.at(i);

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -211,6 +211,10 @@ public:
     void reset() const;
     ~Event();
 
+    inline ze_event_handle_t handle() const {
+        return _handle;
+    }
+
 private:
     std::shared_ptr<EventPool> _event_pool;
     ze_event_handle_t _handle = nullptr;


### PR DESCRIPTION
### Details:
In case of use an immediate command list for concurrent execution of single-tile compiled model, an event should be used for host synchnorization instead of a fence.

### Tickets:
 - *CVS-191119*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
