### PR TITLE
[GPU] Add config option to control host USM zero-copy for cache import

### DIFF
--- a/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
@@ -83,6 +83,12 @@ static constexpr Property<bool> enable_loop_unrolling{"GPU_ENABLE_LOOP_UNROLLING
  */
 static constexpr Property<bool> disable_winograd_convolution{"GPU_DISABLE_WINOGRAD_CONVOLUTION"};
 
+/**
+ * @brief Enable/Disable zero-copy mode for model cache blob load.
+ * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
+ */
+static constexpr Property<bool> enable_zero_copy_cache_load{"GPU_ENABLE_ZERO_COPY_CACHE_LOAD"};
+
 namespace hint {
 /**
  * @brief This enum represents the possible value of ov::intel_gpu::hint::queue_throttle property:

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -43,6 +43,7 @@ OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, mem_pool_util_threshold, 0.5, "Minimum u
 OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, offload_ratio, 0, "Percentage (0-100) of model weights to offload to disk. Currently supported for MoE experts only.", [](size_t v) { return v <= 100; })
 OV_CONFIG_RELEASE_OPTION(ov, enable_weightless, false, "Enable/Disable weightless blob")
 
+OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, enable_zero_copy_cache_load, false, "Enable/Disable zero-copy mode for model cache blob load")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, shape_predictor_settings, {10, 16 * 1024, 2, 1.1f}, "Preallocation settings")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, queue_type, QueueTypes::out_of_order, "Type of the queue that must be used for model execution. May be in-order or out-of-order")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, optimize_data, false, "Enable/Disable data flow optimizations for cldnn::program")

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -2024,7 +2024,8 @@ void program::load(cldnn::BinaryInputBuffer& ib,
 
     memory_ptr host_buffer_base_ptr = nullptr;
 
-    if (ib.get_engine().can_use_host_usm_zero_copy() && !_config.get_enable_weightless() && ib.is_tensor_aligned(ov::util::min_page_alignment)) {
+    if (_config.get_enable_zero_copy_cache_load() && ib.get_engine().can_use_host_usm_zero_copy() && !_config.get_enable_weightless() &&
+        ib.is_tensor_aligned(ov::util::min_page_alignment)) {
         host_buffer_base_ptr =
             ib.get_engine().create_hostbuffer(ib.get_tensor(),
                                               ib.get_stream_size(),

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -767,6 +767,7 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::intel_gpu::hint::enable_sdpa_optimization.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::hint::enable_lora_operation.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::hint::enable_large_allocations.name(), PropertyMutability::RW},
+        ov::PropertyName{ov::intel_gpu::enable_zero_copy_cache_load.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::enable_loop_unrolling.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::disable_winograd_convolution.name(), PropertyMutability::RW},
         ov::PropertyName{ov::cache_dir.name(), PropertyMutability::RW},


### PR DESCRIPTION
[GPU] Add config option to control host USM zero-copy for cache import

#### Details:
Description of the issue (symptom, root-cause, how it was resolved)
•	Zero-copy subbuffer creation in cache import caused regressions on some models.
•	Added ov::intel_gpu::enable_host_usm_zero_copy config option (default: false).

#### Implementation changes:
•	Added _config.get_enable_host_usm_zero_copy() check in program::load() before host_buffer_base_ptr creation.
•	Registered new GPU property with default false.

#### Changed files:
•	src/plugins/intel_gpu/src/graph/program.cpp
•	src/inference/include/openvino/runtime/intel_gpu/properties.hpp
•	src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
•	src/plugins/intel_gpu/src/plugin/plugin.cpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model): NA

#### Problematic graph: NA

#### Checklist:
- [x] Is it a proper fix? Yes (ensures small device buffers and image2d formats use their optimized staging paths instead of zero-copy)
- [x] Did you include test case for this fix, if necessary? Existing tests cover the staging buffer paths
- [x] Did you review existing test that can be extended to cover this scenario? Existing cache serialization tests validate the behavior

#### Tickets:
- CVS-189224

#### AI Assistance:
- AI assistance used: yes
- AI was used for logic refinement, variable naming, and commit message structure.