### PR TITLE
[CPU] Fix "stoi" crash on non-contiguous cpuset (containers with limited cores)

### DIFF
--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -90,7 +90,15 @@ CPU::CPU() {
                             if (cache_file.is_open()) {
                                 std::getline(cache_file, one_info);
                             } else {
-                                if ((cpu_index == core_1) && (n == 0)) {
+                                // A missing shared_cpu_list (n == 0) for an online CPU means the sysfs
+                                // topology is incomplete for the CPUs this process may run on. This
+                                // happens inside containers with a non-contiguous cpuset (e.g. an LXC
+                                // limited to cores 0,1,2,5,6,7): the masked cores have no
+                                // /sys/devices/system/cpu/cpuN/cache/... entries, so an empty string
+                                // would be stored and later parsed with std::stoi("") -> throws
+                                // "stoi". Bail out to the /proc/cpuinfo based fallback below, which
+                                // handles restricted CPU sets correctly.
+                                if (n == 0) {
                                     system_info_table.clear();
                                     return -1;
                                 }


### PR DESCRIPTION
### Details

Fixes the `stoi` runtime error thrown by `compile_model` (and CPU-topology init in general) when OpenVINO runs inside a container with a **non-contiguous cpuset** — e.g. a Proxmox LXC limited to a subset of host cores (cpuset `0,1,2,5,6,7`, cores 3/4 masked).

In `get_info_linux()`, a masked CPU that is still inside the online range has no `/sys/devices/system/cpu/cpuN/cache/indexK/shared_cpu_list`. The previous code only fell back to `/proc/cpuinfo` when the **first** CPU's file was missing; a missing file for a **middle** CPU stored an empty string that a later stage parsed with `std::stoi("")`, throwing the opaque `stoi` error.

This changes the guard so that a missing `shared_cpu_list` (`n == 0`) for **any** online CPU triggers the existing `/proc/cpuinfo`-based fallback, which already handles restricted CPU sets correctly.

### Tickets:

Closes #37051

### Testing / validation

- Reproduced on Proxmox LXC (Debian 12), host i5-1135G7 (8 threads), container limited to 6 cores → cpuset `0,1,2,5,6,7`; `Core().compile_model(model, "GPU")` threw `stoi` for every model (MobileNet IR, YOLOv9 ONNX and IR). Giving the container all cores made it work, which isolated the cause to the topology parser, not the GPU/driver.
- Root cause confirmed with `strace -f -e trace=openat`: the reads immediately preceding the throw are the cache-topology files of exactly the present CPUs (`0,1,2,5,6,7`), with none for the masked `cpu3`/`cpu4`.

> Note: I was not able to build the full OpenVINO toolchain locally to run the C++ unit tests; the change is small and reuses the pre-existing `/proc/cpuinfo` fallback path. Relying on CI and maintainer review — happy to iterate.
