### PR TITLE
[GPU] Prevent out-of-bounds input reads in convolution osv32

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_os_iyx_osv32.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_os_iyx_osv32.cl
@@ -44,6 +44,7 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv32)(
     const uint batch_idx = (fm / SUB_GROUP_SIZE) % OUTPUT_BATCH_NUM;
     const uint fmg = (fm / SUB_GROUP_SIZE) / OUTPUT_BATCH_NUM;
     const uint feature_idx = fmg * OSV_SIZE + lid;
+    const uint input0_physical_len = INPUT0_OFFSET_WITH_PADDING + INPUT0_BATCH_PITCH * INPUT0_BATCH_NUM;
 
     UNIT_TYPE in[IN_BLOCK_ARRAY_SIZE];
     CALC_UNIT_TYPE out[OUTPUT_BLOCK_WIDTH * OUTPUT_BLOCK_HEIGHT];
@@ -66,8 +67,9 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv32)(
         for(uint in_block_pos = 0; in_block_pos < IN_BLOCK_ARRAY_SIZE * SUB_GROUP_SIZE; in_block_pos += SUB_GROUP_SIZE) {
             // Horizontal position in input block after read.
             const uint in_block_next_x_pos = in_block_pos % IN_BLOCK_WIDTH + SUB_GROUP_SIZE;
-
-            in[in_block_pos / SUB_GROUP_SIZE] = input[tmp_in_addr + (in_block_pos % IN_BLOCK_WIDTH) * INPUT0_X_PITCH];
+            uint idx = tmp_in_addr + (in_block_pos % IN_BLOCK_WIDTH) * INPUT0_X_PITCH;
+            idx = min(idx, input0_physical_len - 1);
+            in[in_block_pos / SUB_GROUP_SIZE] = input[idx];
 
             // If we have row break, move to the next row.
             if (in_block_next_x_pos == IN_BLOCK_WIDTH)
@@ -80,7 +82,9 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv32)(
             const uint in_block_next_x_pos = in_block_pos % IN_BLOCK_WIDTH + SUB_GROUP_SIZE;
 
             if (in_block_next_x_pos <= IN_BLOCK_WIDTH) { //
-                in[in_block_pos / SUB_GROUP_SIZE] = input[tmp_in_addr + (in_block_pos % IN_BLOCK_WIDTH) * INPUT0_X_PITCH];
+                uint idx = tmp_in_addr + (in_block_pos % IN_BLOCK_WIDTH) * INPUT0_X_PITCH;
+                idx = min(idx, input0_physical_len - 1);
+                in[in_block_pos / SUB_GROUP_SIZE] = input[idx];
 
                 // If we have row break, move to the next row.
                 if (in_block_next_x_pos == IN_BLOCK_WIDTH)
@@ -91,12 +95,18 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv32)(
                 // Position in sub-group on which new row need to be read.
                 const uint sg_br_pos = IN_BLOCK_WIDTH - in_block_pos % IN_BLOCK_WIDTH;
 
-                if (lid < sg_br_pos)
-                    in[in_block_pos / SUB_GROUP_SIZE] = input[tmp_in_addr + (in_block_pos % IN_BLOCK_WIDTH) * INPUT0_X_PITCH];
+                if (lid < sg_br_pos) {
+                    uint idx = tmp_in_addr + (in_block_pos % IN_BLOCK_WIDTH) * INPUT0_X_PITCH;
+                    idx = min(idx, input0_physical_len - 1);
+                    in[in_block_pos / SUB_GROUP_SIZE] = input[idx];
+                }
                 // We have row break inside sub-group. Need to move to next line.
                 tmp_in_addr += INPUT0_Y_PITCH;
-                if (lid >= sg_br_pos)
-                    in[in_block_pos / SUB_GROUP_SIZE] = input[tmp_in_addr - (sg_br_pos * INPUT0_X_PITCH)];
+                if (lid >= sg_br_pos) {
+                    uint idx = tmp_in_addr - (sg_br_pos * INPUT0_X_PITCH);
+                    idx = min(idx, input0_physical_len - 1);
+                    in[in_block_pos / SUB_GROUP_SIZE] = input[idx];
+                }
 
                 // If we have another row break, move to the next row.
                 if (in_block_next_x_pos == 2 * IN_BLOCK_WIDTH)


### PR DESCRIPTION
## Issue
Running the following GPU unit test on B70 device fails with `CL_OUT_OF_RESOURCES` :
```
./ov_gpu_unit_tests \
    --gtest_filter=*onednn_replace_full_tensor_sum_to_binary_add* \
    --device_suffix=1
```
## Root cause
- The failure is caused by out-of-bounds read in `convolution_gpu_bfyx_os_iyx_osv32`.
- The convolution that reproduces the issue has the following tensor shapes:
```
input:   [ 1, 32, 4, 4]
weights: [32, 32, 3, 3]
output:  [ 1, 32, 2, 2]
```
- The input allocation contains 512 elements, so its valid indices are 0..511.
- However, the kernel can attempt to read index up to 523. 
- On b70 device, this invalid memory access results in `CL_OUT_OF_RESOURCES`.

## Solution
- Calculate the physical input buffer length and clamp every input read to the last valid element.
- Please refer `convolution_gpu_bfyx_os_iyx_osv16.cl` https://github.com/openvinotoolkit/openvino/blob/743bbe2e920a8aeded3e133597a93c12ffafe8a6/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_os_iyx_osv16.cl#L134-L136

## Tickets
 - CVS-191540
