### PR TITLE
[GPU][CLANG-TIDY] Enable readability-container-size-empty

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -7,7 +7,8 @@
 
 Checks: >
   -*,
-  modernize-use-override
+  modernize-use-override,
+  readability-container-size-empty
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/custom_layer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/custom_layer.hpp
@@ -60,7 +60,7 @@ protected:
     CustomLayer() : m_wgDimInputIdx(0) {}
     explicit CustomLayer(const std::string dirname) : m_configDir(dirname), m_wgDimInputIdx(0) {}
 
-    bool Error() const { return m_ErrorMessage.length() > 0; }
+    bool Error() const { return !m_ErrorMessage.empty(); }
     void LoadSingleLayer(const pugi::xml_node& node);
     void ProcessKernelNode(const pugi::xml_node& node);
     void ProcessBuffersNode(const pugi::xml_node& node);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
@@ -125,7 +125,7 @@ struct custom_gpu_primitive : public primitive_base<custom_gpu_primitive> {
           kernel_arguments(kernel_arguments),
           build_options(build_options),
           output_layouts(output_layouts),
-          gws(gws.size() ? gws : std::vector<size_t>{output_layouts[0].count()}),
+          gws(!gws.empty() ? gws : std::vector<size_t>{output_layouts[0].count()}),
           lws(lws),
           kernels_code(kernels_code),
           op(op),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -83,7 +83,7 @@ private:
                                      std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheMap> cache_attr_map = nullptr) {
         const auto& ops = model->get_ops();
 
-        if (cache_attr_map != nullptr && cache_attr_map->size() > 0) {
+        if (cache_attr_map != nullptr && !cache_attr_map->empty()) {
             for (const auto& node : ops) {
                 if (ov::op::util::is_constant(node)) {
                     auto it = cache_attr_map->find(node->get_instance_id());

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
@@ -37,7 +37,7 @@ public:
      * @return std::pair<Key, Value>
      */
     std::pair<Key, Value> get_lru_element() const {
-        if (_lru_data_list.size()) {
+        if (!_lru_data_list.empty()) {
             return _lru_data_list.back();
         } else {
             return std::make_pair(Key(), Value());

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
@@ -581,7 +581,7 @@ public:
         }
 
         assert(my_sizes.size() == adjusted_coords.size());
-        assert(adjusted_coords.size() > 0);
+        assert(!adjusted_coords.empty());
 
         size_t offset = adjusted_coords[0];
         for (size_t i = 1; i < adjusted_coords.size(); i++) {

--- a/src/plugins/intel_gpu/src/graph/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/condition.cpp
@@ -41,7 +41,7 @@ static std::vector<layout> get_output_layouts(std::map<primitive_id, layout>&& o
             }
         }
     }
-    OPENVINO_ASSERT(out_layouts.size() > 0, "Not found any matched output");
+    OPENVINO_ASSERT(!out_layouts.empty(), "Not found any matched output");
     return out_layouts;
 }
 

--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -412,7 +412,7 @@ NodeDebugHelper::NodeDebugHelper(const primitive_inst& inst)
             if (m_inst.is_input()) {
                 // Loading binary dumps for output tensors of input-layers : only one output exists or index(dstN) exists
                 auto dump_file = get_matched_from_filelist(files, "_dst0__");
-                OPENVINO_ASSERT((files.size() == 1 || dump_file.length() != 0), "Unexpected binary dump for input layer");
+                OPENVINO_ASSERT((files.size() == 1 || !dump_file.empty()), "Unexpected binary dump for input layer");
 
                 OPENVINO_ASSERT(files.size() == m_inst.outputs_memory_count(), "Mismatch dump file count");
 
@@ -422,7 +422,7 @@ NodeDebugHelper::NodeDebugHelper(const primitive_inst& inst)
                         std::string pattern = "_dst" + std::to_string(i) + "__";
                         dump_file = get_matched_from_filelist(files, pattern);
                     }
-                    OPENVINO_ASSERT((dump_file.length() > 0), "Could not find expected pattern '_dst[N]__' for binary dump");
+                    OPENVINO_ASSERT((!dump_file.empty()), "Could not find expected pattern '_dst[N]__' for binary dump");
                     GPU_DEBUG_COUT << " Load binary dump : " << dump_file << " for " << layer_name << std::endl;
 
                     std::vector<uint8_t> bin = ov::util::load_binary(dump_file);
@@ -436,11 +436,11 @@ NodeDebugHelper::NodeDebugHelper(const primitive_inst& inst)
                 }
             } else {
                 auto check_dst = get_matched_from_filelist(files, "_dst0__");
-                OPENVINO_ASSERT(check_dst.length() == 0, "Expected to load binaries for inputs of " + layer_name);
+                OPENVINO_ASSERT(check_dst.empty(), "Expected to load binaries for inputs of " + layer_name);
 
                 // Loading input tensors for any layer
                 auto dump_file = get_matched_from_filelist(files, "_src0__");
-                OPENVINO_ASSERT(dump_file.length() != 0, "Could not find expected pattern '_src[N]__' for binary dump input : " + layer_name);
+                OPENVINO_ASSERT(!dump_file.empty(), "Could not find expected pattern '_src[N]__' for binary dump input : " + layer_name);
 
                 for (size_t i = 0; i < m_inst.dependencies().size(); i++) {
                     auto dump_file = files[0];
@@ -448,11 +448,11 @@ NodeDebugHelper::NodeDebugHelper(const primitive_inst& inst)
                         std::string pattern = "_src" + std::to_string(i) + "__";
                         dump_file = get_matched_from_filelist(files, pattern);
                     }
-                    if (dump_file.length() == 0) {
+                    if (dump_file.empty()) {
                         GPU_DEBUG_COUT  << " Skip loading for  input(" << i << ") of " << layer_name << std::endl;
                         continue;
                     }
-                    OPENVINO_ASSERT((dump_file.length() > 0), "Could not find expected pattern '_src[N]__' for binary dump input");
+                    OPENVINO_ASSERT((!dump_file.empty()), "Could not find expected pattern '_src[N]__' for binary dump input");
                     GPU_DEBUG_COUT  << " Load binary dump : " << dump_file << " for input(" << i << ") of " << layer_name << std::endl;
 
                     std::vector<uint8_t> bin = ov::util::load_binary(dump_file);
@@ -472,7 +472,7 @@ NodeDebugHelper::NodeDebugHelper(const primitive_inst& inst)
     }
 
     // Dump input buffers of 'inst'
-    if (config.get_dump_tensors_path().length() > 0) {
+    if (!config.get_dump_tensors_path().empty()) {
         const std::string& layer_name = inst.id();
 
         if (is_target_iteration(m_iter, config.get_dump_iterations()) &&
@@ -554,7 +554,7 @@ NodeDebugHelper::~NodeDebugHelper() {
     }
 
     // Dump output buffers of 'inst'
-    if (config.get_dump_tensors_path().length() > 0) {
+    if (!config.get_dump_tensors_path().empty()) {
         const std::string layer_name = m_inst.id();
 
         if (is_target_iteration(m_iter, config.get_dump_iterations()) &&

--- a/src/plugins/intel_gpu/src/graph/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/dft.cpp
@@ -71,13 +71,13 @@ std::vector<layout> dft_inst::calc_output_layouts(dft_node const& /*node*/, kern
     auto& memory_deps = impl_param.memory_deps;
 
     // Consider axes and signal_size are constant case
-    if ((primitive->axes.size() > 0) &&
-        ((impl_param.input_layouts.size() == 2) || (primitive->signal_size.size() > 0))) {
+    if ((!primitive->axes.empty()) &&
+        ((impl_param.input_layouts.size() == 2) || (!primitive->signal_size.empty()))) {
         auto axes_ptr = reinterpret_cast<uint8_t*>(const_cast<int64_t*>(primitive->axes.data()));
         axes_tensor = ov::Tensor(ov::element::i64, ov::Shape({primitive->axes.size()}), axes_ptr, {});
         const_data.emplace(1, axes_tensor);
 
-        if (primitive->signal_size.size() > 0) {
+        if (!primitive->signal_size.empty()) {
             auto signal_size_ptr = reinterpret_cast<uint8_t*>(const_cast<int64_t*>(primitive->signal_size.data()));
             signal_size_tensor = ov::Tensor(ov::element::i64, ov::Shape({primitive->signal_size.size()}), signal_size_ptr, {});
             const_data.emplace(2, signal_size_tensor);

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -387,7 +387,7 @@ bool fully_connected_inst::can_apply_single_batch_optimization(const kernel_impl
     }
 
     // Don't support swiglu fused
-    if (impl_param.fused_desc.size() > 0) {
+    if (!impl_param.fused_desc.empty()) {
         for (const auto& f : impl_param.fused_desc) {
             if (f.is_type<swiglu>())
                 return false;

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -83,7 +83,7 @@ layout gemm_inst::calc_output_layout(gemm_node const& node, kernel_impl_params c
     size_t ones_to_add = 4 - std::min(output_shape.size(), static_cast<size_t>(4));
     output_shape.insert(output_shape.begin(), ones_to_add, 1);
 
-    if (prim->output_transpose_order.size() > 0)
+    if (!prim->output_transpose_order.empty())
         output_shape = transpose_shape(output_shape, prim->output_transpose_order);
 
     auto output_type = input0_layout.data_type;
@@ -294,7 +294,7 @@ layout gemm_inst::transform_output_layout(const std::shared_ptr<const gemm> prim
         output_pshape[get_spatial_idx(updated_output_layout.format, 0)] = std::move(N);
         output_pshape[get_spatial_idx(updated_output_layout.format, 1)] = std::move(M);
 
-        if (primitive->output_transpose_order.size() > 0) {
+        if (!primitive->output_transpose_order.empty()) {
             output_pshape = transpose_pshape(output_pshape, primitive->output_transpose_order);
         }
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -172,7 +172,7 @@ void add_required_reorders::run(program& p) {
     auto usr_itr = p.get_processing_order().begin();
     while (usr_itr != p.get_processing_order().end()) {
         auto& usr = *usr_itr++;
-        if (usr->get_dependencies().size() == 0)
+        if (usr->get_dependencies().empty())
             continue;  // only nodes with dependencies
         if (usr->is_type<data>())
             continue;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
@@ -172,7 +172,7 @@ void handle_reshape::run(program& p) {
                     }
                 }
 
-                if (reorder_reshape_nodes.size() == 0)
+                if (reorder_reshape_nodes.empty())
                     continue;
 
                 // add new reorder nodes to proper reshape node

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -80,7 +80,7 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
                                          kernel_impl_params& concat_params,
                                          std::vector<kernel_impl_params>& pred_params,
                                          bool is_runtime) {
-    if (concat_node.is_output() || concat_params.fused_desc.size() > 0 || concat_node.is_in_shape_of_subgraph())
+    if (concat_node.is_output() || !concat_params.fused_desc.empty() || concat_node.is_in_shape_of_subgraph())
         return false;
     bool do_runtime_buffer_fusing = true;
     GPU_DEBUG_IF(concat_node.get_config().get_disable_runtime_buffer_fusing()) {
@@ -578,7 +578,7 @@ bool crop_in_place_optimization::match(const program_node& node,
         (!crop_node.get_dependency(1).is_constant() || !crop_node.get_dependency(2).is_constant()))
         return false;
 
-    if (node.get_users().size() > 0) {
+    if (!node.get_users().empty()) {
         GPU_DEBUG_IF(node.get_config().get_disable_runtime_buffer_fusing() && dyn_aware) {
             return false;
         }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
@@ -25,7 +25,7 @@ void prepare_padding::run(program& p) {
             const size_t alignment = 2;
             auto weight_layout = weight_node.get_output_layout(0);
             const auto const_shape = weight_layout.get_partial_shape().to_shape();
-            OPENVINO_ASSERT(const_shape.size() > 0, "Data padding for int4 type data with an odd innermost dimension does not support zero dimension.");
+            OPENVINO_ASSERT(!const_shape.empty(), "Data padding for int4 type data with an odd innermost dimension does not support zero dimension.");
             auto inner_most_idx = node->as<fully_connected>().get_primitive()->weights_rank - 1;
 
             if (const_shape[inner_most_idx] % alignment != 0) {
@@ -121,11 +121,11 @@ void prepare_padding::run(program& p) {
 
                 ov::Dimension::value_type pb_z = std::max<std::ptrdiff_t>(padding_begin.size() >= 3 ? padding_begin[padding_begin.size() - 3] : 0, 0);
                 ov::Dimension::value_type pb_y = std::max<std::ptrdiff_t>(padding_begin.size() >= 2 ? padding_begin[padding_begin.size() - 2] : 0, 0);
-                ov::Dimension::value_type pb_x = std::max<std::ptrdiff_t>(padding_begin.size() >= 1 ? padding_begin[padding_begin.size() - 1] : 0, 0);
+                ov::Dimension::value_type pb_x = std::max<std::ptrdiff_t>(!padding_begin.empty() ? padding_begin[padding_begin.size() - 1] : 0, 0);
 
                 ov::Dimension::value_type pe_z = std::max<std::ptrdiff_t>(padding_end.size() >= 3 ? padding_end[padding_end.size() - 3] : 0, 0);
                 ov::Dimension::value_type pe_y = std::max<std::ptrdiff_t>(padding_end.size() >= 2 ? padding_end[padding_end.size() - 2] : 0, 0);
-                ov::Dimension::value_type pe_x = std::max<std::ptrdiff_t>(padding_end.size() >= 1 ? padding_end[padding_end.size() - 1] : 0, 0);
+                ov::Dimension::value_type pe_x = std::max<std::ptrdiff_t>(!padding_end.empty() ? padding_end[padding_end.size() - 1] : 0, 0);
 
                 const auto& lower_sizes = in_layout.data_padding._lower_size;
                 const auto& upper_sizes = in_layout.data_padding._upper_size;
@@ -292,15 +292,15 @@ cldnn::padding prepare_padding::get_needed_padding_for_convolution(convolution_n
     auto dilation = conv->dilation;
     uint32_t stride_z = stride.size() >= 3 ? static_cast<uint32_t>(stride[stride.size() - 3]) : 1;
     uint32_t stride_y = stride.size() >= 2 ? static_cast<uint32_t>(stride[stride.size() - 2]) : 1;
-    uint32_t stride_x = stride.size() >= 1 ? static_cast<uint32_t>(stride[stride.size() - 1]) : 1;
+    uint32_t stride_x = !stride.empty() ? static_cast<uint32_t>(stride[stride.size() - 1]) : 1;
 
     uint32_t dilation_z = dilation.size() >= 3 ? static_cast<uint32_t>(dilation[dilation.size() - 3]) : 1;
     uint32_t dilation_y = dilation.size() >= 2 ? static_cast<uint32_t>(dilation[dilation.size() - 2]) : 1;
-    uint32_t dilation_x = dilation.size() >= 1 ? static_cast<uint32_t>(dilation[dilation.size() - 1]) : 1;
+    uint32_t dilation_x = !dilation.empty() ? static_cast<uint32_t>(dilation[dilation.size() - 1]) : 1;
 
     ov::Dimension::value_type pad_z = padding_begin.size() >= 3 ? padding_begin[padding_begin.size() - 3] : 0;
     ov::Dimension::value_type pad_y = padding_begin.size() >= 2 ? padding_begin[padding_begin.size() - 2] : 0;
-    ov::Dimension::value_type pad_x = padding_begin.size() >= 1 ? padding_begin[padding_begin.size() - 1] : 0;
+    ov::Dimension::value_type pad_x = !padding_begin.empty() ? padding_begin[padding_begin.size() - 1] : 0;
 
     ov::Dimension::value_type padding_begin_x, padding_begin_y, padding_begin_z;
     ov::Dimension::value_type padding_end_x, padding_end_y, padding_end_z;
@@ -312,7 +312,7 @@ cldnn::padding prepare_padding::get_needed_padding_for_convolution(convolution_n
 
         pad_z = padding_end.size() >= 3 ? padding_end[padding_end.size() - 3] : 0;
         pad_y = padding_end.size() >= 2 ? padding_end[padding_end.size() - 2] : 0;
-        pad_x = padding_end.size() >= 1 ? padding_end[padding_end.size() - 1] : 0;
+        pad_x = !padding_end.empty() ? padding_end[padding_end.size() - 1] : 0;
 
         padding_end_x = std::max<ov::Dimension::value_type>(pad_x, 0);
         padding_end_y = std::max<ov::Dimension::value_type>(pad_y, 0);
@@ -344,7 +344,7 @@ cldnn::padding prepare_padding::get_needed_padding_for_convolution(convolution_n
         needed_padding = padding({0, 0, padding_begin_z, padding_begin_y, padding_begin_x}, {0, 0, padding_end_z, padding_end_y, padding_end_x}, 0);
     else if (padding_begin.size() >= 2)
         needed_padding = padding({0, 0, padding_begin_y, padding_begin_x}, {0, 0, padding_end_y, padding_end_x}, 0);
-    else if (padding_begin.size() >= 1)
+    else if (!padding_begin.empty())
         needed_padding = padding({0, 0, padding_begin_x}, {0, 0, padding_end_x}, 0);
     needed_padding = padding::max(prev_prim_output_layout.data_padding, needed_padding);
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -368,7 +368,7 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
             bias_node.users.push_back(&new_node);
 
             // Remove all edges connected with peer node
-            while (eltw_node.get_dependencies().size() > 0) {
+            while (!eltw_node.get_dependencies().empty()) {
                 auto& dep = eltw_node.get_dependency(eltw_node.get_dependencies().size() - 1);
                 p.remove_connection(dep, eltw_node);
             }
@@ -686,11 +686,11 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
         auto eltwise_supports_fusings = [&](eltwise_node& node) -> bool {
             auto has_reorder_behind_mvn = [&]() -> bool {
                 // MVN with rank size 3 always requires Reorder and Reshape. This pattern always run simple formats(bfyx..).
-                if (node.get_dependencies().size() > 0 && node.get_dependency(0).is_type<reshape>()) {
+                if (!node.get_dependencies().empty() && node.get_dependency(0).is_type<reshape>()) {
                     auto& reshape_node = node.get_dependency(0);
-                    if (reshape_node.get_dependencies().size() > 0 && reshape_node.get_dependency(0).is_type<reorder>()) {
+                    if (!reshape_node.get_dependencies().empty() && reshape_node.get_dependency(0).is_type<reorder>()) {
                         auto& reorder_node = reshape_node.get_dependency(0);
-                        if (reorder_node.get_dependencies().size() > 0 && reorder_node.get_dependency(0).is_type<mvn>()) {
+                        if (!reorder_node.get_dependencies().empty() && reorder_node.get_dependency(0).is_type<mvn>()) {
                             return true;
                         }
                     }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -264,7 +264,7 @@ void prepare_quantization::prepare_scale_shift_opt(program &p, quantize_node& qu
     quantize_inputs.push_back(out_scale_prim->id);
     quantize_inputs.push_back(out_shift_prim->id);
 
-    data_types out_dt = primitive->output_data_types.size() ? primitive->output_data_types[0].value_or(data_types::f32) : data_types::f32;
+    data_types out_dt = !primitive->output_data_types.empty() ? primitive->output_data_types[0].value_or(data_types::f32) : data_types::f32;
     auto new_quantize_prim = std::make_shared<quantize>(quantize_node.id() + "_opt", quantize_inputs, primitive->levels, out_dt);
     new_quantize_prim->origin_op_name = primitive->origin_op_name;
     new_quantize_prim->origin_op_type_name = primitive->origin_op_type_name;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -235,7 +235,7 @@ void remove_redundant_reorders::run(program& p) {
             r_node.is_output() ||
             r_node.has_mean() ||
             r_node.get_users().size() > 1 ||
-            r_node.get_primitive()->subtract_per_feature.size() ||
+            !r_node.get_primitive()->subtract_per_feature.empty() ||
             r_node.has_fused_primitives())
             continue;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -916,7 +916,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
                         continue;
 
                     auto data_shape = data_layout.get_shape();
-                    if (data_shape.size() && shape_size(data_shape) == 1ul)
+                    if (!data_shape.empty() && shape_size(data_shape) == 1ul)
                         continue;
 
                     static size_t idx = 0;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/skipped_branch_memory_dependencies.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/skipped_branch_memory_dependencies.cpp
@@ -21,7 +21,7 @@ void skipped_branch_memory_dependencies::run(program& p) {
         auto itrA = ++itrB;
         if (!nodeB->may_use_mempool())
             continue;
-        if (nodeB->get_users().size() == 0)
+        if (nodeB->get_users().empty())
             continue;
 
         // find the last user of B in processing order

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention.cpp
@@ -151,9 +151,9 @@ public:
         m_xattn_meta.clear();
         m_xattn_find_wg_map.clear();
         m_xattn_post_wg_map.clear();
-        m_xattn_meta.reserve((subsequence_begins.size() > 0 ? (subsequence_begins.size() - 1) : 0) * XATTN_META_STRIDE);
-        m_xattn_find_wg_map.reserve((subsequence_begins.size() > 0 ? (subsequence_begins.size() - 1) : 0) * 2);
-        m_xattn_post_wg_map.reserve((subsequence_begins.size() > 0 ? (subsequence_begins.size() - 1) : 0) * 2);
+        m_xattn_meta.reserve((!subsequence_begins.empty() ? (subsequence_begins.size() - 1) : 0) * XATTN_META_STRIDE);
+        m_xattn_find_wg_map.reserve((!subsequence_begins.empty() ? (subsequence_begins.size() - 1) : 0) * 2);
+        m_xattn_post_wg_map.reserve((!subsequence_begins.empty() ? (subsequence_begins.size() - 1) : 0) * 2);
 
         auto to_i32_checked = [](size_t value, const char* field_name) {
             OPENVINO_ASSERT(value <= static_cast<size_t>(std::numeric_limits<int32_t>::max()),

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
@@ -221,7 +221,7 @@ public:
         if (top_k != -1)
             if (scoreIndexPairs.size() > static_cast<size_t>(top_k))
                 scoreIndexPairs.resize(top_k);
-        while (scoreIndexPairs.size() != 0) {
+        while (!scoreIndexPairs.empty()) {
             const int cls = scoreIndexPairs.front().second.first;
             const int prior = scoreIndexPairs.front().second.second;
             std::vector<int>& currInd = indices[cls];

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
@@ -58,7 +58,7 @@ struct read_value_impl : public typed_primitive_impl<read_value> {
                 " read_value output layout: ", instance.get_output_layout().to_short_string());
 
         if (!variable.is_set()) {
-            if (instance.get_impl_params()->input_layouts.size() > 0) {
+            if (!instance.get_impl_params()->input_layouts.empty()) {
                 const auto copy_size = instance.get_impl_params()->get_input_layout(0).bytes_count();
                 variable.get_memory()->copy_from(stream, instance.dep_memory(0), 0, 0, copy_size, true);
             } else {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -33,7 +33,7 @@ struct activation_impl : typed_primitive_impl_ocl<activation> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -47,7 +47,7 @@ struct arg_max_min_impl : typed_primitive_impl_ocl<arg_max_min> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
@@ -124,7 +124,7 @@ struct border_impl : typed_primitive_impl_ocl<border> {
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
         ib >> zero_input;
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -25,7 +25,7 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
@@ -55,7 +55,7 @@ struct concatenation_impl : typed_primitive_impl_ocl<concatenation> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
@@ -27,7 +27,7 @@ struct crop_impl : typed_primitive_impl_ocl<crop> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
@@ -58,7 +58,7 @@ struct cum_sum_impl : typed_primitive_impl_ocl<cum_sum> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
@@ -26,7 +26,7 @@ struct dynamic_quantize_impl : typed_primitive_impl_ocl<dynamic_quantize> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -25,7 +25,7 @@ struct eltwise_impl : typed_primitive_impl_ocl<eltwise> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -50,7 +50,7 @@ struct fully_connected_impl : typed_primitive_impl_ocl<fully_connected> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);
@@ -152,7 +152,7 @@ public:
         bool allow_new_shape_infer = impl_param.get_program().is_new_shape_infer();
         auto updated_impl_param = impl_param;
         bool swiglu_fused = false;
-        if (updated_impl_param.fused_desc.size() > 0) {
+        if (!updated_impl_param.fused_desc.empty()) {
             for (const auto& f : updated_impl_param.fused_desc) {
                 if (f.is_type<swiglu>())
                     swiglu_fused = true;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -70,7 +70,7 @@ struct gather_impl : typed_primitive_impl_ocl<gather> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
@@ -56,7 +56,7 @@ struct gather_elements_impl : typed_primitive_impl_ocl<gather_elements> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
@@ -26,7 +26,7 @@ struct gather_nd_impl : typed_primitive_impl_ocl<gather_nd> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
@@ -317,7 +317,7 @@ void kernels_cache::build_batch(const batch_program& batch, compiled_kernels& co
     } else {
         auto combined_source = join_strings(batch.source);
         _builder->build_kernels(combined_source.data(), combined_source.size(), KernelFormat::SOURCE, batch.options, kernels);
-        OPENVINO_ASSERT(kernels.size() > 0, "[GPU] Expected to compile more than 0 kernels in the batch");
+        OPENVINO_ASSERT(!kernels.empty(), "[GPU] Expected to compile more than 0 kernels in the batch");
         OPENVINO_ASSERT(kernels.size() == batch.kernels_counter, "[GPU] Number of compiled kernels is different than kernel batch size");
         if (dump_sources && dump_file.good()) {
             dump_file << "\n/* Build Log:\n";
@@ -387,7 +387,7 @@ std::vector<kernel::ptr> kernels_cache::get_kernels(const kernel_impl_params& pa
     }
     auto res = _kernels.find(params);
     OPENVINO_ASSERT(_kernels.end() != res, "Kernel for {" + current_node_id + "} is not found in the kernel cache!");
-    OPENVINO_ASSERT(res->second.size() != 0, "Number of kernels should not be zero for " + current_node_id);
+    OPENVINO_ASSERT(!res->second.empty(), "Number of kernels should not be zero for " + current_node_id);
 
     std::vector<kernel::ptr> kernels(res->second.size());
     for (auto& k : res->second) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
@@ -25,7 +25,7 @@ struct mvn_impl : typed_primitive_impl_ocl<mvn> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -27,7 +27,7 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);
@@ -72,7 +72,7 @@ struct gather_nonzero_impl : typed_primitive_impl_ocl<gather_nonzero> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
@@ -52,7 +52,7 @@ struct permute_impl : typed_primitive_impl_ocl<permute> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
@@ -135,22 +135,22 @@ public:
 
         uint32_t kernel_z = kernel.size() >= 3 ? static_cast<uint32_t>(kernel[kernel.size() - 3]) : 1;
         uint32_t kernel_y = kernel.size() >= 2 ? static_cast<uint32_t>(kernel[kernel.size() - 2]) : 1;
-        uint32_t kernel_x = kernel.size() >= 1 ? static_cast<uint32_t>(kernel[kernel.size() - 1]) : 1;
+        uint32_t kernel_x = !kernel.empty() ? static_cast<uint32_t>(kernel[kernel.size() - 1]) : 1;
         pp.poolSize = {kernel_x, kernel_y, kernel_z};
 
         uint32_t pad_z = static_cast<uint32_t>(std::max<std::ptrdiff_t>(pads_begin.size() >= 3 ? pads_begin[pads_begin.size() - 3] : 0, 0));
         uint32_t pad_y = static_cast<uint32_t>(std::max<std::ptrdiff_t>(pads_begin.size() >= 2 ? pads_begin[pads_begin.size() - 2] : 0, 0));
-        uint32_t pad_x = static_cast<uint32_t>(std::max<std::ptrdiff_t>(pads_begin.size() >= 1 ? pads_begin[pads_begin.size() - 1] : 0, 0));
+        uint32_t pad_x = static_cast<uint32_t>(std::max<std::ptrdiff_t>(!pads_begin.empty() ? pads_begin[pads_begin.size() - 1] : 0, 0));
         pp.poolPad  = {pad_x, pad_y, pad_z};
 
         uint32_t stride_z = stride.size() >= 3 ? static_cast<uint32_t>(stride[stride.size() - 3]) : 1;
         uint32_t stride_y = stride.size() >= 2 ? static_cast<uint32_t>(stride[stride.size() - 2]) : 1;
-        uint32_t stride_x = stride.size() >= 1 ? static_cast<uint32_t>(stride[stride.size() - 1]) : 1;
+        uint32_t stride_x = !stride.empty() ? static_cast<uint32_t>(stride[stride.size() - 1]) : 1;
         pp.poolStride = {stride_x, stride_y, stride_z};
 
         uint32_t dilation_z = dilation.size() >= 3 ? static_cast<uint32_t>(dilation[dilation.size() - 3]) : 1;
         uint32_t dilation_y = dilation.size() >= 2 ? static_cast<uint32_t>(dilation[dilation.size() - 2]) : 1;
-        uint32_t dilation_x = dilation.size() >= 1 ? static_cast<uint32_t>(dilation[dilation.size() - 1]) : 1;
+        uint32_t dilation_x = !dilation.empty() ? static_cast<uint32_t>(dilation[dilation.size() - 1]) : 1;
         pp.poolDilation = {dilation_x, dilation_y, dilation_z};
 
         return params;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -277,7 +277,7 @@ protected:
             kernel_dump_info.add_entry_point(_kernels[kd_idx]->get_id());
         }
 
-        if ((all_events.size() == 0) && (tmp_events.size() > 0))
+        if ((all_events.empty()) && (!tmp_events.empty()))
             return stream.aggregate_events(tmp_events);
 
         bool group_events = (all_events.size() > 1);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
@@ -25,7 +25,7 @@ struct quantize_impl : typed_primitive_impl_ocl<quantize> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
@@ -25,7 +25,7 @@ struct random_uniform_impl : typed_primitive_impl_ocl<random_uniform> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
@@ -25,7 +25,7 @@ struct range_impl : typed_primitive_impl_ocl<range> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -27,7 +27,7 @@ struct reorder_impl : typed_primitive_impl_ocl<reorder> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rms.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rms.cpp
@@ -25,7 +25,7 @@ struct rms_impl : typed_primitive_impl_ocl<rms> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
@@ -73,7 +73,7 @@ struct scatter_elements_update_impl : typed_primitive_impl_ocl<scatter_elements_
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
@@ -51,7 +51,7 @@ struct scatter_update_impl : typed_primitive_impl_ocl<scatter_update> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
@@ -25,7 +25,7 @@ struct select_impl : typed_primitive_impl_ocl<select> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
@@ -64,7 +64,7 @@ struct slice_impl : typed_primitive_impl_ocl<slice> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -48,7 +48,7 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -80,7 +80,7 @@ struct strided_slice_impl : typed_primitive_impl_ocl<strided_slice> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
@@ -25,7 +25,7 @@ struct swiglu_impl : typed_primitive_impl_ocl<swiglu> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
@@ -25,7 +25,7 @@ struct tile_impl : typed_primitive_impl_ocl<tile> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/unique.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/unique.cpp
@@ -24,7 +24,7 @@ struct unique_count_impl : typed_primitive_impl_ocl<unique_count> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);
@@ -106,7 +106,7 @@ struct unique_gather_impl : typed_primitive_impl_ocl<unique_gather> {
 
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
-        if (is_dynamic() && _kernel_data.kernelName.length() != 0) {
+        if (is_dynamic() && !_kernel_data.kernelName.empty()) {
             auto& kernel_selector = kernel_selector_t::Instance();
             auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
             kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1378,9 +1378,9 @@ public:
 #ifdef ENABLE_ONEDNN_FOR_GPU
     bool valid_micro_stage(const PagedAttentionStage& stage) const {
         if (stage == PagedAttentionStage::PREFILL)
-            return pa_sdpa_micro->kd.micro_kernels.size() > 0;
+            return !pa_sdpa_micro->kd.micro_kernels.empty();
         else if (stage == PagedAttentionStage::MIXED)
-            return pa_sdpa_micro_mixed->kd.micro_kernels.size() > 0;
+            return !pa_sdpa_micro_mixed->kd.micro_kernels.empty();
         return false;
     }
 
@@ -1447,7 +1447,7 @@ public:
     }
 
     static size_t get_micro_tile_qsize(KernelData& kernel_data) {
-        OPENVINO_ASSERT(kernel_data.micro_kernels.size() > 0, "[GPU] Invalid kernels passed to get_tile_qsize() function");
+        OPENVINO_ASSERT(!kernel_data.micro_kernels.empty(), "[GPU] Invalid kernels passed to get_tile_qsize() function");
 
         const auto& gemms = kernel_data.micro_kernels;
         const auto wg_tile_q = gemms[0]->p.getSetting("wg_tile_n");

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1475,7 +1475,7 @@ DispatchDataFunc SDPAMicroGenerator::get_dispatch_data_func() const {
 }
 
 size_t SDPAMicroGenerator::get_tile_qsize(const KernelData& kernel_data) {
-    OPENVINO_ASSERT(kernel_data.micro_kernels.size() > 0, "[GPU] Invalid kernels passed to get_tile_qsize() function");
+    OPENVINO_ASSERT(!kernel_data.micro_kernels.empty(), "[GPU] Invalid kernels passed to get_tile_qsize() function");
 
     const auto& gemms = kernel_data.micro_kernels;
     const auto wg_tile_q = gemms[kq_id]->p.getSetting("wg_tile_n");

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -265,7 +265,7 @@ struct typed_primitive_onednn_impl : public typed_primitive_impl<PType> {
                         dnnl::algorithm aalgorithm = dnnl::algorithm::undef;
                         ib >> make_data(&aalgorithm, sizeof(dnnl::algorithm));
 
-                        if (fused_desc.at(idx).dims.size() > 0) {
+                        if (!fused_desc.at(idx).dims.empty()) {
                             _post_ops.append_binary(aalgorithm,
                                 dnnl::memory::desc(fused_desc.at(idx).dims, fused_desc.at(idx).dt, fused_desc.at(idx).tag));
                         } else {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
@@ -102,7 +102,7 @@ public:
         ib >> prim_cache;
 
         _scratchpad_md = _pd.scratchpad_desc();
-        if (prim_cache.size() > 0)
+        if (!prim_cache.empty())
             _prim = dnnl::reorder(_pd, prim_cache);
         else
             _prim = dnnl::reorder(_pd);

--- a/src/plugins/intel_gpu/src/graph/include/kv_cache_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/kv_cache_inst.h
@@ -84,7 +84,7 @@ public:
         const int64_t sequence_element_size = total_elements / concat_axis_size;
         const int64_t max_sequence_elements = buffer_size / sequence_element_size;
         auto max_pad = std::max<int64_t>(max_sequence_elements - concat_axis_size, 0);
-        auto target_layout_name = (target_name != "") ? target_name : "target_layout";
+        auto target_layout_name = (!target_name.empty()) ? target_name : "target_layout";
         GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] " << target_name  << " : " << target_layout.to_string() << std::endl;
         GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] buffer size " << buffer_size << std::endl;
         GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] total_elements " << total_elements << std::endl;

--- a/src/plugins/intel_gpu/src/graph/include/resample_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/resample_inst.h
@@ -24,7 +24,7 @@ public:
 
     std::vector<size_t> get_shape_infer_dependencies() const override {
         // if vector of sizes or scales exists, resample in CreateInterpolateOp generates no dependency for inputs of sizes and scales
-        if (typed_desc()->sizes.size() != 0 && typed_desc()->scales.size() != 0) {
+        if (!typed_desc()->sizes.empty() && !typed_desc()->scales.empty()) {
             return {};
         } else {
             return {1, 2};

--- a/src/plugins/intel_gpu/src/graph/include/sliding_window_utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/sliding_window_utils.hpp
@@ -101,15 +101,15 @@ inline tensor calc_sliding_window_output_range<swor_mode::all>(const tensor& inp
     auto off_factor = sym_pad ? -2 : -1;
     auto stride_z = stride.size() >= 3 ? stride[stride.size() - 3] : 1;
     auto stride_y = stride.size() >= 2 ? stride[stride.size() - 2] : 1;
-    auto stride_x = stride.size() >= 1 ? stride[stride.size() - 1] : 1;
+    auto stride_x = !stride.empty() ? stride[stride.size() - 1] : 1;
 
     tensor::value_type dilation_z = dilation.size() >= 3 ? static_cast<int32_t>(dilation[dilation.size() - 3]) : 1;
     tensor::value_type dilation_y = dilation.size() >= 2 ? static_cast<int32_t>(dilation[dilation.size() - 2]) : 1;
-    tensor::value_type dilation_x = dilation.size() >= 1 ? static_cast<int32_t>(dilation[dilation.size() - 1]) : 1;
+    tensor::value_type dilation_x = !dilation.empty() ? static_cast<int32_t>(dilation[dilation.size() - 1]) : 1;
 
     auto pad_z = pad.size() >= 3 ? pad[pad.size() - 3] : 0;
     auto pad_y = pad.size() >= 2 ? pad[pad.size() - 2] : 0;
-    auto pad_x = pad.size() >= 1 ? pad[pad.size() - 1] : 0;
+    auto pad_x = !pad.empty() ? pad[pad.size() - 1] : 0;
 
     tensor wnd_ext_size{0,
                         0,
@@ -158,15 +158,15 @@ inline tensor calc_sliding_window_output_range<swor_mode::exceed_once>(const ten
     int64_t off_factor = sym_pad ? -2 : -1;
     int64_t stride_z = stride.size() >= 3 ? stride[stride.size() - 3] : 1;
     int64_t stride_y = stride.size() >= 2 ? stride[stride.size() - 2] : 1;
-    int64_t stride_x = stride.size() >= 1 ? stride[stride.size() - 1] : 1;
+    int64_t stride_x = !stride.empty() ? stride[stride.size() - 1] : 1;
 
     tensor::value_type dilation_z = dilation.size() >= 3 ? static_cast<int32_t>(dilation[dilation.size() - 3]) : 1;
     tensor::value_type dilation_y = dilation.size() >= 2 ? static_cast<int32_t>(dilation[dilation.size() - 2]) : 1;
-    tensor::value_type dilation_x = dilation.size() >= 1 ? static_cast<int32_t>(dilation[dilation.size() - 1]) : 1;
+    tensor::value_type dilation_x = !dilation.empty() ? static_cast<int32_t>(dilation[dilation.size() - 1]) : 1;
 
     int64_t pad_z = pad.size() >= 3 ? pad[pad.size() - 3] : 0;
     int64_t pad_y = pad.size() >= 2 ? pad[pad.size() - 2] : 0;
-    int64_t pad_x = pad.size() >= 1 ? pad[pad.size() - 1] : 0;
+    int64_t pad_x = !pad.empty() ? pad[pad.size() - 1] : 0;
 
     tensor extend{0,
                   0,
@@ -223,11 +223,11 @@ inline tensor calc_sliding_window_output_range<swor_mode::any>(const tensor& inp
 
     auto stride_z = stride.size() >= 3 ? stride[stride.size() - 3] : 1;
     auto stride_y = stride.size() >= 2 ? stride[stride.size() - 2] : 1;
-    auto stride_x = stride.size() >= 1 ? stride[stride.size() - 1] : 1;
+    auto stride_x = !stride.empty() ? stride[stride.size() - 1] : 1;
 
     auto pad_z = pad.size() >= 3 ? pad[pad.size() - 3] : 0;
     auto pad_y = pad.size() >= 2 ? pad[pad.size() - 2] : 0;
-    auto pad_x = pad.size() >= 1 ? pad[pad.size() - 1] : 0;
+    auto pad_x = !pad.empty() ? pad[pad.size() - 1] : 0;
 
     auto off_factor = sym_pad ? -2 : -1;
 
@@ -344,15 +344,15 @@ inline tensor calc_sliding_window_needed_input_range(const tensor& output_size,
     auto off_factor = sym_pad ? -2 : -1;
     auto stride_z = stride.size() >= 3 ? stride[stride.size() - 3] : 1;
     auto stride_y = stride.size() >= 2 ? stride[stride.size() - 2] : 1;
-    auto stride_x = stride.size() >= 1 ? stride[stride.size() - 1] : 1;
+    auto stride_x = !stride.empty() ? stride[stride.size() - 1] : 1;
 
     tensor::value_type dilation_z = dilation.size() >= 3 ? static_cast<int32_t>(dilation[dilation.size() - 3]) : 1;
     tensor::value_type dilation_y = dilation.size() >= 2 ? static_cast<int32_t>(dilation[dilation.size() - 2]) : 1;
-    tensor::value_type dilation_x = dilation.size() >= 1 ? static_cast<int32_t>(dilation[dilation.size() - 1]) : 1;
+    tensor::value_type dilation_x = !dilation.empty() ? static_cast<int32_t>(dilation[dilation.size() - 1]) : 1;
 
     auto pad_z = pad.size() >= 3 ? pad[pad.size() - 3] : 0;
     auto pad_y = pad.size() >= 2 ? pad[pad.size() - 2] : 0;
-    auto pad_x = pad.size() >= 1 ? pad[pad.size() - 1] : 0;
+    auto pad_x = !pad.empty() ? pad[pad.size() - 1] : 0;
 
     tensor wnd_ext_size{0,
                         0,

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1017,7 +1017,7 @@ bool layout_optimizer::is_mixed_layout(program_node& prev, program_node& next, b
         { format::bs_fs_zyx_bsv32_fsv32, format::bs_fs_zyx_bsv16_fsv16 },
     };
 
-    auto& check_list = custom_list.size() > 0 ? custom_list : supported_list;
+    auto& check_list = !custom_list.empty() ? custom_list : supported_list;
 
     for (auto& pair : check_list) {
         if ((prev_fmt == pair.first && next_fmt == pair.second) &&
@@ -1294,7 +1294,7 @@ format layout_optimizer::get_expected_format(quantize_node const& node) {
     auto expected = format::any;
 
     std::function<bool(const program_node& node)> only_gemm_users = [&](const program_node& node) {
-        bool all_users_gemm = (node.get_users().size() != 0);
+        bool all_users_gemm = (!node.get_users().empty());
 
         for (auto user : node.get_users()) {
             if (user->is_type<reorder>() || user->is_type<reshape>())
@@ -1313,7 +1313,7 @@ format layout_optimizer::get_expected_format(quantize_node const& node) {
     if (use_onednn_impls) {
         expected = format::any;
         auto& users = node.get_users();
-        if (users.size() != 0) {
+        if (!users.empty()) {
             auto& user = users.front();
             if (user != nullptr && user->get_preferred_input_fmt(user->get_dependency_index(node)) != format::any) {
                 expected = user->get_preferred_input_fmt(user->get_dependency_index(node));

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -203,7 +203,7 @@ static void validate_mappings(loop_node const & node) {
         }
         const auto results = find_io_primitive_maps(node.get_input_primitive_maps(),
                                                     node.get_output_primitive_maps(), id, true);
-        OPENVINO_ASSERT(results.size() > 0, node.id(), " : outer input '", id, "' does not have primitive map");
+        OPENVINO_ASSERT(!results.empty(), node.id(), " : outer input '", id, "' does not have primitive map");
     }
 
     // check all io_primitive_maps have their corresponding external id
@@ -456,7 +456,7 @@ void loop_inst::preprocess_input_memory(const int64_t num_iterations) {
         const primitive_id& input_external_id = dependencies().at(memory_num).first->id();
         auto input_map_ptrs = find_io_primitive_maps(_input_primitive_maps,
                                                     _output_primitive_maps, input_external_id, true);
-        if (input_map_ptrs.size() == 0) {
+        if (input_map_ptrs.empty()) {
             OPENVINO_ASSERT((input_external_id == _trip_count_id
                                 || input_external_id == _num_iterations_id
                                 || input_external_id == _initial_execution_id),

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -125,7 +125,7 @@ void dump_perf_data_raw(std::string dump_path, bool per_iter_mode, const std::li
                 std::string stage_suffix = "";
                 if (key.cache_hit)
                     stage_suffix += " (cache_hit) ";
-                if (key.memalloc_info != "")
+                if (!key.memalloc_info.empty())
                     stage_suffix += " (" + key.memalloc_info + ") ";
                 of << prim_id << ","
                 << inst->desc()->type_string() << ","

--- a/src/plugins/intel_gpu/src/graph/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/permute.cpp
@@ -146,7 +146,7 @@ void permute_inst::update_output_memory() {
     if (input_memory_ptr() == nullptr)
         return;
 
-    if (_outputs.size() > 0 && static_cast<bool>(_outputs[0])
+    if (!_outputs.empty() && static_cast<bool>(_outputs[0])
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;
 

--- a/src/plugins/intel_gpu/src/graph/pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/pooling.cpp
@@ -48,11 +48,11 @@ layout pooling_inst::calc_output_layout(parent::typed_node const& node, kernel_i
 
     auto stride_z = stride.size() >= 3 ? stride[stride.size() - 3] : 1;
     auto stride_y = stride.size() >= 2 ? stride[stride.size() - 2] : 1;
-    auto stride_x = stride.size() >= 1 ? stride[stride.size() - 1] : 1;
+    auto stride_x = !stride.empty() ? stride[stride.size() - 1] : 1;
 
     auto kernel_z = window_size.size() >= 3 ? window_size[window_size.size() - 3] : 1;
     auto kernel_y = window_size.size() >= 2 ? window_size[window_size.size() - 2] : 1;
-    auto kernel_x = window_size.size() >= 1 ? window_size[window_size.size() - 1] : 1;
+    auto kernel_x = !window_size.empty() ? window_size[window_size.size() - 1] : 1;
 
     // TODO: Consider moving general parameter verification to arguments constructor.
     CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -578,7 +578,7 @@ kernel_impl_params primitive_inst::get_fake_aligned_params_if_possible(program_n
     if ((dev_info.supports_immad && dev_info.dev_type == device_type::integrated_gpu) || dev_info.gfx_ver.major >= 20) {
         // Check whether the input node has enough space for output data. Otherwise, fake alignment is not possible due to page fault
         // i.e. predecessor node was supposed be increased already
-        if (get_node().is_type<fully_connected>() && dependencies().size() > 0 && dep_memory(0).get_layout().is_static()
+        if (get_node().is_type<fully_connected>() && !dependencies().empty() && dep_memory(0).get_layout().is_static()
             && dep_memory(0).count() < updated_params.input_layouts[0].count()) {
             GPU_DEBUG_TRACE_DETAIL << "Roll back fake_aligned params for " << id()
                 << "  allocated: " << dep_memory(0).count()
@@ -1480,7 +1480,7 @@ void primitive_inst::do_runtime_skip_reorder() {
     if (can_be_optimized())
         return;
 
-    if (_impl_params->fused_desc.size() > 0)
+    if (!_impl_params->fused_desc.empty())
         return;
 
     // set successive reorder can_be_optimized if layouts are same
@@ -2016,7 +2016,7 @@ void primitive_inst::do_runtime_skip_resample() {
 }
 
 bool primitive_inst::has_inner_networks() const {
-    return (_impl_params->inner_nets.size() > 0);
+    return (!_impl_params->inner_nets.empty());
 }
 
 void primitive_inst::add_dep_events(const std::vector<event::ptr>& events) {
@@ -3165,7 +3165,7 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
 
             std::unique_ptr<primitive_impl> impl = find_impl(&inst.get_node(), updated_params, shape_types::static_shape);
 
-            if (impl && impl->get_kernels_source().size() > 0) {
+            if (impl && !impl->get_kernels_source().empty()) {
                 auto kernels = _program.get_kernels_cache().compile(updated_params, impl->get_kernels_source());
                 impl->set_kernels(kernels);
             }

--- a/src/plugins/intel_gpu/src/graph/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/prior_box.cpp
@@ -81,7 +81,7 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
                 auto density = static_cast<size_t>(argument.density[fs]);
                 auto shift = fixed_size / density;
 
-                if (argument.fixed_ratio.size() > 0) {
+                if (!argument.fixed_ratio.empty()) {
                     for (auto fr : argument.fixed_ratio) {
                         box_width = fixed_size * sqrtf(fr);
                         box_height = fixed_size / sqrtf(fr);
@@ -158,7 +158,7 @@ void calculate_prior_box_output(memory::ptr output_mem, stream& stream, layout c
                 // ymax
                 out_ptr[idx++] = (dtype)((center_y + box_height / 2.f) / img_height);
 
-                if (argument.max_sizes.size() > 0) {
+                if (!argument.max_sizes.empty()) {
                     float max_size_ = argument.max_sizes[s];
                     // second prior: aspect_ratio = 1, size = sqrt(min_size * max_size)
                     box_width = box_height = sqrtf(min_size * max_size_);
@@ -315,7 +315,7 @@ void prior_box_node::calc_result() {
                                        0,
                                        "Min size must be positive.");
     }
-    if (argument.max_sizes.size() > 0) {
+    if (!argument.max_sizes.empty()) {
         CLDNN_ERROR_NOT_EQUAL(id(),
                               "Argument min sizes",
                               argument.min_sizes.size(),

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -429,7 +429,7 @@ void program::prepare_nodes(std::set<std::shared_ptr<program_node>> const& nodes
         if (!found) {
             add_node_dependencies(node_ptr.get());
         }
-        if (node_ptr->dependencies.size() == 0)
+        if (node_ptr->dependencies.empty())
             inputs.push_back(node_ptr.get());
     }
 }
@@ -445,7 +445,7 @@ void program::prepare_nodes(topology const& topology) {
         if (node_ptr == nullptr)
             throw std::runtime_error("NULL pointer in nodes_map.");
         add_node_dependencies(node_ptr);
-        if (node_ptr->dependencies.size() == 0) {
+        if (node_ptr->dependencies.empty()) {
             inputs.push_back(node_ptr);
         }
     }
@@ -781,7 +781,7 @@ program::nodes_ordering& program::get_processing_order() { return processing_ord
 const program::nodes_ordering& program::get_processing_order() const { return processing_order; }
 
 const std::vector<primitive_id>& program::get_allocating_order(bool forced_update) {
-    if (!forced_update && allocating_order.size() > 0)
+    if (!forced_update && !allocating_order.empty())
         return allocating_order;
 
     std::vector<std::shared_ptr<program_node>> nodes_to_allocate{};
@@ -1284,7 +1284,7 @@ void program::fuse_nodes(program_node &fused_node,
         local_desc.deps.emplace_back(dep->id(), deps_idx++);
         dep->users.push_back(&fused_node);
     }
-    if (local_desc.deps.size()) {
+    if (!local_desc.deps.empty()) {
         local_desc.outer_dep_start_idx = orig_fused_node_num_deps;
     }
 
@@ -1308,7 +1308,7 @@ void program::fuse_nodes(program_node &fused_node,
     }
 
     // Remove all edges connected with peer node
-    while (peer_node.get_dependencies().size() > 0) {
+    while (!peer_node.get_dependencies().empty()) {
         auto& dep = peer_node.get_dependency(peer_node.get_dependencies().size() - 1);
         remove_connection(dep, peer_node);
     }

--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -115,7 +115,7 @@ static bool is_direct_ancestor(const program_node& child, const program_node& ta
     for (int i = 0; i < 5; i++) {
         if (iter == &target)
             return true;
-        if (iter->get_dependencies().size() == 0)
+        if (iter->get_dependencies().empty())
             break;
         iter = &iter->get_dependency(0);
     }

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -251,7 +251,7 @@ std::unique_ptr<json_composite> program_node::desc_to_json() const {
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
     auto& onednn_post_ops = get_fused_primitives_onednn();
-    if (onednn_post_ops.size()) {
+    if (!onednn_post_ops.empty()) {
         size_t post_op_index = 0;
         json_composite post_ops_info;
         for (auto& fused_prim_desc : onednn_post_ops) {

--- a/src/plugins/intel_gpu/src/graph/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorder.cpp
@@ -212,7 +212,7 @@ std::string reorder_inst::to_string(reorder_node const& node) {
     reorder_info.add("input id", input.id());
     reorder_info.add("mean", mean);
     reorder_info.add("input mem type", input_mem_type);
-    if (desc->subtract_per_feature.size() > 0) {
+    if (!desc->subtract_per_feature.empty()) {
         reorder_info.add("subtract per feature", desc->subtract_per_feature);
     }
 

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -316,7 +316,7 @@ reshape_inst::typed_primitive_inst(network& network, reshape_node const& node) :
             update_output_memory();
         }
     } else {
-        if (_exec_deps.size() > 0 && input_memory_ptr())
+        if (!_exec_deps.empty() && input_memory_ptr())
             update_output_memory();
     }
 }

--- a/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
@@ -65,7 +65,7 @@ void scatter_elements_update_inst::update_output_memory() {
     if (!can_be_optimized() || _impl_params->is_dynamic())
         return;
 
-    if (_outputs.size() > 0 && static_cast<bool>(_outputs[0])
+    if (!_outputs.empty() && static_cast<bool>(_outputs[0])
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;
 

--- a/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
@@ -77,7 +77,7 @@ void scatter_nd_update_inst::update_output_memory() {
     if (!can_be_optimized() || _impl_params->is_dynamic())
         return;
 
-    if (_outputs.size() > 0 && static_cast<bool>(_outputs[0])
+    if (!_outputs.empty() && static_cast<bool>(_outputs[0])
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;
 

--- a/src/plugins/intel_gpu/src/graph/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_update.cpp
@@ -56,7 +56,7 @@ void scatter_update_inst::update_output_memory() {
     if (!can_be_optimized() || _impl_params->is_dynamic())
         return;
 
-    if (_outputs.size() > 0 && static_cast<bool>(_outputs[0])
+    if (!_outputs.empty() && static_cast<bool>(_outputs[0])
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;
 

--- a/src/plugins/intel_gpu/src/graph/slice_scatter.cpp
+++ b/src/plugins/intel_gpu/src/graph/slice_scatter.cpp
@@ -72,7 +72,7 @@ void slice_scatter_inst::update_output_memory() {
     if (input_memory_ptr() == nullptr)
         return;
 
-    if (_outputs.size() > 0 && static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
+    if (!_outputs.empty() && static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;
 
     if (static_cast<bool>(_outputs[0]) && get_node().get_program().get_config().get_enable_memory_pool()) {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.h
@@ -133,7 +133,7 @@ inline std::string toVectorString(const VecT& vec,
                                   ValT padFillingVal,
                                   Func fetchFunc) {
     std::stringstream ss;
-    if (vectorType.length())
+    if (!vectorType.empty())
         ss << "(" << vectorType << " [])";
     ss << toVectorInitString(vec, vectorType, maxDim, padFillingVal, fetchFunc);
     return ss.str();

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
@@ -167,7 +167,7 @@ std::shared_ptr<KernelString> KernelBaseOpenCL::GetKernelString(const std::strin
 
     auto codes = db.get(name);
 
-    if (codes.size()) {
+    if (!codes.empty()) {
         kernel_string->str = codes[0];
         kernel_string->jit = jit.first;
         kernel_string->undefs = jit.second;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.cpp
@@ -83,7 +83,7 @@ KernelsData kernel_selector_base::GetNaiveBestKernel(const KernelList& all_impls
         try {
             KernelsData kds = implementation->GetKernelsData(params);
 
-            if (kds.size() && kds[0].kernels.size()) {
+            if (!kds.empty() && !kds[0].kernels.empty()) {
                 kernelsData = kds;
                 kernelName = implementation->GetName();
                 break;
@@ -96,7 +96,7 @@ KernelsData kernel_selector_base::GetNaiveBestKernel(const KernelList& all_impls
     }
 
     // TODO: find a better place to located this assignment
-    if (kernelsData.size()) {
+    if (!kernelsData.empty()) {
         kernelsData[0].kernelName = kernelName;
         kernelsData[0].kernels[0].params.layerID = params.layerID;
     }
@@ -128,7 +128,7 @@ KernelsData kernel_selector_base::GetAutoTuneBestKernel(const Params& params, Ke
             // TODO: make sure kernel names are unique.
             if (implementation->GetName().compare(cachedkernelName) == 0) {
                 KernelsData kds = implementation->GetTunedKernelsDataByIndex(params, autoTuneIndex);
-                if (kds.size() && kds[0].kernels.size()) {
+                if (!kds.empty() && !kds[0].kernels.empty()) {
                     kernelsData = kds;
                     kernelsData[0].kernelName = cachedkernelName;
                     kernelsData[0].kernels[0].params.layerID = params.layerID;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_utils.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_utils.cpp
@@ -470,7 +470,7 @@ bool CheckInputsOutputNoPitchSameDims(const base_params& params) {
         {DataLayout::bs_fs_zyx_bsv32_fsv32,  {32, 32}}
     };
 
-    if (params.inputs.size()) {
+    if (!params.inputs.empty()) {
         no_pitch_same_dims = !params.inputs[0].PitchesDifferFromLogicalDims();
 
         auto block_layout = block_layouts.find(params.inputs[0].GetLayout());
@@ -480,7 +480,7 @@ bool CheckInputsOutputNoPitchSameDims(const base_params& params) {
                     return false;
         }
 
-        if (params.fused_ops.size()) {
+        if (!params.fused_ops.empty()) {
             for (auto fused_op : params.fused_ops) {
                 for (size_t in = 0; in < fused_op.tensors.size(); in++) {
                     if (fused_op.tensors[in].LogicalSize() == 1)

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.cpp
@@ -256,7 +256,7 @@ bool ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::ValidateAutoTuneParams(const c
     }
 
     // Filter out combinations that are known to be sub-optimal in order to reduce search space
-    valid_tune_params &= tparams.exeMode == EXE_MODE_DEFAULT;
+    valid_tune_params &= tparams.exeMode.empty();
     valid_tune_params &= tparams.preload_input_slm || tparams.lws0 * tparams.lws1 == 1;
     valid_tune_params &= !tparams.preload_input_slm || (tparams.lws0 * tparams.lws1) % 2 == 0;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
@@ -266,7 +266,7 @@ KernelsData ConvolutionKernelBase::GetCommonKernelsData(const Params& params,
 }
 
 bool CheckConvolutionPaddedInputDesc(const convolution_params& params, const DataTensor& reqDesc) {
-    assert(params.inputs.size() >= 1);
+    assert(!params.inputs.empty());
 
     bool properPadding = reqDesc.X().pad.before <= params.inputs[0].X().pad.before &&
                          reqDesc.Y().pad.before <= params.inputs[0].Y().pad.before &&
@@ -284,7 +284,7 @@ bool CheckConvolutionPaddedInputDesc(const convolution_params& params, const Dat
 }
 
 static DataTensor GetConvolutionBFYXPaddedTensor(const convolution_params& cp) {
-    assert(cp.inputs.size() >= 1);
+    assert(!cp.inputs.empty());
     auto ndims = cp.inputs[0].GetDims().size();
 
     DataTensor t = cp.inputs[0];

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
@@ -117,13 +117,13 @@ bool EltwiseKernelBase::Validate(const Params& p) const {
 
     const eltwise_params& params = static_cast<const eltwise_params&>(p);
 
-    if (params.inputs.size() == 0) {
+    if (params.inputs.empty()) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
     auto& operations = params.operations;
 
-    if (operations.size() == 0) {
+    if (operations.empty()) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_vload8.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_vload8.cpp
@@ -35,7 +35,7 @@ bool EltwiseKernel_vload8::Validate(const Params& params) const {
 
     // Only one activation can be fused.
     if (ewParams.fused_ops.size() > 1 ||
-        (ewParams.activations.size() !=0 && ewParams.fused_ops.size() != 0)) {
+        (!ewParams.activations.empty() && !ewParams.fused_ops.empty())) {
         DO_NOT_USE_THIS_KERNEL(params.layerID);
     }
 
@@ -117,7 +117,7 @@ KernelsData EltwiseKernel_vload8::GetKernelsData(const Params& params) const {
 
     try {
         // move a fused activation from fused_ops to activations
-        if (newParams.activations.size() == 0 &&
+        if (newParams.activations.empty() &&
             newParams.fused_ops.size() == 1 &&
             newParams.fused_ops[0].GetType() == KernelType::ACTIVATION) {
             auto p = newParams.fused_ops[0].GetOpParams<activation_fuse_params>();

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -108,7 +108,7 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         tuning_data.simd_size = 16;
         tuning_data.tile_k_size = tuning_data.simd_size;
         tuning_data.tile_m_size = tuning_data.simd_size;
-        bool output_ndim_transposed = (params.output_order.size() > 0 && (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1)));
+        bool output_ndim_transposed = (!params.output_order.empty() && (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1)));
         if ((params.transpose_input0 == 0 /*X_LAST*/) && (params.transpose_input1 == 0 /*X_LAST*/ || params.transpose_input1 == 1 /*Y_LAST*/)
             && (!params.indirect_input0 && !params.inputs[0].has_dynamic_pad() && params.indirect_axis != 1)
             && (!output_ndim_transposed || params.fused_ops.empty())
@@ -201,7 +201,7 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
             MakeJitConstant("TR_X", GetTransposedDims(params.output_order, true).at(7)),
         });
 
-        bool transpose_output = (params.output_order.size() > 0 && (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1)));
+        bool transpose_output = (!params.output_order.empty() && (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1)));
         if (transpose_output)
             jit.AddConstant(MakeJitConstant("TRANSPOSE_OUTPUT", 2 /* set as TRANSPOSE_OTHER */));
         else
@@ -218,18 +218,18 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
             const size_t rank = data_tensor.GetDims().size();
             if (dims_order.size() > 1 && dim.compare("Y") == 0) {
                 target_dim_idx = dims_order.at(dims_order.size() - 2);
-            } else if (dims_order.size() > 0 && dim.compare("X") == 0) {
+            } else if (!dims_order.empty() && dim.compare("X") == 0) {
                 target_dim_idx = dims_order.back();
-            } else if (dims_order.size() == 0 && dim.compare("Y") == 0) {
+            } else if (dims_order.empty() && dim.compare("Y") == 0) {
                 target_dim_idx = rank - 2;
-            } else if (dims_order.size() == 0 && dim.compare("X") == 0) {
+            } else if (dims_order.empty() && dim.compare("X") == 0) {
                 target_dim_idx = rank - 1;
             } else {
                 OPENVINO_THROW("Unsupported dimension: ", dim);
             }
 
             size_t loc = static_cast<size_t>(target_dim_idx);
-            if (dims_order.size() > 0) {
+            if (!dims_order.empty()) {
                 loc += (dims_order.size() < rank) ? (rank - dims_order.size()) : 0;
             }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.cpp
@@ -102,7 +102,7 @@ bool ResampleKernelBase::Validate(const Params& p) const {
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    if (params.inputs.size() == 0) {
+    if (params.inputs.empty()) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reshape/reshape_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reshape/reshape_kernel_ref.cpp
@@ -48,7 +48,7 @@ KernelsData ReshapeKernelRef::GetKernelsData(const Params& params) const {
     size_t gws2 = 1;
     const auto& in_dims = in.GetDims();
 
-    if (in_dims.size() >= 1)
+    if (!in_dims.empty())
         gws0 = in_dims[0].v;
     if (in_dims.size() >= 2)
         gws1 = in_dims[1].v;

--- a/src/plugins/intel_gpu/src/plugin/custom_layer.cpp
+++ b/src/plugins/intel_gpu/src/plugin/custom_layer.cpp
@@ -40,7 +40,7 @@ void CustomLayer::LoadSingleLayer(const pugi::xml_node & node) {
     CheckStrAttrAndReturnError(node, "type", "SimpleGPU");
     CheckIntAttrAndReturnError(node, "version", 1);
     m_layerName = get_str_attr(node, "name", "");
-    CheckAndReturnError(m_layerName.length() == 0, "Missing Layer name in CustomLayer");
+    CheckAndReturnError(m_layerName.empty(), "Missing Layer name in CustomLayer");
 
     // Process child nodes
     ProcessKernelNode(node.child("Kernel"));
@@ -51,9 +51,9 @@ void CustomLayer::LoadSingleLayer(const pugi::xml_node & node) {
 
 void CustomLayer::ProcessKernelNode(const pugi::xml_node & node) {
     CheckNodeTypeAndReturnError(node, "Kernel");
-    CheckAndReturnError(m_kernelSource.length() > 0, "Multiple definition of Kernel");
+    CheckAndReturnError(!m_kernelSource.empty(), "Multiple definition of Kernel");
     m_kernelEntry = get_str_attr(node, "entry", "");
-    CheckAndReturnError(m_kernelEntry.length() == 0, "No Kernel entry in layer: " << get_str_attr(node.parent(), "name"));
+    CheckAndReturnError(m_kernelEntry.empty(), "No Kernel entry in layer: " << get_str_attr(node.parent(), "name"));
 
     // Handle Source nodes
     FOREACH_CHILD(sourceNode, node, "Source") {
@@ -80,7 +80,7 @@ void CustomLayer::ProcessKernelNode(const pugi::xml_node & node) {
     FOREACH_CHILD(defineNode, node, "Define") {
         KernelDefine kd;
         kd.name = get_str_attr(defineNode, "name", "");
-        CheckAndReturnError((kd.name.length() == 0), "Missing name for define node");
+        CheckAndReturnError((kd.name.empty()), "Missing name for define node");
         kd.param = get_str_attr(defineNode, "param", "");
         kd.default_value = get_str_attr(defineNode, "default", "");
         std::string type = get_str_attr(defineNode, "type", "");
@@ -132,7 +132,7 @@ void CustomLayer::ProcessCompilerOptionsNode(const pugi::xml_node & node) {
         return;  // Optional node doesn't exist
     }
     CheckNodeTypeAndReturnError(node, "CompilerOptions");
-    CheckAndReturnError(m_compilerOptions.length() > 0, "Multiple definition of CompilerOptions");
+    CheckAndReturnError(!m_compilerOptions.empty(), "Multiple definition of CompilerOptions");
     m_compilerOptions = get_str_attr(node, "options", "");
 }
 

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -186,7 +186,7 @@ Graph::~Graph() {
             }
         };
 
-        if (host_exec_times.size() >= 1) {
+        if (!host_exec_times.empty()) {
             print_entry("First", host_exec_times[0], 1);
         }
 
@@ -775,7 +775,7 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
         if (perfIter == perfMap.end())  continue;
 
         bool existInProfiling = std::find(profilingIDs.begin(), profilingIDs.end(), primId) != profilingIDs.end();
-        if ((!existInProfiling || (existInProfiling && perfIter->second.first.length() == 0)) &&
+        if ((!existInProfiling || (existInProfiling && perfIter->second.first.empty())) &&
             executedPrimitives.find(primId) != executedPrimitives.end()) {
             auto event = executedPrimitives.at(primId);
             if (!event)

--- a/src/plugins/intel_gpu/src/plugin/ops/condition.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/condition.cpp
@@ -53,7 +53,7 @@ static cldnn::condition::branch gen_branch(ProgramBuilder& p, const std::shared_
 
 static void CreateIfOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v8::If>& op) {
     auto inputs = p.GetInputInfo(op);
-    OPENVINO_ASSERT(inputs.size() >= 1, "Invalid inputs count (Not allowed no input)");
+    OPENVINO_ASSERT(!inputs.empty(), "Invalid inputs count (Not allowed no input)");
     auto compare_node_pshape = op->get_input_partial_shape(0);
     auto p_input_name = inputs[0].pid;
     std::string type_name_str = op->get_input_node_ptr(0)->get_type_name();

--- a/src/plugins/intel_gpu/src/plugin/ops/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/fully_connected.cpp
@@ -43,7 +43,7 @@ static void CreateFullyConnectedCompressedOp(ProgramBuilder& p, const std::share
 
     float zp_value = 0.0f;
     bool has_scalar_zp = false;
-    if (zp_name.size() > 0) {
+    if (!zp_name.empty()) {
         auto zp_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(W_ZP_IDX));
         if (zp_const && ov::shape_size(zp_const->get_output_shape(0)) == 1) {
             has_scalar_zp = true;

--- a/src/plugins/intel_gpu/src/plugin/ops/split.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/split.cpp
@@ -74,7 +74,7 @@ static void CreateCommonSplitOp(ProgramBuilder& p, const std::shared_ptr<ov::Nod
         for (size_t i = 0; i < op->get_output_size(); i++) {
             const auto& users = op->get_output_target_inputs(i);
             // don't add crop primitive if port is not used by anyone
-            if (users.size() == 0)
+            if (users.empty())
                 continue;
             auto cropPrim = cldnn::crop(get_layer_name(i),
                                         inputs,
@@ -107,7 +107,7 @@ static void CreateCommonSplitOp(ProgramBuilder& p, const std::shared_ptr<ov::Nod
 
             const auto& users = op->get_output_target_inputs(i);
             // don't add crop primitive if port is not used by anyone
-            if (users.size() != 0) {
+            if (!users.empty()) {
                 auto cropPrim = cldnn::crop(get_layer_name(i), inputs[0], outTensor, offsetTensor);
                 p.add_primitive(*op, cropPrim);
             }

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -928,7 +928,7 @@ uint32_t Plugin::get_max_batch_size(const ov::AnyMap& options) const {
             }
         }
 
-        if (!batched_inputs.size()) {
+        if (batched_inputs.empty()) {
             GPU_DEBUG_LOG << "[MAX_BATCH_SIZE] MAX_BATCH_SIZE supports only networks with inputs/outputs featuring batched dim." << std::endl;
             return static_cast<uint32_t>(max_batch_size);
         }

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -58,7 +58,7 @@ RemoteContextImpl::RemoteContextImpl(const std::map<std::string, RemoteContextIm
     int target_tile_id = -1;
     m_type = get_default_context_type();
 
-    if (params.size()) {
+    if (!params.empty()) {
         auto ctx_type = extract_object(params, ov::intel_gpu::context_type);
 
         if (ctx_type == ov::intel_gpu::ContextType::OCL) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -233,7 +233,7 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
                  k = shape_a[shape_a.rank().get_length() - 1].get_length();
              // M is the row/token dimension and N the output dimension of the matmul.
              size_t m = output_shape.size() >= 2 ? output_shape[output_shape.size() - 2] : 1;
-             size_t n = output_shape.size() >= 1 ? output_shape[output_shape.size() - 1] : 1;
+             size_t n = !output_shape.empty() ? output_shape[output_shape.size() - 1] : 1;
              // Empirical benchdnn study (f16 GPU matmul, see
              // temp/gemm_transpose_study): the non-transposed weight layout
              // (onednn abc) wins for matmuls with a large reduction dimension

--- a/src/plugins/intel_gpu/src/plugin/transformations/einsum_decomposition.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/einsum_decomposition.cpp
@@ -481,7 +481,7 @@ ov::Output<ov::Node> build_multi_identity(EinsumDecomposition* einsum_decompose_
                                                   const std::vector<std::string>& repeated_labels,
                                                   const LabelDimMap& label_dim_map,
                                                   ov::NodeVector& subgraph_nodes) {
-    OPENVINO_ASSERT(repeated_labels.size() > 0);
+    OPENVINO_ASSERT(!repeated_labels.empty());
 
     const auto get_identity = [&](size_t idx) {
         const auto repeated_label_dims = label_dim_map.find(repeated_labels[idx]);

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
@@ -240,7 +240,7 @@ FullyConnectedHorizontalFusion::FullyConnectedHorizontalFusion(bool fuse_mlp_swi
         }
 
         std::shared_ptr<ov::Node> fused_zps;
-        if (zp_nodes.size() > 0) {
+        if (!zp_nodes.empty()) {
             // scalar zp
             auto zp_shape = zp_nodes[0]->get_output_shape(0);
             bool is_scalar = (ov::shape_size(zp_nodes[0]->get_output_shape(0)) == 1);

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
@@ -103,7 +103,7 @@ std::vector<ov::PartialShape> shape_infer(const Gemm* op,
     OPENVINO_ASSERT(op != nullptr, "op should not be nullptr for shape_infer.");
     auto out_shapes = ov::op::v0::shape_infer(ov::as_type<const ov::op::v0::MatMul>(op), std::vector<ov::PartialShape>{shape_a_t, shape_b_t});
 
-    if (order_c.size() > 0) {
+    if (!order_c.empty()) {
         return { transpose_pshape(out_shapes[0], order_c) };
     } else {
         return { out_shapes[0] };

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/read_value.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/read_value.cpp
@@ -137,7 +137,7 @@ std::shared_ptr<Node> ReadValues::clone_with_new_inputs(const ov::OutputVector& 
                     "Incorrect number of inputs. Expected: 0 or ", m_internal_states_infos.size(), ". ",
                     "Actual: ", new_args.size(), ".");
 
-    if (new_args.size() > 0) {
+    if (!new_args.empty()) {
         return std::make_shared<ReadValues>(new_args, m_variable, m_internal_states_infos);
     } else {
         return std::make_shared<ReadValues>(m_variable, m_internal_states_infos);

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/sdpa.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/sdpa.cpp
@@ -164,7 +164,7 @@ std::vector<ov::PartialShape> shape_infer(const SDPA* op,
     OPENVINO_ASSERT(op_v13 != nullptr, "ov::op::v13::ScaledDotProductAttention*>(op) should not be nullptr.");
     auto out_shapes = ov::op::v13::shape_infer(op_v13, transposed_input_shapes);
 
-    if (order_out.size() > 0) {
+    if (!order_out.empty()) {
         return { transpose_pshape(out_shapes[0], order_out) };
     } else {
         return { out_shapes[0] };

--- a/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
+++ b/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
@@ -10,7 +10,7 @@
 namespace ov::intel_gpu {
 std::ostream& get_verbose_stream() {
 #ifdef GPU_DEBUG_CONFIG
-    if (ExecutionConfig::get_log_to_file().length() > 0) {
+    if (!ExecutionConfig::get_log_to_file().empty()) {
         static std::ofstream fout;
         if (!fout.is_open())
             fout.open(ExecutionConfig::get_log_to_file());

--- a/src/plugins/intel_gpu/src/runtime/device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/device.cpp
@@ -39,7 +39,7 @@ struct DeviceOps {
     }
 
     bool match(device_info& info) const {
-        if (dev_id_list.size() > 0) {
+        if (!dev_id_list.empty()) {
             return std::find(dev_id_list.begin(), dev_id_list.end(), info.device_id) != dev_id_list.end();
         }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
@@ -488,7 +488,7 @@ public:
         std::vector<cl_mem>& surfaces,
         cl_int * err = NULL)
         : m_queue(queue), m_surfaces(surfaces), m_errPtr(err) {
-        if (pfn_acquire != NULL && m_surfaces.size()) {
+        if (pfn_acquire != NULL && !m_surfaces.empty()) {
             cl_int error = pfn_acquire(m_queue,
                 static_cast<cl_uint>(m_surfaces.size()),
                 m_surfaces.data(),
@@ -501,7 +501,7 @@ public:
     }
 
     ~SharedSurfLock() {
-        if (pfn_release != NULL && m_surfaces.size()) {
+        if (pfn_release != NULL && !m_surfaces.empty()) {
             cl_int error = pfn_release(m_queue,
                 static_cast<cl_uint>(m_surfaces.size()),
                 m_surfaces.data(),

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel.cpp
@@ -43,7 +43,7 @@ std::string ocl_kernel::get_build_log() const {
     auto log = program.getBuildInfo<CL_PROGRAM_BUILD_LOG>();
     // Assume program was build for only 1 device
     // Return first log
-    if (log.size() > 0) {
+    if (!log.empty()) {
         return log[0].second;
     }
     OPENVINO_THROW("[GPU] Failed to retrieve kernel build log");


### PR DESCRIPTION
Enables the `readability-container-size-empty` clang-tidy check for the Intel GPU plugin and replaces size comparisons such as `.size() == 0` with `.empty()`. Next check in the incremental clang-tidy rollout for the plugin.
