### PR TITLE
[CPU][DEBUG_CAPS] Add OV_CPU_MAX_ISA to mimic ONEDNN_MAX_CPU_ISA

### DIFF
--- a/src/inference/dev_api/openvino/runtime/system_conf.hpp
+++ b/src/inference/dev_api/openvino/runtime/system_conf.hpp
@@ -126,6 +126,13 @@ OPENVINO_RUNTIME_API bool with_cpu_x86_avx2();
 OPENVINO_RUNTIME_API bool with_cpu_x86_avx2_vnni();
 
 /**
+ * @brief      Checks whether CPU supports AVX2_VNNI_2 capability
+ * @ingroup    ov_dev_api_system_conf
+ * @return     `True` is AVX2_VNNI_2 instructions are available, `false` otherwise
+ */
+OPENVINO_RUNTIME_API bool with_cpu_x86_avx2_vnni_2();
+
+/**
  * @brief      Checks whether CPU supports AVX 512 capability
  * @ingroup    ov_dev_api_system_conf
  * @return     `True` is AVX512F (foundation) instructions are available, `false` otherwise

--- a/src/inference/src/system_conf.cpp
+++ b/src/inference/src/system_conf.cpp
@@ -4,6 +4,7 @@
 
 #include "openvino/runtime/system_conf.hpp"
 
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -11,6 +12,7 @@
 #include <map>
 #include <mutex>
 #include <numeric>
+#include <string>
 #include <vector>
 
 #ifdef __linux__
@@ -60,52 +62,148 @@ static Xbyak::util::Cpu& get_cpu_info() {
     return cpu;
 }
 
+// OV_CPU_MAX_ISA caps runtime ISA dispatch for OV kernels. Debug-caps only:
+// release builds get `isa_allowed() == true` which the compiler inlines away,
+// keeping the ISA getters branch-free. Useful to force lower-ISA path on
+// higher-ISA hardware (e.g., cap AVX-512 machine to AVX2 to reproduce
+// non-AVX-512 behavior).
+//
+// oneDNN reads ONEDNN_MAX_CPU_ISA independently and caches it on first
+// mayiuse() call. Static init order across TUs is undefined, so we cannot
+// reliably propagate OV_CPU_MAX_ISA -> ONEDNN_MAX_CPU_ISA from library code.
+// Instead we require both variables to be set to the same value: OV kernels
+// honor OV_CPU_MAX_ISA, oneDNN honors ONEDNN_MAX_CPU_ISA, no skew possible.
+enum class CpuIsaCap : int {
+    SSE41 = 10,
+    AVX = 20,
+    AVX2 = 30,
+    AVX2_VNNI = 31,
+    AVX2_VNNI_2 = 32,
+    AVX512_CORE = 40,
+    AVX512_CORE_VNNI = 41,
+    AVX512_CORE_BF16 = 42,
+    AVX512_CORE_FP16 = 43,
+    AVX512_CORE_AMX = 44,
+    AVX512_CORE_AMX_FP16 = 45,
+    ALL = 1000,
+};
+
+#    ifdef ENABLE_DEBUG_CAPS
+static CpuIsaCap parse_isa_cap(const std::string& v) {
+    if (v == "SSE41" || v == "SSE42")
+        return CpuIsaCap::SSE41;
+    if (v == "AVX")
+        return CpuIsaCap::AVX;
+    if (v == "AVX2")
+        return CpuIsaCap::AVX2;
+    if (v == "AVX2_VNNI")
+        return CpuIsaCap::AVX2_VNNI;
+    if (v == "AVX2_VNNI_2")
+        return CpuIsaCap::AVX2_VNNI_2;
+    if (v == "AVX512_CORE")
+        return CpuIsaCap::AVX512_CORE;
+    if (v == "AVX512_CORE_VNNI")
+        return CpuIsaCap::AVX512_CORE_VNNI;
+    if (v == "AVX512_CORE_BF16")
+        return CpuIsaCap::AVX512_CORE_BF16;
+    if (v == "AVX512_CORE_FP16")
+        return CpuIsaCap::AVX512_CORE_FP16;
+    if (v == "AVX512_CORE_AMX")
+        return CpuIsaCap::AVX512_CORE_AMX;
+    if (v == "AVX512_CORE_AMX_FP16")
+        return CpuIsaCap::AVX512_CORE_AMX_FP16;
+    // Unknown / DEFAULT / ALL — no cap.
+    return CpuIsaCap::ALL;
+}
+
+static std::string upper(const char* s) {
+    std::string v = s ? s : "";
+    for (auto& c : v) {
+        c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    }
+    return v;
+}
+
+static CpuIsaCap resolve_isa_cap() {
+    const std::string ov = upper(std::getenv("OV_CPU_MAX_ISA"));
+    const std::string dnn = upper(std::getenv("ONEDNN_MAX_CPU_ISA"));
+    if (ov.empty() && dnn.empty()) {
+        return CpuIsaCap::ALL;
+    }
+    OPENVINO_ASSERT(ov == dnn,
+                    "OV_CPU_MAX_ISA and ONEDNN_MAX_CPU_ISA must both be set to the same value. Got OV_CPU_MAX_ISA='",
+                    ov,
+                    "', ONEDNN_MAX_CPU_ISA='",
+                    dnn,
+                    "'");
+    return parse_isa_cap(ov);
+}
+
+static bool isa_allowed(CpuIsaCap level) {
+    static const CpuIsaCap cap = resolve_isa_cap();
+    return static_cast<int>(level) <= static_cast<int>(cap);
+}
+#    else
+static constexpr bool isa_allowed(CpuIsaCap /*level*/) {
+    return true;
+}
+#    endif
+
 bool with_cpu_x86_sse42() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tSSE42);
