### PR TITLE
[GPU][CLANG-TIDY][TEST] Enable all rollout checks without fixes (DO NOT MERGE)

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -7,7 +7,18 @@
 
 Checks: >
   -*,
-  modernize-use-override
+  modernize-use-override,
+  modernize-redundant-void-arg,
+  modernize-use-using,
+  modernize-deprecated-headers,
+  modernize-use-bool-literals,
+  modernize-use-nullptr,
+  readability-redundant-control-flow,
+  readability-redundant-string-init,
+  readability-redundant-string-cstr,
+  readability-redundant-member-init,
+  readability-container-size-empty,
+  google-readability-namespace-comments
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'
@@ -17,4 +28,8 @@ HeaderFilterRegex: "src/plugins/intel_gpu/(include|src)/.*\\.(h|hpp)$"
 CheckOptions:
   - key: modernize-use-override.AllowOverrideAndFinal
     value: true
+  - key: google-readability-namespace-comments.ShortNamespaceLines
+    value: 10
+  - key: google-readability-namespace-comments.SpacesBeforeComments
+    value: 2
 ---


### PR DESCRIPTION
> ⚠️ **DO NOT REVIEW / DO NOT MERGE — TEST PR ONLY.**

This PR intentionally enables **all** the clang-tidy checks from the incremental GPU rollout at once **without applying any of the fixes**, purely to confirm that the GPU clang-tidy CI job actually fails when diagnostics are present (i.e. that `WarningsAsErrors: '*'` is really enforced at build time).

It is expected to **fail** the `Build-gpu` clang-tidy job with hundreds of findings. It will not be merged and will be closed once the CI result is observed. No source files are changed — only `src/plugins/intel_gpu/.clang-tidy`.
