### PR TITLE
[GPU] Fix RMS last-axis normalization and scalar gamma support

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_bfyx_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_bfyx_opt.cl
@@ -206,6 +206,10 @@ KERNEL(rms_gpu_bfyx_opt)(
     rms = slm_buf[0];
 #endif
 
+    #if ELEMENTWISE_AFFINE && SCALAR_GAMMA
+        const ACCUMULATOR_TYPE scalar_gamma = TO_ACCUMULATOR_TYPE(gamma[INPUT1_OFFSET]);
+    #endif
+
     #if HAS_FUSED_OPS
         uint b, f, z, y, x;
         #if INPUT_RANK == 1
@@ -232,7 +236,7 @@ KERNEL(rms_gpu_bfyx_opt)(
         const uint obase = output_data_offset + subgroup_offset;
         const uint gbase = subgroup_offset;
         for (; i + 8 <= items_num; i += 8) {
-#if ELEMENTWISE_AFFINE
+    #if ELEMENTWISE_AFFINE && !SCALAR_GAMMA
             MAKE_VECTOR_TYPE(INPUT1_TYPE, 8) g = DT_INPUT_BLOCK_READ8(gamma, gbase + i * sgs);
 #endif
             MAKE_VECTOR_TYPE(OUTPUT_TYPE, 8) o;
@@ -242,7 +246,9 @@ KERNEL(rms_gpu_bfyx_opt)(
 #else
                 ACCUMULATOR_TYPE data_value = data[i + j];
 #endif
-#if ELEMENTWISE_AFFINE
+#if ELEMENTWISE_AFFINE && SCALAR_GAMMA
+                OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * scalar_gamma);
+#elif ELEMENTWISE_AFFINE
                 OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * TO_ACCUMULATOR_TYPE(g[j]));
 #else
                 OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value);
@@ -257,7 +263,7 @@ KERNEL(rms_gpu_bfyx_opt)(
             DT_OUTPUT_BLOCK_WRITE8(output, obase + i * sgs, o);
         }
         for (; i + 4 <= items_num; i += 4) {
-#if ELEMENTWISE_AFFINE
+    #if ELEMENTWISE_AFFINE && !SCALAR_GAMMA
             MAKE_VECTOR_TYPE(INPUT1_TYPE, 4) g = DT_INPUT_BLOCK_READ4(gamma, gbase + i * sgs);
 #endif
             MAKE_VECTOR_TYPE(OUTPUT_TYPE, 4) o;
@@ -267,7 +273,9 @@ KERNEL(rms_gpu_bfyx_opt)(
 #else
                 ACCUMULATOR_TYPE data_value = data[i + j];
 #endif
-#if ELEMENTWISE_AFFINE
+#if ELEMENTWISE_AFFINE && SCALAR_GAMMA
+                OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * scalar_gamma);
+#elif ELEMENTWISE_AFFINE
                 OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * TO_ACCUMULATOR_TYPE(g[j]));
 #else
                 OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value);
@@ -282,7 +290,7 @@ KERNEL(rms_gpu_bfyx_opt)(
             DT_OUTPUT_BLOCK_WRITE4(output, obase + i * sgs, o);
         }
         for (; i + 2 <= items_num; i += 2) {
-#if ELEMENTWISE_AFFINE
+    #if ELEMENTWISE_AFFINE && !SCALAR_GAMMA
             MAKE_VECTOR_TYPE(INPUT1_TYPE, 2) g = DT_INPUT_BLOCK_READ2(gamma, gbase + i * sgs);
 #endif
             MAKE_VECTOR_TYPE(OUTPUT_TYPE, 2) o;
@@ -292,7 +300,9 @@ KERNEL(rms_gpu_bfyx_opt)(
 #else
                 ACCUMULATOR_TYPE data_value = data[i + j];
 #endif
-#if ELEMENTWISE_AFFINE
+#if ELEMENTWISE_AFFINE && SCALAR_GAMMA
+                OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * scalar_gamma);
+#elif ELEMENTWISE_AFFINE
                 OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * TO_ACCUMULATOR_TYPE(g[j]));
 #else
                 OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value);
@@ -315,7 +325,9 @@ KERNEL(rms_gpu_bfyx_opt)(
     #else
         ACCUMULATOR_TYPE data_value = data[i];
     #endif
-#if ELEMENTWISE_AFFINE
+#if ELEMENTWISE_AFFINE && SCALAR_GAMMA
+    OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * scalar_gamma);
+#elif ELEMENTWISE_AFFINE
         ACCUMULATOR_TYPE temp = TO_ACCUMULATOR_TYPE(gamma[subgroup_offset + get_sub_group_local_id() + i * sgs]);
         OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * temp);
 #else