+    return isa_allowed(CpuIsaCap::SSE41) && get_cpu_info().has(Xbyak::util::Cpu::tSSE42);
 }
 
 bool with_cpu_x86_avx() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX);
+    return isa_allowed(CpuIsaCap::AVX) && get_cpu_info().has(Xbyak::util::Cpu::tAVX);
 }
 
 bool with_cpu_x86_avx2() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX2);
+    return isa_allowed(CpuIsaCap::AVX2) && get_cpu_info().has(Xbyak::util::Cpu::tAVX2);
 }
 
 bool with_cpu_x86_avx2_vnni() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX2 | Xbyak::util::Cpu::tAVX_VNNI);
+    return isa_allowed(CpuIsaCap::AVX2_VNNI) &&
+           get_cpu_info().has(Xbyak::util::Cpu::tAVX2 | Xbyak::util::Cpu::tAVX_VNNI);
+}
+
+bool with_cpu_x86_avx2_vnni_2() {
+    return isa_allowed(CpuIsaCap::AVX2_VNNI_2) &&
+           get_cpu_info().has(Xbyak::util::Cpu::tAVX2 | Xbyak::util::Cpu::tAVX_VNNI | Xbyak::util::Cpu::tAVX_VNNI_INT8 |
+                              Xbyak::util::Cpu::tAVX_NE_CONVERT);
 }
 
 bool with_cpu_x86_avx512f() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512F);
+    return isa_allowed(CpuIsaCap::AVX512_CORE) && get_cpu_info().has(Xbyak::util::Cpu::tAVX512F);
 }
 
 bool with_cpu_x86_avx512_core() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512F | Xbyak::util::Cpu::tAVX512DQ | Xbyak::util::Cpu::tAVX512BW);
