### PR TITLE
[GPU][CLANG-TIDY] Enable modernize-redundant-void-arg

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -7,7 +7,8 @@
 
 Checks: >
   -*,
-  modernize-use-override
+  modernize-use-override,
+  modernize-redundant-void-arg
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.hpp
@@ -109,7 +109,7 @@ struct FusedOpsConfiguration {
         shuffle_var_name = std::move(val);
         return *this;
     }
-    [[nodiscard]] bool is_post_reorder_fused(void) const {
+    [[nodiscard]] bool is_post_reorder_fused() const {
         return orig_output_layout != cldnn::format::any;
     }
 

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -83,7 +83,7 @@ public:
         return res;
     }
 
-    bool is_shape_infer_dep(void) const {
+    bool is_shape_infer_dep() const {
         if (!myprog.is_new_shape_infer())
             return false;
         for (auto u : users) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -549,7 +549,7 @@ struct FusedOpsConfiguration {
         allow_for_partial_preload = partial_preload;
         return *this; }
     FusedOpsConfiguration& SetShuffleVarName(std::string val) { shuffle_var_name = val; return *this; }
-    bool IsPostReorderFused(void) const { return orig_output_layout != DataLayout::DataLayoutCount; }
+    bool IsPostReorderFused() const { return orig_output_layout != DataLayout::DataLayoutCount; }
     int GetDimIndexFromOrder(Tensor::DataChannelName val) const {
         int dims_num = static_cast<int>(bfzyx_idx_order.size());
         if (val == Tensor::DataChannelName::BATCH && dims_num >= 1) {

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -788,7 +788,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
         {
             // Disable XAttention if GPU Xe2/Xe3 architectures is unavaiable or IGC incompatiable.
-            auto check_xattn_gpu_compatibility  = [&](void) -> bool {
+            auto check_xattn_gpu_compatibility  = [&]() -> bool {
                         auto& engine = m_context->get_engine();
                         const auto& info = engine.get_device_info();
                          if (!info.supports_immad) {  // CM optimized for systolic-array architectures


### PR DESCRIPTION
Enables the `modernize-redundant-void-arg` clang-tidy check for the Intel GPU plugin and fixes the resulting diagnostics by replacing C-style `(void)` parameter lists with `()` in function, method and lambda declarations. Next check in the incremental clang-tidy rollout for the plugin.
