### PR TITLE
[GPU] Added 7-8D support for Concatenation

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
@@ -7,6 +7,7 @@
 #include "concatenation_inst.h"
 #include "concatenation/concatenation_kernel_selector.h"
 #include "concatenation/concatenation_kernel_base.h"
+#include <set>
 
 namespace cldnn {
 namespace ocl {
@@ -33,6 +34,8 @@ kernel_selector::concat_axis convert_axis(int64_t axis, size_t rank) {
         case 3: return kernel_selector::concat_axis::Y;
         case 4: return kernel_selector::concat_axis::Z;
         case 5: return kernel_selector::concat_axis::W;
+        case 6: return kernel_selector::concat_axis::U;
+        case 7: return kernel_selector::concat_axis::V;
         default: OPENVINO_THROW("Unsupported concatenation axis: ", axis);
     }
 
@@ -95,12 +98,22 @@ public:
 namespace detail {
 
 attach_concatenation_impl::attach_concatenation_impl() {
-    auto dyn_types = {data_types::i8, data_types::u8, data_types::f16, data_types::f32, data_types::i32, data_types::i64, data_types::f8e4m3};
+    auto dyn_types = {
+        data_types::i8,
+        data_types::u8,
+        data_types::f16,
+        data_types::f32,
+        data_types::i32,
+        data_types::i64,
+        data_types::f8e4m3
+    };
 
     auto dyn_formats = {
         format::bfyx,
         format::bfzyx,
-        format::bfwzyx
+        format::bfwzyx,
+        format::bfuwzyx,
+        format::bfvuwzyx
     };
 
     implementation_map<concatenation>::add(impl_types::ocl,
@@ -109,78 +122,58 @@ attach_concatenation_impl::attach_concatenation_impl() {
                                            dyn_types,
                                            dyn_formats);
 
-    implementation_map<concatenation>::add(impl_types::ocl, typed_primitive_impl_ocl<concatenation>::create<concatenation_impl>, {
-        std::make_tuple(data_types::f32, format::yxfb),
-        std::make_tuple(data_types::f16, format::yxfb),
-        std::make_tuple(data_types::i8, format::yxfb),
-        std::make_tuple(data_types::u8, format::yxfb),
-        std::make_tuple(data_types::i32, format::yxfb),
-        std::make_tuple(data_types::i64, format::yxfb),
-        std::make_tuple(data_types::f32, format::bfyx),
-        std::make_tuple(data_types::f16, format::bfyx),
-        std::make_tuple(data_types::i8, format::bfyx),
-        std::make_tuple(data_types::u8, format::bfyx),
-        std::make_tuple(data_types::i32, format::bfyx),
-        std::make_tuple(data_types::i64, format::bfyx),
-        std::make_tuple(data_types::f32, format::byxf),
-        std::make_tuple(data_types::f16, format::byxf),
-        std::make_tuple(data_types::i8, format::byxf),
-        std::make_tuple(data_types::u8, format::byxf),
-        std::make_tuple(data_types::i32, format::byxf),
-        std::make_tuple(data_types::i64, format::byxf),
-        std::make_tuple(data_types::f32, format::fyxb),
-        std::make_tuple(data_types::f16, format::fyxb),
-        std::make_tuple(data_types::f32, format::bfzyx),
-        std::make_tuple(data_types::f16, format::bfzyx),
-        std::make_tuple(data_types::i8, format::bfzyx),
-        std::make_tuple(data_types::u8, format::bfzyx),
-        std::make_tuple(data_types::i32, format::bfzyx),
-        std::make_tuple(data_types::i64, format::bfzyx),
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::i32, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::i64, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::i32, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::i64, format::bs_fs_zyx_bsv16_fsv16),
+    std::set<implementation_map<concatenation>::key_type> keys;
 
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::i32, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::i64, format::bs_fs_yx_bsv32_fsv32),
+    auto static_types = {
+        data_types::i8,
+        data_types::u8,
+        data_types::f16,
+        data_types::f32,
+        data_types::i32,
+        data_types::i64
+    };
 
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::i32, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::i64, format::bs_fs_yx_bsv32_fsv16),
+    const auto static_formats = {
+        format::yxfb,
+        format::bfyx,
+        format::byxf,
+        format::bfzyx,
+        format::bfwzyx,
+        format::bfuwzyx,
+        format::bfvuwzyx,
+        format::b_fs_zyx_fsv16,
+        format::bs_fs_zyx_bsv16_fsv16,
+        format::bs_fs_yx_bsv32_fsv32,
+        format::bs_fs_yx_bsv32_fsv16,
+    };
+    for (const auto type : static_types) {
+        for (const auto format : static_formats) {
+            keys.emplace(type, format);
+        }
+    }
 
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv4),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv4),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::f32, format::bfwzyx),
-        std::make_tuple(data_types::f16, format::bfwzyx),
-        std::make_tuple(data_types::u8, format::bfwzyx),
-        std::make_tuple(data_types::i8, format::bfwzyx),
-        std::make_tuple(data_types::i32, format::bfwzyx),
-        std::make_tuple(data_types::i64, format::bfwzyx),
-        std::make_tuple(data_types::f16, format::fs_b_yx_fsv32),
-    });
+    keys.emplace(data_types::f32, format::fyxb);
+    keys.emplace(data_types::f16, format::fyxb);
+
+    keys.emplace(data_types::f32, format::bs_fs_yx_bsv16_fsv16);
+    keys.emplace(data_types::f16, format::bs_fs_yx_bsv16_fsv16);
+
+    keys.emplace(data_types::f32, format::b_fs_yx_fsv16);
+    keys.emplace(data_types::f16, format::b_fs_yx_fsv16);
+    keys.emplace(data_types::u8, format::b_fs_yx_fsv16);
+    keys.emplace(data_types::i8, format::b_fs_yx_fsv16);
+
+    keys.emplace(data_types::i8, format::b_fs_yx_fsv4);
+    keys.emplace(data_types::u8, format::b_fs_yx_fsv4);
+
+    keys.emplace(data_types::i8, format::b_fs_yx_fsv32);
+    keys.emplace(data_types::u8, format::b_fs_yx_fsv32);
+
+    keys.emplace(data_types::f16, format::fs_b_yx_fsv32);
+
+    implementation_map<concatenation>::add(impl_types::ocl,
+                                           typed_primitive_impl_ocl<concatenation>::create<concatenation_impl>,
+                                           keys);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_simple_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_simple_ref.cl
@@ -16,8 +16,14 @@ KERNEL (concatenation_gpu_ref)(
 {
     const uint x = (uint)get_global_id(0) % INPUT0_SIZE_X;
     const uint y = (uint)get_global_id(0) / INPUT0_SIZE_X;
-    const uint z = (uint)get_global_id(1) % INPUT0_SIZE_Z;
-    const uint w = (uint)get_global_id(1) / INPUT0_SIZE_Z;
+    uint gid1 = (uint)get_global_id(1);
+    const uint z = gid1 % INPUT0_SIZE_Z;
+    gid1 /= INPUT0_SIZE_Z;
+    const uint w = gid1 % INPUT0_SIZE_W;
+    gid1 /= INPUT0_SIZE_W;
+    const uint u = gid1 % INPUT0_SIZE_U;
+    gid1 /= INPUT0_SIZE_U;
+    const uint v = gid1;
     const uint f = (uint)get_global_id(2) % INPUT0_FEATURE_NUM;
     const uint b = (uint)get_global_id(2) / INPUT0_FEATURE_NUM;
 
@@ -25,6 +31,8 @@ KERNEL (concatenation_gpu_ref)(
     uint out_y = y;
     uint out_z = z;
     uint out_w = w;
+    uint out_u = u;
+    uint out_v = v;
     uint out_f = f;
     uint out_b = b;
 
@@ -36,6 +44,10 @@ KERNEL (concatenation_gpu_ref)(
     out_z += output_offset_in_concat_axis;
 #elif CONCAT_W
     out_w += output_offset_in_concat_axis;
+#elif CONCAT_U
+    out_u += output_offset_in_concat_axis;
+#elif CONCAT_V
+    out_v += output_offset_in_concat_axis;
 #elif CONCAT_FEATURE
     out_f += output_offset_in_concat_axis;
 #elif CONCAT_BATCH
@@ -44,8 +56,8 @@ KERNEL (concatenation_gpu_ref)(
 #   error concatenation_gpu_bfzyx_ref.cl: Unrecognized concat axis.
 #endif
 
-    uint input_offset  = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
-    uint output_offset = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR out_b, out_f, out_w, out_z, out_y, out_x);
+    uint input_offset  = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, v, u, w, z, y, x);
+    uint output_offset = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR out_b, out_f, out_v, out_u, out_w, out_z, out_y, out_x);
 
     INPUT0_TYPE result = input[input_offset];
 

--- a/src/plugins/intel_gpu/src/kernel_selector/common_types.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/common_types.h
@@ -380,6 +380,8 @@ enum class ConcatAxis {
     Y,
     Z,
     W,
+    U,
+    V,
     FEATURE,
     BATCH
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
@@ -413,6 +413,8 @@ std::string toString(ConcatAxis a) {
         case ConcatAxis::Y:       return "Y";
         case ConcatAxis::Z:       return "Z";
         case ConcatAxis::W:       return "W";
+        case ConcatAxis::U:       return "U";
+        case ConcatAxis::V:       return "V";
         case ConcatAxis::FEATURE: return "FEATURE";
         case ConcatAxis::BATCH:   return "BATCH";
         default: return "";

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
@@ -351,6 +351,12 @@ void ParamsKey::EnableConcatAxis(ConcatAxis a) {
         case ConcatAxis::W:
             key.restrict.val.dedicated.concat.axisW = 1;
             break;
+        case ConcatAxis::U:
+            key.restrict.val.dedicated.concat.axisU = 1;
+            break;
+        case ConcatAxis::V:
+            key.restrict.val.dedicated.concat.axisV = 1;
+            break;
         case ConcatAxis::FEATURE:
             key.restrict.val.dedicated.concat.axisFeature = 1;
             break;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -206,6 +206,8 @@ public:
                         uint32_t axisY : 1;
                         uint32_t axisZ : 1;
                         uint32_t axisW : 1;
+                        uint32_t axisU : 1;
+                        uint32_t axisV : 1;
                         uint32_t axisFeature : 1;
                         uint32_t axisBatch : 1;
                         uint32_t kernelPerInput : 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_base.cpp
@@ -19,6 +19,10 @@ Tensor::DataChannelName ConcatenationKernelBase::GetConcatChannel(const concaten
             return Tensor::DataChannelName::Z;
         case ConcatAxis::W:
             return Tensor::DataChannelName::W;
+        case ConcatAxis::U:
+            return Tensor::DataChannelName::U;
+        case ConcatAxis::V:
+            return Tensor::DataChannelName::V;
         case ConcatAxis::FEATURE:
             return Tensor::DataChannelName::FEATURE;
         case ConcatAxis::BATCH:

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_simple_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_simple_ref.cpp
@@ -34,6 +34,10 @@ ParamsKey ConcatenationKernel_simple_Ref::GetSupportedKey() const {
     k.EnableOutputLayout(DataLayout::bfzyx);
     k.EnableInputLayout(DataLayout::bfwzyx);
     k.EnableOutputLayout(DataLayout::bfwzyx);
+    k.EnableInputLayout(DataLayout::bfuwzyx);
+    k.EnableOutputLayout(DataLayout::bfuwzyx);
+    k.EnableInputLayout(DataLayout::bfvuwzyx);
+    k.EnableOutputLayout(DataLayout::bfvuwzyx);
     k.EnableInputLayout(DataLayout::b_fs_zyx_fsv16);
     k.EnableOutputLayout(DataLayout::b_fs_zyx_fsv16);
     k.EnableInputLayout(DataLayout::b_fs_zyx_fsv32);
@@ -51,6 +55,8 @@ ParamsKey ConcatenationKernel_simple_Ref::GetSupportedKey() const {
     k.EnableConcatAxis(ConcatAxis::Y);
     k.EnableConcatAxis(ConcatAxis::Z);
     k.EnableConcatAxis(ConcatAxis::W);
+    k.EnableConcatAxis(ConcatAxis::U);
+    k.EnableConcatAxis(ConcatAxis::V);
     k.EnableConcatAxis(ConcatAxis::FEATURE);
     k.EnableConcatAxis(ConcatAxis::BATCH);
     k.EnableConcatKernelPerInput();
@@ -89,13 +95,14 @@ ConcatenationKernelBase::DispatchData ConcatenationKernel_simple_Ref::SetDefault
     const auto& input = params.inputs[0];
 
     dispatchData.gws = { input.X().v * input.Y().v,
-                         input.Z().v * input.W().v,
+                         input.Z().v * input.W().v * input.U().v * input.V().v,
                          input.Feature().v * input.Batch().v };
 
     auto in_layout = params.inputs[0].GetLayout();
     auto out_layout = params.outputs[0].GetLayout();
     std::vector<std::vector<Tensor::DataChannelName>> dims_by_gws = {{ Tensor::DataChannelName::X, Tensor::DataChannelName::Y },
-                                                                     { Tensor::DataChannelName::Z, Tensor::DataChannelName::W },
+                                                                     { Tensor::DataChannelName::Z, Tensor::DataChannelName::W,
+                                                                       Tensor::DataChannelName::U, Tensor::DataChannelName::V },
                                                                      { Tensor::DataChannelName::FEATURE, Tensor::DataChannelName::BATCH }};
 
     dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo, in_layout, out_layout, dims_by_gws);
@@ -110,7 +117,11 @@ JitConstants ConcatenationKernel_simple_Ref::GetJitConstants(const concatenation
         const auto& output = params.outputs[0];
         std::vector<std::string> idx_order;
 
-        if (output.Dimentions() == 6) {
+        if (output.Dimentions() == 8) {
+            idx_order = { "out_b", "out_f", "out_v", "out_u", "out_w", "out_z", "out_y", "out_x" };
+        } else if (output.Dimentions() == 7) {
+            idx_order = { "out_b", "out_f", "out_u", "out_w", "out_z", "out_y", "out_x" };
+        } else if (output.Dimentions() == 6) {
             idx_order = { "out_b", "out_f", "out_w", "out_z", "out_y", "out_x" };
         } else if (output.Dimentions() == 5) {
             idx_order = { "out_b", "out_f", "out_z", "out_y", "out_x" };

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
@@ -30,4 +30,43 @@ INSTANTIATE_TEST_SUITE_P(smoke_NoReshape, ConcatLayerTest,
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         ConcatLayerTest::getTestCaseName);
+
+std::vector<int> axes6D = {-6, -3, -1, 0, 1, 2, 3, 4, 5};
+std::vector<std::vector<ov::Shape>> inShapes6D = {
+        {{2, 4, 2, 3, 2, 3}, {2, 4, 2, 3, 2, 3}},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Concat6D, ConcatLayerTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(axes6D),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inShapes6D)),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                        ConcatLayerTest::getTestCaseName);
+
+std::vector<int> axes7D = {-7, -3, -1, 0, 1, 2, 3, 4, 5, 6};
+std::vector<std::vector<ov::Shape>> inShapes7D = {
+        {{2, 4, 2, 3, 2, 3, 2}, {2, 4, 2, 3, 2, 3, 2}},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Concat7D, ConcatLayerTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(axes7D),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inShapes7D)),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                        ConcatLayerTest::getTestCaseName);
+
+std::vector<int> axes8D = {-8, -3, -1, 0, 1, 2, 3, 4, 5, 6, 7};
+std::vector<std::vector<ov::Shape>> inShapes8D = {
+        {{2, 4, 2, 2, 2, 2, 2, 2}, {2, 4, 2, 2, 2, 2, 2, 2}},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Concat8D, ConcatLayerTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(axes8D),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inShapes8D)),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                        ConcatLayerTest::getTestCaseName);
 }  // namespace

--- a/src/plugins/intel_gpu/tests/unit/fusions/concatenate_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/concatenate_fusion_test.cpp
@@ -62,7 +62,7 @@ public:
         ASSERT_FALSE(network_fused_onednn.get_primitives_info().empty());
 
         auto find_and_check = [&](primitive_info& p) -> bool {
-            if (p.original_id == "concat" || p.original_id == "reorder_bfyx")
+            if (p.original_id == "concat" || p.original_id == "reorder_planar")
                 return true;
             return false;
         };
@@ -105,7 +105,7 @@ TEST_P(concat_onednn_activation, along_f) {
                       1,
                       data_types::f16),
         activation("act", input_info("concat"), activation_func::relu),
-        reorder("reorder_bfyx", input_info("act"), cldnn::format::bfyx, p.default_type)
+        reorder("reorder_planar", input_info("act"), p.default_format, p.default_type)
     );
 
     tolerance = 1.f;
@@ -126,7 +126,7 @@ TEST_P(concat_onednn_eltwise, along_f) {
                       1,
                       data_types::f16),
         eltwise("scale", { input_info("concat"), input_info("scale_data") }, eltwise_mode::prod, p.default_type),
-        reorder("reorder_bfyx", input_info("scale"), cldnn::format::bfyx, p.default_type)
+        reorder("reorder_planar", input_info("scale"), cldnn::format::bfyx, p.default_type)
     );
 
     tolerance = 1.f;
@@ -163,7 +163,7 @@ public:
         ASSERT_FALSE(network_fused.get_primitives_info().empty());
 
         auto find_and_check = [&](primitive_info& p) -> bool {
-            return p.original_id == "concat" || p.original_id == "reorder_bfyx";
+            return p.original_id == "concat" || p.original_id == "reorder_planar";
         };
 
         auto pi_fused = network_fused.get_primitives_info();
@@ -194,6 +194,8 @@ public:
 /* ----------------------------------------------------------------------------------------------------- */
 #define CASE_CONCAT_F32_1 { 1, 8, 4, 4 }, data_types::f32, format::bfyx, data_types::f32, format::bfyx
 #define CASE_CONCAT_F16_1 { 1, 8, 4, 4 }, data_types::f16, format::bfyx, data_types::f16, format::bfyx
+#define CASE_CONCAT_F16_7D { 1, 8, 2, 2, 2, 2, 2 }, data_types::f16, format::bfuwzyx, data_types::f16, format::bfuwzyx
+#define CASE_CONCAT_F16_8D { 1, 8, 2, 2, 2, 2, 2, 2 }, data_types::f16, format::bfvuwzyx, data_types::f16, format::bfvuwzyx
 
 class concat_activation : public ConcatFusingTest {};
 TEST_P(concat_activation, along_f) {
@@ -208,7 +210,7 @@ TEST_P(concat_activation, along_f) {
         concatenation("concat", { input_info("input0"), input_info("input1") }, 1, p.data_type),
         activation("act1", input_info("concat"), activation_func::round_half_to_even),
         activation("act2", input_info("act1"), activation_func::clamp, { -0.5f, 0.5f }),
-        reorder("reorder_bfyx", input_info("act2"), cldnn::format::bfyx, p.default_type)
+        reorder("reorder_planar", input_info("act2"), p.default_format, p.default_type)
     );
 
     tolerance = default_tolerance(p.data_type);
@@ -225,7 +227,7 @@ TEST_P(concat_eltwise_with_broadcast, along_f) {
         data("scale_data", get_mem(data_layout, 1.0f / tensor{ 1, 1, 4, 4 }.count())),
         concatenation("concat", { input_info("input0"), input_info("input1") }, 1, p.data_type),
         eltwise("scale", { input_info("concat"), input_info("scale_data") }, eltwise_mode::prod, p.default_type),
-        reorder("reorder_bfyx", input_info("scale"), cldnn::format::bfyx, p.default_type)
+        reorder("reorder_planar", input_info("scale"), p.default_format, p.default_type)
     );
 
     tolerance = default_tolerance(p.data_type);
@@ -244,7 +246,7 @@ TEST_P(concat_eltwise_wo_broadcast, along_f) {
         data("scale_data", get_mem(data_layout, 1.0f / tensor{ 1, 1, 4, 4 }.count())),
         concatenation("concat", { input_info("input0"), input_info("input1") }, 1, p.data_type),
         eltwise("scale", { input_info("concat"), input_info("scale_data") }, eltwise_mode::prod, p.default_type),
-        reorder("reorder_bfyx", input_info("scale"), cldnn::format::bfyx, p.default_type)
+        reorder("reorder_planar", input_info("scale"), p.default_format, p.default_type)
     );
 
     tolerance = default_tolerance(p.data_type);
@@ -264,7 +266,7 @@ TEST_P(concat_quantize, along_f) {
         concatenation("concat", { input_info("input0"), input_info("input1") }, 1, p.data_type),
         quantize("quantize", input_info("concat"), input_info("in_lo"), input_info("in_hi"),
                  input_info("out_lo"), input_info("out_hi"), 256, data_types::u8),
-        reorder("reorder_bfyx", input_info("quantize"), cldnn::format::bfyx, p.default_type)
+        reorder("reorder_planar", input_info("quantize"), p.default_format, p.default_type)
     );
 
     tolerance = 1.f;
@@ -274,19 +276,27 @@ TEST_P(concat_quantize, along_f) {
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, concat_activation, ::testing::ValuesIn(std::vector<concat_test_params>{
     concat_test_params{ CASE_CONCAT_F32_1, 3, 5, "" },
     concat_test_params{ CASE_CONCAT_F16_1, 3, 5, "" },
+    concat_test_params{ CASE_CONCAT_F16_7D, 3, 5, "" },
+    concat_test_params{ CASE_CONCAT_F16_8D, 3, 5, "" },
 }));
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, concat_eltwise_with_broadcast, ::testing::ValuesIn(std::vector<concat_test_params>{
     concat_test_params{ CASE_CONCAT_F32_1, 4, 4, "" },
     concat_test_params{ CASE_CONCAT_F16_1, 4, 4, "" },
+    concat_test_params{ CASE_CONCAT_F16_7D, 4, 4, "" },
+    concat_test_params{ CASE_CONCAT_F16_8D, 4, 4, "" },
 }));
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, concat_eltwise_wo_broadcast, ::testing::ValuesIn(std::vector<concat_test_params>{
     concat_test_params{ CASE_CONCAT_F32_1, 4, 4, "" },
     concat_test_params{ CASE_CONCAT_F16_1, 4, 4, "" },
+    concat_test_params{ CASE_CONCAT_F16_7D, 4, 4, "" },
+    concat_test_params{ CASE_CONCAT_F16_8D, 4, 4, "" },
 }));
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, concat_quantize, ::testing::ValuesIn(std::vector<concat_test_params>{
     concat_test_params{ CASE_CONCAT_F32_1, 4, 4, "" },
     concat_test_params{ CASE_CONCAT_F16_1, 4, 4, "" },
+    concat_test_params{ CASE_CONCAT_F16_7D, 4, 4, "" },
+    concat_test_params{ CASE_CONCAT_F16_8D, 4, 4, "" },
 }));

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/single_op/concat.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/single_op/concat.hpp
@@ -30,7 +30,7 @@ protected:
 };
 
 using ConcatStringParamsTuple = typename std::tuple<int,                                     // Concat axis
-                                                    std::vector<ov::Shape>,                 // Input shapes
+                                                    std::vector<ov::Shape>,                  // Input shapes
                                                     ov::element::Type,                       // Model type
                                                     std::string,                             // Device name
                                                     std::vector<std::vector<std::string>>>;  // String data


### PR DESCRIPTION
### Details:
 - *Added U/V Concat axis support and enabled 7D/8D layouts (bfuwzyx, bfvuwzyx) for the reference concatenation kernel*
 - *Updated the reference OCL kernel indexing/dispatch to handle additional dimensions (U/V)*
 - *Expanded GPU Concat tests (fusion + single-layer functional instances) to include 6D/7D/8D scenarios*