@@ -335,7 +347,9 @@ KERNEL(rms_gpu_bfyx_opt)(
     #else
         ACCUMULATOR_TYPE data_value = data[items_num];
     #endif
-#if ELEMENTWISE_AFFINE
+#if ELEMENTWISE_AFFINE && SCALAR_GAMMA
+    OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * scalar_gamma);
+#elif ELEMENTWISE_AFFINE
         ACCUMULATOR_TYPE temp = TO_ACCUMULATOR_TYPE(gamma[workers_per_data * items_num + local_data_idx]);
         OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * temp);
 #else

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_bfyx_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_bfyx_opt.cl
@@ -206,9 +206,9 @@ KERNEL(rms_gpu_bfyx_opt)(
     rms = slm_buf[0];
 #endif
 
-    #if ELEMENTWISE_AFFINE && SCALAR_GAMMA
-        const ACCUMULATOR_TYPE scalar_gamma = TO_ACCUMULATOR_TYPE(gamma[INPUT1_OFFSET]);
-    #endif
+#if ELEMENTWISE_AFFINE && SCALAR_GAMMA
+    const ACCUMULATOR_TYPE scalar_gamma = TO_ACCUMULATOR_TYPE(gamma[INPUT1_OFFSET]);
+#endif
 
     #if HAS_FUSED_OPS
         uint b, f, z, y, x;
@@ -236,7 +236,7 @@ KERNEL(rms_gpu_bfyx_opt)(
         const uint obase = output_data_offset + subgroup_offset;
         const uint gbase = subgroup_offset;
         for (; i + 8 <= items_num; i += 8) {
-    #if ELEMENTWISE_AFFINE && !SCALAR_GAMMA
+#if ELEMENTWISE_AFFINE && !SCALAR_GAMMA
             MAKE_VECTOR_TYPE(INPUT1_TYPE, 8) g = DT_INPUT_BLOCK_READ8(gamma, gbase + i * sgs);
 #endif
             MAKE_VECTOR_TYPE(OUTPUT_TYPE, 8) o;
@@ -263,7 +263,7 @@ KERNEL(rms_gpu_bfyx_opt)(
             DT_OUTPUT_BLOCK_WRITE8(output, obase + i * sgs, o);
         }
         for (; i + 4 <= items_num; i += 4) {
-    #if ELEMENTWISE_AFFINE && !SCALAR_GAMMA
+#if ELEMENTWISE_AFFINE && !SCALAR_GAMMA
             MAKE_VECTOR_TYPE(INPUT1_TYPE, 4) g = DT_INPUT_BLOCK_READ4(gamma, gbase + i * sgs);
 #endif
             MAKE_VECTOR_TYPE(OUTPUT_TYPE, 4) o;
@@ -290,7 +290,7 @@ KERNEL(rms_gpu_bfyx_opt)(
             DT_OUTPUT_BLOCK_WRITE4(output, obase + i * sgs, o);
         }
         for (; i + 2 <= items_num; i += 2) {
-    #if ELEMENTWISE_AFFINE && !SCALAR_GAMMA
+#if ELEMENTWISE_AFFINE && !SCALAR_GAMMA
             MAKE_VECTOR_TYPE(INPUT1_TYPE, 2) g = DT_INPUT_BLOCK_READ2(gamma, gbase + i * sgs);
 #endif
             MAKE_VECTOR_TYPE(OUTPUT_TYPE, 2) o;
@@ -326,7 +326,7 @@ KERNEL(rms_gpu_bfyx_opt)(
         ACCUMULATOR_TYPE data_value = data[i];
     #endif
 #if ELEMENTWISE_AFFINE && SCALAR_GAMMA
-    OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * scalar_gamma);
+        OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * scalar_gamma);
 #elif ELEMENTWISE_AFFINE
         ACCUMULATOR_TYPE temp = TO_ACCUMULATOR_TYPE(gamma[subgroup_offset + get_sub_group_local_id() + i * sgs]);
         OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * temp);
@@ -348,7 +348,7 @@ KERNEL(rms_gpu_bfyx_opt)(
         ACCUMULATOR_TYPE data_value = data[items_num];
     #endif
 #if ELEMENTWISE_AFFINE && SCALAR_GAMMA
-    OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * scalar_gamma);
+        OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * scalar_gamma);
 #elif ELEMENTWISE_AFFINE
         ACCUMULATOR_TYPE temp = TO_ACCUMULATOR_TYPE(gamma[workers_per_data * items_num + local_data_idx]);
         OUTPUT_TYPE normalized = TO_OUTPUT_TYPE(rms * data_value * temp);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_ref.cl
@@ -20,39 +20,61 @@ KERNEL(rms_gpu_ref)(
     const uint f = get_global_id(1);
     const uint w = 0;
 
-    ACCUMULATOR_TYPE rms = ACCUMULATOR_VAL_ZERO;
-    for (uint z = 0; z < INPUT0_SIZE_Z; z++) {
-        for (uint y = 0; y < INPUT0_SIZE_Y; y++) {
-            for (uint x = 0; x < INPUT0_SIZE_X; x++) {
-                const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
-                rms += pow(TO_ACCUMULATOR_TYPE(input[input_idx]), 2);
-            }
-        }
-    }
-
-    rms /= INPUT0_SIZE_X * INPUT0_SIZE_Y * INPUT0_SIZE_Z;
-    rms = pow(sqrt(rms + TO_ACCUMULATOR_TYPE(EPSILON)), -1);
-
-    for (uint z = 0; z < INPUT0_SIZE_Z; z++) {
-        for (uint y = 0; y < INPUT0_SIZE_Y; y++) {
-            for (uint x = 0; x < INPUT0_SIZE_X; x++) {
-                const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
-                const uint output_idx = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
-#if ELEMENTWISE_AFFINE
-#if INPUT0_DIMS == 4
-                const uint gamma_idx = y;
-#elif INPUT0_DIMS == 5
-                const uint gamma_idx = z;
-#endif
-                OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]) * TO_OUTPUT_TYPE(gamma[gamma_idx]);
+    // INPUT_RANK selects the logical normalization axis.
+#if INPUT_RANK >= 4
+    const uint outer_z_size = INPUT0_SIZE_Z;
+    const uint outer_y_size = INPUT0_SIZE_Y;
+    const uint norm_size = INPUT0_SIZE_X;
 #else
-                OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]);
+    const uint outer_z_size = 1;
+    const uint outer_y_size = 1;
+    const uint norm_size = INPUT0_SIZE_X * INPUT0_SIZE_Y * INPUT0_SIZE_Z;
 #endif
-                #if HAS_FUSED_OPS
-                    FUSED_OPS;
-                    result = FUSED_OPS_RESULT;
-                #endif
-                output[output_idx] = result;
+
+    for (uint outer_z = 0; outer_z < outer_z_size; outer_z++) {
+        for (uint outer_y = 0; outer_y < outer_y_size; outer_y++) {
+#if INPUT_RANK >= 4
+            const uint z_begin = outer_z;
+            const uint z_end = outer_z + 1;
+            const uint y_begin = outer_y;
+            const uint y_end = outer_y + 1;
+#else
+            const uint z_begin = 0;
+            const uint z_end = INPUT0_SIZE_Z;
+            const uint y_begin = 0;
+            const uint y_end = INPUT0_SIZE_Y;
+#endif
+            ACCUMULATOR_TYPE rms = ACCUMULATOR_VAL_ZERO;
+            for (uint z = z_begin; z < z_end; z++) {
+                for (uint y = y_begin; y < y_end; y++) {
+                    for (uint x = 0; x < INPUT0_SIZE_X; x++) {
+                        const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
+                        rms += pow(TO_ACCUMULATOR_TYPE(input[input_idx]), 2);
+                    }
+                }
+            }
+
+            rms /= norm_size;
+            rms = pow(sqrt(rms + TO_ACCUMULATOR_TYPE(EPSILON)), -1);
+
+            for (uint z = z_begin; z < z_end; z++) {
+                for (uint y = y_begin; y < y_end; y++) {
+                    for (uint x = 0; x < INPUT0_SIZE_X; x++) {
+                        const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
+                        const uint output_idx = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
+#if ELEMENTWISE_AFFINE
+                        const uint gamma_idx = INPUT1_LENGTH == 1 ? 0 : GAMMA_AXIS_INDEX;
+                        OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]) * TO_OUTPUT_TYPE(gamma[gamma_idx]);
+#else
+                        OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]);
+#endif
+                        #if HAS_FUSED_OPS
+                            FUSED_OPS;
+                            result = FUSED_OPS_RESULT;
+                        #endif
+                        output[output_idx] = result;
+                    }
+                }
             }
         }
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_ref.cl
@@ -4,6 +4,20 @@
 
 #include "include/fetch_utils.cl"
 