+    return isa_allowed(CpuIsaCap::AVX512_CORE) &&
+           get_cpu_info().has(Xbyak::util::Cpu::tAVX512F | Xbyak::util::Cpu::tAVX512DQ | Xbyak::util::Cpu::tAVX512BW);
 }
 
 bool with_cpu_x86_avx512_core_vnni() {
-    return with_cpu_x86_avx512_core() && get_cpu_info().has(Xbyak::util::Cpu::tAVX512_VNNI);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_VNNI) && with_cpu_x86_avx512_core() &&
+           get_cpu_info().has(Xbyak::util::Cpu::tAVX512_VNNI);
 }
 
 bool with_cpu_x86_bfloat16() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_BF16);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_BF16) && get_cpu_info().has(Xbyak::util::Cpu::tAVX512_BF16);
 }
 
 bool with_cpu_x86_avx512_core_fp16() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_FP16);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_FP16) && get_cpu_info().has(Xbyak::util::Cpu::tAVX512_FP16);
 }
 
 bool with_cpu_x86_avx512_core_amx_int8() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAMX_INT8);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_AMX) && get_cpu_info().has(Xbyak::util::Cpu::tAMX_INT8);
 }
 
 bool with_cpu_x86_avx512_core_amx_bf16() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAMX_BF16);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_AMX) && get_cpu_info().has(Xbyak::util::Cpu::tAMX_BF16);
 }
 
 bool with_cpu_x86_avx512_core_amx_fp16() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAMX_FP16);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_AMX_FP16) && get_cpu_info().has(Xbyak::util::Cpu::tAMX_FP16);
 }
 
 bool with_cpu_x86_avx512_core_amx() {
@@ -140,6 +238,9 @@ bool with_cpu_x86_avx2() {
     return false;
 }
 bool with_cpu_x86_avx2_vnni() {
+    return false;
+}
+bool with_cpu_x86_avx2_vnni_2() {
     return false;
 }
 bool with_cpu_x86_avx512f() {

--- a/src/inference/src/system_conf.cpp
+++ b/src/inference/src/system_conf.cpp
@@ -4,6 +4,7 @@
 
 #include "openvino/runtime/system_conf.hpp"
 
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -11,6 +12,7 @@
 #include <map>
 #include <mutex>
 #include <numeric>
+#include <string>
 #include <vector>
 
 #ifdef __linux__
@@ -60,57 +62,138 @@ static Xbyak::util::Cpu& get_cpu_info() {
     return cpu;
 }
 
+// OV_CPU_MAX_ISA caps runtime ISA dispatch for OV kernels. Debug-caps only:
+// release builds get `isa_allowed() == true` which the compiler inlines away,
+// keeping the ISA getters branch-free. Useful to force lower-ISA path on
+// higher-ISA hardware (e.g., cap AVX-512 machine to AVX2 to reproduce
+// non-AVX-512 behavior).
+//
+// Only OV kernels are affected. oneDNN has its own independent ONEDNN_MAX_CPU_ISA,
+// which has to be set separately (oneDNN caches it on first mayiuse() call, and
+// static init order across TUs is undefined, so it cannot be reliably propagated
+// from here). Keeping the two knobs independent is intentional: it allows capping
+// one side only. Setting them to different values is the user's responsibility.
+enum class CpuIsaCap : int {
+    SSE41 = 10,
+    AVX = 20,
+    AVX2 = 30,
+    AVX2_VNNI = 31,
+    AVX2_VNNI_2 = 32,
+    AVX512_CORE = 40,
+    AVX512_CORE_VNNI = 41,
+    AVX512_CORE_BF16 = 42,
+    AVX512_CORE_FP16 = 43,
+    AVX512_CORE_AMX = 44,
+    AVX512_CORE_AMX_FP16 = 45,
+    ALL = 1000,
+};
+
+#    ifdef ENABLE_DEBUG_CAPS
+static CpuIsaCap parse_isa_cap(const std::string& v) {
+    if (v == "SSE41" || v == "SSE42")
+        return CpuIsaCap::SSE41;
+    if (v == "AVX")
+        return CpuIsaCap::AVX;
+    if (v == "AVX2")
+        return CpuIsaCap::AVX2;
+    if (v == "AVX2_VNNI")
+        return CpuIsaCap::AVX2_VNNI;
+    if (v == "AVX2_VNNI_2")
+        return CpuIsaCap::AVX2_VNNI_2;
+    if (v == "AVX512_CORE")
+        return CpuIsaCap::AVX512_CORE;
+    if (v == "AVX512_CORE_VNNI")
+        return CpuIsaCap::AVX512_CORE_VNNI;
+    if (v == "AVX512_CORE_BF16")
+        return CpuIsaCap::AVX512_CORE_BF16;
+    if (v == "AVX512_CORE_FP16")
+        return CpuIsaCap::AVX512_CORE_FP16;
+    if (v == "AVX512_CORE_AMX")
+        return CpuIsaCap::AVX512_CORE_AMX;
+    if (v == "AVX512_CORE_AMX_FP16")
+        return CpuIsaCap::AVX512_CORE_AMX_FP16;
+    // Unknown / DEFAULT / ALL — no cap.
+    return CpuIsaCap::ALL;
+}
+
+static std::string upper(const char* s) {
+    std::string v = s ? s : "";
+    for (auto& c : v) {
+        c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    }
+    return v;
+}
+
+static CpuIsaCap resolve_isa_cap() {
+    const std::string ov = upper(std::getenv("OV_CPU_MAX_ISA"));
+    return parse_isa_cap(ov);
+}
+
+static bool isa_allowed(CpuIsaCap level) {
+    static const CpuIsaCap cap = resolve_isa_cap();
+    return static_cast<int>(level) <= static_cast<int>(cap);
+}
+#    else
+static constexpr bool isa_allowed(CpuIsaCap /*level*/) {
+    return true;
+}
+#    endif
+
 bool with_cpu_x86_sse42() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tSSE42);
+    return isa_allowed(CpuIsaCap::SSE41) && get_cpu_info().has(Xbyak::util::Cpu::tSSE42);
 }
 
 bool with_cpu_x86_avx() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX);
