### PR TITLE
[GPU] Rework MatrixNms kernel: bounded top-K, fix pointer offset, clear stale slots

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/matrix_nms_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/matrix_nms_ref.cl
@@ -25,90 +25,36 @@ inline INPUT1_TYPE FUNC(decay_linear)(INPUT1_TYPE iou, INPUT1_TYPE max_iou) {
     return (INPUT1_VAL_ONE - iou) / (INPUT1_VAL_ONE - max_iou + TINY);
 }
 
-inline void FUNC(swap)(int* a, int* b) {
-    int temp = *a;
-    *a = *b;
-    *b = temp;
-}
-
-inline void FUNC(sortIterative)(const __global INPUT1_TYPE* scores,
-                                      const int batchId,
-                                      const int classId,
-                                      int* indices,
-                                      const int size) {
-    for (int i = 1; i <= size; i++) {
-        bool swapped = false;
-        for (int j = 0; j < size - i; j++) {
-            const INPUT1_TYPE score_curr = scores[INPUT1_GET_INDEX(batchId, classId, 0, indices[j])];
-            const INPUT1_TYPE score_next = scores[INPUT1_GET_INDEX(batchId, classId, 0, indices[j + 1])];
-            if (score_curr < score_next) {
-                FUNC_CALL(swap)(&indices[j], &indices[j + 1]);
-                swapped = true;
-            }
-        }
-
-        if (!swapped)
-            break;
-    }
-}
-
 inline void FUNC(swap_boxes)(__global BOX_INFO* a, __global BOX_INFO* b) {
     BOX_INFO temp = *a;
     *a = *b;
     *b = temp;
 }
 