+#if NORMALIZE_BATCH
+    #define NORM_SIZE INPUT0_BATCH_NUM
+    #define NORM_INDEX b
+#elif NORMALIZE_FEATURE
+    #define NORM_SIZE INPUT0_FEATURE_NUM
+    #define NORM_INDEX f
+#elif NORMALIZE_Y
+    #define NORM_SIZE INPUT0_SIZE_Y
+    #define NORM_INDEX y
+#else
+    #define NORM_SIZE INPUT0_SIZE_X
+    #define NORM_INDEX x
+#endif
+
 KERNEL(rms_gpu_ref)(
     OPTIONAL_SHAPE_INFO_ARG
     const __global INPUT0_TYPE* input,
@@ -16,66 +30,52 @@ KERNEL(rms_gpu_ref)(
     #endif
 )
 {
-    const uint b = get_global_id(0);
-    const uint f = get_global_id(1);
-    const uint w = 0;
-
-    // INPUT_RANK selects the logical normalization axis.
-#if INPUT_RANK >= 4
+#if NORMALIZE_X
     const uint outer_z_size = INPUT0_SIZE_Z;
     const uint outer_y_size = INPUT0_SIZE_Y;
-    const uint norm_size = INPUT0_SIZE_X;
 #else
     const uint outer_z_size = 1;
     const uint outer_y_size = 1;
-    const uint norm_size = INPUT0_SIZE_X * INPUT0_SIZE_Y * INPUT0_SIZE_Z;
 #endif
 
     for (uint outer_z = 0; outer_z < outer_z_size; outer_z++) {
         for (uint outer_y = 0; outer_y < outer_y_size; outer_y++) {
-#if INPUT_RANK >= 4
-            const uint z_begin = outer_z;
-            const uint z_end = outer_z + 1;
-            const uint y_begin = outer_y;
-            const uint y_end = outer_y + 1;
-#else
-            const uint z_begin = 0;
-            const uint z_end = INPUT0_SIZE_Z;
-            const uint y_begin = 0;
-            const uint y_end = INPUT0_SIZE_Y;
-#endif
+            uint b = get_global_id(0);
+            uint f = get_global_id(1);
+            uint z = outer_z;
+            uint y = outer_y;
+            uint x = 0;
+
             ACCUMULATOR_TYPE rms = ACCUMULATOR_VAL_ZERO;
-            for (uint z = z_begin; z < z_end; z++) {
-                for (uint y = y_begin; y < y_end; y++) {
-                    for (uint x = 0; x < INPUT0_SIZE_X; x++) {
-                        const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
-                        rms += pow(TO_ACCUMULATOR_TYPE(input[input_idx]), 2);
-                    }
-                }
+            for (uint n = 0; n < NORM_SIZE; n++) {
+                NORM_INDEX = n;
+                const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, 0, z, y, x);
+                const ACCUMULATOR_TYPE value = TO_ACCUMULATOR_TYPE(input[input_idx]);
+                rms += value * value;
             }
 
-            rms /= norm_size;
+            rms /= NORM_SIZE;
             rms = pow(sqrt(rms + TO_ACCUMULATOR_TYPE(EPSILON)), -1);
 
-            for (uint z = z_begin; z < z_end; z++) {
-                for (uint y = y_begin; y < y_end; y++) {
-                    for (uint x = 0; x < INPUT0_SIZE_X; x++) {
-                        const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
-                        const uint output_idx = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
+            for (uint n = 0; n < NORM_SIZE; n++) {
+                NORM_INDEX = n;
+                const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, 0, z, y, x);
+                const uint output_idx = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, 0, z, y, x);
 #if ELEMENTWISE_AFFINE
-                        const uint gamma_idx = INPUT1_LENGTH == 1 ? 0 : GAMMA_AXIS_INDEX;
-                        OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]) * TO_OUTPUT_TYPE(gamma[gamma_idx]);
+                const uint gamma_idx = INPUT1_OFFSET + (INPUT1_LENGTH == 1 ? 0 : n);
+                OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]) * TO_OUTPUT_TYPE(gamma[gamma_idx]);
 #else
-                        OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]);
+                OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]);
 #endif
