### PR TITLE
[GPU] Fix deconvolution shape inference reading a fused bias as the output-shape tensor

### DIFF
--- a/src/plugins/intel_gpu/src/graph/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deconvolution.cpp
@@ -167,6 +167,27 @@ std::vector<layout> deconvolution_inst::calc_output_layouts(deconvolution_node c
     // already swapped when creating constant op. So we need to swap I/O dimensions according to the original
     // dimension order for shape inference.
     auto weights_pshape = weights_layout.get_partial_shape();
+    const auto shape_infer_deps = node.get_shape_infer_dependencies();
+
+    auto infer_output_shapes = [&](auto& op) {
+        if (output_partial_shape.size() != 0) {
+            op.set_output_shape(output_partial_shape.to_shape());
+            input_shapes.push_back(ov::Shape{output_partial_shape.size()});
+            output_shapes = ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end);
+        } else if (!shape_infer_deps.empty() && memory_deps.count(shape_infer_deps.front())) {
+            auto mem = memory_deps.at(shape_infer_deps.front());
+            auto dims = read_vector<int64_t>(mem, impl_param.get_stream());
+            auto dims_shape = ov::Shape{dims.size()};
+            auto const_data =
+                std::unordered_map<size_t, ov::Tensor>{{2, ov::Tensor(ov::element::i64, dims_shape, dims.data())}};
+            input_shapes.push_back(dims_shape);
+            output_shapes =
+                ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end, ov::make_tensor_accessor(const_data));
+        } else {
+            output_shapes = ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end);
+        }
+    };
+
     if (desc->groups > 1) {
         ov::op::v1::GroupConvolutionBackpropData op;
         op.set_strides(strides);
@@ -175,22 +196,7 @@ std::vector<layout> deconvolution_inst::calc_output_layouts(deconvolution_node c
         op.set_auto_pad(ov::op::PadType::EXPLICIT);
         std::swap(weights_pshape[2], weights_pshape[1]);
         input_shapes.push_back(weights_pshape);
-        if (output_partial_shape.size() != 0) {
-            op.set_output_shape(output_partial_shape.to_shape());
-            input_shapes.push_back(ov::Shape{output_partial_shape.size()});
-            output_shapes = ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end);
-        } else if (memory_deps.count(2)) {
-            auto mem = memory_deps.at(2);
-            auto dims = read_vector<int64_t>(mem, impl_param.get_stream());
-            auto dims_shape = ov::Shape{dims.size()};
-            auto const_data =
-                std::unordered_map<size_t, ov::Tensor>{{2, ov::Tensor(ov::element::i64, dims_shape, dims.data())}};
-            input_shapes.push_back(dims_shape);
-            output_shapes =
-                ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end, ov::make_tensor_accessor(const_data));
-        } else {
-            output_shapes = ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end);
-        }
+        infer_output_shapes(op);
     } else {
         ov::op::v1::ConvolutionBackpropData op;
         op.set_strides(strides);
@@ -199,23 +205,7 @@ std::vector<layout> deconvolution_inst::calc_output_layouts(deconvolution_node c
         op.set_auto_pad(ov::op::PadType::EXPLICIT);
         std::swap(weights_pshape[1], weights_pshape[0]);
         input_shapes.push_back(weights_pshape);
-        if (output_partial_shape.size() != 0) {
-            op.set_output_shape(output_partial_shape.to_shape());
-            input_shapes.push_back(ov::Shape{output_partial_shape.size()});
-            output_shapes = ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end);
-        } else if ((desc->output_shape_id.is_valid() || desc->output_partial_shape.size() > 0) && memory_deps.count(2)) {
-            auto mem = memory_deps.at(2);
-            auto dims = read_vector<int64_t>(mem, impl_param.get_stream());
-            auto dims_shape = ov::Shape{dims.size()};
-            auto const_data =
-                std::unordered_map<size_t, ov::Tensor>{{2, ov::Tensor(ov::element::i64, dims_shape, dims.data())}};
-            input_shapes.push_back(dims_shape);
-
-            output_shapes =
-                ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end, ov::make_tensor_accessor(const_data));
-        } else {
-            output_shapes = ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end);
-        }
+        infer_output_shapes(op);
     }
     return {layout{output_shapes[0], output_type, out_fmt.value}};
 }

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -32,7 +32,12 @@ public:
 
     bool bias_term() const { return get_primitive()->bias.is_valid();}
 
