### PR TITLE
[GPU] Fix dynamic fused input loads

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -701,18 +701,25 @@ JitTerm FusedOpsCodeGenerator::get_jit_load(const FusedOpsConfiguration& conf,
     // 2. If in given configuration data can't be loaded by a simple UNIT_BLOCK_READx call or load from casted ptr,
     //    we can gather the data to vector
     if (conf.load_type == FusedOpsConfiguration::LoadType::LT_ALIGNED_READ) {
-        bool multiple_elements = false;
-        // For dynamic shape input tensor, check any one of static dimension has more than one element.
         if (input_tensor.is_dynamic()) {
-            for (const auto& dim : input_tensor.get_partial_shape()) {
-                if (dim.is_static() && dim.get_length() > 1) {
-                    multiple_elements = true;
-                    break;
-                }
+            LayoutJitter input_jitter(input_tensor, params.in_port_to_shape_info_offset.at(input_id));
+            JitTerm input_tensor_count{"1"};
+            for (const auto channel : {ov::intel_gpu::ChannelName::BATCH,
+                                       ov::intel_gpu::ChannelName::FEATURE,
+                                       ov::intel_gpu::ChannelName::V,
+                                       ov::intel_gpu::ChannelName::U,
+                                       ov::intel_gpu::ChannelName::W,
+                                       ov::intel_gpu::ChannelName::Z,
+                                       ov::intel_gpu::ChannelName::Y,
+                                       ov::intel_gpu::ChannelName::X}) {
+                input_tensor_count = input_tensor_count * JitTerm{input_jitter.dim(channel)};
             }
+            auto block_load = make_block_read(input_dt, vec_size, in_ptr + index_func_call);
+            auto scalar_load = broadcast(in_ptr[index_func_call], input_dt, vec_size);
+            return ternary(input_tensor_count.gt(JitTerm{1}), block_load, scalar_load);
         }
 
-        if ((input_tensor.is_static() && input_tensor.count() > 1) || multiple_elements) {
+        if (input_tensor.count() > 1) {
             // Currently we assume that in such scenario we can safely load sub_group_size elements from the pointer
             return make_block_read(input_dt, vec_size, in_ptr + index_func_call);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -703,7 +703,7 @@ JitTerm FusedOpsCodeGenerator::get_jit_load(const FusedOpsConfiguration& conf,
     if (conf.load_type == FusedOpsConfiguration::LoadType::LT_ALIGNED_READ) {
         if (input_tensor.is_dynamic()) {
             LayoutJitter input_jitter(input_tensor, params.in_port_to_shape_info_offset.at(input_id));
-            JitTerm input_tensor_count{"1"};
+            std::string has_multiple_elements;
             for (const auto channel : {ov::intel_gpu::ChannelName::BATCH,
                                        ov::intel_gpu::ChannelName::FEATURE,
                                        ov::intel_gpu::ChannelName::V,
@@ -712,11 +712,14 @@ JitTerm FusedOpsCodeGenerator::get_jit_load(const FusedOpsConfiguration& conf,
                                        ov::intel_gpu::ChannelName::Z,
                                        ov::intel_gpu::ChannelName::Y,
                                        ov::intel_gpu::ChannelName::X}) {
-                input_tensor_count = input_tensor_count * JitTerm{input_jitter.dim(channel)};
+                const auto dim_gt_1 = JitTerm{input_jitter.dim(channel)}.gt(JitTerm{1}).str();
+                if (!has_multiple_elements.empty())
+                    has_multiple_elements += " || ";
+                has_multiple_elements += dim_gt_1;
             }
             auto block_load = make_block_read(input_dt, vec_size, in_ptr + index_func_call);
             auto scalar_load = broadcast(in_ptr[index_func_call], input_dt, vec_size);
-            return ternary(input_tensor_count.gt(JitTerm{1}), block_load, scalar_load);
+            return ternary(JitTerm{"(" + has_multiple_elements + ")"}, block_load, scalar_load);
         }
 
         if (input_tensor.count() > 1) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -12,6 +12,7 @@
 #include "intel_gpu/primitives/activation.hpp"
 #include "intel_gpu/primitives/reorder.hpp"
 #include "jitter.hpp"
+#include "kernel_selector/jitter.h"
 #include "openvino/core/type/element_type.hpp"
 #include "quantize_inst.h"
 
@@ -702,21 +703,8 @@ JitTerm FusedOpsCodeGenerator::get_jit_load(const FusedOpsConfiguration& conf,
     //    we can gather the data to vector
     if (conf.load_type == FusedOpsConfiguration::LoadType::LT_ALIGNED_READ) {
         if (input_tensor.is_dynamic()) {
-            LayoutJitter input_jitter(input_tensor, params.in_port_to_shape_info_offset.at(input_id));
-            std::string has_multiple_elements;
-            for (const auto channel : {ov::intel_gpu::ChannelName::BATCH,
-                                       ov::intel_gpu::ChannelName::FEATURE,
-                                       ov::intel_gpu::ChannelName::V,
-                                       ov::intel_gpu::ChannelName::U,
-                                       ov::intel_gpu::ChannelName::W,
-                                       ov::intel_gpu::ChannelName::Z,
-                                       ov::intel_gpu::ChannelName::Y,
-                                       ov::intel_gpu::ChannelName::X}) {
-                const auto dim_gt_1 = JitTerm{input_jitter.dim(channel)}.gt(JitTerm{1}).str();
-                if (!has_multiple_elements.empty())
-                    has_multiple_elements += " || ";
-                has_multiple_elements += dim_gt_1;
-            }
+            const auto has_multiple_elements =
+                kernel_selector::GetTensorHasMultipleElementsCondition(get_input_tensor_name(input_id).str());
             auto block_load = make_block_read(input_dt, vec_size, in_ptr + index_func_call);
             auto scalar_load = broadcast(in_ptr[index_func_call], input_dt, vec_size);
             return ternary(JitTerm{"(" + has_multiple_elements + ")"}, block_load, scalar_load);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -703,8 +703,7 @@ JitTerm FusedOpsCodeGenerator::get_jit_load(const FusedOpsConfiguration& conf,
     //    we can gather the data to vector
     if (conf.load_type == FusedOpsConfiguration::LoadType::LT_ALIGNED_READ) {
         if (input_tensor.is_dynamic()) {
-            const auto has_multiple_elements =
-                kernel_selector::GetTensorHasMultipleElementsCondition(get_input_tensor_name(input_id).str());
+            const auto has_multiple_elements = kernel_selector::GetTensorHasMultipleElementsCondition(get_input_tensor_name(input_id).str());
             auto block_load = make_block_read(input_dt, vec_size, in_ptr + index_func_call);
             auto scalar_load = broadcast(in_ptr[index_func_call], input_dt, vec_size);
             return ternary(JitTerm{"(" + has_multiple_elements + ")"}, block_load, scalar_load);

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -2350,7 +2350,10 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
                 // broadcasting while using a subgroup block read for non-scalar tensors.
                 const auto has_multiple_elements = GetTensorHasMultipleElementsCondition(GetInputTensorName(input_id));
                 auto scalar_load = Broadcast(GetInputPtrName(input_id) + "[" + index_func_call + "]", input_dt, vec_size);
-                return "((" + has_multiple_elements + ") ? " + Broadcast(block_read, input_dt, vec_size) + " : " + scalar_load + ")";
+                return ternary(JitTerm{"(" + has_multiple_elements + ")"},
+                               JitTerm{Broadcast(block_read, input_dt, vec_size)},
+                               JitTerm{scalar_load})
+                    .str();
             }
 
             if (input_tensor.LogicalSize() > 1) {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -2342,9 +2342,12 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
                 // The compile-time logical size of a fully dynamic tensor may be reported as one even though
                 // the runtime tensor contains multiple elements. Select the load at runtime to preserve scalar
                 // broadcasting while using a subgroup block read for non-scalar tensors.
-                auto tensor_length = GetInputTensorName(input_id) + "_LENGTH";
+                const auto tensor_name = GetInputTensorName(input_id);
+                const auto has_multiple_elements = tensor_name + "_SIZE_X > 1 || " + tensor_name + "_SIZE_Y > 1 || " + tensor_name + "_SIZE_Z > 1 || " +
+                                                   tensor_name + "_SIZE_W > 1 || " + tensor_name + "_SIZE_U > 1 || " + tensor_name + "_SIZE_V > 1 || " +
+                                                   tensor_name + "_FEATURE_NUM > 1 || " + tensor_name + "_BATCH_NUM > 1";
                 auto scalar_load = Broadcast(GetInputPtrName(input_id) + "[" + index_func_call + "]", input_dt, vec_size);
-                return "((" + tensor_length + " > 1) ? " + Broadcast(block_read, input_dt, vec_size) + " : " + scalar_load + ")";
+                return "((" + has_multiple_elements + ") ? " + Broadcast(block_read, input_dt, vec_size) + " : " + scalar_load + ")";
             }
 
             if (input_tensor.LogicalSize() > 1) {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -2350,11 +2350,7 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
                 // broadcasting while using a subgroup block read for non-scalar tensors.
                 const auto has_multiple_elements = GetTensorHasMultipleElementsCondition(GetInputTensorName(input_id));
                 auto scalar_load = Broadcast(GetInputPtrName(input_id) + "[" + index_func_call + "]", input_dt, vec_size);
-                return ternary(JitTerm{"(" + has_multiple_elements + ")"},
-                               JitTerm{Broadcast(block_read, input_dt, vec_size)},
-                               JitTerm{scalar_load})
-                    .str();
-            }
+                return ternary(JitTerm{"(" + has_multiple_elements + ")"}, JitTerm{Broadcast(block_read, input_dt, vec_size)}, JitTerm{scalar_load}) .str(); }
 
             if (input_tensor.LogicalSize() > 1) {
                 // Currently we assume that in such scenario we can safely load sub_group_size elements from the pointer

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -2198,6 +2198,12 @@ std::string FusedOpsCodeGenerator::GetInputTensorName(size_t input_id) const {
     return "FUSED_OP_" + toCodeString(desc.op_id) + "_INPUT" + toCodeString(input_id);
 }
 
+std::string GetTensorHasMultipleElementsCondition(const std::string& tensor_name) {
+    return tensor_name + "_SIZE_X > 1 || " + tensor_name + "_SIZE_Y > 1 || " + tensor_name + "_SIZE_Z > 1 || " +
+           tensor_name + "_SIZE_W > 1 || " + tensor_name + "_SIZE_U > 1 || " + tensor_name + "_SIZE_V > 1 || " +
+           tensor_name + "_FEATURE_NUM > 1 || " + tensor_name + "_BATCH_NUM > 1";
+}
+
 std::string FusedOpsCodeGenerator::GetOutputTensorName() const {
     return "FUSED_OP_" + toCodeString(desc.op_id) + "_OUTPUT";
 }
@@ -2342,10 +2348,7 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
                 // The compile-time logical size of a fully dynamic tensor may be reported as one even though
                 // the runtime tensor contains multiple elements. Select the load at runtime to preserve scalar
                 // broadcasting while using a subgroup block read for non-scalar tensors.
-                const auto tensor_name = GetInputTensorName(input_id);
-                const auto has_multiple_elements = tensor_name + "_SIZE_X > 1 || " + tensor_name + "_SIZE_Y > 1 || " + tensor_name + "_SIZE_Z > 1 || " +
-                                                   tensor_name + "_SIZE_W > 1 || " + tensor_name + "_SIZE_U > 1 || " + tensor_name + "_SIZE_V > 1 || " +
-                                                   tensor_name + "_FEATURE_NUM > 1 || " + tensor_name + "_BATCH_NUM > 1";
+                const auto has_multiple_elements = GetTensorHasMultipleElementsCondition(GetInputTensorName(input_id));
                 auto scalar_load = Broadcast(GetInputPtrName(input_id) + "[" + index_func_call + "]", input_dt, vec_size);
                 return "((" + has_multiple_elements + ") ? " + Broadcast(block_read, input_dt, vec_size) + " : " + scalar_load + ")";
             }

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -2350,7 +2350,8 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
                 // broadcasting while using a subgroup block read for non-scalar tensors.
                 const auto has_multiple_elements = GetTensorHasMultipleElementsCondition(GetInputTensorName(input_id));
                 auto scalar_load = Broadcast(GetInputPtrName(input_id) + "[" + index_func_call + "]", input_dt, vec_size);
-                return ternary(JitTerm{"(" + has_multiple_elements + ")"}, JitTerm{Broadcast(block_read, input_dt, vec_size)}, JitTerm{scalar_load}) .str(); }
+                return ternary(JitTerm{"(" + has_multiple_elements + ")"}, JitTerm{Broadcast(block_read, input_dt, vec_size)}, JitTerm{scalar_load}) .str();
+            }
 
             if (input_tensor.LogicalSize() > 1) {
                 // Currently we assume that in such scenario we can safely load sub_group_size elements from the pointer

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -2338,19 +2338,16 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
                 return block_read;
             }
 
-            bool multiple_elements = false;
-            // For dynamic shape input tensor, check any one of static dimension has more than one element.
             if (input_tensor.is_dynamic()) {
-                for (auto dim : input_tensor.GetDims()) {
-                    auto v = dim.v;
-                    if (v > 1) {
-                        multiple_elements = true;
-                        break;
-                    }
-                }
+                // The compile-time logical size of a fully dynamic tensor may be reported as one even though
+                // the runtime tensor contains multiple elements. Select the load at runtime to preserve scalar
+                // broadcasting while using a subgroup block read for non-scalar tensors.
+                auto tensor_length = GetInputTensorName(input_id) + "_LENGTH";
+                auto scalar_load = Broadcast(GetInputPtrName(input_id) + "[" + index_func_call + "]", input_dt, vec_size);
+                return "((" + tensor_length + " > 1) ? " + Broadcast(block_read, input_dt, vec_size) + " : " + scalar_load + ")";
             }
 
-            if (input_tensor.LogicalSize() > 1 || multiple_elements) {
+            if (input_tensor.LogicalSize() > 1) {
                 // Currently we assume that in such scenario we can safely load sub_group_size elements from the pointer
                 return Broadcast(block_read, input_dt, vec_size);
             } else {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.h
@@ -72,6 +72,7 @@ inline std::string GetTypeName<double>() {
 std::string toCLType(WeightsType wType);
 std::string toCLType(Datatype dType);
 std::string getMeanOpString(MeanOp op);
+std::string GetTensorHasMultipleElementsCondition(const std::string& tensor_name);
 inline std::string toVectorMulString(const std::vector<std::string>& vec) {
     std::stringstream ss;
     ss << "(";

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -13226,3 +13226,76 @@ TEST(convolution_gpu_bfyx_f16, dynamic_tail_spatial_block_with_output_padding) {
         ASSERT_NEAR(test_val, ref_val, tol) << "Mismatch at idx=" << i;
     }
 }
+
+TEST(convolution_gpu_bfyx_f16, dynamic_fused_input_scalar_and_non_scalar_fp32) {
+    auto& engine = get_test_engine();
+
+    const ov::Shape input_shape = {1, 32, 3, 5};
+    const ov::Shape weights_shape = {32, 32, 1, 1};
+    const ov::Shape scalar_shape = {1, 1, 1, 1};
+
+    auto input_mem = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
+    auto weights_mem = engine.allocate_memory({weights_shape, data_types::f32, format::bfyx});
+    auto residual_mem = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
+    auto scalar_mem = engine.allocate_memory({scalar_shape, data_types::f32, format::bfyx});
+
+    tests::random_generator rg(GET_SUITE_NAME);
+    set_values(input_mem, rg.generate_random_1d<float>(ov::shape_size(input_shape), -1, 1));
+    set_values(weights_mem, rg.generate_random_1d<float>(ov::shape_size(weights_shape), -1, 1));
+    set_values(residual_mem, rg.generate_random_1d<float>(ov::shape_size(input_shape), -1, 1));
+    set_values(scalar_mem, std::vector<float>{0.25f});
+
+    const layout dynamic_layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx};
+    auto make_topology = [&]() {
+        return topology(
+            input_layout("input", dynamic_layout),
+            input_layout("residual", dynamic_layout),
+            reorder("input_fsv16", input_info("input"), format::b_fs_yx_fsv16, data_types::f32),
+            data("weights", weights_mem),
+            convolution("conv", input_info("input_fsv16"), "weights", no_bias, 1,
+                        ov::Strides{1, 1}, ov::Strides{1, 1},
+                        ov::CoordinateDiff{0, 0}, ov::CoordinateDiff{0, 0}, false),
+            eltwise("add", {input_info("conv"), input_info("residual")}, eltwise_mode::sum),
+            reorder("output", input_info("add"), format::bfyx, data_types::f32));
+    };
+
+    ExecutionConfig cfg_fused = get_test_default_config(engine);
+    cfg_fused.set_property(ov::intel_gpu::optimize_data(true));
+    cfg_fused.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{
+        {"conv", {format::b_fs_yx_fsv16, "convolution_gpu_bfyx_f16_1x1", impl_types::ocl}}
+    }));
+
+    ExecutionConfig cfg_ref = cfg_fused;
+    cfg_ref.set_property(ov::intel_gpu::optimize_data(false));
+
+    network net_fused(engine, make_topology(), cfg_fused);
+    network net_ref(engine, make_topology(), cfg_ref);
+    net_fused.set_input_data("input", input_mem);
+    net_ref.set_input_data("input", input_mem);
+
+    auto compare = [&](const memory::ptr& fused_input) {
+        net_fused.set_input_data("residual", fused_input);
+        net_ref.set_input_data("residual", fused_input);
+
+        auto fused_outputs = net_fused.execute();
+        auto ref_outputs = net_ref.execute();
+        auto fused_values = get_output_values_to_float(net_fused, fused_outputs.at("output"));
+        auto ref_values = get_output_values_to_float(net_ref, ref_outputs.at("output"));
+
+        ASSERT_EQ(fused_values.size(), ref_values.size());
+        for (size_t i = 0; i < fused_values.size(); ++i)
+            ASSERT_NEAR(fused_values[i], ref_values[i], 1e-4f) << "Mismatch at idx=" << i;
+    };
+
+    compare(residual_mem);
+    compare(scalar_mem);
+
+    const auto primitives_info = net_fused.get_primitives_info();
+    const auto conv_info = std::find_if(primitives_info.begin(), primitives_info.end(), [](const primitive_info& info) {
+        return info.original_id == "conv";
+    });
+    ASSERT_NE(conv_info, primitives_info.end());
+    ASSERT_NE(std::find(conv_info->c_fused_ids.begin(), conv_info->c_fused_ids.end(), "add"), conv_info->c_fused_ids.end());
+    ASSERT_NE(conv_info->kernel_id.find("convolution_gpu_bfyx_f16_1x1"), std::string::npos);
+}


### PR DESCRIPTION
+ Fix correctness bug where a non-scalar fused input is incorrectly treated as a scalar and broadcast
+ Added relevant test-cases

### Details:
he fused-ops JIT generator selected between a subgroup block read and a scalar broadcast using compile-time shape information.

For fully dynamic fused inputs, compile-time dimensions may not indicate whether the runtime tensor is scalar or contains multiple elements. As a result, a non-scalar fused input could be incorrectly treated as a scalar and broadcast, producing incorrect results.

The same compiled dynamic network may also receive both non-scalar and scalar fused inputs across different inference calls, so the load type cannot be determined reliably at JIT generation time.

### Tickets:
 - CVS-190210
 
### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).
  Analyze comparison of intermedia buffers of fp16 and fp32 execution.
  Add test-cases