-                        #if HAS_FUSED_OPS
-                            FUSED_OPS;
-                            result = FUSED_OPS_RESULT;
-                        #endif
-                        output[output_idx] = result;
-                    }
-                }
+                #if HAS_FUSED_OPS
+                    FUSED_OPS;
+                    result = FUSED_OPS_RESULT;
+                #endif
+                output[output_idx] = result;
             }
         }
     }
 }
+
+#undef NORM_SIZE
+#undef NORM_INDEX

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.cpp
@@ -21,18 +21,55 @@ bool RMSKernelBase::Validate(const Params& p) const {
 JitConstants RMSKernelBase::GetJitConstants(const rms_params& params, RMSKernelBase::DispatchData) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
 
+    const auto normalization_axis = GetNormalizationAxis(params);
     jit.AddConstant(MakeJitConstant("EPSILON", params.epsilon));
     jit.AddConstant(MakeJitConstant("ELEMENTWISE_AFFINE", params.elementwise_affine));
+    jit.AddConstant(MakeJitConstant("INPUT_RANK", params.ov_input_rank));
+    jit.AddConstants({
+        MakeJitConstant("NORMALIZE_BATCH", normalization_axis == Tensor::DataChannelName::BATCH),
+        MakeJitConstant("NORMALIZE_FEATURE", normalization_axis == Tensor::DataChannelName::FEATURE),
+        MakeJitConstant("NORMALIZE_Y", normalization_axis == Tensor::DataChannelName::Y),
+        MakeJitConstant("NORMALIZE_X", normalization_axis == Tensor::DataChannelName::X),
+    });
     jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
 
     return jit;
+}
+
+Tensor::DataChannelName RMSKernelBase::GetNormalizationAxis(const rms_params& params) {
+    switch (params.ov_input_rank) {
+        case 1: return Tensor::DataChannelName::BATCH;
+        case 2: return Tensor::DataChannelName::FEATURE;
+        case 3: return Tensor::DataChannelName::Y;
+        default: return Tensor::DataChannelName::X;
+    }
+}
+
+const char* RMSKernelBase::GetNormalizationAxisName(Tensor::DataChannelName axis) {
+    switch (axis) {
+        case Tensor::DataChannelName::BATCH: return "b";
+        case Tensor::DataChannelName::FEATURE: return "f";
+        case Tensor::DataChannelName::Y: return "y";
+        case Tensor::DataChannelName::X: return "x";
+        default: OPENVINO_THROW("Unsupported RMS normalization axis");
+    }
 }
 
 RMSKernelBase::DispatchData RMSKernelBase::SetDefault(const rms_params& params) const {
     DispatchData dispatchData;
     const auto& output = params.outputs[0];
 
-    dispatchData.gws = {output.Batch().v, output.Feature().v, 1};
+    switch (GetNormalizationAxis(params)) {
+        case Tensor::DataChannelName::BATCH:
+            dispatchData.gws = {1, 1, 1};
+            break;
+        case Tensor::DataChannelName::FEATURE:
+            dispatchData.gws = {output.Batch().v, 1, 1};
+            break;
+        default:
+            dispatchData.gws = {output.Batch().v, output.Feature().v, 1};
+            break;
+    }
     dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo);
 
     return dispatchData;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.h
@@ -40,6 +40,8 @@ protected:
     bool Validate(const Params&) const override;
     virtual JitConstants GetJitConstants(const rms_params& params, DispatchData dispatchData) const;
     virtual DispatchData SetDefault(const rms_params& params) const;
+    static Tensor::DataChannelName GetNormalizationAxis(const rms_params& params);
+    static const char* GetNormalizationAxisName(Tensor::DataChannelName axis);
     KernelsData GetCommonKernelsData(const Params& params) const;
     Datatype GetAccumulatorType(const rms_params& params) const;
     void GetUpdateDispatchDataFunc(KernelData& kd) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
