### PR TITLE
Fix clang -Wthread-safety-analysis warning in cache_guard

### DIFF
--- a/src/inference/src/cache_guard.cpp
+++ b/src/inference/src/cache_guard.cpp
@@ -13,19 +13,25 @@ CacheGuardEntry::CacheGuardEntry(CacheGuard& cacheGuard,
     : m_cacheGuard(cacheGuard),
       m_hash(hash),
       m_mutex(std::move(m)),
-      m_refCount(refCount) {
-    // Don't lock mutex right here for exception-safe considerations
+      m_refCount(refCount),
+      // Deferred: don't lock the mutex here for exception-safety considerations.
+      m_lock(*m_mutex, std::defer_lock) {
     m_refCount++;
 }
 
 CacheGuardEntry::~CacheGuardEntry() {
     m_refCount--;
-    m_mutex->unlock();
+    // Unlock only if this entry actually acquired the lock. perform_lock() is
+    // called after construction, so the entry may be destroyed (e.g. on an
+    // exception path) without ever having locked the mutex.
+    if (m_lock.owns_lock()) {
+        m_lock.unlock();
+    }
     m_cacheGuard.check_for_remove(m_hash);
 }
 
 void CacheGuardEntry::perform_lock() {
-    m_mutex->lock();
+    m_lock.lock();
 }
 
 //////////////////////////////////////////////////////

--- a/src/inference/src/cache_guard.hpp
+++ b/src/inference/src/cache_guard.hpp
@@ -65,6 +65,10 @@ private:
     std::string m_hash;
     std::shared_ptr<std::mutex> m_mutex;
     std::atomic_int& m_refCount;
+    // NOTE: m_lock is initialized from '*m_mutex' and therefore must be declared
+    // after m_mutex so that m_mutex is constructed first (members are initialized
+    // in declaration order). Do not reorder these members.
+    std::unique_lock<std::mutex> m_lock;
 };
 
 /**


### PR DESCRIPTION
CacheGuardEntry acquired the per-hash mutex in perform_lock() and released it in the destructor via a raw std::mutex, which clang's thread safety analysis (`-Wthread-safety-analysis`) cannot verify across function boundaries ("mutex is still held at the end of function").

Manage the lock with a deferred std::unique_lock member instead. This satisfies the analyzer without any suppression attribute, and also fixes a latent undefined-behavior bug: the previous destructor unconditionally called unlock() even when perform_lock() had never run (e.g. on an exception path), unlocking a mutex the thread did not own. The unique_lock now unlocks only when it actually owns the lock.

### AI Assistance:
 - *AI assistance used*: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*  
    I asked AI to generate the patch to use `std::unique_lock` and ask it to write the commit message. I've manually look at this patch as it's small.
