### PR TITLE
[GPU][CLANG-TIDY] Enable modernize-use-using

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -7,7 +7,8 @@
 
 Checks: >
   -*,
-  modernize-use-override
+  modernize-use-override,
+  modernize-use-using
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -54,11 +54,11 @@ struct program {
 public:
     struct nodes_ordering {
     public:
-        typedef std::list<program_node*> list_of_nodes;
-        typedef list_of_nodes::const_iterator const_iterator;
-        typedef list_of_nodes::const_reverse_iterator const_reverse_iterator;
-        typedef list_of_nodes::iterator node_iterator;
-        typedef list_of_nodes::reverse_iterator node_reverse_iterator;
+        using list_of_nodes = std::list<program_node *>;
+        using const_iterator = list_of_nodes::const_iterator;
+        using const_reverse_iterator = list_of_nodes::const_reverse_iterator;
+        using node_iterator = list_of_nodes::iterator;
+        using node_reverse_iterator = list_of_nodes::reverse_iterator;
         const_iterator begin() const { return _processing_order.begin(); }
         const_iterator end() const { return _processing_order.end(); }
         const_reverse_iterator rbegin() const { return _processing_order.rbegin(); }
@@ -126,9 +126,9 @@ public:
         T* elem;
     };
 
-    typedef std::vector<primitive_info> primitives_info;
-    typedef std::vector<std::pair<std::string, primitives_info>> graph_optimizer_info;
-    typedef std::pair<primitive_id, std::vector<primitive_id>> optimized_info;
+    using primitives_info = std::vector<primitive_info>;
+    using graph_optimizer_info = std::vector<std::pair<std::string, primitives_info>>;
+    using optimized_info = std::pair<primitive_id, std::vector<primitive_id>>;
 
     program(engine& engine_ref,
             topology const& topology,

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/topology.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/topology.hpp
@@ -13,7 +13,7 @@
 
 namespace cldnn {
 
-typedef std::map<primitive_id, std::shared_ptr<primitive>> topology_map;
+using topology_map = std::map<primitive_id, std::shared_ptr<primitive>>;
 
 struct topology {
 public:

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/custom_layer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/custom_layer.hpp
@@ -21,12 +21,12 @@ public:
         CustomLayerMap& customLayers,
         bool can_be_missed = false);
 
-    typedef enum {
+    enum ParamType {
         Input,
         Output,
         Data,
         Internal,
-    } ParamType;
+    };
     struct KerenlParam {
         KerenlParam() :type(Input), paramIndex(-1), portIndex(-1),
                        format(cldnn::format::any) {}

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
@@ -25,11 +25,11 @@ namespace cldnn {
 struct gemm : public primitive_base<gemm> {
     CLDNN_DECLARE_PRIMITIVE(gemm)
 
-    typedef enum {
+    enum TransposeType {
         X_LAST = 0,
         Y_LAST,
         OTHER,
-    } TransposeType;
+    };
 
     gemm() : primitive_base("", {}) {}
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lrn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lrn.hpp
@@ -6,10 +6,10 @@
 #include "primitive.hpp"
 
 namespace cldnn {
-typedef enum { /*:int32_t*/
+enum lrn_norm_region { /*:int32_t*/
     lrn_norm_region_across_channel,
     lrn_norm_region_within_channel
-} lrn_norm_region;
+};
 
 /// @brief Local response normalization
 /// @details LRN layer as described in chapter 3.3 of "ImageNet Classification with Deep Convolutional

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/compounds.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/compounds.hpp
@@ -205,7 +205,7 @@ _NODISCARD constexpr checked_array_iterator<_Ptr> make_checked_array_iterator(
 template <typename T>
 class mutable_array_ref {
 public:
-    typedef size_t size_type;
+    using size_type = size_t;
 
     mutable_array_ref() : _data(nullptr), _size(0) {}
     explicit mutable_array_ref(T& val) : _data(&val), _size(1) {}
@@ -236,8 +236,8 @@ public:
     const_iterator cbegin() const { return make_checked_array_iterator(_data, _size); }
     const_iterator cend() const { return make_checked_array_iterator(_data, _size, _size); }
 #else
-    typedef T* iterator;
-    typedef T* const_iterator;
+    using iterator = T *;
+    using const_iterator = T *;
     iterator begin() const { return _data; }
     iterator end() const { return _data + _size; }
     const_iterator cbegin() const { return _data; }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/profiling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/profiling.hpp
@@ -56,7 +56,7 @@ class timer {
 
 public:
     /// @brief Timer value type.
-    typedef typename ClockTy::duration val_type;
+    using val_type = typename ClockTy::duration;
 
     /// @brief Starts timer.
     timer() : start_point(ClockTy::now()) {}

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
@@ -123,7 +123,7 @@ struct tensor {
     friend class details::dim_vec_kind_init<details::dim_vec_kind::spatial>;
     friend class details::dim_vec_kind_init<details::dim_vec_kind::group>;
 
-    typedef ov::Dimension::value_type value_type;   ///< Values type stored in tensor.
+    using value_type = ov::Dimension::value_type;   ///< Values type stored in tensor.
     // TODO find the way to prevent direct change of following fields.
     mutable_array_ref<value_type> raw;      ///< Raw representation of all dimensions.
     mutable_array_ref<value_type> batch;    ///< Batch dimensions.

--- a/src/plugins/intel_gpu/include/va/va.h
+++ b/src/plugins/intel_gpu/include/va/va.h
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-typedef cl_uint VASurfaceID;
-typedef void* VADisplay;
-typedef void* VAImageFormat;
+using VASurfaceID = cl_uint;
+using VADisplay = void *;
+using VAImageFormat = void *;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/grouped_matmul_helper.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/grouped_matmul_helper.hpp
@@ -194,7 +194,7 @@ struct onednn_matmul {
 template <typename... TTypes>
 class tuple_hasher {
 private:
-    typedef std::tuple<TTypes...> Tuple;
+    using Tuple = std::tuple<TTypes...>;
     template <int N>
     size_t hash(Tuple& value) const {
         return 0;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -242,7 +242,7 @@ public:
 
         static_assert(sizeof(restrict_t) == sizeof(uint64_t), "problem with union");
 
-        typedef union DataTypesKey_t {
+        union DataTypesKey {
             struct val_t {
                 uint32_t int4 : 1;
                 uint32_t uint4 : 1;
@@ -261,7 +261,7 @@ public:
                 uint32_t F8E8M0 : 1;
             } val;
             uint32_t raw;
-        } DataTypesKey;
+        };
 
         DataTypesKey inputType;
         DataTypesKey outputType;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
@@ -31,8 +31,8 @@ typedef cl_d3d11_device_source_khr cl_device_source_intel;
 typedef cl_d3d11_device_set_khr    cl_device_set_intel;
 #else
 # include <CL/cl_va_api_media_sharing_intel.h>
-typedef cl_va_api_device_source_intel cl_device_source_intel;
-typedef cl_va_api_device_set_intel    cl_device_set_intel;
+using cl_device_source_intel = cl_va_api_device_source_intel;
+using cl_device_set_intel = cl_va_api_device_set_intel;
 #endif
 
 #include <sstream>
@@ -428,7 +428,7 @@ T load_entrypoint(const cl_command_queue queue, const std::string name) {
 
 namespace cl {
 
-typedef CL_API_ENTRY cl_int(CL_API_CALL *PFN_clEnqueueAcquireMediaSurfacesINTEL)(
+using PFN_clEnqueueAcquireMediaSurfacesINTEL = CL_API_ENTRY cl_int(CL_API_CALL *)(
     cl_command_queue /* command_queue */,
     cl_uint /* num_objects */,
     const cl_mem* /* mem_objects */,
@@ -436,7 +436,7 @@ typedef CL_API_ENTRY cl_int(CL_API_CALL *PFN_clEnqueueAcquireMediaSurfacesINTEL)
     const cl_event* /* event_wait_list */,
     cl_event* /* event */);
 
-typedef CL_API_ENTRY cl_int(CL_API_CALL *PFN_clEnqueueReleaseMediaSurfacesINTEL)(
+using PFN_clEnqueueReleaseMediaSurfacesINTEL = CL_API_ENTRY cl_int(CL_API_CALL *)(
     cl_command_queue /* command_queue */,
     cl_uint /* num_objects */,
     const cl_mem* /* mem_objects */,
@@ -444,7 +444,7 @@ typedef CL_API_ENTRY cl_int(CL_API_CALL *PFN_clEnqueueReleaseMediaSurfacesINTEL)
     const cl_event* /* event_wait_list */,
     cl_event* /* event */);
 
-typedef CL_API_ENTRY cl_mem(CL_API_CALL * PFN_clCreateFromMediaSurfaceINTEL)(
+using PFN_clCreateFromMediaSurfaceINTEL = CL_API_ENTRY cl_mem(CL_API_CALL *)(
     cl_context /* context */,
     cl_mem_flags /* flags */,
     void* /* surface */,
@@ -453,7 +453,7 @@ typedef CL_API_ENTRY cl_mem(CL_API_CALL * PFN_clCreateFromMediaSurfaceINTEL)(
 
 
 #ifdef WIN32
-    typedef CL_API_ENTRY cl_mem(CL_API_CALL * PFN_clCreateFromD3D11Buffer)(
+    using PFN_clCreateFromD3D11Buffer = CL_API_ENTRY cl_mem(CL_API_CALL *)(
         cl_context context,
         cl_mem_flags flags,
         void* resource, cl_int* errcode_ret);
@@ -694,7 +694,7 @@ public:
 #endif
 
 class ExternalMemoryHelper {
-    typedef CL_API_ENTRY cl_int(CL_API_CALL * PFN_clEnqueueAcquireExternalMemObjectsKHR)(
+    using PFN_clEnqueueAcquireExternalMemObjectsKHR = CL_API_ENTRY cl_int(CL_API_CALL *)(
         cl_command_queue /* command_queue */,
         cl_uint /* num_mem_objects */,
         const cl_mem* /* mem_objects */,
@@ -702,7 +702,7 @@ class ExternalMemoryHelper {
         const cl_event* /* event_wait_list */,
         cl_event* /* event */);
 
-    typedef CL_API_ENTRY cl_int(CL_API_CALL * PFN_clEnqueueReleaseExternalMemObjectsKHR)(
+    using PFN_clEnqueueReleaseExternalMemObjectsKHR = CL_API_ENTRY cl_int(CL_API_CALL *)(
         cl_command_queue /* command_queue */,
         cl_uint /* num_mem_objects */,
         const cl_mem* /* mem_objects */,
@@ -756,7 +756,7 @@ public:
         void *                 media_adapter,
         cl_device_set_intel    media_adapter_set,
         vector<Device>* devices) const {
-        typedef CL_API_ENTRY cl_int(CL_API_CALL * PFN_clGetDeviceIDsFromMediaAdapterINTEL)(
+        using PFN_clGetDeviceIDsFromMediaAdapterINTEL = CL_API_ENTRY cl_int(CL_API_CALL *)(
             cl_platform_id /* platform */,
             cl_device_source_intel /* media_adapter_type */,
             void * /* media_adapter */,


### PR DESCRIPTION
Enables the `modernize-use-using` clang-tidy check for the Intel GPU plugin and converts C-style `typedef` declarations to `using` type aliases. Anonymous `typedef enum {...} X;` / `typedef union {...} X;` are instead given a name directly (`enum X {...}` / `union X {...}`) so the type keeps external linkage when used as a class data member (avoids `-Werror=subobject-linkage`). Function-pointer typedefs in `ocl_ext.hpp` are converted by hand to keep the `CL_API_ENTRY`/`CL_API_CALL` calling-convention macros. Next check in the incremental clang-tidy rollout for the plugin.
