### PR TITLE
[GPU] Optimize sliding window attention for large-input decoding

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -181,7 +181,7 @@ KERNEL(pa_sdpa_opt)(
 
     const uint total_blocks_num = CEIL_DIV(seq_len, PAGED_ATTENTION_BLOCK_SIZE);
 
-#if SWA_BLOCK_SKIP && SLIDING_WINDOW_SIZE != 0 && !MULTI_TOKENS_PROCESSING
+#if SLIDING_WINDOW_SIZE != 0 && !MULTI_TOKENS_PROCESSING
     const uint window_blocks = CEIL_DIV(SLIDING_WINDOW_SIZE, PAGED_ATTENTION_BLOCK_SIZE);
     const uint swa_start_block = (total_blocks_num > window_blocks) ? (total_blocks_num - window_blocks) : 0;
     const uint effective_blocks_num = total_blocks_num - swa_start_block;
@@ -267,17 +267,6 @@ KERNEL(pa_sdpa_opt)(
             const uint head_idx = head_num_idx / KV_HEADS_GROUP_SIZE;
             const uint block_indice = block_indices[start_block_idx + block_num * SUBGROUPS_PER_WG];
 
-#if KV_PREFETCH && IS_KV_COMPRESSED
-            if (block_num + 1 < blocks_num) {
-                const uint next_block_indice = block_indices[start_block_idx + (block_num + 1) * SUBGROUPS_PER_WG];
-    #ifdef IS_KEY_BY_CHANNEL
-                const uint next_key_offset = next_block_indice * KV_HEADS_NUM * phys_adjusted_k_head_size * ADJUSTED_PAGED_ATTENTION_BLOCK_SIZE + head_idx * phys_adjusted_k_head_size * ADJUSTED_PAGED_ATTENTION_BLOCK_SIZE;
-    #else
-                const uint next_key_offset = next_block_indice * phys_adjusted_k_head_size * KV_HEADS_NUM * SUBGROUP_SIZE + head_idx * phys_adjusted_k_head_size * SUBGROUP_SIZE;
-    #endif
-                prefetch(key_cache + next_key_offset, phys_adjusted_k_head_size * PAGED_ATTENTION_BLOCK_SIZE);
-            }
-#endif
 
             SOFTMAX_ACCUMULATOR_VEC_TYPE qk_acc = SOFTMAX_ACCUMULATOR_VAL_ZERO;
 
@@ -691,13 +680,6 @@ KERNEL(pa_sdpa_opt)(
 
             const uint value_offset = block_offset + head_size_idx;
 
-#if KV_PREFETCH && IS_KV_COMPRESSED
-            if (block_num + 1 < block_end_idx) {
-                const uint next_packed_v_offset = block_indices[start_block_idx + block_num + 1] * KV_HEADS_NUM * phys_adjusted_v_head_size * PAGED_ATTENTION_BLOCK_SIZE
-                                                    + head_idx * phys_adjusted_v_head_size * PAGED_ATTENTION_BLOCK_SIZE;
-                prefetch(value_cache + next_packed_v_offset, phys_adjusted_v_head_size * PAGED_ATTENTION_BLOCK_SIZE);
-            }
-#endif
 
 #if IS_KV_COMPRESSED
             const uint packed_block_offset = block_indices[start_block_idx + block_num] * KV_HEADS_NUM * phys_adjusted_v_head_size * PAGED_ATTENTION_BLOCK_SIZE
@@ -1037,11 +1019,7 @@ KERNEL(pa_sdpa_finalization_stage)(
     const uint seq_len = past_lens[seq_idx] + 1;
 #endif
 
-#if FINALIZATION_SWA_FIX
     const uint num_of_partitions = min((uint)CEIL_DIV(seq_len, SEQ_LEN_PARTITION_SIZE), total_partitions_num);
-#else
-    const uint num_of_partitions = CEIL_DIV(seq_len, SEQ_LEN_PARTITION_SIZE);
-#endif
 
     if (num_of_partitions <= 1) {
         /* Short path, no need any actions for currently processing sequence */

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -181,11 +181,13 @@ KERNEL(pa_sdpa_opt)(
 
     const uint total_blocks_num = CEIL_DIV(seq_len, PAGED_ATTENTION_BLOCK_SIZE);
 
-#if SLIDING_WINDOW_SIZE != 0 && !MULTI_TOKENS_PROCESSING && !PAGED_ATTENTION_SCORES_OUTPUT
+#if SWA_BLOCK_SKIP_ENABLED && !MULTI_TOKENS_PROCESSING
     const uint swa_start_block = (seq_len > SLIDING_WINDOW_SIZE) ? ((seq_len - SLIDING_WINDOW_SIZE) / PAGED_ATTENTION_BLOCK_SIZE) : 0;
+    const uint swa_start_token = swa_start_block * PAGED_ATTENTION_BLOCK_SIZE;
     const uint effective_blocks_num = total_blocks_num - swa_start_block;
 #else
     const uint swa_start_block = 0;
+    const uint swa_start_token = 0;
     const uint effective_blocks_num = total_blocks_num;
 #endif
 
@@ -429,7 +431,7 @@ KERNEL(pa_sdpa_opt)(
             }
 #endif  // !(IS_KV_COMPRESSED && IS_INT4_COMPRESSED)
 
-            const uint token_idx = swa_start_block * PAGED_ATTENTION_BLOCK_SIZE + partition_idx * SEQ_LEN_PARTITION_SIZE + block_num * SUBGROUPS_PER_WG * SUBGROUP_SIZE + sgid * SUBGROUP_SIZE + sglid;
+            const uint token_idx = swa_start_token + partition_idx * SEQ_LEN_PARTITION_SIZE + block_num * SUBGROUPS_PER_WG * SUBGROUP_SIZE + sgid * SUBGROUP_SIZE + sglid;
 
 #ifdef HAS_ALIBI
             const int alibi_val = (1 - seq_len) + token_idx;
@@ -513,7 +515,7 @@ KERNEL(pa_sdpa_opt)(
         for (uint qk_idx = 0; qk_idx < qk_iters_num; qk_idx++) {
             const uint local_data_idx = qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
             // TODO: const uint global_data_idx = partition_idx * SEQ_LEN_PARTITION_SIZE + local_data_idx
-            const uint global_data_idx = swa_start_block * PAGED_ATTENTION_BLOCK_SIZE + partition_idx * SEQ_LEN_PARTITION_SIZE + qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
+            const uint global_data_idx = swa_start_token + partition_idx * SEQ_LEN_PARTITION_SIZE + qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
 
 #if (SEQ_LEN_PARTITION_SIZE % (SUBGROUPS_PER_WG * SUBGROUP_SIZE)) == 0
             if (global_data_idx < seq_len) {
@@ -561,7 +563,7 @@ KERNEL(pa_sdpa_opt)(
 
         for (uint qk_idx = 0; qk_idx < qk_iters_num; qk_idx++) {
             const uint local_data_idx = qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
-            const uint global_data_idx = swa_start_block * PAGED_ATTENTION_BLOCK_SIZE + partition_idx * SEQ_LEN_PARTITION_SIZE + qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
+            const uint global_data_idx = swa_start_token + partition_idx * SEQ_LEN_PARTITION_SIZE + qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
 
 #if (SEQ_LEN_PARTITION_SIZE % (SUBGROUPS_PER_WG * SUBGROUP_SIZE)) == 0
             if (global_data_idx < seq_len) {
@@ -656,7 +658,7 @@ KERNEL(pa_sdpa_opt)(
         MAKE_VECTOR_TYPE(OUTPUT_TYPE, QUERIES_PER_WI) acc = OUTPUT_VAL_ZERO;
 #endif
 
-#if SLIDING_WINDOW_SIZE != 0 && !MULTI_TOKENS_PROCESSING
+#if SWA_BLOCK_SKIP_ENABLED && !MULTI_TOKENS_PROCESSING
         const uint effective_seq_len = min(effective_blocks_num * PAGED_ATTENTION_BLOCK_SIZE, seq_len);
 #else
         const uint effective_seq_len = seq_len;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -181,9 +181,8 @@ KERNEL(pa_sdpa_opt)(
 
     const uint total_blocks_num = CEIL_DIV(seq_len, PAGED_ATTENTION_BLOCK_SIZE);
 
-#if SLIDING_WINDOW_SIZE != 0 && !MULTI_TOKENS_PROCESSING
-    const uint window_blocks = CEIL_DIV(SLIDING_WINDOW_SIZE, PAGED_ATTENTION_BLOCK_SIZE);
-    const uint swa_start_block = (total_blocks_num > window_blocks) ? (total_blocks_num - window_blocks) : 0;
+#if SLIDING_WINDOW_SIZE != 0 && !MULTI_TOKENS_PROCESSING && !PAGED_ATTENTION_SCORES_OUTPUT
+    const uint swa_start_block = (seq_len > SLIDING_WINDOW_SIZE) ? ((seq_len - SLIDING_WINDOW_SIZE) / PAGED_ATTENTION_BLOCK_SIZE) : 0;
     const uint effective_blocks_num = total_blocks_num - swa_start_block;
 #else
     const uint swa_start_block = 0;
@@ -574,6 +573,10 @@ KERNEL(pa_sdpa_opt)(
                     SOFTMAX_ACCUMULATOR_TYPE qk_new = TO_SOFTMAX_ACCUMULATOR_TYPE(slm_qk_vals[slm_idx]) / GET_VECTOR_ELEMENT(exp_sum, q_idx);
                     slm_qk_vals[slm_idx] = qk_new;
                 }
+            } else if (local_data_idx < SEQ_LEN_PARTITION_SIZE) {
+                unroll_for (uint q_idx = 0; q_idx < QUERIES_PER_WI; q_idx++) {
+                    slm_qk_vals[q_idx * SEQ_LEN_PARTITION_SIZE + local_data_idx] = 0;
+                }
             }
         }
 
@@ -653,7 +656,11 @@ KERNEL(pa_sdpa_opt)(
         MAKE_VECTOR_TYPE(OUTPUT_TYPE, QUERIES_PER_WI) acc = OUTPUT_VAL_ZERO;
 #endif
 
-        const uint effective_seq_len = effective_blocks_num * PAGED_ATTENTION_BLOCK_SIZE;
+#if SLIDING_WINDOW_SIZE != 0 && !MULTI_TOKENS_PROCESSING
+        const uint effective_seq_len = min(effective_blocks_num * PAGED_ATTENTION_BLOCK_SIZE, seq_len);
+#else
+        const uint effective_seq_len = seq_len;
+#endif
         const uint partition_seq_len = min(effective_seq_len - partition_idx * SEQ_LEN_PARTITION_SIZE, (uint)SEQ_LEN_PARTITION_SIZE);
 
 #if SG_SCALE_FACTOR > 1
@@ -910,7 +917,7 @@ KERNEL(pa_sdpa_opt)(
 #endif
 
 #ifdef USE_DUAL_NIBBLE_V_OPT
-        if (seq_len > SEQ_LEN_PARTITION_SIZE) {
+        if (seq_len > SEQ_LEN_PARTITION_SIZE && total_partitions_num > 1) {
             unroll_for (uint q_idx = 0; q_idx < HEADS_PER_WI; q_idx++) {
 #if HEADS_LEFTOVERS_NUM > 0
                 if (q_idx >= iter_heads_num)
@@ -937,7 +944,7 @@ KERNEL(pa_sdpa_opt)(
             }
         }
 #else  // !USE_DUAL_NIBBLE_V_OPT
-        if (seq_len > SEQ_LEN_PARTITION_SIZE) {
+        if (seq_len > SEQ_LEN_PARTITION_SIZE && total_partitions_num > 1) {
             unroll_for (uint q_idx = 0; q_idx < HEADS_PER_WI; q_idx++) {
 #if HEADS_LEFTOVERS_NUM > 0
                 if (q_idx >= iter_heads_num)
@@ -1162,7 +1169,7 @@ KERNEL(pa_sdpa_scores_calculation)(
     const int subsequence_end = subsequence_begins[subsequence_idx + 1];
     const uint seq_len = (subsequence_end - subsequence_begin) + past_lens[subsequence_idx];
 
-    const uint num_of_partitions = CEIL_DIV(seq_len, partition_size);
+    const uint num_of_partitions = min((uint)CEIL_DIV(seq_len, partition_size), max_partitions_num);
 
     if (partition_idx >= num_of_partitions)
         return;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -1017,9 +1017,13 @@ KERNEL(pa_sdpa_finalization_stage)(
     const uint seq_len = past_lens[seq_idx] + 1;
 #endif
 
+#if FINALIZATION_SWA_FIX
+    const uint num_of_partitions = min((uint)CEIL_DIV(seq_len, SEQ_LEN_PARTITION_SIZE), total_partitions_num);
+#else
     const uint num_of_partitions = CEIL_DIV(seq_len, SEQ_LEN_PARTITION_SIZE);
+#endif
 
-    if (seq_len <= SEQ_LEN_PARTITION_SIZE) {
+    if (num_of_partitions <= 1) {
         /* Short path, no need any actions for currently processing sequence */
         return;
     } else if (num_of_partitions <= SUBGROUP_SIZE * REG_VERSION_MAX_VALUES_PER_WI) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -179,11 +179,20 @@ KERNEL(pa_sdpa_opt)(
 
     const uint partition_idx = get_group_id(2);
 
-    if (partition_idx * SEQ_LEN_PARTITION_SIZE >= seq_len) {
+    const uint total_blocks_num = CEIL_DIV(seq_len, PAGED_ATTENTION_BLOCK_SIZE);
+
+#if SWA_BLOCK_SKIP && SLIDING_WINDOW_SIZE != 0 && !MULTI_TOKENS_PROCESSING
+    const uint window_blocks = CEIL_DIV(SLIDING_WINDOW_SIZE, PAGED_ATTENTION_BLOCK_SIZE);
+    const uint swa_start_block = (total_blocks_num > window_blocks) ? (total_blocks_num - window_blocks) : 0;
+    const uint effective_blocks_num = total_blocks_num - swa_start_block;
+#else
+    const uint swa_start_block = 0;
+    const uint effective_blocks_num = total_blocks_num;
+#endif
+
+    if (partition_idx * SEQ_LEN_PARTITION_SIZE >= effective_blocks_num * PAGED_ATTENTION_BLOCK_SIZE) {
         return;
     }
-
-    const uint total_blocks_num = CEIL_DIV(seq_len, PAGED_ATTENTION_BLOCK_SIZE);
 
 #ifdef STORE_QUERY_TO_SLM
     // SLM buffer for query inputs
@@ -247,13 +256,13 @@ KERNEL(pa_sdpa_opt)(
         }
 #endif // STORE_QUERY_TO_SLM
 
-        const uint blocks_num_per_partition = min(total_blocks_num - partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION, (uint)PAGED_ATTENTION_BLOCKS_PER_PARTITION);
+        const uint blocks_num_per_partition = min(effective_blocks_num - partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION, (uint)PAGED_ATTENTION_BLOCKS_PER_PARTITION);
 
         uint blocks_num = blocks_num_per_partition / SUBGROUPS_PER_WG;
         if (sgid < blocks_num_per_partition % SUBGROUPS_PER_WG)
             blocks_num++;
 
-        const uint start_block_idx = block_indices_begins[subsequence_idx] + partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION + sgid;
+        const uint start_block_idx = block_indices_begins[subsequence_idx] + swa_start_block + partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION + sgid;
         for (uint block_num = 0; block_num < blocks_num; block_num++) {
             const uint head_idx = head_num_idx / KV_HEADS_GROUP_SIZE;
             const uint block_indice = block_indices[start_block_idx + block_num * SUBGROUPS_PER_WG];
@@ -420,7 +429,7 @@ KERNEL(pa_sdpa_opt)(
             }
 #endif  // !(IS_KV_COMPRESSED && IS_INT4_COMPRESSED)
 
-            const uint token_idx = partition_idx * SEQ_LEN_PARTITION_SIZE + block_num * SUBGROUPS_PER_WG * SUBGROUP_SIZE + sgid * SUBGROUP_SIZE + sglid;
+            const uint token_idx = swa_start_block * PAGED_ATTENTION_BLOCK_SIZE + partition_idx * SEQ_LEN_PARTITION_SIZE + block_num * SUBGROUPS_PER_WG * SUBGROUP_SIZE + sgid * SUBGROUP_SIZE + sglid;
 
 #ifdef HAS_ALIBI
             const int alibi_val = (1 - seq_len) + token_idx;
@@ -504,7 +513,7 @@ KERNEL(pa_sdpa_opt)(
         for (uint qk_idx = 0; qk_idx < qk_iters_num; qk_idx++) {
             const uint local_data_idx = qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
             // TODO: const uint global_data_idx = partition_idx * SEQ_LEN_PARTITION_SIZE + local_data_idx
-            const uint global_data_idx = partition_idx * SEQ_LEN_PARTITION_SIZE + qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
+            const uint global_data_idx = swa_start_block * PAGED_ATTENTION_BLOCK_SIZE + partition_idx * SEQ_LEN_PARTITION_SIZE + qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
 
 #if (SEQ_LEN_PARTITION_SIZE % (SUBGROUPS_PER_WG * SUBGROUP_SIZE)) == 0
             if (global_data_idx < seq_len) {
@@ -552,7 +561,7 @@ KERNEL(pa_sdpa_opt)(
 
         for (uint qk_idx = 0; qk_idx < qk_iters_num; qk_idx++) {
             const uint local_data_idx = qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
-            const uint global_data_idx = partition_idx * SEQ_LEN_PARTITION_SIZE + qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
+            const uint global_data_idx = swa_start_block * PAGED_ATTENTION_BLOCK_SIZE + partition_idx * SEQ_LEN_PARTITION_SIZE + qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
 
 #if (SEQ_LEN_PARTITION_SIZE % (SUBGROUPS_PER_WG * SUBGROUP_SIZE)) == 0
             if (global_data_idx < seq_len) {
@@ -643,7 +652,8 @@ KERNEL(pa_sdpa_opt)(
         MAKE_VECTOR_TYPE(OUTPUT_TYPE, QUERIES_PER_WI) acc = OUTPUT_VAL_ZERO;
 #endif
 
-        const uint partition_seq_len = min(seq_len - partition_idx * SEQ_LEN_PARTITION_SIZE, (uint)SEQ_LEN_PARTITION_SIZE);
+        const uint effective_seq_len = effective_blocks_num * PAGED_ATTENTION_BLOCK_SIZE;
+        const uint partition_seq_len = min(effective_seq_len - partition_idx * SEQ_LEN_PARTITION_SIZE, (uint)SEQ_LEN_PARTITION_SIZE);
 
 #if SG_SCALE_FACTOR > 1
         const uint block_start_idx = (sgid / (SUBGROUPS_PER_WG / SG_SCALE_FACTOR)) * (SEQ_LEN_PARTITION_SIZE / SG_SCALE_FACTOR / SUBGROUP_SIZE);
@@ -653,7 +663,7 @@ KERNEL(pa_sdpa_opt)(
         const uint block_end_idx = partition_seq_len / SUBGROUP_SIZE;
 #endif
 
-        uint blocks_num_per_partition = min(total_blocks_num - partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION, (uint)PAGED_ATTENTION_BLOCKS_PER_PARTITION);
+        uint blocks_num_per_partition = min(effective_blocks_num - partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION, (uint)PAGED_ATTENTION_BLOCKS_PER_PARTITION);
 
         uint leftovers = blocks_num_per_partition * PAGED_ATTENTION_BLOCK_SIZE - partition_seq_len;
         if (leftovers != 0) {
@@ -661,7 +671,7 @@ KERNEL(pa_sdpa_opt)(
             blocks_num_per_partition = blocks_num_per_partition - 1;
         }
 
-        const uint start_block_idx = block_indices_begins[subsequence_idx] + partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION;
+        const uint start_block_idx = block_indices_begins[subsequence_idx] + swa_start_block + partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION;
 
         for (uint block_num = block_start_idx; block_num < block_end_idx; block_num++) {
             const uint head_idx = head_num_idx / KV_HEADS_GROUP_SIZE;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -514,7 +514,7 @@ KERNEL(pa_sdpa_opt)(
         const uint qk_iters_num = CEIL_DIV(SEQ_LEN_PARTITION_SIZE, SUBGROUPS_PER_WG * SUBGROUP_SIZE);
         for (uint qk_idx = 0; qk_idx < qk_iters_num; qk_idx++) {
             const uint local_data_idx = qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
-            // TODO: const uint global_data_idx = partition_idx * SEQ_LEN_PARTITION_SIZE + local_data_idx
+            // TODO: const uint global_data_idx = swa_start_token + partition_idx * SEQ_LEN_PARTITION_SIZE + local_data_idx
             const uint global_data_idx = swa_start_token + partition_idx * SEQ_LEN_PARTITION_SIZE + qk_idx * (SUBGROUPS_PER_WG * SUBGROUP_SIZE) + sgid * SUBGROUP_SIZE + sglid;
 
 #if (SEQ_LEN_PARTITION_SIZE % (SUBGROUPS_PER_WG * SUBGROUP_SIZE)) == 0

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -267,6 +267,18 @@ KERNEL(pa_sdpa_opt)(
             const uint head_idx = head_num_idx / KV_HEADS_GROUP_SIZE;
             const uint block_indice = block_indices[start_block_idx + block_num * SUBGROUPS_PER_WG];
 
+#if KV_PREFETCH && IS_KV_COMPRESSED
+            if (block_num + 1 < blocks_num) {
+                const uint next_block_indice = block_indices[start_block_idx + (block_num + 1) * SUBGROUPS_PER_WG];
+    #ifdef IS_KEY_BY_CHANNEL
+                const uint next_key_offset = next_block_indice * KV_HEADS_NUM * phys_adjusted_k_head_size * ADJUSTED_PAGED_ATTENTION_BLOCK_SIZE + head_idx * phys_adjusted_k_head_size * ADJUSTED_PAGED_ATTENTION_BLOCK_SIZE;
+    #else
+                const uint next_key_offset = next_block_indice * phys_adjusted_k_head_size * KV_HEADS_NUM * SUBGROUP_SIZE + head_idx * phys_adjusted_k_head_size * SUBGROUP_SIZE;
+    #endif
+                prefetch(key_cache + next_key_offset, phys_adjusted_k_head_size * PAGED_ATTENTION_BLOCK_SIZE);
+            }
+#endif
+
             SOFTMAX_ACCUMULATOR_VEC_TYPE qk_acc = SOFTMAX_ACCUMULATOR_VAL_ZERO;
 
             #define KEY_VEC_SIZE SUBGROUP_SIZE
@@ -678,6 +690,14 @@ KERNEL(pa_sdpa_opt)(
             const uint block_offset = block_indices[start_block_idx + block_num] * KV_HEADS_NUM * ADJUSTED_V_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE + head_idx * ADJUSTED_V_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
 
             const uint value_offset = block_offset + head_size_idx;
+
+#if KV_PREFETCH && IS_KV_COMPRESSED
+            if (block_num + 1 < block_end_idx) {
+                const uint next_packed_v_offset = block_indices[start_block_idx + block_num + 1] * KV_HEADS_NUM * phys_adjusted_v_head_size * PAGED_ATTENTION_BLOCK_SIZE
+                                                    + head_idx * phys_adjusted_v_head_size * PAGED_ATTENTION_BLOCK_SIZE;
+                prefetch(value_cache + next_packed_v_offset, phys_adjusted_v_head_size * PAGED_ATTENTION_BLOCK_SIZE);
+            }
+#endif
 
 #if IS_KV_COMPRESSED
             const uint packed_block_offset = block_indices[start_block_idx + block_num] * KV_HEADS_NUM * phys_adjusted_v_head_size * PAGED_ATTENTION_BLOCK_SIZE

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1489,7 +1489,7 @@ public:
         rt_params->partition_size = get_partitioning_size(params, desc->v_head_size, rt_params->stage);
 
         auto effective_context_len = rt_params->max_context_len;
-        if (desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE) {
+        if (desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE && !desc->has_scores_output()) {
             effective_context_len = std::min(rt_params->max_context_len, desc->sliding_window);
         }
         rt_params->num_of_partitions = ceil_div(effective_context_len, rt_params->partition_size);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -301,6 +301,8 @@ public:
         jit.make("PAGED_ATTENTION_BLOCK_SIZE", paged_attention_block_size);
         jit.make("SUBGROUP_SIZE", subgroup_size);
         jit.make("SLIDING_WINDOW_SIZE", desc->sliding_window);
+        static bool swa_block_skip_env = std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP") && std::string(std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP")) == "1";
+        jit.make("SWA_BLOCK_SKIP", swa_block_skip_env ? 1 : 0);
 
         const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
         const bool is_kv_compressed = get_kv_compressed(params);
@@ -1484,7 +1486,13 @@ public:
         rt_params->max_context_len = get_max_context_len(params);
         rt_params->stage = stage;
         rt_params->partition_size = get_partitioning_size(params, desc->v_head_size, rt_params->stage);
-        rt_params->num_of_partitions = ceil_div(rt_params->max_context_len, rt_params->partition_size);
+
+        auto effective_context_len = rt_params->max_context_len;
+        static bool swa_block_skip = std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP") && std::string(std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP")) == "1";
+        if (swa_block_skip && desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE) {
+            effective_context_len = std::min(rt_params->max_context_len, desc->sliding_window);
+        }
+        rt_params->num_of_partitions = ceil_div(effective_context_len, rt_params->partition_size);
 
         if ((rt_params->stage == PagedAttentionStage::PREFILL || rt_params->stage == PagedAttentionStage::MIXED) && !params.is_dynamic())
             rt_params->paged_attention_aligned_seq_len = static_cast<size_t>(get_aligned_seq_len(params, rt_params->stage));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -301,6 +301,7 @@ public:
         jit.make("PAGED_ATTENTION_BLOCK_SIZE", paged_attention_block_size);
         jit.make("SUBGROUP_SIZE", subgroup_size);
         jit.make("SLIDING_WINDOW_SIZE", desc->sliding_window);
+        jit.make("SWA_BLOCK_SKIP_ENABLED", desc->sliding_window > 0 && !desc->has_scores_output());
 
         const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
         const bool is_kv_compressed = get_kv_compressed(params);
@@ -1486,6 +1487,7 @@ public:
         rt_params->partition_size = get_partitioning_size(params, desc->v_head_size, rt_params->stage);
 
         auto effective_context_len = rt_params->max_context_len;
+        // scores_output is only used in SnapKV path, and it doesn't yet handle the SWA block skip offset
         if (desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE && !desc->has_scores_output()) {
             auto total_blocks = ceil_div(rt_params->max_context_len, paged_attention_block_size);
             auto swa_start_block =

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -30,10 +30,9 @@ namespace {
 
 constexpr ov::element::Type softmax_accumulator_type = ov::element::f32;
 constexpr size_t paged_attention_block_size = 16;
+constexpr size_t seq_len_partition_size = 256;
 constexpr size_t subgroup_size = 16;
 constexpr size_t u4_elems_per_byte = 2;
-
-constexpr size_t seq_len_partition_size = 256;
 
 inline bool get_kv_compressed(const RuntimeParams& params) {
     auto key_cache_layout = params.input_layouts[PagedAttentionInputIdx::KEY_CACHE];
@@ -302,8 +301,6 @@ public:
         jit.make("PAGED_ATTENTION_BLOCK_SIZE", paged_attention_block_size);
         jit.make("SUBGROUP_SIZE", subgroup_size);
         jit.make("SLIDING_WINDOW_SIZE", desc->sliding_window);
-        jit.make("SWA_BLOCK_SKIP", 1);
-        jit.make("FINALIZATION_SWA_FIX", 1);
 
         const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
         const bool is_kv_compressed = get_kv_compressed(params);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -30,9 +30,46 @@ namespace {
 
 constexpr ov::element::Type softmax_accumulator_type = ov::element::f32;
 constexpr size_t paged_attention_block_size = 16;
-constexpr size_t seq_len_partition_size = 256;
 constexpr size_t subgroup_size = 16;
 constexpr size_t u4_elems_per_byte = 2;
+
+static size_t get_seq_len_partition_size_config() {
+    static size_t val = []() -> size_t {
+        const char* env = std::getenv("OV_GPU_PA_PARTITION_SIZE");
+        if (env) {
+            size_t v = std::stoull(env);
+            if (v >= 16 && (v % paged_attention_block_size == 0))
+                return v;
+        }
+        return 256;
+    }();
+    return val;
+}
+
+static size_t get_sg_scale_override() {
+    static size_t val = []() -> size_t {
+        const char* env = std::getenv("OV_GPU_PA_SG_SCALE");
+        if (env) {
+            size_t v = std::stoull(env);
+            if (v >= 1 && v <= 4)
+                return v;
+        }
+        return 0;  // 0 = no override, use default logic
+    }();
+    return val;
+}
+
+static bool get_finalization_swa_fix_enabled() {
+    static bool val = []() -> bool {
+        const char* env = std::getenv("OV_GPU_PA_FINALIZATION_SWA_FIX");
+        if (env && std::string(env) == "1")
+            return true;
+        return false;  // disabled by default (master as-is)
+    }();
+    return val;
+}
+
+constexpr size_t seq_len_partition_size = 256;
 
 inline bool get_kv_compressed(const RuntimeParams& params) {
     auto key_cache_layout = params.input_layouts[PagedAttentionInputIdx::KEY_CACHE];
@@ -56,6 +93,11 @@ inline size_t get_element_size(ov::element::Type_t type) {
 }
 
 static size_t get_pa_sg_number_scale_factor(const device_info& info, size_t head_size, size_t kernel_type, bool is_kv_compressed = false) {
+    size_t override_val = get_sg_scale_override();
+    if (override_val > 0) {
+        if (head_size * override_val < info.max_work_group_size)
+            return override_val;
+    }
     if (is_kv_compressed) {
         const size_t optimal_scale_factor = 2;
         if (kernel_type == SDPAStage::SINGLE_TOKEN || kernel_type == SDPAStage::MULTI_TOKENS) {
@@ -216,7 +258,7 @@ size_t get_partitioning_size(const kernel_impl_params& params, size_t head_size,
     if (stage == PagedAttentionStage::PREFILL) {
         partition_size = head_size * get_sg_number_scale_factor(params.get_device_info(), head_size, SDPAStage::MULTI_TOKENS);
     } else {
-        partition_size = seq_len_partition_size;
+        partition_size = get_seq_len_partition_size_config();
     }
 
     return partition_size;
@@ -297,12 +339,13 @@ public:
         jit.make("HEADS_NUM", desc->heads_num);
         jit.make("KV_HEADS_NUM", desc->kv_heads_num);
         jit.make("KV_HEADS_GROUP_SIZE", kv_group_size);
-        jit.make("SEQ_LEN_PARTITION_SIZE", seq_len_partition_size);
+        jit.make("SEQ_LEN_PARTITION_SIZE", get_seq_len_partition_size_config());
         jit.make("PAGED_ATTENTION_BLOCK_SIZE", paged_attention_block_size);
         jit.make("SUBGROUP_SIZE", subgroup_size);
         jit.make("SLIDING_WINDOW_SIZE", desc->sliding_window);
         static bool swa_block_skip_env = std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP") && std::string(std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP")) == "1";
         jit.make("SWA_BLOCK_SKIP", swa_block_skip_env ? 1 : 0);
+        jit.make("FINALIZATION_SWA_FIX", get_finalization_swa_fix_enabled() ? 1 : 0);
 
         const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
         const bool is_kv_compressed = get_kv_compressed(params);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -46,6 +46,19 @@ static size_t get_seq_len_partition_size_config() {
     return val;
 }
 
+static size_t get_fa_partition_size_config() {
+    static size_t val = []() -> size_t {
+        const char* env = std::getenv("OV_GPU_PA_FA_PARTITION_SIZE");
+        if (env) {
+            size_t v = std::stoull(env);
+            if (v >= 16 && (v % paged_attention_block_size == 0))
+                return v;
+        }
+        return 0;  // 0 = no override, use default partition size
+    }();
+    return val;
+}
+
 static size_t get_sg_scale_override() {
     static size_t val = []() -> size_t {
         const char* env = std::getenv("OV_GPU_PA_SG_SCALE");
@@ -55,6 +68,16 @@ static size_t get_sg_scale_override() {
                 return v;
         }
         return 0;  // 0 = no override, use default logic
+    }();
+    return val;
+}
+
+static bool get_kv_prefetch_enabled() {
+    static bool val = []() -> bool {
+        const char* env = std::getenv("OV_GPU_PA_KV_PREFETCH");
+        if (env && std::string(env) == "1")
+            return true;
+        return false;
     }();
     return val;
 }
@@ -258,7 +281,13 @@ size_t get_partitioning_size(const kernel_impl_params& params, size_t head_size,
     if (stage == PagedAttentionStage::PREFILL) {
         partition_size = head_size * get_sg_number_scale_factor(params.get_device_info(), head_size, SDPAStage::MULTI_TOKENS);
     } else {
-        partition_size = get_seq_len_partition_size_config();
+        const auto desc = params.typed_desc<paged_attention>();
+        size_t fa_ps = get_fa_partition_size_config();
+        if (fa_ps > 0 && desc->sliding_window == 0) {
+            partition_size = fa_ps;
+        } else {
+            partition_size = get_seq_len_partition_size_config();
+        }
     }
 
     return partition_size;
@@ -339,13 +368,18 @@ public:
         jit.make("HEADS_NUM", desc->heads_num);
         jit.make("KV_HEADS_NUM", desc->kv_heads_num);
         jit.make("KV_HEADS_GROUP_SIZE", kv_group_size);
-        jit.make("SEQ_LEN_PARTITION_SIZE", get_seq_len_partition_size_config());
+        {
+            size_t fa_ps = get_fa_partition_size_config();
+            size_t effective_partition_size = (fa_ps > 0 && desc->sliding_window == 0) ? fa_ps : get_seq_len_partition_size_config();
+            jit.make("SEQ_LEN_PARTITION_SIZE", effective_partition_size);
+        }
         jit.make("PAGED_ATTENTION_BLOCK_SIZE", paged_attention_block_size);
         jit.make("SUBGROUP_SIZE", subgroup_size);
         jit.make("SLIDING_WINDOW_SIZE", desc->sliding_window);
         static bool swa_block_skip_env = std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP") && std::string(std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP")) == "1";
         jit.make("SWA_BLOCK_SKIP", swa_block_skip_env ? 1 : 0);
         jit.make("FINALIZATION_SWA_FIX", get_finalization_swa_fix_enabled() ? 1 : 0);
+        jit.make("KV_PREFETCH", get_kv_prefetch_enabled() ? 1 : 0);
 
         const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
         const bool is_kv_compressed = get_kv_compressed(params);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -33,65 +33,6 @@ constexpr size_t paged_attention_block_size = 16;
 constexpr size_t subgroup_size = 16;
 constexpr size_t u4_elems_per_byte = 2;
 
-static size_t get_seq_len_partition_size_config() {
-    static size_t val = []() -> size_t {
-        const char* env = std::getenv("OV_GPU_PA_PARTITION_SIZE");
-        if (env) {
-            size_t v = std::stoull(env);
-            if (v >= 16 && (v % paged_attention_block_size == 0))
-                return v;
-        }
-        return 256;
-    }();
-    return val;
-}
-
-static size_t get_fa_partition_size_config() {
-    static size_t val = []() -> size_t {
-        const char* env = std::getenv("OV_GPU_PA_FA_PARTITION_SIZE");
-        if (env) {
-            size_t v = std::stoull(env);
-            if (v >= 16 && (v % paged_attention_block_size == 0))
-                return v;
-        }
-        return 0;  // 0 = no override, use default partition size
-    }();
-    return val;
-}
-
-static size_t get_sg_scale_override() {
-    static size_t val = []() -> size_t {
-        const char* env = std::getenv("OV_GPU_PA_SG_SCALE");
-        if (env) {
-            size_t v = std::stoull(env);
-            if (v >= 1 && v <= 4)
-                return v;
-        }
-        return 0;  // 0 = no override, use default logic
-    }();
-    return val;
-}
-
-static bool get_kv_prefetch_enabled() {
-    static bool val = []() -> bool {
-        const char* env = std::getenv("OV_GPU_PA_KV_PREFETCH");
-        if (env && std::string(env) == "1")
-            return true;
-        return false;
-    }();
-    return val;
-}
-
-static bool get_finalization_swa_fix_enabled() {
-    static bool val = []() -> bool {
-        const char* env = std::getenv("OV_GPU_PA_FINALIZATION_SWA_FIX");
-        if (env && std::string(env) == "1")
-            return true;
-        return false;  // disabled by default (master as-is)
-    }();
-    return val;
-}
-
 constexpr size_t seq_len_partition_size = 256;
 
 inline bool get_kv_compressed(const RuntimeParams& params) {
@@ -116,11 +57,6 @@ inline size_t get_element_size(ov::element::Type_t type) {
 }
 
 static size_t get_pa_sg_number_scale_factor(const device_info& info, size_t head_size, size_t kernel_type, bool is_kv_compressed = false) {
-    size_t override_val = get_sg_scale_override();
-    if (override_val > 0) {
-        if (head_size * override_val < info.max_work_group_size)
-            return override_val;
-    }
     if (is_kv_compressed) {
         const size_t optimal_scale_factor = 2;
         if (kernel_type == SDPAStage::SINGLE_TOKEN || kernel_type == SDPAStage::MULTI_TOKENS) {
@@ -281,13 +217,7 @@ size_t get_partitioning_size(const kernel_impl_params& params, size_t head_size,
     if (stage == PagedAttentionStage::PREFILL) {
         partition_size = head_size * get_sg_number_scale_factor(params.get_device_info(), head_size, SDPAStage::MULTI_TOKENS);
     } else {
-        const auto desc = params.typed_desc<paged_attention>();
-        size_t fa_ps = get_fa_partition_size_config();
-        if (fa_ps > 0 && desc->sliding_window == 0) {
-            partition_size = fa_ps;
-        } else {
-            partition_size = get_seq_len_partition_size_config();
-        }
+        partition_size = seq_len_partition_size;
     }
 
     return partition_size;
@@ -368,18 +298,12 @@ public:
         jit.make("HEADS_NUM", desc->heads_num);
         jit.make("KV_HEADS_NUM", desc->kv_heads_num);
         jit.make("KV_HEADS_GROUP_SIZE", kv_group_size);
-        {
-            size_t fa_ps = get_fa_partition_size_config();
-            size_t effective_partition_size = (fa_ps > 0 && desc->sliding_window == 0) ? fa_ps : get_seq_len_partition_size_config();
-            jit.make("SEQ_LEN_PARTITION_SIZE", effective_partition_size);
-        }
+        jit.make("SEQ_LEN_PARTITION_SIZE", seq_len_partition_size);
         jit.make("PAGED_ATTENTION_BLOCK_SIZE", paged_attention_block_size);
         jit.make("SUBGROUP_SIZE", subgroup_size);
         jit.make("SLIDING_WINDOW_SIZE", desc->sliding_window);
-        static bool swa_block_skip_env = std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP") && std::string(std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP")) == "1";
-        jit.make("SWA_BLOCK_SKIP", swa_block_skip_env ? 1 : 0);
-        jit.make("FINALIZATION_SWA_FIX", get_finalization_swa_fix_enabled() ? 1 : 0);
-        jit.make("KV_PREFETCH", get_kv_prefetch_enabled() ? 1 : 0);
+        jit.make("SWA_BLOCK_SKIP", 1);
+        jit.make("FINALIZATION_SWA_FIX", 1);
 
         const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
         const bool is_kv_compressed = get_kv_compressed(params);
@@ -1565,8 +1489,7 @@ public:
         rt_params->partition_size = get_partitioning_size(params, desc->v_head_size, rt_params->stage);
 
         auto effective_context_len = rt_params->max_context_len;
-        static bool swa_block_skip = std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP") && std::string(std::getenv("OV_GPU_PA_SWA_BLOCK_SKIP")) == "1";
-        if (swa_block_skip && desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE) {
+        if (desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE) {
             effective_context_len = std::min(rt_params->max_context_len, desc->sliding_window);
         }
         rt_params->num_of_partitions = ceil_div(effective_context_len, rt_params->partition_size);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1487,7 +1487,11 @@ public:
 
         auto effective_context_len = rt_params->max_context_len;
         if (desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE && !desc->has_scores_output()) {
-            effective_context_len = std::min(rt_params->max_context_len, desc->sliding_window);
+            auto total_blocks = ceil_div(rt_params->max_context_len, paged_attention_block_size);
+            auto swa_start_block = rt_params->max_context_len > desc->sliding_window
+                                 ? (rt_params->max_context_len - desc->sliding_window) / paged_attention_block_size : 0;
+            auto effective_blocks = total_blocks - swa_start_block;
+            effective_context_len = effective_blocks * paged_attention_block_size;
         }
         rt_params->num_of_partitions = ceil_div(effective_context_len, rt_params->partition_size);
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1488,8 +1488,8 @@ public:
         auto effective_context_len = rt_params->max_context_len;
         if (desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE && !desc->has_scores_output()) {
             auto total_blocks = ceil_div(rt_params->max_context_len, paged_attention_block_size);
-            auto swa_start_block = rt_params->max_context_len > desc->sliding_window
-                                 ? (rt_params->max_context_len - desc->sliding_window) / paged_attention_block_size : 0;
+            auto swa_start_block =
+                rt_params->max_context_len > desc->sliding_window ? (rt_params->max_context_len - desc->sliding_window) / paged_attention_block_size : 0;
             auto effective_blocks = total_blocks - swa_start_block;
             effective_context_len = effective_blocks * paged_attention_block_size;
         }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -305,6 +305,13 @@ INSTANTIATE_TEST_SUITE_P(smoke_paged_attention, paged_attention_test, ::testing:
     paged_attention_test_params{ {{1, 4200}}, 8, 2, 64, 64, 16, 8, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // GQA 8/2 + scores + sw=8, kv_group_size=4 -> QUERIES_PER_WI=4
     paged_attention_test_params{ {{1, 4200}}, 4, 2, 64, 64, 16, 8, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // GQA 4/2 + scores + sw=8, kv_group_size=2 -> QUERIES_PER_WI=2
     paged_attention_test_params{ {{1, 5000}}, 16, 4, 128, 128, 16, 16, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // GQA 16/4 + scores + sw=16, k_head_size=128, kv_group_size=4
+
+    /* SWA block skip: decode with past_len >> sliding_window */
+    paged_attention_test_params{ {{1, 1024}}, 2, 2, 64, 64, 16, 32, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // decode, past_len=1024 >> sw=32
+    paged_attention_test_params{ {{1, 2048}}, 8, 2, 128, 128, 16, 512, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // GQA decode, Gemma4-like config (sw=512)
+    paged_attention_test_params{ {{1, 4096}}, 8, 2, 128, 128, 16, 512, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // GQA decode, triggers GQA kernel path (context>=4096)
+    paged_attention_test_params{ {{1, 2048}}, 8, 2, 128, 128, 16, 512, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // GQA decode + KV compression + SWA
+    paged_attention_test_params{ {{1, 1024}, {1, 2048}}, 8, 2, 128, 128, 16, 512, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // multi-seq GQA decode with SWA
 }));
 
 INSTANTIATE_TEST_SUITE_P(smoke_cm_xattention, xattention_test, ::testing::ValuesIn(std::vector<paged_attention_test_params>{


### PR DESCRIPTION
### Summary
For Gemma4 models the majority of decoder layers use sliding-window attention (SWA). During token generation these layers only need to attend to the last sliding_window tokens, yet the Paged-Attention decode kernel was reading and scoring the entire KV history on every layer. This work makes the PA decode kernel and its finalization stage window-aware, so SWA layers stop scaling with context length. This is the change that delivers the real decode gain, growing with sequence length up to +28% at 32K.

### Target
• Model: gemma-4-E4B-it-int4-ov (42 layers, INT4). 35 sliding-window layers (window = 512), 7 full-attention layers.
• HW: Intel Arc B390 (Panther Lake iGPU, UMA, peak BW 153.6 GB/s).
 
### Problem:
Sliding layers looped over all KV blocks; blocks outside the window are masked ->wasted read + compute. At 32K each SWA layer read ~32K tokens instead of 512.

### Fix:
Skip KV blocks outside the sliding window during PA decode, reducing launched partitions to cover only the effective window range. Align the finalization kernel's partition count with the actual dispatched partitions to avoid redundant reduction work.
 
#### Gemma-4-E4B-it-int4 on B390 Decode (Token/sec)
| Context | PA | PA + SWA Opt | Gain |
|----------|------:|-------------:|------:|
| 2K  | 30.32 | 31.86 | +5.1% |
| 4K  | 30.55 | 31.79 | +4.1% |
| 8K  | 29.12 | 31.37 | +7.7% |
| 16K | 26.55 | 30.20 | +13.7% |
| 32K | 21.89 | 28.04 | +28.1% |
- Gain scales with context length (longer history = more wasted KV read eliminated)

### Tickets:
 - *CVS-191543*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
