### PR TITLE
[GPU][CLANG-TIDY] Enable readability-redundant-control-flow

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -7,7 +7,8 @@
 
 Checks: >
   -*,
-  modernize-use-override
+  modernize-use-override,
+  readability-redundant-control-flow
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1522,7 +1522,6 @@ public:
         } else {
             rt_params->use_gqa_kernel = false;
         }
-        return;
     }
 
     // update impl_parameter and rt_parameter

--- a/src/plugins/intel_gpu/src/graph/include/program_helpers.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_helpers.h
@@ -71,7 +71,6 @@ struct program_helpers {
     // this is the termination case for parameter pack recurrence, see overload below for logic
     template <class... T>
     static void do_for_types(program_node&) {
-        return;
     }
 
     // helper function for selecting function basing on the type of the given primitive

--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -204,7 +204,6 @@ public:
             this->set_output_padding(cldnn::padding({static_cast<int32_t>(new_batch_pad), 0, 0, 0}, {0, 0, 0, 0}));
         }
 
-        return;
     }
 
     std::vector<size_t> get_shape_infer_dependencies() const override { return {1}; }

--- a/src/plugins/intel_gpu/src/graph/nodes_ordering.cpp
+++ b/src/plugins/intel_gpu/src/graph/nodes_ordering.cpp
@@ -19,7 +19,6 @@ void program::nodes_ordering::calc_processing_order_visit(program_node* node) {
     node->mark();
     _processing_order.push_front(node);
     processing_order_iterators[node] = _processing_order.begin();
-    return;
 }
 
 // DFS to sort nodes topologically
@@ -32,7 +31,6 @@ void program::nodes_ordering::calc_processing_order(program& p) {
     for (auto& node : _processing_order) {
         node->unmark();
     }
-    return;
 }
 
 /*
@@ -77,7 +75,6 @@ void program::nodes_ordering::calculate_BFS_processing_order() {
             processing_order_iterators[node]--;
         }
     }
-    return;
 }
 
 // verifies if a given node will be processed before all its dependent nodes

--- a/src/plugins/intel_gpu/src/graph/pa_kv_reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/pa_kv_reorder.cpp
@@ -40,7 +40,6 @@ pa_kv_reorder_inst::typed_primitive_inst(network& network, const pa_kv_reorder_n
 void pa_kv_reorder_inst::on_execute() {}
 
 void pa_kv_reorder_inst::update_output_memory() {
-    return;
 }
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2651,7 +2651,6 @@ void primitive_inst::update_weights() {
 
     GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(true);
 
-    return;
 }
 
 static bool user_requesting_mem_reuse_false(const program_node& node) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -424,10 +424,8 @@ struct Params {
     virtual ParamsKey GetParamsKey() const;
 
     virtual void set_dynamic_shape_offsets() {
-        return;
     }
     virtual void set_dynamic_shape_offsets(std::map<size_t, size_t> in_tensor_to_offset_map, std::map<size_t, size_t> out_tensor_to_offset_map) {
-        return;
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_ref.cpp
@@ -43,7 +43,6 @@ static void GetOrderVector(std::string s, std::vector<std::string>* res) {
     }
 
     res->push_back(s.substr(pos_start));
-    return;
 }
 
 static std::string GetReorderedOutputOrder(const permute_params& params, const std::vector<std::string>& permute_out_idx,

--- a/src/plugins/intel_gpu/src/runtime/event.cpp
+++ b/src/plugins/intel_gpu/src/runtime/event.cpp
@@ -18,7 +18,6 @@ void event::wait() {
     // TODO: refactor in context of multiple simultaneous calls (for generic engine)
     wait_impl();
     _set = true;
-    return;
 }
 
 void event::set() {


### PR DESCRIPTION
Enables the `readability-redundant-control-flow` clang-tidy check for the Intel GPU plugin and removes redundant `return;`/`continue;` statements at the end of functions and loops. Next check in the incremental clang-tidy rollout for the plugin.