-inline void FUNC(sortIterativeBoxes)(__global BOX_INFO* boxes, int l, int h) {
-    for (int i = 1; i < h - l; i++) {
-        bool swapped = false;
-        for (int j = l; j < h - i; j++) {
-            if ((boxes[j].score < boxes[j + 1].score) ||
-                (boxes[j].score == boxes[j + 1].score && boxes[j].class_idx > boxes[j + 1].class_idx) ||
-                (boxes[j].score == boxes[j + 1].score && boxes[j].class_idx == boxes[j + 1].class_idx &&
-                 boxes[j].box_idx > boxes[j + 1].box_idx)) {
-                FUNC_CALL(swap_boxes)(&boxes[j], &boxes[j + 1]);
-                swapped = true;
-            }
-        }
-
-        if (!swapped)
-            break;
-    }
+inline bool FUNC(is_better_score)(__global BOX_INFO* lhs, __global BOX_INFO* rhs) {
+    return (lhs->score > rhs->score) ||
+           (lhs->score == rhs->score && lhs->class_idx < rhs->class_idx) ||
+           (lhs->score == rhs->score && lhs->class_idx == rhs->class_idx && lhs->box_idx < rhs->box_idx);
 }
 
-inline void FUNC(sortIterativeBoxesAcrossBatches)(__global BOX_INFO* boxes) {
-    const int size = NUM_BATCHES * NUM_CLASSES * MAX_BOXES_PER_CLASS;
-    for (int i = 1; i < size; i++) {
-        bool swapped = false;
-        for (int j = 0; j < size - i; j++) {
-            __global BOX_INFO* l = boxes + j;
-            __global BOX_INFO* r = boxes + j + 1;
-// sort by score
+inline bool FUNC(is_better_sort_type)(__global BOX_INFO* lhs, __global BOX_INFO* rhs) {
 #if SORT_TYPE == 1
-            if ((l->score < r->score) || (l->score == r->score && l->batch_idx > r->batch_idx) ||
-                (l->score == r->score && l->batch_idx == r->batch_idx && l->class_idx > r->class_idx) ||
-                (l->score == r->score && l->batch_idx == r->batch_idx && l->class_idx == r->class_idx &&
-                 l->box_idx > r->box_idx)) {
-                FUNC_CALL(swap_boxes)(l, r);
-                swapped = true;
-            }
-// sort by class id
+    return (lhs->score > rhs->score) ||
+           (lhs->score == rhs->score && lhs->batch_idx < rhs->batch_idx) ||
+           (lhs->score == rhs->score && lhs->batch_idx == rhs->batch_idx && lhs->class_idx < rhs->class_idx) ||
+           (lhs->score == rhs->score && lhs->batch_idx == rhs->batch_idx && lhs->class_idx == rhs->class_idx &&
+            lhs->box_idx < rhs->box_idx);
 #elif SORT_TYPE == 0
-            if (r->score != INPUT1_VAL_ZERO &&
-                ((l->score == INPUT1_VAL_ZERO) ||  // case with empty buffer
-                 (l->class_idx > r->class_idx) || (l->class_idx == r->class_idx && l->batch_idx > r->batch_idx) ||
-                 (l->class_idx == r->class_idx && l->batch_idx == r->batch_idx && l->score < r->score) ||
-                 (l->class_idx == r->class_idx && l->batch_idx == r->batch_idx && l->score == r->score &&
-                  l->box_idx > r->box_idx))) {
-                FUNC_CALL(swap_boxes)(l, r);
-                swapped = true;
-            }
+    return (lhs->score != INPUT1_VAL_ZERO) &&
+           ((rhs->score == INPUT1_VAL_ZERO) ||
+            (lhs->class_idx < rhs->class_idx) ||
+            (lhs->class_idx == rhs->class_idx && lhs->batch_idx < rhs->batch_idx) ||
+            (lhs->class_idx == rhs->class_idx && lhs->batch_idx == rhs->batch_idx && lhs->score > rhs->score) ||
+            (lhs->class_idx == rhs->class_idx && lhs->batch_idx == rhs->batch_idx && lhs->score == rhs->score &&
+             lhs->box_idx < rhs->box_idx));
+#else
+    return false;
 #endif
-        }
-
-        if (!swapped)
-            break;
-    }
 }
 
 inline COORD_TYPE_4 FUNC(getBoxCoords)(const __global INPUT0_TYPE* boxes, const short batch, const ushort box_idx) {
@@ -173,38 +119,54 @@ KERNEL(matrix_nms_ref_stage_0)
     const int batchId = get_global_id(0);
     const int classId = get_global_id(1);
 
-    if (classId == BACKGROUND_CLASS)
-        return;
+    __global BOX_INFO* box_info = (__global BOX_INFO*)buffer0;
+    box_info = &box_info[batchId * NUM_CLASSES * MAX_BOXES_PER_CLASS + classId * MAX_BOXES_PER_CLASS];
 
-    const int offset = batchId * NUM_CLASSES + classId;
-    int sorted_score_indices[NUM_BOXES];
-    int valid_boxes_num = 0;
-
-    const int BLOCK_SIZE = 256;
-    const int num_blocks = (NUM_BOXES + BLOCK_SIZE - 1) / BLOCK_SIZE;
-    for (int i = 0; i < num_blocks; i++) {
-        for (int j = 0; j < BLOCK_SIZE; j++) {
-            const int idx = i * BLOCK_SIZE + j;
-            if (idx >= NUM_BOXES)
-                break;
-            if (input_scores[INPUT1_GET_INDEX(batchId, classId, 0, idx)] > SCORE_THRESHOLD) {
-                sorted_score_indices[valid_boxes_num] = idx;
-                ++valid_boxes_num;
-            }
-        }
+    for (int i = 0; i < MAX_BOXES_PER_CLASS; ++i) {
+        box_info[i].batch_idx = 0;
+        box_info[i].class_idx = 0;
+        box_info[i].box_idx = 0;
+        box_info[i].score = INPUT1_VAL_ZERO;
     }
 
-    for (int i = valid_boxes_num; i < NUM_BOXES; ++i)
-        sorted_score_indices[i] = 0;
+    if (classId == BACKGROUND_CLASS) {
+        selected_boxes_num[batchId * NUM_CLASSES + classId] = 0;
+        return;
+    }
 
-    // TODO: consider faster sorting algorithm
-    FUNC_CALL(sortIterative)(input_scores, batchId, classId, sorted_score_indices, valid_boxes_num);
+    const int offset = batchId * NUM_CLASSES + classId;
+    int sorted_score_indices[MAX_BOXES_PER_CLASS];
+    INPUT1_TYPE sorted_scores[MAX_BOXES_PER_CLASS];
+    int valid_boxes_num = 0;
 
-    valid_boxes_num = min(valid_boxes_num, MAX_BOXES_PER_CLASS);
+    for (int idx = 0; idx < NUM_BOXES; ++idx) {
+        const INPUT1_TYPE score = input_scores[INPUT1_GET_INDEX(batchId, classId, 0, idx)];
+        if (score <= SCORE_THRESHOLD)
+            continue;
 
-    __global INPUT1_TYPE* iou_matrix = input_iou_matrix + offset * MAX_BOXES_PER_CLASS * sizeof(INPUT1_TYPE);
-    __global INPUT1_TYPE* iou_max = input_iou_max + offset * MAX_BOXES_PER_CLASS * sizeof(INPUT1_TYPE);
-    __global INPUT1_TYPE* min_decays = input_min_decays + offset * MAX_BOXES_PER_CLASS * sizeof(INPUT1_TYPE);
+        int pos;
+        if (valid_boxes_num < MAX_BOXES_PER_CLASS) {
+            pos = valid_boxes_num;
+            ++valid_boxes_num;
+        } else {
+            if (score <= sorted_scores[MAX_BOXES_PER_CLASS - 1])
+                continue;
+            pos = MAX_BOXES_PER_CLASS - 1;
+        }
+
+        while (pos > 0 && sorted_scores[pos - 1] < score) {
+            sorted_score_indices[pos] = sorted_score_indices[pos - 1];
+            sorted_scores[pos] = sorted_scores[pos - 1];
+            --pos;
+        }
+
+        sorted_score_indices[pos] = idx;
+        sorted_scores[pos] = score;
+    }
+
+    __global INPUT1_TYPE* iou_matrix = input_iou_matrix + offset * MAX_BOXES_PER_CLASS;
+    __global INPUT1_TYPE* iou_max = input_iou_max + offset * MAX_BOXES_PER_CLASS;
+    __global INPUT1_TYPE* min_decays = input_min_decays + offset * MAX_BOXES_PER_CLASS;
 
     iou_max[0] = INPUT1_VAL_ZERO;
     for (int i = 1; i < valid_boxes_num; ++i) {
@@ -228,10 +190,7 @@ KERNEL(matrix_nms_ref_stage_0)
         min_decays[i] = min_decay;
     }
 
-    const INPUT1_TYPE first_score = input_scores[INPUT1_GET_INDEX(batchId, classId, 0, sorted_score_indices[0])];
-
-    __global BOX_INFO* box_info = (__global BOX_INFO*)buffer0;
-    box_info = &box_info[batchId * NUM_CLASSES * MAX_BOXES_PER_CLASS + classId * MAX_BOXES_PER_CLASS];
+    const INPUT1_TYPE first_score = valid_boxes_num > 0 ? sorted_scores[0] : INPUT1_VAL_ZERO;
 
     int box_info_counter = 0;
     if (first_score > POST_THRESHOLD && valid_boxes_num > 0) {
@@ -255,6 +214,13 @@ KERNEL(matrix_nms_ref_stage_0)
         ++box_info_counter;
     }
 
+    for (int i = box_info_counter; i < MAX_BOXES_PER_CLASS; ++i) {
+        box_info[i].batch_idx = 0;
+        box_info[i].class_idx = 0;
+        box_info[i].box_idx = 0;
+        box_info[i].score = INPUT1_VAL_ZERO;
+    }
+
     selected_boxes_num[batchId * NUM_CLASSES + classId] = box_info_counter;
 }
 #endif /* MATRIX_NMS_STAGE_0 */
@@ -269,15 +235,32 @@ KERNEL(matrix_nms_ref_stage_1)
     const int first_idx = batchId * NUM_CLASSES * MAX_BOXES_PER_CLASS;
     const int last_idx = first_idx + NUM_CLASSES * MAX_BOXES_PER_CLASS;
 
-    // TODO: consider faster sorting algorithm
-    FUNC_CALL(sortIterativeBoxes)(box_info, first_idx, last_idx);
-
+    int total_valid = 0;
     for (int i = 0; i < NUM_CLASSES; ++i) {
         if (i == BACKGROUND_CLASS)
             continue;
-
-        valid_outputs[OUTPUT2_GET_INDEX(batchId, 0, 0, 0)] += selected_boxes_num[batchId * NUM_CLASSES + i];
+        total_valid += selected_boxes_num[batchId * NUM_CLASSES + i];
     }
+
+    int k = total_valid;
+    if (KEEP_TOP_K != -1 && KEEP_TOP_K < k)
+        k = KEEP_TOP_K;
+
+    for (int i = 0; i < k; ++i) {
+        int best = first_idx + i;
+        for (int j = first_idx + i + 1; j < last_idx; ++j) {
+            if (FUNC_CALL(is_better_score)(&box_info[j], &box_info[best]))
+                best = j;
+        }
+
+        if (box_info[best].score == INPUT1_VAL_ZERO)
+            break;
+
+        if (best != first_idx + i)
+            FUNC_CALL(swap_boxes)(&box_info[first_idx + i], &box_info[best]);
+    }
+
+    valid_outputs[OUTPUT2_GET_INDEX(batchId, 0, 0, 0)] = total_valid;
 }
 #endif /* MATRIX_NMS_STAGE_1 */
 
@@ -293,7 +276,25 @@ KERNEL(matrix_nms_ref_stage_2)
     // TODO: consider faster sorting algorithm
     // and index sorting instead of data sorting
 #if SORT_RESULT_ACROSS_BATCH == 1 && SORT_TYPE != 2
-    FUNC_CALL(sortIterativeBoxesAcrossBatches)(box_info);
+    const int size = NUM_BATCHES * NUM_CLASSES * MAX_BOXES_PER_CLASS;
+    int total_valid = 0;
+    for (int i = 0; i < NUM_BATCHES; ++i) {
+        total_valid += valid_outputs[OUTPUT2_GET_INDEX(i, 0, 0, 0)];
+    }
+
+    for (int i = 0; i < total_valid; ++i) {
+        int best = i;
+        for (int j = i + 1; j < size; ++j) {
+            if (FUNC_CALL(is_better_sort_type)(&box_info[j], &box_info[best]))
+                best = j;
+        }
+
+        if (box_info[best].score == INPUT1_VAL_ZERO)
+            break;
+
+        if (best != i)
+            FUNC_CALL(swap_boxes)(&box_info[i], &box_info[best]);
+    }
 #endif
 
     int output_idx = 0;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/matrix_nms_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/matrix_nms_ref.cl
@@ -277,12 +277,15 @@ KERNEL(matrix_nms_ref_stage_2)
     // and index sorting instead of data sorting
 #if SORT_RESULT_ACROSS_BATCH == 1 && SORT_TYPE != 2
     const int size = NUM_BATCHES * NUM_CLASSES * MAX_BOXES_PER_CLASS;
-    int total_valid = 0;
+    int sort_k = 0;
     for (int i = 0; i < NUM_BATCHES; ++i) {
-        total_valid += valid_outputs[OUTPUT2_GET_INDEX(i, 0, 0, 0)];
+        int v = valid_outputs[OUTPUT2_GET_INDEX(i, 0, 0, 0)];
+        if (KEEP_TOP_K != -1 && KEEP_TOP_K < v)
+            v = KEEP_TOP_K;
+        sort_k += v;
     }
 
-    for (int i = 0; i < total_valid; ++i) {
+    for (int i = 0; i < sort_k; ++i) {
         int best = i;
         for (int j = i + 1; j < size; ++j) {
             if (FUNC_CALL(is_better_sort_type)(&box_info[j], &box_info[best]))

--- a/src/plugins/intel_gpu/tests/unit/test_cases/matrix_nms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/matrix_nms_gpu_test.cpp
@@ -109,7 +109,9 @@ public:
 
         cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
-        if (!test_inputs.prime_scores_values.empty() && !is_caching_test) {
+        if (!is_caching_test && !test_inputs.prime_boxes_values.empty() && !test_inputs.prime_scores_values.empty()) {
+            ASSERT_EQ(test_inputs.prime_boxes_values.size(), test_inputs.boxes_values.size());
+            ASSERT_EQ(test_inputs.prime_scores_values.size(), test_inputs.scores_values.size());
             set_values(boxes, convert<T>(test_inputs.prime_boxes_values));
             set_values(scores, convert<T>(test_inputs.prime_scores_values));
             network->set_input_data("boxes", boxes);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/matrix_nms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/matrix_nms_gpu_test.cpp
@@ -46,6 +46,8 @@ struct matrix_nms_test_inputs {
     ov::op::v8::MatrixNms::SortResultType sort_result_type;
     ov::op::v8::MatrixNms::DecayFunction decay_function;
     std::string test_name;
+    std::vector<float> prime_boxes_values;
+    std::vector<float> prime_scores_values;
 };
 
 using matrix_nms_test_params = std::tuple<matrix_nms_test_inputs, format::type, bool>;
@@ -106,6 +108,20 @@ public:
         topology.add(reorder("matrix_nms", input_info("reordered_matrix_nms"), plain_format, data_type));
 
         cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
+
+        if (!test_inputs.prime_scores_values.empty() && !is_caching_test) {
+            set_values(boxes, convert<T>(test_inputs.prime_boxes_values));
+            set_values(scores, convert<T>(test_inputs.prime_scores_values));
+            network->set_input_data("boxes", boxes);
+            network->set_input_data("scores", scores);
+            network->execute();
+
+            cldnn::mem_lock<int, mem_lock_type::write> valid_outputs_reset(valid_outputs, get_test_stream());
+            std::fill(valid_outputs_reset.begin(), valid_outputs_reset.end(), 0);
+
+            set_values(boxes, convert<T>(test_inputs.boxes_values));
+            set_values(scores, convert<T>(test_inputs.scores_values));
+        }
 
         network->set_input_data("boxes", boxes);
         network->set_input_data("scores", scores);
@@ -674,6 +690,32 @@ matrix_nms_test_inputs get_matrix_nms_large_value_of_max_boxes_per_class() {
             "large_value_of_max_boxes_per_class"};
 }
 
+matrix_nms_test_inputs get_matrix_nms_stale_buffer_inputs() {
+    return {1,       // num_butches
+            2,       // num_boxes
+            1,       // num_classes
+            2,       // num_selected_boxes
+            false,   // sort_result_across_bch
+            0.5f,    // score_threshold
+            -1,      // nms_top_k
+            -1,      // keep_top_k
+            -1,      // background_class
+            2.0f,    // gaussian_sigma
+            0.0f,    // post_threshold
+            true,    // normalized
+            std::vector<float>{0.0, 0.0, 1.0, 1.0, 0.0, 5.0, 1.0, 6.0},     // boxes (main inference)
+            std::vector<float>{0.6, 0.1},                                   // scores (only box 0 passes)
+            std::vector<float>{0.00, 0.60, 0.00, 0.00, 1.00, 1.00,          // expected_output
+                               PAD,  PAD,  PAD,  PAD,  PAD,  PAD},
+            std::vector<int>{0, PADI},                                      // expected_selected_boxes
+            std::vector<int>{1},                                            // expected_valid_output
+            ov::op::v8::MatrixNms::SortResultType::SCORE,                   // sort_result_type
+            ov::op::v8::MatrixNms::DecayFunction::LINEAR,                   // decay_function
+            "stale_box_info_across_inferences",                             // test_name
+            std::vector<float>{0.0, 50.0, 1.0, 51.0, 0.0, 90.0, 1.0, 91.0}, // prime_boxes (1st inference)
+            std::vector<float>{0.9, 0.9}};                                  // prime_scores (fill box_info)
+}
+
 const std::vector<format::type> layout_formats = {format::bfyx,
                                                   format::b_fs_yx_fsv16,
                                                   format::b_fs_yx_fsv32,
@@ -712,6 +754,7 @@ INSTANTIATE_MATRIX_NMS_TEST_SUITE(float, get_matrix_nms_top_k_inputs)
 INSTANTIATE_MATRIX_NMS_TEST_SUITE(float, get_matrix_nms_single_box_inputs)
 INSTANTIATE_MATRIX_NMS_TEST_SUITE(float, get_matrix_nms_no_output_inputs)
 INSTANTIATE_MATRIX_NMS_TEST_SUITE(float, get_matrix_nms_large_value_of_max_boxes_per_class)
+INSTANTIATE_MATRIX_NMS_TEST_SUITE(float, get_matrix_nms_stale_buffer_inputs)
 
 using ov::float16;
 INSTANTIATE_MATRIX_NMS_TEST_SUITE(float16, get_matrix_nms_smoke_inputs)
@@ -728,6 +771,7 @@ INSTANTIATE_MATRIX_NMS_TEST_SUITE(float16, get_matrix_nms_top_k_inputs)
 INSTANTIATE_MATRIX_NMS_TEST_SUITE(float16, get_matrix_nms_single_box_inputs)
 INSTANTIATE_MATRIX_NMS_TEST_SUITE(float16, get_matrix_nms_no_output_inputs)
 INSTANTIATE_MATRIX_NMS_TEST_SUITE(float16, get_matrix_nms_large_value_of_max_boxes_per_class)
+INSTANTIATE_MATRIX_NMS_TEST_SUITE(float16, get_matrix_nms_stale_buffer_inputs)
 
 #ifndef RUN_ALL_MODEL_CACHING_TESTS
 INSTANTIATE_TEST_SUITE_P(matrix_nms_test_float16get_matrix_nms_smoke_inputs_cached,


### PR DESCRIPTION
### Details:
  - Fix the MatrixNms GPU reference kernel:
    - (1) replacing the full-sort / large-private-array Stage 0 path with bounded top-K insertion
    - (2) fixing a typed-pointer offset bug
    - (3) explicitly zeroing stale `box_info` slots
    - (4) replacing Stage 1/2 full O(N²) bubble sorts with bounded selection sorts.

    This resolves all known manifestations of the bug: `clCreateKernel` / Exit 255 on Windows dGPU at `-nstreams 8 -nireq 16`, GPU hang (TDR) at `-nstreams 1 -nireq 2`.

### Description of the issue (symptom, root-cause, how it was resolved)
  - **Symptom**:
    - pp-yolo (PADDLE, FP16/FP32) on Intel Arc A770 dGPU (Windows) fails:
      - Reporter reproduction (`-nstreams 1 -nireq 2 --use_device_mem`): `First inference took 5840.74 ms` → Exit code 255 (CRASH, OV-WORK-86, CI log confirmed).
      - Manual test:
        - Iteration 1(`-nstreams 8 -nireq 16 --use_device_mem`): Fails at `Step 7` with `clCreateKernel` (Exit 3).
        - Iteration 2(`-nstreams 1 -nireq 2 --use_device_mem`): First run crashed at `Step 10` (exit code `3221226505` / `C0000409`); succeeded on retry.

  - **Root Cause (three independent problems in the same kernel)**:
    - **Problem 1 – Oversized private memory**: Stage 0 declared `int sorted_score_indices[NUM_BOXES]` as a private (per-work-item) array. For pp-yolo `NUM_BOXES=22743`, this is ≈91 KB per work-item. On Windows dGPU with `-nstreams 8`, the OpenCL compiler/runtime rejects the kernel resource demand at `clCreateKernel`.
    - **Problem 2 – Typed-pointer offset bug**: Stage 0 computed `input_iou_matrix + offset * MAX_BOXES_PER_CLASS * sizeof(INPUT1_TYPE)`. For a typed pointer (`INPUT1_TYPE*`), pointer arithmetic already scales by element size, so the extra `sizeof` factor caused a 4× offset error that corrupts adjacent internal buffers.
    - **Problem 3 – Stale `box_info` buffer**: The `box_info` internal buffer is allocated once and never reset between inferences. Stage 0 left the background-class slice and unused tail slots with data from previous inferences. Stage 1's full O(N²) sort had no empty-slot guard, so stale high-score slots sorted to the top and Stage 2 emitted them as if they were valid detections.

  - **Resolution**:
    - Reworked `matrix_nms_ref.cl` in-place:
      - Stage 0: single-pass bounded top-K insertion into `MAX_BOXES_PER_CLASS`-sized arrays, fixing Problem 1 and laying the groundwork for Problem 3
      - Stage 0: removed erroneous `* sizeof(INPUT1_TYPE)` from the three typed-pointer offsets, fixing Problem 2
      - Stage 0: zero the full per-class `box_info` range at entry (including background-class slice), and zero the unused tail slots after writing, fixing Problem 3
      - Stage 1: replace full O(N²) `sortIterativeBoxes` with partial selection sort over `min(total_valid, KEEP_TOP_K)` items; assign `valid_outputs = total_valid` instead of incrementally accumulating
      - Stage 2: replace full O(N²) `sortIterativeBoxesAcrossBatches` with bounded selection sort
      - Added unified comparison helpers `is_better_score` / `is_better_sort_type`
    - Added native regression case `get_matrix_nms_stale_buffer_inputs` (TN=`stale_box_info_across_inferences`) in the existing parametrised-fixture style; extends `matrix_nms_test_inputs` with `prime_boxes_values` / `prime_scores_values` fields to drive two inferences on one network and expose the stale-buffer leak.
    - Fix is general across all model shapes / class counts / `sort_type` / background-class configs; no host code changes; all 360 `*matrix_nms*` unit tests pass.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
Model: `pp-yolo.xml` | Device: `GPU.0` (Intel Arc A770) | Precision: `f32`
```
$env:CLI_CallLogging = "1"
$env:CLI_QueueInfoLogging = "1"
opencl-intercept-layer\build\cliloader\Debug\cliloader.exe `
    --debug `
    -f `
    -dv `
    -dsrc `
    --dump-dir ./cliloader_log `
    openvino\bin\intel64\Release\benchmark_app.exe `
    -nstreams 1 `
    -nireq 2 `
    -use_device_mem `
    -m pp-yolo.xml `
    -t 60 `
    -infer_precision f32 `
    -d GPU.0 `
    -hint none `
    -inference_only=false `
    -niter 1
```

##### Kernel-Level Performance (CLILoader Device Timing, Arc A770 dGPU, `-nstreams 1 -nireq 1 -use_device_mem`)
Measured with OpenCL Intercept Layer v3.0.6 (DevicePerformanceTiming).

| Kernel Stage | Pre-Fix Avg (ms) | Post-Fix Avg (ms) | Speedup | Pre-Fix GPU% | Post-Fix GPU% |
|---|---|---|---|---|---|
| `matrix_nms_ref` Stage 0 (per-class top-K + NMS decay) | 5.19 | 4.23 | 1.2× | 0.13% | 20.34% |
| `matrix_nms_ref` **Stage 1** (global sort) | **3,933.68** | **0.003** | **1,449,000×** | **99.40%** | **0.01%** |
| `matrix_nms_ref` Stage 2 (format output) | 0.009 | 0.005 | 1.6× | 0.00% | 0.03% |

**Analysis**: Stage 1 consumed 99.4% of total GPU time before the fix (O(N²) bubble sort over 8000 `box_info` slots, most containing stale/uninitialized data). The fix replaces it with partial selection sort over `min(total_valid, KEEP_TOP_K)` items with zero-score early-break.
This simultaneously：
 * Eliminates the performance bottleneck that triggers Windows TDR (single kernel > 2s → GPU reset → Exit 255)
 * Prevents stale slots from being sorted into top-K positions (the correctness root cause).

##### Performance Regression Summary (Windows, CliLoader, TdrDelay=2s(Default))
| Config | Metric | Pre-Fix | Post-Fix |
|---|---|---|---|
| **nstreams 1, nireq 2** | Result | ❌ First run crashed (exit code `3221226505` / `C0000409`); succeeded only on retry | ✅ Success |
| | Total Enqueues | 12 | 12 |
| | First inference | 4061.49 ms | 79.54 ms |
| | Iterations (Count) | 18 | 2194 |
| | Duration | 71414.34 ms | 60074.22 ms |
| | Median Latency | 7928.86 ms | 54.06 ms |
| | Average Latency | 7712.06 ms | 53.73 ms |
| | Min / Max Latency | 3977.21 ms / 7959.66 ms | 42.40 ms / 72.72 ms |
| | Throughput | 0.25 FPS | 36.52 FPS |
| **nstreams 8, nireq 16** | Result | ❌ Failed to load model (`clCreateKernel` exception, exit code `3`) | ✅ Success |
| | Total Enqueues | 0 | 96 |
| | First inference | N/A (load failure) | 69.87 ms |
| | Iterations (Count) | N/A | 2816 |
| | Duration | N/A | 60446.61 ms |
| | Median Latency | N/A | 341.14 ms |
| | Throughput | N/A | 46.59 FPS |
##### Key Takeaways
- **nstreams 1, nireq 2**: Pre-fix run was unstable (initial crash) and, even after succeeding on retry, showed a **~147x throughput regression** (0.25 FPS vs 36.52 FPS post-fix) with first-inference latency inflated from ~80 ms to ~4061 ms.
- **nstreams 8, nireq 16**: Pre-fix consistently **failed to load the model** (`clCreateKernel` exception), making the workload completely non-functional. Post-fix runs cleanly at 46.59 FPS.

#### Problematic graph
 - Original IR: pp-yolo MatrixNms layer with attrs `nms_top_k=-1, keep_top_k=100, background_class=-1, score_threshold=0.01, post_threshold=0.01, decay_function=linear`, inputs `boxes [1,22743,4]` + `scores [1,80,22743]`.
<img width="3601" height="972" alt="image" src="https://github.com/user-attachments/assets/64a0c54a-a01d-4f0d-813f-35dee7d0181c" />

 - Current IR: unchanged, the fix is entirely in the GPU kernel; 

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
       Added `get_matrix_nms_stale_buffer_inputs` (TN=`stale_box_info_across_inferences`) in `src/plugins/intel_gpu/tests/unit/test_cases/matrix_nms_gpu_test.cpp` using the existing parametrised-fixture style (`matrix_nms_test_inputs`, `INSTANTIATE_MATRIX_NMS_TEST_SUITE`). It runs two inferences on one network to expose the non-reset `box_info` buffer; 12 non-caching variants FAIL before the fix and all 24 PASS after it.
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
       Reviewed `matrix_nms_gpu_test.cpp`; all 336 existing cases passed both before and after the fix because they each run a single inference on a freshly allocated network, which hides the stale-buffer bug. Extended the fixture with the two new `prime_*` fields rather than adding a standalone test.

### Tickets:
  - *CVS-186753*
