### PR TITLE
[NPU][IE-MDK] Unskip UMD Caching test

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/work_with_devices.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/work_with_devices.cpp
@@ -10,7 +10,9 @@
 namespace {
 
 const std::vector<ov::AnyMap> configs = {
-    {{ov::intel_npu::bypass_umd_caching(true)}},
+        {{ov::intel_npu::bypass_umd_caching(true),
+            // Test manipulates UMD caching, compiler needs to be set to CID
+            ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}}
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -923,17 +923,6 @@ Example:
         </filters>
     </skip_config>
 
-    <!-- E#210236-->
-    <skip_config>
-        <message>Test fails sporadically on NPU Windows drivers</message>
-        <enable_rules>
-            <operating_system>windows</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*samePlatformProduceTheSameBlobCacheEnabled.*</filter>
-        </filters>
-    </skip_config>
-
     <skip_config>
         <message>PV driver cannot compile models securely</message>
         <enable_rules>


### PR DESCRIPTION
### Details:
 - Unskips samePlatformProduceTheSameBlobCacheEnabled
 - Forces test to use CID every time, otherwise test is meaningless

### Tickets:
 - E 210236

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