+    return isa_allowed(CpuIsaCap::AVX) && get_cpu_info().has(Xbyak::util::Cpu::tAVX);
 }
 
 bool with_cpu_x86_avx2() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX2);
+    return isa_allowed(CpuIsaCap::AVX2) && get_cpu_info().has(Xbyak::util::Cpu::tAVX2);
 }
 
 bool with_cpu_x86_avx2_vnni() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX2 | Xbyak::util::Cpu::tAVX_VNNI);
+    return isa_allowed(CpuIsaCap::AVX2_VNNI) &&
+           get_cpu_info().has(Xbyak::util::Cpu::tAVX2 | Xbyak::util::Cpu::tAVX_VNNI);
 }
 
 bool with_cpu_x86_avx2_vnni_2() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX2 | Xbyak::util::Cpu::tAVX_VNNI | Xbyak::util::Cpu::tAVX_VNNI_INT8 |
+    return isa_allowed(CpuIsaCap::AVX2_VNNI_2) &&
+           get_cpu_info().has(Xbyak::util::Cpu::tAVX2 | Xbyak::util::Cpu::tAVX_VNNI | Xbyak::util::Cpu::tAVX_VNNI_INT8 |
                               Xbyak::util::Cpu::tAVX_NE_CONVERT);
 }
 
 bool with_cpu_x86_avx512f() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512F);
+    return isa_allowed(CpuIsaCap::AVX512_CORE) && get_cpu_info().has(Xbyak::util::Cpu::tAVX512F);
 }
 
 bool with_cpu_x86_avx512_core() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512F | Xbyak::util::Cpu::tAVX512DQ | Xbyak::util::Cpu::tAVX512BW);
+    return isa_allowed(CpuIsaCap::AVX512_CORE) &&
+           get_cpu_info().has(Xbyak::util::Cpu::tAVX512F | Xbyak::util::Cpu::tAVX512DQ | Xbyak::util::Cpu::tAVX512BW);
 }
 
 bool with_cpu_x86_avx512_core_vnni() {
-    return with_cpu_x86_avx512_core() && get_cpu_info().has(Xbyak::util::Cpu::tAVX512_VNNI);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_VNNI) && with_cpu_x86_avx512_core() &&
+           get_cpu_info().has(Xbyak::util::Cpu::tAVX512_VNNI);
 }
 
 bool with_cpu_x86_bfloat16() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_BF16);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_BF16) && get_cpu_info().has(Xbyak::util::Cpu::tAVX512_BF16);
 }
 
 bool with_cpu_x86_avx512_core_fp16() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_FP16);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_FP16) && get_cpu_info().has(Xbyak::util::Cpu::tAVX512_FP16);
 }
 
 bool with_cpu_x86_avx512_core_amx_int8() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAMX_INT8);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_AMX) && get_cpu_info().has(Xbyak::util::Cpu::tAMX_INT8);
 }
 
 bool with_cpu_x86_avx512_core_amx_bf16() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAMX_BF16);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_AMX) && get_cpu_info().has(Xbyak::util::Cpu::tAMX_BF16);
 }
 
 bool with_cpu_x86_avx512_core_amx_fp16() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAMX_FP16);
