### PR TITLE
[GPU] Fix merged Loop outputs when execution count is zero

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
@@ -182,6 +182,7 @@ struct loop_impl : typed_primitive_impl<loop> {
             memory::ptr num_actual_iterations_mem = outer_network.get_primitive(instance.get_num_iterations_id())->output_memory_ptr();
             write_scalar_value(num_actual_iterations_mem, stream, current_iteration_idx);
 
+            stream.wait_for_events(events);
             instance.handle_zero_iterations();
             ev->set();
             return ev;

--- a/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
@@ -182,7 +182,7 @@ struct loop_impl : typed_primitive_impl<loop> {
             memory::ptr num_actual_iterations_mem = outer_network.get_primitive(instance.get_num_iterations_id())->output_memory_ptr();
             write_scalar_value(num_actual_iterations_mem, stream, current_iteration_idx);
 
-            instance.update_output_layout();
+            instance.handle_zero_iterations();
             ev->set();
             return ev;
         }

--- a/src/plugins/intel_gpu/src/graph/include/loop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/loop_inst.h
@@ -351,6 +351,7 @@ public:
 
     void update_shape() override { primitive_inst::update_shape(); }
     void update_output_layout();
+    void handle_zero_iterations();
 
     // num_iteration is used for slicing input memory
     int64_t get_num_iterations();

--- a/src/plugins/intel_gpu/src/graph/include/loop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/loop_inst.h
@@ -14,6 +14,7 @@
 #include "primitive_inst.h"
 #include <string>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace cldnn {
@@ -369,6 +370,7 @@ private:
     network::ptr body_network;
     memory::ptr get_external_memory(const primitive_id& external_id, size_t mem_idx = 0) const;
     layout get_external_output_layout(const primitive_id& external_id, size_t mem_idx = 0) const;
+    std::pair<memory::ptr, layout> get_external_memory_and_layout(const input_info& external_id) const;
     std::shared_ptr<concatenated_memory_mapping> get_sliced_mem(const primitive_id& internal_id) const;
     int64_t calculate_num_iterations(const cldnn::loop::io_primitive_map& io_prim_map, ov::PartialShape& pshape);
     std::vector<event::ptr> handle_buffers_for_next_iteration(const backedge_memory_mapping& mapping,

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -796,6 +796,48 @@ void loop_inst::update_output_layout() {
     }
 }
 
+void loop_inst::handle_zero_iterations() {
+    update_output_layout();
+
+    for (const auto& output_mapping : _output_primitive_maps) {
+        if (output_mapping.axis >= 0)
+            continue;
+
+        const auto back_edge = std::find_if(_back_edges.begin(), _back_edges.end(), [&](const loop::backedge_mapping& mapping) {
+            return mapping.from == output_mapping.internal_id.pid;
+        });
+        if (back_edge == _back_edges.end())
+            continue;
+
+        const auto input_mapping = std::find_if(_input_primitive_maps.begin(),
+                                                _input_primitive_maps.end(),
+                                                [&](const loop::io_primitive_map& mapping) {
+                                                    return mapping.internal_id.pid == back_edge->to;
+                                                });
+        OPENVINO_ASSERT(input_mapping != _input_primitive_maps.end(),
+                        id(),
+                        " has no input mapping for backedge destination ",
+                        back_edge->to);
+
+        auto initial_mem = get_external_memory(input_mapping->external_id.pid, input_mapping->external_id.idx);
+        OPENVINO_ASSERT(initial_mem != nullptr, id(), " initial carried memory should not be null");
+
+        const auto initial_layout = get_external_output_layout(input_mapping->external_id.pid,
+                                                               input_mapping->external_id.idx);
+        if (!initial_mem->get_layout().identical(initial_layout)) {
+            OPENVINO_ASSERT(initial_layout.bytes_count() <= initial_mem->get_layout().bytes_count(),
+                            "initial layout size(", initial_layout.to_short_string(),
+                            ") should not exceed initial memory size(", initial_mem->get_layout().to_short_string(), ")");
+            initial_mem = _network.get_engine().reinterpret_buffer(*initial_mem, initial_layout);
+        }
+
+        const auto output_idx = output_mapping.external_id.idx;
+        set_output_layout(initial_layout, output_idx);
+        set_output_memory(initial_mem, false, output_idx);
+        set_flag(ExecutionFlags::MEMORY_CHANGED);
+    }
+}
+
 void loop_inst::concatenated_memory_mapping::slice_mem(const int64_t num_iterations) const {
     size_t num_iters = static_cast<size_t>(num_iterations);
     OPENVINO_ASSERT(num_iters > 0 && num_iters == sliced_mems.size(), "num_iterations(", num_iters,

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -527,20 +527,10 @@ void loop_inst::preprocess_backedge_memory() {
         const auto backedge_to_prim = body_network->get_primitive(back_edge.to);
         const auto backedge_from_prim = body_network->get_primitive(back_edge.from);
 
-        memory::ptr initial_mem;
         OPENVINO_ASSERT(!input_map_ptrs.empty(), id(), " has no input_mapping for backedged input");
-        auto& external_id = input_map_ptrs.front()->external_id;
-        initial_mem = get_external_memory(external_id.pid, external_id.idx);
-        // in case where memory buffer has been over-allocated by shape predictor, memory layout might be unexpected shape.
-        // so memory layout needs to be re-interprete according to original layout.
-        auto initial_layout = get_external_output_layout(external_id.pid, external_id.idx);
-        OPENVINO_ASSERT(initial_mem != nullptr, "initial_mem should not be null");
-        if (!initial_mem->get_layout().identical(initial_layout)) {
-            OPENVINO_ASSERT(initial_layout.bytes_count() <= initial_mem->get_layout().bytes_count(),
-                            "initial layout size(", initial_layout.to_short_string(),
-                            ") should not exceed initial memory size(", initial_mem->get_layout().to_short_string(), ")");
-            initial_mem = body_network->get_engine().reinterpret_buffer(*initial_mem, initial_layout);
-        }
+        const auto& external_id = input_map_ptrs.front()->external_id;
+        auto initial_mem_and_layout = get_external_memory_and_layout(external_id);
+        auto initial_mem = std::move(initial_mem_and_layout.first);
 
         GPU_DEBUG_LOG << idx << ") back_edge mapping - back_edge.from " << back_edge.from << std::endl;
         GPU_DEBUG_LOG << idx << ") back_edge mapping - back_edge.to   " << back_edge.to << std::endl;
@@ -654,6 +644,21 @@ memory::ptr loop_inst::get_external_memory(const primitive_id& external_id, size
 layout loop_inst::get_external_output_layout(const primitive_id& external_id, size_t mem_idx) const {
     const auto outputPrim = _network.get_primitive(external_id);
     return outputPrim->get_output_layout(mem_idx);
+}
+
+std::pair<memory::ptr, layout> loop_inst::get_external_memory_and_layout(const input_info& external_id) const {
+    auto external_mem = get_external_memory(external_id.pid, external_id.idx);
+    const auto external_layout = get_external_output_layout(external_id.pid, external_id.idx);
+    OPENVINO_ASSERT(external_mem != nullptr, id(), " external memory should not be null");
+
+    if (!external_mem->get_layout().identical(external_layout)) {
+        OPENVINO_ASSERT(external_layout.bytes_count() <= external_mem->get_layout().bytes_count(),
+                        "external layout size(", external_layout.to_short_string(),
+                        ") should not exceed external memory size(", external_mem->get_layout().to_short_string(), ")");
+        external_mem = _network.get_engine().reinterpret_buffer(*external_mem, external_layout);
+    }
+
+    return {external_mem, external_layout};
 }
 
 loop_inst::typed_primitive_inst(network & network, loop_node const & node)
@@ -809,32 +814,40 @@ void loop_inst::handle_zero_iterations() {
         if (back_edge == _back_edges.end())
             continue;
 
-        const auto input_mapping = std::find_if(_input_primitive_maps.begin(),
-                                                _input_primitive_maps.end(),
-                                                [&](const loop::io_primitive_map& mapping) {
-                                                    return mapping.internal_id.pid == back_edge->to;
-                                                });
-        OPENVINO_ASSERT(input_mapping != _input_primitive_maps.end(),
+        const auto input_map_ptrs = find_io_primitive_maps(_input_primitive_maps,
+                                                           _output_primitive_maps,
+                                                           back_edge->to,
+                                                           false);
+        OPENVINO_ASSERT(!input_map_ptrs.empty(),
                         id(),
                         " has no input mapping for backedge destination ",
                         back_edge->to);
 
-        auto initial_mem = get_external_memory(input_mapping->external_id.pid, input_mapping->external_id.idx);
-        OPENVINO_ASSERT(initial_mem != nullptr, id(), " initial carried memory should not be null");
+        const auto& external_id = input_map_ptrs.front()->external_id;
+        auto [initial_mem, initial_layout] = get_external_memory_and_layout(external_id);
 
-        const auto initial_layout = get_external_output_layout(input_mapping->external_id.pid,
-                                                               input_mapping->external_id.idx);
-        if (!initial_mem->get_layout().identical(initial_layout)) {
-            OPENVINO_ASSERT(initial_layout.bytes_count() <= initial_mem->get_layout().bytes_count(),
-                            "initial layout size(", initial_layout.to_short_string(),
-                            ") should not exceed initial memory size(", initial_mem->get_layout().to_short_string(), ")");
-            initial_mem = _network.get_engine().reinterpret_buffer(*initial_mem, initial_layout);
+        const auto output_idx = static_cast<size_t>(output_mapping.external_id.idx);
+        set_output_layout(initial_layout, output_idx);
+        const bool output_allocated = output_idx < _outputs.size() && _outputs[output_idx] != nullptr;
+        if (!output_allocated) {
+            set_output_memory(initial_mem, false, output_idx);
+            set_flag(ExecutionFlags::MEMORY_CHANGED);
+            continue;
         }
 
-        const auto output_idx = output_mapping.external_id.idx;
-        set_output_layout(initial_layout, output_idx);
-        set_output_memory(initial_mem, false, output_idx);
-        set_flag(ExecutionFlags::MEMORY_CHANGED);
+        auto output_mem = _outputs[output_idx];
+        if (output_mem == initial_mem)
+            continue;
+
+        if (_network.get_engine().is_the_same_buffer(*output_mem, *initial_mem)) {
+            if (output_mem->get_layout() != initial_layout)
+                _outputs[output_idx] = initial_mem;
+        } else if (output_mem->get_layout() == initial_layout) {
+            output_mem->copy_from(get_network().get_stream(), *initial_mem);
+        } else {
+            set_output_memory(initial_mem, false, output_idx);
+            set_flag(ExecutionFlags::MEMORY_CHANGED);
+        }
     }
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/loop_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/loop_gpu_test.cpp
@@ -438,6 +438,71 @@ TEST(loop_gpu, basic_concat_nested_cached) {
     test_loop_gpu_basic_concat_nested<float>(true);
 }
 
+TEST(loop_gpu, zero_iterations_dynamic_merged_output) {
+    auto& engine = get_test_engine();
+
+    const ov::PartialShape dynamic_shape{ov::Dimension(0, 1), ov::Dimension::dynamic(), ov::Dimension(0, 4)};
+    const ov::PartialShape input_shape{1, 2, 4};
+    const layout dynamic_layout{dynamic_shape, data_types::f32, format::bfyx};
+    const layout input_layout{input_shape, data_types::f32, format::bfyx};
+    const layout scalar_layout{ov::PartialShape{}, data_types::i64, format::bfyx};
+
+    auto input_mem = engine.allocate_memory(input_layout);
+    auto initial_condition_mem = engine.allocate_memory(scalar_layout);
+    auto num_iteration_mem = engine.allocate_memory(scalar_layout);
+    std::vector<float> input_data{1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f};
+    set_values(input_mem, input_data);
+    set_values(initial_condition_mem, {0});
+
+    topology body(
+        cldnn::input_layout("body_input", dynamic_layout),
+        eltwise("body_output", input_info("body_input"), input_info("body_input"), eltwise_mode::sum));
+
+    std::vector<loop::io_primitive_map> input_primitive_maps{
+        loop::io_primitive_map("input", "body_input")};
+    std::vector<loop::io_primitive_map> output_primitive_maps{
+        loop::io_primitive_map("loop", "body_output")};
+    std::vector<loop::backedge_mapping> back_edges{
+        loop::backedge_mapping("body_output", "body_input")};
+
+    auto body_program = build_program(engine, body, "", output_primitive_maps, back_edges, true);
+
+    topology outer_topology(
+        cldnn::input_layout("input", dynamic_layout),
+        cldnn::input_layout("initial_condition", scalar_layout),
+        mutable_data("num_iteration", num_iteration_mem),
+        loop("loop",
+             {input_info("num_iteration"), input_info("initial_condition"), input_info("input")},
+             body_program,
+             "",
+             "initial_condition",
+             "num_iteration",
+             input_primitive_maps,
+             output_primitive_maps,
+             back_edges,
+             8));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    auto network = get_network(engine, outer_topology, config, get_test_stream_ptr(), false);
+    network->set_input_data("input", input_mem);
+    network->set_input_data("initial_condition", initial_condition_mem);
+
+    auto outputs = network->execute();
+    ASSERT_EQ(outputs.size(), 1);
+
+    mem_lock<int64_t, mem_lock_type::read> num_iteration_ptr{num_iteration_mem, get_test_stream()};
+    ASSERT_EQ(num_iteration_ptr[0], 0);
+
+    auto output_mem = outputs.begin()->second.get_memory();
+    ASSERT_EQ(output_mem->get_layout().get_partial_shape(), input_shape);
+
+    mem_lock<float, mem_lock_type::read> output_ptr{output_mem, get_test_stream()};
+    for (size_t index = 0; index < input_data.size(); ++index) {
+        ASSERT_FLOAT_EQ(output_ptr[index], input_data[index]);
+    }
+}
+
 static void test_loop_gpu_wo_trip_count(ov::PartialShape body_input_layout,
                                         ov::PartialShape whole_layout,
                                         std::vector<float> input_data,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/loop_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/loop_gpu_test.cpp
@@ -491,15 +491,33 @@ TEST(loop_gpu, zero_iterations_dynamic_merged_output) {
     auto outputs = network->execute();
     ASSERT_EQ(outputs.size(), 1);
 
-    mem_lock<int64_t, mem_lock_type::read> num_iteration_ptr{num_iteration_mem, get_test_stream()};
-    ASSERT_EQ(num_iteration_ptr[0], 0);
+    {
+        mem_lock<int64_t, mem_lock_type::read> num_iteration_ptr{num_iteration_mem, get_test_stream()};
+        ASSERT_EQ(num_iteration_ptr[0], 0);
+    }
 
     auto output_mem = outputs.begin()->second.get_memory();
     ASSERT_EQ(output_mem->get_layout().get_partial_shape(), input_shape);
+    {
+        mem_lock<float, mem_lock_type::read> output_ptr{output_mem, get_test_stream()};
+        for (size_t index = 0; index < input_data.size(); ++index) {
+            ASSERT_FLOAT_EQ(output_ptr[index], input_data[index]);
+        }
+    }
 
-    mem_lock<float, mem_lock_type::read> output_ptr{output_mem, get_test_stream()};
-    for (size_t index = 0; index < input_data.size(); ++index) {
-        ASSERT_FLOAT_EQ(output_ptr[index], input_data[index]);
+    auto preset_output_mem = engine.allocate_memory(input_layout);
+    network->set_output_memory("loop", preset_output_mem);
+    outputs = network->execute();
+    ASSERT_EQ(outputs.size(), 1);
+
+    output_mem = outputs.begin()->second.get_memory();
+    ASSERT_EQ(output_mem->get_layout().get_partial_shape(), input_shape);
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mem, *preset_output_mem));
+    {
+        mem_lock<float, mem_lock_type::read> output_ptr{output_mem, get_test_stream()};
+        for (size_t index = 0; index < input_data.size(); ++index) {
+            ASSERT_FLOAT_EQ(output_ptr[index], input_data[index]);
+        }
     }
 }
 


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
- A Loop with a false initial execution condition produced `[0,0,0]` for a dynamic merged output, causing a shape mismatch in a following operation.
- The zero-iteration path updated the output layout without forwarding the initial loop-carried value.
- Fixed the path to forward the initial input memory and concrete layout for merged outputs.
- Concatenated outputs retain their existing zero-length iteration axis behavior.
- Added a GPU unit test that verifies zero iterations, preserved output shape, and preserved data.

#### The code and line that caused this issue (if it is not changed directly)
- `intel_gpu/src/graph/loop.cpp`: `get_output_layouts()`
- `intel_gpu/src/graph/impls/common/loop.cpp`: zero-iteration early-return path

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
- `benchmark_app -m <model.xml> -d GPU -hint none -niter 1 -data_shape '[1,448,672,3]'`
- Before the fix, inference failed due to a shape mismatch between `[1,512,512]` and `[0,0,0]`.
- After the fix, inference completes successfully.
- The customer model is not attached.

#### Problematic graph
```mermaid
flowchart LR
    Initial["Initial carried input<br/>shape: [1, 512, 4]"]
    Condition{"Initial condition"}
    Body["Loop body"]
    BodyOutput["Body output"]
    MergedOutput["Merged Loop output"]
    WrongOutput["Incorrect output<br/>shape: [0, 0, 0]"]
    NextOp["Following operation<br/>expected: [1, 512, 4]"]

    Initial --> Condition
    Condition -->|"true"| Body
    Body --> BodyOutput
    BodyOutput -->|"back-edge"| Body
    BodyOutput --> MergedOutput

    Condition -->|"false: zero iterations"| MergedOutput
    Initial -.->|"expected: forward initial value"| MergedOutput

    Condition -->|"previous behavior"| WrongOutput
    WrongOutput -->|"shape mismatch"| NextOp
```
- When the initial condition is `false`, the Loop body executes zero times.
- The merged output must forward the initial loop-carried input with shape `[1,512,4]`.
- Previously, the GPU implementation produced `[0,0,0]`, causing a shape mismatch in the following operation.

#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
  - Reviewed the existing GPU Loop dynamic-shape tests in `loop_gpu_test.cpp`.
  - Added `loop_gpu.zero_iterations_dynamic_merged_output` because the existing tests did not cover a false initial condition with a dynamic merged output.

### Tickets:
- [CVS-191353](https://jira.devtools.intel.com/browse/CVS-191353)