### PR TITLE
CVS-191290 Enable HostCompile_Interpreter by default for dynamic batch

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -72,7 +72,8 @@ std::shared_ptr<IGraph> PluginCompilerAdapter::compile(const std::shared_ptr<con
         !(config.has<DYNAMIC_SHAPE_TO_STATIC>() && config.get<DYNAMIC_SHAPE_TO_STATIC>())) {
         const auto isDynamic = [](const auto& port) {
             auto& shape = port.get_partial_shape();
-            return shape.is_dynamic() && (shape.rank().get_length() == 4) && shape[0].is_static();
+            return shape.rank().is_static() && (shape.rank().get_length() == 4) &&
+                   (shape[1].is_dynamic() || shape[2].is_dynamic() || shape[3].is_dynamic());
         };
 
         if (model) {


### PR DESCRIPTION
### Details:
Enable HostCompile_Interpreter mode by default for inputs of dynamic batch and dynamic height or dynamic_width

### Tickets:
 - *CVS-191290 *

### AI Assistance:
 - *AI assistance used: no*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