-    std::vector<size_t> get_shape_infer_dependencies() const override { return {2}; }
+    std::vector<size_t> get_shape_infer_dependencies() const override {
+        auto prim = get_primitive();
+        if (!prim->output_shape_id.is_valid())
+            return {};
+        return {prim->input.size() + 1 + (prim->bias.is_valid() ? 1 : 0)};
+    }
 
     using parent::get_kernel_impl_params;
     std::unique_ptr<kernel_impl_params> get_kernel_impl_params(const std::vector<layout>& in_layouts, const std::vector<layout>& out_layouts) const override {

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -34,8 +34,6 @@ public:
 
     std::vector<size_t> get_shape_infer_dependencies() const override {
         auto prim = get_primitive();
-        if (!prim->output_shape_id.is_valid())
-            return {};
         return {prim->input.size() + 1 /* weights */ + (prim->bias.is_valid() ? 1 : 0)};
     }
 

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -36,7 +36,7 @@ public:
         auto prim = get_primitive();
         if (!prim->output_shape_id.is_valid())
             return {};
-        return {prim->input.size() + 1 + (prim->bias.is_valid() ? 1 : 0)};
+        return {prim->input.size() + 1 /* weights */ + (prim->bias.is_valid() ? 1 : 0)};
     }
 
     using parent::get_kernel_impl_params;

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -34,6 +34,8 @@ public:
 
     std::vector<size_t> get_shape_infer_dependencies() const override {
         auto prim = get_primitive();
+        if (!prim->output_shape_id.is_valid())
+            return {};
         return {prim->input.size() + 1 /* weights */ + (prim->bias.is_valid() ? 1 : 0)};
     }
 

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -36,7 +36,7 @@ public:
         auto prim = get_primitive();
         if (!prim->output_shape_id.is_valid())
             return {};
