### PR TITLE
[GPU][CLANG-TIDY] Enable modernize-deprecated-headers

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -7,7 +7,8 @@
 
 Checks: >
   -*,
-  modernize-use-override
+  modernize-use-override,
+  modernize-deprecated-headers
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -20,7 +20,7 @@
 #include "scatter_update/scatter_elements_update_kernel_ref.h"
 #include "openvino/core/dimension.hpp"
 
-#include <limits.h>
+#include <climits>
 
 namespace cldnn {
 namespace ocl {

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -103,7 +103,7 @@
 #include <map>
 #include <memory>
 #include <set>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/plugins/intel_gpu/src/kernel_selector/auto_tuner.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/auto_tuner.cpp
@@ -31,7 +31,7 @@
 #include <cstring>
 #else
 #include <unistd.h>
-#include <limits.h>
+#include <climits>
 #include <link.h>
 #include <dlfcn.h>
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/primitive_db.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/primitive_db.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "primitive_db.h"
-#include <assert.h>
+#include <cassert>
 #include <algorithm>
 #include <vector>
 #include <utility>

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -21,7 +21,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
-#include <time.h>
+#include <ctime>
 #include <limits>
 #include <chrono>
 #include <fstream>
@@ -41,7 +41,7 @@
 #include <cstring>
 #else
 #include <unistd.h>
-#include <limits.h>
+#include <climits>
 #include <link.h>
 #include <dlfcn.h>
 #endif


### PR DESCRIPTION
Enables the `modernize-deprecated-headers` clang-tidy check for the Intel GPU plugin and replaces deprecated C standard library headers (e.g. `<stdio.h>`) with their C++ counterparts (e.g. `<cstdio>`). Next check in the incremental clang-tidy rollout for the plugin.