+    return isa_allowed(CpuIsaCap::AVX512_CORE_AMX_FP16) && get_cpu_info().has(Xbyak::util::Cpu::tAMX_FP16);
 }
 
 bool with_cpu_x86_avx512_core_amx() {

--- a/src/plugins/intel_cpu/docs/debug_capabilities/README.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/README.md
@@ -46,6 +46,10 @@ Use the following cmake option to enable debug capabilities:
   When to use: slow inference — displays per-node timing summary when the model is destructed.
   Example: `OV_CPU_SUMMARY_PERF=1`
 
+* [Max ISA cap](max_isa.md)
+  When to use: reproduce lower-ISA behavior on higher-ISA hardware — caps runtime ISA dispatch for OV kernels and oneDNN. Both `OV_CPU_MAX_ISA` and `ONEDNN_MAX_CPU_ISA` must be set to the same value.
+  Example: `OV_CPU_MAX_ISA=AVX2 ONEDNN_MAX_CPU_ISA=AVX2`
+
 * Memory statistics
   When to use:
   - high memory usage or just memory profiling — dumps memory usage statistics per compiled model.

--- a/src/plugins/intel_cpu/docs/debug_capabilities/README.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/README.md
@@ -46,6 +46,10 @@ Use the following cmake option to enable debug capabilities:
   When to use: slow inference — displays per-node timing summary when the model is destructed.
   Example: `OV_CPU_SUMMARY_PERF=1`
 
+* [Max ISA cap](max_isa.md)
+  When to use: reproduce lower-ISA behavior on higher-ISA hardware — caps runtime ISA dispatch. `OV_CPU_MAX_ISA` covers OV kernels, `ONEDNN_MAX_CPU_ISA` covers oneDNN primitives; independent, set both to cap everything.
+  Example: `OV_CPU_MAX_ISA=AVX2 ONEDNN_MAX_CPU_ISA=AVX2`
+
 * Memory statistics
   When to use:
   - high memory usage or just memory profiling — dumps memory usage statistics per compiled model.

--- a/src/plugins/intel_cpu/docs/debug_capabilities/max_isa.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/max_isa.md
@@ -1,0 +1,54 @@
+# Max ISA cap
+
+Cap the maximum x86 ISA used at runtime for both OV CPU kernels and oneDNN.
+Useful to reproduce lower-ISA behavior on higher-ISA hardware (e.g., force
+AVX2 path on an AVX-512 machine) without recompiling.
+
+## Usage
+
+Set **both** variables to the same value:
+
+```sh
+OV_CPU_MAX_ISA=<isa> ONEDNN_MAX_CPU_ISA=<isa> binary ...
+```
+
+- `OV_CPU_MAX_ISA` caps ISA dispatch inside OV CPU kernels (`with_cpu_x86_*` getters).
+- `ONEDNN_MAX_CPU_ISA` caps ISA dispatch inside oneDNN primitives.
+
+Both must be set to the **same value**. On mismatch OV throws at first ISA
+query. Reason: oneDNN caches its cap on first `mayiuse()` call and static
+init order across TUs is undefined, so library-side propagation is not
+reliable. Requiring both eliminates skew.
+
+## Supported values
+
+Case-insensitive. Ordered from lowest to highest:
+
+- `SSE41` (alias: `SSE42`)
+- `AVX`
+- `AVX2`
+- `AVX2_VNNI`
+- `AVX2_VNNI_2`
+- `AVX512_CORE`
+- `AVX512_CORE_VNNI`
+- `AVX512_CORE_BF16`
+- `AVX512_CORE_FP16`
+- `AVX512_CORE_AMX`
+- `AVX512_CORE_AMX_FP16`
+- `ALL` / `DEFAULT` / unset — no cap
+
+Unknown values are treated as no cap on the OV side. oneDNN rejects unknown
+values on its side, so typos surface via oneDNN.
+
+## Examples
+
+Force AVX2 path on AVX-512 hardware:
+```sh
+OV_CPU_MAX_ISA=AVX2 ONEDNN_MAX_CPU_ISA=AVX2 ./benchmark_app -m model.xml
+```
+
+Disable AMX on Sapphire Rapids, keep AVX-512 FP16:
+```sh
+OV_CPU_MAX_ISA=AVX512_CORE_FP16 ONEDNN_MAX_CPU_ISA=AVX512_CORE_FP16 ./benchmark_app -m model.xml
+```
+

--- a/src/plugins/intel_cpu/docs/debug_capabilities/max_isa.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/max_isa.md
@@ -1,0 +1,74 @@
+# Max ISA cap
+
+Cap max x86 ISA at runtime. Reproduces lower-ISA behavior on higher-ISA hardware
+without recompiling.
+
+Two independent knobs:
+
+- `OV_CPU_MAX_ISA` — OV CPU kernels (`with_cpu_x86_*` getters).
+- `ONEDNN_MAX_CPU_ISA` — oneDNN primitives.
+
+## Usage
+
+Cap everything — set both to the same value:
+
+```sh
+OV_CPU_MAX_ISA=<isa> ONEDNN_MAX_CPU_ISA=<isa> binary ...
+```
+
+Cap one side only — attributes a regression to OV kernels vs oneDNN primitives:
+
+```sh
+OV_CPU_MAX_ISA=AVX2 binary ...        # OV kernels capped, oneDNN unrestricted
+ONEDNN_MAX_CPU_ISA=AVX2 binary ...    # oneDNN capped, OV kernels unrestricted
+```
+
+Not cross-validated — consistency is the user's responsibility. OV cannot
+propagate its value to oneDNN: oneDNN caches its cap on first `mayiuse()`, and
+static init order across TUs is undefined, so there is no reliable hook.
+
+## Supported values
+
+Case-insensitive. Ordered from lowest to highest:
+
+- `SSE41` (alias: `SSE42`)
+- `AVX`
+- `AVX2`
+- `AVX2_VNNI`
+- `AVX2_VNNI_2`
+- `AVX512_CORE`
+- `AVX512_CORE_VNNI`
+- `AVX512_CORE_BF16`
+- `AVX512_CORE_FP16`
+- `AVX512_CORE_AMX`
+- `AVX512_CORE_AMX_FP16`
+- `ALL` / `DEFAULT` / unset — no cap
+
+Unknown values are treated as no cap on the OV side. oneDNN rejects unknown
+values on its side, so typos surface via oneDNN when both are set.
+
+## Examples
+
+Force the AVX2 path on AVX-512 hardware:
+```sh
+OV_CPU_MAX_ISA=AVX2 ONEDNN_MAX_CPU_ISA=AVX2 ./benchmark_app -m model.xml
+```
+
+Disable AMX on Sapphire Rapids, keep AVX-512 FP16:
+```sh
+OV_CPU_MAX_ISA=AVX512_CORE_FP16 ONEDNN_MAX_CPU_ISA=AVX512_CORE_FP16 ./benchmark_app -m model.xml
+```
+
+## Build requirement
+
+`OV_CPU_MAX_ISA` requires `-DENABLE_DEBUG_CAPS=ON`. In release builds the cap
+check is compiled to `true` and inlined away — zero runtime cost.
+
+`ONEDNN_MAX_CPU_ISA` is always available, since OV forces
+`DNNL_ENABLE_MAX_CPU_ISA=ON` for the bundled oneDNN.
+
+## Caveats
+
+- `OV_CPU_MAX_ISA` read once on first ISA query. Mid-run changes ignored.
+- Caps runtime detection only. Statically dispatched kernels behind `#ifdef` stay as built.
+- Non-x86 builds (ARM, RISC-V) ignore `OV_CPU_MAX_ISA`.

--- a/src/plugins/intel_cpu/docs/debug_capabilities/max_isa.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/max_isa.md
@@ -5,8 +5,10 @@ without recompiling.
 
 Two independent knobs:
 
-- `OV_CPU_MAX_ISA` — OV CPU kernels (`with_cpu_x86_*` getters).
-- `ONEDNN_MAX_CPU_ISA` — oneDNN primitives.
+- `OV_CPU_MAX_ISA` — dispatch based on `with_cpu_x86_*` getters.
+- `ONEDNN_MAX_CPU_ISA` — oneDNN primitives, plus any dispatch based on
+  `dnnl::impl::cpu::x64::mayiuse()` and CPU plugin jit kernels inheriting
+  `dnnl::impl::cpu::x64::jit_generator_t` (practically almost all x64 jit kernels).
 
 ## Usage
 
@@ -16,11 +18,11 @@ Cap everything — set both to the same value:
 OV_CPU_MAX_ISA=<isa> ONEDNN_MAX_CPU_ISA=<isa> binary ...
 ```
 
-Cap one side only — attributes a regression to OV kernels vs oneDNN primitives:
+Cap one side only — narrows down which dispatch path causes a regression:
 
 ```sh
-OV_CPU_MAX_ISA=AVX2 binary ...        # OV kernels capped, oneDNN unrestricted
-ONEDNN_MAX_CPU_ISA=AVX2 binary ...    # oneDNN capped, OV kernels unrestricted
+OV_CPU_MAX_ISA=AVX2 binary ...        # with_cpu_x86_* dispatch capped, oneDNN/jit unrestricted
+ONEDNN_MAX_CPU_ISA=AVX2 binary ...    # oneDNN/jit capped, with_cpu_x86_* dispatch unrestricted
 ```
 
 Not cross-validated — consistency is the user's responsibility. OV cannot


### PR DESCRIPTION
### Details:
 - Both variables must be set together to avoid any conflicts because of static initialization order
<!-- Message of single commit: -->