### PR TITLE
[GPU] Fix dynamic VariadicSplit crop offsets

### DIFF
--- a/src/plugins/intel_gpu/src/graph/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/crop.cpp
@@ -124,18 +124,20 @@ std::vector<layout> crop_inst::calc_output_layouts(const crop_node& /*node*/, co
         return {layout{ref_in_sizes.get_partial_shape(in_layout.get_partial_shape().size(), in_layout.get_rank()), in_layout.data_type, in_layout.format}};
     }
 
-    bool is_output_static = false;
     std::vector<layout> output_layouts;
     for (size_t i = 0; i < output_shapes.size(); ++i) {
         output_layouts.push_back(layout({output_shapes[i], in_layout.data_type, in_layout.format}));
-        is_output_static = (output_shapes[i].is_static()) ? true : is_output_static;
     }
 
     // update split offsets
-    if (is_output_static) {
+    const auto& input_shape = impl_param.input_layouts[0].get_partial_shape();
+    bool can_update_offsets = input_shape.is_static();
+    for (int32_t prev = 0; prev < desc->output_idx && can_update_offsets; ++prev) {
+        can_update_offsets = output_layouts[prev].is_static();
+    }
+    if (can_update_offsets) {
         auto p_param = const_cast<kernel_impl_params*>(&impl_param);
-        ov::Shape startOffset(p_param->input_layouts[0].get_partial_shape().size());
-        auto input_shape = p_param->input_layouts[0].get_partial_shape();
+        ov::Shape startOffset(input_shape.size());
         auto dims = p_param->input_layouts[0].get_partial_shape().size();
         for (int32_t prev = 0; prev < desc->output_idx; prev++) {
             auto prev_crop_shape = output_layouts[prev].get_partial_shape().to_shape();

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/crop_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/crop_si_test.cpp
@@ -207,6 +207,16 @@ INSTANTIATE_TEST_SUITE_P(smoke, crop_si_test,
             -1,
             {{{128,100,4},data_types::f32,format::bfyx}},
             {{{128,100,3},data_types::f32,format::bfyx}}, 0
+        },
+        // Dynamic VariadicSplit input with static leading outputs and a dynamic remainder.
+        // [1, ?] -> [1, 2], [1, 1], [1, ?].
+        {
+            tensor({1,1,1,1,1,1,1}),
+            {tensor({0,0,0,0,1,1,1}), tensor({0,0,0,0,1,1,1}), tensor({0,0,0,0,1,1,1})},
+            {{1}, {2,1,-1}},
+            1,
+            {{ov::PartialShape{1, ov::Dimension::dynamic()},data_types::f32,format::bfyx}, {{},data_types::i64,format::bfyx}, {{3},data_types::i64,format::bfyx}},
+            {{{1,2},data_types::f32,format::bfyx}, {{1,1},data_types::f32,format::bfyx}, {ov::PartialShape{1, ov::Dimension::dynamic()},data_types::f32,format::bfyx}}, 0
         }
     }));
 


### PR DESCRIPTION
### Details:
- Fixes GPU compilation of dynamic models containing VariadicSplit outputs with a mixture of static and dynamic dimensions.

- The crop implementation previously updated split offsets when any output was static, then converted the dynamic input PartialShape with `to_shape()`. It causes runtime error from input_shape.to_shape() because input_shape is dynamic.

- Offset calculation is now limited to static input shapes with static preceding split outputs.

- Problematic crop layer
input:         [1, ?]
split lengths: [2, 1, -1]
outputs:       [1, 2], [1, 1], [1, ?]

### Tickets:
 - 190466

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed: Root cause tracing and proto typing by agent, validation by human*
