### PR TITLE
[GPU] Fix visibility mismatch for zero-copy cache load property

### DIFF
--- a/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
@@ -83,12 +83,6 @@ static constexpr Property<bool> enable_loop_unrolling{"GPU_ENABLE_LOOP_UNROLLING
  */
 static constexpr Property<bool> disable_winograd_convolution{"GPU_DISABLE_WINOGRAD_CONVOLUTION"};
 
-/**
- * @brief Enable/Disable zero-copy mode for model cache blob load.
- * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
- */
-static constexpr Property<bool> enable_zero_copy_cache_load{"GPU_ENABLE_ZERO_COPY_CACHE_LOAD"};
-
 namespace hint {
 /**
  * @brief This enum represents the possible value of ov::intel_gpu::hint::queue_throttle property:

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
@@ -135,6 +135,7 @@ static constexpr Property<float, PropertyMutability::RW> buffers_preallocation_r
 static constexpr Property<size_t, PropertyMutability::RW> max_kernels_per_batch{"GPU_MAX_KERNELS_PER_BATCH"};
 static constexpr Property<bool, PropertyMutability::RW> use_onednn{"GPU_USE_ONEDNN"};
 static constexpr Property<bool, PropertyMutability::RW> use_cm{"GPU_USE_CM"};
+static constexpr Property<bool, PropertyMutability::RW> enable_zero_copy_cache_load{"GPU_ENABLE_ZERO_COPY_CACHE_LOAD"};
 
 static constexpr Property<bool, ov::PropertyMutability::RW> help{"HELP"};
 static constexpr Property<size_t, ov::PropertyMutability::RW> verbose{"VERBOSE"};

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -767,7 +767,6 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::intel_gpu::hint::enable_sdpa_optimization.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::hint::enable_lora_operation.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::hint::enable_large_allocations.name(), PropertyMutability::RW},
-        ov::PropertyName{ov::intel_gpu::enable_zero_copy_cache_load.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::enable_loop_unrolling.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::disable_winograd_convolution.name(), PropertyMutability::RW},
         ov::PropertyName{ov::cache_dir.name(), PropertyMutability::RW},


### PR DESCRIPTION
[GPU] Fix visibility mismatch for zero-copy cache load property

#### Details:
Description of the issue (symptom, root-cause, how it was resolved)
•	GPU_ENABLE_ZERO_COPY_CACHE_LOAD property was throwing exception when accessed via get_property() API.
•	Root cause: Property was registered with RELEASE_INTERNAL visibility but declared in public header, causing visibility check failure.
•	Fixed by removing declaration from public properties.hpp to align with RELEASE_INTERNAL registration.

#### Implementation changes:
•	Removed ov::intel_gpu::enable_zero_copy_cache_load declaration from public API header.
•	Property remains accessible via environment variable and config file only.

#### Changed files:
•	src/inference/include/openvino/runtime/intel_gpu/properties.hpp
•	src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model): NA

#### Problematic graph: NA

#### Checklist:
- [x] Is it a proper fix? Yes (ensures small device buffers and image2d formats use their optimized staging paths instead of zero-copy)
- [x] Did you include test case for this fix, if necessary? Existing tests cover the staging buffer paths
- [x] Did you review existing test that can be extended to cover this scenario? Existing cache serialization tests validate the behavior

#### Tickets:
- CVS-189224, CVS-191308

#### AI Assistance:
- AI assistance used: yes
- AI was used for logic refinement, variable naming, and commit message structure.