### PR TITLE
[GPU] Fix rank-2 weights detection in FullyConnected

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -131,7 +131,8 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
 
     if (weights_pshape.size() != 2) {
         // Detect 3D weights being passed to oneDNN
-        if (supports_immad && weights_pshape.size() == 4 && weights_layout.batch() > 1 && weights_layout.spatial(1) == feature) {
+        if (supports_immad && desc->weights_rank == 3 && weights_pshape.size() == 4 &&
+            weights_layout.batch() > 1 && weights_layout.spatial(1) == feature) {
             return calc_output_layouts<ov::PartialShape>(node, impl_param)[0];
         } else {
             weights_layout.set_partial_shape(reshape_to_2d(weights_pshape, feature));

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -150,6 +150,20 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMul_fc_fb_io_block_f16, GPUMatMulLayerTest,
                 ::testing::Values(additional_config)),
         MatMulLayerTest::getTestCaseName);
 
+std::vector<std::vector<ov::Shape>> fc_rank2_weights_shapeRelatedParams = {
+        { {1, 1}, {64, 1} },
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatMul_fc_rank2_weights, GPUMatMulLayerTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(fc_rank2_weights_shapeRelatedParams)),
+                ::testing::Values(std::make_pair(false, true)),
+                ::testing::ValuesIn(fc_f16_inputPrecisions),
+                ::testing::ValuesIn(fc_f16_secondaryInputTypes),
+                ::testing::Values(ov::test::utils::DEVICE_GPU),
+                ::testing::Values(additional_config)),
+        MatMulLayerTest::getTestCaseName);
+
 std::vector<std::vector<ov::Shape>> fc4d_shapeRelatedParams = {
         { {16, 16, 16, 576}, {576, 1728} },
 };

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -163,6 +163,27 @@ void generic_fully_connected_test(cldnn::format test_input_fmt, cldnn::format te
 }
 }  // namespace
 
+TEST(fully_connected_gpu, rank2_weights_are_not_treated_as_3d) {
+    auto& engine = get_test_engine();
+    if (!engine.get_device_info().supports_immad)
+        GTEST_SKIP() << "Test requires oneDNN FC support";
+
+    auto input = engine.allocate_memory({ov::PartialShape{1, 1}, data_types::f16, format::bfyx});
+    auto weights = engine.allocate_memory({ov::PartialShape{64, 1, 1, 1}, data_types::f16, format::bfyx});
+
+    topology topology(
+        input_layout("input", input->get_layout()),
+        data("weights", weights),
+        fully_connected("fc", input_info("input"), "weights", "", data_types::f16, 2, 2, true));
+
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    network network(engine, topology, config);
+
+    const auto output_layout = network.get_output_layout("fc");
+    ASSERT_EQ(output_layout.get_partial_shape(), ov::PartialShape({1, 64, 1, 1}));
+}
+
 TEST(DISABLED_fully_connected_gpu, generic_random_short) {
     VF<cldnn::format> test_input_fmts = { cldnn::format::bfyx, cldnn::format::yxfb };
     VF<cldnn::format> test_weights_fmts = { cldnn::format::yxfb };

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -163,27 +163,6 @@ void generic_fully_connected_test(cldnn::format test_input_fmt, cldnn::format te
 }
 }  // namespace
 
-TEST(fully_connected_gpu, rank2_weights_are_not_treated_as_3d) {
-    auto& engine = get_test_engine();
-    if (!engine.get_device_info().supports_immad)
-        GTEST_SKIP() << "Test requires oneDNN FC support";
-
-    auto input = engine.allocate_memory({ov::PartialShape{1, 1}, data_types::f16, format::bfyx});
-    auto weights = engine.allocate_memory({ov::PartialShape{64, 1, 1, 1}, data_types::f16, format::bfyx});
-
-    topology topology(
-        input_layout("input", input->get_layout()),
-        data("weights", weights),
-        fully_connected("fc", input_info("input"), "weights", "", data_types::f16, 2, 2, true));
-
-    auto config = get_test_default_config(engine);
-    config.set_property(ov::intel_gpu::optimize_data(true));
-    network network(engine, topology, config);
-
-    const auto output_layout = network.get_output_layout("fc");
-    ASSERT_EQ(output_layout.get_partial_shape(), ov::PartialShape({1, 64, 1, 1}));
-}
-
 TEST(DISABLED_fully_connected_gpu, generic_random_short) {
     VF<cldnn::format> test_input_fmts = { cldnn::format::bfyx, cldnn::format::yxfb };
     VF<cldnn::format> test_weights_fmts = { cldnn::format::yxfb };


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - This is a regression introduced by https://github.com/openvinotoolkit/openvino/pull/35279.
 - GPU compilation of the V-Diffusion model failed with `could not create a primitive descriptor for the matmul primitive`.
 - The legacy FullyConnected shape inference detected 3D weights using only their physical rank-4 `bfyx` layout. As a result, logical rank-2 weights could be incorrectly handled as rank-3 weights.
 - The 3D weights path was restricted to FullyConnected primitives whose logical `weights_rank` is 3.

#### The code and line that caused this issue (if it is not changed directly)
 - `src/plugins/intel_gpu/src/graph/fully_connected.cpp`
 - `fully_connected_inst::calc_output_layout()`
 - The 3D weights detection added by PR #35279 did not check `fully_connected::weights_rank`.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - Run the added GPU unit test on an IMMAD-capable device:

```bash
./ov_gpu_unit_tests \
  --gtest_filter=*rank2_weights_are_not_treated_as_3d* \
  --device_suffix=1
```

 - Before the fix:

```text
[GPU] Failed to select implementation for
name:fc
type: fully_connected
original_type: could not create a primitive descriptor for the matmul primitive.
```

 - After the fix, the unit test and the V-Diffusion e2e test pass.

#### Problematic graph
 - The minimal trigger is a rank-2 MatMul used by the V-Diffusion timestep embedding:

```text
Input:   [1, 1]
Weights: [64, 1]
MatMul:  [1, 1] x [64, 1]^T -> [1, 64]
```

 - The logical rank-2 weights are represented internally by the canonical `bfyx` layout `[64, 1, 1, 1]`.
 - Because `spatial(1) == feature == 1`, the layout was incorrectly detected as 3D weights.
 - This produced an invalid FullyConnected output layout and caused oneDNN matmul primitive descriptor creation to fail.

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
 - Reviewed the existing FullyConnected GPU tests in `fully_connected_gpu_test.cpp`.
 - A focused regression test was added because the existing tests did not cover canonical rank-4 storage with logical rank-2 weights.

### Tickets:
 - [CVS-191080](https://jira.devtools.intel.com/browse/CVS-191080)