### PR TITLE
[GPU] Don't assume work-group collective functions on sub-CL3.0 builds

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -267,8 +267,8 @@ device_info init_device_info(const cl::Device& device, const cl::Context& contex
     info.supports_work_group_collective_functions = device.getInfo<CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT>();
     info.supports_non_uniform_work_group = device.getInfo<CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT>();
 #elif CL_HPP_TARGET_OPENCL_VERSION >= 200
-    // OpenCL C2.0: work_group_<ops> are mandatory.
-    info.supports_work_group_collective_functions = true;
+    // Can't query the optional CL3.0 feature below target 300; assume unsupported and use safe CL2.0.
+    info.supports_work_group_collective_functions = false;
     info.supports_non_uniform_work_group = true;
 #else
     info.supports_work_group_collective_functions = false;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -260,20 +260,18 @@ device_info init_device_info(const cl::Device& device, const cl::Context& contex
 
     info.supports_queue_families = extensions.find("cl_intel_command_queue_families ") != std::string::npos;
 
-#if CL_HPP_TARGET_OPENCL_VERSION >= 300
-    // refer: https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#optional-functionality
-    // These flags are supported from OPENCL_300: CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT, CL_DEVICE_OPENCL_C_FEATURES
-    // OpenCL C3.0: work_group_<ops> are optional. It should be checked 'work group collective functions' are supported in OpenCL C 3.0.
-    info.supports_work_group_collective_functions = device.getInfo<CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT>();
-    info.supports_non_uniform_work_group = device.getInfo<CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT>();
-#elif CL_HPP_TARGET_OPENCL_VERSION >= 200
-    // Can't query the optional CL3.0 feature below target 300; assume unsupported and use safe CL2.0.
-    info.supports_work_group_collective_functions = false;
-    info.supports_non_uniform_work_group = true;
-#else
-    info.supports_work_group_collective_functions = false;
-    info.supports_non_uniform_work_group = false;
-#endif
+    auto query_device_bool = [&](cl_device_info param) -> bool {
+        cl_bool value = CL_FALSE;
+        try {
+            if (device.getInfo(param, &value) != CL_SUCCESS)
+                return false;
+        } catch (const cl::Error&) {
+            return false;
+        }
+        return value == CL_TRUE;
+    };
+    info.supports_work_group_collective_functions = query_device_bool(CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT);
+    info.supports_non_uniform_work_group = query_device_bool(CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT);
 
     if (info.supports_intel_required_subgroup_size) {
         info.supported_simd_sizes = device.getInfo<CL_DEVICE_SUB_GROUP_SIZES_INTEL>();

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
@@ -59,6 +59,14 @@ CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SUB_GROUP_SIZES_INTEL, cl
 
 #endif // OPENVINO_CLHPP_HEADERS_ARE_OLDER_THAN_V2024_10_24
 
+#if !defined(CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT)
+#define CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT 0x1065
+#endif
+
+#if !defined(CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT)
+#define CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT 0x1068
+#endif
+
 /***************************************************************
 * cl_intel_command_queue_families
 ***************************************************************/


### PR DESCRIPTION
###  Details:
  - Compiling any model containing `LayerNorm`/`MVN` on an Intel GPU that does not support the optional OpenCL 3.0 work-group collective functions (e.g. Gen9 / Apollo Lake, Intel HD Graphics 500) fails:
```
  [GPU] ProgramBuilder build failed!  (program_builder.cpp:168)
  [GPU] clBuildProgram, error code: -11 CL_BUILD_PROGRAM_FAILURE  (ocl_kernel_builder.hpp:73)
  error: implicit declaration of function 'work_group_reduce_add' is invalid in OpenCL
  error: implicit declaration of function 'work_group_broadcast' is invalid in OpenCL
```
 - `LayerNorm` lowers to `MVN`: the `mvn_gpu_bfyx_opt` kernel, which uses `work_group_reduce_add` / `work_group_broadcast`. These built-ins are mandatory in OpenCL C 2.0 but optional in OpenCL C 3.0. Requesting `-cl-std=CL3.0` on a device that reports `CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT = CL_FALSE` makes the compiler reject the kernel. Reproduced on official nightly wheels (verified on `2026.4.0-22520`); the wheel was observed emitting `-cl-std=CL3.0` on such a device.

### Root cause: 
 - The nightly wheel is built with `ENABLE_SYSTEM_OPENCL=ON` and `OpenCL_INCLUDE_DIR=/usr/include`, i.e. it uses the build host's system OpenCL C++ headers. That system `CL/cl2.hpp` is old and only supports up to OpenCL 2.0, so even though the plugin is compiled with `-DCL_TARGET_OPENCL_VERSION=300`, the header silently clamps the target down to 200. The build log shows this:
```
  /usr/include/CL/cl2.hpp:444: #pragma message: cl2.hpp: CL_HPP_TARGET_OPENCL_VERSION
  is not a valid value (100, 110, 120 or 200). It will be set to 200
```
 - As a result `ocl_device.cpp` compiles the `#elif >= 200` branch, which unconditionally assumes collective-function support and forces `-cl-std=CL3.0` even on devices that don't have it.

### Fix: 
  - In the `CL_HPP_TARGET_OPENCL_VERSION >= 200` branch, default `supports_work_group_collective_functions` to `false` instead of `true`. When collective support can't be queried (any build effectively targeting OpenCL < 3.0), the plugin now selects `-cl-std=CL2.0`, where these built-ins are mandatory and are accepted by Intel drivers on all supported devices. This restores the pre-#29640 behavior for sub-3.0 builds (that path historically emitted `-cl-std=CL2.0` unconditionally).