@@ -42,6 +42,11 @@ DeviceFeaturesKey RMSKernelBfyxOpt::get_required_device_features_key(const Param
 JitConstants RMSKernelBfyxOpt::GetJitConstants(const rms_params& params, DispatchData dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
 
+    const bool scalar_gamma = params.elementwise_affine &&
+                              !params.inputs[1].is_dynamic() &&
+                              params.inputs[1].LogicalSize() == 1;
+    jit.AddConstant(MakeJitConstant("SCALAR_GAMMA", scalar_gamma));
+
     // Check for any padding (dynamic or static) on input dimensions.
     // The flat addressing path (data_idx * data_size) assumes contiguous memory,
     // which breaks when padding introduces gaps between slices (e.g., from in-place crop).
@@ -229,7 +234,7 @@ bool RMSKernelBfyxOpt::Validate(const Params& p) const {
 
         if (!gamma.is_dynamic()) {
             size_t data_size = gamma.LogicalSize();
-            if (data_size < RmsSchedulingPolicy::kSubgroupSize) {
+            if (data_size != 1 && data_size < RmsSchedulingPolicy::kSubgroupSize) {
                 DO_NOT_USE_THIS_KERNEL(p.layerID);
             }
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
@@ -41,6 +41,7 @@ DeviceFeaturesKey RMSKernelBfyxOpt::get_required_device_features_key(const Param
 
 JitConstants RMSKernelBfyxOpt::GetJitConstants(const rms_params& params, DispatchData dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
+    const auto normalization_axis = GetNormalizationAxis(params);
 
     const bool scalar_gamma = params.elementwise_affine &&
                               !params.inputs[1].is_dynamic() &&
@@ -66,14 +67,14 @@ JitConstants RMSKernelBfyxOpt::GetJitConstants(const rms_params& params, Dispatc
         const auto& input = params.inputs[0];
         DimensionAccessHelperJit dims(input);
         std::string data_size;
-        switch (params.ov_input_rank) {
-            case 1 :
+        switch (normalization_axis) {
+            case Tensor::DataChannelName::BATCH:
                 data_size = dims.b();
                 break;
-            case 2 :
+            case Tensor::DataChannelName::FEATURE:
                 data_size = dims.f();
                 break;
-            case 3 :
+            case Tensor::DataChannelName::Y:
                 data_size = dims.y();
                 break;
             default:
@@ -137,23 +138,9 @@ JitConstants RMSKernelBfyxOpt::GetJitConstants(const rms_params& params, Dispatc
             MakeJitConstant("RMS_REREAD_INPUT", stack_size > policy.stack_cap),
         });
     }
-    jit.AddConstant(MakeJitConstant("INPUT_RANK", params.ov_input_rank));
     jit.AddConstant(MakeJitConstant("SUB_GROUP_SIZE", RmsSchedulingPolicy::kSubgroupSize));
     if (!params.fused_ops.empty()) {
-        switch (params.ov_input_rank) {
-            case 1 :
-                jit.AddConstant(MakeJitConstant("LAST_DIM", "b"));
-                break;
-            case 2 :
-                jit.AddConstant(MakeJitConstant("LAST_DIM", "f"));
-                break;
-            case 3 :
-                jit.AddConstant(MakeJitConstant("LAST_DIM", "y"));
-                break;
-            default:
-                jit.AddConstant(MakeJitConstant("LAST_DIM", "x"));
-                break;
-        }
+        jit.AddConstant(MakeJitConstant("LAST_DIM", GetNormalizationAxisName(normalization_axis)));
 
         std::vector<std::string> idx_order;
         if (params.inputs[0].GetDims().size() == 5) {
@@ -182,16 +169,16 @@ RMSKernelBase::DispatchData RMSKernelBfyxOpt::SetDefault(const rms_params& param
     // data size to be processed within a LWG. For dynamic kernels, these values are
     // populated during dispatch update once concrete dimensions are known; if a dimension
     // is still unknown, leave the default dynamic dispatch data untouched.
-    switch (params.ov_input_rank) {
-        case 1:
+    switch (GetNormalizationAxis(params)) {
+        case Tensor::DataChannelName::BATCH:
             dispatchData.dataSize = input.Batch().v;
             dispatchData.dataCount = 1;
             break;
-        case 2:
+        case Tensor::DataChannelName::FEATURE:
             dispatchData.dataSize = input.Feature().v;
             dispatchData.dataCount = input.Batch().v;
             break;
-        case 3:
+        case Tensor::DataChannelName::Y:
             dispatchData.dataSize = input.Y().v;
             dispatchData.dataCount = input.Batch().v * input.Feature().v;
             break;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.cpp
@@ -27,19 +27,6 @@ ParamsKey RMSKernelRef::GetSupportedKey() const {
 
 JitConstants RMSKernelRef::GetJitConstants(const rms_params& params, DispatchData dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
-    jit.AddConstant(MakeJitConstant("INPUT_RANK", params.ov_input_rank));
-    if (params.elementwise_affine) {
-        // ov_input_rank describes the original logical OpenVINO shape, while GetDims()
-        // describes the physical GPU storage. Rank 4+ uses logical X; otherwise a
-        // lower-rank tensor padded to 5D bfzyx uses Z, and padded 4D bfyx uses Y.
-        if (params.ov_input_rank >= 4) {
-            jit.AddConstant(MakeJitConstant("GAMMA_AXIS_INDEX", "x"));
-        } else if (params.inputs[0].GetDims().size() == 5) {
-            jit.AddConstant(MakeJitConstant("GAMMA_AXIS_INDEX", "z"));
-        } else {
-            jit.AddConstant(MakeJitConstant("GAMMA_AXIS_INDEX", "y"));
-        }
-    }
 
     if (!params.fused_ops.empty()) {
         std::vector<std::string> idx_order;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.cpp
@@ -27,6 +27,19 @@ ParamsKey RMSKernelRef::GetSupportedKey() const {
 
 JitConstants RMSKernelRef::GetJitConstants(const rms_params& params, DispatchData dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
+    jit.AddConstant(MakeJitConstant("INPUT_RANK", params.ov_input_rank));
+    if (params.elementwise_affine) {
+        // ov_input_rank describes the original logical OpenVINO shape, while GetDims()
+        // describes the physical GPU storage. Rank 4+ uses logical X; otherwise a
+        // lower-rank tensor padded to 5D bfzyx uses Z, and padded 4D bfyx uses Y.
+        if (params.ov_input_rank >= 4) {
+            jit.AddConstant(MakeJitConstant("GAMMA_AXIS_INDEX", "x"));
+        } else if (params.inputs[0].GetDims().size() == 5) {
+            jit.AddConstant(MakeJitConstant("GAMMA_AXIS_INDEX", "z"));
+        } else {
+            jit.AddConstant(MakeJitConstant("GAMMA_AXIS_INDEX", "y"));
+        }
+    }
 
     if (!params.fused_ops.empty()) {
         std::vector<std::string> idx_order;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
@@ -690,3 +690,58 @@ TEST(rms_gpu_test, in_place_crop_rms_spatial_split) {
         ASSERT_NEAR(out1[i], ref1[i], 1e-4f) << "Branch 1 mismatch at index=" << i;
     }
 }
+
+TEST(rms_gpu_test, rms_test_bfyx_opt_rank4_scalar_gamma_dyn) {
+    auto& engine = get_test_engine();
+
+    for (const int64_t hidden_size : {128, 2560}) {
+        const ov::PartialShape input_shape{1, 3, 4, hidden_size};
+        auto input_layout_dynamic = layout{ov::PartialShape{-1, -1, 4, hidden_size},
+                                           data_types::f32,
+                                           format::bfyx};
+        auto input = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
+        auto gamma = engine.allocate_memory({ov::PartialShape{1}, data_types::f32, format::bfyx});
+        auto reference_gamma = engine.allocate_memory({ov::PartialShape{1, 1, 1, hidden_size},
+                                   data_types::f32,
+                                   format::bfyx});
+        auto output_ref = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
+
+        std::vector<float> input_values(input->count());
+        for (size_t index = 0; index < input_values.size(); ++index) {
+            input_values[index] = static_cast<float>(index % 17) - 8.0f;
+        }
+        set_values(input, input_values);
+        constexpr float gamma_value = 3.875f;
+        constexpr float epsilon = 1e-5f;
+        set_values(gamma, {gamma_value});
+        set_values(reference_gamma, std::vector<float>(static_cast<size_t>(hidden_size), gamma_value));
+        rms_ref<float>(input, reference_gamma, output_ref, epsilon);
+
+        topology topology;
+        topology.add(input_layout("input", input_layout_dynamic));
+        topology.add(input_layout("gamma", gamma->get_layout()));
+        topology.add(rms("rms", input_info("input"), input_info("gamma"), epsilon));
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{
+            {"rms", {format::bfyx, "rms_gpu_bfyx_opt"}}
+        }));
+        network network(engine, topology, config);
+        network.set_input_data("input", input);
+        network.set_input_data("gamma", gamma);
+
+        auto impl = network.get_primitive("rms")->get_impl();
+        ASSERT_NE(impl, nullptr);
+        ASSERT_TRUE(impl->is_dynamic());
+        ASSERT_EQ(impl->get_kernel_name(), "rms_gpu_bfyx_opt");
+
+        auto output = network.execute().at("rms").get_memory();
+        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
+        for (size_t index = 0; index < output_ref->count(); ++index) {
+            EXPECT_NEAR(output_ptr[index], output_ref_ptr[index], 1e-4f)
+                << " hidden_size=" << hidden_size << " index=" << index;
+        }
+    }
+}

--- a/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
@@ -33,11 +33,8 @@ void rms_ref(const memory::ptr input, const memory::ptr gamma, memory::ptr outpu
     }
     const bool scalar_gamma = gamma && gamma->count() == 1;
 
-    // RMS normalization across the last (innermost populated) dimension.
-    // For bfyx with x_size > 1 (rank 4): normalize across X per (b, f, y).
-    // For bfyx with x_size == 1 (rank 3 mapped to bfyx): normalize across Y per (b, f).
-    // This matches the kernel behavior based on ov_input_rank.
-    bool norm_over_x = (x_size > 1);
+    // RMS normalization follows the last logical axis, including rank-4 inputs with X == 1.
+    bool norm_over_x = input_layout.get_partial_shape().size() >= 4;
     uint32_t outer_y = norm_over_x ? y_size : 1;
     uint32_t norm_size = norm_over_x ? x_size : y_size;
 
@@ -109,6 +106,69 @@ TEST(rms_gpu_test, rms_test_bfyx_ref) {
     }
 }
 
+TEST(rms_gpu_test, rms_test_bfyx_ref_last_axis_by_rank) {
+    auto& engine = get_test_engine();
+    const std::vector<ov::PartialShape> input_shapes = {
+        {8},
+        {2, 8},
+        {2, 3, 8},
+        {2, 3, 4, 8},
+    };
+
+    for (const auto& input_shape : input_shapes) {
+        const auto rank = input_shape.size();
+        const auto norm_size = static_cast<size_t>(input_shape[rank - 1].get_length());
+        auto input = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
+        auto gamma = engine.allocate_memory({ov::PartialShape{static_cast<int64_t>(norm_size)},
+                             data_types::f32,
+                             format::bfyx});
+
+        std::vector<float> input_values(input->count());
+        std::vector<float> gamma_values(norm_size);
+        for (size_t index = 0; index < input_values.size(); ++index) {
+            input_values[index] = static_cast<float>(index % 13) - 6.0f;
+        }
+        for (size_t index = 0; index < gamma_values.size(); ++index) {
+            gamma_values[index] = 0.5f + static_cast<float>(index) * 0.125f;
+        }
+        set_values(input, input_values);
+        set_values(gamma, gamma_values);
+
+        constexpr float epsilon = 1e-5f;
+        std::vector<float> expected(input_values.size());
+        for (size_t offset = 0; offset < input_values.size(); offset += norm_size) {
+            float sum_squares = 0.0f;
+            for (size_t index = 0; index < norm_size; ++index) {
+                sum_squares += input_values[offset + index] * input_values[offset + index];
+            }
+            const float rms = 1.0f / std::sqrt(sum_squares / norm_size + epsilon);
+            for (size_t index = 0; index < norm_size; ++index) {
+                expected[offset + index] = input_values[offset + index] * rms * gamma_values[index];
+            }
+        }
+
+        topology topology;
+        topology.add(input_layout("input", input->get_layout()));
+        topology.add(input_layout("gamma", gamma->get_layout()));
+        topology.add(rms("rms", input_info("input"), input_info("gamma"), epsilon));
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{
+            {"rms", {format::bfyx, "rms_gpu_ref"}}
+        }));
+        network network(engine, topology, config);
+        network.set_input_data("input", input);
+        network.set_input_data("gamma", gamma);
+
+        auto output = network.execute().at("rms").get_memory();
+        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        for (size_t index = 0; index < expected.size(); ++index) {
+            EXPECT_NEAR(output_ptr[index], expected[index], 1e-4f)
+                << " rank=" << rank << " index=" << index;
+        }
+    }
+}
+
 TEST(rms_gpu_test, rms_test_bfyx_ref_rank4_scalar_gamma_dyn) {
     auto& engine = get_test_engine();
 
@@ -150,6 +210,57 @@ TEST(rms_gpu_test, rms_test_bfyx_ref_rank4_scalar_gamma_dyn) {
     cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
     for (size_t index = 0; index < output_ref->count(); ++index) {
         EXPECT_NEAR(output_ptr[index], output_ref_ptr[index], 1e-4f) << " index=" << index;
+    }
+}
+
+TEST(rms_gpu_test, rms_test_bfyx_opt_rank4_scalar_gamma_dyn) {
+    auto& engine = get_test_engine();
+
+    for (const int64_t hidden_size : {1, 128, 2560}) {
+        const ov::PartialShape input_shape{1, 3, 4, hidden_size};
+        auto input_layout_dynamic = layout{ov::PartialShape{-1, -1, 4, hidden_size},
+                                           data_types::f32,
+                                           format::bfyx};
+        auto input = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
+        auto gamma = engine.allocate_memory({ov::PartialShape{1}, data_types::f32, format::bfyx});
+        auto output_ref = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
+
+        std::vector<float> input_values(input->count());
+        for (size_t index = 0; index < input_values.size(); ++index) {
+            input_values[index] = static_cast<float>(index % 17) - 8.0f;
+        }
+        set_values(input, input_values);
+        constexpr float gamma_value = 3.875f;
+        constexpr float epsilon = 1e-5f;
+        set_values(gamma, {gamma_value});
+        rms_ref<float>(input, gamma, output_ref, epsilon);
+
+        topology topology;
+        topology.add(input_layout("input", input_layout_dynamic));
+        topology.add(input_layout("gamma", gamma->get_layout()));
+        topology.add(rms("rms", input_info("input"), input_info("gamma"), epsilon));
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{
+            {"rms", {format::bfyx, "rms_gpu_bfyx_opt"}}
+        }));
+        network network(engine, topology, config);
+        network.set_input_data("input", input);
+        network.set_input_data("gamma", gamma);
+
+        auto impl = network.get_primitive("rms")->get_impl();
+        ASSERT_NE(impl, nullptr);
+        ASSERT_TRUE(impl->is_dynamic());
+        ASSERT_EQ(impl->get_kernel_name(), "rms_gpu_bfyx_opt");
+
+        auto output = network.execute().at("rms").get_memory();
+        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
+        for (size_t index = 0; index < output_ref->count(); ++index) {
+            EXPECT_NEAR(output_ptr[index], output_ref_ptr[index], 1e-4f)
+                << " hidden_size=" << hidden_size << " index=" << index;
+        }
     }
 }
 
@@ -688,60 +799,5 @@ TEST(rms_gpu_test, in_place_crop_rms_spatial_split) {
     ASSERT_EQ(out1.size(), ref1.size());
     for (size_t i = 0; i < ref1.size(); i++) {
         ASSERT_NEAR(out1[i], ref1[i], 1e-4f) << "Branch 1 mismatch at index=" << i;
-    }
-}
-
-TEST(rms_gpu_test, rms_test_bfyx_opt_rank4_scalar_gamma_dyn) {
-    auto& engine = get_test_engine();
-
-    for (const int64_t hidden_size : {128, 2560}) {
-        const ov::PartialShape input_shape{1, 3, 4, hidden_size};
-        auto input_layout_dynamic = layout{ov::PartialShape{-1, -1, 4, hidden_size},
-                                           data_types::f32,
-                                           format::bfyx};
-        auto input = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
-        auto gamma = engine.allocate_memory({ov::PartialShape{1}, data_types::f32, format::bfyx});
-        auto reference_gamma = engine.allocate_memory({ov::PartialShape{1, 1, 1, hidden_size},
-                                   data_types::f32,
-                                   format::bfyx});
-        auto output_ref = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
-
-        std::vector<float> input_values(input->count());
-        for (size_t index = 0; index < input_values.size(); ++index) {
-            input_values[index] = static_cast<float>(index % 17) - 8.0f;
-        }
-        set_values(input, input_values);
-        constexpr float gamma_value = 3.875f;
-        constexpr float epsilon = 1e-5f;
-        set_values(gamma, {gamma_value});
-        set_values(reference_gamma, std::vector<float>(static_cast<size_t>(hidden_size), gamma_value));
-        rms_ref<float>(input, reference_gamma, output_ref, epsilon);
-
-        topology topology;
-        topology.add(input_layout("input", input_layout_dynamic));
-        topology.add(input_layout("gamma", gamma->get_layout()));
-        topology.add(rms("rms", input_info("input"), input_info("gamma"), epsilon));
-
-        ExecutionConfig config = get_test_default_config(engine);
-        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
-        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{
-            {"rms", {format::bfyx, "rms_gpu_bfyx_opt"}}
-        }));
-        network network(engine, topology, config);
-        network.set_input_data("input", input);
-        network.set_input_data("gamma", gamma);
-
-        auto impl = network.get_primitive("rms")->get_impl();
-        ASSERT_NE(impl, nullptr);
-        ASSERT_TRUE(impl->is_dynamic());
-        ASSERT_EQ(impl->get_kernel_name(), "rms_gpu_bfyx_opt");
-
-        auto output = network.execute().at("rms").get_memory();
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
-        cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
-        for (size_t index = 0; index < output_ref->count(); ++index) {
-            EXPECT_NEAR(output_ptr[index], output_ref_ptr[index], 1e-4f)
-                << " hidden_size=" << hidden_size << " index=" << index;
-        }
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
@@ -31,6 +31,7 @@ void rms_ref(const memory::ptr input, const memory::ptr gamma, memory::ptr outpu
     if (gamma) {
         weight = std::make_unique<cldnn::mem_lock<T>>(gamma, get_test_stream());
     }
+    const bool scalar_gamma = gamma && gamma->count() == 1;
 
     // RMS normalization across the last (innermost populated) dimension.
     // For bfyx with x_size > 1 (rank 4): normalize across X per (b, f, y).
@@ -60,7 +61,7 @@ void rms_ref(const memory::ptr input, const memory::ptr gamma, memory::ptr outpu
                     auto t = tensor(batch(b), feature(f), spatial(x, y, 0, 0));
                     size_t offset = input_layout.get_linear_offset(t);
 
-                    float gamma_val = weight ? static_cast<float>((*weight)[n]) : 1.0f;
+                    float gamma_val = weight ? static_cast<float>((*weight)[scalar_gamma ? 0 : n]) : 1.0f;
                     dst[offset] = static_cast<T>(rms * static_cast<float>(src[offset]) * gamma_val);
                 }
             }
@@ -105,6 +106,50 @@ TEST(rms_gpu_test, rms_test_bfyx_ref) {
 
     for (unsigned int i = 0; i < output_ref->count(); ++i) {
         EXPECT_NEAR(output_ptr[i], output_ref_ptr[i], 1e-3);
+    }
+}
+
+TEST(rms_gpu_test, rms_test_bfyx_ref_rank4_scalar_gamma_dyn) {
+    auto& engine = get_test_engine();
+
+    const ov::PartialShape input_shape{1, 3, 4, 8};
+    auto input_layout_dynamic = layout{ov::PartialShape{-1, -1, 4, 8}, data_types::f32, format::bfyx};
+    auto input = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
+    auto gamma = engine.allocate_memory({ov::PartialShape{1}, data_types::f32, format::bfyx});
+    auto output_ref = engine.allocate_memory({input_shape, data_types::f32, format::bfyx});
+
+    std::vector<float> input_values(input->count());
+    for (size_t index = 0; index < input_values.size(); ++index) {
+        input_values[index] = static_cast<float>(index % 17) - 8.0f;
+    }
+    set_values(input, input_values);
+    set_values(gamma, {3.875f});
+    rms_ref<float>(input, gamma, output_ref, 1e-5f);
+
+    topology topology;
+    topology.add(input_layout("input", input_layout_dynamic));
+    topology.add(input_layout("gamma", gamma->get_layout()));
+    topology.add(rms("rms", input_info("input"), input_info("gamma"), 1e-5f));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{
+        {"rms", {format::bfyx, "rms_gpu_ref"}}
+    }));
+    network network(engine, topology, config);
+    network.set_input_data("input", input);
+    network.set_input_data("gamma", gamma);
+
+    auto impl = network.get_primitive("rms")->get_impl();
+    ASSERT_NE(impl, nullptr);
+    ASSERT_TRUE(impl->is_dynamic());
+    ASSERT_EQ(impl->get_kernel_name(), "rms_gpu_ref");
+
+    auto output = network.execute().at("rms").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
+    for (size_t index = 0; index < output_ref->count(); ++index) {
+        EXPECT_NEAR(output_ptr[index], output_ref_ptr[index], 1e-4f) << " index=" << index;
     }
 }
 


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
- Dynamic rank-4 inputs with scalar gamma produced incorrect results in the GPU RMS kernels.
- The reference kernel normalized over physical `X * Y * Z` instead of the logical last dimension. The optimized kernel already selected the correct normalization axis, but rejected scalar gamma and indexed it as a vector.
- The fix shares the logical rank-to-axis mapping (`B/F/Y/X`) between both kernels, updates the reference kernel to normalize over that axis, and broadcasts scalar gamma in every ref/opt output path.

#### The code and line that caused this issue (if it is not changed directly)
- `src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.cpp`
- `src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_ref.cl`
- `src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_bfyx_opt.cl`
- `src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp`

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
- `./bin/intel64/Debug/ov_gpu_unit_tests --device_suffix=1 --gtest_filter='rms_gpu_test.rms_test_bfyx_ref_rank4_scalar_gamma_dyn:rms_gpu_test.rms_test_bfyx_opt_rank4_scalar_gamma_dyn'`
- Before the fix: reference numerical mismatch; optimized kernel did not support scalar gamma
- After the fix: both focused tests passed
- Full RMS suite passed: 15/15

#### Problematic graph
- The regression is covered with the following RMS graph:
  ```
  Input: dynamic [-1, -1, 4, 8]
         runtime [1, 3, 4, 8]
            |
            v
  RMS(epsilon=1e-5) <--- Gamma [1]
            |
            v
  Output: [1, 3, 4, 8]
  ```
- RMS normalization must be calculated independently over each 8-element logical last-dimension row.
- The input is represented physically as `bfyx`; however, the normalization axis must be selected using the logical OpenVINO rank rather than the fixed physical layout rank.
- The scalar gamma value must be broadcast to every output element.

#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
  - Reviewed `rms_test_bfyx_ref` and reused the existing `rms_ref` helper with scalar gamma and logical last-axis support.
  - Added rank 1-4 axis coverage and dynamic scalar-gamma tests for both ref and opt kernels.