-        return {prim->input.size() + 1 /* weights */ + (prim->bias.is_valid() ? 1 : 0)};
+        return {prim->dependencies().size() - 1};
     }
 
     using parent::get_kernel_impl_params;

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1408,8 +1408,7 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         for (size_t i = 0; i < dep_size; i++) {
             auto in_lay_rank = node.get_input_layout(i).get_rank();
             const auto& shape_infer_deps = node.get_shape_infer_dependencies();
-            if (std::find(shape_infer_deps.begin(), shape_infer_deps.end(), i) != shape_infer_deps.end() ||
-                node.is_fused_dep(i)) {
+            if (std::find(shape_infer_deps.begin(), shape_infer_deps.end(), i) != shape_infer_deps.end()) {
                 auto fmt = format::get_default_format(in_lay_rank, false, false);
                 node.set_preferred_input_fmt(i, fmt);
             } else if (in_lay_rank != out_lay_rank) {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1408,7 +1408,11 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         for (size_t i = 0; i < dep_size; i++) {
             auto in_lay_rank = node.get_input_layout(i).get_rank();
             const auto& shape_infer_deps = node.get_shape_infer_dependencies();
-            if (std::find(shape_infer_deps.begin(), shape_infer_deps.end(), i) != shape_infer_deps.end()) {
+            const bool is_shape_infer_input =
+                std::find(shape_infer_deps.begin(), shape_infer_deps.end(), i) != shape_infer_deps.end();
+            const bool needs_plain_input =
+                is_shape_infer_input || (node.is_type<deconvolution>() && node.is_fused_dep(i));
+            if (needs_plain_input) {
                 auto fmt = format::get_default_format(in_lay_rank, false, false);
                 node.set_preferred_input_fmt(i, fmt);
             } else if (in_lay_rank != out_lay_rank) {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1408,11 +1408,8 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         for (size_t i = 0; i < dep_size; i++) {
             auto in_lay_rank = node.get_input_layout(i).get_rank();
             const auto& shape_infer_deps = node.get_shape_infer_dependencies();
-            const bool is_shape_infer_input =
-                std::find(shape_infer_deps.begin(), shape_infer_deps.end(), i) != shape_infer_deps.end();
-            const bool needs_plain_input =
-                is_shape_infer_input || (node.is_type<deconvolution>() && node.is_fused_dep(i));
-            if (needs_plain_input) {
+            if (std::find(shape_infer_deps.begin(), shape_infer_deps.end(), i) != shape_infer_deps.end() ||
+                node.is_fused_dep(i)) {
                 auto fmt = format::get_default_format(in_lay_rank, false, false);
                 node.set_preferred_input_fmt(i, fmt);
             } else if (in_lay_rank != out_lay_rank) {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2910,9 +2910,10 @@ cldnn::network::ptr primitive_inst::get_unfused_subgraph() {
                 GPU_DEBUG_TRACE_DETAIL << "    input of prim " << prim->id << "  - idx" << i << "  " << in << std::endl;
                 if (!has_primitive_id(added_prim_ids, in.pid)) {
                     if (fd.has_outer_dep()) {
-                        if (std::find_if(fd.deps.begin(), fd.deps.end(), [&](const std::pair<cldnn::primitive_id, size_t>& dep_info) {
-                                return dep_info.second == i;
-                            }) == fd.deps.end()) {
+                        auto dep_it = std::find_if(fd.deps.begin(), fd.deps.end(), [&](const std::pair<cldnn::primitive_id, size_t>& dep_info) {
+                            return dep_info.second == i;
+                        });
+                        if (dep_it == fd.deps.end()) {
                             in = get_node().id();
                         } else {
                             auto k = std::distance(fd.deps.begin(), dep_it);

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2910,15 +2910,14 @@ cldnn::network::ptr primitive_inst::get_unfused_subgraph() {
                 GPU_DEBUG_TRACE_DETAIL << "    input of prim " << prim->id << "  - idx" << i << "  " << in << std::endl;
                 if (!has_primitive_id(added_prim_ids, in.pid)) {
                     if (fd.has_outer_dep()) {
-                        size_t dep_id = fd.outer_dep_start_idx;
-                        auto outer_dep_id = get_node().get_dependency(dep_id).id();
-
                         if (std::find_if(fd.deps.begin(), fd.deps.end(), [&](const std::pair<cldnn::primitive_id, size_t>& dep_info) {
-                                return (dep_info.first == outer_dep_id && dep_info.second == i);
+                                return dep_info.second == i;
                             }) == fd.deps.end()) {
                             in = get_node().id();
                         } else {
-                            in = outer_dep_id;
+                            auto k = std::distance(fd.deps.begin(), dep_it);
+                            size_t dep_id = static_cast<size_t>(fd.outer_dep_start_idx) + static_cast<size_t>(k);
+                            in = get_node().get_dependency(dep_id).id();
                         }
                     } else {
                         in = get_node().id();

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/deconvolution_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/deconvolution_si_test.cpp
@@ -31,6 +31,8 @@ struct deconvolution_test_params {
     bool with_output_shape;
     ov::PartialShape output_pshape;
     layout expected_layout;
+    std::vector<int64_t> output_shape_data;
+    bool with_bias;
 };
 
 class deconvolution_si_test : public testing::TestWithParam<deconvolution_test_params> { };
@@ -47,11 +49,32 @@ TEST_P(deconvolution_si_test, shape_infer) {
 
     auto input_prim = std::make_shared<input_layout>("data", input_data_layout);
     auto weight_prim = std::make_shared<input_layout>("weight", weight_layout);
+
+    std::shared_ptr<data> bias_prim;
+    if (p.with_bias) {
+        bias = "bias";
+        const int64_t out_features = static_cast<int64_t>(p.expected_layout.get_partial_shape()[1].get_length());
+        auto bias_layout = layout{ov::PartialShape{1, out_features, 1, 1}, data_types::f32, format::bfyx};
+        auto bias_mem = engine.allocate_memory(bias_layout);
+        set_values<float>(bias_mem, std::vector<float>(bias_layout.count(), 1.0f));
+        bias_prim = std::make_shared<data>(bias, bias_mem);
+    }
+
     auto deconv_prim = std::make_shared<deconvolution>("deconv", input_info("data"), weights, bias, p.groups,
                                                        p.stride, p.pads_begin, p.dilations, p.pads_begin,
                                                        p.pads_end, p.output_padding, false);
     if (p.with_output_shape) {
         deconv_prim->output_partial_shape = p.output_pshape;
+    }
+
+    std::shared_ptr<data> out_shape_prim;
+    if (!p.output_shape_data.empty()) {
+        auto out_shape_layout = layout{ov::PartialShape{static_cast<int64_t>(p.output_shape_data.size())},
+                                       data_types::i64, format::bfyx};
+        auto out_shape_mem = engine.allocate_memory(out_shape_layout);
+        set_values<int64_t>(out_shape_mem, p.output_shape_data);
+        out_shape_prim = std::make_shared<data>("output_shape", out_shape_mem);
+        deconv_prim->output_shape_id = input_info("output_shape");
     }
 
     cldnn::program prog(engine);
@@ -61,6 +84,18 @@ TEST_P(deconvolution_si_test, shape_infer) {
     auto& deconv_node = prog.get_or_create(deconv_prim);
     program_wrapper::add_connection(prog, input_node, deconv_node);
     program_wrapper::add_connection(prog, weight_node, deconv_node);
+    if (p.with_bias) {
+        auto& bias_node = prog.get_or_create(bias_prim);
+        program_wrapper::add_connection(prog, bias_node, deconv_node);
+    }
+    if (!p.output_shape_data.empty()) {
+        auto& out_shape_node = prog.get_or_create(out_shape_prim);
+        program_wrapper::add_connection(prog, out_shape_node, deconv_node);
+
+        auto shape_infer_deps = deconv_node.get_shape_infer_dependencies();
+        ASSERT_EQ(shape_infer_deps.size(), 1u);
+        ASSERT_EQ(shape_infer_deps.front(), p.with_bias ? 3u : 2u);
+    }
 
     auto params = deconv_node.get_kernel_impl_params();
     auto res = deconvolution_inst::calc_output_layouts<ov::PartialShape>(deconv_node, *params);
@@ -149,92 +184,17 @@ INSTANTIATE_TEST_SUITE_P(smoke_with_output_shape, deconvolution_si_test,
         },
     }));
 
-struct deconvolution_output_shape_from_data_params {
-    ov::PartialShape input_shape;
-    ov::PartialShape weight_shape;
-    uint32_t groups;
-    ov::Strides stride;
-    ov::Strides dilations;
-    ov::CoordinateDiff pads_begin;
-    ov::CoordinateDiff pads_end;
-    ov::CoordinateDiff output_padding;
-    std::vector<int64_t> output_shape_data;
-    bool with_bias;
-    layout expected_layout;
-};
-
-class deconvolution_output_shape_from_data_si_test
-    : public testing::TestWithParam<deconvolution_output_shape_from_data_params> { };
-
-TEST_P(deconvolution_output_shape_from_data_si_test, shape_infer) {
-    auto p = GetParam();
-
-    auto& engine = get_test_engine();
-    auto input_data_layout = layout{p.input_shape, data_types::f32, format::bfyx};
-    auto weight_layout = layout{p.weight_shape, data_types::f32, format::bfyx};
-
-    cldnn::program prog(engine);
-
-    auto input_prim = std::make_shared<input_layout>("data", input_data_layout);
-    auto weight_prim = std::make_shared<input_layout>("weight", weight_layout);
-
-    const int64_t out_features = static_cast<int64_t>(p.expected_layout.get_partial_shape()[1].get_length());
-
-    cldnn::primitive_id bias = "";
-    std::shared_ptr<data> bias_prim;
-    if (p.with_bias) {
-        bias = "bias";
-        auto bias_layout = layout{ov::PartialShape{1, out_features, 1, 1}, data_types::f32, format::bfyx};
-        auto bias_mem = engine.allocate_memory(bias_layout);
-        set_values<float>(bias_mem, std::vector<float>(bias_layout.count(), 1.0f));
-        bias_prim = std::make_shared<data>(bias, bias_mem);
-    }
-
-    auto out_shape_layout = layout{ov::PartialShape{static_cast<int64_t>(p.output_shape_data.size())},
-                                   data_types::i64, format::bfyx};
-    auto out_shape_mem = engine.allocate_memory(out_shape_layout);
-    set_values<int64_t>(out_shape_mem, p.output_shape_data);
-    auto out_shape_prim = std::make_shared<data>("output_shape", out_shape_mem);
-
-    auto deconv_prim = std::make_shared<deconvolution>("deconv", input_info("data"), "weight", bias, p.groups,
-                                                       p.stride, p.pads_begin, p.dilations, p.pads_begin,
-                                                       p.pads_end, p.output_padding, false);
-    deconv_prim->output_shape_id = input_info("output_shape");
-
-    auto& input_node = prog.get_or_create(input_prim);
-    auto& weight_node = prog.get_or_create(weight_prim);
-    auto& out_shape_node = prog.get_or_create(out_shape_prim);
-    auto& deconv_node = prog.get_or_create(deconv_prim);
-
-    program_wrapper::add_connection(prog, input_node, deconv_node);
-    program_wrapper::add_connection(prog, weight_node, deconv_node);
-    if (p.with_bias) {
-        auto& bias_node = prog.get_or_create(bias_prim);
-        program_wrapper::add_connection(prog, bias_node, deconv_node);
-    }
-    program_wrapper::add_connection(prog, out_shape_node, deconv_node);
-
-    auto shape_infer_deps = deconv_node.get_shape_infer_dependencies();
-    ASSERT_EQ(shape_infer_deps.size(), 1u);
-    ASSERT_EQ(shape_infer_deps.front(), p.with_bias ? 3u : 2u);
-
-    auto params = deconv_node.get_kernel_impl_params();
-    auto res = deconvolution_inst::calc_output_layouts<ov::PartialShape>(deconv_node, *params);
-
-    ASSERT_EQ(res.size(), 1);
-    ASSERT_EQ(res[0], p.expected_layout);
-}
-
-INSTANTIATE_TEST_SUITE_P(smoke, deconvolution_output_shape_from_data_si_test,
-    testing::ValuesIn(std::vector<deconvolution_output_shape_from_data_params>{
+INSTANTIATE_TEST_SUITE_P(smoke_with_output_shape_from_data, deconvolution_si_test,
+    testing::ValuesIn(std::vector<deconvolution_test_params>{
         // 2d deconv, runtime output shape, no bias (output shape dep at index 2)
         {
             ov::PartialShape{1, 20, 224, 224}, ov::PartialShape{10, 20, 3, 3},
             1, {2, 2}, {1, 1},
             std::vector<ptrdiff_t>{1, 1}, std::vector<ptrdiff_t>{1, 1},
             std::vector<ptrdiff_t>{0, 0},
-            std::vector<int64_t>{500, 500}, false,
-            layout{ov::PartialShape{1, 10, 500, 500}, data_types::f32, format::bfyx}
+            false, {},
+            layout{ov::PartialShape{1, 10, 500, 500}, data_types::f32, format::bfyx},
+            std::vector<int64_t>{500, 500}, false
         },
         // 2d deconv, runtime output shape, with fused bias (output shape dep at index 3)
         {
@@ -242,8 +202,9 @@ INSTANTIATE_TEST_SUITE_P(smoke, deconvolution_output_shape_from_data_si_test,
             1, {2, 2}, {1, 1},
             std::vector<ptrdiff_t>{1, 1}, std::vector<ptrdiff_t>{1, 1},
             std::vector<ptrdiff_t>{0, 0},
-            std::vector<int64_t>{500, 500}, true,
-            layout{ov::PartialShape{1, 10, 500, 500}, data_types::f32, format::bfyx}
+            false, {},
+            layout{ov::PartialShape{1, 10, 500, 500}, data_types::f32, format::bfyx},
+            std::vector<int64_t>{500, 500}, true
         },
         // 2d groupdeconv, runtime output shape, with fused bias (output shape dep at index 3)
         {
@@ -251,8 +212,9 @@ INSTANTIATE_TEST_SUITE_P(smoke, deconvolution_output_shape_from_data_si_test,
             4, {2, 2}, {1, 1},
             std::vector<ptrdiff_t>{1, 1}, std::vector<ptrdiff_t>{1, 1},
             std::vector<ptrdiff_t>{0, 0},
-            std::vector<int64_t>{500, 500}, true,
-            layout{ov::PartialShape{1, 8, 500, 500}, data_types::f32, format::bfyx}
+            false, {},
+            layout{ov::PartialShape{1, 8, 500, 500}, data_types::f32, format::bfyx},
+            std::vector<int64_t>{500, 500}, true
         },
     }));
 

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/deconvolution_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/deconvolution_si_test.cpp
@@ -149,4 +149,111 @@ INSTANTIATE_TEST_SUITE_P(smoke_with_output_shape, deconvolution_si_test,
         },
     }));
 
+struct deconvolution_output_shape_from_data_params {
+    ov::PartialShape input_shape;
+    ov::PartialShape weight_shape;
+    uint32_t groups;
+    ov::Strides stride;
+    ov::Strides dilations;
+    ov::CoordinateDiff pads_begin;
+    ov::CoordinateDiff pads_end;
+    ov::CoordinateDiff output_padding;
+    std::vector<int64_t> output_shape_data;
+    bool with_bias;
+    layout expected_layout;
+};
+
+class deconvolution_output_shape_from_data_si_test
+    : public testing::TestWithParam<deconvolution_output_shape_from_data_params> { };
+
+TEST_P(deconvolution_output_shape_from_data_si_test, shape_infer) {
+    auto p = GetParam();
+
+    auto& engine = get_test_engine();
+    auto input_data_layout = layout{p.input_shape, data_types::f32, format::bfyx};
+    auto weight_layout = layout{p.weight_shape, data_types::f32, format::bfyx};
+
+    cldnn::program prog(engine);
+
+    auto input_prim = std::make_shared<input_layout>("data", input_data_layout);
+    auto weight_prim = std::make_shared<input_layout>("weight", weight_layout);
+
+    const int64_t out_features = static_cast<int64_t>(p.expected_layout.get_partial_shape()[1].get_length());
+
+    cldnn::primitive_id bias = "";
+    std::shared_ptr<data> bias_prim;
+    if (p.with_bias) {
+        bias = "bias";
+        auto bias_layout = layout{ov::PartialShape{1, out_features, 1, 1}, data_types::f32, format::bfyx};
+        auto bias_mem = engine.allocate_memory(bias_layout);
+        set_values<float>(bias_mem, std::vector<float>(bias_layout.count(), 1.0f));
+        bias_prim = std::make_shared<data>(bias, bias_mem);
+    }
+
+    auto out_shape_layout = layout{ov::PartialShape{static_cast<int64_t>(p.output_shape_data.size())},
+                                   data_types::i64, format::bfyx};
+    auto out_shape_mem = engine.allocate_memory(out_shape_layout);
+    set_values<int64_t>(out_shape_mem, p.output_shape_data);
+    auto out_shape_prim = std::make_shared<data>("output_shape", out_shape_mem);
+
+    auto deconv_prim = std::make_shared<deconvolution>("deconv", input_info("data"), "weight", bias, p.groups,
+                                                       p.stride, p.pads_begin, p.dilations, p.pads_begin,
+                                                       p.pads_end, p.output_padding, false);
+    deconv_prim->output_shape_id = input_info("output_shape");
+
+    auto& input_node = prog.get_or_create(input_prim);
+    auto& weight_node = prog.get_or_create(weight_prim);
+    auto& out_shape_node = prog.get_or_create(out_shape_prim);
+    auto& deconv_node = prog.get_or_create(deconv_prim);
+
+    program_wrapper::add_connection(prog, input_node, deconv_node);
+    program_wrapper::add_connection(prog, weight_node, deconv_node);
+    if (p.with_bias) {
+        auto& bias_node = prog.get_or_create(bias_prim);
+        program_wrapper::add_connection(prog, bias_node, deconv_node);
+    }
+    program_wrapper::add_connection(prog, out_shape_node, deconv_node);
+
+    auto shape_infer_deps = deconv_node.get_shape_infer_dependencies();
+    ASSERT_EQ(shape_infer_deps.size(), 1u);
+    ASSERT_EQ(shape_infer_deps.front(), p.with_bias ? 3u : 2u);
+
+    auto params = deconv_node.get_kernel_impl_params();
+    auto res = deconvolution_inst::calc_output_layouts<ov::PartialShape>(deconv_node, *params);
+
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res[0], p.expected_layout);
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke, deconvolution_output_shape_from_data_si_test,
+    testing::ValuesIn(std::vector<deconvolution_output_shape_from_data_params>{
+        // 2d deconv, runtime output shape, no bias (output shape dep at index 2)
+        {
+            ov::PartialShape{1, 20, 224, 224}, ov::PartialShape{10, 20, 3, 3},
+            1, {2, 2}, {1, 1},
+            std::vector<ptrdiff_t>{1, 1}, std::vector<ptrdiff_t>{1, 1},
+            std::vector<ptrdiff_t>{0, 0},
+            std::vector<int64_t>{500, 500}, false,
+            layout{ov::PartialShape{1, 10, 500, 500}, data_types::f32, format::bfyx}
+        },
+        // 2d deconv, runtime output shape, with fused bias (output shape dep at index 3)
+        {
+            ov::PartialShape{1, 20, 224, 224}, ov::PartialShape{10, 20, 3, 3},
+            1, {2, 2}, {1, 1},
+            std::vector<ptrdiff_t>{1, 1}, std::vector<ptrdiff_t>{1, 1},
+            std::vector<ptrdiff_t>{0, 0},
+            std::vector<int64_t>{500, 500}, true,
+            layout{ov::PartialShape{1, 10, 500, 500}, data_types::f32, format::bfyx}
+        },
+        // 2d groupdeconv, runtime output shape, with fused bias (output shape dep at index 3)
+        {
+            ov::PartialShape{1, 20, 224, 224}, ov::PartialShape{4, 2, 5, 3, 3},
+            4, {2, 2}, {1, 1},
+            std::vector<ptrdiff_t>{1, 1}, std::vector<ptrdiff_t>{1, 1},
+            std::vector<ptrdiff_t>{0, 0},
+            std::vector<int64_t>{500, 500}, true,
+            layout{ov::PartialShape{1, 8, 500, 500}, data_types::f32, format::bfyx}
+        },
+    }));
+
 }  // shape_infer_tests


### PR DESCRIPTION
### Details:
On dynamic-shape deconvolutions, shape inference could read a fused bias as if it were the optional output-shape input, failing model compilation with:
```
  Check 'false' failed at .../runtime/memory.hpp:246:
  [GPU] read_vector: attempt to convert floating point memory to non-floating point memory
```

### Root cause:
A deconvolution's dependencies are ordered input(0), weights(1), [bias], [output_shape], so the optional output-shape input sits at index 2 without a bias and index 3 with a bias. Two places hardcoded index 2:
  - `deconvolution_inst::get_shape_infer_dependencies()` returned {2}, so `get_const_memory_deps()` gathered whatever constant data was at index 2 into memory_deps.
  - `deconvolution_inst::calc_output_layouts()` read `memory_deps.at(2)` and passed it to `read_vector<int64_t>()`.

When a bias is present (e.g. a bias fused as a `data` node), index 2 is the bias - not an output-shape tensor. `read_vector<int64_t>` on the bias's f16/f32 memory then trips the assert above.

### Fix:
  - `get_shape_infer_dependencies()` now returns the actual output-shape dependency index `input.size() + 1 /*weights*/ + (bias ? 1 : 0)`.
  - `calc_output_layouts()` no longer re-derives the index: it reads `node.get_shape_infer_dependencies()` and keys the `memory_deps` lookup off `shape_infer_deps.front()`. This keeps the lookup index identical to the index that populated `memory_deps` (both iterate the same list), so the two cannot drift apart, which is the class of bug that caused this. The `const_data` map key stays `2`, since port 2 is always the output-shape port for both `ConvolutionBackpropData` and `GroupConvolutionBackpropData`.
  - The duplicated grouped / non-grouped shape-infer blocks are unified into a single `infer_output_shapes` lambda.