### PR TITLE
GPU: support non-tile-aligned shapes in permute_xy_swap kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_xy_swap.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_xy_swap.cl
@@ -26,9 +26,9 @@
 // Required WG size: (WG_DIM, WG_DIM, 1).
 // GWS: (ceil(INPUT0_SIZE_X, TILE_SIZE) / ELEMS_PER_DIM,
 //       ceil(INPUT0_SIZE_Y, TILE_SIZE) / ELEMS_PER_DIM, B*F).
-// When REMAINDER is set, X and/or Y need not be multiples of TILE_SIZE and
-// out-of-range reads/writes are guarded; otherwise the fast (branch-free) path
-// is used and X and Y must both be multiples of TILE_SIZE (enforced by Validate).
+// When REMAINDER is set, X/Y need not be multiples of TILE_SIZE and out-of-range
+// reads/writes are guarded. When REMAINDER is 0, TILE_SIZE is chosen so it
+// divides both X and Y (host-side tile selection).
 
 __attribute__((reqd_work_group_size(WG_DIM, WG_DIM, 1)))
 KERNEL(permute_xy_swap)(

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_xy_swap.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_xy_swap.cl
@@ -24,8 +24,11 @@
 //   ELEMS_PER_DIM  - TILE_SIZE / WG_DIM
 //
 // Required WG size: (WG_DIM, WG_DIM, 1).
-// GWS: (INPUT0_SIZE_X / ELEMS_PER_DIM, INPUT0_SIZE_Y / ELEMS_PER_DIM, B*F).
-// Input X and Y must both be multiples of TILE_SIZE (enforced by Validate).
+// GWS: (ceil(INPUT0_SIZE_X, TILE_SIZE) / ELEMS_PER_DIM,
+//       ceil(INPUT0_SIZE_Y, TILE_SIZE) / ELEMS_PER_DIM, B*F).
+// When REMAINDER is set, X and/or Y need not be multiples of TILE_SIZE and
+// out-of-range reads/writes are guarded; otherwise the fast (branch-free) path
+// is used and X and Y must both be multiples of TILE_SIZE (enforced by Validate).
 
 __attribute__((reqd_work_group_size(WG_DIM, WG_DIM, 1)))
 KERNEL(permute_xy_swap)(
@@ -58,7 +61,12 @@ KERNEL(permute_xy_swap)(
         for (uint dx = 0; dx < ELEMS_PER_DIM; ++dx) {
             const uint sub_x = lx + dx * WG_DIM;   // 0 .. TILE_SIZE-1
             const uint in_x  = tx * TILE_SIZE + sub_x;
+#if REMAINDER
+            if (in_y < INPUT0_SIZE_Y && in_x < INPUT0_SIZE_X)
+                tile[sub_y][sub_x] = input[INPUT0_GET_INDEX(b, f, in_y, in_x)];
+#else
             tile[sub_y][sub_x] = input[INPUT0_GET_INDEX(b, f, in_y, in_x)];
+#endif
         }
     }
 
@@ -75,6 +83,10 @@ KERNEL(permute_xy_swap)(
         for (uint dx = 0; dx < ELEMS_PER_DIM; ++dx) {
             const uint sub_x = lx + dx * WG_DIM;   // local col in output tile
             const uint out_x = ty * TILE_SIZE + sub_x;
+#if REMAINDER
+            if (out_y >= OUTPUT_SIZE_Y || out_x >= OUTPUT_SIZE_X)
+                continue;
+#endif
             const INPUT0_TYPE val = tile[sub_x][sub_y];  // transposed SLM read
 
 #if HAS_FUSED_OPS

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_xy_swap.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_xy_swap.cl
@@ -22,10 +22,11 @@
 //   TILE_SIZE      - tile edge length in elements
 //   WG_DIM         - WG size along each of X/Y (kept at 16 for SIMD8 occupancy)
 //   ELEMS_PER_DIM  - TILE_SIZE / WG_DIM
+//   REMAINDER      - 1 when ragged-edge bounds checks are needed, else 0
 //
 // Required WG size: (WG_DIM, WG_DIM, 1).
-// GWS: (ceil(INPUT0_SIZE_X, TILE_SIZE) / ELEMS_PER_DIM,
-//       ceil(INPUT0_SIZE_Y, TILE_SIZE) / ELEMS_PER_DIM, B*F).
+// GWS: (ceil(INPUT0_SIZE_X, TILE_SIZE) * WG_DIM,
+//       ceil(INPUT0_SIZE_Y, TILE_SIZE) * WG_DIM, B*F).
 // When REMAINDER is set, X/Y need not be multiples of TILE_SIZE and out-of-range
 // reads/writes are guarded. When REMAINDER is 0, TILE_SIZE is chosen so it
 // divides both X and Y (host-side tile selection).

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.cpp
@@ -40,6 +40,25 @@ size_t PickTileSize(const permute_params& params) {
     return is_one_byte_type ? pick_tile(kOneByteTileCandidates) : pick_tile(kTileCandidates);
 }
 
+// Tile plan: an exact tile (branch-free fast path) when X and Y are both
+// divisible by a candidate tile size, otherwise a WG_DIM tile with per-tile
+// remainder handling so arbitrary X/Y (e.g. head_size 72) are still supported.
+struct TilePlan {
+    size_t tile = 0;
+    bool remainder = false;
+};
+
+TilePlan PlanTile(const permute_params& params) {
+    const size_t exact = PickTileSize(params);
+    if (exact != 0)
+        return {exact, false};
+    // Fall back to a WG_DIM-sized tile and guard the ragged edges. This keeps
+    // coalesced loads/stores and SLM transposition for shapes whose X/Y are
+    // not tile-aligned, which would otherwise drop to the scalar reference
+    // permute (e.g. {0,1,3,2} with Y=72).
+    return {kWgDim, true};
+}
+
 bool IsXYSwapOrder(const std::vector<uint16_t>& order) {
     // 4D only, last two dims swapped, others identity.
     // cldnn order produced from IE {0,1,3,2} is also {0,1,3,2} for 4D inputs.
@@ -74,11 +93,13 @@ ParamsKey PermuteKernel_xy_swap::GetSupportedKey() const {
 JitConstants PermuteKernel_xy_swap::GetJitConstants(const permute_params& params,
                                                     const CommonDispatchData& dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
-    const size_t tile_size = PickTileSize(params);
+    const TilePlan plan = PlanTile(params);
+    const size_t tile_size = plan.tile;
     const size_t elems_per_dim = tile_size / kWgDim;
     jit.AddConstant(MakeJitConstant("TILE_SIZE", tile_size));
     jit.AddConstant(MakeJitConstant("WG_DIM", kWgDim));
     jit.AddConstant(MakeJitConstant("ELEMS_PER_DIM", elems_per_dim));
+    jit.AddConstant(MakeJitConstant("REMAINDER", plan.remainder ? 1 : 0));
 
     if (!params.fused_ops.empty()) {
         // Output layout indices for fused ops (bfyx in IE naming).
@@ -92,11 +113,14 @@ JitConstants PermuteKernel_xy_swap::GetJitConstants(const permute_params& params
 CommonDispatchData PermuteKernel_xy_swap::SetDefault(const permute_params& params) const {
     CommonDispatchData dispatchData;
     const auto& in = params.inputs[0];
-    const size_t tile_size = PickTileSize(params);
-    const size_t elems_per_dim = tile_size / kWgDim;
+    const TilePlan plan = PlanTile(params);
+    const size_t tile_size = plan.tile;
     // One WG covers a TILE_SIZE x TILE_SIZE block; with WG = WG_DIM x WG_DIM,
-    // each WI does ELEMS_PER_DIM^2 work, so GWS shrinks accordingly.
-    dispatchData.gws = {in.X().v / elems_per_dim, in.Y().v / elems_per_dim, in.Batch().v * in.Feature().v};
+    // each WI does ELEMS_PER_DIM^2 work, so GWS shrinks accordingly. Round the
+    // number of tiles up so ragged edges (REMAINDER path) are still covered.
+    const size_t x_tiles = CeilDiv(in.X().v, tile_size);
+    const size_t y_tiles = CeilDiv(in.Y().v, tile_size);
+    dispatchData.gws = {x_tiles * kWgDim, y_tiles * kWgDim, in.Batch().v * in.Feature().v};
     dispatchData.lws = {kWgDim, kWgDim, 1};
     return dispatchData;
 }
@@ -125,10 +149,8 @@ bool PermuteKernel_xy_swap::Validate(const Params& p) const {
         params.outputs[0].PitchesDifferFromLogicalDims()) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
-    // Require X and Y to be tile-aligned for at least one supported tile size.
-    if (PickTileSize(params) == 0) {
-        DO_NOT_USE_THIS_KERNEL(p.layerID);
-    }
+    // A WG_DIM tile with remainder handling covers any X/Y, so no divisibility
+    // requirement remains; PlanTile always yields a usable tile.
 
     return true;
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.cpp
@@ -153,8 +153,6 @@ bool PermuteKernel_xy_swap::Validate(const Params& p) const {
         params.outputs[0].PitchesDifferFromLogicalDims()) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
-    // A WG_DIM tile with remainder handling covers any X/Y, so no divisibility
-    // requirement remains; PlanTile always yields a usable tile.
 
     return true;
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_xy_swap.cpp
@@ -40,6 +40,25 @@ size_t PickTileSize(const permute_params& params) {
     return is_one_byte_type ? pick_tile(kOneByteTileCandidates) : pick_tile(kTileCandidates);
 }
 
+// Tile plan: an exact tile (branch-free fast path) when X and Y are both
+// divisible by a candidate tile size, otherwise a WG_DIM tile with per-tile
+// remainder handling so arbitrary X/Y (e.g. head_size 72) are still supported.
+struct TilePlan {
+    size_t tile = 0;
+    bool remainder = false;
+};
+
+TilePlan PlanTile(const permute_params& params) {
+    const size_t exact = PickTileSize(params);
+    if (exact != 0)
+        return {exact, false};
+    // Fall back to a WG_DIM-sized tile and guard the ragged edges. This keeps
+    // coalesced loads/stores and SLM transposition for shapes whose X/Y are
+    // not tile-aligned, which would otherwise drop to the scalar reference
+    // permute (e.g. {0,1,3,2} with Y=72).
+    return {kWgDim, true};
+}
+
 bool IsXYSwapOrder(const std::vector<uint16_t>& order) {
     // 4D only, last two dims swapped, others identity.
     // cldnn order produced from IE {0,1,3,2} is also {0,1,3,2} for 4D inputs.
@@ -74,11 +93,13 @@ ParamsKey PermuteKernel_xy_swap::GetSupportedKey() const {
 JitConstants PermuteKernel_xy_swap::GetJitConstants(const permute_params& params,
                                                     const CommonDispatchData& dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
-    const size_t tile_size = PickTileSize(params);
+    const TilePlan plan = PlanTile(params);
+    const size_t tile_size = plan.tile;
     const size_t elems_per_dim = tile_size / kWgDim;
     jit.AddConstant(MakeJitConstant("TILE_SIZE", tile_size));
     jit.AddConstant(MakeJitConstant("WG_DIM", kWgDim));
     jit.AddConstant(MakeJitConstant("ELEMS_PER_DIM", elems_per_dim));
+    jit.AddConstant(MakeJitConstant("REMAINDER", plan.remainder ? 1 : 0));
 
     if (!params.fused_ops.empty()) {
         // Output layout indices for fused ops (bfyx in IE naming).
@@ -92,15 +113,18 @@ JitConstants PermuteKernel_xy_swap::GetJitConstants(const permute_params& params
 CommonDispatchData PermuteKernel_xy_swap::SetDefault(const permute_params& params) const {
     CommonDispatchData dispatchData;
     const auto& in = params.inputs[0];
-    const size_t tile_size = PickTileSize(params);
-    const size_t elems_per_dim = tile_size / kWgDim;
-    // Validate() rejects params with PickTileSize() == 0, and every tile candidate is a multiple of
-    // kWgDim, so elems_per_dim is always >= 1 here. Guard the invariant explicitly rather than
-    // dividing by a value a static analyzer cannot prove to be non-zero.
-    OPENVINO_ASSERT(elems_per_dim != 0, "[GPU] permute_xy_swap: invalid tile size ", tile_size, " for WG dim ", kWgDim);
+    const TilePlan plan = PlanTile(params);
+    const size_t tile_size = plan.tile;
+    // PlanTile() always returns a non-zero tile (an exact candidate or the
+    // kWgDim fallback), so tile_size >= kWgDim >= 1 and the CeilDiv divisors
+    // below are never zero. Guard the invariant explicitly for static analysis.
+    OPENVINO_ASSERT(tile_size != 0, "[GPU] permute_xy_swap: invalid tile size");
     // One WG covers a TILE_SIZE x TILE_SIZE block; with WG = WG_DIM x WG_DIM,
-    // each WI does ELEMS_PER_DIM^2 work, so GWS shrinks accordingly.
-    dispatchData.gws = {in.X().v / elems_per_dim, in.Y().v / elems_per_dim, in.Batch().v * in.Feature().v};
+    // each WI does ELEMS_PER_DIM^2 work, so GWS shrinks accordingly. Round the
+    // number of tiles up so ragged edges (REMAINDER path) are still covered.
+    const size_t x_tiles = CeilDiv(in.X().v, tile_size);
+    const size_t y_tiles = CeilDiv(in.Y().v, tile_size);
+    dispatchData.gws = {x_tiles * kWgDim, y_tiles * kWgDim, in.Batch().v * in.Feature().v};
     dispatchData.lws = {kWgDim, kWgDim, 1};
     return dispatchData;
 }
@@ -129,10 +153,8 @@ bool PermuteKernel_xy_swap::Validate(const Params& p) const {
         params.outputs[0].PitchesDifferFromLogicalDims()) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
-    // Require X and Y to be tile-aligned for at least one supported tile size.
-    if (PickTileSize(params) == 0) {
-        DO_NOT_USE_THIS_KERNEL(p.layerID);
-    }
+    // A WG_DIM tile with remainder handling covers any X/Y, so no divisibility
+    // requirement remains; PlanTile always yields a usable tile.
 
     return true;
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
@@ -2378,8 +2378,9 @@ TEST_P(permute_f_y_axes_tile, combined) {
 // Constraints (see PermuteKernel_xy_swap::Validate):
 //   * 4D plain bfyx layout only.
 //   * Order must be {0, 1, 3, 2}.
-//   * Both X and Y must be divisible by one of the supported tile sizes (32 or 16).
 //   * No dynamic shapes; pitches must equal logical dims.
+// X and Y need NOT be tile-aligned: when neither divides a supported tile size
+// (32/16) the kernel uses a WG_DIM tile with per-tile remainder handling.
 // Sizes here use the test convention {B, F, Y, X}.
 class permute_xy_swap : public TiledPermuteTest {};
 
@@ -2399,6 +2400,13 @@ INSTANTIATE_TEST_SUITE_P(smoke_permute_xy_swap,
                              // larger / batched
                              {{1, 32, 128, 64}, format::bfyx},
                              {{4, 16, 64, 128}, format::bfyx},
+                             // remainder path (X and/or Y not tile-aligned)
+                             {{1, 16, 72, 256}, format::bfyx},  // Y=72 ragged (pi05 K-transpose)
+                             {{1, 16, 256, 72}, format::bfyx},  // X=72 ragged (reverse)
+                             {{2, 3, 72, 100}, format::bfyx},   // both X and Y ragged
+                             {{1, 1, 17, 33}, format::bfyx},    // both ragged, small
+                             {{3, 5, 100, 72}, format::bfyx},   // both ragged, batched
+                             {{1, 8, 24, 40}, format::bfyx},    // both ragged (24, 40)
                          }),
                          TiledPermuteTest::PrintToStringParamName);
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
@@ -2379,8 +2379,9 @@ TEST_P(permute_f_y_axes_tile, combined) {
 //   * 4D plain bfyx layout only.
 //   * Order must be {0, 1, 3, 2}.
 //   * No dynamic shapes; pitches must equal logical dims.
-// X and Y need NOT be tile-aligned: when neither divides a supported tile size
-// (32/16) the kernel uses a WG_DIM tile with per-tile remainder handling.
+// X and Y need NOT be tile-aligned: when no supported tile size (32/16)
+// divides both X and Y, the kernel uses a WG_DIM tile with per-tile
+// remainder handling.
 // Sizes here use the test convention {B, F, Y, X}.
 class permute_xy_swap : public TiledPermuteTest {};
 


### PR DESCRIPTION
The optimized 4D X<->Y transpose kernel (order {0,1,3,2}) previously required both X and Y to be multiples of a supported tile size (32 or 16). Shapes that failed this dropped to the scalar permute_ref kernel; for example any transpose whose head_size dimension is not a multiple of 16 (e.g. 72) could not use the tiled kernel.

Add per-tile remainder handling: when no candidate tile size divides X and Y exactly, fall back to a WG_DIM-sized tile and guard the ragged edges (bounds-checked SLM loads/stores), rounding the dispatch up to cover partial tiles. The aligned case keeps its branch-free fast path, and the kernel now produces bitwise-identical output for ragged shapes that previously used permute_ref.

Extend the permute_xy_swap unit tests with ragged (non-tile-aligned) shapes covering X-ragged, Y-ragged, both-ragged, small and batched cases, validated against permute_ref.

### Tickets:
 - [CVS-190013](https://jira.devtools.intel.com/browse/CVS-190013)

### AI Assistance:
 - *AI assistance used: yes
