### PR TITLE
[GPU][CLANG-TIDY] Enable modernize-use-bool-literals

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -7,7 +7,8 @@
 
 Checks: >
   -*,
-  modernize-use-override
+  modernize-use-override,
+  modernize-use-bool-literals
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
@@ -299,7 +299,7 @@ void mark_runtime_skippable_nodes::run(program& p) {
             // for dynamic case, postpone the judgement to runtime
             // for static case, judge if input/output are same here.
             if (!node.is_dynamic()) {
-                can_be_optimized = node.get_input_layout(0) == node.get_output_layout(0);
+                can_be_optimized = node.get_input_layout(0) == node.get_output_layout(false);
             }
             if (!node.has_fused_primitives() && can_be_optimized) {
                 node.can_be_optimized(true);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -294,7 +294,7 @@ void concat_in_place_optimization::update_in_place_concat_paddings(
         // set dynamic pad dims for shape agnostic kernel
         for (auto& dep_output_layout : preds_layouts) {
             padding::DynamicDimsMask info_dynamic_pad;
-            info_dynamic_pad[concat_axis] = 1;
+            info_dynamic_pad[concat_axis] = true;
             dep_output_layout.data_padding._dynamic_dims_mask = info_dynamic_pad;
         }
         return;
@@ -318,7 +318,7 @@ void concat_in_place_optimization::update_in_place_concat_paddings(
     lower_padd[concat_axis] = concat_out_layout.data_padding._lower_size[concat_axis];
     upper_padd[concat_axis] = concat_out_layout.data_padding._upper_size[concat_axis];
     padding::DynamicDimsMask dyn_pad_dims;
-    dyn_pad_dims[concat_axis] = 1;
+    dyn_pad_dims[concat_axis] = true;
     concat_out_layout.data_padding = padding(lower_padd, upper_padd);
 
     upper_padd[concat_axis] += concat_out_layout.get_dims()[concat_axis];
@@ -663,7 +663,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
     // If it's build-time and node is dynamic, only dynamic padding is set first
     if ((crop_layout.is_dynamic() || input_layout.is_dynamic()) && !is_runtime) {
         padding::DynamicDimsMask info_dynamic_pad;
-        info_dynamic_pad[crop_axis] = 1;
+        info_dynamic_pad[crop_axis] = true;
         crop_layout.data_padding._dynamic_dims_mask = info_dynamic_pad;
         return;
     }
@@ -695,7 +695,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
     // set padding
     if (is_runtime) {
         padding::DynamicDimsMask dyn_pad_sizes;
-        dyn_pad_sizes[crop_axis] = 1;
+        dyn_pad_sizes[crop_axis] = true;
         crop_layout.data_padding = padding(lower_sizes, upper_sizes, dyn_pad_sizes);
     } else {
         crop_layout.data_padding = padding(lower_sizes, upper_sizes);
@@ -711,7 +711,7 @@ bool crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
     // If it's build-time and node is dynamic, only dynamic padding is set first
     if ((crop_layout.is_dynamic() || input_layout.is_dynamic()) && !is_runtime) {
         padding::DynamicDimsMask dyn_pad_sizes;
-        dyn_pad_sizes[crop_axis] = 1;
+        dyn_pad_sizes[crop_axis] = true;
         crop_layout.data_padding._dynamic_dims_mask = dyn_pad_sizes;
 
         if (user_info.first && user_info.first->is_type<reshape>()) {
@@ -750,7 +750,7 @@ bool crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
             }
 
             auto reshape_dyn_pad_mask = padding::DynamicDimsMask();
-            reshape_dyn_pad_mask[reshape_axis] = 1;
+            reshape_dyn_pad_mask[reshape_axis] = true;
             user_info.second.data_padding._dynamic_dims_mask = reshape_dyn_pad_mask;
         }
         return true;
@@ -773,7 +773,7 @@ bool crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
 
     if (is_runtime) {
         padding::DynamicDimsMask dyn_pad_sizes;
-        dyn_pad_sizes[crop_axis] = 1;
+        dyn_pad_sizes[crop_axis] = true;
         crop_layout.data_padding = padding(lower_sizes, upper_sizes, dyn_pad_sizes);
         if (user_info.first) {
             auto reshape_desc = user_info.first->as<reshape>().get_primitive();
@@ -797,7 +797,7 @@ bool crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
                     const auto batch_stride_factor = reshape_ps[0].get_length();
                     reshape_lower_sizes[0] = lower_sizes[0] * batch_stride_factor;
                     reshape_upper_sizes[0] = upper_sizes[0] * batch_stride_factor;
-                    reshape_dyn_pad_mask[0] = 1;
+                    reshape_dyn_pad_mask[0] = true;
                 } else {
                     ov::Dimension::value_type divider = 1;
                     auto reshape_axis = reshape_ps.size();
@@ -822,7 +822,7 @@ bool crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
 
                     reshape_lower_sizes[reshape_axis] = lower_sizes[crop_axis];
                     reshape_upper_sizes[reshape_axis] = upper_sizes[crop_axis];
-                    reshape_dyn_pad_mask[reshape_axis] = 1;
+                    reshape_dyn_pad_mask[reshape_axis] = true;
 
                     if (reshape_lower_sizes[reshape_axis])
                         reshape_lower_sizes[reshape_axis] /= divider;
@@ -851,7 +851,7 @@ bool crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
 
                 reshape_lower_sizes[reshape_axis] = lower_sizes[crop_axis];
                 reshape_upper_sizes[reshape_axis] = upper_sizes[crop_axis];
-                reshape_dyn_pad_mask[reshape_axis] = 1;
+                reshape_dyn_pad_mask[reshape_axis] = true;
 
                 user_info.second.data_padding = padding(reshape_lower_sizes, reshape_upper_sizes, reshape_dyn_pad_mask);
             }
@@ -1019,7 +1019,7 @@ void prepare_buffer_fusing::run(program& p) {
                 // set dynamic pad dims for shape agnostic kernel
                 const auto& desc = node.get_primitive();
                 padding::DynamicDimsMask info_dynamic_pad;
-                info_dynamic_pad[concat_axis] = 1;
+                info_dynamic_pad[concat_axis] = true;
                 kv_out_layout.data_padding._dynamic_dims_mask = info_dynamic_pad;
                 node.set_output_layout(kv_out_layout);
                 node.can_share_buffer(false);
@@ -1036,7 +1036,7 @@ void prepare_buffer_fusing::run(program& p) {
 
                     const auto scales_zp_concat_axis = kv_cache_inst::get_scale_zp_sequence_axis();
                     padding::DynamicDimsMask info_dynamic_pad_scales;
-                    info_dynamic_pad_scales[scales_zp_concat_axis] = 1;
+                    info_dynamic_pad_scales[scales_zp_concat_axis] = true;
                     scales_out_layout.data_padding._dynamic_dims_mask = info_dynamic_pad_scales;
                     node.set_output_layout(scales_out_layout, true, kv_cache_output_idx);
 
@@ -1107,7 +1107,7 @@ void prepare_buffer_fusing::run(program& p) {
             }
 
             auto &input_layout = node.get_input_layout(0);
-            auto &output_layout = node.get_output_layout(0);
+            auto &output_layout = node.get_output_layout(false);
             if (!format::is_simple_data_format(input_layout.format) || input_layout.data_type != output_layout.data_type) {
                 return;
             }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
@@ -23,7 +23,7 @@ void prepare_padding::run(program& p) {
         auto& weight_node = node->get_dependency(1);
         if (weight_node.is_constant()) {
             const size_t alignment = 2;
-            auto weight_layout = weight_node.get_output_layout(0);
+            auto weight_layout = weight_node.get_output_layout(false);
             const auto const_shape = weight_layout.get_partial_shape().to_shape();
             OPENVINO_ASSERT(const_shape.size() > 0, "Data padding for int4 type data with an odd innermost dimension does not support zero dimension.");
             auto inner_most_idx = node->as<fully_connected>().get_primitive()->weights_rank - 1;
@@ -34,8 +34,8 @@ void prepare_padding::run(program& p) {
 
                 if (node->get_preferred_impl_type() == impl_types::onednn &&
                     weight_node.is_type<data>() &&
-                    (weight_node.get_output_layout(0).data_type == cldnn::data_types::u4 ||
-                     weight_node.get_output_layout(0).data_type == cldnn::data_types::i4)) {
+                    (weight_node.get_output_layout(false).data_type == cldnn::data_types::u4 ||
+                     weight_node.get_output_layout(false).data_type == cldnn::data_types::i4)) {
                     auto weight_in_layout  = weight_layout.convert_to_weights_layout(false);
                     auto weight_out_layout = weight_in_layout;
                     weight_out_layout.data_padding = padding::max(weight_out_layout.data_padding, padding({0}, new_paddings));
@@ -52,7 +52,7 @@ void prepare_padding::run(program& p) {
                            node->get_input_layout(0).get_partial_shape()[1].is_static() && // feature dim of input should be static
                            node->as<fully_connected>().get_primitive()->input_size == 2 && // only 2D fc is supported
                            node->as<fully_connected>().get_primitive()->weights_rank == 2 &&
-                           weight_node.get_output_layout(0).data_type == cldnn::data_types::f16) {
+                           weight_node.get_output_layout(false).data_type == cldnn::data_types::f16) {
                     // fully_connected_bf_tiled_opt requires 4-bytes aligned input.
                     auto input0_new_layout = node->get_input_layout(0);
                     input0_new_layout.data_padding = padding::max(input0_new_layout.data_padding, padding({0}, new_paddings));

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -220,7 +220,7 @@ void prepare_primitive_fusing::fuse_swiglu(program &p) {
         if (node->get_dependencies().size() > 1)
             continue;
         if (swiglu_prim->glu_type != ov::op::internal::GLU::GluType::Swish ||
-           !(swiglu_prim->axis == -1 || swiglu_prim->axis == static_cast<int64_t>(node->get_output_layout(0).get_partial_shape().size()) - 1))
+           !(swiglu_prim->axis == -1 || swiglu_prim->axis == static_cast<int64_t>(node->get_output_layout(false).get_partial_shape().size()) - 1))
             continue;
 
         auto& dep_node = node->get_dependency(0);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
@@ -165,7 +165,7 @@ private:
 
         const SliceKernelRefNeededInputs kernel_needed_inputs = SliceKernelRefNeededInputs::Create(arg);
         if (kernel_needed_inputs.IsInputNeededInRuntime(idx)) {
-            const auto layout = inputs[idx].first->get_output_layout(0);
+            const auto layout = inputs[idx].first->get_output_layout(false);
             out_buff_data_type = to_data_type(layout.data_type);
             out_compile_time_buff.clear();
             out_runtime_inputs.push_back(convert_data_tensor(layout));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/slice_scatter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/slice_scatter.cpp
@@ -90,7 +90,7 @@ ParamConfig getParamConfig(const program_node& node, const RuntimeParams& params
     } else if (deps.size() <= kStart) {
         config.compile_time_start.resize(config.input_rank, 0);
     } else {
-        config.start_data_type = deps[kStart].first->get_output_layout(0).data_type;
+        config.start_data_type = deps[kStart].first->get_output_layout(false).data_type;
     }
 
     // Step
@@ -99,7 +99,7 @@ ParamConfig getParamConfig(const program_node& node, const RuntimeParams& params
     } else if (deps.size() <= kStep) {
         config.compile_time_step.resize(config.input_rank, 1);
     } else {
-        config.step_data_type = deps[kStep].first->get_output_layout(0).data_type;
+        config.step_data_type = deps[kStep].first->get_output_layout(false).data_type;
     }
 
     // Axes
@@ -113,7 +113,7 @@ ParamConfig getParamConfig(const program_node& node, const RuntimeParams& params
         config.compile_time_axes.resize(config.input_rank);
         std::iota(config.compile_time_axes.begin(), config.compile_time_axes.end(), 0);
     } else {
-        config.axes_data_type = deps[kAxes].first->get_output_layout(0).data_type;
+        config.axes_data_type = deps[kAxes].first->get_output_layout(false).data_type;
     }
 
     return config;

--- a/src/plugins/intel_gpu/src/graph/include/loop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/loop_inst.h
@@ -178,7 +178,7 @@ public:
 
         memory::ptr get_or_create_sliced_mem(int64_t idx, const layout& mem_layout) const {
             while (sliced_mems.size() <= static_cast<size_t>(idx)) {
-                memory::ptr sliced_mem = engine.allocate_memory(mem_layout, 0);
+                memory::ptr sliced_mem = engine.allocate_memory(mem_layout, false);
                 sliced_mems.push_back(sliced_mem);
             }
             return sliced_mems.at(idx);

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1522,7 +1522,7 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         } else { // gemm
             if (!use_onednn_impls && !allow_new_shape_infer) {
                 // Plain input format is enforced because gemm opt kernels allow only plain formats.
-                expected = format::get_default_format(node.get_output_layout(0).get_rank());
+                expected = format::get_default_format(node.get_output_layout(false).get_rank());
                 node.set_preferred_input_fmt(0, expected);
             }
         }

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -318,7 +318,7 @@ void loop_inst::update_backedge_mapped_memory() {
                             // generally, shouldn't go this way, but...
                             auto output_prim = body_network->get_primitive(back_edge.from);
                             layout output_layout = output_prim->output_memory().get_layout();
-                            backedge_mem = body_network->get_engine().allocate_memory(output_layout, 0);
+                            backedge_mem = body_network->get_engine().allocate_memory(output_layout, false);
                         }
                     } else {
                         auto external_id = output_mapping.front()->external_id;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1045,7 +1045,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
     int32_t tmp_prealloc_count = get_prealloc_iter_num();
     // If we allocated too large memory, reclaim the memory.
     for (size_t i = 0; i < updated_layouts.size(); ++i) {
-        bool reclaim = 0;
+        bool reclaim = false;
         size_t required_buffer_size = 0;
         if (get_node().is_type<kv_cache>() && i != 1) {
             // Relax reclaiming condition for kv cache


### PR DESCRIPTION
Enables the `modernize-use-bool-literals` clang-tidy check for the Intel GPU plugin and fixes the resulting diagnostics by replacing integer literals used in boolean contexts with `true`/`false`. Next check in the incremental clang-tidy rollout for the plugin.
