### PR TITLE
[GPU][CLANG-TIDY] Enable modernize-use-nullptr

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -7,7 +7,8 @@
 
 Checks: >
   -*,
-  modernize-use-override
+  modernize-use-override,
+  modernize-use-nullptr
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -50,7 +50,7 @@ static size_t get_shape_data_size(const layout& l) {
 thread_local size_t program_node::cur_id = 0;
 
 program_node::program_node(std::shared_ptr<primitive> prim, program& prog)
-    : desc(prim), myprog(prog), preferred_input_fmts({}), preferred_output_fmts({}), org_id(prim ? (prim->id) : 0) {
+    : desc(prim), myprog(prog), preferred_input_fmts({}), preferred_output_fmts({}), org_id(prim ? (prim->id) : std::string()) {
     if (prim) {
         num_outputs = prim->num_outputs;
         for (size_t i = 0 ; i < num_outputs; ++i) {

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -401,7 +401,7 @@ device_info init_device_info(const cl::Device& device, const cl::Context& contex
 
 bool does_device_support(int32_t param, const cl::Device& device) {
     cl_device_unified_shared_memory_capabilities_intel capabilities;
-    auto err = clGetDeviceInfo(device.get(), param, sizeof(cl_device_unified_shared_memory_capabilities_intel), &capabilities, NULL);
+    auto err = clGetDeviceInfo(device.get(), param, sizeof(cl_device_unified_shared_memory_capabilities_intel), &capabilities, nullptr);
     if (err) throw std::runtime_error("[CLDNN ERROR]. clGetDeviceInfo error " + std::to_string(err));
 
     return !((capabilities & CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL) == 0u);

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
@@ -177,7 +177,7 @@ std::map<std::string, device::ptr> ocl_device_detector::get_available_devices(vo
 std::vector<device::ptr> ocl_device_detector::create_device_list() const {
     cl_uint num_platforms = 0;
     // Get number of platforms available
-    cl_int error_code = clGetPlatformIDs(0, NULL, &num_platforms);
+    cl_int error_code = clGetPlatformIDs(0, nullptr, &num_platforms);
     if (num_platforms == 0 || error_code == CL_PLATFORM_NOT_FOUND_KHR) {
         return {};
     }
@@ -185,7 +185,7 @@ std::vector<device::ptr> ocl_device_detector::create_device_list() const {
     OPENVINO_ASSERT(error_code == CL_SUCCESS, create_device_error_msg, "[GPU] clGetPlatformIDs error code: ", std::to_string(error_code));
     // Get platform list
     std::vector<cl_platform_id> platform_ids(num_platforms);
-    error_code = clGetPlatformIDs(num_platforms, platform_ids.data(), NULL);
+    error_code = clGetPlatformIDs(num_platforms, platform_ids.data(), nullptr);
     OPENVINO_ASSERT(error_code == CL_SUCCESS, create_device_error_msg, "[GPU] clGetPlatformIDs error code: ", std::to_string(error_code));
 
     std::vector<device::ptr> supported_devices;
@@ -233,12 +233,12 @@ std::vector<device::ptr> ocl_device_detector::create_device_list_from_user_conte
 std::vector<device::ptr> ocl_device_detector::create_device_list_from_user_device(void* user_device) const {
     cl_uint num_platforms = 0;
     // Get number of platforms availible
-    cl_int error_code = clGetPlatformIDs(0, NULL, &num_platforms);
+    cl_int error_code = clGetPlatformIDs(0, nullptr, &num_platforms);
     OPENVINO_ASSERT(error_code == CL_SUCCESS, create_device_error_msg, "[GPU] clGetPlatformIDs error code: ", std::to_string(error_code));
 
     // Get platform list
     std::vector<cl_platform_id> platform_ids(num_platforms);
-    error_code = clGetPlatformIDs(num_platforms, platform_ids.data(), NULL);
+    error_code = clGetPlatformIDs(num_platforms, platform_ids.data(), nullptr);
     OPENVINO_ASSERT(error_code == CL_SUCCESS, create_device_error_msg, "[GPU] clGetPlatformIDs error code: ", std::to_string(error_code));
 
     std::vector<device::ptr> supported_devices;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
@@ -28,9 +28,9 @@
 #endif
 
 // static class memebers - pointers to dynamically obtained OpenCL extension functions
-cl::PFN_clEnqueueAcquireMediaSurfacesINTEL cl::SharedSurfLock::pfn_acquire = NULL;
-cl::PFN_clEnqueueReleaseMediaSurfacesINTEL cl::SharedSurfLock::pfn_release = NULL;
-cl::PFN_clCreateFromMediaSurfaceINTEL cl::ImageVA::pfn_clCreateFromMediaSurfaceINTEL = NULL;
+cl::PFN_clEnqueueAcquireMediaSurfacesINTEL cl::SharedSurfLock::pfn_acquire = nullptr;
+cl::PFN_clEnqueueReleaseMediaSurfacesINTEL cl::SharedSurfLock::pfn_release = nullptr;
+cl::PFN_clCreateFromMediaSurfaceINTEL cl::ImageVA::pfn_clCreateFromMediaSurfaceINTEL = nullptr;
 #ifdef _WIN32
 cl::PFN_clCreateFromD3D11Buffer cl::BufferDX::pfn_clCreateFromD3D11Buffer = NULL;
 #endif

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
@@ -486,27 +486,27 @@ public:
 
     SharedSurfLock(cl_command_queue queue,
         std::vector<cl_mem>& surfaces,
-        cl_int * err = NULL)
+        cl_int * err = nullptr)
         : m_queue(queue), m_surfaces(surfaces), m_errPtr(err) {
-        if (pfn_acquire != NULL && m_surfaces.size()) {
+        if (pfn_acquire != nullptr && m_surfaces.size()) {
             cl_int error = pfn_acquire(m_queue,
                 static_cast<cl_uint>(m_surfaces.size()),
                 m_surfaces.data(),
-                0, NULL, NULL);
+                0, nullptr, nullptr);
 
-            if (error != CL_SUCCESS && m_errPtr != NULL) {
+            if (error != CL_SUCCESS && m_errPtr != nullptr) {
                 *m_errPtr = error;
             }
         }
     }
 
     ~SharedSurfLock() {
-        if (pfn_release != NULL && m_surfaces.size()) {
+        if (pfn_release != nullptr && m_surfaces.size()) {
             cl_int error = pfn_release(m_queue,
                 static_cast<cl_uint>(m_surfaces.size()),
                 m_surfaces.data(),
-                0, NULL, NULL);
-            if (error != CL_SUCCESS && m_errPtr != NULL) {
+                0, nullptr, nullptr);
+            if (error != CL_SUCCESS && m_errPtr != nullptr) {
                 *m_errPtr = error;
             }
         }
@@ -542,7 +542,7 @@ public:
         uint32_t surface,
 #endif
         uint32_t plane,
-        cl_int * err = NULL) {
+        cl_int * err = nullptr) {
         cl_int error;
         object_ = pfn_clCreateFromMediaSurfaceINTEL(
             context(),
@@ -556,7 +556,7 @@ public:
             &error);
 
         detail::errHandler(error);
-        if (err != NULL) {
+        if (err != nullptr) {
             *err = error;
         }
     }
@@ -769,14 +769,14 @@ public:
 #else
         const char* fname = "clGetDeviceIDsFromVA_APIMediaAdapterINTEL";
 #endif
-        if (devices == NULL) {
+        if (devices == nullptr) {
             return detail::errHandler(CL_INVALID_ARG_VALUE, fname);
         }
 
         PFN_clGetDeviceIDsFromMediaAdapterINTEL pfn_clGetDeviceIDsFromMediaAdapterINTEL =
             try_load_entrypoint<PFN_clGetDeviceIDsFromMediaAdapterINTEL>(object_, fname);
 
-        if (NULL == pfn_clGetDeviceIDsFromMediaAdapterINTEL) {
+        if (nullptr == pfn_clGetDeviceIDsFromMediaAdapterINTEL) {
             return CL_INVALID_PLATFORM;
         }
 
@@ -787,7 +787,7 @@ public:
             media_adapter,
             media_adapter_set,
             0,
-            NULL,
+            nullptr,
             &n);
         if (err != CL_SUCCESS && err != CL_DEVICE_NOT_FOUND) {
             return detail::errHandler(err, fname);
@@ -802,7 +802,7 @@ public:
                 media_adapter_set,
                 n,
                 ids.data(),
-                NULL);
+                nullptr);
             if (err != CL_SUCCESS) {
                 return detail::errHandler(err, fname);
             }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -54,7 +54,7 @@ cl_int set_kernel_arg(ocl_kernel_type& kernel, uint32_t idx, uint32_t size) {
         return CL_INVALID_ARG_VALUE;
 
     GPU_DEBUG_TRACE_DETAIL << "kernel: " << kernel.get() << " set arg " << idx << " local memory size : " << size << std::endl;
-    return kernel.setArg(idx, size, NULL);
+    return kernel.setArg(idx, size, nullptr);
 }
 
 cl_int set_kernel_arg(ocl_kernel_type& kernel, uint32_t idx, cldnn::memory::cptr mem) {


### PR DESCRIPTION
Enables the `modernize-use-nullptr` clang-tidy check for the Intel GPU plugin and fixes the resulting diagnostics by replacing `NULL`/`0` used as the null pointer constant with `nullptr`, mostly in the OpenCL runtime wrappers. One diagnostic in `program_node.cpp` was on `org_id(prim ? prim->id : 0)` where `org_id` is a `std::string`; rather than forcing `nullptr` there, the branch is changed to `std::string()` so the string is not constructed from a null pointer. Next check in the incremental clang-tidy rollout for the plugin.
