### PR TITLE
Disable CPU pinning on dual-socket Windows platform

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_map_scheduling.cpp
+++ b/src/plugins/intel_cpu/src/cpu_map_scheduling.cpp
@@ -76,13 +76,23 @@ std::vector<std::vector<int>> apply_hyper_threading(bool& input_ht_hint,
 bool check_cpu_pinning(const bool cpu_pinning,
                        const bool cpu_pinning_changed,
                        const bool cpu_reservation,
+                       int num_sockets,
                        const std::vector<std::vector<int>>& streams_info_table) {
     bool result_value = false;
 
 #if defined(__APPLE__)
     result_value = false;
 #elif defined(_WIN32)
-    result_value = cpu_pinning_changed ? cpu_pinning : cpu_reservation;
+    if (num_sockets < 0) {
+        num_sockets = get_num_sockets();
+    }
+    if (num_sockets > 1) {
+        result_value = false;
+    } else if (cpu_pinning_changed) {
+        result_value = cpu_pinning;
+    } else {
+        result_value = false;
+    }
 #else
     // The following code disables pinning in case stream contains both Pcore and Ecore
     auto hyper_cores_in_stream = [&]() {

--- a/src/plugins/intel_cpu/src/cpu_map_scheduling.hpp
+++ b/src/plugins/intel_cpu/src/cpu_map_scheduling.hpp
@@ -44,12 +44,14 @@ std::vector<std::vector<int>> apply_hyper_threading(bool& input_ht_hint,
  * @param[in]  cpu_pinning_changed the property changedCpuPinning which value depends on whether user sets
  * enableCpuPinning. true: user sets property enableCpuPinning. false: user does not set property enableCpuPinning.
  * @param[in]  cpu_reservation the property enableCpuReservation set by user. False by default
+ * @param[in]  num_sockets the number of CPU sockets available
  * @param[in]  streams_info_table indicate streams detail of this model
  * @return     whether pinning threads to cpu cores
  */
 bool check_cpu_pinning(bool cpu_pinning,
                        bool cpu_pinning_changed,
                        bool cpu_reservation,
+                       int num_sockets,
                        const std::vector<std::vector<int>>& streams_info_table);
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -1434,6 +1434,7 @@ std::vector<std::vector<int>> generate_stream_info(const int streams,
     config.enableCpuPinning = check_cpu_pinning(config.enableCpuPinning,
                                                 config.changedCpuPinning,
                                                 config.enableCpuReservation,
+                                                -1,
                                                 streams_info_table);
 
     config.streamExecutorConfig = IStreamsExecutor::Config{"CPUStreamsExecutor",

--- a/src/plugins/intel_cpu/tests/unit/streams_info/cpu_pinning_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info/cpu_pinning_test.cpp
@@ -17,6 +17,7 @@ namespace {
 struct CpuPinningTestCase {
     bool input_cpu_pinning;
     bool input_changed;
+    int input_num_sockets;
     std::vector<std::vector<int>> input_cpu_map_table;
     std::vector<std::vector<int>> input_proc_type_table;
     std::vector<std::vector<int>> input_stream_info_table;
@@ -39,6 +40,7 @@ public:
         test_data.input_cpu_pinning = ov::intel_cpu::check_cpu_pinning(test_data.input_cpu_pinning,
                                                                        test_data.input_changed,
                                                                        cpu_reservation,
+                                                                       test_data.input_num_sockets,
                                                                        test_data.input_stream_info_table);
 
         ASSERT_EQ(test_data.output_cpu_pinning, test_data.input_cpu_pinning);
@@ -50,6 +52,7 @@ TEST_P(CpuPinningTests, CpuPinning) {}
 CpuPinningTestCase cpu_pinning_macos_mock_set_true = {
     true,                             // param[in]: simulated settting for cpu pinning property
     true,                             // param[in]: simulated settting for user changing cpu pinning property
+    1,                                // param[in]: number of CPU sockets
     {},                               // param[in]: simulated setting for current cpu_mapping_table
     {{40, 20, 0, 20, 0, 0}},          // param[in]: simulated setting for current proc_type_table
     {{1, MAIN_CORE_PROC, 20, 0, 0}},  // param[in]: simulated setting for current streams_info_table
@@ -58,6 +61,7 @@ CpuPinningTestCase cpu_pinning_macos_mock_set_true = {
 CpuPinningTestCase cpu_pinning_macos_mock_set_false = {
     false,
     true,
+    1,
     {},
     {{40, 20, 0, 20, 0, 0}},
     {{1, MAIN_CORE_PROC, 20, 0, 0}},
@@ -66,6 +70,7 @@ CpuPinningTestCase cpu_pinning_macos_mock_set_false = {
 CpuPinningTestCase cpu_pinning_macos_mock_set_default = {
     true,
     false,
+    1,
     {},
     {{40, 20, 0, 20, 0, 0}},
     {{1, MAIN_CORE_PROC, 20, 0, 0}},
@@ -74,6 +79,7 @@ CpuPinningTestCase cpu_pinning_macos_mock_set_default = {
 CpuPinningTestCase cpu_pinning_win_mock_set_true = {
     true,
     true,
+    1,
     {
         {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 1, HYPER_THREADING_PROC, 1, -1},
         {2, 0, 0, 2, HYPER_THREADING_PROC, 2, -1},    {3, 0, 0, 3, HYPER_THREADING_PROC, 3, -1},
@@ -103,6 +109,7 @@ CpuPinningTestCase cpu_pinning_win_mock_set_true = {
 CpuPinningTestCase cpu_pinning_win_mock_set_true_2 = {
     true,
     true,
+    2,
     {
         {0, 0, 0, 0, MAIN_CORE_PROC, 0, -1},    {1, 0, 0, 1, MAIN_CORE_PROC, 1, -1},
         {2, 0, 0, 2, MAIN_CORE_PROC, 2, -1},    {3, 0, 0, 3, MAIN_CORE_PROC, 3, -1},
@@ -131,11 +138,12 @@ CpuPinningTestCase cpu_pinning_win_mock_set_true_2 = {
     },
     {{48, 48, 0, 0, -1, -1}, {24, 24, 0, 0, 0, 0}, {24, 24, 0, 0, 1, 1}},
     {{1, MAIN_CORE_PROC, 24, 0, 0}},
-    true,
+    false,
 };
 CpuPinningTestCase cpu_pinning_win_mock_set_false = {
     false,
     true,
+    1,
     {
         {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 1, HYPER_THREADING_PROC, 1, -1},
         {2, 0, 0, 2, HYPER_THREADING_PROC, 2, -1},    {3, 0, 0, 3, HYPER_THREADING_PROC, 3, -1},
@@ -165,6 +173,7 @@ CpuPinningTestCase cpu_pinning_win_mock_set_false = {
 CpuPinningTestCase cpu_pinning_win_mock_set_false_2 = {
     false,
     true,
+    2,
     {
         {0, 0, 0, 0, MAIN_CORE_PROC, 0, -1},    {1, 0, 0, 1, MAIN_CORE_PROC, 1, -1},
         {2, 0, 0, 2, MAIN_CORE_PROC, 2, -1},    {3, 0, 0, 3, MAIN_CORE_PROC, 3, -1},
@@ -198,6 +207,7 @@ CpuPinningTestCase cpu_pinning_win_mock_set_false_2 = {
 CpuPinningTestCase cpu_pinning_win_mock_set_default = {
     true,
     false,
+    1,
     {
         {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 1, HYPER_THREADING_PROC, 1, -1},
         {2, 0, 0, 2, HYPER_THREADING_PROC, 2, -1},    {3, 0, 0, 3, HYPER_THREADING_PROC, 3, -1},
@@ -227,6 +237,7 @@ CpuPinningTestCase cpu_pinning_win_mock_set_default = {
 CpuPinningTestCase cpu_pinning_win_mock_set_default_2 = {
     true,
     false,
+    2,
     {
         {0, 0, 0, 0, MAIN_CORE_PROC, 0, -1},    {1, 0, 0, 1, MAIN_CORE_PROC, 1, -1},
         {2, 0, 0, 2, MAIN_CORE_PROC, 2, -1},    {3, 0, 0, 3, MAIN_CORE_PROC, 3, -1},
@@ -260,6 +271,7 @@ CpuPinningTestCase cpu_pinning_win_mock_set_default_2 = {
 CpuPinningTestCase cpu_pinning_linux_mock_set_true = {
     true,
     true,
+    1,
     {
         {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 1, HYPER_THREADING_PROC, 1, -1},
         {2, 0, 0, 2, HYPER_THREADING_PROC, 2, -1},    {3, 0, 0, 3, HYPER_THREADING_PROC, 3, -1},
@@ -289,6 +301,7 @@ CpuPinningTestCase cpu_pinning_linux_mock_set_true = {
 CpuPinningTestCase cpu_pinning_linux_mock_set_true_2 = {
     true,
     true,
+    2,
     {
         {0, 0, 0, 0, MAIN_CORE_PROC, 0, -1},    {1, 0, 0, 1, MAIN_CORE_PROC, 1, -1},
         {2, 0, 0, 2, MAIN_CORE_PROC, 2, -1},    {3, 0, 0, 3, MAIN_CORE_PROC, 3, -1},
@@ -322,6 +335,7 @@ CpuPinningTestCase cpu_pinning_linux_mock_set_true_2 = {
 CpuPinningTestCase cpu_pinning_linux_mock_set_false = {
     false,
     true,
+    1,
     {
         {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 1, HYPER_THREADING_PROC, 1, -1},
         {2, 0, 0, 2, HYPER_THREADING_PROC, 2, -1},    {3, 0, 0, 3, HYPER_THREADING_PROC, 3, -1},
@@ -351,6 +365,7 @@ CpuPinningTestCase cpu_pinning_linux_mock_set_false = {
 CpuPinningTestCase cpu_pinning_linux_mock_set_false_2 = {
     false,
     true,
+    2,
     {
         {0, 0, 0, 0, MAIN_CORE_PROC, 0, -1},    {1, 0, 0, 1, MAIN_CORE_PROC, 1, -1},
         {2, 0, 0, 2, MAIN_CORE_PROC, 2, -1},    {3, 0, 0, 3, MAIN_CORE_PROC, 3, -1},
@@ -384,6 +399,7 @@ CpuPinningTestCase cpu_pinning_linux_mock_set_false_2 = {
 CpuPinningTestCase cpu_pinning_linux_mock_set_default = {
     false,
     false,
+    1,
     {
         {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 1, HYPER_THREADING_PROC, 1, -1},
         {2, 0, 0, 2, HYPER_THREADING_PROC, 2, -1},    {3, 0, 0, 3, HYPER_THREADING_PROC, 3, -1},
@@ -413,6 +429,7 @@ CpuPinningTestCase cpu_pinning_linux_mock_set_default = {
 CpuPinningTestCase cpu_pinning_linux_mock_set_default_2 = {
     true,
     false,
+    1,
     {
         {0, 0, 0, 0, MAIN_CORE_PROC, 0, -1},         {1, 0, 0, 0, HYPER_THREADING_PROC, 1, -1},
         {2, 0, 0, 1, MAIN_CORE_PROC, 2, -1},         {3, 0, 0, 1, HYPER_THREADING_PROC, 3, -1},
@@ -432,6 +449,7 @@ CpuPinningTestCase cpu_pinning_linux_mock_set_default_2 = {
 CpuPinningTestCase cpu_pinning_linux_mock_set_default_3 = {
     false,
     false,
+    2,
     {
         {0, 0, 0, 0, MAIN_CORE_PROC, 0, -1},    {1, 0, 0, 1, MAIN_CORE_PROC, 1, -1},
         {2, 0, 0, 2, MAIN_CORE_PROC, 2, -1},    {3, 0, 0, 3, MAIN_CORE_PROC, 3, -1},


### PR DESCRIPTION
This pull request updates the CPU pinning logic to improve Windows platform support by considering the number of CPU sockets, and refactors related code and tests to support this change. The main updates include changes to the `check_cpu_pinning` function's interface and logic, as well as updates to unit tests to pass the number of sockets explicitly.

**CPU Pinning Logic Improvements:**

* Updated the `check_cpu_pinning` function to take an explicit `num_sockets` parameter and changed its logic on Windows to disable pinning when more than one socket is present. [[1]](diffhunk://#diff-ab2ade98e24584ccbe26c804942bafb1377f1dd8f2bb9c40911f080c2614e9b2R79-R95) [[2]](diffhunk://#diff-72de4822a20d445dd82d126fa30217105e6bc11537f651c5463a35d2655d51f8R47-R54)
* Updated all call sites, including `generate_stream_info`, to provide the `num_sockets` parameter (using `-1` as a default when unknown).

**Unit Test Refactoring:**

* Refactored the `CpuPinningTestCase` struct and all test cases to include and pass the `input_num_sockets` parameter, ensuring that tests accurately reflect the new logic. [[1]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R20) [[2]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R43)
* Updated all CPU pinning test cases to specify the number of sockets and adjusted expected outcomes where necessary (e.g., for multi-socket Windows scenarios). [[1]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R55) [[2]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R64) [[3]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R73) [[4]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R82) [[5]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R112) [[6]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5L134-R146) [[7]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R176) [[8]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R210) [[9]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R240) [[10]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R274) [[11]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R304) [[12]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R338) [[13]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R368) [[14]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R402) [[15]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R432) [[16]](diffhunk://#diff-628a915e7955bb3fcd879fb24adb1023c79d57adadfefceed3f78d272289d1b5R452)

Tickets:
* CVS-191433
